### PR TITLE
feat(hook): implement frontmost_bundle_id on Linux via X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,6 +4702,7 @@ dependencies = [
  "openlogi-core",
  "thiserror 2.0.18",
  "tracing",
+ "x11rb",
 ]
 
 [[package]]

--- a/crates/openlogi-gui/src/watchers/foreground_app.rs
+++ b/crates/openlogi-gui/src/watchers/foreground_app.rs
@@ -14,7 +14,7 @@ pub type ForegroundUpdate = Option<String>;
 /// Watch foreground application changes.
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     let (tx, rx) = mpsc::unbounded_channel();
-    if !cfg!(target_os = "macos") {
+    if !cfg!(any(target_os = "macos", target_os = "linux")) {
         drop(tx);
         let _ = period;
         return rx;

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -16,6 +16,7 @@ tracing = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = "0.13"
 libc = "0.2"
+x11rb = "0.13"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctrlc = "3"

--- a/crates/openlogi-hook/examples/frontmost_app.rs
+++ b/crates/openlogi-hook/examples/frontmost_app.rs
@@ -10,18 +10,16 @@
 //! ./target/debug/examples/frontmost_app
 //! ```
 
+#[cfg(target_os = "linux")]
 fn main() {
-    #[cfg(not(target_os = "linux"))]
-    {
-        eprintln!("frontmost_app: Linux only");
-        return;
+    println!("Polling focused app every second — switch windows to test.");
+    loop {
+        println!("{:?}", openlogi_hook::frontmost_bundle_id());
+        std::thread::sleep(std::time::Duration::from_secs(1));
     }
-    #[cfg(target_os = "linux")]
-    {
-        println!("Polling focused app every second — switch windows to test.");
-        loop {
-            println!("{:?}", openlogi_hook::frontmost_bundle_id());
-            std::thread::sleep(std::time::Duration::from_secs(1));
-        }
-    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("frontmost_app is a Linux-only smoke test (no-op on this platform).");
 }

--- a/crates/openlogi-hook/examples/frontmost_app.rs
+++ b/crates/openlogi-hook/examples/frontmost_app.rs
@@ -10,12 +10,18 @@
 //! ./target/debug/examples/frontmost_app
 //! ```
 
-#![cfg(target_os = "linux")]
-
 fn main() {
-    println!("Polling focused app every second — switch windows to test.");
-    loop {
-        println!("{:?}", openlogi_hook::frontmost_bundle_id());
-        std::thread::sleep(std::time::Duration::from_secs(1));
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("frontmost_app: Linux only");
+        return;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        println!("Polling focused app every second — switch windows to test.");
+        loop {
+            println!("{:?}", openlogi_hook::frontmost_bundle_id());
+            std::thread::sleep(std::time::Duration::from_secs(1));
+        }
     }
 }

--- a/crates/openlogi-hook/examples/frontmost_app.rs
+++ b/crates/openlogi-hook/examples/frontmost_app.rs
@@ -1,0 +1,21 @@
+//! Smoke-test for `frontmost_bundle_id()` on Linux.
+//!
+//! Polls the focused application once per second and prints its identifier.
+//! Switch between windows while it runs to verify detection.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo build --example frontmost_app -p openlogi-hook
+//! ./target/debug/examples/frontmost_app
+//! ```
+
+#![cfg(target_os = "linux")]
+
+fn main() {
+    println!("Polling focused app every second — switch windows to test.");
+    loop {
+        println!("{:?}", openlogi_hook::frontmost_bundle_id());
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -210,22 +210,28 @@ impl Hook {
     }
 }
 
-/// Return the macOS bundle identifier of the currently frontmost application,
-/// e.g. `"com.microsoft.VSCode"`. `None` when no app is frontmost, when
-/// reading the value fails, or on any non-macOS platform.
+/// Return an opaque string identifying the currently frontmost application.
 ///
-/// On Linux, per-application profile switching is not yet implemented and this
-/// always returns `None`.
+/// On macOS this is the bundle identifier, e.g. `"com.microsoft.VSCode"`.
+/// On Linux (X11 / XWayland) this is the `WM_CLASS` class component,
+/// e.g. `"Code"` or `"Firefox"`. Pure Wayland windows (not running under
+/// XWayland) are not visible through this path and return `None`.
 ///
-/// Costs four `objc_msgSend`s plus a UTF-8 copy — well under a millisecond
-/// at the 1 Hz polling cadence in `openlogi-gui::app_watcher`.
+/// `None` when no app is frontmost, when reading fails, or on unsupported
+/// platforms. Costs one X11 round-trip on Linux, four `objc_msgSend`s on
+/// macOS — well under a millisecond at the 1 Hz polling cadence in
+/// `openlogi-gui::app_watcher`.
 #[must_use]
 pub fn frontmost_bundle_id() -> Option<String> {
     #[cfg(target_os = "macos")]
     {
         macos::frontmost_bundle_id()
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        linux::frontmost_bundle_id()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         None
     }

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -369,7 +369,11 @@ static X11_STATE: LazyLock<Option<X11State>> = LazyLock::new(|| {
         .reply()
         .ok()?
         .atom;
-    Some(X11State { conn, root, net_active_window })
+    Some(X11State {
+        conn,
+        root,
+        net_active_window,
+    })
 });
 
 /// Return the X11 `WM_CLASS` class component of the currently active window,
@@ -384,7 +388,14 @@ pub(crate) fn frontmost_bundle_id() -> Option<String> {
     // _NET_ACTIVE_WINDOW on the root window holds the focused window's XID.
     let window: Window = state
         .conn
-        .get_property(false, state.root, state.net_active_window, AtomEnum::WINDOW, 0, 1)
+        .get_property(
+            false,
+            state.root,
+            state.net_active_window,
+            AtomEnum::WINDOW,
+            0,
+            1,
+        )
         .ok()?
         .reply()
         .ok()?
@@ -397,7 +408,10 @@ pub(crate) fn frontmost_bundle_id() -> Option<String> {
     // WM_CLASS is instance_name\0class_name\0; the class component is more
     // stable across window instances and is what profiles should key on
     // (e.g. "Firefox", not "Navigator").
-    let wm = WmClass::get(&state.conn, window).ok()?.reply_unchecked().ok()??;
+    let wm = WmClass::get(&state.conn, window)
+        .ok()?
+        .reply_unchecked()
+        .ok()??;
     std::str::from_utf8(wm.class())
         .ok()
         .filter(|s| !s.is_empty())

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -122,9 +122,10 @@ fn signal_pipe(fd: &OwnedFd) {
 
 fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
     let mut fds = [0i32; 2];
-    // SAFETY: fds is a valid two-element array; pipe2() fills it with two new
-    // fds on success. O_CLOEXEC keeps the pipe from leaking into any child
-    // process the app spawns.
+    // SAFETY: fds is a valid two-element array; pipe2() fills it with two new fds on success.
+    // O_CLOEXEC prevents the fds from being inherited by forked children — without it a child
+    // holding the write-end would prevent the hook thread's read-end from ever seeing EOF,
+    // blocking clean shutdown.
     if unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) } < 0 {
         return Err(io::Error::last_os_error());
     }

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -166,6 +166,7 @@ fn build_virtual_device(device: &Device) -> io::Result<evdev::uinput::VirtualDev
 /// Returns `true` when the device is ready to read, `false` on stop signal or
 /// unrecoverable poll error.
 fn wait_readable(device_fd: i32, stop_fd: i32) -> bool {
+    const ERR_FLAGS: libc::c_short = libc::POLLERR | libc::POLLHUP | libc::POLLNVAL;
     let mut fds = [
         libc::pollfd {
             fd: device_fd,
@@ -188,6 +189,17 @@ fn wait_readable(device_fd: i32, stop_fd: i32) -> bool {
             }
             error!("poll() failed: {err}");
             return false;
+        }
+        // An error/hangup on either fd (e.g. the grabbed device was unplugged →
+        // POLLHUP) leaves it permanently "ready", so without this check neither
+        // POLLIN branch fires and the loop spins at 100% CPU. Treat it as a stop
+        // so the caller exits the thread and releases the grab.
+        if fds[0].revents & ERR_FLAGS != 0 {
+            warn!("hooked device closed or errored; stopping its thread");
+            return false;
+        }
+        if fds[1].revents & ERR_FLAGS != 0 {
+            return false; // stop pipe closed → shut down
         }
         if fds[1].revents & libc::POLLIN != 0 {
             return false; // stop signal

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -15,7 +15,7 @@
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::sync::{
-    Arc,
+    Arc, LazyLock,
     atomic::{AtomicBool, Ordering},
 };
 use std::thread;
@@ -23,6 +23,10 @@ use std::thread;
 use evdev::uinput::VirtualDevice;
 use evdev::{Device, EventSummary, KeyCode, RelativeAxisCode};
 use tracing::{debug, error, warn};
+use x11rb::connection::Connection as _;
+use x11rb::properties::WmClass;
+use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
+use x11rb::rust_connection::RustConnection;
 
 use crate::{ButtonId, EventDisposition, HookError, MouseEvent};
 
@@ -343,6 +347,60 @@ fn device_thread(
 
     debug!("hook stopped on {}", path.display());
     // Dropping `device` releases the exclusive grab, restoring normal input delivery.
+}
+
+// ── frontmost_bundle_id ──────────────────────────────────────────────────────
+
+struct X11State {
+    conn: RustConnection,
+    root: Window,
+    net_active_window: Atom,
+}
+
+static X11_STATE: LazyLock<Option<X11State>> = LazyLock::new(|| {
+    let (conn, screen_num) = RustConnection::connect(None)
+        .map_err(|e| debug!("X11 not available, frontmost_bundle_id will return None: {e}"))
+        .ok()?;
+    let root = conn.setup().roots[screen_num].root;
+    let net_active_window = conn
+        .intern_atom(false, b"_NET_ACTIVE_WINDOW")
+        .ok()?
+        .reply()
+        .ok()?
+        .atom;
+    Some(X11State { conn, root, net_active_window })
+});
+
+/// Return the X11 `WM_CLASS` class component of the currently active window,
+/// e.g. `"Firefox"` or `"Code"`.
+///
+/// Returns `None` when there is no active window, when the X11 display is
+/// unavailable (Wayland-only session without XWayland), or on read error.
+/// Native Wayland windows are not visible through this path.
+pub(crate) fn frontmost_bundle_id() -> Option<String> {
+    let state = X11_STATE.as_ref()?;
+
+    // _NET_ACTIVE_WINDOW on the root window holds the focused window's XID.
+    let window: Window = state
+        .conn
+        .get_property(false, state.root, state.net_active_window, AtomEnum::WINDOW, 0, 1)
+        .ok()?
+        .reply()
+        .ok()?
+        .value32()?
+        .next()?;
+    if window == 0 {
+        return None;
+    }
+
+    // WM_CLASS is instance_name\0class_name\0; the class component is more
+    // stable across window instances and is what profiles should key on
+    // (e.g. "Firefox", not "Navigator").
+    let wm = WmClass::get(&state.conn, window).ok()?.reply_unchecked().ok()??;
+    std::str::from_utf8(wm.class())
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Queries `_NET_ACTIVE_WINDOW` on the X11 root window to find the focused window XID
- Reads `WM_CLASS` via `x11rb::properties::WmClass` and returns the **class component** (e.g. `"Firefox"`, `"Code"`) — the stable per-app identifier on X11, analogous to a macOS bundle ID for profile-matching purposes
- Lazily initialises the X11 connection and `_NET_ACTIVE_WINDOW` atom once via `LazyLock`; subsequent 1 Hz calls in `app_watcher` reuse the connection with a single round-trip
- Adds `frontmost_app` example for manual smoke-testing
- Updates the `frontmost_bundle_id()` doc to describe the Linux semantics and the Wayland limitation

## Known limitation

Native Wayland windows (not running under XWayland) are not visible through this path and return `None`. A compositor-specific D-Bus path (GNOME Shell / KWin) would be needed to cover those; deferred as the vast majority of apps run under XWayland today.

## Depends on

#119 — this branch is based on it. The diff will include #119's changes until that merges to master; after merge only the `frontmost_bundle_id` additions will remain.

## Test plan

- [x] Manual: ran `./target/debug/examples/frontmost_app` and switched between GNOME Terminal, Google Chrome, and VS Code — output correctly changed to `Some("Gnome-terminal")`, `Some("Google-chrome")`, `Some("Code")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)