### PR TITLE
ci(release-plz): prune stale release branches before opening the PR

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -66,6 +66,26 @@ jobs:
         with:
           app-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
           private-key: ${{ steps.app_key.outputs.pem }}
+      # release-plz leaves its release branch behind after a release PR merges,
+      # and a leftover ref then makes the next `release-pr` fail with HTTP 422
+      # (so no PR is created). Prune any `release-plz-*` branch that no longer
+      # has an open PR — never the active release PR's branch — before running.
+      - name: Prune stale release-plz branches
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          for branch in $(gh api "repos/$REPO/branches" --paginate --jq '.[].name' \
+            | grep '^release-plz-' || true); do
+            open=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq 'length')
+            if [ "$open" = "0" ]; then
+              echo "Pruning stale release branch: $branch"
+              gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" \
+                || echo "::warning::could not delete $branch"
+            else
+              echo "Keeping $branch (open PR exists)"
+            fi
+          done
       - name: Run release-plz (release-pr)
         uses: release-plz/action@v0.5
         with:


### PR DESCRIPTION
### Problem
`release-plz release-pr` has been failing with **HTTP 422** and the job swallows it as a warning (`release-plz release-pr failed with HTTP 422; continuing with no PRs created` → `{"prs":[]}`), so **no release PR is created and releases silently stopped** (latest tag is still v0.1.2 despite merged feat/fix commits).

Root cause: a leftover `release-plz-2026-05-30T18-10-22Z` branch from the merged v0.1.1 release PR (#3) — release-plz collides with the stale ref when creating the next release branch/PR.

### Fix
Add a prune step to the `release-pr` job (after minting the GitHub App token, before `release-plz release-pr`): delete any `release-plz-*` branch that has **no open PR**, keeping the active release PR's branch untouched. The pipeline now self-heals instead of needing a manual branch deletion.

Merging this to master re-triggers release-plz with the prune step, which should clear the stale branch and finally open the pending release PR.

### Note
The pending release will be computed by release-plz from conventional commits — with the `feat(gui)` commits since 0.1.2 that's a **0.2.0** (minor) bump, not 0.1.3. Version decision to be made on the release PR it opens.