### PR TITLE
fix(gui): stabilize device tab ordering

### DIFF
--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -108,8 +108,9 @@ fn format_model(m: &DeviceModelInfo) -> String {
         use std::fmt::Write as _;
         let _ = write!(unit, "{b:02x}");
     }
+    let serial = m.serial_number.as_deref().unwrap_or("—");
     format!(
-        "     model_ids=[{ids}] ext={:02x} unit_id={unit} transports={transports}",
+        "     model_ids=[{ids}] ext={:02x} serial={serial} unit_id={unit} transports={transports}",
         m.extended_model_id
     )
 }

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -73,9 +73,12 @@ pub struct ReceiverInfo {
 /// Options+ asset registry's `modelId` (e.g. `"6b023"`) is the concatenation
 /// of an extended-model byte and one of these PIDs, so callers usually want
 /// to format `extended_model_id` + `model_ids[N]` to match.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DeviceModelInfo {
     pub entity_count: u8,
+    /// HID++ DeviceInformation serial number, when the device supports the
+    /// optional serial-number function.
+    pub serial_number: Option<String>,
     pub unit_id: [u8; 4],
     pub transports: DeviceTransports,
     pub model_ids: [u16; 3],

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -446,6 +446,6 @@ fn collect_models(inventories: &[DeviceInventory]) -> Vec<DeviceModelInfo> {
     inventories
         .iter()
         .flat_map(|inv| inv.paired.iter())
-        .filter_map(|p| p.model_info)
+        .filter_map(|p| p.model_info.clone())
         .collect()
 }

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -20,11 +20,36 @@ pub struct DeviceRecord {
     pub config_key: String,
     pub display_name: String,
     pub asset: Option<ResolvedAsset>,
+    pub serial_number: Option<String>,
+    pub unit_id: [u8; 4],
     pub route: Option<DeviceRoute>,
     pub kind: DeviceKind,
     pub slot: u8,
     pub online: bool,
     pub battery: Option<BatteryInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum DeviceStableId {
+    Bolt {
+        receiver_uid: String,
+        slot: u8,
+    },
+    Direct {
+        vendor_id: u16,
+        product_id: u16,
+        identity: DeviceIdentity,
+    },
+    Unknown {
+        slot: u8,
+        identity: DeviceIdentity,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum DeviceIdentity {
+    Serial(String),
+    Unit([u8; 4]),
 }
 
 pub(super) fn build_device_list(
@@ -48,6 +73,8 @@ pub(super) fn build_device_list(
                 config_key,
                 display_name,
                 asset,
+                serial_number: model.serial_number.clone(),
+                unit_id: model.unit_id,
                 route: device_route(inv, paired.slot),
                 kind: paired.kind,
                 slot: paired.slot,
@@ -56,7 +83,51 @@ pub(super) fn build_device_list(
             });
         }
     }
+    // HID enumeration order can change as different mice wake, sleep, or are
+    // selected. Keep the header carousel stable by ordering by the physical
+    // route instead of by whichever HID node happened to be reported first.
+    list.sort_by_key(device_order_key);
     list
+}
+
+fn device_order_key(record: &DeviceRecord) -> (DeviceStableId, String, String) {
+    (
+        DeviceStableId::from_record(record),
+        record.config_key.clone(),
+        record.display_name.clone(),
+    )
+}
+
+impl DeviceStableId {
+    fn from_record(record: &DeviceRecord) -> Self {
+        match &record.route {
+            Some(DeviceRoute::Bolt { receiver_uid, slot }) => Self::Bolt {
+                receiver_uid: receiver_uid.to_ascii_lowercase(),
+                slot: *slot,
+            },
+            Some(DeviceRoute::Direct {
+                vendor_id,
+                product_id,
+            }) => Self::Direct {
+                vendor_id: *vendor_id,
+                product_id: *product_id,
+                identity: DeviceIdentity::from_record(record),
+            },
+            None => Self::Unknown {
+                slot: record.slot,
+                identity: DeviceIdentity::from_record(record),
+            },
+        }
+    }
+}
+
+impl DeviceIdentity {
+    fn from_record(record: &DeviceRecord) -> Self {
+        record.serial_number.as_ref().map_or_else(
+            || Self::Unit(record.unit_id),
+            |serial| Self::Serial(serial.to_ascii_lowercase()),
+        )
+    }
 }
 
 /// Build the [`DeviceRoute`] HID++ writes use to reach a device.

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -298,18 +298,32 @@ async fn probe_features(
 
     let model_info = match device.get_feature::<DeviceInformationFeatureV0>() {
         Some(feature) => match feature.get_device_info().await {
-            Ok(info) => Some(DeviceModelInfo {
-                entity_count: info.entity_count,
-                unit_id: info.unit_id,
-                transports: DeviceTransports {
-                    usb: info.transport.usb,
-                    equad: info.transport.e_quad,
-                    btle: info.transport.btle,
-                    bluetooth: info.transport.bluetooth,
-                },
-                model_ids: info.model_id,
-                extended_model_id: info.extended_model_id,
-            }),
+            Ok(info) => {
+                let serial_number = if info.capabilities.serial_number {
+                    match feature.get_serial_number().await {
+                        Ok(serial) => normalize_serial_number(&serial),
+                        Err(e) => {
+                            debug!(slot, error = ?e, "DeviceInformation serial read failed");
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+                Some(DeviceModelInfo {
+                    entity_count: info.entity_count,
+                    serial_number,
+                    unit_id: info.unit_id,
+                    transports: DeviceTransports {
+                        usb: info.transport.usb,
+                        equad: info.transport.e_quad,
+                        btle: info.transport.btle,
+                        bluetooth: info.transport.bluetooth,
+                    },
+                    model_ids: info.model_id,
+                    extended_model_id: info.extended_model_id,
+                })
+            }
             Err(e) => {
                 debug!(slot, error = ?e, "DeviceInformation read failed");
                 None
@@ -319,6 +333,11 @@ async fn probe_features(
     };
 
     (battery, model_info)
+}
+
+fn normalize_serial_number(serial: &str) -> Option<String> {
+    let serial = serial.trim_matches('\0').trim().to_string();
+    (!serial.is_empty()).then_some(serial)
 }
 
 /// HID++ feature IDs that mark a device as a controllable peripheral rather


### PR DESCRIPTION
## Summary
- sort the GUI device list by a stable device identity instead of HID enumeration order
- read HID++ DeviceInformation serial numbers when supported and use them for direct/unknown device identity, falling back to unit_id
- expose serial numbers in the CLI list output for diagnostics

## Verification
- cargo fmt --check
- cargo check -p openlogi-gui -p openlogi-cli
- cargo clippy -p openlogi-gui -p openlogi-cli