### PR TITLE
feat(gui): SmartShift settings panel (wheel mode, sensitivity, permanent ratchet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ OpenLogi talks to Logitech HID++ mice over a Logi Bolt receiver — or a
 Bluetooth-direct / wired connection — without running Logi Options+. It ships
 two binaries:
 
-- **[OpenLogi GUI](crates/openlogi-gui)** — a GPUI desktop app: an interactive mouse diagram with clickable hotspots, a per-button action picker (39 built-in actions plus recorded custom shortcuts), DPI presets, a SmartShift toggle, per-application profile overlays, a device carousel that switches between paired devices live, and a Settings window with a UI localized into six languages.
+- **[OpenLogi GUI](crates/openlogi-gui)** — a GPUI desktop app: an interactive mouse diagram with clickable hotspots, a per-button action picker (39 built-in actions plus recorded custom shortcuts), DPI presets, a SmartShift panel (wheel mode, sensitivity, permanent ratchet), per-application profile overlays, a device carousel that switches between paired devices live, and a Settings window with a UI localized into six languages.
 - **[OpenLogi CLI](crates/openlogi-cli)** — a CLI for headless inventory (`list`) plus asset-sync and on-device diagnostic subcommands.
 
 Everything is local: bindings live in a plain TOML file, button presses are remapped through the OS event tap, and DPI / SmartShift changes are written straight to the device over HID++.
@@ -54,7 +54,7 @@ macOS is supported today; Linux and Windows are coming soon — see
 | Button remapping via the OS event tap (side Back / Forward today) | ✅ macOS |
 | 39-action catalog + recorded custom keyboard shortcuts | ✅ macOS¹ |
 | DPI control + presets + Cycle / Set-preset actions (HID++ `0x2201`) | ✅ macOS |
-| SmartShift wheel-mode toggle (HID++ `0x2111`) | ✅ macOS |
+| SmartShift wheel: mode toggle + sensitivity + permanent-ratchet panel (HID++ `0x2111`) | ✅ macOS |
 | Per-application profile overlays (auto-switch on app focus) | ✅ macOS |
 | Settings window: launch-at-login, update check, menu-bar, permissions, language | ✅ macOS |
 | Interface localization (6 languages: en, ja, ru, zh-CN, zh-HK, zh-TW) | ✅ macOS |

--- a/crates/openlogi-cli/src/cmd/diag/smartshift.rs
+++ b/crates/openlogi-cli/src/cmd/diag/smartshift.rs
@@ -21,8 +21,8 @@ pub async fn run(args: SmartshiftArgs) -> Result<()> {
         .await
         .context("read SmartShift status")?;
     println!(
-        "  current: mode={:?} sensitivity={}",
-        before.mode, before.sensitivity
+        "  current: mode={:?} auto_disengage={} torque={}",
+        before.mode, before.auto_disengage, before.tunable_torque
     );
 
     let new_mode = openlogi_hid::toggle_smartshift(&route)
@@ -34,8 +34,8 @@ pub async fn run(args: SmartshiftArgs) -> Result<()> {
         .await
         .context("read SmartShift after toggle")?;
     println!(
-        "  read-back: mode={:?} sensitivity={}",
-        after.mode, after.sensitivity
+        "  read-back: mode={:?} auto_disengage={} torque={}",
+        after.mode, after.auto_disengage, after.tunable_torque
     );
 
     if after.mode == before.mode {

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -585,6 +585,79 @@ _version: 2
   zh-HK: 新增
   zh-TW: 新增
 
+# ── SmartShift panel (components/smartshift_panel.rs) ───────────────────────
+# "SmartShift" (card title) and "On"/"Off" are intentionally absent: the brand
+# name is identical across locales (English-key fallback), and On/Off are
+# already defined for the lighting toggle above. "Sensitivity" is rendered as
+# "切换灵敏度" / "切り替え感度" etc. rather than the bare "灵敏度" the DPI panel
+# uses, so the two cards stacked in the Pointer tab stay distinguishable.
+"Wheel mode":
+  ja: ホイールモード
+  ru: "Режим колеса"
+  zh-CN: 滚轮模式
+  zh-HK: 滾輪模式
+  zh-TW: 滾輪模式
+"Free spin":
+  ja: フリースピン
+  ru: "Свободное вращение"
+  zh-CN: 自由滚动
+  zh-HK: 自由滾動
+  zh-TW: 自由滾動
+"Ratchet":
+  ja: ラチェット
+  ru: "Трещотка"
+  zh-CN: 棘轮
+  zh-HK: 棘輪
+  zh-TW: 棘輪
+"Sensitivity":
+  ja: 切り替え感度
+  ru: "Чувствительность переключения"
+  zh-CN: 切换灵敏度
+  zh-HK: 切換靈敏度
+  zh-TW: 切換靈敏度
+"Higher keeps the ratchet engaged longer before free-spin.":
+  ja: 値を大きくすると、フリースピンに切り替わるまでラチェットが長く維持されます。
+  ru: "Большее значение дольше удерживает трещотку до перехода в свободное вращение."
+  zh-CN: 数值越高，棘轮保持越久才进入自由滚动。
+  zh-HK: 數值越高，棘輪維持越久才進入自由滾動。
+  zh-TW: 數值越高，棘輪維持越久才會進入自由滾動。
+"Permanent ratchet":
+  ja: 常時ラチェット
+  ru: "Постоянная трещотка"
+  zh-CN: 永久棘轮
+  zh-HK: 永久棘輪
+  zh-TW: 永久棘輪
+"Never auto-switch to free-spin.":
+  ja: フリースピンに自動で切り替えません。
+  ru: "Никогда автоматически не переключаться в свободное вращение."
+  zh-CN: 永不自动切换到自由滚动。
+  zh-HK: 永不自動切換至自由滾動。
+  zh-TW: 永不自動切換至自由滾動。
+"Device offline — SmartShift unavailable.":
+  ja: デバイスがオフラインです — SmartShift は利用できません。
+  ru: "Устройство не в сети — SmartShift недоступен."
+  zh-CN: 设备离线 —— SmartShift 不可用。
+  zh-HK: 裝置離線 —— SmartShift 不可用。
+  zh-TW: 裝置離線 —— SmartShift 無法使用。
+"Reading SmartShift settings…":
+  ja: SmartShift 設定を読み取り中…
+  ru: "Чтение настроек SmartShift…"
+  zh-CN: 正在读取 SmartShift 设置…
+  zh-HK: 正在讀取 SmartShift 設定…
+  zh-TW: 正在讀取 SmartShift 設定…
+"Couldn't read SmartShift — click to retry.":
+  ja: SmartShift を読み取れませんでした — クリックして再試行。
+  ru: "Не удалось прочитать SmartShift — нажмите, чтобы повторить."
+  zh-CN: 无法读取 SmartShift —— 点击重试。
+  zh-HK: 無法讀取 SmartShift —— 點擊重試。
+  zh-TW: 無法讀取 SmartShift —— 按一下重試。
+"This device does not support SmartShift.":
+  ja: このデバイスは SmartShift に対応していません。
+  ru: "Это устройство не поддерживает SmartShift."
+  zh-CN: 此设备不支持 SmartShift。
+  zh-HK: 此裝置不支援 SmartShift。
+  zh-TW: 此裝置不支援 SmartShift。
+
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
   ja: "%{name} を割り当て"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -25,6 +25,7 @@ use crate::asset::AssetResolver;
 use crate::components::carousel::Carousel;
 use crate::components::dpi_panel::DpiPanel;
 use crate::components::lighting_panel::LightingPanel;
+use crate::components::smartshift_panel::SmartShiftPanel;
 use crate::mouse_model::view::MouseModelView;
 use crate::state::{AppState, DeviceRecord};
 use crate::theme::{self, FOOTER_H, HEADER_H, Palette};
@@ -129,6 +130,7 @@ pub struct AppView {
     route: Route,
     mouse_model: Entity<MouseModelView>,
     dpi_panel: Entity<DpiPanel>,
+    smartshift_panel: Entity<SmartShiftPanel>,
     lighting_panel: Entity<LightingPanel>,
     #[allow(dead_code, reason = "held to keep the appearance observer alive")]
     appearance_obs: Option<Subscription>,
@@ -175,12 +177,14 @@ impl AppView {
 
         let mouse_model = cx.new(MouseModelView::new);
         let dpi_panel = cx.new(DpiPanel::new);
+        let smartshift_panel = cx.new(SmartShiftPanel::new);
         let lighting_panel = cx.new(LightingPanel::new);
         let state_obs = cx.observe_global::<AppState>(|_, cx| cx.notify());
         Self {
             route: Route::Home,
             mouse_model,
             dpi_panel,
+            smartshift_panel,
             lighting_panel,
             appearance_obs: None,
             state_obs,
@@ -345,6 +349,7 @@ impl Render for AppView {
                 detail_content(
                     &self.mouse_model,
                     &self.dpi_panel,
+                    &self.smartshift_panel,
                     &self.lighting_panel,
                     self.active_tab,
                     pal,
@@ -713,6 +718,7 @@ fn main_window_title(show_device: bool, cx: &Context<AppView>) -> SharedString {
 fn detail_content(
     mouse_model: &Entity<MouseModelView>,
     dpi_panel: &Entity<DpiPanel>,
+    smartshift_panel: &Entity<SmartShiftPanel>,
     lighting_panel: &Entity<LightingPanel>,
     active: DetailTab,
     pal: Palette,
@@ -731,7 +737,7 @@ fn detail_content(
     };
     let content = match active {
         DetailTab::Buttons => buttons_tab(mouse_model).into_any_element(),
-        DetailTab::Pointer => pointer_tab(dpi_panel, pal).into_any_element(),
+        DetailTab::Pointer => pointer_tab(dpi_panel, smartshift_panel, pal).into_any_element(),
         DetailTab::Lighting => lighting_tab(lighting_panel, pal).into_any_element(),
         DetailTab::Device => device_tab(pal, cx).into_any_element(),
     };
@@ -785,8 +791,13 @@ fn buttons_tab(mouse_model: &Entity<MouseModelView>) -> impl IntoElement {
         )
 }
 
-/// Pointer tab: the DPI panel in a titled card.
-fn pointer_tab(dpi_panel: &Entity<DpiPanel>, pal: Palette) -> impl IntoElement {
+/// Pointer tab: the DPI panel and the SmartShift wheel controls, each in a
+/// titled card, stacked.
+fn pointer_tab(
+    dpi_panel: &Entity<DpiPanel>,
+    smartshift_panel: &Entity<SmartShiftPanel>,
+    pal: Palette,
+) -> impl IntoElement {
     v_flex()
         .flex_1()
         .w_full()
@@ -794,11 +805,18 @@ fn pointer_tab(dpi_panel: &Entity<DpiPanel>, pal: Palette) -> impl IntoElement {
         .items_center()
         .overflow_y_scrollbar()
         .p_6()
+        .gap_4()
         .child(div().w_full().max_w(px(560.)).child(panel_card(
             tr!("Pointer tuning"),
             IconName::Settings,
             pal,
             dpi_panel.clone().into_any_element(),
+        )))
+        .child(div().w_full().max_w(px(560.)).child(panel_card(
+            tr!("SmartShift"),
+            IconName::Settings,
+            pal,
+            smartshift_panel.clone().into_any_element(),
         )))
 }
 

--- a/crates/openlogi-gui/src/components/mod.rs
+++ b/crates/openlogi-gui/src/components/mod.rs
@@ -7,3 +7,4 @@
 pub mod carousel;
 pub mod dpi_panel;
 pub mod lighting_panel;
+pub mod smartshift_panel;

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -1,0 +1,450 @@
+//! SmartShift wheel controls for the pointer-detail column.
+//!
+//! Three controls over the HID++ `0x2111` config: a wheel-mode segmented
+//! control (free-spin ↔ ratchet), an auto-disengage **sensitivity** slider,
+//! and a **permanent ratchet** toggle. The latter two only apply in ratchet
+//! mode, so they grey out under free-spin.
+//!
+//! Unlike DPI presets, nothing here is written to `config.toml`: the device
+//! persists wheel mode / threshold / torque in its own non-volatile memory, so
+//! the panel only reads and writes the device (via
+//! [`AppState::commit_smartshift`]). The current state is read lazily on the
+//! same background-thread pattern as [`crate::components::dpi_panel`].
+
+use gpui::{
+    AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, InteractiveElement,
+    IntoElement, ParentElement, Render, SharedString, StatefulInteractiveElement as _, Styled,
+    Subscription, Window, div, px, rgb,
+};
+use gpui_component::{
+    h_flex,
+    slider::{Slider, SliderEvent, SliderState},
+    v_flex,
+};
+use openlogi_hid::{AUTO_DISENGAGE_PERMANENT, DeviceRoute, SmartShiftMode, SmartShiftStatus};
+
+use crate::hardware::read_smartshift_status_blocking;
+use crate::state::{AppState, SmartShiftLoad};
+use crate::theme::{self, ACCENT_BLUE, Palette};
+
+/// Friendly slider range for the `autoDisengage` threshold. The wire field is
+/// `0x01`–`0xFE` (0.25 turn/s steps), but realistic scroll speeds sit well
+/// inside 1–50 (≈12.5 turn/s) — Logitech's own default is ~16. A device
+/// reporting a value above this is clamped for display; it is only rewritten
+/// once the user actually drags the slider.
+const THRESHOLD_MIN: u8 = 1;
+const THRESHOLD_MAX: u8 = 50;
+const DEFAULT_THRESHOLD: u8 = 16;
+
+pub struct SmartShiftPanel {
+    /// The auto-disengage threshold slider. Always constructed (range is
+    /// builder-only); only *rendered* in ratchet, non-permanent mode.
+    threshold: Entity<SliderState>,
+    /// Last threshold pushed into the slider from the device, so toggling
+    /// "permanent" off restores it and an external change re-seats the thumb —
+    /// but an in-progress drag (tracked by `pending_threshold`) doesn't.
+    last_threshold: u8,
+    /// The live drag value, shown in the numeric label until release commits.
+    pending_threshold: Option<u8>,
+    _threshold_sub: Subscription,
+    _state_obs: Subscription,
+}
+
+impl SmartShiftPanel {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        let threshold = cx.new(|_| {
+            SliderState::new()
+                .max(f32::from(THRESHOLD_MAX))
+                .min(f32::from(THRESHOLD_MIN))
+                .step(1.)
+                .default_value(f32::from(DEFAULT_THRESHOLD))
+        });
+        // Drive the device only on release (a drag would stream a write burst);
+        // Change just updates the numeric label.
+        let threshold_sub =
+            cx.subscribe(
+                &threshold,
+                |panel, _slider, event: &SliderEvent, cx| match event {
+                    SliderEvent::Change(value) => {
+                        panel.pending_threshold = Some(raw_to_threshold(value.start()));
+                        cx.notify();
+                    }
+                    SliderEvent::Release(value) => {
+                        let t = raw_to_threshold(value.start());
+                        panel.pending_threshold = None;
+                        panel.last_threshold = t;
+                        cx.update_global::<AppState, _>(|state, _| {
+                            let torque = state
+                                .current_smartshift_ready()
+                                .map_or(0, |s| s.tunable_torque);
+                            state.commit_smartshift(SmartShiftMode::Ratchet, t, torque);
+                        });
+                        cx.notify();
+                    }
+                },
+            );
+        let state_obs = cx.observe_global::<AppState>(|_, cx| cx.notify());
+        Self {
+            threshold,
+            last_threshold: DEFAULT_THRESHOLD,
+            pending_threshold: None,
+            _threshold_sub: threshold_sub,
+            _state_obs: state_obs,
+        }
+    }
+
+    /// Kick off a one-shot SmartShift read for the active device when it hasn't
+    /// been queried yet — same lazy, dedicated-OS-thread pattern as
+    /// [`crate::components::dpi_panel::DpiPanel`].
+    fn ensure_smartshift_load(cx: &mut Context<Self>) {
+        let Some((key, route)) = smartshift_load_target(cx) else {
+            return;
+        };
+
+        cx.update_global::<AppState, _>(|state, _| state.mark_smartshift_loading(&key));
+        let key_for_reset = key.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        std::thread::spawn(move || {
+            let result = read_smartshift_status_blocking(&route);
+            let _ = tx.send((key, route, result));
+        });
+        cx.spawn(async move |_panel, cx| match rx.await {
+            Ok((key, route, result)) => {
+                cx.update_global::<AppState, _>(|state, cx| {
+                    state.store_smartshift_status(key, &route, result);
+                    cx.refresh_windows();
+                });
+            }
+            Err(_) => {
+                cx.update_global::<AppState, _>(|state, cx| {
+                    state.clear_smartshift_loading(&key_for_reset);
+                    cx.refresh_windows();
+                });
+            }
+        })
+        .detach();
+    }
+
+    /// The interactive body shown once the device's SmartShift config resolves.
+    fn ready_body(
+        &mut self,
+        status: SmartShiftStatus,
+        window: &mut Window,
+        pal: Palette,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let mode = status.mode;
+        let permanent = status.auto_disengage == AUTO_DISENGAGE_PERMANENT;
+        let torque = status.tunable_torque;
+        let cur_auto = status.auto_disengage;
+        let ratchet = matches!(mode, SmartShiftMode::Ratchet);
+        let sensitivity_enabled = ratchet && !permanent;
+
+        let committed = if permanent {
+            self.last_threshold
+        } else {
+            clamp_threshold(status.auto_disengage)
+        };
+        // Re-seat the thumb on an external change (device re-read / mode switch),
+        // never mid-drag, and keep `last_threshold` tracking the real value so a
+        // permanent→off toggle can restore it.
+        if !permanent && self.pending_threshold.is_none() && committed != self.last_threshold {
+            self.last_threshold = committed;
+            let v = f32::from(committed);
+            self.threshold
+                .update(cx, |s, cx| s.set_value(v, window, cx));
+        }
+        let display = self.pending_threshold.unwrap_or(committed);
+        let restore_threshold = if permanent {
+            self.last_threshold
+        } else {
+            committed
+        };
+
+        let mode_row = v_flex()
+            .gap_2()
+            .child(section_label(tr!("Wheel mode"), pal))
+            .child(
+                h_flex()
+                    .gap_2()
+                    .child(mode_pill(
+                        tr!("Free spin"),
+                        !ratchet,
+                        SmartShiftMode::Free,
+                        cur_auto,
+                        torque,
+                        pal,
+                    ))
+                    .child(mode_pill(
+                        tr!("Ratchet"),
+                        ratchet,
+                        SmartShiftMode::Ratchet,
+                        cur_auto,
+                        torque,
+                        pal,
+                    )),
+            );
+
+        let value_color = if sensitivity_enabled {
+            rgb(ACCENT_BLUE).into()
+        } else {
+            pal.text_muted
+        };
+        let sensitivity_row = v_flex()
+            .gap_2()
+            .child(
+                h_flex()
+                    .justify_between()
+                    .items_baseline()
+                    .child(section_label(tr!("Sensitivity"), pal))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(value_color)
+                            .child(format!("{display}")),
+                    ),
+            )
+            .child(if sensitivity_enabled {
+                Slider::new(&self.threshold).horizontal().into_any_element()
+            } else {
+                disabled_track(pal)
+            })
+            .child(div().text_xs().text_color(pal.text_muted).child(tr!(
+                "Higher keeps the ratchet engaged longer before free-spin."
+            )));
+
+        let permanent_row = h_flex()
+            .justify_between()
+            .items_center()
+            .child(
+                v_flex()
+                    .child(section_label(tr!("Permanent ratchet"), pal))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(pal.text_muted)
+                            .child(tr!("Never auto-switch to free-spin.")),
+                    ),
+            )
+            .child(permanent_toggle(
+                permanent,
+                ratchet,
+                restore_threshold,
+                torque,
+                pal,
+            ));
+
+        v_flex()
+            .gap_4()
+            .w_full()
+            .child(mode_row)
+            .child(sensitivity_row)
+            .child(permanent_row)
+            .into_any_element()
+    }
+}
+
+impl Render for SmartShiftPanel {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        Self::ensure_smartshift_load(cx);
+        let pal = theme::palette(cx);
+
+        let status = cx
+            .try_global::<AppState>()
+            .map_or(SmartShiftLoad::Unknown, AppState::current_smartshift_status);
+        let reachable = cx
+            .try_global::<AppState>()
+            .and_then(AppState::current_record)
+            .is_some_and(|r| r.route.is_some());
+
+        let content: AnyElement = match status {
+            SmartShiftLoad::Ready(s) => self.ready_body(s, window, pal, cx),
+            SmartShiftLoad::Loading | SmartShiftLoad::Unknown if !reachable => {
+                status_line(tr!("Device offline — SmartShift unavailable."), pal)
+            }
+            SmartShiftLoad::Loading | SmartShiftLoad::Unknown => {
+                status_line(tr!("Reading SmartShift settings…"), pal)
+            }
+            SmartShiftLoad::Failed(_) => {
+                retry_line(tr!("Couldn't read SmartShift — click to retry."), pal)
+            }
+            SmartShiftLoad::Unsupported(_) => {
+                status_line(tr!("This device does not support SmartShift."), pal)
+            }
+        };
+
+        v_flex().gap_3().w_full().child(content)
+    }
+}
+
+fn smartshift_load_target(cx: &mut Context<SmartShiftPanel>) -> Option<(String, DeviceRoute)> {
+    cx.try_global::<AppState>().and_then(|state| {
+        if !state.current_smartshift_unqueried() {
+            return None;
+        }
+        let record = state.current_record()?;
+        Some((record.config_key.clone(), record.route.clone()?))
+    })
+}
+
+/// A small muted section heading.
+fn section_label(text: SharedString, pal: Palette) -> AnyElement {
+    div()
+        .text_sm()
+        .text_color(pal.text_muted)
+        .child(text)
+        .into_any_element()
+}
+
+/// One wheel-mode pill. Clicking it writes `target` while preserving the
+/// device's current threshold + torque.
+fn mode_pill(
+    label: SharedString,
+    selected: bool,
+    target: SmartShiftMode,
+    cur_auto: u8,
+    torque: u8,
+    pal: Palette,
+) -> AnyElement {
+    let id = match target {
+        SmartShiftMode::Free => "smartshift-mode-free",
+        SmartShiftMode::Ratchet => "smartshift-mode-ratchet",
+    };
+    div()
+        .id(id)
+        .px_3()
+        .py_1()
+        .rounded_md()
+        .border_1()
+        .border_color(if selected {
+            rgb(ACCENT_BLUE).into()
+        } else {
+            pal.border
+        })
+        .bg(if selected {
+            pal.surface_hover
+        } else {
+            pal.surface
+        })
+        .text_sm()
+        .text_color(if selected {
+            rgb(ACCENT_BLUE).into()
+        } else {
+            pal.text_primary
+        })
+        .cursor_pointer()
+        .hover(|s| s.bg(pal.surface_hover))
+        .child(label)
+        .on_click(move |_event, _window, cx| {
+            cx.update_global::<AppState, _>(|state, _| {
+                state.commit_smartshift(target, cur_auto, torque);
+            });
+            cx.refresh_windows();
+        })
+        .into_any_element()
+}
+
+/// The permanent-ratchet on/off pill. Disabled (muted, non-clickable) under
+/// free-spin, where it has no meaning.
+fn permanent_toggle(
+    on: bool,
+    enabled: bool,
+    restore_threshold: u8,
+    torque: u8,
+    pal: Palette,
+) -> AnyElement {
+    let label = if on { tr!("On") } else { tr!("Off") };
+    if !enabled {
+        return div()
+            .px_2()
+            .py_1()
+            .rounded_md()
+            .border_1()
+            .border_color(pal.border)
+            .text_xs()
+            .text_color(pal.text_muted)
+            .child(label)
+            .into_any_element();
+    }
+    div()
+        .id("smartshift-permanent")
+        .px_2()
+        .py_1()
+        .rounded_md()
+        .border_1()
+        .border_color(if on {
+            rgb(ACCENT_BLUE).into()
+        } else {
+            pal.border
+        })
+        .text_xs()
+        .text_color(if on {
+            rgb(ACCENT_BLUE).into()
+        } else {
+            pal.text_muted
+        })
+        .cursor_pointer()
+        .child(label)
+        .on_click(move |_event, _window, cx| {
+            cx.update_global::<AppState, _>(|state, _| {
+                let next = if on {
+                    restore_threshold
+                } else {
+                    AUTO_DISENGAGE_PERMANENT
+                };
+                state.commit_smartshift(SmartShiftMode::Ratchet, next, torque);
+            });
+            cx.refresh_windows();
+        })
+        .into_any_element()
+}
+
+/// A greyed bar standing in for the slider when sensitivity isn't adjustable.
+fn disabled_track(pal: Palette) -> AnyElement {
+    div()
+        .w_full()
+        .h(px(6.))
+        .rounded_full()
+        .bg(pal.border)
+        .into_any_element()
+}
+
+fn status_line(text: SharedString, pal: Palette) -> AnyElement {
+    div()
+        .text_sm()
+        .text_color(pal.text_muted)
+        .child(text)
+        .into_any_element()
+}
+
+/// A `Failed`-state line that re-arms the SmartShift read on click — the only
+/// recovery path when the carousel holds a single device.
+fn retry_line(text: SharedString, pal: Palette) -> AnyElement {
+    div()
+        .id("smartshift-retry")
+        .text_sm()
+        .text_color(rgb(ACCENT_BLUE))
+        .hover(|s| s.text_color(pal.text_primary))
+        .child(text)
+        .on_click(|_event, _window, cx| {
+            cx.update_global::<AppState, _>(|state, _| state.retry_active_smartshift());
+            cx.refresh_windows();
+        })
+        .into_any_element()
+}
+
+/// Round + clamp a raw slider read into the friendly threshold range.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "value is rounded and clamped into THRESHOLD_MIN..=THRESHOLD_MAX before the cast"
+)]
+fn raw_to_threshold(raw: f32) -> u8 {
+    raw.round()
+        .clamp(f32::from(THRESHOLD_MIN), f32::from(THRESHOLD_MAX)) as u8
+}
+
+/// Clamp a device-reported threshold into the slider's friendly range.
+fn clamp_threshold(value: u8) -> u8 {
+    value.clamp(THRESHOLD_MIN, THRESHOLD_MAX)
+}

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -179,7 +179,11 @@ impl SmartShiftPanel {
                         tr!("Ratchet"),
                         ratchet,
                         SmartShiftMode::Ratchet,
-                        cur_auto,
+                        // `committed`, not `cur_auto`: when the cached value is
+                        // `0xFF` (permanent ratchet) this resolves to the last
+                        // real threshold, so switching to ratchet mode doesn't
+                        // silently re-arm permanent ratchet behind the toggle.
+                        committed,
                         torque,
                         pal,
                     )),

--- a/crates/openlogi-gui/src/hardware.rs
+++ b/crates/openlogi-gui/src/hardware.rs
@@ -15,7 +15,10 @@
 use std::time::Duration;
 
 use openlogi_core::config::Lighting;
-use openlogi_hid::{CaptureChannel, DeviceRoute, DpiInfo, SharedChannel, WriteError};
+use openlogi_hid::{
+    CaptureChannel, DeviceRoute, DpiInfo, SharedChannel, SmartShiftMode, SmartShiftStatus,
+    WriteError,
+};
 use tracing::{debug, warn};
 
 /// Upper bound on a single HID++ write. `hidpp` has no request timeout of its
@@ -96,6 +99,94 @@ pub fn toggle_smartshift_in_background(
             Err(_) => warn!(
                 index,
                 "SmartShift toggle timed out (device asleep/unresponsive)"
+            ),
+        }
+    });
+}
+
+/// Read the device's current SmartShift configuration (wheel mode +
+/// auto-disengage threshold + tunable torque) on a background worker.
+///
+/// Blocking, like [`read_dpi_info_blocking`], so the SmartShift panel can run
+/// it off a dedicated OS thread without the UI thread owning a Tokio runtime.
+pub fn read_smartshift_status_blocking(
+    target: &DeviceRoute,
+) -> Result<SmartShiftStatus, WriteError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| WriteError::Hidpp(format!("tokio runtime init failed: {e}")))?;
+
+    rt.block_on(async {
+        tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_smartshift_status(target))
+            .await
+            .map_err(|_| WriteError::Hidpp("SmartShift status read timed out".into()))?
+    })
+}
+
+/// Spawn an OS thread that writes a full SmartShift configuration to the device
+/// at `target` via [`openlogi_hid::set_smartshift`]. Returns immediately;
+/// failures (incl. devices that don't support `0x2111`) are logged.
+///
+/// `target == None` is a no-op (dev environment without a real device).
+pub fn write_smartshift_in_background(
+    capture: Option<&CaptureChannel>,
+    target: Option<DeviceRoute>,
+    mode: SmartShiftMode,
+    auto_disengage: u8,
+    tunable_torque: u8,
+) {
+    let Some(target) = target else {
+        debug!("no target device — SmartShift write skipped");
+        return;
+    };
+    let shared = reusable_channel(capture, &target);
+    let reused = shared.is_some();
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                warn!(error = %e, "tokio runtime init failed; SmartShift write skipped");
+                return;
+            }
+        };
+        let result = rt.block_on(async {
+            tokio::time::timeout(WRITE_BUDGET, async {
+                match &shared {
+                    Some(shared) => {
+                        openlogi_hid::set_smartshift_on(
+                            shared,
+                            mode,
+                            auto_disengage,
+                            tunable_torque,
+                        )
+                        .await
+                    }
+                    None => {
+                        openlogi_hid::set_smartshift(&target, mode, auto_disengage, tunable_torque)
+                            .await
+                    }
+                }
+            })
+            .await
+        });
+        let index = target.device_index();
+        match result {
+            Ok(Ok(())) => debug!(
+                index,
+                ?mode,
+                auto_disengage,
+                tunable_torque,
+                reused,
+                "SmartShift config written"
+            ),
+            Ok(Err(e)) => warn!(error = ?e, "SmartShift write failed"),
+            Err(_) => warn!(
+                index,
+                "SmartShift write timed out (device asleep/unresponsive)"
             ),
         }
     });

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -20,7 +20,9 @@ use std::sync::{Arc, RwLock};
 use gpui::Global;
 use openlogi_core::config::{AppSettings, Config, Lighting};
 use openlogi_core::device::DeviceInventory;
-use openlogi_hid::{DeviceRoute, DpiCapabilities, DpiInfo, WriteError};
+use openlogi_hid::{
+    DeviceRoute, DpiCapabilities, DpiInfo, SmartShiftMode, SmartShiftStatus, WriteError,
+};
 use openlogi_hook::Hook;
 use tracing::{debug, warn};
 
@@ -70,6 +72,27 @@ pub enum DpiStatus {
     Unsupported(String),
 }
 
+/// Per-device SmartShift (`0x2111`) loading state. Mirrors [`DpiStatus`]:
+/// lazily loaded because the HID++ read must not block device switching or
+/// rendering. Unlike DPI presets, the resolved config is *not* persisted to
+/// `config.toml` — the device stores wheel mode / threshold / torque in its
+/// own non-volatile memory, so the GUI only ever reads and writes the device.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmartShiftLoad {
+    /// The selected device has not been queried yet.
+    Unknown,
+    /// A background HID++ read is in flight.
+    Loading,
+    /// The device reported its current SmartShift configuration.
+    Ready(SmartShiftStatus),
+    /// Transient read errors exhausted the retry budget; retryable on
+    /// re-select.
+    Failed(String),
+    /// The device genuinely does not expose SmartShift (`0x2111`); never
+    /// retried.
+    Unsupported(String),
+}
+
 pub struct AppState {
     /// Index into [`Self::device_list`] of the currently visible device. May
     /// be out of bounds briefly while inventories re-enumerate; views must
@@ -111,6 +134,14 @@ pub struct AppState {
     /// times (see [`DPI_LOAD_MAX_ATTEMPTS`]) instead of sticking the device on
     /// [`DpiStatus::Unsupported`] forever.
     dpi_load_attempts: BTreeMap<String, u8>,
+    /// SmartShift (`0x2111`) configuration state keyed by
+    /// [`DeviceRecord::config_key`]. Loaded lazily on the same pattern as
+    /// [`Self::dpi_by_device`]; the device persists the values itself, so this
+    /// is a read/write cache, not a source of truth saved to disk.
+    pub smartshift_by_device: BTreeMap<String, SmartShiftLoad>,
+    /// Consecutive failed SmartShift read attempts, keyed by
+    /// [`DeviceRecord::config_key`] — mirrors [`Self::dpi_load_attempts`].
+    smartshift_load_attempts: BTreeMap<String, u8>,
     /// All paired devices, in carousel order. Each entry caches the per-
     /// device data the views need so a switch is a pure index update.
     pub device_list: Vec<DeviceRecord>,
@@ -187,6 +218,8 @@ impl AppState {
             dpi_by_device: BTreeMap::new(),
             inventory_misses: BTreeMap::new(),
             dpi_load_attempts: BTreeMap::new(),
+            smartshift_by_device: BTreeMap::new(),
+            smartshift_load_attempts: BTreeMap::new(),
             device_list,
             config,
             hook_bindings,
@@ -313,10 +346,16 @@ impl AppState {
         for key in &rerouted {
             self.dpi_by_device.remove(key);
             self.dpi_load_attempts.remove(key);
+            self.smartshift_by_device.remove(key);
+            self.smartshift_load_attempts.remove(key);
         }
         self.dpi_by_device
             .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
         self.dpi_load_attempts
+            .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
+        self.smartshift_by_device
+            .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
+        self.smartshift_load_attempts
             .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
         self.current_device = new_index;
         // The active device may have changed (selection fell back to index 0
@@ -388,6 +427,13 @@ impl AppState {
             if matches!(self.dpi_by_device.get(&key), Some(DpiStatus::Failed(_))) {
                 self.dpi_by_device.remove(&key);
                 self.dpi_load_attempts.remove(&key);
+            }
+            if matches!(
+                self.smartshift_by_device.get(&key),
+                Some(SmartShiftLoad::Failed(_))
+            ) {
+                self.smartshift_by_device.remove(&key);
+                self.smartshift_load_attempts.remove(&key);
             }
         }
         // `self.dpi` is the active device's value; adopt the newly-selected
@@ -586,6 +632,154 @@ impl AppState {
     pub fn normalize_active_dpi(&self, dpi: u32) -> u32 {
         self.active_dpi_capabilities()
             .map_or(dpi, |caps| caps.snap(dpi))
+    }
+
+    /// SmartShift configuration status for the active device.
+    #[must_use]
+    pub fn current_smartshift_status(&self) -> SmartShiftLoad {
+        self.current_record()
+            .and_then(|record| self.smartshift_by_device.get(&record.config_key).cloned())
+            .unwrap_or(SmartShiftLoad::Unknown)
+    }
+
+    /// Whether the active device still needs a SmartShift read (no status
+    /// recorded). Cheaper than comparing a cloned [`SmartShiftLoad`] on the
+    /// per-frame render path.
+    #[must_use]
+    pub fn current_smartshift_unqueried(&self) -> bool {
+        self.current_record()
+            .is_some_and(|record| !self.smartshift_by_device.contains_key(&record.config_key))
+    }
+
+    /// The active device's resolved SmartShift config, if the read succeeded.
+    /// Callers use it to preserve fields they don't mean to change (e.g.
+    /// tunable torque) when writing back.
+    #[must_use]
+    pub fn current_smartshift_ready(&self) -> Option<SmartShiftStatus> {
+        self.current_record()
+            .and_then(|record| self.smartshift_by_device.get(&record.config_key))
+            .and_then(|status| match status {
+                SmartShiftLoad::Ready(s) => Some(*s),
+                SmartShiftLoad::Unknown
+                | SmartShiftLoad::Loading
+                | SmartShiftLoad::Failed(_)
+                | SmartShiftLoad::Unsupported(_) => None,
+            })
+    }
+
+    /// Mark SmartShift discovery as in flight for `key`.
+    pub fn mark_smartshift_loading(&mut self, key: &str) {
+        self.smartshift_by_device
+            .insert(key.to_string(), SmartShiftLoad::Loading);
+    }
+
+    /// Reset a stuck `Loading` for `key` back to `Unknown` — called when the
+    /// read worker vanished without delivering a result.
+    pub fn clear_smartshift_loading(&mut self, key: &str) {
+        if matches!(
+            self.smartshift_by_device.get(key),
+            Some(SmartShiftLoad::Loading)
+        ) {
+            self.smartshift_by_device.remove(key);
+        }
+    }
+
+    /// Drop the active device's recorded SmartShift status so the next render
+    /// re-runs discovery. Backs the "click to retry" affordance on a
+    /// [`SmartShiftLoad::Failed`] device.
+    pub fn retry_active_smartshift(&mut self) {
+        if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
+            self.smartshift_by_device.remove(&key);
+            self.smartshift_load_attempts.remove(&key);
+        }
+    }
+
+    /// Store a SmartShift read result if it still matches the known device
+    /// route, with the same transient-retry / permanent-unsupported handling
+    /// as [`Self::store_dpi_info`].
+    pub fn store_smartshift_status(
+        &mut self,
+        key: String,
+        route: &DeviceRoute,
+        result: Result<SmartShiftStatus, WriteError>,
+    ) {
+        let still_matches = self
+            .device_list
+            .iter()
+            .any(|record| record.config_key == key && record.route.as_ref() == Some(route));
+        if !still_matches {
+            debug!(key, ?route, "stale SmartShift result ignored");
+            if self.device_list.iter().any(|r| r.config_key == key) {
+                self.smartshift_by_device.remove(&key);
+            }
+            return;
+        }
+
+        let status = match result {
+            Ok(status) => {
+                self.smartshift_load_attempts.remove(&key);
+                SmartShiftLoad::Ready(status)
+            }
+            Err(error) if smartshift_error_is_permanent(&error) => {
+                self.smartshift_load_attempts.remove(&key);
+                SmartShiftLoad::Unsupported(error.to_string())
+            }
+            Err(error) => {
+                let attempts = self
+                    .smartshift_load_attempts
+                    .entry(key.clone())
+                    .or_insert(0);
+                *attempts = attempts.saturating_add(1);
+                if *attempts < DPI_LOAD_MAX_ATTEMPTS {
+                    debug!(
+                        key,
+                        attempts = *attempts,
+                        error = %error,
+                        "transient SmartShift read error — will retry"
+                    );
+                    self.smartshift_by_device.remove(&key);
+                    return;
+                }
+                self.smartshift_load_attempts.remove(&key);
+                SmartShiftLoad::Failed(error.to_string())
+            }
+        };
+        self.smartshift_by_device.insert(key, status);
+    }
+
+    /// Write a full SmartShift configuration to the active device (best-effort,
+    /// on a background thread) and optimistically cache it. The device persists
+    /// the values in its own NVM, so nothing is written to `config.toml`.
+    /// No-op when no device is selected.
+    pub fn commit_smartshift(
+        &mut self,
+        mode: SmartShiftMode,
+        auto_disengage: u8,
+        tunable_torque: u8,
+    ) {
+        let Some(record) = self.current_record() else {
+            debug!("no active device — SmartShift change ignored");
+            return;
+        };
+        let key = record.config_key.clone();
+        let target = record.route.clone();
+        crate::hardware::write_smartshift_in_background(
+            None,
+            target,
+            mode,
+            auto_disengage,
+            tunable_torque,
+        );
+        // Reflect the write immediately so the panel doesn't flicker back to
+        // the previous value before a re-read lands.
+        self.smartshift_by_device.insert(
+            key,
+            SmartShiftLoad::Ready(SmartShiftStatus {
+                mode,
+                auto_disengage,
+                tunable_torque,
+            }),
+        );
     }
 
     /// The lighting config for the active device, or the default when none is
@@ -876,6 +1070,13 @@ fn dpi_error_is_permanent(error: &WriteError) -> bool {
         error,
         WriteError::FeatureUnsupported { .. } | WriteError::EmptyDpiList
     )
+}
+
+/// Whether a SmartShift read error is permanent: a genuine "feature not
+/// supported" reply (the device lacks `0x2111`) never changes, so stop
+/// probing. Everything else (timeouts, busy device) is transient.
+fn smartshift_error_is_permanent(error: &WriteError) -> bool {
+    matches!(error, WriteError::FeatureUnsupported { .. })
 }
 
 impl Global for AppState {}

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -137,8 +137,10 @@ pub struct AppState {
     /// SmartShift (`0x2111`) configuration state keyed by
     /// [`DeviceRecord::config_key`]. Loaded lazily on the same pattern as
     /// [`Self::dpi_by_device`]; the device persists the values itself, so this
-    /// is a read/write cache, not a source of truth saved to disk.
-    pub smartshift_by_device: BTreeMap<String, SmartShiftLoad>,
+    /// is a read/write cache, not a source of truth saved to disk. Private so
+    /// all access goes through the accessor methods below (`current_smartshift_*`,
+    /// `store_smartshift_status`), which enforce the stale-result and retry rules.
+    smartshift_by_device: BTreeMap<String, SmartShiftLoad>,
     /// Consecutive failed SmartShift read attempts, keyed by
     /// [`DeviceRecord::config_key`] — mirrors [`Self::dpi_load_attempts`].
     smartshift_load_attempts: BTreeMap<String, u8>,

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -24,9 +24,9 @@ pub use pairing::{
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
 };
 pub use route::{DIRECT_DEVICE_INDEX, DeviceRoute};
-pub use smartshift::{SmartShiftMode, SmartShiftStatus};
+pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus};
 pub use write::{
     DpiCapabilities, DpiInfo, FeatureEntry, SharedChannel, WriteError, dump_features, get_dpi,
-    get_dpi_info, get_smartshift_status, set_dpi, set_dpi_on, set_keyboard_color,
-    toggle_smartshift, toggle_smartshift_on,
+    get_dpi_info, get_smartshift_status, set_dpi, set_dpi_on, set_keyboard_color, set_smartshift,
+    set_smartshift_on, toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-hid/src/smartshift.rs
+++ b/crates/openlogi-hid/src/smartshift.rs
@@ -10,10 +10,12 @@
 //! previous state.
 //!
 //! Mode encoding (consistent across 0x2110 / 0x2111):
-//! - `1` = free-spin (no ratchet, infinite scroll)
-//! - `2` = ratchet (clicky); when paired with sensitivity 1–50 the
-//!   firmware also engages auto-switch ("SmartShift active"); `0xff`
-//!   means "permanent ratchet, never auto-switch".
+//! - `wheelMode` `1` = free-spin (no ratchet, infinite scroll), `2` =
+//!   ratchet (clicky).
+//! - `autoDisengage` `0x01`–`0xFE` = the wheel speed (in 0.25 turn/s steps)
+//!   past which a ratchet-mode wheel releases into free-spin — i.e. the
+//!   "SmartShift" threshold. `0xFF` keeps the ratchet engaged permanently
+//!   (never auto-switches). See [`AUTO_DISENGAGE_PERMANENT`].
 
 use std::sync::Arc;
 
@@ -63,13 +65,25 @@ impl SmartShiftMode {
     }
 }
 
+/// `autoDisengage` value that keeps the ratchet engaged permanently — the
+/// wheel never auto-releases into free-spin, regardless of speed. Any other
+/// value (`0x01`–`0xFE`) is a SmartShift speed threshold.
+pub const AUTO_DISENGAGE_PERMANENT: u8 = 0xff;
+
 /// Snapshot returned from [`SmartShiftFeatureV0::get_status`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SmartShiftStatus {
     pub mode: SmartShiftMode,
-    /// Auto-switch threshold (0–255). Higher = harder to flip into free-
-    /// spin while scrolling. Logitech defaults to ~32 on the MX line.
-    pub sensitivity: u8,
+    /// SmartShift speed threshold: `0x01`–`0xFE` in 0.25 turn/s steps (higher
+    /// = harder to flip into free-spin while scrolling; Logitech defaults to
+    /// ~16 on the MX line), or [`AUTO_DISENGAGE_PERMANENT`] for a permanently
+    /// engaged ratchet.
+    pub auto_disengage: u8,
+    /// Tunable-torque force as a percentage (`1`–`100`) of the device's max
+    /// force, or `0` when the device doesn't support tunable torque. Read back
+    /// and re-sent unchanged so adjusting the mode or threshold doesn't
+    /// disturb the wheel's resistance.
+    pub tunable_torque: u8,
 }
 
 /// `SmartShift` / `0x2111` feature, version 0+.
@@ -104,9 +118,9 @@ const FUNCTION_GET_STATUS: u8 = 1;
 const FUNCTION_SET_STATUS: u8 = 2;
 
 impl SmartShiftFeatureV0 {
-    /// Read the current mode + sensitivity. Reserved mode bytes fall back
-    /// to [`SmartShiftMode::Ratchet`] because that's the "safe" / clicky
-    /// behaviour most users expect.
+    /// Read the current `wheelMode` + `autoDisengage` + `currentTunableTorque`.
+    /// Reserved mode bytes fall back to [`SmartShiftMode::Ratchet`] because
+    /// that's the "safe" / clicky behaviour most users expect.
     pub async fn get_status(&self) -> Result<SmartShiftStatus, Hidpp20Error> {
         let response = self
             .chan
@@ -124,17 +138,20 @@ impl SmartShiftFeatureV0 {
         let mode = SmartShiftMode::from_byte(payload[0]).unwrap_or(SmartShiftMode::Ratchet);
         Ok(SmartShiftStatus {
             mode,
-            sensitivity: payload[1],
+            auto_disengage: payload[1],
+            tunable_torque: payload.get(2).copied().unwrap_or(0),
         })
     }
 
-    /// Write a new mode + sensitivity. The third payload byte is
-    /// `defaultSensitivity` per the spec; we pass `0` to mean "don't
-    /// change the firmware default".
+    /// Write a new `wheelMode` + `autoDisengage` + `currentTunableTorque`. The
+    /// firmware stores all three persistently in the device's NVM, so callers
+    /// should read the current `tunable_torque` (and any field they don't mean
+    /// to change) via [`Self::get_status`] and re-send it here.
     pub async fn set_status(
         &self,
         mode: SmartShiftMode,
-        sensitivity: u8,
+        auto_disengage: u8,
+        tunable_torque: u8,
     ) -> Result<(), Hidpp20Error> {
         let _ = self
             .chan
@@ -145,7 +162,7 @@ impl SmartShiftFeatureV0 {
                     function_id: U4::from_lo(FUNCTION_SET_STATUS),
                     software_id: self.chan.get_sw_id(),
                 },
-                [mode.as_byte(), sensitivity, 0],
+                [mode.as_byte(), auto_disengage, tunable_torque],
             ))
             .await?;
         Ok(())

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -454,17 +454,67 @@ async fn toggle_smartshift_on_channel(
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
     let feature = open_feature::<SmartShiftFeatureV0>(&mut device).await?;
-    let SmartShiftStatus { mode, sensitivity } = feature
+    let SmartShiftStatus {
+        mode,
+        auto_disengage,
+        tunable_torque,
+    } = feature
         .get_status()
         .await
         .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
     let next = mode.flipped();
     feature
-        .set_status(next, sensitivity)
+        .set_status(next, auto_disengage, tunable_torque)
         .await
         .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
     debug!(index, ?next, "wrote SmartShift mode");
     Ok(next)
+}
+
+/// Write a full SmartShift configuration — wheel mode, auto-disengage
+/// threshold, and tunable torque — to `route`. The firmware persists all three
+/// to the device's NVM. Callers that mean to change only one field should read
+/// the rest via [`get_smartshift_status`] first and pass them back unchanged.
+///
+/// `FeatureUnsupported` when the device doesn't expose HID++ `0x2111`.
+pub async fn set_smartshift(
+    route: &DeviceRoute,
+    mode: SmartShiftMode,
+    auto_disengage: u8,
+    tunable_torque: u8,
+) -> Result<(), WriteError> {
+    let index = route.device_index();
+    with_route(route, move |channel| async move {
+        set_smartshift_on_channel(&channel, index, mode, auto_disengage, tunable_torque).await
+    })
+    .await
+}
+
+/// The SmartShift write itself, on an already-open channel at HID++ `index`.
+/// Shared by [`set_smartshift`] and [`set_smartshift_on`].
+async fn set_smartshift_on_channel(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+    mode: SmartShiftMode,
+    auto_disengage: u8,
+    tunable_torque: u8,
+) -> Result<(), WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<SmartShiftFeatureV0>(&mut device).await?;
+    feature
+        .set_status(mode, auto_disengage, tunable_torque)
+        .await
+        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+    debug!(
+        index,
+        ?mode,
+        auto_disengage,
+        tunable_torque,
+        "wrote SmartShift config"
+    );
+    Ok(())
 }
 
 /// An open HID++ channel to a device, shared so DPI / SmartShift writes can
@@ -504,6 +554,24 @@ pub async fn set_dpi_on(shared: &SharedChannel, dpi: u16) -> Result<(), WriteErr
 /// Toggle SmartShift on an already-open [`SharedChannel`].
 pub async fn toggle_smartshift_on(shared: &SharedChannel) -> Result<SmartShiftMode, WriteError> {
     toggle_smartshift_on_channel(&shared.channel, shared.route.device_index()).await
+}
+
+/// Write a full SmartShift configuration on an already-open [`SharedChannel`]
+/// — the fast path that skips enumeration and channel setup.
+pub async fn set_smartshift_on(
+    shared: &SharedChannel,
+    mode: SmartShiftMode,
+    auto_disengage: u8,
+    tunable_torque: u8,
+) -> Result<(), WriteError> {
+    set_smartshift_on_channel(
+        &shared.channel,
+        shared.route.device_index(),
+        mode,
+        auto_disengage,
+        tunable_torque,
+    )
+    .await
 }
 
 /// Boilerplate-eater: open the channel that reaches `route`, then run `f` once


### PR DESCRIPTION
## What

Adds a SmartShift settings panel to the **Pointer** tab, exposing the full HID++ `0x2111` config that was previously reachable only as a bound-button toggle:

- **Wheel mode** — a free-spin / ratchet segmented control
- **Sensitivity** — the auto-disengage threshold (the wheel speed past which a ratcheting wheel releases into free-spin)
- **Permanent ratchet** — a toggle that pins `autoDisengage` to `0xFF` (the wheel never auto-switches)

Sensitivity and the permanent toggle grey out under free-spin, where they have no effect.

## How

- State is read lazily on a dedicated background thread (mirroring the DPI panel) and written straight to the device. The firmware persists wheel mode / threshold / torque in its own NVM, so **nothing is stored in `config.toml`**.
- Devices without `0x2111` degrade gracefully ("This device does not support SmartShift"); offline / loading / failed-with-retry states are handled like the DPI panel.

### Low-level `0x2111` fixes (commit 1)
While wiring this up I corrected the existing wrapper:
- Renamed the mislabelled `sensitivity` field to `auto_disengage` (matches the spec's `autoDisengage`).
- Read and round-trip the `tunable_torque` byte — it was hard-coded to `0`, which **zeroed the wheel's resistance on every write** (including the existing toggle).
- Added `AUTO_DISENGAGE_PERMANENT` plus `set_smartshift` / `set_smartshift_on` write helpers.

### i18n (commit 2)
New panel strings localized into ja / ru / zh-CN / zh-HK / zh-TW. "Sensitivity" is rendered distinctly (e.g. 切换灵敏度) from the DPI panel's "灵敏度" so the two cards stacked in the Pointer tab stay distinguishable.

## Verification

- `cargo check` / `clippy --workspace --all-targets -D warnings` / `fmt --check` / `test --workspace` all green (pre-push clippy passed).
- ⚠️ This is interactive GUI behavior — the on-device read/write path has **not** been exercised on hardware. Needs a manual check on a `0x2111` device (MX Master 3 / 3S / 4): open the Pointer tab → flip wheel mode, drag sensitivity, toggle permanent ratchet, confirm the wheel feel changes and survives a reconnect.

## Known trade-offs

- Sensitivity slider is presented as **1–50** (Logitech's range; default ~16). A device reporting a higher `autoDisengage` is clamped for display but **not rewritten** until you drag the slider.
- `tunable_torque` is read and preserved but not exposed in the UI.
