### PR TITLE
docs: Linux device permissions (udev rule for Bolt + Bluetooth-direct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ brew install --cask openlogi
 
 To build from source, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
+### Linux device permissions (preview)
+
+The CLI/device layer builds and runs on Linux today (`cargo build -p openlogi`;
+needs `libudev-dev` + `pkg-config`). By default every `hidraw` node is
+`root:root 0600`, so without a udev rule the tools fail with
+`PermissionDenied (os error 13)`.
+
+Install the bundled rule, which covers both transports — Bolt receiver (USB) and
+Bluetooth-direct (which hangs off `uhid` and exposes no USB `idVendor`, so it is
+matched by its HID id `0005:046D:*`):
+
+```sh
+sudo cp udev/70-openlogi.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules && sudo udevadm trigger
+# then power-cycle the device (or replug the receiver) so the ACL is applied
+```
+
+It uses systemd `uaccess` (group-free, works under X11 and Wayland/GNOME). After
+applying it, `openlogi list` runs without `sudo`.
+
 ## Usage (CLI)
 
 See [USAGE.md](docs/USAGE.md)

--- a/udev/70-openlogi.rules
+++ b/udev/70-openlogi.rules
@@ -1,0 +1,28 @@
+# OpenLogi — Linux device permissions
+#
+# Grants the active local-seat user read/write access to Logitech HID++ devices
+# (and to uinput, for the evdev+uinput event hook) without root, via systemd
+# `uaccess`. This is group-free and works under both X11 and Wayland/GNOME.
+#
+# Install:
+#   sudo cp udev/70-openlogi.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload-rules && sudo udevadm trigger
+#   # then power-cycle the device (or replug the receiver) so the ACL is applied
+#
+# Two matchers are needed because the vendor id is exposed differently per
+# transport:
+#   - Bolt receiver / USB cable: the device sits on the USB tree, so the vendor
+#     is a USB attribute (`ATTRS{idVendor}`).
+#   - Bluetooth-direct: the device hangs off `uhid`
+#     (/devices/virtual/misc/uhid/0005:046D:XXXX.NNNN), which has no USB
+#     `idVendor` attribute — the vendor only appears in the HID id `0005:046D:*`,
+#     matched here via `KERNELS`.
+
+# Logitech over USB / Bolt receiver
+KERNEL=="hidraw*", ATTRS{idVendor}=="046d", MODE="0660", TAG+="uaccess"
+
+# Logitech over Bluetooth-direct (uhid; vendor only in the HID id, uppercase)
+KERNEL=="hidraw*", KERNELS=="0005:046D:*", MODE="0660", TAG+="uaccess"
+
+# uinput — required by the Linux evdev+uinput event hook to inject events
+KERNEL=="uinput", MODE="0660", TAG+="uaccess", OPTIONS+="static_node=uinput"


### PR DESCRIPTION
Part of #148 (Finding 1).

On Linux every `hidraw` node is `root:root 0600` by default, so the CLI/device
layer fails with `PermissionDenied (os error 13)` without a udev rule. The common
`ATTRS{idVendor}=="046d"` rule covers the Bolt receiver (USB) but **not**
Bluetooth-direct devices: those hang off `uhid`
(`/devices/virtual/misc/uhid/0005:046D:XXXX.NNNN`), which exposes no USB
`idVendor` attribute — the vendor only appears in the HID id `0005:046D:*`.

This adds:
- `udev/70-openlogi.rules` with both matchers + a `uinput` rule for the event hook.
- A "Linux device permissions (preview)" section in the README.

Uses systemd `uaccess` (group-free; works under X11 and Wayland/GNOME).

Verified on Ubuntu 26.04 / GNOME Wayland: after reload + power-cycling the device,
the node becomes `crw-rw----+` with `CURRENT_TAGS=…:uaccess:` and `openlogi list`
runs without sudo — for both the Bolt and Bluetooth-direct paths.

Docs-only; no code changes.