### PR TITLE
feat(openlogi-gui): add Russian localization and language select

### DIFF
--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -88,9 +88,10 @@ pub struct AppSettings {
     #[serde(default = "default_true")]
     pub show_in_menu_bar: bool,
     /// UI language as a BCP-47-ish locale code matching the GUI's bundled
-    /// locales (`"en"`, `"zh-CN"`, `"zh-HK"`). `None` means "follow the
-    /// system locale", which the GUI resolves at startup. Stored here so a
-    /// user's explicit choice survives restarts regardless of the OS setting.
+    /// locales (`"en"`, `"ja"`, `"ru"`, `"zh-CN"`, `"zh-HK"`). `None`
+    /// means "follow the system locale", which the GUI resolves at startup.
+    /// Stored here so a user's explicit choice survives restarts regardless of
+    /// the OS setting.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
 }

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -3,8 +3,8 @@
 # `_version: 2` packs every translated locale for one message into a single
 # entry. The **key is the English msgid** (gettext-style): a `t!`/`tr!` lookup
 # that misses the current locale falls back to the key itself, so English needs
-# no column here — only the `ja` / `zh-CN` / `zh-HK` translations. Keys must
-# match the code verbatim, and the device/action vocabulary must match
+# no column here — only the `ja` / `ru` / `zh-CN` / `zh-HK` translations. Keys
+# must match the code verbatim, and the device/action vocabulary must match
 # `openlogi_core::binding`'s `label()`.
 #
 # Interpolation uses `%{name}` and must be preserved verbatim in every locale.
@@ -13,464 +13,574 @@ _version: 2
 # ── App chrome: accessibility gate, empty state, footer (app.rs) ────────────
 "No device connected":
   ja: デバイスが接続されていません
+  ru: "Устройство не подключено"
   zh-CN: 未连接设备
   zh-HK: 未連接裝置
 
 # ── Menu-bar status item (platform/menubar.rs) ──────────────────────────────
 "Open OpenLogi":
   ja: OpenLogi を開く
+  ru: "Открыть OpenLogi"
   zh-CN: 打开 OpenLogi
   zh-HK: 開啟 OpenLogi
 "Quit OpenLogi":
   ja: OpenLogi を終了
+  ru: "Выйти из OpenLogi"
   zh-CN: 退出 OpenLogi
   zh-HK: 結束 OpenLogi
 
 "Plug in or pair a supported Logitech device — it'll show up here automatically.":
   ja: 対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。
+  ru: "Подключите или сопрягите поддерживаемое устройство Logitech — оно автоматически появится здесь."
   zh-CN: 接入或配对受支持的 Logitech 设备，它会自动显示在这里。
   zh-HK: 接入或配對受支援的 Logitech 裝置，它會自動顯示在這裡。
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.":
   ja: Logi Options+ をお使いですか?まず終了してください — 両方のアプリが HID++ アクセスを奪い合います。
+  ru: "Используете Logi Options+? Сначала закройте его — оба приложения конкурируют за доступ к HID++."
   zh-CN: 正在使用 Logi Options+?请先退出 —— 两个应用会争夺 HID++ 访问权限。
   zh-HK: 正在使用 Logi Options+?請先結束 —— 兩個應用會爭奪 HID++ 存取權限。
 "Accessibility permission required":
   ja: アクセシビリティ権限が必要です
+  ru: "Требуется разрешение Универсального доступа"
   zh-CN: 需要「辅助功能」权限
   zh-HK: 需要「輔助使用」權限
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
   ja: OpenLogi はシステムの「アクセシビリティ」権限を通じてマウスボタン(戻る / 進む / ジェスチャーボタン)を捕捉し、割り当てた操作を実行します。DPI、SmartShift などデバイスと直接通信する機能には影響しません。
+  ru: "OpenLogi перехватывает кнопки мыши (Назад / Вперёд / кнопку жестов) через системное разрешение Универсального доступа и выполняет назначенные вами действия. Функции, которые обращаются к устройству напрямую — DPI, SmartShift — не затрагиваются."
   zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
   zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
 "Open System Settings to grant access":
   ja: システム設定を開いて許可する
+  ru: "Открыть системные настройки для выдачи доступа"
   zh-CN: 打开系统设置授权
   zh-HK: 開啟系統設定授權
 "Takes effect automatically once granted — no restart needed.":
   ja: 許可すると自動的に反映されます — 再起動は不要です。
+  ru: "Вступит в силу автоматически после выдачи разрешения — перезапуск не нужен."
   zh-CN: 授权后会自动生效,无需重启。
   zh-HK: 授權後會自動生效,無需重新啟動。
 "Not now (use DPI and other features only)":
   ja: 後で(DPI などの機能のみ使用)
+  ru: "Не сейчас (использовать только DPI и другие функции)"
   zh-CN: 稍后再说(仅使用 DPI 等功能)
   zh-HK: 稍後再說(僅使用 DPI 等功能)
 "Settings":
   ja: 設定
+  ru: "Настройки"
   zh-CN: 设置
   zh-HK: 設定
 "About":
   ja: 情報
+  ru: "О программе"
   zh-CN: 关于
   zh-HK: 關於
 "Accessibility granted":
   ja: アクセシビリティは許可済み
+  ru: "Универсальный доступ разрешён"
   zh-CN: 辅助功能已授权
   zh-HK: 輔助使用已授權
 "Accessibility not granted · click to grant":
   ja: アクセシビリティ未許可 · クリックして許可
+  ru: "Универсальный доступ не разрешён · нажмите, чтобы выдать доступ"
   zh-CN: 辅助功能未授权 · 点击授权
   zh-HK: 輔助使用未授權 · 點擊授權
 
 # ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
 "About OpenLogi":
   ja: OpenLogi について
+  ru: "Об OpenLogi"
   zh-CN: 关于 OpenLogi
   zh-HK: 關於 OpenLogi
 "Settings…":
   ja: 設定…
+  ru: "Настройки…"
   zh-CN: 设置…
   zh-HK: 設定…
 "Hide OpenLogi":
   ja: OpenLogi を隠す
+  ru: "Скрыть OpenLogi"
   zh-CN: 隐藏 OpenLogi
   zh-HK: 隱藏 OpenLogi
 "Hide Others":
   ja: ほかを隠す
+  ru: "Скрыть остальные"
   zh-CN: 隐藏其他
   zh-HK: 隱藏其他
 "Show All":
   ja: すべてを表示
+  ru: "Показать все"
   zh-CN: 全部显示
   zh-HK: 全部顯示
 "Window":
   ja: ウインドウ
+  ru: "Окно"
   zh-CN: 窗口
   zh-HK: 視窗
 "Minimize":
   ja: しまう
+  ru: "Свернуть"
   zh-CN: 最小化
   zh-HK: 最小化
 "Zoom":
   ja: ズーム
+  ru: "Масштабировать"
   zh-CN: 缩放
   zh-HK: 縮放
 "Close Window":
   ja: ウインドウを閉じる
+  ru: "Закрыть окно"
   zh-CN: 关闭窗口
   zh-HK: 關閉視窗
 
 # ── About window (about.rs) ─────────────────────────────────────────────────
 "Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
   ja: オープンソースの Logitech マウス設定ツール —— DPI、SmartShift、ボタン割り当て、ジェスチャー。
+  ru: "Открытая настройка мышей Logitech — DPI, SmartShift, привязки кнопок и жесты."
   zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
   zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
 
 # ── Settings window (settings.rs) ───────────────────────────────────────────
 "General":
   ja: 一般
+  ru: "Основные"
   zh-CN: 通用
   zh-HK: 一般
 "Launch at login":
   ja: ログイン時に起動
+  ru: "Запускать при входе"
   zh-CN: 开机自启
   zh-HK: 開機自動啟動
 "Automatically start OpenLogi when you log in to macOS.":
   ja: macOS にログインしたときに OpenLogi を自動的に起動します。
+  ru: "Автоматически запускать OpenLogi при входе в macOS."
   zh-CN: 登录 macOS 时自动启动 OpenLogi。
   zh-HK: 登入 macOS 時自動啟動 OpenLogi。
 "Check for updates":
   ja: アップデートを確認
+  ru: "Проверять обновления"
   zh-CN: 检查更新
   zh-HK: 檢查更新
 "Check once per launch for a new version (query only — no automatic download).":
   ja: 起動ごとに新しいバージョンを一度だけ確認します(確認のみ — 自動ダウンロードはしません)。
+  ru: "Один раз при запуске проверять наличие новой версии (только проверка — без автоматической загрузки)."
   zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
   zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
 "Show in menu bar":
   ja: メニューバーに表示
+  ru: "Показывать в строке меню"
   zh-CN: 显示在菜单栏
   zh-HK: 顯示在選單列
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.":
   ja: OpenLogi のアイコンをメニューバーに表示します。オフにすると Dock に残ります。
+  ru: "Оставлять значок OpenLogi в строке меню. Если выключено, приложение остаётся в Dock."
   zh-CN: 在菜单栏保留 OpenLogi 图标；关闭后改为停留在程序坞中。
   zh-HK: 在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。
 "Language":
   ja: 言語
+  ru: "Язык"
   zh-CN: 语言
   zh-HK: 語言
 "Choose the interface language.":
   ja: インターフェースの言語を選択します。
+  ru: "Выберите язык интерфейса."
   zh-CN: 选择界面语言。
   zh-HK: 選擇介面語言。
 "Follow system":
   ja: システムに従う
+  ru: "Как в системе"
   zh-CN: 跟随系统
   zh-HK: 跟隨系統
 
 # ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
 "PRESETS":
   ja: プリセット
+  ru: "ПРЕСЕТЫ"
   zh-CN: 预设
   zh-HK: 預設
 "Add":
   ja: 追加
+  ru: "Добавить"
   zh-CN: 添加
   zh-HK: 新增
 
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
   ja: "%{name} を割り当て"
+  ru: "Назначить %{name}"
   zh-CN: 绑定 %{name}
   zh-HK: 綁定 %{name}
 "Gesture %{name}":
   ja: ジェスチャー %{name}
+  ru: "Жест %{name}"
   zh-CN: 手势 %{name}
   zh-HK: 手勢 %{name}
 
 # ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
 "Left Click":
   ja: 左クリック
+  ru: "Левый щелчок"
   zh-CN: 左键单击
   zh-HK: 左鍵單擊
 "Right Click":
   ja: 右クリック
+  ru: "Правый щелчок"
   zh-CN: 右键单击
   zh-HK: 右鍵單擊
 "Middle Click":
   ja: 中クリック
+  ru: "Средний щелчок"
   zh-CN: 中键单击
   zh-HK: 中鍵單擊
 "Back":
   ja: 戻る
+  ru: "Назад"
   zh-CN: 后退
   zh-HK: 後退
 "Forward":
   ja: 進む
+  ru: "Вперёд"
   zh-CN: 前进
   zh-HK: 前進
 "DPI Toggle":
   ja: DPI 切り替え
+  ru: "Переключение DPI"
   zh-CN: DPI 切换
   zh-HK: DPI 切換
 "Thumb Wheel":
   ja: サムホイール
+  ru: "Колесо под большой палец"
   zh-CN: 拇指滚轮
   zh-HK: 拇指滾輪
 "Gesture Button":
   ja: ジェスチャーボタン
+  ru: "Кнопка жестов"
   zh-CN: 手势按钮
   zh-HK: 手勢按鈕
 
 # ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
 "Up":
   ja: 上
+  ru: "Вверх"
   zh-CN: 上
   zh-HK: 上
 "Down":
   ja: 下
+  ru: "Вниз"
   zh-CN: 下
   zh-HK: 下
 "Left":
   ja: 左
+  ru: "Влево"
   zh-CN: 左
   zh-HK: 左
 "Right":
   ja: 右
+  ru: "Вправо"
   zh-CN: 右
   zh-HK: 右
 "Click":
   ja: 押し込み
+  ru: "Щелчок"
   zh-CN: 按下
   zh-HK: 按下
 
 # ── Categories (openlogi_core::binding::Category) ───────────────────────────
 "EDITING":
   ja: 編集
+  ru: "РЕДАКТИРОВАНИЕ"
   zh-CN: 编辑
   zh-HK: 編輯
 "BROWSER":
   ja: ブラウザ
+  ru: "БРАУЗЕР"
   zh-CN: 浏览器
   zh-HK: 瀏覽器
 "MEDIA":
   ja: メディア
+  ru: "МЕДИА"
   zh-CN: 媒体
   zh-HK: 媒體
 "MOUSE":
   ja: マウス
+  ru: "МЫШЬ"
   zh-CN: 鼠标
   zh-HK: 滑鼠
 "SCROLL":
   ja: スクロール
+  ru: "ПРОКРУТКА"
   zh-CN: 滚动
   zh-HK: 捲動
 "NAVIGATION":
   ja: ナビゲーション
+  ru: "НАВИГАЦИЯ"
   zh-CN: 导航
   zh-HK: 導覽
 "SYSTEM":
   ja: システム
+  ru: "СИСТЕМА"
   zh-CN: 系统
   zh-HK: 系統
 
 # ── Actions (openlogi_core::binding::Action) ────────────────────────────────
 "Copy":
   ja: コピー
+  ru: "Копировать"
   zh-CN: 复制
   zh-HK: 複製
 "Paste":
   ja: ペースト
+  ru: "Вставить"
   zh-CN: 粘贴
   zh-HK: 貼上
 "Cut":
   ja: カット
+  ru: "Вырезать"
   zh-CN: 剪切
   zh-HK: 剪下
 "Undo":
   ja: 取り消す
+  ru: "Отменить"
   zh-CN: 撤销
   zh-HK: 復原
 "Redo":
   ja: やり直す
+  ru: "Повторить"
   zh-CN: 重做
   zh-HK: 重做
 "Select All":
   ja: すべて選択
+  ru: "Выбрать всё"
   zh-CN: 全选
   zh-HK: 全選
 "Find":
   ja: 検索
+  ru: "Найти"
   zh-CN: 查找
   zh-HK: 尋找
 "Save":
   ja: 保存
+  ru: "Сохранить"
   zh-CN: 保存
   zh-HK: 儲存
 "Browser Back":
   ja: ブラウザで戻る
+  ru: "Назад в браузере"
   zh-CN: 浏览器后退
   zh-HK: 瀏覽器後退
 "Browser Forward":
   ja: ブラウザで進む
+  ru: "Вперёд в браузере"
   zh-CN: 浏览器前进
   zh-HK: 瀏覽器前進
 "New Tab":
   ja: 新規タブ
+  ru: "Новая вкладка"
   zh-CN: 新建标签页
   zh-HK: 新增分頁
 "Close Tab":
   ja: タブを閉じる
+  ru: "Закрыть вкладку"
   zh-CN: 关闭标签页
   zh-HK: 關閉分頁
 "Reopen Tab":
   ja: タブを再度開く
+  ru: "Открыть закрытую вкладку"
   zh-CN: 重开标签页
   zh-HK: 重新開啟分頁
 "Next Tab":
   ja: 次のタブ
+  ru: "Следующая вкладка"
   zh-CN: 下一个标签页
   zh-HK: 下一個分頁
 "Previous Tab":
   ja: 前のタブ
+  ru: "Предыдущая вкладка"
   zh-CN: 上一个标签页
   zh-HK: 上一個分頁
 "Reload Page":
   ja: ページを再読み込み
+  ru: "Перезагрузить страницу"
   zh-CN: 刷新页面
   zh-HK: 重新載入頁面
 "Mission Control":
   ja: Mission Control
+  ru: "Mission Control"
   zh-CN: 调度中心
   zh-HK: 調度中心
 "App Exposé":
   ja: App Exposé
+  ru: "App Exposé"
   zh-CN: 应用程序窗口
   zh-HK: 應用程式視窗
 "Show Desktop":
   ja: デスクトップを表示
+  ru: "Показать рабочий стол"
   zh-CN: 显示桌面
   zh-HK: 顯示桌面
 "Launchpad":
   ja: Launchpad
+  ru: "Launchpad"
   zh-CN: 启动台
   zh-HK: 啟動台
 "Lock Screen":
   ja: 画面をロック
+  ru: "Заблокировать экран"
   zh-CN: 锁定屏幕
   zh-HK: 鎖定螢幕
 "Screenshot":
   ja: スクリーンショット
+  ru: "Снимок экрана"
   zh-CN: 截屏
   zh-HK: 截圖
 "Play / Pause":
   ja: 再生 / 一時停止
+  ru: "Воспроизведение / пауза"
   zh-CN: 播放 / 暂停
   zh-HK: 播放 / 暫停
 "Next Track":
   ja: 次の曲
+  ru: "Следующий трек"
   zh-CN: 下一首
   zh-HK: 下一首
 "Previous Track":
   ja: 前の曲
+  ru: "Предыдущий трек"
   zh-CN: 上一首
   zh-HK: 上一首
 "Volume Up":
   ja: 音量を上げる
+  ru: "Увеличить громкость"
   zh-CN: 增大音量
   zh-HK: 調高音量
 "Volume Down":
   ja: 音量を下げる
+  ru: "Уменьшить громкость"
   zh-CN: 减小音量
   zh-HK: 調低音量
 "Mute":
   ja: ミュート
+  ru: "Выключить звук"
   zh-CN: 静音
   zh-HK: 靜音
 "Cycle DPI Presets":
   ja: DPI プリセットを循環
+  ru: "Переключать пресеты DPI"
   zh-CN: 循环 DPI 预设
   zh-HK: 循環 DPI 預設
 "Toggle SmartShift":
   ja: SmartShift を切り替え
+  ru: "Переключить SmartShift"
   zh-CN: 切换 SmartShift
   zh-HK: 切換 SmartShift
 "Scroll Up":
   ja: 上にスクロール
+  ru: "Прокрутить вверх"
   zh-CN: 向上滚动
   zh-HK: 向上捲動
 "Scroll Down":
   ja: 下にスクロール
+  ru: "Прокрутить вниз"
   zh-CN: 向下滚动
   zh-HK: 向下捲動
 "Scroll Left":
   ja: 左にスクロール
+  ru: "Прокрутить влево"
   zh-CN: 向左滚动
   zh-HK: 向左捲動
 "Scroll Right":
   ja: 右にスクロール
+  ru: "Прокрутить вправо"
   zh-CN: 向右滚动
   zh-HK: 向右捲動
 
 # ── Add Device / pairing flow (windows/add_device.rs, app_menu.rs, app.rs) ──
 "Add Device":
   ja: デバイスを追加
+  ru: "Добавить устройство"
   zh-CN: 添加设备
   zh-HK: 新增裝置
 "Add Device…":
   ja: デバイスを追加…
+  ru: "Добавить устройство…"
   zh-CN: 添加设备…
   zh-HK: 新增裝置…
 "Put the device in pairing mode, then start searching.":
   ja: デバイスをペアリングモードにしてから検索を開始してください。
+  ru: "Переведите устройство в режим сопряжения, затем начните поиск."
   zh-CN: 先让设备进入配对模式，然后开始搜索。
   zh-HK: 先讓裝置進入配對模式，然後開始搜尋。
 "Search for devices":
   ja: デバイスを検索
+  ru: "Искать устройства"
   zh-CN: 搜索设备
   zh-HK: 搜尋裝置
 "Searching for devices…":
   ja: デバイスを検索中…
+  ru: "Поиск устройств…"
   zh-CN: 正在搜索设备…
   zh-HK: 正在搜尋裝置…
 "Make sure the device is on and in pairing mode.":
   ja: デバイスの電源が入り、ペアリングモードになっていることを確認してください。
+  ru: "Убедитесь, что устройство включено и находится в режиме сопряжения."
   zh-CN: 请确认设备已开机并处于配对模式。
   zh-HK: 請確認裝置已開機並處於配對模式。
 "No devices found yet…":
   ja: まだデバイスが見つかりません…
+  ru: "Устройства пока не найдены…"
   zh-CN: 暂未发现设备…
   zh-HK: 暫未發現裝置…
 "Select a device to pair:":
   ja: "ペアリングするデバイスを選択してください:"
+  ru: "Выберите устройство для сопряжения:"
   zh-CN: 选择要配对的设备：
   zh-HK: 選擇要配對的裝置：
 "Pairing…":
   ja: ペアリング中…
+  ru: "Сопряжение…"
   zh-CN: 正在配对…
   zh-HK: 正在配對…
 "Follow the instructions on your device.":
   ja: デバイスの指示に従ってください。
+  ru: "Следуйте инструкциям на устройстве."
   zh-CN: 请按照设备上的提示操作。
   zh-HK: 請按照裝置上的提示操作。
 "Type this passkey on the new keyboard, then press Enter:":
   ja: "新しいキーボードでこのパスキーを入力し、Enter キーを押してください:"
+  ru: "Введите этот код на новой клавиатуре, затем нажмите Enter:"
   zh-CN: 在新键盘上输入此配对码，然后按回车：
   zh-HK: 在新鍵盤上輸入此配對碼，然後按 Enter：
 "On the new mouse, click in this order, then press both buttons together:":
   ja: "新しいマウスでこの順にクリックし、最後に両方のボタンを同時に押してください:"
+  ru: "На новой мыши нажмите кнопки в этом порядке, затем нажмите обе кнопки одновременно:"
   zh-CN: 在新鼠标上按此顺序点击，最后同时按下左右键：
   zh-HK: 在新滑鼠上按此順序點擊，最後同時按下左右鍵：
 "Device paired":
   ja: デバイスをペアリングしました
+  ru: "Устройство сопряжено"
   zh-CN: 设备已配对
   zh-HK: 裝置已配對
 "Paired to slot %{slot}.":
   ja: スロット %{slot} にペアリングしました。
+  ru: "Сопряжено со слотом %{slot}."
   zh-CN: 已配对到插槽 %{slot}。
   zh-HK: 已配對到插槽 %{slot}。
 "Done":
   ja: 完了
+  ru: "Готово"
   zh-CN: 完成
   zh-HK: 完成
 "Pairing failed":
   ja: ペアリングに失敗しました
+  ru: "Сопряжение не удалось"
   zh-CN: 配对失败
   zh-HK: 配對失敗
 "Try again":
   ja: 再試行
+  ru: "Повторить"
   zh-CN: 重试
   zh-HK: 重試
 "Cancel":
   ja: キャンセル
+  ru: "Отмена"
   zh-CN: 取消
   zh-HK: 取消

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -4,8 +4,8 @@
 //! at compile time by the `rust_i18n::i18n!` macro in `main.rs`. Call sites use
 //! the [`tr!`](crate::tr) helper (or `rust_i18n::t!`) with the **English string
 //! as the key** — a missing entry falls back to that English text, so the file
-//! carries only the translated `ja` / `zh-CN` / `zh-HK` columns; English is the
-//! key itself.
+//! carries only the translated `ja` / `ru` / `zh-CN` / `zh-HK` columns;
+//! English is the key itself.
 //!
 //! The current locale is a process-global atomic inside `rust_i18n`. Setting it
 //! re-localizes both our own call sites *and* gpui-component's built-in widget
@@ -19,12 +19,14 @@ use openlogi_core::config::AppSettings;
 /// Locales the GUI ships, as `(code, native name)`. The codes match the
 /// sub-keys in `locales/app.yml`; `en` / `zh-CN` / `zh-HK` also match
 /// gpui-component's bundled `ui.yml`, so choosing one localizes the framework's
-/// own widgets too. `ja` is *not* in `ui.yml`, so under Japanese our app strings
-/// localize but the framework's built-in widget strings fall back to English.
+/// own widgets too. `ja` and `ru` are *not* in `ui.yml`, so under Japanese or
+/// Russian our app strings localize but the framework's built-in widget strings
+/// fall back to English.
 /// Order here is the order shown in the Settings picker (after "Follow system").
 pub const SUPPORTED: &[(&str, &str)] = &[
     ("en", "English"),
     ("ja", "日本語"),
+    ("ru", "Русский"),
     ("zh-CN", "简体中文"),
     ("zh-HK", "繁體中文"),
 ];
@@ -56,6 +58,7 @@ fn match_supported(code: &str) -> Option<&'static str> {
     match subtags.next() {
         Some("en") => Some("en"),
         Some("ja") => Some("ja"),
+        Some("ru") => Some("ru"),
         Some("zh") => {
             let traditional = matches!(
                 subtags.find(|t| matches!(*t, "hans" | "hant" | "tw" | "hk" | "mo")),
@@ -94,6 +97,8 @@ mod tests {
         assert_eq!(match_supported("zh-HK"), Some("zh-HK"));
         assert_eq!(match_supported("ja"), Some("ja"));
         assert_eq!(match_supported("ja-JP"), Some("ja"));
+        assert_eq!(match_supported("ru"), Some("ru"));
+        assert_eq!(match_supported("ru-RU"), Some("ru"));
         assert_eq!(match_supported("en-US"), Some("en"));
         assert_eq!(match_supported("fr-FR"), None);
     }
@@ -157,6 +162,10 @@ mod tests {
         rust_i18n::set_locale("ja");
         assert_eq!(rust_i18n::t!("Settings"), "設定");
         assert_eq!(rust_i18n::t!("Left Click"), "左クリック");
+
+        rust_i18n::set_locale("ru");
+        assert_eq!(rust_i18n::t!("Settings"), "Настройки");
+        assert_eq!(rust_i18n::t!("Left Click"), "Левый щелчок");
 
         // English has no column: every key falls back to the English source.
         rust_i18n::set_locale("en");

--- a/crates/openlogi-gui/src/windows/about.rs
+++ b/crates/openlogi-gui/src/windows/about.rs
@@ -33,7 +33,7 @@ pub struct AboutView {
 }
 
 impl AboutView {
-    fn new(cx: &mut Context<Self>) -> Self {
+    fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         // Reuse the app-wide shared updater installed at launch, so a launch-time
         // check result is already visible here. Fall back to a fresh one if it
         // somehow wasn't installed.

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -116,7 +116,7 @@ pub struct AddDeviceView {
 }
 
 impl AddDeviceView {
-    fn new(cx: &mut Context<Self>) -> Self {
+    fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         let state_obs = cx.observe_global::<PairingUi>(|_, cx| cx.notify());
         Self {
             appearance_obs: None,

--- a/crates/openlogi-gui/src/windows/mod.rs
+++ b/crates/openlogi-gui/src/windows/mod.rs
@@ -54,7 +54,7 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
     slot: impl Fn(&mut WindowRegistry) -> &mut Option<WindowHandle<Root>>,
     title: impl Into<SharedString>,
     size: Size<Pixels>,
-    build_view: impl FnOnce(&mut Context<V>) -> V + 'static,
+    build_view: impl FnOnce(&mut gpui::Window, &mut Context<V>) -> V + 'static,
     cx: &mut App,
 ) {
     let title = title.into();
@@ -84,7 +84,7 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
 
     let opened = cx.open_window(options, |window, cx| {
         Theme::change(ThemeMode::from(window.appearance()), Some(window), cx);
-        let view = cx.new(build_view);
+        let view = cx.new(|cx| build_view(window, cx));
         let appearance_obs = window.observe_window_appearance(|window, cx| {
             Theme::change(ThemeMode::from(window.appearance()), Some(window), cx);
         });

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -7,12 +7,17 @@
 //! set grows enough to warrant pages, this can migrate to that widget.
 
 use gpui::{
-    App, BorrowAppContext as _, Context, FontWeight, InteractiveElement, IntoElement,
-    ParentElement as _, Render, SharedString, Size, StatefulInteractiveElement as _, Styled as _,
-    Subscription, Window, div, px, rgb,
+    App, AppContext as _, BorrowAppContext as _, Context, Entity, FontWeight, IntoElement,
+    ParentElement as _, Render, SharedString, Size, Styled as _, Subscription, Window, div, px,
 };
 use gpui_component::{
-    Icon, IconName, group_box::GroupBox, h_flex, scroll::ScrollableElement, switch::Switch, v_flex,
+    Icon, IconName, IndexPath, Sizable,
+    group_box::GroupBox,
+    h_flex,
+    scroll::ScrollableElement,
+    select::{Select, SelectEvent, SelectItem, SelectState},
+    switch::Switch,
+    v_flex,
 };
 
 use crate::state::AppState;
@@ -23,13 +28,52 @@ use crate::windows::{self, AuxWindow};
 pub struct SettingsView {
     #[allow(dead_code, reason = "held to keep the appearance observer alive")]
     appearance_obs: Option<Subscription>,
+    language_select: Entity<SelectState<Vec<LanguageOption>>>,
 }
 
 impl SettingsView {
-    fn new(_: &mut Context<Self>) -> Self {
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let current = cx
+            .try_global::<AppState>()
+            .and_then(|s| s.app_settings().language.clone());
+        let options = language_options();
+        let selected = selected_language_index(current.as_deref(), &options);
+        let language_select = cx.new(|cx| SelectState::new(options, Some(selected), window, cx));
+        cx.subscribe_in(&language_select, window, Self::on_language_select)
+            .detach();
+
         Self {
             appearance_obs: None,
+            language_select,
         }
+    }
+
+    fn on_language_select(
+        &mut self,
+        _: &Entity<SelectState<Vec<LanguageOption>>>,
+        event: &SelectEvent<Vec<LanguageOption>>,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let SelectEvent::Confirm(_) = event;
+        let language = self
+            .language_select
+            .read(cx)
+            .selected_value()
+            .copied()
+            .filter(|code| !code.is_empty())
+            .map(ToOwned::to_owned);
+
+        cx.update_global::<AppState, _>(|s, _| s.set_language(language));
+        // `t!` reads the locale at render time, so a repaint is what actually
+        // applies the switch; the app menu and status item aren't in any
+        // window's view tree, so re-title them too. The status item's device
+        // line lives on the spawn loop, so ask it to re-localize the whole menu
+        // rather than writing from here.
+        cx.refresh_windows();
+        crate::app_menu::rebuild(cx);
+        #[cfg(target_os = "macos")]
+        crate::platform::tray::request_refresh();
     }
 }
 
@@ -53,12 +97,10 @@ pub fn open(cx: &mut App) {
 impl Render for SettingsView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
-        let (launch, updates, language) =
-            cx.try_global::<AppState>()
-                .map_or((false, false, None), |s| {
-                    let a = s.app_settings();
-                    (a.launch_at_login, a.check_for_updates, a.language.clone())
-                });
+        let (launch, updates) = cx.try_global::<AppState>().map_or((false, false), |s| {
+            let a = s.app_settings();
+            (a.launch_at_login, a.check_for_updates)
+        });
 
         let general = GroupBox::new()
             .title(group_title(IconName::Settings, tr!("General")))
@@ -137,10 +179,60 @@ impl Render for SettingsView {
                     .child(
                         GroupBox::new()
                             .title(group_title(IconName::Globe, tr!("Language")))
-                            .child(language_row(language.as_deref(), pal, cx)),
+                            .child(language_row(&self.language_select, pal)),
                     ),
             )
     }
+}
+
+#[derive(Clone)]
+struct LanguageOption {
+    label: &'static str,
+    value: &'static str,
+    localize_label: bool,
+}
+
+impl SelectItem for LanguageOption {
+    type Value = &'static str;
+
+    fn title(&self) -> SharedString {
+        if self.localize_label {
+            SharedString::from(rust_i18n::t!("Follow system").into_owned())
+        } else {
+            SharedString::from(self.label)
+        }
+    }
+
+    fn value(&self) -> &Self::Value {
+        &self.value
+    }
+}
+
+fn language_options() -> Vec<LanguageOption> {
+    let mut options = vec![LanguageOption {
+        label: "Follow system",
+        value: "",
+        localize_label: true,
+    }];
+    options.extend(
+        crate::i18n::SUPPORTED
+            .iter()
+            .map(|(code, name)| LanguageOption {
+                label: name,
+                value: code,
+                localize_label: false,
+            }),
+    );
+    options
+}
+
+fn selected_language_index(current: Option<&str>, options: &[LanguageOption]) -> IndexPath {
+    let value = current.unwrap_or_default();
+    let row = options
+        .iter()
+        .position(|option| option.value == value)
+        .unwrap_or_default();
+    IndexPath::default().row(row)
 }
 
 /// A GroupBox title with a small leading icon. `GroupBox::title` styles the
@@ -181,71 +273,31 @@ fn setting_row(
         .child(control)
 }
 
-/// The language picker: a muted hint above a wrapping row of locale chips. The
-/// leading "Follow system" chip clears the stored preference (`None`); the rest
-/// pin an explicit locale from [`crate::i18n::SUPPORTED`]. Selecting one
-/// switches the locale live, then repaints every window and the menu bar so the
-/// whole UI re-renders without a restart.
+/// The language picker. "Follow system" clears the stored preference (`None`);
+/// the explicit locale entries come from [`crate::i18n::SUPPORTED`]. Selecting
+/// one switches the locale live, then repaints every window and the menu bar so
+/// the whole UI re-renders without a restart.
 fn language_row(
-    current: Option<&str>,
+    language_select: &Entity<SelectState<Vec<LanguageOption>>>,
     pal: Palette,
-    cx: &mut Context<SettingsView>,
 ) -> impl IntoElement {
-    let mut options: Vec<(SharedString, Option<String>)> = vec![(tr!("Follow system"), None)];
-    options.extend(
-        crate::i18n::SUPPORTED
-            .iter()
-            .map(|(code, name)| (SharedString::from(*name), Some((*code).to_string()))),
-    );
-
-    let chips: Vec<_> = options
-        .into_iter()
-        .enumerate()
-        .map(|(idx, (label, lang))| {
-            let active = current == lang.as_deref();
-            div()
-                .id(("lang-chip", idx))
-                .px_2()
-                .py_1()
-                .rounded_md()
-                .border_1()
-                .border_color(if active {
-                    rgb(theme::ACCENT_BLUE).into()
-                } else {
-                    pal.border
-                })
-                .text_xs()
-                .text_color(if active {
-                    rgb(theme::ACCENT_BLUE).into()
-                } else {
-                    pal.text_primary
-                })
-                .cursor_pointer()
-                .hover(|s| s.bg(pal.surface_hover))
-                .child(label)
-                .on_click(cx.listener(move |_, _, _, cx| {
-                    cx.update_global::<AppState, _>(|s, _| s.set_language(lang.clone()));
-                    // `t!` reads the locale at render time, so a repaint is what
-                    // actually applies the switch; the app menu and status item
-                    // aren't in any window's view tree, so re-title them too. The
-                    // status item's device line lives on the spawn loop, so ask it
-                    // to re-localize the whole menu rather than writing from here.
-                    cx.refresh_windows();
-                    crate::app_menu::rebuild(cx);
-                    #[cfg(target_os = "macos")]
-                    crate::platform::tray::request_refresh();
-                }))
-        })
-        .collect();
-
-    v_flex()
+    h_flex()
         .w_full()
-        .gap_2()
+        .items_center()
+        .justify_between()
+        .gap_4()
         .child(
             div()
+                .flex_1()
+                .min_w(px(0.))
                 .text_xs()
                 .text_color(pal.text_muted)
                 .child(tr!("Choose the interface language.")),
         )
-        .child(h_flex().gap_2().flex_wrap().children(chips))
+        .child(
+            Select::new(language_select)
+                .small()
+                .w(px(220.))
+                .menu_width(px(220.)),
+        )
 }

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -27,7 +27,7 @@ pub struct UpdateConsentView {
 }
 
 impl UpdateConsentView {
-    fn new(_: &mut Context<Self>) -> Self {
+    fn new(_: &mut Window, _: &mut Context<Self>) -> Self {
         Self {
             appearance_obs: None,
         }


### PR DESCRIPTION
## Summary
- add Russian (ru) to the supported GUI locale list and locale resolver
- add Russian translations for all existing OpenLogi GUI strings
- replace the Settings language chip row with a gpui-component Select for a more compact, scalable language picker
- cover ru/ru-RU locale matching and basic translation loading in i18n tests

## Verification
- cargo test -p openlogi-gui
- cargo check -p openlogi-gui
- cargo clippy -p openlogi-gui -- -D warnings
- cargo fmt --check
- git diff --check