### PR TITLE
feat(core): implement Action::execute on Linux via uinput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,6 +4622,7 @@ version = "0.5.1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
+ "evdev",
  "serde",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -22,6 +22,9 @@ tempfile = "3"
 [lints]
 workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+evdev = "0.13"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = { version = "0.25.0", features = ["highsierra"] }
 core-foundation = { workspace = true }

--- a/crates/openlogi-core/examples/inject_action.rs
+++ b/crates/openlogi-core/examples/inject_action.rs
@@ -121,7 +121,7 @@ fn parse_hex_u16(s: &str) -> Option<u16> {
 }
 
 fn main() {
-    let mut args = std::env::args().skip(1).peekable();
+    let mut args = std::env::args().skip(1);
 
     let mut initial_delay_secs: f64 = 2.0;
     let mut between_ms: u64 = 200;

--- a/crates/openlogi-core/examples/inject_action.rs
+++ b/crates/openlogi-core/examples/inject_action.rs
@@ -104,20 +104,18 @@ fn parse_action(s: &str) -> Result<Action, String> {
     })
 }
 
-fn parse_hex_u8(s: &str) -> Option<u8> {
-    let hex = s
-        .strip_prefix("0x")
+fn strip_hex_prefix(s: &str) -> &str {
+    s.strip_prefix("0x")
         .or_else(|| s.strip_prefix("0X"))
-        .unwrap_or(s);
-    u8::from_str_radix(hex, 16).ok()
+        .unwrap_or(s)
+}
+
+fn parse_hex_u8(s: &str) -> Option<u8> {
+    u8::from_str_radix(strip_hex_prefix(s), 16).ok()
 }
 
 fn parse_hex_u16(s: &str) -> Option<u16> {
-    let hex = s
-        .strip_prefix("0x")
-        .or_else(|| s.strip_prefix("0X"))
-        .unwrap_or(s);
-    u16::from_str_radix(hex, 16).ok()
+    u16::from_str_radix(strip_hex_prefix(s), 16).ok()
 }
 
 fn main() {

--- a/crates/openlogi-core/examples/inject_action.rs
+++ b/crates/openlogi-core/examples/inject_action.rs
@@ -37,6 +37,8 @@
 
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
+use openlogi_core::binding::action_device_path;
 use openlogi_core::binding::{Action, KeyCombo};
 
 fn parse_action(s: &str) -> Result<Action, String> {
@@ -166,6 +168,20 @@ fn main() {
         eprintln!("error: no actions specified");
         print_usage();
         std::process::exit(1);
+    }
+
+    // On Linux, initialise the uinput device eagerly so we can print its node
+    // path before the countdown — giving time to attach evtest in another terminal.
+    #[cfg(target_os = "linux")]
+    match action_device_path() {
+        Some(path) => {
+            println!("uinput device: {}", path.display());
+            println!("  To monitor raw events, open another terminal and run:");
+            println!("  sudo evtest {}", path.display());
+        }
+        None => {
+            eprintln!("warning: could not find uinput device node (check /dev/uinput permissions)");
+        }
     }
 
     let delay = Duration::from_secs_f64(initial_delay_secs);

--- a/crates/openlogi-core/examples/inject_action.rs
+++ b/crates/openlogi-core/examples/inject_action.rs
@@ -1,0 +1,221 @@
+//! Manual smoke-test for `Action::execute`.
+//!
+//! Parses action names from arguments, waits for the configured delay, then
+//! fires each one in order. The delay lets you focus the target window before
+//! injection begins.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo build --example inject_action -p openlogi-core
+//! sudo ./target/debug/examples/inject_action [--delay <secs>] <Action> [<Action> ...]
+//! ```
+//!
+//! # Examples
+//!
+//! ```text
+//! # Open a text editor, select some text, then:
+//! sudo ./target/debug/examples/inject_action --delay 3 Copy
+//!
+//! # Fire several actions back-to-back (0.5 s between each):
+//! sudo ./target/debug/examples/inject_action --delay 2 --between 500 VolumeUp VolumeDown PlayPause
+//!
+//! # Inject a scroll sequence:
+//! sudo ./target/debug/examples/inject_action ScrollDown ScrollDown ScrollDown ScrollUp
+//! ```
+//!
+//! # Available actions
+//!
+//! LeftClick RightClick MiddleClick
+//! Copy Paste Cut Undo Redo SelectAll Find Save
+//! BrowserBack BrowserForward NewTab CloseTab ReopenTab NextTab PrevTab ReloadPage
+//! MissionControl AppExpose PreviousDesktop NextDesktop ShowDesktop LaunchpadShow
+//! LockScreen Screenshot
+//! PlayPause NextTrack PrevTrack VolumeUp VolumeDown MuteVolume
+//! CycleDpiPresets ToggleSmartShift
+//! ScrollUp ScrollDown HorizontalScrollLeft HorizontalScrollRight
+
+use std::time::Duration;
+
+use openlogi_core::binding::{Action, KeyCombo};
+
+fn parse_action(s: &str) -> Result<Action, String> {
+    Ok(match s {
+        "LeftClick" => Action::LeftClick,
+        "RightClick" => Action::RightClick,
+        "MiddleClick" => Action::MiddleClick,
+        "Copy" => Action::Copy,
+        "Paste" => Action::Paste,
+        "Cut" => Action::Cut,
+        "Undo" => Action::Undo,
+        "Redo" => Action::Redo,
+        "SelectAll" => Action::SelectAll,
+        "Find" => Action::Find,
+        "Save" => Action::Save,
+        "BrowserBack" => Action::BrowserBack,
+        "BrowserForward" => Action::BrowserForward,
+        "NewTab" => Action::NewTab,
+        "CloseTab" => Action::CloseTab,
+        "ReopenTab" => Action::ReopenTab,
+        "NextTab" => Action::NextTab,
+        "PrevTab" => Action::PrevTab,
+        "ReloadPage" => Action::ReloadPage,
+        "MissionControl" => Action::MissionControl,
+        "AppExpose" => Action::AppExpose,
+        "PreviousDesktop" => Action::PreviousDesktop,
+        "NextDesktop" => Action::NextDesktop,
+        "ShowDesktop" => Action::ShowDesktop,
+        "LaunchpadShow" => Action::LaunchpadShow,
+        "LockScreen" => Action::LockScreen,
+        "Screenshot" => Action::Screenshot,
+        "PlayPause" => Action::PlayPause,
+        "NextTrack" => Action::NextTrack,
+        "PrevTrack" => Action::PrevTrack,
+        "VolumeUp" => Action::VolumeUp,
+        "VolumeDown" => Action::VolumeDown,
+        "MuteVolume" => Action::MuteVolume,
+        "CycleDpiPresets" => Action::CycleDpiPresets,
+        "ToggleSmartShift" => Action::ToggleSmartShift,
+        "ScrollUp" => Action::ScrollUp,
+        "ScrollDown" => Action::ScrollDown,
+        "HorizontalScrollLeft" => Action::HorizontalScrollLeft,
+        "HorizontalScrollRight" => Action::HorizontalScrollRight,
+        other if other.starts_with("CustomShortcut:") => {
+            // Format: CustomShortcut:<modifiers>:<key_code>
+            // modifiers is a hex byte (e.g. 0x05 for Ctrl+Shift), key_code is a hex u16.
+            // Example: CustomShortcut:0x04:0x08 → Ctrl+C on macOS layout
+            let parts: Vec<&str> = other.splitn(3, ':').collect();
+            if parts.len() != 3 {
+                return Err(
+                    "CustomShortcut format: CustomShortcut:<mod_hex>:<key_hex> (e.g. CustomShortcut:0x01:0x08)".to_string()
+                );
+            }
+            let modifiers = parse_hex_u8(parts[1])
+                .ok_or_else(|| format!("invalid modifier byte: {}", parts[1]))?;
+            let key_code =
+                parse_hex_u16(parts[2]).ok_or_else(|| format!("invalid key code: {}", parts[2]))?;
+            Action::CustomShortcut(KeyCombo {
+                modifiers,
+                key_code,
+                display: String::new(),
+            })
+        }
+        _ => return Err(format!("unknown action: {s}")),
+    })
+}
+
+fn parse_hex_u8(s: &str) -> Option<u8> {
+    let hex = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s);
+    u8::from_str_radix(hex, 16).ok()
+}
+
+fn parse_hex_u16(s: &str) -> Option<u16> {
+    let hex = s
+        .strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .unwrap_or(s);
+    u16::from_str_radix(hex, 16).ok()
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1).peekable();
+
+    let mut initial_delay_secs: f64 = 2.0;
+    let mut between_ms: u64 = 200;
+    let mut actions: Vec<Action> = Vec::new();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--delay" => {
+                let val = args.next().unwrap_or_else(|| {
+                    eprintln!("--delay requires a value");
+                    std::process::exit(1);
+                });
+                initial_delay_secs = val.parse().unwrap_or_else(|_| {
+                    eprintln!("--delay: expected a number, got {val}");
+                    std::process::exit(1);
+                });
+            }
+            "--between" => {
+                let val = args.next().unwrap_or_else(|| {
+                    eprintln!("--between requires a value (milliseconds)");
+                    std::process::exit(1);
+                });
+                between_ms = val.parse().unwrap_or_else(|_| {
+                    eprintln!("--between: expected a number, got {val}");
+                    std::process::exit(1);
+                });
+            }
+            "--help" | "-h" => {
+                print_usage();
+                return;
+            }
+            name => match parse_action(name) {
+                Ok(action) => actions.push(action),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    eprintln!("Run with --help for the list of available actions.");
+                    std::process::exit(1);
+                }
+            },
+        }
+    }
+
+    if actions.is_empty() {
+        eprintln!("error: no actions specified");
+        print_usage();
+        std::process::exit(1);
+    }
+
+    let delay = Duration::from_secs_f64(initial_delay_secs);
+    println!(
+        "Injecting {} action(s) in {:.1}s — focus the target window now...",
+        actions.len(),
+        initial_delay_secs
+    );
+    std::thread::sleep(delay);
+
+    let between = Duration::from_millis(between_ms);
+    for (i, action) in actions.iter().enumerate() {
+        println!("  → {}", action.label());
+        action.execute();
+        if i + 1 < actions.len() {
+            std::thread::sleep(between);
+        }
+    }
+    println!("Done.");
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: inject_action [--delay <secs>] [--between <ms>] <Action> [<Action> ...]\n\
+         \n\
+         Options:\n\
+           --delay <secs>    seconds to wait before first injection (default: 2)\n\
+           --between <ms>    milliseconds between actions (default: 200)\n\
+         \n\
+         Actions: LeftClick RightClick MiddleClick\n\
+                  Copy Paste Cut Undo Redo SelectAll Find Save\n\
+                  BrowserBack BrowserForward NewTab CloseTab ReopenTab\n\
+                  NextTab PrevTab ReloadPage\n\
+                  MissionControl AppExpose PreviousDesktop NextDesktop\n\
+                  ShowDesktop LaunchpadShow\n\
+                  LockScreen Screenshot\n\
+                  PlayPause NextTrack PrevTrack VolumeUp VolumeDown MuteVolume\n\
+                  CycleDpiPresets ToggleSmartShift\n\
+                  ScrollUp ScrollDown HorizontalScrollLeft HorizontalScrollRight\n\
+                  CustomShortcut:<mod_hex>:<key_hex>\n\
+         \n\
+         CustomShortcut modifier bits: 0x01=Cmd/Ctrl 0x02=Shift 0x04=Ctrl 0x08=Option/Alt\n\
+         CustomShortcut key_hex: macOS kVK_* code (e.g. 0x08=C, 0x09=V, 0x7E=Up)\n\
+         \n\
+         Examples:\n\
+           inject_action --delay 3 Copy\n\
+           inject_action --delay 2 --between 500 VolumeUp VolumeDown PlayPause\n\
+           inject_action ScrollDown ScrollDown ScrollDown\n\
+           inject_action CustomShortcut:0x01:0x08   # Ctrl+C"
+    );
+}

--- a/crates/openlogi-core/examples/inject_action.rs
+++ b/crates/openlogi-core/examples/inject_action.rs
@@ -37,73 +37,42 @@
 
 use std::time::Duration;
 
+use serde::Deserialize;
+use serde::de::IntoDeserializer;
+
 #[cfg(target_os = "linux")]
 use openlogi_core::binding::action_device_path;
 use openlogi_core::binding::{Action, KeyCombo};
 
 fn parse_action(s: &str) -> Result<Action, String> {
-    Ok(match s {
-        "LeftClick" => Action::LeftClick,
-        "RightClick" => Action::RightClick,
-        "MiddleClick" => Action::MiddleClick,
-        "Copy" => Action::Copy,
-        "Paste" => Action::Paste,
-        "Cut" => Action::Cut,
-        "Undo" => Action::Undo,
-        "Redo" => Action::Redo,
-        "SelectAll" => Action::SelectAll,
-        "Find" => Action::Find,
-        "Save" => Action::Save,
-        "BrowserBack" => Action::BrowserBack,
-        "BrowserForward" => Action::BrowserForward,
-        "NewTab" => Action::NewTab,
-        "CloseTab" => Action::CloseTab,
-        "ReopenTab" => Action::ReopenTab,
-        "NextTab" => Action::NextTab,
-        "PrevTab" => Action::PrevTab,
-        "ReloadPage" => Action::ReloadPage,
-        "MissionControl" => Action::MissionControl,
-        "AppExpose" => Action::AppExpose,
-        "PreviousDesktop" => Action::PreviousDesktop,
-        "NextDesktop" => Action::NextDesktop,
-        "ShowDesktop" => Action::ShowDesktop,
-        "LaunchpadShow" => Action::LaunchpadShow,
-        "LockScreen" => Action::LockScreen,
-        "Screenshot" => Action::Screenshot,
-        "PlayPause" => Action::PlayPause,
-        "NextTrack" => Action::NextTrack,
-        "PrevTrack" => Action::PrevTrack,
-        "VolumeUp" => Action::VolumeUp,
-        "VolumeDown" => Action::VolumeDown,
-        "MuteVolume" => Action::MuteVolume,
-        "CycleDpiPresets" => Action::CycleDpiPresets,
-        "ToggleSmartShift" => Action::ToggleSmartShift,
-        "ScrollUp" => Action::ScrollUp,
-        "ScrollDown" => Action::ScrollDown,
-        "HorizontalScrollLeft" => Action::HorizontalScrollLeft,
-        "HorizontalScrollRight" => Action::HorizontalScrollRight,
-        other if other.starts_with("CustomShortcut:") => {
-            // Format: CustomShortcut:<modifiers>:<key_code>
-            // modifiers is a hex byte (e.g. 0x05 for Ctrl+Shift), key_code is a hex u16.
-            // Example: CustomShortcut:0x04:0x08 → Ctrl+C on macOS layout
-            let parts: Vec<&str> = other.splitn(3, ':').collect();
-            if parts.len() != 3 {
-                return Err(
-                    "CustomShortcut format: CustomShortcut:<mod_hex>:<key_hex> (e.g. CustomShortcut:0x01:0x08)".to_string()
-                );
-            }
-            let modifiers = parse_hex_u8(parts[1])
-                .ok_or_else(|| format!("invalid modifier byte: {}", parts[1]))?;
-            let key_code =
-                parse_hex_u16(parts[2]).ok_or_else(|| format!("invalid key code: {}", parts[2]))?;
-            Action::CustomShortcut(KeyCombo {
-                modifiers,
-                key_code,
-                display: String::new(),
-            })
+    // `CustomShortcut` has its own CLI syntax (serde expects a table for the
+    // tuple variant), so parse it by hand.
+    if let Some(rest) = s.strip_prefix("CustomShortcut:") {
+        // Format: <modifiers>:<key_code> — modifiers is a hex byte (e.g. 0x05
+        // for Ctrl+Shift), key_code a hex u16. Example: 0x04:0x08 → Ctrl+C on
+        // the macOS layout.
+        let parts: Vec<&str> = rest.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err(
+                "CustomShortcut format: CustomShortcut:<mod_hex>:<key_hex> (e.g. CustomShortcut:0x01:0x08)".to_string()
+            );
         }
-        _ => return Err(format!("unknown action: {s}")),
-    })
+        let modifiers =
+            parse_hex_u8(parts[0]).ok_or_else(|| format!("invalid modifier byte: {}", parts[0]))?;
+        let key_code =
+            parse_hex_u16(parts[1]).ok_or_else(|| format!("invalid key code: {}", parts[1]))?;
+        return Ok(Action::CustomShortcut(KeyCombo {
+            modifiers,
+            key_code,
+            display: String::new(),
+        }));
+    }
+
+    // Every other variant is a serde unit variant that deserializes straight
+    // from its name, so this list never drifts out of sync with the `Action`
+    // enum the way a hand-written match would.
+    Action::deserialize(s.into_deserializer())
+        .map_err(|_: serde::de::value::Error| format!("unknown action: {s}"))
 }
 
 fn strip_hex_prefix(s: &str) -> &str {
@@ -138,6 +107,11 @@ fn main() {
                     eprintln!("--delay: expected a number, got {val}");
                     std::process::exit(1);
                 });
+                // Duration::from_secs_f64 panics on negative / NaN / inf.
+                if !initial_delay_secs.is_finite() || initial_delay_secs < 0.0 {
+                    eprintln!("--delay: expected a non-negative number, got {val}");
+                    std::process::exit(1);
+                }
             }
             "--between" => {
                 let val = args.next().unwrap_or_else(|| {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1504,26 +1504,23 @@ mod linux {
     /// Force the virtual device to initialise (if it hasn't already) and return
     /// its `/dev/input/eventN` node path.
     ///
-    /// Scans `/sys/class/input/*/name` for the device name. Returns `None` if
-    /// the device couldn't be created or if the node hasn't appeared yet (udev
-    /// typically creates it within a few milliseconds of the `ioctl`).
+    /// Uses `VirtualDevice::enumerate_dev_nodes()` which returns the correct
+    /// `/dev/input/eventN` path directly. Returns `None` if the device couldn't
+    /// be created or if the node hasn't appeared yet (udev typically creates it
+    /// within a few milliseconds of the `ioctl`).
     pub(super) fn device_node() -> Option<std::path::PathBuf> {
         // Touch the LazyLock to force initialisation.
         let _ = &*VIRTUAL_INPUT;
         // Give udev a moment to create the /dev node.
         std::thread::sleep(std::time::Duration::from_millis(150));
-        std::fs::read_dir("/sys/class/input")
-            .ok()?
-            .flatten()
-            .find_map(|entry| {
-                let name = std::fs::read_to_string(entry.path().join("name")).ok()?;
-                if name.trim() == DEVICE_NAME {
-                    Some(std::path::Path::new("/dev/input").join(entry.file_name()))
-                } else {
-                    None
-                }
-            })
+        if let Some(m) = &*VIRTUAL_INPUT {
+            if let Ok(mut guard) = m.lock() {
+                return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
+            }
+        }
+        None
     }
+
 
     /// Convert a [`KeyCombo`] modifier bitmask to the evdev keys to hold.
     ///

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1366,7 +1366,8 @@ mod linux {
         KeyCode::KEY_HOME,  KeyCode::KEY_END,   KeyCode::KEY_PAGEUP,   KeyCode::KEY_PAGEDOWN,
         KeyCode::KEY_TAB,   KeyCode::KEY_ENTER, KeyCode::KEY_BACKSPACE, KeyCode::KEY_DELETE,
         KeyCode::KEY_ESC,   KeyCode::KEY_SPACE,
-        // Modifiers
+        // Modifiers (KEY_LEFTMETA not emitted by any current action — reserved
+        // for future Super/Windows-key mappings once D-Bus per-app profiles land)
         KeyCode::KEY_LEFTCTRL, KeyCode::KEY_LEFTSHIFT, KeyCode::KEY_LEFTALT, KeyCode::KEY_LEFTMETA,
         // Function keys
         KeyCode::KEY_F1,  KeyCode::KEY_F2,  KeyCode::KEY_F3,  KeyCode::KEY_F4,
@@ -1431,25 +1432,36 @@ mod linux {
         InputEvent::new(EventType::RELATIVE.0, axis.0, value)
     }
 
-    /// Inject modifier-down, key-down, key-up, modifier-up (in reverse order),
-    /// followed by `SYN_REPORT`.
+    /// Inject modifier-down + key-down in one SYN frame, then key-up +
+    /// modifier-up in a second SYN frame.
+    ///
+    /// Two separate frames give the kernel distinct timestamps for press and
+    /// release, which matches what the kernel `uinput` docs show and avoids
+    /// toolkits treating a zero-duration event as invalid.
     pub(super) fn press_key(mods: &[KeyCode], key: KeyCode) {
-        let mut events: Vec<InputEvent> = Vec::with_capacity(mods.len() * 2 + 3);
+        // Down phase.
+        let mut down: Vec<InputEvent> = Vec::with_capacity(mods.len() + 2);
         for &m in mods {
-            events.push(key_ev(m, 1));
+            down.push(key_ev(m, 1));
         }
-        events.push(key_ev(key, 1));
-        events.push(key_ev(key, 0));
+        down.push(key_ev(key, 1));
+        down.push(syn());
+        emit(&down);
+
+        // Up phase.
+        let mut up: Vec<InputEvent> = Vec::with_capacity(mods.len() + 2);
+        up.push(key_ev(key, 0));
         for &m in mods.iter().rev() {
-            events.push(key_ev(m, 0));
+            up.push(key_ev(m, 0));
         }
-        events.push(syn());
-        emit(&events);
+        up.push(syn());
+        emit(&up);
     }
 
-    /// Inject a button-down + button-up pair followed by `SYN_REPORT`.
+    /// Inject a button-down in one SYN frame and button-up in a second.
     pub(super) fn click(button: KeyCode) {
-        emit(&[key_ev(button, 1), key_ev(button, 0), syn()]);
+        emit(&[key_ev(button, 1), syn()]);
+        emit(&[key_ev(button, 0), syn()]);
     }
 
     /// Inject a single relative-axis delta followed by `SYN_REPORT`.

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -847,6 +847,10 @@ pub fn post_horizontal_scroll(delta: i32) {
     #[cfg(target_os = "macos")]
     macos::post_horizontal_scroll(delta);
 
+    // `delta` is already in "one line per rotation increment" units (see doc
+    // above), which matches REL_HWHEEL's convention of one unit per detent.
+    // This is intentionally different from Action::HorizontalScrollLeft/Right,
+    // which hardcode ±3 as a fixed "scroll tick" with no device delta involved.
     #[cfg(target_os = "linux")]
     linux::scroll(evdev::RelativeAxisCode::REL_HWHEEL, delta);
 
@@ -1520,7 +1524,6 @@ mod linux {
         }
         None
     }
-
 
     /// Convert a [`KeyCombo`] modifier bitmask to the evdev keys to hold.
     ///

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -313,7 +313,13 @@ pub enum Action {
     LaunchpadShow,
 
     // ── System ────────────────────────────────────────────────────────────────
-    /// Lock the screen.
+    /// Lock the screen (⌘⌃Q on macOS / Ctrl+Alt+L on Linux).
+    ///
+    /// On Linux, Ctrl+Alt+L is the default shortcut in GNOME and KDE. Other
+    /// desktop environments may use a different shortcut or none at all. A
+    /// future improvement would use `org.freedesktop.login1.LockSession()` via
+    /// D-Bus for compositor-independent locking; deferred until D-Bus support
+    /// (`zbus`) is added for per-app profiles.
     LockScreen,
     /// Capture a screenshot.
     Screenshot,

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -712,6 +712,8 @@ impl Action {
             Action::ScrollDown => linux::scroll(RelativeAxisCode::REL_WHEEL, -3),
             Action::HorizontalScrollLeft => linux::scroll(RelativeAxisCode::REL_HWHEEL, -3),
             Action::HorizontalScrollRight => linux::scroll(RelativeAxisCode::REL_HWHEEL, 3),
+            // ── No-op ─────────────────────────────────────────────────────────
+            Action::None => {}
             // ── Custom shortcut ───────────────────────────────────────────────
             Action::CustomShortcut(combo) => {
                 if combo.key_code == 0 {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -266,7 +266,12 @@ pub enum Action {
     Cut,
     /// Undo the last action (⌘Z / Ctrl+Z).
     Undo,
-    /// Redo the last undone action (⌘⇧Z / Ctrl+Y).
+    /// Redo the last undone action (⌘⇧Z on macOS / Ctrl+Shift+Z on Linux).
+    ///
+    /// Note: Ctrl+Y is the dominant redo shortcut in LibreOffice and many GTK
+    /// apps. Ctrl+Shift+Z is used here because it mirrors the macOS convention
+    /// and works in GNOME text fields, browsers, and Electron apps. If Ctrl+Y
+    /// coverage is needed, a `CustomShortcut` binding is the escape hatch.
     Redo,
     /// Select all content (⌘A / Ctrl+A).
     SelectAll,

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -361,8 +361,8 @@ pub enum Action {
 ///
 /// `modifiers` is a bitmask of [`KeyCombo::MOD_CMD`] etc. so the wire format
 /// is a compact integer, not a string. `key_code` is the macOS virtual key
-/// (kVK_*); other platforms map at `execute` time when they grow real
-/// support.
+/// (`kVK_*`); on Linux, `Action::execute` maps it to an evdev `KeyCode` via
+/// `linux::macos_vk_to_linux`.
 ///
 /// `display` is purely for rendering — e.g. `"⌘⇧P"`. Callers regenerate it
 /// from the captured chord; we keep it in the struct so older configs
@@ -372,7 +372,8 @@ pub struct KeyCombo {
     /// Bitmask of [`Self::MOD_CMD`] etc.
     pub modifiers: u8,
     /// macOS virtual key code (`kVK_*`). 0 means "no key" — useful for
-    /// modifier-only placeholders that the recorder UI rejects.
+    /// modifier-only placeholders that the recorder UI rejects. On Linux,
+    /// `Action::execute` translates this to an evdev `KeyCode`.
     pub key_code: u16,
     /// Pre-rendered chord label, e.g. `"⌘⇧P"`. Empty falls through to a
     /// generated label at runtime.
@@ -716,19 +717,7 @@ impl Action {
                     );
                     return;
                 };
-                let mut mods: Vec<KeyCode> = Vec::new();
-                // macOS Cmd and Ctrl both map to Linux Ctrl; the bitwise OR
-                // deduplicates them so we only push one KEY_LEFTCTRL.
-                if combo.modifiers & (KeyCombo::MOD_CMD | KeyCombo::MOD_CTRL) != 0 {
-                    mods.push(ctrl);
-                }
-                if combo.modifiers & KeyCombo::MOD_SHIFT != 0 {
-                    mods.push(shift);
-                }
-                if combo.modifiers & KeyCombo::MOD_OPTION != 0 {
-                    mods.push(alt);
-                }
-                linux::press_key(&mods, key);
+                linux::press_key(&linux::modifiers_to_keycodes(combo.modifiers), key);
             }
         }
     }
@@ -1495,6 +1484,26 @@ mod linux {
     /// Inject a single relative-axis delta followed by `SYN_REPORT`.
     pub(super) fn scroll(axis: RelativeAxisCode, value: i32) {
         emit(&[rel_ev(axis, value), syn()]);
+    }
+
+    /// Convert a [`KeyCombo`] modifier bitmask to the evdev keys to hold.
+    ///
+    /// macOS Cmd (`MOD_CMD`) and Ctrl (`MOD_CTRL`) both map to `KEY_LEFTCTRL`;
+    /// the bitwise-OR check deduplicates them so at most one Ctrl is pushed.
+    /// Order is canonical: Ctrl → Shift → Alt.
+    pub(super) fn modifiers_to_keycodes(modifiers: u8) -> Vec<KeyCode> {
+        use crate::binding::KeyCombo;
+        let mut mods = Vec::new();
+        if modifiers & (KeyCombo::MOD_CMD | KeyCombo::MOD_CTRL) != 0 {
+            mods.push(KeyCode::KEY_LEFTCTRL);
+        }
+        if modifiers & KeyCombo::MOD_SHIFT != 0 {
+            mods.push(KeyCode::KEY_LEFTSHIFT);
+        }
+        if modifiers & KeyCombo::MOD_OPTION != 0 {
+            mods.push(KeyCode::KEY_LEFTALT);
+        }
+        mods
     }
 
     /// Map a macOS `kVK_*` virtual key code to the corresponding Linux `KeyCode`.

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -854,6 +854,18 @@ pub fn post_horizontal_scroll(delta: i32) {
     let _ = delta;
 }
 
+/// Return the `/dev/input/eventN` node for the action-injector uinput device,
+/// initialising it if needed.
+///
+/// Intended for debugging and manual smoke-testing (e.g. attaching `evtest`
+/// before firing `Action::execute`). Returns `None` on non-Linux platforms or
+/// when the device could not be created (e.g. `/dev/uinput` not writable).
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn action_device_path() -> Option<std::path::PathBuf> {
+    linux::device_node()
+}
+
 // ── macOS virtual key codes ────────────────────────────────────────────────
 // Source: <HIToolbox/Events.h> kVK_* constants. Values are layout-independent
 // for the US ANSI keyboard.
@@ -1306,6 +1318,8 @@ mod linux {
     use evdev::uinput::VirtualDevice;
     use evdev::{AttributeSet, EventType, InputEvent, KeyCode, RelativeAxisCode};
 
+    const DEVICE_NAME: &str = "OpenLogi action injector";
+
     static VIRTUAL_INPUT: LazyLock<Option<Mutex<VirtualDevice>>> = LazyLock::new(|| {
         build()
             .map(Mutex::new)
@@ -1428,7 +1442,7 @@ mod linux {
         }
 
         VirtualDevice::builder()?
-            .name("OpenLogi action injector")
+            .name(DEVICE_NAME)
             .with_keys(&keys)?
             .with_relative_axes(&axes)?
             .build()
@@ -1485,6 +1499,30 @@ mod linux {
     /// Inject a single relative-axis delta followed by `SYN_REPORT`.
     pub(super) fn scroll(axis: RelativeAxisCode, value: i32) {
         emit(&[rel_ev(axis, value), syn()]);
+    }
+
+    /// Force the virtual device to initialise (if it hasn't already) and return
+    /// its `/dev/input/eventN` node path.
+    ///
+    /// Scans `/sys/class/input/*/name` for the device name. Returns `None` if
+    /// the device couldn't be created or if the node hasn't appeared yet (udev
+    /// typically creates it within a few milliseconds of the `ioctl`).
+    pub(super) fn device_node() -> Option<std::path::PathBuf> {
+        // Touch the LazyLock to force initialisation.
+        let _ = &*VIRTUAL_INPUT;
+        // Give udev a moment to create the /dev node.
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        std::fs::read_dir("/sys/class/input")
+            .ok()?
+            .flatten()
+            .find_map(|entry| {
+                let name = std::fs::read_to_string(entry.path().join("name")).ok()?;
+                if name.trim() == DEVICE_NAME {
+                    Some(std::path::Path::new("/dev/input").join(entry.file_name()))
+                } else {
+                    None
+                }
+            })
     }
 
     /// Convert a [`KeyCombo`] modifier bitmask to the evdev keys to hold.

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1342,107 +1342,48 @@ mod linux {
             .ok()
     });
 
-    #[allow(clippy::too_many_lines)] // key-capability table — inherently long
+    #[rustfmt::skip]
+    const KEY_CAPABILITIES: &[KeyCode] = &[
+        // Letters
+        KeyCode::KEY_A, KeyCode::KEY_B, KeyCode::KEY_C, KeyCode::KEY_D,
+        KeyCode::KEY_E, KeyCode::KEY_F, KeyCode::KEY_G, KeyCode::KEY_H,
+        KeyCode::KEY_I, KeyCode::KEY_J, KeyCode::KEY_K, KeyCode::KEY_L,
+        KeyCode::KEY_M, KeyCode::KEY_N, KeyCode::KEY_O, KeyCode::KEY_P,
+        KeyCode::KEY_Q, KeyCode::KEY_R, KeyCode::KEY_S, KeyCode::KEY_T,
+        KeyCode::KEY_U, KeyCode::KEY_V, KeyCode::KEY_W, KeyCode::KEY_X,
+        KeyCode::KEY_Y, KeyCode::KEY_Z,
+        // Digits
+        KeyCode::KEY_0, KeyCode::KEY_1, KeyCode::KEY_2, KeyCode::KEY_3,
+        KeyCode::KEY_4, KeyCode::KEY_5, KeyCode::KEY_6, KeyCode::KEY_7,
+        KeyCode::KEY_8, KeyCode::KEY_9,
+        // Punctuation / symbols
+        KeyCode::KEY_MINUS,      KeyCode::KEY_EQUAL,   KeyCode::KEY_LEFTBRACE,
+        KeyCode::KEY_RIGHTBRACE, KeyCode::KEY_BACKSLASH, KeyCode::KEY_SEMICOLON,
+        KeyCode::KEY_APOSTROPHE, KeyCode::KEY_GRAVE,   KeyCode::KEY_COMMA,
+        KeyCode::KEY_DOT,        KeyCode::KEY_SLASH,
+        // Navigation / editing
+        KeyCode::KEY_LEFT,  KeyCode::KEY_RIGHT, KeyCode::KEY_UP,       KeyCode::KEY_DOWN,
+        KeyCode::KEY_HOME,  KeyCode::KEY_END,   KeyCode::KEY_PAGEUP,   KeyCode::KEY_PAGEDOWN,
+        KeyCode::KEY_TAB,   KeyCode::KEY_ENTER, KeyCode::KEY_BACKSPACE, KeyCode::KEY_DELETE,
+        KeyCode::KEY_ESC,   KeyCode::KEY_SPACE,
+        // Modifiers
+        KeyCode::KEY_LEFTCTRL, KeyCode::KEY_LEFTSHIFT, KeyCode::KEY_LEFTALT, KeyCode::KEY_LEFTMETA,
+        // Function keys
+        KeyCode::KEY_F1,  KeyCode::KEY_F2,  KeyCode::KEY_F3,  KeyCode::KEY_F4,
+        KeyCode::KEY_F5,  KeyCode::KEY_F6,  KeyCode::KEY_F7,  KeyCode::KEY_F8,
+        KeyCode::KEY_F9,  KeyCode::KEY_F10, KeyCode::KEY_F11, KeyCode::KEY_F12,
+        // System
+        KeyCode::KEY_SYSRQ,
+        // Multimedia
+        KeyCode::KEY_PLAYPAUSE, KeyCode::KEY_NEXTSONG, KeyCode::KEY_PREVIOUSSONG,
+        KeyCode::KEY_VOLUMEUP,  KeyCode::KEY_VOLUMEDOWN, KeyCode::KEY_MUTE,
+        // Mouse buttons (injected as EV_KEY with BTN_* codes)
+        KeyCode::BTN_LEFT, KeyCode::BTN_RIGHT, KeyCode::BTN_MIDDLE,
+    ];
+
     fn build() -> io::Result<VirtualDevice> {
         let mut keys = AttributeSet::<KeyCode>::default();
-        for k in [
-            // Letters
-            KeyCode::KEY_A,
-            KeyCode::KEY_B,
-            KeyCode::KEY_C,
-            KeyCode::KEY_D,
-            KeyCode::KEY_E,
-            KeyCode::KEY_F,
-            KeyCode::KEY_G,
-            KeyCode::KEY_H,
-            KeyCode::KEY_I,
-            KeyCode::KEY_J,
-            KeyCode::KEY_K,
-            KeyCode::KEY_L,
-            KeyCode::KEY_M,
-            KeyCode::KEY_N,
-            KeyCode::KEY_O,
-            KeyCode::KEY_P,
-            KeyCode::KEY_Q,
-            KeyCode::KEY_R,
-            KeyCode::KEY_S,
-            KeyCode::KEY_T,
-            KeyCode::KEY_U,
-            KeyCode::KEY_V,
-            KeyCode::KEY_W,
-            KeyCode::KEY_X,
-            KeyCode::KEY_Y,
-            KeyCode::KEY_Z,
-            // Digits
-            KeyCode::KEY_0,
-            KeyCode::KEY_1,
-            KeyCode::KEY_2,
-            KeyCode::KEY_3,
-            KeyCode::KEY_4,
-            KeyCode::KEY_5,
-            KeyCode::KEY_6,
-            KeyCode::KEY_7,
-            KeyCode::KEY_8,
-            KeyCode::KEY_9,
-            // Punctuation / symbols
-            KeyCode::KEY_MINUS,
-            KeyCode::KEY_EQUAL,
-            KeyCode::KEY_LEFTBRACE,
-            KeyCode::KEY_RIGHTBRACE,
-            KeyCode::KEY_BACKSLASH,
-            KeyCode::KEY_SEMICOLON,
-            KeyCode::KEY_APOSTROPHE,
-            KeyCode::KEY_GRAVE,
-            KeyCode::KEY_COMMA,
-            KeyCode::KEY_DOT,
-            KeyCode::KEY_SLASH,
-            // Navigation / editing
-            KeyCode::KEY_LEFT,
-            KeyCode::KEY_RIGHT,
-            KeyCode::KEY_UP,
-            KeyCode::KEY_DOWN,
-            KeyCode::KEY_HOME,
-            KeyCode::KEY_END,
-            KeyCode::KEY_PAGEUP,
-            KeyCode::KEY_PAGEDOWN,
-            KeyCode::KEY_TAB,
-            KeyCode::KEY_ENTER,
-            KeyCode::KEY_BACKSPACE,
-            KeyCode::KEY_DELETE,
-            KeyCode::KEY_ESC,
-            KeyCode::KEY_SPACE,
-            // Modifiers
-            KeyCode::KEY_LEFTCTRL,
-            KeyCode::KEY_LEFTSHIFT,
-            KeyCode::KEY_LEFTALT,
-            KeyCode::KEY_LEFTMETA,
-            // Function keys
-            KeyCode::KEY_F1,
-            KeyCode::KEY_F2,
-            KeyCode::KEY_F3,
-            KeyCode::KEY_F4,
-            KeyCode::KEY_F5,
-            KeyCode::KEY_F6,
-            KeyCode::KEY_F7,
-            KeyCode::KEY_F8,
-            KeyCode::KEY_F9,
-            KeyCode::KEY_F10,
-            KeyCode::KEY_F11,
-            KeyCode::KEY_F12,
-            // System
-            KeyCode::KEY_SYSRQ,
-            // Multimedia
-            KeyCode::KEY_PLAYPAUSE,
-            KeyCode::KEY_NEXTSONG,
-            KeyCode::KEY_PREVIOUSSONG,
-            KeyCode::KEY_VOLUMEUP,
-            KeyCode::KEY_VOLUMEDOWN,
-            KeyCode::KEY_MUTE,
-            // Mouse buttons (injected as EV_KEY with BTN_* codes)
-            KeyCode::BTN_LEFT,
-            KeyCode::BTN_RIGHT,
-            KeyCode::BTN_MIDDLE,
-        ] {
+        for &k in KEY_CAPABILITIES {
             keys.insert(k);
         }
 

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -607,18 +607,129 @@ impl Action {
     /// `SetDpiPreset`, `ToggleSmartShift`) have no CGEvent equivalent and are
     /// handled at the hook/HID layer, logging a trace here.
     ///
+    /// On Linux, key and scroll events are injected via a lazily-created `uinput`
+    /// virtual device. Mouse clicks inject `BTN_*` events. macOS-only window
+    /// manager actions (`MissionControl`, `AppExpose`, `ShowDesktop`,
+    /// `LaunchpadShow`) have no universal Linux equivalent and are silently
+    /// skipped (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes to
+    /// Linux key codes; macOS Cmd maps to Ctrl.
+    ///
     /// On other platforms a warning is logged and the function returns
     /// immediately — the binary compiles clean on all targets.
     pub fn execute(&self) {
         #[cfg(target_os = "macos")]
         self.execute_macos();
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "linux")]
+        self.execute_linux();
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
             tracing::warn!(
                 action = self.label(),
                 "Action::execute unsupported on this platform"
             );
+        }
+    }
+
+    /// Linux implementation: inject events via a shared `uinput` virtual device.
+    #[cfg(target_os = "linux")]
+    fn execute_linux(&self) {
+        use evdev::{KeyCode, RelativeAxisCode};
+        let ctrl = KeyCode::KEY_LEFTCTRL;
+        let shift = KeyCode::KEY_LEFTSHIFT;
+        let alt = KeyCode::KEY_LEFTALT;
+        match self {
+            // ── Mouse clicks ──────────────────────────────────────────────────
+            Action::LeftClick => linux::click(KeyCode::BTN_LEFT),
+            Action::RightClick => linux::click(KeyCode::BTN_RIGHT),
+            Action::MiddleClick => linux::click(KeyCode::BTN_MIDDLE),
+            // ── Editing ───────────────────────────────────────────────────────
+            Action::Copy => linux::press_key(&[ctrl], KeyCode::KEY_C),
+            Action::Paste => linux::press_key(&[ctrl], KeyCode::KEY_V),
+            Action::Cut => linux::press_key(&[ctrl], KeyCode::KEY_X),
+            Action::Undo => linux::press_key(&[ctrl], KeyCode::KEY_Z),
+            // Redo is Ctrl+Shift+Z on Linux (matches macOS ⌘⇧Z convention).
+            Action::Redo => linux::press_key(&[ctrl, shift], KeyCode::KEY_Z),
+            Action::SelectAll => linux::press_key(&[ctrl], KeyCode::KEY_A),
+            Action::Find => linux::press_key(&[ctrl], KeyCode::KEY_F),
+            Action::Save => linux::press_key(&[ctrl], KeyCode::KEY_S),
+            // ── Browser / Navigation ──────────────────────────────────────────
+            Action::BrowserBack => linux::press_key(&[alt], KeyCode::KEY_LEFT),
+            Action::BrowserForward => linux::press_key(&[alt], KeyCode::KEY_RIGHT),
+            Action::NewTab => linux::press_key(&[ctrl], KeyCode::KEY_T),
+            Action::CloseTab => linux::press_key(&[ctrl], KeyCode::KEY_W),
+            Action::ReopenTab => linux::press_key(&[ctrl, shift], KeyCode::KEY_T),
+            Action::NextTab => linux::press_key(&[ctrl], KeyCode::KEY_TAB),
+            Action::PrevTab => linux::press_key(&[ctrl, shift], KeyCode::KEY_TAB),
+            Action::ReloadPage => linux::press_key(&[ctrl], KeyCode::KEY_R),
+            // ── Navigation — macOS-specific ───────────────────────────────────
+            // No universal Linux equivalent; the compositor shortcut varies.
+            Action::MissionControl
+            | Action::AppExpose
+            | Action::ShowDesktop
+            | Action::LaunchpadShow => {
+                tracing::debug!(
+                    action = self.label(),
+                    "no Linux equivalent — action skipped"
+                );
+            }
+            // Ctrl+Alt+←/→ is the default in GNOME and KDE.
+            Action::PreviousDesktop => linux::press_key(&[ctrl, alt], KeyCode::KEY_LEFT),
+            Action::NextDesktop => linux::press_key(&[ctrl, alt], KeyCode::KEY_RIGHT),
+            // ── System ────────────────────────────────────────────────────────
+            // Ctrl+Alt+L is the standard lock shortcut in GNOME and KDE.
+            Action::LockScreen => linux::press_key(&[ctrl, alt], KeyCode::KEY_L),
+            Action::Screenshot => linux::press_key(&[], KeyCode::KEY_SYSRQ),
+            // ── Media ─────────────────────────────────────────────────────────
+            Action::PlayPause => linux::press_key(&[], KeyCode::KEY_PLAYPAUSE),
+            Action::NextTrack => linux::press_key(&[], KeyCode::KEY_NEXTSONG),
+            Action::PrevTrack => linux::press_key(&[], KeyCode::KEY_PREVIOUSSONG),
+            Action::VolumeUp => linux::press_key(&[], KeyCode::KEY_VOLUMEUP),
+            Action::VolumeDown => linux::press_key(&[], KeyCode::KEY_VOLUMEDOWN),
+            Action::MuteVolume => linux::press_key(&[], KeyCode::KEY_MUTE),
+            // ── DPI / SmartShift: handled at hook/HID layer ───────────────────
+            Action::CycleDpiPresets | Action::SetDpiPreset(_) | Action::ToggleSmartShift => {
+                tracing::debug!(
+                    action = self.label(),
+                    "device action handled by hook/HID layer"
+                );
+            }
+            // ── Scroll ────────────────────────────────────────────────────────
+            Action::ScrollUp => linux::scroll(RelativeAxisCode::REL_WHEEL, 3),
+            Action::ScrollDown => linux::scroll(RelativeAxisCode::REL_WHEEL, -3),
+            Action::HorizontalScrollLeft => linux::scroll(RelativeAxisCode::REL_HWHEEL, -3),
+            Action::HorizontalScrollRight => linux::scroll(RelativeAxisCode::REL_HWHEEL, 3),
+            // ── Custom shortcut ───────────────────────────────────────────────
+            Action::CustomShortcut(combo) => {
+                if combo.key_code == 0 {
+                    tracing::warn!(
+                        chord = %combo.rendered_label(),
+                        "CustomShortcut with no key code — press ignored"
+                    );
+                    return;
+                }
+                let Some(key) = linux::macos_vk_to_linux(combo.key_code) else {
+                    tracing::warn!(
+                        key_code = combo.key_code,
+                        "CustomShortcut key code has no Linux mapping — press ignored"
+                    );
+                    return;
+                };
+                let mut mods: Vec<KeyCode> = Vec::new();
+                // macOS Cmd and Ctrl both map to Linux Ctrl; the bitwise OR
+                // deduplicates them so we only push one KEY_LEFTCTRL.
+                if combo.modifiers & (KeyCombo::MOD_CMD | KeyCombo::MOD_CTRL) != 0 {
+                    mods.push(ctrl);
+                }
+                if combo.modifiers & KeyCombo::MOD_SHIFT != 0 {
+                    mods.push(shift);
+                }
+                if combo.modifiers & KeyCombo::MOD_OPTION != 0 {
+                    mods.push(alt);
+                }
+                linux::press_key(&mods, key);
+            }
         }
     }
 
@@ -742,12 +853,15 @@ impl Action {
 /// rotation convention and its magnitude (one line per rotation increment) may
 /// need tuning per device, since the diverted resolution differs from native.
 ///
-/// No-op (logs nothing) on platforms without CGEvent.
+/// No-op (logs nothing) on platforms without a supported injection mechanism.
 pub fn post_horizontal_scroll(delta: i32) {
     #[cfg(target_os = "macos")]
     macos::post_horizontal_scroll(delta);
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    linux::scroll(evdev::RelativeAxisCode::REL_HWHEEL, delta);
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     let _ = delta;
 }
 
@@ -1186,6 +1300,285 @@ pub fn default_gesture_binding(direction: GestureDirection) -> Action {
         GestureDirection::Left => Action::PrevTab,
         GestureDirection::Right => Action::NextTab,
         GestureDirection::Click => Action::AppExpose,
+    }
+}
+
+/// Linux helpers for synthesising OS-level input events via a shared `uinput`
+/// virtual device.
+///
+/// The device is created lazily on first use. If `/dev/uinput` is inaccessible
+/// (missing group membership or udev rule) every call logs a `warn` and returns
+/// without panicking.
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::io;
+    use std::sync::{LazyLock, Mutex};
+
+    use evdev::uinput::VirtualDevice;
+    use evdev::{AttributeSet, EventType, InputEvent, KeyCode, RelativeAxisCode};
+
+    static VIRTUAL_INPUT: LazyLock<Option<Mutex<VirtualDevice>>> = LazyLock::new(|| {
+        build()
+            .map(Mutex::new)
+            .map_err(|e| tracing::warn!("failed to create uinput action device: {e}"))
+            .ok()
+    });
+
+    #[allow(clippy::too_many_lines)] // key-capability table — inherently long
+    fn build() -> io::Result<VirtualDevice> {
+        let mut keys = AttributeSet::<KeyCode>::default();
+        for k in [
+            // Letters
+            KeyCode::KEY_A,
+            KeyCode::KEY_B,
+            KeyCode::KEY_C,
+            KeyCode::KEY_D,
+            KeyCode::KEY_E,
+            KeyCode::KEY_F,
+            KeyCode::KEY_G,
+            KeyCode::KEY_H,
+            KeyCode::KEY_I,
+            KeyCode::KEY_J,
+            KeyCode::KEY_K,
+            KeyCode::KEY_L,
+            KeyCode::KEY_M,
+            KeyCode::KEY_N,
+            KeyCode::KEY_O,
+            KeyCode::KEY_P,
+            KeyCode::KEY_Q,
+            KeyCode::KEY_R,
+            KeyCode::KEY_S,
+            KeyCode::KEY_T,
+            KeyCode::KEY_U,
+            KeyCode::KEY_V,
+            KeyCode::KEY_W,
+            KeyCode::KEY_X,
+            KeyCode::KEY_Y,
+            KeyCode::KEY_Z,
+            // Digits
+            KeyCode::KEY_0,
+            KeyCode::KEY_1,
+            KeyCode::KEY_2,
+            KeyCode::KEY_3,
+            KeyCode::KEY_4,
+            KeyCode::KEY_5,
+            KeyCode::KEY_6,
+            KeyCode::KEY_7,
+            KeyCode::KEY_8,
+            KeyCode::KEY_9,
+            // Punctuation / symbols
+            KeyCode::KEY_MINUS,
+            KeyCode::KEY_EQUAL,
+            KeyCode::KEY_LEFTBRACE,
+            KeyCode::KEY_RIGHTBRACE,
+            KeyCode::KEY_BACKSLASH,
+            KeyCode::KEY_SEMICOLON,
+            KeyCode::KEY_APOSTROPHE,
+            KeyCode::KEY_GRAVE,
+            KeyCode::KEY_COMMA,
+            KeyCode::KEY_DOT,
+            KeyCode::KEY_SLASH,
+            // Navigation / editing
+            KeyCode::KEY_LEFT,
+            KeyCode::KEY_RIGHT,
+            KeyCode::KEY_UP,
+            KeyCode::KEY_DOWN,
+            KeyCode::KEY_HOME,
+            KeyCode::KEY_END,
+            KeyCode::KEY_PAGEUP,
+            KeyCode::KEY_PAGEDOWN,
+            KeyCode::KEY_TAB,
+            KeyCode::KEY_ENTER,
+            KeyCode::KEY_BACKSPACE,
+            KeyCode::KEY_DELETE,
+            KeyCode::KEY_ESC,
+            KeyCode::KEY_SPACE,
+            // Modifiers
+            KeyCode::KEY_LEFTCTRL,
+            KeyCode::KEY_LEFTSHIFT,
+            KeyCode::KEY_LEFTALT,
+            KeyCode::KEY_LEFTMETA,
+            // Function keys
+            KeyCode::KEY_F1,
+            KeyCode::KEY_F2,
+            KeyCode::KEY_F3,
+            KeyCode::KEY_F4,
+            KeyCode::KEY_F5,
+            KeyCode::KEY_F6,
+            KeyCode::KEY_F7,
+            KeyCode::KEY_F8,
+            KeyCode::KEY_F9,
+            KeyCode::KEY_F10,
+            KeyCode::KEY_F11,
+            KeyCode::KEY_F12,
+            // System
+            KeyCode::KEY_SYSRQ,
+            // Multimedia
+            KeyCode::KEY_PLAYPAUSE,
+            KeyCode::KEY_NEXTSONG,
+            KeyCode::KEY_PREVIOUSSONG,
+            KeyCode::KEY_VOLUMEUP,
+            KeyCode::KEY_VOLUMEDOWN,
+            KeyCode::KEY_MUTE,
+            // Mouse buttons (injected as EV_KEY with BTN_* codes)
+            KeyCode::BTN_LEFT,
+            KeyCode::BTN_RIGHT,
+            KeyCode::BTN_MIDDLE,
+        ] {
+            keys.insert(k);
+        }
+
+        let mut axes = AttributeSet::<RelativeAxisCode>::default();
+        for a in [
+            RelativeAxisCode::REL_X,
+            RelativeAxisCode::REL_Y,
+            RelativeAxisCode::REL_WHEEL,
+            RelativeAxisCode::REL_HWHEEL,
+        ] {
+            axes.insert(a);
+        }
+
+        VirtualDevice::builder()?
+            .name("OpenLogi action injector")
+            .with_keys(&keys)?
+            .with_relative_axes(&axes)?
+            .build()
+    }
+
+    fn emit(events: &[InputEvent]) {
+        if let Some(m) = &*VIRTUAL_INPUT {
+            if let Ok(mut guard) = m.lock() {
+                if let Err(e) = guard.emit(events) {
+                    tracing::warn!("uinput action emit failed: {e}");
+                }
+            } else {
+                tracing::warn!("uinput action device mutex poisoned");
+            }
+        } else {
+            tracing::warn!("uinput action device unavailable");
+        }
+    }
+
+    fn syn() -> InputEvent {
+        InputEvent::new(EventType::SYNCHRONIZATION.0, 0, 0)
+    }
+
+    fn key_ev(code: KeyCode, value: i32) -> InputEvent {
+        InputEvent::new(EventType::KEY.0, code.0, value)
+    }
+
+    fn rel_ev(axis: RelativeAxisCode, value: i32) -> InputEvent {
+        InputEvent::new(EventType::RELATIVE.0, axis.0, value)
+    }
+
+    /// Inject modifier-down, key-down, key-up, modifier-up (in reverse order),
+    /// followed by `SYN_REPORT`.
+    pub(super) fn press_key(mods: &[KeyCode], key: KeyCode) {
+        let mut events: Vec<InputEvent> = Vec::with_capacity(mods.len() * 2 + 3);
+        for &m in mods {
+            events.push(key_ev(m, 1));
+        }
+        events.push(key_ev(key, 1));
+        events.push(key_ev(key, 0));
+        for &m in mods.iter().rev() {
+            events.push(key_ev(m, 0));
+        }
+        events.push(syn());
+        emit(&events);
+    }
+
+    /// Inject a button-down + button-up pair followed by `SYN_REPORT`.
+    pub(super) fn click(button: KeyCode) {
+        emit(&[key_ev(button, 1), key_ev(button, 0), syn()]);
+    }
+
+    /// Inject a single relative-axis delta followed by `SYN_REPORT`.
+    pub(super) fn scroll(axis: RelativeAxisCode, value: i32) {
+        emit(&[rel_ev(axis, value), syn()]);
+    }
+
+    /// Map a macOS `kVK_*` virtual key code to the corresponding Linux `KeyCode`.
+    ///
+    /// Source: `HIToolbox/Events.h` (macOS side) and
+    /// `linux/input-event-codes.h` (Linux side). Only the codes the recorder UI
+    /// is likely to produce are mapped; unknown codes return `None`.
+    pub(super) fn macos_vk_to_linux(vk: u16) -> Option<KeyCode> {
+        Some(match vk {
+            0x00 => KeyCode::KEY_A,          // kVK_ANSI_A
+            0x01 => KeyCode::KEY_S,          // kVK_ANSI_S
+            0x02 => KeyCode::KEY_D,          // kVK_ANSI_D
+            0x03 => KeyCode::KEY_F,          // kVK_ANSI_F
+            0x04 => KeyCode::KEY_H,          // kVK_ANSI_H
+            0x05 => KeyCode::KEY_G,          // kVK_ANSI_G
+            0x06 => KeyCode::KEY_Z,          // kVK_ANSI_Z
+            0x07 => KeyCode::KEY_X,          // kVK_ANSI_X
+            0x08 => KeyCode::KEY_C,          // kVK_ANSI_C
+            0x09 => KeyCode::KEY_V,          // kVK_ANSI_V
+            0x0B => KeyCode::KEY_B,          // kVK_ANSI_B
+            0x0C => KeyCode::KEY_Q,          // kVK_ANSI_Q
+            0x0D => KeyCode::KEY_W,          // kVK_ANSI_W
+            0x0E => KeyCode::KEY_E,          // kVK_ANSI_E
+            0x0F => KeyCode::KEY_R,          // kVK_ANSI_R
+            0x10 => KeyCode::KEY_Y,          // kVK_ANSI_Y
+            0x11 => KeyCode::KEY_T,          // kVK_ANSI_T
+            0x12 => KeyCode::KEY_1,          // kVK_ANSI_1
+            0x13 => KeyCode::KEY_2,          // kVK_ANSI_2
+            0x14 => KeyCode::KEY_3,          // kVK_ANSI_3
+            0x15 => KeyCode::KEY_4,          // kVK_ANSI_4
+            0x16 => KeyCode::KEY_6,          // kVK_ANSI_6
+            0x17 => KeyCode::KEY_5,          // kVK_ANSI_5
+            0x18 => KeyCode::KEY_EQUAL,      // kVK_ANSI_Equal
+            0x19 => KeyCode::KEY_9,          // kVK_ANSI_9
+            0x1A => KeyCode::KEY_7,          // kVK_ANSI_7
+            0x1B => KeyCode::KEY_MINUS,      // kVK_ANSI_Minus
+            0x1C => KeyCode::KEY_8,          // kVK_ANSI_8
+            0x1D => KeyCode::KEY_0,          // kVK_ANSI_0
+            0x1E => KeyCode::KEY_RIGHTBRACE, // kVK_ANSI_RightBracket
+            0x1F => KeyCode::KEY_O,          // kVK_ANSI_O
+            0x20 => KeyCode::KEY_U,          // kVK_ANSI_U
+            0x21 => KeyCode::KEY_LEFTBRACE,  // kVK_ANSI_LeftBracket
+            0x22 => KeyCode::KEY_I,          // kVK_ANSI_I
+            0x23 => KeyCode::KEY_P,          // kVK_ANSI_P
+            0x24 => KeyCode::KEY_ENTER,      // kVK_Return
+            0x25 => KeyCode::KEY_L,          // kVK_ANSI_L
+            0x26 => KeyCode::KEY_J,          // kVK_ANSI_J
+            0x27 => KeyCode::KEY_APOSTROPHE, // kVK_ANSI_Quote
+            0x28 => KeyCode::KEY_K,          // kVK_ANSI_K
+            0x29 => KeyCode::KEY_SEMICOLON,  // kVK_ANSI_Semicolon
+            0x2A => KeyCode::KEY_BACKSLASH,  // kVK_ANSI_Backslash
+            0x2B => KeyCode::KEY_COMMA,      // kVK_ANSI_Comma
+            0x2C => KeyCode::KEY_SLASH,      // kVK_ANSI_Slash
+            0x2D => KeyCode::KEY_N,          // kVK_ANSI_N
+            0x2E => KeyCode::KEY_M,          // kVK_ANSI_M
+            0x2F => KeyCode::KEY_DOT,        // kVK_ANSI_Period
+            0x30 => KeyCode::KEY_TAB,        // kVK_Tab
+            0x31 => KeyCode::KEY_SPACE,      // kVK_Space
+            0x32 => KeyCode::KEY_GRAVE,      // kVK_ANSI_Grave
+            0x33 => KeyCode::KEY_BACKSPACE,  // kVK_Delete (= Backspace on macOS)
+            0x35 => KeyCode::KEY_ESC,        // kVK_Escape
+            0x60 => KeyCode::KEY_F5,         // kVK_F5
+            0x61 => KeyCode::KEY_F6,         // kVK_F6
+            0x62 => KeyCode::KEY_F7,         // kVK_F7
+            0x63 => KeyCode::KEY_F3,         // kVK_F3
+            0x64 => KeyCode::KEY_F8,         // kVK_F8
+            0x65 => KeyCode::KEY_F9,         // kVK_F9
+            0x67 => KeyCode::KEY_F11,        // kVK_F11
+            0x6D => KeyCode::KEY_F10,        // kVK_F10
+            0x6F => KeyCode::KEY_F12,        // kVK_F12
+            0x76 => KeyCode::KEY_F4,         // kVK_F4
+            0x78 => KeyCode::KEY_F2,         // kVK_F2
+            0x7A => KeyCode::KEY_F1,         // kVK_F1
+            0x73 => KeyCode::KEY_HOME,       // kVK_Home
+            0x77 => KeyCode::KEY_END,        // kVK_End
+            0x74 => KeyCode::KEY_PAGEUP,     // kVK_PageUp
+            0x79 => KeyCode::KEY_PAGEDOWN,   // kVK_PageDown
+            0x75 => KeyCode::KEY_DELETE,     // kVK_ForwardDelete
+            0x7B => KeyCode::KEY_LEFT,       // kVK_LeftArrow
+            0x7C => KeyCode::KEY_RIGHT,      // kVK_RightArrow
+            0x7D => KeyCode::KEY_DOWN,       // kVK_DownArrow
+            0x7E => KeyCode::KEY_UP,         // kVK_UpArrow
+            _ => return None,
+        })
     }
 }
 

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1390,13 +1390,12 @@ mod linux {
             keys.insert(k);
         }
 
+        // Only scroll axes: the device never emits cursor movement, so leaving
+        // out REL_X/REL_Y keeps libinput from classifying it as a pointer —
+        // which can otherwise cause injected key/wheel events to be grabbed by
+        // pointer-grabbing X11 clients or routed oddly by some Wayland compositors.
         let mut axes = AttributeSet::<RelativeAxisCode>::default();
-        for a in [
-            RelativeAxisCode::REL_X,
-            RelativeAxisCode::REL_Y,
-            RelativeAxisCode::REL_WHEEL,
-            RelativeAxisCode::REL_HWHEEL,
-        ] {
+        for a in [RelativeAxisCode::REL_WHEEL, RelativeAxisCode::REL_HWHEEL] {
             axes.insert(a);
         }
 

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1802,4 +1802,68 @@ mod tests {
             Action::CycleDpiPresets
         );
     }
+
+    // ── macos_vk_to_linux ────────────────────────────────────────────────────
+
+    #[cfg(target_os = "linux")]
+    mod vk_mapping {
+        use evdev::KeyCode;
+
+        use crate::binding::linux::macos_vk_to_linux;
+
+        #[test]
+        fn common_letters_map_correctly() {
+            assert_eq!(macos_vk_to_linux(0x08), Some(KeyCode::KEY_C)); // kVK_ANSI_C
+            assert_eq!(macos_vk_to_linux(0x09), Some(KeyCode::KEY_V)); // kVK_ANSI_V
+            assert_eq!(macos_vk_to_linux(0x07), Some(KeyCode::KEY_X)); // kVK_ANSI_X
+            assert_eq!(macos_vk_to_linux(0x00), Some(KeyCode::KEY_A)); // kVK_ANSI_A
+            assert_eq!(macos_vk_to_linux(0x06), Some(KeyCode::KEY_Z)); // kVK_ANSI_Z
+            assert_eq!(macos_vk_to_linux(0x0D), Some(KeyCode::KEY_W)); // kVK_ANSI_W
+        }
+
+        #[test]
+        fn digits_map_correctly() {
+            assert_eq!(macos_vk_to_linux(0x12), Some(KeyCode::KEY_1)); // kVK_ANSI_1
+            assert_eq!(macos_vk_to_linux(0x1D), Some(KeyCode::KEY_0)); // kVK_ANSI_0
+        }
+
+        #[test]
+        fn arrow_keys_map_correctly() {
+            assert_eq!(macos_vk_to_linux(0x7B), Some(KeyCode::KEY_LEFT));
+            assert_eq!(macos_vk_to_linux(0x7C), Some(KeyCode::KEY_RIGHT));
+            assert_eq!(macos_vk_to_linux(0x7D), Some(KeyCode::KEY_DOWN));
+            assert_eq!(macos_vk_to_linux(0x7E), Some(KeyCode::KEY_UP));
+        }
+
+        #[test]
+        fn function_keys_map_correctly() {
+            assert_eq!(macos_vk_to_linux(0x7A), Some(KeyCode::KEY_F1)); // kVK_F1
+            assert_eq!(macos_vk_to_linux(0x78), Some(KeyCode::KEY_F2)); // kVK_F2
+            assert_eq!(macos_vk_to_linux(0x76), Some(KeyCode::KEY_F4)); // kVK_F4
+            assert_eq!(macos_vk_to_linux(0x60), Some(KeyCode::KEY_F5)); // kVK_F5
+            assert_eq!(macos_vk_to_linux(0x6F), Some(KeyCode::KEY_F12)); // kVK_F12
+        }
+
+        #[test]
+        fn nav_keys_map_correctly() {
+            assert_eq!(macos_vk_to_linux(0x73), Some(KeyCode::KEY_HOME));
+            assert_eq!(macos_vk_to_linux(0x77), Some(KeyCode::KEY_END));
+            assert_eq!(macos_vk_to_linux(0x74), Some(KeyCode::KEY_PAGEUP));
+            assert_eq!(macos_vk_to_linux(0x79), Some(KeyCode::KEY_PAGEDOWN));
+            assert_eq!(macos_vk_to_linux(0x75), Some(KeyCode::KEY_DELETE));
+        }
+
+        #[test]
+        fn brackets_follow_ansi_layout() {
+            // kVK_ANSI_LeftBracket=0x21 → KEY_LEFTBRACE, RightBracket=0x1E → KEY_RIGHTBRACE
+            assert_eq!(macos_vk_to_linux(0x21), Some(KeyCode::KEY_LEFTBRACE));
+            assert_eq!(macos_vk_to_linux(0x1E), Some(KeyCode::KEY_RIGHTBRACE));
+        }
+
+        #[test]
+        fn unmapped_code_returns_none() {
+            assert_eq!(macos_vk_to_linux(0xFF), None);
+            assert_eq!(macos_vk_to_linux(0x34), None); // gap in the kVK table
+        }
+    }
 }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1444,7 +1444,8 @@ mod linux {
                 tracing::warn!("uinput action device mutex poisoned");
             }
         } else {
-            tracing::warn!("uinput action device unavailable");
+            // Device creation failed at init; already logged once in LazyLock.
+            tracing::debug!("uinput action device unavailable — action skipped");
         }
     }
 
@@ -1810,6 +1811,60 @@ mod tests {
             default_binding(ButtonId::DpiToggle),
             Action::CycleDpiPresets
         );
+    }
+
+    // ── modifiers_to_keycodes ─────────────────────────────────────────────────
+
+    #[cfg(target_os = "linux")]
+    mod modifier_mapping {
+        use evdev::KeyCode;
+
+        use crate::binding::{KeyCombo, linux::modifiers_to_keycodes};
+
+        #[test]
+        fn mod_cmd_alone_maps_to_ctrl() {
+            assert_eq!(
+                modifiers_to_keycodes(KeyCombo::MOD_CMD),
+                vec![KeyCode::KEY_LEFTCTRL]
+            );
+        }
+
+        #[test]
+        fn mod_ctrl_alone_maps_to_ctrl() {
+            assert_eq!(
+                modifiers_to_keycodes(KeyCombo::MOD_CTRL),
+                vec![KeyCode::KEY_LEFTCTRL]
+            );
+        }
+
+        #[test]
+        fn mod_cmd_and_ctrl_together_produce_single_ctrl() {
+            // Both bits set must not push KEY_LEFTCTRL twice.
+            assert_eq!(
+                modifiers_to_keycodes(KeyCombo::MOD_CMD | KeyCombo::MOD_CTRL),
+                vec![KeyCode::KEY_LEFTCTRL]
+            );
+        }
+
+        #[test]
+        fn all_modifiers_produce_canonical_order() {
+            let mods = modifiers_to_keycodes(
+                KeyCombo::MOD_CMD | KeyCombo::MOD_SHIFT | KeyCombo::MOD_OPTION,
+            );
+            assert_eq!(
+                mods,
+                vec![
+                    KeyCode::KEY_LEFTCTRL,
+                    KeyCode::KEY_LEFTSHIFT,
+                    KeyCode::KEY_LEFTALT
+                ]
+            );
+        }
+
+        #[test]
+        fn no_modifiers_produces_empty_vec() {
+            assert!(modifiers_to_keycodes(0).is_empty());
+        }
     }
 
     // ── macos_vk_to_linux ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Implements `Action::execute` on Linux using a lazily-created `uinput` virtual device (`"OpenLogi action injector"`) shared for the process lifetime
- Maps all 39 action variants to evdev events: `EV_KEY` for keyboard shortcuts and mouse buttons, `REL_WHEEL`/`REL_HWHEEL` for scroll
- `post_horizontal_scroll()` now injects `REL_HWHEEL` on Linux
- Adds `macos_vk_to_linux()` mapping table (75 keys, full ANSI layout + F-keys + navigation)
- Adds 7 unit tests for the mapping table and an `inject_action` example CLI for manual smoke-testing

## Action mapping

| Category | Linux equivalent |
|---|---|
| Copy/Paste/Cut/Undo/Redo/SelectAll/Find/Save | `Ctrl+letter` |
| Browser Back/Forward | `Alt+←/→` |
| New/Close/Reopen/Next/Prev Tab, Reload | `Ctrl+T/W/Shift+T/Tab/Shift+Tab/R` |
| Previous/Next Desktop | `Ctrl+Alt+←/→` (GNOME/KDE default) |
| Lock Screen | `Ctrl+Alt+L` |
| Screenshot | `KEY_SYSRQ` (Print Screen) |
| Media keys | `KEY_PLAYPAUSE`, `KEY_NEXTSONG`, `KEY_PREVIOUSSONG`, `KEY_MUTE`, `KEY_VOLUMEUP/DOWN` |
| Mouse clicks | `BTN_LEFT/RIGHT/MIDDLE` |
| Scroll | `REL_WHEEL ±3`, `REL_HWHEEL ±3` |
| CustomShortcut | macOS `kVK_*` → evdev `KeyCode`; `MOD_CMD` → `Ctrl` |
| MissionControl/AppExpose/ShowDesktop/LaunchpadShow | debug-logged, no universal Linux equivalent |
| DPI/SmartShift | handled at hook/HID layer (unchanged) |

## Manual testing

```sh
cargo build --example inject_action -p openlogi-core

# Open a text editor, select some text, then:
sudo ./target/debug/examples/inject_action --delay 3 Copy

# Volume / media (no window focus needed):
sudo ./target/debug/examples/inject_action --delay 2 VolumeUp VolumeDown PlayPause

# Scrolling (focus a scrollable window first):
sudo ./target/debug/examples/inject_action --delay 3 ScrollDown ScrollDown ScrollUp

# Custom shortcut — Ctrl+Z (mod=0x01 = MOD_CMD→Ctrl, key=0x06 = kVK_ANSI_Z):
sudo ./target/debug/examples/inject_action --delay 3 "CustomShortcut:0x01:0x06"
```

Requires write access to `/dev/uinput` (add user to `input` group or apply a udev rule). If the device can't be opened, every call degrades to a `warn` log with no panic.