### PR TITLE
Migrate macOS ObjC FFI to objc2, fixing the menu-bar leak (#99)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4278,6 +4278,39 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -4296,6 +4329,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,6 +4389,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4322,6 +4405,17 @@ dependencies = [
  "block2",
  "dispatch2",
  "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4489,14 +4583,15 @@ name = "openlogi-gui"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "cocoa 0.26.0",
  "fs4",
  "gpui",
  "gpui-component",
  "gpui-component-assets",
  "gpui-updater",
  "gpui_platform",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "openlogi-assets",
  "openlogi-core",
  "openlogi-hid",
@@ -4544,10 +4639,11 @@ dependencies = [
 name = "openlogi-hook"
 version = "0.4.1"
 dependencies = [
- "cocoa 0.26.0",
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "openlogi-core",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -35,18 +35,18 @@ rust-i18n = "4"
 sys-locale = "0.3.2"
 gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.3", features = ["gpui"] }
 
-# Menu-bar (NSStatusItem) FFI — GPUI has no status-bar API. Same crates the
-# openlogi-hook CGEventTap uses, so the toolchain is already proven here.
+# Menu-bar (NSStatusItem) FFI — GPUI has no status-bar API. objc2 gives typed,
+# `Retained<T>`-owned AppKit bindings so the status-item code can't leak (#99).
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26"
-objc = "0.2"
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication"] }
+objc2-foundation = { version = "0.3.2", features = ["NSString"] }
 
-# Mirrors [workspace.lints], plus an allow for the legacy `cfg(cargo-clippy)`
-# check emitted by objc 0.2's macros (same as openlogi-hook). unsafe_code stays
-# denied; the menubar module opts in locally with #[expect(unsafe_code)].
+# unsafe_code stays denied; the status-item/tray modules opt in locally with
+# #[expect(unsafe_code)] for the few objc2 calls (init-with-action, set-target,
+# super-init) that remain unsafe.
 [lints.rust]
 unsafe_code = "deny"
-unexpected_cfgs = { level = "allow", check-cfg = [] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/openlogi-gui/src/platform/CLAUDE.md
+++ b/crates/openlogi-gui/src/platform/CLAUDE.md
@@ -1,0 +1,88 @@
+# `platform/` — macOS native FFI
+
+This directory is OpenLogi's macOS-native surface. The Objective-C FFI here runs
+on **`objc2`** (0.6 / framework crates 0.3): `Retained<T>` smart pointers, typed
+AppKit objects, `define_class!` for subclasses. The whole workspace's ObjC-runtime
+FFI is exactly these files — keep them in sync:
+
+- `status_item.rs` — safe `objc2` wrappers over `NSStatusItem` / `NSMenu` / `NSMenuItem`.
+- `tray.rs` — the OpenLogi menu-bar semantics + the `OpenLogiMenuTarget` (`define_class!`).
+- `permissions.rs` — `CBCentralManager.authorization` (`objc2` class lookup) + `IOHIDCheckAccess` (C FFI).
+- `crates/openlogi-hook/src/macos.rs` — CGEventTap (on `core-graphics`, see below) + the `NSWorkspace` frontmost-app read (`objc2`).
+
+`single_instance.rs` (fs4 lock), `launch_agent.rs` (plist via `std::fs`), `updater.rs`
+(gpui_updater) contain **no** ObjC FFI — don't add any.
+
+## Ownership: `Retained<T>`, never raw `id`
+
+`objc2` makes ownership a value: a `Retained<T>` releases exactly once on `Drop`.
+That is *why* this code can't reproduce issue #99 (a `+1` `NSString` leaked on every
+2 s tray refresh under the old `cocoa`/`objc` 0.x path).
+
+- Every string is `NSString::from_str(s)` → a `Retained<NSString>` used as a borrowed
+  temporary; it releases at the end of the statement. **There is no `nsstring()` helper
+  and no autorelease pool in the tray path** — don't reintroduce either.
+- `alloc`/`init`/`new`/`copy` and the framework getters return `Retained<T>` /
+  `Option<Retained<T>>`; you keep what you need in a field and let `Drop` free it.
+- **Never** call manual `retain`/`release`/`autorelease`, add raw `cocoa`/`objc` 0.x, or
+  build a bespoke retain/release helper layer — that re-derives `Retained<T>`, worse.
+
+## Thread affinity is in the type system
+
+- `NSMenu` and `NSMenuItem` are `#[thread_kind = MainThreadOnly]` → their `Retained` is
+  `!Send`. `NSStatusItem`, `NSImage`, `NSWorkspace` are `AnyThread` (their `Retained` is
+  still `!Send`, because a bare ObjC object is `!Sync`).
+- Constructing a `MainThreadOnly` object needs a `MainThreadMarker` (`NSMenu::new(mtm)`,
+  `NSMenuItem::alloc(mtm)`, `status_item.button(mtm)`). Mutating an already-held
+  `Retained<NSMenuItem>` (`setTitle`/`setHidden`) does **not** — possessing the `!Send`
+  handle already proves you're on the main thread.
+- The tray's state lives in a **`thread_local`** (`TRAY`), not a `static`: a `Retained`
+  of a `MainThreadOnly`/ObjC object can't satisfy a `Sync` static. `install`/`show_in_dock`/
+  `hide_from_dock` obtain `mtm` via `MainThreadMarker::new()` at the GPUI→objc2 boundary
+  (they always run on GPUI's main thread). Do **not** copy gpui's own
+  `NSThread.isMainThread` + `dispatch2` runtime-check idiom here — we use the compile-time
+  `MainThreadMarker` guarantee.
+
+## The `unsafe` that remains (and the `# SAFETY` rule)
+
+`objc2` marks only a few calls `unsafe`; each `unsafe` block does one operation with a
+`SAFETY` comment (workspace lint policy). The current set:
+
+- `NSMenuItem::initWithTitle_action_keyEquivalent` + `setTarget:` (raw selector; target is a
+  *weak* reference, so the tray retains `MenuTarget` for the app's lifetime).
+- `msg_send![super(this), init]` in `MenuTarget::new`.
+- `NSString::to_str(pool)` in the hook (borrow tied to the pool).
+- the hook's accessibility C FFI + the `CBCentralManager` class-method send.
+
+`status_item.rs`/`tray.rs` opt into `#[expect(unsafe_code)]` locally; `unsafe_code` stays
+`deny` for the gui crate otherwise.
+
+## CGEventTap stays on `core-graphics` — on purpose
+
+The event tap in `openlogi-hook/macos.rs` is **not** migrated. `objc2-core-graphics` 0.3
+*does* expose `CGEvent::tap_create`/`tap_enable` (it's not an availability gap), but the
+tap's Accessibility-revoke **freeze-hazard** state machine (the 500 ms run-loop slice +
+self-disable on its own thread) is load-bearing and must stay byte-for-byte. Only the
+`NSWorkspace` frontmost-app read moved to `objc2`. Don't "modernize" the tap casually.
+
+## Off-main autorelease pools
+
+Tray code needs no pool (it runs on the main run loop, and `Retained` frees deterministically).
+The hook's `frontmost_bundle_id` runs on a watcher thread with no run loop, so it keeps an
+explicit `objc2::rc::autoreleasepool` — that's the *only* place a pool belongs.
+
+## Dependencies
+
+`cocoa` / `objc` 0.x are gone from this crate's and the hook's direct deps (they remain in
+`Cargo.lock` only transitively via gpui — expected). Use `cargo add` for objc2 framework
+crates, then **verify the `zed`/`gpui-component` git pins in `Cargo.lock` didn't move** (the
+gpui pin is held only by the lock; a resolve can bump it — restore with `cargo update -p gpui
+--precise <commit>`).
+
+## Build & verify
+
+The gui crate needs the real Xcode toolchain for gpui's Metal shader compile:
+`DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`, `SDKROOT=$(xcrun --show-sdk-path)`,
+`xcbuild` stripped from `PATH`. Behavioural checks (tray icon shows, Open/Quit fire, device
+rows update) need the running app. Confirm an FFI memory fix with `leaks` over a multi-minute
+session: the `CFString`/`NSString` count must stay **flat** (the empirical inverse of #99).

--- a/crates/openlogi-gui/src/platform/permissions.rs
+++ b/crates/openlogi-gui/src/platform/permissions.rs
@@ -85,8 +85,8 @@ mod macos {
         reason = "IOKit (IOHIDCheckAccess) + CoreBluetooth privacy-permission FFI"
     )]
 
-    use objc::runtime::Class;
-    use objc::{msg_send, sel, sel_impl};
+    use objc2::msg_send;
+    use objc2::runtime::AnyClass;
 
     use super::PermissionStatus;
 
@@ -119,13 +119,14 @@ mod macos {
     pub(super) fn bluetooth() -> PermissionStatus {
         // `+[CBManager authorization]` (inherited by CBCentralManager) is a
         // class method returning `CBManagerAuthorization`: notDetermined = 0,
-        // restricted = 1, denied = 2, allowedAlways = 3. Use `Class::get` (not
-        // the `class!` macro) so a missing class degrades to `Unknown` instead
-        // of panicking.
-        let Some(cls) = Class::get("CBCentralManager") else {
+        // restricted = 1, denied = 2, allowedAlways = 3. Use `AnyClass::get`
+        // (not the `class!` macro) so a missing class degrades to `Unknown`
+        // instead of panicking.
+        let Some(cls) = AnyClass::get(c"CBCentralManager") else {
             return PermissionStatus::Unknown;
         };
-        // SAFETY: sending a documented class method that returns an NSInteger.
+        // SAFETY: sending a documented class method (`+authorization`) that
+        // returns a `CBManagerAuthorization` NSInteger.
         let authorization: isize = unsafe { msg_send![cls, authorization] };
         match authorization {
             3 => PermissionStatus::Granted,

--- a/crates/openlogi-gui/src/platform/status_item.rs
+++ b/crates/openlogi-gui/src/platform/status_item.rs
@@ -1,20 +1,31 @@
-//! Thin macOS `NSStatusItem` / `NSMenu` wrapper used by the OpenLogi tray.
+//! Thin `objc2` wrappers over the macOS `NSStatusItem` / `NSMenu` primitives.
+//!
+//! GPUI exposes no status-bar API, so OpenLogi drives `NSStatusItem` directly.
+//! Where the old `cocoa`/`objc` 0.x path modelled every object as a raw,
+//! hand-retained `id` (the source of the issue-#99 `CFString` leak), `objc2`
+//! gives [`Retained<T>`]: ownership is a value, so each object releases itself
+//! on `Drop` and a "+1 with no owner" can't be written. The only `unsafe`
+//! Objective-C calls left — `initWithTitle:action:keyEquivalent:` and
+//! `setTarget:`, which take a raw selector and store a *weak* reference — are
+//! wrapped here behind safe functions; [`super::tray`] builds the OpenLogi menu
+//! on top.
 
 #![expect(
     unsafe_code,
-    reason = "Cocoa NSStatusItem/NSMenu FFI; GPUI has no menu-bar API"
+    reason = "the two Objective-C calls objc2 marks unsafe (init-with-action, set-target) are wrapped here"
 )]
 
-use std::sync::Once;
+use objc2::rc::Retained;
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{MainThreadMarker, MainThreadOnly};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSImage, NSMenu, NSMenuItem, NSStatusBar,
+    NSStatusItem,
+};
+use objc2_foundation::NSString;
 
-use cocoa::base::{NO, YES, id, nil};
-use cocoa::foundation::NSString;
-use objc::declare::ClassDecl;
-use objc::runtime::{Class, Object, Sel};
-use objc::{class, msg_send, sel, sel_impl};
-
-/// Objective-C action callback signature used by status-item menu entries.
-pub(super) type ActionCallback = extern "C" fn(&Object, Sel, id);
+/// `NSVariableStatusItemLength` — a status item sized to its content.
+const VARIABLE_LENGTH: f64 = -1.0;
 
 /// macOS application activation policy values used by OpenLogi.
 #[derive(Clone, Copy)]
@@ -25,297 +36,95 @@ pub(super) enum ActivationPolicy {
     Accessory,
 }
 
-impl ActivationPolicy {
-    fn as_raw(self) -> i64 {
-        match self {
-            Self::Regular => 0,
-            Self::Accessory => 1,
-        }
-    }
+/// Create and return a variable-width status item. The returned [`Retained`]
+/// owns it; the tray keeps it for the app's lifetime.
+pub(super) fn create_status_item() -> Retained<NSStatusItem> {
+    NSStatusBar::systemStatusBar().statusItemWithLength(VARIABLE_LENGTH)
 }
 
-/// Set the process-wide AppKit activation policy.
-pub(super) fn set_activation_policy(policy: ActivationPolicy) {
-    let app: id = unsafe {
-        // SAFETY: `NSApplication.sharedApplication` is a process-wide AppKit
-        // singleton and is available on the main thread after GPUI starts.
-        msg_send![class!(NSApplication), sharedApplication]
+/// Remove `item` from the system status bar during teardown.
+pub(super) fn remove_status_item(item: &NSStatusItem) {
+    NSStatusBar::systemStatusBar().removeStatusItem(item);
+}
+
+/// Use an SF Symbol as the status-item icon, falling back to a text title.
+pub(super) fn set_symbol_icon(
+    item: &NSStatusItem,
+    mtm: MainThreadMarker,
+    symbol: &str,
+    description: &str,
+    fallback_title: &str,
+) {
+    let Some(button) = item.button(mtm) else {
+        return;
     };
-    unsafe {
-        // SAFETY: `app` is the shared `NSApplication`, and the integer value is
-        // one of AppKit's documented activation policies.
-        let _: () = msg_send![app, setActivationPolicy: policy.as_raw()];
+    match NSImage::imageWithSystemSymbolName_accessibilityDescription(
+        &NSString::from_str(symbol),
+        Some(&NSString::from_str(description)),
+    ) {
+        Some(image) => {
+            image.setTemplate(true);
+            button.setImage(Some(&image));
+        }
+        None => button.setTitle(&NSString::from_str(fallback_title)),
     }
 }
 
-/// A retained `NSStatusItem` handle.
-#[derive(Clone, Copy)]
-pub(super) struct StatusItem(usize);
-
-impl StatusItem {
-    /// Create and retain a variable-width status item.
-    pub(super) fn new() -> Self {
-        const VARIABLE_LENGTH: f64 = -1.0;
-
-        let status_bar: id = unsafe {
-            // SAFETY: `NSStatusBar.systemStatusBar` returns the process-wide
-            // status bar when called from the main AppKit thread.
-            msg_send![class!(NSStatusBar), systemStatusBar]
-        };
-        let status_item: id = unsafe {
-            // SAFETY: `status_bar` is AppKit's shared `NSStatusBar`; variable
-            // length is the documented `NSVariableStatusItemLength` sentinel.
-            msg_send![status_bar, statusItemWithLength: VARIABLE_LENGTH]
-        };
-        unsafe {
-            // SAFETY: the newly-created status item is a valid Objective-C
-            // object; retaining keeps it alive for the app lifetime.
-            let _: id = msg_send![status_item, retain];
-        }
-        Self(status_item as usize)
-    }
-
-    /// Show or hide the status item without tearing it down.
-    pub(super) fn set_visible(&self, visible: bool) {
-        let flag = if visible { YES } else { NO };
-        unsafe {
-            // SAFETY: `self.raw()` is the retained `NSStatusItem` created by
-            // `StatusItem::new`; `setVisible:` accepts an Objective-C BOOL.
-            let _: () = msg_send![self.raw(), setVisible: flag];
-        }
-    }
-
-    /// Remove the status item from the system status bar.
-    pub(super) fn remove_from_status_bar(&self) {
-        let status_bar: id = unsafe {
-            // SAFETY: `NSStatusBar.systemStatusBar` returns the process-wide
-            // status bar when called from the main AppKit thread.
-            msg_send![class!(NSStatusBar), systemStatusBar]
-        };
-        unsafe {
-            // SAFETY: `self.raw()` is the retained `NSStatusItem` created by
-            // `StatusItem::new`; removing it from the owning status bar is the
-            // documented AppKit teardown path for menu-bar extras.
-            let _: () = msg_send![status_bar, removeStatusItem: self.raw()];
-        }
-    }
-
-    /// Attach a menu to the status item.
-    pub(super) fn set_menu(&self, menu: Menu) {
-        unsafe {
-            // SAFETY: both handles are retained AppKit objects created by this
-            // module, and `setMenu:` does not take Rust ownership.
-            let _: () = msg_send![self.raw(), setMenu: menu.raw()];
-        }
-    }
-
-    /// Use an SF Symbol as the status-item icon, falling back to a text title.
-    pub(super) fn set_symbol_icon(&self, symbol: &str, description: &str, fallback_title: &str) {
-        let button: id = unsafe {
-            // SAFETY: `self.raw()` is a valid retained `NSStatusItem`; AppKit
-            // returns its button or nil on unsupported versions.
-            msg_send![self.raw(), button]
-        };
-        let image: id = unsafe {
-            // SAFETY: the selector is an AppKit constructor; the arguments are
-            // temporary `NSString`s valid for the duration of the message send.
-            msg_send![class!(NSImage), imageWithSystemSymbolName: nsstring(symbol) accessibilityDescription: nsstring(description)]
-        };
-        if image == nil {
-            unsafe {
-                // SAFETY: `button` is the status-item button returned by
-                // AppKit; setting a text title is valid when no image exists.
-                let _: () = msg_send![button, setTitle: nsstring(fallback_title)];
-            }
-        } else {
-            unsafe {
-                // SAFETY: `image` is a valid `NSImage`; `setTemplate:` accepts
-                // an Objective-C BOOL and does not transfer ownership.
-                let _: () = msg_send![image, setTemplate: YES];
-            }
-            unsafe {
-                // SAFETY: `button` and `image` are AppKit objects; `setImage:`
-                // stores the image according to AppKit ownership rules.
-                let _: () = msg_send![button, setImage: image];
-            }
-        }
-    }
-
-    fn raw(&self) -> id {
-        self.0 as id
-    }
+/// Create a menu with AppKit auto-enabling disabled (OpenLogi manages item
+/// state itself).
+pub(super) fn new_menu(mtm: MainThreadMarker) -> Retained<NSMenu> {
+    let menu = NSMenu::new(mtm);
+    menu.setAutoenablesItems(false);
+    menu
 }
 
-/// A retained `NSMenu` handle.
-#[derive(Clone, Copy)]
-pub(super) struct Menu(usize);
-
-impl Menu {
-    /// Create and retain a menu with AppKit auto-enabling disabled.
-    pub(super) fn new() -> Self {
-        let menu: id = unsafe {
-            // SAFETY: `NSMenu.new` creates a valid AppKit menu on the main
-            // thread.
-            msg_send![class!(NSMenu), new]
-        };
-        unsafe {
-            // SAFETY: `menu` is a valid Objective-C object; retaining keeps it
-            // alive for the status item's lifetime.
-            let _: id = msg_send![menu, retain];
-        }
-        unsafe {
-            // SAFETY: `menu` is a valid `NSMenu`; disabling auto-enabling is a
-            // standard AppKit property mutation.
-            let _: () = msg_send![menu, setAutoenablesItems: NO];
-        }
-        Self(menu as usize)
-    }
-
-    /// Append a menu item.
-    pub(super) fn add_item(&self, item: MenuItem) {
-        unsafe {
-            // SAFETY: `self` and `item` are valid AppKit objects created by
-            // this module; `addItem:` retains according to AppKit rules.
-            let _: () = msg_send![self.raw(), addItem: item.raw()];
-        }
-    }
-
-    /// Append a separator item.
-    pub(super) fn add_separator(&self) {
-        let separator: id = unsafe {
-            // SAFETY: `NSMenuItem.separatorItem` returns a valid autoreleased
-            // separator item suitable for adding to a menu.
-            msg_send![class!(NSMenuItem), separatorItem]
-        };
-        unsafe {
-            // SAFETY: `self.raw()` is a valid `NSMenu`, and `separator` is a
-            // valid `NSMenuItem` returned by AppKit.
-            let _: () = msg_send![self.raw(), addItem: separator];
-        }
-    }
-
-    fn raw(&self) -> id {
-        self.0 as id
-    }
+/// Create a disabled, title-only menu item (used for the device rows).
+pub(super) fn new_disabled_item(mtm: MainThreadMarker, title: &str) -> Retained<NSMenuItem> {
+    let item = NSMenuItem::new(mtm);
+    item.setTitle(&NSString::from_str(title));
+    item.setEnabled(false);
+    item
 }
 
-/// A retained `NSMenuItem` handle.
-#[derive(Clone, Copy)]
-pub(super) struct MenuItem(usize);
-
-impl MenuItem {
-    /// Create a disabled title-only item.
-    pub(super) fn disabled(title: &str) -> Self {
-        let item: id = unsafe {
-            // SAFETY: `NSMenuItem.new` creates a valid menu item on the main
-            // AppKit thread.
-            msg_send![class!(NSMenuItem), new]
-        };
-        unsafe {
-            // SAFETY: `item` is a valid `NSMenuItem`; the temporary `NSString`
-            // is valid for the duration of the message send.
-            let _: () = msg_send![item, setTitle: nsstring(title)];
-        }
-        unsafe {
-            // SAFETY: `item` is a valid `NSMenuItem`; `setEnabled:` accepts an
-            // Objective-C BOOL.
-            let _: () = msg_send![item, setEnabled: NO];
-        }
-        Self(item as usize)
-    }
-
-    /// Create an action item targeting the supplied Objective-C receiver.
-    pub(super) fn action(title: &str, action: Sel, target: &ActionTarget) -> Self {
-        let item: id = unsafe {
-            // SAFETY: `NSMenuItem.alloc` allocates a menu item object for the
-            // following initializer.
-            msg_send![class!(NSMenuItem), alloc]
-        };
-        let item: id = unsafe {
-            // SAFETY: `item` is allocated, `action` is registered on `target`,
-            // and the `NSString` arguments live for this message send.
-            msg_send![item, initWithTitle: nsstring(title) action: action keyEquivalent: nsstring("")]
-        };
-        unsafe {
-            // SAFETY: `item` is an initialized `NSMenuItem`, and `target.raw()`
-            // is a retained Objective-C target object.
-            let _: () = msg_send![item, setTarget: target.raw()];
-        }
-        Self(item as usize)
-    }
-
-    /// Replace the menu item title.
-    pub(super) fn set_title(&self, title: &str) {
-        unsafe {
-            // SAFETY: `self.raw()` is a valid `NSMenuItem`; the temporary
-            // `NSString` is valid for the duration of the message send.
-            let _: () = msg_send![self.raw(), setTitle: nsstring(title)];
-        }
-    }
-
-    /// Show or hide the item — used to collapse spare device rows.
-    pub(super) fn set_hidden(&self, hidden: bool) {
-        let value = if hidden { YES } else { NO };
-        unsafe {
-            // SAFETY: `self.raw()` is a valid `NSMenuItem`; `setHidden:` takes a
-            // BOOL.
-            let _: () = msg_send![self.raw(), setHidden: value];
-        }
-    }
-
-    fn raw(&self) -> id {
-        self.0 as id
-    }
+/// Create an action item that sends `action` to `target` when clicked.
+///
+/// `target` is stored as a *weak* reference by AppKit, so the caller must keep
+/// it alive for as long as the item can be clicked (the tray holds the
+/// `Retained` target for the app's lifetime).
+pub(super) fn new_action_item(
+    mtm: MainThreadMarker,
+    title: &str,
+    action: Sel,
+    target: &AnyObject,
+) -> Retained<NSMenuItem> {
+    // SAFETY: `initWithTitle:action:keyEquivalent:` is NSMenuItem's designated
+    // initializer; the two `NSString`s outlive the call and `action` is a
+    // selector `target` responds to (wired up by `setTarget:` below).
+    let item = unsafe {
+        NSMenuItem::initWithTitle_action_keyEquivalent(
+            NSMenuItem::alloc(mtm),
+            &NSString::from_str(title),
+            Some(action),
+            &NSString::from_str(""),
+        )
+    };
+    // SAFETY: `target` is a live Objective-C object that responds to `action`.
+    // NSMenuItem keeps only a weak reference, so the caller retains `target`
+    // (see the doc comment) — there is no dangling-target window.
+    unsafe { item.setTarget(Some(target)) };
+    item
 }
 
-/// A retained Objective-C target object for menu actions.
-pub(super) struct ActionTarget(usize);
-
-impl ActionTarget {
-    /// Register the target class once and create a retained target instance.
-    pub(super) fn new(class_name: &'static str, methods: &[(Sel, ActionCallback)]) -> Self {
-        register_target_class(class_name, methods);
-        let target_cls = Class::get(class_name).unwrap_or_else(|| class!(NSObject));
-        let target: id = unsafe {
-            // SAFETY: `target_cls` is either the registered target class or
-            // NSObject fallback; `new` returns a valid Objective-C object.
-            msg_send![target_cls, new]
-        };
-        // NSMenuItem keeps only a weak reference to its target — retain it so it
-        // outlives the caller and the action callbacks stay valid.
-        unsafe {
-            // SAFETY: `target` is a valid Objective-C object created above;
-            // retaining intentionally leaks it for the app lifetime.
-            let _: id = msg_send![target, retain];
-        }
-        Self(target as usize)
-    }
-
-    fn raw(&self) -> id {
-        self.0 as id
-    }
+/// Append a separator to `menu`.
+pub(super) fn add_separator(menu: &NSMenu, mtm: MainThreadMarker) {
+    menu.addItem(&NSMenuItem::separatorItem(mtm));
 }
 
-fn register_target_class(class_name: &'static str, methods: &[(Sel, ActionCallback)]) {
-    static REGISTER: Once = Once::new();
-    REGISTER.call_once(|| {
-        if let Some(mut decl) = ClassDecl::new(class_name, class!(NSObject)) {
-            for (selector, callback) in methods {
-                unsafe {
-                    // SAFETY: each callback uses the Objective-C method ABI and
-                    // matches the selector signature used by `NSMenuItem`.
-                    decl.add_method(*selector, *callback);
-                }
-            }
-            decl.register();
-        }
-    });
-}
-
-fn nsstring(s: &str) -> id {
-    unsafe {
-        // SAFETY: `NSString::alloc(nil).init_str` constructs an Objective-C
-        // string from a Rust `&str`; callers use it immediately in msg_send.
-        NSString::alloc(nil).init_str(s)
-    }
+/// Set the process-wide AppKit activation policy (Dock + menu-bar presence).
+pub(super) fn set_activation_policy(mtm: MainThreadMarker, policy: ActivationPolicy) {
+    let raw = match policy {
+        ActivationPolicy::Regular => NSApplicationActivationPolicy::Regular,
+        ActivationPolicy::Accessory => NSApplicationActivationPolicy::Accessory,
+    };
+    let _ = NSApplication::sharedApplication(mtm).setActivationPolicy(raw);
 }

--- a/crates/openlogi-gui/src/platform/tray.rs
+++ b/crates/openlogi-gui/src/platform/tray.rs
@@ -121,6 +121,18 @@ mod macos {
         static TRAY: RefCell<Option<TrayState>> = const { RefCell::new(None) };
     }
 
+    /// Debug-time guard for the tray mutators: GPUI drives them on the main
+    /// thread. A future off-main caller is a bug — it would silently no-op
+    /// (the `!Send` `TrayState` only exists in the main thread's TLS), so make
+    /// that loud in debug builds while staying free in release.
+    #[inline]
+    fn debug_assert_main_thread() {
+        debug_assert!(
+            MainThreadMarker::new().is_some(),
+            "tray function called off the main thread"
+        );
+    }
+
     /// Build and show the status item + its menu. A no-op if already installed
     /// or if called off the main thread (it never is — GPUI drives the tray).
     pub fn install(tx: mpsc::UnboundedSender<TrayEvent>) {
@@ -183,6 +195,7 @@ mod macos {
     /// Remove the status item from the system status bar during teardown.
     /// Dropping [`TrayState`] releases every retained object.
     pub fn uninstall() {
+        debug_assert_main_thread();
         TRAY.with_borrow_mut(|slot| {
             if let Some(state) = slot.take() {
                 status_item::remove_status_item(&state.status_item);
@@ -193,6 +206,7 @@ mod macos {
     /// Show or hide the status-item icon without tearing it down — backs the
     /// "Show in menu bar" setting. A no-op until [`install`] has run.
     pub fn set_visible(visible: bool) {
+        debug_assert_main_thread();
         TRAY.with_borrow(|slot| {
             if let Some(state) = slot.as_ref() {
                 state.status_item.setVisible(visible);
@@ -207,6 +221,7 @@ mod macos {
     /// Each title is a fresh `Retained<NSString>` that releases when the
     /// statement ends — no leak, no autorelease pool (the issue-#99 fix).
     pub fn set_device_lines(lines: &[String]) {
+        debug_assert_main_thread();
         TRAY.with_borrow(|slot| {
             let Some(state) = slot.as_ref() else {
                 return;
@@ -236,6 +251,7 @@ mod macos {
     /// Re-title the Open/Quit items for the current locale. The device rows are
     /// refreshed separately via [`set_device_lines`].
     pub fn refresh_labels() {
+        debug_assert_main_thread();
         TRAY.with_borrow(|slot| {
             if let Some(state) = slot.as_ref() {
                 state
@@ -253,6 +269,7 @@ mod macos {
     /// (recomputed from the live `AppState`, which only the task can read) is
     /// rewritten on the main thread alongside the static labels.
     pub fn request_refresh() {
+        debug_assert_main_thread();
         TRAY.with_borrow(|slot| {
             if let Some(state) = slot.as_ref()
                 && state.sender.send(TrayEvent::Refresh).is_err()

--- a/crates/openlogi-gui/src/platform/tray.rs
+++ b/crates/openlogi-gui/src/platform/tray.rs
@@ -1,14 +1,19 @@
 //! System-tray / status-item presence. macOS-only today, via `NSStatusItem`
-//! (which lives in the menu bar) over raw Cocoa FFI — GPUI exposes no
-//! status-bar API.
+//! (which lives in the menu bar) over `objc2` — GPUI exposes no status-bar API.
 //!
 //! `tray` is the cross-platform-neutral name: macOS has the menu-bar status
 //! item, Windows the system tray / notification area, Linux the
 //! StatusNotifierItem spec. Only macOS is implemented, so the module carries no
 //! stub — every caller gates on `cfg(target_os = "macos")` instead.
 //!
-//! Menu clicks can't reach GPUI's `App`, so they post a [`TrayEvent`] on a
-//! channel that a dedicated task in `main.rs` drains.
+//! All AppKit objects are owned as `Retained<T>` (issue #99: the old raw-`id`
+//! path leaked a `CFString` on every refresh). `NSMenu`/`NSMenuItem` are
+//! `MainThreadOnly`, hence `!Send`, so the tray's state lives in a main-thread
+//! `thread_local` rather than a `Sync` static — the "main thread only" contract
+//! is now enforced by the type system instead of a doc comment.
+//!
+//! Menu clicks can't reach GPUI's `App`, so the [`MenuTarget`] action methods
+//! post a [`TrayEvent`] on a channel that a dedicated task in `main.rs` drains.
 
 #[cfg(target_os = "macos")]
 pub use macos::{
@@ -18,20 +23,22 @@ pub use macos::{
 
 #[cfg(target_os = "macos")]
 mod macos {
-    use std::sync::{
-        OnceLock,
-        atomic::{AtomicBool, Ordering},
-    };
+    #![expect(
+        unsafe_code,
+        reason = "define_class! menu-target subclass + its super-init; GPUI has no menu-bar API"
+    )]
 
-    use cocoa::base::id;
-    use objc::runtime::{Object, Sel};
-    use objc::{sel, sel_impl};
+    use std::cell::RefCell;
+
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyObject, NSObject};
+    use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
+    use objc2_app_kit::{NSMenuItem, NSStatusItem};
+    use objc2_foundation::NSString;
     use tokio::sync::mpsc;
     use tracing::warn;
 
-    use super::super::status_item::{
-        self, ActionCallback, ActionTarget, ActivationPolicy, Menu, MenuItem, StatusItem,
-    };
+    use super::super::status_item::{self, ActivationPolicy};
 
     /// A request raised by clicking a status-bar menu item, or by a live
     /// language switch asking the drain task to re-localize the whole menu.
@@ -43,190 +50,202 @@ mod macos {
         Refresh,
     }
 
-    const TARGET_CLASS: &str = "OpenLogiMenuTarget";
-
-    // Read by the Objective-C action callbacks, which can't capture state.
-    static MENU_TX: OnceLock<mpsc::UnboundedSender<TrayEvent>> = OnceLock::new();
-
-    /// Open/Quit item pointers, kept so a live locale switch can re-title them.
-    /// Stored as opaque menu-item handles; only touched on the main thread.
-    static MENU_REFS: OnceLock<MenuRefs> = OnceLock::new();
-
     /// How many device rows the tray menu can show at once.
     const MAX_DEVICE_ROWS: usize = 8;
 
-    /// The device-status line items, written by [`set_device_lines`] — one per
-    /// connected device, spare rows hidden. Only ever touched on the main thread.
-    static DEVICE_ITEMS: OnceLock<Vec<MenuItem>> = OnceLock::new();
-
-    /// The `NSStatusItem` itself, so [`set_visible`] can show / hide the icon.
-    static STATUS_ITEM: OnceLock<StatusItem> = OnceLock::new();
-
-    /// Whether the status item is currently installed in `NSStatusBar`.
-    static INSTALLED: AtomicBool = AtomicBool::new(false);
-
-    struct MenuRefs {
-        open: MenuItem,
-        quit: MenuItem,
+    /// Instance state for [`MenuTarget`]: the channel back to the drain task.
+    struct MenuTargetIvars {
+        tx: mpsc::UnboundedSender<TrayEvent>,
     }
 
-    struct InstalledMenu {
-        menu: Menu,
-        refs: MenuRefs,
-        device_items: Vec<MenuItem>,
+    define_class!(
+        // SAFETY: NSObject has no subclassing requirements, and `MenuTarget`
+        // does not implement `Drop`.
+        #[unsafe(super(NSObject))]
+        #[thread_kind = MainThreadOnly]
+        #[name = "OpenLogiMenuTarget"]
+        #[ivars = MenuTargetIvars]
+        struct MenuTarget;
+
+        impl MenuTarget {
+            #[unsafe(method(openOpenLogi:))]
+            fn open_openlogi(&self, _sender: Option<&AnyObject>) {
+                self.post(TrayEvent::Open);
+            }
+
+            #[unsafe(method(quitOpenLogi:))]
+            fn quit_openlogi(&self, _sender: Option<&AnyObject>) {
+                self.post(TrayEvent::Quit);
+            }
+        }
+    );
+
+    impl MenuTarget {
+        fn new(mtm: MainThreadMarker, tx: mpsc::UnboundedSender<TrayEvent>) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(MenuTargetIvars { tx });
+            // SAFETY: `init` initializes our freshly-allocated, ivar-set NSObject
+            // subclass and returns it — the two-phase construction objc2's
+            // `define_class!` is designed around.
+            unsafe { msg_send![super(this), init] }
+        }
+
+        fn post(&self, event: TrayEvent) {
+            if self.ivars().tx.send(event).is_err() {
+                warn!(?event, "menu-bar event dropped — GPUI loop gone");
+            }
+        }
     }
 
-    /// Install the status item. Main thread only.
-    ///
-    /// The activation policy (Dock + menu-bar visibility) is *not* set here —
-    /// [`show_in_dock`] / [`hide_from_dock`] manage it as windows open and
-    /// close. The status item, its menu, and the click target are all retained
-    /// for the app's lifetime (a status item lives as long as the process); the
-    /// target in particular *must* be retained, since `NSMenuItem` keeps only a
-    /// weak reference to it.
+    /// Every retained AppKit object the tray needs. `MainThreadOnly` objects are
+    /// `!Send`, so this can only live in a main-thread `thread_local`.
+    struct TrayState {
+        status_item: Retained<NSStatusItem>,
+        /// Open/Quit items, kept so a live locale switch can re-title them.
+        open_item: Retained<NSMenuItem>,
+        quit_item: Retained<NSMenuItem>,
+        /// One per device row; spare rows hidden.
+        device_items: Vec<Retained<NSMenuItem>>,
+        /// A clone of the click channel, so `request_refresh` can post without
+        /// reaching into the (weakly-referenced) target.
+        sender: mpsc::UnboundedSender<TrayEvent>,
+        #[expect(
+            dead_code,
+            reason = "kept alive: NSMenuItem stores only a weak reference to its target"
+        )]
+        target: Retained<MenuTarget>,
+    }
+
+    thread_local! {
+        /// The live tray, or `None` before [`install`] / after [`uninstall`].
+        /// Main-thread only by construction (it holds `!Send` AppKit objects).
+        static TRAY: RefCell<Option<TrayState>> = const { RefCell::new(None) };
+    }
+
+    /// Build and show the status item + its menu. A no-op if already installed
+    /// or if called off the main thread (it never is — GPUI drives the tray).
     pub fn install(tx: mpsc::UnboundedSender<TrayEvent>) {
-        if INSTALLED.swap(true, Ordering::AcqRel) {
-            return;
-        }
-
-        let _ = MENU_TX.set(tx);
-
-        let status_item = StatusItem::new();
-        let _ = STATUS_ITEM.set(status_item);
-        status_item.set_symbol_icon("computermouse.fill", "OpenLogi", "OpenLogi");
-
-        let installed_menu = build_menu();
-        let _ = DEVICE_ITEMS.set(installed_menu.device_items);
-        let _ = MENU_REFS.set(installed_menu.refs);
-        status_item.set_menu(installed_menu.menu);
-    }
-
-    /// Remove the status item from the system status bar during app teardown.
-    ///
-    /// `NSStatusItem`s normally disappear when the process exits, but GPUI's
-    /// graceful quit can leave background workers winding down briefly. Removing
-    /// it explicitly avoids a stale, non-clickable menu-bar gap during teardown
-    /// and makes repeated calls harmless.
-    pub fn uninstall() {
-        if !INSTALLED.swap(false, Ordering::AcqRel) {
-            return;
-        }
-        let Some(item) = STATUS_ITEM.get() else {
+        let Some(mtm) = MainThreadMarker::new() else {
+            warn!("tray install requested off the main thread — skipped");
             return;
         };
-        item.remove_from_status_bar();
+        TRAY.with_borrow_mut(|slot| {
+            if slot.is_some() {
+                return;
+            }
+
+            let status_item = status_item::create_status_item();
+            status_item::set_symbol_icon(
+                &status_item,
+                mtm,
+                "computermouse.fill",
+                "OpenLogi",
+                "OpenLogi",
+            );
+
+            let target = MenuTarget::new(mtm, tx.clone());
+            let menu = status_item::new_menu(mtm);
+
+            let idle = rust_i18n::t!("No devices connected");
+            let mut device_items = Vec::with_capacity(MAX_DEVICE_ROWS);
+            for i in 0..MAX_DEVICE_ROWS {
+                let title = if i == 0 { idle.as_ref() } else { "" };
+                let item = status_item::new_disabled_item(mtm, title);
+                item.setHidden(i != 0);
+                menu.addItem(&item);
+                device_items.push(item);
+            }
+
+            status_item::add_separator(&menu, mtm);
+
+            let open_title = rust_i18n::t!("Open OpenLogi");
+            let open_item =
+                status_item::new_action_item(mtm, &open_title, sel!(openOpenLogi:), &target);
+            menu.addItem(&open_item);
+            let quit_title = rust_i18n::t!("Quit OpenLogi");
+            let quit_item =
+                status_item::new_action_item(mtm, &quit_title, sel!(quitOpenLogi:), &target);
+            menu.addItem(&quit_item);
+
+            // The status item retains the menu, so `menu` may drop after this.
+            status_item.setMenu(Some(&menu));
+
+            *slot = Some(TrayState {
+                status_item,
+                open_item,
+                quit_item,
+                device_items,
+                sender: tx,
+                target,
+            });
+        });
     }
 
-    fn build_menu() -> InstalledMenu {
-        let target = action_target();
-        let menu = Menu::new();
-
-        let idle = rust_i18n::t!("No devices connected");
-        let mut device_items = Vec::with_capacity(MAX_DEVICE_ROWS);
-        for i in 0..MAX_DEVICE_ROWS {
-            let label = if i == 0 {
-                idle.to_string()
-            } else {
-                String::new()
-            };
-            let item = MenuItem::disabled(&label);
-            item.set_hidden(i != 0);
-            menu.add_item(item);
-            device_items.push(item);
-        }
-
-        menu.add_separator();
-
-        let open_selector = sel!(openOpenLogi:);
-        let quit_selector = sel!(quitOpenLogi:);
-        let open_title = rust_i18n::t!("Open OpenLogi");
-        let open_item = MenuItem::action(&open_title, open_selector, &target);
-        menu.add_item(open_item);
-        let quit_title = rust_i18n::t!("Quit OpenLogi");
-        let quit_item = MenuItem::action(&quit_title, quit_selector, &target);
-        menu.add_item(quit_item);
-
-        InstalledMenu {
-            menu,
-            refs: MenuRefs {
-                open: open_item,
-                quit: quit_item,
-            },
-            device_items,
-        }
-    }
-
-    fn action_target() -> ActionTarget {
-        let open_selector = sel!(openOpenLogi:);
-        let quit_selector = sel!(quitOpenLogi:);
-        let target_methods = [
-            (open_selector, open_action as ActionCallback),
-            (quit_selector, quit_action as ActionCallback),
-        ];
-        ActionTarget::new(TARGET_CLASS, &target_methods)
-    }
-
-    /// Show the app in the Dock + menu bar — called when a window opens, so the
-    /// app menu (⌘Q, Settings, …) is available while the window is up.
-    pub fn show_in_dock() {
-        status_item::set_activation_policy(ActivationPolicy::Regular);
-    }
-
-    /// Drop the app out of the Dock + menu bar, leaving only the status item —
-    /// called when the last window closes (and on a `--minimized` launch).
-    pub fn hide_from_dock() {
-        status_item::set_activation_policy(ActivationPolicy::Accessory);
+    /// Remove the status item from the system status bar during teardown.
+    /// Dropping [`TrayState`] releases every retained object.
+    pub fn uninstall() {
+        TRAY.with_borrow_mut(|slot| {
+            if let Some(state) = slot.take() {
+                status_item::remove_status_item(&state.status_item);
+            }
+        });
     }
 
     /// Show or hide the status-item icon without tearing it down — backs the
     /// "Show in menu bar" setting. A no-op until [`install`] has run.
     pub fn set_visible(visible: bool) {
-        let Some(item) = STATUS_ITEM.get() else {
-            return;
-        };
-        item.set_visible(visible);
+        TRAY.with_borrow(|slot| {
+            if let Some(state) = slot.as_ref() {
+                state.status_item.setVisible(visible);
+            }
+        });
     }
 
     /// Update the device rows — one per connected device (e.g.
-    /// `"MX Master 3S · 80%"`, `"G513 Carbon GX Blue"`). Spare rows are hidden;
-    /// an empty list shows the "No devices connected" placeholder. Main-thread
-    /// only, and a no-op until [`install`] has published the items.
+    /// `"MX Master 3S · 80%"`). Spare rows are hidden; an empty list shows the
+    /// "No devices connected" placeholder. A no-op until [`install`] has run.
+    ///
+    /// Each title is a fresh `Retained<NSString>` that releases when the
+    /// statement ends — no leak, no autorelease pool (the issue-#99 fix).
     pub fn set_device_lines(lines: &[String]) {
-        let Some(items) = DEVICE_ITEMS.get() else {
-            return;
-        };
-        if lines.is_empty() {
-            let idle = rust_i18n::t!("No devices connected");
-            if let Some(first) = items.first() {
-                first.set_title(&idle);
-                first.set_hidden(false);
+        TRAY.with_borrow(|slot| {
+            let Some(state) = slot.as_ref() else {
+                return;
+            };
+            if lines.is_empty() {
+                let idle = rust_i18n::t!("No devices connected");
+                if let Some(first) = state.device_items.first() {
+                    first.setTitle(&NSString::from_str(&idle));
+                    first.setHidden(false);
+                }
+                for item in state.device_items.iter().skip(1) {
+                    item.setHidden(true);
+                }
+                return;
             }
-            for item in items.iter().skip(1) {
-                item.set_hidden(true);
+            for (i, item) in state.device_items.iter().enumerate() {
+                if let Some(line) = lines.get(i) {
+                    item.setTitle(&NSString::from_str(line));
+                    item.setHidden(false);
+                } else {
+                    item.setHidden(true);
+                }
             }
-            return;
-        }
-        for (i, item) in items.iter().enumerate() {
-            if let Some(line) = lines.get(i) {
-                item.set_title(line);
-                item.set_hidden(false);
-            } else {
-                item.set_hidden(true);
-            }
-        }
+        });
     }
 
-    /// Re-title the Open/Quit items for the current locale. Main-thread only,
-    /// like every status-item write. The device rows are refreshed separately via
-    /// [`set_device_lines`].
+    /// Re-title the Open/Quit items for the current locale. The device rows are
+    /// refreshed separately via [`set_device_lines`].
     pub fn refresh_labels() {
-        let Some(refs) = MENU_REFS.get() else {
-            return;
-        };
-        let open_title = rust_i18n::t!("Open OpenLogi");
-        let quit_title = rust_i18n::t!("Quit OpenLogi");
-        refs.open.set_title(&open_title);
-        refs.quit.set_title(&quit_title);
+        TRAY.with_borrow(|slot| {
+            if let Some(state) = slot.as_ref() {
+                state
+                    .open_item
+                    .setTitle(&NSString::from_str(&rust_i18n::t!("Open OpenLogi")));
+                state
+                    .quit_item
+                    .setTitle(&NSString::from_str(&rust_i18n::t!("Quit OpenLogi")));
+            }
+        });
     }
 
     /// Ask the drain task to re-localize the whole menu after a live language
@@ -234,22 +253,28 @@ mod macos {
     /// (recomputed from the live `AppState`, which only the task can read) is
     /// rewritten on the main thread alongside the static labels.
     pub fn request_refresh() {
-        post(TrayEvent::Refresh);
+        TRAY.with_borrow(|slot| {
+            if let Some(state) = slot.as_ref()
+                && state.sender.send(TrayEvent::Refresh).is_err()
+            {
+                warn!("tray refresh dropped — GPUI loop gone");
+            }
+        });
     }
 
-    extern "C" fn open_action(_this: &Object, _cmd: Sel, _sender: id) {
-        post(TrayEvent::Open);
+    /// Show the app in the Dock + menu bar — called when a window opens, so the
+    /// app menu (⌘Q, Settings, …) is available while the window is up.
+    pub fn show_in_dock() {
+        if let Some(mtm) = MainThreadMarker::new() {
+            status_item::set_activation_policy(mtm, ActivationPolicy::Regular);
+        }
     }
 
-    extern "C" fn quit_action(_this: &Object, _cmd: Sel, _sender: id) {
-        post(TrayEvent::Quit);
-    }
-
-    fn post(event: TrayEvent) {
-        if let Some(tx) = MENU_TX.get()
-            && tx.send(event).is_err()
-        {
-            warn!(?event, "menu-bar event dropped — GPUI loop gone");
+    /// Drop the app out of the Dock + menu bar, leaving only the status item —
+    /// called when the last window closes (and on a `--minimized` launch).
+    pub fn hide_from_dock() {
+        if let Some(mtm) = MainThreadMarker::new() {
+            status_item::set_activation_policy(mtm, ActivationPolicy::Accessory);
         }
     }
 }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -79,6 +79,12 @@ fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
 /// busy and its heap dirty around the clock (issue #99). Reusing one long-lived
 /// backend is the usage async-hid intends, and keeps the device set warm between
 /// polls. `HidBackend` is `Arc`-backed, so this is shared, not copied.
+///
+/// `enumerate` is also reached from `open_route_writer`, so the inventory
+/// watcher and a (rare) lighting write can enumerate through this one backend
+/// concurrently. That is sound: async-hid declares the backend `Send + Sync`,
+/// `enumerate` only reads a snapshot (`IOHIDManagerCopyDevices`), and sharing a
+/// single long-lived `IOHIDManager` across threads is the model hidapi uses too.
 static HID_BACKEND: LazyLock<HidBackend> = LazyLock::new(HidBackend::default);
 
 pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, async_hid::HidError>

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -8,7 +8,10 @@
 //! collections carry both reports; BLE-direct collections are long-only, and the
 //! `hidpp` channel up-converts outgoing short messages to long for them.
 
-use std::{error::Error, sync::Arc};
+use std::{
+    error::Error,
+    sync::{Arc, LazyLock},
+};
 
 use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceInfo, DeviceReader, DeviceWriter, HidBackend};
 use futures_lite::StreamExt as _;
@@ -67,10 +70,20 @@ fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
         .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
 }
 
+/// Process-wide HID backend, created once and reused for every enumeration.
+///
+/// async-hid's macOS backend wraps an `IOHIDManager`; `HidBackend::default()`
+/// builds, schedules, and (on drop) cancels one. The inventory watcher
+/// enumerates every ~2 s, so building a fresh backend per call spun up and tore
+/// down an `IOHIDManager` on every tick — needless churn that kept the process
+/// busy and its heap dirty around the clock (issue #99). Reusing one long-lived
+/// backend is the usage async-hid intends, and keeps the device set warm between
+/// polls. `HidBackend` is `Arc`-backed, so this is shared, not copied.
+static HID_BACKEND: LazyLock<HidBackend> = LazyLock::new(HidBackend::default);
+
 pub(crate) async fn enumerate_hidpp_devices() -> Result<Vec<async_hid::Device>, async_hid::HidError>
 {
-    let backend = HidBackend::default();
-    let all: Vec<async_hid::Device> = backend.enumerate().await?.collect().await;
+    let all: Vec<async_hid::Device> = HID_BACKEND.enumerate().await?.collect().await;
 
     // One-time visibility into what the OS actually reports for Logitech nodes,
     // so a transport that uses an unexpected vendor page (e.g. a new BLE mouse)

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -13,15 +13,17 @@ openlogi-core = { path = "../openlogi-core", version = "0.4.1" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
+# CGEventTap stays on core-graphics/core-foundation (the freeze-hazard run-loop
+# machinery). The frontmost-app read uses objc2 (NSWorkspace) so no raw `objc`.
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = { workspace = true }
 core-foundation = { workspace = true }
-cocoa = "0.26"
-objc = "0.2"
+objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", features = ["NSString"] }
+objc2-app-kit = { version = "0.3.2", features = ["NSWorkspace", "NSRunningApplication"] }
 
 [lints.rust]
 unsafe_code = "allow"
-unexpected_cfgs = { level = "allow", check-cfg = [] }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -62,54 +62,27 @@ pub(crate) fn prompt_accessibility() {
     let _trusted = unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef().cast()) };
 }
 
-/// Read the frontmost application's bundle identifier via NSWorkspace.
-/// Pure FFI — returns `None` when no app is frontmost or the identifier
-/// is missing / non-UTF8.
+/// Read the frontmost application's bundle identifier via `NSWorkspace`.
+/// Returns `None` when no app is frontmost or the identifier is missing.
 ///
-/// Wrapped in a per-call `NSAutoreleasePool`. Without it, every call on
-/// a non-main thread (the watcher loop) leaks the workspace, app, and
-/// bundle-id objects — at one call per second that's hundreds of MB
-/// after a full workday.
+/// `NSWorkspace` is `AnyThread`, so this is sound on the watcher thread. The
+/// reads return owned `Retained` values (no leak by construction), but the
+/// framework still autoreleases internal temporaries and `to_str` borrows its
+/// UTF-8 view from the pool — so an explicit `autoreleasepool` is required off
+/// the main thread, where no run loop drains one. (Without it the old raw path
+/// leaked the workspace/app/bundle-id objects: hundreds of MB across a workday.)
 pub(crate) fn frontmost_bundle_id() -> Option<String> {
-    use cocoa::base::{id, nil};
-    use cocoa::foundation::{NSAutoreleasePool, NSString};
-    use objc::{class, msg_send, sel, sel_impl};
+    use objc2::rc::autoreleasepool;
+    use objc2_app_kit::NSWorkspace;
 
-    // SAFETY: NSWorkspace is part of AppKit, available on every supported
-    // macOS (≥13.0). Each `msg_send!` returns either `nil` (handled below)
-    // or an autoreleased Objective-C object. The surrounding
-    // `NSAutoreleasePool` drains those temporaries when this function
-    // returns; the Rust `String` we hand back is a copy that outlives
-    // the pool.
-    unsafe {
-        let pool = NSAutoreleasePool::new(nil);
-        let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-        if workspace == nil {
-            let _: () = msg_send![pool, drain];
-            return None;
-        }
-        let app: id = msg_send![workspace, frontmostApplication];
-        if app == nil {
-            let _: () = msg_send![pool, drain];
-            return None;
-        }
-        let bundle_id: id = msg_send![app, bundleIdentifier];
-        if bundle_id == nil {
-            let _: () = msg_send![pool, drain];
-            return None;
-        }
-        let ptr: *const std::os::raw::c_char = NSString::UTF8String(bundle_id);
-        let result = if ptr.is_null() {
-            None
-        } else {
-            std::ffi::CStr::from_ptr(ptr)
-                .to_str()
-                .ok()
-                .map(str::to_owned)
-        };
-        let _: () = msg_send![pool, drain];
-        result
-    }
+    autoreleasepool(|pool| {
+        let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
+        let bundle_id = app.bundleIdentifier()?;
+        // SAFETY: `to_str` yields a UTF-8 view valid for `pool`'s lifetime; we
+        // copy it into an owned `String` before the pool (and `bundle_id`) drop,
+        // so the borrow never escapes.
+        Some(unsafe { bundle_id.to_str(pool) }.to_owned())
+    })
 }
 
 /// Translate a raw OS button number to a [`ButtonId`].


### PR DESCRIPTION
## Why

Issue #99 reports memory climbing to 1 GB+. There were two distinct things behind it:

1. **A real leak.** `status_item.rs::nsstring()` returned a `+1`-owned `NSString` (`NSString::alloc(nil).init_str`) that was never released, and it ran on every 2 s tray refresh via `set_title`. That is exactly the ~26k leaked `CFString`s the reporter's `leaks` run found. The root cause isn't one missing `release` — it's the *representation*: `cocoa`/`objc` 0.x model every object as a raw, hand-retained `id`, so retain/release is an unenforced runtime discipline.
2. **Footprint churn.** `enumerate_hidpp_devices()` rebuilt a whole `HidBackend` (a macOS `IOHIDManager` it schedules and, on drop, cancels) on every ~2 s inventory tick — needless create/teardown that kept the process busy and its heap dirty around the clock.

## What this does

**Migrate the macOS Objective-C FFI from `cocoa`/`objc` 0.x to `objc2`** (already in the tree via gpui/async-hid), so the leak class can't be *written*:

- `Retained<T>` owns each AppKit object and releases it once on `Drop`. `nsstring()` and the autorelease-pool workaround are gone — every string is `NSString::from_str(s)` used as a borrowed temporary. A `+1`-with-no-owner is unrepresentable.
- The `OpenLogiMenuTarget` click target is now a `define_class!` subclass with the event channel in a typed `#[ivars]` (no `ClassDecl`/`add_method`, no `OnceLock<MENU_TX>` read in the callbacks).
- `NSMenu`/`NSMenuItem` are `MainThreadOnly` (`!Send`), so the tray's retained state moves from `OnceLock` statics into a main-thread `thread_local` — "main-thread only" is enforced by the type system, not a doc comment.
- `permissions.rs` (`CBCentralManager.authorization`) and the hook's `frontmost_bundle_id` (`NSWorkspace`, which is `AnyThread` so it's sound on the watcher thread) also move to `objc2`. `cocoa`/`objc` 0.x leave both crates' **direct** dependencies (they remain in `Cargo.lock` only transitively via gpui).

**Reuse one HID backend** in a `LazyLock` instead of rebuilding it per poll — the usage async-hid intends; it also keeps the device set warm between polls.

Plus a scoped `crates/openlogi-gui/src/platform/CLAUDE.md` documenting the conventions.

## What deliberately stays

The CGEventTap stays on `core-graphics`/CF. `objc2-core-graphics` *does* expose the tap API, but the Accessibility-revoke freeze-hazard run-loop machinery is load-bearing — out of scope here, byte-for-byte unchanged. Only the `NSWorkspace` read in that file moved.

## Verification

- `cargo fmt --check`, full-workspace `cargo clippy --all-targets -- -D warnings`, and all tests pass (hook+hid 26, gui 11).
- The `zed`/gpui-component git pins in `Cargo.lock` are unchanged — the lock diff is only the new `objc2-*` crates.io packages.
- **Runtime, against a live MX Master 4:** the dev bundle launches with no crash/panic; the `computermouse.fill` status item renders; the menu builds correctly (AX dump: device row `MX Master 4 · NN%`, separator, `Open OpenLogi`, `Quit OpenLogi`, spare rows hidden); and clicking **Quit OpenLogi** exits the app — confirming the `define_class!` action callback → ivar channel → `cx.quit()` chain fires end to end.

Closes #99.