### PR TITLE
fix(gui): gate the menu-bar (now "tray") to macOS

### DIFF
--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -116,7 +116,9 @@ fn main() -> Result<()> {
         watchers::accessibility::spawn(std::time::Duration::from_millis(1200));
     let (pairing_ctrl_tx, mut pairing_evt_rx) = watchers::pairing::spawn();
 
-    // Menu-bar click events (Open / Quit), drained by the loop below.
+    // Menu-bar click events (Open / Quit), drained by a dedicated task below.
+    // macOS-only: there is no status item on other platforms.
+    #[cfg(target_os = "macos")]
     let (menubar_tx, mut menubar_rx) =
         tokio::sync::mpsc::unbounded_channel::<platform::menubar::MenuBarEvent>();
 
@@ -146,14 +148,15 @@ fn main() -> Result<()> {
         // window-opening task below.
         platform::updater::install(cx, &initial_config.app_settings);
 
-        // Menu-bar app: this also hides the Dock icon. The window opens at
-        // launch and again on demand from the status-item menu.
-        let menubar: platform::menubar::MenuBarHandle = platform::menubar::install(menubar_tx);
+        // Menu-bar app (macOS only): also hides the Dock icon. The window opens
+        // at launch and again on demand from the status-item menu.
+        #[cfg(target_os = "macos")]
+        platform::menubar::install(menubar_tx);
 
         cx.spawn(async move |cx| {
             // Install the hook-shared AppState up front, then open the window at
             // launch; closing it leaves the app live in the menu bar.
-            let status = cx.update(|cx| {
+            cx.update(|cx| {
                 if !cx.has_global::<AppState>() {
                     let cache = asset::AssetResolver::new();
                     cx.set_global(AppState::with_runtime_shared(
@@ -166,9 +169,9 @@ fn main() -> Result<()> {
                     ));
                 }
                 open_main_window(&inventories, cx);
-                menubar_status(cx)
+                #[cfg(target_os = "macos")]
+                platform::menubar::set_device_status(&menubar_status(cx));
             });
-            menubar.set_device_status(&status);
 
             // First launch only: offer to opt in to the update check, since it
             // defaults to off. Marked seen either way so it shows just once.
@@ -185,14 +188,14 @@ fn main() -> Result<()> {
             loop {
                 tokio::select! {
                     Some(new_inv) = inventory_rx.recv() => {
-                        let status = cx.update(|cx| {
+                        cx.update(|cx| {
                             let cache = asset::AssetResolver::new();
                             cx.update_global::<AppState, _>(|state, _| {
                                 state.refresh_inventories(&new_inv, &cache);
                             });
-                            menubar_status(cx)
+                            #[cfg(target_os = "macos")]
+                            platform::menubar::set_device_status(&menubar_status(cx));
                         });
-                        menubar.set_device_status(&status);
                     }
                     Some(bundle) = app_rx.recv() => {
                         cx.update(|cx| {
@@ -227,27 +230,26 @@ fn main() -> Result<()> {
                             windows::add_device::apply_event(cx, event);
                         });
                     }
-                    Some(event) = menubar_rx.recv() => {
-                        let status = cx.update(|cx| match event {
-                            platform::menubar::MenuBarEvent::Open => {
-                                open_main_window(&[], cx);
-                                None
-                            }
-                            platform::menubar::MenuBarEvent::Quit => {
-                                cx.quit();
-                                None
-                            }
-                            platform::menubar::MenuBarEvent::Refresh => {
-                                platform::menubar::refresh_labels();
-                                Some(menubar_status(cx))
-                            }
-                        });
-                        if let Some(status) = status {
-                            menubar.set_device_status(&status);
-                        }
-                    }
                     else => break,
                 }
+            }
+        })
+        .detach();
+
+        // Drain status-item menu clicks (macOS only). Kept off the main select
+        // loop above because `tokio::select!` branches can't be `#[cfg]`-gated,
+        // and the whole status item is macOS-only anyway.
+        #[cfg(target_os = "macos")]
+        cx.spawn(async move |cx| {
+            while let Some(event) = menubar_rx.recv().await {
+                cx.update(|cx| match event {
+                    platform::menubar::MenuBarEvent::Open => open_main_window(&[], cx),
+                    platform::menubar::MenuBarEvent::Quit => cx.quit(),
+                    platform::menubar::MenuBarEvent::Refresh => {
+                        platform::menubar::refresh_labels();
+                        platform::menubar::set_device_status(&menubar_status(cx));
+                    }
+                });
             }
         })
         .detach();
@@ -331,6 +333,7 @@ fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
 
 /// Format the status-item device line from the live [`AppState`], e.g.
 /// `"MX Master 3S · 80%"`, or a placeholder when nothing is connected.
+#[cfg(target_os = "macos")]
 fn menubar_status(cx: &gpui::App) -> String {
     cx.try_global::<AppState>()
         .and_then(AppState::current_record)

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -116,11 +116,11 @@ fn main() -> Result<()> {
         watchers::accessibility::spawn(std::time::Duration::from_millis(1200));
     let (pairing_ctrl_tx, mut pairing_evt_rx) = watchers::pairing::spawn();
 
-    // Menu-bar click events (Open / Quit), drained by a dedicated task below.
-    // macOS-only: there is no status item on other platforms.
+    // Status-item (tray) click events (Open / Quit), drained by a dedicated
+    // task below. macOS-only: there is no status item on other platforms.
     #[cfg(target_os = "macos")]
-    let (menubar_tx, mut menubar_rx) =
-        tokio::sync::mpsc::unbounded_channel::<platform::menubar::MenuBarEvent>();
+    let (tray_tx, mut tray_rx) =
+        tokio::sync::mpsc::unbounded_channel::<platform::tray::TrayEvent>();
 
     // `with_assets` registers the embedded app logo ([`app_assets`]) plus the
     // lucide SVGs that back `gpui_component::IconName`; without it `img()` /
@@ -148,10 +148,10 @@ fn main() -> Result<()> {
         // window-opening task below.
         platform::updater::install(cx, &initial_config.app_settings);
 
-        // Menu-bar app (macOS only): also hides the Dock icon. The window opens
-        // at launch and again on demand from the status-item menu.
+        // Status-item / tray (macOS only): also hides the Dock icon. The window
+        // opens at launch and again on demand from the status-item menu.
         #[cfg(target_os = "macos")]
-        platform::menubar::install(menubar_tx);
+        platform::tray::install(tray_tx);
 
         cx.spawn(async move |cx| {
             // Install the hook-shared AppState up front, then open the window at
@@ -170,7 +170,7 @@ fn main() -> Result<()> {
                 }
                 open_main_window(&inventories, cx);
                 #[cfg(target_os = "macos")]
-                platform::menubar::set_device_status(&menubar_status(cx));
+                platform::tray::set_device_status(&tray_status(cx));
             });
 
             // First launch only: offer to opt in to the update check, since it
@@ -194,7 +194,7 @@ fn main() -> Result<()> {
                                 state.refresh_inventories(&new_inv, &cache);
                             });
                             #[cfg(target_os = "macos")]
-                            platform::menubar::set_device_status(&menubar_status(cx));
+                            platform::tray::set_device_status(&tray_status(cx));
                         });
                     }
                     Some(bundle) = app_rx.recv() => {
@@ -241,13 +241,13 @@ fn main() -> Result<()> {
         // and the whole status item is macOS-only anyway.
         #[cfg(target_os = "macos")]
         cx.spawn(async move |cx| {
-            while let Some(event) = menubar_rx.recv().await {
+            while let Some(event) = tray_rx.recv().await {
                 cx.update(|cx| match event {
-                    platform::menubar::MenuBarEvent::Open => open_main_window(&[], cx),
-                    platform::menubar::MenuBarEvent::Quit => cx.quit(),
-                    platform::menubar::MenuBarEvent::Refresh => {
-                        platform::menubar::refresh_labels();
-                        platform::menubar::set_device_status(&menubar_status(cx));
+                    platform::tray::TrayEvent::Open => open_main_window(&[], cx),
+                    platform::tray::TrayEvent::Quit => cx.quit(),
+                    platform::tray::TrayEvent::Refresh => {
+                        platform::tray::refresh_labels();
+                        platform::tray::set_device_status(&tray_status(cx));
                     }
                 });
             }
@@ -334,7 +334,7 @@ fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
 /// Format the status-item device line from the live [`AppState`], e.g.
 /// `"MX Master 3S · 80%"`, or a placeholder when nothing is connected.
 #[cfg(target_os = "macos")]
-fn menubar_status(cx: &gpui::App) -> String {
+fn tray_status(cx: &gpui::App) -> String {
     cx.try_global::<AppState>()
         .and_then(AppState::current_record)
         .map_or_else(

--- a/crates/openlogi-gui/src/platform/menubar.rs
+++ b/crates/openlogi-gui/src/platform/menubar.rs
@@ -1,21 +1,16 @@
 //! macOS menu-bar (`NSStatusItem`) presence via raw Cocoa FFI — GPUI exposes
-//! no status-bar API. Menu clicks can't reach GPUI's `App`, so they post a
-//! [`MenuBarEvent`] on a channel the `main.rs` watcher loop drains.
-
-/// A request raised by clicking a status-bar menu item, or by a live language
-/// switch asking the spawn loop to re-localize the whole menu.
-#[derive(Debug, Clone, Copy)]
-pub enum MenuBarEvent {
-    Open,
-    Quit,
-    /// Re-title Open/Quit *and* the device line for the current locale.
-    Refresh,
-}
+//! no status-bar API.
+//!
+//! This whole feature is macOS-only: there is no cross-platform "menu bar"
+//! status item (Windows has the system tray / notification area, Linux the
+//! StatusNotifierItem spec), so the module carries no non-macOS stub — every
+//! caller gates on `cfg(target_os = "macos")` instead.
+//!
+//! Menu clicks can't reach GPUI's `App`, so they post a [`MenuBarEvent`] on a
+//! channel that a dedicated task in `main.rs` drains.
 
 #[cfg(target_os = "macos")]
-pub use macos::{MenuBarHandle, install, refresh_labels, request_refresh};
-#[cfg(not(target_os = "macos"))]
-pub use stub::{MenuBarHandle, install, refresh_labels, request_refresh};
+pub use macos::{MenuBarEvent, install, refresh_labels, request_refresh, set_device_status};
 
 #[cfg(target_os = "macos")]
 #[expect(
@@ -33,7 +28,15 @@ mod macos {
     use tokio::sync::mpsc;
     use tracing::warn;
 
-    use super::MenuBarEvent;
+    /// A request raised by clicking a status-bar menu item, or by a live
+    /// language switch asking the drain task to re-localize the whole menu.
+    #[derive(Debug, Clone, Copy)]
+    pub enum MenuBarEvent {
+        Open,
+        Quit,
+        /// Re-title Open/Quit *and* the device line for the current locale.
+        Refresh,
+    }
 
     const VARIABLE_LENGTH: f64 = -1.0;
     const ACTIVATION_POLICY_ACCESSORY: i64 = 1;
@@ -46,34 +49,24 @@ mod macos {
     /// Stored as `usize` because a raw `id` is not `Sync`.
     static MENU_REFS: OnceLock<MenuRefs> = OnceLock::new();
 
+    /// The device-status line item, written by [`set_device_status`]. Stored as
+    /// `usize` (a raw `id` is not `Sync`); only ever touched on the main thread.
+    static DEVICE_ITEM: OnceLock<usize> = OnceLock::new();
+
     struct MenuRefs {
         open: usize,
         quit: usize,
     }
 
-    /// Cocoa objects retained for the app's lifetime; only ever touched on the
-    /// main thread, so the raw `id`s never cross threads.
-    pub struct MenuBarHandle {
-        device_item: id,
-        _status_item: id,
-        _target: id,
-        _menu: id,
-    }
-
-    impl MenuBarHandle {
-        /// Update the device line, e.g. `"MX Master 3S · 80%"`. Main thread only.
-        pub fn set_device_status(&self, text: &str) {
-            unsafe {
-                let title = nsstring(text);
-                let _: () = msg_send![self.device_item, setTitle: title];
-            }
-        }
-    }
-
     /// Install the status item and switch to accessory activation, dropping the
-    /// app from the Dock and app switcher.
-    #[must_use]
-    pub fn install(tx: mpsc::UnboundedSender<MenuBarEvent>) -> MenuBarHandle {
+    /// app from the Dock and app switcher. Main thread only.
+    ///
+    /// The status item, its menu, and the click target are all retained for the
+    /// app's lifetime (a status item lives as long as the process). The target
+    /// in particular *must* be retained: `NSMenuItem` does not retain its
+    /// target, so without this the action callbacks would fire into freed
+    /// memory.
+    pub fn install(tx: mpsc::UnboundedSender<MenuBarEvent>) {
         let _ = MENU_TX.set(tx);
         ensure_target_class();
 
@@ -90,8 +83,12 @@ mod macos {
 
             let target_cls = Class::get(TARGET_CLASS).unwrap_or_else(|| class!(NSObject));
             let target: id = msg_send![target_cls, new];
+            // NSMenuItem keeps only a weak reference to its target — retain it so
+            // it outlives this function and the action callbacks stay valid.
+            let _: id = msg_send![target, retain];
 
             let menu: id = msg_send![class!(NSMenu), new];
+            let _: id = msg_send![menu, retain];
             let _: () = msg_send![menu, setAutoenablesItems: NO];
 
             let device_item: id = msg_send![class!(NSMenuItem), new];
@@ -99,6 +96,7 @@ mod macos {
             let _: () = msg_send![device_item, setTitle: nsstring(&idle)];
             let _: () = msg_send![device_item, setEnabled: NO];
             let _: () = msg_send![menu, addItem: device_item];
+            let _ = DEVICE_ITEM.set(device_item as usize);
 
             let separator: id = msg_send![class!(NSMenuItem), separatorItem];
             let _: () = msg_send![menu, addItem: separator];
@@ -116,20 +114,24 @@ mod macos {
             });
 
             let _: () = msg_send![status_item, setMenu: menu];
+        }
+    }
 
-            MenuBarHandle {
-                device_item,
-                _status_item: status_item,
-                _target: target,
-                _menu: menu,
-            }
+    /// Update the device line, e.g. `"MX Master 3S · 80%"`. Main thread only.
+    /// A no-op until [`install`] has published the item.
+    pub fn set_device_status(text: &str) {
+        let Some(item) = DEVICE_ITEM.get() else {
+            return;
+        };
+        unsafe {
+            let title = nsstring(text);
+            let _: () = msg_send![*item as id, setTitle: title];
         }
     }
 
     /// Re-title the Open/Quit items for the current locale. Main-thread only,
-    /// like every status-item write. The device line is owned by the spawn
-    /// loop's [`MenuBarHandle`], so [`request_refresh`] drives that side; this
-    /// only touches the items reachable through `MENU_REFS`.
+    /// like every status-item write. The device line is refreshed separately via
+    /// [`set_device_status`].
     pub fn refresh_labels() {
         let Some(refs) = MENU_REFS.get() else {
             return;
@@ -144,10 +146,10 @@ mod macos {
         }
     }
 
-    /// Ask the spawn loop to re-localize the whole menu after a live language
-    /// switch. The device line is recomputed from the live `AppState`, which
-    /// only the loop can read, so we post through the same channel as menu
-    /// clicks instead of writing the status item from the settings view.
+    /// Ask the drain task to re-localize the whole menu after a live language
+    /// switch. Posts through the same channel as menu clicks so the device line
+    /// (recomputed from the live `AppState`, which only the task can read) is
+    /// rewritten on the main thread alongside the static labels.
     pub fn request_refresh() {
         post(MenuBarEvent::Refresh);
     }
@@ -214,26 +216,4 @@ mod macos {
             }
         });
     }
-}
-
-#[cfg(not(target_os = "macos"))]
-mod stub {
-    use tokio::sync::mpsc;
-
-    use super::MenuBarEvent;
-
-    pub struct MenuBarHandle;
-
-    impl MenuBarHandle {
-        pub fn set_device_status(&self, _text: &str) {}
-    }
-
-    #[must_use]
-    pub fn install(_tx: mpsc::UnboundedSender<MenuBarEvent>) -> MenuBarHandle {
-        MenuBarHandle
-    }
-
-    pub fn refresh_labels() {}
-
-    pub fn request_refresh() {}
 }

--- a/crates/openlogi-gui/src/platform/mod.rs
+++ b/crates/openlogi-gui/src/platform/mod.rs
@@ -1,6 +1,6 @@
 //! Platform and OS integration helpers.
 
 pub mod launch_agent;
-pub mod menubar;
 pub mod single_instance;
+pub mod tray;
 pub mod updater;

--- a/crates/openlogi-gui/src/platform/tray.rs
+++ b/crates/openlogi-gui/src/platform/tray.rs
@@ -1,16 +1,17 @@
-//! macOS menu-bar (`NSStatusItem`) presence via raw Cocoa FFI — GPUI exposes
-//! no status-bar API.
+//! System-tray / status-item presence. macOS-only today, via `NSStatusItem`
+//! (which lives in the menu bar) over raw Cocoa FFI — GPUI exposes no
+//! status-bar API.
 //!
-//! This whole feature is macOS-only: there is no cross-platform "menu bar"
-//! status item (Windows has the system tray / notification area, Linux the
-//! StatusNotifierItem spec), so the module carries no non-macOS stub — every
-//! caller gates on `cfg(target_os = "macos")` instead.
+//! `tray` is the cross-platform-neutral name: macOS has the menu-bar status
+//! item, Windows the system tray / notification area, Linux the
+//! StatusNotifierItem spec. Only macOS is implemented, so the module carries no
+//! stub — every caller gates on `cfg(target_os = "macos")` instead.
 //!
-//! Menu clicks can't reach GPUI's `App`, so they post a [`MenuBarEvent`] on a
+//! Menu clicks can't reach GPUI's `App`, so they post a [`TrayEvent`] on a
 //! channel that a dedicated task in `main.rs` drains.
 
 #[cfg(target_os = "macos")]
-pub use macos::{MenuBarEvent, install, refresh_labels, request_refresh, set_device_status};
+pub use macos::{TrayEvent, install, refresh_labels, request_refresh, set_device_status};
 
 #[cfg(target_os = "macos")]
 #[expect(
@@ -31,7 +32,7 @@ mod macos {
     /// A request raised by clicking a status-bar menu item, or by a live
     /// language switch asking the drain task to re-localize the whole menu.
     #[derive(Debug, Clone, Copy)]
-    pub enum MenuBarEvent {
+    pub enum TrayEvent {
         Open,
         Quit,
         /// Re-title Open/Quit *and* the device line for the current locale.
@@ -43,7 +44,7 @@ mod macos {
     const TARGET_CLASS: &str = "OpenLogiMenuTarget";
 
     // Read by the Objective-C action callbacks, which can't capture state.
-    static MENU_TX: OnceLock<mpsc::UnboundedSender<MenuBarEvent>> = OnceLock::new();
+    static MENU_TX: OnceLock<mpsc::UnboundedSender<TrayEvent>> = OnceLock::new();
 
     /// Open/Quit item pointers, kept so a live locale switch can re-title them.
     /// Stored as `usize` because a raw `id` is not `Sync`.
@@ -66,7 +67,7 @@ mod macos {
     /// in particular *must* be retained: `NSMenuItem` does not retain its
     /// target, so without this the action callbacks would fire into freed
     /// memory.
-    pub fn install(tx: mpsc::UnboundedSender<MenuBarEvent>) {
+    pub fn install(tx: mpsc::UnboundedSender<TrayEvent>) {
         let _ = MENU_TX.set(tx);
         ensure_target_class();
 
@@ -151,7 +152,7 @@ mod macos {
     /// (recomputed from the live `AppState`, which only the task can read) is
     /// rewritten on the main thread alongside the static labels.
     pub fn request_refresh() {
-        post(MenuBarEvent::Refresh);
+        post(TrayEvent::Refresh);
     }
 
     fn nsstring(s: &str) -> id {
@@ -183,14 +184,14 @@ mod macos {
     }
 
     extern "C" fn open_action(_this: &Object, _cmd: Sel, _sender: id) {
-        post(MenuBarEvent::Open);
+        post(TrayEvent::Open);
     }
 
     extern "C" fn quit_action(_this: &Object, _cmd: Sel, _sender: id) {
-        post(MenuBarEvent::Quit);
+        post(TrayEvent::Quit);
     }
 
-    fn post(event: MenuBarEvent) {
+    fn post(event: TrayEvent) {
         if let Some(tx) = MENU_TX.get()
             && tx.send(event).is_err()
         {

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -199,6 +199,7 @@ fn language_row(
                     // to re-localize the whole menu rather than writing from here.
                     cx.refresh_windows();
                     crate::app_menu::rebuild(cx);
+                    #[cfg(target_os = "macos")]
                     crate::platform::menubar::request_refresh();
                 }))
         })

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -200,7 +200,7 @@ fn language_row(
                     cx.refresh_windows();
                     crate::app_menu::rebuild(cx);
                     #[cfg(target_os = "macos")]
-                    crate::platform::menubar::request_refresh();
+                    crate::platform::tray::request_refresh();
                 }))
         })
         .collect();


### PR DESCRIPTION
Fixes the red `cargo check (linux)` + `clippy` jobs introduced by #4.

### Why it was red
The `NSStatusItem` menu-bar is macOS-only, but #4 modeled it as cross-platform behind a no-op stub. On non-macOS that left `MenuBarEvent`'s variants never constructed and the stub's `set_device_status` carrying an unused `&self` — both hard errors under `-D warnings`, while the macOS build stayed green (so it slipped through #4).

### The root fix (not lint annotations)
Make the whole feature `cfg(target_os = "macos")` so non-macOS compiles **zero** status-item code — the lints can't recur by construction:

- `MenuBarEvent` moves into the macOS module; the stub module is deleted.
- Drop `MenuBarHandle`; `set_device_status` is a free fn over a static. Retain the menu/target explicitly (`NSMenuItem` doesn't retain its target).
- Drain menu clicks in a dedicated macOS-only task instead of an inline `tokio::select!` arm (select branches can't be `#[cfg]`-gated).
- Gate the channel, install, device-line updates, `menubar_status`, and the settings-page refresh call.

Second commit renames the module `menubar` → `tray` (cross-platform-neutral: macOS menu-bar item, Windows system tray, Linux StatusNotifierItem). Pure rename, no behavior change.

### Verification
`cargo clippy --workspace --all-targets -- -D warnings` clean on macOS; the Linux/clippy path is confirmed by this PR's CI.