### PR TITLE
fix(cli): diag selects a device that exposes the feature under test

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag/dpi.rs
+++ b/crates/openlogi-cli/src/cmd/diag/dpi.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use clap::Args;
 
-use crate::cmd::diag::first_online_device;
+use crate::cmd::diag::select_device;
 
 #[derive(Debug, Args)]
 pub struct DpiArgs {
@@ -11,10 +11,17 @@ pub struct DpiArgs {
     /// device's HID++ AdjustableDpi feature.
     #[arg(long)]
     pub target: Option<u16>,
+
+    /// Run against the device whose name contains this string
+    /// (case-insensitive) instead of auto-selecting. Useful when several
+    /// devices are paired (e.g. a mouse and a keyboard over Bluetooth).
+    #[arg(long, value_name = "NAME")]
+    pub device: Option<String>,
 }
 
 pub async fn run(args: DpiArgs) -> Result<()> {
-    let (route, name) = first_online_device().await?;
+    // 0x2201 = AdjustableDpi — auto-skip devices (keyboards) that lack it.
+    let (route, name) = select_device(args.device.as_deref(), &[0x2201]).await?;
     println!("device: {name} ({route})");
 
     let info = openlogi_hid::get_dpi_info(&route)

--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -31,7 +31,7 @@ pub async fn run(args: LightingArgs) -> Result<()> {
     let b = (rgb & 0xff) as u8;
 
     let device_query = args.device;
-    let needle = device_query.as_deref().map(|d| d.to_lowercase());
+    let needle = device_query.as_deref().map(str::to_lowercase);
 
     let inventories = openlogi_hid::enumerate().await?;
     let (route, name) = inventories
@@ -62,7 +62,9 @@ pub async fn run(args: LightingArgs) -> Result<()> {
         })
         .ok_or_else(|| match &device_query {
             Some(q) => anyhow!("no wired device matches `--device {q}`"),
-            None => anyhow!("no wired (direct-USB) Logitech device found — is the keyboard plugged in?"),
+            None => {
+                anyhow!("no wired (direct-USB) Logitech device found — is the keyboard plugged in?")
+            }
         })?;
 
     println!("setting {name} ({route}) to #{r:02x}{g:02x}{b:02x}");

--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -12,6 +12,11 @@ use openlogi_hid::DeviceRoute;
 pub struct LightingArgs {
     /// Colour as `RRGGBB` hex (e.g. `ff0000` for red).
     pub color: String,
+
+    /// Run against the wired device whose name contains this string
+    /// (case-insensitive). Useful when several keyboards are connected.
+    #[arg(long, value_name = "NAME")]
+    pub device: Option<String>,
 }
 
 pub async fn run(args: LightingArgs) -> Result<()> {
@@ -25,6 +30,9 @@ pub async fn run(args: LightingArgs) -> Result<()> {
     let g = ((rgb >> 8) & 0xff) as u8;
     let b = (rgb & 0xff) as u8;
 
+    let device_query = args.device;
+    let needle = device_query.as_deref().map(|d| d.to_lowercase());
+
     let inventories = openlogi_hid::enumerate().await?;
     let (route, name) = inventories
         .iter()
@@ -35,20 +43,26 @@ pub async fn run(args: LightingArgs) -> Result<()> {
                 return None;
             }
             let paired = inv.paired.iter().find(|p| p.online)?;
-            let route = DeviceRoute::Direct {
-                vendor_id: inv.receiver.vendor_id,
-                product_id: inv.receiver.product_id,
-            };
             let name = paired.codename.clone().unwrap_or_else(|| {
                 format!(
                     "{:04x}:{:04x}",
                     inv.receiver.vendor_id, inv.receiver.product_id
                 )
             });
+            if let Some(ref n) = needle {
+                if !name.to_lowercase().contains(n.as_str()) {
+                    return None;
+                }
+            }
+            let route = DeviceRoute::Direct {
+                vendor_id: inv.receiver.vendor_id,
+                product_id: inv.receiver.product_id,
+            };
             Some((route, name))
         })
-        .ok_or_else(|| {
-            anyhow!("no wired (direct-USB) Logitech device found — is the keyboard plugged in?")
+        .ok_or_else(|| match &device_query {
+            Some(q) => anyhow!("no wired device matches `--device {q}`"),
+            None => anyhow!("no wired (direct-USB) Logitech device found — is the keyboard plugged in?"),
         })?;
 
     println!("setting {name} ({route}) to #{r:02x}{g:02x}{b:02x}");

--- a/crates/openlogi-cli/src/cmd/diag/mod.rs
+++ b/crates/openlogi-cli/src/cmd/diag/mod.rs
@@ -118,11 +118,16 @@ pub(crate) async fn select_device(
 
     if !required_features.is_empty() {
         for c in &devices {
-            // dump_features can legitimately fail for a sleepy/offline device;
-            // skip those and keep looking rather than aborting the whole pick.
-            if let Ok(entries) = dump_features(&c.route).await {
-                if entries.iter().any(|e| required_features.contains(&e.id)) {
-                    return Ok((c.route.clone(), c.name.clone()));
+            match dump_features(&c.route).await {
+                Ok(entries) => {
+                    if entries.iter().any(|e| required_features.contains(&e.id)) {
+                        return Ok((c.route.clone(), c.name.clone()));
+                    }
+                }
+                Err(e) => {
+                    // Sleepy/offline devices can fail legitimately; log so the
+                    // silent fallthrough is visible if a healthy device is skipped.
+                    tracing::warn!("skipping {} ({}): feature probe failed: {e:#}", c.name, c.route);
                 }
             }
         }

--- a/crates/openlogi-cli/src/cmd/diag/mod.rs
+++ b/crates/openlogi-cli/src/cmd/diag/mod.rs
@@ -127,7 +127,11 @@ pub(crate) async fn select_device(
                 Err(e) => {
                     // Sleepy/offline devices can fail legitimately; log so the
                     // silent fallthrough is visible if a healthy device is skipped.
-                    tracing::warn!("skipping {} ({}): feature probe failed: {e:#}", c.name, c.route);
+                    tracing::warn!(
+                        "skipping {} ({}): feature probe failed: {e:#}",
+                        c.name,
+                        c.route
+                    );
                 }
             }
         }

--- a/crates/openlogi-cli/src/cmd/diag/mod.rs
+++ b/crates/openlogi-cli/src/cmd/diag/mod.rs
@@ -6,9 +6,9 @@
 //! same `openlogi_hid` API the GPUI app uses, so a green diag means the
 //! GUI's write path works on this host.
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use clap::Subcommand;
-use openlogi_hid::DeviceRoute;
+use openlogi_hid::{DeviceRoute, dump_features};
 
 pub mod dpi;
 pub mod features;
@@ -38,20 +38,23 @@ impl DiagCmd {
     }
 }
 
-/// Shared device picker: enumerate inventories, return the [`DeviceRoute`] +
-/// display name of the first online paired device (the same selection rule the
-/// GUI uses for its initial target). Builds a Bolt route when the device is
-/// behind a receiver, a direct route otherwise (USB cable / Bluetooth).
-pub(crate) async fn first_online_device() -> Result<(DeviceRoute, String)> {
-    use anyhow::anyhow;
+/// One online, paired device discovered during enumeration, already resolved to
+/// the [`DeviceRoute`] needed to talk to it. Builds a Bolt route when the device
+/// is behind a receiver, a direct route otherwise (USB cable / Bluetooth).
+struct Candidate {
+    route: DeviceRoute,
+    name: String,
+}
+
+/// Enumerate inventories and resolve every *online* paired device to a route.
+async fn online_devices() -> Result<Vec<Candidate>> {
     let inventories = openlogi_hid::enumerate().await?;
-    inventories
-        .into_iter()
-        .find_map(|inv| {
-            let paired = inv.paired.into_iter().find(|p| p.online)?;
-            let route = match inv.receiver.unique_id {
-                Some(receiver_uid) => DeviceRoute::Bolt {
-                    receiver_uid,
+    let mut out = Vec::new();
+    for inv in inventories {
+        for paired in inv.paired.into_iter().filter(|p| p.online) {
+            let route = match &inv.receiver.unique_id {
+                Some(uid) => DeviceRoute::Bolt {
+                    receiver_uid: uid.clone(),
                     slot: paired.slot,
                 },
                 None => DeviceRoute::Direct {
@@ -62,7 +65,75 @@ pub(crate) async fn first_online_device() -> Result<(DeviceRoute, String)> {
             let name = paired
                 .codename
                 .unwrap_or_else(|| format!("Slot {}", paired.slot));
-            Some((route, name))
-        })
-        .ok_or_else(|| anyhow!("no online HID++ device found — is a Logi mouse paired?"))
+            out.push(Candidate { route, name });
+        }
+    }
+    Ok(out)
+}
+
+/// Build a helpful "couldn't pick a device" error that lists what *is* online.
+fn no_match_err(devices: &[Candidate], query: Option<&str>) -> anyhow::Error {
+    if devices.is_empty() {
+        return anyhow!("no online HID++ device found — is a Logi device paired and awake?");
+    }
+    let list = devices
+        .iter()
+        .map(|c| format!("    - {} ({})", c.name, c.route))
+        .collect::<Vec<_>>()
+        .join("\n");
+    match query {
+        Some(q) => anyhow!("no online device matches `--device {q}`.\n  online devices:\n{list}"),
+        None => anyhow!(
+            "could not pick a device automatically.\n  online devices:\n{list}\n  \
+             pass --device <name> to choose one."
+        ),
+    }
+}
+
+/// Pick the device a diag should run against.
+///
+/// Selection order:
+/// 1. If `query` is set, the first online device whose name contains it
+///    (case-insensitive) — lets the user disambiguate explicitly.
+/// 2. Else, if `required_features` is non-empty, the first online device whose
+///    HID++ feature table exposes *any* of them. This is what stops a
+///    mouse-only diag (DPI, SmartShift) from picking a paired keyboard when
+///    several devices are online — a real hazard on Bluetooth-direct setups
+///    where each device enumerates as its own inventory.
+/// 3. Else, the first online device (the original behaviour).
+pub(crate) async fn select_device(
+    query: Option<&str>,
+    required_features: &[u16],
+) -> Result<(DeviceRoute, String)> {
+    let devices = online_devices().await?;
+
+    if let Some(q) = query {
+        let needle = q.to_lowercase();
+        return devices
+            .iter()
+            .find(|c| c.name.to_lowercase().contains(&needle))
+            .map(|c| (c.route.clone(), c.name.clone()))
+            .ok_or_else(|| no_match_err(&devices, query));
+    }
+
+    if !required_features.is_empty() {
+        for c in &devices {
+            // dump_features can legitimately fail for a sleepy/offline device;
+            // skip those and keep looking rather than aborting the whole pick.
+            if let Ok(entries) = dump_features(&c.route).await {
+                if entries.iter().any(|e| required_features.contains(&e.id)) {
+                    return Ok((c.route.clone(), c.name.clone()));
+                }
+            }
+        }
+        // None advertised the feature — fall through to first-online so the
+        // caller's own "device does not expose feature 0x….." error still
+        // fires against a concrete device.
+    }
+
+    devices
+        .into_iter()
+        .next()
+        .map(|c| (c.route, c.name))
+        .ok_or_else(|| no_match_err(&[], None))
 }

--- a/crates/openlogi-cli/src/cmd/diag/smartshift.rs
+++ b/crates/openlogi-cli/src/cmd/diag/smartshift.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroU8;
 use anyhow::{Context, Result};
 use clap::Args;
 
-use crate::cmd::diag::first_online_device;
+use crate::cmd::diag::select_device;
 
 #[derive(Debug, Args)]
 pub struct SmartshiftArgs {
@@ -21,10 +21,17 @@ pub struct SmartshiftArgs {
     /// always preserved). `0` is rejected — the device treats it as "no change".
     #[arg(long, value_name = "N")]
     pub sensitivity: Option<NonZeroU8>,
+
+    /// Run against the device whose name contains this string
+    /// (case-insensitive) instead of auto-selecting. Useful when several
+    /// devices are paired (e.g. a mouse and a keyboard over Bluetooth).
+    #[arg(long, value_name = "NAME")]
+    pub device: Option<String>,
 }
 
 pub async fn run(args: SmartshiftArgs) -> Result<()> {
-    let (route, name) = first_online_device().await?;
+    // 0x2110 / 0x2111 = SmartShift — auto-skip devices that expose neither.
+    let (route, name) = select_device(args.device.as_deref(), &[0x2110, 0x2111]).await?;
     println!("device: {name} ({route})");
 
     if let Some(n) = args.sensitivity {


### PR DESCRIPTION
Closes #148 (Finding 2). Builds on the verification in #148.

`first_online_device()` returned the first online paired device regardless of
kind. With a keyboard + mouse paired over Bluetooth-direct (each enumerates as
its own inventory), a mouse-only diag picks the **keyboard** and fails:

    device: MX Keys (direct 046d:b35b)
    Error: device does not expose HID++ feature 0x2201

This replaces it with `select_device(query, required_features)`:
- `diag dpi` / `diag smartshift` now prefer an online device whose HID++ feature
  table advertises the feature under test (`0x2201`, and `0x2110`/`0x2111`),
  so a paired keyboard is skipped automatically.
- Adds a `--device <name>` override (case-insensitive substring match).
- On no match, the error lists the online devices instead of a generic message.

Non-breaking: existing invocations work unchanged; `diag features` and
`diag lighting` are untouched. Verified on Ubuntu 26.04 / Wayland — with both
devices online, `diag dpi` now targets the MX Master 3S without powering off the
keyboard, and `--device master` selects it explicitly.