### PR TITLE
docs: add ja/de/fr/ko READMEs and fix the relocated zh-CN one

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -1,0 +1,109 @@
+> [!WARNING]
+> **OpenLogi befindet sich in aktiver Entwicklung** und ist noch nicht stabil —— Funktionen und Konfiguration können sich noch ändern. Gib dem Repo einen **Star** ⭐ und **beobachte** 👀 es, um sofort benachrichtigt zu werden, sobald ein Release erscheint.
+
+<h4 align="right"><a href="../README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a> | <strong>Deutsch</strong> | <a href="README.fr.md">Français</a> | <a href="README.ko.md">한국어</a></h4>
+
+<p align="center">
+    <img src="https://assets.openlogi.org/brand/openlogi-animated.svg" width="138" alt="OpenLogi"/>
+</p>
+
+<h1 align="center">OpenLogi</h1>
+<p align="center"><strong>⚡️ Eine native, lokal-zuerst arbeitende Alternative zu Logitech Options+, geschrieben in Rust 🦀<br/>Tasten, DPI und SmartShift über HID++ neu belegen. Kein Konto, keine Telemetrie.</strong></p>
+
+
+<div align="center">
+    <a href="https://twitter.com/AprilNEA" target="_blank">
+    <img alt="twitter" src="https://img.shields.io/badge/follow-AprilNEA-green?style=social&logo=Twitter"></a>
+    <a href="https://t.me/+u8DfyLlIqPYxZjJh" target="_blank">
+    <img alt="telegram" src="https://img.shields.io/badge/chat-telegram-blueviolet?style=flat&logo=Telegram"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/releases" target="_blank">
+    <img alt="GitHub downloads" src="https://img.shields.io/github/downloads/AprilNEA/OpenLogi/total.svg?style=flat"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/commits" target="_blank">
+    <img alt="GitHub commit" src="https://img.shields.io/github/commit-activity/m/AprilNEA/OpenLogi?style=flat"></a>
+    <img alt="Hits" src="https://hits.aprilnea.com/hits?url=https://github.com/aprilnea/openlogi">
+</div>
+
+> **Genug von Options+? Probier OpenLogi.**
+
+Belege Tasten neu, steuere DPI und SmartShift und wechsle Profile pro App —— ohne Logitech-Konto, ohne Telemetrie und ohne die offizielle Options+-Installation. Keine Cloud, schlichte TOML-Konfiguration; die einzigen Netzwerkzugriffe sind das Laden der Gerätebilder und eine optionale, standardmäßig deaktivierte Update-Prüfung.
+
+---
+
+## Was es ist
+
+OpenLogi spricht mit Logitech-HID++-Mäusen über einen Logi-Bolt-Empfänger —— oder eine direkte Bluetooth- bzw. kabelgebundene Verbindung —— ohne Logi Options+ auszuführen. Es liefert zwei Binärdateien:
+
+- **[OpenLogi GUI](../crates/openlogi-gui)** —— eine GPUI-Desktop-App: ein interaktives Maus-Diagramm mit anklickbaren Hotspots, ein Aktions-Auswahlmenü pro Taste (39 eingebaute Aktionen plus aufgezeichnete eigene Tastenkürzel), DPI-Presets, ein SmartShift-Schalter, anwendungsspezifische Profil-Overlays, ein Geräte-Karussell, das live zwischen gekoppelten Geräten wechselt, und ein Einstellungsfenster mit einer in sechs Sprachen lokalisierten Oberfläche.
+- **[OpenLogi CLI](../crates/openlogi-cli)** —— ein CLI für die kopflose Inventarisierung (`list`) sowie Unterbefehle zur Asset-Synchronisierung und Geräte-Diagnose.
+
+Alles bleibt lokal: Belegungen liegen in einer schlichten TOML-Datei, Tastendrücke werden über den OS-Event-Tap neu belegt, und DPI-/SmartShift-Änderungen werden direkt über HID++ auf das Gerät geschrieben.
+
+macOS wird heute unterstützt; Linux und Windows folgen bald —— siehe [Roadmap](#roadmap).
+
+## Roadmap
+
+| Funktion | Status |
+|---|---|
+| Bolt-Empfänger erkennen + gekoppelte Geräte auflisten (CLI + GUI) | ✅ |
+| Geräte per Bluetooth-Direktverbindung / Kabel (ohne Empfänger) | ✅ |
+| Akkustand / Ladezustand | ✅ (Geräte online) |
+| Interaktive GUI: Karussell, Maus-Diagramm, Aktions-Auswahl | ✅ macOS |
+| Tastenneubelegung über den OS-Event-Tap (derzeit Seitentasten Back / Forward) | ✅ macOS |
+| Katalog mit 39 Aktionen + aufgezeichnete eigene Tastenkürzel | ✅ macOS¹ |
+| DPI-Steuerung + Presets + Aktionen „Durchschalten“ / „Preset setzen“ (HID++ `0x2201`) | ✅ macOS |
+| SmartShift-Umschaltung des Radmodus (HID++ `0x2111`) | ✅ macOS |
+| Anwendungsspezifische Profil-Overlays (automatischer Wechsel bei App-Fokus) | ✅ macOS |
+| Einstellungsfenster: Start bei Anmeldung, Update-Prüfung, Menüleiste, Berechtigungen, Sprache | ✅ macOS |
+| Oberflächen-Lokalisierung (6 Sprachen: en, ja, ru, zh-CN, zh-HK, zh-TW) | ✅ macOS |
+| Richtungsbelegungen der Gestentaste | 🟡 konfigurierbar; Hardware-Erfassung ausstehend |
+| Erfassung von Mittel- / Modus-Umschalt- / Daumenrad-Taste | 🟡 konfigurierbar; Hook belegt nur die Seitentasten |
+| Linux-/Windows-Event-Hook | ❌ Stub (`Unsupported`) |
+| Unifying-Empfänger | ❌ (noch nicht unterstützt) |
+
+¹ Einige Aktionen (z. B. die Medientasten) protokollieren derzeit nur das beabsichtigte Ereignis, statt es tatsächlich auszulösen —— als Folgeaufgabe vermerkt.
+
+## Installation
+
+> [!IMPORTANT]
+> Beende zuerst **Logi Options+** —— beide Programme konkurrieren um den HID++-Zugriff, und ein Empfänger kann jeweils nur von einem belegt werden.
+
+Lade die signierte, notarisierte `.dmg` aus dem [neuesten Release](https://github.com/AprilNEA/OpenLogi/releases/latest) herunter und ziehe `OpenLogi.app` nach `/Applications`.
+
+Oder installiere via [Homebrew](https://brew.sh):
+
+```sh
+brew install --cask openlogi
+```
+
+Zum Bauen aus dem Quellcode siehe [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Verwendung (CLI)
+
+Siehe [USAGE.md](USAGE.md).
+
+## Konfiguration
+
+Siehe [CONFIGURATION.md](CONFIGURATION.md).
+
+## Entwicklung
+
+Siehe [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Danksagungen
+
+- [`hidpp`](https://crates.io/crates/hidpp) von [@lus](https://github.com/lus)
+- [Solaar](https://github.com/pwr-Solaar/Solaar)
+- [Mouser](https://github.com/TomBadash/Mouser) von Tom Badash
+
+## Lizenz
+
+Dual-lizenziert unter wahlweise
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE))
+- MIT-Lizenz ([LICENSE-MIT](../LICENSE-MIT))
+
+—— nach deiner Wahl.
+
+---
+
+**Nicht mit Logitech verbunden.** „Logitech“, „MX Master“ und „Options+“ sind Marken der Logitech International S.A.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -1,0 +1,109 @@
+> [!WARNING]
+> **OpenLogi est en cours de développement actif** et n'est pas encore stable —— les fonctionnalités et la configuration peuvent encore changer. Mettez une **Star** ⭐ au dépôt et **suivez-le** 👀 pour être averti dès qu'une version est publiée.
+
+<h4 align="right"><a href="../README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.de.md">Deutsch</a> | <strong>Français</strong> | <a href="README.ko.md">한국어</a></h4>
+
+<p align="center">
+    <img src="https://assets.openlogi.org/brand/openlogi-animated.svg" width="138" alt="OpenLogi"/>
+</p>
+
+<h1 align="center">OpenLogi</h1>
+<p align="center"><strong>⚡️ Une alternative native et locale d'abord à Logitech Options+, écrite en Rust 🦀<br/>Réaffectez les boutons, le DPI et SmartShift via HID++. Sans compte, sans télémétrie.</strong></p>
+
+
+<div align="center">
+    <a href="https://twitter.com/AprilNEA" target="_blank">
+    <img alt="twitter" src="https://img.shields.io/badge/follow-AprilNEA-green?style=social&logo=Twitter"></a>
+    <a href="https://t.me/+u8DfyLlIqPYxZjJh" target="_blank">
+    <img alt="telegram" src="https://img.shields.io/badge/chat-telegram-blueviolet?style=flat&logo=Telegram"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/releases" target="_blank">
+    <img alt="GitHub downloads" src="https://img.shields.io/github/downloads/AprilNEA/OpenLogi/total.svg?style=flat"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/commits" target="_blank">
+    <img alt="GitHub commit" src="https://img.shields.io/github/commit-activity/m/AprilNEA/OpenLogi?style=flat"></a>
+    <img alt="Hits" src="https://hits.aprilnea.com/hits?url=https://github.com/aprilnea/openlogi">
+</div>
+
+> **Marre d'Options+ ? Essayez OpenLogi.**
+
+Réaffectez les boutons, pilotez le DPI et SmartShift, et changez de profil selon l'application —— sans compte Logitech, sans télémétrie et sans l'installation officielle d'Options+. Aucun cloud, configuration en simple TOML ; les seuls accès réseau sont le téléchargement des images d'appareils et une vérification de mise à jour optionnelle, désactivée par défaut.
+
+---
+
+## Présentation
+
+OpenLogi communique avec les souris Logitech HID++ via un récepteur Logi Bolt —— ou une connexion Bluetooth directe / filaire —— sans exécuter Logi Options+. Il fournit deux binaires :
+
+- **[OpenLogi GUI](../crates/openlogi-gui)** —— une application de bureau GPUI : un schéma de souris interactif avec des zones cliquables, un sélecteur d'action par bouton (39 actions intégrées plus des raccourcis personnalisés enregistrés), des préréglages DPI, un interrupteur SmartShift, des surcouches de profil par application, un carrousel d'appareils qui bascule en direct entre les appareils appairés, et une fenêtre de réglages dont l'interface est localisée en six langues.
+- **[OpenLogi CLI](../crates/openlogi-cli)** —— une interface en ligne de commande pour l'inventaire sans interface graphique (`list`), ainsi que des sous-commandes de synchronisation des ressources et de diagnostic des appareils.
+
+Tout reste local : les affectations vivent dans un simple fichier TOML, les appuis sur les boutons sont réaffectés via l'event tap du système, et les changements de DPI / SmartShift sont écrits directement sur l'appareil via HID++.
+
+macOS est pris en charge aujourd'hui ; Linux et Windows arrivent bientôt —— voir la [Feuille de route](#feuille-de-route).
+
+## Feuille de route
+
+| Fonctionnalité | État |
+|---|---|
+| Détecter les récepteurs Bolt + lister les appareils appairés (CLI + GUI) | ✅ |
+| Appareils Bluetooth direct / filaires (sans récepteur) | ✅ |
+| Pourcentage de batterie / état de charge | ✅ (appareils en ligne) |
+| GUI interactive : carrousel, schéma de souris, sélecteur d'action | ✅ macOS |
+| Réaffectation des boutons via l'event tap du système (boutons latéraux Back / Forward pour l'instant) | ✅ macOS |
+| Catalogue de 39 actions + raccourcis clavier personnalisés enregistrés | ✅ macOS¹ |
+| Contrôle du DPI + préréglages + actions Cycler / Définir un préréglage (HID++ `0x2201`) | ✅ macOS |
+| Bascule du mode molette SmartShift (HID++ `0x2111`) | ✅ macOS |
+| Surcouches de profil par application (bascule auto au focus de l'app) | ✅ macOS |
+| Fenêtre de réglages : lancement à l'ouverture de session, vérification des mises à jour, barre de menus, autorisations, langue | ✅ macOS |
+| Localisation de l'interface (6 langues : en, ja, ru, zh-CN, zh-HK, zh-TW) | ✅ macOS |
+| Affectations par direction du bouton gestuel | 🟡 configurable ; capture matérielle à venir |
+| Capture des boutons central / changement de mode / molette du pouce | 🟡 configurable ; le hook ne gère que les boutons latéraux |
+| Hook d'événements Linux / Windows | ❌ stub (`Unsupported`) |
+| Récepteurs Unifying | ❌ (pas encore pris en charge) |
+
+¹ Quelques actions (p. ex. les touches multimédias) se contentent pour l'instant de journaliser l'événement prévu au lieu de l'émettre réellement —— suivi en tant que tâche ultérieure.
+
+## Installation
+
+> [!IMPORTANT]
+> Quittez d'abord **Logi Options+** —— les deux applications se disputent l'accès HID++, et un récepteur ne peut être détenu que par une seule à la fois.
+
+Téléchargez le `.dmg` signé et notarisé depuis la [dernière version](https://github.com/AprilNEA/OpenLogi/releases/latest) et glissez `OpenLogi.app` dans `/Applications`.
+
+Ou installez via [Homebrew](https://brew.sh) :
+
+```sh
+brew install --cask openlogi
+```
+
+Pour compiler depuis les sources, voir [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Utilisation (CLI)
+
+Voir [USAGE.md](USAGE.md).
+
+## Configuration
+
+Voir [CONFIGURATION.md](CONFIGURATION.md).
+
+## Développement
+
+Voir [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Remerciements
+
+- [`hidpp`](https://crates.io/crates/hidpp) par [@lus](https://github.com/lus)
+- [Solaar](https://github.com/pwr-Solaar/Solaar)
+- [Mouser](https://github.com/TomBadash/Mouser) par Tom Badash
+
+## Licence
+
+Sous double licence, au choix :
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE))
+- Licence MIT ([LICENSE-MIT](../LICENSE-MIT))
+
+à votre convenance.
+
+---
+
+**Sans affiliation avec Logitech.** « Logitech », « MX Master » et « Options+ » sont des marques de Logitech International S.A.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,0 +1,109 @@
+> [!WARNING]
+> **OpenLogi は現在活発に開発中**であり、まだ安定していません —— 機能や設定は今後も変わる可能性があります。リポジトリに **Star** ⭐ と **Watch** 👀 を付けて、リリースが出た瞬間に通知を受け取りましょう。
+
+<h4 align="right"><a href="../README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <strong>日本語</strong> | <a href="README.de.md">Deutsch</a> | <a href="README.fr.md">Français</a> | <a href="README.ko.md">한국어</a></h4>
+
+<p align="center">
+    <img src="https://assets.openlogi.org/brand/openlogi-animated.svg" width="138" alt="OpenLogi"/>
+</p>
+
+<h1 align="center">OpenLogi</h1>
+<p align="center"><strong>⚡️ Rust 製の、ネイティブでローカルファーストな Logitech Options+ の代替 🦀<br/>HID++ 経由でボタン・DPI・SmartShift を再マッピング。アカウント不要、テレメトリなし。</strong></p>
+
+
+<div align="center">
+    <a href="https://twitter.com/AprilNEA" target="_blank">
+    <img alt="twitter" src="https://img.shields.io/badge/follow-AprilNEA-green?style=social&logo=Twitter"></a>
+    <a href="https://t.me/+u8DfyLlIqPYxZjJh" target="_blank">
+    <img alt="telegram" src="https://img.shields.io/badge/chat-telegram-blueviolet?style=flat&logo=Telegram"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/releases" target="_blank">
+    <img alt="GitHub downloads" src="https://img.shields.io/github/downloads/AprilNEA/OpenLogi/total.svg?style=flat"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/commits" target="_blank">
+    <img alt="GitHub commit" src="https://img.shields.io/github/commit-activity/m/AprilNEA/OpenLogi?style=flat"></a>
+    <img alt="Hits" src="https://hits.aprilnea.com/hits?url=https://github.com/aprilnea/openlogi">
+</div>
+
+> **Options+ にうんざり？ OpenLogi を試してみてください。**
+
+ボタンの再マッピング、DPI と SmartShift の制御、アプリごとのプロファイル切り替えを —— Logitech アカウントもテレメトリも、公式 Options+ のインストールも不要で実現します。クラウドなし、設定はプレーンな TOML。ネットワーク通信はデバイス画像の取得と、オプトイン・既定でオフの更新チェックだけです。
+
+---
+
+## 概要
+
+OpenLogi は Logi Bolt レシーバー —— あるいは Bluetooth 直結 / 有線接続 —— を通じて Logitech HID++ マウスと通信し、Logi Options+ を実行する必要はありません。2 つのバイナリを提供します：
+
+- **[OpenLogi GUI](../crates/openlogi-gui)** —— GPUI 製のデスクトップアプリ：クリック可能なホットスポット付きのインタラクティブなマウス図、ボタンごとのアクションピッカー（39 個の組み込みアクション＋録音したカスタムショートカット）、DPI プリセット、SmartShift トグル、アプリ別のプロファイルオーバーレイ、ペアリング済みデバイスをライブで切り替えるデバイスカルーセル、そして UI が 6 言語にローカライズされた設定ウィンドウ。
+- **[OpenLogi CLI](../crates/openlogi-cli)** —— ヘッドレスなインベントリ表示（`list`）に加え、アセット同期やデバイス診断のサブコマンドを備えた CLI。
+
+すべてローカルで完結します：バインディングはプレーンな TOML ファイルに保存され、ボタン押下は OS のイベント tap を介して再マッピングされ、DPI / SmartShift の変更は HID++ 経由でデバイスに直接書き込まれます。
+
+現在は macOS に対応しています。Linux と Windows は近日対応予定です —— [ロードマップ](#ロードマップ)を参照してください。
+
+## ロードマップ
+
+| 機能 | 状態 |
+|---|---|
+| Bolt レシーバーの検出とペアリング済みデバイスの一覧（CLI + GUI） | ✅ |
+| Bluetooth 直結 / 有線デバイス（レシーバー不要） | ✅ |
+| バッテリー残量 / 充電状態 | ✅（オンラインのデバイス） |
+| インタラクティブ GUI：カルーセル、マウス図、アクションピッカー | ✅ macOS |
+| OS イベント tap によるボタン再マッピング（現在はサイドボタンの Back / Forward） | ✅ macOS |
+| 39 アクションのカタログ＋録音したカスタムキーボードショートカット | ✅ macOS¹ |
+| DPI 制御＋プリセット＋循環 / プリセット指定アクション（HID++ `0x2201`） | ✅ macOS |
+| SmartShift ホイールモードの切り替え（HID++ `0x2111`） | ✅ macOS |
+| アプリ別プロファイルオーバーレイ（アプリのフォーカス時に自動切り替え） | ✅ macOS |
+| 設定ウィンドウ：ログイン時起動、更新チェック、メニューバー、権限、言語 | ✅ macOS |
+| インターフェースのローカライズ（6 言語：en、ja、ru、zh-CN、zh-HK、zh-TW） | ✅ macOS |
+| ジェスチャーボタンの方向別バインディング | 🟡 設定可能；ハードウェアでの取得は未対応 |
+| 中ボタン / モードシフト / サムホイールのボタン取得 | 🟡 設定可能；フックはサイドボタンのみを占有 |
+| Linux / Windows のイベントフック | ❌ スタブ（`Unsupported`） |
+| Unifying レシーバー | ❌（未対応） |
+
+¹ 一部のアクション（例：メディアキー）は現在、想定するイベントを実際に送出せずログに記録するだけです —— フォローアップとして管理しています。
+
+## インストール
+
+> [!IMPORTANT]
+> 先に **Logi Options+** を終了してください —— 両アプリは HID++ アクセスを奪い合い、1 つのレシーバーは同時に一方しか占有できません。
+
+[最新リリース](https://github.com/AprilNEA/OpenLogi/releases/latest)から署名・公証済みの `.dmg` をダウンロードし、`OpenLogi.app` を `/Applications` にドラッグします。
+
+または [Homebrew](https://brew.sh) でインストール：
+
+```sh
+brew install --cask openlogi
+```
+
+ソースからのビルドは [DEVELOPMENT.md](DEVELOPMENT.md) を参照してください。
+
+## 使い方（CLI）
+
+[USAGE.md](USAGE.md) を参照してください。
+
+## 設定
+
+[CONFIGURATION.md](CONFIGURATION.md) を参照してください。
+
+## 開発
+
+[DEVELOPMENT.md](DEVELOPMENT.md) を参照してください。
+
+## 謝辞
+
+- [`hidpp`](https://crates.io/crates/hidpp) by [@lus](https://github.com/lus)
+- [Solaar](https://github.com/pwr-Solaar/Solaar)
+- [Mouser](https://github.com/TomBadash/Mouser) by Tom Badash
+
+## ライセンス
+
+以下のいずれかのデュアルライセンスです：
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](../LICENSE-MIT))
+
+お好きな方をお選びください。
+
+---
+
+**Logitech とは無関係です。** 「Logitech」「MX Master」「Options+」は Logitech International S.A. の商標です。

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -1,0 +1,109 @@
+> [!WARNING]
+> **OpenLogi는 활발히 개발 중**이며 아직 안정 단계가 아닙니다 —— 기능과 설정이 변경될 수 있습니다. 저장소에 **Star** ⭐ 와 **Watch** 👀 를 눌러 두면 릴리스가 나오는 즉시 알림을 받을 수 있습니다.
+
+<h4 align="right"><a href="../README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.de.md">Deutsch</a> | <a href="README.fr.md">Français</a> | <strong>한국어</strong></h4>
+
+<p align="center">
+    <img src="https://assets.openlogi.org/brand/openlogi-animated.svg" width="138" alt="OpenLogi"/>
+</p>
+
+<h1 align="center">OpenLogi</h1>
+<p align="center"><strong>⚡️ Rust로 작성된, 네이티브하고 로컬 우선의 Logitech Options+ 대체 도구 🦀<br/>HID++로 버튼, DPI, SmartShift를 재매핑하세요. 계정 불필요, 텔레메트리 없음.</strong></p>
+
+
+<div align="center">
+    <a href="https://twitter.com/AprilNEA" target="_blank">
+    <img alt="twitter" src="https://img.shields.io/badge/follow-AprilNEA-green?style=social&logo=Twitter"></a>
+    <a href="https://t.me/+u8DfyLlIqPYxZjJh" target="_blank">
+    <img alt="telegram" src="https://img.shields.io/badge/chat-telegram-blueviolet?style=flat&logo=Telegram"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/releases" target="_blank">
+    <img alt="GitHub downloads" src="https://img.shields.io/github/downloads/AprilNEA/OpenLogi/total.svg?style=flat"></a>
+    <a href="https://github.com/AprilNEA/OpenLogi/commits" target="_blank">
+    <img alt="GitHub commit" src="https://img.shields.io/github/commit-activity/m/AprilNEA/OpenLogi?style=flat"></a>
+    <img alt="Hits" src="https://hits.aprilnea.com/hits?url=https://github.com/aprilnea/openlogi">
+</div>
+
+> **Options+에 지치셨나요? OpenLogi를 사용해 보세요.**
+
+Logitech 계정도, 텔레메트리도, 공식 Options+ 설치도 없이 버튼을 재매핑하고 DPI와 SmartShift를 제어하며 앱별로 프로필을 전환하세요. 클라우드 없이 단순한 TOML 설정만 사용하며, 네트워크 통신은 기기 이미지 가져오기와 옵트인 방식의 기본 비활성화 업데이트 확인뿐입니다.
+
+---
+
+## 소개
+
+OpenLogi는 Logi Bolt 수신기 —— 또는 Bluetooth 직접 연결 / 유선 연결 —— 를 통해 Logitech HID++ 마우스와 통신하며, Logi Options+를 실행할 필요가 없습니다. 두 개의 바이너리를 제공합니다:
+
+- **[OpenLogi GUI](../crates/openlogi-gui)** —— GPUI 데스크톱 앱: 클릭 가능한 핫스폿이 있는 인터랙티브 마우스 다이어그램, 버튼별 동작 선택기(39개의 기본 제공 동작과 녹화된 사용자 지정 단축키), DPI 프리셋, SmartShift 토글, 애플리케이션별 프로필 오버레이, 페어링된 기기 간을 실시간으로 전환하는 기기 캐러셀, 그리고 UI가 6개 언어로 현지화된 설정 창을 제공합니다.
+- **[OpenLogi CLI](../crates/openlogi-cli)** —— 헤드리스 인벤토리 조회(`list`)와 에셋 동기화 및 기기 진단 하위 명령을 제공하는 CLI.
+
+모든 것이 로컬에서 이루어집니다: 바인딩은 단순한 TOML 파일에 저장되고, 버튼 입력은 OS 이벤트 탭을 통해 재매핑되며, DPI / SmartShift 변경은 HID++로 기기에 직접 기록됩니다.
+
+현재 macOS를 지원하며, Linux와 Windows도 곧 지원될 예정입니다 —— [로드맵](#로드맵)을 참조하세요.
+
+## 로드맵
+
+| 기능 | 상태 |
+|---|---|
+| Bolt 수신기 검색 + 페어링된 기기 목록(CLI + GUI) | ✅ |
+| Bluetooth 직접 연결 / 유선 기기(수신기 불필요) | ✅ |
+| 배터리 잔량 / 충전 상태 | ✅(온라인 기기) |
+| 인터랙티브 GUI: 캐러셀, 마우스 다이어그램, 동작 선택기 | ✅ macOS |
+| OS 이벤트 탭을 통한 버튼 재매핑(현재는 측면 Back / Forward) | ✅ macOS |
+| 39개 동작 카탈로그 + 녹화된 사용자 지정 키보드 단축키 | ✅ macOS¹ |
+| DPI 제어 + 프리셋 + 순환 / 프리셋 지정 동작(HID++ `0x2201`) | ✅ macOS |
+| SmartShift 휠 모드 전환(HID++ `0x2111`) | ✅ macOS |
+| 애플리케이션별 프로필 오버레이(앱 포커스 시 자동 전환) | ✅ macOS |
+| 설정 창: 로그인 시 실행, 업데이트 확인, 메뉴 막대, 권한, 언어 | ✅ macOS |
+| 인터페이스 현지화(6개 언어: en, ja, ru, zh-CN, zh-HK, zh-TW) | ✅ macOS |
+| 제스처 버튼의 방향별 바인딩 | 🟡 설정 가능; 하드웨어 캡처는 대기 중 |
+| 가운데 / 모드 전환 / 엄지 휠 버튼 캡처 | 🟡 설정 가능; 훅은 측면 버튼만 점유 |
+| Linux / Windows 이벤트 훅 | ❌ 스텁(`Unsupported`) |
+| Unifying 수신기 | ❌(아직 미지원) |
+
+¹ 일부 동작(예: 미디어 키)은 현재 의도한 이벤트를 실제로 전송하지 않고 로그로만 기록합니다 —— 후속 작업으로 관리 중입니다.
+
+## 설치
+
+> [!IMPORTANT]
+> 먼저 **Logi Options+**를 종료하세요 —— 두 애플리케이션은 HID++ 접근 권한을 두고 경쟁하며, 하나의 수신기는 한 번에 한쪽만 점유할 수 있습니다.
+
+[최신 릴리스](https://github.com/AprilNEA/OpenLogi/releases/latest)에서 서명 및 공증된 `.dmg`를 내려받아 `OpenLogi.app`을 `/Applications`로 드래그하세요.
+
+또는 [Homebrew](https://brew.sh)로 설치하세요:
+
+```sh
+brew install --cask openlogi
+```
+
+소스에서 빌드하려면 [DEVELOPMENT.md](DEVELOPMENT.md)를 참조하세요.
+
+## 사용법(CLI)
+
+[USAGE.md](USAGE.md)를 참조하세요.
+
+## 설정
+
+[CONFIGURATION.md](CONFIGURATION.md)를 참조하세요.
+
+## 개발
+
+[DEVELOPMENT.md](DEVELOPMENT.md)를 참조하세요.
+
+## 감사의 말
+
+- [`hidpp`](https://crates.io/crates/hidpp) — [@lus](https://github.com/lus)
+- [Solaar](https://github.com/pwr-Solaar/Solaar)
+- [Mouser](https://github.com/TomBadash/Mouser) — Tom Badash
+
+## 라이선스
+
+다음 중 하나로 이중 라이선스됩니다:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE))
+- MIT 라이선스 ([LICENSE-MIT](../LICENSE-MIT))
+
+원하는 쪽을 선택하시면 됩니다.
+
+---
+
+**Logitech과 무관합니다.** "Logitech", "MX Master", "Options+"는 Logitech International S.A.의 상표입니다.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,7 +1,7 @@
 > [!WARNING]
 > **OpenLogi 仍在积极开发中**，尚未稳定 —— 功能与配置仍可能变动。点个 **Star** ⭐ 并 **Watch** 👀 本仓库，第一时间获得发布通知。
 
-<h4 align="right"><a href="README.md">English</a> | <strong>简体中文</strong></h4>
+<h4 align="right"><a href="../README.md">English</a> | <strong>简体中文</strong> | <a href="README.ja.md">日本語</a> | <a href="README.de.md">Deutsch</a> | <a href="README.fr.md">Français</a> | <a href="README.ko.md">한국어</a></h4>
 
 <p align="center">
     <img src="https://assets.openlogi.org/brand/openlogi-animated.svg" width="138" alt="OpenLogi"/>
@@ -35,8 +35,8 @@ SmartShift、按应用切换配置。完全本地化，纯 TOML 配置；
 
 OpenLogi 通过 Logi Bolt 接收器 —— 或蓝牙直连 / 有线连接 —— 与罗技 HID++ 鼠标通信，无需运行 Logi Options+。它包含两个二进制：
 
-- **[OpenLogi GUI](crates/openlogi-gui)** —— 基于 GPUI 的桌面应用：交互式鼠标示意图（按钮可点击）、按钮动作选择器（37 个内置动作 + 录制的自定义快捷键）、DPI 预设、SmartShift 开关、按应用的配置叠加层，以及可在配对设备间实时切换的设备轮播。
-- **[OpenLogi CLI](crates/openlogi-cli)** —— 用于无头清单查看（`list`）以及资源同步与设备诊断的命令行工具。
+- **[OpenLogi GUI](../crates/openlogi-gui)** —— 基于 GPUI 的桌面应用：交互式鼠标示意图（按钮可点击）、按钮动作选择器（39 个内置动作 + 录制的自定义快捷键）、DPI 预设、SmartShift 开关、按应用的配置叠加层、可在配对设备间实时切换的设备轮播，以及一个界面支持六种语言本地化的设置窗口。
+- **[OpenLogi CLI](../crates/openlogi-cli)** —— 用于无头清单查看（`list`）以及资源同步与设备诊断的命令行工具。
 
 所有数据都在本地：绑定保存在普通 TOML 文件里，按键按下经由系统事件 tap 重映射，DPI / SmartShift 变更通过 HID++ 直接写入设备。
 
@@ -51,15 +51,16 @@ OpenLogi 通过 Logi Bolt 接收器 —— 或蓝牙直连 / 有线连接 ——
 | 电量百分比 / 充电状态 | ✅（在线设备） |
 | 交互式 GUI：轮播、鼠标示意图、动作选择器 | ✅ macOS |
 | 经由 OS 事件 tap 的按键重映射（目前为侧键 Back / Forward） | ✅ macOS |
-| 37 个动作目录 + 录制的自定义键盘快捷键 | ✅ macOS¹ |
+| 39 个动作目录 + 录制的自定义键盘快捷键 | ✅ macOS¹ |
 | DPI 控制 + 预设 + 循环 / 按预设设置动作（HID++ `0x2201`） | ✅ macOS |
 | SmartShift 滚轮模式切换（HID++ `0x2111`） | ✅ macOS |
 | 按应用的配置叠加层（应用获得焦点时自动切换） | ✅ macOS |
-| 开机启动 + 可选更新检查 | ✅（仅 TOML —— 暂无设置 UI） |
+| 设置窗口：开机启动、检查更新、菜单栏、权限、语言 | ✅ macOS |
+| 界面本地化（6 种语言：en、ja、ru、zh-CN、zh-HK、zh-TW） | ✅ macOS |
 | 手势按键的方向绑定 | 🟡 可配置；硬件捕获待办 |
 | 中键 / 模式切换键 / 拇指轮的按键捕获 | 🟡 可配置；钩子目前只占用侧键 |
 | Linux / Windows 事件钩子 | ❌ 占位（`Unsupported`） |
-| Unifying 接收器 | ❌（`hidpp 0.2` 暂未实现） |
+| Unifying 接收器 | ❌（暂未支持） |
 
 ¹ 少数动作（例如媒体键）目前只记录预期事件而没有真正发送 —— 已列入待办。
 
@@ -76,19 +77,19 @@ OpenLogi 通过 Logi Bolt 接收器 —— 或蓝牙直连 / 有线连接 ——
 brew install --cask openlogi
 ```
 
-需要从源码构建请看 [DEVELOPMENT.md](docs/DEVELOPMENT.md)。
+需要从源码构建请看 [DEVELOPMENT.md](DEVELOPMENT.md)。
 
 ## 用法（CLI）
 
-查看 [USAGE.md](docs/USAGE.md)
+查看 [USAGE.md](USAGE.md)
 
 ## 配置
 
-查看 [CONFIGURATION.md](docs/CONFIGURATION.md)
+查看 [CONFIGURATION.md](CONFIGURATION.md)
 
 ## 开发
 
-查看 [DEVELOPMENT.md](docs/DEVELOPMENT.md)
+查看 [DEVELOPMENT.md](DEVELOPMENT.md)
 
 ## 致谢
 
@@ -100,8 +101,8 @@ brew install --cask openlogi
 
 双重许可，任选其一：
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
-- MIT license ([LICENSE-MIT](LICENSE-MIT))
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE))
+- MIT license ([LICENSE-MIT](../LICENSE-MIT))
 
 ---
 


### PR DESCRIPTION
## What

#29 moved `README_CN.md` → `docs/README.zh-CN.md` and pointed the root README switcher at five translations, but the translation files were never added and the moved zh-CN file kept a stale switcher, broken relative links, and outdated content. This PR finishes that work.

- Add **Japanese, German, French, and Korean** translations under `docs/`.
- Rewrite `docs/README.zh-CN.md`:
  - multi-language switcher (was still single-language `English | 简体中文`)
  - fixed relative links — from inside `docs/` it pointed at `README.md`, `docs/*.md`, and `LICENSE-*`, all broken; now `../README.md`, `../crates/...`, sibling `DEVELOPMENT.md`, `../LICENSE-*`
  - synced content (39-action catalog, Settings window, interface-localization row, "not yet supported" Unifying wording)

The root `README.md` already carries the switcher + content updates from #29, so it is unchanged here.

## Verification

- Every relative link in the five `docs/README.*.md` files resolves to an existing target; no stale `docs/`, `crates/`, `LICENSE-`, or `README_CN` prefixes remain.
- Non-English roadmap headings use native anchors (`#ロードマップ`, `#feuille-de-route`, `#로드맵`), which GitHub resolves.