### PR TITLE
chore(release-plz): disable cargo-semver-checks

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -22,6 +22,10 @@
 [workspace]
 # Open release PRs from a `release-plz/`-prefixed branch.
 pr_branch_prefix = "release-plz/"
+# OpenLogi ships as an application, not a published-API library, so
+# cargo-semver-checks' "⚠ API breaking changes" analysis is just noise in the
+# release PR. Disable it so the PR shows the changelog, not the break risk.
+semver_check = false
 # Per-crate tags/releases are off; the root crate owns the one workspace release.
 git_tag_enable = false
 git_release_enable = false


### PR DESCRIPTION
OpenLogi ships as an **application**, not a published-API library — so the `⚠ API breaking changes` section that `cargo-semver-checks` injects into every release PR (e.g. the `DeviceConfig.lighting` "breaking change" on #111) is just noise.

Set `semver_check = false` at the `[workspace]` level so release PRs surface the **changelog** instead of the break risk. The version bump is still driven by conventional commits (`feat` → minor, `fix` → patch).

Once merged, the next release-plz run regenerates the open release PR (#111) without the breaking-changes section.