### PR TITLE
Polish empty state UI and improve user hints for UX/usability

### DIFF
--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -33,12 +33,12 @@ _version: 2
   zh-HK: 結束 OpenLogi
   zh-TW: 結束 OpenLogi
 
-"Plug in or pair a supported Logitech device — it'll show up here automatically.":
-  ja: 対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。
-  ru: "Подключите или сопрягите поддерживаемое устройство Logitech — оно автоматически появится здесь."
-  zh-CN: 接入或配对受支持的 Logitech 设备，它会自动显示在这里。
-  zh-HK: 接入或配對受支援的 Logitech 裝置，它會自動顯示在這裡。
-  zh-TW: 接上或配對相容的 Logitech 裝置，裝置就會自動顯示在這裡。
+"Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.":
+  ja: 対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。直接 Bluetooth 接続の場合は、コンピューターの Bluetooth 設定でペアリングしてください。
+  ru: "Подключите или сопрягите поддерживаемое устройство Logitech — оно автоматически появится здесь. Для прямых Bluetooth-подключений выполните сопряжение в настройках Bluetooth вашего компьютера."
+  zh-CN: 接入或配对受支持的 Logitech 设备，它会自动显示在这里。如需直接蓝牙连接，请在电脑的蓝牙设置中配对。
+  zh-HK: 接入或配對受支援的 Logitech 裝置，它會自動顯示在這裡。如需直接藍牙連接，請在電腦的藍牙設定中配對。
+  zh-TW: 接上或配對相容的 Logitech 裝置，裝置就會自動顯示在這裡。若要使用直接藍牙連線，請在電腦的藍牙設定中配對。
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.":
   ja: Logi Options+ をお使いですか?まず終了してください — 両方のアプリが HID++ アクセスを奪い合います。
   ru: "Используете Logi Options+? Сначала закройте его — оба приложения конкурируют за доступ к HID++."

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -12,7 +12,7 @@
 _version: 2
 
 # ── App chrome: accessibility gate, empty state, footer (app.rs) ────────────
-"No device connected":
+"No devices connected":
   ja: デバイスが接続されていません
   ru: "Устройство не подключено"
   zh-CN: 未连接设备

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -255,6 +255,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
             div()
                 .max_w(px(440.))
                 .text_sm()
+                .text_center()
                 .child(tr!(
                     "Plug in or pair a supported Logitech device — it'll show up here automatically."
                 )),
@@ -278,7 +279,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
                 )
                 .on_click(|_, _, cx| crate::windows::add_device::open(cx)),
         )
-        .child(div().max_w(px(440.)).text_xs().text_color(pal.text_muted).child(tr!(
+        .child(div().max_w(px(440.)).text_xs().text_center().text_color(pal.text_muted).child(tr!(
             "Using Logi Options+? Quit it first — both apps compete for HID++ access."
         )))
         .into_any_element()

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -257,7 +257,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
                 .text_sm()
                 .text_center()
                 .child(tr!(
-                    "Plug in or pair a supported Logitech device — it'll show up here automatically."
+                    "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings."
                 )),
         )
         .child(

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -255,7 +255,6 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
             div()
                 .max_w(px(440.))
                 .text_sm()
-                .text_color(pal.text_muted)
                 .child(tr!(
                     "Plug in or pair a supported Logitech device — it'll show up here automatically."
                 )),

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -265,7 +265,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
                 .id("empty-add-device")
                 .mt_1()
                 .px_4()
-                .py_2()
+                .py_1()
                 .rounded_md()
                 .bg(rgb(theme::ACCENT_BLUE))
                 .text_color(rgb(0x00ff_ffff))

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -248,7 +248,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
                 .child(if scanning {
                     tr!("Scanning for devices…")
                 } else {
-                    tr!("No device connected")
+                    tr!("No devices connected")
                 }),
         )
         .child(

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -263,6 +263,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
         .child(
             div()
                 .id("empty-add-device")
+                .mt_1()
                 .px_4()
                 .py_2()
                 .rounded_md()
@@ -279,7 +280,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
                 )
                 .on_click(|_, _, cx| crate::windows::add_device::open(cx)),
         )
-        .child(div().max_w(px(440.)).text_xs().text_center().text_color(pal.text_muted).child(tr!(
+        .child(div().mt_1().max_w(px(440.)).text_xs().text_center().text_color(pal.text_muted).child(tr!(
             "Using Logi Options+? Quit it first — both apps compete for HID++ access."
         )))
         .into_any_element()

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(rust_i18n::t!("Left Click"), "左键单击"); // core enum label
         assert_eq!(rust_i18n::t!("Bind %{name}", name => "X"), "绑定 X"); // interpolation
         assert_eq!(rust_i18n::t!("Quit OpenLogi"), "退出 OpenLogi"); // menu-bar status item
-        assert_eq!(rust_i18n::t!("No device connected"), "未连接设备"); // menu-bar device line
+        assert_eq!(rust_i18n::t!("No devices connected"), "未连接设备"); // menu-bar device line
         assert_ne!(
             rust_i18n::t!(BLURB),
             BLURB,

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -401,7 +401,7 @@ fn tray_status(cx: &gpui::App) -> String {
     cx.try_global::<AppState>()
         .and_then(AppState::current_record)
         .map_or_else(
-            || rust_i18n::t!("No device connected").into_owned(),
+            || rust_i18n::t!("No devices connected").into_owned(),
             |record| match &record.battery {
                 Some(battery) => format!("{} · {}%", record.display_name, battery.percentage),
                 None => record.display_name.clone(),

--- a/crates/openlogi-gui/src/platform/tray.rs
+++ b/crates/openlogi-gui/src/platform/tray.rs
@@ -92,7 +92,7 @@ mod macos {
         let target = action_target();
         let menu = Menu::new();
 
-        let idle = rust_i18n::t!("No device connected");
+        let idle = rust_i18n::t!("No devices connected");
         let device_item = MenuItem::disabled(&idle);
         menu.add_item(device_item);
 

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -57,7 +57,7 @@ pub struct AppState {
     pub accessibility_granted: bool,
     /// Whether the first device enumeration is still in flight. Startup no
     /// longer blocks on enumeration (see `main`); this drives the "Scanning…"
-    /// vs "No device connected" empty state and is cleared once the inventory
+    /// vs "No devices connected" empty state and is cleared once the inventory
     /// watcher delivers its first snapshot.
     pub scanning: bool,
     /// Bindings for the *currently selected* device. Reloaded whenever the

--- a/crates/openlogi-gui/src/watchers/inventory.rs
+++ b/crates/openlogi-gui/src/watchers/inventory.rs
@@ -59,7 +59,7 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<Vec<DeviceInventory>> 
         // OS thread / fork limits are non-fatal — but startup no longer does a
         // synchronous enumeration, so the GUI keys its initial "Scanning…"
         // state off the first snapshot. Emit one empty snapshot here so it
-        // falls through to "No device connected" instead of showing
+        // falls through to "No devices connected" instead of showing
         // "Scanning…" forever; there's just no hot-plug / auto-reconnect.
         warn!(error = %e, "could not spawn inventory watcher — auto-reconnect disabled");
         let _ = tx.send(Vec::new());


### PR DESCRIPTION
# Improvements
1. **Remove text_muted color**: Makes the "Plug in or pair a device…" hint readable instead of dimmed. Users skip dimmed text.
2. **Center text**: Aligns instruction and warning lines with the heading for visual symmetry.
3. **Improve whitespace**: Change whitespace between in the page that shows when no devices are connected for improved aesthetics.
4. **Instruct users to pair in their computer's settings for direct Bluetooth connections**: Adds a hint to the empty state for users with Bluetooth-only devices, preventing confusion when the device doesn't appear automatically.
5. **Quieter "Add device" button**: Reduces vertical padding so it doesn't dominate the empty state and prevents it from stealing attention from the "pair in your computer's settings" instruction to the user.
6. **Pluralize "No device connected"**: Corrects grammar.

# Screenshots

## Now
<img width="1212" height="894" alt="image" src="https://github.com/user-attachments/assets/7deea1d0-2989-4a55-b45c-54a4f9a06b91" />

## Before
<img width="1212" height="894" alt="image" src="https://github.com/user-attachments/assets/ceccbd71-8fcc-4810-9361-6a6fe64fc0e8" />