### PR TITLE
refactor: replace hand-rolled code with std/num_enum equivalents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4628,7 +4628,6 @@ dependencies = [
  "futures",
  "hex",
  "hidreport",
- "lazy_static",
  "num_enum",
  "rand 0.9.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,6 +4611,7 @@ version = "0.5.1"
 dependencies = [
  "async-hid",
  "futures-lite 2.6.1",
+ "num_enum",
  "openlogi-core",
  "openlogi-hidpp",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ sha2 = "0.10"
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 thiserror = "2"
+num_enum = "0.7.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 core-graphics = { version = "0.25", default-features = false, features = ["link"] }

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { workspace = true }
 futures-lite = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-num_enum = "0.7.3"
+num_enum = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { workspace = true }
 futures-lite = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+num_enum = "0.7.3"
 
 [lints]
 workspace = true

--- a/crates/openlogi-hid/src/smartshift.rs
+++ b/crates/openlogi-hid/src/smartshift.rs
@@ -25,36 +25,20 @@ use hidpp::{
     nibble::U4,
     protocol::v20::{self, Hidpp20Error},
 };
+use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 /// SmartShift mode values understood by the firmware. `Free` = free-spin,
-/// `Ratchet` = clicky / smartshift-off.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// `Ratchet` = clicky / smartshift-off. The discriminant is the wire byte;
+/// reserved values (`0` / `3` / future) fail [`TryFrom`] and callers fall back
+/// to whatever they consider sane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
+#[repr(u8)]
 pub enum SmartShiftMode {
-    Free,
-    Ratchet,
+    Free = 1,
+    Ratchet = 2,
 }
 
 impl SmartShiftMode {
-    /// Wire byte for the `setRatchetControlMode` request.
-    #[must_use]
-    pub fn as_byte(self) -> u8 {
-        match self {
-            SmartShiftMode::Free => 1,
-            SmartShiftMode::Ratchet => 2,
-        }
-    }
-
-    /// Inverse of [`Self::as_byte`]. `None` for reserved values (0 / 3 /
-    /// future). Callers fall back to whatever they consider sane.
-    #[must_use]
-    pub fn from_byte(b: u8) -> Option<Self> {
-        match b {
-            1 => Some(Self::Free),
-            2 => Some(Self::Ratchet),
-            _ => None,
-        }
-    }
-
     /// The opposite mode — used by [`crate::write::toggle_smartshift`].
     #[must_use]
     pub fn flipped(self) -> Self {
@@ -135,7 +119,7 @@ impl SmartShiftFeatureV0 {
             ))
             .await?;
         let payload = response.extend_payload();
-        let mode = SmartShiftMode::from_byte(payload[0]).unwrap_or(SmartShiftMode::Ratchet);
+        let mode = SmartShiftMode::try_from(payload[0]).unwrap_or(SmartShiftMode::Ratchet);
         Ok(SmartShiftStatus {
             mode,
             auto_disengage: payload[1],
@@ -162,7 +146,7 @@ impl SmartShiftFeatureV0 {
                     function_id: U4::from_lo(FUNCTION_SET_STATUS),
                     software_id: self.chan.get_sw_id(),
                 },
-                [mode.as_byte(), auto_disengage, tunable_torque],
+                [u8::from(mode), auto_disengage, tunable_torque],
             ))
             .await?;
         Ok(())

--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -33,7 +33,6 @@ hidreport = "0.5.0"
 futures = "0.3.31"
 async-trait = "0.1.88"
 rand = "0.9.0"
-lazy_static = "1.5.0"
 num_enum = "0.7.3"
 async-channel = "2.3.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/openlogi-hidpp/src/feature/registry.rs
+++ b/crates/openlogi-hidpp/src/feature/registry.rs
@@ -1,9 +1,11 @@
 //! Maintains a registry of well-known HID++2.0 features and their default
 //! implementations.
 
-use std::{any::TypeId, collections::HashMap, sync::Arc};
-
-use lazy_static::lazy_static;
+use std::{
+    any::TypeId,
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+};
 
 use super::Feature;
 use crate::{
@@ -77,17 +79,17 @@ fn new_dyn<F: CreatableFeature>(
     )
 }
 
-lazy_static! {
-    static ref KNOWN_FEATURES: HashMap<u16, KnownFeature> = HashMap::from([
+static KNOWN_FEATURES: LazyLock<HashMap<u16, KnownFeature>> = LazyLock::new(|| {
+    HashMap::from([
         (
             0x0000,
             KnownFeature {
                 name: "Root",
                 versions: &[FeatureVersion {
                     starting_version: RootFeature::STARTING_VERSION,
-                    producer: new_dyn::<RootFeature>
-                }]
-            }
+                    producer: new_dyn::<RootFeature>,
+                }],
+            },
         ),
         (
             0x0001,
@@ -95,16 +97,16 @@ lazy_static! {
                 name: "FeatureSet",
                 versions: &[FeatureVersion {
                     starting_version: FeatureSetFeature::STARTING_VERSION,
-                    producer: new_dyn::<FeatureSetFeature>
-                }]
-            }
+                    producer: new_dyn::<FeatureSetFeature>,
+                }],
+            },
         ),
         (
             0x0002,
             KnownFeature {
                 name: "FeatureInfo",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0003,
@@ -112,16 +114,16 @@ lazy_static! {
                 name: "DeviceInformation",
                 versions: &[FeatureVersion {
                     starting_version: DeviceInformationFeature::STARTING_VERSION,
-                    producer: new_dyn::<DeviceInformationFeature>
-                }]
-            }
+                    producer: new_dyn::<DeviceInformationFeature>,
+                }],
+            },
         ),
         (
             0x0004,
             KnownFeature {
                 name: "UnitId",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0005,
@@ -129,16 +131,16 @@ lazy_static! {
                 name: "DeviceTypeAndName",
                 versions: &[FeatureVersion {
                     starting_version: DeviceTypeAndNameFeature::STARTING_VERSION,
-                    producer: new_dyn::<DeviceTypeAndNameFeature>
-                }]
-            }
+                    producer: new_dyn::<DeviceTypeAndNameFeature>,
+                }],
+            },
         ),
         (
             0x0006,
             KnownFeature {
                 name: "DeviceGroups",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0007,
@@ -146,100 +148,100 @@ lazy_static! {
                 name: "DeviceFriendlyName",
                 versions: &[FeatureVersion {
                     starting_version: DeviceFriendlyNameFeature::STARTING_VERSION,
-                    producer: new_dyn::<DeviceFriendlyNameFeature>
-                }]
-            }
+                    producer: new_dyn::<DeviceFriendlyNameFeature>,
+                }],
+            },
         ),
         (
             0x0008,
             KnownFeature {
                 name: "KeepAlive",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0020,
             KnownFeature {
                 name: "ConfigChange",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0021,
             KnownFeature {
                 name: "UniqueRandomId",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0030,
             KnownFeature {
                 name: "TargetSoftware",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x0080,
             KnownFeature {
                 name: "WirelessSignalStrength",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x00c0,
             KnownFeature {
                 name: "DfuControlLegacy",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x00c1,
             KnownFeature {
                 name: "DfuControlUnsigned",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x00c2,
             KnownFeature {
                 name: "DfuControlSigned",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x00c3,
             KnownFeature {
                 name: "DfuControlBolt",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x00d0,
             KnownFeature {
                 name: "Dfu",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x00d1,
             KnownFeature {
                 name: "DfuResumable",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1000,
             KnownFeature {
                 name: "BatteryStatus",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1001,
             KnownFeature {
                 name: "BatteryVoltage",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1004,
@@ -247,170 +249,170 @@ lazy_static! {
                 name: "UnifiedBattery",
                 versions: &[FeatureVersion {
                     starting_version: UnifiedBatteryFeature::STARTING_VERSION,
-                    producer: new_dyn::<UnifiedBatteryFeature>
-                }]
-            }
+                    producer: new_dyn::<UnifiedBatteryFeature>,
+                }],
+            },
         ),
         (
             0x1010,
             KnownFeature {
                 name: "ChargingControl",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1300,
             KnownFeature {
                 name: "LedControl",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1800,
             KnownFeature {
                 name: "GenericTest",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1802,
             KnownFeature {
                 name: "DeviceReset",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1805,
             KnownFeature {
                 name: "OobState",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1806,
             KnownFeature {
                 name: "ConfigDeviceProps",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1814,
             KnownFeature {
                 name: "ChangeHost",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1815,
             KnownFeature {
                 name: "HostsInfo",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1981,
             KnownFeature {
                 name: "Backlight1",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1982,
             KnownFeature {
                 name: "Backlight2",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1983,
             KnownFeature {
                 name: "Backlight3",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1990,
             KnownFeature {
                 name: "Illumination",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x19b0,
             KnownFeature {
                 name: "HapticFeedback",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x19c0,
             KnownFeature {
                 name: "ForceSensingButton",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1a00,
             KnownFeature {
                 name: "PresenterControl",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1a01,
             KnownFeature {
                 name: "Sensor3D",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1b00,
             KnownFeature {
                 name: "ReprogControls",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1b01,
             KnownFeature {
                 name: "ReprogControls2",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1b02,
             KnownFeature {
                 name: "ReprogControls3",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1b03,
             KnownFeature {
                 name: "ReprogControls4",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1b04,
             KnownFeature {
                 name: "ReprogControls5",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1bc0,
             KnownFeature {
                 name: "ReportHidUsages",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1c00,
             KnownFeature {
                 name: "PersistentRemappableAction",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1d4b,
@@ -418,58 +420,58 @@ lazy_static! {
                 name: "WirelessDeviceStatus",
                 versions: &[FeatureVersion {
                     starting_version: WirelessDeviceStatusFeature::STARTING_VERSION,
-                    producer: new_dyn::<WirelessDeviceStatusFeature>
-                }]
-            }
+                    producer: new_dyn::<WirelessDeviceStatusFeature>,
+                }],
+            },
         ),
         (
             0x1df0,
             KnownFeature {
                 name: "RemainingPairings",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1f1f,
             KnownFeature {
                 name: "FirmwareProperties",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x1f20,
             KnownFeature {
                 name: "AdcMeasurement",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2001,
             KnownFeature {
                 name: "SwapLeftRightButton",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2005,
             KnownFeature {
                 name: "ButtonSwapCancel",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2006,
             KnownFeature {
                 name: "PointerAxesOrientation",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2100,
             KnownFeature {
                 name: "VerticalScrolling",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2110,
@@ -477,23 +479,23 @@ lazy_static! {
                 name: "SmartShiftWheel",
                 versions: &[FeatureVersion {
                     starting_version: SmartShiftFeature::STARTING_VERSION,
-                    producer: new_dyn::<SmartShiftFeature>
-                }]
-            }
+                    producer: new_dyn::<SmartShiftFeature>,
+                }],
+            },
         ),
         (
             0x2111,
             KnownFeature {
                 name: "SmartShiftWheelEnhanced",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2120,
             KnownFeature {
                 name: "HighResolutionScrolling",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2121,
@@ -501,16 +503,16 @@ lazy_static! {
                 name: "HiResWheel",
                 versions: &[FeatureVersion {
                     starting_version: HiResWheelFeature::STARTING_VERSION,
-                    producer: new_dyn::<HiResWheelFeature>
-                }]
-            }
+                    producer: new_dyn::<HiResWheelFeature>,
+                }],
+            },
         ),
         (
             0x2130,
             KnownFeature {
                 name: "RatchetWheel",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2150,
@@ -518,16 +520,16 @@ lazy_static! {
                 name: "Thumbwheel",
                 versions: &[FeatureVersion {
                     starting_version: ThumbwheelFeature::STARTING_VERSION,
-                    producer: new_dyn::<ThumbwheelFeature>
-                }]
-            }
+                    producer: new_dyn::<ThumbwheelFeature>,
+                }],
+            },
         ),
         (
             0x2200,
             KnownFeature {
                 name: "MousePointer",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2201,
@@ -535,366 +537,366 @@ lazy_static! {
                 name: "AdjustableDpi",
                 versions: &[FeatureVersion {
                     starting_version: AdjustableDpiFeature::STARTING_VERSION,
-                    producer: new_dyn::<AdjustableDpiFeature>
-                }]
-            }
+                    producer: new_dyn::<AdjustableDpiFeature>,
+                }],
+            },
         ),
         (
             0x2202,
             KnownFeature {
                 name: "ExtendedAdjustableDpi",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2205,
             KnownFeature {
                 name: "PointerMotionScaling",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2230,
             KnownFeature {
                 name: "SensorAngleSnapping",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2240,
             KnownFeature {
                 name: "SurfaceTuning",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2250,
             KnownFeature {
                 name: "XyStats",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2251,
             KnownFeature {
                 name: "WheelStats",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x2400,
             KnownFeature {
                 name: "HybridTrackingEngine",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x40a0,
             KnownFeature {
                 name: "FnInversion",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x40a2,
             KnownFeature {
                 name: "FnInversionWithDefaultState",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x40a3,
             KnownFeature {
                 name: "FnInversionForMultiHostDevices",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4100,
             KnownFeature {
                 name: "Encryption",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4220,
             KnownFeature {
                 name: "LockKeyState",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4301,
             KnownFeature {
                 name: "SolarKeyboardDashboard",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4520,
             KnownFeature {
                 name: "KeyboardLayout",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4521,
             KnownFeature {
                 name: "DisableKeys",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4522,
             KnownFeature {
                 name: "DisableKeysByUsage",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4530,
             KnownFeature {
                 name: "DualPlatform",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4531,
             KnownFeature {
                 name: "MultiPlatform",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4540,
             KnownFeature {
                 name: "KeyboardInternationalLayouts",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x4600,
             KnownFeature {
                 name: "Crown",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6010,
             KnownFeature {
                 name: "TouchpadFwItems",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6011,
             KnownFeature {
                 name: "TouchpadSwItems",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6012,
             KnownFeature {
                 name: "TouchpadWin8FwItems",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6020,
             KnownFeature {
                 name: "TapEnable",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6021,
             KnownFeature {
                 name: "TapEnableExtended",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6030,
             KnownFeature {
                 name: "CursorBallistic",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6040,
             KnownFeature {
                 name: "TouchpadResolutionDivider",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6100,
             KnownFeature {
                 name: "TouchpadRawXy",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6110,
             KnownFeature {
                 name: "TouchMouseRawTouchPoints",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6120,
             KnownFeature {
                 name: "BtTouchMouseSettings",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6500,
             KnownFeature {
                 name: "Gestures1",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x6501,
             KnownFeature {
                 name: "Gestures2",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8010,
             KnownFeature {
                 name: "GamingGKeys",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8020,
             KnownFeature {
                 name: "GamingMKeys",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8030,
             KnownFeature {
                 name: "MacroRecord",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8040,
             KnownFeature {
                 name: "BrightnessControl",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8060,
             KnownFeature {
                 name: "AdjustableReportRate",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8061,
             KnownFeature {
                 name: "ExtendedAdjustableReportRate",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8070,
             KnownFeature {
                 name: "ColorLedEffects",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8071,
             KnownFeature {
                 name: "RgbEffects",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8080,
             KnownFeature {
                 name: "PerKeyLighting",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8081,
             KnownFeature {
                 name: "PerKeyLighting2",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8090,
             KnownFeature {
                 name: "ModeStatus",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8100,
             KnownFeature {
                 name: "OnboardProfiles",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8110,
             KnownFeature {
                 name: "MouseButtonFilter",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8111,
             KnownFeature {
                 name: "LatencyMonitoring",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8120,
             KnownFeature {
                 name: "GamingAttachments",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8123,
             KnownFeature {
                 name: "ForceFeedback",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8300,
             KnownFeature {
                 name: "Sidetone",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8310,
             KnownFeature {
                 name: "Equalizer",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
         (
             0x8320,
             KnownFeature {
                 name: "HeadsetOut",
-                versions: &[]
-            }
+                versions: &[],
+            },
         ),
-    ]);
-}
+    ])
+});


### PR DESCRIPTION
Two independent cleanups from a codebase-wide audit for "hand-rolled code where a mature/std equivalent already exists". Each is its own commit.

## 1. `hidpp`: `lazy_static` → `std::sync::LazyLock`
`feature/registry.rs` was the **only** `lazy_static!` user left in the workspace — every other static/enum already relies on std or `num_enum`, and `openlogi-hid/transport.rs` already uses `LazyLock`. `std::sync::LazyLock` (stable since 1.80, well under the 1.85 MSRV) expresses the same lazily-initialized `HashMap` with no external dependency.

- Drops the `lazy_static` dependency entirely.
- Public API (`lookup`, `lookup_version`) unchanged.
- The large diff is rustfmt reformatting the map literal — it now lives in a real expression rather than an unformatted macro body.

## 2. `hid`: `SmartShiftMode` conversions via `num_enum`
`SmartShiftMode` hand-wrote `as_byte`/`from_byte` match arms for a two-variant enum whose discriminants are the wire bytes (`1` = Free, `2` = Ratchet). `num_enum` is already a dependency of `openlogi-hidpp`, where the sibling `WheelMode` enum uses exactly this pattern, so the hand-rolled conversions were a stray inconsistency.

- Encode the wire bytes as the `#[repr(u8)]` discriminant; derive `IntoPrimitive` + `TryFromPrimitive`.
- Reserved bytes now surface as a `TryFrom` error (callers already fall back to `Ratchet`). `flipped()` stays — no primitive equivalent.
- Deliberately omits `#[non_exhaustive]` (unlike `WheelMode`): the GUI's SmartShift panel matches `SmartShiftMode` exhaustively across the crate boundary, and keeping the enum closed preserves that compile-time check.

## Verification
- `cargo clippy -p openlogi-hidpp -p openlogi-hid -p openlogi-cli --all-targets` — clean (pedantic + denied unsafe/unwrap).
- `cargo test -p openlogi-hidpp -p openlogi-hid` — all pass.
- `cargo fmt --check` — clean.