### PR TITLE
ci: generate release notes with Amp

### DIFF
--- a/.github/actions/github-app-token-from-1password/action.yml
+++ b/.github/actions/github-app-token-from-1password/action.yml
@@ -1,0 +1,74 @@
+name: GitHub App token from 1Password
+description: Load GitHub App credentials from 1Password, decode the base64 private key, and mint an installation token.
+
+inputs:
+  op-service-account-token:
+    description: 1Password service account token.
+    required: true
+  op-github-app-item:
+    description: 1Password item reference that contains GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY.
+    required: true
+  owner:
+    description: Optional GitHub owner for cross-repository tokens.
+    required: false
+    default: ""
+  repositories:
+    description: Optional comma- or newline-separated repository list for cross-repository tokens.
+    required: false
+    default: ""
+
+outputs:
+  token:
+    description: Minted GitHub App installation token.
+    value: ${{ steps.app-token.outputs.token || steps.scoped-app-token.outputs.token }}
+  cargo-registry-token:
+    description: Optional Cargo registry token loaded from the same 1Password item.
+    value: ${{ steps.load-secrets.outputs.CARGO_REGISTRY_TOKEN }}
+
+runs:
+  using: composite
+  steps:
+    - name: Load GitHub App credentials from 1Password
+      id: load-secrets
+      uses: 1password/load-secrets-action@v4
+      with:
+        export-env: false
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
+        GITHUB_APP_ID: ${{ inputs.op-github-app-item }}/GITHUB_APP_ID
+        GITHUB_APP_PRIVATE_KEY: ${{ inputs.op-github-app-item }}/GITHUB_APP_PRIVATE_KEY
+        CARGO_REGISTRY_TOKEN: ${{ inputs.op-github-app-item }}/CARGO_REGISTRY_TOKEN
+
+    # The App private key is stored base64-encoded in 1Password (a raw PEM's
+    # newlines get mangled to spaces on paste). Decode it here; base64 ignores
+    # whitespace, so it survives re-mangling.
+    - name: Decode GitHub App private key
+      id: app-key
+      shell: bash
+      env:
+        APP_KEY_B64: ${{ steps.load-secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
+      run: |
+        key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
+        {
+          echo 'pem<<__PEM__'
+          printf '%s\n' "$key"
+          echo '__PEM__'
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Mint GitHub App token
+      id: app-token
+      if: inputs.owner == ''
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ steps.load-secrets.outputs.GITHUB_APP_ID }}
+        private-key: ${{ steps.app-key.outputs.pem }}
+
+    - name: Mint scoped GitHub App token
+      id: scoped-app-token
+      if: inputs.owner != ''
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ steps.load-secrets.outputs.GITHUB_APP_ID }}
+        private-key: ${{ steps.app-key.outputs.pem }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repositories }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -37,36 +37,12 @@ jobs:
       # GitHub App token (not a PAT) so the release PR / tag trigger CI and the
       # DMG release workflow — the default GITHUB_TOKEN cannot trigger workflows.
       # App credentials come from the same 1Password item as release.yml.
-      - name: Load GitHub App credentials from 1Password
-        id: load_secrets
-        uses: 1password/load-secrets-action@v4
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
-          CARGO_REGISTRY_TOKEN: ${{ secrets.OP_GITHUB_APP_ITEM }}/CARGO_REGISTRY_TOKEN
-      # App key is stored base64-encoded in 1Password (raw PEM newlines get
-      # mangled to spaces on paste); decode it (base64 ignores whitespace).
-      - name: Decode GitHub App private key
-        id: app_key
-        env:
-          APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-        run: |
-          key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
-          {
-            echo 'pem<<__PEM__'
-            printf '%s\n' "$key"
-            echo '__PEM__'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: ./.github/actions/github-app-token-from-1password
         with:
-          client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-          private-key: ${{ steps.app_key.outputs.pem }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
       - name: Run release-plz (release-pr)
         id: release_pr
         uses: release-plz/action@v0.5
@@ -74,7 +50,7 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.load_secrets.outputs.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.app-token.outputs.cargo-registry-token }}
       # `release-plz/action` swallows a release-pr HTTP 422 as a warning and
       # reports no PR, which silently stalls releases (it looks identical to a
       # quiet week of commits). Fail loudly when release-plz opened/updated no
@@ -85,46 +61,68 @@ jobs:
       # lands and we pin an action release that includes it, this guard can go.)
       - name: Guard against a silently stalled release
         if: steps.release_pr.outputs.prs_created == 'false'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          # An already-open release PR is the normal "updated, not created" path.
-          open_release_pr=$(gh pr list --repo "$REPO" --state open --json headRefName \
-            --jq '[.[] | select(.headRefName | startswith("release-plz/"))] | length')
-          if [ "$open_release_pr" != "0" ]; then
-            echo "A release PR is already open — nothing to flag."
-            exit 0
-          fi
-          last_tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)
-          # The release job runs in parallel and cuts the `v{version}` tag only
-          # after publishing, so that tag is usually absent from this job's
-          # checkout — never trust the local tag list to decide "did a release
-          # just happen". Read the manifest instead: merging a release PR bumps
-          # the workspace version, so a manifest version ahead of the last tag
-          # means the release already landed (the parallel job is tagging it),
-          # not a stall. Only when the manifest still sits at the last released
-          # tag can leftover release-worthy commits mean a swallowed release-pr.
-          manifest_version=$(awk '
-            /^\[workspace\.package\]/ { in_section = 1; next }
-            /^\[/ { in_section = 0 }
-            in_section && /^version[[:space:]]*=/ {
-              gsub(/.*=[[:space:]]*"|".*/, ""); print; exit
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { readFileSync } = require("node:fs");
+            const { owner, repo } = context.repo;
+
+            // An already-open release PR is the normal "updated, not created" path.
+            const openPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100,
+            });
+            if (openPulls.some((pull) => pull.head.ref.startsWith("release-plz/"))) {
+              core.info("A release PR is already open — nothing to flag.");
+              return;
             }
-          ' Cargo.toml)
-          if [ -n "$last_tag" ] && [ -n "$manifest_version" ] \
-            && [ "v$manifest_version" != "$last_tag" ]; then
-            echo "Workspace version $manifest_version is ahead of $last_tag — a release PR already merged; the release job cuts the tag. Nothing to flag."
-            exit 0
-          fi
-          range="${last_tag:+$last_tag..}HEAD"
-          worthy=$(git log "$range" --format='%s' \
-            | grep -cE '^(feat|fix|perf)(\(.+\))?!?:|^[a-z]+(\(.+\))?!:' || true)
-          if [ "$worthy" != "0" ]; then
-            echo "::error::release-plz opened no release PR, but $worthy release-worthy commit(s) exist since ${last_tag:-repo start} and none is open — likely a swallowed release-plz failure (see the release-pr step)."
-            exit 1
-          fi
-          echo "No release PR and no release-worthy commits since ${last_tag:-repo start}; nothing to release."
+
+            const tags = await github.paginate(github.rest.repos.listTags, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const lastTag = tags
+              .map((tag) => tag.name)
+              .filter((tag) => /^v\d+\.\d+\.\d+/.test(tag))
+              .sort((left, right) => right.localeCompare(left, undefined, { numeric: true, sensitivity: "base" }))[0] ?? "";
+
+            // The release job runs in parallel and cuts the `v{version}` tag only
+            // after publishing, so that tag is usually absent from this job's
+            // checkout — never trust the local tag list to decide "did a release
+            // just happen". Read the manifest instead: merging a release PR bumps
+            // the workspace version, so a manifest version ahead of the last tag
+            // means the release already landed (the parallel job is tagging it),
+            // not a stall. Only when the manifest still sits at the last released
+            // tag can leftover release-worthy commits mean a swallowed release-pr.
+            const manifestVersion = readFileSync("Cargo.toml", "utf8")
+              .match(/\[workspace\.package\][\s\S]*?^version\s*=\s*"([^"]+)"/m)?.[1] ?? "";
+            if (lastTag && manifestVersion && `v${manifestVersion}` !== lastTag) {
+              core.info(`Workspace version ${manifestVersion} is ahead of ${lastTag} — a release PR already merged; the release job cuts the tag. Nothing to flag.`);
+              return;
+            }
+
+            const commits = lastTag
+              ? (await github.rest.repos.compareCommitsWithBasehead({
+                  owner,
+                  repo,
+                  basehead: `${lastTag}...${context.sha}`,
+                })).data.commits
+              : await github.paginate(github.rest.repos.listCommits, {
+                  owner,
+                  repo,
+                  sha: context.sha,
+                  per_page: 100,
+                });
+            const worthy = commits.filter(({ commit }) => /^(feat|fix|perf)(\(.+\))?!?:|^[a-z]+(\(.+\))?!:/.test(commit.message.split("\n")[0])).length;
+            if (worthy !== 0) {
+              core.setFailed(`release-plz opened no release PR, but ${worthy} release-worthy commit(s) exist since ${lastTag || "repo start"} and none is open — likely a swallowed release-plz failure (see the release-pr step).`);
+              return;
+            }
+            core.info(`No release PR and no release-worthy commits since ${lastTag || "repo start"}; nothing to release.`);
 
   # On every push to master, publishes any crate whose manifest version is not yet
   # on crates.io — i.e. a no-op until the release PR is merged, at which point it
@@ -147,40 +145,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libudev-dev pkg-config gcc g++ clang libssl-dev libzstd-dev
-      - name: Load GitHub App credentials from 1Password
-        id: load_secrets
-        uses: 1password/load-secrets-action@v4
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
-          CARGO_REGISTRY_TOKEN: ${{ secrets.OP_GITHUB_APP_ITEM }}/CARGO_REGISTRY_TOKEN
-      # App key is stored base64-encoded in 1Password (raw PEM newlines get
-      # mangled to spaces on paste); decode it (base64 ignores whitespace).
-      - name: Decode GitHub App private key
-        id: app_key
-        env:
-          APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-        run: |
-          key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
-          {
-            echo 'pem<<__PEM__'
-            printf '%s\n' "$key"
-            echo '__PEM__'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: ./.github/actions/github-app-token-from-1password
         with:
-          client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-          private-key: ${{ steps.app_key.outputs.pem }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
       - name: Run release-plz (release)
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.load_secrets.outputs.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.app-token.outputs.cargo-registry-token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,63 @@ jobs:
           name: OpenLogi-macos-dmg-${{ matrix.arch }}
           path: dist/*.dmg
 
+  release-notes:
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: scripts/release-notes/pnpm-lock.yaml
+
+      - name: Load Amp release-notes credentials from 1Password
+        id: release_notes_config
+        continue-on-error: true
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AMP_API_KEY: ${{ secrets.OP_AMP_SECRET_ITEM }}/credential
+
+      - name: Mint release-notes GitHub App token
+        id: release_notes_app_token
+        continue-on-error: true
+        uses: ./.github/actions/github-app-token-from-1password
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
+
+      - name: Install release-notes dependencies
+        run: pnpm --dir scripts/release-notes install --frozen-lockfile
+
+      - name: Generate GitHub Release notes
+        env:
+          AMP_API_KEY: ${{ steps.release_notes_config.outputs.AMP_API_KEY }}
+          GH_TOKEN: ${{ steps.release_notes_app_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          node scripts/release-notes/generate.ts \
+            --tag "$GITHUB_REF_NAME" \
+            --output .release/RELEASE_NOTES.md
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: OpenLogi-release-notes
+          path: .release/RELEASE_NOTES.md
+
   # Single owner of the GitHub Release. softprops/action-gh-release@v3 creates the
   # release as a draft, uploads every asset to that (mutable) draft, then publishes
   # it as its final step — so the release only becomes immutable once all DMGs and
@@ -167,7 +224,7 @@ jobs:
   publish:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: dmg
+    needs: [dmg, release-notes]
     permissions:
       contents: write
     steps:
@@ -183,6 +240,11 @@ jobs:
           pattern: OpenLogi-macos-dmg-*
           path: dist
           merge-multiple: true
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: OpenLogi-release-notes
+          path: .release
 
       - name: Generate checksums
         run: |
@@ -288,15 +350,15 @@ jobs:
       # a draft, uploads every file, and only then flips it to published. That keeps
       # the release mutable for the whole upload, which is what avoids the "immutable
       # release" rejection. latest.json is intentionally not attached — it lives in
-      # R2 only.
+      # R2 only; RELEASE_NOTES.md is kept outside dist for the same reason.
       - name: Publish GitHub Release with assets
         uses: softprops/action-gh-release@v3
         with:
+          body_path: .release/RELEASE_NOTES.md
           files: |
             dist/*.dmg
             dist/*.minisig
             dist/SHA256SUMS
-          generate_release_notes: true
           fail_on_unmatched_files: true
 
   homebrew-tap:
@@ -306,37 +368,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Load GitHub App credentials from 1Password
-        id: load_secrets
-        uses: 1password/load-secrets-action@v4
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_APP_ID: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_ID
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.OP_GITHUB_APP_ITEM }}/GITHUB_APP_PRIVATE_KEY
-
-      # The App private key is stored base64-encoded in 1Password (a raw PEM's
-      # newlines get mangled to spaces on paste, which breaks key decoding).
-      # Decode it here; base64 ignores whitespace, so it survives re-mangling.
-      - name: Decode GitHub App private key
-        id: app_key
-        env:
-          APP_KEY_B64: ${{ steps.load_secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
-        run: |
-          key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
-          {
-            echo 'pem<<__PEM__'
-            printf '%s\n' "$key"
-            echo '__PEM__'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Mint homebrew-tap token (GitHub App)
         id: tap_token
-        uses: actions/create-github-app-token@v3
+        uses: ./.github/actions/github-app-token-from-1password
         with:
-          client-id: ${{ steps.load_secrets.outputs.GITHUB_APP_ID }}
-          private-key: ${{ steps.app_key.outputs.pem }}
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
           owner: AprilNEA
           repositories: homebrew-tap
 

--- a/scripts/release-notes/generate.ts
+++ b/scripts/release-notes/generate.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { Command } from "commander";
+import parseChangelog from "changelog-parser";
+import { Octokit } from "@octokit/rest";
+import semver from "semver";
+import { truncate, uniqBy } from "lodash-es";
+
+const options = new Command()
+  .requiredOption("--tag <tag>", "release tag, for example v0.6.0", process.env.GITHUB_REF_NAME)
+  .option("--previous-tag <tag>", "previous release tag")
+  .option("--output <path>", "release notes output path", ".release/RELEASE_NOTES.md")
+  .parse()
+  .opts();
+
+const tag = options.tag;
+const version = tag.replace(/^v/, "");
+const [owner, repoName] = process.env.GITHUB_REPOSITORY?.split("/") ?? [];
+const repo = owner && repoName ? { owner, repo: repoName } : undefined;
+const fullRepoName = repo ? `${repo.owner}/${repo.repo}` : undefined;
+const octokit = new Octokit({ auth: process.env.GH_TOKEN || process.env.GITHUB_TOKEN });
+
+const previousTag = options.previousTag ?? (repo ? await octokit.paginate(octokit.rest.repos.listTags, {
+  owner: repo.owner,
+  repo: repo.repo,
+  per_page: 100,
+})
+  .then((tags) => tags
+    .map(({ name }) => name)
+    .filter((candidate) => semver.valid(candidate) && semver.lt(candidate, tag))
+    .sort(semver.rcompare)[0] ?? "")
+  .catch((error) => {
+    console.warn(error.message);
+    return "";
+  }) : "");
+
+const comparison = repo && previousTag ? await octokit.rest.repos
+  .compareCommitsWithBasehead({
+    owner: repo.owner,
+    repo: repo.repo,
+    basehead: `${previousTag}...${tag}`,
+  })
+  .then(({ data }) => data)
+  .catch((error) => {
+    console.warn(error.message);
+    return undefined;
+  }) : undefined;
+
+const fullChangelog = comparison?.html_url;
+
+const githubNotes = repo ? await octokit.rest.repos
+  .generateReleaseNotes({
+    owner: repo.owner,
+    repo: repo.repo,
+    tag_name: tag,
+    previous_tag_name: previousTag || undefined,
+  })
+  .then(({ data }) => data.body ?? "")
+  .catch((error) => {
+    console.warn(error.message);
+    return "";
+  }) : "";
+
+const pullRequests = repo && comparison ? uniqBy((await Promise.all(comparison.commits.slice(0, 50).map(({ sha }) => octokit.rest.repos
+  .listPullRequestsAssociatedWithCommit({ owner: repo.owner, repo: repo.repo, commit_sha: sha })
+  .then(({ data }) => data)
+  .catch((error) => {
+    console.warn(error.message);
+    return [];
+  })))).flat(), "number").slice(0, 20) : [];
+
+const prDetails = pullRequests
+  .map((pull) => [`#${pull.number} ${pull.title}`, pull.html_url, pull.body ?? ""].join("\n"))
+  .join("\n\n---\n\n");
+
+const commits = truncate(comparison?.commits
+  .map(({ sha, commit }) => `${sha.slice(0, 7)} ${commit.message}`)
+  .join("\n\n---\n\n") ?? "", { length: 80_000, omission: "\n\n[truncated]" });
+
+const changelogSection = await parseChangelog({ filePath: "CHANGELOG.md", removeMarkdown: false })
+  .then((changelog) => {
+    const entry = changelog.versions.find((release) => release.version === version);
+    return entry ? [`## ${entry.title}`, entry.body].filter(Boolean).join("\n\n") : "";
+  })
+  .catch((error) => {
+    console.warn(error.message);
+    return "";
+  });
+
+const prompt = `Generate polished GitHub Release notes for OpenLogi ${tag}.
+
+Audience: end users and technical users installing OpenLogi.
+Tone: concise, concrete, product-facing.
+
+Required sections:
+- Highlights
+- What's new
+- macOS packaging and startup
+- Fixes and hardening
+- Upgrade notes
+- Included PRs
+- Full changelog
+
+Rules:
+- Prefer user impact over implementation details.
+- Mention macOS Accessibility, helper app, launch-at-login, signing/notarization, updater, or Homebrew behavior when relevant.
+- Do not invent changes.
+- If a required section has no meaningful entries, omit that section.
+- Return only Markdown, with no surrounding code fence.
+
+Repository: ${fullRepoName ?? "unknown"}
+Previous tag: ${previousTag || "unknown"}
+Current tag: ${tag}
+Full changelog URL: ${fullChangelog ?? "unknown"}
+
+GitHub generated notes:
+${truncate(githubNotes, { length: 30_000, omission: "\n\n[truncated]" })}
+
+CHANGELOG section:
+${truncate(changelogSection, { length: 30_000, omission: "\n\n[truncated]" })}
+
+PR details:
+${truncate(prDetails, { length: 60_000, omission: "\n\n[truncated]" })}
+
+Commit details:
+${truncate(commits, { length: 80_000, omission: "\n\n[truncated]" })}
+`;
+
+let notes = "";
+if (process.env.AMP_API_KEY) {
+  try {
+    const { execute } = await import("@ampcode/sdk");
+    for await (const message of execute({ prompt, options: { cwd: process.cwd() } })) {
+      if (message.type === "result") {
+        if (message.is_error) throw new Error(message.error ?? "Amp returned an error");
+        notes = message.result ?? "";
+      }
+    }
+  } catch (error) {
+    console.warn(`AI release notes unavailable: ${error.message}`);
+  }
+} else {
+  console.warn("AI release notes unavailable: AMP_API_KEY is not set");
+}
+
+if (!notes.trim()) {
+  notes = githubNotes.trim()
+    || (changelogSection.trim() && `${changelogSection}\n\n${fullChangelog ? `**Full changelog**: ${fullChangelog}` : ""}`)
+    || [`## ${tag}`, "", commits.trim() || "No release notes were generated.", "", fullChangelog ? `**Full changelog**: ${fullChangelog}` : ""].join("\n");
+}
+
+mkdirSync(dirname(options.output), { recursive: true });
+writeFileSync(options.output, `${notes.trim()}\n`);
+console.log(`Wrote release notes to ${options.output}`);

--- a/scripts/release-notes/package.json
+++ b/scripts/release-notes/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@ampcode/sdk": "0.1.0-20260605144103-g77da114",
+    "@octokit/rest": "^22.0.1",
+    "changelog-parser": "^3.0.1",
+    "commander": "^15.0.0",
+    "lodash-es": "^4.18.1",
+    "semver": "^7.8.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@ampcode/cli"
+    ]
+  },
+  "packageManager": "pnpm@10.11.0"
+}

--- a/scripts/release-notes/pnpm-lock.yaml
+++ b/scripts/release-notes/pnpm-lock.yaml
@@ -1,0 +1,273 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@ampcode/sdk':
+        specifier: 0.1.0-20260605144103-g77da114
+        version: 0.1.0-20260605144103-g77da114
+      '@octokit/rest':
+        specifier: ^22.0.1
+        version: 22.0.1
+      changelog-parser:
+        specifier: ^3.0.1
+        version: 3.0.1
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
+      lodash-es:
+        specifier: ^4.18.1
+        version: 4.18.1
+      semver:
+        specifier: ^7.8.2
+        version: 7.8.2
+
+packages:
+
+  '@ampcode/cli-darwin-arm64@0.0.1780884556-g9cd342':
+    resolution: {integrity: sha512-T74jB3MWp+qCZr4uGvj+eBZw63QY3R35/ay9r0idHhPvryBqK0fxD9jbYu5xIn3BGf5mOxCp/j+bISSrqr3hmg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ampcode/cli-darwin-x64@0.0.1780884556-g9cd342':
+    resolution: {integrity: sha512-GQMy8q6hWdt1Z9gK6JN261LFuTvlYZiTfwGRzwDATHEN1dXq9+XihCeUiKaK9MZWopAl5fQBWYaJBlRWp+VP+g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ampcode/cli-linux-arm64@0.0.1780884556-g9cd342':
+    resolution: {integrity: sha512-2bL+Br9GGxXAMguOO/FyWRHY1/X37+kD7hjOJ6affUJIdF510fv5XiywB8w1kvnhrUd3XwdMB4WdcZg0zA7Bcw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ampcode/cli-linux-x64@0.0.1780884556-g9cd342':
+    resolution: {integrity: sha512-O2vdZ49LzRnbq/V6kWnBh7XyQmaXp7aID30uYB6YFXx0IB1bqaQ05YXAuuINtXMqCdrKVb/ZP5nh+EcFcWUDHg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@ampcode/cli-win32-x64@0.0.1780884556-g9cd342':
+    resolution: {integrity: sha512-7rlYQhQPS3aYZ9r3d5iIy3pLOXF+1DVWhu0EEd7R3ZOhv0F7fSEL3Zl5HqN5+QOx+LjbGgKhtn+6OUUwZG6i4Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@ampcode/cli@0.0.1780884556-g9cd342':
+    resolution: {integrity: sha512-kJbVr7n70izNwqF0dvWvptm+phEgNS8ELme7+pdCo6Ayr4WAfvf5L6Dyxz8gpFNvJajE6GIf8MaM8O3te1Um7g==}
+    hasBin: true
+
+  '@ampcode/sdk@0.1.0-20260605144103-g77da114':
+    resolution: {integrity: sha512-EIo9xy/qQMSNWKKmID2sOGUCVEPtnE3mMKgtw5LInedCy3U99LVK83BB45rqWGaqaCnzu99GkPruoqgIE/kyvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.10':
+    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  changelog-parser@3.0.1:
+    resolution: {integrity: sha512-1AEVJgnFEO4v5ukfEH/j9cr2Z39Y/GCieNi605azhufAolXF4vQAwZBY8BrUVRkvlI3gwe3i621/PIAW0zmmEQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
+  line-reader@0.2.4:
+    resolution: {integrity: sha512-342xzyZZS9uTiKwHJcMacopVl/WjrMMCZS1Qg4Uhl/WBknWRrGFdKOIS1Kec6SaiTcZMtmuxWvvIbPXj/+FMjA==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  remove-markdown@0.5.5:
+    resolution: {integrity: sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g==}
+
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@ampcode/cli-darwin-arm64@0.0.1780884556-g9cd342':
+    optional: true
+
+  '@ampcode/cli-darwin-x64@0.0.1780884556-g9cd342':
+    optional: true
+
+  '@ampcode/cli-linux-arm64@0.0.1780884556-g9cd342':
+    optional: true
+
+  '@ampcode/cli-linux-x64@0.0.1780884556-g9cd342':
+    optional: true
+
+  '@ampcode/cli-win32-x64@0.0.1780884556-g9cd342':
+    optional: true
+
+  '@ampcode/cli@0.0.1780884556-g9cd342':
+    optionalDependencies:
+      '@ampcode/cli-darwin-arm64': 0.0.1780884556-g9cd342
+      '@ampcode/cli-darwin-x64': 0.0.1780884556-g9cd342
+      '@ampcode/cli-linux-arm64': 0.0.1780884556-g9cd342
+      '@ampcode/cli-linux-x64': 0.0.1780884556-g9cd342
+      '@ampcode/cli-win32-x64': 0.0.1780884556-g9cd342
+
+  '@ampcode/sdk@0.1.0-20260605144103-g77da114':
+    dependencies:
+      '@ampcode/cli': 0.0.1780884556-g9cd342
+      zod: 3.25.76
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.10
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.10
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.10':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  before-after-hook@4.0.0: {}
+
+  changelog-parser@3.0.1:
+    dependencies:
+      line-reader: 0.2.4
+      remove-markdown: 0.5.5
+
+  commander@15.0.0: {}
+
+  content-type@2.0.0: {}
+
+  json-with-bigint@3.5.8: {}
+
+  line-reader@0.2.4: {}
+
+  lodash-es@4.18.1: {}
+
+  remove-markdown@0.5.5: {}
+
+  semver@7.8.2: {}
+
+  universal-user-agent@7.0.3: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary

- Generate GitHub Release notes before `softprops/action-gh-release` publishes assets.
- Use Amp SDK when `AMP_API_KEY` is available from a new 1Password item (`OP_AMP_SECRET_ITEM` → `AMP_API_KEY`).
- Fall back to GitHub generated notes / CHANGELOG data so release publishing is not blocked if Amp credentials or SDK install are unavailable.
- Keep generated notes outside `dist/` so they are not uploaded to R2.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `GITHUB_REPOSITORY=AprilNEA/OpenLogi node scripts/generate-release-notes.ts --tag v0.5.3 --previous-tag v0.5.2 --output /tmp/openlogi-release-notes-pr.md`
