### PR TITLE
fix(release): publish after uploading draft assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,30 @@ env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
 jobs:
+  create-draft:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if is_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if [ "$is_draft" != "true" ]; then
+              echo "Release ${GITHUB_REF_NAME} already exists and is not a draft; cannot upload assets before publish." >&2
+              exit 1
+            fi
+          else
+            gh release create "${GITHUB_REF_NAME}" --draft \
+              --title "${GITHUB_REF_NAME}" --generate-notes
+          fi
+
   dmg:
     name: macOS DMG (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    needs: create-draft
     strategy:
       fail-fast: false
       matrix:
@@ -171,8 +192,14 @@ jobs:
           name: OpenLogi-macos-dmg-${{ matrix.arch }}
           path: dist/*.dmg
 
+      - name: Upload DMG to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" dist/*.dmg --clobber
+
   publish:
-    name: Publish release assets
+    name: Publish release
     runs-on: ubuntu-latest
     needs: dmg
     permissions:
@@ -228,12 +255,11 @@ jobs:
             --base-url "$OPENLOGI_UPDATE_BASE_URL" \
             --output dist/latest.json
 
-      - name: Attach DMG to GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            dist/*.dmg
-            dist/SHA256SUMS
+      - name: Upload checksums to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" dist/SHA256SUMS --clobber
 
       - name: Upload static updater assets to R2
         env:
@@ -259,6 +285,20 @@ jobs:
             --content-type "application/json" \
             --cache-control "no-cache" \
             --endpoint-url "$endpoint"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "${GITHUB_REF_NAME}" --draft=false
+
+  homebrew-tap:
+    name: Dispatch homebrew-tap update
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: read
+    steps:
 
       - name: Load GitHub App credentials from 1Password
         id: load_secrets


### PR DESCRIPTION
## Summary
- create or reuse only a draft GitHub release before macOS DMG builds start
- upload built DMGs and checksums to the draft release with gh release upload --clobber
- upload static updater assets to R2 before publishing the GitHub release
- move the Homebrew tap dispatch into a follow-up job after publish

## Verification
- YAML parsed successfully
- pre-commit hooks passed during commit and push