### PR TITLE
chore(release): stop publishing the redundant generic -macos.dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,6 @@ jobs:
           ref_name="${GITHUB_REF_NAME:-dev}"
           ref_name="${ref_name//\//-}"
           cp target/release/OpenLogi.dmg "dist/OpenLogi-${ref_name}-macos-${{ matrix.arch }}.dmg"
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            cp target/release/OpenLogi.dmg "dist/OpenLogi-${ref_name}-macos.dmg"
-          fi
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## What

The release matrix already uploads per-arch `OpenLogi-vX-macos-arm64.dmg` and `OpenLogi-vX-macos-x86_64.dmg`. The extra generic `OpenLogi-vX-macos.dmg` was just an arm64 duplicate (a stable-name download alias). Nothing consumes it anymore, so drop it.

## Why it's safe

- **Homebrew cask**: the cask and its generator now fetch the per-arch DMGs — AprilNEA/homebrew-tap#1.
- **Updater manifest**: `xtask` only collects DMGs whose name matches `-macos-<arch>` (`arm64`/`x86_64`); the generic name is already skipped, so the self-updater is unaffected.
- **README / README_CN**: download links point at the releases page (`/releases/latest`), not this asset.

## ⚠️ Merge ordering

Merge AprilNEA/homebrew-tap#1 **before the next release tag**. Until that lands, the live tap generator still fetches `-macos.dmg`; cutting a release without it would 404 the tap-update job. (PR #1 alone is forward-safe — it only needs the per-arch DMGs, which still exist.)

## Not covered here

If openlogi.org (or any external page) hard-links `…-macos.dmg` as a download button, that link will 404 after the next release. I couldn't verify the site from the repo — worth a check before merging.