### PR TITLE
feat: SmartShift 0x2110 support (MX Master 2S) + diag smartshift --sensitivity

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag/smartshift.rs
+++ b/crates/openlogi-cli/src/cmd/diag/smartshift.rs
@@ -1,5 +1,7 @@
 //! `openlogi diag smartshift` — SmartShift toggle round-trip.
 
+use std::num::NonZeroU8;
+
 use anyhow::{Context, Result};
 use clap::Args;
 
@@ -15,9 +17,10 @@ pub struct SmartshiftArgs {
     /// Set the auto-disengage sensitivity instead of toggling, keeping the
     /// current Free/Ratchet mode. N is 1-255 (the wheel's speed threshold to
     /// free-spin): lower = more sensitive; typical 10-40; 255 = permanent
-    /// ratchet.
+    /// ratchet (only meaningful while in Ratchet mode; the current mode is
+    /// always preserved). `0` is rejected — the device treats it as "no change".
     #[arg(long, value_name = "N")]
-    pub sensitivity: Option<u8>,
+    pub sensitivity: Option<NonZeroU8>,
 }
 
 pub async fn run(args: SmartshiftArgs) -> Result<()> {
@@ -25,10 +28,6 @@ pub async fn run(args: SmartshiftArgs) -> Result<()> {
     println!("device: {name} ({route})");
 
     if let Some(n) = args.sensitivity {
-        if n == 0 {
-            anyhow::bail!("sensitivity must be 1-255 (0 means \"no change\")");
-        }
-
         let before = openlogi_hid::get_smartshift_status(&route)
             .await
             .context("read SmartShift status")?;
@@ -45,7 +44,7 @@ pub async fn run(args: SmartshiftArgs) -> Result<()> {
             after.mode, after.auto_disengage
         );
 
-        if after.auto_disengage != n {
+        if after.auto_disengage != n.get() {
             anyhow::bail!(
                 "SmartShift sensitivity write not applied: requested {n}, device reports {}",
                 after.auto_disengage

--- a/crates/openlogi-cli/src/cmd/diag/smartshift.rs
+++ b/crates/openlogi-cli/src/cmd/diag/smartshift.rs
@@ -9,13 +9,62 @@ use crate::cmd::diag::first_online_device;
 pub struct SmartshiftArgs {
     /// Leave the wheel in the toggled mode (skip the second toggle that
     /// restores the original). Useful for visually verifying the flip.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "sensitivity")]
     pub leave_flipped: bool,
+
+    /// Set the auto-disengage sensitivity instead of toggling, keeping the
+    /// current Free/Ratchet mode. N is 1-255 (the wheel's speed threshold to
+    /// free-spin): lower = more sensitive; typical 10-40; 255 = permanent
+    /// ratchet.
+    #[arg(long, value_name = "N")]
+    pub sensitivity: Option<u8>,
 }
 
 pub async fn run(args: SmartshiftArgs) -> Result<()> {
     let (route, name) = first_online_device().await?;
     println!("device: {name} ({route})");
+
+    if let Some(n) = args.sensitivity {
+        if n == 0 {
+            anyhow::bail!("sensitivity must be 1-255 (0 means \"no change\")");
+        }
+
+        let before = openlogi_hid::get_smartshift_status(&route)
+            .await
+            .context("read SmartShift status")?;
+        println!(
+            "  current: mode={:?} sensitivity={}",
+            before.mode, before.auto_disengage
+        );
+
+        let after = openlogi_hid::set_smartshift_sensitivity(&route, n)
+            .await
+            .context("set SmartShift sensitivity")?;
+        println!(
+            "  read-back: mode={:?} sensitivity={}",
+            after.mode, after.auto_disengage
+        );
+
+        if after.auto_disengage != n {
+            anyhow::bail!(
+                "SmartShift sensitivity write not applied: requested {n}, device reports {}",
+                after.auto_disengage
+            );
+        }
+        if after.mode != before.mode {
+            anyhow::bail!(
+                "SmartShift mode changed unexpectedly: was {:?}, now {:?}",
+                before.mode,
+                after.mode
+            );
+        }
+
+        println!(
+            "✓ SmartShift sensitivity set to {n} (mode {:?} preserved)",
+            after.mode
+        );
+        return Ok(());
+    }
 
     let before = openlogi_hid::get_smartshift_status(&route)
         .await

--- a/crates/openlogi-gui/src/hardware.rs
+++ b/crates/openlogi-gui/src/hardware.rs
@@ -60,8 +60,8 @@ fn reusable_channel(
 
 /// Spawn an OS thread that toggles SmartShift (free ↔ ratchet) on the
 /// device at `target` via `openlogi_hid::toggle_smartshift`. Returns
-/// immediately; failures (incl. devices that don't support `0x2111`) are
-/// logged.
+/// immediately; failures (incl. devices that expose neither `0x2111` nor
+/// the older `0x2110` SmartShift feature) are logged.
 pub fn toggle_smartshift_in_background(
     capture: Option<&CaptureChannel>,
     target: Option<DeviceRoute>,
@@ -126,7 +126,8 @@ pub fn read_smartshift_status_blocking(
 
 /// Spawn an OS thread that writes a full SmartShift configuration to the device
 /// at `target` via [`openlogi_hid::set_smartshift`]. Returns immediately;
-/// failures (incl. devices that don't support `0x2111`) are logged.
+/// failures (incl. devices that expose neither `0x2111` nor the older `0x2110`
+/// SmartShift feature) are logged.
 ///
 /// `target == None` is a no-op (dev environment without a real device).
 pub fn write_smartshift_in_background(

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -28,5 +28,5 @@ pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus}
 pub use write::{
     DpiCapabilities, DpiInfo, FeatureEntry, SharedChannel, WriteError, dump_features, get_dpi,
     get_dpi_info, get_smartshift_status, set_dpi, set_dpi_on, set_keyboard_color, set_smartshift,
-    set_smartshift_on, toggle_smartshift, toggle_smartshift_on,
+    set_smartshift_on, set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-hid/src/smartshift.rs
+++ b/crates/openlogi-hid/src/smartshift.rs
@@ -152,3 +152,18 @@ impl SmartShiftFeatureV0 {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flipped_is_an_involution() {
+        assert_eq!(SmartShiftMode::Free.flipped(), SmartShiftMode::Ratchet);
+        assert_eq!(SmartShiftMode::Ratchet.flipped(), SmartShiftMode::Free);
+        assert_eq!(
+            SmartShiftMode::Free.flipped().flipped(),
+            SmartShiftMode::Free
+        );
+    }
+}

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -15,6 +15,7 @@ use hidpp::{
     device::Device,
     feature::CreatableFeature,
     feature::adjustable_dpi::AdjustableDpiFeature,
+    feature::smartshift::{SmartShiftFeature, WheelMode},
     protocol::v20::{ErrorType, Hidpp20Error},
 };
 use thiserror::Error;
@@ -213,6 +214,130 @@ async fn open_feature<F: CreatableFeature + 'static>(
     Ok(device.add_feature::<F>(info.index))
 }
 
+/// Whether a failure to open the `0x2111` Enhanced SmartShift feature should
+/// trigger the `0x2110` legacy fallback. Only a missing-`0x2111` feature
+/// qualifies; transport and protocol errors propagate unchanged so a real
+/// failure is never masked by a second open attempt.
+fn is_missing_enhanced(err: &WriteError) -> bool {
+    matches!(
+        err,
+        WriteError::FeatureUnsupported { feature_hex } if *feature_hex == 0x2111
+    )
+}
+
+/// Map the fork's `0x2110` [`WheelMode`] onto OpenLogi's [`SmartShiftMode`].
+/// A future `#[non_exhaustive]` variant maps to [`SmartShiftMode::Ratchet`],
+/// the "safe" clicky default OpenLogi uses elsewhere. (Reserved wire bytes
+/// never reach here — the fork's `get_ratchet_control_mode` rejects them.)
+fn wheel_mode_to_smartshift(wheel: WheelMode) -> SmartShiftMode {
+    if matches!(wheel, WheelMode::Freespin) {
+        SmartShiftMode::Free
+    } else {
+        SmartShiftMode::Ratchet
+    }
+}
+
+/// Map OpenLogi's [`SmartShiftMode`] onto the fork's `0x2110` [`WheelMode`] —
+/// the inverse of [`wheel_mode_to_smartshift`], used when writing the legacy
+/// ratchet-control mode.
+fn smartshift_to_wheel(mode: SmartShiftMode) -> WheelMode {
+    match mode {
+        SmartShiftMode::Free => WheelMode::Freespin,
+        SmartShiftMode::Ratchet => WheelMode::Ratchet,
+    }
+}
+
+/// Whichever SmartShift feature a device exposes, normalised onto
+/// [`SmartShiftMode`]. Devices ship one or the other: MX Master 3 / 3S use the
+/// `0x2111` Enhanced variant, the MX Master 2S uses the original `0x2110`.
+enum SmartShift {
+    /// `0x2111 SmartShiftWheelEnhanced`.
+    Enhanced(Arc<SmartShiftFeatureV0>),
+    /// `0x2110 SmartShiftWheel`.
+    Legacy(Arc<SmartShiftFeature>),
+}
+
+impl SmartShift {
+    /// Open whichever SmartShift feature the device exposes. Tries `0x2111`
+    /// first; on a missing-`0x2111` error (and only that), retries with
+    /// `0x2110`. Any other error from the first attempt propagates unchanged.
+    async fn open(device: &mut Device) -> Result<Self, WriteError> {
+        match open_feature::<SmartShiftFeatureV0>(device).await {
+            Ok(feature) => Ok(Self::Enhanced(feature)),
+            Err(err) if is_missing_enhanced(&err) => {
+                let feature = open_feature::<SmartShiftFeature>(device).await?;
+                Ok(Self::Legacy(feature))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Read the current mode + auto-disengage threshold. Enhanced (`0x2111`)
+    /// also reports tunable torque; Legacy (`0x2110`) has no such concept, so
+    /// `tunable_torque` is reported as `0` per [`SmartShiftStatus`]'s contract.
+    async fn status(&self) -> Result<SmartShiftStatus, WriteError> {
+        match self {
+            Self::Enhanced(feature) => feature
+                .get_status()
+                .await
+                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+            Self::Legacy(feature) => {
+                let rcm = feature
+                    .get_ratchet_control_mode()
+                    .await
+                    .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+                Ok(SmartShiftStatus {
+                    mode: wheel_mode_to_smartshift(rcm.wheel_mode),
+                    auto_disengage: rcm.auto_disengage,
+                    // 0x2110 has no tunable-torque function; report 0 like
+                    // `SmartShiftStatus::tunable_torque` documents for devices
+                    // that don't support it.
+                    tunable_torque: 0,
+                })
+            }
+        }
+    }
+
+    /// Write a full desired status. Enhanced (`0x2111`) takes mode +
+    /// auto-disengage + tunable torque directly. Legacy (`0x2110`) has no
+    /// tunable-torque function, so that field is ignored; the wheel mode and
+    /// auto-disengage threshold are written explicitly — never relying on the
+    /// device treating a `None`/`0` field as "keep current".
+    async fn set_status(&self, status: SmartShiftStatus) -> Result<(), WriteError> {
+        let SmartShiftStatus {
+            mode,
+            auto_disengage,
+            tunable_torque,
+        } = status;
+        match self {
+            Self::Enhanced(feature) => feature
+                .set_status(mode, auto_disengage, tunable_torque)
+                .await
+                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+            Self::Legacy(feature) => feature
+                .set_ratchet_control_mode(
+                    Some(smartshift_to_wheel(mode)),
+                    Some(auto_disengage),
+                    None,
+                )
+                .await
+                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+        }
+    }
+
+    /// Write a new auto-disengage `sensitivity`, preserving the current mode
+    /// (and, on Enhanced, the tunable torque). Reads the current status first
+    /// so every preserved field is written back explicitly.
+    async fn set_sensitivity(&self, value: u8) -> Result<(), WriteError> {
+        let current = self.status().await?;
+        self.set_status(SmartShiftStatus {
+            auto_disengage: value,
+            ..current
+        })
+        .await
+    }
+}
+
 /// Read the device's current DPI on sensor 0 — companion to [`set_dpi`].
 /// Used by `openlogi diag dpi` and any future Settings → Diagnostics
 /// surface that wants to display the current value without writing.
@@ -291,11 +416,34 @@ pub async fn get_smartshift_status(route: &DeviceRoute) -> Result<SmartShiftStat
         let mut device = Device::new(Arc::clone(&channel), index)
             .await
             .map_err(|_| WriteError::DeviceUnreachable { index })?;
-        let feature = open_feature::<SmartShiftFeatureV0>(&mut device).await?;
-        feature
-            .get_status()
+        let smartshift = SmartShift::open(&mut device).await?;
+        smartshift.status().await
+    })
+    .await
+}
+
+/// Set the SmartShift auto-disengage sensitivity on `route`, preserving the
+/// current mode. Returns the read-back status after the write so the caller can
+/// display and verify it.
+///
+/// `value` is written verbatim: `0x01..=0xfe` is the auto-disengage threshold
+/// (smaller = releases sooner / more sensitive) and `0xff` is permanent ratchet.
+/// Callers should reject `0`, which the device treats as "no change".
+///
+/// `FeatureUnsupported` when the device exposes neither HID++ `0x2111`
+/// (MX Master 3 / 3S) nor the older `0x2110` (MX Master 2S).
+pub async fn set_smartshift_sensitivity(
+    route: &DeviceRoute,
+    value: u8,
+) -> Result<SmartShiftStatus, WriteError> {
+    let index = route.device_index();
+    with_route(route, move |channel| async move {
+        let mut device = Device::new(Arc::clone(&channel), index)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))
+            .map_err(|_| WriteError::DeviceUnreachable { index })?;
+        let smartshift = SmartShift::open(&mut device).await?;
+        smartshift.set_sensitivity(value).await?;
+        smartshift.status().await
     })
     .await
 }
@@ -434,8 +582,9 @@ async fn set_dpi_on_channel(
 /// mode first, then writes the opposite — keeps current sensitivity.
 /// Returns the new mode written.
 ///
-/// `FeatureUnsupported` when the device doesn't expose HID++ `0x2111`
-/// (older Logi mice and most non-MX devices).
+/// `FeatureUnsupported` when the device exposes neither HID++ `0x2111`
+/// (MX Master 3 / 3S) nor the older `0x2110` (MX Master 2S) — i.e. it has no
+/// SmartShift wheel.
 pub async fn toggle_smartshift(route: &DeviceRoute) -> Result<SmartShiftMode, WriteError> {
     let index = route.device_index();
     with_route(route, move |channel| async move {
@@ -453,20 +602,15 @@ async fn toggle_smartshift_on_channel(
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = open_feature::<SmartShiftFeatureV0>(&mut device).await?;
-    let SmartShiftStatus {
-        mode,
-        auto_disengage,
-        tunable_torque,
-    } = feature
-        .get_status()
-        .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
-    let next = mode.flipped();
-    feature
-        .set_status(next, auto_disengage, tunable_torque)
-        .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+    let smartshift = SmartShift::open(&mut device).await?;
+    let status = smartshift.status().await?;
+    let next = status.mode.flipped();
+    smartshift
+        .set_status(SmartShiftStatus {
+            mode: next,
+            ..status
+        })
+        .await?;
     debug!(index, ?next, "wrote SmartShift mode");
     Ok(next)
 }
@@ -475,8 +619,10 @@ async fn toggle_smartshift_on_channel(
 /// threshold, and tunable torque — to `route`. The firmware persists all three
 /// to the device's NVM. Callers that mean to change only one field should read
 /// the rest via [`get_smartshift_status`] first and pass them back unchanged.
+/// On a Legacy (`0x2110`) device the `tunable_torque` field is ignored.
 ///
-/// `FeatureUnsupported` when the device doesn't expose HID++ `0x2111`.
+/// `FeatureUnsupported` when the device exposes neither HID++ `0x2111`
+/// (MX Master 3 / 3S) nor the older `0x2110` (MX Master 2S).
 pub async fn set_smartshift(
     route: &DeviceRoute,
     mode: SmartShiftMode,
@@ -502,11 +648,14 @@ async fn set_smartshift_on_channel(
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = open_feature::<SmartShiftFeatureV0>(&mut device).await?;
-    feature
-        .set_status(mode, auto_disengage, tunable_torque)
-        .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+    let smartshift = SmartShift::open(&mut device).await?;
+    smartshift
+        .set_status(SmartShiftStatus {
+            mode,
+            auto_disengage,
+            tunable_torque,
+        })
+        .await?;
     debug!(
         index,
         ?mode,
@@ -589,7 +738,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{DpiCapabilities, WriteError};
+    use super::*;
 
     #[test]
     fn capabilities_sort_and_deduplicate_values() -> Result<(), WriteError> {
@@ -644,5 +793,65 @@ mod tests {
         assert_eq!(caps.adjacent_test_target(1000), Some(1600));
         assert_eq!(caps.adjacent_test_target(2000), Some(1600));
         Ok(())
+    }
+
+    #[test]
+    fn smartshift_and_wheel_mode_byte_encodings_match() {
+        // The whole design relies on 0x2110 WheelMode and 0x2111
+        // SmartShiftMode sharing one wire encoding (Free/Freespin = 1,
+        // Ratchet = 2). If the fork ever renumbers WheelMode this fails loudly.
+        assert_eq!(
+            u8::from(SmartShiftMode::Free),
+            u8::from(WheelMode::Freespin)
+        );
+        assert_eq!(
+            u8::from(SmartShiftMode::Ratchet),
+            u8::from(WheelMode::Ratchet)
+        );
+    }
+
+    #[test]
+    fn wheel_mode_maps_to_smartshift_mode() {
+        assert_eq!(
+            wheel_mode_to_smartshift(WheelMode::Freespin),
+            SmartShiftMode::Free
+        );
+        assert_eq!(
+            wheel_mode_to_smartshift(WheelMode::Ratchet),
+            SmartShiftMode::Ratchet
+        );
+    }
+
+    #[test]
+    fn smartshift_to_wheel_round_trips() {
+        // smartshift_to_wheel is the inverse of wheel_mode_to_smartshift.
+        for mode in [SmartShiftMode::Free, SmartShiftMode::Ratchet] {
+            assert_eq!(wheel_mode_to_smartshift(smartshift_to_wheel(mode)), mode);
+        }
+    }
+
+    #[test]
+    fn missing_enhanced_triggers_fallback() {
+        assert!(is_missing_enhanced(&WriteError::FeatureUnsupported {
+            feature_hex: 0x2111,
+        }));
+    }
+
+    #[test]
+    fn missing_legacy_does_not_trigger_fallback() {
+        // A device missing 0x2110 must NOT loop back — it genuinely has no
+        // SmartShift.
+        assert!(!is_missing_enhanced(&WriteError::FeatureUnsupported {
+            feature_hex: 0x2110,
+        }));
+    }
+
+    #[test]
+    fn transport_errors_do_not_trigger_fallback() {
+        // Real failures must propagate, not be masked by a fallback attempt.
+        assert!(!is_missing_enhanced(&WriteError::DeviceUnreachable {
+            index: 0xff,
+        }));
+        assert!(!is_missing_enhanced(&WriteError::Hidpp("boom".into())));
     }
 }

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -7,6 +7,7 @@
 //! (once per slider release) — unless a [`SharedChannel`] from the capture
 //! session is reused.
 
+use std::num::NonZeroU8;
 use std::sync::Arc;
 
 use async_hid::AsyncHidWrite;
@@ -327,11 +328,13 @@ impl SmartShift {
 
     /// Write a new auto-disengage `sensitivity`, preserving the current mode
     /// (and, on Enhanced, the tunable torque). Reads the current status first
-    /// so every preserved field is written back explicitly.
-    async fn set_sensitivity(&self, value: u8) -> Result<(), WriteError> {
+    /// so every preserved field is written back explicitly. The [`NonZeroU8`]
+    /// rules out `0`, which the device would treat as "no change" — a silent
+    /// non-write rather than a real sensitivity update.
+    async fn set_sensitivity(&self, value: NonZeroU8) -> Result<(), WriteError> {
         let current = self.status().await?;
         self.set_status(SmartShiftStatus {
-            auto_disengage: value,
+            auto_disengage: value.get(),
             ..current
         })
         .await
@@ -428,13 +431,14 @@ pub async fn get_smartshift_status(route: &DeviceRoute) -> Result<SmartShiftStat
 ///
 /// `value` is written verbatim: `0x01..=0xfe` is the auto-disengage threshold
 /// (smaller = releases sooner / more sensitive) and `0xff` is permanent ratchet.
-/// Callers should reject `0`, which the device treats as "no change".
+/// The [`NonZeroU8`] parameter rules out `0` at the type level — the device
+/// treats a `0` threshold as "no change", so it could never be a real write.
 ///
 /// `FeatureUnsupported` when the device exposes neither HID++ `0x2111`
 /// (MX Master 3 / 3S) nor the older `0x2110` (MX Master 2S).
 pub async fn set_smartshift_sensitivity(
     route: &DeviceRoute,
-    value: u8,
+    value: NonZeroU8,
 ) -> Result<SmartShiftStatus, WriteError> {
     let index = route.device_index();
     with_route(route, move |channel| async move {


### PR DESCRIPTION
## Summary

Adds support for the original `0x2110` SmartShift feature so devices that
predate `0x2111 SmartShiftWheelEnhanced` (e.g. the MX Master 2S) can toggle
the ratchet and adjust sensitivity, plus a `diag smartshift --sensitivity`
flag.

## Changes

- **openlogi-hid:** a private `SmartShift` enum wraps whichever feature a
  device exposes — `0x2111` Enhanced (MX Master 3/3S) or the original
  `0x2110`. It tries `0x2111` first and falls back to `0x2110` **only** on a
  missing-`0x2111` error, so transport/protocol failures are never masked by
  a second open attempt. `toggle_smartshift` and `get_smartshift_status` now
  work on both. New `set_smartshift_sensitivity` writes the auto-disengage
  threshold while preserving the current Free/Ratchet mode.
- **openlogi-cli:** `diag smartshift --sensitivity N` (1–255; 255 = permanent
  ratchet) sets sensitivity without toggling, rejects `0` (a device no-op),
  conflicts with `--leave-flipped`, and verifies the read-back value + mode.

## Testing

- Unit tests cover byte-encoding parity (Free/Freespin = 1, Ratchet = 2) and
  the fallback decision.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace` all pass.
- Device writes smoke-tested on a physical MX Master 2S: toggle round-trips
  Free↔Ratchet and `--sensitivity` writes verify via read-back.
