### PR TITLE
fix: correct MX Master 4 B PID (0xb048) and harden BLE detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "hidpp",
  "openlogi-core",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -11,12 +11,18 @@ pub async fn run(_args: ListArgs) -> Result<()> {
         .context("failed to enumerate HID++ devices")?;
 
     if inventories.is_empty() {
-        println!("No Logitech HID++ receivers found.");
+        println!("No Logitech HID++ devices found.");
         println!();
         println!("Notes:");
         println!("  - On macOS, quit Logi Options+ first — both apps fight over HID++ access.");
-        println!("  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548).");
-        println!("  - Devices paired directly over Bluetooth are not enumerated yet.");
+        println!(
+            "  - A Bluetooth-direct mouse (e.g. Lift, Signature) needs Input Monitoring \
+             permission: System Settings → Privacy & Security → Input Monitoring."
+        );
+        println!(
+            "  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other \
+             receivers (Unifying) aren't surfaced yet."
+        );
         std::process::exit(2);
     }
 

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -11,7 +11,9 @@ use gpui::{
     ParentElement as _, Render, SharedString, Size, StatefulInteractiveElement as _, Styled as _,
     Subscription, Window, div, px, rgb,
 };
-use gpui_component::{Icon, IconName, group_box::GroupBox, h_flex, switch::Switch, v_flex};
+use gpui_component::{
+    Icon, IconName, group_box::GroupBox, h_flex, scroll::ScrollableElement, switch::Switch, v_flex,
+};
 
 use crate::state::AppState;
 use crate::theme::{self, Palette};
@@ -119,19 +121,24 @@ impl Render for SettingsView {
             .size_full()
             .bg(pal.bg)
             .text_color(pal.text_primary)
-            .p_6()
-            .gap_6()
             .child(
-                div()
-                    .text_lg()
-                    .font_weight(FontWeight::SEMIBOLD)
-                    .child(tr!("Settings")),
-            )
-            .child(general)
-            .child(
-                GroupBox::new()
-                    .title(group_title(IconName::Globe, tr!("Language")))
-                    .child(language_row(language.as_deref(), pal, cx)),
+                v_flex()
+                    .w_full()
+                    .p_6()
+                    .gap_6()
+                    .overflow_y_scrollbar()
+                    .child(
+                        div()
+                            .text_lg()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(tr!("Settings")),
+                    )
+                    .child(general)
+                    .child(
+                        GroupBox::new()
+                            .title(group_title(IconName::Globe, tr!("Language")))
+                            .child(language_row(language.as_deref(), pal, cx)),
+                    ),
             )
     }
 }

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -16,6 +16,7 @@ hidpp = { workspace = true }
 async-hid = { workspace = true }
 tokio = { workspace = true }
 futures-lite = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -24,7 +24,7 @@ use openlogi_core::device::{
 };
 use thiserror::Error;
 use tokio::time::timeout;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::route::DIRECT_DEVICE_INDEX;
 use crate::transport::{enumerate_hidpp_devices, is_logitech_mouse, open_hidpp_channel};
@@ -248,7 +248,7 @@ fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
         return Vec::new();
     }
 
-    info!("hidutil found MX Master 4 B (BLE-direct) — synthesising inventory");
+    debug!("hidutil found MX Master 4 B (BLE-direct) — synthesising inventory");
     vec![synthetic_direct_mouse_inventory(
         MX_MASTER_4_NAME,
         MX_MASTER_4_PID,

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -1,6 +1,6 @@
 //! Enumerate connected HID++ receivers and their paired devices.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, process::Command, sync::Arc, time::Duration};
 
 use hidpp::{
     channel::HidppChannel,
@@ -27,7 +27,7 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::route::DIRECT_DEVICE_INDEX;
-use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
+use crate::transport::{enumerate_hidpp_devices, is_logitech_mouse, open_hidpp_channel};
 
 /// How long to wait for device-arrival event bursts before assuming the
 /// receiver has finished reporting. MX Master 4 (and other devices that may
@@ -38,6 +38,10 @@ const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
 /// Maximum number of pairing slots a Bolt receiver supports. We iterate this
 /// range to surface paired-but-offline devices that won't fire arrival events.
 const MAX_BOLT_SLOTS: u8 = 6;
+const LOGITECH_VID: u16 = 0x046d;
+const MX_MASTER_4_PID: u16 = 0xb042;
+const MX_MASTER_4_EXT_MODEL_ID: u8 = 0x02;
+const MX_MASTER_4_NAME: &str = "MX Master 4";
 
 #[derive(Debug, Error)]
 pub enum InventoryError {
@@ -73,6 +77,13 @@ pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
         }
     }
 
+    if inventories.is_empty() {
+        let fallback = hidutil_direct_mouse_fallback();
+        if !fallback.is_empty() {
+            return Ok(fallback);
+        }
+    }
+
     Ok(inventories)
 }
 
@@ -86,7 +97,9 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
         // addresses the device's own features. Probe in case it answers.
         // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-        return Ok(probe_direct(channel, &info).await);
+        return Ok(probe_direct(Arc::clone(&channel), &info)
+            .await
+            .or_else(|| fallback_direct_mouse(&info)));
     };
 
     let unique_id = bolt.get_unique_id().await.ok();
@@ -160,6 +173,110 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         },
         paired,
     }))
+}
+
+fn fallback_direct_mouse(info: &async_hid::DeviceInfo) -> Option<DeviceInventory> {
+    if !is_logitech_mouse(info) || info.product_id != MX_MASTER_4_PID {
+        return None;
+    }
+
+    debug!(
+        name = %info.name,
+        vid = format_args!("{:04x}", info.vendor_id),
+        pid = format_args!("{:04x}", info.product_id),
+        "Logitech mouse exposed only as a generic HID mouse; adding HID-only fallback"
+    );
+
+    Some(synthetic_direct_mouse_inventory(
+        &info.name,
+        info.product_id,
+        MX_MASTER_4_EXT_MODEL_ID,
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
+    let Ok(output) = Command::new("/usr/bin/hidutil")
+        .args([
+            "list",
+            "--ndjson",
+            "--matching",
+            r#"{"VendorID":0x046d,"ProductID":0xb042}"#,
+        ])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() || !hidutil_lists_mx_master_4(&output.stdout) {
+        return Vec::new();
+    }
+
+    debug!("hidutil found MX Master 4 after HID enumeration returned no inventories");
+    vec![synthetic_direct_mouse_inventory(
+        MX_MASTER_4_NAME,
+        MX_MASTER_4_PID,
+        MX_MASTER_4_EXT_MODEL_ID,
+    )]
+}
+
+#[cfg(not(target_os = "macos"))]
+fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
+    Vec::new()
+}
+
+#[cfg(target_os = "macos")]
+fn hidutil_lists_mx_master_4(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout).lines().any(|line| {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            return false;
+        };
+        value.get("Product").and_then(|v| v.as_str()) == Some(MX_MASTER_4_NAME)
+            && value.get("VendorID").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(LOGITECH_VID))
+            && value.get("ProductID").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(MX_MASTER_4_PID))
+            && value
+                .get("PrimaryUsagePage")
+                .and_then(serde_json::Value::as_u64)
+                == Some(1)
+            && value
+                .get("PrimaryUsage")
+                .and_then(serde_json::Value::as_u64)
+                == Some(2)
+    })
+}
+
+fn synthetic_direct_mouse_inventory(
+    name: &str,
+    product_id: u16,
+    extended_model_id: u8,
+) -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: name.to_string(),
+            vendor_id: LOGITECH_VID,
+            product_id,
+            unique_id: None,
+        },
+        paired: vec![PairedDevice {
+            slot: DIRECT_DEVICE_INDEX,
+            codename: Some(name.to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 0,
+                unit_id: [0; 4],
+                transports: DeviceTransports {
+                    btle: true,
+                    ..DeviceTransports::default()
+                },
+                model_ids: [product_id, 0, 0],
+                extended_model_id,
+            }),
+        }],
+    }
 }
 
 /// Probe a HID++ channel that doesn't host a Bolt receiver — for
@@ -388,5 +505,26 @@ fn map_battery_status(status: HidppBatteryStatus) -> BatteryStatus {
         HidppBatteryStatus::Full => BatteryStatus::Full,
         HidppBatteryStatus::Error => BatteryStatus::Error,
         _ => BatteryStatus::Unknown,
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hidutil_parser_matches_mx_master_4_mouse_node() {
+        let stdout = br#"{"Product":"MX Master 4","VendorID":1133,"IOClass":"IOHIDUserDevice","type":"device","PrimaryUsage":2,"PrimaryUsagePage":1,"Transport":"Bluetooth Low Energy","ProductID":45122}
+"#;
+
+        assert!(hidutil_lists_mx_master_4(stdout));
+    }
+
+    #[test]
+    fn hidutil_parser_rejects_other_logitech_mouse() {
+        let stdout = br#"{"Product":"MX Master 3","VendorID":1133,"IOClass":"IOHIDUserDevice","type":"device","PrimaryUsage":2,"PrimaryUsagePage":1,"Transport":"Bluetooth Low Energy","ProductID":45091}
+"#;
+
+        assert!(!hidutil_lists_mx_master_4(stdout));
     }
 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -38,9 +38,15 @@ const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
 /// Maximum number of pairing slots a Bolt receiver supports. We iterate this
 /// range to surface paired-but-offline devices that won't fire arrival events.
 const MAX_BOLT_SLOTS: u8 = 6;
+
+/// Logitech vendor ID (mirrors `transport::LOGITECH_VID`; local copy avoids
+/// a `pub(crate)` re-export just for this module).
 const LOGITECH_VID: u16 = 0x046d;
-const MX_MASTER_4_PID: u16 = 0xb048;  // MX Master 4 B (Bluetooth-direct)
+/// MX Master 4 B (Bluetooth-direct) ProductID — distinct from 0xb042 which is
+/// the USB cable / Bolt-receiver variant of the same device family.
+const MX_MASTER_4_PID: u16 = 0xb048;
 const MX_MASTER_4_EXT_MODEL_ID: u8 = 0x02;
+/// Product name as reported by macOS for the BLE-direct variant.
 const MX_MASTER_4_NAME: &str = "MX Master 4 B";
 
 #[derive(Debug, Error)]
@@ -77,30 +83,151 @@ pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
         }
     }
 
-    // Run the hidutil fallback whenever the MX Master 4 B is absent from the
-    // inventory, not only when the whole list is empty. A user with a Bolt
-    // receiver attached alongside a BLE-paired MX Master 4 B would otherwise
-    // have the Bolt path populate `inventories` and suppress this fallback,
-    // leaving the BLE device undetected.
+    // Run the hidutil fallback whenever MX Master 4 B is absent — not only when
+    // the list is empty. A Bolt receiver attached alongside the BLE-paired
+    // MX Master 4 B would otherwise populate `inventories` and suppress this
+    // fallback, leaving the BLE device undetected.
     let already_has_mx4b = inventories.iter().any(|inv| {
         inv.receiver.product_id == MX_MASTER_4_PID
-            || inv
-                .paired
-                .iter()
-                .any(|p| p.model_info.as_ref().is_some_and(|m| m.model_ids[0] == MX_MASTER_4_PID))
+            || inv.paired.iter().any(|p| {
+                p.model_info
+                    .as_ref()
+                    .is_some_and(|m| m.model_ids[0] == MX_MASTER_4_PID)
+            })
     });
     if !already_has_mx4b {
         // spawn_blocking so the synchronous hidutil shell-out does not stall
-        // the async executor (tokio current-thread or multi-thread).
+        // the async executor.
         let fallback = tokio::task::spawn_blocking(hidutil_direct_mouse_fallback)
             .await
             .unwrap_or_default();
-        if !fallback.is_empty() {
-            inventories.extend(fallback);
-        }
+        inventories.extend(fallback);
     }
 
     Ok(inventories)
+}
+
+/// Synthesise a `DeviceInventory` for a Logitech generic-desktop mouse node
+/// when `probe_direct` returned `None` (device doesn't speak HID++).
+/// Only fires for the MX Master 4 B PID to keep the scope narrow.
+fn fallback_direct_mouse(info: &async_hid::DeviceInfo) -> Option<DeviceInventory> {
+    if !is_logitech_mouse(info) || info.product_id != MX_MASTER_4_PID {
+        return None;
+    }
+    debug!(
+        name = %info.name,
+        pid = format_args!("{:04x}", info.product_id),
+        "Logitech mouse node has no HID++ collection — using synthetic inventory"
+    );
+    Some(synthetic_direct_mouse_inventory(
+        &info.name,
+        info.product_id,
+        MX_MASTER_4_EXT_MODEL_ID,
+    ))
+}
+
+/// Last-resort fallback: shell out to `hidutil list --ndjson` on macOS to check
+/// whether the MX Master 4 B is connected when the HID enumerate path returned
+/// nothing (e.g. because `async-hid` couldn't open the device node).
+///
+/// Confirmed working on macOS 13 (Ventura) and later; `--ndjson` was added no
+/// later than macOS 10.15. On non-macOS this is a no-op.
+#[cfg(target_os = "macos")]
+fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
+    use std::process::Command;
+    let output = match Command::new("/usr/bin/hidutil")
+        .args([
+            "list",
+            "--ndjson",
+            "--matching",
+            // VendorID 0x046d = Logitech; ProductID 0xb048 = MX Master 4 B
+            r#"{"VendorID":0x046d,"ProductID":0xb048}"#,
+        ])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            debug!(error = %e, "hidutil unavailable; skipping MX Master 4 B fallback");
+            return Vec::new();
+        }
+    };
+    if !output.status.success() {
+        debug!(
+            status = %output.status,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "hidutil exited non-zero (--ndjson requires macOS 10.15+)"
+        );
+        return Vec::new();
+    }
+    if !hidutil_lists_mx_master_4b(&output.stdout) {
+        return Vec::new();
+    }
+    debug!("hidutil found MX Master 4 B (BLE-direct) — synthesising inventory");
+    vec![synthetic_direct_mouse_inventory(
+        MX_MASTER_4_NAME,
+        MX_MASTER_4_PID,
+        MX_MASTER_4_EXT_MODEL_ID,
+    )]
+}
+
+#[cfg(not(target_os = "macos"))]
+fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
+    Vec::new()
+}
+
+#[cfg(target_os = "macos")]
+fn hidutil_lists_mx_master_4b(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout).lines().any(|line| {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            return false;
+        };
+        value.get("Product").and_then(|v| v.as_str()) == Some(MX_MASTER_4_NAME)
+            && value.get("VendorID").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(LOGITECH_VID))
+            && value.get("ProductID").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(MX_MASTER_4_PID))
+            && value
+                .get("PrimaryUsagePage")
+                .and_then(serde_json::Value::as_u64)
+                == Some(1)
+            && value
+                .get("PrimaryUsage")
+                .and_then(serde_json::Value::as_u64)
+                == Some(2)
+    })
+}
+
+fn synthetic_direct_mouse_inventory(
+    name: &str,
+    product_id: u16,
+    extended_model_id: u8,
+) -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: name.to_string(),
+            vendor_id: LOGITECH_VID,
+            product_id,
+            unique_id: None,
+        },
+        paired: vec![PairedDevice {
+            slot: DIRECT_DEVICE_INDEX,
+            codename: Some(name.to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 0,
+                unit_id: [0; 4],
+                transports: DeviceTransports {
+                    btle: true,
+                    ..DeviceTransports::default()
+                },
+                model_ids: [product_id, 0, 0],
+                extended_model_id,
+            }),
+        }],
+    }
 }
 
 async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, InventoryError> {
@@ -189,131 +316,6 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         },
         paired,
     }))
-}
-
-fn fallback_direct_mouse(info: &async_hid::DeviceInfo) -> Option<DeviceInventory> {
-    if !is_logitech_mouse(info) || info.product_id != MX_MASTER_4_PID {
-        return None;
-    }
-
-    debug!(
-        name = %info.name,
-        vid = format_args!("{:04x}", info.vendor_id),
-        pid = format_args!("{:04x}", info.product_id),
-        "Logitech mouse exposed only as a generic HID mouse; adding HID-only fallback"
-    );
-
-    Some(synthetic_direct_mouse_inventory(
-        &info.name,
-        info.product_id,
-        MX_MASTER_4_EXT_MODEL_ID,
-    ))
-}
-
-/// Confirmed working on macOS 13 (Ventura) and later.
-/// `hidutil list --ndjson` was introduced no later than macOS 10.15; if
-/// `hidutil` exits non-zero (unsupported flag, sandbox denial, etc.) we log
-/// the failure and return an empty vec rather than silently swallowing it.
-#[cfg(target_os = "macos")]
-fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
-    use std::process::Command;
-    let output = match Command::new("/usr/bin/hidutil")
-        .args([
-            "list",
-            "--ndjson",
-            "--matching",
-            // VendorID 0x046d = Logitech; ProductID 0xb048 = MX Master 4 B
-            // (Bluetooth-direct). This is distinct from 0xb042 which is the
-            // USB / Bolt-receiver variant.
-            r#"{"VendorID":0x046d,"ProductID":0xb048}"#,
-        ])
-        .output()
-    {
-        Ok(o) => o,
-        Err(e) => {
-            debug!(error = %e, "hidutil unavailable; skipping MX Master 4 B fallback");
-            return Vec::new();
-        }
-    };
-    if !output.status.success() {
-        debug!(
-            status = %output.status,
-            stderr = %String::from_utf8_lossy(&output.stderr),
-            "hidutil exited non-zero; skipping MX Master 4 B fallback \
-             (--ndjson requires macOS 10.15+)"
-        );
-        return Vec::new();
-    }
-    if !hidutil_lists_mx_master_4(&output.stdout) {
-        return Vec::new();
-    }
-
-    debug!("hidutil found MX Master 4 B (BLE-direct) — synthesising inventory");
-    vec![synthetic_direct_mouse_inventory(
-        MX_MASTER_4_NAME,
-        MX_MASTER_4_PID,
-        MX_MASTER_4_EXT_MODEL_ID,
-    )]
-}
-
-#[cfg(not(target_os = "macos"))]
-fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
-    Vec::new()
-}
-
-#[cfg(target_os = "macos")]
-fn hidutil_lists_mx_master_4(stdout: &[u8]) -> bool {
-    String::from_utf8_lossy(stdout).lines().any(|line| {
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            return false;
-        };
-        value.get("Product").and_then(|v| v.as_str()) == Some(MX_MASTER_4_NAME)
-            && value.get("VendorID").and_then(serde_json::Value::as_u64)
-                == Some(u64::from(LOGITECH_VID))
-            && value.get("ProductID").and_then(serde_json::Value::as_u64)
-                == Some(u64::from(MX_MASTER_4_PID))
-            && value
-                .get("PrimaryUsagePage")
-                .and_then(serde_json::Value::as_u64)
-                == Some(1)
-            && value
-                .get("PrimaryUsage")
-                .and_then(serde_json::Value::as_u64)
-                == Some(2)
-    })
-}
-
-fn synthetic_direct_mouse_inventory(
-    name: &str,
-    product_id: u16,
-    extended_model_id: u8,
-) -> DeviceInventory {
-    DeviceInventory {
-        receiver: ReceiverInfo {
-            name: name.to_string(),
-            vendor_id: LOGITECH_VID,
-            product_id,
-            unique_id: None,
-        },
-        paired: vec![PairedDevice {
-            slot: DIRECT_DEVICE_INDEX,
-            codename: Some(name.to_string()),
-            wpid: None,
-            kind: DeviceKind::Mouse,
-            online: true,
-            battery: None,
-            model_info: Some(DeviceModelInfo {
-                entity_count: 0,
-                unit_id: [0; 4],
-                transports: DeviceTransports {
-                    btle: true,
-                    ..DeviceTransports::default()
-                },
-                model_ids: [product_id, 0, 0],
-                extended_model_id,
-            }),
-        }],
-    }
 }
 
 /// Probe a HID++ channel that doesn't host a Bolt receiver — for
@@ -542,26 +544,5 @@ fn map_battery_status(status: HidppBatteryStatus) -> BatteryStatus {
         HidppBatteryStatus::Full => BatteryStatus::Full,
         HidppBatteryStatus::Error => BatteryStatus::Error,
         _ => BatteryStatus::Unknown,
-    }
-}
-
-#[cfg(all(test, target_os = "macos"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn hidutil_parser_matches_mx_master_4_mouse_node() {
-        let stdout = br#"{"Product":"MX Master 4 B","VendorID":1133,"IOClass":"IOHIDUserDevice","type":"device","PrimaryUsage":2,"PrimaryUsagePage":1,"Transport":"Bluetooth Low Energy","ProductID":45128}
-"#;
-
-        assert!(hidutil_lists_mx_master_4(stdout));
-    }
-
-    #[test]
-    fn hidutil_parser_rejects_other_logitech_mouse() {
-        let stdout = br#"{"Product":"MX Master 3","VendorID":1133,"IOClass":"IOHIDUserDevice","type":"device","PrimaryUsage":2,"PrimaryUsagePage":1,"Transport":"Bluetooth Low Energy","ProductID":45091}
-"#;
-
-        assert!(!hidutil_lists_mx_master_4(stdout));
     }
 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -1,6 +1,6 @@
 //! Enumerate connected HID++ receivers and their paired devices.
 
-use std::{collections::HashMap, process::Command, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use hidpp::{
     channel::HidppChannel,
@@ -24,7 +24,7 @@ use openlogi_core::device::{
 };
 use thiserror::Error;
 use tokio::time::timeout;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::route::DIRECT_DEVICE_INDEX;
 use crate::transport::{enumerate_hidpp_devices, is_logitech_mouse, open_hidpp_channel};
@@ -39,9 +39,9 @@ const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
 /// range to surface paired-but-offline devices that won't fire arrival events.
 const MAX_BOLT_SLOTS: u8 = 6;
 const LOGITECH_VID: u16 = 0x046d;
-const MX_MASTER_4_PID: u16 = 0xb042;
+const MX_MASTER_4_PID: u16 = 0xb048;  // MX Master 4 B (Bluetooth-direct)
 const MX_MASTER_4_EXT_MODEL_ID: u8 = 0x02;
-const MX_MASTER_4_NAME: &str = "MX Master 4";
+const MX_MASTER_4_NAME: &str = "MX Master 4 B";
 
 #[derive(Debug, Error)]
 pub enum InventoryError {
@@ -77,10 +77,26 @@ pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
         }
     }
 
-    if inventories.is_empty() {
-        let fallback = hidutil_direct_mouse_fallback();
+    // Run the hidutil fallback whenever the MX Master 4 B is absent from the
+    // inventory, not only when the whole list is empty. A user with a Bolt
+    // receiver attached alongside a BLE-paired MX Master 4 B would otherwise
+    // have the Bolt path populate `inventories` and suppress this fallback,
+    // leaving the BLE device undetected.
+    let already_has_mx4b = inventories.iter().any(|inv| {
+        inv.receiver.product_id == MX_MASTER_4_PID
+            || inv
+                .paired
+                .iter()
+                .any(|p| p.model_info.as_ref().is_some_and(|m| m.model_ids[0] == MX_MASTER_4_PID))
+    });
+    if !already_has_mx4b {
+        // spawn_blocking so the synchronous hidutil shell-out does not stall
+        // the async executor (tokio current-thread or multi-thread).
+        let fallback = tokio::task::spawn_blocking(hidutil_direct_mouse_fallback)
+            .await
+            .unwrap_or_default();
         if !fallback.is_empty() {
-            return Ok(fallback);
+            inventories.extend(fallback);
         }
     }
 
@@ -194,24 +210,45 @@ fn fallback_direct_mouse(info: &async_hid::DeviceInfo) -> Option<DeviceInventory
     ))
 }
 
+/// Confirmed working on macOS 13 (Ventura) and later.
+/// `hidutil list --ndjson` was introduced no later than macOS 10.15; if
+/// `hidutil` exits non-zero (unsupported flag, sandbox denial, etc.) we log
+/// the failure and return an empty vec rather than silently swallowing it.
 #[cfg(target_os = "macos")]
 fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
-    let Ok(output) = Command::new("/usr/bin/hidutil")
+    use std::process::Command;
+    let output = match Command::new("/usr/bin/hidutil")
         .args([
             "list",
             "--ndjson",
             "--matching",
-            r#"{"VendorID":0x046d,"ProductID":0xb042}"#,
+            // VendorID 0x046d = Logitech; ProductID 0xb048 = MX Master 4 B
+            // (Bluetooth-direct). This is distinct from 0xb042 which is the
+            // USB / Bolt-receiver variant.
+            r#"{"VendorID":0x046d,"ProductID":0xb048}"#,
         ])
         .output()
-    else {
-        return Vec::new();
+    {
+        Ok(o) => o,
+        Err(e) => {
+            debug!(error = %e, "hidutil unavailable; skipping MX Master 4 B fallback");
+            return Vec::new();
+        }
     };
-    if !output.status.success() || !hidutil_lists_mx_master_4(&output.stdout) {
+    if !output.status.success() {
+        debug!(
+            status = %output.status,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "hidutil exited non-zero; skipping MX Master 4 B fallback \
+             (--ndjson requires macOS 10.15+)"
+        );
+        return Vec::new();
+    }
+    if !hidutil_lists_mx_master_4(&output.stdout) {
         return Vec::new();
     }
 
-    debug!("hidutil found MX Master 4 after HID enumeration returned no inventories");
+    info!("hidutil found MX Master 4 B (BLE-direct) — synthesising inventory");
     vec![synthetic_direct_mouse_inventory(
         MX_MASTER_4_NAME,
         MX_MASTER_4_PID,
@@ -514,7 +551,7 @@ mod tests {
 
     #[test]
     fn hidutil_parser_matches_mx_master_4_mouse_node() {
-        let stdout = br#"{"Product":"MX Master 4","VendorID":1133,"IOClass":"IOHIDUserDevice","type":"device","PrimaryUsage":2,"PrimaryUsagePage":1,"Transport":"Bluetooth Low Energy","ProductID":45122}
+        let stdout = br#"{"Product":"MX Master 4 B","VendorID":1133,"IOClass":"IOHIDUserDevice","type":"device","PrimaryUsage":2,"PrimaryUsagePage":1,"Transport":"Bluetooth Low Energy","ProductID":45128}
 "#;
 
         assert!(hidutil_lists_mx_master_4(stdout));

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -37,6 +37,23 @@ pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, 
         .await)
 }
 
+/// Return `true` for HID nodes that should enter the `probe_one` path.
+///
+/// Two kinds are admitted:
+/// 1. HID++ long-report collection (`0xFF00 / 0x0002`) — the established path
+///    for receivers, USB-direct, and BT-classic devices.
+/// 2. Logitech generic-desktop mouse (`0x0001 / 0x0002`) — added to surface
+///    BLE-direct devices (e.g. MX Master 4 B) whose macOS BLE HID descriptor
+///    does not expose a vendor HID++ collection.
+///
+/// **Invariant:** admitting a generic-desktop node is safe only because
+/// `probe_one` is resilient to non-HID++ endpoints — `open_hidpp_channel`
+/// returns `None` when the channel does not speak HID++, and
+/// `fallback_direct_mouse` in `inventory.rs` re-filters by a known-good PID
+/// before synthesising an inventory. Any future widening of
+/// `fallback_direct_mouse` to additional PIDs must re-verify that the
+/// corresponding devices tolerate `open_hidpp_channel`'s probe writes (or
+/// adjust `supports_short_long_hidpp` accordingly).
 fn is_hidpp_candidate(d: &DeviceInfo) -> bool {
     (d.usage_page == HIDPP_USAGE_PAGE && d.usage_id == HIDPP_LONG_USAGE_ID) || is_logitech_mouse(d)
 }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -23,6 +23,8 @@ const LOGITECH_VID: u16 = 0x046d;
 /// HID node per physical HID++ device on every supported OS.
 const HIDPP_USAGE_PAGE: u16 = 0xff00;
 const HIDPP_LONG_USAGE_ID: u16 = 0x0002;
+pub(crate) const HID_GENERIC_DESKTOP: u16 = 0x0001;
+pub(crate) const HID_MOUSE_USAGE_ID: u16 = 0x0002;
 
 pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, async_hid::HidError>
 {
@@ -30,13 +32,19 @@ pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, 
     Ok(backend
         .enumerate()
         .await?
-        .filter(|d| {
-            d.vendor_id == LOGITECH_VID
-                && d.usage_page == HIDPP_USAGE_PAGE
-                && d.usage_id == HIDPP_LONG_USAGE_ID
-        })
+        .filter(|d| d.vendor_id == LOGITECH_VID && is_hidpp_candidate(d))
         .collect()
         .await)
+}
+
+fn is_hidpp_candidate(d: &DeviceInfo) -> bool {
+    (d.usage_page == HIDPP_USAGE_PAGE && d.usage_id == HIDPP_LONG_USAGE_ID) || is_logitech_mouse(d)
+}
+
+pub(crate) fn is_logitech_mouse(d: &DeviceInfo) -> bool {
+    d.vendor_id == LOGITECH_VID
+        && d.usage_page == HID_GENERIC_DESKTOP
+        && d.usage_id == HID_MOUSE_USAGE_ID
 }
 
 pub(crate) async fn open_hidpp_channel(

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -19,49 +19,118 @@ use tracing::debug;
 
 /// Logitech HID vendor ID.
 const LOGITECH_VID: u16 = 0x046d;
-/// HID++ long-report usage page / usage. Filtering on this pair gives us one
-/// HID node per physical HID++ device on every supported OS.
-const HIDPP_USAGE_PAGE: u16 = 0xff00;
-const HIDPP_LONG_USAGE_ID: u16 = 0x0002;
-pub(crate) const HID_GENERIC_DESKTOP: u16 = 0x0001;
-pub(crate) const HID_MOUSE_USAGE_ID: u16 = 0x0002;
+/// HID++ long-report vendor collections, as `(usage_page, usage_id, long_only)`.
+///
+/// Logitech exposes its HID++ long-report (report id `0x11`) under a
+/// vendor-defined HID collection, but the page differs by transport:
+///
+/// - `0xFF00 / 0x0002` — USB, Logi Bolt / Unifying receivers, and
+///   Bluetooth-*classic* devices (MX Master over BT).
+/// - `0xFF43 / 0x0202` — Bluetooth-*Low-Energy* directly-paired devices
+///   (e.g. the Logitech Lift / Signature mice). Same HID++ protocol, just a
+///   different vendor page on the BLE HID report descriptor.
+///
+/// `long_only` marks a transport that exposes *only* the long report — no
+/// short-report (`0x10`) collection — so short HID++ requests must be
+/// up-converted to long (see [`short_as_long`]). BLE-direct devices on macOS
+/// are long-only; USB / receiver devices carry both. Keeping the flag in this
+/// table means a new long-only transport is a single-line addition here, with
+/// no second site to update.
+///
+/// Filtering on these pairs gives us one HID node per physical HID++ device on
+/// every supported OS, without reading report descriptors (`async-hid 0.4`
+/// only exposes those on Linux).
+const HIDPP_LONG_COLLECTIONS: [(u16, u16, bool); 2] =
+    [(0xff00, 0x0002, false), (0xff43, 0x0202, true)];
+
+/// HID++ short / long report IDs and the long report's on-wire length
+/// (report id + 19 payload bytes). Mirrors `hidpp`'s private constants.
+const SHORT_REPORT_ID: u8 = 0x10;
+const LONG_REPORT_ID: u8 = 0x11;
+const LONG_REPORT_LEN: usize = 20;
+
+/// Whether `(usage_page, usage_id)` is one of the HID++ long-report collections.
+fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
+    HIDPP_LONG_COLLECTIONS
+        .iter()
+        .any(|&(page, usage, _)| (page, usage) == (usage_page, usage_id))
+}
+
+/// Whether the matched HID++ collection exposes only the long report, so short
+/// requests must be re-framed as long (see [`short_as_long`]). `false` for
+/// pages not in [`HIDPP_LONG_COLLECTIONS`].
+fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
+    HIDPP_LONG_COLLECTIONS
+        .iter()
+        .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
+}
+
+/// Re-frame a short HID++ report (`0x10`, 7 bytes) as a long one (`0x11`, 20
+/// bytes) for a transport that only exposes the long report.
+///
+/// `hidpp 0.2` always pings with — and often sends — short reports, but a
+/// BLE-direct device exposes only the long report on macOS, so a short
+/// `IOHIDDeviceSetReport` fails with `kIOReturnNotFound`. The header bytes
+/// (device / feature / function / sw id) sit at the same offsets in both
+/// widths; only the trailing payload is zero-padded. The device answers with a
+/// long report, which `hidpp` parses and matches by header regardless of width.
+///
+/// Returns `None` (pass the report through unchanged) when `src` isn't a short
+/// report or wouldn't fit the long frame.
+fn short_as_long(src: &[u8]) -> Option<[u8; LONG_REPORT_LEN]> {
+    if src.first() != Some(&SHORT_REPORT_ID) || src.len() > LONG_REPORT_LEN {
+        return None;
+    }
+    let mut long = [0u8; LONG_REPORT_LEN];
+    long[0] = LONG_REPORT_ID;
+    long[1..src.len()].copy_from_slice(&src[1..]);
+    Some(long)
+}
 
 pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, async_hid::HidError>
 {
     let backend = HidBackend::default();
-    Ok(backend
-        .enumerate()
-        .await?
-        .filter(|d| d.vendor_id == LOGITECH_VID && is_hidpp_candidate(d))
-        .collect()
-        .await)
+    let all: Vec<async_hid::Device> = backend.enumerate().await?.collect().await;
+
+    // One-time visibility into what the OS actually reports for Logitech nodes,
+    // so a transport that uses an unexpected vendor page (e.g. a new BLE mouse)
+    // can be diagnosed from `OPENLOGI_LOG=debug` without a rebuild.
+    for d in all.iter().filter(|d| d.vendor_id == LOGITECH_VID) {
+        debug!(
+            name = %d.name,
+            pid = format_args!("{:04x}", d.product_id),
+            usage_page = format_args!("{:#06x}", d.usage_page),
+            usage_id = format_args!("{:#06x}", d.usage_id),
+            matched = is_hidpp_long_collection(d.usage_page, d.usage_id),
+            "logitech HID node"
+        );
+    }
+
+    Ok(all
+        .into_iter()
+        .filter(|d| {
+            d.vendor_id == LOGITECH_VID
+                && (is_hidpp_long_collection(d.usage_page, d.usage_id)
+                    || is_logitech_mouse(d))
+        })
+        .collect())
 }
 
-/// Return `true` for HID nodes that should enter the `probe_one` path.
+/// Return `true` for Logitech generic-desktop mouse nodes (`0x0001 / 0x0002`).
 ///
-/// Two kinds are admitted:
-/// 1. HID++ long-report collection (`0xFF00 / 0x0002`) — the established path
-///    for receivers, USB-direct, and BT-classic devices.
-/// 2. Logitech generic-desktop mouse (`0x0001 / 0x0002`) — added to surface
-///    BLE-direct devices (e.g. MX Master 4 B) whose macOS BLE HID descriptor
-///    does not expose a vendor HID++ collection.
+/// Certain BLE-direct mice (e.g. MX Master 4 B, PID `0xb048`) do not expose a
+/// Logitech vendor HID++ collection on macOS — the OS only surfaces a standard
+/// mouse interface. `enumerate_hidpp_devices` admits these so `probe_one` can
+/// attempt an HID++ probe; if that fails, `fallback_direct_mouse` in
+/// `inventory.rs` synthesises an inventory keyed by PID.
 ///
-/// **Invariant:** admitting a generic-desktop node is safe only because
-/// `probe_one` is resilient to non-HID++ endpoints — `open_hidpp_channel`
-/// returns `None` when the channel does not speak HID++, and
-/// `fallback_direct_mouse` in `inventory.rs` re-filters by a known-good PID
-/// before synthesising an inventory. Any future widening of
-/// `fallback_direct_mouse` to additional PIDs must re-verify that the
-/// corresponding devices tolerate `open_hidpp_channel`'s probe writes (or
-/// adjust `supports_short_long_hidpp` accordingly).
-fn is_hidpp_candidate(d: &DeviceInfo) -> bool {
-    (d.usage_page == HIDPP_USAGE_PAGE && d.usage_id == HIDPP_LONG_USAGE_ID) || is_logitech_mouse(d)
-}
-
+/// **Invariant:** this is safe only because both `open_hidpp_channel` (returns
+/// `None` on non-HID++ endpoints) and `fallback_direct_mouse` (re-filters by
+/// known-good PID) handle the case gracefully. Widening the PID set in
+/// `fallback_direct_mouse` requires verifying that the new device also tolerates
+/// HID++ probe writes — or adjusting `supports_short_long_hidpp` accordingly.
 pub(crate) fn is_logitech_mouse(d: &DeviceInfo) -> bool {
-    d.vendor_id == LOGITECH_VID
-        && d.usage_page == HID_GENERIC_DESKTOP
-        && d.usage_id == HID_MOUSE_USAGE_ID
+    d.vendor_id == LOGITECH_VID && d.usage_page == 0x0001 && d.usage_id == 0x0002
 }
 
 pub(crate) async fn open_hidpp_channel(
@@ -71,7 +140,10 @@ pub(crate) async fn open_hidpp_channel(
     // keep using `dev` (which `to_device_info` would consume).
     let info: DeviceInfo = (*dev).clone();
     let (reader, writer) = dev.open().await?;
-    let raw = AsyncHidChannel::new(reader, writer, info.clone());
+    // BLE-direct devices expose only the long HID++ report; flag the channel so
+    // outgoing short requests get up-converted to long (see `write_report`).
+    let long_only = is_long_only_collection(info.usage_page, info.usage_id);
+    let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
     let channel = match HidppChannel::from_raw_channel(raw).await {
         Ok(c) => Arc::new(c),
         Err(e) => {
@@ -86,14 +158,23 @@ pub(crate) struct AsyncHidChannel {
     reader: Mutex<DeviceReader>,
     writer: Mutex<DeviceWriter>,
     info: DeviceInfo,
+    /// When set, outgoing short HID++ reports are rewritten as long ones — the
+    /// device (a BLE-direct peripheral) only exposes the long report on macOS.
+    long_only: bool,
 }
 
 impl AsyncHidChannel {
-    pub(crate) fn new(reader: DeviceReader, writer: DeviceWriter, info: DeviceInfo) -> Self {
+    pub(crate) fn new(
+        reader: DeviceReader,
+        writer: DeviceWriter,
+        info: DeviceInfo,
+        long_only: bool,
+    ) -> Self {
         Self {
             reader: Mutex::new(reader),
             writer: Mutex::new(writer),
             info,
+            long_only,
         }
     }
 }
@@ -110,7 +191,10 @@ impl RawHidChannel for AsyncHidChannel {
 
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error>> {
         let mut w = self.writer.lock().await;
-        w.write_output_report(src).await?;
+        match self.long_only.then(|| short_as_long(src)).flatten() {
+            Some(long) => w.write_output_report(&long).await?,
+            None => w.write_output_report(src).await?,
+        }
         Ok(src.len())
     }
 
@@ -125,5 +209,48 @@ impl RawHidChannel for AsyncHidChannel {
 
     async fn get_report_descriptor(&self, _buf: &mut [u8]) -> Result<usize, Box<dyn Error>> {
         Err("get_report_descriptor is not implemented; pre-filter to HID++ usage pages".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_both_usb_and_ble_hidpp_collections() {
+        assert!(is_hidpp_long_collection(0xff00, 0x0002)); // USB / receiver / BT-classic
+        assert!(is_hidpp_long_collection(0xff43, 0x0202)); // BLE-direct (Lift, Signature)
+        assert!(!is_hidpp_long_collection(0x0001, 0x0002)); // generic-desktop mouse
+        assert!(!is_hidpp_long_collection(0xff43, 0x0002)); // page right, usage wrong
+    }
+
+    #[test]
+    fn only_ble_collection_is_long_only() {
+        assert!(is_long_only_collection(0xff43, 0x0202)); // BLE-direct → up-convert short→long
+        assert!(!is_long_only_collection(0xff00, 0x0002)); // USB / receiver carries both reports
+        assert!(!is_long_only_collection(0x0001, 0x0002)); // not a HID++ collection at all
+    }
+
+    #[test]
+    fn upconverts_short_report_preserving_header_and_padding() {
+        // [report id, device, feature, func|sw, p0, p1, p2]
+        let short = [SHORT_REPORT_ID, 0xff, 0x00, 0x1e, 0xaa, 0xbb, 0xcc];
+        let Some(long) = short_as_long(&short) else {
+            panic!("short report should up-convert");
+        };
+
+        assert_eq!(long[0], LONG_REPORT_ID);
+        assert_eq!(&long[1..7], &short[1..]); // header + payload copied verbatim
+        assert!(long[7..].iter().all(|&b| b == 0)); // remainder zero-padded
+        assert_eq!(long.len(), LONG_REPORT_LEN);
+    }
+
+    #[test]
+    fn passes_through_non_short_reports() {
+        // Already a long report — leave it alone.
+        let long_in = [LONG_REPORT_ID, 0xff, 0x00, 0x1e];
+        assert!(short_as_long(&long_in).is_none());
+        // Empty / unknown frames are passed through too.
+        assert!(short_as_long(&[]).is_none());
     }
 }

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -36,69 +36,10 @@ unsafe extern "C" {
 }
 
 /// Check whether this process has been granted Accessibility access.
-///
-/// `AXIsProcessTrustedWithOptions(NULL)` is the canonical API, but it can
-/// return `false` for locally-built / ad-hoc-signed binaries even after the
-/// user toggles the permission on in System Settings, because the TCC entry
-/// that was created by a previous (differently-signed) build does not match
-/// the current binary's code-signing identity.
-///
-/// When the API returns `false` we fall back to reading the user TCC database
-/// directly. `auth_value = 2` means "allowed"; any other value (0 = denied,
-/// 1 = limited) keeps `false`. This fallback is intentionally best-effort:
-/// if `sqlite3` is unavailable or the DB path changes, we silently return the
-/// API result unchanged.
 pub(crate) fn has_accessibility() -> bool {
     // SAFETY: NULL is documented as a valid argument; it queries the current
     // trust state without raising a permission dialog.
-    if unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) } {
-        return true;
-    }
-    // TCC fallback for locally-built / ad-hoc-signed binaries.
-    if tcc_accessibility_allowed() {
-        debug!(
-            "AXIsProcessTrustedWithOptions returned false but TCC db shows \
-             auth_value=2 — treating as granted (locally-signed build)"
-        );
-        return true;
-    }
-    false
-}
-
-/// Return `true` when the user TCC database records `auth_value = 2`
-/// (allowed) for `kTCCServiceAccessibility` and this app's bundle ID.
-fn tcc_accessibility_allowed() -> bool {
-    const BUNDLE_ID: &str = "org.openlogi.openlogi";
-    const QUERY: &str =
-        "SELECT auth_value FROM access \
-         WHERE service='kTCCServiceAccessibility' AND client=?1 LIMIT 1";
-
-    let home = match std::env::var("HOME") {
-        Ok(h) => h,
-        Err(_) => return false,
-    };
-    let db = format!(
-        "{home}/Library/Application Support/com.apple.TCC/TCC.db"
-    );
-    let out = std::process::Command::new("sqlite3")
-        .args([&db, &format!("{QUERY}"), BUNDLE_ID])
-        .output();
-    match out {
-        Ok(o) if o.status.success() => {
-            String::from_utf8_lossy(&o.stdout).trim() == "2"
-        }
-        Ok(o) => {
-            debug!(
-                status = %o.status,
-                "sqlite3 TCC query exited non-zero; skipping accessibility fallback"
-            );
-            false
-        }
-        Err(e) => {
-            debug!(error = %e, "sqlite3 not available; skipping accessibility fallback");
-            false
-        }
-    }
+    unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) }
 }
 
 /// Raise the Accessibility prompt + register the process. See

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -36,10 +36,69 @@ unsafe extern "C" {
 }
 
 /// Check whether this process has been granted Accessibility access.
+///
+/// `AXIsProcessTrustedWithOptions(NULL)` is the canonical API, but it can
+/// return `false` for locally-built / ad-hoc-signed binaries even after the
+/// user toggles the permission on in System Settings, because the TCC entry
+/// that was created by a previous (differently-signed) build does not match
+/// the current binary's code-signing identity.
+///
+/// When the API returns `false` we fall back to reading the user TCC database
+/// directly. `auth_value = 2` means "allowed"; any other value (0 = denied,
+/// 1 = limited) keeps `false`. This fallback is intentionally best-effort:
+/// if `sqlite3` is unavailable or the DB path changes, we silently return the
+/// API result unchanged.
 pub(crate) fn has_accessibility() -> bool {
     // SAFETY: NULL is documented as a valid argument; it queries the current
     // trust state without raising a permission dialog.
-    unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) }
+    if unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) } {
+        return true;
+    }
+    // TCC fallback for locally-built / ad-hoc-signed binaries.
+    if tcc_accessibility_allowed() {
+        debug!(
+            "AXIsProcessTrustedWithOptions returned false but TCC db shows \
+             auth_value=2 — treating as granted (locally-signed build)"
+        );
+        return true;
+    }
+    false
+}
+
+/// Return `true` when the user TCC database records `auth_value = 2`
+/// (allowed) for `kTCCServiceAccessibility` and this app's bundle ID.
+fn tcc_accessibility_allowed() -> bool {
+    const BUNDLE_ID: &str = "org.openlogi.openlogi";
+    const QUERY: &str =
+        "SELECT auth_value FROM access \
+         WHERE service='kTCCServiceAccessibility' AND client=?1 LIMIT 1";
+
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => return false,
+    };
+    let db = format!(
+        "{home}/Library/Application Support/com.apple.TCC/TCC.db"
+    );
+    let out = std::process::Command::new("sqlite3")
+        .args([&db, &format!("{QUERY}"), BUNDLE_ID])
+        .output();
+    match out {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout).trim() == "2"
+        }
+        Ok(o) => {
+            debug!(
+                status = %o.status,
+                "sqlite3 TCC query exited non-zero; skipping accessibility fallback"
+            );
+            false
+        }
+        Err(e) => {
+            debug!(error = %e, "sqlite3 not available; skipping accessibility fallback");
+            false
+        }
+    }
 }
 
 /// Raise the Accessibility prompt + register the process. See


### PR DESCRIPTION
## What this fixes

This PR corrects two bugs in #20 that prevented MX Master 4 **B** (Bluetooth-direct) from being detected, and adds three improvements flagged in the Pullfrog review of that PR.

### Bug 1 — Wrong ProductID

The MX Master 4 **B** (Bluetooth LE direct) reports `ProductID = 0xb048` (45128), not `0xb042` (45122). Confirmed via `ioreg`, `hidutil list`, and `system_profiler` on macOS 15 with firmware `RBM27.00_0015`.

`0xb042` appears to be the USB cable / Bolt-receiver variant.

Three independent sites hardcoded the wrong PID:
- `MX_MASTER_4_PID` constant → `0xb042` should be **`0xb048`**
- `MX_MASTER_4_NAME` constant → `"MX Master 4"` should be **`"MX Master 4 B"`** (exact string macOS reports)
- `hidutil --matching` literal string in `hidutil_direct_mouse_fallback` — hardcoded `"0xb042"` and **did not use the `MX_MASTER_4_PID` constant**, so fixing the constant alone was not enough

### Bug 2 — hidutil fallback masked by a Bolt receiver

The `hidutil_direct_mouse_fallback()` was gated on `inventories.is_empty()`. A user with a Bolt receiver attached alongside a BLE-paired MX Master 4 B would have the Bolt path fill `inventories`, suppressing the fallback — the BLE device would never appear. The fix runs the fallback whenever MX Master 4 B is absent from the current inventory.

## Improvements (Pullfrog review items)

| # | Finding | Resolution |
|---|---------|------------|
| 1 | hidutil fallback masked by non-empty inventory | Fixed — runs when MX Master 4 B is absent, not only when list is empty |
| 2 | `--ndjson` support unverified, no log on failure | Added `debug!` on non-zero exit with status + stderr; comment documents macOS 13+ floor |
| 3 | Blocking `Command::output()` inside async | Wrapped in `tokio::task::spawn_blocking` |

## Bonus: Accessibility gate on locally-built binaries

`AXIsProcessTrustedWithOptions(NULL)` returns `false` for locally-built / ad-hoc-signed binaries even after the user grants access in System Settings, because the TCC entry is tied to the code-signing identity of a previous build. This blocks the entire device panel behind the Accessibility gate with no way forward except clicking "Open System Settings" in a loop.

The fix adds a lightweight TCC fallback in `has_accessibility()`: when the API returns `false`, we query the user TCC database via `sqlite3` and return `true` if `auth_value = 2`. If `sqlite3` is unavailable the API result is returned unchanged. The CGEventTap hook install will still fail if the OS rejects it — the only change is that the UI no longer shows the gate when the permission is actually present.

## Prerequisite for users still on Logi G HUB

If `com.logi.ghub.hidfilter` (the G HUB HID Driver Extension) is still active, it claims exclusive HID access to the device and every `IOHIDDeviceOpen()` call fails. The extension must be removed via **System Settings → General → Login Items & Extensions → Driver Extensions** before OpenLogi can communicate with the mouse.

## Test environment

- macOS 15.x, Apple Silicon (M-series)
- MX Master 4 B, firmware `RBM27.00_0015`, paired over Bluetooth LE
- `hidutil list --ndjson`: `ProductID=45128 (0xb048)`, `Product="MX Master 4 B"`
- Logi G HUB HID filter removed

Fixes #32