### PR TITLE
feat(hook): implement Linux evdev+uinput mouse hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1812,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix 0.29.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,6 +2092,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -4651,6 +4692,9 @@ version = "0.5.1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
+ "ctrlc",
+ "evdev",
+ "libc",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -5188,6 +5232,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -6535,6 +6585,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -8468,6 +8524,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x11"

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -6,12 +6,19 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "OS-level mouse-event hook for OpenLogi. macOS via CGEventTap; Linux/Windows are stubs."
+description = "OS-level mouse-event hook for OpenLogi. macOS via CGEventTap; Linux via evdev+uinput; Windows is a stub."
 
 [dependencies]
 openlogi-core = { path = "../openlogi-core", version = "0.5.1" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+evdev = "0.13"
+libc = "0.2"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+ctrlc = "3"
 
 # CGEventTap stays on core-graphics/core-foundation (the freeze-hazard run-loop
 # machinery). The frontmost-app read uses objc2 (NSWorkspace) so no raw `objc`.

--- a/crates/openlogi-hook/examples/print_events.rs
+++ b/crates/openlogi-hook/examples/print_events.rs
@@ -1,0 +1,52 @@
+//! Manual smoke-test for the OS-level mouse hook.
+//!
+//! Prints every mouse event to stdout and passes all events through unchanged.
+//! Press Ctrl-C to stop.
+//!
+//! # Linux permissions
+//!
+//! Requires read access to `/dev/input/eventN` and write access to
+//! `/dev/uinput`. Add your user to the `input` group and apply a udev rule:
+//!
+//! ```sh
+//! sudo usermod -aG input $USER
+//! echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' \
+//!     | sudo tee /etc/udev/rules.d/99-uinput.rules
+//! sudo udevadm trigger /dev/uinput
+//! # log out and back in, then:
+//! cargo run --example print_events -p openlogi-hook
+//! ```
+
+use openlogi_hook::{EventDisposition, Hook};
+
+fn main() {
+    if !Hook::has_accessibility() {
+        eprintln!("error: Accessibility permission not granted");
+        std::process::exit(1);
+    }
+
+    let hook = match Hook::start(|event| {
+        println!("{event:?}");
+        EventDisposition::PassThrough
+    }) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("error: failed to start hook: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("Hook running — move the mouse or click buttons. Press Ctrl-C to stop.");
+
+    // Block until Ctrl-C.
+    let (tx, rx) = std::sync::mpsc::channel();
+    #[allow(clippy::expect_used)]
+    ctrlc::set_handler(move || {
+        let _ = tx.send(());
+    })
+    .expect("failed to set Ctrl-C handler");
+    rx.recv().ok();
+
+    hook.stop();
+    println!("Hook stopped.");
+}

--- a/crates/openlogi-hook/examples/print_events.rs
+++ b/crates/openlogi-hook/examples/print_events.rs
@@ -17,11 +17,14 @@
 //! cargo run --example print_events -p openlogi-hook
 //! ```
 
-#![cfg(target_os = "linux")]
-
-use openlogi_hook::{EventDisposition, Hook};
-
+// Linux-only smoke test. A crate-level `#![cfg(target_os = "linux")]` would
+// leave an empty crate with no `main` on other targets (E0601), breaking
+// `cargo build --all-targets` there — so gate the body on `main` instead and
+// provide a trivial fallback.
+#[cfg(target_os = "linux")]
 fn main() {
+    use openlogi_hook::{EventDisposition, Hook};
+
     let hook = match Hook::start(|event| {
         println!("{event:?}");
         EventDisposition::PassThrough
@@ -46,4 +49,9 @@ fn main() {
 
     hook.stop();
     println!("Hook stopped.");
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("print_events is a Linux-only smoke test (no-op on this platform).");
 }

--- a/crates/openlogi-hook/examples/print_events.rs
+++ b/crates/openlogi-hook/examples/print_events.rs
@@ -17,14 +17,11 @@
 //! cargo run --example print_events -p openlogi-hook
 //! ```
 
+#![cfg(target_os = "linux")]
+
 use openlogi_hook::{EventDisposition, Hook};
 
 fn main() {
-    if !Hook::has_accessibility() {
-        eprintln!("error: Accessibility permission not granted");
-        std::process::exit(1);
-    }
-
     let hook = match Hook::start(|event| {
         println!("{event:?}");
         EventDisposition::PassThrough

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -1,9 +1,10 @@
 //! OS-level mouse-event hook for OpenLogi.
 //!
-//! On macOS the hook is implemented with `CGEventTap` (the same primitive used
-//! by Logi Options+ and external-reference). Linux and Windows return
-//! [`HookError::Unsupported`] from [`Hook::start`] — stubs that let the
-//! workspace compile on all platforms without feature-gating callers.
+//! | Platform | Implementation |
+//! |----------|---------------|
+//! | macOS    | `CGEventTap` (same primitive used by Logi Options+) |
+//! | Linux    | `evdev` grab + `uinput` re-injection |
+//! | Windows  | stub — returns [`HookError::Unsupported`] |
 //!
 //! # Usage
 //!
@@ -57,7 +58,7 @@ pub enum EventDisposition {
 /// Errors that [`Hook::start`] and related functions can produce.
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
-    /// This platform has no hook implementation yet (Linux, Windows).
+    /// This platform has no hook implementation yet (Windows).
     #[error("mouse event hook is not supported on this platform")]
     Unsupported,
     /// macOS Accessibility permission has not been granted to this process.
@@ -70,20 +71,37 @@ pub enum HookError {
     /// created. The inner string carries the context.
     #[error("CGEventTap setup failed: {0}")]
     MacOsTap(String),
+    /// No mouse device was found under `/dev/input`. Either no pointing device
+    /// is connected, or the process lacks read permission on the device nodes
+    /// (add the user to the `input` group, or add a `udev` rule).
+    #[cfg(target_os = "linux")]
+    #[error(
+        "no mouse device found under /dev/input; \
+         ensure a pointing device is connected and the process has read permission \
+         (add user to the `input` group or add a udev rule)"
+    )]
+    NoDeviceFound,
+    /// A Linux-specific I/O error occurred while setting up or running the hook.
+    #[cfg(target_os = "linux")]
+    #[error("Linux input error: {0}")]
+    Linux(#[source] std::io::Error),
 }
 
 /// A running OS-level mouse hook. Call [`Hook::stop`] to tear down.
 ///
-/// Internally on macOS, a dedicated `std::thread` runs a `CFRunLoop` that
-/// drains the `CGEventTap` queue. `stop` signals that run loop and joins the
-/// thread so the process exits cleanly. Dropping a `Hook` without calling
-/// `stop` has the same effect via `Drop`.
+/// On macOS a dedicated thread runs a `CFRunLoop` draining a `CGEventTap`.
+/// On Linux one thread per physical mouse device reads `evdev` events and
+/// re-injects pass-through events via a `uinput` virtual device.
+/// Call `stop` (or let the value drop) to shut down all threads and release
+/// grabbed devices.
 pub struct Hook {
     #[cfg(target_os = "macos")]
     inner: Option<macos::HookInner>,
-    /// Makes `Hook` uninhabited on non-macOS targets, so [`Hook::start`] can
+    #[cfg(target_os = "linux")]
+    inner: Option<linux::HookInner>,
+    /// Makes `Hook` uninhabited on unsupported targets so [`Hook::start`] can
     /// only ever return `Err` there and the type can never be constructed.
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     never: std::convert::Infallible,
 }
 
@@ -93,7 +111,11 @@ impl Drop for Hook {
         if let Some(inner) = self.inner.take() {
             macos::stop(inner);
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        if let Some(inner) = self.inner.take() {
+            linux::stop(inner);
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         // Unreachable: `never: Infallible` makes `Hook` uninhabited here.
         {}
     }
@@ -102,14 +124,14 @@ impl Drop for Hook {
 impl Hook {
     /// Install the mouse hook and start delivering events to `cb`.
     ///
-    /// The callback runs on a private background thread (not the GPUI thread)
-    /// for every mouse button or scroll event at the OS HID tap. It must
-    /// return [`EventDisposition`] quickly — blocking it stalls input delivery
-    /// system-wide.
+    /// The callback runs on a private background thread for every mouse button
+    /// or scroll event. It must return [`EventDisposition`] quickly — blocking
+    /// it stalls input delivery system-wide.
     ///
-    /// On macOS, returns [`HookError::AccessibilityDenied`] when the process
-    /// has not been granted Accessibility permission. On Linux and Windows,
-    /// returns [`HookError::Unsupported`].
+    /// On macOS, returns [`HookError::AccessibilityDenied`] when Accessibility
+    /// permission has not been granted. On Linux, returns
+    /// [`HookError::NoDeviceFound`] when no mouse device is accessible.
+    /// On Windows, always returns [`HookError::Unsupported`].
     pub fn start(
         cb: impl Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static,
     ) -> Result<Self, HookError> {
@@ -117,7 +139,11 @@ impl Hook {
         {
             macos::start(cb).map(|inner| Self { inner: Some(inner) })
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        {
+            linux::start(cb).map(|inner| Self { inner: Some(inner) })
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             let _ = cb;
             Err(HookError::Unsupported)
@@ -126,14 +152,14 @@ impl Hook {
 
     /// Stop the hook and release OS resources.
     ///
-    /// Signals the background run loop to exit and blocks until the thread
-    /// joins. Calling this explicitly is preferred over relying on `Drop` when
-    /// errors in cleanup should be visible. `Drop` calls this automatically.
+    /// Signals background threads to exit and blocks until they join. Calling
+    /// this explicitly is preferred over relying on `Drop` when errors in
+    /// cleanup should be visible. `Drop` calls this automatically.
     #[cfg_attr(
-        not(target_os = "macos"),
+        not(any(target_os = "macos", target_os = "linux")),
         allow(
             unused_mut,
-            reason = "`mut self` is only consumed by the macOS teardown path"
+            reason = "`mut self` is only consumed by macOS and Linux teardown paths"
         )
     )]
     pub fn stop(mut self) {
@@ -141,15 +167,20 @@ impl Hook {
         if let Some(inner) = self.inner.take() {
             macos::stop(inner);
         }
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        if let Some(inner) = self.inner.take() {
+            linux::stop(inner);
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         match self.never {}
     }
 
-    /// Returns `true` when the process has the macOS Accessibility entitlement
-    /// required to install an active `CGEventTap`.
+    /// Returns `true` when the process has the permissions required to install
+    /// the hook.
     ///
-    /// On Linux and Windows this always returns `true`; those platforms handle
-    /// permissions at a higher layer.
+    /// On macOS, checks the Accessibility entitlement. On Linux and Windows
+    /// this always returns `true`; those platforms enforce permissions at a
+    /// lower layer (device node ownership / group membership).
     #[must_use]
     pub fn has_accessibility() -> bool {
         #[cfg(target_os = "macos")]
@@ -181,7 +212,10 @@ impl Hook {
 
 /// Return the macOS bundle identifier of the currently frontmost application,
 /// e.g. `"com.microsoft.VSCode"`. `None` when no app is frontmost, when
-/// reading the value fails, or on any non-macOS platform (P1.4).
+/// reading the value fails, or on any non-macOS platform.
+///
+/// On Linux, per-application profile switching is not yet implemented and this
+/// always returns `None`.
 ///
 /// Costs four `objc_msgSend`s plus a UTF-8 copy — well under a millisecond
 /// at the 1 Hz polling cadence in `openlogi-gui::app_watcher`.
@@ -199,6 +233,9 @@ pub fn frontmost_bundle_id() -> Option<String> {
 
 #[cfg(target_os = "macos")]
 mod macos;
+
+#[cfg(target_os = "linux")]
+mod linux;
 
 #[cfg(test)]
 mod tests;

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -1,0 +1,497 @@
+//! Linux `evdev` + `uinput` implementation of the OS-level mouse hook.
+//!
+//! Each physical mouse found under `/dev/input/` is grabbed exclusively;
+//! a paired `uinput` virtual device re-injects events the callback marks
+//! [`crate::EventDisposition::PassThrough`]. Events marked
+//! [`crate::EventDisposition::Suppress`] are consumed and never reach the desktop.
+//!
+//! # Permissions
+//!
+//! The process needs read access to `/dev/input/eventN` (typically the `input`
+//! group) and write access to `/dev/uinput` (the `input` or `uinput` group, or
+//! a `udev` rule granting access). Without those, `start()` returns
+//! [`crate::HookError::Linux`].
+
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::thread;
+
+use evdev::uinput::VirtualDevice;
+use evdev::{Device, EventSummary, KeyCode, RelativeAxisCode};
+use tracing::{debug, error, warn};
+
+use crate::{ButtonId, EventDisposition, HookError, MouseEvent};
+
+/// Name stamped on every uinput pass-through device; used to skip those
+/// devices during enumeration so we don't hook our own virtual mice.
+const VIRTUAL_DEVICE_NAME: &str = "OpenLogi virtual mouse";
+
+/// Hi-res scroll resolution: 120 units per standard wheel tick, matching the
+/// Linux kernel's `REL_WHEEL_HI_RES` convention and Windows HID semantics.
+const HIRES_UNITS_PER_TICK: f32 = 120.0;
+
+pub(crate) struct HookInner {
+    stop: Arc<AtomicBool>,
+    /// One pipe write-end per device thread; writing wakes the blocking poll.
+    stop_pipes: Vec<OwnedFd>,
+    threads: Vec<thread::JoinHandle<()>>,
+}
+
+pub(crate) fn start(
+    cb: impl Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static,
+) -> Result<HookInner, HookError> {
+    let devices = find_mouse_devices();
+    if devices.is_empty() {
+        return Err(HookError::NoDeviceFound);
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let cb: Arc<dyn Fn(MouseEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
+    let mut threads: Vec<thread::JoinHandle<()>> = Vec::with_capacity(devices.len());
+    let mut stop_pipes: Vec<OwnedFd> = Vec::with_capacity(devices.len());
+
+    let result = (|| -> io::Result<()> {
+        for (path, device) in devices {
+            let (rx, tx) = create_pipe()?;
+            let stop_clone = Arc::clone(&stop);
+            let cb_clone = Arc::clone(&cb);
+            let handle = thread::Builder::new()
+                .name(format!("openlogi-hook:{}", path.display()))
+                .spawn(move || device_thread(path, device, cb_clone, stop_clone, rx))?;
+            threads.push(handle);
+            stop_pipes.push(tx);
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        shutdown(&stop, &stop_pipes, threads);
+        return Err(HookError::Linux(e));
+    }
+
+    Ok(HookInner {
+        stop,
+        stop_pipes,
+        threads,
+    })
+}
+
+pub(crate) fn stop(inner: HookInner) {
+    shutdown(&inner.stop, &inner.stop_pipes, inner.threads);
+}
+
+fn shutdown(stop: &AtomicBool, pipes: &[OwnedFd], threads: Vec<thread::JoinHandle<()>>) {
+    stop.store(true, Ordering::Relaxed);
+    for fd in pipes {
+        signal_pipe(fd);
+    }
+    for handle in threads {
+        if let Err(e) = handle.join() {
+            error!("hook thread panicked on shutdown: {e:?}");
+        }
+    }
+}
+
+/// Write one wake-up byte to a pipe, retrying on EINTR.
+fn signal_pipe(fd: &OwnedFd) {
+    loop {
+        // SAFETY: fd is a valid open pipe write end; writing one byte is safe.
+        let ret = unsafe { libc::write(fd.as_raw_fd(), [0u8].as_ptr().cast(), 1) };
+        if ret >= 0 {
+            return;
+        }
+        let err = io::Error::last_os_error();
+        if err.kind() == io::ErrorKind::Interrupted {
+            continue;
+        }
+        error!("failed to signal hook thread pipe ({err}): hook thread may not wake");
+        return;
+    }
+}
+
+fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
+    let mut fds = [0i32; 2];
+    // SAFETY: fds is a valid two-element array; pipe() fills it with two new fds on success.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: pipe() succeeded, so both fds are valid open file descriptors we own.
+    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
+}
+
+fn find_mouse_devices() -> Vec<(std::path::PathBuf, Device)> {
+    evdev::enumerate()
+        .filter(|(_, d)| d.name().unwrap_or("") != VIRTUAL_DEVICE_NAME)
+        .filter(|(_, d)| {
+            d.supported_keys()
+                .is_some_and(|keys| keys.contains(KeyCode::BTN_LEFT))
+        })
+        .collect()
+}
+
+fn build_virtual_device(device: &Device) -> io::Result<evdev::uinput::VirtualDevice> {
+    let builder = VirtualDevice::builder()?.name(VIRTUAL_DEVICE_NAME);
+
+    let builder = if let Some(keys) = device.supported_keys() {
+        builder.with_keys(keys)?
+    } else {
+        builder
+    };
+
+    let builder = if let Some(axes) = device.supported_relative_axes() {
+        builder.with_relative_axes(axes)?
+    } else {
+        builder
+    };
+
+    builder.build()
+}
+
+/// Block until `device_fd` has data or `stop_fd` is readable.
+///
+/// Returns `true` when the device is ready to read, `false` on stop signal or
+/// unrecoverable poll error.
+fn wait_readable(device_fd: i32, stop_fd: i32) -> bool {
+    let mut fds = [
+        libc::pollfd {
+            fd: device_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: stop_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+    ];
+    loop {
+        // SAFETY: fds is a valid two-element pollfd array.
+        let ret = unsafe { libc::poll(fds.as_mut_ptr(), 2, -1) };
+        if ret < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue; // interrupted by signal — retry
+            }
+            error!("poll() failed: {err}");
+            return false;
+        }
+        if fds[1].revents & libc::POLLIN != 0 {
+            return false; // stop signal
+        }
+        if fds[0].revents & libc::POLLIN != 0 {
+            return true; // device has data
+        }
+    }
+}
+
+fn scroll(delta_x: f32, delta_y: f32) -> MouseEvent {
+    MouseEvent::Scroll { delta_x, delta_y }
+}
+
+fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent> {
+    match event.destructure() {
+        EventSummary::Key(_, key, value) => {
+            let id = key_to_button(key)?;
+            Some(MouseEvent::Button {
+                id,
+                pressed: value != 0,
+            })
+        }
+        #[allow(clippy::cast_precision_loss)] // scroll deltas fit comfortably in f32 mantissa
+        EventSummary::RelativeAxis(_, axis, value) => {
+            let v = value as f32;
+            if hires_scroll {
+                match axis {
+                    RelativeAxisCode::REL_WHEEL_HI_RES => {
+                        Some(scroll(0.0, v / HIRES_UNITS_PER_TICK))
+                    }
+                    RelativeAxisCode::REL_HWHEEL_HI_RES => {
+                        Some(scroll(v / HIRES_UNITS_PER_TICK, 0.0))
+                    }
+                    // Low-res ticks are redundant when hi-res is active.
+                    _ => None,
+                }
+            } else {
+                match axis {
+                    RelativeAxisCode::REL_WHEEL => Some(scroll(0.0, v)),
+                    RelativeAxisCode::REL_HWHEEL => Some(scroll(v, 0.0)),
+                    _ => None,
+                }
+            }
+        }
+        _ => None,
+    }
+}
+
+fn key_to_button(key: KeyCode) -> Option<ButtonId> {
+    match key {
+        KeyCode::BTN_LEFT => Some(ButtonId::LeftClick),
+        KeyCode::BTN_RIGHT => Some(ButtonId::RightClick),
+        KeyCode::BTN_MIDDLE => Some(ButtonId::MiddleClick),
+        // BTN_BACK/BTN_SIDE both appear as the back thumb button across mice.
+        KeyCode::BTN_BACK | KeyCode::BTN_SIDE => Some(ButtonId::Back),
+        // BTN_FORWARD/BTN_EXTRA both appear as the forward thumb button.
+        KeyCode::BTN_FORWARD | KeyCode::BTN_EXTRA => Some(ButtonId::Forward),
+        // BTN_TASK is the closest generic match for a mode/DPI toggle button.
+        KeyCode::BTN_TASK => Some(ButtonId::DpiToggle),
+        _ => None,
+    }
+}
+
+// All params are owned: path/cb/stop/stop_rx are moved into the thread and must not be refs.
+#[allow(clippy::needless_pass_by_value)]
+fn device_thread(
+    path: std::path::PathBuf,
+    mut device: Device,
+    cb: Arc<dyn Fn(MouseEvent) -> EventDisposition + Send + Sync>,
+    stop: Arc<AtomicBool>,
+    stop_rx: OwnedFd,
+) {
+    let mut virtual_device = match build_virtual_device(&device) {
+        Ok(vd) => vd,
+        Err(e) => {
+            warn!("failed to create uinput device for {}: {e}", path.display());
+            return;
+        }
+    };
+
+    if let Err(e) = device.grab() {
+        warn!(
+            "failed to grab {} exclusively: {e} — button events will be duplicated",
+            path.display()
+        );
+    }
+
+    let hires_scroll = device
+        .supported_relative_axes()
+        .is_some_and(|axes| axes.contains(RelativeAxisCode::REL_WHEEL_HI_RES));
+
+    let device_fd = device.as_raw_fd();
+    let stop_fd = stop_rx.as_raw_fd();
+    // Events that will be re-injected at the next SYN_REPORT.
+    let mut pending: Vec<evdev::InputEvent> = Vec::new();
+
+    debug!("hook started on {}", path.display());
+
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+        if !wait_readable(device_fd, stop_fd) {
+            break;
+        }
+
+        let events = match device.fetch_events() {
+            Ok(iter) => iter,
+            Err(e) => {
+                error!("read error on {}: {e}", path.display());
+                break;
+            }
+        };
+
+        for event in events {
+            if let EventSummary::Synchronization(..) = event.destructure() {
+                // Flush pending pass-through events followed by the sync marker.
+                if !pending.is_empty() {
+                    pending.push(event);
+                    if let Err(e) = virtual_device.emit(&pending) {
+                        error!("uinput emit failed: {e}");
+                    }
+                    pending.clear();
+                }
+            } else {
+                let disposition = translate(&event, hires_scroll)
+                    .map_or(EventDisposition::PassThrough, |me| cb(me));
+                if matches!(disposition, EventDisposition::PassThrough) {
+                    pending.push(event);
+                }
+            }
+        }
+    }
+
+    debug!("hook stopped on {}", path.display());
+    // Dropping `device` releases the exclusive grab, restoring normal input delivery.
+}
+
+#[cfg(test)]
+mod tests {
+    use evdev::{EventType, InputEvent, KeyCode, RelativeAxisCode};
+
+    use super::*;
+
+    // ── key_to_button ────────────────────────────────────────────────────────
+
+    #[test]
+    fn key_to_button_maps_standard_mouse_buttons() {
+        let cases = [
+            (KeyCode::BTN_LEFT, ButtonId::LeftClick),
+            (KeyCode::BTN_RIGHT, ButtonId::RightClick),
+            (KeyCode::BTN_MIDDLE, ButtonId::MiddleClick),
+            (KeyCode::BTN_BACK, ButtonId::Back),
+            (KeyCode::BTN_SIDE, ButtonId::Back),
+            (KeyCode::BTN_FORWARD, ButtonId::Forward),
+            (KeyCode::BTN_EXTRA, ButtonId::Forward),
+            (KeyCode::BTN_TASK, ButtonId::DpiToggle),
+        ];
+        for (key, expected) in cases {
+            assert_eq!(
+                key_to_button(key),
+                Some(expected),
+                "key_to_button({key:?}) should be {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn key_to_button_returns_none_for_non_mouse_keys() {
+        assert_eq!(key_to_button(KeyCode::KEY_A), None);
+        assert_eq!(key_to_button(KeyCode::KEY_LEFTSHIFT), None);
+    }
+
+    // ── translate ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn translate_btn_left_down_returns_button_pressed() {
+        let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_LEFT.0, 1);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Button {
+                id: ButtonId::LeftClick,
+                pressed: true
+            })
+        ));
+    }
+
+    #[test]
+    fn translate_btn_left_up_returns_button_released() {
+        let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_LEFT.0, 0);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Button {
+                id: ButtonId::LeftClick,
+                pressed: false
+            })
+        ));
+    }
+
+    #[test]
+    fn translate_btn_back_returns_back() {
+        let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_BACK.0, 1);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Button {
+                id: ButtonId::Back,
+                pressed: true
+            })
+        ));
+    }
+
+    #[test]
+    fn translate_btn_side_returns_back() {
+        let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_SIDE.0, 1);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Button {
+                id: ButtonId::Back,
+                pressed: true
+            })
+        ));
+    }
+
+    #[test]
+    fn translate_btn_forward_returns_forward() {
+        let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_FORWARD.0, 1);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Button {
+                id: ButtonId::Forward,
+                pressed: true
+            })
+        ));
+    }
+
+    // ── scroll — standard ────────────────────────────────────────────────────
+
+    #[test]
+    fn translate_rel_wheel_returns_scroll_y() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_WHEEL.0, 3);
+        let result = translate(&event, false);
+        assert!(
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+                if delta_x.abs() < f32::EPSILON && (delta_y - 3.0).abs() < f32::EPSILON),
+            "expected Scroll {{ delta_x: 0.0, delta_y: 3.0 }}, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn translate_rel_hwheel_returns_scroll_x() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_HWHEEL.0, -2);
+        let result = translate(&event, false);
+        assert!(
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+                if (delta_x - -2.0).abs() < f32::EPSILON && delta_y.abs() < f32::EPSILON),
+            "expected Scroll {{ delta_x: -2.0, delta_y: 0.0 }}, got {result:?}"
+        );
+    }
+
+    // ── scroll — hi-res ──────────────────────────────────────────────────────
+
+    #[test]
+    fn translate_hires_wheel_returns_fractional_scroll_y() {
+        // 60 hi-res units = 0.5 standard ticks
+        let event = InputEvent::new(
+            EventType::RELATIVE.0,
+            RelativeAxisCode::REL_WHEEL_HI_RES.0,
+            60,
+        );
+        let result = translate(&event, true);
+        assert!(
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+                if delta_x.abs() < f32::EPSILON && (delta_y - 0.5).abs() < f32::EPSILON),
+            "expected Scroll {{ delta_x: 0.0, delta_y: 0.5 }}, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn translate_hires_hwheel_returns_fractional_scroll_x() {
+        let event = InputEvent::new(
+            EventType::RELATIVE.0,
+            RelativeAxisCode::REL_HWHEEL_HI_RES.0,
+            -120,
+        );
+        let result = translate(&event, true);
+        assert!(
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+                if (delta_x - -1.0).abs() < f32::EPSILON && delta_y.abs() < f32::EPSILON),
+            "expected Scroll {{ delta_x: -1.0, delta_y: 0.0 }}, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn translate_low_res_wheel_skipped_when_hires_active() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_WHEEL.0, 1);
+        assert!(translate(&event, true).is_none());
+    }
+
+    #[test]
+    fn translate_low_res_hwheel_skipped_when_hires_active() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_HWHEEL.0, 1);
+        assert!(translate(&event, true).is_none());
+    }
+
+    #[test]
+    fn translate_non_mouse_key_returns_none() {
+        let event = InputEvent::new(EventType::KEY.0, KeyCode::KEY_A.0, 1);
+        assert!(translate(&event, false).is_none());
+    }
+
+    #[test]
+    fn translate_sync_event_returns_none() {
+        let event = InputEvent::new(EventType::SYNCHRONIZATION.0, 0, 0);
+        assert!(translate(&event, false).is_none());
+    }
+}

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -56,12 +56,15 @@ pub(crate) fn start(
 
     let result = (|| -> io::Result<()> {
         for (path, device) in devices {
+            let virtual_device = build_virtual_device(&device)?;
             let (rx, tx) = create_pipe()?;
             let stop_clone = Arc::clone(&stop);
             let cb_clone = Arc::clone(&cb);
             let handle = thread::Builder::new()
                 .name(format!("openlogi-hook:{}", path.display()))
-                .spawn(move || device_thread(path, device, cb_clone, stop_clone, rx))?;
+                .spawn(move || {
+                    device_thread(path, device, virtual_device, cb_clone, stop_clone, rx)
+                })?;
             threads.push(handle);
             stop_pipes.push(tx);
         }
@@ -247,18 +250,11 @@ fn key_to_button(key: KeyCode) -> Option<ButtonId> {
 fn device_thread(
     path: std::path::PathBuf,
     mut device: Device,
+    mut virtual_device: VirtualDevice,
     cb: Arc<dyn Fn(MouseEvent) -> EventDisposition + Send + Sync>,
     stop: Arc<AtomicBool>,
     stop_rx: OwnedFd,
 ) {
-    let mut virtual_device = match build_virtual_device(&device) {
-        Ok(vd) => vd,
-        Err(e) => {
-            warn!("failed to create uinput device for {}: {e}", path.display());
-            return;
-        }
-    };
-
     if let Err(e) = device.grab() {
         warn!(
             "failed to grab {} exclusively: {e} — button events will be duplicated",
@@ -304,8 +300,24 @@ fn device_thread(
                     pending.clear();
                 }
             } else {
-                let disposition = translate(&event, hires_scroll)
-                    .map_or(EventDisposition::PassThrough, |me| cb(me));
+                let disposition = match translate(&event, hires_scroll) {
+                    Some(me) => cb(me),
+                    // Low-res companions (REL_WHEEL/REL_HWHEEL) must be suppressed when hi-res
+                    // is active — passing them through would double the scroll distance.
+                    None if hires_scroll
+                        && matches!(
+                            event.destructure(),
+                            EventSummary::RelativeAxis(
+                                _,
+                                RelativeAxisCode::REL_WHEEL | RelativeAxisCode::REL_HWHEEL,
+                                _
+                            )
+                        ) =>
+                    {
+                        EventDisposition::Suppress
+                    }
+                    None => EventDisposition::PassThrough,
+                };
                 if matches!(disposition, EventDisposition::PassThrough) {
                     pending.push(event);
                 }

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -63,7 +63,7 @@ pub(crate) fn start(
             let handle = thread::Builder::new()
                 .name(format!("openlogi-hook:{}", path.display()))
                 .spawn(move || {
-                    device_thread(path, device, virtual_device, cb_clone, stop_clone, rx)
+                    device_thread(path, device, virtual_device, cb_clone, stop_clone, rx);
                 })?;
             threads.push(handle);
             stop_pipes.push(tx);
@@ -118,11 +118,13 @@ fn signal_pipe(fd: &OwnedFd) {
 
 fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [0i32; 2];
-    // SAFETY: fds is a valid two-element array; pipe() fills it with two new fds on success.
-    if unsafe { libc::pipe(fds.as_mut_ptr()) } < 0 {
+    // SAFETY: fds is a valid two-element array; pipe2() fills it with two new
+    // fds on success. O_CLOEXEC keeps the pipe from leaking into any child
+    // process the app spawns.
+    if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } < 0 {
         return Err(io::Error::last_os_error());
     }
-    // SAFETY: pipe() succeeded, so both fds are valid open file descriptors we own.
+    // SAFETY: pipe2() succeeded, so both fds are valid open file descriptors we own.
     Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
 }
 
@@ -256,10 +258,14 @@ fn device_thread(
     stop_rx: OwnedFd,
 ) {
     if let Err(e) = device.grab() {
+        // Without the exclusive grab the desktop still receives the physical
+        // events, so reading and re-injecting them here would duplicate every
+        // one. Skip this device instead — it stays usable, just un-hooked.
         warn!(
-            "failed to grab {} exclusively: {e} — button events will be duplicated",
+            "failed to grab {} exclusively: {e} — skipping (left un-hooked)",
             path.display()
         );
+        return;
     }
 
     let hires_scroll = device
@@ -273,7 +279,7 @@ fn device_thread(
 
     debug!("hook started on {}", path.display());
 
-    loop {
+    'read: loop {
         if stop.load(Ordering::Relaxed) {
             break;
         }
@@ -291,11 +297,21 @@ fn device_thread(
 
         for event in events {
             if let EventSummary::Synchronization(..) = event.destructure() {
-                // Flush pending pass-through events followed by the sync marker.
+                // Flush the report. `emit()` appends its own SYN_REPORT, so the
+                // incoming sync event is dropped rather than re-emitted — pushing
+                // it would send a redundant second SYN_REPORT.
                 if !pending.is_empty() {
-                    pending.push(event);
                     if let Err(e) = virtual_device.emit(&pending) {
-                        error!("uinput emit failed: {e}");
+                        // The physical device is grabbed, so these pass-through
+                        // events can't reach the desktop any other way. A uinput
+                        // emit failure means the virtual device is broken, so
+                        // stop here — dropping the grab restores normal input —
+                        // rather than silently dropping events on every report.
+                        error!(
+                            "uinput emit failed on {}: {e} — stopping hook for this device",
+                            path.display()
+                        );
+                        break 'read;
                     }
                     pending.clear();
                 }

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -9,6 +9,10 @@ fn hook_error_display() {
         HookError::Unsupported,
         HookError::AccessibilityDenied,
         HookError::MacOsTap("test reason".into()),
+        #[cfg(target_os = "linux")]
+        HookError::NoDeviceFound,
+        #[cfg(target_os = "linux")]
+        HookError::Linux(std::io::Error::other("test reason")),
     ];
     for e in errors {
         assert!(!e.to_string().is_empty(), "empty display for {e:?}");
@@ -43,12 +47,28 @@ fn event_disposition_equality() {
     assert_ne!(EventDisposition::PassThrough, EventDisposition::Suppress);
 }
 
-/// On non-macOS targets, `Hook::start` returns `Unsupported`.
-#[cfg(not(target_os = "macos"))]
+/// On unsupported targets (not macOS, not Linux), `Hook::start` returns `Unsupported`.
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 #[test]
-fn non_macos_start_returns_unsupported() {
+fn unsupported_start_returns_unsupported() {
     let result = Hook::start(|_| EventDisposition::PassThrough);
     assert!(matches!(result, Err(HookError::Unsupported)));
+}
+
+/// On Linux, `Hook::start` never returns `Unsupported` — it either succeeds or
+/// returns a Linux-specific error (e.g. `NoDeviceFound` in a headless CI env).
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_start_does_not_return_unsupported() {
+    let result = Hook::start(|_| EventDisposition::PassThrough);
+    assert!(
+        !matches!(result, Err(HookError::Unsupported)),
+        "Hook::start returned Unsupported on Linux"
+    );
+    // Clean up if a hook was actually installed.
+    if let Ok(hook) = result {
+        hook.stop();
+    }
 }
 
 /// On non-macOS targets, `Hook::has_accessibility` is always `true`.


### PR DESCRIPTION
## Summary

- Enumerates mouse devices via `evdev::enumerate()` (devices with `BTN_LEFT`), grabs each exclusively, and re-injects pass-through events via a paired `uinput` virtual device. `Suppress` events are consumed without reaching the desktop.
- Supports fractional scroll via `REL_WHEEL_HI_RES` / `REL_HWHEEL_HI_RES` (÷120 per the kernel convention), with automatic fallback to integer `REL_WHEEL` / `REL_HWHEEL` on devices that don't expose hi-res axes.
- `HookError` gains `NoDeviceFound` and `Linux(io::Error)` variants (Linux-only). The `Unsupported` stub is now Windows-only.
- Shutdown uses a per-thread pipe to interrupt blocking `poll()` cleanly.

## Known limitations

- **No hotplug** — devices are enumerated at `Hook::start` only; a mouse plugged in afterwards won't be hooked until restart.
- **No per-app profiles** — `frontmost_bundle_id()` always returns `None` on Linux (the roadmap item P1.4).

## Manual testing (Linux)

Build and run the included smoke-test example with `sudo` (requires access to `/dev/input` and `/dev/uinput`):

```sh
cargo build --example print_events -p openlogi-hook
sudo ./target/debug/examples/print_events
```

Move the mouse, scroll, and click buttons — events should print to stdout and still reach the desktop normally. Ctrl-C shuts down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)