### PR TITLE
fix(release): set repository for gh commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           if is_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq .isDraft 2>/dev/null)"; then
             if [ "$is_draft" != "true" ]; then
@@ -195,6 +196,7 @@ jobs:
       - name: Upload DMG to draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "${GITHUB_REF_NAME}" dist/*.dmg --clobber
 
@@ -258,6 +260,7 @@ jobs:
       - name: Upload checksums to draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "${GITHUB_REF_NAME}" dist/SHA256SUMS --clobber
 
@@ -289,6 +292,7 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release edit "${GITHUB_REF_NAME}" --draft=false
 


### PR DESCRIPTION
## Summary
- set GH_REPO for release workflow gh commands
- fixes create-draft failing before checkout with `fatal: not a git repository`
- covers later gh release upload/edit steps that also run without relying on repo inference

## Verification
- YAML parsed successfully
- git diff --check passed
- pre-commit hooks passed during commit and push