### PR TITLE
feat(i18n): update italian language

### DIFF
--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -3,7 +3,7 @@
 # `_version: 2` packs every translated locale for one message into a single
 # entry. The **key is the English msgid** (gettext-style): a `t!`/`tr!` lookup
 # that misses the current locale falls back to the key itself, so English needs
-# no column here — only the `ja` / `ru` / `zh-CN` / `zh-HK` / `zh-TW`
+# no column here — only the `ja` / `ru` / `zh-CN` / `zh-HK` / `zh-TW` / `it`
 # translations. Keys must match the code verbatim, and the device/action
 # vocabulary must match
 # `openlogi_core::binding`'s `label()`.
@@ -18,6 +18,7 @@ _version: 2
   zh-CN: 未连接设备
   zh-HK: 未連接裝置
   zh-TW: 沒有已連線的裝置
+  it: Nessun dispositivo connesso
 "Devices":
   ja: デバイス
   ru: "Устройства"
@@ -77,12 +78,14 @@ _version: 2
   zh-CN: 打开 OpenLogi
   zh-HK: 開啟 OpenLogi
   zh-TW: 開啟 OpenLogi
+  it: Apri OpenLogi
 "Quit OpenLogi":
   ja: OpenLogi を終了
   ru: "Выйти из OpenLogi"
   zh-CN: 退出 OpenLogi
   zh-HK: 結束 OpenLogi
   zh-TW: 結束 OpenLogi
+  it: Esci da OpenLogi
 
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.":
   ja: 対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。直接 Bluetooth 接続の場合は、コンピューターの Bluetooth 設定でペアリングしてください。
@@ -300,54 +303,63 @@ _version: 2
   zh-CN: 正在使用 Logi Options+?请先退出 —— 两个应用会争夺 HID++ 访问权限。
   zh-HK: 正在使用 Logi Options+?請先結束 —— 兩個應用會爭奪 HID++ 存取權限。
   zh-TW: 正在使用 Logi Options+？請先結束，兩個應用程式會爭用 HID++ 存取權限。
+  it: Usi Logi Options+? Esci prima da lì — entrambe le app competono per l'accesso HID++.
 "Accessibility permission required":
   ja: アクセシビリティ権限が必要です
   ru: "Требуется разрешение Универсального доступа"
   zh-CN: 需要「辅助功能」权限
   zh-HK: 需要「輔助使用」權限
   zh-TW: 需要「輔助使用」權限
+  it: Permesso di Accessibilità richiesto
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.":
   ja: OpenLogi はシステムの「アクセシビリティ」権限を通じてマウスボタン(戻る / 進む / ジェスチャーボタン)を捕捉し、割り当てた操作を実行します。DPI、SmartShift などデバイスと直接通信する機能には影響しません。
   ru: "OpenLogi перехватывает кнопки мыши (Назад / Вперёд / кнопку жестов) через системное разрешение Универсального доступа и выполняет назначенные вами действия. Функции, которые обращаются к устройству напрямую — DPI, SmartShift — не затрагиваются."
   zh-CN: OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。
   zh-HK: OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
   zh-TW: OpenLogi 會透過系統的「輔助使用」權限擷取滑鼠按鍵（後退 / 前進 / 手勢按鈕），並執行指派的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。
+  it: OpenLogi cattura i pulsanti del mouse (Indietro / Avanti / pulsante gesture) tramite i permessi di Accessibilità del sistema ed esegue le azioni associate. Le funzionalità che comunicano direttamente con il dispositivo — DPI, SmartShift — non sono influenzate.
 "Open System Settings to grant access":
   ja: システム設定を開いて許可する
   ru: "Открыть системные настройки для выдачи доступа"
   zh-CN: 打开系统设置授权
   zh-HK: 開啟系統設定授權
   zh-TW: 開啟系統設定以授權
+  it: Apri Impostazioni di Sistema per concedere l'accesso
 "Takes effect automatically once granted — no restart needed.":
   ja: 許可すると自動的に反映されます — 再起動は不要です。
   ru: "Вступит в силу автоматически после выдачи разрешения — перезапуск не нужен."
   zh-CN: 授权后会自动生效,无需重启。
   zh-HK: 授權後會自動生效,無需重新啟動。
   zh-TW: 授權後會自動生效，無需重新啟動。
+  it: Diventa effettivo automaticamente una volta concesso — nessun riavvio necessario.
 "Not now (use DPI and other features only)":
   ja: 後で(DPI などの機能のみ使用)
   ru: "Не сейчас (использовать только DPI и другие функции)"
   zh-CN: 稍后再说(仅使用 DPI 等功能)
   zh-HK: 稍後再說(僅使用 DPI 等功能)
   zh-TW: 稍後再說（僅使用 DPI 等功能）
+  it: Non ora (usa solo DPI e altre funzionalità)
 "Settings":
   ja: 設定
   ru: "Настройки"
   zh-CN: 设置
   zh-HK: 設定
   zh-TW: 設定
+  it: Impostazioni
 "Accessibility granted":
   ja: アクセシビリティは許可済み
   ru: "Универсальный доступ разрешён"
   zh-CN: 辅助功能已授权
   zh-HK: 輔助使用已授權
   zh-TW: 輔助使用已授權
+  it: Accessibilità concessa
 "Accessibility not granted · click to grant":
   ja: アクセシビリティ未許可 · クリックして許可
   ru: "Универсальный доступ не разрешён · нажмите, чтобы выдать доступ"
   zh-CN: 辅助功能未授权 · 点击授权
   zh-HK: 輔助使用未授權 · 點擊授權
   zh-TW: 輔助使用未授權 · 按一下以授權
+  it: Accessibilità non concessa · clicca per concedere
 
 # ── macOS menu bar (app_menu.rs) ────────────────────────────────────────────
 "About OpenLogi":
@@ -356,12 +368,14 @@ _version: 2
   zh-CN: 关于 OpenLogi
   zh-HK: 關於 OpenLogi
   zh-TW: 關於 OpenLogi
+  it: Informazioni su OpenLogi
 "Settings…":
   ja: 設定…
   ru: "Настройки…"
   zh-CN: 设置…
   zh-HK: 設定…
   zh-TW: 設定…
+  it: Impostazioni…
 "Check for Updates…":
   ja: アップデートを確認…
   ru: "Проверить обновления…"
@@ -380,36 +394,42 @@ _version: 2
   zh-CN: 撤销
   zh-HK: 復原
   zh-TW: 復原
+  it: Annulla
 "Redo":
   ja: やり直す
   ru: "Повторить"
   zh-CN: 重做
   zh-HK: 重做
   zh-TW: 重做
+  it: Ripristina
 "Cut":
   ja: カット
   ru: "Вырезать"
   zh-CN: 剪切
   zh-HK: 剪下
   zh-TW: 剪下
+  it: Taglia
 "Copy":
   ja: コピー
   ru: "Копировать"
   zh-CN: 复制
   zh-HK: 複製
   zh-TW: 複製
+  it: Copia
 "Paste":
   ja: ペースト
   ru: "Вставить"
   zh-CN: 粘贴
   zh-HK: 貼上
   zh-TW: 貼上
+  it: Incolla
 "Select All":
   ja: すべて選択
   ru: "Выбрать всё"
   zh-CN: 全选
   zh-HK: 全選
   zh-TW: 全選
+  it: Seleziona tutto
 "View":
   ja: 表示
   ru: "Вид"
@@ -434,42 +454,49 @@ _version: 2
   zh-CN: 隐藏 OpenLogi
   zh-HK: 隱藏 OpenLogi
   zh-TW: 隱藏 OpenLogi
+  it: Nascondi OpenLogi
 "Hide Others":
   ja: ほかを隠す
   ru: "Скрыть остальные"
   zh-CN: 隐藏其他
   zh-HK: 隱藏其他
   zh-TW: 隱藏其他
+  it: Nascondi altre
 "Show All":
   ja: すべてを表示
   ru: "Показать все"
   zh-CN: 全部显示
   zh-HK: 全部顯示
   zh-TW: 顯示全部
+  it: Mostra tutte
 "Window":
   ja: ウインドウ
   ru: "Окно"
   zh-CN: 窗口
   zh-HK: 視窗
   zh-TW: 視窗
+  it: Finestra
 "Minimize":
   ja: しまう
   ru: "Свернуть"
   zh-CN: 最小化
   zh-HK: 最小化
   zh-TW: 最小化
+  it: Minimizza
 "Zoom":
   ja: ズーム
   ru: "Масштабировать"
   zh-CN: 缩放
   zh-HK: 縮放
   zh-TW: 縮放
+  it: Ridimensiona
 "Close Window":
   ja: ウインドウを閉じる
   ru: "Закрыть окно"
   zh-CN: 关闭窗口
   zh-HK: 關閉視窗
   zh-TW: 關閉視窗
+  it: Chiudi finestra
 "Bring All to Front":
   ja: すべてを手前に移動
   ru: "Поместить все окна вперед"
@@ -508,6 +535,7 @@ _version: 2
   zh-CN: 开源的 Logitech 鼠标配置工具 —— DPI、SmartShift、按键绑定与手势。
   zh-HK: 開源的 Logitech 滑鼠設定工具 —— DPI、SmartShift、按鍵綁定與手勢。
   zh-TW: 開源的 Logitech 滑鼠設定工具，可設定 DPI、SmartShift、按鍵指派與手勢。
+  it: Configurazione open-source per mouse Logitech — DPI, SmartShift, associazioni pulsanti e gesture.
 
 # ── Settings window (settings.rs) ───────────────────────────────────────────
 "General":
@@ -516,60 +544,70 @@ _version: 2
   zh-CN: 通用
   zh-HK: 一般
   zh-TW: 一般
+  it: Generale
 "Launch at login":
   ja: ログイン時に起動
   ru: "Запускать при входе"
   zh-CN: 开机自启
   zh-HK: 開機自動啟動
   zh-TW: 登入時自動啟動
+  it: Avvia al login
 "Automatically start OpenLogi when you log in to macOS.":
   ja: macOS にログインしたときに OpenLogi を自動的に起動します。
   ru: "Автоматически запускать OpenLogi при входе в macOS."
   zh-CN: 登录 macOS 时自动启动 OpenLogi。
   zh-HK: 登入 macOS 時自動啟動 OpenLogi。
   zh-TW: 登入 macOS 時自動啟動 OpenLogi。
+  it: Avvia automaticamente OpenLogi quando accedi a macOS.
 "Check for updates":
   ja: アップデートを確認
   ru: "Проверять обновления"
   zh-CN: 检查更新
   zh-HK: 檢查更新
   zh-TW: 檢查更新
+  it: Controlla aggiornamenti
 "Check once per launch for a new version (query only — no automatic download).":
   ja: 起動ごとに新しいバージョンを一度だけ確認します(確認のみ — 自動ダウンロードはしません)。
   ru: "Один раз при запуске проверять наличие новой версии (только проверка — без автоматической загрузки)."
   zh-CN: 每次启动检查一次新版本(仅查询,不自动下载)。
   zh-HK: 每次啟動檢查一次新版本(僅查詢,不自動下載)。
   zh-TW: 每次啟動時檢查一次新版本（僅查詢，不自動下載）。
+  it: Controlla la presenza di una nuova versione ad ogni avvio (solo verifica — nessun download automatico).
 "Show in menu bar":
   ja: メニューバーに表示
   ru: "Показывать в строке меню"
   zh-CN: 显示在菜单栏
   zh-HK: 顯示在選單列
   zh-TW: 顯示在選單列
+  it: Mostra nella barra dei menu
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.":
   ja: OpenLogi のアイコンをメニューバーに表示します。オフにすると Dock に残ります。
   ru: "Оставлять значок OpenLogi в строке меню. Если выключено, приложение остаётся в Dock."
   zh-CN: 在菜单栏保留 OpenLogi 图标；关闭后改为停留在程序坞中。
   zh-HK: 在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。
   zh-TW: 在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。
+  it: Mantieni l'icona di OpenLogi nella barra dei menu. Quando è disattivata, rimarrà invece nel Dock.
 "Language":
   ja: 言語
   ru: "Язык"
   zh-CN: 语言
   zh-HK: 語言
   zh-TW: 語言
+  it: Lingua
 "Choose the interface language.":
   ja: インターフェースの言語を選択します。
   ru: "Выберите язык интерфейса."
   zh-CN: 选择界面语言。
   zh-HK: 選擇介面語言。
   zh-TW: 選擇介面語言。
+  it: Scegli la lingua dell'interfaccia.
 "Follow system":
   ja: システムに従う
   ru: "Как в системе"
   zh-CN: 跟随系统
   zh-HK: 跟隨系統
   zh-TW: 依照系統
+  it: Segui il sistema
 
 # ── DPI panel (dpi_panel.rs) ────────────────────────────────────────────────
 "PRESETS":
@@ -578,12 +616,14 @@ _version: 2
   zh-CN: 预设
   zh-HK: 預設
   zh-TW: 預設
+  it: PRESET
 "Add":
   ja: 追加
   ru: "Добавить"
   zh-CN: 添加
   zh-HK: 新增
   zh-TW: 新增
+  it: Aggiungi
 
 # ── SmartShift panel (components/smartshift_panel.rs) ───────────────────────
 # "SmartShift" (card title) and "On"/"Off" are intentionally absent: the brand
@@ -665,6 +705,7 @@ _version: 2
   zh-CN: 绑定 %{name}
   zh-HK: 綁定 %{name}
   zh-TW: 設定 %{name}
+  it: Associa %{name}
 "Unbound":
   ja: 未割り当て
   ru: "Не назначено"
@@ -695,6 +736,7 @@ _version: 2
   zh-CN: 手势 %{name}
   zh-HK: 手勢 %{name}
   zh-TW: 手勢 %{name}
+  it: Gesture %{name}
 
 # ── Buttons (openlogi_core::binding::ButtonId) ──────────────────────────────
 "Left Click":
@@ -703,48 +745,56 @@ _version: 2
   zh-CN: 左键单击
   zh-HK: 左鍵單擊
   zh-TW: 左鍵按一下
+  it: Click sinistro
 "Right Click":
   ja: 右クリック
   ru: "Правый щелчок"
   zh-CN: 右键单击
   zh-HK: 右鍵單擊
   zh-TW: 右鍵按一下
+  it: Click destro
 "Middle Click":
   ja: 中クリック
   ru: "Средний щелчок"
   zh-CN: 中键单击
   zh-HK: 中鍵單擊
   zh-TW: 中鍵按一下
+  it: Click centrale
 "Back":
   ja: 戻る
   ru: "Назад"
   zh-CN: 后退
   zh-HK: 後退
   zh-TW: 後退
+  it: Indietro
 "Forward":
   ja: 進む
   ru: "Вперёд"
   zh-CN: 前进
   zh-HK: 前進
   zh-TW: 前進
+  it: Avanti
 "DPI Toggle":
   ja: DPI 切り替え
   ru: "Переключение DPI"
   zh-CN: 灵敏度切换
   zh-HK: 靈敏度切換
   zh-TW: 靈敏度切換
+  it: Cambia DPI
 "Thumb Wheel":
   ja: サムホイール
   ru: "Колесо под большой палец"
   zh-CN: 拇指滚轮
   zh-HK: 拇指滾輪
   zh-TW: 拇指滾輪
+  it: Volante da pollice
 "Gesture Button":
   ja: ジェスチャーボタン
   ru: "Кнопка жестов"
   zh-CN: 手势按钮
   zh-HK: 手勢按鈕
   zh-TW: 手勢按鈕
+  it: Pulsante gesture
 
 # ── Gesture directions (openlogi_core::binding::GestureDirection) ───────────
 "Up":
@@ -753,30 +803,35 @@ _version: 2
   zh-CN: 上
   zh-HK: 上
   zh-TW: 上
+  it: Su
 "Down":
   ja: 下
   ru: "Вниз"
   zh-CN: 下
   zh-HK: 下
   zh-TW: 下
+  it: Giù
 "Left":
   ja: 左
   ru: "Влево"
   zh-CN: 左
   zh-HK: 左
   zh-TW: 左
+  it: Sinistra
 "Right":
   ja: 右
   ru: "Вправо"
   zh-CN: 右
   zh-HK: 右
   zh-TW: 右
+  it: Destra
 "Click":
   ja: 押し込み
   ru: "Щелчок"
   zh-CN: 按下
   zh-HK: 按下
   zh-TW: 按下
+  it: Click
 
 # ── Categories (openlogi_core::binding::Category) ───────────────────────────
 "EDITING":
@@ -785,42 +840,49 @@ _version: 2
   zh-CN: 编辑
   zh-HK: 編輯
   zh-TW: 編輯
+  it: MODIFICA
 "BROWSER":
   ja: ブラウザ
   ru: "БРАУЗЕР"
   zh-CN: 浏览器
   zh-HK: 瀏覽器
   zh-TW: 瀏覽器
+  it: BROWSER
 "MEDIA":
   ja: メディア
   ru: "МЕДИА"
   zh-CN: 媒体
   zh-HK: 媒體
   zh-TW: 媒體
+  it: MEDIA
 "MOUSE":
   ja: マウス
   ru: "МЫШЬ"
   zh-CN: 鼠标
   zh-HK: 滑鼠
   zh-TW: 滑鼠
+  it: MOUSE
 "SCROLL":
   ja: スクロール
   ru: "ПРОКРУТКА"
   zh-CN: 滚动
   zh-HK: 捲動
   zh-TW: 捲動
+  it: SCROLL
 "NAVIGATION":
   ja: ナビゲーション
   ru: "НАВИГАЦИЯ"
   zh-CN: 导航
   zh-HK: 導覽
   zh-TW: 導覽
+  it: NAVIGAZIONE
 "SYSTEM":
   ja: システム
   ru: "СИСТЕМА"
   zh-CN: 系统
   zh-HK: 系統
   zh-TW: 系統
+  it: SISTEMA
 "DPI":
   ja: DPI
   ru: "DPI"
@@ -835,72 +897,84 @@ _version: 2
   zh-CN: 查找
   zh-HK: 尋找
   zh-TW: 尋找
+  it: Trova
 "Save":
   ja: 保存
   ru: "Сохранить"
   zh-CN: 保存
   zh-HK: 儲存
   zh-TW: 儲存
+  it: Salva
 "Browser Back":
   ja: ブラウザで戻る
   ru: "Назад в браузере"
   zh-CN: 浏览器后退
   zh-HK: 瀏覽器後退
   zh-TW: 瀏覽器上一頁
+  it: Indietro nel browser
 "Browser Forward":
   ja: ブラウザで進む
   ru: "Вперёд в браузере"
   zh-CN: 浏览器前进
   zh-HK: 瀏覽器前進
   zh-TW: 瀏覽器下一頁
+  it: Avanti nel browser
 "New Tab":
   ja: 新規タブ
   ru: "Новая вкладка"
   zh-CN: 新建标签页
   zh-HK: 新增分頁
   zh-TW: 新增分頁
+  it: Nuova scheda
 "Close Tab":
   ja: タブを閉じる
   ru: "Закрыть вкладку"
   zh-CN: 关闭标签页
   zh-HK: 關閉分頁
   zh-TW: 關閉分頁
+  it: Chiudi scheda
 "Reopen Tab":
   ja: タブを再度開く
   ru: "Открыть закрытую вкладку"
   zh-CN: 重开标签页
   zh-HK: 重新開啟分頁
   zh-TW: 重新開啟分頁
+  it: Riapri scheda
 "Next Tab":
   ja: 次のタブ
   ru: "Следующая вкладка"
   zh-CN: 下一个标签页
   zh-HK: 下一個分頁
   zh-TW: 下一個分頁
+  it: Scheda successiva
 "Previous Tab":
   ja: 前のタブ
   ru: "Предыдущая вкладка"
   zh-CN: 上一个标签页
   zh-HK: 上一個分頁
   zh-TW: 上一個分頁
+  it: Scheda precedente
 "Reload Page":
   ja: ページを再読み込み
   ru: "Перезагрузить страницу"
   zh-CN: 刷新页面
   zh-HK: 重新載入頁面
   zh-TW: 重新載入頁面
+  it: Ricarica pagina
 "Mission Control":
   ja: Mission Control
   ru: "Mission Control"
   zh-CN: 调度中心
   zh-HK: 調度中心
   zh-TW: Mission Control
+  it: Mission Control
 "App Exposé":
   ja: App Exposé
   ru: "App Exposé"
   zh-CN: 应用程序窗口
   zh-HK: 應用程式視窗
   zh-TW: App Exposé
+  it: App Exposé
 "Previous Desktop":
   ja: 前のデスクトップ
   ru: "Предыдущий рабочий стол"
@@ -917,96 +991,112 @@ _version: 2
   zh-CN: 显示桌面
   zh-HK: 顯示桌面
   zh-TW: 顯示桌面
+  it: Mostra scrivania
 "Launchpad":
   ja: Launchpad
   ru: "Launchpad"
   zh-CN: 启动台
   zh-HK: 啟動台
   zh-TW: 啟動台
+  it: Launchpad
 "Lock Screen":
   ja: 画面をロック
   ru: "Заблокировать экран"
   zh-CN: 锁定屏幕
   zh-HK: 鎖定螢幕
   zh-TW: 鎖定螢幕
+  it: Blocca schermo
 "Screenshot":
   ja: スクリーンショット
   ru: "Снимок экрана"
   zh-CN: 截屏
   zh-HK: 截圖
   zh-TW: 截圖
+  it: Istantanea schermo
 "Play / Pause":
   ja: 再生 / 一時停止
   ru: "Воспроизведение / пауза"
   zh-CN: 播放 / 暂停
   zh-HK: 播放 / 暫停
   zh-TW: 播放 / 暫停
+  it: Riproduci / Pausa
 "Next Track":
   ja: 次の曲
   ru: "Следующий трек"
   zh-CN: 下一首
   zh-HK: 下一首
   zh-TW: 下一首
+  it: Traccia successiva
 "Previous Track":
   ja: 前の曲
   ru: "Предыдущий трек"
   zh-CN: 上一首
   zh-HK: 上一首
   zh-TW: 上一首
+  it: Traccia precedente
 "Volume Up":
   ja: 音量を上げる
   ru: "Увеличить громкость"
   zh-CN: 增大音量
   zh-HK: 調高音量
   zh-TW: 調高音量
+  it: Alza il volume
 "Volume Down":
   ja: 音量を下げる
   ru: "Уменьшить громкость"
   zh-CN: 减小音量
   zh-HK: 調低音量
   zh-TW: 調低音量
+  it: Abbassa il volume
 "Mute":
   ja: ミュート
   ru: "Выключить звук"
   zh-CN: 静音
   zh-HK: 靜音
   zh-TW: 靜音
+  it: Muto
 "Cycle DPI Presets":
   ja: DPI プリセットを循環
   ru: "Переключать пресеты DPI"
   zh-CN: 循环灵敏度预设
   zh-HK: 循環靈敏度預設
   zh-TW: 循環靈敏度預設
+  it: Cicla preset DPI
 "Toggle SmartShift":
   ja: SmartShift を切り替え
   ru: "Переключить SmartShift"
   zh-CN: 切换 SmartShift
   zh-HK: 切換 SmartShift
   zh-TW: 切換 SmartShift
+  it: Attiva/Disattiva SmartShift
 "Scroll Up":
   ja: 上にスクロール
   ru: "Прокрутить вверх"
   zh-CN: 向上滚动
   zh-HK: 向上捲動
   zh-TW: 向上捲動
+  it: Scorri su
 "Scroll Down":
   ja: 下にスクロール
   ru: "Прокрутить вниз"
   zh-CN: 向下滚动
   zh-HK: 向下捲動
   zh-TW: 向下捲動
+  it: Scorri giù
 "Scroll Left":
   ja: 左にスクロール
   ru: "Прокрутить влево"
   zh-CN: 向左滚动
   zh-HK: 向左捲動
   zh-TW: 向左捲動
+  it: Scorri a sinistra
 "Scroll Right":
   ja: 右にスクロール
   ru: "Прокрутить вправо"
   zh-CN: 向右滚动
   zh-HK: 向右捲動
   zh-TW: 向右捲動
+  it: Scorri a destra
 
 # ── Add Device / pairing flow (windows/add_device.rs, app_menu.rs, app.rs) ──
 "Add Device":
@@ -1015,108 +1105,126 @@ _version: 2
   zh-CN: 添加设备
   zh-HK: 新增裝置
   zh-TW: 新增裝置
+  it: Aggiungi dispositivo
 "Add Device…":
   ja: デバイスを追加…
   ru: "Добавить устройство…"
   zh-CN: 添加设备…
   zh-HK: 新增裝置…
   zh-TW: 新增裝置…
+  it: Aggiungi dispositivo…
 "Put the device in pairing mode, then start searching.":
   ja: デバイスをペアリングモードにしてから検索を開始してください。
   ru: "Переведите устройство в режим сопряжения, затем начните поиск."
   zh-CN: 先让设备进入配对模式，然后开始搜索。
   zh-HK: 先讓裝置進入配對模式，然後開始搜尋。
   zh-TW: 先讓裝置進入配對模式，然後開始搜尋。
+  it: Metti il dispositivo in modalità di associazione, quindi avvia la ricerca.
 "Search for devices":
   ja: デバイスを検索
   ru: "Искать устройства"
   zh-CN: 搜索设备
   zh-HK: 搜尋裝置
   zh-TW: 搜尋裝置
+  it: Cerca dispositivi
 "Searching for devices…":
   ja: デバイスを検索中…
   ru: "Поиск устройств…"
   zh-CN: 正在搜索设备…
   zh-HK: 正在搜尋裝置…
   zh-TW: 正在搜尋裝置…
+  it: Ricerca dispositivi in corso…
 "Make sure the device is on and in pairing mode.":
   ja: デバイスの電源が入り、ペアリングモードになっていることを確認してください。
   ru: "Убедитесь, что устройство включено и находится в режиме сопряжения."
   zh-CN: 请确认设备已开机并处于配对模式。
   zh-HK: 請確認裝置已開機並處於配對模式。
   zh-TW: 請確認裝置已開機並處於配對模式。
+  it: Assicurati che il dispositivo sia acceso e in modalità di associazione.
 "No devices found yet…":
   ja: まだデバイスが見つかりません…
   ru: "Устройства пока не найдены…"
   zh-CN: 暂未发现设备…
   zh-HK: 暫未發現裝置…
   zh-TW: 尚未找到裝置…
+  it: Nessun dispositivo ancora trovato…
 "Select a device to pair:":
   ja: "ペアリングするデバイスを選択してください:"
   ru: "Выберите устройство для сопряжения:"
   zh-CN: 选择要配对的设备：
   zh-HK: 選擇要配對的裝置：
   zh-TW: 選擇要配對的裝置：
+  it: "Seleziona un dispositivo da associare:"
 "Pairing…":
   ja: ペアリング中…
   ru: "Сопряжение…"
   zh-CN: 正在配对…
   zh-HK: 正在配對…
   zh-TW: 正在配對…
+  it: Associazione in corso…
 "Follow the instructions on your device.":
   ja: デバイスの指示に従ってください。
   ru: "Следуйте инструкциям на устройстве."
   zh-CN: 请按照设备上的提示操作。
   zh-HK: 請按照裝置上的提示操作。
   zh-TW: 請按照裝置上的提示操作。
+  it: Segui le istruzioni sul tuo dispositivo.
 "Type this passkey on the new keyboard, then press Enter:":
   ja: "新しいキーボードでこのパスキーを入力し、Enter キーを押してください:"
   ru: "Введите этот код на новой клавиатуре, затем нажмите Enter:"
   zh-CN: 在新键盘上输入此配对码，然后按回车：
   zh-HK: 在新鍵盤上輸入此配對碼，然後按 Enter：
   zh-TW: 在新鍵盤上輸入此配對碼，然後按 Enter：
+  it: "Digita questa passkey sulla nuova tastiera, quindi premi Invio:"
 "On the new mouse, click in this order, then press both buttons together:":
   ja: "新しいマウスでこの順にクリックし、最後に両方のボタンを同時に押してください:"
   ru: "На новой мыши нажмите кнопки в этом порядке, затем нажмите обе кнопки одновременно:"
   zh-CN: 在新鼠标上按此顺序点击，最后同时按下左右键：
   zh-HK: 在新滑鼠上按此順序點擊，最後同時按下左右鍵：
   zh-TW: 請在新滑鼠上依序按一下，最後同時按下左右鍵：
+  it: "Sul nuovo mouse, fai clic in questo ordine, quindi premi entrambi i pulsanti contemporaneamente:"
 "Device paired":
   ja: デバイスをペアリングしました
   ru: "Устройство сопряжено"
   zh-CN: 设备已配对
   zh-HK: 裝置已配對
   zh-TW: 裝置已配對
+  it: Dispositivo associato
 "Paired to slot %{slot}.":
   ja: スロット %{slot} にペアリングしました。
   ru: "Сопряжено со слотом %{slot}."
   zh-CN: 已配对到插槽 %{slot}。
   zh-HK: 已配對到插槽 %{slot}。
   zh-TW: 已配對到插槽 %{slot}。
+  it: Associato allo slot %{slot}.
 "Done":
   ja: 完了
   ru: "Готово"
   zh-CN: 完成
   zh-HK: 完成
   zh-TW: 完成
+  it: Fatto
 "Pairing failed":
   ja: ペアリングに失敗しました
   ru: "Сопряжение не удалось"
   zh-CN: 配对失败
   zh-HK: 配對失敗
   zh-TW: 配對失敗
+  it: Associazione fallita
 "Try again":
   ja: 再試行
   ru: "Повторить"
   zh-CN: 重试
   zh-HK: 重試
   zh-TW: 重試
+  it: Riprova
 "Cancel":
   ja: キャンセル
   ru: "Отмена"
   zh-CN: 取消
   zh-HK: 取消
   zh-TW: 取消
+  it: Annulla
 
 # ── Settings → Permissions section (windows/settings.rs) ────────────────────
 "Permissions":
@@ -1124,56 +1232,67 @@ _version: 2
   zh-CN: 权限
   zh-HK: 權限
   zh-TW: 權限
+  it: Permessi
 "Accessibility":
   ja: アクセシビリティ
   zh-CN: 辅助功能
   zh-HK: 輔助使用
   zh-TW: 輔助使用
+  it: Accessibilità
 "Input Monitoring":
   ja: 入力監視
   zh-CN: 输入监控
   zh-HK: 輸入監控
   zh-TW: 輸入監控
+  it: Monitoraggio input
 "Bluetooth":
   ja: Bluetooth
   zh-CN: 蓝牙
   zh-HK: 藍牙
   zh-TW: 藍牙
+  it: Bluetooth
 "Granted":
   ja: 許可済み
   zh-CN: 已授权
   zh-HK: 已授權
   zh-TW: 已授權
+  it: Concesso
 "Not granted":
   ja: 未許可
   zh-CN: 未授权
   zh-HK: 未授權
   zh-TW: 未授權
+  it: Non concesso
 "Unknown":
   ja: 不明
   zh-CN: 未知
   zh-HK: 未知
   zh-TW: 未知
+  it: Sconosciuto
 "Open":
   ja: 開く
   zh-CN: 打开
   zh-HK: 開啟
   zh-TW: 開啟
+  it: Apri
 "Needed for gesture and button remapping (event tap).":
   ja: ジェスチャーとボタンの再割り当てに必要です（イベントタップ）。
   zh-CN: 手势与按键重映射所需（事件捕获）。
   zh-HK: 手勢與按鍵重新對應所需（事件攔截）。
   zh-TW: 手勢與按鍵重新對應需要此權限（事件監聽）。
+  it: Necessario per la rimappatura di gesture e pulsanti (event tap).
 "Needed to read HID++ data, including Bluetooth-direct mice.":
   ja: Bluetooth 直結マウスを含む HID++ データの読み取りに必要です。
   zh-CN: 读取 HID++ 数据所需，包括蓝牙直连鼠标。
   zh-HK: 讀取 HID++ 數據所需，包括藍牙直連滑鼠。
   zh-TW: 需要此權限才能讀取 HID++ 資料，包括藍牙直連滑鼠。
+  it: Necessario per leggere i dati HID++, inclusi i mouse con connessione diretta Bluetooth.
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).":
   ja: OpenLogi が CoreBluetooth を使用できるようにします（HID アクセスには不要）。
   zh-CN: 允许 OpenLogi 使用 CoreBluetooth（HID 访问不需要）。
   zh-HK: 允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。
   zh-TW: 允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。
+  it: Consente a OpenLogi di utilizzare CoreBluetooth (non richiesto per l'accesso HID).
 
 # ── Empty / scanning state (app.rs) ─────────────────────────────────────────
 "Scanning for devices…":
@@ -1181,6 +1300,7 @@ _version: 2
   zh-CN: 正在扫描设备…
   zh-HK: 正在掃描裝置…
   zh-TW: 正在掃描裝置…
+  it: Scansione dispositivi in corso…
 
 # ── Thumb wheel (binding.rs labels + settings.rs) ───────────────────────────
 "Thumb Wheel Up":

--- a/crates/openlogi-gui/locales/app.yml
+++ b/crates/openlogi-gui/locales/app.yml
@@ -25,6 +25,7 @@ _version: 2
   zh-CN: 设备
   zh-HK: 裝置
   zh-TW: 裝置
+  it: Dispositivi
 # Device-detail tabs (app.rs)
 "Buttons":
   ja: ボタン
@@ -32,12 +33,14 @@ _version: 2
   zh-CN: 按键
   zh-HK: 按鍵
   zh-TW: 按鍵
+  it: Pulsanti
 "Pointer":
   ja: ポインター
   ru: "Указатель"
   zh-CN: 指针
   zh-HK: 指標
   zh-TW: 指標
+  it: Puntatore
 
 # Keyboard lighting tab + panel (app.rs, components/lighting_panel.rs)
 "Lighting":
@@ -46,30 +49,35 @@ _version: 2
   zh-CN: 灯光
   zh-HK: 燈光
   zh-TW: 燈光
+  it: Illuminazione
 "LIGHTING":
   ja: ライト
   ru: "ПОДСВЕТКА"
   zh-CN: 灯光
   zh-HK: 燈光
   zh-TW: 燈光
+  it: ILLUMINAZIONE
 "BRIGHTNESS":
   ja: 明るさ
   ru: "ЯРКОСТЬ"
   zh-CN: 亮度
   zh-HK: 亮度
   zh-TW: 亮度
+  it: LUMINOSITÀ
 "On":
   ja: オン
   ru: "Вкл"
   zh-CN: 开
   zh-HK: 開
   zh-TW: 開
+  it: On
 "Off":
   ja: オフ
   ru: "Выкл"
   zh-CN: 关
   zh-HK: 關
   zh-TW: 關
+  it: Off
 
 # ── Menu-bar status item (platform/menubar.rs) ──────────────────────────────
 "Open OpenLogi":
@@ -93,210 +101,245 @@ _version: 2
   zh-CN: 接入或配对受支持的 Logitech 设备，它会自动显示在这里。如需直接蓝牙连接，请在电脑的蓝牙设置中配对。
   zh-HK: 接入或配對受支援的 Logitech 裝置，它會自動顯示在這裡。如需直接藍牙連接，請在電腦的藍牙設定中配對。
   zh-TW: 接上或配對相容的 Logitech 裝置，裝置就會自動顯示在這裡。若要使用直接藍牙連線，請在電腦的藍牙設定中配對。
+  it: Collega o associa un dispositivo Logitech supportato: apparirà qui automaticamente. Per le connessioni Bluetooth dirette, esegui l'associazione nelle impostazioni Bluetooth del tuo computer.
 "No active device":
   ja: アクティブなデバイスがありません
   ru: "Нет активного устройства"
   zh-CN: 没有活动设备
   zh-HK: 沒有使用中的裝置
   zh-TW: 沒有使用中的裝置
+  it: Nessun dispositivo attivo
 "Pointer tuning":
   ja: ポインター調整
   ru: "Настройка указателя"
   zh-CN: 指针调校
   zh-HK: 指標調校
   zh-TW: 指標調整
+  it: Regolazione puntatore
 "Device details":
   ja: デバイス詳細
   ru: "Сведения об устройстве"
   zh-CN: 设备详情
   zh-HK: 裝置詳情
   zh-TW: 裝置詳細資訊
+  it: Dettagli dispositivo
 "Configuration":
   ja: 設定
   ru: "Конфигурация"
   zh-CN: 配置
   zh-HK: 設定
   zh-TW: 設定
+  it: Configurazione
 "Connection":
   ja: 接続
   ru: "Подключение"
   zh-CN: 连接
   zh-HK: 連線
   zh-TW: 連線
+  it: Connessione
 "Slot":
   ja: スロット
   ru: "Слот"
   zh-CN: 槽位
   zh-HK: 插槽
   zh-TW: 插槽
+  it: Slot
 "Device key":
   ja: デバイスキー
   ru: "Ключ устройства"
   zh-CN: 设备键
   zh-HK: 裝置鍵
   zh-TW: 裝置鍵
+  it: Chiave dispositivo
 "Serial":
   ja: シリアル
   ru: "Серийный номер"
   zh-CN: 序列号
   zh-HK: 序號
   zh-TW: 序號
+  it: Seriale
 "Active profile":
   ja: アクティブなプロファイル
   ru: "Активный профиль"
   zh-CN: 当前配置文件
   zh-HK: 目前設定檔
   zh-TW: 目前設定檔
+  it: Profilo attivo
 "Default profile":
   ja: デフォルトプロファイル
   ru: "Профиль по умолчанию"
   zh-CN: 默认配置文件
   zh-HK: 預設設定檔
   zh-TW: 預設設定檔
+  it: Profilo predefinito
 "Button bindings":
   ja: ボタン割り当て
   ru: "Привязки кнопок"
   zh-CN: 按键绑定
   zh-HK: 按鍵綁定
   zh-TW: 按鍵指派
+  it: Associazioni pulsanti
 "Gesture bindings":
   ja: ジェスチャー割り当て
   ru: "Привязки жестов"
   zh-CN: 手势绑定
   zh-HK: 手勢綁定
   zh-TW: 手勢指派
+  it: Associazioni gesture
 "DPI presets":
   ja: DPI プリセット
   ru: "Пресеты DPI"
   zh-CN: DPI 预设
   zh-HK: DPI 預設
   zh-TW: DPI 預設
+  it: Preset DPI
 "Config folder":
   ja: 設定フォルダー
   ru: "Папка конфигурации"
   zh-CN: 配置文件夹
   zh-HK: 設定資料夾
   zh-TW: 設定資料夾
+  it: Cartella di configurazione
 "Connected":
   ja: 接続済み
   ru: "Подключено"
   zh-CN: 已连接
   zh-HK: 已連線
   zh-TW: 已連線
+  it: Connesso
 "Offline":
   ja: オフライン
   ru: "Не в сети"
   zh-CN: 离线
   zh-HK: 離線
   zh-TW: 離線
+  it: Offline
 "Battery":
   ja: バッテリー
   ru: "Батарея"
   zh-CN: 电量
   zh-HK: 電量
   zh-TW: 電量
+  it: Batteria
 "Charging":
   ja: 充電中
   ru: "Заряжается"
   zh-CN: 充电中
   zh-HK: 充電中
   zh-TW: 充電中
+  it: In carica
 "Full":
   ja: フル充電
   ru: "Полный заряд"
   zh-CN: 已充满
   zh-HK: 已充滿
   zh-TW: 已充滿
+  it: Carica completa
 "Battery error":
   ja: バッテリーエラー
   ru: "Ошибка батареи"
   zh-CN: 电池错误
   zh-HK: 電池錯誤
   zh-TW: 電池錯誤
+  it: Errore batteria
 "Bolt receiver":
   ja: Bolt レシーバー
   ru: "Приёмник Bolt"
   zh-CN: Bolt 接收器
   zh-HK: Bolt 接收器
   zh-TW: Bolt 接收器
+  it: Ricevitore Bolt
 "Direct connection":
   ja: 直接接続
   ru: "Прямое подключение"
   zh-CN: 直接连接
   zh-HK: 直接連線
   zh-TW: 直接連線
+  it: Connessione diretta
 "Unavailable":
   ja: 利用不可
   ru: "Недоступно"
   zh-CN: 不可用
   zh-HK: 不可用
   zh-TW: 無法使用
+  it: Non disponibile
 "Mouse":
   ja: マウス
   ru: "Мышь"
   zh-CN: 鼠标
   zh-HK: 滑鼠
   zh-TW: 滑鼠
+  it: Mouse
 "Keyboard":
   ja: キーボード
   ru: "Клавиатура"
   zh-CN: 键盘
   zh-HK: 鍵盤
   zh-TW: 鍵盤
+  it: Tastiera
 "Numpad":
   ja: テンキー
   ru: "Цифровая клавиатура"
   zh-CN: 数字键盘
   zh-HK: 數字鍵盤
   zh-TW: 數字鍵盤
+  it: Tastierino numerico
 "Presenter":
   ja: プレゼンター
   ru: "Презентер"
   zh-CN: 演示器
   zh-HK: 簡報器
   zh-TW: 簡報器
+  it: Presenter
 "Remote":
   ja: リモコン
   ru: "Пульт"
   zh-CN: 遥控器
   zh-HK: 遙控器
   zh-TW: 遙控器
+  it: Telecomando
 "Trackball":
   ja: トラックボール
   ru: "Трекбол"
   zh-CN: 轨迹球
   zh-HK: 軌跡球
   zh-TW: 軌跡球
+  it: Trackball
 "Touchpad":
   ja: タッチパッド
   ru: "Сенсорная панель"
   zh-CN: 触控板
   zh-HK: 觸控板
   zh-TW: 觸控板
+  it: Touchpad
 "Tablet":
   ja: タブレット
   ru: "Планшет"
   zh-CN: 数位板
   zh-HK: 平板
   zh-TW: 平板
+  it: Tablet
 "Gamepad":
   ja: ゲームパッド
   ru: "Геймпад"
   zh-CN: 游戏手柄
   zh-HK: 遊戲手掣
   zh-TW: 遊戲手把
+  it: Gamepad
 "Joystick":
   ja: ジョイスティック
   ru: "Джойстик"
   zh-CN: 摇杆
   zh-HK: 搖桿
   zh-TW: 搖桿
+  it: Joystick
 "Headset":
   ja: ヘッドセット
   ru: "Гарнитура"
   zh-CN: 耳机
   zh-HK: 耳機
   zh-TW: 耳機
+  it: Cuffie
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.":
   ja: Logi Options+ をお使いですか?まず終了してください — 両方のアプリが HID++ アクセスを奪い合います。
   ru: "Используете Logi Options+? Сначала закройте его — оба приложения конкурируют за доступ к HID++."
@@ -382,12 +425,14 @@ _version: 2
   zh-CN: 检查更新…
   zh-HK: 檢查更新…
   zh-TW: 檢查更新…
+  it: Controlla aggiornamenti…
 "Edit":
   ja: 編集
   ru: "Правка"
   zh-CN: 编辑
   zh-HK: 編輯
   zh-TW: 編輯
+  it: Modifica
 "Undo":
   ja: 取り消す
   ru: "Отменить"
@@ -436,18 +481,21 @@ _version: 2
   zh-CN: 显示
   zh-HK: 顯示
   zh-TW: 顯示
+  it: Vista
 "Open Configuration Folder":
   ja: 設定フォルダーを開く
   ru: "Открыть папку конфигурации"
   zh-CN: 打开配置文件夹
   zh-HK: 開啟設定資料夾
   zh-TW: 開啟設定資料夾
+  it: Apri cartella configurazione
 "Device":
   ja: デバイス
   ru: "Устройство"
   zh-CN: 设备
   zh-HK: 裝置
   zh-TW: 裝置
+  it: Dispositivo
 "Hide OpenLogi":
   ja: OpenLogi を隠す
   ru: "Скрыть OpenLogi"
@@ -503,30 +551,35 @@ _version: 2
   zh-CN: 全部移到前面
   zh-HK: 全部移到最前
   zh-TW: 全部移到最前
+  it: Porta tutto in primo piano
 "Help":
   ja: ヘルプ
   ru: "Справка"
   zh-CN: 帮助
   zh-HK: 說明
   zh-TW: 輔助說明
+  it: Aiuto
 "OpenLogi Help":
   ja: OpenLogi ヘルプ
   ru: "Справка OpenLogi"
   zh-CN: OpenLogi 帮助
   zh-HK: OpenLogi 說明
   zh-TW: OpenLogi 輔助說明
+  it: Aiuto OpenLogi
 "Open GitHub Repository":
   ja: GitHub リポジトリを開く
   ru: "Открыть репозиторий GitHub"
   zh-CN: 打开 GitHub 仓库
   zh-HK: 開啟 GitHub 儲存庫
   zh-TW: 開啟 GitHub 儲存庫
+  it: Apri repository GitHub
 "Latest Release":
   ja: 最新リリース
   ru: "Последний выпуск"
   zh-CN: 最新版本
   zh-HK: 最新版本
   zh-TW: 最新版本
+  it: Ultima versione
 
 # ── About window (about.rs) ─────────────────────────────────────────────────
 "Open-source Logitech mouse configuration — DPI, SmartShift, button bindings, and gestures.":
@@ -626,77 +679,83 @@ _version: 2
   it: Aggiungi
 
 # ── SmartShift panel (components/smartshift_panel.rs) ───────────────────────
-# "SmartShift" (card title) and "On"/"Off" are intentionally absent: the brand
-# name is identical across locales (English-key fallback), and On/Off are
-# already defined for the lighting toggle above. "Sensitivity" is rendered as
-# "切换灵敏度" / "切り替え感度" etc. rather than the bare "灵敏度" the DPI panel
-# uses, so the two cards stacked in the Pointer tab stay distinguishable.
 "Wheel mode":
   ja: ホイールモード
   ru: "Режим колеса"
   zh-CN: 滚轮模式
   zh-HK: 滾輪模式
   zh-TW: 滾輪模式
+  it: Modalità rotellina
 "Free spin":
   ja: フリースピン
   ru: "Свободное вращение"
   zh-CN: 自由滚动
   zh-HK: 自由滾動
   zh-TW: 自由滾動
+  it: Rotazione libera
 "Ratchet":
   ja: ラチェット
   ru: "Трещотка"
   zh-CN: 棘轮
   zh-HK: 棘輪
   zh-TW: 棘輪
+  it: Scatto
 "Sensitivity":
   ja: 切り替え感度
   ru: "Чувствительность переключения"
   zh-CN: 切换灵敏度
   zh-HK: 切換靈敏度
   zh-TW: 切換靈敏度
+  it: Sensibilità
 "Higher keeps the ratchet engaged longer before free-spin.":
   ja: 値を大きくすると、フリースピンに切り替わるまでラチェットが長く維持されます。
   ru: "Большее значение дольше удерживает трещотку до перехода в свободное вращение."
   zh-CN: 数值越高，棘轮保持越久才进入自由滚动。
   zh-HK: 數值越高，棘輪維持越久才進入自由滾動。
   zh-TW: 數值越高，棘輪維持越久才會進入自由滾動。
+  it: Un valore più alto mantiene lo scatto più a lungo prima della rotazione libera.
 "Permanent ratchet":
   ja: 常時ラチェット
   ru: "Постоянная трещотка"
   zh-CN: 永久棘轮
   zh-HK: 永久棘輪
   zh-TW: 永久棘輪
+  it: Scatto permanente
 "Never auto-switch to free-spin.":
   ja: フリースピンに自動で切り替えません。
   ru: "Никогда автоматически не переключаться в свободное вращение."
   zh-CN: 永不自动切换到自由滚动。
   zh-HK: 永不自動切換至自由滾動。
   zh-TW: 永不自動切換至自由滾動。
+  it: Non passare mai automaticamente alla rotazione libera.
 "Device offline — SmartShift unavailable.":
   ja: デバイスがオフラインです — SmartShift は利用できません。
   ru: "Устройство не в сети — SmartShift недоступен."
   zh-CN: 设备离线 —— SmartShift 不可用。
   zh-HK: 裝置離線 —— SmartShift 不可用。
   zh-TW: 裝置離線 —— SmartShift 無法使用。
+  it: Dispositivo offline — SmartShift non disponibile.
 "Reading SmartShift settings…":
   ja: SmartShift 設定を読み取り中…
   ru: "Чтение настроек SmartShift…"
   zh-CN: 正在读取 SmartShift 设置…
   zh-HK: 正在讀取 SmartShift 設定…
   zh-TW: 正在讀取 SmartShift 設定…
+  it: Lettura impostazioni SmartShift in corso…
 "Couldn't read SmartShift — click to retry.":
   ja: SmartShift を読み取れませんでした — クリックして再試行。
   ru: "Не удалось прочитать SmartShift — нажмите, чтобы повторить."
   zh-CN: 无法读取 SmartShift —— 点击重试。
   zh-HK: 無法讀取 SmartShift —— 點擊重試。
-  zh-TW: 無法讀取 SmartShift —— 按一下重試。
+  zh-TW: 正在讀取 SmartShift 設定…
+  it: Impossibile leggere SmartShift — clicca per riprovare.
 "This device does not support SmartShift.":
   ja: このデバイスは SmartShift に対応していません。
   ru: "Это устройство не поддерживает SmartShift."
   zh-CN: 此设备不支持 SmartShift。
   zh-HK: 此裝置不支援 SmartShift。
   zh-TW: 此裝置不支援 SmartShift。
+  it: Questo dispositivo non supporta SmartShift.
 
 # ── Binding popover scaffolding (mouse_model/picker.rs) ─────────────────────
 "Bind %{name}":
@@ -712,24 +771,28 @@ _version: 2
   zh-CN: 未绑定
   zh-HK: 未綁定
   zh-TW: 未設定
+  it: Non associato
 "Default":
   ja: デフォルト
   ru: "По умолчанию"
   zh-CN: 默认
   zh-HK: 預設
   zh-TW: 預設
+  it: Predefinito
 "5 directions":
   ja: 5 方向
   ru: "5 направлений"
   zh-CN: 5 个方向
   zh-HK: 5 個方向
   zh-TW: 5 個方向
+  it: 5 direzioni
 "DPI Preset %{index}":
   ja: DPI プリセット %{index}
   ru: "Пресет DPI %{index}"
   zh-CN: 灵敏度预设 %{index}
   zh-HK: 靈敏度預設 %{index}
   zh-TW: 靈敏度預設 %{index}
+  it: Preset DPI %{index}
 "Gesture %{name}":
   ja: ジェスチャー %{name}
   ru: "Жест %{name}"
@@ -889,6 +952,7 @@ _version: 2
   zh-CN: 灵敏度
   zh-HK: 靈敏度
   zh-TW: 靈敏度
+  it: DPI
 
 # ── Actions (openlogi_core::binding::Action) ────────────────────────────────
 "Find":
@@ -980,11 +1044,15 @@ _version: 2
   ru: "Предыдущий рабочий стол"
   zh-CN: 上一个桌面
   zh-HK: 上一個桌面
+  zh-TW: 上一個桌面
+  it: Desktop precedente
 "Next Desktop":
   ja: 次のデスクトップ
   ru: "Следующий рабочий стол"
   zh-CN: 下一个桌面
   zh-HK: 下一個桌面
+  zh-TW: 下一個桌面
+  it: Desktop successivo
 "Show Desktop":
   ja: デスクトップを表示
   ru: "Показать рабочий стол"
@@ -1309,27 +1377,32 @@ _version: 2
   zh-CN: 拇指滚轮向上
   zh-HK: 拇指滾輪向上
   zh-TW: 拇指滾輪向上
+  it: Volante da pollice su
 "Thumb Wheel Down":
   ja: サムホイール 下
   ru: "Колесо большого пальца вниз"
   zh-CN: 拇指滚轮向下
   zh-HK: 拇指滾輪向下
   zh-TW: 拇指滾輪向下
+  it: Volante da pollice giù
 "Do Nothing":
   ja: 何もしない
   ru: "Ничего не делать"
   zh-CN: 不执行任何操作
   zh-HK: 不執行任何操作
   zh-TW: 不執行任何操作
+  it: Non fare nulla
 "Thumb Wheel Sensitivity":
   ja: サムホイールの感度
   ru: "Чувствительность колеса большого пальца"
   zh-CN: 拇指滚轮灵敏度
   zh-HK: 拇指滾輪靈敏度
   zh-TW: 拇指滾輪靈敏度
+  it: Sensibilità volante da pollice
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.":
   ja: サムホイールの横スクロール速度と、カスタムホイール操作の発動しやすさを調整します。
   ru: "Масштабирует скорость горизонтальной прокрутки колеса и лёгкость срабатывания пользовательских действий колеса."
   zh-CN: 调整拇指滚轮的横向滚动速度，以及自定义滚轮操作的触发难易程度。
   zh-HK: 調整拇指滾輪的水平捲動速度，以及自訂滾輪操作的觸發難易度。
   zh-TW: 調整拇指滾輪的水平捲動速度，以及自訂滾輪操作的觸發難易度。
+  it: Regola la velocità di scorrimento orizzontale del volante da pollice e la facilità di attivazione delle azioni personalizzate della rotellina.

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -216,7 +216,7 @@ mod tests {
         rust_i18n::set_locale("it");
         assert_eq!(rust_i18n::t!("Settings"), "Impostazioni");
         assert_eq!(rust_i18n::t!("Left Click"), "Click sinistro");
-        assert_eq!(rust_i18n::t!("Thanks"), "Grazie");
+        assert_eq!(rust_i18n::t!("Cancel"), "Annulla");
 
         // English has no column: every key falls back to the English source.
         rust_i18n::set_locale("en");

--- a/crates/openlogi-gui/src/i18n.rs
+++ b/crates/openlogi-gui/src/i18n.rs
@@ -4,7 +4,7 @@
 //! at compile time by the `rust_i18n::i18n!` macro in `main.rs`. Call sites use
 //! the [`tr!`](crate::tr) helper (or `rust_i18n::t!`) with the **English string
 //! as the key** — a missing entry falls back to that English text, so the file
-//! carries only the translated `ja` / `ru` / `zh-CN` / `zh-HK` / `zh-TW`
+//! carries only the translated `ja` / `ru` / `zh-CN` / `zh-HK` / `zh-TW` / `it`
 //! columns; English is the key itself.
 //!
 //! The current locale is a process-global atomic inside `rust_i18n`. Setting it
@@ -17,7 +17,7 @@
 use openlogi_core::config::AppSettings;
 
 /// Locales the GUI ships, as `(code, native name)`. The codes match the
-/// sub-keys in `locales/app.yml`; `en` / `zh-CN` / `zh-HK` also match
+/// sub-keys in `locales/app.yml`; `en` / `zh-CN` / `zh-HK` / `it` also match
 /// gpui-component's bundled `ui.yml`, so choosing one localizes the framework's
 /// own widgets too. `ja`, `ru`, and `zh-TW` are *not* in `ui.yml`, so under
 /// those locales our app strings localize but the framework's built-in widget
@@ -30,6 +30,7 @@ pub const SUPPORTED: &[(&str, &str)] = &[
     ("zh-CN", "简体中文"),
     ("zh-HK", "繁體中文（香港）"),
     ("zh-TW", "正體中文（臺灣）"),
+    ("it", "Italiano"),
 ];
 
 /// Resolve the locale to apply, preferring an explicit stored `setting`, then
@@ -67,6 +68,7 @@ fn match_supported(code: &str) -> Option<&'static str> {
         Some("en") => Some("en"),
         Some("ja") => Some("ja"),
         Some("ru") => Some("ru"),
+        Some("it") => Some("it"),
         Some("zh") => {
             let mut script = None;
             let mut region = None;
@@ -125,6 +127,8 @@ mod tests {
         assert_eq!(match_supported("ru-RU"), Some("ru"));
         assert_eq!(match_supported("en-US"), Some("en"));
         assert_eq!(match_supported("fr-FR"), None);
+        assert_eq!(match_supported("it"), Some("it"));
+        assert_eq!(match_supported("it-IT"), Some("it"));
     }
 
     #[test]
@@ -208,6 +212,11 @@ mod tests {
             BLURB,
             "blurb key missing from zh-TW app.yml"
         );
+
+        rust_i18n::set_locale("it");
+        assert_eq!(rust_i18n::t!("Settings"), "Impostazioni");
+        assert_eq!(rust_i18n::t!("Left Click"), "Click sinistro");
+        assert_eq!(rust_i18n::t!("Thanks"), "Grazie");
 
         // English has no column: every key falls back to the English source.
         rust_i18n::set_locale("en");


### PR DESCRIPTION
Update Italian (it) localization entries to `openlogi-gui/locales/app.yml.` Provides Italian translations for many UI strings across device/pointer/lighting panels, menu bar items, about/help, SmartShift panel, binding popovers, actions and thumb-wheel texts. 