### PR TITLE
fix(gui): stop sensitivity Default label clipping

### DIFF
--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -8,13 +8,14 @@
 use gpui::{
     AnyElement, App, AppContext as _, BorrowAppContext as _, Context, Entity, InteractiveElement,
     IntoElement, ParentElement as _, Render, SharedString, Size, StatefulInteractiveElement as _,
-    Styled as _, Subscription, Window, div, px, rgb,
+    Styled as _, Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::{
     IconName, IndexPath, Sizable, h_flex,
     select::{Select, SelectEvent, SelectItem, SelectState},
     setting::{SettingField, SettingGroup, SettingItem, SettingPage, Settings},
     slider::{Slider, SliderEvent, SliderState},
+    v_flex,
 };
 use openlogi_core::config::{
     DEFAULT_THUMBWHEEL_SENSITIVITY, MAX_THUMBWHEEL_SENSITIVITY, MIN_THUMBWHEEL_SENSITIVITY,
@@ -439,23 +440,32 @@ fn language_select_field(
 )]
 fn sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
     let value = slider.read(cx).value().start().round() as i32;
-    let label = if value == DEFAULT_THUMBWHEEL_SENSITIVITY {
-        format!("{value} ({})", rust_i18n::t!("Default"))
-    } else {
-        value.to_string()
-    };
+    let is_default = value == DEFAULT_THUMBWHEEL_SENSITIVITY;
     let pal = theme::palette(cx);
-    h_flex()
+    v_flex()
         .flex_shrink_0()
-        .items_center()
-        .gap_3()
-        .child(div().w(px(180.)).child(Slider::new(slider)))
+        .gap_1()
         .child(
-            div()
-                .w(px(72.))
-                .text_sm()
-                .text_color(pal.text_muted)
-                .child(label),
+            h_flex()
+                .items_center()
+                .gap_3()
+                .child(div().w(px(180.)).child(Slider::new(slider)))
+                .child(
+                    div()
+                        .w(px(72.))
+                        .text_sm()
+                        .text_color(pal.text_muted)
+                        .child(value.to_string()),
+                ),
         )
+        .when(is_default, |this| {
+            this.child(
+                div()
+                    .text_xs()
+                    .text_color(pal.text_muted)
+                    .whitespace_nowrap()
+                    .child(format!("({})", rust_i18n::t!("Default"))),
+            )
+        })
         .into_any_element()
 }


### PR DESCRIPTION
## Context
- the "(Default)" tag on the Thumb Wheel Sensitivity readout was cut off ("14 (Defa)")
- the readout sits hard against the window edge, so there's no room to just widen it
- moved "(Default)" onto its own line under the slider, where it has room

## Testing
- built the GUI, opened Settings → General
- confirmed "(Default)" now renders in full under the slider

## Screenshots
### Before:
<img width="1095" height="782" alt="Screenshot 2026-06-09 at 12 13 27 AM" src="https://github.com/user-attachments/assets/353207cb-3b9b-497b-b06b-857c028b2054" />


### After:
<img width="1095" height="782" alt="Screenshot 2026-06-09 at 12 27 06 AM" src="https://github.com/user-attachments/assets/13ff48e4-481c-40f3-a7b6-586451f44425" />
<img width="1095" height="782" alt="Screenshot 2026-06-09 at 12 27 14 AM" src="https://github.com/user-attachments/assets/d69d4f32-ed34-476e-9ef3-38497dcd7751" />

