### PR TITLE
fix(openlogi-hid): enumerate Bluetooth-LE-direct HID++ mice (Lift, Signature)

### DIFF
--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -11,12 +11,18 @@ pub async fn run(_args: ListArgs) -> Result<()> {
         .context("failed to enumerate HID++ devices")?;
 
     if inventories.is_empty() {
-        println!("No Logitech HID++ receivers found.");
+        println!("No Logitech HID++ devices found.");
         println!();
         println!("Notes:");
         println!("  - On macOS, quit Logi Options+ first — both apps fight over HID++ access.");
-        println!("  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548).");
-        println!("  - Devices paired directly over Bluetooth are not enumerated yet.");
+        println!(
+            "  - A Bluetooth-direct mouse (e.g. Lift, Signature) needs Input Monitoring \
+             permission: System Settings → Privacy & Security → Input Monitoring."
+        );
+        println!(
+            "  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other \
+             receivers (Unifying) aren't surfaced yet."
+        );
         std::process::exit(2);
     }
 

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -19,24 +19,86 @@ use tracing::debug;
 
 /// Logitech HID vendor ID.
 const LOGITECH_VID: u16 = 0x046d;
-/// HID++ long-report usage page / usage. Filtering on this pair gives us one
-/// HID node per physical HID++ device on every supported OS.
-const HIDPP_USAGE_PAGE: u16 = 0xff00;
-const HIDPP_LONG_USAGE_ID: u16 = 0x0002;
+/// HID++ long-report vendor collections, as `(usage_page, usage_id)` pairs.
+///
+/// Logitech exposes its HID++ long-report (report id `0x11`) under a
+/// vendor-defined HID collection, but the page differs by transport:
+///
+/// - `0xFF00 / 0x0002` — USB, Logi Bolt / Unifying receivers, and
+///   Bluetooth-*classic* devices (MX Master over BT).
+/// - `0xFF43 / 0x0202` — Bluetooth-*Low-Energy* directly-paired devices
+///   (e.g. the Logitech Lift / Signature mice). Same HID++ protocol, just a
+///   different vendor page on the BLE HID report descriptor.
+///
+/// Filtering on these pairs gives us one HID node per physical HID++ device on
+/// every supported OS, without reading report descriptors (`async-hid 0.4`
+/// only exposes those on Linux).
+const HIDPP_LONG_COLLECTIONS: [(u16, u16); 2] = [(0xff00, 0x0002), (0xff43, 0x0202)];
+
+/// The vendor usage page Logitech uses for HID++ over Bluetooth Low Energy.
+/// On macOS a BLE-direct device exposes *only* the long HID++ report (`0x11`)
+/// under this page — there is no short-report (`0x10`) collection — so this
+/// crate up-converts short HID++ requests to long for these channels (see
+/// [`AsyncHidChannel::write_report`]).
+const HIDPP_BLE_USAGE_PAGE: u16 = 0xff43;
+
+/// HID++ short / long report IDs and the long report's on-wire length
+/// (report id + 19 payload bytes). Mirrors `hidpp`'s private constants.
+const SHORT_REPORT_ID: u8 = 0x10;
+const LONG_REPORT_ID: u8 = 0x11;
+const LONG_REPORT_LEN: usize = 20;
+
+fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
+    HIDPP_LONG_COLLECTIONS.contains(&(usage_page, usage_id))
+}
+
+/// Re-frame a short HID++ report (`0x10`, 7 bytes) as a long one (`0x11`, 20
+/// bytes) for a transport that only exposes the long report.
+///
+/// `hidpp 0.2` always pings with — and often sends — short reports, but a
+/// BLE-direct device exposes only the long report on macOS, so a short
+/// `IOHIDDeviceSetReport` fails with `kIOReturnNotFound`. The header bytes
+/// (device / feature / function / sw id) sit at the same offsets in both
+/// widths; only the trailing payload is zero-padded. The device answers with a
+/// long report, which `hidpp` parses and matches by header regardless of width.
+///
+/// Returns `None` (pass the report through unchanged) when `src` isn't a short
+/// report or wouldn't fit the long frame.
+fn short_as_long(src: &[u8]) -> Option<[u8; LONG_REPORT_LEN]> {
+    if src.first() != Some(&SHORT_REPORT_ID) || src.len() > LONG_REPORT_LEN {
+        return None;
+    }
+    let mut long = [0u8; LONG_REPORT_LEN];
+    long[0] = LONG_REPORT_ID;
+    long[1..src.len()].copy_from_slice(&src[1..]);
+    Some(long)
+}
 
 pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, async_hid::HidError>
 {
     let backend = HidBackend::default();
-    Ok(backend
-        .enumerate()
-        .await?
+    let all: Vec<async_hid::Device> = backend.enumerate().await?.collect().await;
+
+    // One-time visibility into what the OS actually reports for Logitech nodes,
+    // so a transport that uses an unexpected vendor page (e.g. a new BLE mouse)
+    // can be diagnosed from `OPENLOGI_LOG=debug` without a rebuild.
+    for d in all.iter().filter(|d| d.vendor_id == LOGITECH_VID) {
+        debug!(
+            name = %d.name,
+            pid = format_args!("{:04x}", d.product_id),
+            usage_page = format_args!("{:#06x}", d.usage_page),
+            usage_id = format_args!("{:#06x}", d.usage_id),
+            matched = is_hidpp_long_collection(d.usage_page, d.usage_id),
+            "logitech HID node"
+        );
+    }
+
+    Ok(all
+        .into_iter()
         .filter(|d| {
-            d.vendor_id == LOGITECH_VID
-                && d.usage_page == HIDPP_USAGE_PAGE
-                && d.usage_id == HIDPP_LONG_USAGE_ID
+            d.vendor_id == LOGITECH_VID && is_hidpp_long_collection(d.usage_page, d.usage_id)
         })
-        .collect()
-        .await)
+        .collect())
 }
 
 pub(crate) async fn open_hidpp_channel(
@@ -46,7 +108,10 @@ pub(crate) async fn open_hidpp_channel(
     // keep using `dev` (which `to_device_info` would consume).
     let info: DeviceInfo = (*dev).clone();
     let (reader, writer) = dev.open().await?;
-    let raw = AsyncHidChannel::new(reader, writer, info.clone());
+    // BLE-direct devices expose only the long HID++ report; flag the channel so
+    // outgoing short requests get up-converted to long (see `write_report`).
+    let long_only = info.usage_page == HIDPP_BLE_USAGE_PAGE;
+    let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
     let channel = match HidppChannel::from_raw_channel(raw).await {
         Ok(c) => Arc::new(c),
         Err(e) => {
@@ -61,14 +126,23 @@ pub(crate) struct AsyncHidChannel {
     reader: Mutex<DeviceReader>,
     writer: Mutex<DeviceWriter>,
     info: DeviceInfo,
+    /// When set, outgoing short HID++ reports are rewritten as long ones — the
+    /// device (a BLE-direct peripheral) only exposes the long report on macOS.
+    long_only: bool,
 }
 
 impl AsyncHidChannel {
-    pub(crate) fn new(reader: DeviceReader, writer: DeviceWriter, info: DeviceInfo) -> Self {
+    pub(crate) fn new(
+        reader: DeviceReader,
+        writer: DeviceWriter,
+        info: DeviceInfo,
+        long_only: bool,
+    ) -> Self {
         Self {
             reader: Mutex::new(reader),
             writer: Mutex::new(writer),
             info,
+            long_only,
         }
     }
 }
@@ -85,7 +159,10 @@ impl RawHidChannel for AsyncHidChannel {
 
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error>> {
         let mut w = self.writer.lock().await;
-        w.write_output_report(src).await?;
+        match self.long_only.then(|| short_as_long(src)).flatten() {
+            Some(long) => w.write_output_report(&long).await?,
+            None => w.write_output_report(src).await?,
+        }
         Ok(src.len())
     }
 
@@ -100,5 +177,41 @@ impl RawHidChannel for AsyncHidChannel {
 
     async fn get_report_descriptor(&self, _buf: &mut [u8]) -> Result<usize, Box<dyn Error>> {
         Err("get_report_descriptor is not implemented; pre-filter to HID++ usage pages".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_both_usb_and_ble_hidpp_collections() {
+        assert!(is_hidpp_long_collection(0xff00, 0x0002)); // USB / receiver / BT-classic
+        assert!(is_hidpp_long_collection(0xff43, 0x0202)); // BLE-direct (Lift, Signature)
+        assert!(!is_hidpp_long_collection(0x0001, 0x0002)); // generic-desktop mouse
+        assert!(!is_hidpp_long_collection(0xff43, 0x0002)); // page right, usage wrong
+    }
+
+    #[test]
+    fn upconverts_short_report_preserving_header_and_padding() {
+        // [report id, device, feature, func|sw, p0, p1, p2]
+        let short = [SHORT_REPORT_ID, 0xff, 0x00, 0x1e, 0xaa, 0xbb, 0xcc];
+        let Some(long) = short_as_long(&short) else {
+            panic!("short report should up-convert");
+        };
+
+        assert_eq!(long[0], LONG_REPORT_ID);
+        assert_eq!(&long[1..7], &short[1..]); // header + payload copied verbatim
+        assert!(long[7..].iter().all(|&b| b == 0)); // remainder zero-padded
+        assert_eq!(long.len(), LONG_REPORT_LEN);
+    }
+
+    #[test]
+    fn passes_through_non_short_reports() {
+        // Already a long report — leave it alone.
+        let long_in = [LONG_REPORT_ID, 0xff, 0x00, 0x1e];
+        assert!(short_as_long(&long_in).is_none());
+        // Empty / unknown frames are passed through too.
+        assert!(short_as_long(&[]).is_none());
     }
 }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -19,7 +19,7 @@ use tracing::debug;
 
 /// Logitech HID vendor ID.
 const LOGITECH_VID: u16 = 0x046d;
-/// HID++ long-report vendor collections, as `(usage_page, usage_id)` pairs.
+/// HID++ long-report vendor collections, as `(usage_page, usage_id, long_only)`.
 ///
 /// Logitech exposes its HID++ long-report (report id `0x11`) under a
 /// vendor-defined HID collection, but the page differs by transport:
@@ -30,17 +30,18 @@ const LOGITECH_VID: u16 = 0x046d;
 ///   (e.g. the Logitech Lift / Signature mice). Same HID++ protocol, just a
 ///   different vendor page on the BLE HID report descriptor.
 ///
+/// `long_only` marks a transport that exposes *only* the long report — no
+/// short-report (`0x10`) collection — so short HID++ requests must be
+/// up-converted to long (see [`short_as_long`]). BLE-direct devices on macOS
+/// are long-only; USB / receiver devices carry both. Keeping the flag in this
+/// table means a new long-only transport is a single-line addition here, with
+/// no second site to update.
+///
 /// Filtering on these pairs gives us one HID node per physical HID++ device on
 /// every supported OS, without reading report descriptors (`async-hid 0.4`
 /// only exposes those on Linux).
-const HIDPP_LONG_COLLECTIONS: [(u16, u16); 2] = [(0xff00, 0x0002), (0xff43, 0x0202)];
-
-/// The vendor usage page Logitech uses for HID++ over Bluetooth Low Energy.
-/// On macOS a BLE-direct device exposes *only* the long HID++ report (`0x11`)
-/// under this page — there is no short-report (`0x10`) collection — so this
-/// crate up-converts short HID++ requests to long for these channels (see
-/// [`AsyncHidChannel::write_report`]).
-const HIDPP_BLE_USAGE_PAGE: u16 = 0xff43;
+const HIDPP_LONG_COLLECTIONS: [(u16, u16, bool); 2] =
+    [(0xff00, 0x0002, false), (0xff43, 0x0202, true)];
 
 /// HID++ short / long report IDs and the long report's on-wire length
 /// (report id + 19 payload bytes). Mirrors `hidpp`'s private constants.
@@ -48,8 +49,20 @@ const SHORT_REPORT_ID: u8 = 0x10;
 const LONG_REPORT_ID: u8 = 0x11;
 const LONG_REPORT_LEN: usize = 20;
 
+/// Whether `(usage_page, usage_id)` is one of the HID++ long-report collections.
 fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
-    HIDPP_LONG_COLLECTIONS.contains(&(usage_page, usage_id))
+    HIDPP_LONG_COLLECTIONS
+        .iter()
+        .any(|&(page, usage, _)| (page, usage) == (usage_page, usage_id))
+}
+
+/// Whether the matched HID++ collection exposes only the long report, so short
+/// requests must be re-framed as long (see [`short_as_long`]). `false` for
+/// pages not in [`HIDPP_LONG_COLLECTIONS`].
+fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
+    HIDPP_LONG_COLLECTIONS
+        .iter()
+        .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
 }
 
 /// Re-frame a short HID++ report (`0x10`, 7 bytes) as a long one (`0x11`, 20
@@ -110,7 +123,7 @@ pub(crate) async fn open_hidpp_channel(
     let (reader, writer) = dev.open().await?;
     // BLE-direct devices expose only the long HID++ report; flag the channel so
     // outgoing short requests get up-converted to long (see `write_report`).
-    let long_only = info.usage_page == HIDPP_BLE_USAGE_PAGE;
+    let long_only = is_long_only_collection(info.usage_page, info.usage_id);
     let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
     let channel = match HidppChannel::from_raw_channel(raw).await {
         Ok(c) => Arc::new(c),
@@ -190,6 +203,13 @@ mod tests {
         assert!(is_hidpp_long_collection(0xff43, 0x0202)); // BLE-direct (Lift, Signature)
         assert!(!is_hidpp_long_collection(0x0001, 0x0002)); // generic-desktop mouse
         assert!(!is_hidpp_long_collection(0xff43, 0x0002)); // page right, usage wrong
+    }
+
+    #[test]
+    fn only_ble_collection_is_long_only() {
+        assert!(is_long_only_collection(0xff43, 0x0202)); // BLE-direct → up-convert short→long
+        assert!(!is_long_only_collection(0xff00, 0x0002)); // USB / receiver carries both reports
+        assert!(!is_long_only_collection(0x0001, 0x0002)); // not a HID++ collection at all
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bluetooth-LE-direct Logitech mice (e.g. **Logitech Lift**, Signature series)
were never enumerated — `list` reported "no devices" even with the mouse
connected and working. This makes them fully controllable (inventory,
battery, DPI) without a Bolt receiver.

## Root cause

Three layered issues, found by inspecting what macOS actually reports for a
BLE-connected Lift:

1. **Enumeration filter too narrow.** Over USB / receivers / BT-classic,
   Logitech exposes its HID++ long-report collection under usage page
   `0xFF00 / 0x0002`. Over **BLE it uses `0xFF43 / 0x0202`** instead, so the
   device was filtered out before it was ever probed.
2. **Short report doesn't exist on BLE.** On macOS the BLE device exposes
   **only the long report (`0x11`)** — there is no short-report (`0x10`)
   collection. `hidpp 0.2`'s `determine_version()` hardcodes a *short*-report
   ping with no long fallback, so `IOHIDDeviceSetReport` returns
   `kIOReturnNotFound`.
3. (Environmental) BLE-direct mice also expose Generic-Desktop collections, so
   macOS requires **Input Monitoring** permission to open them — unlike a Bolt
   receiver, which is a vendor device.

## Changes

- **`transport.rs`** — broaden the enumeration filter to accept both the
  USB/receiver (`0xFF00/0x0002`) and BLE (`0xFF43/0x0202`) HID++ vendor
  collections. Add a `long_only` channel flag (set when `usage_page == 0xFF43`)
  that **up-converts outgoing short HID++ reports to long** (`0x11`, zero-padded,
  same header bytes). The device answers with a long report, which `hidpp`
  parses and matches by header regardless of width — the same long-only
  approach Solaar uses over BLE. The receiver/USB path is byte-for-byte
  unchanged. Adds unit tests for the filter and the up-conversion.
- **`list.rs`** — refresh the "no devices" hint: BLE-direct mice need Input
  Monitoring permission; drop the stale "Bluetooth not enumerated" note.

## Testing

Verified on a real **Logitech Lift** (BLE-direct, `046d:b031`, config key `2b031`):

- `list` — device, kind, online, **battery 45%** ✓
- `diag features` — 32 HID++ features dumped (incl. `0x2201` DPI, `0x1b04`
  reprog controls; no `0x2111`, so no SmartShift — expected for the Lift) ✓
- `diag dpi` — read 1000 → write 1200 → read-back 1200 → restore 1000 ✓
- GUI enumerates and renders the device (hotspots, DPI, battery) ✓

`cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, and
`cargo test` all pass.

## Follow-up (not in this PR)

This fixes HID++ *control* for BLE-direct mice. The device render for the
Lift (`2b031`) isn't in the asset registry on `assets.openlogi.org` yet, so
the GUI falls back to the synthetic silhouette — functional, just no photo.
Adding `2b031` to the asset host is a separate follow-up.
