### PR TITLE
feat(windows): port the headless agent to Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       # openlogi-gui's GPUI backend doesn't build on Windows yet — restrict to
       # the platform-agnostic crates so the workspace stays green on push. clippy
       # subsumes `cargo check` and additionally lints the Windows-only code paths
-      # (the WH_MOUSE_LL hook, SendInput synthesis, native HID writer, WinRT
-      # pairing) that the Linux/macOS clippy jobs never compile.
-      - run: cargo clippy -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-assets -p openlogi-cli -p openlogi -p openlogi-hook --all-targets -- -D warnings
+      # (the WH_MOUSE_LL hook, SendInput synthesis, native HID writer, the
+      # composite HID++ channel, and the agent's HKCU-Run autostart) that the
+      # Linux/macOS clippy jobs never compile.
+      - run: cargo clippy -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-assets -p openlogi-cli -p openlogi -p openlogi-hook -p openlogi-agent -p openlogi-agent-core --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3433,6 +3439,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,6 +4662,7 @@ name = "openlogi-agent"
 version = "0.6.3"
 dependencies = [
  "futures",
+ "interprocess",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -4659,6 +4681,7 @@ dependencies = [
 name = "openlogi-agent-core"
 version = "0.6.3"
 dependencies = [
+ "interprocess",
  "openlogi-core",
  "openlogi-hid",
  "openlogi-hook",
@@ -4724,6 +4747,7 @@ dependencies = [
  "gpui-updater",
  "gpui_platform",
  "image",
+ "interprocess",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -5536,6 +5560,12 @@ dependencies = [
  "core_maths",
  "font-types",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -8088,6 +8118,12 @@ dependencies = [
  "rustix 0.38.44",
  "winsafe",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4652,6 +4652,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "winreg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,6 +4708,7 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
  "zbus",
 ]
 
@@ -4756,6 +4757,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4789,6 +4791,7 @@ dependencies = [
  "openlogi-core",
  "thiserror 2.0.18",
  "tracing",
+ "windows-sys 0.61.2",
  "x11rb",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ description = "Lightweight, local-first alternative to Logitech Options+ for HID
 [workspace.dependencies]
 hidpp = { package = "openlogi-hidpp", path = "crates/openlogi-hidpp", version = "0.6.3" }
 async-hid = "0.5.2"
+# Cross-platform local IPC for the agent <-> GUI tarpc transport: a Unix-domain
+# socket on Unix, a named pipe on Windows. The `tokio` feature gives the async
+# Stream/Listener used by serde_transport.
+interprocess = { version = "2", features = ["tokio"] }
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync", "time"] }
 futures-lite = "2"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ async-hid = "0.5.2"
 # socket on Unix, a named pipe on Windows. The `tokio` feature gives the async
 # Stream/Listener used by serde_transport.
 interprocess = { version = "2", features = ["tokio"] }
+# Windows FFI for the leaf input/HID paths (WH_MOUSE_LL hook, SendInput action
+# synthesis, native HID writes). Features are selected per crate.
+windows-sys = "0.61"
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync", "time"] }
 futures-lite = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/openlogi-agent-core/Cargo.toml
+++ b/crates/openlogi-agent-core/Cargo.toml
@@ -15,7 +15,8 @@ openlogi-core = { path = "../openlogi-core" }
 openlogi-hid = { path = "../openlogi-hid" }
 openlogi-hook = { path = "../openlogi-hook" }
 serde = { workspace = true }
-tarpc = { version = "0.37", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1", "unix"] }
+tarpc = { version = "0.37", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1"] }
+interprocess = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/openlogi-agent-core/src/lib.rs
+++ b/crates/openlogi-agent-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hardware;
 pub mod hook_runtime;
 pub mod ipc;
 pub mod orchestrator;
+pub mod transport;
 pub mod watchers;
 
 pub use dpi::DpiCycleState;

--- a/crates/openlogi-agent-core/src/transport.rs
+++ b/crates/openlogi-agent-core/src/transport.rs
@@ -50,9 +50,13 @@ pub fn endpoint_name() -> io::Result<interprocess::local_socket::Name<'static>> 
 
 /// Bind the agent's IPC listener.
 ///
-/// `interprocess` reclaims a stale name by default (`reclaim_name` is on), so a
-/// socket left by a crashed prior agent is removed before binding — `main` holds
-/// the single-instance lock, so no *live* agent owns it.
+/// `try_overwrite(true)` unlinks a stale Unix-domain socket left by a *non-clean*
+/// exit (SIGKILL / panic=abort / power loss, where the listener's `Drop` never
+/// ran) before binding — otherwise `bind` fails with `AddrInUse` on the leftover
+/// file, since the OS does not remove a socket inode on process death, and the
+/// agent's IPC would stay dead across every relaunch. `main` holds the
+/// single-instance lock, so no *live* agent owns the socket. No-op for Windows
+/// named pipes (no filesystem entry to reclaim).
 ///
 /// # Errors
 ///
@@ -67,7 +71,10 @@ pub fn bind() -> io::Result<Listener> {
     {
         std::fs::create_dir_all(parent)?;
     }
-    ListenerOptions::new().name(endpoint_name()?).create_tokio()
+    ListenerOptions::new()
+        .name(endpoint_name()?)
+        .try_overwrite(true)
+        .create_tokio()
 }
 
 /// Connect a client stream to the agent's IPC endpoint.

--- a/crates/openlogi-agent-core/src/transport.rs
+++ b/crates/openlogi-agent-core/src/transport.rs
@@ -1,0 +1,95 @@
+//! Cross-platform local-socket transport for the agent ↔ GUI tarpc IPC.
+//!
+//! `interprocess` exposes one API over a Unix-domain socket on Unix and a named
+//! pipe on Windows, so the agent (server) and GUI (client) share a single code
+//! path. The agent [`bind`]s a listener; the GUI [`connect`]s a stream; each
+//! connection is wrapped in a tarpc `serde_transport` `Transport` with the same
+//! length-delimited + bincode framing on both ends (see [`wrap`]).
+//!
+//! This replaces the previous Unix-domain-socket-only `tarpc::serde_transport::unix`
+//! path, which did not compile on Windows.
+
+use std::io;
+
+use interprocess::local_socket::ListenerOptions;
+use interprocess::local_socket::tokio::prelude::*;
+use interprocess::local_socket::tokio::{Listener, Stream};
+use serde::{Serialize, de::DeserializeOwned};
+use tarpc::serde_transport::Transport;
+use tarpc::tokio_serde::formats::Bincode;
+
+/// Resolve the IPC endpoint name.
+///
+/// On Unix this is the filesystem Unix-domain socket at
+/// [`agent_socket_path`](openlogi_core::paths::agent_socket_path) (preserving
+/// the existing `~/.config/openlogi/agent.sock` location, so macOS/Linux see no
+/// behavior change). On Windows it is a named pipe in the OS namespace
+/// (`\\.\pipe\openlogi-agent.sock`).
+///
+/// # Errors
+///
+/// Fails if the home directory can't be resolved (Unix) or the platform rejects
+/// the name.
+pub fn endpoint_name() -> io::Result<interprocess::local_socket::Name<'static>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        openlogi_core::paths::agent_socket_path()
+            .map_err(|e| io::Error::other(e.to_string()))?
+            .to_fs_name::<GenericFilePath>()
+    }
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        // A fixed per-machine pipe name. The default DACL grants the creating
+        // user + administrators, which is acceptable for a single-user desktop;
+        // per-user isolation on a shared machine is a future hardening point.
+        "openlogi-agent.sock".to_ns_name::<GenericNamespaced>()
+    }
+}
+
+/// Bind the agent's IPC listener.
+///
+/// `interprocess` reclaims a stale name by default (`reclaim_name` is on), so a
+/// socket left by a crashed prior agent is removed before binding — `main` holds
+/// the single-instance lock, so no *live* agent owns it.
+///
+/// # Errors
+///
+/// Fails if the endpoint name can't be resolved, the socket directory can't be
+/// created (Unix), or the listener can't be created.
+pub fn bind() -> io::Result<Listener> {
+    // On Unix the socket is a filesystem path; ensure its directory exists.
+    #[cfg(unix)]
+    if let Some(parent) = openlogi_core::paths::agent_socket_path()
+        .map_err(|e| io::Error::other(e.to_string()))?
+        .parent()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    ListenerOptions::new().name(endpoint_name()?).create_tokio()
+}
+
+/// Connect a client stream to the agent's IPC endpoint.
+///
+/// # Errors
+///
+/// Fails if the endpoint name can't be resolved or the agent isn't listening.
+pub async fn connect() -> io::Result<Stream> {
+    Stream::connect(endpoint_name()?).await
+}
+
+/// Wrap a connected local-socket [`Stream`] in a tarpc transport with the
+/// length-delimited + bincode framing both sides expect. The `Item`/`SinkItem`
+/// types are inferred by the caller (`BaseChannel` on the server, `*Client::new`
+/// on the client).
+#[must_use]
+pub fn wrap<Item, SinkItem>(
+    stream: Stream,
+) -> Transport<Stream, Item, SinkItem, Bincode<Item, SinkItem>>
+where
+    Item: DeserializeOwned,
+    SinkItem: Serialize,
+{
+    Transport::from((stream, Bincode::default()))
+}

--- a/crates/openlogi-agent-core/src/watchers/foreground_app.rs
+++ b/crates/openlogi-agent-core/src/watchers/foreground_app.rs
@@ -14,7 +14,11 @@ pub type ForegroundUpdate = Option<String>;
 /// Watch foreground application changes.
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
     let (tx, rx) = mpsc::unbounded_channel();
-    if !cfg!(any(target_os = "macos", target_os = "linux")) {
+    if !cfg!(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "windows"
+    )) {
         drop(tx);
         let _ = period;
         return rx;

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -19,7 +19,8 @@ openlogi-agent-core = { path = "../openlogi-agent-core" }
 openlogi-core = { path = "../openlogi-core" }
 openlogi-hid = { path = "../openlogi-hid" }
 openlogi-hook = { path = "../openlogi-hook" }
-tarpc = { version = "0.37", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1", "unix"] }
+tarpc = { version = "0.37", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1"] }
+interprocess = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
 futures = "0.3"
 tracing = { workspace = true }

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -34,5 +34,9 @@ objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication"] }
 objc2-foundation = { version = "0.3.2", features = ["NSString", "NSData", "NSArray"] }
 
+# Autostart via the HKCU Run key (launch_agent.rs).
+[target.'cfg(target_os = "windows")'.dependencies]
+winreg = "0.55"
+
 [lints]
 workspace = true

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -176,7 +176,14 @@ fn reconcile_windows(enabled: bool) -> std::io::Result<()> {
     let (run, _) = RegKey::predef(HKEY_CURRENT_USER).create_subkey(RUN_SUBKEY)?;
     if enabled {
         let exe = std::env::current_exe()?;
-        run.set_value(RUN_VALUE, &exe.as_os_str())?;
+        // Windows parses Run-key values as command lines, so a bare path with
+        // spaces (e.g. under "C:\Program Files\") is split at the first space and
+        // the launch silently fails. Quote it. Built via OsString so a non-UTF-8
+        // path survives exactly (no lossy `display()`).
+        let mut quoted = std::ffi::OsString::from("\"");
+        quoted.push(exe.as_os_str());
+        quoted.push("\"");
+        run.set_value(RUN_VALUE, &quoted)?;
         debug!(value = RUN_VALUE, "agent autostart registry value set");
     } else {
         match run.delete_value(RUN_VALUE) {

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -25,7 +25,9 @@ use std::io;
 #[cfg(target_os = "macos")]
 use std::path::PathBuf;
 #[cfg(target_os = "macos")]
-use tracing::{info, warn};
+use tracing::info;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use tracing::warn;
 
 /// Stable launch-agent identifier for the background agent.
 #[cfg(target_os = "macos")]
@@ -46,7 +48,11 @@ pub fn reconcile(enabled: bool) {
             warn!(error = %e, enabled, "agent LaunchAgent reconcile failed");
         }
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "windows")]
+    if let Err(e) = reconcile_windows(enabled) {
+        warn!(error = %e, enabled, "agent autostart reconcile failed");
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         if enabled {
             debug!("launch_at_login set but no autostart backend on this platform");
@@ -148,6 +154,40 @@ fn xml_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+/// HKCU autostart subkey + value name for the agent.
+#[cfg(target_os = "windows")]
+const RUN_SUBKEY: &str = r"Software\Microsoft\Windows\CurrentVersion\Run";
+#[cfg(target_os = "windows")]
+const RUN_VALUE: &str = "OpenLogiAgent";
+
+/// Windows autostart: keep `HKCU\…\Run\OpenLogiAgent` pointed at the running
+/// agent executable so the next login relaunches it, or remove it when disabled.
+///
+/// Unlike the macOS LaunchAgent there is no crash-respawn — a Run-key entry only
+/// fires once at login. A future SCM/Task Scheduler backend could add restart
+/// semantics; the login-launch path is enough for the headless agent today.
+#[cfg(target_os = "windows")]
+fn reconcile_windows(enabled: bool) -> std::io::Result<()> {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CURRENT_USER;
+
+    let (run, _) = RegKey::predef(HKEY_CURRENT_USER).create_subkey(RUN_SUBKEY)?;
+    if enabled {
+        let exe = std::env::current_exe()?;
+        run.set_value(RUN_VALUE, &exe.as_os_str())?;
+        debug!(value = RUN_VALUE, "agent autostart registry value set");
+    } else {
+        match run.delete_value(RUN_VALUE) {
+            Ok(()) => debug!(value = RUN_VALUE, "agent autostart registry value removed"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                debug!("agent autostart registry value already absent");
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -130,18 +130,15 @@ async fn run(config: Config) {
     let mut accessibility_rx = watchers::accessibility::spawn(Duration::from_millis(1200));
 
     // IPC server: the GUI connects here for device state + "apply now" commands.
-    match openlogi_core::paths::agent_socket_path() {
-        Ok(socket_path) => {
-            let server = AgentServer {
-                orchestrator: Arc::clone(&orchestrator),
-                shared: shared.clone(),
-                hook_installed: Arc::clone(&hook_installed),
-                pairing: Arc::clone(&pairing),
-            };
-            tokio::spawn(server::run(server, socket_path));
-        }
-        Err(e) => warn!(error = %e, "could not resolve IPC socket path; IPC disabled"),
-    }
+    // The endpoint (Unix socket / Windows named pipe) is resolved inside
+    // `transport::bind`, called by `server::run`.
+    let server = AgentServer {
+        orchestrator: Arc::clone(&orchestrator),
+        shared: shared.clone(),
+        hook_installed: Arc::clone(&hook_installed),
+        pairing: Arc::clone(&pairing),
+    };
+    tokio::spawn(server::run(server));
 
     // The CGEventTap hook is installed once Accessibility is granted and dropped
     // if it's revoked (the tap self-disables on revoke regardless; dropping the

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -1,17 +1,17 @@
 //! tarpc IPC server: backs the [`Agent`] service with the orchestrator and the
-//! agent-core device-I/O helpers, listening on the agent's Unix-domain socket.
+//! agent-core device-I/O helpers, listening on the agent's local IPC socket
+//! (a Unix-domain socket on Unix, a named pipe on Windows).
 //!
 //! The agent owns all device I/O, so the GUI never opens a device — it routes
 //! "apply now" / "read" commands here, and polls inventory/status.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures::StreamExt as _;
-use openlogi_agent_core::hardware;
 use openlogi_agent_core::ipc::{Agent, AgentStatus, PROTOCOL_VERSION, PairingUpdate};
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
+use openlogi_agent_core::{hardware, transport};
 use openlogi_core::config::{Config, Lighting};
 use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{
@@ -19,10 +19,12 @@ use openlogi_hid::{
 };
 
 use crate::pairing::PairingManager;
+// Brings `Listener::accept` into scope for the concrete listener `transport::bind`
+// returns; `as _` keeps it anonymous (method resolution only).
+use interprocess::local_socket::traits::tokio::Listener as _;
 use openlogi_hook::Hook;
 use tarpc::context::Context;
 use tarpc::server::{BaseChannel, Channel as _};
-use tarpc::tokio_serde::formats::Bincode;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
@@ -131,39 +133,30 @@ impl Agent for AgentServer {
     }
 }
 
-/// Bind the agent's Unix socket and serve [`Agent`] requests until the process
-/// exits. A stale socket left by a prior crash is removed first — `main` holds
-/// the single-instance lock (`agent.lock`), so no other live agent owns this
-/// socket and any leftover file is from a dead instance.
-pub async fn run(server: AgentServer, socket_path: PathBuf) {
-    if let Some(parent) = socket_path.parent()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        warn!(error = %e, "could not create IPC socket dir; IPC disabled");
-        return;
-    }
-    let _ = std::fs::remove_file(&socket_path);
+/// Bind the agent's IPC socket and serve [`Agent`] requests until the process
+/// exits. A stale socket left by a prior crash is reclaimed by the listener —
+/// `main` holds the single-instance lock (`agent.lock`), so no other live agent
+/// owns this socket and any leftover is from a dead instance.
+pub async fn run(server: AgentServer) {
+    let listener = match transport::bind() {
+        Ok(listener) => listener,
+        Err(e) => {
+            warn!(error = %e, "could not bind IPC socket; IPC disabled");
+            return;
+        }
+    };
+    info!("IPC server listening");
 
-    let mut incoming =
-        match tarpc::serde_transport::unix::listen(&socket_path, Bincode::default).await {
-            Ok(incoming) => incoming,
-            Err(e) => {
-                warn!(error = %e, "could not bind IPC socket; IPC disabled");
-                return;
-            }
-        };
-    info!(socket = %socket_path.display(), "IPC server listening");
-
-    while let Some(conn) = incoming.next().await {
-        let transport = match conn {
-            Ok(transport) => transport,
+    loop {
+        let stream = match listener.accept().await {
+            Ok(stream) => stream,
             Err(e) => {
                 warn!(error = %e, "IPC accept failed");
                 continue;
             }
         };
         let server = server.clone();
-        let channel = BaseChannel::with_defaults(transport);
+        let channel = BaseChannel::with_defaults(transport::wrap(stream));
         tokio::spawn(
             channel
                 .execute(server.serve())

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -31,3 +31,7 @@ zbus = "5"
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = { version = "0.25.0", features = ["highsierra"] }
 core-foundation = { workspace = true }
+
+# SendInput-based action synthesis (Action::execute_windows).
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_UI_Input_KeyboardAndMouse"] }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -2031,6 +2031,119 @@ mod linux {
     }
 }
 
+/// Translate a macOS virtual key code (`kVK_*`, captured when a `CustomShortcut`
+/// was recorded on macOS) to the equivalent Windows virtual-key code, so a chord
+/// synced from a Mac fires the right key on Windows.
+///
+/// Covers letters, digits, the ANSI punctuation keys, whitespace/editing keys,
+/// navigation, and F1–F20 — every key a shortcut realistically uses. Modifier
+/// keys are applied separately from `KeyCombo::modifiers`; the numeric keypad,
+/// media, and volume keys are intentionally omitted (they are modifiers or
+/// already have dedicated actions). `None` for an unmapped code, which
+/// `post_custom_shortcut` warns-and-drops.
+///
+/// Source codes: `<HIToolbox/Events.h>` kVK_* constants. Targets: Win32
+/// virtual-key codes (letters/digits are their ASCII values; F1 = 0x70).
+#[cfg_attr(
+    not(target_os = "windows"),
+    allow(
+        dead_code,
+        reason = "pure key-code table is exercised by host unit tests; its only runtime caller is the Windows-gated post_custom_shortcut"
+    )
+)]
+fn mac_virtual_key_to_windows(key_code: u16) -> Option<u16> {
+    Some(match key_code {
+        // ── Letters (Windows VK_A..VK_Z = ASCII 'A'..'Z') ──
+        0x00 => 0x41, // A
+        0x0B => 0x42, // B
+        0x08 => 0x43, // C
+        0x02 => 0x44, // D
+        0x0E => 0x45, // E
+        0x03 => 0x46, // F
+        0x05 => 0x47, // G
+        0x04 => 0x48, // H
+        0x22 => 0x49, // I
+        0x26 => 0x4A, // J
+        0x28 => 0x4B, // K
+        0x25 => 0x4C, // L
+        0x2E => 0x4D, // M
+        0x2D => 0x4E, // N
+        0x1F => 0x4F, // O
+        0x23 => 0x50, // P
+        0x0C => 0x51, // Q
+        0x0F => 0x52, // R
+        0x01 => 0x53, // S
+        0x11 => 0x54, // T
+        0x20 => 0x55, // U
+        0x09 => 0x56, // V
+        0x0D => 0x57, // W
+        0x07 => 0x58, // X
+        0x10 => 0x59, // Y
+        0x06 => 0x5A, // Z
+        // ── Digits (Windows VK_0..VK_9 = ASCII '0'..'9') ──
+        0x1D => 0x30, // 0
+        0x12 => 0x31, // 1
+        0x13 => 0x32, // 2
+        0x14 => 0x33, // 3
+        0x15 => 0x34, // 4
+        0x17 => 0x35, // 5
+        0x16 => 0x36, // 6
+        0x1A => 0x37, // 7
+        0x1C => 0x38, // 8
+        0x19 => 0x39, // 9
+        // ── ANSI punctuation (Windows VK_OEM_*) ──
+        0x1B => 0xBD, // -  VK_OEM_MINUS
+        0x18 => 0xBB, // =  VK_OEM_PLUS
+        0x21 => 0xDB, // [  VK_OEM_4
+        0x1E => 0xDD, // ]  VK_OEM_6
+        0x2A => 0xDC, // \  VK_OEM_5
+        0x29 => 0xBA, // ;  VK_OEM_1
+        0x27 => 0xDE, // '  VK_OEM_7
+        0x2B => 0xBC, // ,  VK_OEM_COMMA
+        0x2F => 0xBE, // .  VK_OEM_PERIOD
+        0x2C => 0xBF, // /  VK_OEM_2
+        0x32 => 0xC0, // `  VK_OEM_3
+        // ── Whitespace / editing ──
+        0x24 => 0x0D, // Return     VK_RETURN
+        0x30 => 0x09, // Tab        VK_TAB
+        0x31 => 0x20, // Space      VK_SPACE
+        0x33 => 0x08, // Backspace  VK_BACK
+        0x35 => 0x1B, // Escape     VK_ESCAPE
+        // ── Navigation ──
+        0x73 => 0x24, // Home          VK_HOME
+        0x77 => 0x23, // End           VK_END
+        0x74 => 0x21, // PageUp        VK_PRIOR
+        0x79 => 0x22, // PageDown      VK_NEXT
+        0x75 => 0x2E, // ForwardDelete VK_DELETE
+        0x7B => 0x25, // LeftArrow     VK_LEFT
+        0x7C => 0x27, // RightArrow    VK_RIGHT
+        0x7D => 0x28, // DownArrow     VK_DOWN
+        0x7E => 0x26, // UpArrow       VK_UP
+        // ── Function keys (Windows VK_F1 = 0x70, sequential through VK_F24) ──
+        0x7A => 0x70, // F1
+        0x78 => 0x71, // F2
+        0x63 => 0x72, // F3
+        0x76 => 0x73, // F4
+        0x60 => 0x74, // F5
+        0x61 => 0x75, // F6
+        0x62 => 0x76, // F7
+        0x64 => 0x77, // F8
+        0x65 => 0x78, // F9
+        0x6D => 0x79, // F10
+        0x67 => 0x7A, // F11
+        0x6F => 0x7B, // F12
+        0x69 => 0x7C, // F13
+        0x6B => 0x7D, // F14
+        0x71 => 0x7E, // F15
+        0x6A => 0x7F, // F16
+        0x40 => 0x80, // F17
+        0x4F => 0x81, // F18
+        0x50 => 0x82, // F19
+        0x5A => 0x83, // F20
+        _ => return None,
+    })
+}
+
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code, reason = "SendInput is the Win32 API for synthetic input")]
 mod windows {
@@ -2134,7 +2247,7 @@ mod windows {
             );
             return;
         }
-        let Some(vk) = mac_virtual_key_to_windows(combo.key_code) else {
+        let Some(vk) = super::mac_virtual_key_to_windows(combo.key_code) else {
             tracing::warn!(
                 key_code = combo.key_code,
                 chord = %combo.rendered_label(),
@@ -2215,31 +2328,6 @@ mod windows {
             },
         }
     }
-
-    fn mac_virtual_key_to_windows(key_code: u16) -> Option<u16> {
-        match key_code {
-            0x00 => Some(VK_A),
-            0x01 => Some(VK_S),
-            0x02 => Some(VK_D),
-            0x03 => Some(VK_F),
-            0x06 => Some(VK_Z),
-            0x07 => Some(VK_X),
-            0x08 => Some(VK_C),
-            0x09 => Some(VK_V),
-            0x0C => Some(0x51), // Q
-            0x0D => Some(VK_W),
-            0x0E => Some(0x45), // E
-            0x0F => Some(VK_R),
-            0x10 => Some(VK_Y),
-            0x11 => Some(VK_T),
-            0x20 => Some(0x55), // U
-            0x22 => Some(0x49), // I
-            0x1F => Some(0x4F), // O
-            0x23 => Some(0x50), // P
-            0x30 => Some(VK_TAB),
-            _ => None,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -2281,6 +2369,21 @@ mod tests {
                 "catalog must not contain CustomShortcut"
             );
         }
+    }
+
+    #[test]
+    fn custom_shortcut_keycodes_map_across_categories() {
+        // One representative per category, checked against independently-known
+        // (kVK → Win32 VK) facts, so a systematic error (swapped digits,
+        // off-by-one F-keys, a wrong OEM code) is caught without restating the
+        // whole table.
+        assert_eq!(mac_virtual_key_to_windows(0x00), Some(0x41)); // A → VK_A
+        assert_eq!(mac_virtual_key_to_windows(0x12), Some(0x31)); // 1 → VK_1
+        assert_eq!(mac_virtual_key_to_windows(0x7A), Some(0x70)); // F1 → VK_F1
+        assert_eq!(mac_virtual_key_to_windows(0x7B), Some(0x25)); // LeftArrow → VK_LEFT
+        assert_eq!(mac_virtual_key_to_windows(0x31), Some(0x20)); // Space → VK_SPACE
+        assert_eq!(mac_virtual_key_to_windows(0x29), Some(0xBA)); // ; → VK_OEM_1
+        assert_eq!(mac_virtual_key_to_windows(0x37), None); // Command is a modifier, not a key
     }
 
     // ── Binding (merged model) serde routing ──────────────────────────────────

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -841,6 +841,12 @@ impl Action {
     /// skipped (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes to
     /// Linux key codes; macOS Cmd maps to Ctrl.
     ///
+    /// On Windows, key and mouse events are synthesised via `SendInput`. The
+    /// macOS window-manager actions map to their Windows equivalents (e.g.
+    /// `MissionControl` → Win+Tab, `ShowDesktop` → Win+D); `CustomShortcut`
+    /// maps macOS `kVK_*` codes to Windows virtual-key codes, with Cmd mapped to
+    /// Ctrl.
+    ///
     /// On other platforms a warning is logged and the function returns
     /// immediately — the binary compiles clean on all targets.
     pub fn execute(&self) {
@@ -850,7 +856,10 @@ impl Action {
         #[cfg(target_os = "linux")]
         self.execute_linux();
 
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(target_os = "windows")]
+        self.execute_windows();
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         {
             tracing::warn!(
                 action = self.label(),
@@ -1062,6 +1071,71 @@ impl Action {
             }
         }
     }
+
+    /// Windows implementation: synthesise events via `SendInput`. macOS
+    /// window-manager actions map to their Windows equivalents; `CustomShortcut`
+    /// maps macOS `kVK_*` codes to Windows virtual-key codes (Cmd → Ctrl).
+    #[cfg(target_os = "windows")]
+    fn execute_windows(&self) {
+        match self {
+            Action::LeftClick => windows::post_click(windows::MouseButton::Left),
+            Action::RightClick => windows::post_click(windows::MouseButton::Right),
+            Action::MiddleClick => windows::post_click(windows::MouseButton::Middle),
+            Action::Copy => windows::post_key(windows::VK_C, &[windows::VK_CONTROL]),
+            Action::Paste => windows::post_key(windows::VK_V, &[windows::VK_CONTROL]),
+            Action::Cut => windows::post_key(windows::VK_X, &[windows::VK_CONTROL]),
+            Action::Undo => windows::post_key(windows::VK_Z, &[windows::VK_CONTROL]),
+            Action::Redo => windows::post_key(windows::VK_Y, &[windows::VK_CONTROL]),
+            Action::SelectAll => windows::post_key(windows::VK_A, &[windows::VK_CONTROL]),
+            Action::Find => windows::post_key(windows::VK_F, &[windows::VK_CONTROL]),
+            Action::Save => windows::post_key(windows::VK_S, &[windows::VK_CONTROL]),
+            Action::BrowserBack => windows::post_key(windows::VK_BROWSER_BACK, &[]),
+            Action::BrowserForward => windows::post_key(windows::VK_BROWSER_FORWARD, &[]),
+            Action::NewTab => windows::post_key(windows::VK_T, &[windows::VK_CONTROL]),
+            Action::CloseTab => windows::post_key(windows::VK_W, &[windows::VK_CONTROL]),
+            Action::ReopenTab => {
+                windows::post_key(windows::VK_T, &[windows::VK_CONTROL, windows::VK_SHIFT]);
+            }
+            Action::NextTab => windows::post_key(windows::VK_TAB, &[windows::VK_CONTROL]),
+            Action::PrevTab => {
+                windows::post_key(windows::VK_TAB, &[windows::VK_CONTROL, windows::VK_SHIFT]);
+            }
+            Action::ReloadPage => windows::post_key(windows::VK_R, &[windows::VK_CONTROL]),
+            Action::MissionControl | Action::AppExpose => {
+                windows::post_key(windows::VK_TAB, &[windows::VK_LWIN]);
+            }
+            Action::PreviousDesktop => {
+                windows::post_key(windows::VK_LEFT, &[windows::VK_LWIN, windows::VK_CONTROL]);
+            }
+            Action::NextDesktop => {
+                windows::post_key(windows::VK_RIGHT, &[windows::VK_LWIN, windows::VK_CONTROL]);
+            }
+            Action::ShowDesktop => windows::post_key(windows::VK_D, &[windows::VK_LWIN]),
+            Action::LaunchpadShow => windows::post_key(windows::VK_LWIN, &[]),
+            Action::LockScreen => windows::post_key(windows::VK_L, &[windows::VK_LWIN]),
+            Action::Screenshot => {
+                windows::post_key(windows::VK_S, &[windows::VK_LWIN, windows::VK_SHIFT]);
+            }
+            Action::PlayPause => windows::post_key(windows::VK_MEDIA_PLAY_PAUSE, &[]),
+            Action::NextTrack => windows::post_key(windows::VK_MEDIA_NEXT_TRACK, &[]),
+            Action::PrevTrack => windows::post_key(windows::VK_MEDIA_PREV_TRACK, &[]),
+            Action::VolumeUp => windows::post_key(windows::VK_VOLUME_UP, &[]),
+            Action::VolumeDown => windows::post_key(windows::VK_VOLUME_DOWN, &[]),
+            Action::MuteVolume => windows::post_key(windows::VK_VOLUME_MUTE, &[]),
+            Action::CycleDpiPresets | Action::SetDpiPreset(_) | Action::ToggleSmartShift => {
+                tracing::debug!(
+                    action = self.label(),
+                    "device action handled by hook/HID layer"
+                );
+            }
+            Action::ScrollUp
+            | Action::ScrollDown
+            | Action::HorizontalScrollLeft
+            | Action::HorizontalScrollRight => windows::post_scroll(self),
+            Action::CustomShortcut(combo) => windows::post_custom_shortcut(combo),
+            Action::None => {}
+        }
+    }
 }
 
 /// Synthesise a horizontal scroll of `delta` wheel lines at the current focus.
@@ -1084,7 +1158,10 @@ pub fn post_horizontal_scroll(delta: i32) {
     #[cfg(target_os = "linux")]
     linux::scroll(evdev::RelativeAxisCode::REL_HWHEEL, delta);
 
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(target_os = "windows")]
+    windows::post_horizontal_scroll(delta);
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     let _ = delta;
 }
 
@@ -1950,6 +2027,217 @@ mod linux {
                 tracing::warn!("MPRIS {command} on {player} failed: {e}");
                 Some(())
             }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[allow(unsafe_code, reason = "SendInput is the Win32 API for synthetic input")]
+mod windows {
+    use std::mem::size_of;
+
+    use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
+        INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP,
+        MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN,
+        MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL,
+        MOUSEINPUT, SendInput,
+    };
+
+    use crate::binding::{Action, KeyCombo};
+
+    const WHEEL_DELTA: i32 = 120;
+
+    pub(super) const VK_A: u16 = 0x41;
+    pub(super) const VK_C: u16 = 0x43;
+    pub(super) const VK_D: u16 = 0x44;
+    pub(super) const VK_F: u16 = 0x46;
+    pub(super) const VK_L: u16 = 0x4C;
+    pub(super) const VK_R: u16 = 0x52;
+    pub(super) const VK_S: u16 = 0x53;
+    pub(super) const VK_T: u16 = 0x54;
+    pub(super) const VK_V: u16 = 0x56;
+    pub(super) const VK_W: u16 = 0x57;
+    pub(super) const VK_X: u16 = 0x58;
+    pub(super) const VK_Y: u16 = 0x59;
+    pub(super) const VK_Z: u16 = 0x5A;
+    pub(super) const VK_TAB: u16 = 0x09;
+    pub(super) const VK_LEFT: u16 = 0x25;
+    pub(super) const VK_RIGHT: u16 = 0x27;
+    pub(super) const VK_SHIFT: u16 = 0x10;
+    pub(super) const VK_CONTROL: u16 = 0x11;
+    pub(super) const VK_MENU: u16 = 0x12;
+    pub(super) const VK_LWIN: u16 = 0x5B;
+    pub(super) const VK_BROWSER_BACK: u16 = 0xA6;
+    pub(super) const VK_BROWSER_FORWARD: u16 = 0xA7;
+    pub(super) const VK_VOLUME_MUTE: u16 = 0xAD;
+    pub(super) const VK_VOLUME_DOWN: u16 = 0xAE;
+    pub(super) const VK_VOLUME_UP: u16 = 0xAF;
+    pub(super) const VK_MEDIA_NEXT_TRACK: u16 = 0xB0;
+    pub(super) const VK_MEDIA_PREV_TRACK: u16 = 0xB1;
+    pub(super) const VK_MEDIA_PLAY_PAUSE: u16 = 0xB3;
+
+    #[derive(Clone, Copy)]
+    pub(super) enum MouseButton {
+        Left,
+        Right,
+        Middle,
+    }
+
+    pub(super) fn post_click(button: MouseButton) {
+        let (down, up) = match button {
+            MouseButton::Left => (MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP),
+            MouseButton::Right => (MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP),
+            MouseButton::Middle => (MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP),
+        };
+        send_inputs(&[mouse_input(down, 0), mouse_input(up, 0)]);
+    }
+
+    pub(super) fn post_key(vk: u16, modifiers: &[u16]) {
+        let mut inputs = Vec::with_capacity(modifiers.len() * 2 + 2);
+        for modifier in modifiers {
+            inputs.push(key_input(*modifier, false));
+        }
+        inputs.push(key_input(vk, false));
+        inputs.push(key_input(vk, true));
+        for modifier in modifiers.iter().rev() {
+            inputs.push(key_input(*modifier, true));
+        }
+        send_inputs(&inputs);
+    }
+
+    pub(super) fn post_scroll(action: &Action) {
+        let (flags, data) = match action {
+            Action::ScrollUp => (MOUSEEVENTF_WHEEL, WHEEL_DELTA),
+            Action::ScrollDown => (MOUSEEVENTF_WHEEL, -WHEEL_DELTA),
+            Action::HorizontalScrollLeft => (MOUSEEVENTF_HWHEEL, -WHEEL_DELTA),
+            Action::HorizontalScrollRight => (MOUSEEVENTF_HWHEEL, WHEEL_DELTA),
+            _ => return,
+        };
+        send_inputs(&[mouse_input(flags, data)]);
+    }
+
+    pub(super) fn post_horizontal_scroll(delta: i32) {
+        if delta == 0 {
+            return;
+        }
+        send_inputs(&[mouse_input(
+            MOUSEEVENTF_HWHEEL,
+            delta.saturating_mul(WHEEL_DELTA),
+        )]);
+    }
+
+    pub(super) fn post_custom_shortcut(combo: &KeyCombo) {
+        if combo.key_code == 0 {
+            tracing::warn!(
+                chord = %combo.rendered_label(),
+                "CustomShortcut with no key code; press ignored"
+            );
+            return;
+        }
+        let Some(vk) = mac_virtual_key_to_windows(combo.key_code) else {
+            tracing::warn!(
+                key_code = combo.key_code,
+                chord = %combo.rendered_label(),
+                "CustomShortcut key has no Windows mapping yet; press ignored"
+            );
+            return;
+        };
+
+        let mut modifiers = Vec::new();
+        if combo.modifiers & KeyCombo::MOD_CMD != 0 {
+            modifiers.push(VK_CONTROL);
+        }
+        if combo.modifiers & KeyCombo::MOD_SHIFT != 0 {
+            modifiers.push(VK_SHIFT);
+        }
+        if combo.modifiers & KeyCombo::MOD_CTRL != 0 && !modifiers.contains(&VK_CONTROL) {
+            modifiers.push(VK_CONTROL);
+        }
+        if combo.modifiers & KeyCombo::MOD_OPTION != 0 {
+            modifiers.push(VK_MENU);
+        }
+        post_key(vk, &modifiers);
+    }
+
+    fn send_inputs(inputs: &[INPUT]) {
+        let Ok(input_count) = u32::try_from(inputs.len()) else {
+            tracing::warn!(
+                requested = inputs.len(),
+                "too many SendInput events requested"
+            );
+            return;
+        };
+        let Ok(input_size) = i32::try_from(size_of::<INPUT>()) else {
+            tracing::warn!("INPUT size does not fit the Win32 SendInput contract");
+            return;
+        };
+        let sent = unsafe { SendInput(input_count, inputs.as_ptr(), input_size) };
+        if sent != input_count {
+            tracing::warn!(
+                requested = inputs.len(),
+                sent,
+                "SendInput accepted fewer events than requested"
+            );
+        }
+    }
+
+    fn key_input(vk: u16, key_up: bool) -> INPUT {
+        let mut flags = 0;
+        if key_up {
+            flags |= KEYEVENTF_KEYUP;
+        }
+        INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: vk,
+                    wScan: 0,
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    fn mouse_input(flags: u32, data: i32) -> INPUT {
+        INPUT {
+            r#type: INPUT_MOUSE,
+            Anonymous: INPUT_0 {
+                mi: MOUSEINPUT {
+                    dx: 0,
+                    dy: 0,
+                    mouseData: u32::from_ne_bytes(data.to_ne_bytes()),
+                    dwFlags: flags,
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    fn mac_virtual_key_to_windows(key_code: u16) -> Option<u16> {
+        match key_code {
+            0x00 => Some(VK_A),
+            0x01 => Some(VK_S),
+            0x02 => Some(VK_D),
+            0x03 => Some(VK_F),
+            0x06 => Some(VK_Z),
+            0x07 => Some(VK_X),
+            0x08 => Some(VK_C),
+            0x09 => Some(VK_V),
+            0x0C => Some(0x51), // Q
+            0x0D => Some(VK_W),
+            0x0E => Some(0x45), // E
+            0x0F => Some(VK_R),
+            0x10 => Some(VK_Y),
+            0x11 => Some(VK_T),
+            0x20 => Some(0x55), // U
+            0x22 => Some(0x49), // I
+            0x1F => Some(0x4F), // O
+            0x23 => Some(0x50), // P
+            0x30 => Some(VK_TAB),
+            _ => None,
         }
     }
 }

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -21,7 +21,8 @@ openlogi-hid = { path = "../openlogi-hid" }
 openlogi-hook = { path = "../openlogi-hook" }
 openlogi-assets = { path = "../openlogi-assets" }
 openlogi-agent-core = { path = "../openlogi-agent-core" }
-tarpc = { version = "0.37", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1", "unix"] }
+tarpc = { version = "0.37", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1"] }
+interprocess = { workspace = true }
 gpui = { workspace = true }
 gpui_platform = { workspace = true }
 gpui-component = { workspace = true }

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -21,7 +21,6 @@ use openlogi_hid::{
 };
 use tarpc::client;
 use tarpc::context;
-use tarpc::tokio_serde::formats::Bincode;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
@@ -219,9 +218,8 @@ fn agent_binary_path() -> Option<PathBuf> {
 /// unreachable right now (it may be starting up / restarting).
 async fn ensure(client: &mut Option<AgentClient>) -> std::io::Result<&AgentClient> {
     if client.is_none() {
-        let path = openlogi_core::paths::agent_socket_path()
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-        let transport = tarpc::serde_transport::unix::connect(&path, Bincode::default).await?;
+        let stream = openlogi_agent_core::transport::connect().await?;
+        let transport = openlogi_agent_core::transport::wrap(stream);
         let fresh = AgentClient::new(client::Config::default(), transport).spawn();
         // Protocol handshake before any real RPC. A freshly-updated GUI can
         // briefly reach an old agent (launchd hasn't restarted it yet); the

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -22,5 +22,18 @@ tracing = { workspace = true }
 num_enum = { workspace = true }
 futures-concurrency = "7"
 
+# Native Win32 HID report writes (windows_hid.rs) — a fallback for async-hid's
+# write path on Windows, plus the composite short/long endpoint handling in
+# transport.rs.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Devices_HumanInterfaceDevice",
+    "Win32_Foundation",
+    # CreateFileW's signature references PSECURITY_ATTRIBUTES, so it is only
+    # exposed when Win32_Security is also enabled.
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+] }
+
 [lints]
 workspace = true

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -8,6 +8,10 @@
 
 mod route;
 mod transport;
+// Native Win32 HID report-write fallback, used by the Windows composite channel
+// in `transport` when async-hid's async write path fails.
+#[cfg(target_os = "windows")]
+mod windows_hid;
 
 pub mod gesture;
 pub mod inventory;

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -300,14 +300,65 @@ impl WindowsHidppChannel {
 async fn find_windows_short_collection(
     long_info: &DeviceInfo,
 ) -> Result<Option<async_hid::Device>, async_hid::HidError> {
+    // Pair the short collection to *this* long collection by physical interface,
+    // not by vendor/product/name. Two identical Logitech devices share all three,
+    // so an attribute match could splice one device's short handle onto another's
+    // long handle. The grouping key (derived from the device path) is unique per
+    // physical interface, so it always pairs the correct siblings. A node whose
+    // path has an unexpected shape yields `None` and stays long-only.
+    let Some(long_key) = grouping_key(long_info) else {
+        return Ok(None);
+    };
     let all: Vec<async_hid::Device> = HID_BACKEND.enumerate().await?.collect().await;
     Ok(all.into_iter().find(|d| {
-        d.vendor_id == long_info.vendor_id
-            && d.product_id == long_info.product_id
-            && d.name == long_info.name
-            && d.usage_page == 0xff00
+        d.usage_page == 0xff00
             && d.usage_id == 0x0001
+            && grouping_key(d).as_deref() == Some(long_key.as_str())
     }))
+}
+
+/// The device-path key shared by the short and long HID++ collections of one
+/// physical interface. `None` for a non-path device id, which never occurs on
+/// Windows (every id is a `UncPath`).
+#[cfg(target_os = "windows")]
+fn grouping_key(info: &DeviceInfo) -> Option<String> {
+    match &info.id {
+        async_hid::DeviceId::UncPath(p) => Some(normalize_collection_path(&p.to_string())),
+        _ => None,
+    }
+}
+
+/// Collapse a Windows HID interface path to a key that is equal for the short
+/// (`&Col01`) and long (`&Col02`) collections of one physical interface and
+/// distinct across different interfaces or physical devices.
+///
+/// A receiver path looks like
+/// `\\?\HID#VID_046D&PID_C548&MI_02&Col01#7&348660ac&0&0000#{guid}`. The two
+/// HID++ collections share everything except the `&Col0X` hardware-id token and
+/// the trailing instance-id segment (`&0000` / `&0001`); stripping both yields a
+/// shared key. Falls back to the whole lowercased path when the shape is
+/// unexpected, so an unrecognized format simply never pairs — safe, as the node
+/// then behaves as a long-only single handle.
+#[cfg_attr(
+    not(target_os = "windows"),
+    allow(
+        dead_code,
+        reason = "pure path parser is exercised by host unit tests; its only runtime caller is the Windows-gated grouping_key"
+    )
+)]
+fn normalize_collection_path(path: &str) -> String {
+    let lower = path.to_ascii_lowercase();
+    let segments: Vec<&str> = lower.split('#').collect();
+    let (Some(hw), Some(inst)) = (segments.get(1), segments.get(2)) else {
+        return lower;
+    };
+    let hw_key = hw
+        .split('&')
+        .filter(|s| !s.starts_with("col"))
+        .collect::<Vec<_>>()
+        .join("&");
+    let inst_key = inst.rsplit_once('&').map_or(*inst, |(head, _)| head);
+    format!("{hw_key}#{inst_key}")
 }
 
 #[cfg(target_os = "windows")]
@@ -347,6 +398,12 @@ impl RawHidChannel for WindowsHidppChannel {
                 let mut long_buf = [0u8; LONG_REPORT_LENGTH];
                 let mut short_reader = short.reader.lock().await;
                 let mut long_reader = long.reader.lock().await;
+                // `select!` drops the losing read future, but no report is lost:
+                // async-hid's win32 `IoBuffer` owns the in-flight OVERLAPPED read and
+                // its buffer (not the future), so the pending operation survives the
+                // drop, and the next `read_report` — re-locking this same endpoint —
+                // resumes it and retrieves the report. This relies on reusing the
+                // per-endpoint reader across calls; do not reopen readers per read.
                 tokio::select! {
                     res = short_reader.read_input_report(&mut short_buf) => {
                         copy_report(&short_buf, res?, buf)
@@ -493,5 +550,56 @@ mod tests {
         assert!(!is_long_only_collection(0xff00, 0x0002)); // USB / receiver carries both reports
         assert!(!is_long_only_collection(0xff43, 0x0602)); // wired G-series keyboard carries both
         assert!(!is_long_only_collection(0x0001, 0x0002)); // not a HID++ collection at all
+    }
+
+    #[test]
+    fn short_and_long_collections_of_one_interface_share_a_grouping_key() {
+        // Real Bolt receiver paths: the short (Col01) and long (Col02) HID++
+        // collections of interface MI_02 must collapse to the same key.
+        let short = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_02&Col01#7&348660ac&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        let long = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_02&Col02#7&348660ac&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        assert_eq!(short, long);
+        assert_eq!(short, "vid_046d&pid_c548&mi_02#7&348660ac&0");
+    }
+
+    #[test]
+    fn distinct_interfaces_do_not_share_a_grouping_key() {
+        // A different interface (MI_01) on the same receiver has its own instance
+        // hash, so it must not pair with MI_02's HID++ collections.
+        let mi01 = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_01&Col02#7&1cc2d467&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        let mi02 = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_02&Col02#7&348660ac&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        assert_ne!(mi01, mi02);
+    }
+
+    #[test]
+    fn distinct_physical_receivers_do_not_share_a_grouping_key() {
+        // Two receivers plugged in at once (here two identical Bolt receivers,
+        // same VID/PID/interface/collection) must not cross-pair: each physical
+        // device has a distinct instance hash, which the key preserves. This is
+        // the multi-receiver scenario the single-interface tests don't cover.
+        let recv_a = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_02&Col01#7&348660ac&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        let recv_b = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_02&Col01#7&9f1be20c&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        assert_ne!(recv_a, recv_b);
+
+        // A Bolt + a Unifying receiver (different PID) must also stay distinct.
+        let bolt = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C548&MI_02&Col02#7&348660ac&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        let unifying = normalize_collection_path(
+            r"\\?\HID#VID_046D&PID_C52B&MI_02&Col02#7&1a2b3c4d&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}",
+        );
+        assert_ne!(bolt, unifying);
     }
 }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -22,6 +22,14 @@ use hidpp::{
 use tokio::sync::Mutex;
 use tracing::debug;
 
+#[cfg(target_os = "windows")]
+use std::io;
+
+#[cfg(target_os = "windows")]
+use crate::windows_hid::NativeHidWriter;
+#[cfg(target_os = "windows")]
+use hidpp::channel::{LONG_REPORT_ID, LONG_REPORT_LENGTH, SHORT_REPORT_ID, SHORT_REPORT_LENGTH};
+
 /// Logitech HID vendor ID.
 const LOGITECH_VID: u16 = 0x046d;
 /// HID++ long-report vendor collections, as `(usage_page, usage_id, long_only)`.
@@ -64,6 +72,16 @@ fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
 /// Whether the matched HID++ collection exposes only the long report, so short
 /// requests must be re-framed as long (done in the `hidpp` channel). `false` for
 /// pages not in [`HIDPP_LONG_COLLECTIONS`].
+// Windows routes short vs long by report id over the composite channel
+// (WindowsHidppChannel), so the long-only up-conversion path — and thus this
+// helper — is only reached off Windows. Still compiled + unit-tested there.
+#[cfg_attr(
+    target_os = "windows",
+    allow(
+        dead_code,
+        reason = "long-only up-conversion is the non-Windows AsyncHidChannel path"
+    )
+)]
 fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
     HIDPP_LONG_COLLECTIONS
         .iter()
@@ -143,25 +161,241 @@ pub(crate) async fn open_hidpp_channel(
     // `Device: Deref<Target = DeviceInfo>` — clone the deref'd value so we can
     // keep using `dev` (which `to_device_info` would consume).
     let info: DeviceInfo = (*dev).clone();
-    let (reader, writer) = dev.open().await?;
-    // BLE-direct devices expose only the long HID++ report; flag the channel so
-    // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
-    let long_only = is_long_only_collection(info.usage_page, info.usage_id);
-    let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
-    let channel = match HidppChannel::from_raw_channel(raw).await {
-        Ok(c) => Arc::new(c),
-        Err(e) => {
-            debug!(name = %info.name, error = ?e, "not a HID++ channel");
-            return Ok(None);
-        }
-    };
-    // Logged once per actual open. The inventory watcher reuses channels across
-    // ticks, so a steadily-connected device should log this on first sight (and
-    // on reconnect) only — not every ~2s tick.
-    debug!(name = %info.name, vid = format_args!("{:04x}", info.vendor_id), "opened HID++ channel");
-    Ok(Some((info, channel)))
+    // On Windows the short (0x10) and long (0x11) HID++ report collections are
+    // exposed as separate device interfaces, so the channel must open both and
+    // route by report id (see WindowsHidppChannel). Elsewhere one node carries
+    // both reports (or is long-only), handled by AsyncHidChannel.
+    #[cfg(target_os = "windows")]
+    {
+        let raw = WindowsHidppChannel::open(dev, info.clone()).await?;
+        let channel = match HidppChannel::from_raw_channel(raw).await {
+            Ok(c) => Arc::new(c),
+            Err(e) => {
+                debug!(name = %info.name, error = ?e, "not a HID++ channel");
+                return Ok(None);
+            }
+        };
+        Ok(Some((info, channel)))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let (reader, writer) = dev.open().await?;
+        // BLE-direct devices expose only the long HID++ report; flag the channel so
+        // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
+        let long_only = is_long_only_collection(info.usage_page, info.usage_id);
+        let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
+        let channel = match HidppChannel::from_raw_channel(raw).await {
+            Ok(c) => Arc::new(c),
+            Err(e) => {
+                debug!(name = %info.name, error = ?e, "not a HID++ channel");
+                return Ok(None);
+            }
+        };
+        // Logged once per actual open. The inventory watcher reuses channels across
+        // ticks, so a steadily-connected device should log this on first sight (and
+        // on reconnect) only — not every ~2s tick.
+        debug!(name = %info.name, vid = format_args!("{:04x}", info.vendor_id), "opened HID++ channel");
+        Ok(Some((info, channel)))
+    }
 }
 
+#[cfg(target_os = "windows")]
+struct HidEndpoint {
+    reader: Mutex<DeviceReader>,
+    writer: Mutex<DeviceWriter>,
+    native_writer: Option<NativeHidWriter>,
+}
+
+#[cfg(target_os = "windows")]
+impl HidEndpoint {
+    fn new(reader: DeviceReader, writer: DeviceWriter, info: &DeviceInfo) -> Self {
+        Self {
+            reader: Mutex::new(reader),
+            writer: Mutex::new(writer),
+            native_writer: NativeHidWriter::new(info),
+        }
+    }
+
+    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        let mut writer = self.writer.lock().await;
+        if let Err(e) = writer.write_output_report(src).await {
+            if let Some(native_writer) = &self.native_writer {
+                debug!(
+                    error = %e,
+                    report_id = format_args!("{:#04x}", src.first().copied().unwrap_or_default()),
+                    len = src.len(),
+                    "async-hid output report write failed; trying native Windows HID fallback"
+                );
+                native_writer.write_report(src)?;
+                return Ok(src.len());
+            }
+
+            return Err(Box::new(e));
+        }
+        Ok(src.len())
+    }
+}
+
+#[cfg(target_os = "windows")]
+struct WindowsHidppChannel {
+    info: DeviceInfo,
+    short: Option<HidEndpoint>,
+    long: Option<HidEndpoint>,
+}
+
+#[cfg(target_os = "windows")]
+impl WindowsHidppChannel {
+    async fn open(
+        long_dev: async_hid::Device,
+        long_info: DeviceInfo,
+    ) -> Result<Self, async_hid::HidError> {
+        let short_dev = find_windows_short_collection(&long_info).await?;
+        let (long_reader, long_writer) = long_dev.open().await?;
+        let long = Some(HidEndpoint::new(long_reader, long_writer, &long_info));
+
+        let short = match short_dev {
+            Some(dev) => {
+                let short_info: DeviceInfo = (*dev).clone();
+                match dev.open().await {
+                    Ok((reader, writer)) => {
+                        debug!(
+                            name = %short_info.name,
+                            pid = format_args!("{:04x}", short_info.product_id),
+                            "paired Windows HID++ short collection"
+                        );
+                        Some(HidEndpoint::new(reader, writer, &short_info))
+                    }
+                    Err(e) => {
+                        debug!(
+                            name = %short_info.name,
+                            pid = format_args!("{:04x}", short_info.product_id),
+                            error = ?e,
+                            "could not open Windows HID++ short collection"
+                        );
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
+
+        debug!(
+            name = %long_info.name,
+            pid = format_args!("{:04x}", long_info.product_id),
+            supports_short = short.is_some(),
+            supports_long = long.is_some(),
+            "opened Windows HID++ composite channel"
+        );
+
+        Ok(Self {
+            info: long_info,
+            short,
+            long,
+        })
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn find_windows_short_collection(
+    long_info: &DeviceInfo,
+) -> Result<Option<async_hid::Device>, async_hid::HidError> {
+    let all: Vec<async_hid::Device> = HID_BACKEND.enumerate().await?.collect().await;
+    Ok(all.into_iter().find(|d| {
+        d.vendor_id == long_info.vendor_id
+            && d.product_id == long_info.product_id
+            && d.name == long_info.name
+            && d.usage_page == 0xff00
+            && d.usage_id == 0x0001
+    }))
+}
+
+#[cfg(target_os = "windows")]
+#[async_trait]
+impl RawHidChannel for WindowsHidppChannel {
+    fn vendor_id(&self) -> u16 {
+        self.info.vendor_id
+    }
+
+    fn product_id(&self) -> u16 {
+        self.info.product_id
+    }
+
+    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        let endpoint = match src.first().copied() {
+            Some(SHORT_REPORT_ID) => self.short.as_ref(),
+            Some(LONG_REPORT_ID) => self.long.as_ref(),
+            _ => None,
+        }
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "unsupported HID++ report id {:#04x}",
+                    src.first().copied().unwrap_or_default()
+                ),
+            )
+        })?;
+
+        endpoint.write_report(src).await
+    }
+
+    async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        match (&self.short, &self.long) {
+            (Some(short), Some(long)) => {
+                let mut short_buf = [0u8; SHORT_REPORT_LENGTH];
+                let mut long_buf = [0u8; LONG_REPORT_LENGTH];
+                let mut short_reader = short.reader.lock().await;
+                let mut long_reader = long.reader.lock().await;
+                tokio::select! {
+                    res = short_reader.read_input_report(&mut short_buf) => {
+                        copy_report(&short_buf, res?, buf)
+                    }
+                    res = long_reader.read_input_report(&mut long_buf) => {
+                        copy_report(&long_buf, res?, buf)
+                    }
+                }
+            }
+            (Some(endpoint), None) | (None, Some(endpoint)) => {
+                let mut reader = endpoint.reader.lock().await;
+                Ok(reader.read_input_report(buf).await?)
+            }
+            (None, None) => Err(Box::new(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "no Windows HID++ endpoints are open",
+            ))),
+        }
+    }
+
+    fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
+        Some((self.short.is_some(), self.long.is_some()))
+    }
+
+    async fn get_report_descriptor(
+        &self,
+        _buf: &mut [u8],
+    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        Err("get_report_descriptor is not implemented; pre-filter to HID++ usage pages".into())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn copy_report(
+    src: &[u8],
+    len: usize,
+    dst: &mut [u8],
+) -> Result<usize, Box<dyn Error + Send + Sync>> {
+    if len > src.len() || len > dst.len() {
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("HID report length {len} exceeds buffer size"),
+        )));
+    }
+    dst[..len].copy_from_slice(&src[..len]);
+    Ok(len)
+}
+
+#[cfg(not(target_os = "windows"))]
 pub(crate) struct AsyncHidChannel {
     reader: Mutex<DeviceReader>,
     writer: Mutex<DeviceWriter>,
@@ -172,6 +406,7 @@ pub(crate) struct AsyncHidChannel {
     long_only: bool,
 }
 
+#[cfg(not(target_os = "windows"))]
 impl AsyncHidChannel {
     pub(crate) fn new(
         reader: DeviceReader,
@@ -188,6 +423,7 @@ impl AsyncHidChannel {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 #[async_trait]
 impl RawHidChannel for AsyncHidChannel {
     fn vendor_id(&self) -> u16 {

--- a/crates/openlogi-hid/src/windows_hid.rs
+++ b/crates/openlogi-hid/src/windows_hid.rs
@@ -1,0 +1,277 @@
+#![expect(unsafe_code, reason = "Win32 HID report writes require FFI")]
+
+use std::{
+    fmt, io,
+    ptr::{null, null_mut},
+};
+
+use async_hid::{DeviceId, DeviceInfo};
+use tracing::debug;
+use windows_sys::Win32::{
+    Devices::HumanInterfaceDevice::{
+        HIDD_ATTRIBUTES, HIDP_CAPS, HIDP_STATUS_SUCCESS, HidD_FreePreparsedData,
+        HidD_GetAttributes, HidD_GetPreparsedData, HidD_SetFeature, HidD_SetOutputReport,
+        HidP_GetCaps, PHIDP_PREPARSED_DATA,
+    },
+    Foundation::{CloseHandle, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE},
+    Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        WriteFile,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct NativeHidWriter {
+    path: Vec<u16>,
+}
+
+impl NativeHidWriter {
+    pub(crate) fn new(info: &DeviceInfo) -> Option<Self> {
+        let DeviceId::UncPath(path) = &info.id else {
+            return None;
+        };
+        let mut path: Vec<u16> = path.to_string_lossy().encode_utf16().collect();
+        path.push(0);
+        Some(Self { path })
+    }
+
+    pub(crate) fn write_report(&self, report: &[u8]) -> Result<(), NativeWriteError> {
+        let mut errors = Vec::new();
+        for desired_access in [GENERIC_READ | GENERIC_WRITE, GENERIC_WRITE, 0] {
+            let handle = match HidHandle::open(&self.path, desired_access) {
+                Ok(handle) => handle,
+                Err(e) => {
+                    errors.push(format!("open({desired_access:#x}): {e}"));
+                    continue;
+                }
+            };
+
+            let caps = match handle.caps() {
+                Ok(caps) => caps,
+                Err(e) => {
+                    errors.push(format!("caps({desired_access:#x}): {e}"));
+                    continue;
+                }
+            };
+
+            debug!(
+                report_id = format_args!("{:#04x}", report.first().copied().unwrap_or_default()),
+                report_len = report.len(),
+                output_len = caps.OutputReportByteLength,
+                feature_len = caps.FeatureReportByteLength,
+                desired_access = format_args!("{desired_access:#x}"),
+                "trying native Windows HID report write"
+            );
+
+            if let Err(e) = try_write_methods(handle.raw(), &caps, report) {
+                errors.push(format!("write({desired_access:#x}): {e}"));
+                continue;
+            }
+
+            return Ok(());
+        }
+
+        Err(NativeWriteError::AllMethodsFailed(errors))
+    }
+}
+
+fn try_write_methods(handle: HANDLE, caps: &HIDP_CAPS, report: &[u8]) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    for len in report_lengths(report.len(), usize::from(caps.OutputReportByteLength)) {
+        let buffer = padded_report(report, len);
+        match write_file(handle, &buffer) {
+            Ok(()) => return Ok(()),
+            Err(e) => errors.push(format!("WriteFile(len={len}): {e}")),
+        }
+
+        match set_output_report(handle, &buffer) {
+            Ok(()) => return Ok(()),
+            Err(e) => errors.push(format!("HidD_SetOutputReport(len={len}): {e}")),
+        }
+    }
+
+    for len in report_lengths(report.len(), usize::from(caps.FeatureReportByteLength)) {
+        let buffer = padded_report(report, len);
+        match set_feature(handle, &buffer) {
+            Ok(()) => return Ok(()),
+            Err(e) => errors.push(format!("HidD_SetFeature(len={len}): {e}")),
+        }
+    }
+
+    Err(errors.join("; "))
+}
+
+fn report_lengths(report_len: usize, caps_len: usize) -> impl Iterator<Item = usize> {
+    [caps_len, report_len]
+        .into_iter()
+        .filter(move |len| *len >= report_len && *len > 0)
+        .fold(Vec::new(), |mut acc, len| {
+            if !acc.contains(&len) {
+                acc.push(len);
+            }
+            acc
+        })
+        .into_iter()
+}
+
+fn padded_report(report: &[u8], len: usize) -> Vec<u8> {
+    let mut buffer = vec![0; len];
+    buffer[..report.len()].copy_from_slice(report);
+    buffer
+}
+
+fn write_file(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
+    let mut written = 0;
+    let ok = unsafe {
+        WriteFile(
+            handle,
+            report.as_ptr(),
+            report.len().try_into().unwrap_or(u32::MAX),
+            &raw mut written,
+            null_mut(),
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if usize::try_from(written).ok() != Some(report.len()) {
+        return Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            format!("wrote {written} of {} bytes", report.len()),
+        ));
+    }
+    Ok(())
+}
+
+fn set_output_report(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
+    bool_result(unsafe {
+        HidD_SetOutputReport(
+            handle,
+            report.as_ptr().cast(),
+            report.len().try_into().unwrap_or(u32::MAX),
+        )
+    })
+}
+
+fn set_feature(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
+    bool_result(unsafe {
+        HidD_SetFeature(
+            handle,
+            report.as_ptr().cast(),
+            report.len().try_into().unwrap_or(u32::MAX),
+        )
+    })
+}
+
+fn bool_result(ok: bool) -> Result<(), io::Error> {
+    if ok {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+struct HidHandle(HANDLE);
+
+impl HidHandle {
+    fn open(path: &[u16], desired_access: u32) -> Result<Self, io::Error> {
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                desired_access,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(handle))
+        }
+    }
+
+    fn raw(&self) -> HANDLE {
+        self.0
+    }
+
+    fn caps(&self) -> Result<HIDP_CAPS, NativeWriteError> {
+        let mut attributes = HIDD_ATTRIBUTES {
+            Size: size_of::<HIDD_ATTRIBUTES>().try_into().unwrap_or(u32::MAX),
+            VendorID: 0,
+            ProductID: 0,
+            VersionNumber: 0,
+        };
+        if !unsafe { HidD_GetAttributes(self.0, &raw mut attributes) } {
+            return Err(NativeWriteError::LastOsError(
+                "HidD_GetAttributes",
+                io::Error::last_os_error(),
+            ));
+        }
+
+        let mut preparsed: PHIDP_PREPARSED_DATA = 0;
+        if !unsafe { HidD_GetPreparsedData(self.0, &raw mut preparsed) } {
+            return Err(NativeWriteError::LastOsError(
+                "HidD_GetPreparsedData",
+                io::Error::last_os_error(),
+            ));
+        }
+
+        let _preparsed = PreparsedData(preparsed);
+        let mut caps = HIDP_CAPS::default();
+        let status = unsafe { HidP_GetCaps(preparsed, &raw mut caps) };
+        if status != HIDP_STATUS_SUCCESS {
+            return Err(NativeWriteError::HidpStatus("HidP_GetCaps", status));
+        }
+
+        Ok(caps)
+    }
+}
+
+impl Drop for HidHandle {
+    fn drop(&mut self) {
+        if self.0 != INVALID_HANDLE_VALUE {
+            let _ = unsafe { CloseHandle(self.0) };
+        }
+    }
+}
+
+struct PreparsedData(PHIDP_PREPARSED_DATA);
+
+impl Drop for PreparsedData {
+    fn drop(&mut self) {
+        if self.0 != 0 {
+            let _ = unsafe { HidD_FreePreparsedData(self.0) };
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum NativeWriteError {
+    AllMethodsFailed(Vec<String>),
+    HidpStatus(&'static str, i32),
+    LastOsError(&'static str, io::Error),
+}
+
+impl fmt::Display for NativeWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AllMethodsFailed(errors) => {
+                write!(f, "all native Windows HID write methods failed")?;
+                for error in errors {
+                    write!(f, "; {error}")?;
+                }
+                Ok(())
+            }
+            Self::HidpStatus(operation, status) => {
+                write!(f, "{operation} returned NTSTATUS {status:#010x}")
+            }
+            Self::LastOsError(operation, error) => write!(f, "{operation}: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for NativeWriteError {}

--- a/crates/openlogi-hid/src/windows_hid.rs
+++ b/crates/openlogi-hid/src/windows_hid.rs
@@ -30,7 +30,11 @@ impl NativeHidWriter {
         let DeviceId::UncPath(path) = &info.id else {
             return None;
         };
-        let mut path: Vec<u16> = path.to_string_lossy().encode_utf16().collect();
+        // `HSTRING` derefs to its UTF-16 code units (`[u16]`, sans terminator);
+        // copy them directly instead of round-tripping through a lossy UTF-8
+        // `String`, which would corrupt a path with unpaired surrogates.
+        // CreateFileW needs the path NUL-terminated.
+        let mut path: Vec<u16> = path.to_vec();
         path.push(0);
         Some(Self { path })
     }

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "OS-level mouse-event hook for OpenLogi. macOS via CGEventTap; Linux via evdev+uinput; Windows is a stub."
+description = "OS-level mouse-event hook for OpenLogi. macOS via CGEventTap; Linux via evdev+uinput; Windows via WH_MOUSE_LL."
 
 [dependencies]
 openlogi-core = { path = "../openlogi-core", version = "0.6.3" }
@@ -29,6 +29,15 @@ core-foundation = { workspace = true }
 objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", features = ["NSString"] }
 objc2-app-kit = { version = "0.3.2", features = ["NSWorkspace", "NSRunningApplication"] }
+
+# WH_MOUSE_LL low-level mouse hook + foreground-process path (GetForegroundWindow
+# / QueryFullProcessImageNameW).
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [lints.rust]
 unsafe_code = "allow"

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -4,7 +4,7 @@
 //! |----------|---------------|
 //! | macOS    | `CGEventTap` (same primitive used by Logi Options+) |
 //! | Linux    | `evdev` grab + `uinput` re-injection |
-//! | Windows  | stub — returns [`HookError::Unsupported`] |
+//! | Windows  | `WH_MOUSE_LL` low-level mouse hook |
 //!
 //! # Usage
 //!
@@ -73,7 +73,8 @@ pub enum EventDisposition {
 /// Errors that [`Hook::start`] and related functions can produce.
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
-    /// This platform has no hook implementation yet (Windows).
+    /// This platform has no hook implementation (neither macOS, Linux, nor
+    /// Windows).
     #[error("mouse event hook is not supported on this platform")]
     Unsupported,
     /// macOS Accessibility permission has not been granted to this process.
@@ -100,13 +101,17 @@ pub enum HookError {
     #[cfg(target_os = "linux")]
     #[error("Linux input error: {0}")]
     Linux(#[source] std::io::Error),
+    /// `SetWindowsHookExW` failed, or the hook thread could not be started.
+    #[error("Windows mouse hook setup failed: {0}")]
+    WindowsHook(String),
 }
 
 /// A running OS-level mouse hook. Call [`Hook::stop`] to tear down.
 ///
 /// On macOS a dedicated thread runs a `CFRunLoop` draining a `CGEventTap`.
 /// On Linux one thread per physical mouse device reads `evdev` events and
-/// re-injects pass-through events via a `uinput` virtual device.
+/// re-injects pass-through events via a `uinput` virtual device. On Windows a
+/// dedicated thread owns a `WH_MOUSE_LL` hook and pumps its message loop.
 /// Call `stop` (or let the value drop) to shut down all threads and release
 /// grabbed devices.
 pub struct Hook {
@@ -114,9 +119,11 @@ pub struct Hook {
     inner: Option<macos::HookInner>,
     #[cfg(target_os = "linux")]
     inner: Option<linux::HookInner>,
+    #[cfg(target_os = "windows")]
+    inner: Option<windows::HookInner>,
     /// Makes `Hook` uninhabited on unsupported targets so [`Hook::start`] can
     /// only ever return `Err` there and the type can never be constructed.
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     never: std::convert::Infallible,
 }
 
@@ -130,7 +137,11 @@ impl Drop for Hook {
         if let Some(inner) = self.inner.take() {
             linux::stop(inner);
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(target_os = "windows")]
+        if let Some(inner) = self.inner.take() {
+            windows::stop(inner);
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         // Unreachable: `never: Infallible` makes `Hook` uninhabited here.
         {}
     }
@@ -145,8 +156,8 @@ impl Hook {
     ///
     /// On macOS, returns [`HookError::AccessibilityDenied`] when Accessibility
     /// permission has not been granted. On Linux, returns
-    /// [`HookError::NoDeviceFound`] when no mouse device is accessible.
-    /// On Windows, always returns [`HookError::Unsupported`].
+    /// [`HookError::NoDeviceFound`] when no mouse device is accessible. On
+    /// Windows, installs a `WH_MOUSE_LL` low-level mouse hook.
     pub fn start(
         cb: impl Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static,
     ) -> Result<Self, HookError> {
@@ -158,7 +169,11 @@ impl Hook {
         {
             linux::start(cb).map(|inner| Self { inner: Some(inner) })
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(target_os = "windows")]
+        {
+            windows::start(cb).map(|inner| Self { inner: Some(inner) })
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         {
             let _ = cb;
             Err(HookError::Unsupported)
@@ -171,10 +186,10 @@ impl Hook {
     /// this explicitly is preferred over relying on `Drop` when errors in
     /// cleanup should be visible. `Drop` calls this automatically.
     #[cfg_attr(
-        not(any(target_os = "macos", target_os = "linux")),
+        not(any(target_os = "macos", target_os = "linux", target_os = "windows")),
         allow(
             unused_mut,
-            reason = "`mut self` is only consumed by macOS and Linux teardown paths"
+            reason = "`mut self` is only consumed by platform teardown paths"
         )
     )]
     pub fn stop(mut self) {
@@ -186,7 +201,11 @@ impl Hook {
         if let Some(inner) = self.inner.take() {
             linux::stop(inner);
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(target_os = "windows")]
+        if let Some(inner) = self.inner.take() {
+            windows::stop(inner);
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         match self.never {}
     }
 
@@ -195,7 +214,8 @@ impl Hook {
     ///
     /// On macOS, checks the Accessibility entitlement. On Linux and Windows
     /// this always returns `true`; those platforms enforce permissions at a
-    /// lower layer (device node ownership / group membership).
+    /// lower layer (device-node ownership / group membership on Linux; the
+    /// Windows low-level hook needs no separate privacy grant).
     #[must_use]
     pub fn has_accessibility() -> bool {
         #[cfg(target_os = "macos")]
@@ -230,7 +250,8 @@ impl Hook {
 /// On macOS this is the bundle identifier, e.g. `"com.microsoft.VSCode"`.
 /// On Linux (X11 / XWayland) this is the `WM_CLASS` class component,
 /// e.g. `"Code"` or `"Firefox"`. Pure Wayland windows (not running under
-/// XWayland) are not visible through this path and return `None`.
+/// XWayland) are not visible through this path and return `None`. On Windows
+/// this is the lower-cased executable path of the foreground process.
 ///
 /// `None` when no app is frontmost, when reading fails, or on unsupported
 /// platforms. Costs one X11 round-trip on Linux, four `objc_msgSend`s on
@@ -246,7 +267,11 @@ pub fn frontmost_bundle_id() -> Option<String> {
     {
         linux::frontmost_bundle_id()
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    #[cfg(target_os = "windows")]
+    {
+        windows::frontmost_process_path()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     {
         None
     }
@@ -257,6 +282,9 @@ mod macos;
 
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(target_os = "windows")]
+mod windows;
 
 #[cfg(test)]
 mod tests;

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -205,9 +205,14 @@ fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
     }
 
     match wparam as u32 {
+        // A positive high word means the wheel was rotated forward (away from the
+        // user). Pass the sign through unchanged so `delta_y > 0` is "scroll up" on
+        // every platform — matching macOS (`SCROLL_WHEEL_EVENT_DELTA_AXIS_1`) and
+        // Linux (`REL_WHEEL`), whose deltas feed the same direction-sensitive
+        // bindings. Negating here flipped scroll-up/-down only on Windows.
         WM_MOUSEWHEEL => Some(MouseEvent::Scroll {
             delta_x: 0.0,
-            delta_y: -(f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA),
+            delta_y: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
         }),
         WM_MOUSEHWHEEL => Some(MouseEvent::Scroll {
             delta_x: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
@@ -275,5 +280,29 @@ mod tests {
         };
 
         assert!(translate_event(WM_LBUTTONDOWN as WPARAM, data).is_none());
+    }
+
+    /// Wheel-forward (away from the user) must produce a positive `delta_y`, the
+    /// same sign macOS and Linux emit for the gesture, so a "scroll up" binding
+    /// fires on the same physical motion on every platform. Guards against the
+    /// sign inversion that previously flipped scroll direction on Windows.
+    #[test]
+    fn wheel_forward_scrolls_up_like_other_platforms() {
+        // The wheel delta lives in the high word of `mouseData`; `+WHEEL_DELTA`
+        // (120) is one notch forward.
+        let forward = MSLLHOOKSTRUCT {
+            mouseData: 120u32 << 16,
+            ..MSLLHOOKSTRUCT::default()
+        };
+        let Some(MouseEvent::Scroll { delta_x, delta_y }) =
+            translate_event(WM_MOUSEWHEEL as WPARAM, forward)
+        else {
+            panic!("expected a scroll event");
+        };
+        assert!(delta_x.abs() < f32::EPSILON);
+        assert!(
+            delta_y > 0.0,
+            "wheel-forward should scroll up, got {delta_y}"
+        );
     }
 }

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -1,0 +1,279 @@
+//! Windows `WH_MOUSE_LL` implementation of the OS-level mouse hook.
+#![allow(
+    clippy::borrow_as_ptr,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::needless_pass_by_value,
+    reason = "Win32 FFI uses raw pointer parameters and fixed-width message values"
+)]
+
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+
+use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, LPARAM, LRESULT, WPARAM};
+use windows_sys::Win32::System::Threading::{
+    GetCurrentThreadId, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
+    HC_ACTION, LLMHF_INJECTED, MSG, MSLLHOOKSTRUCT, PM_NOREMOVE, PeekMessageW, PostThreadMessageW,
+    SetWindowsHookExW, TranslateMessage, UnhookWindowsHookEx, WH_MOUSE_LL, WM_LBUTTONDOWN,
+    WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEWHEEL, WM_QUIT,
+    WM_RBUTTONDOWN, WM_RBUTTONUP, WM_USER, WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1, XBUTTON2,
+};
+
+use crate::{ButtonId, EventDisposition, HookError, MouseEvent};
+
+const WHEEL_DELTA: f32 = 120.0;
+
+type HookCallback = Arc<dyn Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static>;
+
+static CALLBACK: Mutex<Option<HookCallback>> = Mutex::new(None);
+
+pub(crate) struct HookInner {
+    thread_id: u32,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+pub(crate) fn start(
+    cb: impl Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static,
+) -> Result<HookInner, HookError> {
+    let callback: HookCallback = Arc::new(cb);
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let join = thread::Builder::new()
+        .name("openlogi-windows-hook".into())
+        .spawn(move || hook_thread(callback, ready_tx))
+        .map_err(|e| HookError::WindowsHook(format!("could not spawn hook thread: {e}")))?;
+
+    match ready_rx
+        .recv()
+        .map_err(|e| HookError::WindowsHook(format!("hook thread exited before setup: {e}")))?
+    {
+        Ok(thread_id) => Ok(HookInner {
+            thread_id,
+            join: Some(join),
+        }),
+        Err(e) => {
+            let _ = join.join();
+            Err(e)
+        }
+    }
+}
+
+pub(crate) fn stop(mut inner: HookInner) {
+    let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
+    if posted == 0 {
+        tracing::warn!(
+            error = unsafe { GetLastError() },
+            "could not post WM_QUIT to Windows hook thread"
+        );
+    }
+    if let Some(join) = inner.join.take() {
+        if let Err(e) = join.join() {
+            tracing::warn!(?e, "Windows hook thread panicked while stopping");
+        }
+    }
+}
+
+fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError>>) {
+    match CALLBACK.lock() {
+        Ok(mut slot) if slot.is_none() => {
+            *slot = Some(callback);
+        }
+        Ok(_) => {
+            let _ = ready.send(Err(HookError::WindowsHook(
+                "another Windows mouse hook is already installed".into(),
+            )));
+            return;
+        }
+        Err(e) => {
+            let _ = ready.send(Err(HookError::WindowsHook(format!(
+                "callback lock poisoned: {e}"
+            ))));
+            return;
+        }
+    }
+
+    let thread_id = unsafe { GetCurrentThreadId() };
+    let mut bootstrap_msg = MSG::default();
+    unsafe {
+        PeekMessageW(
+            &mut bootstrap_msg,
+            std::ptr::null_mut(),
+            WM_USER,
+            WM_USER,
+            PM_NOREMOVE,
+        );
+    }
+
+    let hook = unsafe {
+        SetWindowsHookExW(
+            WH_MOUSE_LL,
+            Some(mouse_proc),
+            std::ptr::null_mut::<core::ffi::c_void>(),
+            0,
+        )
+    };
+    if hook.is_null() {
+        clear_callback();
+        let _ = ready.send(Err(last_error("SetWindowsHookExW")));
+        return;
+    }
+
+    let _ = ready.send(Ok(thread_id));
+    message_loop();
+
+    unsafe {
+        UnhookWindowsHookEx(hook);
+    }
+    clear_callback();
+}
+
+fn message_loop() {
+    let mut msg = MSG::default();
+    loop {
+        let result = unsafe { GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0) };
+        if result <= 0 {
+            break;
+        }
+        unsafe {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+    }
+}
+
+fn clear_callback() {
+    if let Ok(mut slot) = CALLBACK.lock() {
+        *slot = None;
+    }
+}
+
+unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    if code != HC_ACTION as i32 {
+        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
+    }
+
+    let Some(data) = hook_data(lparam) else {
+        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
+    };
+    let Some(event) = translate_event(wparam, data) else {
+        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
+    };
+
+    let callback = CALLBACK.lock().ok().and_then(|slot| slot.clone());
+    let disposition = callback
+        .as_ref()
+        .map_or(EventDisposition::PassThrough, |cb| cb(event));
+    if disposition == EventDisposition::Suppress {
+        1
+    } else {
+        unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) }
+    }
+}
+
+fn hook_data(lparam: LPARAM) -> Option<MSLLHOOKSTRUCT> {
+    if lparam == 0 {
+        return None;
+    }
+    Some(unsafe { *(lparam as *const MSLLHOOKSTRUCT) })
+}
+
+fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
+    if data.flags & LLMHF_INJECTED != 0 {
+        return None;
+    }
+
+    let pressed = match wparam as u32 {
+        WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN | WM_XBUTTONDOWN => Some(true),
+        WM_LBUTTONUP | WM_RBUTTONUP | WM_MBUTTONUP | WM_XBUTTONUP => Some(false),
+        _ => None,
+    };
+    if let Some(pressed) = pressed {
+        let id = match wparam as u32 {
+            WM_LBUTTONDOWN | WM_LBUTTONUP => ButtonId::LeftClick,
+            WM_RBUTTONDOWN | WM_RBUTTONUP => ButtonId::RightClick,
+            WM_MBUTTONDOWN | WM_MBUTTONUP => ButtonId::MiddleClick,
+            WM_XBUTTONDOWN | WM_XBUTTONUP => match high_word(data.mouseData) {
+                XBUTTON1 => ButtonId::Back,
+                XBUTTON2 => ButtonId::Forward,
+                _ => return None,
+            },
+            _ => return None,
+        };
+        return Some(MouseEvent::Button { id, pressed });
+    }
+
+    match wparam as u32 {
+        WM_MOUSEWHEEL => Some(MouseEvent::Scroll {
+            delta_x: 0.0,
+            delta_y: -(f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA),
+        }),
+        WM_MOUSEHWHEEL => Some(MouseEvent::Scroll {
+            delta_x: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
+            delta_y: 0.0,
+        }),
+        _ => None,
+    }
+}
+
+fn high_word(value: u32) -> u16 {
+    (value >> 16) as u16
+}
+
+fn signed_high_word(value: u32) -> i16 {
+    high_word(value) as i16
+}
+
+pub(crate) fn frontmost_process_path() -> Option<String> {
+    let hwnd = unsafe { GetForegroundWindow() };
+    if hwnd.is_null() {
+        return None;
+    }
+
+    let mut pid = 0;
+    unsafe {
+        GetWindowThreadProcessId(hwnd, &mut pid);
+    }
+    if pid == 0 {
+        return None;
+    }
+
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return None;
+    }
+
+    let mut buf = vec![0u16; 32_768];
+    let mut len = buf.len() as u32;
+    let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &mut len) };
+    unsafe {
+        CloseHandle(process);
+    }
+    if ok == 0 || len == 0 {
+        return None;
+    }
+
+    Some(String::from_utf16_lossy(&buf[..len as usize]).to_lowercase())
+}
+
+fn last_error(context: &str) -> HookError {
+    HookError::WindowsHook(format!("{context} failed with GetLastError={}", unsafe {
+        GetLastError()
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_event_ignores_injected_mouse_input() {
+        let data = MSLLHOOKSTRUCT {
+            flags: LLMHF_INJECTED,
+            ..MSLLHOOKSTRUCT::default()
+        };
+
+        assert!(translate_event(WM_LBUTTONDOWN as WPARAM, data).is_none());
+    }
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -40,6 +40,13 @@ in
       "rust-analyzer"
       "rust-src"
     ];
+    # Cross target for linting the Windows-only code paths locally. `cargo
+    # clippy --target` is check-only (no linking), so this needs the target's
+    # rust-std but NOT a mingw cross-linker; the agent's dep tree is pure Rust
+    # plus prebuilt import libs (no `cc`-compiled C), so it lints cleanly. It is
+    # a fast proxy for CI's authoritative `clippy (windows)` (msvc); building a
+    # runnable .exe would additionally need pkgsCross.mingwW64 and is out of scope.
+    targets = [ "x86_64-pc-windows-gnu" ];
   };
 
   enterShell = ''
@@ -76,6 +83,22 @@ in
         set -e
         crowdin download
         cargo test -p openlogi-gui i18n
+      '';
+    };
+    "openlogi:check-windows" = {
+      description = "Lint the Windows code paths locally (check-only cross lint).";
+      # `clippy --target` is check-only (no linker needed), but a C-compiling
+      # build dep DOES need a cross C toolchain: openlogi-{assets,cli} and the
+      # root `openlogi` pull ureq -> ring, whose curve25519.c can't cross-compile
+      # from macOS without mingw. They have no Windows-specific code, so lint the
+      # ring-free agent/leaf subset here; CI's clippy (windows) covers the rest
+      # natively on windows-latest. The GUI is excluded (GPUI has no Windows
+      # backend).
+      exec = ''
+        cargo clippy --target x86_64-pc-windows-gnu \
+          -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-hook \
+          -p openlogi-agent -p openlogi-agent-core \
+          --all-targets -- -D warnings
       '';
     };
     "openlogi:assets" = {


### PR DESCRIPTION
Ports the headless background agent (`openlogi-agent` + `openlogi-agent-core`) to Windows, building on the daemon split. The GUI is **not** ported — GPUI has no Windows backend yet, so there is no Windows frontend; this delivers a config-driven headless agent that owns the input hook + HID++ device I/O + autostart.

### What's here

1. **Cross-platform IPC transport** — the agent ↔ GUI tarpc IPC used `tarpc::serde_transport::unix`, which is `#[cfg(unix)]` and doesn't compile on Windows. Replaced with the [`interprocess`](https://crates.io/crates/interprocess) crate's local sockets: a Unix-domain socket at the same `~/.config/openlogi/agent.sock` on Unix (no macOS/Linux behavior change), a named pipe on Windows. Same length-delimited + bincode framing; new `openlogi-agent-core::transport` centralizes it.

2. **Native input + HID++ leaf support** — re-homes the Windows leaf code from #93 (thanks @sioaeko): the `WH_MOUSE_LL` hook, `SendInput` action synthesis, and a composite HID++ channel that opens the separate short (`0x10`) / long (`0x11`) report collections Windows exposes and routes writes by report id, with a native Win32 HID write fallback. (Basic HID I/O already worked via async-hid's win32 backend; this adds robustness for real Logitech devices.) These replace the previous no-op stubs.

3. **Windows autostart** — `launch_agent::reconcile` keeps `HKCU\…\CurrentVersion\Run\OpenLogiAgent` in sync via the `winreg` crate.

4. **CI + local tooling** — `clippy (windows)` now lints `openlogi-agent` + `openlogi-agent-core`; `devenv.nix` gains the `x86_64-pc-windows-gnu` target and an `openlogi:check-windows` task for local cross-linting.

### Relationship to #93

This supersedes the **leaf layers** of #93, re-homed onto the post-daemon-split tree (#93's GUI integration was made obsolete by the split — the GUI is now a thin IPC client and doesn't build on Windows). `sioaeko` is credited as co-author on the relevant commits. #93's `windows_pairing.rs` (WinRT direct-Bluetooth pairing) is intentionally **not** included: it only served the GUI Add-Device flow, which has no Windows frontend; the agent pairs over the HID++ receiver path.

### Verification & caveats

- `cargo clippy` passes with `-D warnings` on macOS (host, full workspace) and the `x86_64-pc-windows-gnu` target (agent + leaf subset); `clippy (windows)` covers the rest natively on CI.
- **Not yet runtime-tested on a real Windows machine** — only compiled/linted. Hook capture, `SendInput`, and HID read/write need validation on Windows hardware.
- Deferred (need a Windows frontend): WinRT pairing UI, a Windows tray, the GUI itself.

Co-authored-by: sioaeko <101755125+sioaeko@users.noreply.github.com>