### PR TITLE
feat: unified Binding model + gesture-button menu (gesture uplift Phase A)

### DIFF
--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -34,6 +34,14 @@ pub fn bindings_for(
         .map(|b| (b, default_binding(b)))
         .collect();
     for (k, binding) in stored {
+        // A gesture binding with no explicit `Click` has no opinion on the
+        // plain-press action, so leave the button's default seed in place rather
+        // than clobbering it with the `Action::None` that `click_action()` would
+        // project. (An explicit `Single(Action::None)` — a user-disabled button —
+        // still overrides, as it should.)
+        if binding.is_gesture() && binding.direction_action(GestureDirection::Click).is_none() {
+            continue;
+        }
         bindings.insert(k, binding.click_action());
     }
     bindings
@@ -58,4 +66,43 @@ pub fn gesture_bindings_for(
         bindings.insert(k, v);
     }
     bindings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openlogi_core::binding::Binding;
+
+    #[test]
+    fn click_less_gesture_keeps_default_click_in_projection() {
+        // A gesture binding with no explicit `Click` (a migrated sparse v1 map or
+        // a hand-edited config) must not project to `Action::None` and silently
+        // disable the button — the button's default click survives.
+        let mut cfg = Config::default();
+        let mut map = BTreeMap::new();
+        map.insert(GestureDirection::Up, Action::Copy);
+        cfg.set_binding("2b042", ButtonId::GestureButton, Binding::Gesture(map));
+
+        let projected = bindings_for(&cfg, Some("2b042"), None);
+        assert_eq!(
+            projected.get(&ButtonId::GestureButton),
+            Some(&default_binding(ButtonId::GestureButton)),
+            "a Click-less gesture must keep the default click, not None"
+        );
+    }
+
+    #[test]
+    fn explicit_gesture_click_overrides_default_in_projection() {
+        // A gesture binding that DOES define `Click` projects that action.
+        let mut cfg = Config::default();
+        let mut map = BTreeMap::new();
+        map.insert(GestureDirection::Click, Action::Paste);
+        cfg.set_binding("2b042", ButtonId::GestureButton, Binding::Gesture(map));
+
+        let projected = bindings_for(&cfg, Some("2b042"), None);
+        assert_eq!(
+            projected.get(&ButtonId::GestureButton),
+            Some(&Action::Paste)
+        );
+    }
 }

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -11,8 +11,14 @@ use openlogi_core::binding::{
 };
 use openlogi_core::config::Config;
 
-/// Effective button bindings for the device `config_key`, with `app_bundle`'s
-/// per-app overlay applied. Unset buttons fall back to [`default_binding`].
+/// Effective per-button single-action map for the device `config_key`, with
+/// `app_bundle`'s per-app overlay applied. Unset buttons fall back to
+/// [`default_binding`].
+///
+/// This is the map the OS hook and the HID++ button-press path consume, so a
+/// `Binding::Gesture` is projected to its `click_action()` — the gesture
+/// button's per-direction swipes are dispatched via the separate
+/// [`gesture_bindings_for`] map, not here.
 #[must_use]
 pub fn bindings_for(
     config: &Config,
@@ -27,8 +33,8 @@ pub fn bindings_for(
         .copied()
         .map(|b| (b, default_binding(b)))
         .collect();
-    for (k, v) in stored {
-        bindings.insert(k, v);
+    for (k, binding) in stored {
+        bindings.insert(k, binding.click_action());
     }
     bindings
 }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1407,9 +1407,13 @@ pub fn default_gesture_binding(direction: GestureDirection) -> Action {
 /// [`default_gesture_binding`] — preserving the existing per-direction swipe
 /// behavior — so the GUI mode toggle and the runtime agree it starts in gesture
 /// mode. Every other button defaults to [`Binding::Single`] of its
-/// [`default_binding`]. This is the single source of truth for "what an
-/// un-customized button does"; both the GUI's `AppState` and the agent-side
-/// projection must derive from it so they never disagree.
+/// [`default_binding`].
+///
+/// This is the seed when a button is first promoted to a gesture binding (see
+/// [`Config::set_gesture_direction`](crate::config::Config::set_gesture_direction)),
+/// so a freshly-customized gesture button always carries a full default
+/// direction map — including a [`GestureDirection::Click`] — rather than a sparse
+/// map whose click would project to a no-op [`Action::None`].
 #[must_use]
 pub fn default_binding_for(button: ButtonId) -> Binding {
     match button {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -6,6 +6,7 @@
 //! the TOML config keys/values use the enum variant identifiers verbatim, so
 //! renames are migration events.
 
+use std::collections::BTreeMap;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -444,6 +445,83 @@ impl KeyCombo {
             }
         }
         out
+    }
+}
+
+/// What a single rebindable [`ButtonId`] does: either one [`Action`], or — for a
+/// raw-XY-capable button placed in gesture mode — a per-[`GestureDirection`]
+/// map (hold + swipe up/down/left/right, or a plain click).
+///
+/// There has only ever been one binding map per device; a gesture binding is
+/// just a binding whose payload is a direction map instead of a single action.
+///
+/// # Serialization
+///
+/// `#[serde(untagged)]`: [`Single`](Binding::Single) serializes exactly as the
+/// bare [`Action`] did before (a string `"BrowserBack"`, or a single-key table
+/// for the payload variants), and [`Gesture`](Binding::Gesture) serializes as a
+/// table keyed by [`GestureDirection`] names (`Up`/`Down`/`Left`/`Right`/
+/// `Click`).
+///
+/// The two arms are disambiguated by the **zero overlap** between [`Action`]
+/// variant names and [`GestureDirection`] variant names — untagged tries
+/// `Single(Action)` first, and a table keyed by `Up` etc. cannot parse as an
+/// externally-tagged `Action`, so it falls through to `Gesture`. A payload
+/// action like `{ SetDpiPreset = 2 }` is a valid externally-tagged `Action`, so
+/// it stays `Single` and never reaches the `Gesture` arm. This invariant is the
+/// entire safety basis for untagged routing; the `binding_untagged_*` tests
+/// guard it (a future `Action` named `Up`/`Down`/`Left`/`Right`/`Click` would
+/// silently mis-route, and those tests would fail).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Binding {
+    /// One action, fired on press. The shape every non-gesture button uses.
+    Single(Action),
+    /// Per-direction sub-bindings for a button in gesture mode. Keyed by the
+    /// committed swipe direction, with [`GestureDirection::Click`] holding the
+    /// plain-click (no-swipe) action.
+    Gesture(BTreeMap<GestureDirection, Action>),
+}
+
+impl Binding {
+    /// The plain-click action for this binding: the [`Single`](Binding::Single)
+    /// action, or the [`Gesture`](Binding::Gesture) map's
+    /// [`Click`](GestureDirection::Click) entry. Falls back to [`Action::None`]
+    /// when a gesture binding has no explicit `Click`.
+    ///
+    /// Lets the click-dispatch path stay binding-shape-agnostic.
+    #[must_use]
+    pub fn click_action(&self) -> Action {
+        match self {
+            Binding::Single(action) => action.clone(),
+            Binding::Gesture(map) => map
+                .get(&GestureDirection::Click)
+                .cloned()
+                .unwrap_or(Action::None),
+        }
+    }
+
+    /// The action bound to `direction`, if this is a gesture binding.
+    /// [`Single`](Binding::Single) has no directions and returns `None`.
+    #[must_use]
+    pub fn direction_action(&self, direction: GestureDirection) -> Option<&Action> {
+        match self {
+            Binding::Single(_) => None,
+            Binding::Gesture(map) => map.get(&direction),
+        }
+    }
+
+    /// Whether this binding drives raw-XY swipe capture (the
+    /// [`Gesture`](Binding::Gesture) arm).
+    #[must_use]
+    pub fn is_gesture(&self) -> bool {
+        matches!(self, Binding::Gesture(_))
+    }
+}
+
+impl From<Action> for Binding {
+    fn from(action: Action) -> Self {
+        Binding::Single(action)
     }
 }
 
@@ -1283,9 +1361,11 @@ mod macos {
 /// (per-direction, see [`default_gesture_binding`]). The bindings persist
 /// regardless so the user only configures once.
 ///
-/// `GestureButton`'s entry here is the legacy single-binding placeholder;
-/// the per-direction sub-bindings live in [`default_gesture_binding`] and
-/// are what the UI now edits.
+/// `GestureButton`'s entry here is vestigial: in the merged [`Binding`] model
+/// the gesture button defaults to [`Binding::Gesture`] (see
+/// [`default_binding_for`]), so this single-action value is never the source of
+/// truth for it. It is retained only so the per-button-`Action` callers (the
+/// hook map, scroll defaults, labels) stay total.
 #[must_use]
 pub fn default_binding(button: ButtonId) -> Action {
     match button {
@@ -1318,6 +1398,28 @@ pub fn default_gesture_binding(direction: GestureDirection) -> Action {
         GestureDirection::Left => Action::PrevTab,
         GestureDirection::Right => Action::NextTab,
         GestureDirection::Click => Action::AppExpose,
+    }
+}
+
+/// The canonical default [`Binding`] for a fresh button in the merged model.
+///
+/// [`ButtonId::GestureButton`] defaults to [`Binding::Gesture`] populated from
+/// [`default_gesture_binding`] — preserving the existing per-direction swipe
+/// behavior — so the GUI mode toggle and the runtime agree it starts in gesture
+/// mode. Every other button defaults to [`Binding::Single`] of its
+/// [`default_binding`]. This is the single source of truth for "what an
+/// un-customized button does"; both the GUI's `AppState` and the agent-side
+/// projection must derive from it so they never disagree.
+#[must_use]
+pub fn default_binding_for(button: ButtonId) -> Binding {
+    match button {
+        ButtonId::GestureButton => Binding::Gesture(
+            GestureDirection::ALL
+                .into_iter()
+                .map(|d| (d, default_gesture_binding(d)))
+                .collect(),
+        ),
+        other => Binding::Single(default_binding(other)),
     }
 }
 
@@ -1732,6 +1834,95 @@ mod tests {
                 "catalog must not contain CustomShortcut"
             );
         }
+    }
+
+    // ── Binding (merged model) serde routing ──────────────────────────────────
+
+    /// On-disk shape: a `ButtonId` → [`Binding`] map, as `DeviceConfig.bindings`
+    /// serializes it.
+    #[derive(Serialize, Deserialize)]
+    struct BindingWrapper {
+        bindings: BTreeMap<ButtonId, Binding>,
+    }
+
+    fn binding_roundtrip(bindings: BTreeMap<ButtonId, Binding>) -> BTreeMap<ButtonId, Binding> {
+        let toml = toml::to_string_pretty(&BindingWrapper { bindings }).expect("serialize");
+        toml::from_str::<BindingWrapper>(&toml)
+            .expect("deserialize")
+            .bindings
+    }
+
+    #[test]
+    fn binding_single_roundtrips_including_payload_variants() {
+        let mut bindings = BTreeMap::new();
+        bindings.insert(ButtonId::Back, Binding::Single(Action::BrowserBack));
+        bindings.insert(
+            ButtonId::DpiToggle,
+            Binding::Single(Action::SetDpiPreset(2)),
+        );
+        bindings.insert(
+            ButtonId::Forward,
+            Binding::Single(Action::CustomShortcut(KeyCombo {
+                modifiers: KeyCombo::MOD_CMD,
+                key_code: 0x23,
+                display: "⌘P".into(),
+            })),
+        );
+        let back = binding_roundtrip(bindings);
+        assert_eq!(back[&ButtonId::Back], Binding::Single(Action::BrowserBack));
+        assert_eq!(
+            back[&ButtonId::DpiToggle],
+            Binding::Single(Action::SetDpiPreset(2))
+        );
+        assert!(matches!(
+            back[&ButtonId::Forward],
+            Binding::Single(Action::CustomShortcut(_))
+        ));
+    }
+
+    #[test]
+    fn binding_gesture_roundtrips() {
+        let mut map = BTreeMap::new();
+        map.insert(GestureDirection::Up, Action::Copy);
+        map.insert(GestureDirection::Click, Action::Paste);
+        let mut bindings = BTreeMap::new();
+        bindings.insert(ButtonId::GestureButton, Binding::Gesture(map.clone()));
+        let back = binding_roundtrip(bindings);
+        assert_eq!(back[&ButtonId::GestureButton], Binding::Gesture(map));
+    }
+
+    /// The untagged-routing safety guard. A TOML table keyed by ANY
+    /// [`GestureDirection`] name must deserialize as [`Binding::Gesture`], never
+    /// [`Binding::Single`]. If a future [`Action`] payload variant is ever named
+    /// `Up`/`Down`/`Left`/`Right`/`Click`, the table would parse as `Single`
+    /// first and this test fails — catching the silent mis-route at CI time.
+    #[test]
+    fn binding_direction_keyed_table_routes_to_gesture() {
+        for dir in GestureDirection::ALL {
+            // `GestureDirection`'s serde key equals its `Display`/variant name.
+            let toml = format!("bindings.GestureButton.{dir} = \"None\"");
+            let parsed = toml::from_str::<BindingWrapper>(&toml).expect("deserialize");
+            assert!(
+                matches!(
+                    parsed.bindings[&ButtonId::GestureButton],
+                    Binding::Gesture(_)
+                ),
+                "a {dir}-keyed table must route to Gesture, not Single"
+            );
+        }
+    }
+
+    /// The collision case: a payload [`Action`] also serializes as a single-key
+    /// table, but untagged must keep it [`Binding::Single`] (it parses as a valid
+    /// externally-tagged `Action` before the `Gesture` arm is tried).
+    #[test]
+    fn binding_payload_action_stays_single() {
+        let toml = "bindings.DpiToggle.SetDpiPreset = 2";
+        let parsed = toml::from_str::<BindingWrapper>(toml).expect("deserialize");
+        assert_eq!(
+            parsed.bindings[&ButtonId::DpiToggle],
+            Binding::Single(Action::SetDpiPreset(2))
+        );
     }
 
     // ── Gesture classification ────────────────────────────────────────────────

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -16,7 +16,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::binding::{Action, Binding, ButtonId, GestureDirection};
+use crate::binding::{Action, Binding, ButtonId, GestureDirection, default_binding_for};
 use crate::paths::{self, PathsError};
 
 /// The schema version the current build produces. Bumped on breaking layout
@@ -275,6 +275,19 @@ impl From<RawDeviceConfig> for DeviceConfig {
                 .or_insert_with(|| Binding::Gesture(raw.gesture_bindings));
         }
         for (button, action) in raw.button_bindings {
+            // A legacy `button_bindings[GestureButton]` is vestigial and must not
+            // become a `Binding::Single`: the gesture button never dispatched
+            // through the per-button map (it is not an OS-hook button, and its
+            // plain press routes through the gesture `Click` slot — see
+            // agent-core `bindings_for`). A `Single` here would be unreachable —
+            // the GUI hides it and the runtime ignores it — while folding it into
+            // `Click` would resurrect a dead binding as a behavior change. Drop
+            // it: the gesture map (re-homed above) already owns this button, and
+            // an absent entry falls back to the canonical default, exactly as
+            // pre-v2.
+            if button == ButtonId::GestureButton {
+                continue;
+            }
             bindings.entry(button).or_insert(Binding::Single(action));
         }
 
@@ -422,9 +435,14 @@ impl Config {
     }
 
     /// Records `action` for one `direction` of `button`'s gesture binding,
-    /// creating the device entry if needed. A button with no binding (or a
-    /// [`Binding::Single`]) is upgraded to [`Binding::Gesture`], preserving any
-    /// prior single action as the [`GestureDirection::Click`] entry.
+    /// creating the device entry if needed.
+    ///
+    /// A button with no binding yet is seeded from its canonical
+    /// [`default_binding_for`] — for [`ButtonId::GestureButton`] that is the full
+    /// default direction map (including a [`GestureDirection::Click`]), so the
+    /// merged map never persists a gesture binding whose click projection is a
+    /// no-op. A prior [`Binding::Single`] is upgraded to [`Binding::Gesture`],
+    /// preserving its action as the `Click` entry.
     pub fn set_gesture_direction(
         &mut self,
         device_key: &str,
@@ -438,7 +456,7 @@ impl Config {
             .or_default()
             .bindings
             .entry(button)
-            .or_insert_with(|| Binding::Gesture(BTreeMap::new()));
+            .or_insert_with(|| default_binding_for(button));
         if let Binding::Single(prev) = entry {
             let mut map = BTreeMap::new();
             map.insert(GestureDirection::Click, prev.clone());
@@ -691,18 +709,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unknown_schema_version() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("config.toml");
-        fs::write(&path, "schema_version = 99\n").expect("write");
-        let err = Config::load_from_path(&path).expect_err("should fail");
-        assert!(matches!(
-            err,
-            ConfigError::UnsupportedSchemaVersion { found: 99, .. }
-        ));
-    }
-
-    #[test]
     fn dpi_presets_roundtrip_per_device() {
         let mut cfg = Config::default();
         cfg.set_dpi_presets("2b042", vec![800, 1600, 3200]);
@@ -926,6 +932,38 @@ Down = \"Paste\"
     }
 
     #[test]
+    fn migration_drops_vestigial_lone_gesture_button_single() {
+        // A v1 file with only `button_bindings[GestureButton]` and no
+        // `gesture_bindings` (the pre-gesture-picker shape). That entry never
+        // dispatched in v1 — the gesture button's plain press routes through the
+        // gesture `Click` slot, not the per-button map — so migrating it to a
+        // `Binding::Single` would leave an unreachable entry the GUI hides and the
+        // runtime ignores. It must be dropped, not shadow the gesture path.
+        let v1 = "\
+schema_version = 1
+
+[devices.2b042.button_bindings]
+GestureButton = \"MissionControl\"
+Back = \"BrowserBack\"
+";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, v1).expect("write");
+
+        let bindings = Config::load_from_path(&path)
+            .expect("load v1")
+            .bindings_for("2b042");
+        // An ordinary button still migrates to a `Single`...
+        assert_eq!(
+            bindings.get(&ButtonId::Back),
+            Some(&Binding::Single(Action::BrowserBack))
+        );
+        // ...but the vestigial gesture-button single is gone, leaving the button
+        // to fall back to its canonical default rather than an unreachable entry.
+        assert_eq!(bindings.get(&ButtonId::GestureButton), None);
+    }
+
+    #[test]
     fn rejects_newer_schema_version_but_accepts_v1() {
         // A future version is rejected loudly; the current and older versions
         // load (older ones migrate through the shim).
@@ -965,6 +1003,34 @@ Down = \"Paste\"
                 assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
             }
             other => panic!("expected Gesture after upgrade, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_gesture_direction_on_fresh_gesture_button_seeds_click() {
+        // Binding one direction on a never-configured gesture button must still
+        // persist a `Click`, so the click projection is the canonical default
+        // rather than `Action::None` (which reads as a no-op press).
+        let mut cfg = Config::default();
+        cfg.set_gesture_direction(
+            "2b042",
+            ButtonId::GestureButton,
+            GestureDirection::Up,
+            Action::Copy,
+        );
+
+        match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+            Some(Binding::Gesture(map)) => {
+                assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
+                assert_eq!(
+                    map.get(&GestureDirection::Click),
+                    Some(&crate::binding::default_gesture_binding(
+                        GestureDirection::Click
+                    )),
+                    "a fresh gesture button must seed a Click from its default"
+                );
+            }
+            other => panic!("expected Gesture, got {other:?}"),
         }
     }
 }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -16,13 +16,19 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::binding::{Action, ButtonId, GestureDirection};
+use crate::binding::{Action, Binding, ButtonId, GestureDirection};
 use crate::paths::{self, PathsError};
 
 /// The schema version the current build produces. Bumped on breaking layout
 /// changes; readers branch on the parsed value before consuming the rest of
 /// the file.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2 merged the per-device `button_bindings` + `gesture_bindings` maps into a
+/// single `bindings: BTreeMap<ButtonId, Binding>`. A v1 file still loads (the
+/// [`RawDeviceConfig`] shim folds the legacy fields) and self-heals to v2 on the
+/// next save; [`Config::load_from_path`] rejects only versions *newer* than this
+/// so a forward file fails loudly instead of silently losing bindings.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -197,22 +203,28 @@ where
 }
 
 /// Settings scoped to a single physical device (keyed by HID++ model+ext).
+///
+/// Deserialization goes through [`RawDeviceConfig`] (`#[serde(from)]`) so
+/// pre-v2 files — which split bindings across `button_bindings` +
+/// `gesture_bindings` — fold into the unified [`Self::bindings`] map. Only
+/// `bindings` is ever serialized, so a migrated file self-heals to the v2 shape
+/// on its next save.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(from = "RawDeviceConfig")]
 pub struct DeviceConfig {
+    /// Every rebindable button's binding: a single [`Action`], or — for the
+    /// gesture button (and, later, any raw-XY-capable button) — a
+    /// [`Binding::Gesture`] per-direction map.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub button_bindings: BTreeMap<ButtonId, Action>,
+    pub bindings: BTreeMap<ButtonId, Binding>,
     /// Per-application binding overlays (P1.4). Keyed by bundle identifier
     /// (e.g. `"com.microsoft.VSCode"` on macOS). When the foreground app's
     /// id matches a key here, those bindings take precedence; anything not
-    /// listed falls through to `button_bindings`.
+    /// listed falls through to `bindings`. Deliberately `Action`-valued (not
+    /// `Binding`): a per-app override replaces the whole button with one
+    /// action, never a per-direction gesture overlay.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub per_app_bindings: BTreeMap<String, BTreeMap<ButtonId, Action>>,
-    /// Sub-bindings for the gesture button: hold + swipe direction or a
-    /// plain click. Edited via the gesture picker; the legacy single
-    /// `button_bindings[GestureButton]` entry is ignored on devices that
-    /// have entries here. Hardware dispatch is a P1.5 follow-up.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub gesture_bindings: BTreeMap<GestureDirection, Action>,
     /// Ordered list of DPI presets cycled through by
     /// [`Action::CycleDpiPresets`] and indexed by
     /// [`Action::SetDpiPreset`]. Empty means "no presets configured" —
@@ -223,6 +235,56 @@ pub struct DeviceConfig {
     /// until the user changes it, so it stays out of `config.toml` otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lighting: Option<Lighting>,
+}
+
+/// Deserialize-only shim that folds the pre-v2 `button_bindings` +
+/// `gesture_bindings` fields into [`DeviceConfig::bindings`]. Never serialized
+/// (only [`DeviceConfig`] is), so reading a legacy file and saving rewrites it
+/// in the v2 shape.
+#[derive(Deserialize)]
+struct RawDeviceConfig {
+    /// v2 shape — present on already-migrated files; wins on any key collision.
+    #[serde(default)]
+    bindings: BTreeMap<ButtonId, Binding>,
+    /// Legacy v1 per-button single bindings.
+    #[serde(default)]
+    button_bindings: BTreeMap<ButtonId, Action>,
+    /// Legacy v1 flat gesture map (implicitly the gesture button's directions).
+    #[serde(default)]
+    gesture_bindings: BTreeMap<GestureDirection, Action>,
+    #[serde(default)]
+    per_app_bindings: BTreeMap<String, BTreeMap<ButtonId, Action>>,
+    #[serde(default)]
+    dpi_presets: Vec<u32>,
+    #[serde(default)]
+    lighting: Option<Lighting>,
+}
+
+impl From<RawDeviceConfig> for DeviceConfig {
+    fn from(raw: RawDeviceConfig) -> Self {
+        let mut bindings = raw.bindings; // the v2 map wins on every key.
+
+        // Re-home the legacy flat gesture map under `GestureButton`. This MUST
+        // happen before folding `button_bindings`, so a legacy single
+        // `button_bindings[GestureButton]` entry coexisting with a
+        // `gesture_bindings` map cannot claim the slot first and silently drop
+        // the whole direction map (the pre-v2 rule was "gesture entries win").
+        if !raw.gesture_bindings.is_empty() {
+            bindings
+                .entry(ButtonId::GestureButton)
+                .or_insert_with(|| Binding::Gesture(raw.gesture_bindings));
+        }
+        for (button, action) in raw.button_bindings {
+            bindings.entry(button).or_insert(Binding::Single(action));
+        }
+
+        DeviceConfig {
+            bindings,
+            per_app_bindings: raw.per_app_bindings,
+            dpi_presets: raw.dpi_presets,
+            lighting: raw.lighting,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -269,16 +331,26 @@ impl Config {
     pub fn load_from_path(path: &Path) -> Result<Self, ConfigError> {
         match fs::read_to_string(path) {
             Ok(text) => {
-                let config: Self = toml::from_str(&text).map_err(|source| ConfigError::Parse {
-                    path: path.to_path_buf(),
-                    source,
-                })?;
-                if config.schema_version != SCHEMA_VERSION {
+                let mut config: Self =
+                    toml::from_str(&text).map_err(|source| ConfigError::Parse {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+                // Accept any version up to the current one: older files migrate
+                // through the per-device [`RawDeviceConfig`] shim and self-heal on
+                // the next save. Only a *newer* file is rejected — loudly, so a
+                // downgraded binary refuses to load (and silently wipe) a config
+                // it can't represent.
+                if config.schema_version > SCHEMA_VERSION {
                     return Err(ConfigError::UnsupportedSchemaVersion {
                         path: path.to_path_buf(),
                         found: config.schema_version,
                     });
                 }
+                // Stamp the in-memory doc to the current version so a re-save
+                // writes the migrated v2 shape (the device shim already folded
+                // the legacy fields during deserialize).
+                config.schema_version = SCHEMA_VERSION;
                 Ok(config)
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
@@ -314,50 +386,73 @@ impl Config {
     /// Returns the bindings stored for `device_key`, or an empty map if the
     /// device has no committed bindings yet.
     #[must_use]
-    pub fn bindings_for(&self, device_key: &str) -> BTreeMap<ButtonId, Action> {
+    pub fn bindings_for(&self, device_key: &str) -> BTreeMap<ButtonId, Binding> {
         self.devices
             .get(device_key)
-            .map(|d| d.button_bindings.clone())
+            .map(|d| d.bindings.clone())
             .unwrap_or_default()
     }
 
-    /// Records `action` as the binding for `button` on `device_key`,
-    /// creating the device entry if needed.
-    pub fn set_binding(&mut self, device_key: &str, button: ButtonId, action: Action) {
+    /// Records `binding` for `button` on `device_key`, creating the device
+    /// entry if needed. Replaces the whole binding (use
+    /// [`Self::set_gesture_direction`] to edit one direction of a gesture
+    /// binding in place).
+    pub fn set_binding(&mut self, device_key: &str, button: ButtonId, binding: Binding) {
         self.devices
             .entry(device_key.to_string())
             .or_default()
-            .button_bindings
-            .insert(button, action);
+            .bindings
+            .insert(button, binding);
     }
 
-    /// Returns the gesture sub-bindings stored for `device_key`, or an empty
-    /// map if none are set yet.
+    /// Returns the gesture sub-bindings for `device_key`'s gesture button, or an
+    /// empty map if it isn't in gesture mode. Derived from the unified
+    /// [`DeviceConfig::bindings`]; kept as a convenience for the agent-side
+    /// per-direction adapter.
     #[must_use]
     pub fn gesture_bindings_for(&self, device_key: &str) -> BTreeMap<GestureDirection, Action> {
-        self.devices
+        match self
+            .devices
             .get(device_key)
-            .map(|d| d.gesture_bindings.clone())
-            .unwrap_or_default()
+            .and_then(|d| d.bindings.get(&ButtonId::GestureButton))
+        {
+            Some(Binding::Gesture(map)) => map.clone(),
+            _ => BTreeMap::new(),
+        }
     }
 
-    /// Records `action` for `direction` of `device_key`'s gesture button.
-    pub fn set_gesture_binding(
+    /// Records `action` for one `direction` of `button`'s gesture binding,
+    /// creating the device entry if needed. A button with no binding (or a
+    /// [`Binding::Single`]) is upgraded to [`Binding::Gesture`], preserving any
+    /// prior single action as the [`GestureDirection::Click`] entry.
+    pub fn set_gesture_direction(
         &mut self,
         device_key: &str,
+        button: ButtonId,
         direction: GestureDirection,
         action: Action,
     ) {
-        self.devices
+        let entry = self
+            .devices
             .entry(device_key.to_string())
             .or_default()
-            .gesture_bindings
-            .insert(direction, action);
+            .bindings
+            .entry(button)
+            .or_insert_with(|| Binding::Gesture(BTreeMap::new()));
+        if let Binding::Single(prev) = entry {
+            let mut map = BTreeMap::new();
+            map.insert(GestureDirection::Click, prev.clone());
+            *entry = Binding::Gesture(map);
+        }
+        if let Binding::Gesture(map) = entry {
+            map.insert(direction, action);
+        }
     }
 
     /// Resolve the effective binding map for `device_key`, overlaying the
     /// per-app entry for `bundle_id` (if any) on top of the global per-device
-    /// `button_bindings`. Per-app values win; everything else falls through.
+    /// `bindings`. A per-app override replaces the whole button with a
+    /// [`Binding::Single`]; everything else falls through.
     ///
     /// Returns an empty map when the device has no recorded bindings yet.
     /// Callers (the GUI / hook) layer their own defaults on top.
@@ -366,15 +461,15 @@ impl Config {
         &self,
         device_key: &str,
         bundle_id: Option<&str>,
-    ) -> BTreeMap<ButtonId, Action> {
+    ) -> BTreeMap<ButtonId, Binding> {
         let Some(device) = self.devices.get(device_key) else {
             return BTreeMap::new();
         };
-        let mut out = device.button_bindings.clone();
+        let mut out = device.bindings.clone();
         if let Some(bid) = bundle_id {
             if let Some(overlay) = device.per_app_bindings.get(bid) {
                 for (k, v) in overlay {
-                    out.insert(*k, v.clone());
+                    out.insert(*k, Binding::Single(v.clone()));
                 }
             }
         }
@@ -536,34 +631,39 @@ mod tests {
     #[test]
     fn bindings_roundtrip_per_device() {
         let mut cfg = Config::default();
-        cfg.set_binding("2b042", ButtonId::Back, Action::Copy);
+        cfg.set_binding("2b042", ButtonId::Back, Binding::Single(Action::Copy));
         cfg.set_binding(
             "2b042",
             ButtonId::DpiToggle,
-            Action::CustomShortcut(crate::binding::KeyCombo {
+            Binding::Single(Action::CustomShortcut(crate::binding::KeyCombo {
                 modifiers: crate::binding::KeyCombo::MOD_CMD,
                 key_code: 0x23, // kVK_ANSI_P
                 display: "⌘P".into(),
-            }),
+            })),
         );
-        cfg.set_binding("4082d", ButtonId::Back, Action::Paste);
+        cfg.set_binding("4082d", ButtonId::Back, Binding::Single(Action::Paste));
 
         let parsed = write_and_read(&cfg);
 
         // Per-device isolation.
         let a = parsed.bindings_for("2b042");
-        assert_eq!(a.get(&ButtonId::Back), Some(&Action::Copy));
+        assert_eq!(a.get(&ButtonId::Back), Some(&Binding::Single(Action::Copy)));
         assert_eq!(
             a.get(&ButtonId::DpiToggle),
-            Some(&Action::CustomShortcut(crate::binding::KeyCombo {
-                modifiers: crate::binding::KeyCombo::MOD_CMD,
-                key_code: 0x23,
-                display: "⌘P".into(),
-            }))
+            Some(&Binding::Single(Action::CustomShortcut(
+                crate::binding::KeyCombo {
+                    modifiers: crate::binding::KeyCombo::MOD_CMD,
+                    key_code: 0x23,
+                    display: "⌘P".into(),
+                }
+            )))
         );
 
         let b = parsed.bindings_for("4082d");
-        assert_eq!(b.get(&ButtonId::Back), Some(&Action::Paste));
+        assert_eq!(
+            b.get(&ButtonId::Back),
+            Some(&Binding::Single(Action::Paste))
+        );
         assert_eq!(b.len(), 1, "device b should only see its own bindings");
 
         // Unknown device returns empty map without panic.
@@ -573,17 +673,20 @@ mod tests {
     #[test]
     fn human_readable_toml_layout() {
         let mut cfg = Config::default();
-        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack);
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Back,
+            Binding::Single(Action::BrowserBack),
+        );
         let body = toml::to_string_pretty(&cfg).expect("serialize");
 
         // The model id only contains [A-Za-z0-9_], so TOML emits it as a
         // bare-word table key (no surrounding quotes). The test asserts the
         // observable structure rather than locking in a specific quoting.
-        assert!(body.contains("schema_version = 1"), "got: {body}");
-        assert!(
-            body.contains("[devices.2b042.button_bindings]"),
-            "got: {body}"
-        );
+        assert!(body.contains("schema_version = 2"), "got: {body}");
+        assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
+        // A `Single` binding serializes byte-identically to the pre-v2 bare
+        // `Action`, so the leaf line is unchanged.
         assert!(body.contains("Back = \"BrowserBack\""), "got: {body}");
     }
 
@@ -616,7 +719,7 @@ mod tests {
     fn empty_dpi_presets_skip_serialization() {
         let mut cfg = Config::default();
         // Add a binding so the device block exists.
-        cfg.set_binding("2b042", ButtonId::Back, Action::Copy);
+        cfg.set_binding("2b042", ButtonId::Back, Binding::Single(Action::Copy));
         cfg.set_dpi_presets("2b042", vec![800]);
         cfg.set_dpi_presets("2b042", vec![]); // clear
 
@@ -639,8 +742,16 @@ mod tests {
     #[test]
     fn per_app_overlay_takes_precedence() {
         let mut cfg = Config::default();
-        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack);
-        cfg.set_binding("2b042", ButtonId::Forward, Action::BrowserForward);
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Back,
+            Binding::Single(Action::BrowserBack),
+        );
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Forward,
+            Binding::Single(Action::BrowserForward),
+        );
         cfg.set_per_app_binding(
             "2b042",
             "com.microsoft.VSCode",
@@ -650,23 +761,32 @@ mod tests {
 
         // Global: both buttons are browser nav.
         let global = cfg.effective_bindings("2b042", None);
-        assert_eq!(global.get(&ButtonId::Back), Some(&Action::BrowserBack));
+        assert_eq!(
+            global.get(&ButtonId::Back),
+            Some(&Binding::Single(Action::BrowserBack))
+        );
         assert_eq!(
             global.get(&ButtonId::Forward),
-            Some(&Action::BrowserForward)
+            Some(&Binding::Single(Action::BrowserForward))
         );
 
-        // VSCode: Back overridden, Forward inherits.
+        // VSCode: Back overridden (wrapped as Single), Forward inherits.
         let vscode = cfg.effective_bindings("2b042", Some("com.microsoft.VSCode"));
-        assert_eq!(vscode.get(&ButtonId::Back), Some(&Action::Undo));
+        assert_eq!(
+            vscode.get(&ButtonId::Back),
+            Some(&Binding::Single(Action::Undo))
+        );
         assert_eq!(
             vscode.get(&ButtonId::Forward),
-            Some(&Action::BrowserForward)
+            Some(&Binding::Single(Action::BrowserForward))
         );
 
         // Unrelated app falls through.
         let other = cfg.effective_bindings("2b042", Some("com.apple.Safari"));
-        assert_eq!(other.get(&ButtonId::Back), Some(&Action::BrowserBack));
+        assert_eq!(
+            other.get(&ButtonId::Back),
+            Some(&Binding::Single(Action::BrowserBack))
+        );
     }
 
     #[test]
@@ -718,18 +838,133 @@ mod tests {
     #[test]
     fn empty_device_block_is_skipped_in_output() {
         // Inserting then clearing should not leave a [devices."x"] header
-        // with no bindings under it (skip_serializing_if on button_bindings).
+        // with no bindings under it (skip_serializing_if on bindings).
         let mut cfg = Config::default();
-        cfg.set_binding("2b042", ButtonId::Back, Action::Copy);
+        cfg.set_binding("2b042", ButtonId::Back, Binding::Single(Action::Copy));
         cfg.devices
             .get_mut("2b042")
             .expect("entry")
-            .button_bindings
+            .bindings
             .clear();
         let body = toml::to_string_pretty(&cfg).expect("serialize");
         assert!(
             !body.contains("Back"),
             "cleared bindings should not appear: {body}"
         );
+    }
+
+    #[test]
+    fn migrates_v1_button_and_gesture_bindings() {
+        // A pre-v2 file: split button_bindings + a flat gesture_bindings map.
+        let v1 = "\
+schema_version = 1
+
+[devices.2b042.button_bindings]
+Back = \"BrowserBack\"
+
+[devices.2b042.gesture_bindings]
+Up = \"Copy\"
+Click = \"Paste\"
+";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, v1).expect("write");
+
+        // v1 still loads (version <= current) and folds into the merged map.
+        let cfg = Config::load_from_path(&path).expect("load v1");
+        let bindings = cfg.bindings_for("2b042");
+        assert_eq!(
+            bindings.get(&ButtonId::Back),
+            Some(&Binding::Single(Action::BrowserBack))
+        );
+        let mut gesture = BTreeMap::new();
+        gesture.insert(GestureDirection::Up, Action::Copy);
+        gesture.insert(GestureDirection::Click, Action::Paste);
+        assert_eq!(
+            bindings.get(&ButtonId::GestureButton),
+            Some(&Binding::Gesture(gesture))
+        );
+
+        // Saving self-heals to the v2 shape: stamped version + merged table,
+        // legacy field names gone.
+        let body = toml::to_string_pretty(&cfg).expect("serialize");
+        assert!(body.contains("schema_version = 2"), "got: {body}");
+        assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
+        assert!(!body.contains("button_bindings"), "got: {body}");
+        assert!(!body.contains("gesture_bindings"), "got: {body}");
+    }
+
+    #[test]
+    fn migration_gesture_map_wins_over_legacy_single_gesture_button_entry() {
+        // The data-loss guard: when a legacy single button_bindings[GestureButton]
+        // entry coexists with a gesture_bindings map (reachable via hand-edited
+        // or very old configs), the gesture map must survive — not be shadowed by
+        // the single entry. Mirrors the pre-v2 "gesture entries win" rule.
+        let v1 = "\
+schema_version = 1
+
+[devices.2b042.button_bindings]
+GestureButton = \"MissionControl\"
+
+[devices.2b042.gesture_bindings]
+Up = \"Copy\"
+Down = \"Paste\"
+";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, v1).expect("write");
+
+        let cfg = Config::load_from_path(&path).expect("load v1");
+        let mut gesture = BTreeMap::new();
+        gesture.insert(GestureDirection::Up, Action::Copy);
+        gesture.insert(GestureDirection::Down, Action::Paste);
+        assert_eq!(
+            cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
+            Some(&Binding::Gesture(gesture)),
+            "gesture map must win over the legacy single GestureButton entry"
+        );
+    }
+
+    #[test]
+    fn rejects_newer_schema_version_but_accepts_v1() {
+        // A future version is rejected loudly; the current and older versions
+        // load (older ones migrate through the shim).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "schema_version = 99\n").expect("write");
+        assert!(matches!(
+            Config::load_from_path(&path).expect_err("v99 should fail"),
+            ConfigError::UnsupportedSchemaVersion { found: 99, .. }
+        ));
+
+        fs::write(&path, "schema_version = 1\n").expect("write");
+        assert!(
+            Config::load_from_path(&path).is_ok(),
+            "v1 should still load"
+        );
+    }
+
+    #[test]
+    fn set_gesture_direction_upgrades_single_to_gesture() {
+        let mut cfg = Config::default();
+        // Start from a Single binding, then bind a swipe direction.
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Back,
+            Binding::Single(Action::BrowserBack),
+        );
+        cfg.set_gesture_direction("2b042", ButtonId::Back, GestureDirection::Up, Action::Copy);
+
+        match cfg.bindings_for("2b042").get(&ButtonId::Back) {
+            Some(Binding::Gesture(map)) => {
+                // The prior single action is preserved as the Click entry.
+                assert_eq!(
+                    map.get(&GestureDirection::Click),
+                    Some(&Action::BrowserBack)
+                );
+                assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
+            }
+            other => panic!("expected Gesture after upgrade, got {other:?}"),
+        }
     }
 }

--- a/crates/openlogi-gui/action-icons/arrow-left.svg
+++ b/crates/openlogi-gui/action-icons/arrow-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 19-7-7 7-7" />
+  <path d="M19 12H5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/arrow-right.svg
+++ b/crates/openlogi-gui/action-icons/arrow-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 12h14" />
+  <path d="m12 5 7 7-7 7" />
+</svg>

--- a/crates/openlogi-gui/action-icons/ban.svg
+++ b/crates/openlogi-gui/action-icons/ban.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M4.929 4.929 19.07 19.071" />
+</svg>

--- a/crates/openlogi-gui/action-icons/camera.svg
+++ b/crates/openlogi-gui/action-icons/camera.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z" />
+  <circle cx="12" cy="13" r="3" />
+</svg>

--- a/crates/openlogi-gui/action-icons/chevron-left.svg
+++ b/crates/openlogi-gui/action-icons/chevron-left.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 18-6-6 6-6" />
+</svg>

--- a/crates/openlogi-gui/action-icons/chevron-right.svg
+++ b/crates/openlogi-gui/action-icons/chevron-right.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m9 18 6-6-6-6" />
+</svg>

--- a/crates/openlogi-gui/action-icons/chevrons-down.svg
+++ b/crates/openlogi-gui/action-icons/chevrons-down.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m7 6 5 5 5-5" />
+  <path d="m7 13 5 5 5-5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/chevrons-left.svg
+++ b/crates/openlogi-gui/action-icons/chevrons-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m11 17-5-5 5-5" />
+  <path d="m18 17-5-5 5-5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/chevrons-right.svg
+++ b/crates/openlogi-gui/action-icons/chevrons-right.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 17 5-5-5-5" />
+  <path d="m13 17 5-5-5-5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/chevrons-up.svg
+++ b/crates/openlogi-gui/action-icons/chevrons-up.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m17 11-5-5-5 5" />
+  <path d="m17 18-5-5-5 5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/clipboard-paste.svg
+++ b/crates/openlogi-gui/action-icons/clipboard-paste.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11 14h10" />
+  <path d="M16 4h2a2 2 0 0 1 2 2v1.344" />
+  <path d="m17 18 4-4-4-4" />
+  <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 1.793-1.113" />
+  <rect x="8" y="2" width="8" height="4" rx="1" />
+</svg>

--- a/crates/openlogi-gui/action-icons/copy.svg
+++ b/crates/openlogi-gui/action-icons/copy.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+  <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+</svg>

--- a/crates/openlogi-gui/action-icons/gauge.svg
+++ b/crates/openlogi-gui/action-icons/gauge.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 14 4-4" />
+  <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+</svg>

--- a/crates/openlogi-gui/action-icons/grid-3x3.svg
+++ b/crates/openlogi-gui/action-icons/grid-3x3.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M3 9h18" />
+  <path d="M3 15h18" />
+  <path d="M9 3v18" />
+  <path d="M15 3v18" />
+</svg>

--- a/crates/openlogi-gui/action-icons/keyboard.svg
+++ b/crates/openlogi-gui/action-icons/keyboard.svg
@@ -1,0 +1,21 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 8h.01" />
+  <path d="M12 12h.01" />
+  <path d="M14 8h.01" />
+  <path d="M16 12h.01" />
+  <path d="M18 8h.01" />
+  <path d="M6 8h.01" />
+  <path d="M7 16h10" />
+  <path d="M8 12h.01" />
+  <rect width="20" height="16" x="2" y="4" rx="2" />
+</svg>

--- a/crates/openlogi-gui/action-icons/layers.svg
+++ b/crates/openlogi-gui/action-icons/layers.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z" />
+  <path d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12" />
+  <path d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17" />
+</svg>

--- a/crates/openlogi-gui/action-icons/layout-grid.svg
+++ b/crates/openlogi-gui/action-icons/layout-grid.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="7" height="7" x="3" y="3" rx="1" />
+  <rect width="7" height="7" x="14" y="3" rx="1" />
+  <rect width="7" height="7" x="14" y="14" rx="1" />
+  <rect width="7" height="7" x="3" y="14" rx="1" />
+</svg>

--- a/crates/openlogi-gui/action-icons/list-checks.svg
+++ b/crates/openlogi-gui/action-icons/list-checks.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 5h8" />
+  <path d="M13 12h8" />
+  <path d="M13 19h8" />
+  <path d="m3 17 2 2 4-4" />
+  <path d="m3 7 2 2 4-4" />
+</svg>

--- a/crates/openlogi-gui/action-icons/lock.svg
+++ b/crates/openlogi-gui/action-icons/lock.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+</svg>

--- a/crates/openlogi-gui/action-icons/monitor.svg
+++ b/crates/openlogi-gui/action-icons/monitor.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="14" x="2" y="3" rx="2" />
+  <line x1="8" x2="16" y1="21" y2="21" />
+  <line x1="12" x2="12" y1="17" y2="21" />
+</svg>

--- a/crates/openlogi-gui/action-icons/mouse-pointer-click.svg
+++ b/crates/openlogi-gui/action-icons/mouse-pointer-click.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M14 4.1 12 6" />
+  <path d="m5.1 8-2.9-.8" />
+  <path d="m6 12-1.9 2" />
+  <path d="M7.2 2.2 8 5.1" />
+  <path d="M9.037 9.69a.498.498 0 0 1 .653-.653l11 4.5a.5.5 0 0 1-.074.949l-4.349 1.041a1 1 0 0 0-.74.739l-1.04 4.35a.5.5 0 0 1-.95.074z" />
+</svg>

--- a/crates/openlogi-gui/action-icons/mouse.svg
+++ b/crates/openlogi-gui/action-icons/mouse.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect x="5" y="2" width="14" height="20" rx="7" />
+  <path d="M12 6v4" />
+</svg>

--- a/crates/openlogi-gui/action-icons/move.svg
+++ b/crates/openlogi-gui/action-icons/move.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 2v20" />
+  <path d="m15 19-3 3-3-3" />
+  <path d="m19 9 3 3-3 3" />
+  <path d="M2 12h20" />
+  <path d="m5 9-3 3 3 3" />
+  <path d="m9 5 3-3 3 3" />
+</svg>

--- a/crates/openlogi-gui/action-icons/play.svg
+++ b/crates/openlogi-gui/action-icons/play.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z" />
+</svg>

--- a/crates/openlogi-gui/action-icons/redo-2.svg
+++ b/crates/openlogi-gui/action-icons/redo-2.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m15 14 5-5-5-5" />
+  <path d="M20 9H9.5A5.5 5.5 0 0 0 4 14.5A5.5 5.5 0 0 0 9.5 20H13" />
+</svg>

--- a/crates/openlogi-gui/action-icons/refresh-cw.svg
+++ b/crates/openlogi-gui/action-icons/refresh-cw.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+  <path d="M21 3v5h-5" />
+  <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+  <path d="M8 16H3v5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/rotate-ccw.svg
+++ b/crates/openlogi-gui/action-icons/rotate-ccw.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+  <path d="M3 3v5h5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/rotate-cw.svg
+++ b/crates/openlogi-gui/action-icons/rotate-cw.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" />
+  <path d="M21 3v5h-5" />
+</svg>

--- a/crates/openlogi-gui/action-icons/save.svg
+++ b/crates/openlogi-gui/action-icons/save.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z" />
+  <path d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7" />
+  <path d="M7 3v4a1 1 0 0 0 1 1h7" />
+</svg>

--- a/crates/openlogi-gui/action-icons/scissors.svg
+++ b/crates/openlogi-gui/action-icons/scissors.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="6" cy="6" r="3" />
+  <path d="M8.12 8.12 12 12" />
+  <path d="M20 4 8.12 15.88" />
+  <circle cx="6" cy="18" r="3" />
+  <path d="M14.8 14.8 20 20" />
+</svg>

--- a/crates/openlogi-gui/action-icons/search.svg
+++ b/crates/openlogi-gui/action-icons/search.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m21 21-4.34-4.34" />
+  <circle cx="11" cy="11" r="8" />
+</svg>

--- a/crates/openlogi-gui/action-icons/skip-back.svg
+++ b/crates/openlogi-gui/action-icons/skip-back.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M17.971 4.285A2 2 0 0 1 21 6v12a2 2 0 0 1-3.029 1.715l-9.997-5.998a2 2 0 0 1-.003-3.432z" />
+  <path d="M3 20V4" />
+</svg>

--- a/crates/openlogi-gui/action-icons/skip-forward.svg
+++ b/crates/openlogi-gui/action-icons/skip-forward.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 4v16" />
+  <path d="M6.029 4.285A2 2 0 0 0 3 6v12a2 2 0 0 0 3.029 1.715l9.997-5.998a2 2 0 0 0 .003-3.432z" />
+</svg>

--- a/crates/openlogi-gui/action-icons/square-arrow-left.svg
+++ b/crates/openlogi-gui/action-icons/square-arrow-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="m12 8-4 4 4 4" />
+  <path d="M16 12H8" />
+</svg>

--- a/crates/openlogi-gui/action-icons/square-arrow-right.svg
+++ b/crates/openlogi-gui/action-icons/square-arrow-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M8 12h8" />
+  <path d="m12 16 4-4-4-4" />
+</svg>

--- a/crates/openlogi-gui/action-icons/square-plus.svg
+++ b/crates/openlogi-gui/action-icons/square-plus.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" />
+  <path d="M8 12h8" />
+  <path d="M12 8v8" />
+</svg>

--- a/crates/openlogi-gui/action-icons/square-x.svg
+++ b/crates/openlogi-gui/action-icons/square-x.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+  <path d="m15 9-6 6" />
+  <path d="m9 9 6 6" />
+</svg>

--- a/crates/openlogi-gui/action-icons/undo-2.svg
+++ b/crates/openlogi-gui/action-icons/undo-2.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 14 4 9l5-5" />
+  <path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11" />
+</svg>

--- a/crates/openlogi-gui/action-icons/volume-1.svg
+++ b/crates/openlogi-gui/action-icons/volume-1.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
+  <path d="M16 9a5 5 0 0 1 0 6" />
+</svg>

--- a/crates/openlogi-gui/action-icons/volume-2.svg
+++ b/crates/openlogi-gui/action-icons/volume-2.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
+  <path d="M16 9a5 5 0 0 1 0 6" />
+  <path d="M19.364 18.364a9 9 0 0 0 0-12.728" />
+</svg>

--- a/crates/openlogi-gui/action-icons/volume-x.svg
+++ b/crates/openlogi-gui/action-icons/volume-x.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
+  <line x1="22" x2="16" y1="9" y2="15" />
+  <line x1="16" x2="22" y1="9" y2="15" />
+</svg>

--- a/crates/openlogi-gui/src/app_assets.rs
+++ b/crates/openlogi-gui/src/app_assets.rs
@@ -19,13 +19,68 @@ const LOGO_BYTES: &[u8] = include_bytes!(concat!(
     "/../../design/icon/openlogi.png"
 ));
 
-/// GPUI asset source: the embedded logo plus gpui-component's bundled icons.
+/// Vendored [lucide](https://lucide.dev) icons (ISC license) for the binding
+/// menus, embedded so they resolve identically in a packaged `.app` and a dev
+/// build. Served under the `action-icons/` path prefix and rendered by
+/// `mouse_model::picker::action_icon_path` via `svg().path(..)`. These are
+/// command glyphs (paste / cut / volume / lock / …) that gpui-component's
+/// bundled `IconName` set (UI chrome only) does not cover.
+#[rustfmt::skip]
+const ACTION_ICONS: &[(&str, &[u8])] = &[
+    ("action-icons/arrow-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/arrow-left.svg"))),
+    ("action-icons/arrow-right.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/arrow-right.svg"))),
+    ("action-icons/ban.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/ban.svg"))),
+    ("action-icons/camera.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/camera.svg"))),
+    ("action-icons/chevron-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevron-left.svg"))),
+    ("action-icons/chevron-right.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevron-right.svg"))),
+    ("action-icons/chevrons-down.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevrons-down.svg"))),
+    ("action-icons/chevrons-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevrons-left.svg"))),
+    ("action-icons/chevrons-right.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevrons-right.svg"))),
+    ("action-icons/chevrons-up.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevrons-up.svg"))),
+    ("action-icons/clipboard-paste.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/clipboard-paste.svg"))),
+    ("action-icons/copy.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/copy.svg"))),
+    ("action-icons/gauge.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/gauge.svg"))),
+    ("action-icons/grid-3x3.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/grid-3x3.svg"))),
+    ("action-icons/keyboard.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/keyboard.svg"))),
+    ("action-icons/layers.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/layers.svg"))),
+    ("action-icons/layout-grid.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/layout-grid.svg"))),
+    ("action-icons/list-checks.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/list-checks.svg"))),
+    ("action-icons/lock.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/lock.svg"))),
+    ("action-icons/monitor.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/monitor.svg"))),
+    ("action-icons/mouse-pointer-click.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse-pointer-click.svg"))),
+    ("action-icons/mouse.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse.svg"))),
+    ("action-icons/move.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/move.svg"))),
+    ("action-icons/play.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/play.svg"))),
+    ("action-icons/redo-2.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/redo-2.svg"))),
+    ("action-icons/refresh-cw.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/refresh-cw.svg"))),
+    ("action-icons/rotate-ccw.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/rotate-ccw.svg"))),
+    ("action-icons/rotate-cw.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/rotate-cw.svg"))),
+    ("action-icons/save.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/save.svg"))),
+    ("action-icons/scissors.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/scissors.svg"))),
+    ("action-icons/search.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/search.svg"))),
+    ("action-icons/skip-back.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/skip-back.svg"))),
+    ("action-icons/skip-forward.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/skip-forward.svg"))),
+    ("action-icons/square-arrow-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/square-arrow-left.svg"))),
+    ("action-icons/square-arrow-right.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/square-arrow-right.svg"))),
+    ("action-icons/square-plus.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/square-plus.svg"))),
+    ("action-icons/square-x.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/square-x.svg"))),
+    ("action-icons/undo-2.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/undo-2.svg"))),
+    ("action-icons/volume-1.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/volume-1.svg"))),
+    ("action-icons/volume-2.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/volume-2.svg"))),
+    ("action-icons/volume-x.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/volume-x.svg"))),
+];
+
+/// GPUI asset source: the embedded logo + vendored action icons, then
+/// gpui-component's bundled icons for everything else.
 pub struct AppAssets;
 
 impl AssetSource for AppAssets {
     fn load(&self, path: &str) -> Result<Option<Cow<'static, [u8]>>> {
         if path == LOGO {
             return Ok(Some(Cow::Borrowed(LOGO_BYTES)));
+        }
+        if let Some((_, bytes)) = ACTION_ICONS.iter().find(|(p, _)| *p == path) {
+            return Ok(Some(Cow::Borrowed(*bytes)));
         }
         gpui_component_assets::Assets.load(path)
     }

--- a/crates/openlogi-gui/src/data/mouse_buttons.rs
+++ b/crates/openlogi-gui/src/data/mouse_buttons.rs
@@ -13,7 +13,7 @@
 )]
 
 pub use openlogi_core::binding::{
-    Action, ButtonId, Category, GestureDirection, default_binding, default_gesture_binding,
+    Action, Binding, ButtonId, Category, GestureDirection, default_binding, default_gesture_binding,
 };
 
 /// The size of the mouse model canvas. Hotspot coords are relative to this.

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -24,9 +24,9 @@ use std::rc::Rc;
 use gpui::{
     AnyElement, App, BorrowAppContext as _, Context, Entity, FontWeight, InteractiveElement,
     IntoElement, ParentElement, StatefulInteractiveElement as _, Styled, Window, div, hsla,
-    prelude::FluentBuilder as _, px, rgb,
+    prelude::FluentBuilder as _, px, rgb, svg,
 };
-use gpui_component::{h_flex, popover::PopoverState, v_flex};
+use gpui_component::{Icon, IconName, h_flex, popover::PopoverState, v_flex};
 
 use crate::data::mouse_buttons::{
     Action, ButtonId, Category, GestureDirection, default_gesture_binding,
@@ -70,7 +70,7 @@ pub fn action_picker<T: 'static>(
 
     let pal = theme::palette(cx);
     let button = rust_i18n::t!(btn.label());
-    v_flex()
+    menu_card(pal)
         .min_w(px(POPOVER_W))
         .child(title(tr!("Bind %{name}", name => button), pal))
         .child(divider(pal))
@@ -107,16 +107,21 @@ pub fn gesture_overview(
         .into_any_element()
 }
 
-/// Apply the floating-card surface (own bg, border, rounding, shadow, padding)
-/// shared by both menu levels so they read as separate panels.
-fn gesture_card(pal: Palette) -> gpui::Stateful<gpui::Div> {
+/// The shared floating-card surface for every binding menu — the button picker,
+/// the gesture plus navigator, and its action flyout — so they read as one
+/// consistent, app-branded panel instead of two different surfaces.
+///
+/// Radius scale (shape lock): interactive rows/cells use `rounded_md` (6px); the
+/// card uses `rounded_lg` (8px). The shadow is gpui's soft `shadow_md`, not a
+/// hard drop. Not stateful (no interaction → no element id, so two sibling cards
+/// can't collide on one).
+fn menu_card(pal: Palette) -> gpui::Div {
     v_flex()
-        .id("gesture-card")
         .bg(pal.surface)
         .border_1()
         .border_color(pal.border)
         .rounded_lg()
-        .shadow_lg()
+        .shadow_md()
         .p_1p5()
 }
 
@@ -141,20 +146,10 @@ fn plus_card(
         })
         .collect();
 
-    let view = view.clone();
-    let on_select: SelectFn = Rc::new(move |dir, cx| {
-        view.update(cx, |v, vcx| {
-            // Toggle: clicking the already-active cell again closes its flyout.
-            let next = (v.gesture_selected_dir() != Some(dir)).then_some(dir);
-            v.set_gesture_selected_dir(next);
-            vcx.notify();
-        });
-    });
-    let cell = |dir: GestureDirection| {
-        direction_cell(dir, &actions[&dir], active == Some(dir), &on_select, pal)
-    };
+    let cell =
+        |dir: GestureDirection| direction_cell(dir, &actions[&dir], active == Some(dir), view, pal);
 
-    gesture_card(pal)
+    menu_card(pal)
         .gap_1p5()
         .child(
             h_flex()
@@ -187,7 +182,7 @@ fn direction_cell(
     dir: GestureDirection,
     current: &Action,
     active: bool,
-    on_select: &SelectFn,
+    view: &Entity<MouseModelView>,
     pal: Palette,
 ) -> AnyElement {
     let idx = match dir {
@@ -200,7 +195,7 @@ fn direction_cell(
     let header = format!("{}  {}", dir.glyph(), tr!(dir.label()));
     let action_label = tr!(current.label());
     let is_default = *current == default_gesture_binding(dir);
-    let on_select = on_select.clone();
+    let view = view.clone();
     v_flex()
         .id(("gesture-cell", idx))
         .w(px(GESTURE_CELL_W))
@@ -227,7 +222,16 @@ fn direction_cell(
                 })
                 .child(action_label),
         )
-        .on_click(move |_event, _window, cx| on_select(dir, cx))
+        // Click opens this direction's flyout; clicking the active cell again
+        // closes it. (Hover-to-open was too easy to mis-trigger while moving the
+        // cursor across the plus.)
+        .on_click(move |_event, _window, cx| {
+            view.update(cx, |v, vcx| {
+                let next = (v.gesture_selected_dir() != Some(dir)).then_some(dir);
+                v.set_gesture_selected_dir(next);
+                vcx.notify();
+            });
+        })
         .into_any_element()
 }
 
@@ -253,7 +257,7 @@ fn flyout_card(
         view_pick.update(cx, |_, vcx| vcx.notify());
     });
 
-    gesture_card(pal)
+    menu_card(pal)
         .min_w(px(POPOVER_W))
         .child(title(format!("{}  {}", dir.glyph(), tr!(dir.label())), pal))
         .child(divider(pal))
@@ -271,10 +275,6 @@ fn flyout_card(
 /// differ only in what they do after committing.
 type PickFn = Rc<dyn Fn(Action, &mut Window, &mut App)>;
 
-/// Callback invoked when a plus cell is clicked: activate that direction so its
-/// level-2 flyout card appears. Boxed so the shared cell builder stays one type.
-type SelectFn = Rc<dyn Fn(GestureDirection, &mut App)>;
-
 /// The action catalog grouped by [`Category`], preserving catalog order within
 /// each group and first-seen order across groups.
 fn grouped_catalog() -> Vec<(Category, Vec<Action>)> {
@@ -290,9 +290,64 @@ fn grouped_catalog() -> Vec<(Category, Vec<Action>)> {
     sections
 }
 
-/// Build the category-grouped action rows. `current` is marked with accent
-/// text + a check glyph; clicking any row invokes `on_pick`. `id_prefix`
-/// disambiguates element IDs between pickers that share this builder.
+/// Icon for the gesture button's label card — lucide `move` (a 4-way arrow
+/// cross), standing in for its five swipe directions since it has no single
+/// bound action.
+pub(crate) const GESTURE_BUTTON_ICON: &str = "action-icons/move.svg";
+
+/// Asset path (served by [`crate::app_assets`]) of the vendored lucide glyph for
+/// an action — the leading icon in each action row and in the leader-line label
+/// card. Exhaustive on purpose: a new [`Action`] variant must pick an icon here
+/// (no catch-all fallback).
+pub(crate) fn action_icon_path(action: &Action) -> &'static str {
+    match action {
+        Action::None => "action-icons/ban.svg",
+        Action::LeftClick | Action::RightClick => "action-icons/mouse-pointer-click.svg",
+        Action::MiddleClick => "action-icons/mouse.svg",
+        Action::Copy => "action-icons/copy.svg",
+        Action::Paste => "action-icons/clipboard-paste.svg",
+        Action::Cut => "action-icons/scissors.svg",
+        Action::Undo => "action-icons/undo-2.svg",
+        Action::Redo => "action-icons/redo-2.svg",
+        Action::SelectAll => "action-icons/list-checks.svg",
+        Action::Find => "action-icons/search.svg",
+        Action::Save => "action-icons/save.svg",
+        Action::BrowserBack => "action-icons/arrow-left.svg",
+        Action::BrowserForward => "action-icons/arrow-right.svg",
+        Action::NewTab => "action-icons/square-plus.svg",
+        Action::CloseTab => "action-icons/square-x.svg",
+        Action::ReopenTab => "action-icons/rotate-ccw.svg",
+        Action::NextTab => "action-icons/chevron-right.svg",
+        Action::PrevTab => "action-icons/chevron-left.svg",
+        Action::ReloadPage => "action-icons/rotate-cw.svg",
+        Action::MissionControl => "action-icons/layout-grid.svg",
+        Action::AppExpose => "action-icons/layers.svg",
+        Action::PreviousDesktop => "action-icons/square-arrow-left.svg",
+        Action::NextDesktop => "action-icons/square-arrow-right.svg",
+        Action::ShowDesktop => "action-icons/monitor.svg",
+        Action::LaunchpadShow => "action-icons/grid-3x3.svg",
+        Action::LockScreen => "action-icons/lock.svg",
+        Action::Screenshot => "action-icons/camera.svg",
+        Action::PlayPause => "action-icons/play.svg",
+        Action::NextTrack => "action-icons/skip-forward.svg",
+        Action::PrevTrack => "action-icons/skip-back.svg",
+        Action::VolumeUp => "action-icons/volume-2.svg",
+        Action::VolumeDown => "action-icons/volume-1.svg",
+        Action::MuteVolume => "action-icons/volume-x.svg",
+        Action::CycleDpiPresets | Action::SetDpiPreset(_) => "action-icons/gauge.svg",
+        Action::ToggleSmartShift => "action-icons/refresh-cw.svg",
+        Action::ScrollUp => "action-icons/chevrons-up.svg",
+        Action::ScrollDown => "action-icons/chevrons-down.svg",
+        Action::HorizontalScrollLeft => "action-icons/chevrons-left.svg",
+        Action::HorizontalScrollRight => "action-icons/chevrons-right.svg",
+        Action::CustomShortcut(_) => "action-icons/keyboard.svg",
+    }
+}
+
+/// Build the category-grouped action rows. Each row leads with the action's
+/// icon, then its label; `current` adds a trailing accent check. Clicking any
+/// row invokes `on_pick`. `id_prefix` disambiguates element IDs between pickers
+/// that share this builder.
 fn action_rows(
     id_prefix: &'static str,
     current: Option<&Action>,
@@ -307,20 +362,31 @@ fn action_rows(
         for action in actions {
             let selected = current == Some(&action);
             let label = tr!(action.label());
+            let icon_path = action_icon_path(&action);
             let on_pick = on_pick.clone();
             let row_id = idx;
             idx += 1;
             children.push(
-                menu_row((id_prefix, row_id), pal)
-                    .text_color(if selected {
-                        rgb(ACCENT_BLUE).into()
-                    } else {
-                        pal.text_primary
-                    })
-                    .when(selected, |s| s.bg(hsla(0.6, 0.9, 0.6, 0.14)))
-                    .child(div().child(label))
+                menu_row((id_prefix, row_id), pal, selected)
+                    .child(
+                        h_flex()
+                            .items_center()
+                            .gap_2()
+                            .child(
+                                svg()
+                                    .path(icon_path)
+                                    .size_4()
+                                    .flex_none()
+                                    .text_color(pal.text_muted),
+                            )
+                            .child(div().child(label)),
+                    )
                     .when(selected, |s| {
-                        s.child(div().text_color(rgb(ACCENT_BLUE)).child("✓"))
+                        s.child(
+                            Icon::new(IconName::Check)
+                                .size_3()
+                                .text_color(rgb(ACCENT_BLUE)),
+                        )
                     })
                     .on_click(move |_event, window, cx| (on_pick)(action.clone(), window, cx))
                     .into_any_element(),
@@ -330,10 +396,21 @@ fn action_rows(
     children
 }
 
-/// A clickable, full-width menu row: transparent at rest, hover-filled,
-/// `text-sm`, with its children spread left/right. Children are added by the
-/// caller.
-fn menu_row(id: impl Into<gpui::ElementId>, pal: Palette) -> gpui::Stateful<gpui::Div> {
+/// A clickable, full-width menu row: `text-sm`, children spread left/right.
+/// The label stays in `text_primary` in both states for readability; selection
+/// is shown by a subtle accent fill (plus the caller's trailing check), and the
+/// fill deepens on hover. Unselected rows are transparent at rest, neutral on
+/// hover. One accent, one signal per state — no blue label text (which fails AA
+/// contrast on the near-white surface).
+fn menu_row(
+    id: impl Into<gpui::ElementId>,
+    pal: Palette,
+    selected: bool,
+) -> gpui::Stateful<gpui::Div> {
+    // Accent fill derived from ACCENT_BLUE (≈ hue 0.6 / sat 0.9 / light 0.6),
+    // kept low-alpha so the row reads as tinted, not painted.
+    let tint = hsla(0.6, 0.9, 0.6, 0.12);
+    let tint_hover = hsla(0.6, 0.9, 0.6, 0.18);
     h_flex()
         .id(id)
         .w_full()
@@ -344,7 +421,15 @@ fn menu_row(id: impl Into<gpui::ElementId>, pal: Palette) -> gpui::Stateful<gpui
         .py_1p5()
         .rounded_md()
         .text_sm()
-        .hover(move |s| s.bg(pal.surface_hover))
+        .text_color(pal.text_primary)
+        .when(selected, |s| s.bg(tint))
+        .hover(move |s| {
+            s.bg(if selected {
+                tint_hover
+            } else {
+                pal.surface_hover
+            })
+        })
 }
 
 /// Small uppercase muted group header.

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -1,24 +1,24 @@
-//! Popover content for binding mouse buttons, plus the gesture button's
-//! cascading menu.
+//! Popover content for binding mouse buttons, plus the gesture button's custom
+//! two-level menu.
 //!
 //! - [`action_picker`] — one button → one [`Action`], rendered as a custom flat
 //!   list inside a gpui-component [`Popover`](gpui_component::popover::Popover).
 //!   Generic over the entity that should be notified after a binding changes so
 //!   the trigger re-renders with the new label.
-//! - [`build_gesture_menu`] — the gesture button's two-level
-//!   [`PopupMenu`](gpui_component::menu::PopupMenu): one submenu per
-//!   [`GestureDirection`], each listing the full action catalog with the
-//!   current binding checked. Picking an action commits straight to
-//!   [`AppState`], whose global observers re-render the model, so the menu
-//!   needs no observer.
+//! - [`gesture_overview`] — the gesture button's custom multi-level menu: a
+//!   plus-shaped navigator card (level 1) listing all five [`GestureDirection`]s
+//!   with their bound actions, and — once a direction is activated — a separate
+//!   action-list card (level 2) that flies out beside it. The two are distinct
+//!   floating cards (own surface + height), so this reads like a cascading menu
+//!   while staying fully custom-styled. The active direction is scratch state on
+//!   the [`MouseModelView`].
 //!
-//! The [`Popover`] wraps the [`action_picker`] content in a styled surface
-//! (background, border, shadow, `p_3` padding), so the layout here stays flat:
-//! no extra card background, no extra outer padding. Rows are transparent until
-//! hovered; the active binding is marked with accent text plus a check glyph
-//! rather than a filled box. The [`PopupMenu`] draws its own surface and check
-//! marks, so the gesture menu defers entirely to the framework's styling.
+//! The [`action_picker`] [`Popover`] uses the framework's styled surface; the
+//! gesture menu uses `appearance(false)` and draws its own card surfaces, since
+//! its two levels need independent panels. Rows are transparent until hovered;
+//! the active binding is marked with accent text plus a check glyph.
 
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use gpui::{
@@ -26,16 +26,12 @@ use gpui::{
     IntoElement, ParentElement, StatefulInteractiveElement as _, Styled, Window, div, hsla,
     prelude::FluentBuilder as _, px, rgb,
 };
-use gpui_component::{
-    h_flex,
-    menu::{PopupMenu, PopupMenuItem},
-    popover::PopoverState,
-    v_flex,
-};
+use gpui_component::{h_flex, popover::PopoverState, v_flex};
 
 use crate::data::mouse_buttons::{
     Action, ButtonId, Category, GestureDirection, default_gesture_binding,
 };
+use crate::mouse_model::view::MouseModelView;
 use crate::state::AppState;
 use crate::theme::{self, ACCENT_BLUE, Palette};
 
@@ -85,58 +81,187 @@ pub fn action_picker<T: 'static>(
         .into_any_element()
 }
 
-/// Build the gesture button's two-level [`PopupMenu`]: one submenu per
-/// [`GestureDirection`], each opening the full action catalog with the current
-/// binding checked. Picking an action commits it to [`AppState`] and dismisses
-/// the whole menu.
-pub fn build_gesture_menu(
-    mut menu: PopupMenu,
-    window: &mut Window,
-    cx: &mut Context<PopupMenu>,
-) -> PopupMenu {
-    for dir in GestureDirection::ALL {
-        // Glyph prefix gives the directional cue the old list had; the bound
-        // action shows up as the checked row inside each submenu.
-        let label = format!("{}  {}", dir.glyph(), tr!(dir.label()));
-        menu = menu.submenu(label, window, cx, move |submenu, _window, cx| {
-            gesture_action_submenu(dir, submenu, cx)
-        });
-    }
-    menu
+/// Floor width of a single direction cell in the plus navigator. Three sit side
+/// by side in the middle row, so the plus is roughly `3×` this plus gaps.
+const GESTURE_CELL_W: f32 = 104.;
+
+/// Build the gesture button's custom two-level menu: the plus navigator card
+/// (level 1) plus, once a direction is activated, its action-list card (level 2)
+/// flown out beside it. The two are separate floating cards — own surface and
+/// height — so it reads like a cascading menu without sharing one box. The
+/// active direction is scratch UI state on the [`MouseModelView`] (`None` until
+/// a cell is clicked → only the plus shows), reset on popover close. Mutating it
+/// re-renders the view, which re-renders this open popover's content.
+pub fn gesture_overview(
+    view: &Entity<MouseModelView>,
+    cx: &mut Context<PopoverState>,
+) -> AnyElement {
+    let pal = theme::palette(cx);
+    let active = view.read(cx).gesture_selected_dir();
+    h_flex()
+        .items_start()
+        .gap_2()
+        .child(plus_card(view, active, pal, cx))
+        // The flyout card only appears once a direction is activated.
+        .when_some(active, |row, dir| row.child(flyout_card(dir, view, pal, cx)))
+        .into_any_element()
 }
 
-/// Populate one direction's action submenu: the category-grouped catalog with
-/// the current binding checked and a commit-on-click handler per row. The
-/// submenu scrolls (the catalog is taller than the window) — it has no further
-/// submenus of its own, so scrolling is allowed.
-fn gesture_action_submenu(
-    direction: GestureDirection,
-    submenu: PopupMenu,
-    cx: &mut Context<PopupMenu>,
-) -> PopupMenu {
+/// Apply the floating-card surface (own bg, border, rounding, shadow, padding)
+/// shared by both menu levels so they read as separate panels.
+fn gesture_card(pal: Palette) -> gpui::Stateful<gpui::Div> {
+    v_flex()
+        .id("gesture-card")
+        .bg(pal.surface)
+        .border_1()
+        .border_color(pal.border)
+        .rounded_lg()
+        .shadow_lg()
+        .p_1p5()
+}
+
+/// Level 1: the plus navigator. `Up` on top, `Left`/`Click`/`Right` across the
+/// middle, `Down` on the bottom. Each cell shows its glyph + label and bound
+/// action; the `active` cell (if any) is accented. Clicking a cell activates
+/// that direction (flying out the level-2 card) without committing.
+fn plus_card(
+    view: &Entity<MouseModelView>,
+    active: Option<GestureDirection>,
+    pal: Palette,
+    cx: &mut Context<PopoverState>,
+) -> AnyElement {
+    let actions: BTreeMap<GestureDirection, Action> = GestureDirection::ALL
+        .into_iter()
+        .map(|d| {
+            let action = cx
+                .try_global::<AppState>()
+                .and_then(|s| s.gesture_bindings.get(&d).cloned())
+                .unwrap_or_else(|| default_gesture_binding(d));
+            (d, action)
+        })
+        .collect();
+
+    let view = view.clone();
+    let on_select: SelectFn = Rc::new(move |dir, cx| {
+        view.update(cx, |v, vcx| {
+            // Toggle: clicking the already-active cell again closes its flyout.
+            let next = (v.gesture_selected_dir() != Some(dir)).then_some(dir);
+            v.set_gesture_selected_dir(next);
+            vcx.notify();
+        });
+    });
+    let cell = |dir: GestureDirection| {
+        direction_cell(dir, &actions[&dir], active == Some(dir), &on_select, pal)
+    };
+
+    gesture_card(pal)
+        .gap_1p5()
+        .child(
+            h_flex()
+                .w_full()
+                .justify_center()
+                .child(cell(GestureDirection::Up)),
+        )
+        .child(
+            h_flex()
+                .w_full()
+                .justify_center()
+                .gap_1p5()
+                .child(cell(GestureDirection::Left))
+                .child(cell(GestureDirection::Click))
+                .child(cell(GestureDirection::Right)),
+        )
+        .child(
+            h_flex()
+                .w_full()
+                .justify_center()
+                .child(cell(GestureDirection::Down)),
+        )
+        .into_any_element()
+}
+
+/// One direction's cell in the plus: a fixed-width clickable card with the
+/// direction glyph + label above its bound-action label. The `active` cell is
+/// accented (border + faint fill); a default binding's action is muted.
+fn direction_cell(
+    dir: GestureDirection,
+    current: &Action,
+    active: bool,
+    on_select: &SelectFn,
+    pal: Palette,
+) -> AnyElement {
+    let idx = match dir {
+        GestureDirection::Up => 0usize,
+        GestureDirection::Down => 1,
+        GestureDirection::Left => 2,
+        GestureDirection::Right => 3,
+        GestureDirection::Click => 4,
+    };
+    let header = format!("{}  {}", dir.glyph(), tr!(dir.label()));
+    let action_label = tr!(current.label());
+    let is_default = *current == default_gesture_binding(dir);
+    let on_select = on_select.clone();
+    v_flex()
+        .id(("gesture-cell", idx))
+        .w(px(GESTURE_CELL_W))
+        .gap(px(2.))
+        .px_2()
+        .py_1p5()
+        .rounded_md()
+        .border_1()
+        .border_color(if active {
+            rgb(ACCENT_BLUE).into()
+        } else {
+            pal.border
+        })
+        .when(active, |s| s.bg(hsla(0.6, 0.9, 0.6, 0.10)))
+        .hover(move |s| s.bg(pal.surface_hover))
+        .child(div().text_xs().text_color(pal.text_muted).child(header))
+        .child(
+            div()
+                .text_sm()
+                .text_color(if is_default {
+                    pal.text_muted
+                } else {
+                    pal.text_primary
+                })
+                .child(action_label),
+        )
+        .on_click(move |_event, _window, cx| on_select(dir, cx))
+        .into_any_element()
+}
+
+/// Level 2: the `dir` direction's action picker, flown out as its own card —
+/// the category-grouped catalog with the current binding checked. Picking
+/// commits and stays open, so the level-1 cell + checkmark update in place and
+/// the user can keep editing other directions.
+fn flyout_card(
+    dir: GestureDirection,
+    view: &Entity<MouseModelView>,
+    pal: Palette,
+    cx: &mut Context<PopoverState>,
+) -> AnyElement {
     let current = cx
         .try_global::<AppState>()
-        .and_then(|s| s.gesture_bindings.get(&direction).cloned())
-        .unwrap_or_else(|| default_gesture_binding(direction));
+        .and_then(|s| s.gesture_bindings.get(&dir).cloned())
+        .unwrap_or_else(|| default_gesture_binding(dir));
 
-    let mut submenu = submenu.scrollable(true).max_h(px(POPOVER_LIST_MAX_H));
-    for (category, actions) in grouped_catalog() {
-        submenu = submenu.label(tr!(category.label()));
-        for action in actions {
-            let checked = action == current;
-            let label = tr!(action.label());
-            let commit = action;
-            submenu = submenu.item(PopupMenuItem::new(label).checked(checked).on_click(
-                move |_event, _window, cx| {
-                    let action = commit.clone();
-                    cx.update_global::<AppState, _>(move |state, _| {
-                        state.commit_gesture_binding(direction, action);
-                    });
-                },
-            ));
-        }
-    }
-    submenu
+    let view_pick = view.clone();
+    let on_pick: PickFn = Rc::new(move |action, _window, cx| {
+        cx.update_global::<AppState, _>(|state, _| state.commit_gesture_binding(dir, action));
+        // Stay open; re-render so the level-1 cell + checkmark update.
+        view_pick.update(cx, |_, vcx| vcx.notify());
+    });
+
+    gesture_card(pal)
+        .min_w(px(POPOVER_W))
+        .child(title(format!("{}  {}", dir.glyph(), tr!(dir.label())), pal))
+        .child(divider(pal))
+        .child(scroll_list(
+            "gesture-dir-scroll",
+            action_rows("gesture-action", Some(&current), &on_pick, pal),
+        ))
+        .into_any_element()
 }
 
 // ── Shared building blocks ──────────────────────────────────────────────────
@@ -145,6 +270,10 @@ fn gesture_action_submenu(
 /// be shared between the button picker and any future custom picker, which
 /// differ only in what they do after committing.
 type PickFn = Rc<dyn Fn(Action, &mut Window, &mut App)>;
+
+/// Callback invoked when a plus cell is clicked: activate that direction so its
+/// level-2 flyout card appears. Boxed so the shared cell builder stays one type.
+type SelectFn = Rc<dyn Fn(GestureDirection, &mut App)>;
 
 /// The action catalog grouped by [`Category`], preserving catalog order within
 /// each group and first-seen order across groups.

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -1,13 +1,14 @@
 use gpui::{
-    Anchor, AnyElement, App, Context, DismissEvent, ElementId, Entity, Focusable as _, FontWeight,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, RenderOnce,
-    StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, img, px, rgb,
+    Anchor, AnyElement, App, Context, ElementId, Entity, FontWeight, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, RenderOnce, StatefulInteractiveElement as _,
+    Styled, Subscription, Window, canvas, div, hsla, img, px, rgb,
 };
-use gpui_component::{Selectable, h_flex, menu::PopupMenu, popover::Popover, v_flex};
+use gpui_component::{Selectable, h_flex, popover::Popover, v_flex};
 
 use crate::asset::ResolvedAsset;
 use crate::data::mouse_buttons::{
-    Action, ButtonId, Hotspot, MOUSE_MODEL_SIZE, default_binding, default_hotspots,
+    Action, ButtonId, GestureDirection, Hotspot, MOUSE_MODEL_SIZE, default_binding,
+    default_hotspots,
 };
 use crate::mouse_model::geometry::{
     asset_dimensions_for_png, asset_hotspots_for_png, default_labels, labels_from_hotspots,
@@ -15,7 +16,7 @@ use crate::mouse_model::geometry::{
 use crate::mouse_model::leader_lines::{
     Geometry as LeaderGeometry, Label, Side, paint as paint_leader_lines,
 };
-use crate::mouse_model::picker::{action_picker, build_gesture_menu};
+use crate::mouse_model::picker::{action_picker, gesture_overview};
 use crate::state::AppState;
 use crate::theme::{self, ACCENT_BLUE, Palette};
 
@@ -31,6 +32,12 @@ const HOTSPOT_DOT: f32 = 12.;
 /// Interactive mouse model with button hotspots.
 pub struct MouseModelView {
     hovered: Option<ButtonId>,
+    /// Which gesture direction the open gesture menu has activated (so its
+    /// level-2 flyout card shows), or `None` for the plus-only state. Scratch UI
+    /// state owned here (like [`Self::hovered`]) rather than in window-keyed
+    /// state, so the popover's `on_open_change` — which runs outside paint — can
+    /// reset it without tripping gpui's render-only guard.
+    gesture_active_dir: Option<GestureDirection>,
     _state_obs: Subscription,
 }
 
@@ -40,8 +47,20 @@ impl MouseModelView {
         let state_obs = cx.observe_global::<AppState>(|_view, cx| cx.notify());
         Self {
             hovered: None,
+            gesture_active_dir: None,
             _state_obs: state_obs,
         }
+    }
+
+    /// The gesture direction whose level-2 flyout is open, if any.
+    pub(crate) fn gesture_selected_dir(&self) -> Option<GestureDirection> {
+        self.gesture_active_dir
+    }
+
+    /// Set (or clear, with `None`) the activated gesture direction. Callers must
+    /// `cx.notify()` to re-render.
+    pub(crate) fn set_gesture_selected_dir(&mut self, dir: Option<GestureDirection>) {
+        self.gesture_active_dir = dir;
     }
 }
 
@@ -206,60 +225,36 @@ fn hotspots_layer(
         )
 }
 
-/// One-shot cache for the gesture button's [`PopupMenu`] entity so the
-/// popover's per-frame `content` closure reuses it instead of rebuilding —
-/// rebuilding every frame would reset submenu hover state, so a hovered-open
-/// submenu would snap shut. Cleared on dismiss so the next open rebuilds with
-/// fresh `checked` state. Mirrors gpui-component's `DropdownMenu`.
-#[derive(Default)]
-struct GestureMenuState {
-    menu: Option<Entity<PopupMenu>>,
-}
-
 /// Wrap `trigger` in a left-click [`Popover`] hosting the gesture button's
-/// native cascading [`PopupMenu`]. The popover surface is suppressed
-/// (`appearance(false)`) because the menu draws its own; outside-click dismissal
-/// is driven by the menu and relayed here via [`DismissEvent`].
-fn gesture_menu_popover<Tr>(
+/// custom two-level menu (see [`gesture_overview`]). `appearance(false)` because
+/// the menu draws its own card surfaces (plus + flyout); `overlay_closable`
+/// stays on so an outside click dismisses and re-clicking the trigger toggles.
+/// Closing resets the activated direction (scratch state on the view) so the
+/// next open starts on the plus.
+fn gesture_overview_popover<Tr>(
     popover_id: impl Into<ElementId>,
-    state_key: impl Into<ElementId>,
     anchor: Anchor,
     trigger: Tr,
+    view: Entity<MouseModelView>,
 ) -> impl IntoElement
 where
     Tr: Selectable + IntoElement + 'static,
 {
-    let state_key = state_key.into();
+    let view_reset = view.clone();
     Popover::new(popover_id)
         .appearance(false)
-        .overlay_closable(false)
         .mouse_button(MouseButton::Left)
         .anchor(anchor)
         .trigger(trigger)
-        .content(move |_state, window, cx| {
-            let menu_state =
-                window.use_keyed_state(state_key.clone(), cx, |_, _| GestureMenuState::default());
-            if let Some(menu) = menu_state.read(cx).menu.clone() {
-                return menu;
+        .on_open_change(move |open, _window, cx| {
+            if !*open {
+                view_reset.update(cx, |v, vcx| {
+                    v.set_gesture_selected_dir(None);
+                    vcx.notify();
+                });
             }
-
-            let menu = PopupMenu::build(window, cx, build_gesture_menu);
-            menu_state.update(cx, |state, _| state.menu = Some(menu.clone()));
-            menu.focus_handle(cx).focus(window, cx);
-
-            // Closing the menu (pick or outside-click) emits DismissEvent; relay
-            // it to the host popover and drop the cache so the next open rebuilds.
-            let popover_state = cx.entity();
-            let cache = menu_state.clone();
-            window
-                .subscribe(&menu, cx, move |_, _: &DismissEvent, window, cx| {
-                    popover_state.update(cx, |state, cx| state.dismiss(window, cx));
-                    cache.update(cx, |state, _| state.menu = None);
-                })
-                .detach();
-
-            menu
         })
+        .content(move |_state, _window, cx| gesture_overview(&view, cx))
 }
 
 /// Position the popover wrapper at the label's slot in the side gutter and
@@ -296,11 +291,11 @@ fn label_popover(
         view: view.clone(),
     };
     let popover: AnyElement = if label.id == ButtonId::GestureButton {
-        gesture_menu_popover(
+        gesture_overview_popover(
             ("label-popover", idx),
-            ("label-gesture-menu", idx),
             Anchor::TopLeft,
             trigger,
+            view.clone(),
         )
         .into_any_element()
     } else {
@@ -498,11 +493,11 @@ fn hotspot_popover(
         selected: false,
     };
     let popover: AnyElement = if hotspot.id == ButtonId::GestureButton {
-        gesture_menu_popover(
+        gesture_overview_popover(
             ("hotspot-popover", idx),
-            ("hotspot-gesture-menu", idx),
             Anchor::TopRight,
             trigger,
+            view.clone(),
         )
         .into_any_element()
     } else {

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -127,17 +127,18 @@ impl Render for MouseModelView {
                         icon: Some(GESTURE_BUTTON_ICON),
                     }
                 } else {
-                    match bindings.get(&label.id) {
-                        Some(action) => BindingLabel {
-                            text: localized_action_label(action),
-                            is_default: *action == default_binding(label.id),
-                            icon: Some(action_icon_path(action)),
-                        },
-                        None => BindingLabel {
-                            text: tr!("Unbound"),
-                            is_default: false,
-                            icon: None,
-                        },
+                    // `bindings` is seeded for every `ButtonId::ALL` (agent-core
+                    // `bindings_for`), so a rendered non-gesture button always
+                    // resolves; fall back to the button's own default to stay
+                    // total without inventing an unreachable "Unbound" state.
+                    let action = bindings
+                        .get(&label.id)
+                        .cloned()
+                        .unwrap_or_else(|| default_binding(label.id));
+                    BindingLabel {
+                        text: localized_action_label(&action),
+                        is_default: action == default_binding(label.id),
+                        icon: Some(action_icon_path(&action)),
                     }
                 };
                 label_popover(

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -1,9 +1,9 @@
 use gpui::{
-    Anchor, AnyElement, App, Context, ElementId, Entity, FontWeight, InteractiveElement,
-    IntoElement, MouseButton, ParentElement, Render, RenderOnce, StatefulInteractiveElement as _,
-    Styled, Subscription, Window, canvas, div, hsla, img, px, rgb,
+    Anchor, AnyElement, App, Context, ElementId, Entity, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Render, RenderOnce, StatefulInteractiveElement as _, Styled,
+    Subscription, Window, canvas, div, hsla, img, prelude::FluentBuilder as _, px, rgb, svg,
 };
-use gpui_component::{Selectable, h_flex, popover::Popover, v_flex};
+use gpui_component::{Icon, IconName, Selectable, h_flex, popover::Popover, v_flex};
 
 use crate::asset::ResolvedAsset;
 use crate::data::mouse_buttons::{
@@ -16,7 +16,9 @@ use crate::mouse_model::geometry::{
 use crate::mouse_model::leader_lines::{
     Geometry as LeaderGeometry, Label, Side, paint as paint_leader_lines,
 };
-use crate::mouse_model::picker::{action_picker, gesture_overview};
+use crate::mouse_model::picker::{
+    GESTURE_BUTTON_ICON, action_icon_path, action_picker, gesture_overview,
+};
 use crate::state::AppState;
 use crate::theme::{self, ACCENT_BLUE, Palette};
 
@@ -122,16 +124,19 @@ impl Render for MouseModelView {
                     BindingLabel {
                         text: tr!("5 directions"),
                         is_default: false,
+                        icon: Some(GESTURE_BUTTON_ICON),
                     }
                 } else {
                     match bindings.get(&label.id) {
                         Some(action) => BindingLabel {
                             text: localized_action_label(action),
                             is_default: *action == default_binding(label.id),
+                            icon: Some(action_icon_path(action)),
                         },
                         None => BindingLabel {
                             text: tr!("Unbound"),
                             is_default: false,
+                            icon: None,
                         },
                     }
                 };
@@ -300,6 +305,9 @@ fn label_popover(
         .into_any_element()
     } else {
         Popover::new(("label-popover", idx))
+            // `action_picker` draws its own `menu_card` surface, matching the
+            // gesture menu — so suppress the framework popover surface.
+            .appearance(false)
             .anchor(Anchor::TopLeft)
             .mouse_button(MouseButton::Left)
             .trigger(trigger)
@@ -319,6 +327,9 @@ fn label_popover(
 struct BindingLabel {
     text: gpui::SharedString,
     is_default: bool,
+    /// Vendored action-icon asset path (see [`action_icon_path`]) for the
+    /// card's leading glyph, or `None` for the gesture summary / unbound.
+    icon: Option<&'static str>,
 }
 
 #[derive(IntoElement)]
@@ -355,17 +366,18 @@ impl RenderOnce for LabelTrigger {
         } else {
             pal.text_primary
         };
-        let binding = if self.binding.is_default {
-            tr!("Default")
-        } else {
-            self.binding.text
-        };
-        div()
+        // Always show the action the button actually performs; the muted colour
+        // (set above for `is_default`) is what signals "not customised" — more
+        // informative than the bare word "Default".
+        let binding = self.binding.text;
+        let binding_icon = self.binding.icon;
+        v_flex()
             .id(self.id)
             .w(px(LABEL_W))
             .h(px(LABEL_H))
             .px_3()
-            .py_2()
+            .justify_center()
+            .gap_0p5()
             .rounded_md()
             .border_1()
             .border_color(if highlighted {
@@ -380,35 +392,50 @@ impl RenderOnce for LabelTrigger {
             })
             .cursor_pointer()
             .hover(move |s| s.bg(pal.surface))
+            // Button name — the caption (xs / muted), the same size as the
+            // popover title and category headers it shares the binding flow with.
             .child(
-                v_flex()
-                    .gap_1()
+                div()
+                    .text_xs()
+                    .text_color(pal.text_muted)
+                    .child(tr!(self.label.id.label())),
+            )
+            // Current binding — the value (sm), the same size as the action rows
+            // it edits. Colour, not weight or size, carries the default / set /
+            // highlighted state.
+            .child(
+                h_flex()
+                    .items_center()
+                    .gap_2()
+                    // Leading action icon (same glyph as the picker rows), tinted
+                    // with the value so it tracks the default / set / highlighted
+                    // state. Absent for the gesture summary / unbound.
+                    .when_some(binding_icon, |row, path| {
+                        row.child(
+                            svg()
+                                .path(path)
+                                .size_4()
+                                .flex_none()
+                                .text_color(binding_color),
+                        )
+                    })
                     .child(
-                        h_flex()
-                            .items_center()
-                            .gap_1p5()
-                            .text_xs()
-                            .text_color(pal.text_muted)
-                            .child(div().text_xs().child("•"))
-                            .child(tr!(self.label.id.label())),
+                        // Shrink + ellipsis so a long action name (e.g. "Mission
+                        // Control") doesn't push the chevron out of the fixed card.
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .whitespace_nowrap()
+                            .text_sm()
+                            .text_color(binding_color)
+                            .child(binding),
                     )
                     .child(
-                        h_flex()
-                            .items_center()
-                            .justify_between()
-                            .gap_2()
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .font_weight(if self.binding.is_default {
-                                        FontWeight::NORMAL
-                                    } else {
-                                        FontWeight::SEMIBOLD
-                                    })
-                                    .text_color(binding_color)
-                                    .child(binding),
-                            )
-                            .child(div().text_sm().text_color(pal.text_muted).child("›")),
+                        Icon::new(IconName::ChevronRight)
+                            .size_3()
+                            .text_color(pal.text_muted),
                     ),
             )
             .on_hover(move |hovered, _window, cx| {
@@ -502,6 +529,9 @@ fn hotspot_popover(
         .into_any_element()
     } else {
         Popover::new(("hotspot-popover", idx))
+            // `action_picker` draws its own `menu_card` surface, matching the
+            // gesture menu — so suppress the framework popover surface.
+            .appearance(false)
             .anchor(Anchor::TopRight)
             .mouse_button(MouseButton::Left)
             .trigger(trigger)

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -115,8 +115,11 @@ pub struct AppState {
     /// carousel selection changes.
     pub button_bindings: BTreeMap<ButtonId, Action>,
     /// Per-direction sub-bindings for the gesture button on the currently
-    /// selected device. Edited via the gesture picker; persistence shape
-    /// lives in [`openlogi_core::config::DeviceConfig::gesture_bindings`].
+    /// selected device. Edited via the gesture picker; persisted as a
+    /// [`Binding::Gesture`] entry under [`ButtonId::GestureButton`] in the
+    /// device's unified binding map ([`DeviceConfig::bindings`]).
+    ///
+    /// [`DeviceConfig::bindings`]: openlogi_core::config::DeviceConfig::bindings
     pub gesture_bindings: BTreeMap<GestureDirection, Action>,
     pub dpi: u32,
     /// DPI capability state keyed by [`DeviceRecord::config_key`]. Loaded

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -31,7 +31,7 @@ pub use devices::DeviceRecord;
 pub use openlogi_agent_core::DpiCycleState;
 
 use crate::asset::AssetResolver;
-use crate::data::mouse_buttons::{Action, ButtonId, GestureDirection};
+use crate::data::mouse_buttons::{Action, Binding, ButtonId, GestureDirection};
 use crate::state::devices::{build_device_list, pick_initial_device, sort_device_list};
 use openlogi_agent_core::bindings::{bindings_for, gesture_bindings_for};
 
@@ -948,7 +948,8 @@ impl AppState {
             );
             return;
         };
-        self.config.set_binding(&key, button, action);
+        self.config
+            .set_binding(&key, button, Binding::Single(action));
         if let Err(e) = self.config.save_atomic() {
             warn!(error = %e, "could not persist binding to config.toml");
         }
@@ -983,7 +984,8 @@ impl AppState {
             );
             return;
         };
-        self.config.set_gesture_binding(&key, direction, action);
+        self.config
+            .set_gesture_direction(&key, ButtonId::GestureButton, direction, action);
         if let Err(e) = self.config.save_atomic() {
             warn!(error = %e, "could not persist gesture binding to config.toml");
         }


### PR DESCRIPTION
## Summary

Phase A of the gesture-button uplift: merge the two parallel binding maps
(`button_bindings` + `gesture_bindings`) into a single unified `Binding` model,
and rebuild the gesture-button configuration UI. **No runtime behavior change** —
this is the data-model + UI foundation; the dispatch wiring that lets more
buttons act as gesture buttons lands in Phase B.

## What changed

**Data model (`openlogi-core`)**
- New `Binding = Single(Action) | Gesture(BTreeMap<GestureDirection, Action>)`
  (`#[serde(untagged)]`), replacing per-device `button_bindings` +
  `gesture_bindings` with one `BTreeMap<ButtonId, Binding>`.
- `SCHEMA_VERSION` 1 → 2 with a `RawDeviceConfig` `#[serde(from)]` migration
  shim. Old configs auto-migrate (gesture-map-wins fold order; self-heals to v2
  on save). The load gate accepts any version ≤ current and rejects newer ones
  loudly, so a downgraded binary refuses to load rather than silently wiping.

**Adapters (`openlogi-agent-core`)**
- `bindings_for` / `gesture_bindings_for` project the merged map back to the
  per-button / per-direction shapes the runtime and OS hook consume, so the
  orchestrator, watchers, and hook are untouched.

**GUI (`openlogi-gui`)**
- Custom two-level gesture menu in a single popover: a plus-shaped
  cross-direction navigator (all five directions glanceable) plus a fly-out
  action list beside the active cell.
- Design pass over the binding popover, action list, and leader-line label
  cards; per-action leading icons (vendored lucide glyphs, ISC).

**Review hardening** (final commit)
- Migration drops a vestigial legacy `button_bindings[GestureButton]` instead of
  leaving an unreachable `Binding::Single` that shadows the gesture path.
- Fresh gesture buttons are seeded from `default_binding_for`, so a gesture
  binding always carries a `Click` and its click projection never collapses to a
  no-op `Action::None`.
- Cleanup: dead code, stale doc links, a redundant schema-version test.

## Testing

- `openlogi-core` (53) + `openlogi-agent-core` (9) tests green, including
  migration and click-projection regression tests.
- Full-workspace `cargo clippy --all-targets -- -D warnings` clean.

## Status

**Draft** — Phase A is complete and self-contained, but kept as Draft while
Phase B (dispatch merge + OS-hook hold-swipe detection for Middle/Back/Forward)
is built on top.

> Migration is forward-only: a schema-v2 config is not readable by pre-v2
> binaries (they reject it via the version gate).
