### PR TITLE
fix: refresh device inventory when reopening GUI

### DIFF
--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    AnyElement, AppContext as _, Context, Entity, FontWeight, InteractiveElement, IntoElement,
-    ParentElement, Render, SharedString, StatefulInteractiveElement as _, Styled, Subscription,
-    Window, div, px, rgb,
+    AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, FontWeight,
+    InteractiveElement, IntoElement, ParentElement, Render, SharedString,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, div, px, rgb,
 };
 use gpui_component::{Icon, IconName, h_flex, v_flex};
 use openlogi_core::config::Config;
@@ -45,6 +45,10 @@ impl AppView {
 
         if !cx.has_global::<AppState>() {
             cx.set_global(AppState::with_runtime(config, inventories, &cache));
+        } else if !inventories.is_empty() {
+            cx.update_global::<AppState, _>(|state, _| {
+                state.refresh_inventories(inventories, &cache);
+            });
         }
 
         if let Some(state) = cx.try_global::<AppState>() {

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -191,8 +191,8 @@ fn main() -> Result<()> {
             // Install the hook-shared AppState up front, then open the window at
             // launch; closing it leaves the app live in the menu bar.
             cx.update(|cx| {
+                let cache = asset::AssetResolver::new();
                 if !cx.has_global::<AppState>() {
-                    let cache = asset::AssetResolver::new();
                     cx.set_global(AppState::with_runtime_shared(
                         initial_config,
                         &inventories,
@@ -201,6 +201,10 @@ fn main() -> Result<()> {
                         gesture_bindings,
                         dpi_cycle,
                     ));
+                } else if !inventories.is_empty() {
+                    cx.update_global::<AppState, _>(|state, _| {
+                        state.refresh_inventories(&inventories, &cache);
+                    });
                 }
                 if !start_minimized {
                     open_main_window(&inventories, cx);
@@ -337,6 +341,27 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
 /// repeat call) re-focuses the live window instead of stacking a duplicate, and
 /// a window closed while the app kept running can be brought back.
 fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
+    let refreshed_inventories;
+    let inventories = if inventories.is_empty() {
+        refreshed_inventories = match enumerate_blocking() {
+            Ok(inventories) => inventories,
+            Err(e) => {
+                warn!(error = %e, "could not refresh inventory before opening window");
+                Vec::new()
+            }
+        };
+        refreshed_inventories.as_slice()
+    } else {
+        inventories
+    };
+
+    if !inventories.is_empty() && cx.has_global::<AppState>() {
+        let cache = asset::AssetResolver::new();
+        cx.update_global::<AppState, _>(|state, _| {
+            state.refresh_inventories(inventories, &cache);
+        });
+    }
+
     let existing = cx.default_global::<windows::WindowRegistry>().main;
     if let Some(handle) = existing {
         if handle


### PR DESCRIPTION
## Summary
- refresh the global `AppState` when a new `AppView` receives a non-empty inventory
- refresh inventory before focusing an existing main window opened via dock/tray reopen paths
- update the startup path so a pre-existing global state does not remain stale

## Test plan
- `cargo check -p openlogi-gui`

This is split from the MX Master 4 Bluetooth detection change so the GUI lifecycle fix can be reviewed independently.