### PR TITLE
chore: add GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,146 @@
+name: 🐞 Bug Report
+description: Something is broken or behaves incorrectly.
+title: "[Bug]: "
+labels: ["type: bug", "needs: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report! OpenLogi talks to hardware over HID++, so
+        **device, connection, and version details are essential** — issues without
+        them are usually impossible to reproduce.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched [existing issues](https://github.com/AprilNEA/OpenLogi/issues?q=is%3Aissue) and this is not a duplicate.
+          required: true
+        - label: I am on the [latest release](https://github.com/AprilNEA/OpenLogi/releases/latest) or a recent `master` build.
+          required: true
+        - label: I quit **Logi Options+** before running OpenLogi (the two apps fight over HID++ access and only one can own a receiver at a time).
+          required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which part of OpenLogi?
+      options:
+        - GUI (desktop app)
+        - CLI (the `openlogi` binary)
+        - Both
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenLogi version
+      description: GUI → About window, or run `openlogi --version`.
+      placeholder: e.g. 0.4.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      description: macOS is the only supported platform today; Linux and Windows are still stubs.
+      options:
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version & architecture
+      placeholder: e.g. macOS 15.5 (Sequoia), Apple Silicon
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      description: The Logitech mouse — and receiver, if any — involved.
+      placeholder: e.g. MX Master 3S + Logi Bolt receiver
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connection
+    attributes:
+      label: How is the device connected?
+      options:
+        - Logi Bolt receiver
+        - Bluetooth (direct, no receiver)
+        - Wired (USB cable)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: area
+    attributes:
+      label: Affected area(s)
+      options:
+        - label: Device discovery / detection
+        - label: Button remapping
+        - label: DPI control
+        - label: SmartShift
+        - label: Per-application profiles
+        - label: Battery status
+        - label: Settings / configuration (TOML)
+        - label: Auto-update
+        - label: Menu bar / tray
+        - label: Other
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, plus what you expected to happen instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: device-list
+    attributes:
+      label: "`openlogi list` output"
+      description: Run `openlogi list` and paste the output — it shows your receiver/device IDs and pairing state. Omit only if the CLI is unreachable.
+      render: text
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Re-run with verbose logging and paste the relevant output.
+        CLI: `OPENLOGI_LOG=debug openlogi <command>`.
+        GUI: launch from a terminal with `OPENLOGI_LOG=debug /Applications/OpenLogi.app/Contents/MacOS/OpenLogi`.
+      render: shell
+
+  - type: checkboxes
+    id: permissions
+    attributes:
+      label: macOS permissions (if applicable)
+      description: System Settings → Privacy & Security
+      options:
+        - label: OpenLogi has **Accessibility** permission (needed to remap buttons via the event tap).
+        - label: OpenLogi has **Input Monitoring** permission (needed for Bluetooth-direct devices and capture).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Support (Telegram)
+    url: https://t.me/+pCVJtHAgI3hjYTkx
+    about: Usage questions, setup help, and general discussion. Please don't open an issue for support questions.
+  - name: 📖 Documentation
+    url: https://github.com/AprilNEA/OpenLogi/tree/master/docs
+    about: Install, usage, and configuration guides — check here first.
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/AprilNEA/OpenLogi/security/advisories/new
+    about: Privately disclose security issues. Do NOT open a public issue for them.

--- a/.github/ISSUE_TEMPLATE/device_support.yml
+++ b/.github/ISSUE_TEMPLATE/device_support.yml
@@ -1,0 +1,77 @@
+name: 🖱️ Device Support / Compatibility
+description: A Logitech device isn't detected, isn't fully supported, or you'd like support added.
+title: "[Device]: "
+labels: ["area: hidpp", "needs: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        OpenLogi speaks HID++ — the diagnostic output below tells us exactly what
+        your device reports, which is what we need to add or fix support.
+
+        > **Known limitation:** `hidpp` currently only recognises **Logi Bolt**
+        > receivers (PID `0xC548`). Unifying and other receivers are not surfaced yet.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I quit **Logi Options+** before testing.
+          required: true
+        - label: I searched existing issues for my device.
+          required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      placeholder: e.g. MX Master 3S, MX Anywhere 3, Lift, Signature M650
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connection
+    attributes:
+      label: Connection
+      options:
+        - Logi Bolt receiver
+        - Bluetooth (direct, no receiver)
+        - Wired (USB cable)
+        - Unifying receiver
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: behavior
+    attributes:
+      label: What's the problem?
+      options:
+        - Device is not detected at all
+        - Device is detected but a feature doesn't work
+        - Requesting support for a device not yet supported
+    validations:
+      required: true
+
+  - type: textarea
+    id: list
+    attributes:
+      label: "`openlogi list` output"
+      description: Run `openlogi list` and paste the full output (shows vendor/product IDs and pairing state).
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: features
+    attributes:
+      label: "`openlogi diag features` output"
+      description: If the device is detected, run `openlogi diag features` and paste the HID++ feature dump. Skip this if the device isn't detected at all.
+      render: text
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: What works, what doesn't, your OS + version, and how the device behaves in Logi Options+ for comparison.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: ✨ Feature Request
+description: Suggest a new feature or an improvement to existing functionality.
+title: "[Feature]: "
+labels: ["type: feature", "needs: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? Great. If you want a **specific Logitech device supported**,
+        please use the **🖱️ Device Support / Compatibility** template instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checklist
+      options:
+        - label: I searched existing issues and the [Roadmap](https://github.com/AprilNEA/OpenLogi#roadmap), and this isn't already tracked.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do? What's missing or frustrating today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like OpenLogi to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or how Logi Options+ / other tools handle this.
+
+  - type: checkboxes
+    id: area
+    attributes:
+      label: Related area(s)
+      options:
+        - label: GUI
+        - label: CLI
+        - label: Button actions / remapping
+        - label: DPI
+        - label: SmartShift
+        - label: Per-application profiles
+        - label: Configuration (TOML)
+        - label: Auto-update
+        - label: Other
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, references, or anything else that helps.


### PR DESCRIPTION
## Summary

Adds GitHub issue **form** templates tailored to OpenLogi's HID++/hardware nature, plus the chooser config. Because OpenLogi talks to real Logitech devices over HID++, the forms front-load the details that make hardware bugs reproducible (device model, connection type, `openlogi list` / `openlogi diag features` output, logs, macOS permissions).

### Templates (`.github/ISSUE_TEMPLATE/`)

| File | Purpose | Notable fields |
|------|---------|----------------|
| `bug_report.yml` | Something is broken | Required: quit Logi Options+, on latest version; GUI/CLI, OpenLogi version, OS + arch, device model, connection type, affected areas, repro, `openlogi list` output, `OPENLOGI_LOG=debug` logs, macOS Accessibility/Input Monitoring |
| `feature_request.yml` | New feature / improvement | Motivation, proposed solution, alternatives, area; routes device asks to the device template |
| `device_support.yml` | Unsupported / undetected device | Required `openlogi list`; optional `openlogi diag features` dump; notes the Bolt-only (`0xC548`) receiver limitation |
| `config.yml` | Chooser config | Disables blank issues; links to Telegram (questions), docs, and private security advisories |

Default labels reuse the existing taxonomy: bug → `type: bug` + `needs: triage`, feature → `type: feature` + `needs: triage`, device → `area: hidpp` + `needs: triage`.

### Drive-by fix (separate commit)

The pre-push `cargo clippy` hook was red on `master` independent of this change: stable clippy (now 1.95) flags `language_select_field`'s by-value `Entity` parameter with `needless_pass_by_value`. The suggested `&Entity` doesn't work here — it makes the returned `impl IntoElement` borrow a variable captured by the surrounding `Fn` render closure (edition 2024 RPIT captures the input lifetime), which the closure can't let escape. Suppressed with a scoped `#[allow(..., reason = "...")]` instead; `Entity` is a cheap clonable handle. Kept as its own commit so it can be dropped/cherry-picked independently.

## Notes

- The "Report a Security Vulnerability" contact link points at GitHub's private advisory form; it becomes active once **Private vulnerability reporting** is enabled in repo settings.
- All four files validated as YAML; referenced labels all already exist.
