### PR TITLE
Fix Cmd+W window close handling

### DIFF
--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -19,7 +19,7 @@ use openlogi_core::device::{
 use openlogi_hid::DeviceRoute;
 use tracing::info;
 
-use crate::app_menu::{Minimize, Zoom};
+use crate::app_menu::{CloseWindow, Minimize, Zoom};
 use crate::asset::AssetResolver;
 use crate::components::carousel::Carousel;
 use crate::components::dpi_panel::DpiPanel;
@@ -358,6 +358,7 @@ impl Render for AppView {
             .size_full()
             .bg(pal.bg)
             .text_color(pal.text_primary)
+            .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
             .child(header_el)

--- a/crates/openlogi-gui/src/app_menu.rs
+++ b/crates/openlogi-gui/src/app_menu.rs
@@ -3,8 +3,8 @@
 //! GPUI's menu support is driven by registered actions + a `Keymap`: the
 //! platform layer reads bindings via `cx.set_menus` and stamps the matching
 //! `keyEquivalent` onto each `NSMenuItem`. App-level actions (Hide, Quit)
-//! get global listeners; window-level actions (Minimize, Zoom) are attached
-//! to the root view in [`crate::app`].
+//! get global listeners; window-level actions (Close, Minimize, Zoom) are
+//! attached to window root views.
 //!
 //! On Linux/Windows the menus + key bindings are stored but never surfaced
 //! in a top-of-screen bar — calling `install` there is a harmless no-op.

--- a/crates/openlogi-gui/src/app_menu.rs
+++ b/crates/openlogi-gui/src/app_menu.rs
@@ -64,9 +64,9 @@ pub fn install(cx: &mut App) {
         cx.on_action(|_: &ShowAll, cx| cx.unhide_other_apps());
     }
     cx.on_action(|_: &Quit, cx| cx.quit());
-    // App-level so it closes whichever window is focused. Settings / About /
-    // Add Device each have their own view root, so a view-level handler (like
-    // Minimize / Zoom) would only fire for the main window.
+    // Fallback for future windows that forget to attach a view-level
+    // CloseWindow handler. Existing window roots handle this directly so the
+    // focused window is removed during normal action dispatch.
     cx.on_action(|_: &CloseWindow, cx| {
         if let Some(handle) = cx.active_window() {
             let _ = handle.update(cx, |_, window, _| window.remove_window());

--- a/crates/openlogi-gui/src/windows/about.rs
+++ b/crates/openlogi-gui/src/windows/about.rs
@@ -12,6 +12,7 @@ use gpui::{
 use gpui_component::{IconName, button::Button, h_flex, v_flex};
 use gpui_updater::{UpdateStatus, Updater};
 
+use crate::app_menu::CloseWindow;
 use crate::theme;
 use crate::windows::{self, AuxWindow};
 
@@ -146,6 +147,7 @@ impl Render for AboutView {
             .size_full()
             .bg(pal.bg)
             .text_color(pal.text_primary)
+            .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .items_center()
             .justify_center()
             .gap_3()

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -23,6 +23,7 @@ use gpui_component::v_flex;
 use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
 use openlogi_hid::{Click, PasskeyMethod, ReceiverSelector};
 
+use crate::app_menu::CloseWindow;
 use crate::ipc_client::Command;
 use crate::state::AppState;
 use crate::theme::{self, Palette};
@@ -138,6 +139,7 @@ impl Render for AddDeviceView {
             .size_full()
             .bg(pal.bg)
             .text_color(pal.text_primary)
+            .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .p_6()
             .gap_5()
             .child(

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -20,6 +20,7 @@ use openlogi_core::config::{
     DEFAULT_THUMBWHEEL_SENSITIVITY, MAX_THUMBWHEEL_SENSITIVITY, MIN_THUMBWHEEL_SENSITIVITY,
 };
 
+use crate::app_menu::CloseWindow;
 use crate::platform::permissions::{self, Permission, PermissionStatus};
 use crate::state::AppState;
 use crate::theme::{self, Palette};
@@ -146,6 +147,7 @@ impl Render for SettingsView {
             .size_full()
             .bg(pal.bg)
             .text_color(pal.text_primary)
+            .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .child(
                 Settings::new("settings")
                     .sidebar_width(px(210.))


### PR DESCRIPTION
## Summary
- attach the CloseWindow action to each GPUI window root
- keep Cmd+W as window-close behavior distinct from Cmd+Q app quit
- update menu docs to reflect Close as a window-level action

## Verification
- cargo fmt --check
- cargo check -p openlogi-gui
- cargo clippy (push hook)