### PR TITLE
ci: run clippy on Windows instead of bare cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,18 @@ jobs:
         run: test "$(uname -m)" = "${{ matrix.arch }}"
       - run: cargo test --workspace --all-targets
 
-  check-windows:
-    name: cargo check (windows)
+  clippy-windows:
+    name: clippy (windows)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
-      # openlogi-gui's GPUI/Metal deps don't build on Windows yet — restrict to
-      # the platform-agnostic crates so the workspace stays green on push.
-      - run: cargo check -p openlogi-core -p openlogi-hid -p openlogi-assets -p openlogi -p openlogi-hook --all-targets
+      # openlogi-gui's GPUI backend doesn't build on Windows yet — restrict to
+      # the platform-agnostic crates so the workspace stays green on push. clippy
+      # subsumes `cargo check` and additionally lints the Windows-only code paths
+      # (the WH_MOUSE_LL hook, SendInput synthesis, native HID writer, WinRT
+      # pairing) that the Linux/macOS clippy jobs never compile.
+      - run: cargo clippy -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-assets -p openlogi-cli -p openlogi -p openlogi-hook --all-targets -- -D warnings

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -253,6 +253,10 @@ pub enum ConfigError {
     UnsupportedSchemaVersion { path: PathBuf, found: u32 },
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "Config I/O keeps rich parse/write context and is not a hot path"
+)]
 impl Config {
     /// Loads the config from the default user path, returning
     /// [`Config::default`] if the file does not exist yet.


### PR DESCRIPTION
## What

Upgrade the Windows CI job from `cargo check` to `cargo clippy ... -- -D warnings`.

## Why

The Windows job only ran `cargo check`, so the `-D warnings` clippy gate that protects every other platform never covered the Windows-only code paths. Those paths are non-trivial and growing (the incoming Windows port in #93 adds the `WH_MOUSE_LL` hook, `SendInput` action synthesis, a native HID writer, and WinRT Bluetooth pairing). clippy compiles everything `cargo check` did **plus** runs the lint set, so this strictly widens coverage on the same runner — no extra job.

## Changes

- `check-windows` → `clippy-windows` (runs `cargo clippy -- -D warnings`, adds the `clippy` toolchain component).
- Added `openlogi-cli` to the linted set — its `diag windows-pair` subcommand is Windows-specific — and `openlogi-hidpp` for parity with the Linux/macOS `--workspace` clippy.
- `openlogi-gui` stays excluded; GPUI has no Windows backend wired up yet.

## Validation

The crate list resolves and is clippy-clean on the host; the actual Windows lint runs on this PR's `windows-latest` job. Branch protection pins no status-check contexts, so the job rename is safe.