### PR TITLE
feat: support Bluetooth-direct Logitech mice (MX Master 3) on macOS

### DIFF
--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -16,7 +16,10 @@ pub async fn run(_args: ListArgs) -> Result<()> {
         println!("Notes:");
         println!("  - On macOS, quit Logi Options+ first — both apps fight over HID++ access.");
         println!("  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548).");
-        println!("  - Devices paired directly over Bluetooth are not enumerated yet.");
+        println!(
+            "  - Bluetooth-direct and USB-wired devices are enumerated; make sure the device is \
+             connected and awake."
+        );
         std::process::exit(2);
     }
 

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -155,6 +155,13 @@ fn main() -> Result<()> {
         if !Hook::has_accessibility() {
             Hook::prompt_accessibility();
         }
+        // Reading HID++ input reports from a Bluetooth- or USB-direct device
+        // is gated by Input Monitoring (the device carries pointer/keyboard
+        // collections); without it such devices never appear. Request it up
+        // front so macOS lists the app — the grant takes effect on relaunch.
+        if !Hook::has_input_monitoring() {
+            Hook::prompt_input_monitoring();
+        }
 
         // Publish the shared updater and, if the user opted in, run one
         // check on launch. Done before `initial_config` is moved into the

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -102,7 +102,9 @@ fn main() -> Result<()> {
 
     // HID++ control capture (gesture button, DPI/ModeShift button, thumb wheel)
     // runs independently of the CGEventTap hook — it needs no Accessibility
-    // permission — so start it up front for the active device.
+    // permission — so start it up front for the active device. The session
+    // itself skips Bluetooth-direct devices (see `run_capture_session`), where
+    // holding the HID++ channel open degrades pointer movement.
     watchers::gesture::spawn(
         Arc::clone(&hook_bindings),
         Arc::clone(&gesture_bindings),

--- a/crates/openlogi-gui/src/watchers/inventory.rs
+++ b/crates/openlogi-gui/src/watchers/inventory.rs
@@ -1,15 +1,19 @@
 //! Polling HID inventory watcher.
 //!
-//! Spawns a dedicated OS thread with a one-shot tokio runtime that calls
-//! `openlogi_hid::enumerate` every `period` and forwards the result over an
-//! unbounded mpsc to the GPUI thread. The GUI applies updates via
-//! `AppState::refresh_inventories`.
+//! Spawns a dedicated OS thread with a one-shot tokio runtime that watches for
+//! device connect/disconnect and forwards a fresh inventory over an unbounded
+//! mpsc to the GPUI thread, which applies it via `AppState::refresh_inventories`.
 //!
 //! Polling beats hot-plug event registration on simplicity: HID transport
 //! crates ship different listener APIs across platforms, and `async-hid 0.4`
-//! does not expose any. A 2 s tick is cheap (one HID enumerate per cycle ≤
-//! a few hundred milliseconds) and matches the human-perceptible reconnect
-//! latency budget in PLAN.md.
+//! does not expose any.
+//!
+//! Crucially, each tick first reads a *cheap presence signature*
+//! (`openlogi_hid::present_keys`, which lists the HID registry without opening
+//! anything) and only runs the full `enumerate` — which opens each device's
+//! HID++ channel — when that signature changes. Re-opening a Bluetooth-direct
+//! device's channel renegotiates the BLE link and visibly jitters the pointer,
+//! so it must happen on connect/disconnect only, never on a bare timer.
 
 use std::thread;
 use std::time::Duration;
@@ -39,17 +43,28 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<Vec<DeviceInventory>> 
                     return;
                 }
             };
+            // `None` until the first successful presence read, so the initial
+            // tick always runs a full enumerate and seeds the GUI.
+            let mut last_keys: Option<Vec<(u16, u16, u16)>> = None;
             loop {
-                let inv = match rt.block_on(openlogi_hid::enumerate()) {
-                    Ok(inv) => inv,
-                    Err(e) => {
-                        warn!(error = ?e, "enumerate failed during watch tick");
-                        Vec::new()
+                match rt.block_on(openlogi_hid::present_keys()) {
+                    Ok(keys) if last_keys.as_ref() != Some(&keys) => {
+                        // Device set changed (or first run): re-probe + publish.
+                        last_keys = Some(keys);
+                        let inv = match rt.block_on(openlogi_hid::enumerate()) {
+                            Ok(inv) => inv,
+                            Err(e) => {
+                                warn!(error = ?e, "enumerate failed during watch tick");
+                                Vec::new()
+                            }
+                        };
+                        if tx.send(inv).is_err() {
+                            debug!("inventory watcher receiver dropped — exiting");
+                            return;
+                        }
                     }
-                };
-                if tx.send(inv).is_err() {
-                    debug!("inventory watcher receiver dropped — exiting");
-                    return;
+                    Ok(_) => {} // unchanged — no channel opened, pointer undisturbed
+                    Err(e) => warn!(error = ?e, "presence check failed during watch tick"),
                 }
                 thread::sleep(period);
             }

--- a/crates/openlogi-hid/src/battery_status.rs
+++ b/crates/openlogi-hid/src/battery_status.rs
@@ -1,0 +1,127 @@
+//! Bare-minimum HID++ `BatteryStatus` (feature `0x1000`) wrapper.
+//!
+//! This is the legacy battery feature carried by older MX-class mice — the
+//! MX Master 3, for instance, exposes `0x1000` rather than the newer
+//! `0x1004 UnifiedBattery` that `hidpp 0.2` ships a typed wrapper for. We
+//! implement only `getBatteryLevelStatus` (function `0x0`), enough to surface
+//! a charge percentage + charging state.
+//!
+//! Follows the same shape as the typed wrappers `hidpp` ships
+//! (`UnifiedBatteryFeatureV0`, …) and the sibling `AdjustableDpiFeatureV0`.
+
+use std::sync::Arc;
+
+use hidpp::{
+    channel::HidppChannel,
+    feature::{CreatableFeature, Feature},
+    nibble::U4,
+    protocol::v20::{self, Hidpp20Error},
+};
+
+/// Charging state reported by `0x1000`'s `batteryStatus` byte. Mirrors the
+/// HID++ enumeration; unknown/future codes fall through to [`Self::Unknown`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatteryChargeState {
+    Discharging,
+    Recharging,
+    /// Charging, in the final (top-off) stage.
+    AlmostFull,
+    /// Charge complete — battery full.
+    Full,
+    /// Recharging below optimal speed (e.g. weak USB port).
+    SlowRecharge,
+    /// Invalid battery / thermal / other charging error.
+    Error,
+    Unknown,
+}
+
+impl BatteryChargeState {
+    fn from_raw(raw: u8) -> Self {
+        match raw {
+            0 => Self::Discharging,
+            1 => Self::Recharging,
+            2 => Self::AlmostFull,
+            3 => Self::Full,
+            4 => Self::SlowRecharge,
+            5..=7 => Self::Error,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// One reading of `getBatteryLevelStatus`.
+#[derive(Debug, Clone, Copy)]
+pub struct BatteryLevelStatus {
+    /// Current charge as a percentage (0–100).
+    pub level_percent: u8,
+    /// Charging / discharging state.
+    pub charge_state: BatteryChargeState,
+}
+
+/// `BatteryStatus` / `0x1000` feature, version 0+.
+#[derive(Clone)]
+pub struct BatteryStatusFeatureV0 {
+    chan: Arc<HidppChannel>,
+    device_index: u8,
+    feature_index: u8,
+}
+
+impl CreatableFeature for BatteryStatusFeatureV0 {
+    const ID: u16 = 0x1000;
+    const STARTING_VERSION: u8 = 0;
+
+    fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
+        Self {
+            chan,
+            device_index,
+            feature_index,
+        }
+    }
+}
+
+impl Feature for BatteryStatusFeatureV0 {}
+
+impl BatteryStatusFeatureV0 {
+    /// Read the current charge level + charging state (function `0x0`).
+    /// Response payload is `[dischargeLevel, nextLevel, status, …]`.
+    pub async fn get_battery_level_status(&self) -> Result<BatteryLevelStatus, Hidpp20Error> {
+        let response = self
+            .chan
+            .send_v20(v20::Message::Short(
+                v20::MessageHeader {
+                    device_index: self.device_index,
+                    feature_index: self.feature_index,
+                    function_id: U4::from_lo(0),
+                    software_id: self.chan.get_sw_id(),
+                },
+                [0x00, 0x00, 0x00],
+            ))
+            .await?;
+        let payload = response.extend_payload();
+        Ok(BatteryLevelStatus {
+            level_percent: payload[0],
+            charge_state: BatteryChargeState::from_raw(payload[2]),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn charge_state_maps_known_codes_and_falls_back() {
+        use BatteryChargeState::{
+            AlmostFull, Discharging, Error, Full, Recharging, SlowRecharge, Unknown,
+        };
+        assert_eq!(BatteryChargeState::from_raw(0), Discharging);
+        assert_eq!(BatteryChargeState::from_raw(1), Recharging);
+        assert_eq!(BatteryChargeState::from_raw(2), AlmostFull);
+        assert_eq!(BatteryChargeState::from_raw(3), Full);
+        assert_eq!(BatteryChargeState::from_raw(4), SlowRecharge);
+        for code in 5..=7 {
+            assert_eq!(BatteryChargeState::from_raw(code), Error);
+        }
+        assert_eq!(BatteryChargeState::from_raw(99), Unknown);
+    }
+}

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -27,6 +27,7 @@ use tracing::{debug, info, warn};
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::route::{DeviceRoute, open_route_channel};
 use crate::thumbwheel::{self, Thumbwheel};
+use crate::transport::HIDPP_BLE_USAGE_PAGE;
 use crate::write::SharedChannel;
 
 /// Shared slot holding the active capture session's open channel, so DPI /
@@ -64,6 +65,11 @@ pub enum GestureError {
     /// A HID++ feature call returned an error; inner string carries context.
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
+    /// Bluetooth-direct (0xff43) devices cannot hold a persistent HID++ capture
+    /// session without degrading BLE pointer movement.  Transient writes (DPI,
+    /// SmartShift, battery) are unaffected.
+    #[error("BLE-direct device: persistent capture skipped to prevent pointer movement glitch")]
+    BleDirectUnsupported,
 }
 
 /// Minimum hold before raw-XY travel counts as a swipe. A quicker tap stays a
@@ -104,9 +110,27 @@ pub async fn run_capture_session(
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
 ) -> Result<(), GestureError> {
-    let chan = open_route_channel(&route)
+    let (hid_info, chan) = open_route_channel(&route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
+
+    // Holding the `0xff43` HID interface open persistently degrades BLE pointer
+    // movement — jitter that worsens over time — on Bluetooth-direct Logitech
+    // mice (MX Master 3, etc.). A second IOHIDDevice open/activate on the shared
+    // BLE link appears to trigger connection-parameter renegotiation; transient
+    // opens (DPI/SmartShift writes, battery reads) are unaffected. Until a
+    // gentler transport lands (a CoreBluetooth GATT path, like Options+), skip
+    // the capture session for BLE-direct devices so movement stays smooth. Side
+    // buttons still remap via the CGEventTap; Bolt/USB keep full capture.
+    if hid_info.usage_page == HIDPP_BLE_USAGE_PAGE {
+        info!(
+            route = %route,
+            "BLE-direct device: skipping persistent capture to prevent pointer glitch \
+             (gesture/DPI-button/thumbwheel capture unavailable on BLE-direct)"
+        );
+        return Err(GestureError::BleDirectUnsupported);
+    }
+
     let device_index = route.device_index();
     let armed = arm_controls(&chan, device_index, capture_thumbwheel).await?;
 

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -61,6 +61,15 @@ pub enum InventoryError {
 ///
 /// We merge the two so an MX Master that's been asleep still shows up with
 /// its codename and kind even before you click it.
+/// A cheap signature of the currently-connected HID++ nodes, for hot-plug
+/// detection without opening any device. Poll this and only call [`enumerate`]
+/// (which opens each channel) when the signature changes — re-opening a
+/// Bluetooth-direct device's channel renegotiates the BLE link and jitters the
+/// pointer, so it must not happen on a timer.
+pub async fn present_keys() -> Result<Vec<(u16, u16, u16)>, InventoryError> {
+    Ok(crate::transport::present_device_keys().await?)
+}
+
 pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
     let candidates = enumerate_hidpp_devices().await?;
 

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -6,6 +6,7 @@ use hidpp::{
     channel::HidppChannel,
     device::Device,
     feature::{
+        CreatableFeature,
         device_information::v0::DeviceInformationFeatureV0,
         unified_battery::v0::{
             BatteryLevel as HidppBatteryLevel, BatteryStatus as HidppBatteryStatus,
@@ -26,6 +27,7 @@ use thiserror::Error;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
+use crate::battery_status::{BatteryChargeState, BatteryStatusFeatureV0};
 use crate::route::DIRECT_DEVICE_INDEX;
 use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
 
@@ -295,6 +297,13 @@ async fn probe_features(
             }),
         None => None,
     };
+    // Older MX-class devices (e.g. the MX Master 3) expose the legacy
+    // `0x1000 BatteryStatus` instead of `0x1004 UnifiedBattery`; fall back to
+    // it so they report a charge level too.
+    let battery = match battery {
+        some @ Some(_) => some,
+        None => read_legacy_battery(&mut device, slot).await,
+    };
 
     let model_info = match device.get_feature::<DeviceInformationFeatureV0>() {
         Some(feature) => match feature.get_device_info().await {
@@ -319,6 +328,57 @@ async fn probe_features(
     };
 
     (battery, model_info)
+}
+
+/// Read the legacy `0x1000 BatteryStatus` feature as a [`BatteryInfo`].
+///
+/// Resolved through the device root: `0x1000` isn't in hidpp 0.2's typed
+/// registry, so `enumerate_features` won't surface it (same reason the DPI
+/// feature is opened via the root in `write::open_feature`). Returns `None`
+/// when the device doesn't expose `0x1000` or the read fails.
+async fn read_legacy_battery(device: &mut Device, slot: u8) -> Option<BatteryInfo> {
+    let info = match device.root().get_feature(BatteryStatusFeatureV0::ID).await {
+        Ok(Some(info)) => info,
+        Ok(None) => return None,
+        Err(e) => {
+            debug!(slot, error = ?e, "0x1000 root lookup failed");
+            return None;
+        }
+    };
+    let feature = device.add_feature::<BatteryStatusFeatureV0>(info.index);
+    match feature.get_battery_level_status().await {
+        Ok(reading) => Some(BatteryInfo {
+            percentage: reading.level_percent,
+            level: battery_level_from_percent(reading.level_percent),
+            status: map_charge_state(reading.charge_state),
+        }),
+        Err(e) => {
+            debug!(slot, error = ?e, "0x1000 battery read failed");
+            None
+        }
+    }
+}
+
+/// Derive a coarse [`BatteryLevel`] bucket from a charge percentage. `0x1000`
+/// reports only a raw percentage, unlike `0x1004`'s discrete level field.
+fn battery_level_from_percent(pct: u8) -> BatteryLevel {
+    match pct {
+        0..=10 => BatteryLevel::Critical,
+        11..=30 => BatteryLevel::Low,
+        31..=89 => BatteryLevel::Good,
+        _ => BatteryLevel::Full,
+    }
+}
+
+fn map_charge_state(state: BatteryChargeState) -> BatteryStatus {
+    match state {
+        BatteryChargeState::Discharging => BatteryStatus::Discharging,
+        BatteryChargeState::Recharging | BatteryChargeState::AlmostFull => BatteryStatus::Charging,
+        BatteryChargeState::SlowRecharge => BatteryStatus::ChargingSlow,
+        BatteryChargeState::Full => BatteryStatus::Full,
+        BatteryChargeState::Error => BatteryStatus::Error,
+        BatteryChargeState::Unknown => BatteryStatus::Unknown,
+    }
 }
 
 /// HID++ feature IDs that mark a device as a controllable peripheral rather

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -10,6 +10,7 @@ mod route;
 mod transport;
 
 pub mod adjustable_dpi;
+pub mod battery_status;
 pub mod gesture;
 pub mod inventory;
 pub mod pairing;

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -20,7 +20,7 @@ pub mod thumbwheel;
 pub mod write;
 
 pub use gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
-pub use inventory::{InventoryError, enumerate};
+pub use inventory::{InventoryError, enumerate, present_keys};
 pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -73,9 +73,13 @@ impl fmt::Display for DeviceRoute {
 /// device through its slot via [`DeviceRoute::device_index`]); for a direct
 /// route it is the device's own channel. Returns `None` when nothing matching
 /// is currently connected.
+///
+/// The returned [`async_hid::DeviceInfo`] reflects the matched HID node (e.g.
+/// its `usage_page` distinguishes BLE-direct `0xff43` from USB/receiver
+/// `0xff00`). Callers that only need the channel can discard it with `let Some((_, ch)) = …`.
 pub(crate) async fn open_route_channel(
     route: &DeviceRoute,
-) -> Result<Option<Arc<HidppChannel>>, async_hid::HidError> {
+) -> Result<Option<(async_hid::DeviceInfo, Arc<HidppChannel>)>, async_hid::HidError> {
     let candidates = enumerate_hidpp_devices().await?;
     for dev in candidates {
         // A direct route's vendor/product id is on the unopened `DeviceInfo`
@@ -91,7 +95,7 @@ pub(crate) async fn open_route_channel(
         {
             continue;
         }
-        let Some((_, channel)) = open_hidpp_channel(dev).await? else {
+        let Some((info, channel)) = open_hidpp_channel(dev).await? else {
             continue;
         };
         match route {
@@ -102,10 +106,10 @@ pub(crate) async fn open_route_channel(
                 if let Ok(uid) = bolt.get_unique_id().await
                     && uid.eq_ignore_ascii_case(receiver_uid)
                 {
-                    return Ok(Some(channel));
+                    return Ok(Some((info, channel)));
                 }
             }
-            DeviceRoute::Direct { .. } => return Ok(Some(channel)),
+            DeviceRoute::Direct { .. } => return Ok(Some((info, channel))),
         }
     }
     Ok(None)

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -5,6 +5,11 @@
 //! Linux. We avoid the path entirely by pre-filtering to the Logitech HID++
 //! long-report usage page at enumeration time, then returning a hardcoded
 //! `Some((true, true))` from `supports_short_long_hidpp`.
+//!
+//! Bluetooth-direct devices add one wrinkle: they expose *only* the long HID++
+//! report (`0x11`) — there is no short (`0x10`) output report — so any short
+//! frame `hidpp` emits (e.g. the protocol-version ping) is repacked as a long
+//! report on the way out. See [`AsyncHidChannel::write_report`].
 
 use std::{error::Error, sync::Arc};
 
@@ -12,17 +17,34 @@ use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceInfo, DeviceReader, DeviceWri
 use futures_lite::StreamExt as _;
 use hidpp::{
     async_trait,
-    channel::{HidppChannel, RawHidChannel},
+    channel::{HidppChannel, LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel, SHORT_REPORT_ID},
 };
 use tokio::sync::Mutex;
 use tracing::debug;
 
 /// Logitech HID vendor ID.
 const LOGITECH_VID: u16 = 0x046d;
-/// HID++ long-report usage page / usage. Filtering on this pair gives us one
-/// HID node per physical HID++ device on every supported OS.
+/// HID++ long-report usage page / usage for receivers and USB-wired devices.
+/// Filtering on this pair gives us one HID node per physical HID++ device.
 const HIDPP_USAGE_PAGE: u16 = 0xff00;
 const HIDPP_LONG_USAGE_ID: u16 = 0x0002;
+/// HID++ long-report usage page / usage a device exposes when paired directly
+/// over Bluetooth (LE). Logitech moves the HID++ vendor collection to page
+/// `0xff43` with usage `0x0202` there — the MX Master 3, for instance, presents
+/// only generic mouse/keyboard collections on page `0xff00` and its HID++
+/// channel on `0xff43`. Filtering on `0xff00` alone misses every BT-direct
+/// device. (Matches Solaar's Bluetooth HID++ report mapping.)
+const HIDPP_BLE_USAGE_PAGE: u16 = 0xff43;
+const HIDPP_BLE_LONG_USAGE_ID: u16 = 0x0202;
+
+/// Whether a HID interface is the HID++ long-report node we drive devices
+/// through — either the receiver/USB collection (`0xff00`/`0x0002`) or the
+/// Bluetooth-direct one (`0xff43`/`0x0202`).
+fn is_hidpp_long_node(d: &async_hid::DeviceInfo) -> bool {
+    d.vendor_id == LOGITECH_VID
+        && ((d.usage_page == HIDPP_USAGE_PAGE && d.usage_id == HIDPP_LONG_USAGE_ID)
+            || (d.usage_page == HIDPP_BLE_USAGE_PAGE && d.usage_id == HIDPP_BLE_LONG_USAGE_ID))
+}
 
 pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, async_hid::HidError>
 {
@@ -30,11 +52,7 @@ pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, 
     Ok(backend
         .enumerate()
         .await?
-        .filter(|d| {
-            d.vendor_id == LOGITECH_VID
-                && d.usage_page == HIDPP_USAGE_PAGE
-                && d.usage_id == HIDPP_LONG_USAGE_ID
-        })
+        .filter(|d| is_hidpp_long_node(d))
         .collect()
         .await)
 }
@@ -85,6 +103,17 @@ impl RawHidChannel for AsyncHidChannel {
 
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error>> {
         let mut w = self.writer.lock().await;
+        // Bluetooth-direct devices expose only the long HID++ report (`0x11`):
+        // there is no short (`0x10`) output report, and writing one makes macOS
+        // return `kIOReturnNotFound`. `hidpp 0.2` still emits short frames (the
+        // protocol-version ping in `determine_version`, the Root feature
+        // queries), so repack any short report as a long one — same 3-byte
+        // header, payload zero-extended to the long length. The device replies
+        // with a long report either way, which the read path already handles.
+        if self.info.usage_page == HIDPP_BLE_USAGE_PAGE && src.first() == Some(&SHORT_REPORT_ID) {
+            w.write_output_report(&repack_short_as_long(src)).await?;
+            return Ok(src.len());
+        }
         w.write_output_report(src).await?;
         Ok(src.len())
     }
@@ -100,5 +129,40 @@ impl RawHidChannel for AsyncHidChannel {
 
     async fn get_report_descriptor(&self, _buf: &mut [u8]) -> Result<usize, Box<dyn Error>> {
         Err("get_report_descriptor is not implemented; pre-filter to HID++ usage pages".into())
+    }
+}
+
+/// Repack a short HID++ report (`0x10`, 7 bytes) as a long one (`0x11`, 20
+/// bytes) for transports that only carry the long report, e.g. Bluetooth-direct
+/// devices. The 3-byte header (`device_index, feature_index, func/sw`) and the
+/// short payload are preserved at the same offsets; the rest is left zeroed.
+/// Reports that aren't a short HID++ frame are returned padded but otherwise
+/// untouched.
+fn repack_short_as_long(src: &[u8]) -> [u8; LONG_REPORT_LENGTH] {
+    let mut long = [0u8; LONG_REPORT_LENGTH];
+    let n = src.len().min(LONG_REPORT_LENGTH);
+    long[..n].copy_from_slice(&src[..n]);
+    long[0] = LONG_REPORT_ID;
+    long
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hidpp::channel::SHORT_REPORT_LENGTH;
+
+    #[test]
+    fn repack_promotes_report_id_and_preserves_header_payload() {
+        // A short protocol-version ping: id, device_index, feature_index,
+        // func/sw nibble, then the 3-byte payload.
+        let short = [SHORT_REPORT_ID, 0xff, 0x00, 0x11, 0xaa, 0xbb, 0xcc];
+        assert_eq!(short.len(), SHORT_REPORT_LENGTH);
+
+        let long = repack_short_as_long(&short);
+
+        assert_eq!(long.len(), LONG_REPORT_LENGTH);
+        assert_eq!(long[0], LONG_REPORT_ID, "report id upgraded to long");
+        assert_eq!(&long[1..7], &short[1..7], "header + payload preserved");
+        assert!(long[7..].iter().all(|&b| b == 0), "tail zero-padded");
     }
 }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -57,6 +57,24 @@ pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, 
         .await)
 }
 
+/// A cheap presence signature of the currently-connected HID++ nodes:
+/// `(vendor_id, product_id, usage_page)` per node, sorted. Enumerating the HID
+/// registry does *not* open any device, so this is safe to poll frequently —
+/// unlike [`enumerate_hidpp_devices`] callers that open each channel, which on
+/// a Bluetooth-direct device renegotiates the BLE link and jitters the pointer.
+pub(crate) async fn present_device_keys() -> Result<Vec<(u16, u16, u16)>, async_hid::HidError> {
+    let backend = HidBackend::default();
+    let mut keys: Vec<(u16, u16, u16)> = backend
+        .enumerate()
+        .await?
+        .filter(|d| is_hidpp_long_node(d))
+        .map(|d| (d.vendor_id, d.product_id, d.usage_page))
+        .collect()
+        .await;
+    keys.sort_unstable();
+    Ok(keys)
+}
+
 pub(crate) async fn open_hidpp_channel(
     dev: async_hid::Device,
 ) -> Result<Option<(DeviceInfo, Arc<HidppChannel>)>, async_hid::HidError> {

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -34,7 +34,7 @@ const HIDPP_LONG_USAGE_ID: u16 = 0x0002;
 /// only generic mouse/keyboard collections on page `0xff00` and its HID++
 /// channel on `0xff43`. Filtering on `0xff00` alone misses every BT-direct
 /// device. (Matches Solaar's Bluetooth HID++ report mapping.)
-const HIDPP_BLE_USAGE_PAGE: u16 = 0xff43;
+pub(crate) const HIDPP_BLE_USAGE_PAGE: u16 = 0xff43;
 const HIDPP_BLE_LONG_USAGE_ID: u16 = 0x0202;
 
 /// Whether a HID interface is the HID++ long-report node we drive devices

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -271,7 +271,7 @@ where
     Fut: std::future::Future<Output = Result<T, WriteError>>,
 {
     match open_route_channel(route).await? {
-        Some(channel) => f(channel).await,
+        Some((_, channel)) => f(channel).await,
         None => Err(WriteError::DeviceNotFound),
     }
 }

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -177,6 +177,39 @@ impl Hook {
             macos::prompt_accessibility();
         }
     }
+
+    /// Returns `true` when the process has macOS Input Monitoring access —
+    /// required to read HID++ input reports from a directly-attached
+    /// (Bluetooth / USB) device. The Bolt-receiver path does not need it.
+    ///
+    /// On Linux and Windows this always returns `true`; those platforms handle
+    /// permissions at a higher layer.
+    #[must_use]
+    pub fn has_input_monitoring() -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            macos::has_input_monitoring()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            true
+        }
+    }
+
+    /// Show the macOS Input Monitoring permission dialog and register this
+    /// process in System Settings → Privacy & Security → Input Monitoring.
+    ///
+    /// Mirrors [`Self::prompt_accessibility`]: the first time, macOS surfaces
+    /// the native dialog and lists the app there (otherwise the user would
+    /// have to add the binary by hand). The grant only takes effect after the
+    /// app is relaunched. Called for its side effect; the resulting state is
+    /// observed via [`Self::has_input_monitoring`]. No-op on non-macOS.
+    pub fn prompt_input_monitoring() {
+        #[cfg(target_os = "macos")]
+        {
+            macos::prompt_input_monitoring();
+        }
+    }
 }
 
 /// Return the macOS bundle identifier of the currently frontmost application,

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -62,6 +62,41 @@ pub(crate) fn prompt_accessibility() {
     let _trusted = unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef().cast()) };
 }
 
+// Raw FFI for the IOKit HID access checks. `IOHIDCheckAccess` reports the
+// current Input Monitoring (a.k.a. "listen event") authorization without
+// prompting; `IOHIDRequestAccess` raises the system dialog the first time and
+// registers the process in System Settings → Privacy & Security → Input
+// Monitoring. Reading HID++ input reports from a directly-attached
+// (Bluetooth / USB) device — which carries the pointer/keyboard collections —
+// is gated by this permission; the Bolt-receiver path is not.
+#[link(name = "IOKit", kind = "framework")]
+unsafe extern "C" {
+    fn IOHIDCheckAccess(request: u32) -> u32;
+    fn IOHIDRequestAccess(request: u32) -> bool;
+}
+
+/// `IOHIDRequestType::kIOHIDRequestTypeListenEvent` — access to read (listen
+/// to) HID input events, i.e. the "Input Monitoring" privacy category.
+const IOHID_REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
+/// `IOHIDAccessType::kIOHIDAccessTypeGranted`.
+const IOHID_ACCESS_TYPE_GRANTED: u32 = 0;
+
+/// Whether this process has been granted Input Monitoring access.
+pub(crate) fn has_input_monitoring() -> bool {
+    // SAFETY: a plain C call taking an enum value and returning an enum
+    // value; no pointers, always safe to call.
+    unsafe { IOHIDCheckAccess(IOHID_REQUEST_TYPE_LISTEN_EVENT) == IOHID_ACCESS_TYPE_GRANTED }
+}
+
+/// Raise the Input Monitoring prompt + register the process. See
+/// [`super::Hook::prompt_input_monitoring`].
+pub(crate) fn prompt_input_monitoring() {
+    // SAFETY: same as `has_input_monitoring` — a plain C call. Shows the
+    // dialog when access is undetermined and lists the app either way. The
+    // returned grant state is observed separately via `has_input_monitoring`.
+    let _granted = unsafe { IOHIDRequestAccess(IOHID_REQUEST_TYPE_LISTEN_EVENT) };
+}
+
 /// Read the frontmost application's bundle identifier via NSWorkspace.
 /// Pure FFI — returns `None` when no app is frontmost or the identifier
 /// is missing / non-UTF8.


### PR DESCRIPTION
## Summary

Makes Logitech mice that are paired **directly over Bluetooth** (no Logi Bolt receiver) actually work on macOS — discovered, driven, and usable. Verified end-to-end on an **MX Master 3** over Bluetooth LE.

Before this branch, a Bluetooth-direct MX Master 3 was invisible to OpenLogi (`list` reported zero devices, the GUI showed "No device connected"), and once that was fixed, several follow-on issues surfaced. Each is addressed by a focused commit.

## The problems & fixes

### 1. Not discovered at all — `fix(openlogi-hid): discover and drive Bluetooth-direct devices`
Enumeration filtered HID++ to usage page `0xff00`/`0x0002` (receiver + USB-wired). Over Bluetooth, Logitech moves the HID++ vendor collection to **`0xff43`/`0x0202`** — so the device was filtered out before probing.

It also turns out a BLE device exposes **only the long HID++ report (`0x11`)** — there is no short (`0x10`) output report, and writing one makes macOS return `kIOReturnNotFound`. `hidpp 0.2` still emits short frames (the protocol-version ping, Root feature queries), so those are now transparently **repacked as long reports** on the way out (the device replies long either way).

### 2. Battery showed empty — `feat(openlogi-hid): fall back to legacy 0x1000 battery feature`
The MX Master 3 exposes the legacy `0x1000 BatteryStatus` feature, not the newer `0x1004 UnifiedBattery` that `hidpp 0.2` wraps. Added a minimal `BatteryStatusFeatureV0` (getBatteryLevelStatus) resolved through the device root, used as a fallback. Now reports e.g. `100% (discharging)`.

### 3. GUI couldn't see the device (CLI could) — `fix(gui): request Input Monitoring for direct-connected devices`
Reading HID++ input reports from a Bluetooth/USB-direct device is gated by macOS **Input Monitoring** (the device carries the pointer/keyboard collections). The app requested Accessibility (for the CGEventTap) but never Input Monitoring, so the GUI silently saw nothing while the CLI — launched from an already-authorized terminal — worked. Added `Hook::has_input_monitoring` / `prompt_input_monitoring` (IOKit `IOHIDCheckAccess` / `IOHIDRequestAccess`, listen-event type), requested at startup alongside Accessibility.

### 4. Pointer jitter while the app was open — two causes
The cursor stuttered (worsening over time) whenever OpenLogi was running with the BLE mouse. Bisected on hardware to two independent culprits, both about **opening the `0xff43` HID++ channel on the shared BLE radio link** (which renegotiates connection parameters and starves pointer reports). The Bolt-receiver path never hits this, since HID++ rides the dongle, not the mouse.

- **`fix(openlogi-hid): skip persistent capture on Bluetooth-direct devices`** — the control-capture session (gesture button / DPI button / thumb-wheel remap) holds the channel open continuously. `open_route_channel` now surfaces the matched `DeviceInfo`, and `run_capture_session` returns early for the `0xff43` node.
- **`fix(gui): re-enumerate only when the device set changes`** — the inventory watcher re-opened every device's channel every 2 s to refresh features/battery. It now reads a cheap presence signature (`present_keys`, which lists the HID registry **without opening anything**) and only runs the full `enumerate` on connect/disconnect.

## What works now on Bluetooth-direct (MX Master 3, verified)
- Device discovered in `list` and the GUI, with battery %.
- **Smooth pointer movement** — no jitter, no degradation over time.
- DPI control + SmartShift toggle (transient HID++ writes).
- Side-button remapping (Back / Forward / Middle) via the CGEventTap.

## Known limitations / follow-ups (documented in the commits, not blocking)
- **Gesture-button / DPI-button / thumb-wheel capture is unavailable on Bluetooth-direct.** Restoring it needs a transport that doesn't hold a second IOHIDDevice open on the BLE link — most likely a **CoreBluetooth GATT** path (the approach Logi Options+ appears to use). Bolt/USB keep full capture.
- **Battery % does not refresh while a device stays connected** (read once on connect); refreshing means re-opening the channel. An on-demand / connect-time refresh is fine for now.

## Testing
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass.
- New unit tests: short→long repack, `0x1000` charge-state mapping.
- Manually verified on an MX Master 3 over Bluetooth LE (macOS): discovery, `diag features`, `diag dpi` round-trip, GUI device card + battery, smooth pointer, side-button remap, DPI/SmartShift from the UI.

## Notes for reviewers
- The capture-skip and inventory changes are macOS-BLE-motivated but behave correctly for Bolt/USB (no behavior change there).
- The usage-page broadening (`0xff43`) is Logitech-wide; tested on MX Master 3, should hold for other BLE Logitech HID++ devices but hasn't been verified on other models.
