### PR TITLE
feat(i18n): add italian language

### DIFF
--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -16,6 +16,7 @@ _version: 2
   ru: "Устройство не подключено"
   zh-CN: 未连接设备
   zh-HK: 未連接裝置
+  it: Nessun dispositivo connesso
 
 # ── Menu-bar status item (platform/menubar.rs) ──────────────────────────────
 "Open OpenLogi":
@@ -23,67 +24,80 @@ _version: 2
   ru: "Открыть OpenLogi"
   zh-CN: 打开 OpenLogi
   zh-HK: 開啟 OpenLogi
+  it: Apri OpenLogi
 "Quit OpenLogi":
   ja: OpenLogi を終了
   ru: "Выйти из OpenLogi"
   zh-CN: 退出 OpenLogi
   zh-HK: 結束 OpenLogi
+  it: Esci da OpenLogi
 
 "Plug in or pair a supported Logitech device — it'll show up here automatically.":
   ja: 対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。
   ru: "Подключите или сопрягите поддерживаемое устройство Logitech — оно автоматически появится здесь."
   zh-CN: 接入或配对受支持的 Logitech 设备，它会自动显示在这里。
   zh-HK: 接入或配對受支援的 Logitech 裝置，它會自動顯示在這裡。
+  it: Collega o associa un dispositivo Logitech supportato — apparirà qui automaticamente.
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.":
   ja: Logi Options+ をお使いですか?まず終了してください — 両方のアプリが HID++ アクセスを奪い合います。
   ru: "Используете Logi Options+? Сначала закройте его — оба приложения конкурируют за доступ к HID++."
   zh-CN: 正在使用 Logi Options+?请先退出 —— 两个应用会争夺 HID++ 访问权限。
   zh-HK: 正在使用 Logi Options+?請先結束 —— 兩個應用會爭奪 HID++ 存取權限。
+  it: Usi Logi Options+? Esci prima da lì — entrambe le app competono per l'accesso HID++.
 "Accessibility permission required":
   ja: アクセシビリティ権限が必要です
   ru: "Требуется разрешение Универсального доступа"
   zh-CN: 需要「辅助功能」权限
   zh-HK: 需要「輔助使用」權限
+  it: Permesso di Accessibilità richiesto
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
   ja: OpenLogi はシステムの「アクセシビリティ」権限を通じてマウスボタン(戻る / 進む / ジェスチャーボタン)を捕捉し、割り当てた操作を実行します。DPI、SmartShift などデバイスと直接通信する機能には影響しません。
   ru: "OpenLogi перехватывает кнопки мыши (Назад / Вперёд / кнопку жестов) через системное разрешение Универсального доступа и выполняет назначенные вами действия. Функции, которые обращаются к устройству напрямую — DPI, SmartShift — не затрагиваются."
   zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
   zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
+  it: OpenLogi cattura i pulsanti del mouse (Indietro / Avanti / pulsante gesture) tramite i permessi di Accessibilità del sistema ed esegue le azioni associate. Le funzionalità che comunicano direttamente con il dispositivo — DPI, SmartShift — non sono influenzate.
 "Open System Settings to grant access":
   ja: システム設定を開いて許可する
   ru: "Открыть системные настройки для выдачи доступа"
   zh-CN: 打开系统设置授权
   zh-HK: 開啟系統設定授權
+  it: Apri Impostazioni di Sistema per concedere l'accesso
 "Takes effect automatically once granted — no restart needed.":
   ja: 許可すると自動的に反映されます — 再起動は不要です。
   ru: "Вступит в силу автоматически после выдачи разрешения — перезапуск не нужен."
   zh-CN: 授权后会自动生效,无需重启。
   zh-HK: 授權後會自動生效,無需重新啟動。
+  it: Diventa effettivo automaticamente una volta concesso — nessun riavvio necessario.
 "Not now (use DPI and other features only)":
   ja: 後で(DPI などの機能のみ使用)
   ru: "Не сейчас (использовать только DPI и другие функции)"
   zh-CN: 稍后再说(仅使用 DPI 等功能)
   zh-HK: 稍後再說(僅使用 DPI 等功能)
+  it: Non ora (usa solo DPI e altre funzionalità)
 "Settings":
   ja: 設定
   ru: "Настройки"
   zh-CN: 设置
   zh-HK: 設定
+  it: Impostazioni
 "About":
   ja: 情報
   ru: "О программе"
   zh-CN: 关于
   zh-HK: 關於
+  it: Informazioni
 "Accessibility granted":
   ja: アクセシビリティは許可済み
   ru: "Универсальный доступ разрешён"
   zh-CN: 辅助功能已授权
   zh-HK: 輔助使用已授權
+  it: Accessibilità concessa
 "Accessibility not granted · click to grant":
   ja: アクセシビリティ未許可 · クリックして許可
   ru: "Универсальный доступ не разрешён · нажмите, чтобы выдать доступ"
   zh-CN: 辅助功能未授权 · 点击授权
   zh-HK: 輔助使用未授權 · 點擊授權
+  it: Accessibilità non concessa · clicca per concedere
 
 # ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
 "About OpenLogi":
@@ -91,46 +105,55 @@ _version: 2
   ru: "Об OpenLogi"
   zh-CN: 关于 OpenLogi
   zh-HK: 關於 OpenLogi
+  it: Informazioni su OpenLogi
 "Settings…":
   ja: 設定…
   ru: "Настройки…"
   zh-CN: 设置…
   zh-HK: 設定…
+  it: Impostazioni…
 "Hide OpenLogi":
   ja: OpenLogi を隠す
   ru: "Скрыть OpenLogi"
   zh-CN: 隐藏 OpenLogi
   zh-HK: 隱藏 OpenLogi
+  it: Nascondi OpenLogi
 "Hide Others":
   ja: ほかを隠す
   ru: "Скрыть остальные"
   zh-CN: 隐藏其他
   zh-HK: 隱藏其他
+  it: Nascondi altre
 "Show All":
   ja: すべてを表示
   ru: "Показать все"
   zh-CN: 全部显示
   zh-HK: 全部顯示
+  it: Mostra tutte
 "Window":
   ja: ウインドウ
   ru: "Окно"
   zh-CN: 窗口
   zh-HK: 視窗
+  it: Finestra
 "Minimize":
   ja: しまう
   ru: "Свернуть"
   zh-CN: 最小化
   zh-HK: 最小化
+  it: Minimizza
 "Zoom":
   ja: ズーム
   ru: "Масштабировать"
   zh-CN: 缩放
   zh-HK: 縮放
+  it: Ridimensiona
 "Close Window":
   ja: ウインドウを閉じる
   ru: "Закрыть окно"
   zh-CN: 关闭窗口
   zh-HK: 關閉視窗
+  it: Chiudi finestra
 
 # ── About window (about.rs) ─────────────────────────────────────────────────
 "Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
@@ -138,6 +161,7 @@ _version: 2
   ru: "Открытая настройка мышей Logitech — DPI, SmartShift, привязки кнопок и жесты."
   zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
   zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
+  it: Configurazione open-source per mouse Logitech — DPI, SmartShift, associazioni pulsanti e gesture.
 
 # ── Settings window (settings.rs) ───────────────────────────────────────────
 "General":
@@ -145,51 +169,61 @@ _version: 2
   ru: "Основные"
   zh-CN: 通用
   zh-HK: 一般
+  it: Generale
 "Launch at login":
   ja: ログイン時に起動
   ru: "Запускать при входе"
   zh-CN: 开机自启
   zh-HK: 開機自動啟動
+  it: Avvia al login
 "Automatically start OpenLogi when you log in to macOS.":
   ja: macOS にログインしたときに OpenLogi を自動的に起動します。
   ru: "Автоматически запускать OpenLogi при входе в macOS."
   zh-CN: 登录 macOS 时自动启动 OpenLogi。
   zh-HK: 登入 macOS 時自動啟動 OpenLogi。
+  it: Avvia automaticamente OpenLogi quando accedi a macOS.
 "Check for updates":
   ja: アップデートを確認
   ru: "Проверять обновления"
   zh-CN: 检查更新
   zh-HK: 檢查更新
+  it: Controlla aggiornamenti
 "Check once per launch for a new version (query only — no automatic download).":
   ja: 起動ごとに新しいバージョンを一度だけ確認します(確認のみ — 自動ダウンロードはしません)。
   ru: "Один раз при запуске проверять наличие новой версии (только проверка — без автоматической загрузки)."
   zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
   zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
+  it: Controlla la presenza di una nuova versione ad ogni avvio (solo verifica — nessun download automatico).
 "Show in menu bar":
   ja: メニューバーに表示
   ru: "Показывать в строке меню"
   zh-CN: 显示在菜单栏
   zh-HK: 顯示在選單列
+  it: Mostra nella barra dei menu
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.":
   ja: OpenLogi のアイコンをメニューバーに表示します。オフにすると Dock に残ります。
   ru: "Оставлять значок OpenLogi в строке меню. Если выключено, приложение остаётся в Dock."
   zh-CN: 在菜单栏保留 OpenLogi 图标；关闭后改为停留在程序坞中。
   zh-HK: 在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。
+  it: Mantieni l'icona di OpenLogi nella barra dei menu. Quando è disattivata, rimarrà invece nel Dock.
 "Language":
   ja: 言語
   ru: "Язык"
   zh-CN: 语言
   zh-HK: 語言
+  it: Lingua
 "Choose the interface language.":
   ja: インターフェースの言語を選択します。
   ru: "Выберите язык интерфейса."
   zh-CN: 选择界面语言。
   zh-HK: 選擇介面語言。
+  it: Scegli la lingua dell'interfaccia.
 "Follow system":
   ja: システムに従う
   ru: "Как в системе"
   zh-CN: 跟随系统
   zh-HK: 跟隨系統
+  it: Segui il sistema
 
 # ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
 "PRESETS":
@@ -197,11 +231,13 @@ _version: 2
   ru: "ПРЕСЕТЫ"
   zh-CN: 预设
   zh-HK: 預設
+  it: PRESET
 "Add":
   ja: 追加
   ru: "Добавить"
   zh-CN: 添加
   zh-HK: 新增
+  it: Aggiungi
 
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
@@ -209,11 +245,13 @@ _version: 2
   ru: "Назначить %{name}"
   zh-CN: 绑定 %{name}
   zh-HK: 綁定 %{name}
+  it: Associa %{name}
 "Gesture %{name}":
   ja: ジェスチャー %{name}
   ru: "Жест %{name}"
   zh-CN: 手势 %{name}
   zh-HK: 手勢 %{name}
+  it: Gesture %{name}
 
 # ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
 "Left Click":
@@ -221,41 +259,49 @@ _version: 2
   ru: "Левый щелчок"
   zh-CN: 左键单击
   zh-HK: 左鍵單擊
+  it: Click sinistro
 "Right Click":
   ja: 右クリック
   ru: "Правый щелчок"
   zh-CN: 右键单击
   zh-HK: 右鍵單擊
+  it: Click destro
 "Middle Click":
   ja: 中クリック
   ru: "Средний щелчок"
   zh-CN: 中键单击
   zh-HK: 中鍵單擊
+  it: Click centrale
 "Back":
   ja: 戻る
   ru: "Назад"
   zh-CN: 后退
   zh-HK: 後退
+  it: Indietro
 "Forward":
   ja: 進む
   ru: "Вперёд"
   zh-CN: 前进
   zh-HK: 前進
+  it: Avanti
 "DPI Toggle":
   ja: DPI 切り替え
   ru: "Переключение DPI"
   zh-CN: DPI 切换
   zh-HK: DPI 切換
+  it: Cambia DPI
 "Thumb Wheel":
   ja: サムホイール
   ru: "Колесо под большой палец"
   zh-CN: 拇指滚轮
   zh-HK: 拇指滾輪
+  it: Volante da pollice
 "Gesture Button":
   ja: ジェスチャーボタン
   ru: "Кнопка жестов"
   zh-CN: 手势按钮
   zh-HK: 手勢按鈕
+  it: Pulsante gesture
 
 # ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
 "Up":
@@ -263,26 +309,31 @@ _version: 2
   ru: "Вверх"
   zh-CN: 上
   zh-HK: 上
+  it: Su
 "Down":
   ja: 下
   ru: "Вниз"
   zh-CN: 下
   zh-HK: 下
+  it: Giù
 "Left":
   ja: 左
   ru: "Влево"
   zh-CN: 左
   zh-HK: 左
+  it: Sinistra
 "Right":
   ja: 右
   ru: "Вправо"
   zh-CN: 右
   zh-HK: 右
+  it: Destra
 "Click":
   ja: 押し込み
   ru: "Щелчок"
   zh-CN: 按下
   zh-HK: 按下
+  it: Click
 
 # ── Categories (openlogi_core::binding::Category) ───────────────────────────
 "EDITING":
@@ -290,36 +341,43 @@ _version: 2
   ru: "РЕДАКТИРОВАНИЕ"
   zh-CN: 编辑
   zh-HK: 編輯
+  it: MODIFICA
 "BROWSER":
   ja: ブラウザ
   ru: "БРАУЗЕР"
   zh-CN: 浏览器
   zh-HK: 瀏覽器
+  it: BROWSER
 "MEDIA":
   ja: メディア
   ru: "МЕДИА"
   zh-CN: 媒体
   zh-HK: 媒體
+  it: MEDIA
 "MOUSE":
   ja: マウス
   ru: "МЫШЬ"
   zh-CN: 鼠标
   zh-HK: 滑鼠
+  it: MOUSE
 "SCROLL":
   ja: スクロール
   ru: "ПРОКРУТКА"
   zh-CN: 滚动
   zh-HK: 捲動
+  it: SCROLL
 "NAVIGATION":
   ja: ナビゲーション
   ru: "НАВИГАЦИЯ"
   zh-CN: 导航
   zh-HK: 導覽
+  it: NAVIGAZIONE
 "SYSTEM":
   ja: システム
   ru: "СИСТЕМА"
   zh-CN: 系统
   zh-HK: 系統
+  it: SISTEMA
 
 # ── Actions (openlogi_core::binding::Action) ────────────────────────────────
 "Copy":
@@ -327,171 +385,205 @@ _version: 2
   ru: "Копировать"
   zh-CN: 复制
   zh-HK: 複製
+  it: Copia
 "Paste":
   ja: ペースト
   ru: "Вставить"
   zh-CN: 粘贴
   zh-HK: 貼上
+  it: Incolla
 "Cut":
   ja: カット
   ru: "Вырезать"
   zh-CN: 剪切
   zh-HK: 剪下
+  it: Taglia
 "Undo":
   ja: 取り消す
   ru: "Отменить"
   zh-CN: 撤销
   zh-HK: 復原
+  it: Annulla
 "Redo":
   ja: やり直す
   ru: "Повторить"
   zh-CN: 重做
   zh-HK: 重做
+  it: Ripristina
 "Select All":
   ja: すべて選択
   ru: "Выбрать всё"
   zh-CN: 全选
   zh-HK: 全選
+  it: Seleziona tutto
 "Find":
   ja: 検索
   ru: "Найти"
   zh-CN: 查找
   zh-HK: 尋找
+  it: Trova
 "Save":
   ja: 保存
   ru: "Сохранить"
   zh-CN: 保存
   zh-HK: 儲存
+  it: Salva
 "Browser Back":
   ja: ブラウザで戻る
   ru: "Назад в браузере"
   zh-CN: 浏览器后退
   zh-HK: 瀏覽器後退
+  it: Indietro nel browser
 "Browser Forward":
   ja: ブラウザで進む
   ru: "Вперёд в браузере"
   zh-CN: 浏览器前进
   zh-HK: 瀏覽器前進
+  it: Avanti nel browser
 "New Tab":
   ja: 新規タブ
   ru: "Новая вкладка"
   zh-CN: 新建标签页
   zh-HK: 新增分頁
+  it: Nuova scheda
 "Close Tab":
   ja: タブを閉じる
   ru: "Закрыть вкладку"
   zh-CN: 关闭标签页
   zh-HK: 關閉分頁
+  it: Chiudi scheda
 "Reopen Tab":
   ja: タブを再度開く
   ru: "Открыть закрытую вкладку"
   zh-CN: 重开标签页
   zh-HK: 重新開啟分頁
+  it: Riapri scheda
 "Next Tab":
   ja: 次のタブ
   ru: "Следующая вкладка"
   zh-CN: 下一个标签页
   zh-HK: 下一個分頁
+  it: Scheda successiva
 "Previous Tab":
   ja: 前のタブ
   ru: "Предыдущая вкладка"
   zh-CN: 上一个标签页
   zh-HK: 上一個分頁
+  it: Scheda precedente
 "Reload Page":
   ja: ページを再読み込み
   ru: "Перезагрузить страницу"
   zh-CN: 刷新页面
   zh-HK: 重新載入頁面
+  it: Ricarica pagina
 "Mission Control":
   ja: Mission Control
   ru: "Mission Control"
   zh-CN: 调度中心
   zh-HK: 調度中心
+  it: Mission Control
 "App Exposé":
   ja: App Exposé
   ru: "App Exposé"
   zh-CN: 应用程序窗口
   zh-HK: 應用程式視窗
+  it: App Exposé
 "Show Desktop":
   ja: デスクトップを表示
   ru: "Показать рабочий стол"
   zh-CN: 显示桌面
   zh-HK: 顯示桌面
+  it: Mostra scrivania
 "Launchpad":
   ja: Launchpad
   ru: "Launchpad"
   zh-CN: 启动台
   zh-HK: 啟動台
+  it: Launchpad
 "Lock Screen":
   ja: 画面をロック
   ru: "Заблокировать экран"
   zh-CN: 锁定屏幕
   zh-HK: 鎖定螢幕
+  it: Blocca schermo
 "Screenshot":
   ja: スクリーンショット
   ru: "Снимок экрана"
   zh-CN: 截屏
   zh-HK: 截圖
+  it: Istantanea schermo
 "Play / Pause":
   ja: 再生 / 一時停止
   ru: "Воспроизведение / пауза"
   zh-CN: 播放 / 暂停
   zh-HK: 播放 / 暫停
+  it: Riproduci / Pausa
 "Next Track":
   ja: 次の曲
   ru: "Следующий трек"
   zh-CN: 下一首
   zh-HK: 下一首
+  it: Traccia successiva
 "Previous Track":
   ja: 前の曲
   ru: "Предыдущий трек"
   zh-CN: 上一首
   zh-HK: 上一首
+  it: Traccia precedente
 "Volume Up":
   ja: 音量を上げる
   ru: "Увеличить громкость"
   zh-CN: 增大音量
   zh-HK: 調高音量
+  it: Alza il volume
 "Volume Down":
   ja: 音量を下げる
   ru: "Уменьшить громкость"
   zh-CN: 减小音量
   zh-HK: 調低音量
+  it: Abbassa il volume
 "Mute":
   ja: ミュート
   ru: "Выключить звук"
   zh-CN: 静音
   zh-HK: 靜音
+  it: Muto
 "Cycle DPI Presets":
   ja: DPI プリセットを循環
   ru: "Переключать пресеты DPI"
   zh-CN: 循环 DPI 预设
   zh-HK: 循環 DPI 預設
+  it: Cicla preset DPI
 "Toggle SmartShift":
   ja: SmartShift を切り替え
   ru: "Переключить SmartShift"
   zh-CN: 切换 SmartShift
   zh-HK: 切換 SmartShift
+  it: Attiva/Disattiva SmartShift
 "Scroll Up":
   ja: 上にスクロール
   ru: "Прокрутить вверх"
   zh-CN: 向上滚动
   zh-HK: 向上捲動
+  it: Scorri su
 "Scroll Down":
   ja: 下にスクロール
   ru: "Прокрутить вниз"
   zh-CN: 向下滚动
   zh-HK: 向下捲動
+  it: Scorri giù
 "Scroll Left":
   ja: 左にスクロール
   ru: "Прокрутить влево"
   zh-CN: 向左滚动
   zh-HK: 向左捲動
+  it: Scorri a sinistra
 "Scroll Right":
   ja: 右にスクロール
   ru: "Прокрутить вправо"
   zh-CN: 向右滚动
   zh-HK: 向右捲動
+  it: Scorri a destra
 
 # ── Add Device / pairing flow (windows/add_device.rs, app_menu.rs, app.rs) ──
 "Add Device":
@@ -499,140 +591,170 @@ _version: 2
   ru: "Добавить устройство"
   zh-CN: 添加设备
   zh-HK: 新增裝置
+  it: Aggiungi dispositivo
 "Add Device…":
   ja: デバイスを追加…
   ru: "Добавить устройство…"
   zh-CN: 添加设备…
   zh-HK: 新增裝置…
+  it: Aggiungi dispositivo…
 "Put the device in pairing mode, then start searching.":
   ja: デバイスをペアリングモードにしてから検索を開始してください。
   ru: "Переведите устройство в режим сопряжения, затем начните поиск."
   zh-CN: 先让设备进入配对模式，然后开始搜索。
   zh-HK: 先讓裝置進入配對模式，然後開始搜尋。
+  it: Metti il dispositivo in modalità di associazione, quindi avvia la ricerca.
 "Search for devices":
   ja: デバイスを検索
   ru: "Искать устройства"
   zh-CN: 搜索设备
   zh-HK: 搜尋裝置
+  it: Cerca dispositivi
 "Searching for devices…":
   ja: デバイスを検索中…
   ru: "Поиск устройств…"
   zh-CN: 正在搜索设备…
   zh-HK: 正在搜尋裝置…
+  it: Ricerca dispositivi in corso…
 "Make sure the device is on and in pairing mode.":
   ja: デバイスの電源が入り、ペアリングモードになっていることを確認してください。
   ru: "Убедитесь, что устройство включено и находится в режиме сопряжения."
   zh-CN: 请确认设备已开机并处于配对模式。
   zh-HK: 請確認裝置已開機並處於配對模式。
+  it: Assicurati che il dispositivo sia acceso e in modalità di associazione.
 "No devices found yet…":
   ja: まだデバイスが見つかりません…
   ru: "Устройства пока не найдены…"
   zh-CN: 暂未发现设备…
   zh-HK: 暫未發現裝置…
+  it: Nessun dispositivo ancora trovato…
 "Select a device to pair:":
   ja: "ペアリングするデバイスを選択してください:"
   ru: "Выберите устройство для сопряжения:"
   zh-CN: 选择要配对的设备：
   zh-HK: 選擇要配對的裝置：
+  it: Seleziona un dispositivo da associare:
 "Pairing…":
   ja: ペアリング中…
   ru: "Сопряжение…"
   zh-CN: 正在配对…
   zh-HK: 正在配對…
+  it: Associazione in corso…
 "Follow the instructions on your device.":
   ja: デバイスの指示に従ってください。
   ru: "Следуйте инструкциям на устройстве."
   zh-CN: 请按照设备上的提示操作。
   zh-HK: 請按照裝置上的提示操作。
+  it: Segui le istruzioni sul tuo dispositivo.
 "Type this passkey on the new keyboard, then press Enter:":
   ja: "新しいキーボードでこのパスキーを入力し、Enter キーを押してください:"
   ru: "Введите этот код на новой клавиатуре, затем нажмите Enter:"
   zh-CN: 在新键盘上输入此配对码，然后按回车：
   zh-HK: 在新鍵盤上輸入此配對碼，然後按 Enter：
+  it: Digita questa passkey sulla nuova tastiera, quindi premi Invio:
 "On the new mouse, click in this order, then press both buttons together:":
   ja: "新しいマウスでこの順にクリックし、最後に両方のボタンを同時に押してください:"
   ru: "На новой мыши нажмите кнопки в этом порядке, затем нажмите обе кнопки одновременно:"
   zh-CN: 在新鼠标上按此顺序点击，最后同时按下左右键：
   zh-HK: 在新滑鼠上按此順序點擊，最後同時按下左右鍵：
+  it: Sul nuovo mouse, fai clic in questo ordine, quindi premi entrambi i pulsanti contemporaneamente:
 "Device paired":
   ja: デバイスをペアリングしました
   ru: "Устройство сопряжено"
   zh-CN: 设备已配对
   zh-HK: 裝置已配對
+  it: Dispositivo associato
 "Paired to slot %{slot}.":
   ja: スロット %{slot} にペアリングしました。
   ru: "Сопряжено со слотом %{slot}."
   zh-CN: 已配对到插槽 %{slot}。
   zh-HK: 已配對到插槽 %{slot}。
+  it: Associato allo slot %{slot}.
 "Done":
   ja: 完了
   ru: "Готово"
   zh-CN: 完成
   zh-HK: 完成
+  it: Fatto
 "Pairing failed":
   ja: ペアリングに失敗しました
   ru: "Сопряжение не удалось"
   zh-CN: 配对失败
   zh-HK: 配對失敗
+  it: Associazione fallita
 "Try again":
   ja: 再試行
   ru: "Повторить"
   zh-CN: 重试
   zh-HK: 重試
+  it: Riprova
 "Cancel":
   ja: キャンセル
   ru: "Отмена"
   zh-CN: 取消
   zh-HK: 取消
+  it: Annulla
 
 # ── Settings → Permissions section (windows/settings.rs) ────────────────────
 "Permissions":
   ja: 権限
   zh-CN: 权限
   zh-HK: 權限
+  it: Permessi
 "Accessibility":
   ja: アクセシビリティ
   zh-CN: 辅助功能
   zh-HK: 輔助使用
+  it: Accessibilità
 "Input Monitoring":
   ja: 入力監視
   zh-CN: 输入监控
   zh-HK: 輸入監控
+  it: Monitoraggio input
 "Bluetooth":
   ja: Bluetooth
   zh-CN: 蓝牙
-  zh-HK: 藍牙
+  zh-HK: 蓝牙
+  it: Bluetooth
 "Granted":
   ja: 許可済み
   zh-CN: 已授权
   zh-HK: 已授權
+  it: Concesso
 "Not granted":
   ja: 未許可
   zh-CN: 未授权
   zh-HK: 未授權
+  it: Non concesso
 "Unknown":
   ja: 不明
   zh-CN: 未知
   zh-HK: 未知
+  it: Sconosciuto
 "Open":
   ja: 開く
   zh-CN: 打开
   zh-HK: 開啟
+  it: Apri
 "Needed for gesture and button remapping (event tap).":
   ja: ジェスチャーとボタンの再割り当てに必要です（イベントタップ）。
   zh-CN: 手势与按键重映射所需（事件捕获）。
   zh-HK: 手勢與按鍵重新對應所需（事件攔截）。
+  it: Necessario per la rimappatura di gesture e pulsanti (event tap).
 "Needed to read HID++ data, including Bluetooth-direct mice.":
   ja: Bluetooth 直結マウスを含む HID++ データの読み取りに必要です。
   zh-CN: 读取 HID++ 数据所需，包括蓝牙直连鼠标。
   zh-HK: 讀取 HID++ 數據所需，包括藍牙直連滑鼠。
+  it: Necessario per leggere i dati HID++, inclusi i mouse con connessione diretta Bluetooth.
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).":
   ja: OpenLogi が CoreBluetooth を使用できるようにします（HID アクセスには不要）。
   zh-CN: 允许 OpenLogi 使用 CoreBluetooth（HID 访问不需要）。
   zh-HK: 允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。
+  it: Consente a OpenLogi di utilizzare CoreBluetooth (non richiesto per l'accesso HID).
 
 # ── Empty / scanning state (app.rs) ─────────────────────────────────────────
 "Scanning for devices…":
   ja: デバイスを検索中…
   zh-CN: 正在扫描设备…
   zh-HK: 正在掃描裝置…
+  it: Scansione dispositivi in corso…

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -174,7 +174,7 @@ mod tests {
         rust_i18n::set_locale("it");
         assert_eq!(rust_i18n::t!("Settings"), "Impostazioni");
         assert_eq!(rust_i18n::t!("Left Click"), "Click sinistro");
-        assert_eq!(rust_i18n::t!("Thanks"), "Grazie");
+        assert_eq!(rust_i18n::t!("Cancel"), "Annulla");
 
         // English has no column: every key falls back to the English source.
         rust_i18n::set_locale("en");

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -29,6 +29,7 @@ pub const SUPPORTED: &[(&str, &str)] = &[
     ("ru", "Русский"),
     ("zh-CN", "简体中文"),
     ("zh-HK", "繁體中文"),
+    ("it", "Italiano"),
 ];
 
 /// Resolve the locale to apply, preferring an explicit stored `setting`, then
@@ -59,6 +60,7 @@ fn match_supported(code: &str) -> Option<&'static str> {
         Some("en") => Some("en"),
         Some("ja") => Some("ja"),
         Some("ru") => Some("ru"),
+        Some("it") => Some("it"),
         Some("zh") => {
             let traditional = matches!(
                 subtags.find(|t| matches!(*t, "hans" | "hant" | "tw" | "hk" | "mo")),
@@ -101,6 +103,8 @@ mod tests {
         assert_eq!(match_supported("ru-RU"), Some("ru"));
         assert_eq!(match_supported("en-US"), Some("en"));
         assert_eq!(match_supported("fr-FR"), None);
+        assert_eq!(match_supported("it"), Some("it"));
+        assert_eq!(match_supported("it-IT"), Some("it"));
     }
 
     #[test]
@@ -166,6 +170,11 @@ mod tests {
         rust_i18n::set_locale("ru");
         assert_eq!(rust_i18n::t!("Settings"), "Настройки");
         assert_eq!(rust_i18n::t!("Left Click"), "Левый щелчок");
+
+        rust_i18n::set_locale("it");
+        assert_eq!(rust_i18n::t!("Settings"), "Impostazioni");
+        assert_eq!(rust_i18n::t!("Left Click"), "Click sinistro");
+        assert_eq!(rust_i18n::t!("Thanks"), "Grazie");
 
         // English has no column: every key falls back to the English source.
         rust_i18n::set_locale("en");


### PR DESCRIPTION
Add Italian translations for many UI strings in crates/openlogi-gui/locales/app.yml and register the 'it' locale in crates/openlogi-gui/src/i18n.rs (SUPPORTED list and match_supported). Update tests to exercise the Italian locale and translations. This enables Italian interface text across menus, settings, permissions, pairing flow, DPI/actions and other UI copy.