### PR TITLE
fix(release): let softprops own the draft-first GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on:
   push:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,4 +1,4 @@
-name: release-plz
+name: Release PR
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   push:
@@ -12,30 +12,9 @@ env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
 jobs:
-  create-draft:
-    name: Create draft release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if is_draft="$(gh release view "${GITHUB_REF_NAME}" --json isDraft --jq .isDraft 2>/dev/null)"; then
-            if [ "$is_draft" != "true" ]; then
-              echo "Release ${GITHUB_REF_NAME} already exists and is not a draft; cannot upload assets before publish." >&2
-              exit 1
-            fi
-          else
-            gh release create "${GITHUB_REF_NAME}" --draft \
-              --title "${GITHUB_REF_NAME}" --generate-notes
-          fi
-
   dmg:
     name: macOS DMG (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
-    needs: create-draft
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +24,7 @@ jobs:
           - arch: x86_64
             runner: macos-15-intel
     permissions:
-      contents: write
+      contents: read
     env:
       OPENLOGI_BUNDLE_ASSETS: ${{ vars.OPENLOGI_BUNDLE_ASSETS }}
     steps:
@@ -192,12 +171,11 @@ jobs:
           name: OpenLogi-macos-dmg-${{ matrix.arch }}
           path: dist/*.dmg
 
-      - name: Upload DMG to draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${GITHUB_REF_NAME}" dist/*.dmg --clobber
-
+  # Single owner of the GitHub Release. softprops/action-gh-release@v3 creates the
+  # release as a draft, uploads every asset to that (mutable) draft, then publishes
+  # it as its final step — so the release only becomes immutable once all DMGs and
+  # checksums are attached. The static updater assets are pushed to R2 *before* that
+  # softprops call, so the GitHub Release is the last thing published.
   publish:
     name: Publish release
     runs-on: ubuntu-latest
@@ -205,6 +183,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Needed to build & run the xtask manifest generator below.
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
       - uses: actions/download-artifact@v8
         with:
           pattern: OpenLogi-macos-dmg-*
@@ -255,12 +240,6 @@ jobs:
             --base-url "$OPENLOGI_UPDATE_BASE_URL" \
             --output dist/latest.json
 
-      - name: Upload checksums to draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${GITHUB_REF_NAME}" dist/SHA256SUMS --clobber
-
       - name: Upload static updater assets to R2
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.r2_config.outputs.R2_ACCESS_KEY_ID }}
@@ -286,11 +265,20 @@ jobs:
             --cache-control "no-cache" \
             --endpoint-url "$endpoint"
 
-      - name: Publish GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release edit "${GITHUB_REF_NAME}" --draft=false
+      # Create the draft, upload assets to it, then publish — all in one step.
+      # `draft` is omitted, so for a non-prerelease softprops creates the release as
+      # a draft, uploads every file, and only then flips it to published. That keeps
+      # the release mutable for the whole upload, which is what avoids the "immutable
+      # release" rejection. latest.json is intentionally not attached — it lives in
+      # R2 only.
+      - name: Publish GitHub Release with assets
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            dist/*.dmg
+            dist/SHA256SUMS
+          generate_release_notes: true
+          fail_on_unmatched_files: true
 
   homebrew-tap:
     name: Dispatch homebrew-tap update

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,8 +4,15 @@
 # from the root Cargo.toml, so the whole workspace moves on a single shared
 # version. `version_group` ties the crates together so they are always bumped and
 # released in lockstep (the highest next version among them wins), and a single
-# `v{version}` tag + GitHub Release is cut for the workspace as a whole — which is
-# what `.github/workflows/release.yml` listens on to build the macOS DMG.
+# `v{version}` tag is cut for the workspace as a whole — which is what
+# `.github/workflows/release.yml` listens on to build the macOS DMG.
+#
+# release-plz cuts the tag only; it does NOT create the GitHub Release. The tag
+# triggers release.yml, which is the single owner of the GitHub Release: softprops
+# creates it as a draft, uploads the DMGs + checksums, then publishes it last.
+# (release-plz publishing the release outright made it immutable before release.yml
+# could attach assets — "target_commitish cannot be changed when release is
+# immutable". Keep `git_release_enable = false` so release.yml owns the lifecycle.)
 #
 # Single changelog: every crate points `changelog_path` at the repo-root
 # CHANGELOG.md, so release-plz aggregates all crates' sections into that one file
@@ -23,8 +30,8 @@ version_group = "openlogi"
 changelog_path = "CHANGELOG.md"
 git_tag_enable = true
 git_tag_name = "v{{ version }}"
-git_release_enable = true
-git_release_name = "v{{ version }}"
+# GitHub Release is owned by release.yml (softprops), not release-plz — see header.
+git_release_enable = false
 
 [[package]]
 name = "openlogi-core"


### PR DESCRIPTION
## Root cause

`release-plz.toml` had `git_release_enable = true`, so **release-plz created and published the GitHub Release itself** (v0.3.0 / v0.3.1 are both `isDraft:false`, published by release-plz ~2s after creation, with zero assets). By the time the tag it cut triggered `release.yml`, the release was already published → immutable, and GitHub rejected softprops' metadata PATCH:

> target_commitish cannot be changed when release is immutable

- The draft-first guard from #48 couldn't help — it just failed one step earlier (`already exists and is not a draft`).
- The `GH_REPO` fix in #51 couldn't help either — it only addresses "the job has no checkout so `gh` can't infer the repo", which is orthogonal to immutability.

## Fix: make `release.yml` the single owner of the GitHub Release

- **`release-plz.toml`**: `git_release_enable = false`. release-plz now cuts the tag only; it no longer creates or publishes the GitHub Release.
- **`release.yml`**: drop the `create-draft` job and every `gh release create/upload/edit`. A **single** `softprops/action-gh-release@v3` call in the `publish` job does create-draft → upload DMGs + SHA256SUMS → publish.

  For a non-prerelease, softprops v3 **always creates the release as a draft first**, uploads assets to that mutable draft, and only flips it to published in its final `finalizeRelease` step — exactly the immutable-release pattern documented on its `draft` input. The release stays mutable for the whole upload, so the immutability rule is never violated. The static updater assets are pushed to R2 *before* that call, so the GitHub Release is the last thing published. No `gh` invocation remains, so no checkout or `GH_REPO` is needed for it.
- Fix a latent bug: the `publish` job runs `cargo run -p xtask` to generate the updater manifest but had no `actions/checkout` or Rust toolchain — both added.
- The `dmg` job no longer touches the release, so it drops to `contents: read`; only `publish` keeps `contents: write`.

## Drive-by

Normalize the four workflow display names: `CI` / `Release` / `Release PR` / `Pullfrog`. (Top-level `name` is display-only; the branch ruleset has no required status checks, so this affects no gates.)

## Verification

- `actionlint` passes (its only warning is the known false positive for the `macos-15-intel` runner label, which master already uses and v0.3.0 built on).
- All workflow YAML + `release-plz.toml` parse cleanly.
- prek hooks (check-yaml / check-toml, etc.) all pass.

## Impact

v0.3.0 / v0.3.1 are already published → immutable, so their assets can't be backfilled. This fix takes effect for the **next** release (v0.3.2 — the next release-plz PR merge runs the new flow); no manual tag re-push is needed.

Supersedes #51.