### PR TITLE
ci(release): disable homebrew-tap dispatch (openlogi moved to homebrew-cask)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,11 @@ jobs:
           APPLE_ID: ${{ secrets.OP_APPLE_SECRET_ITEM }}/APPLE_ID
           APPLE_PASSWORD: ${{ secrets.OP_APPLE_SECRET_ITEM }}/APPLE_PASSWORD
           APPLE_TEAM_ID: ${{ secrets.OP_APPLE_SECRET_ITEM }}/APPLE_TEAM_ID
-          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
+          # GitHub App creds — unused since openlogi moved to homebrew-cask; the
+          # homebrew-tap dispatch job below is commented out. Re-enable both together
+          # if the tap dispatches again (e.g. a beta cask).
+          # GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
+          # GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
 
       - name: Install packaging tools
@@ -67,8 +70,8 @@ jobs:
           APPLE_ID: ${{ steps.load_secrets.outputs.APPLE_ID }}
           APPLE_PASSWORD: ${{ steps.load_secrets.outputs.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ steps.load_secrets.outputs.APPLE_TEAM_ID }}
-          GITHUB_APP_ID: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+          # GITHUB_APP_ID: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
+          # GITHUB_APP_PRIVATE_KEY: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_BASE_URL }}
         run: |
           set -euo pipefail
@@ -78,8 +81,8 @@ jobs:
           : "${APPLE_ID:?Configure APPLE_ID in 1Password}"
           : "${APPLE_PASSWORD:?Configure APPLE_PASSWORD in 1Password}"
           : "${APPLE_TEAM_ID:?Configure APPLE_TEAM_ID in 1Password}"
-          : "${GITHUB_APP_ID:?Configure GITHUB_APP_ID in 1Password}"
-          : "${GITHUB_APP_PRIVATE_KEY:?Configure GITHUB_APP_PRIVATE_KEY in 1Password}"
+          # : "${GITHUB_APP_ID:?Configure GITHUB_APP_ID in 1Password}"
+          # : "${GITHUB_APP_PRIVATE_KEY:?Configure GITHUB_APP_PRIVATE_KEY in 1Password}"
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in 1Password}"
 
       - name: Import Apple signing certificate
@@ -253,53 +256,58 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
 
-  homebrew-tap:
-    name: Dispatch homebrew-tap update
-    runs-on: ubuntu-latest
-    needs: publish
-    permissions:
-      contents: read
-    steps:
-
-      - name: Load GitHub App credentials from 1Password
-        id: load_secrets
-        uses: 1password/load-secrets-action@v4
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
-
-      # The App private key is stored base64-encoded in 1Password (a raw PEM's
-      # newlines get mangled to spaces on paste, which breaks key decoding).
-      # Decode it here; base64 ignores whitespace, so it survives re-mangling.
-      - name: Decode GitHub App private key
-        id: app_key
-        env:
-          APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-        run: |
-          key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
-          {
-            echo 'pem<<__PEM__'
-            printf '%s\n' "$key"
-            echo '__PEM__'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Mint homebrew-tap token (GitHub App)
-        id: tap_token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-          private-key: ${{ steps.app_key.outputs.pem }}
-          owner: AprilNEA
-          repositories: homebrew-tap
-
-      - name: Dispatch homebrew-tap update
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ steps.tap_token.outputs.token }}
-          repository: AprilNEA/homebrew-tap
-          event-type: update-openlogi
-          client-payload: |
-            {"version": "${{ github.ref_name }}"}
+  # Disabled: openlogi now ships in official Homebrew/homebrew-cask (autobump-
+  # maintained), so the tap no longer needs a per-release dispatch. Kept here
+  # (not deleted) to re-enable quickly if the tap dispatches again, e.g. for a
+  # beta cask. To re-enable: uncomment this job and the GITHUB_APP_* lines in the
+  # `dmg` job's secret load/validate steps above.
+  #
+  # homebrew-tap:
+  #   name: Dispatch homebrew-tap update
+  #   runs-on: ubuntu-latest
+  #   needs: publish
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - name: Load GitHub App credentials from 1Password
+  #       id: load_secrets
+  #       uses: 1password/load-secrets-action@v4
+  #       with:
+  #         export-env: false
+  #       env:
+  #         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+  #         GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
+  #         GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
+  #
+  #     # The App private key is stored base64-encoded in 1Password (a raw PEM's
+  #     # newlines get mangled to spaces on paste, which breaks key decoding).
+  #     # Decode it here; base64 ignores whitespace, so it survives re-mangling.
+  #     - name: Decode GitHub App private key
+  #       id: app_key
+  #       env:
+  #         APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+  #       run: |
+  #         key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
+  #         {
+  #           echo 'pem<<__PEM__'
+  #           printf '%s\n' "$key"
+  #           echo '__PEM__'
+  #         } >> "$GITHUB_OUTPUT"
+  #
+  #     - name: Mint homebrew-tap token (GitHub App)
+  #       id: tap_token
+  #       uses: actions/create-github-app-token@v3
+  #       with:
+  #         client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
+  #         private-key: ${{ steps.app_key.outputs.pem }}
+  #         owner: AprilNEA
+  #         repositories: homebrew-tap
+  #
+  #     - name: Dispatch homebrew-tap update
+  #       uses: peter-evans/repository-dispatch@v4
+  #       with:
+  #         token: ${{ steps.tap_token.outputs.token }}
+  #         repository: AprilNEA/homebrew-tap
+  #         event-type: update-openlogi
+  #         client-payload: |
+  #           {"version": "${{ github.ref_name }}"}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Download the signed, notarized `.dmg` from the [latest release](https://github.c
 Or install via [Homebrew](https://brew.sh):
 
 ```sh
-brew install --cask aprilnea/tap/openlogi
+brew install --cask openlogi
 ```
 
 To build from source, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,7 +73,7 @@ OpenLogi 通过 Logi Bolt 接收器 —— 或蓝牙直连 / 有线连接 ——
 或通过 [Homebrew](https://brew.sh) 安装：
 
 ```sh
-brew install --cask aprilnea/tap/openlogi
+brew install --cask openlogi
 ```
 
 需要从源码构建请看 [DEVELOPMENT.md](docs/DEVELOPMENT.md)。


### PR DESCRIPTION
## Why

OpenLogi now ships in official `Homebrew/homebrew-cask` (Homebrew/homebrew-cask#267385), maintained by Homebrew autobump. The per-release dispatch to `AprilNEA/homebrew-tap` is therefore obsolete — and the tap's `openlogi` cask + `update-openlogi.yml` are being removed (AprilNEA/homebrew-tap#2), so this `repository_dispatch` now targets a deleted listener.

## What

Commented out (not deleted, per preference — easy to re-enable if the tap dispatches again, e.g. for a beta cask):

- The `homebrew-tap` job.
- The now-unused `GITHUB_APP_*` credential **load** + **validate** lines in the `dmg` job (the dispatch job was their only consumer).

Active jobs after this change: `dmg`, `publish`.

## Also

- `README.md` + `README_CN.md`: Homebrew install now points at the official cask — `brew install --cask openlogi` (was `aprilnea/tap/openlogi`).

## Validation

`release.yml` parses as valid YAML (pre-commit `check yaml` + local parse); no active workflow logic removed — only comments.