### PR TITLE
fix(gui): retry asset sync on failure with backoff instead of latching once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,8 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand 2.4.1",
- "gloo-timers",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand 2.4.1",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,6 +4555,7 @@ name = "openlogi-assets"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "backon",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde_json = "1"
 toml = "0.8"
 ureq = { version = "3", default-features = false, features = ["rustls", "json"] }
 sha2 = "0.10"
-backon = "1.6"
+backon = { version = "1.6", default-features = false, features = ["std", "std-blocking-sleep"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde_json = "1"
 toml = "0.8"
 ureq = { version = "3", default-features = false, features = ["rustls", "json"] }
 sha2 = "0.10"
+backon = "1.6"
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 thiserror = "2"

--- a/crates/openlogi-assets/Cargo.toml
+++ b/crates/openlogi-assets/Cargo.toml
@@ -17,6 +17,7 @@ ureq = { workspace = true }
 sha2 = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+backon = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -15,9 +15,10 @@ use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
+use backon::{BlockingRetryable, ExponentialBuilder};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
-use tracing::debug;
+use tracing::{debug, warn};
 use ureq::Agent;
 
 use crate::index::{FileEntry, Index};
@@ -34,6 +35,14 @@ const INDEX_NAME: &str = "index.json";
 /// Bound on DNS + TCP + TLS connect. Deliberately does *not* cap body-read
 /// time, so a slow-but-progressing download of a large asset isn't killed.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Retries after the initial attempt for a single GET (3 tries total).
+const MAX_RETRIES: usize = 2;
+
+/// Backoff before the first retry; doubles each attempt (200ms, 400ms,
+/// plus jitter). Keeps a transient blip from needing an app restart
+/// without a fleet of clients hammering the host in lockstep.
+const RETRY_MIN_DELAY: Duration = Duration::from_millis(200);
 
 /// Blocking client for one asset host.
 ///
@@ -127,18 +136,54 @@ impl AssetClient {
         Ok(FetchOutcome::Fetched { bytes })
     }
 
-    /// GET `url` on the shared agent and read the whole body into memory.
-    /// `read_to_vec` caps the body at ureq's default 10 MB — ample for the
-    /// registry JSON and the device PNGs, and a safety net against a
+    /// GET `url` on the shared agent and read the whole body into memory,
+    /// retrying transient failures (timeouts, dropped connections, 5xx) with
+    /// exponential backoff. Permanent failures (4xx, malformed request) fail
+    /// fast. `read_to_vec` caps the body at ureq's default 10 MB — ample for
+    /// the registry JSON and the device PNGs, and a safety net against a
     /// runaway response.
+    ///
+    /// The backoff sleeps block the calling thread, which is fine: every
+    /// caller runs on the sync's dedicated background thread, never the
+    /// async runtime. `backon` defaults to `std::thread::sleep` here.
     fn get_bytes(&self, url: &str) -> Result<Vec<u8>> {
-        self.agent
-            .get(url)
+        let policy = ExponentialBuilder::default()
+            .with_min_delay(RETRY_MIN_DELAY)
+            .with_factor(2.0)
+            .with_max_times(MAX_RETRIES)
+            .with_jitter();
+        (|| self.try_get_bytes(url))
+            .retry(policy)
+            .when(is_retryable)
+            .notify(|e: &ureq::Error, dur: Duration| {
+                warn!(%url, backoff_ms = dur.as_millis(), error = ?e, "transient fetch error — retrying");
+            })
             .call()
-            .with_context(|| format!("GET {url}"))?
-            .body_mut()
-            .read_to_vec()
-            .with_context(|| format!("read body {url}"))
+            .map_err(|e| anyhow::Error::new(e).context(format!("GET {url}")))
+    }
+
+    /// One GET + full body read, surfacing the typed [`ureq::Error`] so the
+    /// retry loop in [`get_bytes`](Self::get_bytes) can tell transient
+    /// failures from permanent ones.
+    fn try_get_bytes(&self, url: &str) -> std::result::Result<Vec<u8>, ureq::Error> {
+        self.agent.get(url).call()?.body_mut().read_to_vec()
+    }
+}
+
+/// Whether a failed fetch is worth retrying. Transport-level hiccups
+/// (timeouts, dropped/refused connections, DNS blips) and 5xx — plus the two
+/// "back off and retry" 4xx codes — are transient; a 4xx like 404 or a
+/// malformed-request error won't change on a retry.
+fn is_retryable(error: &ureq::Error) -> bool {
+    use ureq::Error;
+    match error {
+        Error::StatusCode(code) => *code >= 500 || matches!(*code, 408 | 429),
+        Error::Io(_)
+        | Error::Timeout(_)
+        | Error::ConnectionFailed
+        | Error::HostNotFound
+        | Error::Protocol(_) => true,
+        _ => false,
     }
 }
 
@@ -174,4 +219,30 @@ pub fn sha256_of_file(path: &Path) -> Result<String> {
 #[must_use]
 pub fn cached_matches(path: &Path, expected_sha: &str) -> bool {
     sha256_of_file(path).is_ok_and(|actual| actual.eq_ignore_ascii_case(expected_sha))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_retryable;
+    use ureq::Error;
+
+    #[test]
+    fn retries_transient_failures_not_permanent_ones() {
+        // Transient: server errors, the two "back off" 4xx codes, and
+        // transport-level failures all warrant a retry.
+        assert!(is_retryable(&Error::StatusCode(500)));
+        assert!(is_retryable(&Error::StatusCode(503)));
+        assert!(is_retryable(&Error::StatusCode(408)));
+        assert!(is_retryable(&Error::StatusCode(429)));
+        assert!(is_retryable(&Error::HostNotFound));
+        assert!(is_retryable(&Error::ConnectionFailed));
+        assert!(is_retryable(&Error::Io(
+            std::io::ErrorKind::ConnectionReset.into()
+        )));
+
+        // Permanent: a missing file or bad request won't change on retry.
+        assert!(!is_retryable(&Error::StatusCode(404)));
+        assert!(!is_retryable(&Error::StatusCode(400)));
+        assert!(!is_retryable(&Error::StatusCode(403)));
+    }
 }

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -51,13 +51,14 @@ pub fn sync(server: &str, models: &[(DeviceModelInfo, Option<String>)]) -> Resul
         .with_context(|| format!("create cache root {}", cache_root.display()))?;
 
     let client = http::AssetClient::new(server);
-    let index = match client.fetch_index_to_dir(&cache_root) {
-        Ok(idx) => idx,
-        Err(e) => {
-            warn!(error = ?e, "index.json fetch failed — proceeding with cached files");
-            return Ok(());
-        }
-    };
+    // The index is the critical shared resource — if it can't be fetched
+    // (after the HTTP layer's own retries) bail with an error so the caller
+    // retries the whole sync on a later device snapshot, rather than latching
+    // success off a run that downloaded nothing. Per-depot failures below stay
+    // best-effort: an optional colour variant 404 shouldn't block everything.
+    let index = client
+        .fetch_index_to_dir(&cache_root)
+        .context("fetch asset index")?;
 
     // Each target carries the HID++ `extended_model_id` byte so the
     // depot sync can fetch the right colour variant. `OPENLOGI_FORCE_DEPOT`

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -45,6 +45,7 @@ rust_i18n::i18n!("locales", fallback = "en");
 
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use gpui::{
@@ -240,9 +241,12 @@ fn main() -> Result<()> {
             let mut hook_handle = None;
             // Asset depots are fetched in the background when devices first
             // appear — startup no longer blocks on it. The sync runs once on
-            // success, but a failed attempt is retried on the next snapshot
-            // instead of being latched off for the session (see SYNC_*).
+            // success; a failed attempt is retried (see SYNC_*) with a
+            // growing, capped delay so a permanently-down host isn't polled
+            // every tick yet a recovered one still self-heals.
             let sync_state = Arc::new(AtomicU8::new(SYNC_IDLE));
+            let mut sync_attempts: u32 = 0;
+            let mut last_sync_at: Option<Instant> = None;
             loop {
                 tokio::select! {
                     Some(new_inv) = inventory_rx.recv() => {
@@ -251,13 +255,18 @@ fn main() -> Result<()> {
                         // alone could fire on a device whose DeviceInformation read
                         // hasn't resolved yet, leaving its art un-synced. `RUNNING`
                         // blocks a second concurrent sync; `DONE` latches it off;
-                        // `FAILED` lets this 2 s tick retry, so a transient network
-                        // error no longer strands the device on the silhouette
-                        // until an app restart.
+                        // `FAILED` retries once its backoff window elapses, so a
+                        // transient network error no longer strands the device on
+                        // the silhouette until an app restart.
                         let state = sync_state.load(Ordering::Acquire);
+                        let backoff_passed = last_sync_at
+                            .is_none_or(|t| t.elapsed() >= sync_retry_delay(sync_attempts));
                         if matches!(state, SYNC_IDLE | SYNC_FAILED)
+                            && backoff_passed
                             && !collect_models(&new_inv).is_empty()
                         {
+                            sync_attempts = sync_attempts.saturating_add(1);
+                            last_sync_at = Some(Instant::now());
                             sync_state.store(SYNC_RUNNING, Ordering::Release);
                             let inv = new_inv.clone();
                             let state = Arc::clone(&sync_state);
@@ -355,6 +364,18 @@ const SYNC_IDLE: u8 = 0;
 const SYNC_RUNNING: u8 = 1;
 const SYNC_DONE: u8 = 2;
 const SYNC_FAILED: u8 = 3;
+
+/// Minimum gap before re-attempting a failed sync, doubling with each
+/// consecutive attempt and capped at a minute. The first attempt is
+/// immediate (`last_sync_at` is `None`); after that a permanently-down host
+/// is polled ever more slowly (1s, 2s, 4s … 60s) instead of on every tick,
+/// while a recovered host still self-heals on the next attempt.
+fn sync_retry_delay(attempts: u32) -> Duration {
+    const CAP: Duration = Duration::from_secs(60);
+    // Cap the shift so `1 << exp` can't overflow, then clamp the result.
+    let exp = attempts.saturating_sub(1).min(6);
+    Duration::from_secs(1u64 << exp).min(CAP)
+}
 
 /// Refresh the asset cache for the connected devices. Returns `true` when the
 /// sync completed (or wasn't needed) and `false` when it failed and should be
@@ -499,4 +520,21 @@ fn collect_models(inventories: &[DeviceInventory]) -> Vec<(DeviceModelInfo, Opti
         .flat_map(|inv| inv.paired.iter())
         .filter_map(|p| p.model_info.clone().map(|m| (m, p.codename.clone())))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sync_retry_delay;
+    use std::time::Duration;
+
+    #[test]
+    fn retry_delay_doubles_then_caps() {
+        assert_eq!(sync_retry_delay(1), Duration::from_secs(1));
+        assert_eq!(sync_retry_delay(2), Duration::from_secs(2));
+        assert_eq!(sync_retry_delay(3), Duration::from_secs(4));
+        assert_eq!(sync_retry_delay(5), Duration::from_secs(16));
+        // Caps at 60s and never overflows the shift for large attempt counts.
+        assert_eq!(sync_retry_delay(7), Duration::from_secs(60));
+        assert_eq!(sync_retry_delay(u32::MAX), Duration::from_secs(60));
+    }
 }

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -43,6 +43,7 @@ mod windows;
 // gpui-component ships, so the framework's own widgets localize alongside ours.
 rust_i18n::i18n!("locales", fallback = "en");
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
@@ -237,20 +238,37 @@ fn main() -> Result<()> {
             });
 
             let mut hook_handle = None;
-            // Asset depots are fetched once, in the background, when devices
-            // first appear — startup no longer blocks on it.
-            let mut assets_synced = false;
+            // Asset depots are fetched in the background when devices first
+            // appear — startup no longer blocks on it. The sync runs once on
+            // success, but a failed attempt is retried on the next snapshot
+            // instead of being latched off for the session (see SYNC_*).
+            let sync_state = Arc::new(AtomicU8::new(SYNC_IDLE));
             loop {
                 tokio::select! {
                     Some(new_inv) = inventory_rx.recv() => {
-                        // Latch on the first snapshot that actually carries
-                        // model info — gating on `!is_empty()` alone could fire
-                        // on a device whose DeviceInformation read hasn't
-                        // resolved yet, leaving its art un-synced all session.
-                        if !assets_synced && !collect_models(&new_inv).is_empty() {
-                            assets_synced = true;
+                        // Kick off (or retry) the one-shot asset sync. Gate on a
+                        // snapshot that actually carries model info — `!is_empty()`
+                        // alone could fire on a device whose DeviceInformation read
+                        // hasn't resolved yet, leaving its art un-synced. `RUNNING`
+                        // blocks a second concurrent sync; `DONE` latches it off;
+                        // `FAILED` lets this 2 s tick retry, so a transient network
+                        // error no longer strands the device on the silhouette
+                        // until an app restart.
+                        let state = sync_state.load(Ordering::Acquire);
+                        if matches!(state, SYNC_IDLE | SYNC_FAILED)
+                            && !collect_models(&new_inv).is_empty()
+                        {
+                            sync_state.store(SYNC_RUNNING, Ordering::Release);
                             let inv = new_inv.clone();
-                            std::thread::spawn(move || sync_assets_if_needed(&inv));
+                            let state = Arc::clone(&sync_state);
+                            std::thread::spawn(move || {
+                                let next = if sync_assets_if_needed(&inv) {
+                                    SYNC_DONE
+                                } else {
+                                    SYNC_FAILED
+                                };
+                                state.store(next, Ordering::Release);
+                            });
                         }
                         cx.update(|cx| {
                             let cache = asset::AssetResolver::new();
@@ -330,14 +348,31 @@ fn reconcile_early_config() {
     }
 }
 
-fn sync_assets_if_needed(inventories: &[DeviceInventory]) {
+/// Asset-sync state, stored in an [`AtomicU8`] and polled on each inventory
+/// snapshot. A failed run flips back to [`SYNC_FAILED`] so the next tick
+/// retries, rather than latching the sync off for the whole session.
+const SYNC_IDLE: u8 = 0;
+const SYNC_RUNNING: u8 = 1;
+const SYNC_DONE: u8 = 2;
+const SYNC_FAILED: u8 = 3;
+
+/// Refresh the asset cache for the connected devices. Returns `true` when the
+/// sync completed (or wasn't needed) and `false` when it failed and should be
+/// retried. Runs on a dedicated background thread — the HTTP layer's blocking
+/// retries are fine here.
+fn sync_assets_if_needed(inventories: &[DeviceInventory]) -> bool {
     let probe_cache = asset::AssetResolver::new();
-    if asset::sync::should_run(probe_cache.has_bundle_root()) {
-        let server = std::env::var("OPENLOGI_ASSETS")
-            .unwrap_or_else(|_| asset::sync::DEFAULT_BASE.to_string());
-        let models = collect_models(inventories);
-        if let Err(e) = asset::sync::sync(&server, &models) {
-            warn!(error = ?e, "asset sync raised — continuing with whatever's cached");
+    if !asset::sync::should_run(probe_cache.has_bundle_root()) {
+        return true;
+    }
+    let server =
+        std::env::var("OPENLOGI_ASSETS").unwrap_or_else(|_| asset::sync::DEFAULT_BASE.to_string());
+    let models = collect_models(inventories);
+    match asset::sync::sync(&server, &models) {
+        Ok(()) => true,
+        Err(e) => {
+            warn!(error = ?e, "asset sync failed — will retry on the next device snapshot");
+            false
         }
     }
 }


### PR DESCRIPTION
## Problem

The startup asset sync ran **once per session and swallowed every failure**, so a single transient hiccup (DNS blip, dropped connection, 5xx, or a thread that downloaded nothing) left the device stuck on the synthetic silhouette until the app was restarted.

Two independent defects (see #134):

1. `assets_synced` latched the moment the background sync thread was *spawned*, not when it *succeeded* — so a failed run was never retried.
2. The sync swallowed errors (`warn!` + `return Ok(())`), and the HTTP layer did a single `.call()` with no retry — one blip dropped the asset for the whole session.

## Fix

**HTTP layer — bounded retry with exponential backoff** (`openlogi-assets`)
- Wrap the blocking GET + body read in [`backon`](https://crates.io/crates/backon)'s `ExponentialBuilder` (3 tries, 200ms base, factor 2, jittered). Default `std::thread::sleep` — every caller runs on the sync's dedicated background thread.
- `is_retryable` classifies the typed `ureq::Error`: transport hiccups, timeouts, and 5xx (plus 408/429) retry; a 404 or malformed request fails fast. Unit-tested.

**Sync orchestration — retry on failure instead of latching once** (`openlogi-gui`)
- `sync()` now returns `Err` when the *index* fetch fails (after the HTTP retries) rather than swallowing it. Per-depot/variant failures stay best-effort (an optional colour-variant 404 shouldn't block everything).
- Replace the spawn-time boolean latch with a small `AtomicU8` state machine polled on the existing 2s inventory tick: `IDLE`/`FAILED` (re)spawns the sync, `RUNNING` blocks a concurrent run, `DONE` latches success for good. A transient outage now self-heals within one tick instead of needing a restart.

## Live verification

Ran the GUI against a refused host (`OPENLOGI_ASSETS=http://127.0.0.1:9`):

- **Backoff (HTTP layer):** each failed sync did 2 backoff retries with exponential + jittered delays (`backoff_ms` ≈ 200→400 nominal, jittered to 390/500, 357/517, 228/619, …), classifying `Io(ConnectionRefused)` as retryable before giving up.
- **Retry-on-tick (orchestration):** `asset sync failed — will retry on the next device snapshot` fired repeatedly (every subsequent inventory snapshot) instead of once-and-done. Once the host recovers, the next tick's sync succeeds → `DONE` → retries stop and the image appears within a tick.

Pre-fix, the same scenario produced zero retries and a permanent silhouette until restart.

## Not included (follow-up)

The optional third direction from #134 — re-syncing when a device resolves to *no* depot at sync time (e.g. codename not yet read) — is deferred. With the `modelIds` matching fix (#137) live, a BLE device resolves by pid without waiting on codename, so that race is largely moot; doing it safely would need a give-up counter to avoid spinning on genuinely-unsupported devices. Tracked as a smaller follow-up.

Closes #134.
