### PR TITLE
fix: detect MX Master 4 B (0xb048) over macOS Bluetooth LE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "hidpp",
  "openlogi-core",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -16,6 +16,7 @@ hidpp = { workspace = true }
 async-hid = { workspace = true }
 tokio = { workspace = true }
 futures-lite = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -27,7 +27,7 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::route::DIRECT_DEVICE_INDEX;
-use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
+use crate::transport::{enumerate_hidpp_devices, is_logitech_mouse, open_hidpp_channel};
 
 /// How long to wait for device-arrival event bursts before assuming the
 /// receiver has finished reporting. MX Master 4 (and other devices that may
@@ -38,6 +38,16 @@ const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
 /// Maximum number of pairing slots a Bolt receiver supports. We iterate this
 /// range to surface paired-but-offline devices that won't fire arrival events.
 const MAX_BOLT_SLOTS: u8 = 6;
+
+/// Logitech vendor ID (mirrors `transport::LOGITECH_VID`; local copy avoids
+/// a `pub(crate)` re-export just for this module).
+const LOGITECH_VID: u16 = 0x046d;
+/// MX Master 4 B (Bluetooth-direct) ProductID — distinct from 0xb042 which is
+/// the USB cable / Bolt-receiver variant of the same device family.
+const MX_MASTER_4_PID: u16 = 0xb048;
+const MX_MASTER_4_EXT_MODEL_ID: u8 = 0x02;
+/// Product name as reported by macOS for the BLE-direct variant.
+const MX_MASTER_4_NAME: &str = "MX Master 4 B";
 
 #[derive(Debug, Error)]
 pub enum InventoryError {
@@ -73,7 +83,151 @@ pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
         }
     }
 
+    // Run the hidutil fallback whenever MX Master 4 B is absent — not only when
+    // the list is empty. A Bolt receiver attached alongside the BLE-paired
+    // MX Master 4 B would otherwise populate `inventories` and suppress this
+    // fallback, leaving the BLE device undetected.
+    let already_has_mx4b = inventories.iter().any(|inv| {
+        inv.receiver.product_id == MX_MASTER_4_PID
+            || inv.paired.iter().any(|p| {
+                p.model_info
+                    .as_ref()
+                    .is_some_and(|m| m.model_ids[0] == MX_MASTER_4_PID)
+            })
+    });
+    if !already_has_mx4b {
+        // spawn_blocking so the synchronous hidutil shell-out does not stall
+        // the async executor.
+        let fallback = tokio::task::spawn_blocking(hidutil_direct_mouse_fallback)
+            .await
+            .unwrap_or_default();
+        inventories.extend(fallback);
+    }
+
     Ok(inventories)
+}
+
+/// Synthesise a `DeviceInventory` for a Logitech generic-desktop mouse node
+/// when `probe_direct` returned `None` (device doesn't speak HID++).
+/// Only fires for the MX Master 4 B PID to keep the scope narrow.
+fn fallback_direct_mouse(info: &async_hid::DeviceInfo) -> Option<DeviceInventory> {
+    if !is_logitech_mouse(info) || info.product_id != MX_MASTER_4_PID {
+        return None;
+    }
+    debug!(
+        name = %info.name,
+        pid = format_args!("{:04x}", info.product_id),
+        "Logitech mouse node has no HID++ collection — using synthetic inventory"
+    );
+    Some(synthetic_direct_mouse_inventory(
+        &info.name,
+        info.product_id,
+        MX_MASTER_4_EXT_MODEL_ID,
+    ))
+}
+
+/// Last-resort fallback: shell out to `hidutil list --ndjson` on macOS to check
+/// whether the MX Master 4 B is connected when the HID enumerate path returned
+/// nothing (e.g. because `async-hid` couldn't open the device node).
+///
+/// Confirmed working on macOS 13 (Ventura) and later; `--ndjson` was added no
+/// later than macOS 10.15. On non-macOS this is a no-op.
+#[cfg(target_os = "macos")]
+fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
+    use std::process::Command;
+    let output = match Command::new("/usr/bin/hidutil")
+        .args([
+            "list",
+            "--ndjson",
+            "--matching",
+            // VendorID 0x046d = Logitech; ProductID 0xb048 = MX Master 4 B
+            r#"{"VendorID":0x046d,"ProductID":0xb048}"#,
+        ])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            debug!(error = %e, "hidutil unavailable; skipping MX Master 4 B fallback");
+            return Vec::new();
+        }
+    };
+    if !output.status.success() {
+        debug!(
+            status = %output.status,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "hidutil exited non-zero (--ndjson requires macOS 10.15+)"
+        );
+        return Vec::new();
+    }
+    if !hidutil_lists_mx_master_4b(&output.stdout) {
+        return Vec::new();
+    }
+    debug!("hidutil found MX Master 4 B (BLE-direct) — synthesising inventory");
+    vec![synthetic_direct_mouse_inventory(
+        MX_MASTER_4_NAME,
+        MX_MASTER_4_PID,
+        MX_MASTER_4_EXT_MODEL_ID,
+    )]
+}
+
+#[cfg(not(target_os = "macos"))]
+fn hidutil_direct_mouse_fallback() -> Vec<DeviceInventory> {
+    Vec::new()
+}
+
+#[cfg(target_os = "macos")]
+fn hidutil_lists_mx_master_4b(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout).lines().any(|line| {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            return false;
+        };
+        value.get("Product").and_then(|v| v.as_str()) == Some(MX_MASTER_4_NAME)
+            && value.get("VendorID").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(LOGITECH_VID))
+            && value.get("ProductID").and_then(serde_json::Value::as_u64)
+                == Some(u64::from(MX_MASTER_4_PID))
+            && value
+                .get("PrimaryUsagePage")
+                .and_then(serde_json::Value::as_u64)
+                == Some(1)
+            && value
+                .get("PrimaryUsage")
+                .and_then(serde_json::Value::as_u64)
+                == Some(2)
+    })
+}
+
+fn synthetic_direct_mouse_inventory(
+    name: &str,
+    product_id: u16,
+    extended_model_id: u8,
+) -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: name.to_string(),
+            vendor_id: LOGITECH_VID,
+            product_id,
+            unique_id: None,
+        },
+        paired: vec![PairedDevice {
+            slot: DIRECT_DEVICE_INDEX,
+            codename: Some(name.to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 0,
+                unit_id: [0; 4],
+                transports: DeviceTransports {
+                    btle: true,
+                    ..DeviceTransports::default()
+                },
+                model_ids: [product_id, 0, 0],
+                extended_model_id,
+            }),
+        }],
+    }
 }
 
 async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, InventoryError> {
@@ -86,7 +240,9 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
         // addresses the device's own features. Probe in case it answers.
         // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-        return Ok(probe_direct(channel, &info).await);
+        return Ok(probe_direct(Arc::clone(&channel), &info)
+            .await
+            .or_else(|| fallback_direct_mouse(&info)));
     };
 
     let unique_id = bolt.get_unique_id().await.ok();

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -109,9 +109,28 @@ pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, 
     Ok(all
         .into_iter()
         .filter(|d| {
-            d.vendor_id == LOGITECH_VID && is_hidpp_long_collection(d.usage_page, d.usage_id)
+            d.vendor_id == LOGITECH_VID
+                && (is_hidpp_long_collection(d.usage_page, d.usage_id)
+                    || is_logitech_mouse(d))
         })
         .collect())
+}
+
+/// Return `true` for Logitech generic-desktop mouse nodes (`0x0001 / 0x0002`).
+///
+/// Certain BLE-direct mice (e.g. MX Master 4 B, PID `0xb048`) do not expose a
+/// Logitech vendor HID++ collection on macOS — the OS only surfaces a standard
+/// mouse interface. `enumerate_hidpp_devices` admits these so `probe_one` can
+/// attempt an HID++ probe; if that fails, `fallback_direct_mouse` in
+/// `inventory.rs` synthesises an inventory keyed by PID.
+///
+/// **Invariant:** this is safe only because both `open_hidpp_channel` (returns
+/// `None` on non-HID++ endpoints) and `fallback_direct_mouse` (re-filters by
+/// known-good PID) handle the case gracefully. Widening the PID set in
+/// `fallback_direct_mouse` requires verifying that the new device also tolerates
+/// HID++ probe writes — or adjusting `supports_short_long_hidpp` accordingly.
+pub(crate) fn is_logitech_mouse(d: &DeviceInfo) -> bool {
+    d.vendor_id == LOGITECH_VID && d.usage_page == 0x0001 && d.usage_id == 0x0002
 }
 
 pub(crate) async fn open_hidpp_channel(


### PR DESCRIPTION
## What this fixes

Supersedes #36 (closed) — clean single commit rebased on master after PR #28 merged.

The **MX Master 4 B** (Bluetooth-direct, PID `0xb048`) was never detected because:

1. The original PR #20 used the wrong PID (`0xb042`) and name (`"MX Master 4"`). The BLE-direct variant reports `ProductID = 0xb048` and `Product = "MX Master 4 B"` — confirmed via `hidutil` and `ioreg` on macOS 15.
2. On macOS, the BLE HID descriptor for this device exposes **only a generic-desktop mouse collection** (`usage_page=0x0001 / usage_id=0x0002`) — no Logitech vendor HID++ collection. `enumerate_hidpp_devices` filtered it out entirely.
3. The `hidutil --matching` literal string hardcoded `0xb042` independently of the constant, so fixing the constant alone was not sufficient.

## Changes

**`transport.rs`**
- Adds `is_logitech_mouse()` for generic-desktop Logitech mouse nodes
- Widens `enumerate_hidpp_devices()` to admit these nodes alongside the HID++ collections (`0xFF00` and `0xFF43`) handled by PR #28
- Documents the safety invariant (see inline comment)

**`inventory.rs`**
- `MX_MASTER_4_PID`: `0xb042` → `0xb048`
- `MX_MASTER_4_NAME`: `"MX Master 4"` → `"MX Master 4 B"`
- `probe_one`: adds `.or_else(fallback_direct_mouse)` after `probe_direct`
- `hidutil_direct_mouse_fallback`: wrapped in `spawn_blocking`, logs stderr on failure
- Ungates the hidutil fallback: runs whenever MX Master 4 B is absent (not only when the whole list is empty — fixes Bolt-alongside-BLE topology)

## Pullfrog review findings (from #36) — all addressed
| Finding | Resolution |
|---|---|
| TCC sqlite3 fallback non-functional (3 independent bugs) | Removed entirely |
| `info!` fires on every enumerate tick | Changed to `debug!` |
| `is_hidpp_candidate` invariant undocumented | Full doc comment in `transport.rs` |
| hidutil fallback masked by non-empty inventory | Ungated, runs on MX Master 4 B absence |
| Blocking `Command::output()` in async context | Wrapped in `spawn_blocking` |

## Prerequisite for users

If `com.logi.ghub.hidfilter` (Logi G HUB HID Driver Extension) is still active it claims exclusive HID access — remove it via **System Settings → General → Login Items & Extensions → Driver Extensions**.

## Tested on
- macOS 15, Apple Silicon
- MX Master 4 B, fw `RBM27.00_0015`, paired over BLE (`PID 0xb048`)
- With and without Bolt receiver attached simultaneously

Fixes #32