### PR TITLE
feat(updater): signed auto-update with fail-closed verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           # GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
           # GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY
 
       - name: Install packaging tools
         run: |
@@ -73,6 +74,7 @@ jobs:
           # GITHUB_APP_ID: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
           # GITHUB_APP_PRIVATE_KEY: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_BASE_URL }}
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           : "${APPLE_SIGNING_IDENTITY:?Configure APPLE_SIGNING_IDENTITY in 1Password}"
@@ -84,6 +86,7 @@ jobs:
           # : "${GITHUB_APP_ID:?Configure GITHUB_APP_ID in 1Password}"
           # : "${GITHUB_APP_PRIVATE_KEY:?Configure GITHUB_APP_PRIVATE_KEY in 1Password}"
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in 1Password}"
+          : "${OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY in 1Password}"
 
       - name: Import Apple signing certificate
         uses: apple-actions/import-codesign-certs@v7
@@ -94,6 +97,7 @@ jobs:
       - name: Build OpenLogi.app with cargo-bundle
         env:
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_BASE_URL }}
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
         run: |
           set -euo pipefail
           export OPENLOGI_UPDATE_MANIFEST_URL="${OPENLOGI_UPDATE_BASE_URL%/}/channels/stable/latest.json"
@@ -185,6 +189,8 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY
+          OPENLOGI_UPDATE_MINISIGN_SECRET_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_SECRET_KEY
           R2_ACCOUNT_ID: ${{ secrets.OP_R2_SECRET_ITEM }}/CLOUDFLARE_R2_ACCOUNT_ID
           R2_BUCKET: ${{ secrets.OP_R2_SECRET_ITEM }}/CLOUDFLARE_R2_BUCKET
           R2_ACCESS_KEY_ID: ${{ secrets.OP_R2_SECRET_ITEM }}/CLOUDFLARE_R2_ACCESS_KEY_ID
@@ -193,6 +199,8 @@ jobs:
       - name: Validate R2 publishing configuration
         env:
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_BASE_URL }}
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
+          OPENLOGI_UPDATE_MINISIGN_SECRET_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_SECRET_KEY }}
           R2_ACCOUNT_ID: ${{ steps.r2_config.outputs.R2_ACCOUNT_ID }}
           R2_BUCKET: ${{ steps.r2_config.outputs.R2_BUCKET }}
           R2_ACCESS_KEY_ID: ${{ steps.r2_config.outputs.R2_ACCESS_KEY_ID }}
@@ -200,10 +208,32 @@ jobs:
         run: |
           set -euo pipefail
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in the R2 1Password item}"
+          : "${OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY in the R2 1Password item}"
+          : "${OPENLOGI_UPDATE_MINISIGN_SECRET_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_SECRET_KEY in the R2 1Password item}"
           : "${R2_ACCOUNT_ID:?Configure CLOUDFLARE_R2_ACCOUNT_ID in the R2 1Password item}"
           : "${R2_BUCKET:?Configure CLOUDFLARE_R2_BUCKET in the R2 1Password item}"
           : "${R2_ACCESS_KEY_ID:?Configure CLOUDFLARE_R2_ACCESS_KEY_ID in the R2 1Password item}"
           : "${R2_SECRET_ACCESS_KEY:?Configure CLOUDFLARE_R2_SECRET_ACCESS_KEY in the R2 1Password item}"
+
+      - name: Install minisign
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Sign updater artifacts
+        env:
+          OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
+          OPENLOGI_UPDATE_MINISIGN_SECRET_KEY: ${{ steps.r2_config.outputs.OPENLOGI_UPDATE_MINISIGN_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          key_file="${RUNNER_TEMP}/openlogi-minisign.key"
+          umask 077
+          printf '%s\n' "$OPENLOGI_UPDATE_MINISIGN_SECRET_KEY" > "$key_file"
+          trap 'rm -f "$key_file"' EXIT
+          for artifact in dist/*.dmg; do
+            minisign -S -m "$artifact" -s "$key_file" -x "$artifact.minisig" -W
+            minisign -V -m "$artifact" -P "$OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY" -x "$artifact.minisig"
+          done
 
       - name: Generate static updater manifest
         env:
@@ -252,6 +282,7 @@ jobs:
         with:
           files: |
             dist/*.dmg
+            dist/*.minisig
             dist/SHA256SUMS
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,12 @@ jobs:
           set -euo pipefail
           key_file="${RUNNER_TEMP}/openlogi-minisign.key"
           umask 077
-          printf '%s\n' "$OPENLOGI_UPDATE_MINISIGN_SECRET_KEY" > "$key_file"
           trap 'rm -f "$key_file"' EXIT
+          # The secret key file is stored base64-encoded in 1Password so its two
+          # lines survive paste/round-trip (a raw multi-line value can have its
+          # newline mangled to a space — see the GitHub App key note above).
+          # `tr -d` drops any wrapping whitespace before decoding.
+          printf '%s' "$OPENLOGI_UPDATE_MINISIGN_SECRET_KEY" | tr -d '[:space:]' | base64 -d > "$key_file"
           for artifact in dist/*.dmg; do
             minisign -S -m "$artifact" -s "$key_file" -x "$artifact.minisig" -W
             minisign -V -m "$artifact" -P "$OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY" -x "$artifact.minisig"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,8 +2531,8 @@ dependencies = [
 
 [[package]]
 name = "gpui-updater"
-version = "0.0.3"
-source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.3#d84910eda00991169ec60f792444eb54176c43db"
+version = "0.0.4"
+source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.4#d9b2872f373b23ab923268c18d8a59f42f4d76e9"
 dependencies = [
  "gpui",
  "minisign-verify",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -33,7 +33,7 @@ thiserror.workspace = true
 ureq.workspace = true
 rust-i18n = "4"
 sys-locale = "0.3.2"
-gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.3", features = ["gpui"] }
+gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.4", features = ["gpui"] }
 
 # Menu-bar (NSStatusItem) FFI — GPUI has no status-bar API. Same crates the
 # openlogi-hook CGEventTap uses, so the toolchain is already proven here.

--- a/crates/openlogi-gui/src/platform/updater.rs
+++ b/crates/openlogi-gui/src/platform/updater.rs
@@ -10,13 +10,17 @@
 //! so a launch-time result is already visible when the window opens.
 
 use gpui::{App, AppContext as _, Entity, Global};
-use gpui_updater::{EngineConfig, StaticManifestSource, Updater, Version};
+use gpui_updater::{EngineConfig, StaticManifestSource, Updater, Verification, Version};
 use openlogi_core::config::AppSettings;
 
 const MANIFEST_URL: &str = match option_env!("OPENLOGI_UPDATE_MANIFEST_URL") {
     Some(url) => url,
     None => "https://updates.openlogi.org/channels/stable/latest.json",
 };
+
+/// Base64 minisign public key, embedded at build time by the release workflow.
+/// Absent in local/dev builds, which then fail closed (see [`new_entity`]).
+const MINISIGN_PUBLIC_KEY: Option<&str> = option_env!("OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY");
 
 /// App-global handle to the shared updater entity.
 #[derive(Clone)]
@@ -25,8 +29,13 @@ pub struct SharedUpdater(pub Entity<Updater>);
 impl Global for SharedUpdater {}
 
 /// Build a fresh updater entity for this app's static update manifest and
-/// running version. The asset is matched by platform metadata and verified
-/// against the manifest's SHA-256.
+/// running version. The asset is matched by platform metadata and, under
+/// [`Verification::Strict`], verified against both the manifest's SHA-256 and a
+/// minisign signature made with [`MINISIGN_PUBLIC_KEY`].
+///
+/// Release builds embed that key and update normally. A build without it
+/// (local/dev) fails closed: `check` returns an error rather than installing an
+/// unverified artifact.
 pub fn new_entity(cx: &mut App) -> Entity<Updater> {
     cx.new(|cx| {
         let source = StaticManifestSource::new(MANIFEST_URL)
@@ -35,8 +44,20 @@ pub fn new_entity(cx: &mut App) -> Entity<Updater> {
             .format(release_format());
         let version =
             Version::parse(env!("CARGO_PKG_VERSION")).unwrap_or_else(|_| Version::new(0, 0, 0));
-        Updater::new(source, EngineConfig::new(version), cx)
+        let mut config = EngineConfig::new(version).verification(Verification::Strict);
+        if let Some(key) = minisign_public_key() {
+            config = config.minisign_public_key(key);
+        }
+        Updater::new(source, config, cx)
     })
+}
+
+/// The embedded minisign public key, trimmed, or `None` when the build did not
+/// bake one in.
+fn minisign_public_key() -> Option<&'static str> {
+    MINISIGN_PUBLIC_KEY
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
 }
 
 fn release_arch() -> &'static str {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -126,13 +126,21 @@ ${OPENLOGI_UPDATE_BASE_URL}/channels/stable/latest.json
 
 The app embeds that manifest URL at build time via
 `OPENLOGI_UPDATE_MANIFEST_URL`, derived from `OPENLOGI_UPDATE_BASE_URL` in the
-release workflow.
+release workflow. Release builds also embed `OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY`
+and run with `Verification::Strict`: an update is installed only if the manifest
+asset carries a minisign signature that verifies against that key, plus a
+matching SHA-256. A build without the key embedded (local/dev) fails closed —
+the update check errors rather than installing an unverified artifact.
 
 Configure the R2/update settings in one 1Password item referenced by the GitHub
 secret `OP_R2_SECRET_ITEM`. The item must contain:
 
 - `OPENLOGI_UPDATE_BASE_URL` — public HTTPS base URL, for example
   `https://updates.openlogi.org`.
+- `OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY` — base64 minisign public key embedded in
+  the app and used to verify updater artifacts.
+- `OPENLOGI_UPDATE_MINISIGN_SECRET_KEY` — passwordless minisign secret key used
+  only in the release publish job to sign DMGs before `latest.json` is generated.
 - `CLOUDFLARE_R2_ACCOUNT_ID` — Cloudflare account ID used for the S3 endpoint.
 - `CLOUDFLARE_R2_BUCKET` — bucket name.
 - `CLOUDFLARE_R2_ACCESS_KEY_ID` — R2 S3 access key.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,8 +139,11 @@ secret `OP_R2_SECRET_ITEM`. The item must contain:
   `https://updates.openlogi.org`.
 - `OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY` — base64 minisign public key embedded in
   the app and used to verify updater artifacts.
-- `OPENLOGI_UPDATE_MINISIGN_SECRET_KEY` — passwordless minisign secret key used
-  only in the release publish job to sign DMGs before `latest.json` is generated.
+- `OPENLOGI_UPDATE_MINISIGN_SECRET_KEY` — the passwordless minisign secret key
+  file, **base64-encoded** (`base64 < minisign.key`), used only in the release
+  publish job to sign DMGs before `latest.json` is generated. It is stored
+  base64 (not raw) so its two lines survive 1Password's paste handling; the
+  workflow decodes it, mirroring the GitHub App key.
 - `CLOUDFLARE_R2_ACCOUNT_ID` — Cloudflare account ID used for the S3 endpoint.
 - `CLOUDFLARE_R2_BUCKET` — bucket name.
 - `CLOUDFLARE_R2_ACCESS_KEY_ID` — R2 S3 access key.

--- a/xtask/src/manifest.rs
+++ b/xtask/src/manifest.rs
@@ -45,6 +45,7 @@ struct Manifest {
 struct Asset {
     name: String,
     url: String,
+    signature_url: String,
     os: &'static str,
     arch: String,
     format: &'static str,
@@ -106,9 +107,19 @@ fn collect_assets(dist: &Path, release_base: &str) -> Result<Vec<Asset>> {
         let Some(arch) = dmg_arch(name) else {
             continue;
         };
+        let signature_name = format!("{name}.minisig");
+        let signature_path = dist.join(&signature_name);
+        if !signature_path.is_file() {
+            bail!(
+                "missing minisign signature {} for updater artifact {}",
+                signature_path.display(),
+                path.display()
+            );
+        }
         assets.push(Asset {
             name: name.to_string(),
             url: format!("{release_base}/{name}"),
+            signature_url: format!("{release_base}/{signature_name}"),
             os: "macos",
             arch: arch.to_string(),
             format: "dmg",
@@ -152,4 +163,49 @@ fn published_at() -> Result<String> {
     OffsetDateTime::from(SystemTime::now())
         .format(&Rfc3339)
         .context("could not format current timestamp")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::{env, fs, process};
+
+    use super::*;
+
+    fn temp_dist(name: &str) -> PathBuf {
+        let path = env::temp_dir().join(format!("openlogi-manifest-test-{}-{name}", process::id()));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn collect_assets_requires_minisign_signature_for_each_dmg() {
+        let dist = temp_dist("missing-signature");
+        fs::write(dist.join("OpenLogi-v1.2.3-macos-arm64.dmg"), b"dmg").unwrap();
+
+        assert!(collect_assets(&dist, "https://updates.example/releases/v1.2.3").is_err());
+
+        let _ = fs::remove_dir_all(dist);
+    }
+
+    #[test]
+    fn collect_assets_publishes_signature_url() {
+        let dist = temp_dist("with-signature");
+        fs::write(dist.join("OpenLogi-v1.2.3-macos-arm64.dmg"), b"dmg").unwrap();
+        fs::write(
+            dist.join("OpenLogi-v1.2.3-macos-arm64.dmg.minisig"),
+            b"signature",
+        )
+        .unwrap();
+
+        let assets = collect_assets(&dist, "https://updates.example/releases/v1.2.3").unwrap();
+
+        assert_eq!(
+            assets[0].signature_url,
+            "https://updates.example/releases/v1.2.3/OpenLogi-v1.2.3-macos-arm64.dmg.minisig"
+        );
+
+        let _ = fs::remove_dir_all(dist);
+    }
 }


### PR DESCRIPTION
## Summary

Wires OpenLogi's in-app updater to **fail closed**: an update installs only if
the manifest asset carries a minisign signature that verifies against an embedded
public key, plus a matching SHA-256. This is the "signed auto-update" slice,
built on `gpui-updater` v0.0.4's upstream `Verification` policy.

## Background / relationship to #66

#66 (thanks @jasoncantor) first added minisign signing + verification to the
updater, using a hand-rolled `RequiredSignedSource` wrapper to force fail-closed
behaviour. That wrapper was exactly the workaround that motivated
AprilNEA/gpui-updater#1 — so the policy now lives upstream
(`EngineConfig::verification(Verification::Strict)`, released as gpui-updater
v0.0.4), and no wrapper is needed.

This PR is the **updater/signing slice only**, rebuilt on that upstream policy.
#66's unrelated fixes (cargo-bundle pin, asset-sync hardening, direct-HID
identity, Bolt discovery-name bounds) are intentionally out of scope and remain
for #66 to land separately.

## Changes

- **Bump `gpui-updater` v0.0.3 → v0.0.4** (adds the `Verification` policy).
- **`updater.rs`**: embed `OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY` at build time and
  configure `Verification::Strict`. A build without the key (local/dev) fails
  closed — the check errors rather than installing an unverified artifact.
- **`xtask` manifest**: emit `signature_url` per asset and fail the manifest
  generation if a DMG's `.minisig` is missing.
- **`release.yml`**: load the minisign key pair from 1Password, sign each DMG and
  self-verify, publish `.minisig` beside the DMG (and into the GitHub Release),
  and embed the public key into release builds. The secret key is written with
  `umask 077` and removed via a `trap … EXIT`.
- **`docs/DEVELOPMENT.md`**: document the two new 1Password fields and the
  fail-closed behaviour.

## ⚠️ Operational prerequisite before the next release

`OP_R2_SECRET_ITEM` must gain two fields or the next release breaks:

- `OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY`
- `OPENLOGI_UPDATE_MINISIGN_SECRET_KEY` (passwordless)

Generate with `minisign -G -W`. Without them: the publish job bails (manifest
requires a `.minisig`), and any already-shipped client built with the embedded
key rejects every update.

## Validation

- `cargo check -p openlogi-gui` (real Xcode/Metal env) — compiles against the
  v0.0.4 API.
- `cargo test -p xtask` — new manifest tests (require-signature, signature_url).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `Cargo.lock` change is surgical: only the `gpui-updater` entry moves to v0.0.4;
  the pinned `zed` gpui commit (`eb2223c0`) is unchanged.

## Follow-ups (tracked in #109)

- Graceful UI for keyless builds: `Verification::Strict` makes the check *error*;
  the About window should show "auto-update not available for this build" rather
  than a failure.
- Bind version/filename into the signature (minisign `-S -t`) once
  AprilNEA/gpui-updater adopts trusted-comment verification (gpui-updater #1,
  item 2) — closes the manifest-rollback gap.

Refs #109. Supersedes the updater portion of #66.
