### PR TITLE
fix: gate device config panels on HID++ capabilities (closes #127)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4664,6 +4664,7 @@ name = "openlogi-hid"
 version = "0.5.1"
 dependencies = [
  "async-hid",
+ "futures-concurrency",
  "futures-lite 2.6.1",
  "num_enum",
  "openlogi-core",

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -60,6 +60,64 @@ impl DeviceKind {
     }
 }
 
+/// What a device can be *configured* to do, derived from the HID++ feature
+/// table it reports (feature `0x0001`). This is the source of truth for which
+/// configuration panels the UI offers — a panel shows iff the device exposes
+/// the feature that drives it. Gating on capability rather than on
+/// [`DeviceKind`] is what keeps a misclassified device from losing its panels
+/// (issue #127): kind is an identity guess, capability is what the firmware
+/// actually announced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+pub struct Capabilities {
+    /// Reprogrammable buttons — HID++ `0x1b00`–`0x1b04` (ReprogControls).
+    pub buttons: bool,
+    /// Adjustable pointer resolution — HID++ `0x2201` / `0x2202` (AdjustableDpi).
+    pub pointer: bool,
+    /// Controllable lighting — HID++ `0x8040`/`0x8070`/`0x8071`/`0x8080`/`0x8081`
+    /// (RGB) or `0x1981`–`0x1983`/`0x1990` (backlight/illumination).
+    pub lighting: bool,
+}
+
+impl Capabilities {
+    /// Derive capabilities from the set of HID++ feature IDs a device reports.
+    /// Membership of a driving feature ID flips the corresponding flag.
+    #[must_use]
+    pub fn from_feature_ids(ids: &[u16]) -> Self {
+        const BUTTONS: [u16; 5] = [0x1b00, 0x1b01, 0x1b02, 0x1b03, 0x1b04];
+        const POINTER: [u16; 2] = [0x2201, 0x2202];
+        const LIGHTING: [u16; 9] = [
+            0x8040, 0x8070, 0x8071, 0x8080, 0x8081, 0x1981, 0x1982, 0x1983, 0x1990,
+        ];
+        let has = |family: &[u16]| ids.iter().any(|id| family.contains(id));
+        Self {
+            buttons: has(&BUTTONS),
+            pointer: has(&POINTER),
+            lighting: has(&LIGHTING),
+        }
+    }
+
+    /// Best-effort capabilities for a device we could not probe (offline /
+    /// never reached), guessed from its [`DeviceKind`]. Used only as a fallback
+    /// when no measured [`Capabilities`] exist — a sleeping mouse should still
+    /// show its button/pointer panels so its bindings (host-side) stay
+    /// configurable.
+    #[must_use]
+    pub fn presumed_from_kind(kind: DeviceKind) -> Self {
+        match kind {
+            DeviceKind::Mouse | DeviceKind::Trackball => Self {
+                buttons: true,
+                pointer: true,
+                lighting: false,
+            },
+            DeviceKind::Keyboard => Self {
+                lighting: true,
+                ..Self::default()
+            },
+            _ => Self::default(),
+        }
+    }
+}
+
 /// Coarse battery bucket reported by the device firmware.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -163,6 +221,10 @@ pub struct PairedDevice {
     /// Output of HID++ feature 0x0003 — populated for online devices that
     /// expose the feature. Drives asset-registry lookups in the GUI.
     pub model_info: Option<DeviceModelInfo>,
+    /// Configuration capabilities derived from the device's HID++ feature
+    /// table. `None` for devices we couldn't probe (offline / unreachable);
+    /// the GUI then falls back to [`Capabilities::presumed_from_kind`].
+    pub capabilities: Option<Capabilities>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -195,5 +257,49 @@ mod tests {
             DeviceKind::Unknown
         );
         assert_eq!(DeviceKind::from_registry_type(""), DeviceKind::Unknown);
+    }
+
+    #[test]
+    fn capabilities_track_the_driving_feature_ids() {
+        use super::Capabilities;
+        // A typical MX mouse: ReprogControls (0x1b04) + ExtendedAdjustableDpi
+        // (0x2202), no lighting.
+        let mouse = Capabilities::from_feature_ids(&[0x0003, 0x1b04, 0x2202, 0x2110]);
+        assert_eq!(
+            mouse,
+            Capabilities {
+                buttons: true,
+                pointer: true,
+                lighting: false,
+            }
+        );
+        // A wired G-series keyboard: PerKeyLighting (0x8080), no DPI/buttons.
+        let keyboard = Capabilities::from_feature_ids(&[0x0001, 0x8080]);
+        assert_eq!(
+            keyboard,
+            Capabilities {
+                buttons: false,
+                pointer: false,
+                lighting: true,
+            }
+        );
+        // No driving features → nothing offered.
+        assert_eq!(
+            Capabilities::from_feature_ids(&[0x0000, 0x0003]),
+            Capabilities::default()
+        );
+    }
+
+    #[test]
+    fn presumed_capabilities_keep_an_unprobed_mouse_configurable() {
+        use super::Capabilities;
+        let mouse = Capabilities::presumed_from_kind(DeviceKind::Mouse);
+        assert!(mouse.buttons && mouse.pointer && !mouse.lighting);
+        assert!(Capabilities::presumed_from_kind(DeviceKind::Keyboard).lighting);
+        // An unidentified device presumes nothing — it must be measured.
+        assert_eq!(
+            Capabilities::presumed_from_kind(DeviceKind::Unknown),
+            Capabilities::default()
+        );
     }
 }

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -8,6 +8,15 @@ use serde::Serialize;
 
 /// What a paired peripheral is. Mirrors `hidpp::receiver::bolt::BoltDeviceKind`
 /// but is owned by us so consumers don't depend on `hidpp`.
+///
+/// Several upstream "device type" vocabularies feed this one enum, and they do
+/// **not** agree on numbers: the Bolt pairing register uses `Unknown=0,
+/// Keyboard=1, Mouse=2, …`, while the HID++ `0x0005` feature uses
+/// `Keyboard=0, …, Mouse=3, …` (no `Unknown` at all). The asset registry adds a
+/// third, free-form *string* type (`"mouse"`, case-inconsistently `"MOUSE"`).
+/// They are converted to this enum at their respective boundaries — never by
+/// reinterpreting one source's raw byte with another's table — so the numeric
+/// mismatch can't leak past those mappers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DeviceKind {
@@ -23,6 +32,32 @@ pub enum DeviceKind {
     Joystick,
     Headset,
     Unknown,
+}
+
+impl DeviceKind {
+    /// Parse the OpenLogi asset registry's `type` string into a [`DeviceKind`].
+    ///
+    /// The registry field is free-form and case-inconsistent (both `"mouse"`
+    /// and `"MOUSE"` ship), so we case-fold before matching. Values we don't
+    /// model map to [`DeviceKind::Unknown`], which callers treat as "no asset
+    /// opinion" and fall back to the HID++ classification.
+    #[must_use]
+    pub fn from_registry_type(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "mouse" => Self::Mouse,
+            "keyboard" => Self::Keyboard,
+            "numpad" => Self::Numpad,
+            "presenter" => Self::Presenter,
+            "remote" | "remotecontrol" => Self::Remote,
+            "trackball" => Self::Trackball,
+            "touchpad" | "trackpad" => Self::Touchpad,
+            "tablet" => Self::Tablet,
+            "gamepad" => Self::Gamepad,
+            "joystick" => Self::Joystick,
+            "headset" => Self::Headset,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 /// Coarse battery bucket reported by the device firmware.
@@ -134,4 +169,31 @@ pub struct PairedDevice {
 pub struct DeviceInventory {
     pub receiver: ReceiverInfo,
     pub paired: Vec<PairedDevice>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeviceKind;
+
+    #[test]
+    fn registry_type_is_case_folded() {
+        // The registry ships both `"mouse"` and `"MOUSE"`; both must resolve so
+        // the asset cross-check can't silently miss a depot.
+        assert_eq!(DeviceKind::from_registry_type("mouse"), DeviceKind::Mouse);
+        assert_eq!(DeviceKind::from_registry_type("MOUSE"), DeviceKind::Mouse);
+        assert_eq!(
+            DeviceKind::from_registry_type("  Keyboard "),
+            DeviceKind::Keyboard
+        );
+    }
+
+    #[test]
+    fn unknown_registry_type_defers_to_the_caller() {
+        // Unmodelled / empty → Unknown, i.e. "no asset opinion".
+        assert_eq!(
+            DeviceKind::from_registry_type("webcam"),
+            DeviceKind::Unknown
+        );
+        assert_eq!(DeviceKind::from_registry_type(""), DeviceKind::Unknown);
+    }
 }

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -15,7 +15,7 @@ use gpui_component::{
 };
 use openlogi_core::config::Config;
 use openlogi_core::device::{
-    BatteryInfo, BatteryLevel, BatteryStatus, DeviceInventory, DeviceKind,
+    BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
 };
 use openlogi_hid::DeviceRoute;
 use tracing::{info, warn};
@@ -73,21 +73,25 @@ impl DetailTab {
     /// The detail sections shown for `record`, in tab order. Always non-empty:
     /// every device gets at least the info tab.
     ///
-    /// This gates panels on the coarse [`DeviceKind`], which is a stand-in for
-    /// the real signal: which HID++ features the device actually exposes. The
-    /// kind can be wrong (the whole of #127) and the `kind ⇒ panel-set` mapping
-    /// bakes in "every mouse has buttons+DPI, every keyboard only has lighting"
-    /// — both false in general. Before keyboard configuration lands, move this
-    /// to capability-driven gating (show Buttons iff `0x1b04`, Pointer iff
-    /// `0x2201`/`0x2202`, Lighting iff `0x8070`/`0x8071`, …) or the keyboard
-    /// will lose its real config the same way the mouse lost its tabs here.
+    /// Each panel is gated on the device's actual [`Capabilities`] — the HID++
+    /// features it announced — not on its [`DeviceKind`]. A panel shows iff the
+    /// device can do that thing, so a misclassified device can't lose its
+    /// panels (issue #127) and a keyboard's future button config won't be hidden
+    /// by a kind check. Devices we never probed (offline at startup) have no
+    /// measured capabilities; we presume a set from their kind so a sleeping
+    /// mouse still shows its (host-side) button bindings.
     fn tabs_for(record: &DeviceRecord) -> Vec<Self> {
+        let caps = record
+            .capabilities
+            .unwrap_or_else(|| Capabilities::presumed_from_kind(record.kind));
         let mut tabs = Vec::new();
-        if is_configurable_pointer(record.kind) {
+        if caps.buttons {
             tabs.push(Self::Buttons);
+        }
+        if caps.pointer {
             tabs.push(Self::Pointer);
         }
-        if supports_lighting(record) {
+        if caps.lighting {
             tabs.push(Self::Lighting);
         }
         tabs.push(Self::Device);
@@ -110,28 +114,6 @@ impl DetailTab {
             Self::Device => tr!("Device"),
         }
     }
-}
-
-/// Whether a device drives the mouse model + DPI panel. Other kinds (keyboards,
-/// numpads, headsets…) don't get a mouse silhouette that doesn't describe them
-/// (issue #19); they fall back to the info tab — and, for wired keyboards, the
-/// lighting tab.
-fn is_configurable_pointer(kind: DeviceKind) -> bool {
-    matches!(kind, DeviceKind::Mouse | DeviceKind::Trackball)
-}
-
-/// Whether to offer the RGB lighting tab. A `Keyboard` is always a keyboard;
-/// wired G-series keyboards, though, enumerate as `Unknown` over the direct
-/// (USB) path (it carries no codename or kind), so a direct-attached `Unknown`
-/// counts too.
-///
-/// [`openlogi_hid::set_keyboard_color`] only drives the *wired* path today (it
-/// opens a raw USB writer), so a Bolt/Unifying-paired keyboard's writes no-op
-/// until a wireless lighting path lands — the tab still persists the config.
-fn supports_lighting(record: &DeviceRecord) -> bool {
-    matches!(record.kind, DeviceKind::Keyboard)
-        || (matches!(record.kind, DeviceKind::Unknown)
-            && matches!(record.route, Some(DeviceRoute::Direct { .. })))
 }
 
 /// Root application view.
@@ -1290,58 +1272,67 @@ fn accessibility_status(pal: Palette, granted: bool) -> AnyElement {
 
 #[cfg(test)]
 mod tests {
-    use super::{DetailTab, DeviceKind, DeviceRecord, DeviceRoute};
+    use super::{Capabilities, DetailTab, DeviceKind, DeviceRecord};
 
-    fn record(kind: DeviceKind, route: Option<DeviceRoute>) -> DeviceRecord {
+    fn record(kind: DeviceKind, capabilities: Option<Capabilities>) -> DeviceRecord {
         DeviceRecord {
             config_key: "test".to_string(),
             display_name: "Test".to_string(),
             asset: None,
             serial_number: None,
             unit_id: [0; 4],
-            route,
+            route: None,
             kind,
+            capabilities,
             slot: 1,
             online: true,
             battery: None,
         }
     }
 
-    /// The #127 contract: a pointer device must always offer button + pointer
-    /// tuning and must never collapse to a lighting-only screen.
+    /// Tabs follow measured capabilities, not kind — the core of the #127 fix.
+    /// A device the registry mislabels (kind=Keyboard) but that exposes button +
+    /// pointer features still gets its Buttons/Pointer tabs and no lighting.
     #[test]
-    fn pointer_devices_always_get_buttons_and_pointer() {
-        for kind in [DeviceKind::Mouse, DeviceKind::Trackball] {
-            let tabs = DetailTab::tabs_for(&record(kind, None));
-            assert!(tabs.contains(&DetailTab::Buttons), "{kind:?} lost Buttons");
-            assert!(tabs.contains(&DetailTab::Pointer), "{kind:?} lost Pointer");
-            assert!(
-                !tabs.contains(&DetailTab::Lighting),
-                "{kind:?} should not show a lighting tab"
-            );
-        }
-    }
-
-    #[test]
-    fn keyboard_gets_lighting_not_pointer_tabs() {
-        let tabs = DetailTab::tabs_for(&record(DeviceKind::Keyboard, None));
-        assert!(tabs.contains(&DetailTab::Lighting));
-        assert!(!tabs.contains(&DetailTab::Buttons));
-        assert!(!tabs.contains(&DetailTab::Pointer));
-    }
-
-    /// The wired-keyboard fallback: an unidentified direct device still offers
-    /// lighting. Kept intentionally — a misdetected mouse is now prevented
-    /// upstream by `0x0005` / asset-registry classification, not by narrowing
-    /// this heuristic.
-    #[test]
-    fn unknown_direct_device_keeps_the_lighting_fallback() {
-        let route = Some(DeviceRoute::Direct {
-            vendor_id: 0x046d,
-            product_id: 0xc548,
+    fn tabs_follow_capabilities_not_kind() {
+        let caps = Some(Capabilities {
+            buttons: true,
+            pointer: true,
+            lighting: false,
         });
-        let tabs = DetailTab::tabs_for(&record(DeviceKind::Unknown, route));
-        assert!(tabs.contains(&DetailTab::Lighting));
-        assert!(!tabs.contains(&DetailTab::Buttons));
+        let tabs = DetailTab::tabs_for(&record(DeviceKind::Keyboard, caps));
+        assert!(tabs.contains(&DetailTab::Buttons));
+        assert!(tabs.contains(&DetailTab::Pointer));
+        assert!(!tabs.contains(&DetailTab::Lighting));
+    }
+
+    /// Each panel is independent: a lighting-only device (e.g. a keyboard with
+    /// RGB but no remappable keys yet) shows only Lighting + Device.
+    #[test]
+    fn lighting_only_device_shows_only_lighting() {
+        let caps = Some(Capabilities {
+            lighting: true,
+            ..Capabilities::default()
+        });
+        let tabs = DetailTab::tabs_for(&record(DeviceKind::Keyboard, caps));
+        assert_eq!(tabs, vec![DetailTab::Lighting, DetailTab::Device]);
+    }
+
+    /// An unprobed (offline) device has no measured capabilities and falls back
+    /// to a kind presumption, so a sleeping mouse keeps its button/pointer tabs.
+    #[test]
+    fn unprobed_mouse_falls_back_to_presumed_capabilities() {
+        let tabs = DetailTab::tabs_for(&record(DeviceKind::Mouse, None));
+        assert!(tabs.contains(&DetailTab::Buttons));
+        assert!(tabs.contains(&DetailTab::Pointer));
+        assert!(!tabs.contains(&DetailTab::Lighting));
+    }
+
+    /// An unprobed, unidentified device presumes nothing — only the info tab,
+    /// rather than guessing wrong panels (the old Unknown+Direct→lighting bug).
+    #[test]
+    fn unprobed_unknown_device_shows_only_device_tab() {
+        let tabs = DetailTab::tabs_for(&record(DeviceKind::Unknown, None));
+        assert_eq!(tabs, vec![DetailTab::Device]);
     }
 }

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -72,6 +72,15 @@ enum DetailTab {
 impl DetailTab {
     /// The detail sections shown for `record`, in tab order. Always non-empty:
     /// every device gets at least the info tab.
+    ///
+    /// This gates panels on the coarse [`DeviceKind`], which is a stand-in for
+    /// the real signal: which HID++ features the device actually exposes. The
+    /// kind can be wrong (the whole of #127) and the `kind ⇒ panel-set` mapping
+    /// bakes in "every mouse has buttons+DPI, every keyboard only has lighting"
+    /// — both false in general. Before keyboard configuration lands, move this
+    /// to capability-driven gating (show Buttons iff `0x1b04`, Pointer iff
+    /// `0x2201`/`0x2202`, Lighting iff `0x8070`/`0x8071`, …) or the keyboard
+    /// will lose its real config the same way the mouse lost its tabs here.
     fn tabs_for(record: &DeviceRecord) -> Vec<Self> {
         let mut tabs = Vec::new();
         if is_configurable_pointer(record.kind) {
@@ -1276,5 +1285,63 @@ fn accessibility_status(pal: Palette, granted: bool) -> AnyElement {
             .child(div().child(tr!("Accessibility not granted · click to grant")))
             .on_click(|_, _, _| open_accessibility_settings())
             .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DetailTab, DeviceKind, DeviceRecord, DeviceRoute};
+
+    fn record(kind: DeviceKind, route: Option<DeviceRoute>) -> DeviceRecord {
+        DeviceRecord {
+            config_key: "test".to_string(),
+            display_name: "Test".to_string(),
+            asset: None,
+            serial_number: None,
+            unit_id: [0; 4],
+            route,
+            kind,
+            slot: 1,
+            online: true,
+            battery: None,
+        }
+    }
+
+    /// The #127 contract: a pointer device must always offer button + pointer
+    /// tuning and must never collapse to a lighting-only screen.
+    #[test]
+    fn pointer_devices_always_get_buttons_and_pointer() {
+        for kind in [DeviceKind::Mouse, DeviceKind::Trackball] {
+            let tabs = DetailTab::tabs_for(&record(kind, None));
+            assert!(tabs.contains(&DetailTab::Buttons), "{kind:?} lost Buttons");
+            assert!(tabs.contains(&DetailTab::Pointer), "{kind:?} lost Pointer");
+            assert!(
+                !tabs.contains(&DetailTab::Lighting),
+                "{kind:?} should not show a lighting tab"
+            );
+        }
+    }
+
+    #[test]
+    fn keyboard_gets_lighting_not_pointer_tabs() {
+        let tabs = DetailTab::tabs_for(&record(DeviceKind::Keyboard, None));
+        assert!(tabs.contains(&DetailTab::Lighting));
+        assert!(!tabs.contains(&DetailTab::Buttons));
+        assert!(!tabs.contains(&DetailTab::Pointer));
+    }
+
+    /// The wired-keyboard fallback: an unidentified direct device still offers
+    /// lighting. Kept intentionally — a misdetected mouse is now prevented
+    /// upstream by `0x0005` / asset-registry classification, not by narrowing
+    /// this heuristic.
+    #[test]
+    fn unknown_direct_device_keeps_the_lighting_fallback() {
+        let route = Some(DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+        });
+        let tabs = DetailTab::tabs_for(&record(DeviceKind::Unknown, route));
+        assert!(tabs.contains(&DetailTab::Lighting));
+        assert!(!tabs.contains(&DetailTab::Buttons));
     }
 }

--- a/crates/openlogi-gui/src/asset/mod.rs
+++ b/crates/openlogi-gui/src/asset/mod.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use openlogi_assets::{
     BUTTONS_RENDER_FILES, DeviceEntry, FRONT_RENDER_FILES, Index, METADATA_FILES, Metadata,
 };
-use openlogi_core::device::DeviceModelInfo;
+use openlogi_core::device::{DeviceKind, DeviceModelInfo};
 use tracing::{debug, warn};
 
 use self::images::{buttons_image_for, load_manifest, read_png_dimensions, variant_image_for};
@@ -36,6 +36,12 @@ pub struct ResolvedAsset {
     )]
     pub depot: String,
     pub display_name: String,
+    /// The registry's curated device type for this model, normalized from the
+    /// asset index `type` string. Per-model and human-maintained, so it's the
+    /// most authoritative kind signal we have — the UI prefers it over the
+    /// runtime HID++ classification when a device matched a known depot.
+    /// [`DeviceKind::Unknown`] when the registry type was missing/unmodelled.
+    pub kind: DeviceKind,
     pub image_path: PathBuf,
     /// The front/hero render (`device_image`, typically `front_*.png`) used for
     /// the device gallery cards — distinct from [`Self::image_path`], which is
@@ -208,6 +214,7 @@ impl AssetResolver {
             return Some(ResolvedAsset {
                 depot: depot.to_string(),
                 display_name: entry.display_name.clone(),
+                kind: DeviceKind::from_registry_type(&entry.kind),
                 image_path,
                 hero_image_path,
                 metadata,

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -390,8 +390,15 @@ impl AppState {
         let mut merged = Vec::with_capacity(by_key.len().max(self.device_list.len()));
 
         for previous in &self.device_list {
-            if let Some(record) = by_key.remove(&previous.config_key) {
+            if let Some(mut record) = by_key.remove(&previous.config_key) {
                 self.inventory_misses.remove(&previous.config_key);
+                // Capabilities can only be measured while the device is online.
+                // When a known device goes offline (or a probe fails) the fresh
+                // record carries `None`; keep the last-known set so a sleeping
+                // mouse doesn't lose its button/pointer panels.
+                if record.capabilities.is_none() {
+                    record.capabilities = previous.capabilities;
+                }
                 merged.push(record);
                 continue;
             }

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -1,6 +1,6 @@
 //! Device-list construction and selection helpers for [`super::AppState`].
 
-use openlogi_core::device::{BatteryInfo, DeviceInventory, DeviceKind};
+use openlogi_core::device::{BatteryInfo, Capabilities, DeviceInventory, DeviceKind};
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use tracing::debug;
 
@@ -25,6 +25,11 @@ pub struct DeviceRecord {
     pub unit_id: [u8; 4],
     pub route: Option<DeviceRoute>,
     pub kind: DeviceKind,
+    /// Configuration capabilities from the device's HID++ feature table. `None`
+    /// when the device couldn't be probed (offline); the snapshot merge carries
+    /// the last-known value forward, and the UI falls back to
+    /// [`Capabilities::presumed_from_kind`] for a never-probed device.
+    pub capabilities: Option<Capabilities>,
     pub slot: u8,
     pub online: bool,
     pub battery: Option<BatteryInfo>,
@@ -79,6 +84,7 @@ pub(super) fn build_device_list(
                 unit_id: model.unit_id,
                 route: device_route(inv, paired.slot),
                 kind,
+                capabilities: paired.capabilities,
                 slot: paired.slot,
                 online: paired.online,
                 battery: paired.battery.clone(),
@@ -156,6 +162,10 @@ fn demo_keyboard() -> DeviceRecord {
         unit_id: [0; 4],
         route: None,
         kind: DeviceKind::Keyboard,
+        capabilities: Some(Capabilities {
+            lighting: true,
+            ..Capabilities::default()
+        }),
         slot: 0,
         online: true,
         battery: None,

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -2,6 +2,7 @@
 
 use openlogi_core::device::{BatteryInfo, DeviceInventory, DeviceKind};
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
+use tracing::debug;
 
 use crate::asset::{AssetResolver, ResolvedAsset};
 
@@ -69,6 +70,7 @@ pub(super) fn build_device_list(
                 .map(|a| a.display_name.clone())
                 .or_else(|| paired.codename.clone())
                 .unwrap_or_else(|| format!("Slot {}", paired.slot));
+            let kind = effective_kind(paired.kind, asset.as_ref().map(|a| a.kind));
             list.push(DeviceRecord {
                 config_key,
                 display_name,
@@ -76,7 +78,7 @@ pub(super) fn build_device_list(
                 serial_number: model.serial_number.clone(),
                 unit_id: model.unit_id,
                 route: device_route(inv, paired.slot),
-                kind: paired.kind,
+                kind,
                 slot: paired.slot,
                 online: paired.online,
                 battery: paired.battery.clone(),
@@ -182,8 +184,57 @@ fn device_route(inv: &DeviceInventory, slot: u8) -> Option<DeviceRoute> {
     }
 }
 
+/// Pick a device's [`DeviceKind`], preferring the asset registry's curated type
+/// over the runtime HID++ classification.
+///
+/// The registry type is per-model and human-maintained, so a device that
+/// matched a known depot is classified by what that model *is* — not by a Bolt
+/// pairing register that can misreport (the failure behind #127). We fall back
+/// to `hid_kind` when there is no asset or its type is `Unknown`. A genuine
+/// disagreement is logged at debug (the list rebuilds on every snapshot, so a
+/// louder level would spam); it flags a HID++ source we shouldn't trust for
+/// that device.
+fn effective_kind(hid_kind: DeviceKind, asset_kind: Option<DeviceKind>) -> DeviceKind {
+    let Some(asset_kind) = asset_kind.filter(|k| *k != DeviceKind::Unknown) else {
+        return hid_kind;
+    };
+    if hid_kind != DeviceKind::Unknown && hid_kind != asset_kind {
+        debug!(
+            ?hid_kind,
+            ?asset_kind,
+            "HID++ device kind disagrees with the asset registry — trusting the registry"
+        );
+    }
+    asset_kind
+}
+
 pub(super) fn pick_initial_device(list: &[DeviceRecord], saved: Option<&str>) -> usize {
     saved
         .and_then(|key| list.iter().position(|r| r.config_key == key))
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeviceKind, effective_kind};
+
+    #[test]
+    fn asset_kind_overrides_a_misreporting_hid_kind() {
+        // #127: the registry knows this depot is a mouse, so a HID++ source that
+        // reported `Keyboard` loses.
+        assert_eq!(
+            effective_kind(DeviceKind::Keyboard, Some(DeviceKind::Mouse)),
+            DeviceKind::Mouse
+        );
+    }
+
+    #[test]
+    fn hid_kind_is_used_without_a_modelled_asset() {
+        // No asset, or an asset whose type we don't model → keep the HID kind.
+        assert_eq!(effective_kind(DeviceKind::Mouse, None), DeviceKind::Mouse);
+        assert_eq!(
+            effective_kind(DeviceKind::Mouse, Some(DeviceKind::Unknown)),
+            DeviceKind::Mouse
+        );
+    }
 }

--- a/crates/openlogi-gui/src/watchers/inventory.rs
+++ b/crates/openlogi-gui/src/watchers/inventory.rs
@@ -40,8 +40,12 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<Vec<DeviceInventory>> 
                     return;
                 }
             };
+            // A persistent enumerator so its per-device probe cache survives
+            // across ticks — a known device's immutable data (model, features)
+            // is reused instead of being re-handshaked every poll.
+            let mut enumerator = openlogi_hid::Enumerator::default();
             loop {
-                let inv = match rt.block_on(openlogi_hid::enumerate()) {
+                let inv = match rt.block_on(enumerator.enumerate()) {
                     Ok(inv) => inv,
                     Err(e) => {
                         warn!(error = ?e, "enumerate failed during watch tick");

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -19,6 +19,7 @@ futures-lite = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 num_enum = { workspace = true }
+futures-concurrency = "7"
 
 [lints]
 workspace = true

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -1,6 +1,10 @@
 //! Enumerate connected HID++ receivers and their paired devices.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use futures_concurrency::future::Join as _;
 use hidpp::{
@@ -84,6 +88,11 @@ enum CacheKey {
     Direct(async_hid::DeviceId),
 }
 
+/// Enumeration ticks a device may be missing before its cache entry is evicted.
+/// A small grace rides out a transient receiver timeout without dropping the
+/// device's memoized data.
+const CACHE_MISS_GRACE: u8 = 3;
+
 /// A memoized probe result plus the tick it was taken on.
 #[derive(Clone)]
 struct Cached {
@@ -91,9 +100,66 @@ struct Cached {
     probed_tick: u64,
 }
 
+/// What a probed device contributes to the cache this tick. The key lets stale
+/// entries be evicted; `Fresh` also carries the value to insert. `Unkeyed` is a
+/// device we can't (or won't) cache — an all-zero unit id, or a rejected
+/// non-peripheral — so its key is neither inserted nor kept alive.
+enum CacheOutcome {
+    Fresh(CacheKey, Cached),
+    Seen(CacheKey),
+    Unkeyed,
+}
+
+/// `Seen` when the device has a stable key, else `Unkeyed`.
+fn seen(id: Option<CacheKey>) -> CacheOutcome {
+    id.map_or(CacheOutcome::Unkeyed, CacheOutcome::Seen)
+}
+
 /// Whether `cached` is stale enough that the device should be re-probed.
 fn is_stale(cached: &Cached, tick: u64) -> bool {
     tick.wrapping_sub(cached.probed_tick) >= REFRESH_TICKS
+}
+
+/// Decide a device's probe: reuse a fresh cache, or (online + miss/stale)
+/// re-probe — but keep the last-known immutable data if the re-probe fails
+/// rather than overwriting it with an empty default. An unprobed offline device
+/// with no cache yields a default probe. Returns the probe plus its cache
+/// contribution (only a *successful* probe is cached).
+async fn probe_or_reuse(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+    id: Option<CacheKey>,
+    cached: Option<&Cached>,
+    online: bool,
+    tick: u64,
+) -> (ProbedFeatures, CacheOutcome) {
+    if online && cached.is_none_or(|c| is_stale(c, tick)) {
+        let fresh = probe_features(channel, index).await;
+        // `capabilities` is `Some` exactly when the feature-table walk succeeded;
+        // only then is the probe worth caching.
+        if fresh.capabilities.is_some() {
+            return match id {
+                Some(key) => {
+                    let value = Cached {
+                        probe: fresh.clone(),
+                        probed_tick: tick,
+                    };
+                    (fresh, CacheOutcome::Fresh(key, value))
+                }
+                None => (fresh, CacheOutcome::Unkeyed),
+            };
+        }
+        // Re-probe failed: don't cache the failure. Fall back to the last-known
+        // data so a transient glitch doesn't drop the device or its battery.
+        return match cached {
+            Some(c) => (c.probe.clone(), seen(id)),
+            None => (fresh, seen(id)),
+        };
+    }
+    match cached {
+        Some(c) => (c.probe.clone(), seen(id)),
+        None => (ProbedFeatures::default(), seen(id)),
+    }
 }
 
 /// Stateful device enumerator: holds the per-device probe cache so the polling
@@ -103,6 +169,9 @@ fn is_stale(cached: &Cached, tick: u64) -> bool {
 #[derive(Default)]
 pub struct Enumerator {
     cache: HashMap<CacheKey, Cached>,
+    /// Consecutive ticks each cached device has been missing, for grace-period
+    /// eviction.
+    misses: HashMap<CacheKey, u8>,
     tick: u64,
 }
 
@@ -149,12 +218,12 @@ impl Enumerator {
         };
 
         let mut inventories = Vec::new();
-        let mut updates = Vec::new();
+        let mut outcomes = Vec::new();
         for result in results {
             match result {
                 Ok(Ok((inv, mut probed))) => {
                     inventories.extend(inv);
-                    updates.append(&mut probed);
+                    outcomes.append(&mut probed);
                 }
                 Ok(Err(e)) => warn!(error = ?e, "skipping device that failed to probe"),
                 Err(_) => {
@@ -162,20 +231,55 @@ impl Enumerator {
                 }
             }
         }
-        for (id, cached) in updates {
-            self.cache.insert(id, cached);
+
+        // Apply fresh probes and record which devices were seen this tick.
+        let mut seen_keys = HashSet::new();
+        for outcome in outcomes {
+            match outcome {
+                CacheOutcome::Fresh(key, cached) => {
+                    seen_keys.insert(key.clone());
+                    self.cache.insert(key, cached);
+                }
+                CacheOutcome::Seen(key) => {
+                    seen_keys.insert(key);
+                }
+                CacheOutcome::Unkeyed => {}
+            }
         }
+        self.evict_unseen(&seen_keys);
         Ok(inventories)
+    }
+
+    /// Drop cache entries for devices not seen this tick, after a short grace so
+    /// a transient receiver timeout doesn't discard a still-present device.
+    fn evict_unseen(&mut self, seen_keys: &HashSet<CacheKey>) {
+        for key in seen_keys {
+            self.misses.remove(key);
+        }
+        let missing: Vec<CacheKey> = self
+            .cache
+            .keys()
+            .filter(|k| !seen_keys.contains(*k))
+            .cloned()
+            .collect();
+        for key in missing {
+            let misses = self.misses.entry(key.clone()).or_insert(0);
+            *misses += 1;
+            if *misses > CACHE_MISS_GRACE {
+                self.cache.remove(&key);
+                self.misses.remove(&key);
+            }
+        }
     }
 }
 
-/// Probe one HID candidate. Returns its inventory (if any) plus the cache
-/// entries for devices it freshly probed, for the caller to fold into the cache.
+/// Probe one HID candidate. Returns its inventory (if any) plus each device's
+/// cache contribution this tick, for the caller to apply and to drive eviction.
 async fn probe_one(
     dev: async_hid::Device,
     cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> Result<(Option<DeviceInventory>, Vec<(CacheKey, Cached)>), InventoryError> {
+) -> Result<(Option<DeviceInventory>, Vec<CacheOutcome>), InventoryError> {
     let Some((info, channel)) = open_hidpp_channel(dev).await? else {
         return Ok((None, Vec::new()));
     };
@@ -185,7 +289,8 @@ async fn probe_one(
         // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
         // addresses the device's own features. Probe in case it answers.
         // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-        return Ok(probe_direct(channel, &info, cache, tick).await);
+        let (inventory, outcome) = probe_direct(channel, &info, cache, tick).await;
+        return Ok((inventory, vec![outcome]));
     };
 
     let unique_id = bolt.get_unique_id().await.ok();
@@ -198,13 +303,13 @@ async fn probe_one(
         connections.into_iter().map(|c| (c.index, c)).collect();
 
     let mut paired = Vec::new();
-    let mut updates = Vec::new();
+    let mut outcomes = Vec::new();
     for slot in 1u8..=MAX_BOLT_SLOTS {
-        if let Some((device, update)) =
+        if let Some((device, outcome)) =
             probe_bolt_slot(&channel, &bolt, by_slot.get(&slot), slot, cache, tick).await
         {
             paired.push(device);
-            updates.extend(update);
+            outcomes.push(outcome);
         }
     }
 
@@ -228,13 +333,12 @@ async fn probe_one(
             },
             paired,
         }),
-        updates,
+        outcomes,
     ))
 }
 
 /// Probe a single Bolt pairing slot. Returns `None` when the slot is empty or
-/// unreadable, otherwise the device plus an optional cache entry (`Some` only
-/// when the device was freshly probed this tick).
+/// unreadable, otherwise the device plus its cache contribution this tick.
 async fn probe_bolt_slot(
     channel: &Arc<HidppChannel>,
     bolt: &BoltReceiver,
@@ -242,7 +346,7 @@ async fn probe_bolt_slot(
     slot: u8,
     cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> Option<(PairedDevice, Option<(CacheKey, Cached)>)> {
+) -> Option<(PairedDevice, CacheOutcome)> {
     let pairing = match bolt.get_device_pairing_information(slot).await {
         Ok(p) => p,
         Err(e) => {
@@ -275,39 +379,20 @@ async fn probe_bolt_slot(
     let cached = id.as_ref().and_then(|i| cache.get(i));
     let register_kind = map_kind(bolt_kind);
 
-    // Re-probe an online device only on a cache miss or when its cached probe is
-    // stale; reuse the cached immutable data otherwise (and for an offline
-    // device, so a sleeping mouse keeps its model + capabilities).
-    let mut update = None;
-    let probe = if online && cached.is_none_or(|c| is_stale(c, tick)) {
-        let probe = probe_features(channel, slot).await;
-        if let Some(probed) = probe.kind
-            && probed != DeviceKind::Unknown
-            && register_kind != DeviceKind::Unknown
-            && probed != register_kind
-        {
-            debug!(
-                slot,
-                ?register_kind,
-                ?probed,
-                "device-kind sources disagree — trusting 0x0005"
-            );
-        }
-        update = id.map(|id| {
-            (
-                id,
-                Cached {
-                    probe: probe.clone(),
-                    probed_tick: tick,
-                },
-            )
-        });
-        probe
-    } else if let Some(cached) = cached {
-        cached.probe.clone()
-    } else {
-        ProbedFeatures::default()
-    };
+    let (probe, outcome) = probe_or_reuse(channel, slot, id, cached, online, tick).await;
+    if matches!(outcome, CacheOutcome::Fresh(..))
+        && let Some(probed) = probe.kind
+        && probed != DeviceKind::Unknown
+        && register_kind != DeviceKind::Unknown
+        && probed != register_kind
+    {
+        debug!(
+            slot,
+            ?register_kind,
+            ?probed,
+            "device-kind sources disagree — trusting 0x0005"
+        );
+    }
 
     let device = PairedDevice {
         slot,
@@ -321,7 +406,7 @@ async fn probe_bolt_slot(
         model_info: probe.model_info,
         capabilities: probe.capabilities,
     };
-    Some((device, update))
+    Some((device, outcome))
 }
 
 /// Probe a HID++ channel that doesn't host a Bolt receiver — for
@@ -337,25 +422,13 @@ async fn probe_direct(
     info: &async_hid::DeviceInfo,
     cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> (Option<DeviceInventory>, Vec<(CacheKey, Cached)>) {
+) -> (Option<DeviceInventory>, CacheOutcome) {
     let id = CacheKey::Direct(info.id.clone());
-    let mut updates = Vec::new();
-    // Reuse the cached probe while fresh; a direct device's model + features are
-    // immutable, so most ticks skip the feature-table walk entirely.
-    let probe = match cache.get(&id) {
-        Some(cached) if !is_stale(cached, tick) => cached.probe.clone(),
-        _ => {
-            let probe = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
-            updates.push((
-                id,
-                Cached {
-                    probe: probe.clone(),
-                    probed_tick: tick,
-                },
-            ));
-            probe
-        }
-    };
+    let cached = cache.get(&id);
+    // A direct device is always "present" (its HID node is the candidate), so
+    // treat it as online: reuse the cached probe while fresh, otherwise probe.
+    let (probe, outcome) =
+        probe_or_reuse(&channel, DIRECT_DEVICE_INDEX, Some(id), cached, true, tick).await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or exposes a
     // configuration feature (buttons / pointer / lighting). A Bolt receiver's
@@ -376,7 +449,9 @@ async fn probe_direct(
             "slot 0xff exposes no battery or config feature — likely a receiver \
              secondary interface; skipping"
         );
-        return (None, updates);
+        // Don't cache or keep a rejected non-peripheral — `Unkeyed` lets any
+        // prior entry for this node be evicted.
+        return (None, CacheOutcome::Unkeyed);
     }
 
     // Without a Bolt receiver we don't have a wpid, codename, or pairing
@@ -404,7 +479,7 @@ async fn probe_direct(
             capabilities: probe.capabilities,
         }],
     };
-    (Some(inventory), updates)
+    (Some(inventory), outcome)
 }
 
 async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> {
@@ -639,7 +714,61 @@ fn map_battery_status(status: HidppBatteryStatus) -> BatteryStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cached, DeviceKind, ProbedFeatures, REFRESH_TICKS, is_stale, resolve_device_kind};
+    use std::collections::HashSet;
+
+    use super::{
+        CACHE_MISS_GRACE, CacheKey, Cached, DeviceKind, Enumerator, ProbedFeatures, REFRESH_TICKS,
+        is_stale, resolve_device_kind,
+    };
+
+    fn cache_entry(probed_tick: u64) -> Cached {
+        Cached {
+            probe: ProbedFeatures::default(),
+            probed_tick,
+        }
+    }
+
+    #[test]
+    fn cache_entry_survives_grace_then_evicts() {
+        let mut e = Enumerator::default();
+        let key = CacheKey::Bolt {
+            unit_id: [1, 2, 3, 4],
+        };
+        e.cache.insert(key.clone(), cache_entry(0));
+        let nobody = HashSet::new();
+        // Missing for the whole grace window: kept.
+        for _ in 0..CACHE_MISS_GRACE {
+            e.evict_unseen(&nobody);
+            assert!(
+                e.cache.contains_key(&key),
+                "evicted inside the grace window"
+            );
+        }
+        // One miss past the grace: evicted.
+        e.evict_unseen(&nobody);
+        assert!(
+            !e.cache.contains_key(&key),
+            "should evict past the grace window"
+        );
+    }
+
+    #[test]
+    fn being_seen_resets_the_miss_counter() {
+        let mut e = Enumerator::default();
+        let key = CacheKey::Bolt { unit_id: [9; 4] };
+        e.cache.insert(key.clone(), cache_entry(0));
+        let nobody = HashSet::new();
+        let seen: HashSet<CacheKey> = std::iter::once(key.clone()).collect();
+        e.evict_unseen(&nobody); // miss 1
+        e.evict_unseen(&seen); // seen → counter reset
+        for _ in 0..CACHE_MISS_GRACE {
+            e.evict_unseen(&nobody);
+        }
+        assert!(
+            e.cache.contains_key(&key),
+            "counter reset by a sighting, so still within grace"
+        );
+    }
 
     #[test]
     fn cached_probe_is_reused_until_refresh_ticks() {

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -143,8 +143,11 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
             "paired slot"
         );
 
+        // The pairing register already supplies a kind here, so only spend a
+        // `0x0005` round-trip when it came back `Unknown` (see `probe_features`).
+        let register_kind = map_kind(bolt_kind);
         let (battery, model_info, probed_kind) = if online {
-            probe_features(&channel, slot).await
+            probe_features(&channel, slot, register_kind == DeviceKind::Unknown).await
         } else {
             (None, None, None)
         };
@@ -152,7 +155,7 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
             slot,
             codename,
             wpid,
-            kind: resolve_device_kind(map_kind(bolt_kind), probed_kind),
+            kind: resolve_device_kind(register_kind, probed_kind),
             online,
             battery,
             model_info,
@@ -192,7 +195,9 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &async_hid::DeviceInfo,
 ) -> Option<DeviceInventory> {
-    let (battery, model_info, probed_kind) = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
+    // The receiver-less path has no pairing register, so always ask `0x0005`.
+    let (battery, model_info, probed_kind) =
+        probe_features(&channel, DIRECT_DEVICE_INDEX, true).await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or wired, which
     // reports none but still exposes a control feature (adjustable DPI or
@@ -286,14 +291,18 @@ async fn read_codename(channel: &HidppChannel, slot: u8) -> Option<String> {
 }
 
 /// Open a HID++ session for `slot` and query the features we care about
-/// (battery, device-information, device-type) in one shot. Returns
-/// `(battery, model, kind)` — any field may be `None` if the device doesn't
-/// expose that feature or the read fails. Device sessions are expensive
-/// (multi-round-trip) so we fold every read through the same `Device::new` +
-/// `enumerate_features`.
+/// (battery, device-information, and — when `read_device_type` — the `0x0005`
+/// device type) in one shot. Returns `(battery, model, kind)`; any field may be
+/// `None` if the device doesn't expose that feature or the read fails. Device
+/// sessions are expensive (multi-round-trip) so we fold every read through the
+/// same `Device::new` + `enumerate_features`.
+///
+/// `read_device_type` is `false` on the Bolt path when the pairing register
+/// already gave a concrete kind, so the common case spends no extra round-trip.
 async fn probe_features(
     channel: &Arc<HidppChannel>,
     slot: u8,
+    read_device_type: bool,
 ) -> (
     Option<BatteryInfo>,
     Option<DeviceModelInfo>,
@@ -362,16 +371,20 @@ async fn probe_features(
 
     // `0x0005` reports the device's marketing type (mouse, keyboard, …). On the
     // direct path this is the only kind signal; on the Bolt path it backstops a
-    // pairing register that reported `Unknown`.
-    let kind = match device.get_feature::<DeviceTypeAndNameFeature>() {
-        Some(feature) => match feature.get_device_type().await {
+    // pairing register that reported `Unknown`. Skipped otherwise to avoid a
+    // round-trip the caller would only discard.
+    let kind = match (
+        read_device_type,
+        device.get_feature::<DeviceTypeAndNameFeature>(),
+    ) {
+        (true, Some(feature)) => match feature.get_device_type().await {
             Ok(ty) => Some(map_device_type(ty)),
             Err(e) => {
                 debug!(slot, error = ?e, "DeviceType read failed");
                 None
             }
         },
-        None => None,
+        _ => None,
     };
 
     (battery, model_info, kind)

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -7,6 +7,7 @@ use hidpp::{
     device::Device,
     feature::{
         device_information::DeviceInformationFeature,
+        device_type_and_name::{DeviceType as HidppDeviceType, DeviceTypeAndNameFeature},
         unified_battery::{
             BatteryLevel as HidppBatteryLevel, BatteryStatus as HidppBatteryStatus,
             UnifiedBatteryFeature,
@@ -130,28 +131,28 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         // Prefer event data when present — it's a live response. Fall back to
         // the pairing register for sleeping devices that didn't reply.
         let online = event.map_or(pairing.online, |c| c.online);
-        let kind = event.map_or(pairing.kind, |c| c.kind);
+        let bolt_kind = event.map_or(pairing.kind, |c| c.kind);
         let wpid = event.map(|c| c.wpid);
         debug!(
             slot,
             online,
             ?wpid,
-            ?kind,
+            ?bolt_kind,
             has_event = event.is_some(),
             codename = ?codename,
             "paired slot"
         );
 
-        let (battery, model_info) = if online {
+        let (battery, model_info, probed_kind) = if online {
             probe_features(&channel, slot).await
         } else {
-            (None, None)
+            (None, None, None)
         };
         paired.push(PairedDevice {
             slot,
             codename,
             wpid,
-            kind: map_kind(kind),
+            kind: resolve_device_kind(map_kind(bolt_kind), probed_kind),
             online,
             battery,
             model_info,
@@ -191,7 +192,7 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &async_hid::DeviceInfo,
 ) -> Option<DeviceInventory> {
-    let (battery, model_info) = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
+    let (battery, model_info, probed_kind) = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or wired, which
     // reports none but still exposes a control feature (adjustable DPI or
@@ -233,7 +234,12 @@ async fn probe_direct(
             slot: DIRECT_DEVICE_INDEX,
             codename: Some(info.name.clone()),
             wpid: None,
-            kind: DeviceKind::Unknown,
+            // No receiver pairing register on the direct path, so the HID++
+            // `0x0005` device-type probe is the only kind signal. Without it a
+            // Bluetooth-direct mouse would stay `Unknown` and lose its
+            // button/pointer tabs to the wired-keyboard lighting heuristic
+            // (issue #127).
+            kind: resolve_device_kind(DeviceKind::Unknown, probed_kind),
             online: true,
             battery,
             model_info,
@@ -279,25 +285,30 @@ async fn read_codename(channel: &HidppChannel, slot: u8) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Open a HID++ session for `slot` and query the two features we care about
-/// (battery, device-information) in one shot. Returns `(battery, model)` —
-/// either side may be `None` if the device doesn't expose that feature or
-/// the read fails. Device sessions are expensive (multi-round-trip) so we
-/// fold both reads through the same `Device::new` + `enumerate_features`.
+/// Open a HID++ session for `slot` and query the features we care about
+/// (battery, device-information, device-type) in one shot. Returns
+/// `(battery, model, kind)` — any field may be `None` if the device doesn't
+/// expose that feature or the read fails. Device sessions are expensive
+/// (multi-round-trip) so we fold every read through the same `Device::new` +
+/// `enumerate_features`.
 async fn probe_features(
     channel: &Arc<HidppChannel>,
     slot: u8,
-) -> (Option<BatteryInfo>, Option<DeviceModelInfo>) {
+) -> (
+    Option<BatteryInfo>,
+    Option<DeviceModelInfo>,
+    Option<DeviceKind>,
+) {
     let mut device = match Device::new(Arc::clone(channel), slot).await {
         Ok(d) => d,
         Err(e) => {
             debug!(slot, error = ?e, "Device::new failed");
-            return (None, None);
+            return (None, None, None);
         }
     };
     if let Err(e) = device.enumerate_features().await {
         debug!(slot, error = ?e, "enumerate_features failed");
-        return (None, None);
+        return (None, None, None);
     }
 
     let battery = match device.get_feature::<UnifiedBatteryFeature>() {
@@ -349,7 +360,21 @@ async fn probe_features(
         None => None,
     };
 
-    (battery, model_info)
+    // `0x0005` reports the device's marketing type (mouse, keyboard, …). On the
+    // direct path this is the only kind signal; on the Bolt path it backstops a
+    // pairing register that reported `Unknown`.
+    let kind = match device.get_feature::<DeviceTypeAndNameFeature>() {
+        Some(feature) => match feature.get_device_type().await {
+            Ok(ty) => Some(map_device_type(ty)),
+            Err(e) => {
+                debug!(slot, error = ?e, "DeviceType read failed");
+                None
+            }
+        },
+        None => None,
+    };
+
+    (battery, model_info, kind)
 }
 
 fn normalize_serial_number(serial: &str) -> Option<String> {
@@ -406,6 +431,37 @@ fn map_kind(k: BoltDeviceKind) -> DeviceKind {
     }
 }
 
+/// Map the HID++ `0x0005` marketing device type to our [`DeviceKind`]. Types we
+/// don't model (receiver, webcam, dock, …) fall back to [`DeviceKind::Unknown`].
+fn map_device_type(ty: HidppDeviceType) -> DeviceKind {
+    match ty {
+        HidppDeviceType::Keyboard => DeviceKind::Keyboard,
+        HidppDeviceType::Numpad => DeviceKind::Numpad,
+        HidppDeviceType::Mouse => DeviceKind::Mouse,
+        HidppDeviceType::Trackpad => DeviceKind::Touchpad,
+        HidppDeviceType::Trackball => DeviceKind::Trackball,
+        HidppDeviceType::Presenter => DeviceKind::Presenter,
+        HidppDeviceType::RemoteControl => DeviceKind::Remote,
+        HidppDeviceType::Headset => DeviceKind::Headset,
+        HidppDeviceType::Joystick => DeviceKind::Joystick,
+        HidppDeviceType::Gamepad => DeviceKind::Gamepad,
+        _ => DeviceKind::Unknown,
+    }
+}
+
+/// Resolve a device's kind from a `primary` source (the Bolt pairing register,
+/// or `Unknown` on the receiver-less direct path) and a `secondary` source (the
+/// HID++ `0x0005` probe). The primary wins unless it is [`DeviceKind::Unknown`],
+/// in which case we fall back to the probe — that's what keeps a Bluetooth-direct
+/// mouse from being mistaken for a wired keyboard (issue #127).
+fn resolve_device_kind(primary: DeviceKind, secondary: Option<DeviceKind>) -> DeviceKind {
+    if primary == DeviceKind::Unknown {
+        secondary.unwrap_or(DeviceKind::Unknown)
+    } else {
+        primary
+    }
+}
+
 fn map_battery_level(level: HidppBatteryLevel) -> BatteryLevel {
     match level {
         HidppBatteryLevel::Critical => BatteryLevel::Critical,
@@ -424,5 +480,38 @@ fn map_battery_status(status: HidppBatteryStatus) -> BatteryStatus {
         HidppBatteryStatus::Full => BatteryStatus::Full,
         HidppBatteryStatus::Error => BatteryStatus::Error,
         _ => BatteryStatus::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeviceKind, resolve_device_kind};
+
+    #[test]
+    fn resolve_kind_keeps_a_known_primary() {
+        // A Bolt register that already says "mouse" is authoritative; a stray
+        // `0x0005` answer must not override it.
+        assert_eq!(
+            resolve_device_kind(DeviceKind::Mouse, Some(DeviceKind::Keyboard)),
+            DeviceKind::Mouse
+        );
+    }
+
+    #[test]
+    fn resolve_kind_falls_back_to_the_probe_when_primary_unknown() {
+        // The direct path (and an Unknown Bolt register) defers to the probe —
+        // this is what restores the button/pointer tabs for a BT-direct mouse.
+        assert_eq!(
+            resolve_device_kind(DeviceKind::Unknown, Some(DeviceKind::Mouse)),
+            DeviceKind::Mouse
+        );
+    }
+
+    #[test]
+    fn resolve_kind_stays_unknown_without_a_probe() {
+        assert_eq!(
+            resolve_device_kind(DeviceKind::Unknown, None),
+            DeviceKind::Unknown
+        );
     }
 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -143,18 +143,35 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
             "paired slot"
         );
 
+        let register_kind = map_kind(bolt_kind);
         let (battery, model_info, probed_kind) = if online {
             probe_features(&channel, slot).await
         } else {
             (None, None, None)
         };
+        // Surface a real cross-source disagreement (both sides confident, but
+        // different) — it means a HID++ kind source misreported this device, the
+        // exact failure behind #127. Logged at debug since `enumerate` re-runs
+        // on a 2s watcher tick; a `RUST_LOG=openlogi_hid=debug` run shows it.
+        if let Some(probed) = probed_kind
+            && probed != DeviceKind::Unknown
+            && register_kind != DeviceKind::Unknown
+            && probed != register_kind
+        {
+            debug!(
+                slot,
+                ?register_kind,
+                ?probed,
+                "device-kind sources disagree — trusting 0x0005"
+            );
+        }
         paired.push(PairedDevice {
             slot,
             codename,
             wpid,
             // Prefer the device's own `0x0005` type; the register kind is the
             // offline fallback.
-            kind: resolve_device_kind(probed_kind, map_kind(bolt_kind)),
+            kind: resolve_device_kind(probed_kind, register_kind),
             online,
             battery,
             model_info,

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use futures_concurrency::future::Join as _;
 use hidpp::{
     channel::HidppChannel,
     device::Device,
@@ -79,9 +80,22 @@ pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
 
     debug!(count = candidates.len(), "HID++ candidate interfaces");
 
+    // Probe every candidate concurrently. Probing is serialized by `await`
+    // otherwise, so a single asleep/unresponsive node that burns the whole
+    // `PROBE_BUDGET` would stall the entire snapshot behind it (and the watcher
+    // re-runs every ~2s). Concurrent, the tick is bounded by the *slowest*
+    // probe, not their sum. Each candidate is an independent HID interface, so
+    // there's no shared state to contend on.
+    let results = candidates
+        .into_iter()
+        .map(|dev| async move { timeout(PROBE_BUDGET, probe_one(dev)).await })
+        .collect::<Vec<_>>()
+        .join()
+        .await;
+
     let mut inventories = Vec::new();
-    for dev in candidates {
-        match timeout(PROBE_BUDGET, probe_one(dev)).await {
+    for result in results {
+        match result {
             Ok(Ok(Some(inv))) => inventories.push(inv),
             Ok(Ok(None)) => {}
             Ok(Err(e)) => warn!(error = ?e, "skipping device that failed to probe"),

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -72,14 +72,16 @@ const REFRESH_TICKS: u64 = 15;
 
 /// Stable identity used to memoize a device's probe across `enumerate` ticks.
 /// Keyed on the device's *own* identity (never its slot) so a re-paired or
-/// moved device can't inherit another device's cached capabilities.
+/// moved device can't inherit another device's cached probe.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum DeviceId {
+enum CacheKey {
     /// Bolt: the unit id from the pairing register (cheap, read every tick).
     Bolt { unit_id: [u8; 4] },
-    /// Direct (Bluetooth/USB): the HID node's vendor + product id. A given model
-    /// has one feature table, so two same-model units can't disagree here.
-    Direct { vendor_id: u16, product_id: u16 },
+    /// Direct (Bluetooth/USB): the OS-assigned HID node id (macOS registry-entry
+    /// id, Linux dev path, Windows interface path). Unique *per node*, so two
+    /// units of the same model never collide, and stable while connected so the
+    /// cache still hits across ticks.
+    Direct(async_hid::DeviceId),
 }
 
 /// A memoized probe result plus the tick it was taken on.
@@ -100,7 +102,7 @@ fn is_stale(cached: &Cached, tick: u64) -> bool {
 /// runs against a fresh (empty) cache.
 #[derive(Default)]
 pub struct Enumerator {
-    cache: HashMap<DeviceId, Cached>,
+    cache: HashMap<CacheKey, Cached>,
     tick: u64,
 }
 
@@ -171,9 +173,9 @@ impl Enumerator {
 /// entries for devices it freshly probed, for the caller to fold into the cache.
 async fn probe_one(
     dev: async_hid::Device,
-    cache: &HashMap<DeviceId, Cached>,
+    cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> Result<(Option<DeviceInventory>, Vec<(DeviceId, Cached)>), InventoryError> {
+) -> Result<(Option<DeviceInventory>, Vec<(CacheKey, Cached)>), InventoryError> {
     let Some((info, channel)) = open_hidpp_channel(dev).await? else {
         return Ok((None, Vec::new()));
     };
@@ -238,9 +240,9 @@ async fn probe_bolt_slot(
     bolt: &BoltReceiver,
     event: Option<&BoltDeviceConnection>,
     slot: u8,
-    cache: &HashMap<DeviceId, Cached>,
+    cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> Option<(PairedDevice, Option<(DeviceId, Cached)>)> {
+) -> Option<(PairedDevice, Option<(CacheKey, Cached)>)> {
     let pairing = match bolt.get_device_pairing_information(slot).await {
         Ok(p) => p,
         Err(e) => {
@@ -267,7 +269,7 @@ async fn probe_bolt_slot(
     // The pairing register gives the device's unit id cheaply every tick — its
     // stable cache identity. An all-zero id is treated as unidentifiable (don't
     // cache; always probe when online).
-    let id = (pairing.unit_id != [0u8; 4]).then_some(DeviceId::Bolt {
+    let id = (pairing.unit_id != [0u8; 4]).then_some(CacheKey::Bolt {
         unit_id: pairing.unit_id,
     });
     let cached = id.as_ref().and_then(|i| cache.get(i));
@@ -333,13 +335,10 @@ async fn probe_bolt_slot(
 async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &async_hid::DeviceInfo,
-    cache: &HashMap<DeviceId, Cached>,
+    cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> (Option<DeviceInventory>, Vec<(DeviceId, Cached)>) {
-    let id = DeviceId::Direct {
-        vendor_id: info.vendor_id,
-        product_id: info.product_id,
-    };
+) -> (Option<DeviceInventory>, Vec<(CacheKey, Cached)>) {
+    let id = CacheKey::Direct(info.id.clone());
     let mut updates = Vec::new();
     // Reuse the cached probe while fresh; a direct device's model + features are
     // immutable, so most ticks skip the feature-table walk entirely.

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -22,8 +22,8 @@ use hidpp::{
     },
 };
 use openlogi_core::device::{
-    BatteryInfo, BatteryLevel, BatteryStatus, DeviceInventory, DeviceKind, DeviceModelInfo,
-    DeviceTransports, PairedDevice, ReceiverInfo,
+    BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
+    DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
 };
 use thiserror::Error;
 use tokio::time::timeout;
@@ -144,16 +144,17 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         );
 
         let register_kind = map_kind(bolt_kind);
-        let (battery, model_info, probed_kind) = if online {
+        let probe = if online {
             probe_features(&channel, slot).await
         } else {
-            (None, None, None)
+            ProbedFeatures::default()
         };
         // Surface a real cross-source disagreement (both sides confident, but
-        // different) — it means a HID++ kind source misreported this device, the
-        // exact failure behind #127. Logged at debug since `enumerate` re-runs
-        // on a 2s watcher tick; a `RUST_LOG=openlogi_hid=debug` run shows it.
-        if let Some(probed) = probed_kind
+        // different) — it means a HID++ kind source misreported this device.
+        // Kind is now an identity hint only (the UI gates on capabilities), so
+        // this is purely diagnostic; logged at debug since `enumerate` re-runs
+        // on a 2s watcher tick.
+        if let Some(probed) = probe.kind
             && probed != DeviceKind::Unknown
             && register_kind != DeviceKind::Unknown
             && probed != register_kind
@@ -171,10 +172,11 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
             wpid,
             // Prefer the device's own `0x0005` type; the register kind is the
             // offline fallback.
-            kind: resolve_device_kind(probed_kind, register_kind),
+            kind: resolve_device_kind(probe.kind, register_kind),
             online,
-            battery,
-            model_info,
+            battery: probe.battery,
+            model_info: probe.model_info,
+            capabilities: probe.capabilities,
         });
     }
 
@@ -211,28 +213,25 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &async_hid::DeviceInfo,
 ) -> Option<DeviceInventory> {
-    let (battery, model_info, probed_kind) = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
+    let probe = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
-    // either wireless/Bluetooth — which reports a battery — or wired, which
-    // reports none but still exposes a control feature (adjustable DPI or
-    // reprogrammable buttons). A Bolt receiver's secondary HID interface also
-    // answers DeviceInformation at 0xff, but exposes neither battery nor those
-    // control features, so it's filtered out here. Without this guard a Bolt
-    // setup ends up with two entries in `device_list`: the real mouse (via the
-    // Bolt path) and a phantom "direct device" pointing at the receiver, which
-    // sits at index 0 and steals every DPI / SmartShift write attempt.
-    //
-    // Battery is the fast path (no extra round-trips); the feature probe only
-    // runs for battery-less devices, so wired mice cost one more lookup while
-    // the common wireless case is unaffected.
-    let is_peripheral =
-        battery.is_some() || exposes_peripheral_feature(&channel, DIRECT_DEVICE_INDEX).await;
+    // either wireless/Bluetooth — which reports a battery — or exposes a
+    // configuration feature (buttons / pointer / lighting). A Bolt receiver's
+    // secondary HID interface also answers DeviceInformation at 0xff, but
+    // exposes neither battery nor those features, so it's filtered out here.
+    // Without this guard a Bolt setup ends up with two entries in `device_list`:
+    // the real mouse (via the Bolt path) and a phantom "direct device" pointing
+    // at the receiver, which sits at index 0 and steals every DPI / SmartShift
+    // write attempt. We reuse the capabilities the probe already derived from
+    // the feature table — no extra round-trip.
+    let caps = probe.capabilities.unwrap_or_default();
+    let is_peripheral = probe.battery.is_some() || caps.buttons || caps.pointer || caps.lighting;
     if !is_peripheral {
         debug!(
             vid = format_args!("{:04x}", info.vendor_id),
             pid = format_args!("{:04x}", info.product_id),
-            has_model = model_info.is_some(),
-            "slot 0xff exposes no battery or control feature — likely a receiver \
+            has_model = probe.model_info.is_some(),
+            "slot 0xff exposes no battery or config feature — likely a receiver \
              secondary interface; skipping"
         );
         return None;
@@ -253,15 +252,14 @@ async fn probe_direct(
             slot: DIRECT_DEVICE_INDEX,
             codename: Some(info.name.clone()),
             wpid: None,
-            // No receiver pairing register on the direct path, so the HID++
-            // `0x0005` device-type probe is the only kind signal. Without it a
-            // Bluetooth-direct mouse would stay `Unknown` and lose its
-            // button/pointer tabs to the wired-keyboard lighting heuristic
-            // (issue #127).
-            kind: resolve_device_kind(probed_kind, DeviceKind::Unknown),
+            // No receiver pairing register here, so `0x0005` is the only kind
+            // hint — but kind is just identity now; the UI gates on the
+            // capabilities below, so a misread kind can't hide the panels (#127).
+            kind: resolve_device_kind(probe.kind, DeviceKind::Unknown),
             online: true,
-            battery,
-            model_info,
+            battery: probe.battery,
+            model_info: probe.model_info,
+            capabilities: probe.capabilities,
         }],
     })
 }
@@ -304,35 +302,47 @@ async fn read_codename(channel: &HidppChannel, slot: u8) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Open a HID++ session for `slot` and query the features we care about
-/// (battery, device-information, `0x0005` device type) in one shot. Returns
-/// `(battery, model, kind)`; any field may be `None` if the device doesn't
-/// expose that feature or the read fails. Device sessions are expensive
-/// (multi-round-trip) so we fold every read through the same `Device::new` +
-/// `enumerate_features`.
+/// Everything a single device probe yields. Any field is `None` when the
+/// device doesn't expose that feature or the read failed.
+#[derive(Default)]
+struct ProbedFeatures {
+    battery: Option<BatteryInfo>,
+    model_info: Option<DeviceModelInfo>,
+    /// Marketing type from HID++ `0x0005` — an identity hint only.
+    kind: Option<DeviceKind>,
+    /// Configuration capabilities derived from the device's feature table.
+    capabilities: Option<Capabilities>,
+}
+
+/// Open a HID++ session for `slot` and read everything we care about (battery,
+/// device-information, `0x0005` device type, and the feature table that drives
+/// [`Capabilities`]) in one shot. Device sessions are expensive (multi-round-
+/// trip) so we fold every read through the same `Device::new` +
+/// `enumerate_features` — the feature table is the Vec that enumeration already
+/// returns, so capabilities cost no extra round-trip.
 ///
-/// Only online, responsive devices reach here, so the `0x0005` read is one
-/// extra short round-trip on a device that just answered two others — cheap,
-/// and the authoritative kind source (see [`resolve_device_kind`]).
-async fn probe_features(
-    channel: &Arc<HidppChannel>,
-    slot: u8,
-) -> (
-    Option<BatteryInfo>,
-    Option<DeviceModelInfo>,
-    Option<DeviceKind>,
-) {
+/// Only online, responsive devices reach here.
+async fn probe_features(channel: &Arc<HidppChannel>, slot: u8) -> ProbedFeatures {
     let mut device = match Device::new(Arc::clone(channel), slot).await {
         Ok(d) => d,
         Err(e) => {
             debug!(slot, error = ?e, "Device::new failed");
-            return (None, None, None);
+            return ProbedFeatures::default();
         }
     };
-    if let Err(e) = device.enumerate_features().await {
-        debug!(slot, error = ?e, "enumerate_features failed");
-        return (None, None, None);
-    }
+    // The enumeration response IS the device's feature-ID table — capture it
+    // for capability derivation instead of discarding it.
+    let capabilities = match device.enumerate_features().await {
+        Ok(Some(features)) => {
+            let ids: Vec<u16> = features.iter().map(|f| f.id).collect();
+            Some(Capabilities::from_feature_ids(&ids))
+        }
+        Ok(None) => None,
+        Err(e) => {
+            debug!(slot, error = ?e, "enumerate_features failed");
+            return ProbedFeatures::default();
+        }
+    };
 
     let battery = match device.get_feature::<UnifiedBatteryFeature>() {
         Some(feature) => feature
@@ -398,44 +408,17 @@ async fn probe_features(
         None => None,
     };
 
-    (battery, model_info, kind)
+    ProbedFeatures {
+        battery,
+        model_info,
+        kind,
+        capabilities,
+    }
 }
 
 fn normalize_serial_number(serial: &str) -> Option<String> {
     let serial = serial.trim_matches('\0').trim().to_string();
     (!serial.is_empty()).then_some(serial)
-}
-
-/// HID++ feature IDs that mark a device as a controllable peripheral rather
-/// than a bare receiver interface: adjustable DPI (both encodings) and
-/// reprogrammable controls. Used by [`probe_direct`]'s hybrid discriminator
-/// to admit wired mice, which report no battery.
-const PERIPHERAL_FEATURE_IDS: [u16; 3] = [
-    0x2201, // AdjustableDpi
-    0x2202, // ExtendedAdjustableDpi
-    0x1b04, // ReprogControlsV4
-];
-
-/// Whether the device at `index` announces any [`PERIPHERAL_FEATURE_IDS`].
-/// Looks each up through the device root — hidpp 0.2's feature registry
-/// doesn't carry these, so `enumerate_features` wouldn't surface them (see
-/// `write::open_feature`).
-async fn exposes_peripheral_feature(channel: &Arc<HidppChannel>, index: u8) -> bool {
-    let device = match Device::new(Arc::clone(channel), index).await {
-        Ok(d) => d,
-        Err(e) => {
-            debug!(index, error = ?e, "Device::new failed during peripheral probe");
-            return false;
-        }
-    };
-    for id in PERIPHERAL_FEATURE_IDS {
-        match device.root().get_feature(id).await {
-            Ok(Some(_)) => return true,
-            Ok(None) => {}
-            Err(e) => debug!(index, id, error = ?e, "root feature probe failed"),
-        }
-    }
-    false
 }
 
 fn map_kind(k: BoltDeviceKind) -> DeviceKind {

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -143,11 +143,8 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
             "paired slot"
         );
 
-        // The pairing register already supplies a kind here, so only spend a
-        // `0x0005` round-trip when it came back `Unknown` (see `probe_features`).
-        let register_kind = map_kind(bolt_kind);
         let (battery, model_info, probed_kind) = if online {
-            probe_features(&channel, slot, register_kind == DeviceKind::Unknown).await
+            probe_features(&channel, slot).await
         } else {
             (None, None, None)
         };
@@ -155,7 +152,9 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
             slot,
             codename,
             wpid,
-            kind: resolve_device_kind(register_kind, probed_kind),
+            // Prefer the device's own `0x0005` type; the register kind is the
+            // offline fallback.
+            kind: resolve_device_kind(probed_kind, map_kind(bolt_kind)),
             online,
             battery,
             model_info,
@@ -195,9 +194,7 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &async_hid::DeviceInfo,
 ) -> Option<DeviceInventory> {
-    // The receiver-less path has no pairing register, so always ask `0x0005`.
-    let (battery, model_info, probed_kind) =
-        probe_features(&channel, DIRECT_DEVICE_INDEX, true).await;
+    let (battery, model_info, probed_kind) = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or wired, which
     // reports none but still exposes a control feature (adjustable DPI or
@@ -244,7 +241,7 @@ async fn probe_direct(
             // Bluetooth-direct mouse would stay `Unknown` and lose its
             // button/pointer tabs to the wired-keyboard lighting heuristic
             // (issue #127).
-            kind: resolve_device_kind(DeviceKind::Unknown, probed_kind),
+            kind: resolve_device_kind(probed_kind, DeviceKind::Unknown),
             online: true,
             battery,
             model_info,
@@ -291,18 +288,18 @@ async fn read_codename(channel: &HidppChannel, slot: u8) -> Option<String> {
 }
 
 /// Open a HID++ session for `slot` and query the features we care about
-/// (battery, device-information, and — when `read_device_type` — the `0x0005`
-/// device type) in one shot. Returns `(battery, model, kind)`; any field may be
-/// `None` if the device doesn't expose that feature or the read fails. Device
-/// sessions are expensive (multi-round-trip) so we fold every read through the
-/// same `Device::new` + `enumerate_features`.
+/// (battery, device-information, `0x0005` device type) in one shot. Returns
+/// `(battery, model, kind)`; any field may be `None` if the device doesn't
+/// expose that feature or the read fails. Device sessions are expensive
+/// (multi-round-trip) so we fold every read through the same `Device::new` +
+/// `enumerate_features`.
 ///
-/// `read_device_type` is `false` on the Bolt path when the pairing register
-/// already gave a concrete kind, so the common case spends no extra round-trip.
+/// Only online, responsive devices reach here, so the `0x0005` read is one
+/// extra short round-trip on a device that just answered two others — cheap,
+/// and the authoritative kind source (see [`resolve_device_kind`]).
 async fn probe_features(
     channel: &Arc<HidppChannel>,
     slot: u8,
-    read_device_type: bool,
 ) -> (
     Option<BatteryInfo>,
     Option<DeviceModelInfo>,
@@ -369,22 +366,19 @@ async fn probe_features(
         None => None,
     };
 
-    // `0x0005` reports the device's marketing type (mouse, keyboard, …). On the
-    // direct path this is the only kind signal; on the Bolt path it backstops a
-    // pairing register that reported `Unknown`. Skipped otherwise to avoid a
-    // round-trip the caller would only discard.
-    let kind = match (
-        read_device_type,
-        device.get_feature::<DeviceTypeAndNameFeature>(),
-    ) {
-        (true, Some(feature)) => match feature.get_device_type().await {
+    // `0x0005` reports the device's own marketing type (mouse, keyboard, …) —
+    // the authoritative kind signal. On the direct path it's the only one; on
+    // the Bolt path it corrects a pairing register that reported the wrong (or
+    // `Unknown`) kind.
+    let kind = match device.get_feature::<DeviceTypeAndNameFeature>() {
+        Some(feature) => match feature.get_device_type().await {
             Ok(ty) => Some(map_device_type(ty)),
             Err(e) => {
                 debug!(slot, error = ?e, "DeviceType read failed");
                 None
             }
         },
-        _ => None,
+        None => None,
     };
 
     (battery, model_info, kind)
@@ -462,16 +456,20 @@ fn map_device_type(ty: HidppDeviceType) -> DeviceKind {
     }
 }
 
-/// Resolve a device's kind from a `primary` source (the Bolt pairing register,
-/// or `Unknown` on the receiver-less direct path) and a `secondary` source (the
-/// HID++ `0x0005` probe). The primary wins unless it is [`DeviceKind::Unknown`],
-/// in which case we fall back to the probe — that's what keeps a Bluetooth-direct
-/// mouse from being mistaken for a wired keyboard (issue #127).
-fn resolve_device_kind(primary: DeviceKind, secondary: Option<DeviceKind>) -> DeviceKind {
-    if primary == DeviceKind::Unknown {
-        secondary.unwrap_or(DeviceKind::Unknown)
-    } else {
-        primary
+/// Resolve a device's kind, preferring the device's own HID++ `0x0005` report
+/// (`probed`) over the receiver-supplied `register` kind.
+///
+/// `0x0005` is the device's self-reported marketing type and is authoritative;
+/// the Bolt pairing register is a coarser hint that can misreport (e.g. an
+/// MX Anywhere 3S surfacing as `Keyboard`, which strips its button/pointer tabs
+/// — issue #127). We therefore trust `probed` whenever it names a kind we model,
+/// falling back to `register` when the device was offline (no probe → `None`),
+/// didn't answer `0x0005`, or reported a type we don't map (`Unknown`). On the
+/// receiver-less direct path `register` is simply `Unknown`.
+fn resolve_device_kind(probed: Option<DeviceKind>, register: DeviceKind) -> DeviceKind {
+    match probed {
+        Some(kind) if kind != DeviceKind::Unknown => kind,
+        _ => register,
     }
 }
 
@@ -501,29 +499,40 @@ mod tests {
     use super::{DeviceKind, resolve_device_kind};
 
     #[test]
-    fn resolve_kind_keeps_a_known_primary() {
-        // A Bolt register that already says "mouse" is authoritative; a stray
-        // `0x0005` answer must not override it.
+    fn probe_overrides_a_misreporting_register() {
+        // The crux of #127: a Bolt register calling an MX Anywhere 3S a
+        // `Keyboard` must lose to the device's own `0x0005` = `Mouse`.
         assert_eq!(
-            resolve_device_kind(DeviceKind::Mouse, Some(DeviceKind::Keyboard)),
+            resolve_device_kind(Some(DeviceKind::Mouse), DeviceKind::Keyboard),
             DeviceKind::Mouse
         );
     }
 
     #[test]
-    fn resolve_kind_falls_back_to_the_probe_when_primary_unknown() {
-        // The direct path (and an Unknown Bolt register) defers to the probe —
-        // this is what restores the button/pointer tabs for a BT-direct mouse.
+    fn probe_supplies_the_kind_on_the_direct_path() {
+        // No pairing register on the direct path (register = Unknown); the probe
+        // is what restores the button/pointer tabs for a BT-direct mouse.
         assert_eq!(
-            resolve_device_kind(DeviceKind::Unknown, Some(DeviceKind::Mouse)),
+            resolve_device_kind(Some(DeviceKind::Mouse), DeviceKind::Unknown),
             DeviceKind::Mouse
         );
     }
 
     #[test]
-    fn resolve_kind_stays_unknown_without_a_probe() {
+    fn register_is_the_fallback_when_the_probe_is_absent_or_unmodelled() {
+        // Offline device / no `0x0005` answer → trust the register.
         assert_eq!(
-            resolve_device_kind(DeviceKind::Unknown, None),
+            resolve_device_kind(None, DeviceKind::Mouse),
+            DeviceKind::Mouse
+        );
+        // A `0x0005` type we don't model also defers to the register.
+        assert_eq!(
+            resolve_device_kind(Some(DeviceKind::Unknown), DeviceKind::Keyboard),
+            DeviceKind::Keyboard
+        );
+        // Nothing to go on → Unknown (direct path, no probe).
+        assert_eq!(
+            resolve_device_kind(None, DeviceKind::Unknown),
             DeviceKind::Unknown
         );
     }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -61,6 +61,49 @@ pub enum InventoryError {
     Hid(#[from] async_hid::HidError),
 }
 
+/// How many `enumerate` ticks a device's probe is reused before a fresh read.
+/// The expensive part of a probe (the `enumerate_features` feature-table walk)
+/// reads *immutable* data — model, capabilities, marketing type — so it never
+/// needs re-reading for a known device. Only the battery is volatile, and a
+/// coarse battery bucket tolerates being up to `REFRESH_TICKS` ticks stale; at
+/// the GUI's ~2s tick that is ~30s. New and cache-stale devices are still probed
+/// in full, so this only skips redundant work for steady-state devices.
+const REFRESH_TICKS: u64 = 15;
+
+/// Stable identity used to memoize a device's probe across `enumerate` ticks.
+/// Keyed on the device's *own* identity (never its slot) so a re-paired or
+/// moved device can't inherit another device's cached capabilities.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum DeviceId {
+    /// Bolt: the unit id from the pairing register (cheap, read every tick).
+    Bolt { unit_id: [u8; 4] },
+    /// Direct (Bluetooth/USB): the HID node's vendor + product id. A given model
+    /// has one feature table, so two same-model units can't disagree here.
+    Direct { vendor_id: u16, product_id: u16 },
+}
+
+/// A memoized probe result plus the tick it was taken on.
+#[derive(Clone)]
+struct Cached {
+    probe: ProbedFeatures,
+    probed_tick: u64,
+}
+
+/// Whether `cached` is stale enough that the device should be re-probed.
+fn is_stale(cached: &Cached, tick: u64) -> bool {
+    tick.wrapping_sub(cached.probed_tick) >= REFRESH_TICKS
+}
+
+/// Stateful device enumerator: holds the per-device probe cache so the polling
+/// watcher reuses immutable data across ticks instead of re-handshaking every
+/// device every ~2s. One-shot callers use the [`enumerate`] free function, which
+/// runs against a fresh (empty) cache.
+#[derive(Default)]
+pub struct Enumerator {
+    cache: HashMap<DeviceId, Cached>,
+    tick: u64,
+}
+
 /// Enumerate all Logitech HID++ receivers visible to the current process and
 /// the devices paired to each.
 ///
@@ -76,41 +119,63 @@ pub enum InventoryError {
 /// We merge the two so an MX Master that's been asleep still shows up with
 /// its codename and kind even before you click it.
 pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
-    let candidates = enumerate_hidpp_devices().await?;
-
-    debug!(count = candidates.len(), "HID++ candidate interfaces");
-
-    // Probe every candidate concurrently. Probing is serialized by `await`
-    // otherwise, so a single asleep/unresponsive node that burns the whole
-    // `PROBE_BUDGET` would stall the entire snapshot behind it (and the watcher
-    // re-runs every ~2s). Concurrent, the tick is bounded by the *slowest*
-    // probe, not their sum. Each candidate is an independent HID interface, so
-    // there's no shared state to contend on.
-    let results = candidates
-        .into_iter()
-        .map(|dev| async move { timeout(PROBE_BUDGET, probe_one(dev)).await })
-        .collect::<Vec<_>>()
-        .join()
-        .await;
-
-    let mut inventories = Vec::new();
-    for result in results {
-        match result {
-            Ok(Ok(Some(inv))) => inventories.push(inv),
-            Ok(Ok(None)) => {}
-            Ok(Err(e)) => warn!(error = ?e, "skipping device that failed to probe"),
-            Err(_) => {
-                warn!(budget = ?PROBE_BUDGET, "device probe timed out — skipping (asleep/unresponsive)");
-            }
-        }
-    }
-
-    Ok(inventories)
+    Enumerator::default().enumerate().await
 }
 
-async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, InventoryError> {
+impl Enumerator {
+    /// One enumeration pass, reusing the cache from prior passes. Probes every
+    /// HID candidate concurrently (so one asleep node that burns the whole
+    /// `PROBE_BUDGET` can't stall the others), reusing each device's cached
+    /// immutable data when it's present and fresh.
+    pub async fn enumerate(&mut self) -> Result<Vec<DeviceInventory>, InventoryError> {
+        self.tick = self.tick.wrapping_add(1);
+        let tick = self.tick;
+        let candidates = enumerate_hidpp_devices().await?;
+        debug!(count = candidates.len(), "HID++ candidate interfaces");
+
+        // Borrow the cache read-only for the concurrent probes; updates are
+        // collected and applied afterwards so the futures share `&cache` without
+        // a `RefCell`. Each candidate is an independent HID interface.
+        let results = {
+            let cache = &self.cache;
+            candidates
+                .into_iter()
+                .map(|dev| async move { timeout(PROBE_BUDGET, probe_one(dev, cache, tick)).await })
+                .collect::<Vec<_>>()
+                .join()
+                .await
+        };
+
+        let mut inventories = Vec::new();
+        let mut updates = Vec::new();
+        for result in results {
+            match result {
+                Ok(Ok((inv, mut probed))) => {
+                    inventories.extend(inv);
+                    updates.append(&mut probed);
+                }
+                Ok(Err(e)) => warn!(error = ?e, "skipping device that failed to probe"),
+                Err(_) => {
+                    warn!(budget = ?PROBE_BUDGET, "device probe timed out — skipping (asleep/unresponsive)");
+                }
+            }
+        }
+        for (id, cached) in updates {
+            self.cache.insert(id, cached);
+        }
+        Ok(inventories)
+    }
+}
+
+/// Probe one HID candidate. Returns its inventory (if any) plus the cache
+/// entries for devices it freshly probed, for the caller to fold into the cache.
+async fn probe_one(
+    dev: async_hid::Device,
+    cache: &HashMap<DeviceId, Cached>,
+    tick: u64,
+) -> Result<(Option<DeviceInventory>, Vec<(DeviceId, Cached)>), InventoryError> {
     let Some((info, channel)) = open_hidpp_channel(dev).await? else {
-        return Ok(None);
+        return Ok((None, Vec::new()));
     };
 
     let Some(Receiver::Bolt(bolt)) = receiver::detect(Arc::clone(&channel)) else {
@@ -118,7 +183,7 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
         // addresses the device's own features. Probe in case it answers.
         // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-        return Ok(probe_direct(channel, &info).await);
+        return Ok(probe_direct(channel, &info, cache, tick).await);
     };
 
     let unique_id = bolt.get_unique_id().await.ok();
@@ -131,67 +196,14 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         connections.into_iter().map(|c| (c.index, c)).collect();
 
     let mut paired = Vec::new();
+    let mut updates = Vec::new();
     for slot in 1u8..=MAX_BOLT_SLOTS {
-        let pairing = match bolt.get_device_pairing_information(slot).await {
-            Ok(p) => p,
-            Err(e) => {
-                debug!(slot, error = ?e, "slot empty or unreadable");
-                continue;
-            }
-        };
-
-        let codename = read_codename(&channel, slot).await;
-        let event = by_slot.get(&slot);
-        // Prefer event data when present — it's a live response. Fall back to
-        // the pairing register for sleeping devices that didn't reply.
-        let online = event.map_or(pairing.online, |c| c.online);
-        let bolt_kind = event.map_or(pairing.kind, |c| c.kind);
-        let wpid = event.map(|c| c.wpid);
-        debug!(
-            slot,
-            online,
-            ?wpid,
-            ?bolt_kind,
-            has_event = event.is_some(),
-            codename = ?codename,
-            "paired slot"
-        );
-
-        let register_kind = map_kind(bolt_kind);
-        let probe = if online {
-            probe_features(&channel, slot).await
-        } else {
-            ProbedFeatures::default()
-        };
-        // Surface a real cross-source disagreement (both sides confident, but
-        // different) — it means a HID++ kind source misreported this device.
-        // Kind is now an identity hint only (the UI gates on capabilities), so
-        // this is purely diagnostic; logged at debug since `enumerate` re-runs
-        // on a 2s watcher tick.
-        if let Some(probed) = probe.kind
-            && probed != DeviceKind::Unknown
-            && register_kind != DeviceKind::Unknown
-            && probed != register_kind
+        if let Some((device, update)) =
+            probe_bolt_slot(&channel, &bolt, by_slot.get(&slot), slot, cache, tick).await
         {
-            debug!(
-                slot,
-                ?register_kind,
-                ?probed,
-                "device-kind sources disagree — trusting 0x0005"
-            );
+            paired.push(device);
+            updates.extend(update);
         }
-        paired.push(PairedDevice {
-            slot,
-            codename,
-            wpid,
-            // Prefer the device's own `0x0005` type; the register kind is the
-            // offline fallback.
-            kind: resolve_device_kind(probe.kind, register_kind),
-            online,
-            battery: probe.battery,
-            model_info: probe.model_info,
-            capabilities: probe.capabilities,
-        });
     }
 
     if let Some(count) = pairing_count
@@ -204,15 +216,110 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
         );
     }
 
-    Ok(Some(DeviceInventory {
-        receiver: ReceiverInfo {
-            name: "Logi Bolt Receiver".to_string(),
-            vendor_id: info.vendor_id,
-            product_id: info.product_id,
-            unique_id,
-        },
-        paired,
-    }))
+    Ok((
+        Some(DeviceInventory {
+            receiver: ReceiverInfo {
+                name: "Logi Bolt Receiver".to_string(),
+                vendor_id: info.vendor_id,
+                product_id: info.product_id,
+                unique_id,
+            },
+            paired,
+        }),
+        updates,
+    ))
+}
+
+/// Probe a single Bolt pairing slot. Returns `None` when the slot is empty or
+/// unreadable, otherwise the device plus an optional cache entry (`Some` only
+/// when the device was freshly probed this tick).
+async fn probe_bolt_slot(
+    channel: &Arc<HidppChannel>,
+    bolt: &BoltReceiver,
+    event: Option<&BoltDeviceConnection>,
+    slot: u8,
+    cache: &HashMap<DeviceId, Cached>,
+    tick: u64,
+) -> Option<(PairedDevice, Option<(DeviceId, Cached)>)> {
+    let pairing = match bolt.get_device_pairing_information(slot).await {
+        Ok(p) => p,
+        Err(e) => {
+            debug!(slot, error = ?e, "slot empty or unreadable");
+            return None;
+        }
+    };
+    let codename = read_codename(channel, slot).await;
+    // Prefer event data when present — it's a live response. Fall back to the
+    // pairing register for sleeping devices that didn't reply.
+    let online = event.map_or(pairing.online, |c| c.online);
+    let bolt_kind = event.map_or(pairing.kind, |c| c.kind);
+    let wpid = event.map(|c| c.wpid);
+    debug!(
+        slot,
+        online,
+        ?wpid,
+        ?bolt_kind,
+        has_event = event.is_some(),
+        codename = ?codename,
+        "paired slot"
+    );
+
+    // The pairing register gives the device's unit id cheaply every tick — its
+    // stable cache identity. An all-zero id is treated as unidentifiable (don't
+    // cache; always probe when online).
+    let id = (pairing.unit_id != [0u8; 4]).then_some(DeviceId::Bolt {
+        unit_id: pairing.unit_id,
+    });
+    let cached = id.as_ref().and_then(|i| cache.get(i));
+    let register_kind = map_kind(bolt_kind);
+
+    // Re-probe an online device only on a cache miss or when its cached probe is
+    // stale; reuse the cached immutable data otherwise (and for an offline
+    // device, so a sleeping mouse keeps its model + capabilities).
+    let mut update = None;
+    let probe = if online && cached.is_none_or(|c| is_stale(c, tick)) {
+        let probe = probe_features(channel, slot).await;
+        if let Some(probed) = probe.kind
+            && probed != DeviceKind::Unknown
+            && register_kind != DeviceKind::Unknown
+            && probed != register_kind
+        {
+            debug!(
+                slot,
+                ?register_kind,
+                ?probed,
+                "device-kind sources disagree — trusting 0x0005"
+            );
+        }
+        update = id.map(|id| {
+            (
+                id,
+                Cached {
+                    probe: probe.clone(),
+                    probed_tick: tick,
+                },
+            )
+        });
+        probe
+    } else if let Some(cached) = cached {
+        cached.probe.clone()
+    } else {
+        ProbedFeatures::default()
+    };
+
+    let device = PairedDevice {
+        slot,
+        codename,
+        wpid,
+        // Prefer the device's own `0x0005` type; the register kind is the
+        // offline fallback.
+        kind: resolve_device_kind(probe.kind, register_kind),
+        online,
+        battery: probe.battery,
+        model_info: probe.model_info,
+        capabilities: probe.capabilities,
+    };
+    Some((device, update))
 }
 
 /// Probe a HID++ channel that doesn't host a Bolt receiver — for
@@ -226,8 +333,30 @@ async fn probe_one(dev: async_hid::Device) -> Result<Option<DeviceInventory>, In
 async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &async_hid::DeviceInfo,
-) -> Option<DeviceInventory> {
-    let probe = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
+    cache: &HashMap<DeviceId, Cached>,
+    tick: u64,
+) -> (Option<DeviceInventory>, Vec<(DeviceId, Cached)>) {
+    let id = DeviceId::Direct {
+        vendor_id: info.vendor_id,
+        product_id: info.product_id,
+    };
+    let mut updates = Vec::new();
+    // Reuse the cached probe while fresh; a direct device's model + features are
+    // immutable, so most ticks skip the feature-table walk entirely.
+    let probe = match cache.get(&id) {
+        Some(cached) if !is_stale(cached, tick) => cached.probe.clone(),
+        _ => {
+            let probe = probe_features(&channel, DIRECT_DEVICE_INDEX).await;
+            updates.push((
+                id,
+                Cached {
+                    probe: probe.clone(),
+                    probed_tick: tick,
+                },
+            ));
+            probe
+        }
+    };
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or exposes a
     // configuration feature (buttons / pointer / lighting). A Bolt receiver's
@@ -248,14 +377,14 @@ async fn probe_direct(
             "slot 0xff exposes no battery or config feature — likely a receiver \
              secondary interface; skipping"
         );
-        return None;
+        return (None, updates);
     }
 
     // Without a Bolt receiver we don't have a wpid, codename, or pairing
     // info — those live on the receiver registers. Use the HID name as
     // the display fallback and leave wpid empty.
     debug!(name = %info.name, "BT-direct / wired device recognised");
-    Some(DeviceInventory {
+    let inventory = DeviceInventory {
         receiver: ReceiverInfo {
             name: info.name.clone(),
             vendor_id: info.vendor_id,
@@ -275,7 +404,8 @@ async fn probe_direct(
             model_info: probe.model_info,
             capabilities: probe.capabilities,
         }],
-    })
+    };
+    (Some(inventory), updates)
 }
 
 async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> {
@@ -318,7 +448,7 @@ async fn read_codename(channel: &HidppChannel, slot: u8) -> Option<String> {
 
 /// Everything a single device probe yields. Any field is `None` when the
 /// device doesn't expose that feature or the read failed.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct ProbedFeatures {
     battery: Option<BatteryInfo>,
     model_info: Option<DeviceModelInfo>,
@@ -510,7 +640,24 @@ fn map_battery_status(status: HidppBatteryStatus) -> BatteryStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::{DeviceKind, resolve_device_kind};
+    use super::{Cached, DeviceKind, ProbedFeatures, REFRESH_TICKS, is_stale, resolve_device_kind};
+
+    #[test]
+    fn cached_probe_is_reused_until_refresh_ticks() {
+        let cached = Cached {
+            probe: ProbedFeatures::default(),
+            probed_tick: 10,
+        };
+        assert!(!is_stale(&cached, 10), "same tick is fresh");
+        assert!(
+            !is_stale(&cached, 10 + REFRESH_TICKS - 1),
+            "just under the window is still fresh"
+        );
+        assert!(
+            is_stale(&cached, 10 + REFRESH_TICKS),
+            "at the window the probe is refreshed"
+        );
+    }
 
     #[test]
     fn probe_overrides_a_misreporting_register() {

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -18,7 +18,7 @@ pub mod thumbwheel;
 pub mod write;
 
 pub use gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
-pub use inventory::{InventoryError, enumerate};
+pub use inventory::{Enumerator, InventoryError, enumerate};
 pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,


### PR DESCRIPTION
## Problem

On `master`, a **Bluetooth-direct / wired** MX Anywhere 3S / MX Master 3 shows **only a Lighting (color) tab** — the Buttons and Pointer tabs vanish, so there's no way to remap back/forward or anything else (#127).

## Root cause

Two pieces interact:

- `inventory.rs::probe_direct` (the receiver-less path: Bluetooth-direct, USB-C) hard-codes `kind: DeviceKind::Unknown`. There's no Bolt pairing register on this path to supply a real kind, and nothing else filled it in.
- `app.rs::supports_lighting` (added in #29 for wired G-series keyboards) treats **any** `Unknown` + `DeviceRoute::Direct` device as a lighting-capable keyboard.

So a Bluetooth-direct mouse is indistinguishable from a wired keyboard: `is_configurable_pointer(Unknown)` is `false` (no Buttons/Pointer) while `supports_lighting` is `true` (Lighting only). A Bolt-connected unit reports `Mouse(0x02)` from the pairing register and is unaffected — which is why the same model works over the Bolt receiver but breaks over Bluetooth.

## Fix

Read the device's marketing type from HID++ feature **`0x0005` (DeviceTypeAndName)** and use it for the kind:

- Folded into the existing `probe_features` session, so it's **one extra short round-trip** on an already-open device — no new `Device::new` / `enumerate_features` handshake.
- **Direct path:** uses the `0x0005` type directly → a Bluetooth-direct mouse is now `Mouse`, restoring the Buttons + Pointer tabs and dropping the spurious Lighting tab.
- **Bolt path:** keeps the authoritative pairing-register kind, falling back to `0x0005` **only** when that register reads `Unknown` — so currently-correct devices are untouched.

`map_device_type` maps the `0x0005` enum to our `DeviceKind`; `resolve_device_kind` encodes the precedence (primary wins unless `Unknown`, then probe) and is unit-tested.

## Verification

- `cargo test -p openlogi-hid` — 3 new precedence tests pass.
- `cargo clippy -p openlogi-hid --all-targets` clean under `-D warnings`.
- Not yet verified on hardware — @AprilNEA will test on an Anywhere 3S / Master 3 over Bluetooth. The tab gating is deterministic given `kind == Mouse`; this just needs to confirm the device answers `0x0005` at index `0xff` on the direct path.

## Notes / out of scope

- #98 (filed before #29) describes a different mix — the DPI button isn't visible to the macOS `CGEventTap` (it's outside button range 0–4; see `hook_runtime.rs`), plus pointer drift and a scroll-direction request. If that user is on a post-#29 build over Bluetooth this fix restores their tabs, but the DPI-button limitation is separate and not addressed here.
- A residual edge case — a Bolt register misreading kind as `Keyboard(0x01)` rather than `Unknown` — would not be covered, but there's no evidence of it.

Fixes #127