### PR TITLE
Fix auxiliary window actions

### DIFF
--- a/crates/openlogi-gui/src/windows/about.rs
+++ b/crates/openlogi-gui/src/windows/about.rs
@@ -12,7 +12,7 @@ use gpui::{
 use gpui_component::{IconName, button::Button, h_flex, v_flex};
 use gpui_updater::{UpdateStatus, Updater};
 
-use crate::app_menu::CloseWindow;
+use crate::app_menu::{CloseWindow, Minimize, Zoom};
 use crate::theme;
 use crate::windows::{self, AuxWindow};
 
@@ -148,6 +148,8 @@ impl Render for AboutView {
             .bg(pal.bg)
             .text_color(pal.text_primary)
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
+            .on_action(|_: &Minimize, window, _| window.minimize_window())
+            .on_action(|_: &Zoom, window, _| window.zoom_window())
             .items_center()
             .justify_center()
             .gap_3()

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -23,7 +23,7 @@ use gpui_component::v_flex;
 use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
 use openlogi_hid::{Click, PasskeyMethod, ReceiverSelector};
 
-use crate::app_menu::CloseWindow;
+use crate::app_menu::{CloseWindow, Minimize, Zoom};
 use crate::ipc_client::Command;
 use crate::state::AppState;
 use crate::theme::{self, Palette};
@@ -140,6 +140,8 @@ impl Render for AddDeviceView {
             .bg(pal.bg)
             .text_color(pal.text_primary)
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
+            .on_action(|_: &Minimize, window, _| window.minimize_window())
+            .on_action(|_: &Zoom, window, _| window.zoom_window())
             .p_6()
             .gap_5()
             .child(

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -20,7 +20,7 @@ use openlogi_core::config::{
     DEFAULT_THUMBWHEEL_SENSITIVITY, MAX_THUMBWHEEL_SENSITIVITY, MIN_THUMBWHEEL_SENSITIVITY,
 };
 
-use crate::app_menu::CloseWindow;
+use crate::app_menu::{CloseWindow, Minimize, Zoom};
 use crate::platform::permissions::{self, Permission, PermissionStatus};
 use crate::state::AppState;
 use crate::theme::{self, Palette};
@@ -148,6 +148,8 @@ impl Render for SettingsView {
             .bg(pal.bg)
             .text_color(pal.text_primary)
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
+            .on_action(|_: &Minimize, window, _| window.minimize_window())
+            .on_action(|_: &Zoom, window, _| window.zoom_window())
             .child(
                 Settings::new("settings")
                     .sidebar_width(px(210.))

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -7,8 +7,8 @@
 //! so it never reappears; "Enable" also runs one check immediately.
 
 use gpui::{
-    App, BorrowAppContext as _, Context, FontWeight, IntoElement, ParentElement as _, Render, Size,
-    Styled as _, Subscription, Window, div, px,
+    App, BorrowAppContext as _, Context, FontWeight, InteractiveElement, IntoElement,
+    ParentElement as _, Render, Size, Styled as _, Subscription, Window, div, px,
 };
 use gpui_component::{
     button::{Button, ButtonVariants as _},
@@ -16,6 +16,7 @@ use gpui_component::{
 };
 use gpui_updater::Updater;
 
+use crate::app_menu::{CloseWindow, Minimize, Zoom};
 use crate::state::AppState;
 use crate::theme;
 use crate::windows::{self, AuxWindow};
@@ -70,6 +71,9 @@ impl Render for UpdateConsentView {
             .size_full()
             .bg(pal.bg)
             .text_color(pal.text_primary)
+            .on_action(|_: &CloseWindow, window, _| window.remove_window())
+            .on_action(|_: &Minimize, window, _| window.minimize_window())
+            .on_action(|_: &Zoom, window, _| window.zoom_window())
             .items_center()
             .justify_center()
             .gap_4()


### PR DESCRIPTION
## Summary
- add CloseWindow handling to the first-run update consent window
- add Minimize and Zoom handlers to Settings, About, Add Device, and Update Consent window roots
- keep Window menu actions consistent across all GPUI windows

## Verification
- cargo fmt --check
- cargo check -p openlogi-gui
- cargo clippy (push hook)