### PR TITLE
Fix security scan findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
           GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY
 
       - name: Install packaging tools
         run: |
@@ -70,6 +71,7 @@ jobs:
           GITHUB_APP_ID: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
           GITHUB_APP_PRIVATE_KEY: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_BASE_URL }}
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           : "${APPLE_SIGNING_IDENTITY:?Configure APPLE_SIGNING_IDENTITY in 1Password}"
@@ -81,6 +83,7 @@ jobs:
           : "${GITHUB_APP_ID:?Configure GITHUB_APP_ID in 1Password}"
           : "${GITHUB_APP_PRIVATE_KEY:?Configure GITHUB_APP_PRIVATE_KEY in 1Password}"
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in 1Password}"
+          : "${OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY in 1Password}"
 
       - name: Import Apple signing certificate
         uses: apple-actions/import-codesign-certs@v7
@@ -91,6 +94,7 @@ jobs:
       - name: Build OpenLogi.app with cargo-bundle
         env:
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_BASE_URL }}
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           export OPENLOGI_UPDATE_MANIFEST_URL="${OPENLOGI_UPDATE_BASE_URL%/}/channels/stable/latest.json"
@@ -182,6 +186,8 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY
+          OPENLOGI_UPDATE_MINISIGN_SECRET_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_SECRET_KEY
           R2_ACCOUNT_ID: ${{ secrets.OP_R2_SECRET_ITEM }}/CLOUDFLARE_R2_ACCOUNT_ID
           R2_BUCKET: ${{ secrets.OP_R2_SECRET_ITEM }}/CLOUDFLARE_R2_BUCKET
           R2_ACCESS_KEY_ID: ${{ secrets.OP_R2_SECRET_ITEM }}/CLOUDFLARE_R2_ACCESS_KEY_ID
@@ -190,6 +196,8 @@ jobs:
       - name: Validate R2 publishing configuration
         env:
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_BASE_URL }}
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
+          OPENLOGI_UPDATE_MINISIGN_SECRET_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_SECRET_KEY }}
           R2_ACCOUNT_ID: ${{ steps.r2_config.outputs.R2_ACCOUNT_ID }}
           R2_BUCKET: ${{ steps.r2_config.outputs.R2_BUCKET }}
           R2_ACCESS_KEY_ID: ${{ steps.r2_config.outputs.R2_ACCESS_KEY_ID }}
@@ -197,10 +205,32 @@ jobs:
         run: |
           set -euo pipefail
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in the R2 1Password item}"
+          : "${OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY in the R2 1Password item}"
+          : "${OPENLOGI_UPDATE_MINISIGN_SECRET_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_SECRET_KEY in the R2 1Password item}"
           : "${R2_ACCOUNT_ID:?Configure CLOUDFLARE_R2_ACCOUNT_ID in the R2 1Password item}"
           : "${R2_BUCKET:?Configure CLOUDFLARE_R2_BUCKET in the R2 1Password item}"
           : "${R2_ACCESS_KEY_ID:?Configure CLOUDFLARE_R2_ACCESS_KEY_ID in the R2 1Password item}"
           : "${R2_SECRET_ACCESS_KEY:?Configure CLOUDFLARE_R2_SECRET_ACCESS_KEY in the R2 1Password item}"
+
+      - name: Install minisign
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Sign updater artifacts
+        env:
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
+          OPENLOGI_UPDATE_MINISIGN_SECRET_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          key_file="${RUNNER_TEMP}/openlogi-minisign.key"
+          umask 077
+          printf '%s\n' "$OPENLOGI_UPDATE_MINISIGN_SECRET_KEY" > "$key_file"
+          for artifact in dist/*.dmg; do
+            minisign -S -m "$artifact" -s "$key_file" -x "$artifact.minisig" -W
+            minisign -V -m "$artifact" -P "$OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY" -x "$artifact.minisig"
+          done
+          rm -f "$key_file"
 
       - name: Generate static updater manifest
         env:
@@ -249,6 +279,7 @@ jobs:
         with:
           files: |
             dist/*.dmg
+            dist/*.minisig
             dist/SHA256SUMS
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -11,10 +11,10 @@
 //! no relation to a host, so they stay off the client.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 use tracing::debug;
@@ -104,7 +104,8 @@ impl AssetClient {
 
     /// Fetch a per-depot file into `dir`, returning the number of bytes written.
     pub fn fetch_file_to_dir(&self, asset_path: &str, dir: &Path, name: &str) -> Result<usize> {
-        let dst = dir.join(name);
+        let dst = safe_component_path(dir, name, "asset file name")?;
+        reject_symlink(&dst)?;
         let bytes = self.fetch_file(asset_path, name)?;
         fs::write(&dst, &bytes).with_context(|| format!("write {}", dst.display()))?;
         Ok(bytes.len())
@@ -120,10 +121,16 @@ impl AssetClient {
         dir: &Path,
         file: &FileEntry,
     ) -> Result<FetchOutcome> {
-        if cached_matches(&dir.join(&file.name), &file.sha256) {
+        let dst = safe_component_path(dir, &file.name, "asset file name")?;
+        reject_symlink(&dst)?;
+        if cached_matches(&dst, &file.sha256) {
             return Ok(FetchOutcome::CacheHit);
         }
         let bytes = self.fetch_file_to_dir(asset_path, dir, &file.name)?;
+        if !cached_matches(&dst, &file.sha256) {
+            let _ = fs::remove_file(&dst);
+            bail!("downloaded asset checksum mismatch: {}", dst.display());
+        }
         Ok(FetchOutcome::Fetched { bytes })
     }
 
@@ -154,6 +161,40 @@ pub fn read_bytes(path: &Path) -> Result<Vec<u8>> {
     fs::read(path).with_context(|| format!("read {}", path.display()))
 }
 
+/// Join one untrusted registry component to a trusted directory.
+///
+/// Remote asset metadata is expected to carry depot and file *names*, not
+/// paths. Rejecting separators, absolute prefixes, and `..` keeps asset syncs
+/// inside the cache or bundle directory chosen by the caller.
+pub fn safe_component_path(base: &Path, component: &str, label: &str) -> Result<PathBuf> {
+    ensure_safe_component(component, label)?;
+    Ok(base.join(component))
+}
+
+fn ensure_safe_component(component: &str, label: &str) -> Result<()> {
+    if component.is_empty() {
+        bail!("{label} is empty");
+    }
+    if component.contains('/') || component.contains('\\') {
+        bail!("{label} must be a single path component: {component}");
+    }
+    let mut parts = Path::new(component).components();
+    match (parts.next(), parts.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => bail!("{label} must be a safe relative path component: {component}"),
+    }
+}
+
+fn reject_symlink(path: &Path) -> Result<()> {
+    if fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        bail!(
+            "refusing to write asset through symlink: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// Hex SHA-256 of an in-memory blob.
 #[must_use]
 pub fn sha256_hex(bytes: &[u8]) -> String {
@@ -174,4 +215,32 @@ pub fn sha256_of_file(path: &Path) -> Result<String> {
 #[must_use]
 pub fn cached_matches(path: &Path, expected_sha: &str) -> bool {
     sha256_of_file(path).is_ok_and(|actual| actual.eq_ignore_ascii_case(expected_sha))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_component_path_accepts_plain_names() {
+        assert_eq!(
+            safe_component_path(Path::new("/cache"), "front_core.png", "asset").unwrap(),
+            Path::new("/cache").join("front_core.png")
+        );
+    }
+
+    #[test]
+    fn safe_component_path_rejects_traversal_and_separators() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../LaunchAgents/x",
+            "nested/file.png",
+            "nested\\file.png",
+        ] {
+            assert!(safe_component_path(Path::new("/cache"), name, "asset").is_err());
+        }
+    }
 }

--- a/crates/openlogi-cli/src/cmd/assets/sync.rs
+++ b/crates/openlogi-cli/src/cmd/assets/sync.rs
@@ -80,7 +80,7 @@ pub fn run(args: SyncArgs) -> Result<()> {
     depots.sort();
     for depot in depots {
         let entry = &index.devices[depot];
-        let dir = out.join(depot);
+        let dir = http::safe_component_path(&out, depot, "asset depot")?;
         fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
 
         // Required core set + every optional asset (side render + colour

--- a/crates/openlogi-cli/src/cmd/diag/mod.rs
+++ b/crates/openlogi-cli/src/cmd/diag/mod.rs
@@ -8,7 +8,7 @@
 
 use anyhow::Result;
 use clap::Subcommand;
-use openlogi_hid::DeviceRoute;
+use openlogi_hid::{DeviceRoute, DirectDeviceIdentity};
 
 pub mod dpi;
 pub mod features;
@@ -45,15 +45,18 @@ pub(crate) async fn first_online_device() -> Result<(DeviceRoute, String)> {
         .into_iter()
         .find_map(|inv| {
             let paired = inv.paired.into_iter().find(|p| p.online)?;
-            let route = match inv.receiver.unique_id {
-                Some(receiver_uid) => DeviceRoute::Bolt {
+            let route = if let Some(receiver_uid) = inv.receiver.unique_id {
+                DeviceRoute::Bolt {
                     receiver_uid,
                     slot: paired.slot,
-                },
-                None => DeviceRoute::Direct {
+                }
+            } else {
+                let model = paired.model_info.as_ref()?;
+                DeviceRoute::Direct {
                     vendor_id: inv.receiver.vendor_id,
                     product_id: inv.receiver.product_id,
-                },
+                    identity: DirectDeviceIdentity::from_model(model),
+                }
             };
             let name = paired
                 .codename

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -98,7 +98,7 @@ fn sync_depot(
     entry: &DeviceEntry,
     ext: u8,
 ) -> Result<()> {
-    let dir = cache_root.join(depot);
+    let dir = http::safe_component_path(cache_root, depot, "asset depot")?;
     fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
 
     // Baseline: metadata + manifest + base PNG. Manifest is mandatory
@@ -158,10 +158,8 @@ fn fetch_to_cache(
     } else {
         warn!(
             file = name,
-            "registry lists no entry — fetching without sha verify"
+            "registry lists no entry — skipping unverified asset"
         );
-        let bytes = client.fetch_file_to_dir(asset_path, dir, name)?;
-        info!(file = name, bytes, "downloaded");
     }
     Ok(())
 }

--- a/crates/openlogi-gui/src/platform/updater.rs
+++ b/crates/openlogi-gui/src/platform/updater.rs
@@ -10,13 +10,17 @@
 //! so a launch-time result is already visible when the window opens.
 
 use gpui::{App, AppContext as _, Entity, Global};
-use gpui_updater::{EngineConfig, StaticManifestSource, Updater, Version};
+use gpui_updater::{
+    EngineConfig, Error as UpdateError, Release, StaticManifestSource, UpdateSource, Updater,
+    Version,
+};
 use openlogi_core::config::AppSettings;
 
 const MANIFEST_URL: &str = match option_env!("OPENLOGI_UPDATE_MANIFEST_URL") {
     Some(url) => url,
     None => "https://updates.openlogi.org/channels/stable/latest.json",
 };
+const MINISIGN_PUBLIC_KEY: Option<&str> = option_env!("OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY");
 
 /// App-global handle to the shared updater entity.
 #[derive(Clone)]
@@ -29,14 +33,59 @@ impl Global for SharedUpdater {}
 /// against the manifest's SHA-256.
 pub fn new_entity(cx: &mut App) -> Entity<Updater> {
     cx.new(|cx| {
+        let public_key = minisign_public_key();
         let source = StaticManifestSource::new(MANIFEST_URL)
             .os(std::env::consts::OS)
             .arch(release_arch())
             .format(release_format());
+        let source = RequiredSignedSource {
+            inner: source,
+            public_key_configured: public_key.is_some(),
+        };
         let version =
             Version::parse(env!("CARGO_PKG_VERSION")).unwrap_or_else(|_| Version::new(0, 0, 0));
-        Updater::new(source, EngineConfig::new(version), cx)
+        let mut config = EngineConfig::new(version);
+        if let Some(key) = public_key {
+            config = config.minisign_public_key(key);
+        }
+        Updater::new(source, config, cx)
     })
+}
+
+struct RequiredSignedSource<S> {
+    inner: S,
+    public_key_configured: bool,
+}
+
+impl<S: UpdateSource> UpdateSource for RequiredSignedSource<S> {
+    fn fetch_latest(&self) -> gpui_updater::Result<Release> {
+        if !self.public_key_configured {
+            return Err(UpdateError::Signature(
+                "update signing public key is not configured".to_string(),
+            ));
+        }
+        let release = self.inner.fetch_latest()?;
+        if release
+            .signature
+            .as_ref()
+            .is_none_or(|s| s.trim().is_empty())
+            && release
+                .signature_url
+                .as_ref()
+                .is_none_or(|s| s.trim().is_empty())
+        {
+            return Err(UpdateError::Signature(
+                "release manifest does not include a minisign signature".to_string(),
+            ));
+        }
+        Ok(release)
+    }
+}
+
+fn minisign_public_key() -> Option<&'static str> {
+    MINISIGN_PUBLIC_KEY
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
 }
 
 fn release_arch() -> &'static str {
@@ -67,4 +116,79 @@ pub fn install(cx: &mut App, settings: &AppSettings) {
 /// The shared updater entity, if [`install`] has run.
 pub fn shared(cx: &App) -> Option<Entity<Updater>> {
     cx.try_global::<SharedUpdater>().map(|g| g.0.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui_updater::{Asset, Release};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct FakeSource {
+        release: Release,
+    }
+
+    impl UpdateSource for FakeSource {
+        fn fetch_latest(&self) -> gpui_updater::Result<Release> {
+            Ok(self.release.clone())
+        }
+    }
+
+    fn release(signature_url: Option<&str>) -> Release {
+        Release {
+            version: Version::new(99, 0, 0),
+            notes: None,
+            asset: Asset {
+                name: "OpenLogi.dmg".to_string(),
+                url: "https://updates.example/OpenLogi.dmg".to_string(),
+                size: 1,
+            },
+            signature: None,
+            signature_url: signature_url.map(str::to_string),
+            sha256: Some("00".to_string()),
+        }
+    }
+
+    #[test]
+    fn signed_source_requires_configured_public_key() {
+        let source = RequiredSignedSource {
+            inner: FakeSource {
+                release: release(Some("https://updates.example/OpenLogi.dmg.minisig")),
+            },
+            public_key_configured: false,
+        };
+
+        assert!(matches!(
+            source.fetch_latest(),
+            Err(UpdateError::Signature(_))
+        ));
+    }
+
+    #[test]
+    fn signed_source_rejects_unsigned_manifest_assets() {
+        let source = RequiredSignedSource {
+            inner: FakeSource {
+                release: release(None),
+            },
+            public_key_configured: true,
+        };
+
+        assert!(matches!(
+            source.fetch_latest(),
+            Err(UpdateError::Signature(_))
+        ));
+    }
+
+    #[test]
+    fn signed_source_accepts_signature_url() {
+        let source = RequiredSignedSource {
+            inner: FakeSource {
+                release: release(Some("https://updates.example/OpenLogi.dmg.minisig")),
+            },
+            public_key_configured: true,
+        };
+
+        assert!(source.fetch_latest().is_ok());
+    }
 }

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -1,7 +1,7 @@
 //! Device-list construction and selection helpers for [`super::AppState`].
 
-use openlogi_core::device::{BatteryInfo, DeviceInventory, DeviceKind};
-use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
+use openlogi_core::device::{BatteryInfo, DeviceInventory, DeviceKind, DeviceModelInfo};
+use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute, DirectDeviceIdentity};
 
 use crate::asset::{AssetResolver, ResolvedAsset};
 
@@ -75,7 +75,7 @@ pub(super) fn build_device_list(
                 asset,
                 serial_number: model.serial_number.clone(),
                 unit_id: model.unit_id,
-                route: device_route(inv, paired.slot),
+                route: device_route(inv, paired.slot, model),
                 kind: paired.kind,
                 slot: paired.slot,
                 online: paired.online,
@@ -108,10 +108,11 @@ impl DeviceStableId {
             Some(DeviceRoute::Direct {
                 vendor_id,
                 product_id,
+                identity,
             }) => Self::Direct {
                 vendor_id: *vendor_id,
                 product_id: *product_id,
-                identity: DeviceIdentity::from_record(record),
+                identity: DeviceIdentity::from_direct(identity),
             },
             None => Self::Unknown {
                 slot: record.slot,
@@ -122,6 +123,13 @@ impl DeviceStableId {
 }
 
 impl DeviceIdentity {
+    fn from_direct(identity: &DirectDeviceIdentity) -> Self {
+        identity.serial_number.as_ref().map_or_else(
+            || Self::Unit(identity.unit_id),
+            |serial| Self::Serial(serial.to_ascii_lowercase()),
+        )
+    }
+
     fn from_record(record: &DeviceRecord) -> Self {
         record.serial_number.as_ref().map_or_else(
             || Self::Unit(record.unit_id),
@@ -138,7 +146,7 @@ impl DeviceIdentity {
 /// instead. A Bolt device whose receiver UID couldn't be read gets no route
 /// (`None`), so hardware writes are skipped rather than mis-routed to the
 /// receiver's own pid.
-fn device_route(inv: &DeviceInventory, slot: u8) -> Option<DeviceRoute> {
+fn device_route(inv: &DeviceInventory, slot: u8, model: &DeviceModelInfo) -> Option<DeviceRoute> {
     match &inv.receiver.unique_id {
         Some(receiver_uid) => Some(DeviceRoute::Bolt {
             receiver_uid: receiver_uid.clone(),
@@ -147,6 +155,7 @@ fn device_route(inv: &DeviceInventory, slot: u8) -> Option<DeviceRoute> {
         None if slot == DIRECT_DEVICE_INDEX => Some(DeviceRoute::Direct {
             vendor_id: inv.receiver.vendor_id,
             product_id: inv.receiver.product_id,
+            identity: DirectDeviceIdentity::from_model(model),
         }),
         None => None,
     }

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -24,7 +24,7 @@ pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
 };
-pub use route::{DIRECT_DEVICE_INDEX, DeviceRoute};
+pub use route::{DIRECT_DEVICE_INDEX, DeviceRoute, DirectDeviceIdentity};
 pub use smartshift::{SmartShiftMode, SmartShiftStatus};
 pub use write::{
     FeatureEntry, SharedChannel, WriteError, dump_features, get_dpi, get_smartshift_status,

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -19,8 +19,12 @@ use std::sync::Arc;
 
 use hidpp::{
     channel::HidppChannel,
+    device::Device,
+    feature::device_information::DeviceInformationFeature,
     receiver::{self, Receiver},
 };
+use openlogi_core::device::DeviceModelInfo;
+use tracing::debug;
 
 use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
 
@@ -35,10 +39,41 @@ pub enum DeviceRoute {
     /// plugged-in receivers; `slot` is the device's pairing slot (1..=6).
     Bolt { receiver_uid: String, slot: u8 },
     /// Attached straight to the host over USB cable or Bluetooth, addressed at
-    /// the HID++ self-index. Re-found by matching the HID node's vendor/product
-    /// id — two identical mice on one host are indistinguishable here, so the
-    /// first match wins (acceptable for v0).
-    Direct { vendor_id: u16, product_id: u16 },
+    /// the HID++ self-index. Re-found by matching both the HID node's
+    /// vendor/product id and the stronger HID++ DeviceInformation identity.
+    Direct {
+        vendor_id: u16,
+        product_id: u16,
+        identity: DirectDeviceIdentity,
+    },
+}
+
+/// Stable identity for a directly-attached HID++ device.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DirectDeviceIdentity {
+    pub serial_number: Option<String>,
+    pub unit_id: [u8; 4],
+}
+
+impl DirectDeviceIdentity {
+    #[must_use]
+    pub fn from_model(model: &DeviceModelInfo) -> Self {
+        Self {
+            serial_number: model.serial_number.clone(),
+            unit_id: model.unit_id,
+        }
+    }
+
+    fn matches(&self, serial_number: Option<&str>, unit_id: [u8; 4]) -> bool {
+        if unit_id != self.unit_id {
+            return false;
+        }
+        match (&self.serial_number, serial_number) {
+            (Some(expected), Some(actual)) => actual.eq_ignore_ascii_case(expected),
+            (Some(_), None) => false,
+            (None, _) => true,
+        }
+    }
 }
 
 impl DeviceRoute {
@@ -62,7 +97,17 @@ impl fmt::Display for DeviceRoute {
             Self::Direct {
                 vendor_id,
                 product_id,
-            } => write!(f, "direct {vendor_id:04x}:{product_id:04x}"),
+                identity,
+            } => match &identity.serial_number {
+                Some(serial) => {
+                    write!(f, "direct {vendor_id:04x}:{product_id:04x} serial {serial}")
+                }
+                None => write!(
+                    f,
+                    "direct {vendor_id:04x}:{product_id:04x} unit {:02x?}",
+                    identity.unit_id
+                ),
+            },
         }
     }
 }
@@ -86,6 +131,7 @@ pub(crate) async fn open_route_channel(
         if let DeviceRoute::Direct {
             vendor_id,
             product_id,
+            ..
         } = route
             && (dev.vendor_id != *vendor_id || dev.product_id != *product_id)
         {
@@ -105,8 +151,85 @@ pub(crate) async fn open_route_channel(
                     return Ok(Some(channel));
                 }
             }
-            DeviceRoute::Direct { .. } => return Ok(Some(channel)),
+            DeviceRoute::Direct { identity, .. } => {
+                if direct_identity_matches(&channel, identity).await {
+                    return Ok(Some(channel));
+                }
+            }
         }
     }
     Ok(None)
+}
+
+async fn direct_identity_matches(
+    channel: &Arc<HidppChannel>,
+    expected: &DirectDeviceIdentity,
+) -> bool {
+    let device = match Device::new(Arc::clone(channel), DIRECT_DEVICE_INDEX).await {
+        Ok(device) => device,
+        Err(e) => {
+            debug!(error = ?e, "direct route DeviceInformation probe failed");
+            return false;
+        }
+    };
+    let Some(feature) = device.get_feature::<DeviceInformationFeature>() else {
+        return false;
+    };
+    let info = match feature.get_device_info().await {
+        Ok(info) => info,
+        Err(e) => {
+            debug!(error = ?e, "direct route device info read failed");
+            return false;
+        }
+    };
+    let serial_number = if expected.serial_number.is_some() && info.capabilities.serial_number {
+        feature
+            .get_serial_number()
+            .await
+            .ok()
+            .and_then(|serial| normalize_serial_number(&serial))
+    } else {
+        None
+    };
+    expected.matches(serial_number.as_deref(), info.unit_id)
+}
+
+fn normalize_serial_number(serial: &str) -> Option<String> {
+    let serial = serial.trim_matches('\0').trim().to_string();
+    (!serial.is_empty()).then_some(serial)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity() -> DirectDeviceIdentity {
+        DirectDeviceIdentity {
+            serial_number: Some("ABC123".to_string()),
+            unit_id: [1, 2, 3, 4],
+        }
+    }
+
+    #[test]
+    fn direct_identity_requires_matching_unit_id() {
+        assert!(!identity().matches(Some("ABC123"), [4, 3, 2, 1]));
+    }
+
+    #[test]
+    fn direct_identity_requires_serial_when_expected() {
+        assert!(identity().matches(Some("abc123"), [1, 2, 3, 4]));
+        assert!(!identity().matches(None, [1, 2, 3, 4]));
+        assert!(!identity().matches(Some("OTHER"), [1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn direct_identity_without_serial_matches_unit_id_only() {
+        let identity = DirectDeviceIdentity {
+            serial_number: None,
+            unit_id: [1, 2, 3, 4],
+        };
+
+        assert!(identity.matches(None, [1, 2, 3, 4]));
+        assert!(identity.matches(Some("anything"), [1, 2, 3, 4]));
+    }
 }

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -158,14 +158,12 @@ impl Receiver {
                             }
                             // Device name
                             1 => {
-                                let Ok(name) =
-                                    str::from_utf8(&payload[4..(4 + payload[3] as usize)])
-                                else {
+                                let Some((counter, name)) = parse_discovery_name(&payload) else {
                                     return;
                                 };
 
                                 emitter.emit(Event::DeviceDiscoveryDeviceName {
-                                    counter: payload[0] as u16 + payload[1] as u16 * 256,
+                                    counter,
                                     name: name.to_string(),
                                 });
                             }
@@ -496,6 +494,13 @@ impl Receiver {
     }
 }
 
+fn parse_discovery_name(payload: &[u8; 17]) -> Option<(u16, &str)> {
+    let len = usize::from(payload[3]);
+    let end = 4usize.checked_add(len)?;
+    let name = str::from_utf8(payload.get(4..end)?).ok()?;
+    Some((payload[0] as u16 + payload[1] as u16 * 256, name))
+}
+
 impl Drop for Receiver {
     fn drop(&mut self) {
         self.chan.remove_msg_listener(self.msg_listener_hdl);
@@ -700,4 +705,27 @@ pub enum PairingPasskeyPressType {
     Initialization = 0x00,
     Keypress = 0x01,
     Submit = 0x04,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_discovery_name_rejects_oversized_length() {
+        let mut payload = [0u8; 17];
+        payload[3] = 200;
+
+        assert!(parse_discovery_name(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_discovery_name_accepts_bounded_utf8_name() {
+        let mut payload = [0u8; 17];
+        payload[0] = 7;
+        payload[3] = 4;
+        payload[4..8].copy_from_slice(b"Casa");
+
+        assert_eq!(parse_discovery_name(&payload), Some((7, "Casa")));
+    }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,7 +9,8 @@ build instructions, see the [README](../README.md).
 - macOS: Xcode 16+ with the optional **Metal Toolchain** component (required by
   GPUI's `gpui_macos` build script to compile shaders)
 - `create-dmg` for packaging (`brew install create-dmg`); `cargo-bundle` is
-  installed automatically by `cargo run -p xtask -- bundle-macos`
+  installed automatically at the pinned version declared in `xtask/src/macos.rs`
+  by `cargo run -p xtask -- bundle-macos`
 
 ## Building from source
 
@@ -126,13 +127,20 @@ ${OPENLOGI_UPDATE_BASE_URL}/channels/stable/latest.json
 
 The app embeds that manifest URL at build time via
 `OPENLOGI_UPDATE_MANIFEST_URL`, derived from `OPENLOGI_UPDATE_BASE_URL` in the
-release workflow.
+release workflow. Release builds also embed
+`OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY`; update checks fail closed if the public
+key is absent or if the selected manifest asset has no minisign signature.
 
 Configure the R2/update settings in one 1Password item referenced by the GitHub
 secret `OP_R2_SECRET_ITEM`. The item must contain:
 
 - `OPENLOGI_UPDATE_BASE_URL` — public HTTPS base URL, for example
   `https://updates.openlogi.org`.
+- `OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY` — base64 minisign public key embedded
+  in the app and used to verify updater artifacts.
+- `OPENLOGI_UPDATE_MINISIGN_SECRET_KEY` — passwordless minisign secret key used
+  only in the release publish job to sign DMGs before `latest.json` is
+  generated.
 - `CLOUDFLARE_R2_ACCOUNT_ID` — Cloudflare account ID used for the S3 endpoint.
 - `CLOUDFLARE_R2_BUCKET` — bucket name.
 - `CLOUDFLARE_R2_ACCESS_KEY_ID` — R2 S3 access key.

--- a/xtask/src/macos.rs
+++ b/xtask/src/macos.rs
@@ -11,6 +11,8 @@ use crate::util::{
     repo_root, run, with_env,
 };
 
+const CARGO_BUNDLE_VERSION: &str = "0.10.0";
+
 #[derive(Parser)]
 pub(crate) struct DmgMacos {
     /// App bundle to package.
@@ -165,12 +167,15 @@ pub(crate) fn bundle_macos() -> Result<()> {
     }
 
     println!("==> bundle (.app)");
-    if !command_exists("cargo-bundle") {
+    if !cargo_bundle_version_matches()? {
         let mut install = ProcessCommand::new("cargo");
         install
             .arg("install")
             .arg("cargo-bundle")
+            .arg("--version")
+            .arg(CARGO_BUNDLE_VERSION)
             .arg("--locked")
+            .arg("--force")
             .env("CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER", "/usr/bin/cc");
         run(with_env(&mut install, &xcode_env))?;
     }
@@ -187,6 +192,16 @@ pub(crate) fn bundle_macos() -> Result<()> {
     println!();
     println!("Bundle ready: {}", app.display());
     Ok(())
+}
+
+fn cargo_bundle_version_matches() -> Result<bool> {
+    if !command_exists("cargo-bundle") {
+        return Ok(false);
+    }
+    let output = command_stdout(ProcessCommand::new("cargo-bundle").arg("--version"))?;
+    Ok(output
+        .split_whitespace()
+        .any(|part| part == CARGO_BUNDLE_VERSION))
 }
 
 fn xcode_env() -> Result<Vec<(String, String)>> {

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -45,6 +45,7 @@ struct Manifest {
 struct Asset {
     name: String,
     url: String,
+    signature_url: String,
     os: &'static str,
     arch: String,
     format: &'static str,
@@ -106,9 +107,19 @@ fn collect_assets(dist: &Path, release_base: &str) -> Result<Vec<Asset>> {
         let Some(arch) = dmg_arch(name) else {
             continue;
         };
+        let signature_name = format!("{name}.minisig");
+        let signature_path = dist.join(&signature_name);
+        if !signature_path.is_file() {
+            bail!(
+                "missing minisign signature {} for updater artifact {}",
+                signature_path.display(),
+                path.display()
+            );
+        }
         assets.push(Asset {
             name: name.to_string(),
             url: format!("{release_base}/{name}"),
+            signature_url: format!("{release_base}/{signature_name}"),
             os: "macos",
             arch: arch.to_string(),
             format: "dmg",
@@ -152,4 +163,49 @@ fn published_at() -> Result<String> {
     OffsetDateTime::from(SystemTime::now())
         .format(&Rfc3339)
         .context("could not format current timestamp")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::{env, fs, process};
+
+    use super::*;
+
+    fn temp_dist(name: &str) -> PathBuf {
+        let path = env::temp_dir().join(format!("openlogi-manifest-test-{}-{name}", process::id()));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn collect_assets_requires_minisign_signature_for_each_dmg() {
+        let dist = temp_dist("missing-signature");
+        fs::write(dist.join("OpenLogi-v1.2.3-macos-arm64.dmg"), b"dmg").unwrap();
+
+        assert!(collect_assets(&dist, "https://updates.example/releases/v1.2.3").is_err());
+
+        let _ = fs::remove_dir_all(dist);
+    }
+
+    #[test]
+    fn collect_assets_publishes_signature_url() {
+        let dist = temp_dist("with-signature");
+        fs::write(dist.join("OpenLogi-v1.2.3-macos-arm64.dmg"), b"dmg").unwrap();
+        fs::write(
+            dist.join("OpenLogi-v1.2.3-macos-arm64.dmg.minisig"),
+            b"signature",
+        )
+        .unwrap();
+
+        let assets = collect_assets(&dist, "https://updates.example/releases/v1.2.3").unwrap();
+
+        assert_eq!(
+            assets[0].signature_url,
+            "https://updates.example/releases/v1.2.3/OpenLogi-v1.2.3-macos-arm64.dmg.minisig"
+        );
+
+        let _ = fs::remove_dir_all(dist);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes six security findings from the repository-wide Codex Security scan:

- pins the release packaging `cargo-bundle` install
- requires minisign verification for updater artifacts
- signs and publishes updater DMG signatures in the release workflow
- hardens GUI and CLI asset sync paths and checksum enforcement
- binds direct HID routes to DeviceInformation identity, not only VID/PID
- bounds Bolt discovery-name parsing to prevent oversized-length panics

## Impact

Release/update flows now fail closed unless updater artifacts are signed and the app is built with the minisign public key. Asset sync rejects path traversal, symlink destinations, and checksum mismatches. Direct device writes require the expected serial/unit identity before a route is accepted.

## Validation

Contributing checklist from `docs/DEVELOPMENT.md`:

- `env CARGO_INCREMENTAL=0 RUSTFLAGS='-D warnings' cargo fmt --all -- --check`
- `env CARGO_INCREMENTAL=0 RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `env CARGO_INCREMENTAL=0 RUSTFLAGS='-D warnings' cargo test --workspace`

Additional focused checks run during the security fix:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p openlogi-assets safe_component_path`
- `cargo test -p xtask collect_assets`
- `cargo test -p openlogi-hidpp parse_discovery_name`
- `cargo test -p openlogi-hid direct_identity`
- `cargo check -p openlogi-cli`
- `xcodebuild -downloadComponent MetalToolchain`
- `cargo test -p openlogi-gui signed_source`
- `cargo check --workspace`
