### PR TITLE
feat(gui): internationalize the UI (en / zh-CN / zh-HK)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,6 +4281,8 @@ dependencies = [
  "openlogi-core",
  "openlogi-hid",
  "openlogi-hook",
+ "rust-i18n",
+ "sys-locale",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -71,6 +71,12 @@ pub struct AppSettings {
     /// available — no automatic download.
     #[serde(default)]
     pub check_for_updates: bool,
+    /// UI language as a BCP-47-ish locale code matching the GUI's bundled
+    /// locales (`"en"`, `"zh-CN"`, `"zh-HK"`). `None` means "follow the
+    /// system locale", which the GUI resolves at startup. Stored here so a
+    /// user's explicit choice survives restarts regardless of the OS setting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
 }
 
 impl AppSettings {

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -73,12 +73,11 @@ pub fn data_dir() -> Result<PathBuf, PathsError> {
     xdg_base(std::env::var_os("XDG_DATA_HOME"), &[".local", "share"])
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn absolute_xdg_override_is_used_verbatim() {
         let dir = xdg_base(Some("/tmp/xdg-config".into()), &[".config"])
@@ -86,7 +85,6 @@ mod tests {
         assert_eq!(dir, PathBuf::from("/tmp/xdg-config/openlogi"));
     }
 
-    #[cfg(unix)]
     #[test]
     fn relative_xdg_value_is_ignored_per_spec() {
         // A relative $XDG_*_HOME is invalid, so this must fall back to

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -30,6 +30,8 @@ tracing-subscriber = { workspace = true }
 fs4 = { version = "1.1.0", features = ["sync"] }
 thiserror.workspace = true
 ureq.workspace = true
+rust-i18n = "4"
+sys-locale = "0.3.2"
 
 [lints]
 workspace = true

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -1,285 +1,372 @@
 # OpenLogi GUI translations.
 #
-# `_version: 2` packs every locale for one message into a single entry. The
-# **key is the English source string** (gettext-style): a `t!`/`tr!` lookup that
-# misses falls back to the key itself, so English needs no entries here — only
-# the non-English columns. Keep keys byte-for-byte identical to the code (and,
-# for the device/action vocabulary, to `openlogi_core::binding`'s `label()`).
+# `_version: 2` packs every shipped locale for one message into a single entry.
+# The **key is the English msgid** (gettext-style): a `t!`/`tr!` lookup that
+# misses still falls back to readable English. The `en:` column mirrors that
+# source text so the file reads as a complete en / zh-CN / zh-HK table — keep it
+# byte-for-byte equal to the key. Keys (and `en:`) must match the code verbatim,
+# and the device/action vocabulary must match `openlogi_core::binding`'s
+# `label()`.
 #
 # Interpolation uses `%{name}` and must be preserved verbatim in every locale.
 _version: 2
 
 # ── App chrome: accessibility gate, footer (app.rs) ─────────────────────────
 "Accessibility permission required":
+  en: Accessibility permission required
   zh-CN: 需要「辅助功能」权限
   zh-HK: 需要「輔助使用」權限
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
+  en: OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.
   zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
   zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
 "Open System Settings to grant access":
+  en: Open System Settings to grant access
   zh-CN: 打开系统设置授权
   zh-HK: 開啟系統設定授權
 "Takes effect automatically once granted — no restart needed.":
+  en: Takes effect automatically once granted — no restart needed.
   zh-CN: 授权后会自动生效,无需重启。
   zh-HK: 授權後會自動生效,無需重新啟動。
 "Not now (use DPI and other features only)":
+  en: Not now (use DPI and other features only)
   zh-CN: 稍后再说(仅使用 DPI 等功能)
   zh-HK: 稍後再說(僅使用 DPI 等功能)
 "Settings":
+  en: Settings
   zh-CN: 设置
   zh-HK: 設定
 "About":
+  en: About
   zh-CN: 关于
   zh-HK: 關於
 "Accessibility granted":
+  en: Accessibility granted
   zh-CN: 辅助功能已授权
   zh-HK: 輔助使用已授權
 "Accessibility not granted · click to grant":
+  en: Accessibility not granted · click to grant
   zh-CN: 辅助功能未授权 · 点击授权
   zh-HK: 輔助使用未授權 · 點擊授權
 
 # ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
 "About OpenLogi":
+  en: About OpenLogi
   zh-CN: 关于 OpenLogi
   zh-HK: 關於 OpenLogi
 "Settings…":
+  en: Settings…
   zh-CN: 设置…
   zh-HK: 設定…
 "Hide OpenLogi":
+  en: Hide OpenLogi
   zh-CN: 隐藏 OpenLogi
   zh-HK: 隱藏 OpenLogi
 "Hide Others":
+  en: Hide Others
   zh-CN: 隐藏其他
   zh-HK: 隱藏其他
 "Show All":
+  en: Show All
   zh-CN: 全部显示
   zh-HK: 全部顯示
 "Quit OpenLogi":
+  en: Quit OpenLogi
   zh-CN: 退出 OpenLogi
   zh-HK: 結束 OpenLogi
 "Window":
+  en: Window
   zh-CN: 窗口
   zh-HK: 視窗
 "Minimize":
+  en: Minimize
   zh-CN: 最小化
   zh-HK: 最小化
 "Zoom":
+  en: Zoom
   zh-CN: 缩放
   zh-HK: 縮放
 
 # ── About window (about.rs) ─────────────────────────────────────────────────
 "Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
+  en: Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.
   zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
   zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
 
 # ── Settings window (settings.rs) ───────────────────────────────────────────
 "General":
+  en: General
   zh-CN: 通用
   zh-HK: 一般
 "Launch at login":
+  en: Launch at login
   zh-CN: 开机自启
   zh-HK: 開機自動啟動
 "Automatically start OpenLogi when you log in to macOS.":
+  en: Automatically start OpenLogi when you log in to macOS.
   zh-CN: 登录 macOS 时自动启动 OpenLogi。
   zh-HK: 登入 macOS 時自動啟動 OpenLogi。
 "Check for updates":
+  en: Check for updates
   zh-CN: 检查更新
   zh-HK: 檢查更新
 "Check once per launch for a new version (query only — no automatic download).":
+  en: Check once per launch for a new version (query only — no automatic download).
   zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
   zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
 "Language":
+  en: Language
   zh-CN: 语言
   zh-HK: 語言
 "Choose the interface language.":
+  en: Choose the interface language.
   zh-CN: 选择界面语言。
   zh-HK: 選擇介面語言。
 "Follow system":
+  en: Follow system
   zh-CN: 跟随系统
   zh-HK: 跟隨系統
 
 # ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
 "PRESETS":
+  en: PRESETS
   zh-CN: 预设
   zh-HK: 預設
 "+ Add":
+  en: + Add
   zh-CN: + 添加
   zh-HK: + 新增
 
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
+  en: Bind %{name}
   zh-CN: 绑定 %{name}
   zh-HK: 綁定 %{name}
 "Gesture %{name}":
+  en: Gesture %{name}
   zh-CN: 手势 %{name}
   zh-HK: 手勢 %{name}
 
 # ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
 "Left Click":
+  en: Left Click
   zh-CN: 左键单击
   zh-HK: 左鍵單擊
 "Right Click":
+  en: Right Click
   zh-CN: 右键单击
   zh-HK: 右鍵單擊
 "Middle Click":
+  en: Middle Click
   zh-CN: 中键单击
   zh-HK: 中鍵單擊
 "Back":
+  en: Back
   zh-CN: 后退
   zh-HK: 後退
 "Forward":
+  en: Forward
   zh-CN: 前进
   zh-HK: 前進
 "DPI Toggle":
+  en: DPI Toggle
   zh-CN: DPI 切换
   zh-HK: DPI 切換
 "Thumb Wheel":
+  en: Thumb Wheel
   zh-CN: 拇指滚轮
   zh-HK: 拇指滾輪
 "Gesture Button":
+  en: Gesture Button
   zh-CN: 手势按钮
   zh-HK: 手勢按鈕
 
 # ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
 "Up":
+  en: Up
   zh-CN: 上
   zh-HK: 上
 "Down":
+  en: Down
   zh-CN: 下
   zh-HK: 下
 "Left":
+  en: Left
   zh-CN: 左
   zh-HK: 左
 "Right":
+  en: Right
   zh-CN: 右
   zh-HK: 右
 "Click":
+  en: Click
   zh-CN: 按下
   zh-HK: 按下
 
 # ── Categories (openlogi_core::binding::Category) ───────────────────────────
 "EDITING":
+  en: EDITING
   zh-CN: 编辑
   zh-HK: 編輯
 "BROWSER":
+  en: BROWSER
   zh-CN: 浏览器
   zh-HK: 瀏覽器
 "MEDIA":
+  en: MEDIA
   zh-CN: 媒体
   zh-HK: 媒體
 "MOUSE":
+  en: MOUSE
   zh-CN: 鼠标
   zh-HK: 滑鼠
 "SCROLL":
+  en: SCROLL
   zh-CN: 滚动
   zh-HK: 捲動
 "NAVIGATION":
+  en: NAVIGATION
   zh-CN: 导航
   zh-HK: 導覽
 "SYSTEM":
+  en: SYSTEM
   zh-CN: 系统
   zh-HK: 系統
 
 # ── Actions (openlogi_core::binding::Action) ────────────────────────────────
 "Copy":
+  en: Copy
   zh-CN: 复制
   zh-HK: 複製
 "Paste":
+  en: Paste
   zh-CN: 粘贴
   zh-HK: 貼上
 "Cut":
+  en: Cut
   zh-CN: 剪切
   zh-HK: 剪下
 "Undo":
+  en: Undo
   zh-CN: 撤销
   zh-HK: 復原
 "Redo":
+  en: Redo
   zh-CN: 重做
   zh-HK: 重做
 "Select All":
+  en: Select All
   zh-CN: 全选
   zh-HK: 全選
 "Find":
+  en: Find
   zh-CN: 查找
   zh-HK: 尋找
 "Save":
+  en: Save
   zh-CN: 保存
   zh-HK: 儲存
 "Browser Back":
+  en: Browser Back
   zh-CN: 浏览器后退
   zh-HK: 瀏覽器後退
 "Browser Forward":
+  en: Browser Forward
   zh-CN: 浏览器前进
   zh-HK: 瀏覽器前進
 "New Tab":
+  en: New Tab
   zh-CN: 新建标签页
   zh-HK: 新增分頁
 "Close Tab":
+  en: Close Tab
   zh-CN: 关闭标签页
   zh-HK: 關閉分頁
 "Reopen Tab":
+  en: Reopen Tab
   zh-CN: 重开标签页
   zh-HK: 重新開啟分頁
 "Next Tab":
+  en: Next Tab
   zh-CN: 下一个标签页
   zh-HK: 下一個分頁
 "Previous Tab":
+  en: Previous Tab
   zh-CN: 上一个标签页
   zh-HK: 上一個分頁
 "Reload Page":
+  en: Reload Page
   zh-CN: 刷新页面
   zh-HK: 重新載入頁面
 "Mission Control":
+  en: Mission Control
   zh-CN: 调度中心
   zh-HK: 調度中心
 "App Exposé":
+  en: App Exposé
   zh-CN: 应用程序窗口
   zh-HK: 應用程式視窗
 "Show Desktop":
+  en: Show Desktop
   zh-CN: 显示桌面
   zh-HK: 顯示桌面
 "Launchpad":
+  en: Launchpad
   zh-CN: 启动台
   zh-HK: 啟動台
 "Lock Screen":
+  en: Lock Screen
   zh-CN: 锁定屏幕
   zh-HK: 鎖定螢幕
 "Screenshot":
+  en: Screenshot
   zh-CN: 截屏
   zh-HK: 截圖
 "Play / Pause":
+  en: Play / Pause
   zh-CN: 播放 / 暂停
   zh-HK: 播放 / 暫停
 "Next Track":
+  en: Next Track
   zh-CN: 下一首
   zh-HK: 下一首
 "Previous Track":
+  en: Previous Track
   zh-CN: 上一首
   zh-HK: 上一首
 "Volume Up":
+  en: Volume Up
   zh-CN: 增大音量
   zh-HK: 調高音量
 "Volume Down":
+  en: Volume Down
   zh-CN: 减小音量
   zh-HK: 調低音量
 "Mute":
+  en: Mute
   zh-CN: 静音
   zh-HK: 靜音
 "Cycle DPI Presets":
+  en: Cycle DPI Presets
   zh-CN: 循环 DPI 预设
   zh-HK: 循環 DPI 預設
 "Toggle SmartShift":
+  en: Toggle SmartShift
   zh-CN: 切换 SmartShift
   zh-HK: 切換 SmartShift
 "Scroll Up":
+  en: Scroll Up
   zh-CN: 向上滚动
   zh-HK: 向上捲動
 "Scroll Down":
+  en: Scroll Down
   zh-CN: 向下滚动
   zh-HK: 向下捲動
 "Scroll Left":
+  en: Scroll Left
   zh-CN: 向左滚动
   zh-HK: 向左捲動
 "Scroll Right":
+  en: Scroll Right
   zh-CN: 向右滚动
   zh-HK: 向右捲動

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -1,11 +1,10 @@
 # OpenLogi GUI translations.
 #
-# `_version: 2` packs every shipped locale for one message into a single entry.
-# The **key is the English msgid** (gettext-style): a `t!`/`tr!` lookup that
-# misses still falls back to readable English. The `en:` column mirrors that
-# source text so the file reads as a complete en / ja / zh-CN / zh-HK table —
-# keep it byte-for-byte equal to the key. Keys (and `en:`) must match the code
-# verbatim, and the device/action vocabulary must match
+# `_version: 2` packs every translated locale for one message into a single
+# entry. The **key is the English msgid** (gettext-style): a `t!`/`tr!` lookup
+# that misses the current locale falls back to the key itself, so English needs
+# no column here — only the `ja` / `zh-CN` / `zh-HK` translations. Keys must
+# match the code verbatim, and the device/action vocabulary must match
 # `openlogi_core::binding`'s `label()`.
 #
 # Interpolation uses `%{name}` and must be preserved verbatim in every locale.
@@ -13,445 +12,360 @@ _version: 2
 
 # ── App chrome: accessibility gate, footer (app.rs) ─────────────────────────
 "Accessibility permission required":
-  en: Accessibility permission required
   ja: アクセシビリティ権限が必要です
   zh-CN: 需要「辅助功能」权限
   zh-HK: 需要「輔助使用」權限
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
-  en: OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.
   ja: OpenLogi はシステムの「アクセシビリティ」権限を通じてマウスボタン(戻る / 進む / ジェスチャーボタン)を捕捉し、割り当てた操作を実行します。DPI、SmartShift などデバイスと直接通信する機能には影響しません。
   zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
   zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
 "Open System Settings to grant access":
-  en: Open System Settings to grant access
   ja: システム設定を開いて許可する
   zh-CN: 打开系统设置授权
   zh-HK: 開啟系統設定授權
 "Takes effect automatically once granted — no restart needed.":
-  en: Takes effect automatically once granted — no restart needed.
   ja: 許可すると自動的に反映されます — 再起動は不要です。
   zh-CN: 授权后会自动生效,无需重启。
   zh-HK: 授權後會自動生效,無需重新啟動。
 "Not now (use DPI and other features only)":
-  en: Not now (use DPI and other features only)
   ja: 後で(DPI などの機能のみ使用)
   zh-CN: 稍后再说(仅使用 DPI 等功能)
   zh-HK: 稍後再說(僅使用 DPI 等功能)
 "Settings":
-  en: Settings
   ja: 設定
   zh-CN: 设置
   zh-HK: 設定
 "About":
-  en: About
   ja: 情報
   zh-CN: 关于
   zh-HK: 關於
 "Accessibility granted":
-  en: Accessibility granted
   ja: アクセシビリティは許可済み
   zh-CN: 辅助功能已授权
   zh-HK: 輔助使用已授權
 "Accessibility not granted · click to grant":
-  en: Accessibility not granted · click to grant
   ja: アクセシビリティ未許可 · クリックして許可
   zh-CN: 辅助功能未授权 · 点击授权
   zh-HK: 輔助使用未授權 · 點擊授權
 
 # ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
 "About OpenLogi":
-  en: About OpenLogi
   ja: OpenLogi について
   zh-CN: 关于 OpenLogi
   zh-HK: 關於 OpenLogi
 "Settings…":
-  en: Settings…
   ja: 設定…
   zh-CN: 设置…
   zh-HK: 設定…
 "Hide OpenLogi":
-  en: Hide OpenLogi
   ja: OpenLogi を隠す
   zh-CN: 隐藏 OpenLogi
   zh-HK: 隱藏 OpenLogi
 "Hide Others":
-  en: Hide Others
   ja: ほかを隠す
   zh-CN: 隐藏其他
   zh-HK: 隱藏其他
 "Show All":
-  en: Show All
   ja: すべてを表示
   zh-CN: 全部显示
   zh-HK: 全部顯示
 "Quit OpenLogi":
-  en: Quit OpenLogi
   ja: OpenLogi を終了
   zh-CN: 退出 OpenLogi
   zh-HK: 結束 OpenLogi
 "Window":
-  en: Window
   ja: ウインドウ
   zh-CN: 窗口
   zh-HK: 視窗
 "Minimize":
-  en: Minimize
   ja: しまう
   zh-CN: 最小化
   zh-HK: 最小化
 "Zoom":
-  en: Zoom
   ja: ズーム
   zh-CN: 缩放
   zh-HK: 縮放
 
 # ── About window (about.rs) ─────────────────────────────────────────────────
 "Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
-  en: Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.
   ja: オープンソースの Logitech マウス設定ツール —— DPI、SmartShift、ボタン割り当て、ジェスチャー。
   zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
   zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
 
 # ── Settings window (settings.rs) ───────────────────────────────────────────
 "General":
-  en: General
   ja: 一般
   zh-CN: 通用
   zh-HK: 一般
 "Launch at login":
-  en: Launch at login
   ja: ログイン時に起動
   zh-CN: 开机自启
   zh-HK: 開機自動啟動
 "Automatically start OpenLogi when you log in to macOS.":
-  en: Automatically start OpenLogi when you log in to macOS.
   ja: macOS にログインしたときに OpenLogi を自動的に起動します。
   zh-CN: 登录 macOS 时自动启动 OpenLogi。
   zh-HK: 登入 macOS 時自動啟動 OpenLogi。
 "Check for updates":
-  en: Check for updates
   ja: アップデートを確認
   zh-CN: 检查更新
   zh-HK: 檢查更新
 "Check once per launch for a new version (query only — no automatic download).":
-  en: Check once per launch for a new version (query only — no automatic download).
   ja: 起動ごとに新しいバージョンを一度だけ確認します(確認のみ — 自動ダウンロードはしません)。
   zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
   zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
 "Language":
-  en: Language
   ja: 言語
   zh-CN: 语言
   zh-HK: 語言
 "Choose the interface language.":
-  en: Choose the interface language.
   ja: インターフェースの言語を選択します。
   zh-CN: 选择界面语言。
   zh-HK: 選擇介面語言。
 "Follow system":
-  en: Follow system
   ja: システムに従う
   zh-CN: 跟随系统
   zh-HK: 跟隨系統
 
 # ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
 "PRESETS":
-  en: PRESETS
   ja: プリセット
   zh-CN: 预设
   zh-HK: 預設
 "+ Add":
-  en: + Add
   ja: + 追加
   zh-CN: + 添加
   zh-HK: + 新增
 
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
-  en: Bind %{name}
   ja: "%{name} を割り当て"
   zh-CN: 绑定 %{name}
   zh-HK: 綁定 %{name}
 "Gesture %{name}":
-  en: Gesture %{name}
   ja: ジェスチャー %{name}
   zh-CN: 手势 %{name}
   zh-HK: 手勢 %{name}
 
 # ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
 "Left Click":
-  en: Left Click
   ja: 左クリック
   zh-CN: 左键单击
   zh-HK: 左鍵單擊
 "Right Click":
-  en: Right Click
   ja: 右クリック
   zh-CN: 右键单击
   zh-HK: 右鍵單擊
 "Middle Click":
-  en: Middle Click
   ja: 中クリック
   zh-CN: 中键单击
   zh-HK: 中鍵單擊
 "Back":
-  en: Back
   ja: 戻る
   zh-CN: 后退
   zh-HK: 後退
 "Forward":
-  en: Forward
   ja: 進む
   zh-CN: 前进
   zh-HK: 前進
 "DPI Toggle":
-  en: DPI Toggle
   ja: DPI 切り替え
   zh-CN: DPI 切换
   zh-HK: DPI 切換
 "Thumb Wheel":
-  en: Thumb Wheel
   ja: サムホイール
   zh-CN: 拇指滚轮
   zh-HK: 拇指滾輪
 "Gesture Button":
-  en: Gesture Button
   ja: ジェスチャーボタン
   zh-CN: 手势按钮
   zh-HK: 手勢按鈕
 
 # ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
 "Up":
-  en: Up
   ja: 上
   zh-CN: 上
   zh-HK: 上
 "Down":
-  en: Down
   ja: 下
   zh-CN: 下
   zh-HK: 下
 "Left":
-  en: Left
   ja: 左
   zh-CN: 左
   zh-HK: 左
 "Right":
-  en: Right
   ja: 右
   zh-CN: 右
   zh-HK: 右
 "Click":
-  en: Click
   ja: 押し込み
   zh-CN: 按下
   zh-HK: 按下
 
 # ── Categories (openlogi_core::binding::Category) ───────────────────────────
 "EDITING":
-  en: EDITING
   ja: 編集
   zh-CN: 编辑
   zh-HK: 編輯
 "BROWSER":
-  en: BROWSER
   ja: ブラウザ
   zh-CN: 浏览器
   zh-HK: 瀏覽器
 "MEDIA":
-  en: MEDIA
   ja: メディア
   zh-CN: 媒体
   zh-HK: 媒體
 "MOUSE":
-  en: MOUSE
   ja: マウス
   zh-CN: 鼠标
   zh-HK: 滑鼠
 "SCROLL":
-  en: SCROLL
   ja: スクロール
   zh-CN: 滚动
   zh-HK: 捲動
 "NAVIGATION":
-  en: NAVIGATION
   ja: ナビゲーション
   zh-CN: 导航
   zh-HK: 導覽
 "SYSTEM":
-  en: SYSTEM
   ja: システム
   zh-CN: 系统
   zh-HK: 系統
 
 # ── Actions (openlogi_core::binding::Action) ────────────────────────────────
 "Copy":
-  en: Copy
   ja: コピー
   zh-CN: 复制
   zh-HK: 複製
 "Paste":
-  en: Paste
   ja: ペースト
   zh-CN: 粘贴
   zh-HK: 貼上
 "Cut":
-  en: Cut
   ja: カット
   zh-CN: 剪切
   zh-HK: 剪下
 "Undo":
-  en: Undo
   ja: 取り消す
   zh-CN: 撤销
   zh-HK: 復原
 "Redo":
-  en: Redo
   ja: やり直す
   zh-CN: 重做
   zh-HK: 重做
 "Select All":
-  en: Select All
   ja: すべて選択
   zh-CN: 全选
   zh-HK: 全選
 "Find":
-  en: Find
   ja: 検索
   zh-CN: 查找
   zh-HK: 尋找
 "Save":
-  en: Save
   ja: 保存
   zh-CN: 保存
   zh-HK: 儲存
 "Browser Back":
-  en: Browser Back
   ja: ブラウザで戻る
   zh-CN: 浏览器后退
   zh-HK: 瀏覽器後退
 "Browser Forward":
-  en: Browser Forward
   ja: ブラウザで進む
   zh-CN: 浏览器前进
   zh-HK: 瀏覽器前進
 "New Tab":
-  en: New Tab
   ja: 新規タブ
   zh-CN: 新建标签页
   zh-HK: 新增分頁
 "Close Tab":
-  en: Close Tab
   ja: タブを閉じる
   zh-CN: 关闭标签页
   zh-HK: 關閉分頁
 "Reopen Tab":
-  en: Reopen Tab
   ja: タブを再度開く
   zh-CN: 重开标签页
   zh-HK: 重新開啟分頁
 "Next Tab":
-  en: Next Tab
   ja: 次のタブ
   zh-CN: 下一个标签页
   zh-HK: 下一個分頁
 "Previous Tab":
-  en: Previous Tab
   ja: 前のタブ
   zh-CN: 上一个标签页
   zh-HK: 上一個分頁
 "Reload Page":
-  en: Reload Page
   ja: ページを再読み込み
   zh-CN: 刷新页面
   zh-HK: 重新載入頁面
 "Mission Control":
-  en: Mission Control
   ja: Mission Control
   zh-CN: 调度中心
   zh-HK: 調度中心
 "App Exposé":
-  en: App Exposé
   ja: App Exposé
   zh-CN: 应用程序窗口
   zh-HK: 應用程式視窗
 "Show Desktop":
-  en: Show Desktop
   ja: デスクトップを表示
   zh-CN: 显示桌面
   zh-HK: 顯示桌面
 "Launchpad":
-  en: Launchpad
   ja: Launchpad
   zh-CN: 启动台
   zh-HK: 啟動台
 "Lock Screen":
-  en: Lock Screen
   ja: 画面をロック
   zh-CN: 锁定屏幕
   zh-HK: 鎖定螢幕
 "Screenshot":
-  en: Screenshot
   ja: スクリーンショット
   zh-CN: 截屏
   zh-HK: 截圖
 "Play / Pause":
-  en: Play / Pause
   ja: 再生 / 一時停止
   zh-CN: 播放 / 暂停
   zh-HK: 播放 / 暫停
 "Next Track":
-  en: Next Track
   ja: 次の曲
   zh-CN: 下一首
   zh-HK: 下一首
 "Previous Track":
-  en: Previous Track
   ja: 前の曲
   zh-CN: 上一首
   zh-HK: 上一首
 "Volume Up":
-  en: Volume Up
   ja: 音量を上げる
   zh-CN: 增大音量
   zh-HK: 調高音量
 "Volume Down":
-  en: Volume Down
   ja: 音量を下げる
   zh-CN: 减小音量
   zh-HK: 調低音量
 "Mute":
-  en: Mute
   ja: ミュート
   zh-CN: 静音
   zh-HK: 靜音
 "Cycle DPI Presets":
-  en: Cycle DPI Presets
   ja: DPI プリセットを循環
   zh-CN: 循环 DPI 预设
   zh-HK: 循環 DPI 預設
 "Toggle SmartShift":
-  en: Toggle SmartShift
   ja: SmartShift を切り替え
   zh-CN: 切换 SmartShift
   zh-HK: 切換 SmartShift
 "Scroll Up":
-  en: Scroll Up
   ja: 上にスクロール
   zh-CN: 向上滚动
   zh-HK: 向上捲動
 "Scroll Down":
-  en: Scroll Down
   ja: 下にスクロール
   zh-CN: 向下滚动
   zh-HK: 向下捲動
 "Scroll Left":
-  en: Scroll Left
   ja: 左にスクロール
   zh-CN: 向左滚动
   zh-HK: 向左捲動
 "Scroll Right":
-  en: Scroll Right
   ja: 右にスクロール
   zh-CN: 向右滚动
   zh-HK: 向右捲動

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -3,10 +3,10 @@
 # `_version: 2` packs every shipped locale for one message into a single entry.
 # The **key is the English msgid** (gettext-style): a `t!`/`tr!` lookup that
 # misses still falls back to readable English. The `en:` column mirrors that
-# source text so the file reads as a complete en / zh-CN / zh-HK table — keep it
-# byte-for-byte equal to the key. Keys (and `en:`) must match the code verbatim,
-# and the device/action vocabulary must match `openlogi_core::binding`'s
-# `label()`.
+# source text so the file reads as a complete en / ja / zh-CN / zh-HK table —
+# keep it byte-for-byte equal to the key. Keys (and `en:`) must match the code
+# verbatim, and the device/action vocabulary must match
+# `openlogi_core::binding`'s `label()`.
 #
 # Interpolation uses `%{name}` and must be preserved verbatim in every locale.
 _version: 2
@@ -14,359 +14,444 @@ _version: 2
 # ── App chrome: accessibility gate, footer (app.rs) ─────────────────────────
 "Accessibility permission required":
   en: Accessibility permission required
+  ja: アクセシビリティ権限が必要です
   zh-CN: 需要「辅助功能」权限
   zh-HK: 需要「輔助使用」權限
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
   en: OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.
+  ja: OpenLogi はシステムの「アクセシビリティ」権限を通じてマウスボタン(戻る / 進む / ジェスチャーボタン)を捕捉し、割り当てた操作を実行します。DPI、SmartShift などデバイスと直接通信する機能には影響しません。
   zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
   zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
 "Open System Settings to grant access":
   en: Open System Settings to grant access
+  ja: システム設定を開いて許可する
   zh-CN: 打开系统设置授权
   zh-HK: 開啟系統設定授權
 "Takes effect automatically once granted — no restart needed.":
   en: Takes effect automatically once granted — no restart needed.
+  ja: 許可すると自動的に反映されます — 再起動は不要です。
   zh-CN: 授权后会自动生效,无需重启。
   zh-HK: 授權後會自動生效,無需重新啟動。
 "Not now (use DPI and other features only)":
   en: Not now (use DPI and other features only)
+  ja: 後で(DPI などの機能のみ使用)
   zh-CN: 稍后再说(仅使用 DPI 等功能)
   zh-HK: 稍後再說(僅使用 DPI 等功能)
 "Settings":
   en: Settings
+  ja: 設定
   zh-CN: 设置
   zh-HK: 設定
 "About":
   en: About
+  ja: 情報
   zh-CN: 关于
   zh-HK: 關於
 "Accessibility granted":
   en: Accessibility granted
+  ja: アクセシビリティは許可済み
   zh-CN: 辅助功能已授权
   zh-HK: 輔助使用已授權
 "Accessibility not granted · click to grant":
   en: Accessibility not granted · click to grant
+  ja: アクセシビリティ未許可 · クリックして許可
   zh-CN: 辅助功能未授权 · 点击授权
   zh-HK: 輔助使用未授權 · 點擊授權
 
 # ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
 "About OpenLogi":
   en: About OpenLogi
+  ja: OpenLogi について
   zh-CN: 关于 OpenLogi
   zh-HK: 關於 OpenLogi
 "Settings…":
   en: Settings…
+  ja: 設定…
   zh-CN: 设置…
   zh-HK: 設定…
 "Hide OpenLogi":
   en: Hide OpenLogi
+  ja: OpenLogi を隠す
   zh-CN: 隐藏 OpenLogi
   zh-HK: 隱藏 OpenLogi
 "Hide Others":
   en: Hide Others
+  ja: ほかを隠す
   zh-CN: 隐藏其他
   zh-HK: 隱藏其他
 "Show All":
   en: Show All
+  ja: すべてを表示
   zh-CN: 全部显示
   zh-HK: 全部顯示
 "Quit OpenLogi":
   en: Quit OpenLogi
+  ja: OpenLogi を終了
   zh-CN: 退出 OpenLogi
   zh-HK: 結束 OpenLogi
 "Window":
   en: Window
+  ja: ウインドウ
   zh-CN: 窗口
   zh-HK: 視窗
 "Minimize":
   en: Minimize
+  ja: しまう
   zh-CN: 最小化
   zh-HK: 最小化
 "Zoom":
   en: Zoom
+  ja: ズーム
   zh-CN: 缩放
   zh-HK: 縮放
 
 # ── About window (about.rs) ─────────────────────────────────────────────────
 "Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
   en: Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.
+  ja: オープンソースの Logitech マウス設定ツール —— DPI、SmartShift、ボタン割り当て、ジェスチャー。
   zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
   zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
 
 # ── Settings window (settings.rs) ───────────────────────────────────────────
 "General":
   en: General
+  ja: 一般
   zh-CN: 通用
   zh-HK: 一般
 "Launch at login":
   en: Launch at login
+  ja: ログイン時に起動
   zh-CN: 开机自启
   zh-HK: 開機自動啟動
 "Automatically start OpenLogi when you log in to macOS.":
   en: Automatically start OpenLogi when you log in to macOS.
+  ja: macOS にログインしたときに OpenLogi を自動的に起動します。
   zh-CN: 登录 macOS 时自动启动 OpenLogi。
   zh-HK: 登入 macOS 時自動啟動 OpenLogi。
 "Check for updates":
   en: Check for updates
+  ja: アップデートを確認
   zh-CN: 检查更新
   zh-HK: 檢查更新
 "Check once per launch for a new version (query only — no automatic download).":
   en: Check once per launch for a new version (query only — no automatic download).
+  ja: 起動ごとに新しいバージョンを一度だけ確認します(確認のみ — 自動ダウンロードはしません)。
   zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
   zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
 "Language":
   en: Language
+  ja: 言語
   zh-CN: 语言
   zh-HK: 語言
 "Choose the interface language.":
   en: Choose the interface language.
+  ja: インターフェースの言語を選択します。
   zh-CN: 选择界面语言。
   zh-HK: 選擇介面語言。
 "Follow system":
   en: Follow system
+  ja: システムに従う
   zh-CN: 跟随系统
   zh-HK: 跟隨系統
 
 # ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
 "PRESETS":
   en: PRESETS
+  ja: プリセット
   zh-CN: 预设
   zh-HK: 預設
 "+ Add":
   en: + Add
+  ja: + 追加
   zh-CN: + 添加
   zh-HK: + 新增
 
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
   en: Bind %{name}
+  ja: "%{name} を割り当て"
   zh-CN: 绑定 %{name}
   zh-HK: 綁定 %{name}
 "Gesture %{name}":
   en: Gesture %{name}
+  ja: ジェスチャー %{name}
   zh-CN: 手势 %{name}
   zh-HK: 手勢 %{name}
 
 # ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
 "Left Click":
   en: Left Click
+  ja: 左クリック
   zh-CN: 左键单击
   zh-HK: 左鍵單擊
 "Right Click":
   en: Right Click
+  ja: 右クリック
   zh-CN: 右键单击
   zh-HK: 右鍵單擊
 "Middle Click":
   en: Middle Click
+  ja: 中クリック
   zh-CN: 中键单击
   zh-HK: 中鍵單擊
 "Back":
   en: Back
+  ja: 戻る
   zh-CN: 后退
   zh-HK: 後退
 "Forward":
   en: Forward
+  ja: 進む
   zh-CN: 前进
   zh-HK: 前進
 "DPI Toggle":
   en: DPI Toggle
+  ja: DPI 切り替え
   zh-CN: DPI 切换
   zh-HK: DPI 切換
 "Thumb Wheel":
   en: Thumb Wheel
+  ja: サムホイール
   zh-CN: 拇指滚轮
   zh-HK: 拇指滾輪
 "Gesture Button":
   en: Gesture Button
+  ja: ジェスチャーボタン
   zh-CN: 手势按钮
   zh-HK: 手勢按鈕
 
 # ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
 "Up":
   en: Up
+  ja: 上
   zh-CN: 上
   zh-HK: 上
 "Down":
   en: Down
+  ja: 下
   zh-CN: 下
   zh-HK: 下
 "Left":
   en: Left
+  ja: 左
   zh-CN: 左
   zh-HK: 左
 "Right":
   en: Right
+  ja: 右
   zh-CN: 右
   zh-HK: 右
 "Click":
   en: Click
+  ja: 押し込み
   zh-CN: 按下
   zh-HK: 按下
 
 # ── Categories (openlogi_core::binding::Category) ───────────────────────────
 "EDITING":
   en: EDITING
+  ja: 編集
   zh-CN: 编辑
   zh-HK: 編輯
 "BROWSER":
   en: BROWSER
+  ja: ブラウザ
   zh-CN: 浏览器
   zh-HK: 瀏覽器
 "MEDIA":
   en: MEDIA
+  ja: メディア
   zh-CN: 媒体
   zh-HK: 媒體
 "MOUSE":
   en: MOUSE
+  ja: マウス
   zh-CN: 鼠标
   zh-HK: 滑鼠
 "SCROLL":
   en: SCROLL
+  ja: スクロール
   zh-CN: 滚动
   zh-HK: 捲動
 "NAVIGATION":
   en: NAVIGATION
+  ja: ナビゲーション
   zh-CN: 导航
   zh-HK: 導覽
 "SYSTEM":
   en: SYSTEM
+  ja: システム
   zh-CN: 系统
   zh-HK: 系統
 
 # ── Actions (openlogi_core::binding::Action) ────────────────────────────────
 "Copy":
   en: Copy
+  ja: コピー
   zh-CN: 复制
   zh-HK: 複製
 "Paste":
   en: Paste
+  ja: ペースト
   zh-CN: 粘贴
   zh-HK: 貼上
 "Cut":
   en: Cut
+  ja: カット
   zh-CN: 剪切
   zh-HK: 剪下
 "Undo":
   en: Undo
+  ja: 取り消す
   zh-CN: 撤销
   zh-HK: 復原
 "Redo":
   en: Redo
+  ja: やり直す
   zh-CN: 重做
   zh-HK: 重做
 "Select All":
   en: Select All
+  ja: すべて選択
   zh-CN: 全选
   zh-HK: 全選
 "Find":
   en: Find
+  ja: 検索
   zh-CN: 查找
   zh-HK: 尋找
 "Save":
   en: Save
+  ja: 保存
   zh-CN: 保存
   zh-HK: 儲存
 "Browser Back":
   en: Browser Back
+  ja: ブラウザで戻る
   zh-CN: 浏览器后退
   zh-HK: 瀏覽器後退
 "Browser Forward":
   en: Browser Forward
+  ja: ブラウザで進む
   zh-CN: 浏览器前进
   zh-HK: 瀏覽器前進
 "New Tab":
   en: New Tab
+  ja: 新規タブ
   zh-CN: 新建标签页
   zh-HK: 新增分頁
 "Close Tab":
   en: Close Tab
+  ja: タブを閉じる
   zh-CN: 关闭标签页
   zh-HK: 關閉分頁
 "Reopen Tab":
   en: Reopen Tab
+  ja: タブを再度開く
   zh-CN: 重开标签页
   zh-HK: 重新開啟分頁
 "Next Tab":
   en: Next Tab
+  ja: 次のタブ
   zh-CN: 下一个标签页
   zh-HK: 下一個分頁
 "Previous Tab":
   en: Previous Tab
+  ja: 前のタブ
   zh-CN: 上一个标签页
   zh-HK: 上一個分頁
 "Reload Page":
   en: Reload Page
+  ja: ページを再読み込み
   zh-CN: 刷新页面
   zh-HK: 重新載入頁面
 "Mission Control":
   en: Mission Control
+  ja: Mission Control
   zh-CN: 调度中心
   zh-HK: 調度中心
 "App Exposé":
   en: App Exposé
+  ja: App Exposé
   zh-CN: 应用程序窗口
   zh-HK: 應用程式視窗
 "Show Desktop":
   en: Show Desktop
+  ja: デスクトップを表示
   zh-CN: 显示桌面
   zh-HK: 顯示桌面
 "Launchpad":
   en: Launchpad
+  ja: Launchpad
   zh-CN: 启动台
   zh-HK: 啟動台
 "Lock Screen":
   en: Lock Screen
+  ja: 画面をロック
   zh-CN: 锁定屏幕
   zh-HK: 鎖定螢幕
 "Screenshot":
   en: Screenshot
+  ja: スクリーンショット
   zh-CN: 截屏
   zh-HK: 截圖
 "Play / Pause":
   en: Play / Pause
+  ja: 再生 / 一時停止
   zh-CN: 播放 / 暂停
   zh-HK: 播放 / 暫停
 "Next Track":
   en: Next Track
+  ja: 次の曲
   zh-CN: 下一首
   zh-HK: 下一首
 "Previous Track":
   en: Previous Track
+  ja: 前の曲
   zh-CN: 上一首
   zh-HK: 上一首
 "Volume Up":
   en: Volume Up
+  ja: 音量を上げる
   zh-CN: 增大音量
   zh-HK: 調高音量
 "Volume Down":
   en: Volume Down
+  ja: 音量を下げる
   zh-CN: 减小音量
   zh-HK: 調低音量
 "Mute":
   en: Mute
+  ja: ミュート
   zh-CN: 静音
   zh-HK: 靜音
 "Cycle DPI Presets":
   en: Cycle DPI Presets
+  ja: DPI プリセットを循環
   zh-CN: 循环 DPI 预设
   zh-HK: 循環 DPI 預設
 "Toggle SmartShift":
   en: Toggle SmartShift
+  ja: SmartShift を切り替え
   zh-CN: 切换 SmartShift
   zh-HK: 切換 SmartShift
 "Scroll Up":
   en: Scroll Up
+  ja: 上にスクロール
   zh-CN: 向上滚动
   zh-HK: 向上捲動
 "Scroll Down":
   en: Scroll Down
+  ja: 下にスクロール
   zh-CN: 向下滚动
   zh-HK: 向下捲動
 "Scroll Left":
   en: Scroll Left
+  ja: 左にスクロール
   zh-CN: 向左滚动
   zh-HK: 向左捲動
 "Scroll Right":
   en: Scroll Right
+  ja: 右にスクロール
   zh-CN: 向右滚动
   zh-HK: 向右捲動

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -1,0 +1,285 @@
+# OpenLogi GUI translations.
+#
+# `_version: 2` packs every locale for one message into a single entry. The
+# **key is the English source string** (gettext-style): a `t!`/`tr!` lookup that
+# misses falls back to the key itself, so English needs no entries here — only
+# the non-English columns. Keep keys byte-for-byte identical to the code (and,
+# for the device/action vocabulary, to `openlogi_core::binding`'s `label()`).
+#
+# Interpolation uses `%{name}` and must be preserved verbatim in every locale.
+_version: 2
+
+# ── App chrome: accessibility gate, footer (app.rs) ─────────────────────────
+"Accessibility permission required":
+  zh-CN: 需要「辅助功能」权限
+  zh-HK: 需要「輔助使用」權限
+"OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
+  zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
+  zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
+"Open System Settings to grant access":
+  zh-CN: 打开系统设置授权
+  zh-HK: 開啟系統設定授權
+"Takes effect automatically once granted — no restart needed.":
+  zh-CN: 授权后会自动生效,无需重启。
+  zh-HK: 授權後會自動生效,無需重新啟動。
+"Not now (use DPI and other features only)":
+  zh-CN: 稍后再说(仅使用 DPI 等功能)
+  zh-HK: 稍後再說(僅使用 DPI 等功能)
+"Settings":
+  zh-CN: 设置
+  zh-HK: 設定
+"About":
+  zh-CN: 关于
+  zh-HK: 關於
+"Accessibility granted":
+  zh-CN: 辅助功能已授权
+  zh-HK: 輔助使用已授權
+"Accessibility not granted · click to grant":
+  zh-CN: 辅助功能未授权 · 点击授权
+  zh-HK: 輔助使用未授權 · 點擊授權
+
+# ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
+"About OpenLogi":
+  zh-CN: 关于 OpenLogi
+  zh-HK: 關於 OpenLogi
+"Settings…":
+  zh-CN: 设置…
+  zh-HK: 設定…
+"Hide OpenLogi":
+  zh-CN: 隐藏 OpenLogi
+  zh-HK: 隱藏 OpenLogi
+"Hide Others":
+  zh-CN: 隐藏其他
+  zh-HK: 隱藏其他
+"Show All":
+  zh-CN: 全部显示
+  zh-HK: 全部顯示
+"Quit OpenLogi":
+  zh-CN: 退出 OpenLogi
+  zh-HK: 結束 OpenLogi
+"Window":
+  zh-CN: 窗口
+  zh-HK: 視窗
+"Minimize":
+  zh-CN: 最小化
+  zh-HK: 最小化
+"Zoom":
+  zh-CN: 缩放
+  zh-HK: 縮放
+
+# ── About window (about.rs) ─────────────────────────────────────────────────
+"Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
+  zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
+  zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
+
+# ── Settings window (settings.rs) ───────────────────────────────────────────
+"General":
+  zh-CN: 通用
+  zh-HK: 一般
+"Launch at login":
+  zh-CN: 开机自启
+  zh-HK: 開機自動啟動
+"Automatically start OpenLogi when you log in to macOS.":
+  zh-CN: 登录 macOS 时自动启动 OpenLogi。
+  zh-HK: 登入 macOS 時自動啟動 OpenLogi。
+"Check for updates":
+  zh-CN: 检查更新
+  zh-HK: 檢查更新
+"Check once per launch for a new version (query only — no automatic download).":
+  zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
+  zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
+"Language":
+  zh-CN: 语言
+  zh-HK: 語言
+"Choose the interface language.":
+  zh-CN: 选择界面语言。
+  zh-HK: 選擇介面語言。
+"Follow system":
+  zh-CN: 跟随系统
+  zh-HK: 跟隨系統
+
+# ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
+"PRESETS":
+  zh-CN: 预设
+  zh-HK: 預設
+"+ Add":
+  zh-CN: + 添加
+  zh-HK: + 新增
+
+# ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
+"Bind %{name}":
+  zh-CN: 绑定 %{name}
+  zh-HK: 綁定 %{name}
+"Gesture %{name}":
+  zh-CN: 手势 %{name}
+  zh-HK: 手勢 %{name}
+
+# ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
+"Left Click":
+  zh-CN: 左键单击
+  zh-HK: 左鍵單擊
+"Right Click":
+  zh-CN: 右键单击
+  zh-HK: 右鍵單擊
+"Middle Click":
+  zh-CN: 中键单击
+  zh-HK: 中鍵單擊
+"Back":
+  zh-CN: 后退
+  zh-HK: 後退
+"Forward":
+  zh-CN: 前进
+  zh-HK: 前進
+"DPI Toggle":
+  zh-CN: DPI 切换
+  zh-HK: DPI 切換
+"Thumb Wheel":
+  zh-CN: 拇指滚轮
+  zh-HK: 拇指滾輪
+"Gesture Button":
+  zh-CN: 手势按钮
+  zh-HK: 手勢按鈕
+
+# ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
+"Up":
+  zh-CN: 上
+  zh-HK: 上
+"Down":
+  zh-CN: 下
+  zh-HK: 下
+"Left":
+  zh-CN: 左
+  zh-HK: 左
+"Right":
+  zh-CN: 右
+  zh-HK: 右
+"Click":
+  zh-CN: 按下
+  zh-HK: 按下
+
+# ── Categories (openlogi_core::binding::Category) ───────────────────────────
+"EDITING":
+  zh-CN: 编辑
+  zh-HK: 編輯
+"BROWSER":
+  zh-CN: 浏览器
+  zh-HK: 瀏覽器
+"MEDIA":
+  zh-CN: 媒体
+  zh-HK: 媒體
+"MOUSE":
+  zh-CN: 鼠标
+  zh-HK: 滑鼠
+"SCROLL":
+  zh-CN: 滚动
+  zh-HK: 捲動
+"NAVIGATION":
+  zh-CN: 导航
+  zh-HK: 導覽
+"SYSTEM":
+  zh-CN: 系统
+  zh-HK: 系統
+
+# ── Actions (openlogi_core::binding::Action) ────────────────────────────────
+"Copy":
+  zh-CN: 复制
+  zh-HK: 複製
+"Paste":
+  zh-CN: 粘贴
+  zh-HK: 貼上
+"Cut":
+  zh-CN: 剪切
+  zh-HK: 剪下
+"Undo":
+  zh-CN: 撤销
+  zh-HK: 復原
+"Redo":
+  zh-CN: 重做
+  zh-HK: 重做
+"Select All":
+  zh-CN: 全选
+  zh-HK: 全選
+"Find":
+  zh-CN: 查找
+  zh-HK: 尋找
+"Save":
+  zh-CN: 保存
+  zh-HK: 儲存
+"Browser Back":
+  zh-CN: 浏览器后退
+  zh-HK: 瀏覽器後退
+"Browser Forward":
+  zh-CN: 浏览器前进
+  zh-HK: 瀏覽器前進
+"New Tab":
+  zh-CN: 新建标签页
+  zh-HK: 新增分頁
+"Close Tab":
+  zh-CN: 关闭标签页
+  zh-HK: 關閉分頁
+"Reopen Tab":
+  zh-CN: 重开标签页
+  zh-HK: 重新開啟分頁
+"Next Tab":
+  zh-CN: 下一个标签页
+  zh-HK: 下一個分頁
+"Previous Tab":
+  zh-CN: 上一个标签页
+  zh-HK: 上一個分頁
+"Reload Page":
+  zh-CN: 刷新页面
+  zh-HK: 重新載入頁面
+"Mission Control":
+  zh-CN: 调度中心
+  zh-HK: 調度中心
+"App Exposé":
+  zh-CN: 应用程序窗口
+  zh-HK: 應用程式視窗
+"Show Desktop":
+  zh-CN: 显示桌面
+  zh-HK: 顯示桌面
+"Launchpad":
+  zh-CN: 启动台
+  zh-HK: 啟動台
+"Lock Screen":
+  zh-CN: 锁定屏幕
+  zh-HK: 鎖定螢幕
+"Screenshot":
+  zh-CN: 截屏
+  zh-HK: 截圖
+"Play / Pause":
+  zh-CN: 播放 / 暂停
+  zh-HK: 播放 / 暫停
+"Next Track":
+  zh-CN: 下一首
+  zh-HK: 下一首
+"Previous Track":
+  zh-CN: 上一首
+  zh-HK: 上一首
+"Volume Up":
+  zh-CN: 增大音量
+  zh-HK: 調高音量
+"Volume Down":
+  zh-CN: 减小音量
+  zh-HK: 調低音量
+"Mute":
+  zh-CN: 静音
+  zh-HK: 靜音
+"Cycle DPI Presets":
+  zh-CN: 循环 DPI 预设
+  zh-HK: 循環 DPI 預設
+"Toggle SmartShift":
+  zh-CN: 切换 SmartShift
+  zh-HK: 切換 SmartShift
+"Scroll Up":
+  zh-CN: 向上滚动
+  zh-HK: 向上捲動
+"Scroll Down":
+  zh-CN: 向下滚动
+  zh-HK: 向下捲動
+"Scroll Left":
+  zh-CN: 向左滚动
+  zh-HK: 向左捲動
+"Scroll Right":
+  zh-CN: 向右滚动
+  zh-HK: 向右捲動

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -88,18 +88,19 @@ impl AppView {
                 div()
                     .text_xl()
                     .font_weight(FontWeight::SEMIBOLD)
-                    .child("需要「辅助功能」权限"),
+                    .child(tr!("Accessibility permission required")),
             )
             .child(
                 div()
                     .max_w(px(440.))
                     .text_sm()
                     .text_color(pal.text_muted)
-                    .child(
-                        "OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / \
-                         手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的 \
-                         功能不受影响。",
-                    ),
+                    .child(tr!(
+                        "OpenLogi captures mouse buttons (Back / Forward / gesture button) \
+                         through the system Accessibility permission and runs the actions you \
+                         bind. Features that talk to the device directly — DPI, SmartShift — \
+                         are unaffected."
+                    )),
             )
             .child(
                 div()
@@ -111,15 +112,12 @@ impl AppView {
                     .text_color(rgb(0x00ff_ffff))
                     .font_weight(FontWeight::MEDIUM)
                     .cursor_pointer()
-                    .child("打开系统设置授权")
+                    .child(tr!("Open System Settings to grant access"))
                     .on_click(|_, _, _| open_accessibility_settings()),
             )
-            .child(
-                div()
-                    .text_xs()
-                    .text_color(pal.text_muted)
-                    .child("授权后会自动生效,无需重启。"),
-            )
+            .child(div().text_xs().text_color(pal.text_muted).child(tr!(
+                "Takes effect automatically once granted — no restart needed."
+            )))
             .child(
                 div()
                     .id("skip-accessibility")
@@ -127,7 +125,7 @@ impl AppView {
                     .text_color(pal.text_muted)
                     .cursor_pointer()
                     .hover(|s| s.text_color(pal.text_primary))
-                    .child("稍后再说(仅使用 DPI 等功能)")
+                    .child(tr!("Not now (use DPI and other features only)"))
                     .on_click(cx.listener(|this, _, _, cx| {
                         this.accessibility_dismissed = true;
                         cx.notify();
@@ -222,7 +220,7 @@ fn footer(pal: Palette, granted: bool) -> impl IntoElement {
                         .id("footer-settings")
                         .cursor_pointer()
                         .hover(|s| s.text_color(pal.text_primary))
-                        .child("Settings")
+                        .child(tr!("Settings"))
                         .on_click(|_, _, cx| crate::windows::settings::open(cx)),
                 )
                 .child(div().child("·"))
@@ -231,7 +229,7 @@ fn footer(pal: Palette, granted: bool) -> impl IntoElement {
                         .id("footer-about")
                         .cursor_pointer()
                         .hover(|s| s.text_color(pal.text_primary))
-                        .child("About")
+                        .child(tr!("About"))
                         .on_click(|_, _, cx| crate::windows::about::open(cx)),
                 ),
         )
@@ -256,7 +254,7 @@ fn accessibility_status(pal: Palette, granted: bool) -> AnyElement {
             .text_xs()
             .text_color(pal.text_muted)
             .child(dot(theme::STATUS_CONNECTED))
-            .child(div().child("辅助功能已授权"))
+            .child(div().child(tr!("Accessibility granted")))
             .into_any_element()
     } else {
         h_flex()
@@ -267,7 +265,7 @@ fn accessibility_status(pal: Palette, granted: bool) -> AnyElement {
             .text_color(pal.text_primary)
             .cursor_pointer()
             .child(dot(theme::STATUS_CONNECTING))
-            .child(div().child("辅助功能未授权 · 点击授权"))
+            .child(div().child(tr!("Accessibility not granted · click to grant")))
             .on_click(|_, _, _| open_accessibility_settings())
             .into_any_element()
     }

--- a/crates/openlogi-gui/src/app_menu.rs
+++ b/crates/openlogi-gui/src/app_menu.rs
@@ -58,15 +58,23 @@ pub fn install(cx: &mut App) {
     cx.set_menus(menus());
 }
 
+/// Re-publish the menu bar with the current locale's titles. Called after a
+/// live language switch — unlike [`install`] it only restamps the menu strings,
+/// leaving the already-registered action handlers and key bindings untouched.
+pub fn rebuild(cx: &mut App) {
+    cx.set_menus(menus());
+}
+
 fn menus() -> Vec<Menu> {
     vec![
         Menu {
+            // The app menu's name is the product name, not a translatable string.
             name: "OpenLogi".into(),
             disabled: false,
             items: vec![
-                MenuItem::action("About OpenLogi", OpenAbout),
+                MenuItem::action(tr!("About OpenLogi"), OpenAbout),
                 MenuItem::separator(),
-                MenuItem::action("Settings…", OpenSettings),
+                MenuItem::action(tr!("Settings…"), OpenSettings),
                 #[cfg(target_os = "macos")]
                 MenuItem::separator(),
                 #[cfg(target_os = "macos")]
@@ -74,22 +82,22 @@ fn menus() -> Vec<Menu> {
                 #[cfg(target_os = "macos")]
                 MenuItem::separator(),
                 #[cfg(target_os = "macos")]
-                MenuItem::action("Hide OpenLogi", Hide),
+                MenuItem::action(tr!("Hide OpenLogi"), Hide),
                 #[cfg(target_os = "macos")]
-                MenuItem::action("Hide Others", HideOthers),
+                MenuItem::action(tr!("Hide Others"), HideOthers),
                 #[cfg(target_os = "macos")]
-                MenuItem::action("Show All", ShowAll),
+                MenuItem::action(tr!("Show All"), ShowAll),
                 #[cfg(target_os = "macos")]
                 MenuItem::separator(),
-                MenuItem::action("Quit OpenLogi", Quit),
+                MenuItem::action(tr!("Quit OpenLogi"), Quit),
             ],
         },
         Menu {
-            name: "Window".into(),
+            name: tr!("Window"),
             disabled: false,
             items: vec![
-                MenuItem::action("Minimize", Minimize),
-                MenuItem::action("Zoom", Zoom),
+                MenuItem::action(tr!("Minimize"), Minimize),
+                MenuItem::action(tr!("Zoom"), Zoom),
             ],
         },
     ]

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -131,7 +131,12 @@ impl Render for DpiPanel {
             .child(
                 v_flex()
                     .gap_2()
-                    .child(div().text_xs().text_color(pal.text_muted).child("PRESETS"))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(pal.text_muted)
+                            .child(tr!("PRESETS")),
+                    )
                     .child(
                         h_flex()
                             .gap_2()
@@ -217,7 +222,12 @@ fn add_preset_chip(pal: Palette) -> AnyElement {
         .border_color(pal.border)
         .bg(pal.surface)
         .hover(|s| s.bg(pal.surface_hover))
-        .child(div().text_sm().text_color(pal.text_muted).child("+ Add"))
+        .child(
+            div()
+                .text_sm()
+                .text_color(pal.text_muted)
+                .child(tr!("+ Add")),
+        )
         .on_click(|_event, _window, cx| {
             // Append the current DPI to the active device's preset list.
             // Duplicates are allowed — the user might want the same value

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -3,8 +3,9 @@
 //! Translations live in `crates/openlogi-gui/locales/app.yml` and are loaded
 //! at compile time by the `rust_i18n::i18n!` macro in `main.rs`. Call sites use
 //! the [`tr!`](crate::tr) helper (or `rust_i18n::t!`) with the **English string
-//! as the key** — a missing translation falls back to that English text, so the
-//! `locales` file only carries the non-English entries.
+//! as the key** — a missing entry still falls back to that English text. Each
+//! entry lists all shipped locales (`en` / `zh-CN` / `zh-HK`), with the `en:`
+//! column mirroring the key as the canonical source.
 //!
 //! The current locale is a process-global atomic inside `rust_i18n`. Setting it
 //! re-localizes both our own call sites *and* gpui-component's built-in widget
@@ -108,6 +109,9 @@ mod tests {
             "blurb key missing from app.yml"
         );
 
+        // The explicit `en:` column resolves back to the English source.
         rust_i18n::set_locale("en");
+        assert_eq!(rust_i18n::t!("Settings"), "Settings");
+        assert_eq!(rust_i18n::t!(BLURB), BLURB);
     }
 }

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -3,9 +3,9 @@
 //! Translations live in `crates/openlogi-gui/locales/app.yml` and are loaded
 //! at compile time by the `rust_i18n::i18n!` macro in `main.rs`. Call sites use
 //! the [`tr!`](crate::tr) helper (or `rust_i18n::t!`) with the **English string
-//! as the key** — a missing entry still falls back to that English text. Each
-//! entry lists all shipped locales (`en` / `ja` / `zh-CN` / `zh-HK`), with the
-//! `en:` column mirroring the key as the canonical source.
+//! as the key** — a missing entry falls back to that English text, so the file
+//! carries only the translated `ja` / `zh-CN` / `zh-HK` columns; English is the
+//! key itself.
 //!
 //! The current locale is a process-global atomic inside `rust_i18n`. Setting it
 //! re-localizes both our own call sites *and* gpui-component's built-in widget
@@ -156,7 +156,7 @@ mod tests {
         assert_eq!(rust_i18n::t!("Settings"), "設定");
         assert_eq!(rust_i18n::t!("Left Click"), "左クリック");
 
-        // The explicit `en:` column resolves back to the English source.
+        // English has no column: every key falls back to the English source.
         rust_i18n::set_locale("en");
         assert_eq!(rust_i18n::t!("Settings"), "Settings");
         assert_eq!(rust_i18n::t!(BLURB), BLURB);

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -17,11 +17,14 @@
 use openlogi_core::config::AppSettings;
 
 /// Locales the GUI ships, as `(code, native name)`. The codes match the
-/// sub-keys in `locales/app.yml` *and* gpui-component's bundled `ui.yml`, so
-/// choosing one also localizes the framework's own widgets. Order here is the
-/// order shown in the Settings picker (after a leading "Follow system").
+/// sub-keys in `locales/app.yml`; `en` / `zh-CN` / `zh-HK` also match
+/// gpui-component's bundled `ui.yml`, so choosing one localizes the framework's
+/// own widgets too. `ja` is *not* in `ui.yml`, so under Japanese our app strings
+/// localize but the framework's built-in widget strings fall back to English.
+/// Order here is the order shown in the Settings picker (after "Follow system").
 pub const SUPPORTED: &[(&str, &str)] = &[
     ("en", "English"),
+    ("ja", "日本語"),
     ("zh-CN", "简体中文"),
     ("zh-HK", "繁體中文"),
 ];
@@ -41,20 +44,21 @@ pub fn resolve(setting: Option<&str>) -> &'static str {
         .unwrap_or("en")
 }
 
-/// Collapse an arbitrary locale string onto one of [`SUPPORTED`], or `None`.
-/// `zh-Hant` / `zh-TW` / `zh-HK` / `zh-MO` map to Traditional (`zh-HK`); other
-/// `zh*` to Simplified (`zh-CN`); anything starting with `en` to English.
+/// Collapse an arbitrary BCP-47 locale onto one of [`SUPPORTED`], or `None`,
+/// by matching its primary subtag. A `zh` tag resolves to Traditional
+/// (`zh-HK`) when any later subtag marks Hant script or a Traditional-using
+/// region (`tw` / `hk` / `mo`), otherwise Simplified (`zh-CN`).
 fn match_supported(code: &str) -> Option<&'static str> {
     let lower = code.to_ascii_lowercase();
-    if lower.starts_with("zh") {
-        let traditional = ["hant", "-tw", "-hk", "-mo"]
-            .iter()
-            .any(|t| lower.contains(t));
-        Some(if traditional { "zh-HK" } else { "zh-CN" })
-    } else if lower.starts_with("en") {
-        Some("en")
-    } else {
-        None
+    let mut subtags = lower.split(['-', '_']);
+    match subtags.next() {
+        Some("en") => Some("en"),
+        Some("ja") => Some("ja"),
+        Some("zh") => {
+            let traditional = subtags.any(|t| matches!(t, "hant" | "tw" | "hk" | "mo"));
+            Some(if traditional { "zh-HK" } else { "zh-CN" })
+        }
+        _ => None,
     }
 }
 
@@ -69,11 +73,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn maps_chinese_variants_to_script() {
+    fn maps_locale_variants() {
         assert_eq!(match_supported("zh-Hans-CN"), Some("zh-CN"));
         assert_eq!(match_supported("zh-CN"), Some("zh-CN"));
         assert_eq!(match_supported("zh-Hant-TW"), Some("zh-HK"));
         assert_eq!(match_supported("zh-HK"), Some("zh-HK"));
+        assert_eq!(match_supported("ja"), Some("ja"));
+        assert_eq!(match_supported("ja-JP"), Some("ja"));
         assert_eq!(match_supported("en-US"), Some("en"));
         assert_eq!(match_supported("fr-FR"), None);
     }
@@ -102,6 +108,10 @@ mod tests {
         assert_eq!(rust_i18n::t!("Settings"), "设置"); // GUI chrome
         assert_eq!(rust_i18n::t!("Left Click"), "左键单击"); // core enum label
         assert_eq!(rust_i18n::t!("Bind %{name}", name => "X"), "绑定 X"); // interpolation
+
+        rust_i18n::set_locale("ja");
+        assert_eq!(rust_i18n::t!("Settings"), "設定");
+        assert_eq!(rust_i18n::t!("Left Click"), "左クリック");
         // Resolves to *something other than* the English source ⇒ the key hit.
         assert_ne!(
             rust_i18n::t!(BLURB),

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -4,8 +4,8 @@
 //! at compile time by the `rust_i18n::i18n!` macro in `main.rs`. Call sites use
 //! the [`tr!`](crate::tr) helper (or `rust_i18n::t!`) with the **English string
 //! as the key** — a missing entry still falls back to that English text. Each
-//! entry lists all shipped locales (`en` / `zh-CN` / `zh-HK`), with the `en:`
-//! column mirroring the key as the canonical source.
+//! entry lists all shipped locales (`en` / `ja` / `zh-CN` / `zh-HK`), with the
+//! `en:` column mirroring the key as the canonical source.
 //!
 //! The current locale is a process-global atomic inside `rust_i18n`. Setting it
 //! re-localizes both our own call sites *and* gpui-component's built-in widget
@@ -45,9 +45,11 @@ pub fn resolve(setting: Option<&str>) -> &'static str {
 }
 
 /// Collapse an arbitrary BCP-47 locale onto one of [`SUPPORTED`], or `None`,
-/// by matching its primary subtag. A `zh` tag resolves to Traditional
-/// (`zh-HK`) when any later subtag marks Hant script or a Traditional-using
-/// region (`tw` / `hk` / `mo`), otherwise Simplified (`zh-CN`).
+/// by matching its primary subtag. A `zh` tag is decided by its *first*
+/// script-or-region subtag (script precedes region in BCP-47): `Hant` or a
+/// Traditional-using region (`tw` / `hk` / `mo`) → `zh-HK`; an explicit `Hans`
+/// or no such subtag → `zh-CN`. So `zh-Hans-HK` stays Simplified — the script
+/// tag wins over the region.
 fn match_supported(code: &str) -> Option<&'static str> {
     let lower = code.to_ascii_lowercase();
     let mut subtags = lower.split(['-', '_']);
@@ -55,17 +57,29 @@ fn match_supported(code: &str) -> Option<&'static str> {
         Some("en") => Some("en"),
         Some("ja") => Some("ja"),
         Some("zh") => {
-            let traditional = subtags.any(|t| matches!(t, "hant" | "tw" | "hk" | "mo"));
+            let traditional = matches!(
+                subtags.find(|t| matches!(*t, "hans" | "hant" | "tw" | "hk" | "mo")),
+                Some("hant" | "tw" | "hk" | "mo")
+            );
             Some(if traditional { "zh-HK" } else { "zh-CN" })
         }
         _ => None,
     }
 }
 
+/// Switch the process-global locale to the resolution of `language`
+/// (`None` = follow system). The single resolve→`set_locale` surface shared by
+/// startup ([`apply`]) and the live Settings switch
+/// ([`AppState::set_language`](crate::state::AppState::set_language)), so the
+/// resolution policy can't drift between them.
+pub fn activate(language: Option<&str>) {
+    rust_i18n::set_locale(resolve(language));
+}
+
 /// Apply the configured language to the process-global locale at startup.
 /// Safe to call before any window opens — the locale is a plain atomic.
 pub fn apply(settings: &AppSettings) {
-    rust_i18n::set_locale(resolve(settings.language.as_deref()));
+    activate(settings.language.as_deref());
 }
 
 #[cfg(test)]
@@ -96,11 +110,14 @@ mod tests {
     }
 
     /// End-to-end check that `locales/app.yml` loaded and the gettext-style
-    /// English keys match — a typo'd key would silently fall back to English,
-    /// which this would catch. Sets the process-global locale, so it owns that
-    /// state; no other test reads it.
+    /// English keys match — a typo'd key silently falls back to English, which
+    /// this catches. All locale-dependent assertions live in this one test on
+    /// purpose: `rust_i18n`'s locale is a process-global, so splitting them into
+    /// separate `#[test]`s would race under the parallel harness.
     #[test]
-    fn locale_file_resolves_known_keys() {
+    fn locale_file_resolves_keys() {
+        use openlogi_core::binding::{Action, ButtonId, GestureDirection};
+
         // The accessibility blurb is the longest, most typo-prone key.
         const BLURB: &str = "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.";
 
@@ -108,16 +125,36 @@ mod tests {
         assert_eq!(rust_i18n::t!("Settings"), "设置"); // GUI chrome
         assert_eq!(rust_i18n::t!("Left Click"), "左键单击"); // core enum label
         assert_eq!(rust_i18n::t!("Bind %{name}", name => "X"), "绑定 X"); // interpolation
-
-        rust_i18n::set_locale("ja");
-        assert_eq!(rust_i18n::t!("Settings"), "設定");
-        assert_eq!(rust_i18n::t!("Left Click"), "左クリック");
-        // Resolves to *something other than* the English source ⇒ the key hit.
         assert_ne!(
             rust_i18n::t!(BLURB),
             BLURB,
             "blurb key missing from app.yml"
         );
+
+        // Exhaustive: every non-parameterized device/action label has a `zh-CN`
+        // entry. `DPI` is a universal initialism, identical across locales — it
+        // has no entry, so it's the one exception to "differs from English".
+        // Parameterized `Action`s (`SetDpiPreset`, `CustomShortcut`) are
+        // English-only by design and absent from the catalog, so they're skipped.
+        let covered = |label: &str| label == "DPI" || rust_i18n::t!(label) != label;
+        for b in ButtonId::ALL {
+            assert!(covered(b.label()), "no zh-CN for ButtonId::{b:?}");
+        }
+        for d in GestureDirection::ALL {
+            assert!(covered(d.label()), "no zh-CN for GestureDirection::{d:?}");
+        }
+        for a in Action::catalog() {
+            assert!(covered(&a.label()), "no zh-CN for Action::{a:?}");
+            assert!(
+                covered(a.category().label()),
+                "no zh-CN for {:?}",
+                a.category()
+            );
+        }
+
+        rust_i18n::set_locale("ja");
+        assert_eq!(rust_i18n::t!("Settings"), "設定");
+        assert_eq!(rust_i18n::t!("Left Click"), "左クリック");
 
         // The explicit `en:` column resolves back to the English source.
         rust_i18n::set_locale("en");

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -1,0 +1,113 @@
+//! UI localization plumbing.
+//!
+//! Translations live in `crates/openlogi-gui/locales/app.yml` and are loaded
+//! at compile time by the `rust_i18n::i18n!` macro in `main.rs`. Call sites use
+//! the [`tr!`](crate::tr) helper (or `rust_i18n::t!`) with the **English string
+//! as the key** — a missing translation falls back to that English text, so the
+//! `locales` file only carries the non-English entries.
+//!
+//! The current locale is a process-global atomic inside `rust_i18n`. Setting it
+//! re-localizes both our own call sites *and* gpui-component's built-in widget
+//! strings, since the framework reads the same global. Apply it once at startup
+//! via [`apply`] and on a live switch via
+//! [`AppState::set_language`](crate::state::AppState::set_language); each must be
+//! followed by a window refresh so open views re-render with the new locale.
+
+use openlogi_core::config::AppSettings;
+
+/// Locales the GUI ships, as `(code, native name)`. The codes match the
+/// sub-keys in `locales/app.yml` *and* gpui-component's bundled `ui.yml`, so
+/// choosing one also localizes the framework's own widgets. Order here is the
+/// order shown in the Settings picker (after a leading "Follow system").
+pub const SUPPORTED: &[(&str, &str)] = &[
+    ("en", "English"),
+    ("zh-CN", "简体中文"),
+    ("zh-HK", "繁體中文"),
+];
+
+/// Resolve the locale to apply, preferring an explicit stored `setting`, then
+/// the system locale, and finally `"en"`. An unrecognized stored code is
+/// treated as "follow system" rather than failing.
+#[must_use]
+pub fn resolve(setting: Option<&str>) -> &'static str {
+    setting
+        .and_then(match_supported)
+        .or_else(|| {
+            sys_locale::get_locale()
+                .as_deref()
+                .and_then(match_supported)
+        })
+        .unwrap_or("en")
+}
+
+/// Collapse an arbitrary locale string onto one of [`SUPPORTED`], or `None`.
+/// `zh-Hant` / `zh-TW` / `zh-HK` / `zh-MO` map to Traditional (`zh-HK`); other
+/// `zh*` to Simplified (`zh-CN`); anything starting with `en` to English.
+fn match_supported(code: &str) -> Option<&'static str> {
+    let lower = code.to_ascii_lowercase();
+    if lower.starts_with("zh") {
+        let traditional = ["hant", "-tw", "-hk", "-mo"]
+            .iter()
+            .any(|t| lower.contains(t));
+        Some(if traditional { "zh-HK" } else { "zh-CN" })
+    } else if lower.starts_with("en") {
+        Some("en")
+    } else {
+        None
+    }
+}
+
+/// Apply the configured language to the process-global locale at startup.
+/// Safe to call before any window opens — the locale is a plain atomic.
+pub fn apply(settings: &AppSettings) {
+    rust_i18n::set_locale(resolve(settings.language.as_deref()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_chinese_variants_to_script() {
+        assert_eq!(match_supported("zh-Hans-CN"), Some("zh-CN"));
+        assert_eq!(match_supported("zh-CN"), Some("zh-CN"));
+        assert_eq!(match_supported("zh-Hant-TW"), Some("zh-HK"));
+        assert_eq!(match_supported("zh-HK"), Some("zh-HK"));
+        assert_eq!(match_supported("en-US"), Some("en"));
+        assert_eq!(match_supported("fr-FR"), None);
+    }
+
+    #[test]
+    fn explicit_setting_wins_over_system() {
+        assert_eq!(resolve(Some("zh-CN")), "zh-CN");
+        // An unknown stored code falls through to system/`en`, never panics.
+        assert!(
+            SUPPORTED
+                .iter()
+                .any(|(c, _)| *c == resolve(Some("klingon")))
+        );
+    }
+
+    /// End-to-end check that `locales/app.yml` loaded and the gettext-style
+    /// English keys match — a typo'd key would silently fall back to English,
+    /// which this would catch. Sets the process-global locale, so it owns that
+    /// state; no other test reads it.
+    #[test]
+    fn locale_file_resolves_known_keys() {
+        // The accessibility blurb is the longest, most typo-prone key.
+        const BLURB: &str = "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.";
+
+        rust_i18n::set_locale("zh-CN");
+        assert_eq!(rust_i18n::t!("Settings"), "设置"); // GUI chrome
+        assert_eq!(rust_i18n::t!("Left Click"), "左键单击"); // core enum label
+        assert_eq!(rust_i18n::t!("Bind %{name}", name => "X"), "绑定 X"); // interpolation
+        // Resolves to *something other than* the English source ⇒ the key hit.
+        assert_ne!(
+            rust_i18n::t!(BLURB),
+            BLURB,
+            "blurb key missing from app.yml"
+        );
+
+        rust_i18n::set_locale("en");
+    }
+}

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -4,6 +4,18 @@
 //! the main thread, so we can't move it onto a tokio runtime). Live polling
 //! lands when there's something to react to.
 
+/// Translate `key` (an English msgid) to the current locale and wrap it as a
+/// [`gpui::SharedString`], ready for `.child(...)` / `.label(...)` / menu items.
+/// Forwards `rust_i18n` interpolation, e.g. `tr!("Bind %{name}", name => x)`.
+///
+/// Defined before the `mod` declarations so every submodule can use it without
+/// an import (textual macro scope). Pairs with the `rust_i18n::i18n!` below.
+macro_rules! tr {
+    ($($args:tt)*) => {
+        ::gpui::SharedString::from(::rust_i18n::t!($($args)*).into_owned())
+    };
+}
+
 mod app;
 mod app_menu;
 mod asset;
@@ -11,12 +23,18 @@ mod components;
 mod data;
 mod hardware;
 mod hook_runtime;
+mod i18n;
 mod mouse_model;
 mod platform;
 mod state;
 mod theme;
 mod watchers;
 mod windows;
+
+// Loads `crates/openlogi-gui/locales/*.yml` at compile time and generates the
+// `t!`/`tr!` lookup backend for this crate. `fallback = "en"` matches the codes
+// gpui-component ships, so the framework's own widgets localize alongside ours.
+rust_i18n::i18n!("locales", fallback = "en");
 
 use std::sync::{Arc, RwLock};
 
@@ -59,6 +77,10 @@ fn main() -> Result<()> {
     let (hook_bindings, gesture_bindings, dpi_cycle, initial_config) =
         load_config_and_bindings(&inventories);
     let hook_arcs = (Arc::clone(&hook_bindings), Arc::clone(&dpi_cycle));
+
+    // Resolve the UI locale before any menu or window is built so the first
+    // frame already renders in the right language.
+    i18n::apply(&initial_config.app_settings);
 
     // Gesture capture runs independently of the CGEventTap hook (it needs no
     // Accessibility permission), so start it up front for the active device.

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -12,7 +12,13 @@
 /// an import (textual macro scope). Pairs with the `rust_i18n::i18n!` below.
 macro_rules! tr {
     ($($args:tt)*) => {
-        ::gpui::SharedString::from(::rust_i18n::t!($($args)*).into_owned())
+        // `t!` yields `Cow<'static, str>`. A borrowed hit — the common case: a
+        // found translation or the English-key fallback — wraps into a
+        // `SharedString` with no copy; only owned (interpolated) results allocate.
+        match ::rust_i18n::t!($($args)*) {
+            ::std::borrow::Cow::Borrowed(s) => ::gpui::SharedString::from(s),
+            ::std::borrow::Cow::Owned(s) => ::gpui::SharedString::from(s),
+        }
     };
 }
 

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -63,9 +63,10 @@ pub fn action_picker<T: 'static>(
     });
 
     let pal = theme::palette(cx);
+    let button = rust_i18n::t!(btn.label());
     v_flex()
         .min_w(px(POPOVER_W))
-        .child(title(format!("Bind {}", btn.label()), pal))
+        .child(title(tr!("Bind %{name}", name => button), pal))
         .child(divider(pal))
         .child(scroll_list(
             "picker-scroll",
@@ -117,7 +118,7 @@ fn gesture_directions_list<T: 'static>(
                         .gap_2()
                         // Fixed-width glyph so the direction names line up.
                         .child(div().w(px(14.)).text_color(pal.text_muted).child(dir.glyph()))
-                        .child(div().text_color(pal.text_primary).child(dir.label())),
+                        .child(div().text_color(pal.text_primary).child(tr!(dir.label()))),
                 )
                 .child(
                     h_flex()
@@ -125,7 +126,7 @@ fn gesture_directions_list<T: 'static>(
                         .gap_1p5()
                         .text_xs()
                         .text_color(pal.text_muted)
-                        .child(action.label())
+                        .child(tr!(action.label()))
                         .child("›"),
                 )
                 .on_click(move |_event, _window, cx| {
@@ -138,7 +139,7 @@ fn gesture_directions_list<T: 'static>(
 
     v_flex()
         .min_w(px(POPOVER_W))
-        .child(title("Gesture Button", pal))
+        .child(title(tr!("Gesture Button"), pal))
         .child(divider(pal))
         .children(rows)
         .into_any_element()
@@ -168,6 +169,7 @@ fn gesture_action_picker<T: 'static>(
 
     let pal = theme::palette(cx);
     let observer_back = observer.clone();
+    let dir_name = rust_i18n::t!(direction.label());
     let back = h_flex()
         .id("gesture-back")
         .w_full()
@@ -180,7 +182,7 @@ fn gesture_action_picker<T: 'static>(
         .text_color(pal.text_muted)
         .hover(|s| s.bg(pal.surface_hover).text_color(pal.text_primary))
         .child("‹")
-        .child(format!("Gesture {}", direction.label()))
+        .child(tr!("Gesture %{name}", name => dir_name))
         .on_click(move |_event, _window, cx| {
             cx.update_global::<AppState, _>(|state, _| state.gesture_edit = None);
             observer_back.update(cx, |_, cx| cx.notify());
@@ -231,10 +233,11 @@ fn action_rows(
     let mut idx = 0usize;
     let mut children: Vec<AnyElement> = Vec::new();
     for (category, actions) in grouped_catalog() {
-        children.push(section_header(category.label(), pal));
+        let category_label = rust_i18n::t!(category.label());
+        children.push(section_header(&category_label, pal));
         for action in actions {
             let selected = current == Some(&action);
-            let label = action.label();
+            let label = tr!(action.label());
             let on_pick = on_pick.clone();
             let row_id = idx;
             idx += 1;

--- a/crates/openlogi-gui/src/platform/launch_agent.rs
+++ b/crates/openlogi-gui/src/platform/launch_agent.rs
@@ -10,13 +10,18 @@
 //! XDG autostart on Linux and the Windows `Run` registry key are future
 //! work tracked by the broader "P2.2 follow-up" item in PLAN.md.
 
-use std::io;
-use std::path::PathBuf;
+use tracing::debug;
 
-use tracing::{debug, info, warn};
+#[cfg(target_os = "macos")]
+use std::io;
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use tracing::{info, warn};
 
 /// Stable launch-agent identifier — matches the bundle id in
 /// `crates/openlogi-gui/Cargo.toml [package.metadata.bundle]`.
+#[cfg(target_os = "macos")]
 const LABEL: &str = "org.openlogi.openlogi";
 
 /// Reconcile the on-disk `LaunchAgent` plist with `enabled`. Idempotent:

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -342,6 +342,32 @@ impl AppState {
         }
     }
 
+    /// The stored UI-language preference: `Some(code)` for an explicit choice,
+    /// `None` for "follow system". Distinct from the *active* locale that
+    /// `None` resolves to at startup, so the Settings picker can show "Follow
+    /// system" as the selected option.
+    #[must_use]
+    pub fn language(&self) -> Option<&str> {
+        self.config.app_settings.language.as_deref()
+    }
+
+    /// Set the UI language (`None` = follow system), persist it, and switch the
+    /// process-global locale live via [`crate::i18n`]. The caller must refresh
+    /// open windows and rebuild the menu so everything re-renders. No-op when
+    /// unchanged.
+    pub fn set_language(&mut self, language: Option<String>) {
+        if self.config.app_settings.language == language {
+            return;
+        }
+        self.config.app_settings.language = language;
+        if let Err(e) = self.config.save_atomic() {
+            warn!(error = %e, "could not persist language setting");
+        }
+        rust_i18n::set_locale(crate::i18n::resolve(
+            self.config.app_settings.language.as_deref(),
+        ));
+    }
+
     /// Update a single binding in memory, on disk, and in the shared hook
     /// map for the currently selected device.
     ///

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -363,9 +363,7 @@ impl AppState {
         if let Err(e) = self.config.save_atomic() {
             warn!(error = %e, "could not persist language setting");
         }
-        rust_i18n::set_locale(crate::i18n::resolve(
-            self.config.app_settings.language.as_deref(),
-        ));
+        crate::i18n::activate(self.config.app_settings.language.as_deref());
     }
 
     /// Update a single binding in memory, on disk, and in the shared hook

--- a/crates/openlogi-gui/src/windows/about.rs
+++ b/crates/openlogi-gui/src/windows/about.rs
@@ -80,7 +80,10 @@ impl Render for AboutView {
                     .text_sm()
                     .text_center()
                     .text_color(pal.text_muted)
-                    .child("开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。"),
+                    .child(tr!(
+                        "Open-source Logitech mouse configuration — DPI, SmartShift, button \
+                         bindings, and gestures."
+                    )),
             )
             .child(
                 h_flex()

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -7,8 +7,9 @@
 //! set grows enough to warrant pages, this can migrate to that widget.
 
 use gpui::{
-    App, BorrowAppContext as _, Context, FontWeight, IntoElement, ParentElement as _, Render, Size,
-    Styled as _, Subscription, Window, div, px,
+    App, BorrowAppContext as _, Context, FontWeight, InteractiveElement, IntoElement,
+    ParentElement as _, Render, SharedString, Size, StatefulInteractiveElement as _, Styled as _,
+    Subscription, Window, div, px, rgb,
 };
 use gpui_component::{group_box::GroupBox, h_flex, switch::Switch, v_flex};
 
@@ -50,10 +51,12 @@ pub fn open(cx: &mut App) {
 impl Render for SettingsView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
-        let (launch, updates) = cx.try_global::<AppState>().map_or((false, false), |s| {
-            let a = s.app_settings();
-            (a.launch_at_login, a.check_for_updates)
-        });
+        let (launch, updates, language) =
+            cx.try_global::<AppState>()
+                .map_or((false, false, None), |s| {
+                    let a = s.app_settings();
+                    (a.launch_at_login, a.check_for_updates, a.language.clone())
+                });
 
         v_flex()
             .size_full()
@@ -65,11 +68,11 @@ impl Render for SettingsView {
                 div()
                     .text_lg()
                     .font_weight(FontWeight::SEMIBOLD)
-                    .child("Settings"),
+                    .child(tr!("Settings")),
             )
             .child(
                 GroupBox::new()
-                    .title("通用")
+                    .title(tr!("General"))
                     .child(setting_row(
                         Switch::new("launch-at-login")
                             .checked(launch)
@@ -80,8 +83,8 @@ impl Render for SettingsView {
                                 });
                                 cx.notify();
                             })),
-                        "开机自启",
-                        "登录 macOS 时自动启动 OpenLogi。",
+                        tr!("Launch at login"),
+                        tr!("Automatically start OpenLogi when you log in to macOS."),
                         pal,
                     ))
                     .child(setting_row(
@@ -94,10 +97,15 @@ impl Render for SettingsView {
                                 });
                                 cx.notify();
                             })),
-                        "检查更新",
-                        "每次启动检查一次新版本(仅查询,不自动下载)。",
+                        tr!("Check for updates"),
+                        tr!("Check once per launch for a new version (query only — no automatic download)."),
                         pal,
                     )),
+            )
+            .child(
+                GroupBox::new()
+                    .title(tr!("Language"))
+                    .child(language_row(language.as_deref(), pal, cx)),
             )
     }
 }
@@ -105,8 +113,8 @@ impl Render for SettingsView {
 /// One row: title + muted description on the left, the control on the right.
 fn setting_row(
     control: Switch,
-    title: &'static str,
-    description: &'static str,
+    title: impl Into<SharedString>,
+    description: impl Into<SharedString>,
     pal: Palette,
 ) -> impl IntoElement {
     h_flex()
@@ -115,12 +123,82 @@ fn setting_row(
         .justify_between()
         .gap_4()
         .child(
-            v_flex().gap_1().child(div().text_sm().child(title)).child(
-                div()
-                    .text_xs()
-                    .text_color(pal.text_muted)
-                    .child(description),
-            ),
+            v_flex()
+                .gap_1()
+                .child(div().text_sm().child(title.into()))
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(pal.text_muted)
+                        .child(description.into()),
+                ),
         )
         .child(control)
+}
+
+/// The language picker: a muted hint on the left, selectable locale chips on
+/// the right. The leading "Follow system" chip clears the stored preference
+/// (`None`); the rest pin an explicit locale from [`crate::i18n::SUPPORTED`].
+/// Selecting one switches the locale live, then repaints every window and the
+/// menu bar so the whole UI re-renders without a restart.
+fn language_row(
+    current: Option<&str>,
+    pal: Palette,
+    cx: &mut Context<SettingsView>,
+) -> impl IntoElement {
+    let mut options: Vec<(SharedString, Option<String>)> = vec![(tr!("Follow system"), None)];
+    options.extend(
+        crate::i18n::SUPPORTED
+            .iter()
+            .map(|(code, name)| (SharedString::from(*name), Some((*code).to_string()))),
+    );
+
+    let chips: Vec<_> = options
+        .into_iter()
+        .enumerate()
+        .map(|(idx, (label, lang))| {
+            let active = current == lang.as_deref();
+            div()
+                .id(("lang-chip", idx))
+                .px_2()
+                .py_1()
+                .rounded_md()
+                .border_1()
+                .border_color(if active {
+                    rgb(theme::ACCENT_BLUE).into()
+                } else {
+                    pal.border
+                })
+                .text_xs()
+                .text_color(if active {
+                    rgb(theme::ACCENT_BLUE).into()
+                } else {
+                    pal.text_primary
+                })
+                .cursor_pointer()
+                .hover(|s| s.bg(pal.surface_hover))
+                .child(label)
+                .on_click(cx.listener(move |_, _, _, cx| {
+                    cx.update_global::<AppState, _>(|s, _| s.set_language(lang.clone()));
+                    // `t!` reads the locale at render time, so a repaint is what
+                    // actually applies the switch; the menu bar is rebuilt
+                    // separately since it isn't part of any window's view tree.
+                    cx.refresh_windows();
+                    crate::app_menu::rebuild(cx);
+                }))
+        })
+        .collect();
+
+    h_flex()
+        .w_full()
+        .items_center()
+        .justify_between()
+        .gap_4()
+        .child(
+            div()
+                .text_xs()
+                .text_color(pal.text_muted)
+                .child(tr!("Choose the interface language.")),
+        )
+        .child(h_flex().gap_2().flex_wrap().children(chips))
 }


### PR DESCRIPTION
## What

Adds internationalization to `openlogi-gui`. Every user-visible string now
routes through `rust-i18n` and the UI ships in **English**, **Simplified
Chinese (`zh-CN`)**, and **Traditional Chinese (`zh-HK`)**.

## How it works

- `rust_i18n::i18n!("locales", fallback = "en")` is wired in `main.rs`, with a
  `tr!` macro that returns a `SharedString` for `.child(...)` / `.label(...)` /
  menu items (defined before the `mod`s so every submodule can use it).
- **Keys are gettext-style English msgids** — a miss falls back to readable
  English. `locales/app.yml` (`_version: 2`) lists every shipped locale per
  entry (`en` / `zh-CN` / `zh-HK`), with the `en:` column mirroring the key.
- The `openlogi_core::binding` device/action vocabulary is localized **at the
  GUI boundary** by reusing its existing `label()` as the translation key, so
  `openlogi-core` stays English-only for the CLI.
- Locale codes match gpui-component's bundled `ui.yml`, so the framework's own
  widget strings (dialogs, pickers, calendar…) localize alongside ours.

## Live switching + persistence

- New **language picker** in Settings (`Follow system` + en / zh-CN / zh-HK).
  Selecting one switches the locale live — repaints every window and rebuilds
  the macOS menu bar — no restart.
- Persisted to `config.toml` as `app_settings.language` (`None` = follow
  system). Startup resolves *config override → system locale (`sys-locale`) →
  English*.

## Tests

- `i18n::tests::locale_file_resolves_known_keys` is an end-to-end check that the
  locale file loaded and the gettext keys match (chrome, a core enum label,
  `%{name}` interpolation, and the longest/most typo-prone string), plus that
  the explicit `en:` column resolves.
- `match_supported` / `resolve` unit tests cover the system-locale mapping.
- `cargo fmt`, `clippy`, and `test` pass for `openlogi-gui` + `openlogi-core`.

## Follow-ups (tracked in PLAN.md P2.5)

- `tracing` / error-banner strings are still English.
- Parameterized `Action::label()` variants (`SetDpiPreset`, `CustomShortcut`)
  fall back to English since core bakes the value into the rendered string.
- A `zh-TW` column needs a matching block upstream in gpui-component, or its
  widgets fall back to English (hence `zh-HK` for Traditional).

## Not verified in this PR

The live language-switch was not exercised in a running GUI (couldn't drive the
GPUI app in the dev sandbox); it's validated by the resolver tests + the fact
the test binary links. Worth a manual smoke test before merge.