### PR TITLE
fix(gui): keep Settings Language description on one line

### DIFF
--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -406,9 +406,14 @@ fn language_row(
                 .child(tr!("Choose the interface language.")),
         )
         .child(
-            Select::new(language_select)
-                .small()
-                .w(px(220.))
-                .menu_width(px(220.)),
+            // The Select's root is `size_full`, so it would otherwise claim the
+            // whole row and starve the description into one char per line. Pin it
+            // to a fixed-size, non-shrinking box (h_6 matches the `.small()` input).
+            div().flex_shrink_0().w(px(220.)).h_6().child(
+                Select::new(language_select)
+                    .small()
+                    .w(px(220.))
+                    .menu_width(px(220.)),
+            ),
         )
 }


### PR DESCRIPTION
Fixes #61.

In **Settings → Language**, the "Choose the interface language." description rendered one character per line (see the issue screenshot). The language `Select`'s root element is `size_full`, so it claimed the entire row and starved the description column to near-zero width, forcing the text to wrap per-character.

## Fix
- Wrap the language `Select` in a fixed-size, non-shrinking box (`flex_shrink_0().w(220px).h_6()`) so it no longer expands to fill the row.
- Let the settings scroll container flex and scroll (`flex_1().min_h(0)`) and grow the window height (360 → 460) so the Language section isn't clipped.

Cherry-picked from #24 — the Settings/Language spacing fix only, none of the locale-expansion or asset changes.

`cargo check -p openlogi-gui` green.

<img width="1091" height="779" alt="Screenshot 2026-06-01 at 6 31 03 PM" src="https://github.com/user-attachments/assets/886b04b9-567e-4d19-b7ca-330c988b2004" />