### PR TITLE
fix(assets): match devices against every model id a depot lists

### DIFF
--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -12,15 +12,23 @@
 //!   "schema_version": 1,
 //!   "devices": {
 //!     "<depot>": {
-//!       "modelId": "6b023",
-//!       "displayName": "MX Master 3",
+//!       "modelId": "2b043",
+//!       "modelIds": ["2b043", "2b034"],
+//!       "displayName": "MX Master 3S",
 //!       "type": "MOUSE",
-//!       "asset_path": "v1/devices/mx_master_3/",
+//!       "asset_path": "v1/devices/mx_master_3s/",
 //!       "files": [{ "name": "front_core.png", "sha256": "...", "bytes": 388329 }]
 //!     }
 //!   }
 //! }
 //! ```
+//!
+//! A depot can answer to several model ids — a product's transports and
+//! hardware revisions share one asset depot (the MX Master 3S reports bolt
+//! pid `b034` over BTLE but `b043` via a Bolt receiver). `modelIds` carries
+//! the full set; `modelId` stays as the primary for older clients. Index
+//! files generated before `modelIds` existed simply omit it, so it defaults
+//! to empty and lookups fall back to `modelId`.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -39,6 +47,12 @@ pub struct Index {
 pub struct DeviceEntry {
     #[serde(rename = "modelId")]
     pub model_id: String,
+    /// Every model id Logi lists for this depot — different transports or
+    /// hardware revisions of the same product. Empty on index files that
+    /// predate the field; [`model_id_candidates`](Self::model_id_candidates)
+    /// then falls back to [`model_id`](Self::model_id).
+    #[serde(rename = "modelIds", default)]
+    pub model_ids: Vec<String>,
     #[serde(rename = "displayName")]
     pub display_name: String,
     #[serde(rename = "type")]
@@ -65,6 +79,20 @@ pub const FRONT_RENDER_FILES: [&str; 2] = ["front_core.png", "front.png"];
 pub const BUTTONS_RENDER_FILES: [&str; 2] = ["side_core.png", "side.png"];
 
 impl DeviceEntry {
+    /// Every model id this depot answers to, primary first. Yields the
+    /// canonical [`model_id`](Self::model_id) followed by any additional
+    /// [`model_ids`](Self::model_ids) (deduplicated against the primary).
+    /// On a legacy index without `modelIds` this is just the primary, so
+    /// matching behaves exactly as it did before the field existed.
+    pub fn model_id_candidates(&self) -> impl Iterator<Item = &str> + '_ {
+        std::iter::once(self.model_id.as_str()).chain(
+            self.model_ids
+                .iter()
+                .map(String::as_str)
+                .filter(move |id| !id.eq_ignore_ascii_case(self.model_id.as_str())),
+        )
+    }
+
     /// First of `candidates` this depot's registry file list contains —
     /// the concrete filename for a schema slot (metadata / hero render /
     /// buttons render). `None` when the depot ships none of them.
@@ -97,38 +125,49 @@ impl Index {
         http::load_json(path)
     }
 
-    /// Find the depot whose `modelId` matches `model_id` exactly.
+    /// Find the depot one of whose model ids matches `model_id` exactly.
     #[must_use]
     pub fn find_by_model_id(&self, model_id: &str) -> Option<(&str, &DeviceEntry)> {
         self.devices
             .iter()
-            .find(|(_, entry)| entry.model_id.eq_ignore_ascii_case(model_id))
+            .find(|(_, entry)| {
+                entry
+                    .model_id_candidates()
+                    .any(|id| id.eq_ignore_ascii_case(model_id))
+            })
             .map(|(depot, entry)| (depot.as_str(), entry))
     }
 
-    /// Find the depot whose `modelId` ends with `suffix` (case-insensitive).
+    /// Find the depot one of whose model ids ends with `suffix`
+    /// (case-insensitive).
     ///
     /// Used as a fallback when the strict `ext + bolt_pid` formatting
     /// doesn't line up — Logi's registry stores e.g. `"2b042"` for the
     /// MX Master 4 even though HID++ DeviceInformation reports `ext=01`
-    /// on the same device. Matching on the trailing bolt PID is still
-    /// unambiguous in practice because Logitech reserves PID ranges per
-    /// product family.
+    /// on the same device. Scanning every listed model id also catches a
+    /// transport whose bolt pid differs from the depot's primary — the
+    /// MX Master 3S reports `b034` over BTLE, listed alongside `b043`.
+    /// Matching on the trailing bolt PID is still unambiguous in practice
+    /// because Logitech reserves PID ranges per product family.
     #[must_use]
     pub fn find_by_model_id_suffix(&self, suffix: &str) -> Option<(&str, &DeviceEntry)> {
         let suffix_lower = suffix.to_ascii_lowercase();
         self.devices
             .iter()
-            .find(|(_, entry)| entry.model_id.to_ascii_lowercase().ends_with(&suffix_lower))
+            .find(|(_, entry)| {
+                entry
+                    .model_id_candidates()
+                    .any(|id| id.to_ascii_lowercase().ends_with(&suffix_lower))
+            })
             .map(|(depot, entry)| (depot.as_str(), entry))
     }
 
     /// Find the depot whose `displayName` equals `name` (case-insensitive,
-    /// exact). Last-resort bridge for devices whose live HID++ model PID is
-    /// absent from the registry under every transport — e.g. an MX Master 3S
-    /// connected over BTLE reports model id `b034`, but Logi's registry keys
-    /// it `2b043` (a different transport's PID). The firmware codename
-    /// ("MX Master 3S") still matches the registry `displayName`.
+    /// exact). Last-resort bridge for a device whose live HID++ model id
+    /// matches none of the depot's listed `modelIds` — now mainly a legacy
+    /// index that predates `modelIds` and so lists only one transport's pid
+    /// (e.g. only `2b043` for an MX Master 3S that reports `b034` over BTLE).
+    /// The firmware codename ("MX Master 3S") still matches the `displayName`.
     #[must_use]
     pub fn find_by_display_name(&self, name: &str) -> Option<(&str, &DeviceEntry)> {
         self.devices
@@ -146,6 +185,7 @@ mod tests {
     fn entry(model_id: &str, display_name: &str) -> DeviceEntry {
         DeviceEntry {
             model_id: model_id.to_string(),
+            model_ids: Vec::new(),
             display_name: display_name.to_string(),
             kind: "mouse".to_string(),
             asset_path: "assets/mx_master_3s/".to_string(),
@@ -154,12 +194,62 @@ mod tests {
     }
 
     fn index_with(depot: &str, model_id: &str, display_name: &str) -> Index {
+        index_of(depot, entry(model_id, display_name))
+    }
+
+    fn index_of(depot: &str, entry: DeviceEntry) -> Index {
         let mut devices = HashMap::new();
-        devices.insert(depot.to_string(), entry(model_id, display_name));
+        devices.insert(depot.to_string(), entry);
         Index {
             schema_version: 1,
             devices,
         }
+    }
+
+    #[test]
+    fn model_id_candidates_falls_back_to_primary_for_legacy_entry() {
+        // No `modelIds` (old index) → matching runs off the lone `modelId`.
+        let e = entry("2b043", "MX Master 3S");
+        assert_eq!(e.model_id_candidates().collect::<Vec<_>>(), ["2b043"]);
+    }
+
+    #[test]
+    fn model_id_candidates_lists_primary_then_extras_without_dupes() {
+        let mut e = entry("2b043", "MX Master 3S");
+        e.model_ids = vec!["2b043".into(), "2b034".into()];
+        assert_eq!(
+            e.model_id_candidates().collect::<Vec<_>>(),
+            ["2b043", "2b034"]
+        );
+    }
+
+    #[test]
+    fn find_by_model_id_matches_any_listed_id() {
+        let mut e = entry("2b043", "MX Master 3S");
+        e.model_ids = vec!["2b043".into(), "2b034".into()];
+        let index = index_of("mx_master_3s", e);
+        // Both the primary and the secondary id resolve to the depot.
+        assert_eq!(
+            index.find_by_model_id("2b034").map(|(d, _)| d),
+            Some("mx_master_3s")
+        );
+        assert_eq!(
+            index.find_by_model_id("2b043").map(|(d, _)| d),
+            Some("mx_master_3s")
+        );
+    }
+
+    #[test]
+    fn find_by_model_id_suffix_matches_secondary_id() {
+        // The BTLE MX Master 3S reports bolt pid `b034`; listing it next to
+        // `b043` lets the suffix match resolve the depot by pid alone.
+        let mut e = entry("2b043", "MX Master 3S");
+        e.model_ids = vec!["2b043".into(), "2b034".into()];
+        let index = index_of("mx_master_3s", e);
+        assert_eq!(
+            index.find_by_model_id_suffix("b034").map(|(d, _)| d),
+            Some("mx_master_3s")
+        );
     }
 
     #[test]

--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -178,6 +178,7 @@ impl Index {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
     use std::collections::HashMap;
@@ -250,6 +251,55 @@ mod tests {
             index.find_by_model_id_suffix("b034").map(|(d, _)| d),
             Some("mx_master_3s")
         );
+    }
+
+    #[test]
+    fn deserializes_modelids_schema_emitted_by_stage_assets() {
+        // The exact entry shape `stage_assets.py` writes — `modelIds` plus
+        // fields the client doesn't model (`extendedDisplayName`). Parsing
+        // must keep the list and resolve the BTLE pid; unknown fields ignored.
+        let json = r#"{
+            "schema_version": 1,
+            "devices": {
+                "mx_master_3s": {
+                    "modelId": "2b043",
+                    "modelIds": ["2b034", "2b043"],
+                    "displayName": "MX Master 3S",
+                    "extendedDisplayName": "Wireless Mouse MX Master 3S",
+                    "type": "MOUSE",
+                    "asset_path": "v1/devices/mx_master_3s/",
+                    "files": [{"name": "front_core.png", "sha256": "ab", "bytes": 1}]
+                }
+            }
+        }"#;
+        let index: Index = serde_json::from_str(json).expect("parse modelIds index");
+        assert_eq!(
+            index.find_by_model_id_suffix("b034").map(|(d, _)| d),
+            Some("mx_master_3s")
+        );
+        assert_eq!(index.devices["mx_master_3s"].model_ids, ["2b034", "2b043"]);
+    }
+
+    #[test]
+    fn deserializes_legacy_schema_without_modelids() {
+        // An index published before `modelIds`: the field is absent, defaults
+        // to empty, and matching still works off the lone `modelId`.
+        let json = r#"{
+            "schema_version": 1,
+            "devices": {
+                "mx_master_3s": {
+                    "modelId": "2b043",
+                    "displayName": "MX Master 3S",
+                    "type": "MOUSE",
+                    "asset_path": "v1/devices/mx_master_3s/",
+                    "files": []
+                }
+            }
+        }"#;
+        let index: Index = serde_json::from_str(json).expect("parse legacy index");
+        let entry = &index.devices["mx_master_3s"];
+        assert!(entry.model_ids.is_empty());
+        assert_eq!(entry.model_id_candidates().collect::<Vec<_>>(), ["2b043"]);
     }
 
     #[test]

--- a/crates/openlogi-gui/src/asset/images.rs
+++ b/crates/openlogi-gui/src/asset/images.rs
@@ -38,11 +38,15 @@ pub(super) fn read_png_dimensions(path: &Path) -> std::io::Result<(u32, u32)> {
     Ok((width, height))
 }
 
-/// Walk the depot's `manifest.json` (if present) for the colour
-/// variant matching `ext`. Returns the `device_image` src filename or
-/// `None` when the manifest is missing / malformed / lacks the variant.
-pub(super) fn variant_image_for(dir: &Path, base_model_id: &str, ext: u8) -> Option<String> {
-    let manifest = load_manifest(dir)?;
+/// Look up the colour variant matching `ext` in an already-loaded depot
+/// manifest. Returns the `device_image` src filename or `None` when the
+/// manifest lacks that variant. Pure — the caller loads the manifest once
+/// (see [`load_manifest`]) and reuses it across candidate bases.
+pub(super) fn variant_image_for(
+    manifest: &DepotManifest,
+    base_model_id: &str,
+    ext: u8,
+) -> Option<String> {
     manifest
         .resource_for_variant(base_model_id, ext, "device_image")
         .map(str::to_string)
@@ -51,14 +55,20 @@ pub(super) fn variant_image_for(dir: &Path, base_model_id: &str, ext: u8) -> Opt
 /// Like [`variant_image_for`] but returns the `device_buttons_image`
 /// resource (typically `side_*.png`) — that's the view Logi calibrates
 /// the assignment markers against, so the mouse-model render uses it.
-pub(super) fn buttons_image_for(dir: &Path, base_model_id: &str, ext: u8) -> Option<String> {
-    let manifest = load_manifest(dir)?;
+pub(super) fn buttons_image_for(
+    manifest: &DepotManifest,
+    base_model_id: &str,
+    ext: u8,
+) -> Option<String> {
     manifest
         .resource_for_variant(base_model_id, ext, "device_buttons_image")
         .map(str::to_string)
 }
 
-fn load_manifest(dir: &Path) -> Option<DepotManifest> {
+/// Load and parse a depot's `manifest.json`, or `None` when it's missing /
+/// malformed. Read once per [`load_files`](super::AssetResolver::load_files)
+/// so the variant lookups above don't re-parse it for each candidate base.
+pub(super) fn load_manifest(dir: &Path) -> Option<DepotManifest> {
     let manifest_path = dir.join("manifest.json");
     if !manifest_path.exists() {
         return None;

--- a/crates/openlogi-gui/src/asset/mod.rs
+++ b/crates/openlogi-gui/src/asset/mod.rs
@@ -129,9 +129,18 @@ impl AssetResolver {
             // `side_*.png`), so we prefer that resource for the
             // mouse-model render — otherwise hotspot percentages drift
             // off every button. `front_*.png` is left for the carousel.
-            let buttons_name = buttons_image_for(&dir, &entry.model_id, model.extended_model_id);
-            let variant_front_name =
-                variant_image_for(&dir, &entry.model_id, model.extended_model_id);
+            //
+            // The depot's manifest keys variants on one of its model ids,
+            // which isn't always the index primary — the MX Master 3S
+            // manifest is keyed on `2b034` while the index lists `2b043`
+            // first. Try each listed id as the variant base so the right
+            // colour render resolves regardless of which pid Logi keyed on.
+            let buttons_name = entry
+                .model_id_candidates()
+                .find_map(|base| buttons_image_for(&dir, base, model.extended_model_id));
+            let variant_front_name = entry
+                .model_id_candidates()
+                .find_map(|base| variant_image_for(&dir, base, model.extended_model_id));
             // Front/hero render for the gallery: the colour variant's
             // `device_image`, falling back to the generic front renders. Resolved
             // against this same root so it sits beside the buttons image.
@@ -289,26 +298,45 @@ mod tests {
     use openlogi_core::device::DeviceTransports;
     use std::collections::HashMap;
 
-    fn mx_master_3s_index() -> Index {
+    fn mx_master_3s_entry(model_ids: Vec<String>) -> DeviceEntry {
+        DeviceEntry {
+            model_id: "2b043".to_string(),
+            model_ids,
+            display_name: "MX Master 3S".to_string(),
+            kind: "mouse".to_string(),
+            asset_path: "assets/mx_master_3s/".to_string(),
+            files: Vec::new(),
+        }
+    }
+
+    fn index_of(depot: &str, entry: DeviceEntry) -> Index {
         let mut devices = HashMap::new();
-        devices.insert(
-            "mx_master_3s".to_string(),
-            DeviceEntry {
-                model_id: "2b043".to_string(),
-                display_name: "MX Master 3S".to_string(),
-                kind: "mouse".to_string(),
-                asset_path: "assets/mx_master_3s/".to_string(),
-                files: Vec::new(),
-            },
-        );
+        devices.insert(depot.to_string(), entry);
         Index {
             schema_version: 1,
             devices,
         }
     }
 
-    /// An MX Master 3S connected over BTLE reports model id `b034` / ext 1 —
-    /// absent from the registry, which keys the 3S under `2b043`.
+    /// The current registry: the 3S depot lists both bolt pids Logi ships for
+    /// it (`b043` via a Bolt receiver, `b034` over BTLE).
+    fn mx_master_3s_index() -> Index {
+        index_of(
+            "mx_master_3s",
+            mx_master_3s_entry(vec!["2b043".into(), "2b034".into()]),
+        )
+    }
+
+    /// A legacy index generated before `modelIds` existed: only the primary
+    /// pid `2b043` is listed, so the BTLE pid `b034` matches nothing.
+    fn legacy_mx_master_3s_index() -> Index {
+        index_of("mx_master_3s", mx_master_3s_entry(Vec::new()))
+    }
+
+    /// An MX Master 3S connected over BTLE reports bolt pid `b034` / ext 1.
+    /// The strict `{ext}{pid}` key (`1b034`) matches no registry entry — the
+    /// depot lists `2b034`/`2b043` (ext 2) — so the suffix `b034` is what
+    /// bridges it.
     fn btle_3s_model() -> DeviceModelInfo {
         DeviceModelInfo {
             entity_count: 0,
@@ -324,17 +352,27 @@ mod tests {
     }
 
     #[test]
-    fn pid_matching_alone_misses_btle_3s() {
-        // The bug: no model id the device reports (`b034`) appears in the
-        // registry, so strict + suffix PID matching both fail.
+    fn secondary_pid_resolves_btle_3s_without_codename() {
+        // The fix: the depot lists `2b034` alongside `2b043`, so the suffix
+        // match on `b034` resolves the BTLE 3S by pid — no codename needed.
         let index = mx_master_3s_index();
+        let hit = resolve_in_index(&index, &btle_3s_model(), None);
+        assert_eq!(hit.map(|(depot, _)| depot), Some("mx_master_3s"));
+    }
+
+    #[test]
+    fn legacy_index_misses_btle_3s_by_pid() {
+        // Before `modelIds`: only `2b043` is listed, so neither strict nor
+        // suffix pid matching finds the BTLE 3S (`b034`).
+        let index = legacy_mx_master_3s_index();
         assert!(resolve_in_index(&index, &btle_3s_model(), None).is_none());
     }
 
     #[test]
-    fn codename_bridges_btle_3s_to_its_depot() {
-        // The fix: the firmware codename matches the registry displayName.
-        let index = mx_master_3s_index();
+    fn codename_bridges_btle_3s_on_legacy_index() {
+        // Back-compat: on a legacy index the firmware codename still bridges
+        // to the depot via displayName.
+        let index = legacy_mx_master_3s_index();
         let hit = resolve_in_index(&index, &btle_3s_model(), Some("MX Master 3S"));
         assert_eq!(hit.map(|(depot, _)| depot), Some("mx_master_3s"));
     }
@@ -390,6 +428,7 @@ mod tests {
         };
         let entry = DeviceEntry {
             model_id: "eb020".to_string(),
+            model_ids: Vec::new(),
             display_name: "MX Vertical".to_string(),
             kind: "MOUSE".to_string(),
             asset_path: format!("v1/devices/{depot}/"),

--- a/crates/openlogi-gui/src/asset/mod.rs
+++ b/crates/openlogi-gui/src/asset/mod.rs
@@ -25,7 +25,7 @@ use openlogi_assets::{
 use openlogi_core::device::DeviceModelInfo;
 use tracing::{debug, warn};
 
-use self::images::{buttons_image_for, read_png_dimensions, variant_image_for};
+use self::images::{buttons_image_for, load_manifest, read_png_dimensions, variant_image_for};
 use self::paths::{bundle_assets_root, load_index, user_cache_root};
 
 #[derive(Debug, Clone)]
@@ -135,12 +135,18 @@ impl AssetResolver {
             // manifest is keyed on `2b034` while the index lists `2b043`
             // first. Try each listed id as the variant base so the right
             // colour render resolves regardless of which pid Logi keyed on.
-            let buttons_name = entry
-                .model_id_candidates()
-                .find_map(|base| buttons_image_for(&dir, base, model.extended_model_id));
-            let variant_front_name = entry
-                .model_id_candidates()
-                .find_map(|base| variant_image_for(&dir, base, model.extended_model_id));
+            // Parse the manifest once and consult it for every candidate.
+            let manifest = load_manifest(&dir);
+            let buttons_name = manifest.as_ref().and_then(|m| {
+                entry
+                    .model_id_candidates()
+                    .find_map(|base| buttons_image_for(m, base, model.extended_model_id))
+            });
+            let variant_front_name = manifest.as_ref().and_then(|m| {
+                entry
+                    .model_id_candidates()
+                    .find_map(|base| variant_image_for(m, base, model.extended_model_id))
+            });
             // Front/hero render for the gallery: the colour variant's
             // `device_image`, falling back to the generic front renders. Resolved
             // against this same root so it sits beside the buttons image.


### PR DESCRIPTION
## Problem

A device whose live HID++ model id wasn't the depot's one published `modelId` couldn't be matched by pid and fell through to the fragile `codename`↔`displayName` string bridge — or missed entirely (webcams have no codename). This is why an **MX Master 3S over BTLE** lands on the synthetic silhouette instead of its render.

## Root cause (verified against real hardware + Logi's data)

A Logitech asset depot can answer to several model ids — a product's transports and hardware revisions share one depot:

- An MX Anywhere 3S over BTLE reports `model_ids=[b037,…]`, `ext=01`, `transports=btle` — a **single** pid, not the spec's "transport-independent dense array". So pid matching genuinely can't reach across to a receiver-side pid.
- The MX Master 3S reports bolt pid `b034` over BTLE but `b043` via a Bolt receiver, and its depot manifest keys colour variants on `2b034` while the index listed `2b043`.

Logi's `devices.json` actually lists **both** ids (`2b034` and `2b043`) for the `mx_master_3s` depot, but the assets generator keyed its registry by depot (last write wins), dropping all but one pid. 8 depots were affected (`mx_master_3s`, `mx_master_3s_for_business`, `k480`, `m280`, several webcams).

The data half — emitting the full `modelIds` list — landed and deployed in [`openlogi-org/assets`](https://github.com/openlogi-org/assets) (`assets.openlogi.org/index.json` now carries `modelIds`).

## This PR (client half)

- `DeviceEntry` parses an optional `modelIds` list (`#[serde(default)]`) and exposes `model_id_candidates()` — the primary `modelId` first, then any extras.
- `find_by_model_id` / `find_by_model_id_suffix` scan every candidate, so the BTLE 3S resolves via the `b034` suffix without touching the codename path.
- The manifest variant-base lookup in `load_files` tries each candidate base, so the right colour render resolves even when the manifest is keyed on a non-primary pid (`2b034` vs the index's `2b043`).
- `find_by_display_name` (codename bridge) drops to a genuine last resort, for legacy indexes only.

## Backward compatibility

- **Old binary + new index**: `modelIds` is an unknown field (no `deny_unknown_fields`) → ignored; matching runs off the unchanged primary `modelId`.
- **New binary + old index**: `modelIds` absent → defaults to empty → `model_id_candidates()` falls back to the single `modelId`, and the codename bridge still covers what pid matching can't.
- `schema_version` is unchanged — the field is purely additive and never validated.

## Test plan

- `openlogi-assets`: unit tests for candidate fallback, exact/suffix matching against a secondary id, and serde round-trips of both the new `modelIds` schema (the exact shape `stage_assets.py` emits, unknown fields ignored) and a legacy entry without it.
- `openlogi-gui`: `secondary_pid_resolves_btle_3s_without_codename` (regression), `legacy_index_misses_btle_3s_by_pid` + `codename_bridges_btle_3s_on_legacy_index` (back-compat).
- `cargo test` / `clippy -D warnings` / `fmt` green for both crates (full-workspace pre-push clippy passed).

Note: the user-facing effect for the Master 3S only activates once this client ships — the live index already carries the data.

## Related

Related to #134. Both leave a device stuck on the synthetic silhouette, but the causes are independent: #134 is the startup asset sync running once and never retrying on failure; this PR is a device's live pid being absent from the published index. They can land separately.
