### PR TITLE
ci(release): dispatch openlogi latest cask updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,8 @@ jobs:
           APPLE_ID: ${{ secrets.OP_APPLE_SECRET_ITEM }}/APPLE_ID
           APPLE_PASSWORD: ${{ secrets.OP_APPLE_SECRET_ITEM }}/APPLE_PASSWORD
           APPLE_TEAM_ID: ${{ secrets.OP_APPLE_SECRET_ITEM }}/APPLE_TEAM_ID
-          # GitHub App creds — unused since openlogi moved to homebrew-cask; the
-          # homebrew-tap dispatch job below is commented out. Re-enable both together
-          # if the tap dispatches again (e.g. a beta cask).
-          # GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-          # GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
+          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
           OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY
 
@@ -71,8 +68,8 @@ jobs:
           APPLE_ID: ${{ steps.load_secrets.outputs.APPLE_ID }}
           APPLE_PASSWORD: ${{ steps.load_secrets.outputs.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ steps.load_secrets.outputs.APPLE_TEAM_ID }}
-          # GITHUB_APP_ID: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-          # GITHUB_APP_PRIVATE_KEY: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+          GITHUB_APP_ID: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_BASE_URL }}
           OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ steps.load_secrets.outputs.OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY }}
         run: |
@@ -83,8 +80,8 @@ jobs:
           : "${APPLE_ID:?Configure APPLE_ID in 1Password}"
           : "${APPLE_PASSWORD:?Configure APPLE_PASSWORD in 1Password}"
           : "${APPLE_TEAM_ID:?Configure APPLE_TEAM_ID in 1Password}"
-          # : "${GITHUB_APP_ID:?Configure GITHUB_APP_ID in 1Password}"
-          # : "${GITHUB_APP_PRIVATE_KEY:?Configure GITHUB_APP_PRIVATE_KEY in 1Password}"
+          : "${GITHUB_APP_ID:?Configure GITHUB_APP_ID in 1Password}"
+          : "${GITHUB_APP_PRIVATE_KEY:?Configure GITHUB_APP_PRIVATE_KEY in 1Password}"
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in 1Password}"
           : "${OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY in 1Password}"
 
@@ -291,58 +288,52 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
 
-  # Disabled: openlogi now ships in official Homebrew/homebrew-cask (autobump-
-  # maintained), so the tap no longer needs a per-release dispatch. Kept here
-  # (not deleted) to re-enable quickly if the tap dispatches again, e.g. for a
-  # beta cask. To re-enable: uncomment this job and the GITHUB_APP_* lines in the
-  # `dmg` job's secret load/validate steps above.
-  #
-  # homebrew-tap:
-  #   name: Dispatch homebrew-tap update
-  #   runs-on: ubuntu-latest
-  #   needs: publish
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Load GitHub App credentials from 1Password
-  #       id: load_secrets
-  #       uses: 1password/load-secrets-action@v4
-  #       with:
-  #         export-env: false
-  #       env:
-  #         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-  #         GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-  #         GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
-  #
-  #     # The App private key is stored base64-encoded in 1Password (a raw PEM's
-  #     # newlines get mangled to spaces on paste, which breaks key decoding).
-  #     # Decode it here; base64 ignores whitespace, so it survives re-mangling.
-  #     - name: Decode GitHub App private key
-  #       id: app_key
-  #       env:
-  #         APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-  #       run: |
-  #         key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
-  #         {
-  #           echo 'pem<<__PEM__'
-  #           printf '%s\n' "$key"
-  #           echo '__PEM__'
-  #         } >> "$GITHUB_OUTPUT"
-  #
-  #     - name: Mint homebrew-tap token (GitHub App)
-  #       id: tap_token
-  #       uses: actions/create-github-app-token@v3
-  #       with:
-  #         client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-  #         private-key: ${{ steps.app_key.outputs.pem }}
-  #         owner: AprilNEA
-  #         repositories: homebrew-tap
-  #
-  #     - name: Dispatch homebrew-tap update
-  #       uses: peter-evans/repository-dispatch@v4
-  #       with:
-  #         token: ${{ steps.tap_token.outputs.token }}
-  #         repository: AprilNEA/homebrew-tap
-  #         event-type: update-openlogi
-  #         client-payload: |
-  #           {"version": "${{ github.ref_name }}"}
+  homebrew-tap:
+    name: Dispatch homebrew-tap update
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: read
+    steps:
+      - name: Load GitHub App credentials from 1Password
+        id: load_secrets
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
+
+      # The App private key is stored base64-encoded in 1Password (a raw PEM's
+      # newlines get mangled to spaces on paste, which breaks key decoding).
+      # Decode it here; base64 ignores whitespace, so it survives re-mangling.
+      - name: Decode GitHub App private key
+        id: app_key
+        env:
+          APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+        run: |
+          key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
+          {
+            echo 'pem<<__PEM__'
+            printf '%s\n' "$key"
+            echo '__PEM__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Mint homebrew-tap token (GitHub App)
+        id: tap_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
+          private-key: ${{ steps.app_key.outputs.pem }}
+          owner: AprilNEA
+          repositories: homebrew-tap
+
+      - name: Dispatch homebrew-tap update
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ steps.tap_token.outputs.token }}
+          repository: AprilNEA/homebrew-tap
+          event-type: update-openlogi
+          client-payload: |
+            {"version": "${{ github.ref_name }}"}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ Or install via [Homebrew](https://brew.sh):
 brew install --cask openlogi
 ```
 
+The official Homebrew cask is the default installation path. To explicitly
+track the latest GitHub release from `aprilnea/tap` instead:
+
+```sh
+brew tap aprilnea/tap
+brew install --cask aprilnea/tap/openlogi@latest
+```
+
+`openlogi@latest` is maintained by OpenLogi's release workflow and may update
+before the official cask autobump lands. Install either `openlogi` or
+`openlogi@latest`, not both.
+
 To build from source, see [DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Usage (CLI)


### PR DESCRIPTION
## Summary

- Restore release workflow dispatch to AprilNEA/homebrew-tap after publishing GitHub releases.
- Re-enable GitHub App credential loading/validation needed for the tap dispatch.
- Document the official openlogi cask as the default Homebrew path and aprilnea/tap/openlogi@latest as the explicit latest-release tap cask.

## Verification

- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check
- Commit and push hooks passed: check yaml, whitespace, merge-conflict, large-file checks; cargo hooks skipped because no Rust files changed.