### PR TITLE
[codex] Update time to fix RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,9 +4154,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -6528,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6543,15 +6543,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ members = [
 [workspace.package]
 version = "0.4.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AprilNEA/OpenLogi"
 authors = ["AprilNEA <dev@aprilnea.me>"]

--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -14,9 +14,9 @@
 name = "openlogi-hidpp"
 version.workspace = true
 edition.workspace = true
-# Upstream HEAD uses std APIs stabilized in 1.87, so this fork's real MSRV is
-# higher than the workspace's 1.85. Declared explicitly (not inherited) — note
-# this makes the workspace effectively need 1.87 via openlogi-hid.
+# Upstream HEAD uses std APIs stabilized in 1.87. Keep this explicit instead
+# of inheriting the workspace MSRV so future syncs can see the fork's own lower
+# bound.
 rust-version = "1.87"
 license = "0BSD"
 repository.workspace = true

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,7 +5,7 @@ build instructions, see the [README](../README.md).
 
 ## Toolchain
 
-- Stable Rust (Edition 2024, MSRV 1.85)
+- Stable Rust (Edition 2024, MSRV 1.88)
 - macOS: Xcode 16+ with the optional **Metal Toolchain** component (required by
   GPUI's `gpui_macos` build script to compile shaders)
 - `create-dmg` for packaging (`brew install create-dmg`); `cargo-bundle` is


### PR DESCRIPTION
## Summary

- Update `time` from 0.3.45 to 0.3.47 to address RUSTSEC-2026-0009.
- Update the workspace MSRV from 1.85 to 1.88 because `time` 0.3.47 requires Rust 1.88.
- Refresh the vendored `openlogi-hidpp` MSRV comment so it no longer references the old workspace lower bound.

## Validation

- `cargo audit` exits 0; RUSTSEC-2026-0009 is no longer reported. Existing unmaintained advisories remain warning-only.
- `cargo fmt --all -- --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo tree --workspace -i time --target all --locked`

`cargo clippy --workspace --all-targets -- -D warnings` was attempted, but local linking is blocked before project code compiles because this machine has not accepted the Xcode license (`sudo xcodebuild -license`).
