### PR TITLE
Gesture button UI + menu-bar app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4411,11 +4411,13 @@ name = "openlogi-gui"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "cocoa 0.26.0",
  "fs4",
  "gpui",
  "gpui-component",
  "gpui-component-assets",
  "gpui_platform",
+ "objc",
  "openlogi-assets",
  "openlogi-core",
  "openlogi-hid",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -34,8 +34,25 @@ ureq.workspace = true
 rust-i18n = "4"
 sys-locale = "0.3.2"
 
-[lints]
-workspace = true
+# Menu-bar (NSStatusItem) FFI — GPUI has no status-bar API. Same crates the
+# openlogi-hook CGEventTap uses, so the toolchain is already proven here.
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26"
+objc = "0.2"
+
+# Mirrors [workspace.lints], plus an allow for the legacy `cfg(cargo-clippy)`
+# check emitted by objc 0.2's macros (same as openlogi-hook). unsafe_code stays
+# denied; the menubar module opts in locally with #[expect(unsafe_code)].
+[lints.rust]
+unsafe_code = "deny"
+unexpected_cfgs = { level = "allow", check-cfg = [] }
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+unwrap_used = "warn"
+expect_used = "warn"
+missing_errors_doc = "allow"
+doc_markdown = "allow"
 
 [package.metadata.bundle]
 name = "OpenLogi"

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -15,6 +15,17 @@ _version: 2
   ja: デバイスが接続されていません
   zh-CN: 未连接设备
   zh-HK: 未連接裝置
+
+# ── Menu-bar status item (platform/menubar.rs) ──────────────────────────────
+"Open OpenLogi":
+  ja: OpenLogi を開く
+  zh-CN: 打开 OpenLogi
+  zh-HK: 開啟 OpenLogi
+"Quit OpenLogi":
+  ja: OpenLogi を終了
+  zh-CN: 退出 OpenLogi
+  zh-HK: 結束 OpenLogi
+
 "Plug in or pair a supported Logitech device — it'll show up here automatically.":
   ja: 対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。
   zh-CN: 接入或配对受支持的 Logitech 设备，它会自动显示在这里。

--- a/crates/openlogi-gui/src/data/mouse_buttons.rs
+++ b/crates/openlogi-gui/src/data/mouse_buttons.rs
@@ -72,5 +72,39 @@ pub fn default_hotspots() -> Vec<Hotspot> {
             w: 70.,
             h: 40.,
         },
+        Hotspot {
+            id: ButtonId::GestureButton,
+            x: 8.,
+            y: 380.,
+            w: 44.,
+            h: 80.,
+        },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_hotspots_expose_the_gesture_button() {
+        let hotspots = default_hotspots();
+        assert!(
+            hotspots
+                .iter()
+                .any(|h| matches!(h.id, ButtonId::GestureButton)),
+            "the gesture button must be a mappable hotspot in the synthetic model"
+        );
+    }
+
+    #[test]
+    fn default_hotspots_omit_primary_clicks() {
+        let hotspots = default_hotspots();
+        assert!(
+            !hotspots
+                .iter()
+                .any(|h| matches!(h.id, ButtonId::LeftClick | ButtonId::RightClick)),
+            "primary clicks are not remappable and must stay out of the model"
+        );
+    }
 }

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -125,6 +125,8 @@ mod tests {
         assert_eq!(rust_i18n::t!("Settings"), "设置"); // GUI chrome
         assert_eq!(rust_i18n::t!("Left Click"), "左键单击"); // core enum label
         assert_eq!(rust_i18n::t!("Bind %{name}", name => "X"), "绑定 X"); // interpolation
+        assert_eq!(rust_i18n::t!("Quit OpenLogi"), "退出 OpenLogi"); // menu-bar status item
+        assert_eq!(rust_i18n::t!("No device connected"), "未连接设备"); // menu-bar device line
         assert_ne!(
             rust_i18n::t!(BLURB),
             BLURB,

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -212,10 +212,23 @@ fn main() -> Result<()> {
                         });
                     }
                     Some(event) = menubar_rx.recv() => {
-                        cx.update(|cx| match event {
-                            platform::menubar::MenuBarEvent::Open => open_main_window(&[], cx),
-                            platform::menubar::MenuBarEvent::Quit => cx.quit(),
+                        let status = cx.update(|cx| match event {
+                            platform::menubar::MenuBarEvent::Open => {
+                                open_main_window(&[], cx);
+                                None
+                            }
+                            platform::menubar::MenuBarEvent::Quit => {
+                                cx.quit();
+                                None
+                            }
+                            platform::menubar::MenuBarEvent::Refresh => {
+                                platform::menubar::refresh_labels();
+                                Some(menubar_status(cx))
+                            }
                         });
+                        if let Some(status) = status {
+                            menubar.set_device_status(&status);
+                        }
                     }
                     else => break,
                 }

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -116,32 +116,39 @@ fn main() -> Result<()> {
         watchers::accessibility::spawn(std::time::Duration::from_millis(1200));
     let (pairing_ctrl_tx, mut pairing_evt_rx) = watchers::pairing::spawn();
 
+    // Menu-bar click events (Open / Quit), drained by the loop below.
+    let (menubar_tx, mut menubar_rx) =
+        tokio::sync::mpsc::unbounded_channel::<platform::menubar::MenuBarEvent>();
+
     // `with_assets` registers the embedded app logo ([`app_assets`]) plus the
     // lucide SVGs that back `gpui_component::IconName`; without it `img()` /
     // `Icon` would fail to load.
-    gpui_platform::application()
-        .with_assets(app_assets::AppAssets)
-        .run(move |cx| {
-            gpui_component::init(cx);
-            app_menu::install(cx);
+    let app = gpui_platform::application().with_assets(app_assets::AppAssets);
 
-            // Publish the pairing control sender + initial UI state so the Add
-            // Device window's buttons can drive the watcher via globals.
-            cx.set_global(windows::add_device::PairingControl(pairing_ctrl_tx));
-            cx.set_global(windows::add_device::PairingUi::Idle);
+    // Reopen the window when the app is relaunched with none open (dock click).
+    app.on_reopen(|cx| open_main_window(&[], cx));
 
-            if !Hook::has_accessibility() {
-                Hook::prompt_accessibility();
-            }
+    app.run(move |cx| {
+        gpui_component::init(cx);
+        app_menu::install(cx);
 
-            cx.spawn(async move |cx| {
-            let options = cx.update(main_window_options);
+        // Publish the pairing control sender + initial UI state so the Add
+        // Device window's buttons can drive the watcher via globals.
+        cx.set_global(windows::add_device::PairingControl(pairing_ctrl_tx));
+        cx.set_global(windows::add_device::PairingUi::Idle);
 
-            #[allow(
-                clippy::expect_used,
-                reason = "failure to open the main window is fatal; nothing useful to recover to"
-            )]
-            cx.open_window(options, move |window, cx| {
+        if !Hook::has_accessibility() {
+            Hook::prompt_accessibility();
+        }
+
+        // Menu-bar app: this also hides the Dock icon. The window opens at
+        // launch and again on demand from the status-item menu.
+        let menubar: platform::menubar::MenuBarHandle = platform::menubar::install(menubar_tx);
+
+        cx.spawn(async move |cx| {
+            // Install the hook-shared AppState up front, then open the window at
+            // launch; closing it leaves the app live in the menu bar.
+            let status = cx.update(|cx| {
                 if !cx.has_global::<AppState>() {
                     let cache = asset::AssetResolver::new();
                     cx.set_global(AppState::with_runtime_shared(
@@ -153,29 +160,23 @@ fn main() -> Result<()> {
                         dpi_cycle,
                     ));
                 }
-                Theme::change(ThemeMode::from(window.appearance()), Some(window), cx);
-
-                let view = cx.new(|cx| AppView::new(&inventories, cx));
-
-                let appearance_obs = window.observe_window_appearance(|window, cx| {
-                    Theme::change(ThemeMode::from(window.appearance()), Some(window), cx);
-                });
-                view.update(cx, |v, _| v.set_appearance_obs(appearance_obs));
-
-                cx.new(|cx| Root::new(view, window, cx).bg(cx.theme().background))
-            })
-            .expect("opening the main window should not fail");
+                open_main_window(&inventories, cx);
+                menubar_status(cx)
+            });
+            menubar.set_device_status(&status);
 
             let mut hook_handle = None;
             loop {
                 tokio::select! {
                     Some(new_inv) = inventory_rx.recv() => {
-                        cx.update(|cx| {
+                        let status = cx.update(|cx| {
                             let cache = asset::AssetResolver::new();
                             cx.update_global::<AppState, _>(|state, _| {
                                 state.refresh_inventories(&new_inv, &cache);
                             });
+                            menubar_status(cx)
                         });
+                        menubar.set_device_status(&status);
                     }
                     Some(bundle) = app_rx.recv() => {
                         cx.update(|cx| {
@@ -210,12 +211,18 @@ fn main() -> Result<()> {
                             windows::add_device::apply_event(cx, event);
                         });
                     }
+                    Some(event) = menubar_rx.recv() => {
+                        cx.update(|cx| match event {
+                            platform::menubar::MenuBarEvent::Open => open_main_window(&[], cx),
+                            platform::menubar::MenuBarEvent::Quit => cx.quit(),
+                        });
+                    }
                     else => break,
                 }
             }
         })
         .detach();
-        });
+    });
 
     Ok(())
 }
@@ -252,6 +259,60 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
         }),
         ..WindowOptions::default()
     }
+}
+
+/// Open the main window — or focus the one already open. The handle is parked
+/// in [`windows::WindowRegistry`] so the dock-icon reopen handler (and any
+/// repeat call) re-focuses the live window instead of stacking a duplicate, and
+/// a window closed while the app kept running can be brought back.
+fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
+    let existing = cx.default_global::<windows::WindowRegistry>().main;
+    if let Some(handle) = existing {
+        if handle
+            .update(cx, |_, window, _| window.activate_window())
+            .is_ok()
+        {
+            cx.activate(true);
+            return;
+        }
+    }
+
+    let options = main_window_options(cx);
+    let opened = cx.open_window(options, |window, cx| {
+        Theme::change(ThemeMode::from(window.appearance()), Some(window), cx);
+
+        let view = cx.new(|cx| AppView::new(inventories, cx));
+
+        let appearance_obs = window.observe_window_appearance(|window, cx| {
+            Theme::change(ThemeMode::from(window.appearance()), Some(window), cx);
+        });
+        view.update(cx, |v, _| v.set_appearance_obs(appearance_obs));
+
+        cx.new(|cx| Root::new(view, window, cx).bg(cx.theme().background))
+    });
+
+    match opened {
+        Ok(handle) => {
+            let _ = handle.update(cx, |_, window, _| window.activate_window());
+            cx.default_global::<windows::WindowRegistry>().main = Some(handle);
+            cx.activate(true);
+        }
+        Err(e) => warn!(error = %e, "could not open the main window"),
+    }
+}
+
+/// Format the status-item device line from the live [`AppState`], e.g.
+/// `"MX Master 3S · 80%"`, or a placeholder when nothing is connected.
+fn menubar_status(cx: &gpui::App) -> String {
+    cx.try_global::<AppState>()
+        .and_then(AppState::current_record)
+        .map_or_else(
+            || rust_i18n::t!("No device connected").into_owned(),
+            |record| match &record.battery {
+                Some(battery) => format!("{} · {}%", record.display_name, battery.percentage),
+                None => record.display_name.clone(),
+            },
+        )
 }
 
 /// Load config from disk and build the initial hook-shared state using the

--- a/crates/openlogi-gui/src/mouse_model/geometry.rs
+++ b/crates/openlogi-gui/src/mouse_model/geometry.rs
@@ -147,7 +147,12 @@ pub fn default_labels() -> Vec<Label> {
         Label {
             id: ButtonId::DpiToggle,
             side: Side::Left,
-            y: 440.,
+            y: 430.,
+        },
+        Label {
+            id: ButtonId::GestureButton,
+            side: Side::Left,
+            y: 510.,
         },
     ]
 }
@@ -166,5 +171,34 @@ fn map_slot_name(name: &str) -> Option<ButtonId> {
         "SLOT_NAME_THUMBWHEEL" => Some(ButtonId::Thumbwheel),
         "SLOT_NAME_GESTURE_BUTTON" => Some(ButtonId::GestureButton),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::mouse_buttons::default_hotspots;
+
+    #[test]
+    fn default_labels_include_the_gesture_button() {
+        let labels = default_labels();
+        assert!(
+            labels
+                .iter()
+                .any(|l| matches!(l.id, ButtonId::GestureButton)),
+            "the gesture button needs a fallback label"
+        );
+    }
+
+    #[test]
+    fn labels_track_hotspots_and_avoid_crossing() {
+        let hotspots = default_hotspots();
+        let labels = labels_from_hotspots(&hotspots);
+        assert_eq!(labels.len(), hotspots.len());
+
+        let mut ys: Vec<f32> = labels.iter().map(|l| l.y).collect();
+        ys.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        ys.dedup();
+        assert_eq!(ys.len(), labels.len(), "each label gets a distinct slot");
     }
 }

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -1,10 +1,7 @@
-use std::time::Duration;
-
 use gpui::{
-    Anchor, Animation, AnimationExt as _, AnyElement, App, Context, DismissEvent, ElementId,
-    Entity, Focusable as _, FontWeight, InteractiveElement, IntoElement, MouseButton,
-    ParentElement, Render, RenderOnce, StatefulInteractiveElement as _, Styled, Subscription,
-    Window, canvas, div, ease_in_out, hsla, img, px, rgb,
+    Anchor, AnyElement, App, Context, DismissEvent, ElementId, Entity, Focusable as _, FontWeight,
+    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, RenderOnce,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, img, px, rgb,
 };
 use gpui_component::{Selectable, menu::PopupMenu, popover::Popover, v_flex};
 
@@ -28,8 +25,6 @@ const LABEL_H: f32 = 56.;
 const CARD_EDGE_INSET: f32 = SIDE_GAP + (SIDE_W - LABEL_W);
 
 const HOTSPOT_DOT: f32 = 12.;
-
-const BREATH_AMPLITUDE: f32 = 2.0;
 
 /// Interactive mouse model with button hotspots.
 pub struct MouseModelView {
@@ -174,16 +169,6 @@ fn breathing_art(
         .w(px(mouse_w))
         .h(px(mouse_h))
         .child(device_art)
-        .with_animation(
-            "mouse-breath",
-            Animation::new(Duration::from_secs(4))
-                .repeat()
-                .with_easing(ease_in_out),
-            |this, delta| {
-                let dy = (delta * std::f32::consts::TAU).sin() * BREATH_AMPLITUDE;
-                this.top(px(dy))
-            },
-        )
 }
 
 fn hotspots_layer(

--- a/crates/openlogi-gui/src/platform/menubar.rs
+++ b/crates/openlogi-gui/src/platform/menubar.rs
@@ -2,17 +2,20 @@
 //! no status-bar API. Menu clicks can't reach GPUI's `App`, so they post a
 //! [`MenuBarEvent`] on a channel the `main.rs` watcher loop drains.
 
-/// A request raised by clicking a status-bar menu item.
+/// A request raised by clicking a status-bar menu item, or by a live language
+/// switch asking the spawn loop to re-localize the whole menu.
 #[derive(Debug, Clone, Copy)]
 pub enum MenuBarEvent {
     Open,
     Quit,
+    /// Re-title Open/Quit *and* the device line for the current locale.
+    Refresh,
 }
 
 #[cfg(target_os = "macos")]
-pub use macos::{MenuBarHandle, install, refresh_labels};
+pub use macos::{MenuBarHandle, install, refresh_labels, request_refresh};
 #[cfg(not(target_os = "macos"))]
-pub use stub::{MenuBarHandle, install, refresh_labels};
+pub use stub::{MenuBarHandle, install, refresh_labels, request_refresh};
 
 #[cfg(target_os = "macos")]
 #[expect(
@@ -123,9 +126,10 @@ mod macos {
         }
     }
 
-    /// Re-title the Open/Quit items for the current locale, e.g. after a live
-    /// language switch. Main-thread only, like every status-item write. The
-    /// device line re-localises on its own via the next `set_device_status`.
+    /// Re-title the Open/Quit items for the current locale. Main-thread only,
+    /// like every status-item write. The device line is owned by the spawn
+    /// loop's [`MenuBarHandle`], so [`request_refresh`] drives that side; this
+    /// only touches the items reachable through `MENU_REFS`.
     pub fn refresh_labels() {
         let Some(refs) = MENU_REFS.get() else {
             return;
@@ -138,6 +142,14 @@ mod macos {
             let _: () = msg_send![open, setTitle: nsstring(&open_title)];
             let _: () = msg_send![quit, setTitle: nsstring(&quit_title)];
         }
+    }
+
+    /// Ask the spawn loop to re-localize the whole menu after a live language
+    /// switch. The device line is recomputed from the live `AppState`, which
+    /// only the loop can read, so we post through the same channel as menu
+    /// clicks instead of writing the status item from the settings view.
+    pub fn request_refresh() {
+        post(MenuBarEvent::Refresh);
     }
 
     fn nsstring(s: &str) -> id {
@@ -222,4 +234,6 @@ mod stub {
     }
 
     pub fn refresh_labels() {}
+
+    pub fn request_refresh() {}
 }

--- a/crates/openlogi-gui/src/platform/menubar.rs
+++ b/crates/openlogi-gui/src/platform/menubar.rs
@@ -1,0 +1,225 @@
+//! macOS menu-bar (`NSStatusItem`) presence via raw Cocoa FFI — GPUI exposes
+//! no status-bar API. Menu clicks can't reach GPUI's `App`, so they post a
+//! [`MenuBarEvent`] on a channel the `main.rs` watcher loop drains.
+
+/// A request raised by clicking a status-bar menu item.
+#[derive(Debug, Clone, Copy)]
+pub enum MenuBarEvent {
+    Open,
+    Quit,
+}
+
+#[cfg(target_os = "macos")]
+pub use macos::{MenuBarHandle, install, refresh_labels};
+#[cfg(not(target_os = "macos"))]
+pub use stub::{MenuBarHandle, install, refresh_labels};
+
+#[cfg(target_os = "macos")]
+#[expect(
+    unsafe_code,
+    reason = "Cocoa NSStatusItem/NSMenu FFI; GPUI has no menu-bar API"
+)]
+mod macos {
+    use std::sync::{Once, OnceLock};
+
+    use cocoa::base::{NO, YES, id, nil};
+    use cocoa::foundation::NSString;
+    use objc::declare::ClassDecl;
+    use objc::runtime::{Class, Object, Sel};
+    use objc::{class, msg_send, sel, sel_impl};
+    use tokio::sync::mpsc;
+    use tracing::warn;
+
+    use super::MenuBarEvent;
+
+    const VARIABLE_LENGTH: f64 = -1.0;
+    const ACTIVATION_POLICY_ACCESSORY: i64 = 1;
+    const TARGET_CLASS: &str = "OpenLogiMenuTarget";
+
+    // Read by the Objective-C action callbacks, which can't capture state.
+    static MENU_TX: OnceLock<mpsc::UnboundedSender<MenuBarEvent>> = OnceLock::new();
+
+    /// Open/Quit item pointers, kept so a live locale switch can re-title them.
+    /// Stored as `usize` because a raw `id` is not `Sync`.
+    static MENU_REFS: OnceLock<MenuRefs> = OnceLock::new();
+
+    struct MenuRefs {
+        open: usize,
+        quit: usize,
+    }
+
+    /// Cocoa objects retained for the app's lifetime; only ever touched on the
+    /// main thread, so the raw `id`s never cross threads.
+    pub struct MenuBarHandle {
+        device_item: id,
+        _status_item: id,
+        _target: id,
+        _menu: id,
+    }
+
+    impl MenuBarHandle {
+        /// Update the device line, e.g. `"MX Master 3S · 80%"`. Main thread only.
+        pub fn set_device_status(&self, text: &str) {
+            unsafe {
+                let title = nsstring(text);
+                let _: () = msg_send![self.device_item, setTitle: title];
+            }
+        }
+    }
+
+    /// Install the status item and switch to accessory activation, dropping the
+    /// app from the Dock and app switcher.
+    #[must_use]
+    pub fn install(tx: mpsc::UnboundedSender<MenuBarEvent>) -> MenuBarHandle {
+        let _ = MENU_TX.set(tx);
+        ensure_target_class();
+
+        unsafe {
+            let app: id = msg_send![class!(NSApplication), sharedApplication];
+            let _: () = msg_send![app, setActivationPolicy: ACTIVATION_POLICY_ACCESSORY];
+
+            let status_bar: id = msg_send![class!(NSStatusBar), systemStatusBar];
+            let status_item: id = msg_send![status_bar, statusItemWithLength: VARIABLE_LENGTH];
+            let _: id = msg_send![status_item, retain];
+
+            let button: id = msg_send![status_item, button];
+            set_button_icon(button);
+
+            let target_cls = Class::get(TARGET_CLASS).unwrap_or_else(|| class!(NSObject));
+            let target: id = msg_send![target_cls, new];
+
+            let menu: id = msg_send![class!(NSMenu), new];
+            let _: () = msg_send![menu, setAutoenablesItems: NO];
+
+            let device_item: id = msg_send![class!(NSMenuItem), new];
+            let idle = rust_i18n::t!("No device connected");
+            let _: () = msg_send![device_item, setTitle: nsstring(&idle)];
+            let _: () = msg_send![device_item, setEnabled: NO];
+            let _: () = msg_send![menu, addItem: device_item];
+
+            let separator: id = msg_send![class!(NSMenuItem), separatorItem];
+            let _: () = msg_send![menu, addItem: separator];
+
+            let open_title = rust_i18n::t!("Open OpenLogi");
+            let open_item = action_item(&open_title, sel!(openOpenLogi:), target);
+            let _: () = msg_send![menu, addItem: open_item];
+            let quit_title = rust_i18n::t!("Quit OpenLogi");
+            let quit_item = action_item(&quit_title, sel!(quitOpenLogi:), target);
+            let _: () = msg_send![menu, addItem: quit_item];
+
+            let _ = MENU_REFS.set(MenuRefs {
+                open: open_item as usize,
+                quit: quit_item as usize,
+            });
+
+            let _: () = msg_send![status_item, setMenu: menu];
+
+            MenuBarHandle {
+                device_item,
+                _status_item: status_item,
+                _target: target,
+                _menu: menu,
+            }
+        }
+    }
+
+    /// Re-title the Open/Quit items for the current locale, e.g. after a live
+    /// language switch. Main-thread only, like every status-item write. The
+    /// device line re-localises on its own via the next `set_device_status`.
+    pub fn refresh_labels() {
+        let Some(refs) = MENU_REFS.get() else {
+            return;
+        };
+        let open_title = rust_i18n::t!("Open OpenLogi");
+        let quit_title = rust_i18n::t!("Quit OpenLogi");
+        unsafe {
+            let open = refs.open as id;
+            let quit = refs.quit as id;
+            let _: () = msg_send![open, setTitle: nsstring(&open_title)];
+            let _: () = msg_send![quit, setTitle: nsstring(&quit_title)];
+        }
+    }
+
+    fn nsstring(s: &str) -> id {
+        unsafe { NSString::alloc(nil).init_str(s) }
+    }
+
+    fn action_item(title: &str, action: Sel, target: id) -> id {
+        unsafe {
+            let item: id = msg_send![class!(NSMenuItem), alloc];
+            let item: id = msg_send![item, initWithTitle: nsstring(title) action: action keyEquivalent: nsstring("")];
+            let _: () = msg_send![item, setTarget: target];
+            item
+        }
+    }
+
+    // Template image adapts to the light/dark menu bar; text title as fallback.
+    fn set_button_icon(button: id) {
+        unsafe {
+            let symbol = nsstring("computermouse.fill");
+            let description = nsstring("OpenLogi");
+            let image: id = msg_send![class!(NSImage), imageWithSystemSymbolName: symbol accessibilityDescription: description];
+            if image == nil {
+                let _: () = msg_send![button, setTitle: nsstring("OpenLogi")];
+            } else {
+                let _: () = msg_send![image, setTemplate: YES];
+                let _: () = msg_send![button, setImage: image];
+            }
+        }
+    }
+
+    extern "C" fn open_action(_this: &Object, _cmd: Sel, _sender: id) {
+        post(MenuBarEvent::Open);
+    }
+
+    extern "C" fn quit_action(_this: &Object, _cmd: Sel, _sender: id) {
+        post(MenuBarEvent::Quit);
+    }
+
+    fn post(event: MenuBarEvent) {
+        if let Some(tx) = MENU_TX.get()
+            && tx.send(event).is_err()
+        {
+            warn!(?event, "menu-bar event dropped — GPUI loop gone");
+        }
+    }
+
+    fn ensure_target_class() {
+        static REGISTER: Once = Once::new();
+        REGISTER.call_once(|| {
+            if let Some(mut decl) = ClassDecl::new(TARGET_CLASS, class!(NSObject)) {
+                unsafe {
+                    decl.add_method(
+                        sel!(openOpenLogi:),
+                        open_action as extern "C" fn(&Object, Sel, id),
+                    );
+                    decl.add_method(
+                        sel!(quitOpenLogi:),
+                        quit_action as extern "C" fn(&Object, Sel, id),
+                    );
+                }
+                decl.register();
+            }
+        });
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod stub {
+    use tokio::sync::mpsc;
+
+    use super::MenuBarEvent;
+
+    pub struct MenuBarHandle;
+
+    impl MenuBarHandle {
+        pub fn set_device_status(&self, _text: &str) {}
+    }
+
+    #[must_use]
+    pub fn install(_tx: mpsc::UnboundedSender<MenuBarEvent>) -> MenuBarHandle {
+        MenuBarHandle
+    }
+
+    pub fn refresh_labels() {}
+}

--- a/crates/openlogi-gui/src/platform/mod.rs
+++ b/crates/openlogi-gui/src/platform/mod.rs
@@ -1,5 +1,6 @@
 //! Platform and OS integration helpers.
 
 pub mod launch_agent;
+pub mod menubar;
 pub mod single_instance;
 pub mod updater;

--- a/crates/openlogi-gui/src/windows/mod.rs
+++ b/crates/openlogi-gui/src/windows/mod.rs
@@ -23,6 +23,10 @@ use tracing::warn;
 /// actions and footer links can find an already-open window and focus it.
 #[derive(Default)]
 pub struct WindowRegistry {
+    /// The primary app window. Held so the dock-icon reopen handler can bring
+    /// it back after the user closes it while the app keeps running in the
+    /// background (mouse hook + watchers).
+    pub main: Option<WindowHandle<Root>>,
     pub settings: Option<WindowHandle<Root>>,
     pub about: Option<WindowHandle<Root>>,
     pub add_device: Option<WindowHandle<Root>>,

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -42,7 +42,7 @@ pub fn open(cx: &mut App) {
     windows::open_or_focus(
         |reg| &mut reg.settings,
         "Settings",
-        Size::new(px(520.), px(420.)),
+        Size::new(px(520.), px(360.)),
         SettingsView::new,
         cx,
     );
@@ -134,6 +134,8 @@ fn setting_row(
         .gap_4()
         .child(
             v_flex()
+                .flex_1()
+                .min_w(px(0.))
                 .gap_1()
                 .child(div().text_sm().child(title.into()))
                 .child(
@@ -146,11 +148,11 @@ fn setting_row(
         .child(control)
 }
 
-/// The language picker: a muted hint on the left, selectable locale chips on
-/// the right. The leading "Follow system" chip clears the stored preference
-/// (`None`); the rest pin an explicit locale from [`crate::i18n::SUPPORTED`].
-/// Selecting one switches the locale live, then repaints every window and the
-/// menu bar so the whole UI re-renders without a restart.
+/// The language picker: a muted hint above a wrapping row of locale chips. The
+/// leading "Follow system" chip clears the stored preference (`None`); the rest
+/// pin an explicit locale from [`crate::i18n::SUPPORTED`]. Selecting one
+/// switches the locale live, then repaints every window and the menu bar so the
+/// whole UI re-renders without a restart.
 fn language_row(
     current: Option<&str>,
     pal: Palette,
@@ -191,19 +193,18 @@ fn language_row(
                 .on_click(cx.listener(move |_, _, _, cx| {
                     cx.update_global::<AppState, _>(|s, _| s.set_language(lang.clone()));
                     // `t!` reads the locale at render time, so a repaint is what
-                    // actually applies the switch; the menu bar is rebuilt
-                    // separately since it isn't part of any window's view tree.
+                    // actually applies the switch; the app menu and status item
+                    // aren't in any window's view tree, so re-title them too.
                     cx.refresh_windows();
                     crate::app_menu::rebuild(cx);
+                    crate::platform::menubar::refresh_labels();
                 }))
         })
         .collect();
 
-    h_flex()
+    v_flex()
         .w_full()
-        .items_center()
-        .justify_between()
-        .gap_4()
+        .gap_2()
         .child(
             div()
                 .text_xs()

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -194,10 +194,12 @@ fn language_row(
                     cx.update_global::<AppState, _>(|s, _| s.set_language(lang.clone()));
                     // `t!` reads the locale at render time, so a repaint is what
                     // actually applies the switch; the app menu and status item
-                    // aren't in any window's view tree, so re-title them too.
+                    // aren't in any window's view tree, so re-title them too. The
+                    // status item's device line lives on the spawn loop, so ask it
+                    // to re-localize the whole menu rather than writing from here.
                     cx.refresh_windows();
                     crate::app_menu::rebuild(cx);
-                    crate::platform::menubar::refresh_labels();
+                    crate::platform::menubar::request_refresh();
                 }))
         })
         .collect();

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -16,6 +16,7 @@
 //! is therefore only diverted when its click is actually bound.
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
+use std::time::{Duration, Instant};
 
 use hidpp::{
     channel::HidppChannel,
@@ -80,12 +81,18 @@ pub enum GestureError {
     Hidpp(String),
 }
 
+/// Minimum hold before raw-XY travel counts as a swipe. A quicker tap stays a
+/// plain click even if the cursor was moving when it fired.
+const GESTURE_HOLD_FOR_SWIPE: Duration = Duration::from_millis(160);
+
 /// Movement + button state accumulated across messages. Lives behind a `Mutex`
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
     /// Whether the gesture button is currently held.
     gesture_held: bool,
+    /// When the current hold began — gates swipe vs. click by duration.
+    held_since: Option<Instant>,
     /// Accumulated raw-XY travel since the press began.
     dx: i32,
     dy: i32,
@@ -341,11 +348,13 @@ fn handle_reprog(
             let gesture_held = cids.contains(&reprog_controls::GESTURE_BUTTON_CID);
             if gesture_held && !acc.gesture_held {
                 acc.gesture_held = true;
+                acc.held_since = Some(Instant::now());
                 acc.dx = 0;
                 acc.dy = 0;
                 acc.fired = false;
             } else if !gesture_held && acc.gesture_held {
                 acc.gesture_held = false;
+                acc.held_since = None;
                 // A press that never committed a direction is a plain click.
                 if !acc.fired {
                     debug!("gesture click");
@@ -365,7 +374,12 @@ fn handle_reprog(
             if acc.gesture_held && !acc.fired {
                 acc.dx = acc.dx.saturating_add(i32::from(dx));
                 acc.dy = acc.dy.saturating_add(i32::from(dy));
-                if let Some(direction) = detect_swipe(acc.dx, acc.dy) {
+                // Held long enough to be a deliberate gesture, not a tap whose
+                // cursor happened to be in motion? Only then does travel commit.
+                let held = acc
+                    .held_since
+                    .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
+                if held && let Some(direction) = detect_swipe(acc.dx, acc.dy) {
                     debug!(?direction, dx = acc.dx, dy = acc.dy, "gesture committed");
                     acc.fired = true;
                     let _ = sink.send(CapturedInput::Gesture(direction));
@@ -396,4 +410,85 @@ async fn open_target_channel(target: &GestureTarget) -> Result<Arc<HidppChannel>
         return Ok(channel);
     }
     Err(GestureError::ReceiverNotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press() -> RawControlEvent {
+        RawControlEvent::DivertedButtons([reprog_controls::GESTURE_BUTTON_CID, 0, 0, 0])
+    }
+
+    fn release() -> RawControlEvent {
+        RawControlEvent::DivertedButtons([0, 0, 0, 0])
+    }
+
+    #[test]
+    fn quick_tap_is_a_click_even_while_the_cursor_moves() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut acc = CaptureAccum::default();
+
+        handle_reprog(&mut acc, press(), &[], &tx);
+        handle_reprog(
+            &mut acc,
+            RawControlEvent::RawXy { dx: 120, dy: 5 },
+            &[],
+            &tx,
+        );
+        handle_reprog(&mut acc, release(), &[], &tx);
+
+        assert_eq!(
+            rx.try_recv(),
+            Ok(CapturedInput::Gesture(GestureDirection::Click))
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a quick tap emits exactly one click"
+        );
+    }
+
+    #[test]
+    fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut acc = CaptureAccum::default();
+
+        handle_reprog(&mut acc, press(), &[], &tx);
+        // Pretend the button has been held well past the swipe gate.
+        acc.held_since = Instant::now().checked_sub(GESTURE_HOLD_FOR_SWIPE * 2);
+        handle_reprog(
+            &mut acc,
+            RawControlEvent::RawXy { dx: 120, dy: 5 },
+            &[],
+            &tx,
+        );
+
+        assert_eq!(
+            rx.try_recv(),
+            Ok(CapturedInput::Gesture(GestureDirection::Right))
+        );
+
+        handle_reprog(&mut acc, release(), &[], &tx);
+        assert!(
+            rx.try_recv().is_err(),
+            "a committed swipe must not also click on release"
+        );
+    }
+
+    #[test]
+    fn a_held_dpi_button_presses_once_on_the_rising_edge() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut acc = CaptureAccum::default();
+        let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
+        let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
+
+        handle_reprog(&mut acc, down, &[dpi], &tx);
+        handle_reprog(&mut acc, down, &[dpi], &tx);
+
+        assert_eq!(
+            rx.try_recv(),
+            Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle))
+        );
+        assert!(rx.try_recv().is_err(), "a held DPI button presses once");
+    }
 }


### PR DESCRIPTION
### What’s New
OpenLogi now runs as a proper menu-bar accessory app on macOS (no more Dock icon) while still being instantly accessible. This PR also turns the gesture button into a proper mappable hotspot in the mouse diagram and includes a few small but high-quality UI fixes.

### Demo

Run `cargo run -p openlogi-gui` to try it out.

#### Menu Bar
- OpenLogi now lives in the macOS menu bar. Click the 🖱️ icon to see the live device status and quick **Open OpenLogi** / **Quit OpenLogi** actions.

<img width="224" height="152" alt="Menu bar status item showing live device and Open/Quit options" src="https://github.com/user-attachments/assets/293a0dae-b0ec-41a0-978f-21344d5dd783" />

#### Gesture Button Hotspot
- The synthetic mouse diagram now clearly exposes the gesture button as a mappable hotspot. Hover or click it to open the mapping popover.

<img width="1105" height="788" alt="Mouse diagram with gesture button highlighted as mappable hotspot" src="https://github.com/user-attachments/assets/6ea58738-bf3b-4528-bdcd-c6495be0f056" />

#### Settings Polish
- Small layout improvements to the language picker (description now wraps cleanly and the toggle no longer clips).

<img width="522" height="393" alt="Settings window showing improved language picker layout" src="https://github.com/user-attachments/assets/b96f4b5b-a5ce-4eec-ab7a-049c34e1ea71" />

### Changes
- Added menu-bar status item in accessory mode (no Dock icon) with live device line and Open/Quit actions (`platform/menubar.rs`, `main.rs`, `platform/mod.rs`, `windows/mod.rs`, `Cargo.toml`)
- Localized menu-bar strings so they follow the Settings language in real time (`platform/menubar.rs`, `windows/settings.rs`, `locales/app.yml`)
- Re-localized the menu-bar device line on a live language switch even while idle, routing a `MenuBarEvent::Refresh` through the spawn loop that owns the status item so it no longer waits for the next inventory event (`platform/menubar.rs`, `main.rs`, `windows/settings.rs`)
- Drew the gesture button as a proper mappable hotspot in the synthetic mouse diagram (`data/mouse_buttons.rs`, `mouse_model/geometry.rs`)
- Added hold-time gate so a quick gesture-button tap registers as a click instead of an accidental swipe (`openlogi-hid/src/gesture.rs`)
- Removed the outdated breathing/bounce animation from the mouse model (`mouse_model/view.rs`)
- Tidied up the Settings language picker (description wrapping + toggle clipping fix) (`windows/settings.rs`)

### Testing
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass
- Added unit tests covering:
  - Gesture button hold-gate behavior (quick tap = click, deliberate hold = swipe, no double-fire on release)
  - Gesture button presence/label as a hotspot in the fallback mouse model
  - Menu-bar string resolution in non-English locales
