### PR TITLE
chore(nix): bump cargo hash and version

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,7 +16,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "openlogi";
-  version = "0.4.0";
+  version = "0.5.3";
 
   # Build from the working tree (target/.git/etc. filtered out). cargo-bundle
   # uses the committed crates/openlogi-gui/icon/AppIcon.icns.
@@ -42,7 +42,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # One FOD vendors every dependency, including the zed / wgpu / font-kit git
   # forks gpui pulls in. Same approach as nixpkgs' zed-editor.
-  cargoHash = "sha256-bY/yKDjdjFAF7A6Q8Yc/r5H0K0ATbP9Jq9zAN72CYi4=";
+  # Stable across version bumps (cargoDepsName decouples the vendored-dir
+  # name from the version so the hash only changes when Cargo.lock deps change).
+  cargoDepsName = finalAttrs.pname;
+  cargoHash = "sha256-HJuEQvMwlIZXb2W44m2WzFSiNb56pozSJSDe7ApmmGI=";
 
   postPatch = ''
     # .cargo/config.toml forces `linker = /usr/bin/cc` + a /Applications/Xcode


### PR DESCRIPTION
The nix flake wasn't building, because the cargo hash was out of date.

- Updates `cargoHash` to present state
- Updates `version` to present version
- Adds `cargoDepsName = finalAttrs.pname`
  - Without setting the dependencies name to a static value, the hash gets invalidated on every version bump of local crates. This creates a large maintenance surface for the nix flake, because the hash needs to be updated with every change.
  - By setting it to `pname`, the hash stays valid as long as external dependencies stay consistent, i.e., only actual changes to `Cargo.lock` will invalidate it.
  - If this were in `nixpkgs`, it would make sense to retain the default for `cargoDepsName` and rely on the autobump behaviour; for a local flake, which will always reflect the state of the current branch, minimising hash churn seems like the better option