### PR TITLE
ci(release-plz): drop the unneeded stale-branch prune step

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -67,26 +67,6 @@ jobs:
         with:
           client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
           private-key: ${{ steps.app_key.outputs.pem }}
-      # release-plz leaves its release branch behind after a release PR merges,
-      # and a leftover ref then makes the next `release-pr` fail with HTTP 422
-      # (so no PR is created). Prune any `release-plz/*` branch that no longer
-      # has an open PR — never the active release PR's branch — before running.
-      - name: Prune stale release-plz branches
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          for branch in $(gh api "repos/$REPO/branches" --paginate --jq '.[].name' \
-            | grep '^release-plz/' || true); do
-            open=$(gh pr list --repo "$REPO" --head "$branch" --state open --json number --jq 'length')
-            if [ "$open" = "0" ]; then
-              echo "Pruning stale release branch: $branch"
-              gh api -X DELETE "repos/$REPO/git/refs/heads/$branch" \
-                || echo "::warning::could not delete $branch"
-            else
-              echo "Keeping $branch (open PR exists)"
-            fi
-          done
       - name: Run release-plz (release-pr)
         id: release_pr
         uses: release-plz/action@v0.5
@@ -100,6 +80,9 @@ jobs:
       # quiet week of commits). Fail loudly when release-plz opened/updated no
       # release PR, none is already open, yet release-worthy commits exist since
       # the last tag — that combination means a swallowed failure, not a no-op.
+      # (The blanket 422-swallow is an acknowledged action hack: release-plz/action#264
+      # added it to fix that action's own CI; #427 aims to remove it. Once #427
+      # lands and we pin an action release that includes it, this guard can go.)
       - name: Guard against a silently stalled release
         if: steps.release_pr.outputs.prs_created == 'false'
         env:


### PR DESCRIPTION
## What

Remove the **"Prune stale release-plz branches"** step from the `release-pr` job. Keep the **"Guard against a silently stalled release"** step untouched.

## Why it's a no-op

The prune was added (03b5591) on the theory that a leftover `release-plz/*` ref makes the next `release-pr` fail with HTTP 422. Reading the release-plz source + checking this repo's live state shows that can't happen:

- **Unique branch names.** `release_branch()` in `release_plz_core` builds every release PR branch as `{prefix}{rfc3339-seconds}` (e.g. `release-plz/2026-06-03T15-50-32Z`). Each `create_pr` uses a fresh timestamp, so a leftover ref never name-collides with the next `create_branch` (`POST /git/refs`) — the only thing that returns "Reference already exists".
- **`delete_branch_on_merge` is on.** GitHub deletes the release PR's branch on merge. Verified live: right after #111 (v0.5.0) merged, its branch `release-plz/2026-06-03T15-50-32Z` was already gone and **zero** `release-plz/*` branches remain. Nothing accumulates for the prune to clean.

So the step ran on every push to master and found nothing — and could never have prevented the 422 it names.

## What actually causes a release-pr 422

Token scope (403 "Resource not accessible by integration") and branch-protection **rulesets** blocking ref creation — see release-plz/release-plz#2376 and #2753. This repo's only ruleset targets `master` and doesn't restrict `release-plz/*` creation, and the late-May token/credential fixes are what actually unstuck releases.

## The guard stays

The blanket 422-swallow in `release-plz/action` is an acknowledged hack (added in release-plz/action#264 to fix that action's own CI; #427 aims to remove it). Until #427 lands and we pin an action release including it, the guard is the real safety net — if a release ever does stall it fails **loudly and recoverably**, which is also why dropping the prune is low-risk.

## Verification

- `ruby -ryaml` parse of the workflow: valid; `release-pr` steps are now Mint-token → Run release-plz → Guard.
- `check-yaml` pre-commit hook: passed.