### PR TITLE
feat: gesture buttons on Middle/Back/Forward via the OS hook (Phase B)

### DIFF
--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -78,17 +78,24 @@ pub fn gesture_bindings_for(
 }
 
 /// Per-direction maps for the OS-hook gesture buttons (Middle/Back/Forward in
-/// gesture mode) on `config_key`, for the OS hook to resolve a hold+swipe.
+/// gesture mode) on `config_key`, with `app_bundle`'s per-app overlay applied,
+/// for the OS hook to resolve a hold+swipe.
 ///
 /// Unlike [`gesture_bindings_for`] (the dedicated HID++ gesture button, which
 /// seeds every direction from [`default_gesture_binding`]), these are the raw
 /// stored maps — a swipe direction the user left unbound simply does nothing.
 /// The dedicated gesture button is intentionally excluded: it never reaches the
 /// OS hook (it's captured over HID++), so it has no entry here.
+///
+/// A per-app override of the owner button turns it into a [`Binding::Single`]
+/// for that app, so it stops being a gesture button there and falls through to
+/// the single-action path (which applies the override) — mirroring how a single
+/// binding is overridden per app.
 #[must_use]
 pub fn oshook_gestures_for(
     config: &Config,
     config_key: Option<&str>,
+    app_bundle: Option<&str>,
 ) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
     let Some(key) = config_key else {
         return BTreeMap::new();
@@ -98,15 +105,15 @@ pub fn oshook_gestures_for(
     // button is dispatched as its single click action. Returning *only* the owner
     // keeps the runtime in lockstep with `gesture_owner` and the GUI, so a stray
     // second gesture map (e.g. a hand-edited config) can't make two buttons fire.
-    let Some(owner) = config.gesture_owner(key).filter(|id| {
-        matches!(
-            id,
-            ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
-        )
-    }) else {
+    let Some(owner) = config
+        .gesture_owner(key)
+        .filter(|id| id.is_os_hook_button())
+    else {
         return BTreeMap::new();
     };
-    match config.bindings_for(key).remove(&owner) {
+    // Read the per-app *effective* map: a per-app override replaces the owner with
+    // a `Single`, dropping it from the gesture set for that app.
+    match config.effective_bindings(key, app_bundle).remove(&owner) {
         Some(Binding::Gesture(map)) => BTreeMap::from([(owner, map)]),
         _ => BTreeMap::new(),
     }
@@ -171,7 +178,7 @@ mod tests {
             )])),
         );
 
-        let oshook = oshook_gestures_for(&cfg, Some("2b042"));
+        let oshook = oshook_gestures_for(&cfg, Some("2b042"), None);
         assert_eq!(oshook.len(), 1, "only the gesture-mode Back belongs here");
         assert_eq!(
             oshook.get(&ButtonId::Back),
@@ -179,6 +186,36 @@ mod tests {
         );
         assert!(!oshook.contains_key(&ButtonId::MiddleClick));
         assert!(!oshook.contains_key(&ButtonId::GestureButton));
+    }
+
+    #[test]
+    fn per_app_override_drops_the_owner_from_the_oshook_gesture_set() {
+        // Back is the gesture owner globally...
+        let mut cfg = Config::default();
+        cfg.set_gesture_owner("2b042", ButtonId::Back);
+        assert!(
+            oshook_gestures_for(&cfg, Some("2b042"), None).contains_key(&ButtonId::Back),
+            "Back gestures globally"
+        );
+
+        // ...but a per-app override makes it a single action in that app, so it
+        // must drop out of the gesture set there (and fall through to the
+        // single-action path, which applies the override).
+        cfg.set_per_app_binding(
+            "2b042",
+            "com.apple.Safari",
+            ButtonId::Back,
+            Some(Action::NextTab),
+        );
+        assert!(
+            oshook_gestures_for(&cfg, Some("2b042"), Some("com.apple.Safari")).is_empty(),
+            "a per-app override of the owner removes it from the gesture set"
+        );
+        // Other apps are unaffected — Back still gestures.
+        assert!(
+            oshook_gestures_for(&cfg, Some("2b042"), Some("com.other.App"))
+                .contains_key(&ButtonId::Back)
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -93,20 +93,23 @@ pub fn oshook_gestures_for(
     let Some(key) = config_key else {
         return BTreeMap::new();
     };
-    config
-        .bindings_for(key)
-        .into_iter()
-        .filter(|(id, _)| {
-            matches!(
-                id,
-                ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
-            )
-        })
-        .filter_map(|(id, binding)| match binding {
-            Binding::Gesture(map) => Some((id, map)),
-            Binding::Single(_) => None,
-        })
-        .collect()
+    // Only an OS-hook button (Middle/Back/Forward) as the device's gesture owner
+    // feeds the OS hook: the thumb pad is captured over HID++, and a non-owner
+    // button is dispatched as its single click action. Returning *only* the owner
+    // keeps the runtime in lockstep with `gesture_owner` and the GUI, so a stray
+    // second gesture map (e.g. a hand-edited config) can't make two buttons fire.
+    let Some(owner) = config.gesture_owner(key).filter(|id| {
+        matches!(
+            id,
+            ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
+        )
+    }) else {
+        return BTreeMap::new();
+    };
+    match config.bindings_for(key).remove(&owner) {
+        Some(Binding::Gesture(map)) => BTreeMap::from([(owner, map)]),
+        _ => BTreeMap::new(),
+    }
 }
 
 #[cfg(test)]

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -54,6 +54,15 @@ pub fn gesture_bindings_for(
     config: &Config,
     config_key: Option<&str>,
 ) -> BTreeMap<GestureDirection, Action> {
+    // The thumb pad (HID++ 0x00c3) only gestures while it is the device's gesture
+    // owner. When the user moves the role to an OS-hook button (Middle/Back/
+    // Forward) or turns gestures off, return an empty map so the gesture watcher
+    // dispatches nothing — otherwise the always-seeded defaults would keep the
+    // thumb pad firing regardless of the selection.
+    let owner = config_key.and_then(|key| config.gesture_owner(key));
+    if owner != Some(ButtonId::GestureButton) {
+        return BTreeMap::new();
+    }
     let stored = config_key
         .map(|key| config.gesture_bindings_for(key))
         .unwrap_or_default();
@@ -167,5 +176,25 @@ mod tests {
         );
         assert!(!oshook.contains_key(&ButtonId::MiddleClick));
         assert!(!oshook.contains_key(&ButtonId::GestureButton));
+    }
+
+    #[test]
+    fn gesture_bindings_silent_when_thumb_pad_is_not_the_owner() {
+        let mut cfg = Config::default();
+        // Default device: the thumb pad owns gestures, so its defaults are seeded.
+        let defaults = gesture_bindings_for(&cfg, Some("2b042"));
+        assert_eq!(
+            defaults.get(&GestureDirection::Up),
+            Some(&default_gesture_binding(GestureDirection::Up)),
+            "the default gesture owner is the thumb pad"
+        );
+
+        // Move the gesture role to an OS-hook button: the thumb pad goes silent,
+        // so the watcher dispatches nothing for 0x00c3.
+        cfg.set_gesture_owner("2b042", ButtonId::Back);
+        assert!(
+            gesture_bindings_for(&cfg, Some("2b042")).is_empty(),
+            "thumb pad must dispatch nothing once another button owns gestures"
+        );
     }
 }

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 
 use openlogi_core::binding::{
-    Action, ButtonId, GestureDirection, default_binding, default_gesture_binding,
+    Action, Binding, ButtonId, GestureDirection, default_binding, default_gesture_binding,
 };
 use openlogi_core::config::Config;
 
@@ -68,10 +68,41 @@ pub fn gesture_bindings_for(
     bindings
 }
 
+/// Per-direction maps for the OS-hook gesture buttons (Middle/Back/Forward in
+/// gesture mode) on `config_key`, for the OS hook to resolve a hold+swipe.
+///
+/// Unlike [`gesture_bindings_for`] (the dedicated HID++ gesture button, which
+/// seeds every direction from [`default_gesture_binding`]), these are the raw
+/// stored maps — a swipe direction the user left unbound simply does nothing.
+/// The dedicated gesture button is intentionally excluded: it never reaches the
+/// OS hook (it's captured over HID++), so it has no entry here.
+#[must_use]
+pub fn oshook_gestures_for(
+    config: &Config,
+    config_key: Option<&str>,
+) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
+    let Some(key) = config_key else {
+        return BTreeMap::new();
+    };
+    config
+        .bindings_for(key)
+        .into_iter()
+        .filter(|(id, _)| {
+            matches!(
+                id,
+                ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
+            )
+        })
+        .filter_map(|(id, binding)| match binding {
+            Binding::Gesture(map) => Some((id, map)),
+            Binding::Single(_) => None,
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openlogi_core::binding::Binding;
 
     #[test]
     fn click_less_gesture_keeps_default_click_in_projection() {
@@ -104,5 +135,37 @@ mod tests {
             projected.get(&ButtonId::GestureButton),
             Some(&Action::Paste)
         );
+    }
+
+    #[test]
+    fn oshook_gestures_collects_only_os_hook_gesture_buttons() {
+        let mut cfg = Config::default();
+        // A gesture-mode Back (an OS-hook button) — included, raw map preserved.
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Back,
+            Binding::Gesture(BTreeMap::from([(GestureDirection::Up, Action::Copy)])),
+        );
+        // A single-mode Middle — excluded (not a gesture button).
+        cfg.set_binding("2b042", ButtonId::MiddleClick, Action::MiddleClick.into());
+        // The dedicated HID++ gesture button — excluded (it never reaches the
+        // OS hook, so it must not appear in the hook's gesture map).
+        cfg.set_binding(
+            "2b042",
+            ButtonId::GestureButton,
+            Binding::Gesture(BTreeMap::from([(
+                GestureDirection::Up,
+                Action::MissionControl,
+            )])),
+        );
+
+        let oshook = oshook_gestures_for(&cfg, Some("2b042"));
+        assert_eq!(oshook.len(), 1, "only the gesture-mode Back belongs here");
+        assert_eq!(
+            oshook.get(&ButtonId::Back),
+            Some(&BTreeMap::from([(GestureDirection::Up, Action::Copy)]))
+        );
+        assert!(!oshook.contains_key(&ButtonId::MiddleClick));
+        assert!(!oshook.contains_key(&ButtonId::GestureButton));
     }
 }

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -82,10 +82,14 @@ pub fn gesture_bindings_for(
 /// for the OS hook to resolve a hold+swipe.
 ///
 /// Unlike [`gesture_bindings_for`] (the dedicated HID++ gesture button, which
-/// seeds every direction from [`default_gesture_binding`]), these are the raw
-/// stored maps — a swipe direction the user left unbound simply does nothing.
-/// The dedicated gesture button is intentionally excluded: it never reaches the
-/// OS hook (it's captured over HID++), so it has no entry here.
+/// seeds every direction from [`default_gesture_binding`] at projection time),
+/// this returns the owner's raw stored map. In practice that map is already
+/// fully populated — [`Config::set_gesture_owner`] seeds all five directions via
+/// [`Binding::fill_gesture_defaults`] when a button is promoted — so only a
+/// hand-edited sparse map leaves a direction unbound, in which case that swipe
+/// simply does nothing. The dedicated gesture button is intentionally excluded:
+/// it never reaches the OS hook (it's captured over HID++), so it has no entry
+/// here.
 ///
 /// A per-app override of the owner button turns it into a [`Binding::Single`]
 /// for that app, so it stops being a gesture button there and falls through to

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -119,10 +119,7 @@ pub fn start(
             // (suppressing them would brick the mouse), and the DPI / thumb /
             // dedicated gesture button aren't visible to the tap at all — the
             // dedicated gesture button is captured separately over HID++.
-            if !matches!(
-                id,
-                ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
-            ) {
+            if !id.is_os_hook_button() {
                 return EventDisposition::PassThrough;
             }
 

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -5,8 +5,9 @@
 //! the binding map, lazy hook installation, and action dispatch for both hook
 //! and gesture events.
 
+use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use openlogi_core::binding::{
     Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
@@ -66,13 +67,23 @@ impl HoldState {
             None
         }
     }
+
+    /// Cancel any in-progress hold without firing anything — used when the OS
+    /// interrupts capture. A dropped button-up would otherwise leave a stale hold
+    /// that the next stray pointer move turns into a phantom swipe.
+    fn cancel(&mut self) {
+        self.button = None;
+        self.swipe.end();
+    }
 }
 
-/// Lock the hold accumulator, recovering the guard if a previous callback
-/// panicked while holding it — a poisoned lock must never wedge the input hook.
-fn lock_hold(hold: &Mutex<HoldState>) -> std::sync::MutexGuard<'_, HoldState> {
-    hold.lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
+thread_local! {
+    /// In-progress gesture hold, one instance per hook-callback thread: the
+    /// single macOS tap thread, or — on Linux — one thread per device, so two
+    /// mice never share a hold (a press on one can't hijack the other's swipe).
+    /// Thread-local rather than a shared `Mutex` keeps the hot path lock-free and
+    /// free of cross-thread contention on the freeze-sensitive callback.
+    static HOLD: RefCell<HoldState> = RefCell::new(HoldState::default());
 }
 
 /// Attempt to start the OS hook. Returns `None` if Accessibility is not
@@ -91,11 +102,8 @@ pub fn start(
         return None;
     }
 
-    // Per-hold pointer accumulator. Touched only from the hook callback, which
-    // runs serially on one thread, so the mutex is always uncontended (and the
-    // callback must never block — see the freeze-hazard note in `macos.rs`).
-    let hold = Mutex::new(HoldState::default());
-
+    // The per-hold pointer accumulator lives in the thread-local `HOLD`; the
+    // callback must never block — see the freeze-hazard note in `macos.rs`.
     let result = Hook::start(move |event| match event {
         MouseEvent::Button { id, pressed } => {
             // The CGEventTap only sees standard buttons 0-4. We remap
@@ -117,15 +125,15 @@ pub fn start(
             if pressed {
                 let is_gesture = hook_gestures.read().is_ok_and(|g| g.contains_key(&id));
                 if is_gesture {
-                    lock_hold(&hold).begin(id);
+                    HOLD.with_borrow_mut(|h| h.begin(id));
                     return EventDisposition::Suppress;
                 }
             } else {
-                // Release: end the hold and drop the `hold` guard *before* any
+                // Release: end the hold and release the `HOLD` borrow *before* any
                 // dispatch — the callback must stay lock-light, since a
-                // synthesized event could otherwise re-enter the tap and re-lock
-                // the non-reentrant `hold` mutex (self-deadlock, freeze hazard).
-                let ended = lock_hold(&hold).end(id);
+                // synthesized event could otherwise re-enter the tap and re-borrow
+                // `HOLD` (a RefCell double-borrow panic, freeze hazard).
+                let ended = HOLD.with_borrow_mut(|h| h.end(id));
                 if let Some(was_click) = ended {
                     if was_click {
                         // No swipe committed → fire the plain click. Resolve to an
@@ -169,7 +177,7 @@ pub fn start(
             // Always pass through so the cursor keeps moving — the swipe is read,
             // not consumed (the B2 cursor-drift tradeoff vs. a HID++ raw-XY divert
             // that would freeze the pointer).
-            let commit = lock_hold(&hold).accumulate(delta_x, delta_y);
+            let commit = HOLD.with_borrow_mut(|h| h.accumulate(delta_x, delta_y));
             if let Some((button, dir)) = commit {
                 // Resolve to an owned action and drop the read guard before
                 // dispatch (same lock-light rule as the release arm).
@@ -182,6 +190,12 @@ pub fn start(
                     dispatch_action(&action, &dpi_cycle, &capture);
                 }
             }
+            EventDisposition::PassThrough
+        }
+        MouseEvent::CaptureInterrupted => {
+            // The OS dropped events (tap disabled); cancel any hold so a lost
+            // button-up can't later commit a phantom swipe off ordinary motion.
+            HOLD.with_borrow_mut(HoldState::cancel);
             EventDisposition::PassThrough
         }
         MouseEvent::Scroll { .. } => EventDisposition::PassThrough,

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -8,7 +8,9 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, RwLock};
 
-use openlogi_core::binding::{Action, ButtonId, GestureDirection, SwipeAccumulator};
+use openlogi_core::binding::{
+    Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
+};
 use openlogi_hid::CaptureChannel;
 use openlogi_hook::{EventDisposition, Hook, MouseEvent};
 use tracing::{info, warn};
@@ -118,17 +120,28 @@ pub fn start(
                     lock_hold(&hold).begin(id);
                     return EventDisposition::Suppress;
                 }
-            } else if let Some(was_click) = lock_hold(&hold).end(id) {
-                if was_click
-                    && let Some(action) = hook_gestures.read().ok().and_then(|g| {
-                        g.get(&id)
-                            .and_then(|m| m.get(&GestureDirection::Click).cloned())
-                    })
-                {
-                    info!(button = %id, action = %action.label(), "gesture click → executing bound action");
-                    dispatch_action(&action, &dpi_cycle, &capture);
+            } else {
+                // Release: end the hold and drop the `hold` guard *before* any
+                // dispatch — the callback must stay lock-light, since a
+                // synthesized event could otherwise re-enter the tap and re-lock
+                // the non-reentrant `hold` mutex (self-deadlock, freeze hazard).
+                let ended = lock_hold(&hold).end(id);
+                if let Some(was_click) = ended {
+                    if was_click {
+                        // No swipe committed → fire the plain click. Resolve to an
+                        // owned action (so no lock is held across dispatch), then
+                        // dispatch with the guard already dropped.
+                        let action = hook_gestures
+                            .read()
+                            .ok()
+                            .map(|g| resolve_gesture_click(&g, id));
+                        if let Some(action) = action {
+                            info!(button = %id, action = %action.label(), "gesture click → executing bound action");
+                            dispatch_action(&action, &dpi_cycle, &capture);
+                        }
+                    }
+                    return EventDisposition::Suppress;
                 }
-                return EventDisposition::Suppress;
             }
 
             // Single-action button.
@@ -157,14 +170,17 @@ pub fn start(
             // not consumed (the B2 cursor-drift tradeoff vs. a HID++ raw-XY divert
             // that would freeze the pointer).
             let commit = lock_hold(&hold).accumulate(delta_x, delta_y);
-            if let Some((button, dir)) = commit
-                && let Some(action) = hook_gestures
+            if let Some((button, dir)) = commit {
+                // Resolve to an owned action and drop the read guard before
+                // dispatch (same lock-light rule as the release arm).
+                let action = hook_gestures
                     .read()
                     .ok()
-                    .and_then(|g| g.get(&button).and_then(|m| m.get(&dir).cloned()))
-            {
-                info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
-                dispatch_action(&action, &dpi_cycle, &capture);
+                    .and_then(|g| g.get(&button).and_then(|m| m.get(&dir).cloned()));
+                if let Some(action) = action {
+                    info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
+                    dispatch_action(&action, &dpi_cycle, &capture);
+                }
             }
             EventDisposition::PassThrough
         }
@@ -181,6 +197,22 @@ pub fn start(
             None
         }
     }
+}
+
+/// The action a gesture button's plain (no-swipe) click should fire: its
+/// explicit [`GestureDirection::Click`] entry — honoring an explicit
+/// [`Action::None`] ("Do Nothing") — or the button's [`default_binding`] when
+/// the gesture map has no `Click` key (a sparse / hand-edited map, or the button
+/// left the gesture set mid-hold). The fallback guarantees a gesture button's
+/// suppressed press is never swallowed into nothing.
+fn resolve_gesture_click(
+    gestures: &BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
+    id: ButtonId,
+) -> Action {
+    gestures
+        .get(&id)
+        .and_then(|m| m.get(&GestureDirection::Click).cloned())
+        .unwrap_or_else(|| default_binding(id))
 }
 
 /// Whether `action` is just `id`'s own native click — i.e. the button is mapped
@@ -281,5 +313,48 @@ mod tests {
         assert_eq!(hold.end(ButtonId::Forward), None);
         // ...and ending the held button with no swipe is a plain click.
         assert_eq!(hold.end(ButtonId::Back), Some(true));
+    }
+
+    #[test]
+    fn resolve_gesture_click_prefers_explicit_then_falls_back_to_default() {
+        // Explicit Click action wins.
+        let gestures = BTreeMap::from([(
+            ButtonId::Back,
+            BTreeMap::from([(GestureDirection::Click, Action::Copy)]),
+        )]);
+        assert_eq!(
+            resolve_gesture_click(&gestures, ButtonId::Back),
+            Action::Copy
+        );
+
+        // Explicit `Click = None` ("Do Nothing") is respected, NOT overridden by
+        // the default — the button intentionally does nothing on a plain click.
+        let off = BTreeMap::from([(
+            ButtonId::Back,
+            BTreeMap::from([(GestureDirection::Click, Action::None)]),
+        )]);
+        assert_eq!(resolve_gesture_click(&off, ButtonId::Back), Action::None);
+    }
+
+    #[test]
+    fn resolve_gesture_click_falls_back_when_click_is_absent() {
+        // A gesture map with no Click key (sparse/hand-edited) falls back to the
+        // button's default, so the suppressed press is never swallowed.
+        let no_click = BTreeMap::from([(
+            ButtonId::Back,
+            BTreeMap::from([(GestureDirection::Up, Action::Copy)]),
+        )]);
+        assert_eq!(
+            resolve_gesture_click(&no_click, ButtonId::Back),
+            default_binding(ButtonId::Back)
+        );
+
+        // The button missing from the map entirely (e.g. removed by a config
+        // reload mid-hold) also falls back to its default rather than nothing.
+        let empty = BTreeMap::new();
+        assert_eq!(
+            resolve_gesture_click(&empty, ButtonId::Forward),
+            default_binding(ButtonId::Forward)
+        );
     }
 }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -19,15 +19,24 @@ use tracing::{info, warn};
 use crate::DpiCycleState;
 use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 
-/// Shared binding map threaded between the config owner and the hook callback.
-pub type BindingMap = Arc<RwLock<BTreeMap<ButtonId, Action>>>;
+/// The two button maps the OS-hook callback reads, kept behind ONE lock so a
+/// config rebuild publishes both atomically — a press during an owner switch can
+/// never see the new single-action bindings against the old gesture map (or vice
+/// versa), and the common case reads one lock instead of two.
+#[derive(Default)]
+pub struct HookMaps {
+    /// Per-button single action — the single-action dispatch path.
+    pub bindings: BTreeMap<ButtonId, Action>,
+    /// Per-direction maps for the OS-hook gesture buttons (Middle/Back/Forward in
+    /// gesture mode), so a hold+swipe resolves to a bound action. The dedicated
+    /// HID++ gesture button (0x00c3) uses the gesture watcher's separate map
+    /// instead — it never reaches the OS hook.
+    pub gestures: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
+}
 
-/// Shared per-direction maps for the OS-hook gesture buttons (Middle/Back/
-/// Forward in gesture mode), threaded into the hook callback so a hold+swipe
-/// resolves to a bound action. The dedicated HID++ gesture button (0x00c3) uses
-/// the separate per-direction map on the gesture watcher instead — it never
-/// reaches the OS hook.
-pub type HookGestures = Arc<RwLock<BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>>>;
+/// Shared, atomically-published [`HookMaps`], threaded between the config owner
+/// (orchestrator), the OS-hook callback, and the gesture watcher.
+pub type SharedHookMaps = Arc<RwLock<HookMaps>>;
 
 /// Tracks which OS-hook button (Middle/Back/Forward) is mid-hold and defers the
 /// swipe detection itself to a shared [`SwipeAccumulator`], which commits a swipe
@@ -89,8 +98,7 @@ thread_local! {
 /// Attempt to start the OS hook. Returns `None` if Accessibility is not
 /// granted or on an unsupported platform — the app continues without crashing.
 pub fn start(
-    bindings: BindingMap,
-    hook_gestures: HookGestures,
+    hooks: SharedHookMaps,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture: CaptureChannel,
 ) -> Option<Hook> {
@@ -123,7 +131,7 @@ pub fn start(
             // only fire the plain `Click` when no swipe committed. The cursor is
             // free to drift via the pass-through `Moved` events during the hold.
             if pressed {
-                let is_gesture = hook_gestures.read().is_ok_and(|g| g.contains_key(&id));
+                let is_gesture = hooks.read().is_ok_and(|m| m.gestures.contains_key(&id));
                 if is_gesture {
                     HOLD.with_borrow_mut(|h| h.begin(id));
                     return EventDisposition::Suppress;
@@ -139,10 +147,10 @@ pub fn start(
                         // No swipe committed → fire the plain click. Resolve to an
                         // owned action (so no lock is held across dispatch), then
                         // dispatch with the guard already dropped.
-                        let action = hook_gestures
+                        let action = hooks
                             .read()
                             .ok()
-                            .map(|g| resolve_gesture_click(&g, id));
+                            .map(|m| resolve_gesture_click(&m.gestures, id));
                         if let Some(action) = action {
                             info!(button = %id, action = %action.label(), "gesture click → executing bound action");
                             dispatch_action(&action, &dpi_cycle, &capture);
@@ -153,7 +161,7 @@ pub fn start(
             }
 
             // Single-action button.
-            let action = bindings.read().ok().and_then(|g| g.get(&id).cloned());
+            let action = hooks.read().ok().and_then(|m| m.bindings.get(&id).cloned());
             let Some(action) = action else {
                 // Unbound → leave the physical button to the OS.
                 return EventDisposition::PassThrough;
@@ -181,10 +189,11 @@ pub fn start(
             if let Some((button, dir)) = commit {
                 // Resolve to an owned action and drop the read guard before
                 // dispatch (same lock-light rule as the release arm).
-                let action = hook_gestures
-                    .read()
-                    .ok()
-                    .and_then(|g| g.get(&button).and_then(|m| m.get(&dir).cloned()));
+                let action = hooks.read().ok().and_then(|m| {
+                    m.gestures
+                        .get(&button)
+                        .and_then(|dirs| dirs.get(&dir).cloned())
+                });
                 if let Some(action) = action {
                     info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
                     dispatch_action(&action, &dpi_cycle, &capture);

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -7,8 +7,11 @@
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::Instant;
 
-use openlogi_core::binding::{Action, ButtonId, GestureDirection, detect_swipe};
+use openlogi_core::binding::{
+    Action, ButtonId, GESTURE_HOLD_FOR_SWIPE, GestureDirection, detect_swipe,
+};
 use openlogi_hid::CaptureChannel;
 use openlogi_hook::{EventDisposition, Hook, MouseEvent};
 use tracing::{info, warn};
@@ -26,43 +29,64 @@ pub type BindingMap = Arc<RwLock<BTreeMap<ButtonId, Action>>>;
 /// reaches the OS hook.
 pub type HookGestures = Arc<RwLock<BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>>>;
 
-/// Pointer-movement accumulator for an in-progress gesture-button hold: which
-/// button is held (between its down and up) and the summed movement, so the
-/// release can resolve a swipe direction via [`detect_swipe`].
+/// Tracks an in-progress gesture-button hold and commits a swipe *mid-motion*,
+/// the moment travel passes [`detect_swipe`] (like Logitech Options+), rather
+/// than waiting for release — matching the HID++ thumb-pad path in
+/// `openlogi-hid`. A press that never commits a direction is a plain click,
+/// fired on release.
 #[derive(Default)]
 struct HoldState {
     button: Option<ButtonId>,
     dx: i32,
     dy: i32,
+    held_since: Option<Instant>,
+    /// Set once a swipe has committed this hold, so it fires exactly once and
+    /// the release doesn't then also fire the click.
+    fired: bool,
 }
 
 impl HoldState {
-    /// Begin a hold for `button`, resetting the accumulated movement.
+    /// Begin a hold for `button`, resetting the accumulator and commit state.
     fn begin(&mut self, button: ButtonId) {
         self.button = Some(button);
         self.dx = 0;
         self.dy = 0;
+        self.held_since = Some(Instant::now());
+        self.fired = false;
     }
 
-    /// Add a pointer-move delta to the in-progress hold. Saturating, so a very
-    /// long hold can never overflow (the direction is all that matters).
-    fn accumulate(&mut self, dx: i32, dy: i32) {
+    /// Feed a pointer-move delta. Once the button has been held past
+    /// [`GESTURE_HOLD_FOR_SWIPE`] (so a quick click whose cursor drifted doesn't
+    /// count) and the travel commits to a direction, returns
+    /// `Some((button, direction))` exactly once per hold; the caller dispatches
+    /// it. Returns `None` while still too short, already fired, or not holding.
+    /// Saturating, so a very long hold can never overflow.
+    fn accumulate(&mut self, dx: i32, dy: i32) -> Option<(ButtonId, GestureDirection)> {
+        let button = self.button?;
+        if self.fired {
+            return None;
+        }
         self.dx = self.dx.saturating_add(dx);
         self.dy = self.dy.saturating_add(dy);
+        let held_long_enough = self
+            .held_since
+            .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
+        if held_long_enough && let Some(dir) = detect_swipe(self.dx, self.dy) {
+            self.fired = true;
+            return Some((button, dir));
+        }
+        None
     }
 
-    /// Whether a gesture button is currently held.
-    fn is_holding(&self) -> bool {
-        self.button.is_some()
-    }
-
-    /// End the hold for `button`, returning the accumulated `(dx, dy)` — but only
-    /// if `button` is the one being held, so a stray release of another button is
-    /// ignored.
-    fn end(&mut self, button: ButtonId) -> Option<(i32, i32)> {
+    /// End the hold for `button`. Returns `Some(true)` when it ended a hold that
+    /// never committed a swipe (the caller should fire the `Click` action),
+    /// `Some(false)` when a swipe already fired, and `None` for a stray release
+    /// of a button we weren't holding.
+    fn end(&mut self, button: ButtonId) -> Option<bool> {
         if self.button == Some(button) {
+            let was_click = !self.fired;
             self.button = None;
-            Some((self.dx, self.dy))
+            Some(was_click)
         } else {
             None
         }
@@ -111,26 +135,25 @@ pub fn start(
                 return EventDisposition::PassThrough;
             }
 
-            // Gesture button: suppress the native click and, on release, resolve
-            // the held movement to a swipe direction (or a plain Click when the
-            // pointer barely moved). The button-down is recorded; the cursor is
-            // free to drift via the pass-through `Moved` events between them.
+            // Gesture button: suppress the native click and begin a hold. The
+            // swipe commits mid-motion in the `Moved` arm; here, on release, we
+            // only fire the plain `Click` when no swipe committed. The cursor is
+            // free to drift via the pass-through `Moved` events during the hold.
             if pressed {
                 let is_gesture = hook_gestures.read().is_ok_and(|g| g.contains_key(&id));
                 if is_gesture {
                     lock_hold(&hold).begin(id);
                     return EventDisposition::Suppress;
                 }
-            } else if let Some((dx, dy)) = lock_hold(&hold).end(id) {
-                if let Some(map) = hook_gestures.read().ok().and_then(|g| g.get(&id).cloned()) {
-                    let action = match detect_swipe(dx, dy) {
-                        Some(dir) => map.get(&dir).cloned(),
-                        None => map.get(&GestureDirection::Click).cloned(),
-                    };
-                    if let Some(action) = action {
-                        info!(button = %id, dx, dy, action = %action.label(), "gesture → executing bound action");
-                        dispatch_action(&action, &dpi_cycle, &capture);
-                    }
+            } else if let Some(was_click) = lock_hold(&hold).end(id) {
+                if was_click
+                    && let Some(action) = hook_gestures.read().ok().and_then(|g| {
+                        g.get(&id)
+                            .and_then(|m| m.get(&GestureDirection::Click).cloned())
+                    })
+                {
+                    info!(button = %id, action = %action.label(), "gesture click → executing bound action");
+                    dispatch_action(&action, &dpi_cycle, &capture);
                 }
                 return EventDisposition::Suppress;
             }
@@ -156,12 +179,19 @@ pub fn start(
             EventDisposition::Suppress
         }
         MouseEvent::Moved { delta_x, delta_y } => {
-            // Feed an in-progress gesture hold; always pass through so the cursor
-            // keeps moving. The swipe is read, not consumed — the B2 cursor-drift
-            // tradeoff vs. a HID++ raw-XY divert that would freeze the pointer.
-            let mut guard = lock_hold(&hold);
-            if guard.is_holding() {
-                guard.accumulate(delta_x, delta_y);
+            // Feed an in-progress hold; a committed swipe fires here, mid-motion.
+            // Always pass through so the cursor keeps moving — the swipe is read,
+            // not consumed (the B2 cursor-drift tradeoff vs. a HID++ raw-XY divert
+            // that would freeze the pointer).
+            let commit = lock_hold(&hold).accumulate(delta_x, delta_y);
+            if let Some((button, dir)) = commit
+                && let Some(action) = hook_gestures
+                    .read()
+                    .ok()
+                    .and_then(|g| g.get(&button).and_then(|m| m.get(&dir).cloned()))
+            {
+                info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
+                dispatch_action(&action, &dpi_cycle, &capture);
             }
             EventDisposition::PassThrough
         }
@@ -244,50 +274,59 @@ pub fn dispatch_action(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlogi_core::binding::GESTURE_SWIPE_THRESHOLD;
 
-    #[test]
-    fn hold_accumulates_movement_between_begin_and_end() {
-        let mut hold = HoldState::default();
-        assert!(!hold.is_holding());
-
-        hold.begin(ButtonId::Back);
-        assert!(hold.is_holding());
-        hold.accumulate(3, -1);
-        hold.accumulate(2, -4);
-
-        // `end` of the held button returns the summed movement and clears the hold.
-        assert_eq!(hold.end(ButtonId::Back), Some((5, -5)));
-        assert!(!hold.is_holding());
+    /// Backdate the hold so it is past the minimum-hold gate and a swipe can
+    /// commit — without sleeping in the test.
+    fn held_long_enough(hold: &mut HoldState) {
+        hold.held_since = Instant::now().checked_sub(GESTURE_HOLD_FOR_SWIPE * 2);
     }
 
     #[test]
-    fn hold_begin_resets_prior_accumulation() {
+    fn swipe_commits_once_mid_motion_and_suppresses_the_click() {
         let mut hold = HoldState::default();
         hold.begin(ButtonId::Back);
-        hold.accumulate(10, 10);
-        // A fresh press starts a clean accumulator.
+        held_long_enough(&mut hold);
+
+        // A clear rightward swipe commits exactly once, mid-motion.
+        assert_eq!(
+            hold.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
+            Some((ButtonId::Back, GestureDirection::Right))
+        );
+        // Further motion in the same hold must not re-fire.
+        assert_eq!(hold.accumulate(50, 0), None);
+        // A release after a committed swipe is NOT a click.
+        assert_eq!(hold.end(ButtonId::Back), Some(false));
+    }
+
+    #[test]
+    fn hold_without_a_swipe_is_a_click_on_release() {
+        let mut hold = HoldState::default();
         hold.begin(ButtonId::Forward);
-        hold.accumulate(1, 2);
-        assert_eq!(hold.end(ButtonId::Forward), Some((1, 2)));
+        held_long_enough(&mut hold);
+        // Tiny drift never commits a direction...
+        assert_eq!(hold.accumulate(2, -1), None);
+        // ...so the release fires the plain click.
+        assert_eq!(hold.end(ButtonId::Forward), Some(true));
     }
 
     #[test]
-    fn hold_end_ignores_a_different_button() {
+    fn swipe_does_not_commit_before_the_minimum_hold() {
+        let mut hold = HoldState::default();
+        hold.begin(ButtonId::MiddleClick); // held_since = now
+        // A big delta arriving immediately (a quick click whose cursor drifted)
+        // must not commit — the hold is younger than GESTURE_HOLD_FOR_SWIPE.
+        assert_eq!(hold.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0), None);
+        // Once held long enough, the next delta commits.
+        held_long_enough(&mut hold);
+        assert!(hold.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0).is_some());
+    }
+
+    #[test]
+    fn end_ignores_a_different_button() {
         let mut hold = HoldState::default();
         hold.begin(ButtonId::Back);
-        hold.accumulate(4, 4);
-        // Releasing a button we aren't holding must not end the hold.
         assert_eq!(hold.end(ButtonId::Forward), None);
-        assert!(hold.is_holding());
-        assert_eq!(hold.end(ButtonId::Back), Some((4, 4)));
-    }
-
-    #[test]
-    fn hold_accumulation_saturates_instead_of_overflowing() {
-        let mut hold = HoldState::default();
-        hold.begin(ButtonId::MiddleClick);
-        hold.accumulate(i32::MAX, i32::MIN);
-        hold.accumulate(i32::MAX, i32::MIN);
-        assert_eq!(hold.end(ButtonId::MiddleClick), Some((i32::MAX, i32::MIN)));
+        assert_eq!(hold.end(ButtonId::Back), Some(true));
     }
 }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -185,11 +185,17 @@ pub fn start(
             let commit = HOLD.with_borrow_mut(|h| h.accumulate(delta_x, delta_y));
             if let Some((button, dir)) = commit {
                 // Resolve to an owned action and drop the read guard before
-                // dispatch (same lock-light rule as the release arm).
-                let action = hooks.read().ok().and_then(|m| {
+                // dispatch (same lock-light rule as the release arm). The button
+                // can leave the gesture set mid-hold (a per-app rebuild); the
+                // commit has already armed `fired`, so the release won't fire a
+                // click. Fall back to the same click action the release path uses
+                // so the suppressed press is never swallowed into nothing —
+                // symmetric with `resolve_gesture_click`.
+                let action = hooks.read().ok().map(|m| {
                     m.gestures
                         .get(&button)
                         .and_then(|dirs| dirs.get(&dir).cloned())
+                        .unwrap_or_else(|| resolve_gesture_click(&m.gestures, button))
                 });
                 if let Some(action) = action {
                     info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -6,9 +6,9 @@
 //! and gesture events.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Action, ButtonId, GestureDirection, detect_swipe};
 use openlogi_hid::CaptureChannel;
 use openlogi_hook::{EventDisposition, Hook, MouseEvent};
 use tracing::{info, warn};
@@ -19,10 +19,68 @@ use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 /// Shared binding map threaded between the config owner and the hook callback.
 pub type BindingMap = Arc<RwLock<BTreeMap<ButtonId, Action>>>;
 
+/// Shared per-direction maps for the OS-hook gesture buttons (Middle/Back/
+/// Forward in gesture mode), threaded into the hook callback so a hold+swipe
+/// resolves to a bound action. The dedicated HID++ gesture button (0x00c3) uses
+/// the separate per-direction map on the gesture watcher instead — it never
+/// reaches the OS hook.
+pub type HookGestures = Arc<RwLock<BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>>>;
+
+/// Pointer-movement accumulator for an in-progress gesture-button hold: which
+/// button is held (between its down and up) and the summed movement, so the
+/// release can resolve a swipe direction via [`detect_swipe`].
+#[derive(Default)]
+struct HoldState {
+    button: Option<ButtonId>,
+    dx: i32,
+    dy: i32,
+}
+
+impl HoldState {
+    /// Begin a hold for `button`, resetting the accumulated movement.
+    fn begin(&mut self, button: ButtonId) {
+        self.button = Some(button);
+        self.dx = 0;
+        self.dy = 0;
+    }
+
+    /// Add a pointer-move delta to the in-progress hold. Saturating, so a very
+    /// long hold can never overflow (the direction is all that matters).
+    fn accumulate(&mut self, dx: i32, dy: i32) {
+        self.dx = self.dx.saturating_add(dx);
+        self.dy = self.dy.saturating_add(dy);
+    }
+
+    /// Whether a gesture button is currently held.
+    fn is_holding(&self) -> bool {
+        self.button.is_some()
+    }
+
+    /// End the hold for `button`, returning the accumulated `(dx, dy)` — but only
+    /// if `button` is the one being held, so a stray release of another button is
+    /// ignored.
+    fn end(&mut self, button: ButtonId) -> Option<(i32, i32)> {
+        if self.button == Some(button) {
+            self.button = None;
+            Some((self.dx, self.dy))
+        } else {
+            None
+        }
+    }
+}
+
+/// Lock the hold accumulator, recovering the guard if a previous callback
+/// panicked while holding it — a poisoned lock must never wedge the input hook.
+fn lock_hold(hold: &Mutex<HoldState>) -> std::sync::MutexGuard<'_, HoldState> {
+    hold.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Attempt to start the OS hook. Returns `None` if Accessibility is not
 /// granted or on an unsupported platform — the app continues without crashing.
 pub fn start(
     bindings: BindingMap,
+    hook_gestures: HookGestures,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture: CaptureChannel,
 ) -> Option<Hook> {
@@ -34,13 +92,18 @@ pub fn start(
         return None;
     }
 
+    // Per-hold pointer accumulator. Touched only from the hook callback, which
+    // runs serially on one thread, so the mutex is always uncontended (and the
+    // callback must never block — see the freeze-hazard note in `macos.rs`).
+    let hold = Mutex::new(HoldState::default());
+
     let result = Hook::start(move |event| match event {
         MouseEvent::Button { id, pressed } => {
             // The CGEventTap only sees standard buttons 0-4. We remap
             // Middle/Back/Forward; the primary L/R clicks always pass through
             // (suppressing them would brick the mouse), and the DPI / thumb /
-            // gesture buttons aren't visible to the tap at all — the gesture
-            // button is captured separately over HID++.
+            // dedicated gesture button aren't visible to the tap at all — the
+            // dedicated gesture button is captured separately over HID++.
             if !matches!(
                 id,
                 ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
@@ -48,6 +111,31 @@ pub fn start(
                 return EventDisposition::PassThrough;
             }
 
+            // Gesture button: suppress the native click and, on release, resolve
+            // the held movement to a swipe direction (or a plain Click when the
+            // pointer barely moved). The button-down is recorded; the cursor is
+            // free to drift via the pass-through `Moved` events between them.
+            if pressed {
+                let is_gesture = hook_gestures.read().is_ok_and(|g| g.contains_key(&id));
+                if is_gesture {
+                    lock_hold(&hold).begin(id);
+                    return EventDisposition::Suppress;
+                }
+            } else if let Some((dx, dy)) = lock_hold(&hold).end(id) {
+                if let Some(map) = hook_gestures.read().ok().and_then(|g| g.get(&id).cloned()) {
+                    let action = match detect_swipe(dx, dy) {
+                        Some(dir) => map.get(&dir).cloned(),
+                        None => map.get(&GestureDirection::Click).cloned(),
+                    };
+                    if let Some(action) = action {
+                        info!(button = %id, dx, dy, action = %action.label(), "gesture → executing bound action");
+                        dispatch_action(&action, &dpi_cycle, &capture);
+                    }
+                }
+                return EventDisposition::Suppress;
+            }
+
+            // Single-action button.
             let action = bindings.read().ok().and_then(|g| g.get(&id).cloned());
             let Some(action) = action else {
                 // Unbound → leave the physical button to the OS.
@@ -66,6 +154,16 @@ pub fn start(
                 dispatch_action(&action, &dpi_cycle, &capture);
             }
             EventDisposition::Suppress
+        }
+        MouseEvent::Moved { delta_x, delta_y } => {
+            // Feed an in-progress gesture hold; always pass through so the cursor
+            // keeps moving. The swipe is read, not consumed — the B2 cursor-drift
+            // tradeoff vs. a HID++ raw-XY divert that would freeze the pointer.
+            let mut guard = lock_hold(&hold);
+            if guard.is_holding() {
+                guard.accumulate(delta_x, delta_y);
+            }
+            EventDisposition::PassThrough
         }
         MouseEvent::Scroll { .. } => EventDisposition::PassThrough,
     });
@@ -140,5 +238,56 @@ pub fn dispatch_action(
             action = %action.label(),
             "no DPI presets configured for active device — press ignored"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hold_accumulates_movement_between_begin_and_end() {
+        let mut hold = HoldState::default();
+        assert!(!hold.is_holding());
+
+        hold.begin(ButtonId::Back);
+        assert!(hold.is_holding());
+        hold.accumulate(3, -1);
+        hold.accumulate(2, -4);
+
+        // `end` of the held button returns the summed movement and clears the hold.
+        assert_eq!(hold.end(ButtonId::Back), Some((5, -5)));
+        assert!(!hold.is_holding());
+    }
+
+    #[test]
+    fn hold_begin_resets_prior_accumulation() {
+        let mut hold = HoldState::default();
+        hold.begin(ButtonId::Back);
+        hold.accumulate(10, 10);
+        // A fresh press starts a clean accumulator.
+        hold.begin(ButtonId::Forward);
+        hold.accumulate(1, 2);
+        assert_eq!(hold.end(ButtonId::Forward), Some((1, 2)));
+    }
+
+    #[test]
+    fn hold_end_ignores_a_different_button() {
+        let mut hold = HoldState::default();
+        hold.begin(ButtonId::Back);
+        hold.accumulate(4, 4);
+        // Releasing a button we aren't holding must not end the hold.
+        assert_eq!(hold.end(ButtonId::Forward), None);
+        assert!(hold.is_holding());
+        assert_eq!(hold.end(ButtonId::Back), Some((4, 4)));
+    }
+
+    #[test]
+    fn hold_accumulation_saturates_instead_of_overflowing() {
+        let mut hold = HoldState::default();
+        hold.begin(ButtonId::MiddleClick);
+        hold.accumulate(i32::MAX, i32::MIN);
+        hold.accumulate(i32::MAX, i32::MIN);
+        assert_eq!(hold.end(ButtonId::MiddleClick), Some((i32::MAX, i32::MIN)));
     }
 }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -7,11 +7,8 @@
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex, RwLock};
-use std::time::Instant;
 
-use openlogi_core::binding::{
-    Action, ButtonId, GESTURE_HOLD_FOR_SWIPE, GestureDirection, detect_swipe,
-};
+use openlogi_core::binding::{Action, ButtonId, GestureDirection, SwipeAccumulator};
 use openlogi_hid::CaptureChannel;
 use openlogi_hook::{EventDisposition, Hook, MouseEvent};
 use tracing::{info, warn};
@@ -29,53 +26,30 @@ pub type BindingMap = Arc<RwLock<BTreeMap<ButtonId, Action>>>;
 /// reaches the OS hook.
 pub type HookGestures = Arc<RwLock<BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>>>;
 
-/// Tracks an in-progress gesture-button hold and commits a swipe *mid-motion*,
-/// the moment travel passes [`detect_swipe`] (like Logitech Options+), rather
-/// than waiting for release — matching the HID++ thumb-pad path in
-/// `openlogi-hid`. A press that never commits a direction is a plain click,
-/// fired on release.
+/// Tracks which OS-hook button (Middle/Back/Forward) is mid-hold and defers the
+/// swipe detection itself to a shared [`SwipeAccumulator`], which commits a swipe
+/// *mid-motion* like the HID++ thumb-pad path in `openlogi-hid`. This wrapper
+/// adds only the button identity the accumulator doesn't track; a press that
+/// never commits a direction is a plain click, fired on release.
 #[derive(Default)]
 struct HoldState {
     button: Option<ButtonId>,
-    dx: i32,
-    dy: i32,
-    held_since: Option<Instant>,
-    /// Set once a swipe has committed this hold, so it fires exactly once and
-    /// the release doesn't then also fire the click.
-    fired: bool,
+    swipe: SwipeAccumulator,
 }
 
 impl HoldState {
-    /// Begin a hold for `button`, resetting the accumulator and commit state.
+    /// Begin a hold for `button`.
     fn begin(&mut self, button: ButtonId) {
         self.button = Some(button);
-        self.dx = 0;
-        self.dy = 0;
-        self.held_since = Some(Instant::now());
-        self.fired = false;
+        self.swipe.begin();
     }
 
-    /// Feed a pointer-move delta. Once the button has been held past
-    /// [`GESTURE_HOLD_FOR_SWIPE`] (so a quick click whose cursor drifted doesn't
-    /// count) and the travel commits to a direction, returns
-    /// `Some((button, direction))` exactly once per hold; the caller dispatches
-    /// it. Returns `None` while still too short, already fired, or not holding.
-    /// Saturating, so a very long hold can never overflow.
+    /// Feed a pointer-move delta into the active hold, tagging a committed swipe
+    /// with the held button. Returns `Some((button, direction))` exactly once per
+    /// hold, or `None` while still too short, already fired, or not holding.
     fn accumulate(&mut self, dx: i32, dy: i32) -> Option<(ButtonId, GestureDirection)> {
         let button = self.button?;
-        if self.fired {
-            return None;
-        }
-        self.dx = self.dx.saturating_add(dx);
-        self.dy = self.dy.saturating_add(dy);
-        let held_long_enough = self
-            .held_since
-            .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
-        if held_long_enough && let Some(dir) = detect_swipe(self.dx, self.dy) {
-            self.fired = true;
-            return Some((button, dir));
-        }
-        None
+        self.swipe.accumulate(dx, dy).map(|dir| (button, dir))
     }
 
     /// End the hold for `button`. Returns `Some(true)` when it ended a hold that
@@ -84,9 +58,8 @@ impl HoldState {
     /// of a button we weren't holding.
     fn end(&mut self, button: ButtonId) -> Option<bool> {
         if self.button == Some(button) {
-            let was_click = !self.fired;
             self.button = None;
-            Some(was_click)
+            Some(self.swipe.end())
         } else {
             None
         }
@@ -276,57 +249,37 @@ mod tests {
     use super::*;
     use openlogi_core::binding::GESTURE_SWIPE_THRESHOLD;
 
-    /// Backdate the hold so it is past the minimum-hold gate and a swipe can
-    /// commit — without sleeping in the test.
-    fn held_long_enough(hold: &mut HoldState) {
-        hold.held_since = Instant::now().checked_sub(GESTURE_HOLD_FOR_SWIPE * 2);
-    }
+    // The mid-swipe gate itself is unit-tested on `SwipeAccumulator` in
+    // `openlogi-core`; these cover only what `HoldState` adds on top — tagging a
+    // commit with the held button, and matching the button on release.
 
     #[test]
-    fn swipe_commits_once_mid_motion_and_suppresses_the_click() {
+    fn accumulate_tags_a_committed_swipe_with_the_held_button() {
         let mut hold = HoldState::default();
         hold.begin(ButtonId::Back);
-        held_long_enough(&mut hold);
+        hold.swipe.backdate_hold_for_test();
 
-        // A clear rightward swipe commits exactly once, mid-motion.
+        // A clear rightward swipe commits, tagged with the held button.
         assert_eq!(
             hold.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
             Some((ButtonId::Back, GestureDirection::Right))
         );
-        // Further motion in the same hold must not re-fire.
-        assert_eq!(hold.accumulate(50, 0), None);
+        assert_eq!(
+            hold.accumulate(50, 0),
+            None,
+            "commits at most once per hold"
+        );
         // A release after a committed swipe is NOT a click.
         assert_eq!(hold.end(ButtonId::Back), Some(false));
     }
 
     #[test]
-    fn hold_without_a_swipe_is_a_click_on_release() {
-        let mut hold = HoldState::default();
-        hold.begin(ButtonId::Forward);
-        held_long_enough(&mut hold);
-        // Tiny drift never commits a direction...
-        assert_eq!(hold.accumulate(2, -1), None);
-        // ...so the release fires the plain click.
-        assert_eq!(hold.end(ButtonId::Forward), Some(true));
-    }
-
-    #[test]
-    fn swipe_does_not_commit_before_the_minimum_hold() {
-        let mut hold = HoldState::default();
-        hold.begin(ButtonId::MiddleClick); // held_since = now
-        // A big delta arriving immediately (a quick click whose cursor drifted)
-        // must not commit — the hold is younger than GESTURE_HOLD_FOR_SWIPE.
-        assert_eq!(hold.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0), None);
-        // Once held long enough, the next delta commits.
-        held_long_enough(&mut hold);
-        assert!(hold.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0).is_some());
-    }
-
-    #[test]
-    fn end_ignores_a_different_button() {
+    fn end_matches_the_held_button() {
         let mut hold = HoldState::default();
         hold.begin(ButtonId::Back);
+        // A stray release of a button we weren't holding is ignored...
         assert_eq!(hold.end(ButtonId::Forward), None);
+        // ...and ending the held button with no swipe is a plain click.
         assert_eq!(hold.end(ButtonId::Back), Some(true));
     }
 }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -123,11 +123,12 @@ impl Orchestrator {
         let key = self.current_key();
         // One write publishes both hook maps atomically, so a button press during
         // an owner switch can't observe a half-updated state.
+        let app = self.current_app.as_deref();
         write_value(
             &self.shared.hook_maps,
             HookMaps {
-                bindings: bindings_for(&self.config, key, self.current_app.as_deref()),
-                gestures: oshook_gestures_for(&self.config, key),
+                bindings: bindings_for(&self.config, key, app),
+                gestures: oshook_gestures_for(&self.config, key, app),
             },
             "hook_maps",
         );
@@ -187,25 +188,26 @@ impl Orchestrator {
         self.config.app_settings.launch_at_login
     }
 
-    /// Foreground-app change → re-overlay per-app bindings (hook map only;
-    /// gestures and DPI are not app-scoped).
+    /// Foreground-app change → re-overlay per-app bindings on the hook maps (DPI
+    /// and the thumb-pad gesture map are not app-scoped, so they're untouched).
+    /// Both hook maps are recomputed: a per-app override of the gesture owner
+    /// turns it into a single action for that app, dropping it from the OS-hook
+    /// gesture set — so the gesture map is app-scoped too.
     pub fn set_current_app(&mut self, bundle: Option<String>) {
         if bundle == self.current_app {
             return;
         }
         self.current_app = bundle;
-        // Only the per-app single-action bindings change on an app switch (gestures
-        // and DPI aren't app-scoped), so update that field in place under the one
-        // lock and leave the gesture map untouched.
-        let bindings = bindings_for(
-            &self.config,
-            self.current_key(),
-            self.current_app.as_deref(),
+        let key = self.current_key();
+        let app = self.current_app.as_deref();
+        write_value(
+            &self.shared.hook_maps,
+            HookMaps {
+                bindings: bindings_for(&self.config, key, app),
+                gestures: oshook_gestures_for(&self.config, key, app),
+            },
+            "hook_maps",
         );
-        match self.shared.hook_maps.write() {
-            Ok(mut maps) => maps.bindings = bindings,
-            Err(e) => warn!(error = %e, lock = "hook_maps", "lock poisoned — keeping stale value"),
-        }
     }
 
     /// Replace the config (after `config.toml` changed) and rebuild everything.

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -118,18 +118,25 @@ impl Orchestrator {
         self.devices.get(self.current).and_then(|d| d.route.clone())
     }
 
+    /// Build the OS-hook callback's maps for `key` + foreground `app`. Both hook
+    /// sub-maps are app-scoped (a per-app override can demote the gesture owner),
+    /// so they're built together here and published under one lock — keeping
+    /// `rebuild` and `set_current_app` from drifting into a half-populated write.
+    fn hook_maps_for(&self, key: Option<&str>, app: Option<&str>) -> HookMaps {
+        HookMaps {
+            bindings: bindings_for(&self.config, key, app),
+            gestures: oshook_gestures_for(&self.config, key, app),
+        }
+    }
+
     /// Rewrite every shared map from the current config + selected device.
     fn rebuild(&self) {
         let key = self.current_key();
         // One write publishes both hook maps atomically, so a button press during
         // an owner switch can't observe a half-updated state.
-        let app = self.current_app.as_deref();
         write_value(
             &self.shared.hook_maps,
-            HookMaps {
-                bindings: bindings_for(&self.config, key, app),
-                gestures: oshook_gestures_for(&self.config, key, app),
-            },
+            self.hook_maps_for(key, self.current_app.as_deref()),
             "hook_maps",
         );
         write_value(
@@ -198,14 +205,9 @@ impl Orchestrator {
             return;
         }
         self.current_app = bundle;
-        let key = self.current_key();
-        let app = self.current_app.as_deref();
         write_value(
             &self.shared.hook_maps,
-            HookMaps {
-                bindings: bindings_for(&self.config, key, app),
-                gestures: oshook_gestures_for(&self.config, key, app),
-            },
+            self.hook_maps_for(self.current_key(), self.current_app.as_deref()),
             "hook_maps",
         );
     }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 use crate::DpiCycleState;
 use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
 use crate::device_order::DeviceStableId;
-use crate::hook_runtime::{BindingMap, HookGestures};
+use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::watchers::gesture::GestureBindings;
 
 /// The minimal per-device facts the agent needs: the config key (binding /
@@ -42,10 +42,10 @@ struct AgentDevice {
 /// on each rebuild and the background threads observe them on their next read.
 #[derive(Clone)]
 pub struct SharedRuntime {
-    pub hook_bindings: BindingMap,
-    /// Per-direction maps for OS-hook gesture buttons (Middle/Back/Forward in
-    /// gesture mode), read by the CGEventTap callback to resolve a hold+swipe.
-    pub hook_gestures: HookGestures,
+    /// The OS-hook callback's single-action + gesture maps, behind one lock so a
+    /// rebuild publishes both atomically (see [`HookMaps`]). Also read by the
+    /// gesture watcher for the thumb-wheel/DPI-button single actions.
+    pub hook_maps: SharedHookMaps,
     pub gesture_bindings: GestureBindings,
     pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
     pub thumbwheel_sensitivity: Arc<AtomicI32>,
@@ -80,8 +80,7 @@ impl Orchestrator {
     #[must_use]
     pub fn new(config: Config) -> Self {
         let shared = SharedRuntime {
-            hook_bindings: Arc::new(RwLock::new(BTreeMap::new())),
-            hook_gestures: Arc::new(RwLock::new(BTreeMap::new())),
+            hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(AtomicI32::new(
@@ -122,15 +121,15 @@ impl Orchestrator {
     /// Rewrite every shared map from the current config + selected device.
     fn rebuild(&self) {
         let key = self.current_key();
+        // One write publishes both hook maps atomically, so a button press during
+        // an owner switch can't observe a half-updated state.
         write_value(
-            &self.shared.hook_bindings,
-            bindings_for(&self.config, key, self.current_app.as_deref()),
-            "hook_bindings",
-        );
-        write_value(
-            &self.shared.hook_gestures,
-            oshook_gestures_for(&self.config, key),
-            "hook_gestures",
+            &self.shared.hook_maps,
+            HookMaps {
+                bindings: bindings_for(&self.config, key, self.current_app.as_deref()),
+                gestures: oshook_gestures_for(&self.config, key),
+            },
+            "hook_maps",
         );
         write_value(
             &self.shared.gesture_bindings,
@@ -195,15 +194,18 @@ impl Orchestrator {
             return;
         }
         self.current_app = bundle;
-        write_value(
-            &self.shared.hook_bindings,
-            bindings_for(
-                &self.config,
-                self.current_key(),
-                self.current_app.as_deref(),
-            ),
-            "hook_bindings",
+        // Only the per-app single-action bindings change on an app switch (gestures
+        // and DPI aren't app-scoped), so update that field in place under the one
+        // lock and leave the gesture map untouched.
+        let bindings = bindings_for(
+            &self.config,
+            self.current_key(),
+            self.current_app.as_deref(),
         );
+        match self.shared.hook_maps.write() {
+            Ok(mut maps) => maps.bindings = bindings,
+            Err(e) => warn!(error = %e, lock = "hook_maps", "lock poisoned — keeping stale value"),
+        }
     }
 
     /// Replace the config (after `config.toml` changed) and rebuild everything.

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -20,9 +20,9 @@ use openlogi_hid::{CaptureChannel, DIRECT_DEVICE_INDEX, DeviceRoute};
 use tracing::warn;
 
 use crate::DpiCycleState;
-use crate::bindings::{bindings_for, gesture_bindings_for};
+use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
 use crate::device_order::DeviceStableId;
-use crate::hook_runtime::BindingMap;
+use crate::hook_runtime::{BindingMap, HookGestures};
 use crate::watchers::gesture::GestureBindings;
 
 /// The minimal per-device facts the agent needs: the config key (binding /
@@ -43,6 +43,9 @@ struct AgentDevice {
 #[derive(Clone)]
 pub struct SharedRuntime {
     pub hook_bindings: BindingMap,
+    /// Per-direction maps for OS-hook gesture buttons (Middle/Back/Forward in
+    /// gesture mode), read by the CGEventTap callback to resolve a hold+swipe.
+    pub hook_gestures: HookGestures,
     pub gesture_bindings: GestureBindings,
     pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
     pub thumbwheel_sensitivity: Arc<AtomicI32>,
@@ -78,6 +81,7 @@ impl Orchestrator {
     pub fn new(config: Config) -> Self {
         let shared = SharedRuntime {
             hook_bindings: Arc::new(RwLock::new(BTreeMap::new())),
+            hook_gestures: Arc::new(RwLock::new(BTreeMap::new())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(AtomicI32::new(
@@ -122,6 +126,11 @@ impl Orchestrator {
             &self.shared.hook_bindings,
             bindings_for(&self.config, key, self.current_app.as_deref()),
             "hook_bindings",
+        );
+        write_value(
+            &self.shared.hook_gestures,
+            oshook_gestures_for(&self.config, key),
+            "hook_gestures",
         );
         write_value(
             &self.shared.gesture_bindings,

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -31,7 +31,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 use crate::DpiCycleState;
-use crate::hook_runtime::{self, BindingMap};
+use crate::hook_runtime::{self, SharedHookMaps};
 
 /// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
 /// direction). The watcher reads it to map a captured swipe to a bound action.
@@ -73,7 +73,7 @@ fn action_threshold(sensitivity: i32) -> i32 {
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
 pub fn spawn(
-    button_bindings: BindingMap,
+    hook_maps: SharedHookMaps,
     gesture_bindings: GestureBindings,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture_channel: CaptureChannel,
@@ -93,7 +93,7 @@ pub fn spawn(
             }
         };
         runtime.block_on(manage(
-            button_bindings,
+            hook_maps,
             gesture_bindings,
             dpi_cycle,
             capture_channel,
@@ -110,11 +110,11 @@ pub fn spawn(
 /// We divert when the sensitivity leaves its default (so we can scale scroll
 /// ourselves) or when the click or either rotation direction is rebound away
 /// from its default; otherwise the OS scrolls the wheel natively.
-fn thumbwheel_armed(button_bindings: &BindingMap, sensitivity: i32) -> bool {
+fn thumbwheel_armed(hook_maps: &SharedHookMaps, sensitivity: i32) -> bool {
     if sensitivity != DEFAULT_THUMBWHEEL_SENSITIVITY {
         return true;
     }
-    button_bindings.read().ok().is_some_and(|guard| {
+    hook_maps.read().ok().is_some_and(|maps| {
         [
             ButtonId::Thumbwheel,
             ButtonId::ThumbwheelScrollUp,
@@ -122,7 +122,7 @@ fn thumbwheel_armed(button_bindings: &BindingMap, sensitivity: i32) -> bool {
         ]
         .iter()
         .any(|&button| {
-            guard
+            maps.bindings
                 .get(&button)
                 .is_some_and(|action| *action != default_binding(button))
         })
@@ -133,7 +133,7 @@ fn thumbwheel_armed(button_bindings: &BindingMap, sensitivity: i32) -> bool {
 /// device or the thumb-wheel arming changes, and dispatch incoming inputs. Runs
 /// for the lifetime of the process.
 async fn manage(
-    button_bindings: BindingMap,
+    hook_maps: SharedHookMaps,
     gesture_bindings: GestureBindings,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture_channel: CaptureChannel,
@@ -154,7 +154,7 @@ async fn manage(
                 dispatch(
                     input,
                     &mut accumulators,
-                    &button_bindings,
+                    &hook_maps,
                     &gesture_bindings,
                     &dpi_cycle,
                     &capture_channel,
@@ -179,7 +179,7 @@ async fn manage(
                     target.map(|t| {
                         (
                             t,
-                            thumbwheel_armed(&button_bindings, sensitivity),
+                            thumbwheel_armed(&hook_maps, sensitivity),
                             divert_gesture,
                         )
                     })
@@ -257,7 +257,7 @@ enum WheelOutput {
 fn dispatch(
     input: CapturedInput,
     accumulators: &mut WheelAccumulators,
-    button_bindings: &BindingMap,
+    hook_maps: &SharedHookMaps,
     gesture_bindings: &GestureBindings,
     dpi_cycle: &Arc<RwLock<DpiCycleState>>,
     capture: &CaptureChannel,
@@ -277,10 +277,10 @@ fn dispatch(
             }
         }
         CapturedInput::ButtonPressed(button) => {
-            let action = button_bindings
+            let action = hook_maps
                 .read()
                 .ok()
-                .and_then(|guard| guard.get(&button).cloned());
+                .and_then(|maps| maps.bindings.get(&button).cloned());
             if let Some(action) = action {
                 debug!(?button, action = %action.label(), "HID++ button → action");
                 hook_runtime::dispatch_action(&action, dpi_cycle, capture);
@@ -296,10 +296,10 @@ fn dispatch(
             } else {
                 ButtonId::ThumbwheelScrollDown
             };
-            let action = button_bindings
+            let action = hook_maps
                 .read()
                 .ok()
-                .and_then(|guard| guard.get(&button).cloned())
+                .and_then(|maps| maps.bindings.get(&button).cloned())
                 .unwrap_or_else(|| default_binding(button));
             let sensitivity = thumbwheel_sensitivity.load(Ordering::Relaxed);
             let dir = if up {

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -142,7 +142,8 @@ async fn manage(
     capture_idle: Arc<AtomicBool>,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
-    let mut current: Option<(DeviceRoute, bool)> = None;
+    // (route, capture_thumbwheel, divert_gesture_button)
+    let mut current: Option<(DeviceRoute, bool, bool)> = None;
     let mut stop: Option<oneshot::Sender<()>> = None;
     let mut ticker = tokio::time::interval(TARGET_POLL);
     let mut accumulators = WheelAccumulators::default();
@@ -169,7 +170,19 @@ async fn manage(
                 } else {
                     let target = dpi_cycle.read().ok().and_then(|guard| guard.target.clone());
                     let sensitivity = thumbwheel_sensitivity.load(Ordering::Relaxed);
-                    target.map(|t| (t, thumbwheel_armed(&button_bindings, sensitivity)))
+                    // Divert the thumb pad only while it owns the gesture role. The
+                    // shared gesture map is non-empty exactly then (gesture_bindings_for
+                    // gates on the owner), so it doubles as that signal — no need to
+                    // thread the full config in. Re-evaluated each tick, so a
+                    // ReloadConfig owner change restarts the session accordingly.
+                    let divert_gesture = gesture_bindings.read().is_ok_and(|g| !g.is_empty());
+                    target.map(|t| {
+                        (
+                            t,
+                            thumbwheel_armed(&button_bindings, sensitivity),
+                            divert_gesture,
+                        )
+                    })
                 };
                 if want == current {
                     continue;
@@ -182,13 +195,20 @@ async fn manage(
                 }
                 current.clone_from(&want);
                 capture_idle.store(want.is_none(), Ordering::Relaxed);
-                if let Some((route, capture_thumbwheel)) = want {
+                if let Some((route, capture_thumbwheel, divert_gesture_button)) = want {
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let sink = tx.clone();
                     let slot = Arc::clone(&capture_channel);
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            run_capture_session(route, capture_thumbwheel, sink, stop_rx, slot).await
+                        if let Err(e) = run_capture_session(
+                            route,
+                            capture_thumbwheel,
+                            divert_gesture_button,
+                            sink,
+                            stop_rx,
+                            slot,
+                        )
+                        .await
                         {
                             debug!(error = %e, "capture session ended");
                         }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -166,6 +166,7 @@ async fn run(config: Config) {
                     info!("accessibility granted — installing OS mouse hook");
                     hook = hook_runtime::start(
                         shared.hook_bindings.clone(),
+                        shared.hook_gestures.clone(),
                         shared.dpi_cycle.clone(),
                         shared.capture_channel.clone(),
                     );

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -116,7 +116,7 @@ async fn run(config: Config) {
     // shared maps and dispatches bound actions itself; the two pairing flags let
     // it release its capture session while a pairing session owns the receiver.
     watchers::gesture::spawn(
-        shared.hook_bindings.clone(),
+        shared.hook_maps.clone(),
         shared.gesture_bindings.clone(),
         shared.dpi_cycle.clone(),
         shared.capture_channel.clone(),
@@ -165,8 +165,7 @@ async fn run(config: Config) {
                 if granted && hook.is_none() {
                     info!("accessibility granted — installing OS mouse hook");
                     hook = hook_runtime::start(
-                        shared.hook_bindings.clone(),
-                        shared.hook_gestures.clone(),
+                        shared.hook_maps.clone(),
                         shared.dpi_cycle.clone(),
                         shared.capture_channel.clone(),
                     );

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -626,6 +626,21 @@ impl Binding {
             *self = Binding::Gesture(map);
         }
     }
+
+    /// Fill any unbound directions of a [`Gesture`](Binding::Gesture) binding
+    /// with their canonical [`default_gesture_binding`], so a button promoted to
+    /// the gesture role always exposes the full five-direction set — rather than
+    /// leaving swipe arms the GUI renders as defaults but the runtime never
+    /// dispatches. A no-op on [`Single`](Binding::Single) and on directions
+    /// already bound (existing user choices are preserved).
+    pub fn fill_gesture_defaults(&mut self) {
+        if let Binding::Gesture(map) = self {
+            for dir in GestureDirection::ALL {
+                map.entry(dir)
+                    .or_insert_with(|| default_gesture_binding(dir));
+            }
+        }
+    }
 }
 
 impl From<Action> for Binding {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -54,6 +54,21 @@ impl ButtonId {
         ButtonId::GestureButton,
     ];
 
+    /// Whether this button is one the OS hook (macOS `CGEventTap` / Linux evdev)
+    /// remaps: Middle, Back, or Forward. The primary L/R clicks always pass
+    /// through (suppressing them would brick the mouse), and the DPI / thumb /
+    /// dedicated gesture controls aren't visible to the OS hook at all (they're
+    /// captured over HID++). These are exactly the buttons that can become an
+    /// OS-hook gesture button, so the hook's remap gate and the gesture-owner
+    /// projection share this one definition.
+    #[must_use]
+    pub fn is_os_hook_button(self) -> bool {
+        matches!(
+            self,
+            ButtonId::MiddleClick | ButtonId::Back | ButtonId::Forward
+        )
+    }
+
     /// Human-readable label for popovers and tooltips.
     #[must_use]
     pub fn label(self) -> &'static str {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -8,6 +8,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 
@@ -182,6 +183,91 @@ pub fn detect_swipe(dx: i32, dy: i32) -> Option<GestureDirection> {
         } else {
             GestureDirection::Up
         })
+    }
+}
+
+/// The mid-swipe state machine shared by both gesture-capture paths: the HID++
+/// thumb pad (`openlogi-hid`'s `0x1b04` raw-XY divert) and the OS-hook
+/// Middle/Back/Forward buttons (`openlogi-agent-core`'s CGEventTap). A gesture
+/// button's hold accumulates travel; the instant the dominant axis commits a
+/// direction — after the button has been held [`GESTURE_HOLD_FOR_SWIPE`], so a
+/// quick click whose cursor drifted doesn't count — [`Self::accumulate`] returns
+/// that direction exactly once, like Logitech Options+. A hold that never
+/// commits is a plain click, reported by [`Self::end`].
+///
+/// The two paths differ only in *what identifies the held control* (a
+/// [`ButtonId`] for the OS hook, a diverted CID for the thumb pad), so each owns
+/// that and embeds this for the shared travel logic. Keeping the logic in one
+/// place is deliberate: the two copies it replaced had already drifted apart
+/// (one resolved a swipe only on release), which mis-fired the click.
+#[derive(Debug, Default)]
+pub struct SwipeAccumulator {
+    /// When the current hold began, or `None` when not holding. Gates a
+    /// deliberate swipe against a quick click whose cursor happened to move.
+    held_since: Option<Instant>,
+    /// Accumulated raw-XY travel since the hold began (saturating, so an
+    /// arbitrarily long hold can never overflow).
+    dx: i32,
+    dy: i32,
+    /// Set once a direction has committed this hold, so it fires exactly once
+    /// and the release isn't then also read as a click.
+    fired: bool,
+}
+
+impl SwipeAccumulator {
+    /// Begin a fresh hold, resetting the travel accumulator and commit state.
+    pub fn begin(&mut self) {
+        self.held_since = Some(Instant::now());
+        self.dx = 0;
+        self.dy = 0;
+        self.fired = false;
+    }
+
+    /// Whether a hold is in progress (between [`Self::begin`] and [`Self::end`]),
+    /// so callers can do rising/falling-edge detection without a second flag.
+    #[must_use]
+    pub fn is_holding(&self) -> bool {
+        self.held_since.is_some()
+    }
+
+    /// Feed a pointer-move / raw-XY delta into the current hold. Returns
+    /// `Some(direction)` exactly once per hold — the instant travel commits, and
+    /// only after the hold passes [`GESTURE_HOLD_FOR_SWIPE`] — and `None` while
+    /// still too short, already committed, or not holding.
+    pub fn accumulate(&mut self, dx: i32, dy: i32) -> Option<GestureDirection> {
+        if self.fired || self.held_since.is_none() {
+            return None;
+        }
+        self.dx = self.dx.saturating_add(dx);
+        self.dy = self.dy.saturating_add(dy);
+        let held_long_enough = self
+            .held_since
+            .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
+        if held_long_enough && let Some(dir) = detect_swipe(self.dx, self.dy) {
+            self.fired = true;
+            return Some(dir);
+        }
+        None
+    }
+
+    /// End the current hold. Returns `true` when it never committed a swipe — the
+    /// caller should fire the plain `Click` action — and `false` when a swipe
+    /// already fired mid-motion.
+    pub fn end(&mut self) -> bool {
+        let was_click = !self.fired;
+        self.held_since = None;
+        was_click
+    }
+
+    /// Test-only seam: backdate the current hold so its [`GESTURE_HOLD_FOR_SWIPE`]
+    /// gate is already satisfied, letting a test exercise a committed swipe
+    /// without sleeping. Real code never calls this — [`Self::begin`] records the
+    /// true start instant. A no-op when not currently holding.
+    #[doc(hidden)]
+    pub fn backdate_hold_for_test(&mut self) {
+        if self.held_since.is_some() {
+            self.held_since = Instant::now().checked_sub(GESTURE_HOLD_FOR_SWIPE * 2);
+        }
     }
 }
 
@@ -521,6 +607,18 @@ impl Binding {
     #[must_use]
     pub fn is_gesture(&self) -> bool {
         matches!(self, Binding::Gesture(_))
+    }
+
+    /// Promote a [`Single`](Binding::Single) binding in place to a
+    /// [`Gesture`](Binding::Gesture), keeping its action as the
+    /// [`GestureDirection::Click`] entry and leaving the swipe arms unbound.
+    /// A no-op when this is already a [`Gesture`].
+    pub fn upgrade_to_gesture(&mut self) {
+        if let Binding::Single(action) = self {
+            let mut map = BTreeMap::new();
+            map.insert(GestureDirection::Click, action.clone());
+            *self = Binding::Gesture(map);
+        }
     }
 }
 
@@ -1972,6 +2070,58 @@ mod tests {
         // Past the threshold but too diagonal (cross axis beyond the band).
         assert_eq!(detect_swipe(60, 60), None);
         assert_eq!(detect_swipe(-60, -60), None);
+    }
+
+    // ── SwipeAccumulator (the shared mid-swipe state machine) ─────────────────
+
+    #[test]
+    fn accumulator_commits_a_direction_once_after_the_hold_gate() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        acc.backdate_hold_for_test();
+        // A clear rightward swipe commits exactly once, mid-motion.
+        assert_eq!(
+            acc.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
+            Some(GestureDirection::Right)
+        );
+        // Further travel in the same hold must not re-fire.
+        assert_eq!(acc.accumulate(50, 0), None);
+    }
+
+    #[test]
+    fn accumulator_does_not_commit_before_the_hold_gate() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin(); // held_since = now, so the gate is not yet satisfied
+        // A big delta arriving immediately (a quick click whose cursor drifted)
+        // must not commit.
+        assert_eq!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0), None);
+        // Once held long enough, the next delta commits.
+        acc.backdate_hold_for_test();
+        assert!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0).is_some());
+    }
+
+    #[test]
+    fn accumulator_end_reports_click_only_when_no_swipe_fired() {
+        // A hold with only tiny drift never commits → end() is a click.
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        acc.backdate_hold_for_test();
+        assert_eq!(acc.accumulate(2, -1), None);
+        assert!(acc.end(), "a hold that never swiped is a click");
+
+        // A hold that committed a swipe → end() is not a click.
+        acc.begin();
+        acc.backdate_hold_for_test();
+        assert!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0).is_some());
+        assert!(!acc.end(), "a committed swipe must not also click");
+    }
+
+    #[test]
+    fn accumulator_ignores_motion_when_not_holding() {
+        let mut acc = SwipeAccumulator::default();
+        assert!(!acc.is_holding());
+        // Travel outside a hold is dropped, never committing a stray swipe.
+        assert_eq!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0), None);
     }
 
     // ── TOML roundtrip ────────────────────────────────────────────────────────

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -159,12 +159,17 @@ pub const GESTURE_HOLD_FOR_SWIPE: std::time::Duration = std::time::Duration::fro
 /// down), so an upward swipe (negative `dy`) maps to [`GestureDirection::Up`].
 #[must_use]
 pub fn detect_swipe(dx: i32, dy: i32) -> Option<GestureDirection> {
-    let (abs_x, abs_y) = (dx.abs(), dy.abs());
+    // Saturating throughout: a [`SwipeAccumulator`] hold that never commits (a
+    // sustained diagonal) keeps summing travel, so `dx`/`dy` can reach the i32
+    // bounds. `i32::MIN.abs()` would panic and a plain `dominant * 35` would
+    // overflow — and a panic in the input-hook callback is exactly the freeze
+    // hazard we must never hit. The clamp is inert in the normal range.
+    let (abs_x, abs_y) = (dx.saturating_abs(), dy.saturating_abs());
     let dominant = abs_x.max(abs_y);
     if dominant < GESTURE_SWIPE_THRESHOLD {
         return None;
     }
-    let cross_limit = GESTURE_SWIPE_DEADZONE.max(dominant * 35 / 100);
+    let cross_limit = GESTURE_SWIPE_DEADZONE.max(dominant.saturating_mul(35) / 100);
     if abs_x > abs_y {
         if abs_y > cross_limit {
             return None;
@@ -250,11 +255,12 @@ impl SwipeAccumulator {
         None
     }
 
-    /// End the current hold. Returns `true` when it never committed a swipe — the
-    /// caller should fire the plain `Click` action — and `false` when a swipe
-    /// already fired mid-motion.
+    /// End the current hold. Returns `true` when an in-progress hold ended
+    /// without committing a swipe — the caller should fire the plain `Click`
+    /// action — and `false` when a swipe already fired mid-motion, or when there
+    /// was no hold to end (a stray release reports no click).
     pub fn end(&mut self) -> bool {
-        let was_click = !self.fired;
+        let was_click = self.held_since.is_some() && !self.fired;
         self.held_since = None;
         was_click
     }
@@ -2072,6 +2078,37 @@ mod tests {
         assert_eq!(detect_swipe(-60, -60), None);
     }
 
+    #[test]
+    fn detect_swipe_threshold_and_cross_band_boundaries() {
+        // The threshold bound is inclusive (`< THRESHOLD` rejects), so exactly at
+        // it commits and one below does not.
+        assert_eq!(
+            detect_swipe(GESTURE_SWIPE_THRESHOLD, 0),
+            Some(GestureDirection::Right)
+        );
+        assert_eq!(detect_swipe(GESTURE_SWIPE_THRESHOLD - 1, 0), None);
+
+        // The cross-axis band is max(deadzone, 35% of dominant). For a large
+        // dominant the 35% term wins (200 → 70): 69 commits, 71 is too diagonal.
+        assert_eq!(detect_swipe(200, 69), Some(GestureDirection::Right));
+        assert_eq!(detect_swipe(200, 71), None);
+        // For a small dominant the 40-unit floor wins (100 → max(40, 35) = 40).
+        assert_eq!(detect_swipe(100, 39), Some(GestureDirection::Right));
+        assert_eq!(detect_swipe(100, 41), None);
+    }
+
+    #[test]
+    fn detect_swipe_does_not_panic_on_extreme_values() {
+        // Saturated accumulator travel can reach the i32 bounds. `i32::MIN.abs()`
+        // panics and `dominant * 35` overflows — both must be clamped, not crash.
+        assert_eq!(detect_swipe(i32::MAX, 0), Some(GestureDirection::Right));
+        assert_eq!(detect_swipe(i32::MIN, 0), Some(GestureDirection::Left));
+        assert_eq!(detect_swipe(0, i32::MAX), Some(GestureDirection::Down));
+        assert_eq!(detect_swipe(0, i32::MIN), Some(GestureDirection::Up));
+        // A diagonal at the extremes is still rejected, without panicking.
+        assert_eq!(detect_swipe(i32::MIN, i32::MIN), None);
+    }
+
     // ── SwipeAccumulator (the shared mid-swipe state machine) ─────────────────
 
     #[test]
@@ -2122,6 +2159,87 @@ mod tests {
         assert!(!acc.is_holding());
         // Travel outside a hold is dropped, never committing a stray swipe.
         assert_eq!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0), None);
+    }
+
+    #[test]
+    fn accumulator_sums_sub_threshold_deltas_until_they_commit() {
+        // The whole reason for an accumulator (vs. detect_swipe on one delta):
+        // several deltas each too small to commit on their own must sum across
+        // the hold until the running total crosses the threshold, then commit.
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        acc.backdate_hold_for_test();
+        // Just under half the threshold: one or two steps never reach it, three do.
+        let step = GESTURE_SWIPE_THRESHOLD / 2 - 1;
+        assert_eq!(acc.accumulate(step, 0), None, "one step is sub-threshold");
+        assert_eq!(acc.accumulate(step, 0), None, "two steps still under");
+        assert_eq!(
+            acc.accumulate(step, 0),
+            Some(GestureDirection::Right),
+            "the running sum finally crosses the threshold"
+        );
+    }
+
+    #[test]
+    fn accumulator_saturates_instead_of_overflowing() {
+        // The doc promises an arbitrarily long hold can't overflow. A perfect
+        // diagonal never commits, so travel keeps summing; feed deltas that would
+        // overflow both an i32 sum and a naive cross-band multiply — both must
+        // saturate, not panic (debug builds panic on overflow).
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        acc.backdate_hold_for_test();
+        assert_eq!(
+            acc.accumulate(i32::MAX, i32::MAX),
+            None,
+            "a diagonal never commits"
+        );
+        assert_eq!(
+            acc.accumulate(i32::MAX, i32::MAX),
+            None,
+            "the saturating sum must not panic"
+        );
+        // A clean axis on a fresh hold still commits with a saturated magnitude.
+        acc.begin();
+        acc.backdate_hold_for_test();
+        assert_eq!(acc.accumulate(i32::MAX, 0), Some(GestureDirection::Right));
+    }
+
+    #[test]
+    fn accumulator_begin_recovers_a_stale_hold() {
+        // A missed release (e.g. focus loss between press and release) can leave
+        // a dangling hold that already fired with travel in some direction. A
+        // fresh begin() must wipe both the `fired` latch and the travel, so the
+        // next press isn't poisoned by the old one.
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        acc.backdate_hold_for_test();
+        // Stale hold commits LEFT (negative dx) and latches `fired`.
+        assert_eq!(
+            acc.accumulate(-(GESTURE_SWIPE_THRESHOLD + 10), 0),
+            Some(GestureDirection::Left)
+        );
+        // No end() — a dropped release, then a fresh press.
+        acc.begin();
+        acc.backdate_hold_for_test();
+        // Had `fired` leaked this would be None; had the negative travel leaked it
+        // would commit Left. Committing Right proves begin() reset both.
+        assert_eq!(
+            acc.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
+            Some(GestureDirection::Right)
+        );
+    }
+
+    #[test]
+    fn accumulator_end_without_a_hold_is_not_a_click() {
+        // end() in isolation (no begin) must not claim a click — there was no
+        // hold — so a stray release can't be read as a press.
+        let mut acc = SwipeAccumulator::default();
+        assert!(!acc.end(), "a release with no hold is not a click");
+        // A redundant second release after a real hold already ended is inert too.
+        acc.begin();
+        assert!(acc.end(), "the held release is a click");
+        assert!(!acc.end(), "the redundant second release is not a click");
     }
 
     // ── TOML roundtrip ────────────────────────────────────────────────────────

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -138,6 +138,11 @@ pub const GESTURE_SWIPE_THRESHOLD: i32 = 50;
 /// Maximum cross-axis travel allowed at the threshold, so only a reasonably
 /// straight swipe commits. Grows with the dominant axis (`max(deadzone, 35%)`).
 pub const GESTURE_SWIPE_DEADZONE: i32 = 40;
+/// Minimum time a gesture button must be held before its travel can commit to a
+/// swipe. Distinguishes a deliberate hold-and-swipe from a quick click whose
+/// cursor happened to be moving. Shared by both gesture paths (the HID++ thumb
+/// pad and the OS-hook Middle/Back/Forward).
+pub const GESTURE_HOLD_FOR_SWIPE: std::time::Duration = std::time::Duration::from_millis(160);
 
 /// Classify the *running* raw-XY travel of a held gesture button into a
 /// directional swipe, the instant it commits — or `None` while it's still too
@@ -987,11 +992,20 @@ const VK_Z: u16 = 0x06;
 #[cfg(target_os = "macos")]
 const VK_TAB: u16 = 0x30;
 
+/// Stamped into the `EVENT_SOURCE_USER_DATA` field of every mouse event
+/// [`Action::execute`] synthesizes on macOS, so OpenLogi's own `CGEventTap` can
+/// recognize and skip its own injections. Without it, a gesture/button action
+/// that posts a mouse button (e.g. a remapped `MiddleClick`) would re-enter the
+/// hook — and for a gesture button, be misread as a fresh hold, looping. The
+/// value is arbitrary but distinctive ("OLGI"); real events carry `0` here.
+pub const SYNTHETIC_EVENT_USER_DATA: i64 = 0x4F4C_4749;
+
 /// Platform helpers for synthesising OS-level input events on macOS.
 #[cfg(target_os = "macos")]
 mod macos {
     use core_graphics::event::{
-        CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGMouseButton, ScrollEventUnit,
+        CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGMouseButton, EventField,
+        ScrollEventUnit,
     };
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
     use core_graphics::geometry::CGPoint;
@@ -1020,6 +1034,13 @@ mod macos {
         };
         for (kind, phase) in [(down, "down"), (up, "up")] {
             if let Ok(ev) = CGEvent::new_mouse_event(src.clone(), kind, location, button) {
+                // Mark it ours so our own CGEventTap skips it instead of treating
+                // a remapped click (e.g. a gesture button's `MiddleClick`) as a
+                // fresh button event and re-entering the hook.
+                ev.set_integer_value_field(
+                    EventField::EVENT_SOURCE_USER_DATA,
+                    super::SYNTHETIC_EVENT_USER_DATA,
+                );
                 ev.post(CGEventTapLocation::HID);
             } else {
                 tracing::warn!(phase, "CGEvent::new_mouse_event failed");

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -16,9 +16,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::binding::{
-    Action, Binding, ButtonId, GestureDirection, default_binding, default_binding_for,
-};
+use crate::binding::{Action, Binding, ButtonId, GestureDirection, default_binding_for};
 use crate::paths::{self, PathsError};
 
 /// The schema version the current build produces. Bumped on breaking layout
@@ -204,6 +202,43 @@ where
     Ok(u8::deserialize(deserializer)?.min(100))
 }
 
+/// Which control owns a device's single gesture role.
+///
+/// Stored explicitly — rather than inferred from which button happens to carry a
+/// [`Binding::Gesture`] — so switching the gesture button never has to collapse
+/// a button's gesture map to encode the choice: every gesture-capable button
+/// keeps its full direction map, and only the owner is dispatched. Serialized as
+/// a bare string (`"Off"` or a [`ButtonId`] name) so it stays a TOML scalar.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GestureOwner {
+    /// Gestures are explicitly turned off for this device.
+    Off,
+    /// The named button owns the gesture role.
+    Button(ButtonId),
+}
+
+impl Serialize for GestureOwner {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            // "Off" can't collide with a ButtonId variant name (all CamelCase
+            // control names), so the string space is unambiguous.
+            GestureOwner::Off => serializer.serialize_str("Off"),
+            GestureOwner::Button(id) => id.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for GestureOwner {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::IntoDeserializer;
+        let s = String::deserialize(deserializer)?;
+        if s == "Off" {
+            return Ok(GestureOwner::Off);
+        }
+        ButtonId::deserialize(s.as_str().into_deserializer()).map(GestureOwner::Button)
+    }
+}
+
 /// Settings scoped to a single physical device (keyed by HID++ model+ext).
 ///
 /// Deserialization goes through [`RawDeviceConfig`] (`#[serde(from)]`) so
@@ -214,6 +249,12 @@ where
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(from = "RawDeviceConfig")]
 pub struct DeviceConfig {
+    /// Which button owns the device's single gesture role, once the user has
+    /// chosen explicitly. Absent means "infer" (the thumb pad owns gestures if
+    /// present) — see [`Config::gesture_owner`]. Listed first so it serializes
+    /// as a scalar ahead of the `bindings` sub-table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gesture_owner: Option<GestureOwner>,
     /// Every rebindable button's binding: a single [`Action`], or — for the
     /// gesture button (and, later, any raw-XY-capable button) — a
     /// [`Binding::Gesture`] per-direction map.
@@ -245,6 +286,10 @@ pub struct DeviceConfig {
 /// in the v2 shape.
 #[derive(Deserialize)]
 struct RawDeviceConfig {
+    /// Explicit gesture owner (v2.1+). Absent on older configs → `None` → the
+    /// owner is inferred in [`Config::gesture_owner`].
+    #[serde(default)]
+    gesture_owner: Option<GestureOwner>,
     /// v2 shape — present on already-migrated files; wins on any key collision.
     #[serde(default)]
     bindings: BTreeMap<ButtonId, Binding>,
@@ -294,6 +339,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
         }
 
         DeviceConfig {
+            gesture_owner: raw.gesture_owner,
             bindings,
             per_app_bindings: raw.per_app_bindings,
             dpi_presets: raw.dpi_presets,
@@ -465,108 +511,80 @@ impl Config {
         }
     }
 
-    /// The device's gesture button, or `None` when gestures are turned off.
+    /// The button that owns `device_key`'s single gesture role, or `None` when
+    /// gestures are turned off.
     ///
-    /// The dedicated thumb pad ([`ButtonId::GestureButton`]) is the *default*
-    /// gesture button: it owns the role whenever it's left at its default or set
-    /// to a [`Binding::Gesture`]. An explicitly-configured OS-hook button
-    /// (Middle/Back/Forward in gesture mode) takes the role over, silencing the
-    /// thumb pad. The thumb pad is off only when it has been explicitly demoted
-    /// to a [`Binding::Single`] (the "Off" selection) with no other gesture
-    /// button set. At most one button gestures per device.
+    /// Resolved from the explicit [`DeviceConfig::gesture_owner`] when present;
+    /// otherwise inferred (see [`Self::infer_gesture_owner`]) for configs
+    /// predating the field and freshly-migrated pre-v2 files. The dedicated thumb
+    /// pad ([`ButtonId::GestureButton`]) owns the role by default. At most one
+    /// button gestures per device.
     #[must_use]
     pub fn gesture_owner(&self, device_key: &str) -> Option<ButtonId> {
-        if let Some(bindings) = self.devices.get(device_key).map(|d| &d.bindings) {
-            // An explicit OS-hook gesture button takes over from the thumb pad.
-            if let Some((id, _)) = bindings
-                .iter()
-                .find(|(id, b)| **id != ButtonId::GestureButton && b.is_gesture())
-            {
-                return Some(*id);
-            }
-            // Thumb pad explicitly demoted (and nothing else set) → gestures off.
-            if matches!(
-                bindings.get(&ButtonId::GestureButton),
-                Some(Binding::Single(_))
-            ) {
-                return None;
-            }
+        let Some(device) = self.devices.get(device_key) else {
+            // No config yet → the thumb pad is the default gesture owner.
+            return Some(ButtonId::GestureButton);
+        };
+        match device.gesture_owner {
+            Some(GestureOwner::Off) => None,
+            Some(GestureOwner::Button(id)) => Some(id),
+            None => Self::infer_gesture_owner(&device.bindings),
         }
-        // No config, or the thumb pad left at its default / a gesture binding:
-        // the thumb pad owns the gesture role.
+    }
+
+    /// Infer the gesture owner for a config predating the explicit
+    /// [`DeviceConfig::gesture_owner`] field, from the shape of `bindings` — the
+    /// pre-field behavior, so old/migrated configs keep working until the first
+    /// explicit owner change stamps the field.
+    fn infer_gesture_owner(bindings: &BTreeMap<ButtonId, Binding>) -> Option<ButtonId> {
+        // An OS-hook button left in gesture mode took the role over.
+        if let Some((id, _)) = bindings
+            .iter()
+            .find(|(id, b)| **id != ButtonId::GestureButton && b.is_gesture())
+        {
+            return Some(*id);
+        }
+        // A thumb pad explicitly demoted to a single action means gestures off.
+        if matches!(
+            bindings.get(&ButtonId::GestureButton),
+            Some(Binding::Single(_))
+        ) {
+            return None;
+        }
+        // Default: the thumb pad owns the gesture role.
         Some(ButtonId::GestureButton)
     }
 
-    /// Make `button` the device's sole gesture button, enforcing the
-    /// one-gesture-button-per-device lock: every *other* button currently in
-    /// gesture mode is demoted to a [`Binding::Single`] of its click action.
-    /// `button` is upgraded to a gesture binding if it isn't already, non-
-    /// destructively — a prior [`Binding::Single`] is kept as the
-    /// [`GestureDirection::Click`] entry with the swipe arms left unbound, and a
-    /// fresh button is seeded from [`default_binding_for`] (so the dedicated
-    /// gesture button gets its full default direction map).
+    /// Make `button` the device's sole gesture button.
     ///
-    /// Returns the demoted buttons so the GUI can explain the swap — normally
-    /// zero or one, more only from a hand-edited config.
-    pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) -> Vec<ButtonId> {
-        let demoted: Vec<ButtonId> = self
-            .devices
-            .get(device_key)
-            .map(|device| {
-                device
-                    .bindings
-                    .iter()
-                    .filter(|(id, binding)| **id != button && binding.is_gesture())
-                    .map(|(id, _)| *id)
-                    .collect()
-            })
-            .unwrap_or_default();
-        for &other in &demoted {
-            self.demote_gesture_to_single(device_key, other);
-        }
-        let entry = self
-            .devices
-            .entry(device_key.to_string())
-            .or_default()
+    /// Records `button` as the explicit [`gesture_owner`](Self::gesture_owner), so
+    /// the one-gesture-button-per-device lock is a data-model fact rather than a
+    /// destructive demotion of the others — every other gesture-capable button
+    /// keeps its own gesture map intact, ready to restore if re-chosen, and is
+    /// simply not dispatched while it isn't the owner. `button` is given a full
+    /// [`Binding::Gesture`] map: a prior [`Binding::Single`] is kept as the
+    /// [`GestureDirection::Click`] action, any existing swipe arms are preserved,
+    /// and unbound directions are seeded from [`default_gesture_binding`] so every
+    /// gesture button exposes the same full five-direction set.
+    pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) {
+        let device = self.devices.entry(device_key.to_string()).or_default();
+        device.gesture_owner = Some(GestureOwner::Button(button));
+        let entry = device
             .bindings
             .entry(button)
             .or_insert_with(|| default_binding_for(button));
         entry.upgrade_to_gesture();
-        demoted
+        entry.fill_gesture_defaults();
     }
 
-    /// Demote `button` from a gesture binding back to a [`Binding::Single`],
-    /// keeping its explicit [`GestureDirection::Click`] action (or the button's
-    /// [`default_binding`] when the gesture map had no click). A no-op when
-    /// `button` is not currently a gesture binding.
-    pub fn demote_gesture_to_single(&mut self, device_key: &str, button: ButtonId) {
-        let Some(device) = self.devices.get_mut(device_key) else {
-            return;
-        };
-        let click = match device.bindings.get(&button) {
-            Some(Binding::Gesture(map)) => map
-                .get(&GestureDirection::Click)
-                .cloned()
-                .unwrap_or_else(|| default_binding(button)),
-            _ => return,
-        };
-        device.bindings.insert(button, Binding::Single(click));
-    }
-
-    /// Turn gestures off entirely for `device_key`: demote every OS-hook gesture
-    /// button and mark the thumb pad explicitly off, so [`Self::gesture_owner`]
-    /// returns `None` rather than falling back to the thumb-pad default. (Plain
-    /// [`Self::demote_gesture_to_single`] on a never-configured thumb pad is a
-    /// no-op, which would leave it the default owner — hence the explicit marker.)
+    /// Turn gestures off for `device_key`, recording the explicit "off" choice.
+    /// Every button keeps its gesture map intact (nothing is destroyed), so
+    /// re-selecting a gesture owner later restores its directions exactly.
     pub fn disable_gestures(&mut self, device_key: &str) {
-        for button in [ButtonId::MiddleClick, ButtonId::Back, ButtonId::Forward] {
-            self.demote_gesture_to_single(device_key, button);
-        }
-        self.set_binding(
-            device_key,
-            ButtonId::GestureButton,
-            Binding::Single(Action::None),
-        );
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .gesture_owner = Some(GestureOwner::Off);
     }
 
     /// Resolve the effective binding map for `device_key`, overlaying the
@@ -708,7 +726,7 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
-    use crate::binding::default_gesture_binding;
+    use crate::binding::{default_binding, default_gesture_binding};
 
     fn write_and_read(config: &Config) -> Config {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1167,85 +1185,132 @@ Back = \"BrowserBack\"
     }
 
     #[test]
-    fn set_gesture_owner_enforces_single_gesture_lock() {
+    fn set_gesture_owner_records_owner_without_destroying_other_maps() {
         let mut cfg = Config::default();
-        // GestureButton starts as the gesture button (full default map).
-        cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
-        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
+        // Customize the thumb pad's Up swipe; it is the (inferred) owner.
+        cfg.set_gesture_direction(
+            "2b042",
+            ButtonId::GestureButton,
+            GestureDirection::Up,
+            Action::Copy,
+        );
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
 
-        // Promote Back: the previous owner must be demoted, preserving its click.
-        let demoted = cfg.set_gesture_owner("2b042", ButtonId::Back);
-        assert_eq!(demoted, vec![ButtonId::GestureButton]);
+        // Promote Back: the owner becomes Back explicitly; the thumb pad keeps
+        // its full gesture map (no destructive demotion).
+        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
+        cfg.set_gesture_owner("2b042", ButtonId::Back);
         assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::Back));
 
         let bindings = cfg.bindings_for("2b042");
-        // GestureButton fell back to a single of its prior click (AppExpose).
-        assert_eq!(
-            bindings.get(&ButtonId::GestureButton),
-            Some(&Binding::Single(default_gesture_binding(
-                GestureDirection::Click
-            )))
-        );
-        // Back became a gesture binding, keeping its single action as Click and
-        // leaving the swipe arms unbound.
+        // Back is a full five-direction gesture button: its prior single action
+        // stays as Click, and the swipe arms are seeded from defaults.
         match bindings.get(&ButtonId::Back) {
             Some(Binding::Gesture(map)) => {
                 assert_eq!(
                     map.get(&GestureDirection::Click),
                     Some(&Action::BrowserBack)
                 );
-                assert_eq!(map.get(&GestureDirection::Up), None, "arms start unbound");
+                assert_eq!(
+                    map.get(&GestureDirection::Up),
+                    Some(&default_gesture_binding(GestureDirection::Up)),
+                    "a promoted button gets full default arms"
+                );
             }
             other => panic!("expected Back to be a gesture binding, got {other:?}"),
+        }
+        // The thumb pad's customized map survived the switch intact.
+        match bindings.get(&ButtonId::GestureButton) {
+            Some(Binding::Gesture(map)) => {
+                assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
+            }
+            other => panic!("expected the thumb pad map preserved, got {other:?}"),
+        }
+
+        // Switching back restores the user's customization, not defaults
+        // (regression guard: owner-switch used to discard the swipe arms).
+        cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
+        match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+            Some(Binding::Gesture(map)) => {
+                assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
+            }
+            other => panic!("expected preserved gesture map, got {other:?}"),
         }
     }
 
     #[test]
-    fn set_gesture_owner_seeds_dedicated_button_with_full_default() {
+    fn set_gesture_owner_seeds_a_fresh_button_with_full_directions() {
         let mut cfg = Config::default();
-        assert!(
-            cfg.set_gesture_owner("2b042", ButtonId::GestureButton)
-                .is_empty()
-        );
+        // The dedicated thumb pad gets the full default direction map.
+        cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
         match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
             Some(Binding::Gesture(map)) => {
-                // The dedicated gesture button gets its full default direction map.
                 for dir in GestureDirection::ALL {
                     assert_eq!(map.get(&dir), Some(&default_gesture_binding(dir)));
                 }
             }
             other => panic!("expected full default gesture map, got {other:?}"),
         }
+
+        // A fresh OS-hook button also gets all five directions, not just a Click:
+        // its native action stays as Click, and the swipe arms are defaults — so
+        // the GUI's shown defaults are exactly what the runtime dispatches.
+        cfg.set_gesture_owner("2b042", ButtonId::Forward);
+        match cfg.bindings_for("2b042").get(&ButtonId::Forward) {
+            Some(Binding::Gesture(map)) => {
+                assert_eq!(
+                    map.get(&GestureDirection::Click),
+                    Some(&default_binding(ButtonId::Forward))
+                );
+                for dir in [
+                    GestureDirection::Up,
+                    GestureDirection::Down,
+                    GestureDirection::Left,
+                    GestureDirection::Right,
+                ] {
+                    assert_eq!(map.get(&dir), Some(&default_gesture_binding(dir)));
+                }
+            }
+            other => panic!("expected full gesture map for Forward, got {other:?}"),
+        }
     }
 
     #[test]
-    fn demote_gesture_to_single_keeps_click_or_falls_back() {
+    fn disable_gestures_turns_off_without_destroying_maps() {
         let mut cfg = Config::default();
-        // Explicit Click is preserved.
-        cfg.set_binding(
+        cfg.set_gesture_direction(
             "2b042",
-            ButtonId::Back,
-            Binding::Gesture(BTreeMap::from([
-                (GestureDirection::Click, Action::Paste),
-                (GestureDirection::Up, Action::Copy),
-            ])),
+            ButtonId::GestureButton,
+            GestureDirection::Up,
+            Action::Copy,
         );
-        cfg.demote_gesture_to_single("2b042", ButtonId::Back);
-        assert_eq!(
-            cfg.bindings_for("2b042").get(&ButtonId::Back),
-            Some(&Binding::Single(Action::Paste))
-        );
+        cfg.disable_gestures("2b042");
+        // Off, but the thumb pad's customized map is preserved (re-enabling
+        // restores it rather than resurrecting a wiped default).
+        assert_eq!(cfg.gesture_owner("2b042"), None);
+        match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+            Some(Binding::Gesture(map)) => {
+                assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
+            }
+            other => panic!("expected the gesture map preserved while off, got {other:?}"),
+        }
+    }
 
-        // A click-less gesture falls back to the button's default single action.
-        cfg.set_binding(
-            "2b042",
-            ButtonId::Forward,
-            Binding::Gesture(BTreeMap::from([(GestureDirection::Up, Action::Copy)])),
-        );
-        cfg.demote_gesture_to_single("2b042", ButtonId::Forward);
-        assert_eq!(
-            cfg.bindings_for("2b042").get(&ButtonId::Forward),
-            Some(&Binding::Single(default_binding(ButtonId::Forward)))
-        );
+    #[test]
+    fn gesture_owner_field_roundtrips_as_a_scalar() {
+        let mut cfg = Config::default();
+        cfg.set_gesture_owner("2b042", ButtonId::Back); // explicit button
+        cfg.disable_gestures("4082d"); // explicit off
+
+        let parsed = write_and_read(&cfg);
+        assert_eq!(parsed.gesture_owner("2b042"), Some(ButtonId::Back));
+        assert_eq!(parsed.gesture_owner("4082d"), None);
+
+        // The custom codec keeps it a bare TOML string (a nested table would risk
+        // a value-after-table serialization error, since `bindings` is a table).
+        let body = toml::to_string_pretty(&cfg).expect("serialize");
+        assert!(body.contains("gesture_owner = \"Back\""), "got: {body}");
+        assert!(body.contains("gesture_owner = \"Off\""), "got: {body}");
     }
 }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -459,11 +459,7 @@ impl Config {
             .bindings
             .entry(button)
             .or_insert_with(|| default_binding_for(button));
-        if let Binding::Single(prev) = entry {
-            let mut map = BTreeMap::new();
-            map.insert(GestureDirection::Click, prev.clone());
-            *entry = Binding::Gesture(map);
-        }
+        entry.upgrade_to_gesture();
         if let Binding::Gesture(map) = entry {
             map.insert(direction, action);
         }
@@ -535,11 +531,7 @@ impl Config {
             .bindings
             .entry(button)
             .or_insert_with(|| default_binding_for(button));
-        if let Binding::Single(prev) = entry {
-            let mut map = BTreeMap::new();
-            map.insert(GestureDirection::Click, prev.clone());
-            *entry = Binding::Gesture(map);
-        }
+        entry.upgrade_to_gesture();
         demoted
     }
 

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -469,24 +469,36 @@ impl Config {
         }
     }
 
-    /// The device's gesture button — the single [`ButtonId`] whose binding is a
-    /// [`Binding::Gesture`]. At most one per device (the v1 one-gesture-button
-    /// lock). If a hand-edited config carries several, [`ButtonId::GestureButton`]
-    /// wins: it is the HID++ raw-XY owner, the only button that consumes the
-    /// per-device raw-XY stream. Otherwise the lowest-ordered gesture button.
+    /// The device's gesture button, or `None` when gestures are turned off.
+    ///
+    /// The dedicated thumb pad ([`ButtonId::GestureButton`]) is the *default*
+    /// gesture button: it owns the role whenever it's left at its default or set
+    /// to a [`Binding::Gesture`]. An explicitly-configured OS-hook button
+    /// (Middle/Back/Forward in gesture mode) takes the role over, silencing the
+    /// thumb pad. The thumb pad is off only when it has been explicitly demoted
+    /// to a [`Binding::Single`] (the "Off" selection) with no other gesture
+    /// button set. At most one button gestures per device.
     #[must_use]
     pub fn gesture_owner(&self, device_key: &str) -> Option<ButtonId> {
-        let bindings = &self.devices.get(device_key)?.bindings;
-        if matches!(
-            bindings.get(&ButtonId::GestureButton),
-            Some(Binding::Gesture(_))
-        ) {
-            return Some(ButtonId::GestureButton);
+        if let Some(bindings) = self.devices.get(device_key).map(|d| &d.bindings) {
+            // An explicit OS-hook gesture button takes over from the thumb pad.
+            if let Some((id, _)) = bindings
+                .iter()
+                .find(|(id, b)| **id != ButtonId::GestureButton && b.is_gesture())
+            {
+                return Some(*id);
+            }
+            // Thumb pad explicitly demoted (and nothing else set) → gestures off.
+            if matches!(
+                bindings.get(&ButtonId::GestureButton),
+                Some(Binding::Single(_))
+            ) {
+                return None;
+            }
         }
-        bindings
-            .iter()
-            .find(|(_, binding)| binding.is_gesture())
-            .map(|(id, _)| *id)
+        // No config, or the thumb pad left at its default / a gesture binding:
+        // the thumb pad owns the gesture role.
+        Some(ButtonId::GestureButton)
     }
 
     /// Make `button` the device's sole gesture button, enforcing the
@@ -547,6 +559,22 @@ impl Config {
             _ => return,
         };
         device.bindings.insert(button, Binding::Single(click));
+    }
+
+    /// Turn gestures off entirely for `device_key`: demote every OS-hook gesture
+    /// button and mark the thumb pad explicitly off, so [`Self::gesture_owner`]
+    /// returns `None` rather than falling back to the thumb-pad default. (Plain
+    /// [`Self::demote_gesture_to_single`] on a never-configured thumb pad is a
+    /// no-op, which would leave it the default owner — hence the explicit marker.)
+    pub fn disable_gestures(&mut self, device_key: &str) {
+        for button in [ButtonId::MiddleClick, ButtonId::Back, ButtonId::Forward] {
+            self.demote_gesture_to_single(device_key, button);
+        }
+        self.set_binding(
+            device_key,
+            ButtonId::GestureButton,
+            Binding::Single(Action::None),
+        );
     }
 
     /// Resolve the effective binding map for `device_key`, overlaying the
@@ -1118,13 +1146,12 @@ Back = \"BrowserBack\"
     }
 
     #[test]
-    fn gesture_owner_reports_the_single_gesture_button() {
+    fn gesture_owner_defaults_to_thumb_pad_yields_to_oshook_and_can_be_off() {
         let mut cfg = Config::default();
-        // No gesture binding yet.
-        assert_eq!(cfg.gesture_owner("2b042"), None);
+        // Default: the thumb pad owns the gesture role even with no config.
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
 
-        // One ordinary single + one gesture button.
-        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
+        // A thumb-pad gesture binding keeps it the owner.
         cfg.set_gesture_direction(
             "2b042",
             ButtonId::GestureButton,
@@ -1133,14 +1160,18 @@ Back = \"BrowserBack\"
         );
         assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
 
-        // Defensive: a hand-edited config with two gesture buttons resolves to
-        // GestureButton (the raw-XY owner), not the other.
+        // An explicit OS-hook gesture button takes the role over.
         cfg.set_binding(
             "2b042",
             ButtonId::Forward,
             Binding::Gesture(BTreeMap::from([(GestureDirection::Up, Action::Copy)])),
         );
-        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::Forward));
+
+        // Turning gestures off explicitly yields `None` (not the thumb-pad default).
+        let mut off = Config::default();
+        off.disable_gestures("2b042");
+        assert_eq!(off.gesture_owner("2b042"), None);
     }
 
     #[test]

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -228,15 +228,27 @@ impl Serialize for GestureOwner {
     }
 }
 
-impl<'de> Deserialize<'de> for GestureOwner {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use serde::de::IntoDeserializer;
-        let s = String::deserialize(deserializer)?;
-        if s == "Off" {
-            return Ok(GestureOwner::Off);
-        }
-        ButtonId::deserialize(s.as_str().into_deserializer()).map(GestureOwner::Button)
+/// Lenient field deserializer for [`RawDeviceConfig::gesture_owner`]. An
+/// unrecognized or miscased value (`"back"`, a typo, a future-version button
+/// name) is treated as absent — i.e. "infer the owner" — rather than failing the
+/// whole-document parse and reverting *every* device's settings to defaults.
+/// Mirrors [`deserialize_brightness`], which clamps a bad value instead of
+/// erroring; a hand-editable config should degrade one field, not the document.
+fn deserialize_gesture_owner<'de, D>(deserializer: D) -> Result<Option<GestureOwner>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    if s == "Off" {
+        return Ok(Some(GestureOwner::Off));
     }
+    // Parse the button name with a throwaway error type so an unknown token maps
+    // to `None` (infer) rather than propagating an error.
+    let button = ButtonId::deserialize(
+        serde::de::value::StrDeserializer::<serde::de::value::Error>::new(&s),
+    )
+    .ok();
+    Ok(button.map(GestureOwner::Button))
 }
 
 /// Settings scoped to a single physical device (keyed by HID++ model+ext).
@@ -287,8 +299,10 @@ pub struct DeviceConfig {
 #[derive(Deserialize)]
 struct RawDeviceConfig {
     /// Explicit gesture owner (v2.1+). Absent on older configs → `None` → the
-    /// owner is inferred in [`Config::gesture_owner`].
-    #[serde(default)]
+    /// owner is inferred in [`Config::gesture_owner`]. A present-but-invalid
+    /// value is tolerated as `None` (infer), not a parse error — see
+    /// [`deserialize_gesture_owner`].
+    #[serde(default, deserialize_with = "deserialize_gesture_owner")]
     gesture_owner: Option<GestureOwner>,
     /// v2 shape — present on already-migrated files; wins on any key collision.
     #[serde(default)]
@@ -498,6 +512,19 @@ impl Config {
         direction: GestureDirection,
         action: Action,
     ) {
+        if let Binding::Gesture(map) = self.ensure_gesture_binding(device_key, button) {
+            map.insert(direction, action);
+        }
+    }
+
+    /// Ensure `button` on `device_key` is a [`Binding::Gesture`], creating the
+    /// device + a default binding if needed and upgrading a [`Binding::Single`]
+    /// in place (its action kept as the [`GestureDirection::Click`]). Returns the
+    /// entry so the caller can finish it — seed every direction
+    /// ([`Binding::fill_gesture_defaults`]) or set just one. Shared by
+    /// [`Self::set_gesture_owner`] and [`Self::set_gesture_direction`] so the two
+    /// promote a button into gesture mode identically.
+    fn ensure_gesture_binding(&mut self, device_key: &str, button: ButtonId) -> &mut Binding {
         let entry = self
             .devices
             .entry(device_key.to_string())
@@ -506,9 +533,7 @@ impl Config {
             .entry(button)
             .or_insert_with(|| default_binding_for(button));
         entry.upgrade_to_gesture();
-        if let Binding::Gesture(map) = entry {
-            map.insert(direction, action);
-        }
+        entry
     }
 
     /// The button that owns `device_key`'s single gesture role, or `None` when
@@ -567,14 +592,12 @@ impl Config {
     /// and unbound directions are seeded from [`default_gesture_binding`] so every
     /// gesture button exposes the same full five-direction set.
     pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) {
-        let device = self.devices.entry(device_key.to_string()).or_default();
-        device.gesture_owner = Some(GestureOwner::Button(button));
-        let entry = device
-            .bindings
-            .entry(button)
-            .or_insert_with(|| default_binding_for(button));
-        entry.upgrade_to_gesture();
-        entry.fill_gesture_defaults();
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .gesture_owner = Some(GestureOwner::Button(button));
+        self.ensure_gesture_binding(device_key, button)
+            .fill_gesture_defaults();
     }
 
     /// Turn gestures off for `device_key`, recording the explicit "off" choice.
@@ -1312,5 +1335,34 @@ Back = \"BrowserBack\"
         let body = toml::to_string_pretty(&cfg).expect("serialize");
         assert!(body.contains("gesture_owner = \"Back\""), "got: {body}");
         assert!(body.contains("gesture_owner = \"Off\""), "got: {body}");
+    }
+
+    #[test]
+    fn invalid_gesture_owner_string_is_tolerated_not_fatal() {
+        // A hand-edit typo in gesture_owner must NOT fail the whole-document parse
+        // (which would revert every device's settings to defaults). It degrades
+        // to "infer" while the rest of the device config survives.
+        let toml = "\
+schema_version = 2
+
+[devices.2b042]
+gesture_owner = \"bogus\"
+
+[devices.2b042.bindings]
+Back = \"Copy\"
+";
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, toml).expect("write");
+
+        let cfg =
+            Config::load_from_path(&path).expect("an invalid gesture_owner must not fail the load");
+        // The rest of the device config survived...
+        assert_eq!(
+            cfg.bindings_for("2b042").get(&ButtonId::Back),
+            Some(&Binding::Single(Action::Copy))
+        );
+        // ...and the bad owner degraded to inference (thumb-pad default here).
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
     }
 }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -16,7 +16,9 @@ use std::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::binding::{Action, Binding, ButtonId, GestureDirection, default_binding_for};
+use crate::binding::{
+    Action, Binding, ButtonId, GestureDirection, default_binding, default_binding_for,
+};
 use crate::paths::{self, PathsError};
 
 /// The schema version the current build produces. Bumped on breaking layout
@@ -467,6 +469,86 @@ impl Config {
         }
     }
 
+    /// The device's gesture button — the single [`ButtonId`] whose binding is a
+    /// [`Binding::Gesture`]. At most one per device (the v1 one-gesture-button
+    /// lock). If a hand-edited config carries several, [`ButtonId::GestureButton`]
+    /// wins: it is the HID++ raw-XY owner, the only button that consumes the
+    /// per-device raw-XY stream. Otherwise the lowest-ordered gesture button.
+    #[must_use]
+    pub fn gesture_owner(&self, device_key: &str) -> Option<ButtonId> {
+        let bindings = &self.devices.get(device_key)?.bindings;
+        if matches!(
+            bindings.get(&ButtonId::GestureButton),
+            Some(Binding::Gesture(_))
+        ) {
+            return Some(ButtonId::GestureButton);
+        }
+        bindings
+            .iter()
+            .find(|(_, binding)| binding.is_gesture())
+            .map(|(id, _)| *id)
+    }
+
+    /// Make `button` the device's sole gesture button, enforcing the
+    /// one-gesture-button-per-device lock: every *other* button currently in
+    /// gesture mode is demoted to a [`Binding::Single`] of its click action.
+    /// `button` is upgraded to a gesture binding if it isn't already, non-
+    /// destructively — a prior [`Binding::Single`] is kept as the
+    /// [`GestureDirection::Click`] entry with the swipe arms left unbound, and a
+    /// fresh button is seeded from [`default_binding_for`] (so the dedicated
+    /// gesture button gets its full default direction map).
+    ///
+    /// Returns the demoted buttons so the GUI can explain the swap — normally
+    /// zero or one, more only from a hand-edited config.
+    pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) -> Vec<ButtonId> {
+        let demoted: Vec<ButtonId> = self
+            .devices
+            .get(device_key)
+            .map(|device| {
+                device
+                    .bindings
+                    .iter()
+                    .filter(|(id, binding)| **id != button && binding.is_gesture())
+                    .map(|(id, _)| *id)
+                    .collect()
+            })
+            .unwrap_or_default();
+        for &other in &demoted {
+            self.demote_gesture_to_single(device_key, other);
+        }
+        let entry = self
+            .devices
+            .entry(device_key.to_string())
+            .or_default()
+            .bindings
+            .entry(button)
+            .or_insert_with(|| default_binding_for(button));
+        if let Binding::Single(prev) = entry {
+            let mut map = BTreeMap::new();
+            map.insert(GestureDirection::Click, prev.clone());
+            *entry = Binding::Gesture(map);
+        }
+        demoted
+    }
+
+    /// Demote `button` from a gesture binding back to a [`Binding::Single`],
+    /// keeping its explicit [`GestureDirection::Click`] action (or the button's
+    /// [`default_binding`] when the gesture map had no click). A no-op when
+    /// `button` is not currently a gesture binding.
+    pub fn demote_gesture_to_single(&mut self, device_key: &str, button: ButtonId) {
+        let Some(device) = self.devices.get_mut(device_key) else {
+            return;
+        };
+        let click = match device.bindings.get(&button) {
+            Some(Binding::Gesture(map)) => map
+                .get(&GestureDirection::Click)
+                .cloned()
+                .unwrap_or_else(|| default_binding(button)),
+            _ => return,
+        };
+        device.bindings.insert(button, Binding::Single(click));
+    }
+
     /// Resolve the effective binding map for `device_key`, overlaying the
     /// per-app entry for `bundle_id` (if any) on top of the global per-device
     /// `bindings`. A per-app override replaces the whole button with a
@@ -606,6 +688,7 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
+    use crate::binding::default_gesture_binding;
 
     fn write_and_read(config: &Config) -> Config {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1032,5 +1115,114 @@ Back = \"BrowserBack\"
             }
             other => panic!("expected Gesture, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn gesture_owner_reports_the_single_gesture_button() {
+        let mut cfg = Config::default();
+        // No gesture binding yet.
+        assert_eq!(cfg.gesture_owner("2b042"), None);
+
+        // One ordinary single + one gesture button.
+        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
+        cfg.set_gesture_direction(
+            "2b042",
+            ButtonId::GestureButton,
+            GestureDirection::Up,
+            Action::MissionControl,
+        );
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
+
+        // Defensive: a hand-edited config with two gesture buttons resolves to
+        // GestureButton (the raw-XY owner), not the other.
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Forward,
+            Binding::Gesture(BTreeMap::from([(GestureDirection::Up, Action::Copy)])),
+        );
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
+    }
+
+    #[test]
+    fn set_gesture_owner_enforces_single_gesture_lock() {
+        let mut cfg = Config::default();
+        // GestureButton starts as the gesture button (full default map).
+        cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
+        cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
+
+        // Promote Back: the previous owner must be demoted, preserving its click.
+        let demoted = cfg.set_gesture_owner("2b042", ButtonId::Back);
+        assert_eq!(demoted, vec![ButtonId::GestureButton]);
+        assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::Back));
+
+        let bindings = cfg.bindings_for("2b042");
+        // GestureButton fell back to a single of its prior click (AppExpose).
+        assert_eq!(
+            bindings.get(&ButtonId::GestureButton),
+            Some(&Binding::Single(default_gesture_binding(
+                GestureDirection::Click
+            )))
+        );
+        // Back became a gesture binding, keeping its single action as Click and
+        // leaving the swipe arms unbound.
+        match bindings.get(&ButtonId::Back) {
+            Some(Binding::Gesture(map)) => {
+                assert_eq!(
+                    map.get(&GestureDirection::Click),
+                    Some(&Action::BrowserBack)
+                );
+                assert_eq!(map.get(&GestureDirection::Up), None, "arms start unbound");
+            }
+            other => panic!("expected Back to be a gesture binding, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn set_gesture_owner_seeds_dedicated_button_with_full_default() {
+        let mut cfg = Config::default();
+        assert!(
+            cfg.set_gesture_owner("2b042", ButtonId::GestureButton)
+                .is_empty()
+        );
+        match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+            Some(Binding::Gesture(map)) => {
+                // The dedicated gesture button gets its full default direction map.
+                for dir in GestureDirection::ALL {
+                    assert_eq!(map.get(&dir), Some(&default_gesture_binding(dir)));
+                }
+            }
+            other => panic!("expected full default gesture map, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn demote_gesture_to_single_keeps_click_or_falls_back() {
+        let mut cfg = Config::default();
+        // Explicit Click is preserved.
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Back,
+            Binding::Gesture(BTreeMap::from([
+                (GestureDirection::Click, Action::Paste),
+                (GestureDirection::Up, Action::Copy),
+            ])),
+        );
+        cfg.demote_gesture_to_single("2b042", ButtonId::Back);
+        assert_eq!(
+            cfg.bindings_for("2b042").get(&ButtonId::Back),
+            Some(&Binding::Single(Action::Paste))
+        );
+
+        // A click-less gesture falls back to the button's default single action.
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Forward,
+            Binding::Gesture(BTreeMap::from([(GestureDirection::Up, Action::Copy)])),
+        );
+        cfg.demote_gesture_to_single("2b042", ButtonId::Forward);
+        assert_eq!(
+            cfg.bindings_for("2b042").get(&ButtonId::Forward),
+            Some(&Binding::Single(default_binding(ButtonId::Forward)))
+        );
     }
 }

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "Unbound"
 "Default": "Default"
 "5 directions": "5 directions"
+"Thumb pad": "Thumb pad"
+"Middle": "Middle"
 "DPI Preset %{index}": "DPI Preset %{index}"
 "Gesture %{name}": "Gesture %{name}"
 "Left Click": "Left Click"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "Non associato"
 "Default": "Predefinito"
 "5 directions": "5 direzioni"
+"Thumb pad": "Pollice"
+"Middle": "Centrale"
 "DPI Preset %{index}": "Preset DPI %{index}"
 "Gesture %{name}": "Gesture %{name}"
 "Left Click": "Click sinistro"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "未割り当て"
 "Default": "デフォルト"
 "5 directions": "5 方向"
+"Thumb pad": "サムパッド"
+"Middle": "中ボタン"
 "DPI Preset %{index}": "DPI プリセット %{index}"
 "Gesture %{name}": "ジェスチャー %{name}"
 "Left Click": "左クリック"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "Не назначено"
 "Default": "По умолчанию"
 "5 directions": "5 направлений"
+"Thumb pad": "Большой палец"
+"Middle": "Средняя"
 "DPI Preset %{index}": "Пресет DPI %{index}"
 "Gesture %{name}": "Жест %{name}"
 "Left Click": "Левый щелчок"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "未绑定"
 "Default": "默认"
 "5 directions": "5 个方向"
+"Thumb pad": "拇指板"
+"Middle": "中键"
 "DPI Preset %{index}": "灵敏度预设 %{index}"
 "Gesture %{name}": "手势 %{name}"
 "Left Click": "左键单击"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "未綁定"
 "Default": "預設"
 "5 directions": "5 個方向"
+"Thumb pad": "拇指板"
+"Middle": "中鍵"
 "DPI Preset %{index}": "靈敏度預設 %{index}"
 "Gesture %{name}": "手勢 %{name}"
 "Left Click": "左鍵單擊"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -108,6 +108,8 @@ _version: 1
 "Unbound": "未設定"
 "Default": "預設"
 "5 directions": "5 個方向"
+"Thumb pad": "拇指板"
+"Middle": "中鍵"
 "DPI Preset %{index}": "靈敏度預設 %{index}"
 "Gesture %{name}": "手勢 %{name}"
 "Left Click": "左鍵按一下"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -330,14 +330,32 @@ impl Render for AppView {
         window.set_window_title(&main_window_title(show_device, cx));
 
         let (header_el, content_el) = if show_device {
+            // Resolve the active section once and share it between the header
+            // (which renders the section tabs) and the body, so the two can't
+            // disagree about which tab is live. The stored tab may not belong to
+            // this device — it can linger across a hot-plug onto a different kind
+            // — so fall back to the device's first tab for display, without
+            // mutating `active_tab`.
+            let record = cx
+                .try_global::<AppState>()
+                .and_then(AppState::current_record)
+                .cloned();
+            let tabs = record
+                .as_ref()
+                .map_or_else(|| vec![DetailTab::Device], DetailTab::tabs_for);
+            let active = if tabs.contains(&self.active_tab) {
+                self.active_tab
+            } else {
+                tabs.first().copied().unwrap_or(DetailTab::Device)
+            };
             (
-                detail_header(pal, cx).into_any_element(),
+                detail_header(record.as_ref(), &tabs, active, pal, cx).into_any_element(),
                 detail_content(
                     &self.mouse_model,
                     &self.dpi_panel,
                     &self.smartshift_panel,
                     &self.lighting_panel,
-                    self.active_tab,
+                    active,
                     pal,
                     cx,
                 )
@@ -391,15 +409,33 @@ fn home_header(pal: Palette) -> impl IntoElement {
         .child(add_device_button(pal))
 }
 
-/// Device-detail top bar: a back affordance returning to the gallery, the
-/// active device's name, its connection status, and the Add-Device button.
-fn detail_header(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
-    let record = cx
-        .try_global::<AppState>()
-        .and_then(AppState::current_record)
-        .cloned();
+/// Device-detail top bar, in three zones: a back affordance + device name
+/// (leading), the section tabs as a centred segmented control (middle), and the
+/// connection status + Add-Device button (trailing). Hoisting the tabs here —
+/// rather than a separate row beneath the bar — gives the section body the full
+/// remaining height. A device with a single section shows no tab strip.
+fn detail_header(
+    record: Option<&DeviceRecord>,
+    tabs: &[DetailTab],
+    active: DetailTab,
+    pal: Palette,
+    cx: &mut Context<AppView>,
+) -> impl IntoElement {
+    let name = record.map_or_else(|| tr!("Device").to_string(), |r| r.display_name.clone());
+    let online = record.map(|r| r.online);
+    // Only a real choice gets a strip; a lone section (e.g. a keyboard with just
+    // the info tab) would render a one-segment control, which reads as broken.
+    // `into_any_element` here severs the returned element from `cx`'s lifetime
+    // (RPIT would otherwise capture it), so the borrow ends with this call and
+    // `back_button` below can take `cx` again.
+    let tab_strip = (tabs.len() > 1).then(|| detail_tabs(tabs, active, cx).into_any_element());
     h_flex()
         .h(px(HEADER_H))
+        // Fixed-height chrome must never shrink: a tab whose body overflows the
+        // viewport would otherwise squeeze this shrinkable bar, so the header
+        // height would visibly change between tabs. The body (flex_1 + its own
+        // scroll) absorbs the overflow instead.
+        .flex_shrink_0()
         .w_full()
         .px_5()
         .gap_3()
@@ -409,17 +445,17 @@ fn detail_header(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
         .child(back_button(pal, cx))
         .child(
             div()
-                .flex_1()
                 .min_w_0()
                 .text_lg()
                 .font_weight(FontWeight::SEMIBOLD)
-                .child(
-                    record
-                        .as_ref()
-                        .map_or_else(|| tr!("Device").to_string(), |r| r.display_name.clone()),
-                ),
+                .child(name),
         )
-        .when_some(record, |this, r| this.child(status_badge(r.online, pal)))
+        // Flexible spacers on either side centre the segmented tabs in the space
+        // left between the leading and trailing zones.
+        .child(div().flex_1())
+        .children(tab_strip)
+        .child(div().flex_1())
+        .when_some(online, |this, online| this.child(status_badge(online, pal)))
         .child(add_device_button(pal))
 }
 
@@ -699,9 +735,11 @@ fn main_window_title(show_device: bool, cx: &Context<AppView>) -> SharedString {
         )
 }
 
-/// The device-detail body: a tab bar over the active device's sections (which
-/// vary by kind — see [`DetailTab::tabs_for`]), with the active section filling
-/// the rest of the screen.
+/// The device-detail body: the active section, filling the height between the
+/// header and the footer. Which sections exist — and the segmented control that
+/// switches them — is the header's job (see [`detail_header`] and
+/// [`DetailTab::tabs_for`]); `active` arrives pre-resolved against this device's
+/// tab set, so this only has to render the chosen section.
 fn detail_content(
     mouse_model: &Entity<MouseModelView>,
     dpi_panel: &Entity<DpiPanel>,
@@ -711,34 +749,18 @@ fn detail_content(
     pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
-    let tabs = cx
-        .try_global::<AppState>()
-        .and_then(AppState::current_record)
-        .map_or_else(|| vec![DetailTab::Device], DetailTab::tabs_for);
-    // The stored tab may not belong to this device — e.g. it lingered across a
-    // hot-plug onto a different kind. Fall back to the device's first tab.
-    let active = if tabs.contains(&active) {
-        active
-    } else {
-        tabs.first().copied().unwrap_or(DetailTab::Device)
-    };
-    let content = match active {
+    match active {
         DetailTab::Buttons => buttons_tab(mouse_model).into_any_element(),
         DetailTab::Pointer => pointer_tab(dpi_panel, smartshift_panel, pal).into_any_element(),
         DetailTab::Lighting => lighting_tab(lighting_panel, pal).into_any_element(),
         DetailTab::Device => device_tab(pal, cx).into_any_element(),
-    };
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .child(detail_tab_bar(&tabs, active, cx))
-        .child(content)
+    }
 }
 
-/// The detail screen's tab bar, built from the active device's tab set. Clicking
-/// a tab swaps the active section.
-fn detail_tab_bar(
+/// The device's sections as a compact, centred segmented control for the
+/// header. Clicking a segment swaps the active section. Only called with more
+/// than one tab — see [`detail_header`].
+fn detail_tabs(
     tabs: &[DetailTab],
     active: DetailTab,
     cx: &mut Context<AppView>,
@@ -747,35 +769,33 @@ fn detail_tab_bar(
     // Owned copy so the click handler can map a clicked index back to its tab
     // without borrowing the caller's slice.
     let order = tabs.to_vec();
-    div().w_full().px_5().pt_3().child(
-        TabBar::new("detail-tabs")
-            .underline()
-            .w_full()
-            .selected_index(active_ix)
-            .children(tabs.iter().map(|t| t.label()))
-            .on_click(cx.listener(move |this, ix: &usize, _, cx| {
-                this.active_tab = order.get(*ix).copied().unwrap_or(DetailTab::Device);
-                cx.notify();
-            })),
-    )
+    TabBar::new("detail-tabs")
+        .segmented()
+        .selected_index(active_ix)
+        .children(tabs.iter().map(|t| t.label()))
+        .on_click(cx.listener(move |this, ix: &usize, _, cx| {
+            this.active_tab = order.get(*ix).copied().unwrap_or(DetailTab::Device);
+            cx.notify();
+        }))
 }
 
-/// Buttons tab: the mouse model with clickable hotspots, centred with a max
-/// width so it doesn't stretch across a wide window.
+/// Buttons tab: the mouse model with clickable hotspots, horizontally centred
+/// with a max width so it doesn't stretch across a wide window.
+///
+/// A `v_flex` (top-aligned), like the pointer/device/lighting tabs — *not* an
+/// `h_flex`, which carries an implicit `items_center` and would vertically
+/// centre the fixed-height model. That left a tall header-to-content gap that
+/// collapsed to the top-aligned card tabs on switch — a visible vertical jump.
+/// Top-aligning every tab keeps the content's start fixed across switches.
 fn buttons_tab(mouse_model: &Entity<MouseModelView>) -> impl IntoElement {
-    h_flex()
+    v_flex()
         .flex_1()
         .w_full()
         .min_h_0()
+        .items_center()
         .justify_center()
         .p_6()
-        .child(
-            div()
-                .flex_1()
-                .min_w_0()
-                .max_w(px(760.))
-                .child(mouse_model.clone()),
-        )
+        .child(div().w_full().max_w(px(760.)).child(mouse_model.clone()))
 }
 
 /// Pointer tab: the DPI panel and the SmartShift wheel controls, each in a
@@ -1209,6 +1229,8 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
 fn footer(pal: Palette, granted: bool) -> impl IntoElement {
     h_flex()
         .h(px(FOOTER_H))
+        // Fixed chrome — never shrink when a tab body overflows (see `detail_header`).
+        .flex_shrink_0()
         .w_full()
         .px_5()
         .gap_4()

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -324,7 +324,10 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
     let bounds = Bounds::centered(None, Size::new(px(1100.), px(750.)), cx);
     WindowOptions {
         window_bounds: Some(WindowBounds::Windowed(bounds)),
-        window_min_size: Some(Size::new(px(720.), px(520.))),
+        // Min height keeps the buttons tab's mouse model above its scale floor
+        // (`MODEL_MIN_H` + the chrome/padding reserve) so its side labels never
+        // overlap; below this the model can't shrink further without crowding.
+        window_min_size: Some(Size::new(px(720.), px(680.))),
         titlebar: Some(TitlebarOptions {
             title: Some(SharedString::from("OpenLogi")),
             appears_transparent: false,

--- a/crates/openlogi-gui/src/mouse_model/geometry.rs
+++ b/crates/openlogi-gui/src/mouse_model/geometry.rs
@@ -129,11 +129,12 @@ fn with_thumbwheel_rotation(mut hotspots: Vec<Hotspot>) -> Vec<Hotspot> {
     clippy::cast_precision_loss,
     reason = "hotspot count is bounded by ButtonId variants — well under f32 mantissa"
 )]
-pub fn labels_from_hotspots(hotspots: &[Hotspot]) -> Vec<Label> {
+pub fn labels_from_hotspots(hotspots: &[Hotspot], mouse_h: f32) -> Vec<Label> {
     if hotspots.is_empty() {
         return Vec::new();
     }
-    let mouse_h = MOUSE_MODEL_SIZE.1;
+    // Even vertical slots across the (possibly scaled) model height, so the
+    // labels track the model when it shrinks to fit the viewport.
     let step = mouse_h / (hotspots.len() as f32 + 1.);
 
     let mut ranks: Vec<usize> = (0..hotspots.len()).collect();
@@ -270,7 +271,7 @@ mod tests {
     #[test]
     fn labels_track_hotspots_and_avoid_crossing() {
         let hotspots = default_hotspots();
-        let labels = labels_from_hotspots(&hotspots);
+        let labels = labels_from_hotspots(&hotspots, MOUSE_MODEL_SIZE.1);
         assert_eq!(labels.len(), hotspots.len());
 
         let mut ys: Vec<f32> = labels.iter().map(|l| l.y).collect();

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -32,6 +32,15 @@ const CARD_EDGE_INSET: f32 = SIDE_GAP + (SIDE_W - LABEL_W);
 
 const HOTSPOT_DOT: f32 = 12.;
 
+/// Vertical space around the model that it can't draw into: the detail header
+/// and footer, the buttons-tab padding, and the gesture selector row above the
+/// canvas. The model scales to fit whatever viewport height remains.
+const MODEL_VERTICAL_RESERVE: f32 = 224.;
+/// Floor for the scaled model height. Below this the evenly-slotted side labels
+/// (≈[`LABEL_H`] each) start to overlap; the window's minimum height is sized to
+/// keep the viewport above [`MODEL_VERTICAL_RESERVE`] + this.
+const MODEL_MIN_H: f32 = 448.;
+
 /// Interactive mouse model with button hotspots.
 pub struct MouseModelView {
     hovered: Option<ButtonId>,
@@ -68,7 +77,7 @@ impl MouseModelView {
 }
 
 impl Render for MouseModelView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let (asset, active, bindings, gesture_owner) = cx
             .try_global::<AppState>()
             .map(|s| {
@@ -81,16 +90,14 @@ impl Render for MouseModelView {
             })
             .unwrap_or_default();
 
-        let (mouse_w, mouse_h) = MOUSE_MODEL_SIZE;
-        let (mouse_w, mouse_h, hotspots, labels) = match asset.as_ref() {
-            Some(a) => {
-                let (w, h) = asset_dimensions_for_png(a, mouse_h);
-                let hotspots = asset_hotspots_for_png(a, w, h);
-                let labels = labels_from_hotspots(&hotspots);
-                (w, h, hotspots, labels)
-            }
-            None => (mouse_w, mouse_h, default_hotspots(), default_labels()),
-        };
+        // Scale the model to the viewport height so it always fits the content
+        // area. An oversized model would otherwise overflow and compress the
+        // fixed header/footer. Capped at the design height; floored so the side
+        // labels stay readable (the window's min height keeps the viewport above
+        // the floor — see `main`).
+        let viewport_h = f32::from(window.viewport_size().height);
+        let target_h = (viewport_h - MODEL_VERTICAL_RESERVE).clamp(MODEL_MIN_H, MOUSE_MODEL_SIZE.1);
+        let (mouse_w, mouse_h, hotspots, labels) = scaled_model(asset.as_ref(), target_h);
 
         let canvas_w = SIDE_W + SIDE_GAP + mouse_w;
         let canvas_h = mouse_h;
@@ -179,6 +186,42 @@ impl Render for MouseModelView {
     }
 }
 
+/// Model geometry at `target_h`, scaled to fit. With a real asset the hotspots
+/// and labels are recomputed from the scaled dimensions; the synthetic
+/// silhouette's authored coordinates are scaled by the same factor. Returns
+/// `(mouse_w, mouse_h, hotspots, labels)`.
+fn scaled_model(
+    asset: Option<&ResolvedAsset>,
+    target_h: f32,
+) -> (f32, f32, Vec<Hotspot>, Vec<Label>) {
+    if let Some(a) = asset {
+        let (w, h) = asset_dimensions_for_png(a, target_h);
+        let hotspots = asset_hotspots_for_png(a, w, h);
+        let labels = labels_from_hotspots(&hotspots, h);
+        (w, h, hotspots, labels)
+    } else {
+        let scale = target_h / MOUSE_MODEL_SIZE.1;
+        let hotspots = default_hotspots()
+            .into_iter()
+            .map(|hs| Hotspot {
+                x: hs.x * scale,
+                y: hs.y * scale,
+                w: hs.w * scale,
+                h: hs.h * scale,
+                ..hs
+            })
+            .collect();
+        let labels = default_labels()
+            .into_iter()
+            .map(|l| Label {
+                y: l.y * scale,
+                ..l
+            })
+            .collect();
+        (MOUSE_MODEL_SIZE.0 * scale, target_h, hotspots, labels)
+    }
+}
+
 /// The gesture-capable buttons present on this device, in a stable display
 /// order: the dedicated thumb pad first, then the OS-hook Middle/Back/Forward.
 fn gesture_capable_buttons(labels: &[Label]) -> Vec<ButtonId> {
@@ -224,7 +267,7 @@ fn gesture_owner_selector(
             div()
                 .text_xs()
                 .text_color(pal.text_muted)
-                .child(tr!("Gesture button")),
+                .child(tr!("Gesture Button")),
         )
         .children(
             capable

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -103,6 +103,12 @@ impl Render for MouseModelView {
 
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
+        // Resolve the gesture owner against the buttons this device actually has:
+        // a mouse with no thumb pad must not surface the default thumb-pad owner
+        // (it has none) — the role then reads as "Off" until the user picks a
+        // present button. Display-only; the stored config still infers as usual.
+        let capable = gesture_capable_buttons(&labels_outer);
+        let gesture_owner = gesture_owner.filter(|id| capable.contains(id));
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
         let breathing_art = breathing_art(asset.as_ref(), mouse_left, mouse_w, mouse_h, pal);
         let hotspots_layer = hotspots_layer(
@@ -112,10 +118,9 @@ impl Render for MouseModelView {
             mouse_h,
             hovered,
             active,
+            gesture_owner,
             &view,
         );
-
-        let capable = gesture_capable_buttons(&labels_outer);
         let canvas = div()
             .relative()
             .w(px(canvas_w))
@@ -321,6 +326,10 @@ fn breathing_art(
         .child(device_art)
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "layout inputs + hover/active/owner state; bundling would just hide the dependency"
+)]
 fn hotspots_layer(
     hotspots: &[Hotspot],
     mouse_left: f32,
@@ -328,6 +337,7 @@ fn hotspots_layer(
     mouse_h: f32,
     hovered: Option<ButtonId>,
     active: Option<ButtonId>,
+    gesture_owner: Option<ButtonId>,
     view: &Entity<MouseModelView>,
 ) -> impl IntoElement {
     div()
@@ -336,12 +346,9 @@ fn hotspots_layer(
         .top(px(0.))
         .w(px(mouse_w))
         .h(px(mouse_h))
-        .children(
-            hotspots
-                .iter()
-                .enumerate()
-                .map(|(idx, hotspot)| hotspot_popover(idx, *hotspot, hovered, active, view)),
-        )
+        .children(hotspots.iter().enumerate().map(|(idx, hotspot)| {
+            hotspot_popover(idx, *hotspot, hovered, active, gesture_owner, view)
+        }))
 }
 
 /// Wrap `trigger` in a left-click [`Popover`] hosting the gesture button's
@@ -624,6 +631,7 @@ fn hotspot_popover(
     hotspot: Hotspot,
     hovered: Option<ButtonId>,
     active: Option<ButtonId>,
+    gesture_owner: Option<ButtonId>,
     view: &Entity<MouseModelView>,
 ) -> AnyElement {
     let view = view.clone();
@@ -634,7 +642,11 @@ fn hotspot_popover(
         view: view.clone(),
         selected: false,
     };
-    let popover: AnyElement = if hotspot.id == ButtonId::GestureButton {
+    // Open the gesture menu only for the button that currently OWNS gestures —
+    // matching the side-label path — so a promoted Middle/Back/Forward opens it
+    // here too, a demoted thumb pad opens the plain picker, and (when gestures
+    // are off) no hotspot re-enters the gesture editor.
+    let popover: AnyElement = if Some(hotspot.id) == gesture_owner {
         gesture_overview_popover(
             ("hotspot-popover", idx),
             Anchor::TopRight,

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -1,7 +1,8 @@
 use gpui::{
-    Anchor, AnyElement, App, Context, ElementId, Entity, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, RenderOnce, StatefulInteractiveElement as _, Styled,
-    Subscription, Window, canvas, div, hsla, img, prelude::FluentBuilder as _, px, rgb, svg,
+    Anchor, AnyElement, App, BorrowAppContext as _, Context, ElementId, Entity, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, RenderOnce, StatefulInteractiveElement as _,
+    Styled, Subscription, Window, canvas, div, hsla, img, prelude::FluentBuilder as _, px, rgb,
+    svg,
 };
 use gpui_component::{Icon, IconName, Selectable, h_flex, popover::Popover, v_flex};
 
@@ -68,13 +69,14 @@ impl MouseModelView {
 
 impl Render for MouseModelView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let (asset, active, bindings) = cx
+        let (asset, active, bindings, gesture_owner) = cx
             .try_global::<AppState>()
             .map(|s| {
                 (
                     s.current_record().and_then(|r| r.asset.clone()),
                     s.active_button,
                     s.button_bindings.clone(),
+                    s.current_gesture_owner(),
                 )
             })
             .unwrap_or_default();
@@ -113,14 +115,15 @@ impl Render for MouseModelView {
             &view,
         );
 
-        div()
+        let capable = gesture_capable_buttons(&labels_outer);
+        let canvas = div()
             .relative()
             .w(px(canvas_w))
             .h(px(canvas_h))
             .child(breathing_art)
             .child(leader_canvas)
             .children(labels_outer.iter().enumerate().map(|(idx, label)| {
-                let binding = if label.id == ButtonId::GestureButton {
+                let binding = if Some(label.id) == gesture_owner {
                     BindingLabel {
                         text: tr!("5 directions"),
                         is_default: false,
@@ -150,11 +153,121 @@ impl Render for MouseModelView {
                     mouse_w,
                     hovered,
                     active,
+                    gesture_owner,
                     &view,
                 )
             }))
-            .child(hotspots_layer)
+            .child(hotspots_layer);
+
+        // The gesture-button selector sits above the mouse: a single-select of
+        // the device's gesture-capable buttons (the dedicated thumb pad plus the
+        // OS-hook Middle/Back/Forward) makes the one-gesture-button-per-device
+        // lock visible and obvious — pick one and its card opens the gesture
+        // menu, the rest stay single-action.
+        v_flex()
+            .w(px(canvas_w))
+            .gap_4()
+            .when(!capable.is_empty(), |col| {
+                col.child(gesture_owner_selector(&capable, gesture_owner, &view, pal))
+            })
+            .child(canvas)
     }
+}
+
+/// The gesture-capable buttons present on this device, in a stable display
+/// order: the dedicated thumb pad first, then the OS-hook Middle/Back/Forward.
+fn gesture_capable_buttons(labels: &[Label]) -> Vec<ButtonId> {
+    const ORDER: [ButtonId; 4] = [
+        ButtonId::GestureButton,
+        ButtonId::MiddleClick,
+        ButtonId::Back,
+        ButtonId::Forward,
+    ];
+    ORDER
+        .into_iter()
+        .filter(|id| labels.iter().any(|l| l.id == *id))
+        .collect()
+}
+
+/// Short, context-appropriate name for a gesture-button choice. In a selector
+/// *of* gesture buttons, calling the thumb pad "Gesture Button" would be
+/// circular, so it reads "Thumb pad" here.
+fn gesture_owner_label(btn: ButtonId) -> &'static str {
+    match btn {
+        ButtonId::GestureButton => "Thumb pad",
+        ButtonId::MiddleClick => "Middle",
+        ButtonId::Back => "Back",
+        ButtonId::Forward => "Forward",
+        other => other.label(),
+    }
+}
+
+/// The "Gesture button: ( … )" single-select row above the mouse. The single
+/// select makes the one-gesture-button-per-device lock visible; picking a button
+/// commits it as the owner (demoting any previous one).
+fn gesture_owner_selector(
+    capable: &[ButtonId],
+    owner: Option<ButtonId>,
+    view: &Entity<MouseModelView>,
+    pal: Palette,
+) -> impl IntoElement {
+    h_flex()
+        .items_center()
+        .gap_2()
+        .pl(px(SIDE_W + SIDE_GAP))
+        .child(
+            div()
+                .text_xs()
+                .text_color(pal.text_muted)
+                .child(tr!("Gesture button")),
+        )
+        .children(
+            capable
+                .iter()
+                .map(|&btn| owner_chip(Some(btn), owner, view, pal)),
+        )
+        .child(owner_chip(None, owner, view, pal))
+}
+
+/// One selectable chip in [`gesture_owner_selector`]. Clicking commits the new
+/// gesture owner via [`AppState::commit_gesture_owner`].
+fn owner_chip(
+    btn: Option<ButtonId>,
+    owner: Option<ButtonId>,
+    view: &Entity<MouseModelView>,
+    pal: Palette,
+) -> AnyElement {
+    let selected = btn == owner;
+    let text = match btn {
+        Some(b) => tr!(gesture_owner_label(b)),
+        None => tr!("Off"),
+    };
+    let id_part = btn.map_or(0usize, |b| b as usize + 1);
+    let tint = hsla(0.6, 0.9, 0.6, 0.12);
+    let tint_border = hsla(0.6, 0.9, 0.6, 0.5);
+    let view = view.clone();
+    div()
+        .id(("gesture-owner", id_part))
+        .px_2()
+        .py_1()
+        .rounded_md()
+        .border_1()
+        .border_color(if selected { tint_border } else { pal.border })
+        .text_xs()
+        .text_color(if selected {
+            pal.text_primary
+        } else {
+            pal.text_muted
+        })
+        .when(selected, |s| s.bg(tint))
+        .when(!selected, |s| s.hover(|s| s.bg(pal.surface_hover)))
+        .cursor_pointer()
+        .child(text)
+        .on_click(move |_event, _window, cx| {
+            cx.update_global::<AppState, _>(|state, _| state.commit_gesture_owner(btn));
+            view.update(cx, |_, vcx| vcx.notify());
+        })
+        .into_any_element()
 }
 
 fn leader_canvas(
@@ -281,6 +394,7 @@ fn label_popover(
     mouse_w: f32,
     hovered: Option<ButtonId>,
     active: Option<ButtonId>,
+    gesture_owner: Option<ButtonId>,
     view: &Entity<MouseModelView>,
 ) -> AnyElement {
     let x = match label.side {
@@ -296,7 +410,7 @@ fn label_popover(
         selected: false,
         view: view.clone(),
     };
-    let popover: AnyElement = if label.id == ButtonId::GestureButton {
+    let popover: AnyElement = if Some(label.id) == gesture_owner {
         gesture_overview_popover(
             ("label-popover", idx),
             Anchor::TopLeft,

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -975,8 +975,9 @@ impl AppState {
         match self.config.gesture_owner(key) {
             // The dedicated thumb pad seeds every direction from the defaults.
             Some(ButtonId::GestureButton) => gesture_bindings_for(&self.config, Some(key)),
-            // A promoted OS-hook button shows only what the user bound (its swipe
-            // arms start unbound) — read its raw stored direction map.
+            // A promoted OS-hook button is shown from its raw stored map (which
+            // `set_gesture_owner` seeds with full defaults), so the menu matches
+            // exactly what `oshook_gestures_for` dispatches — no seeding here.
             Some(owner) => match self.config.bindings_for(key).get(&owner) {
                 Some(Binding::Gesture(map)) => map.clone(),
                 _ => BTreeMap::new(),
@@ -1021,20 +1022,25 @@ impl AppState {
     /// Update a single gesture-button sub-binding in memory, on disk, and in the
     /// shared gesture map the watcher thread reads.
     pub fn commit_gesture_binding(&mut self, direction: GestureDirection, action: Action) {
-        self.gesture_bindings.insert(direction, action.clone());
-
         let Some(key) = self.current_record().map(|r| r.config_key.clone()) else {
             debug!(
                 ?direction,
-                "no active device key — gesture binding kept in memory only"
+                "no active device key — gesture binding edit ignored"
             );
             return;
         };
-        // Edit whichever button is the gesture owner — not always the thumb pad.
-        let owner = self
-            .config
-            .gesture_owner(&key)
-            .unwrap_or(ButtonId::GestureButton);
+        // Edit whichever button owns gestures — not always the thumb pad. When
+        // gestures are off, a stray edit must NOT silently re-enable them on the
+        // thumb pad (the gesture editor shouldn't be reachable in that state):
+        // no-op instead.
+        let Some(owner) = self.config.gesture_owner(&key) else {
+            debug!(
+                ?direction,
+                "gestures are off — ignoring gesture binding edit"
+            );
+            return;
+        };
+        self.gesture_bindings.insert(direction, action.clone());
         self.config
             .set_gesture_direction(&key, owner, direction, action);
         if let Err(e) = self.config.save_atomic() {

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -114,10 +114,11 @@ pub struct AppState {
     /// Bindings for the *currently selected* device. Reloaded whenever the
     /// carousel selection changes.
     pub button_bindings: BTreeMap<ButtonId, Action>,
-    /// Per-direction sub-bindings for the gesture button on the currently
-    /// selected device. Edited via the gesture picker; persisted as a
-    /// [`Binding::Gesture`] entry under [`ButtonId::GestureButton`] in the
-    /// device's unified binding map ([`DeviceConfig::bindings`]).
+    /// Per-direction sub-bindings for the current device's gesture owner. Edited
+    /// via the gesture picker and persisted as a [`Binding::Gesture`] entry under
+    /// the owning button — the thumb pad ([`ButtonId::GestureButton`]) by default,
+    /// or a promoted Middle/Back/Forward — in the device's unified binding map
+    /// ([`DeviceConfig::bindings`]). Rebuilt by the `gesture_bindings_for_current` helper.
     ///
     /// [`DeviceConfig::bindings`]: openlogi_core::config::DeviceConfig::bindings
     pub gesture_bindings: BTreeMap<GestureDirection, Action>,

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -969,10 +969,53 @@ impl AppState {
     }
 
     fn gesture_bindings_for_current(&self) -> BTreeMap<GestureDirection, Action> {
-        gesture_bindings_for(
-            &self.config,
-            self.current_record().map(|r| r.config_key.as_str()),
-        )
+        let Some(key) = self.current_record().map(|r| r.config_key.as_str()) else {
+            return BTreeMap::new();
+        };
+        match self.config.gesture_owner(key) {
+            // The dedicated thumb pad seeds every direction from the defaults.
+            Some(ButtonId::GestureButton) => gesture_bindings_for(&self.config, Some(key)),
+            // A promoted OS-hook button shows only what the user bound (its swipe
+            // arms start unbound) — read its raw stored direction map.
+            Some(owner) => match self.config.bindings_for(key).get(&owner) {
+                Some(Binding::Gesture(map)) => map.clone(),
+                _ => BTreeMap::new(),
+            },
+            None => BTreeMap::new(),
+        }
+    }
+
+    /// The current device's gesture button — the [`Binding::Gesture`] owner — or
+    /// `None` when no button is in gesture mode. Drives which button's card opens
+    /// the gesture menu rather than the single-action picker.
+    #[must_use]
+    pub fn current_gesture_owner(&self) -> Option<ButtonId> {
+        let key = self.current_record()?.config_key.as_str();
+        self.config.gesture_owner(key)
+    }
+
+    /// Make `button` the current device's gesture button (or clear it with
+    /// `None`), enforcing the one-gesture-button-per-device lock. Persists, tells
+    /// the agent to rebuild, and refreshes the projected maps the UI reads.
+    pub fn commit_gesture_owner(&mut self, button: Option<ButtonId>) {
+        let Some(key) = self.current_record().map(|r| r.config_key.clone()) else {
+            return;
+        };
+        match button {
+            Some(b) => {
+                self.config.set_gesture_owner(&key, b);
+            }
+            None => {
+                self.config.disable_gestures(&key);
+            }
+        }
+        if let Err(e) = self.config.save_atomic() {
+            warn!(error = %e, "could not persist gesture-button change to config.toml");
+        }
+        // The owner change shuffles bindings between the single + gesture maps.
+        self.button_bindings = self.bindings_for_current();
+        self.gesture_bindings = self.gesture_bindings_for_current();
+        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
     }
 
     /// Update a single gesture-button sub-binding in memory, on disk, and in the
@@ -987,8 +1030,13 @@ impl AppState {
             );
             return;
         };
+        // Edit whichever button is the gesture owner — not always the thumb pad.
+        let owner = self
+            .config
+            .gesture_owner(&key)
+            .unwrap_or(ButtonId::GestureButton);
         self.config
-            .set_gesture_direction(&key, ButtonId::GestureButton, direction, action);
+            .set_gesture_direction(&key, owner, direction, action);
         if let Err(e) = self.config.save_atomic() {
             warn!(error = %e, "could not persist gesture binding to config.toml");
         }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -81,6 +81,12 @@ struct CaptureAccum {
 /// `capture_thumbwheel`) the thumb wheel on `route` until `shutdown` resolves,
 /// forwarding each event to `sink`.
 ///
+/// The gesture button (raw-XY) is diverted only when `divert_gesture_button` —
+/// i.e. it is the device's gesture owner. When the user moves the gesture role
+/// to an OS-hook button or turns gestures off, the thumb pad is left undiverted
+/// so it keeps its native behavior instead of being captured-and-swallowed. The
+/// DPI/ModeShift capture and the channel-reuse slot are independent of this.
+///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
 /// device exposes, and listens. Returns once `shutdown` fires (or its sender is
 /// dropped), after restoring every diverted control. Setup errors are returned;
@@ -88,6 +94,7 @@ struct CaptureAccum {
 pub async fn run_capture_session(
     route: DeviceRoute,
     capture_thumbwheel: bool,
+    divert_gesture_button: bool,
     sink: mpsc::UnboundedSender<CapturedInput>,
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
@@ -96,7 +103,13 @@ pub async fn run_capture_session(
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
     let device_index = route.device_index();
-    let armed = arm_controls(&chan, device_index, capture_thumbwheel).await?;
+    let armed = arm_controls(
+        &chan,
+        device_index,
+        capture_thumbwheel,
+        divert_gesture_button,
+    )
+    .await?;
 
     // Publish this device's open channel so DPI/SmartShift writes reuse it
     // instead of opening their own. Cleared on the way out.
@@ -199,6 +212,7 @@ async fn arm_controls(
     chan: &Arc<HidppChannel>,
     slot: u8,
     capture_thumbwheel: bool,
+    divert_gesture_button: bool,
 ) -> Result<ArmedControls, GestureError> {
     let device = Device::new(Arc::clone(chan), slot)
         .await
@@ -216,9 +230,12 @@ async fn arm_controls(
         let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
         let controls = enumerate_controls(&rc).await?;
 
-        if controls
-            .iter()
-            .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
+        // Only divert the gesture button when it owns the gesture role; otherwise
+        // leave it native (a non-owner thumb pad must not be captured-and-dropped).
+        if divert_gesture_button
+            && controls
+                .iter()
+                .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
         {
             rc.set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, true, true)
                 .await

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -423,4 +423,31 @@ mod tests {
         );
         assert!(rx.try_recv().is_err(), "a held DPI button presses once");
     }
+
+    #[test]
+    fn a_dpi_button_re_presses_after_a_release() {
+        // Rising-edge detection must re-arm: press → release → press is two
+        // distinct presses. The release (a frame without the CID) is what resets
+        // the edge; without it a re-press would be swallowed as "still held".
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut acc = CaptureAccum::default();
+        let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
+        let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
+        let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
+
+        handle_reprog(&mut acc, down, &[dpi], &tx);
+        handle_reprog(&mut acc, up, &[dpi], &tx);
+        handle_reprog(&mut acc, down, &[dpi], &tx);
+
+        assert_eq!(
+            rx.try_recv(),
+            Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle))
+        );
+        assert_eq!(
+            rx.try_recv(),
+            Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle)),
+            "a release re-arms the rising edge"
+        );
+        assert!(rx.try_recv().is_err());
+    }
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -16,10 +16,10 @@
 //! is therefore only diverted when its click is actually bound.
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use hidpp::{channel::HidppChannel, device::Device, protocol::v20};
-use openlogi_core::binding::{ButtonId, GestureDirection, detect_swipe};
+use openlogi_core::binding::{ButtonId, GESTURE_HOLD_FOR_SWIPE, GestureDirection, detect_swipe};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -66,10 +66,6 @@ pub enum GestureError {
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
 }
-
-/// Minimum hold before raw-XY travel counts as a swipe. A quicker tap stays a
-/// plain click even if the cursor was moving when it fired.
-const GESTURE_HOLD_FOR_SWIPE: Duration = Duration::from_millis(160);
 
 /// Movement + button state accumulated across messages. Lives behind a `Mutex`
 /// because the channel's read thread invokes the listener by shared reference.

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -16,10 +16,9 @@
 //! is therefore only diverted when its click is actually bound.
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
-use std::time::Instant;
 
 use hidpp::{channel::HidppChannel, device::Device, protocol::v20};
-use openlogi_core::binding::{ButtonId, GESTURE_HOLD_FOR_SWIPE, GestureDirection, detect_swipe};
+use openlogi_core::binding::{ButtonId, GestureDirection, SwipeAccumulator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
@@ -71,16 +70,8 @@ pub enum GestureError {
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
-    /// Whether the gesture button is currently held.
-    gesture_held: bool,
-    /// When the current hold began — gates swipe vs. click by duration.
-    held_since: Option<Instant>,
-    /// Accumulated raw-XY travel since the press began.
-    dx: i32,
-    dy: i32,
-    /// Whether a directional swipe has already committed during this hold.
-    /// Gestures fire mid-swipe (like Options+) and once per press.
-    fired: bool,
+    /// Mid-swipe state for the diverted thumb-pad gesture button (raw-XY).
+    swipe: SwipeAccumulator,
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
@@ -326,17 +317,11 @@ fn handle_reprog(
     match event {
         RawControlEvent::DivertedButtons(cids) => {
             let gesture_held = cids.contains(&reprog_controls::GESTURE_BUTTON_CID);
-            if gesture_held && !acc.gesture_held {
-                acc.gesture_held = true;
-                acc.held_since = Some(Instant::now());
-                acc.dx = 0;
-                acc.dy = 0;
-                acc.fired = false;
-            } else if !gesture_held && acc.gesture_held {
-                acc.gesture_held = false;
-                acc.held_since = None;
+            if gesture_held && !acc.swipe.is_holding() {
+                acc.swipe.begin();
+            } else if !gesture_held && acc.swipe.is_holding() {
                 // A press that never committed a direction is a plain click.
-                if !acc.fired {
+                if acc.swipe.end() {
                     debug!("gesture click");
                     let _ = sink.send(CapturedInput::Gesture(GestureDirection::Click));
                 }
@@ -349,21 +334,12 @@ fn handle_reprog(
             acc.dpi_down = dpi_down;
         }
         RawControlEvent::RawXy { dx, dy } => {
-            // Accumulate until a clean direction commits, then fire immediately
-            // and ignore the rest of the hold (one gesture per press).
-            if acc.gesture_held && !acc.fired {
-                acc.dx = acc.dx.saturating_add(i32::from(dx));
-                acc.dy = acc.dy.saturating_add(i32::from(dy));
-                // Held long enough to be a deliberate gesture, not a tap whose
-                // cursor happened to be in motion? Only then does travel commit.
-                let held = acc
-                    .held_since
-                    .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
-                if held && let Some(direction) = detect_swipe(acc.dx, acc.dy) {
-                    debug!(?direction, dx = acc.dx, dy = acc.dy, "gesture committed");
-                    acc.fired = true;
-                    let _ = sink.send(CapturedInput::Gesture(direction));
-                }
+            // Commit the instant a clean direction emerges (mid-swipe, once per
+            // hold); the accumulator gates on hold duration internally and drops
+            // travel that arrives outside a hold.
+            if let Some(direction) = acc.swipe.accumulate(i32::from(dx), i32::from(dy)) {
+                debug!(?direction, "gesture committed");
+                let _ = sink.send(CapturedInput::Gesture(direction));
             }
         }
     }
@@ -411,7 +387,7 @@ mod tests {
 
         handle_reprog(&mut acc, press(), &[], &tx);
         // Pretend the button has been held well past the swipe gate.
-        acc.held_since = Instant::now().checked_sub(GESTURE_HOLD_FOR_SWIPE * 2);
+        acc.swipe.backdate_hold_for_test();
         handle_reprog(
             &mut acc,
             RawControlEvent::RawXy { dx: 120, dy: 5 },

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -53,6 +53,12 @@ pub enum MouseEvent {
         /// Positive = down, negative = up.
         delta_y: i32,
     },
+    /// The OS interrupted event capture (on macOS, the tap was disabled by a
+    /// timeout or by competing user input). Any in-progress gesture hold must be
+    /// cancelled: a button-up dropped during the gap would otherwise leave a
+    /// stale hold that the next stray pointer move turns into a phantom swipe.
+    /// Carries no data and is always passed through.
+    CaptureInterrupted,
 }
 
 /// What the hook callback wants the OS to do with the captured event.

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -44,6 +44,15 @@ pub enum MouseEvent {
         /// Positive = down, negative = up.
         delta_y: f32,
     },
+    /// Pointer movement, in device units. Emitted so a held gesture button can
+    /// accumulate a swipe; the callback passes these through (the cursor keeps
+    /// moving) and only reads them while a gesture button is down.
+    Moved {
+        /// Positive = right, negative = left.
+        delta_x: i32,
+        /// Positive = down, negative = up.
+        delta_y: i32,
+    },
 }
 
 /// What the hook callback wants the OS to do with the captured event.

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -223,28 +223,43 @@ fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent
                 pressed: value != 0,
             })
         }
-        #[allow(clippy::cast_precision_loss)] // scroll deltas fit comfortably in f32 mantissa
-        EventSummary::RelativeAxis(_, axis, value) => {
-            let v = value as f32;
-            if hires_scroll {
-                match axis {
-                    RelativeAxisCode::REL_WHEEL_HI_RES => {
-                        Some(scroll(0.0, v / HIRES_UNITS_PER_TICK))
+        EventSummary::RelativeAxis(_, axis, value) => match axis {
+            // Pointer movement feeds gesture-button swipe detection. Emitted as a
+            // `Moved` and always passed through, so the cursor keeps moving while
+            // a held gesture button accumulates the swipe (the B2 cursor-drift
+            // design).
+            RelativeAxisCode::REL_X => Some(MouseEvent::Moved {
+                delta_x: value,
+                delta_y: 0,
+            }),
+            RelativeAxisCode::REL_Y => Some(MouseEvent::Moved {
+                delta_x: 0,
+                delta_y: value,
+            }),
+            _ => {
+                #[allow(clippy::cast_precision_loss)]
+                // scroll deltas fit comfortably in f32 mantissa
+                let v = value as f32;
+                if hires_scroll {
+                    match axis {
+                        RelativeAxisCode::REL_WHEEL_HI_RES => {
+                            Some(scroll(0.0, v / HIRES_UNITS_PER_TICK))
+                        }
+                        RelativeAxisCode::REL_HWHEEL_HI_RES => {
+                            Some(scroll(v / HIRES_UNITS_PER_TICK, 0.0))
+                        }
+                        // Low-res ticks are redundant when hi-res is active.
+                        _ => None,
                     }
-                    RelativeAxisCode::REL_HWHEEL_HI_RES => {
-                        Some(scroll(v / HIRES_UNITS_PER_TICK, 0.0))
+                } else {
+                    match axis {
+                        RelativeAxisCode::REL_WHEEL => Some(scroll(0.0, v)),
+                        RelativeAxisCode::REL_HWHEEL => Some(scroll(v, 0.0)),
+                        _ => None,
                     }
-                    // Low-res ticks are redundant when hi-res is active.
-                    _ => None,
-                }
-            } else {
-                match axis {
-                    RelativeAxisCode::REL_WHEEL => Some(scroll(0.0, v)),
-                    RelativeAxisCode::REL_HWHEEL => Some(scroll(v, 0.0)),
-                    _ => None,
                 }
             }
-        }
+        },
         _ => None,
     }
 }
@@ -523,6 +538,32 @@ mod tests {
             Some(MouseEvent::Button {
                 id: ButtonId::Forward,
                 pressed: true
+            })
+        ));
+    }
+
+    // ── movement ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn translate_rel_x_returns_horizontal_move() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_X.0, 7);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Moved {
+                delta_x: 7,
+                delta_y: 0
+            })
+        ));
+    }
+
+    #[test]
+    fn translate_rel_y_returns_vertical_move() {
+        let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_Y.0, -4);
+        assert!(matches!(
+            translate(&event, false),
+            Some(MouseEvent::Moved {
+                delta_x: 0,
+                delta_y: -4
             })
         ));
     }

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -105,9 +105,22 @@ fn button_number_to_id(n: i64) -> Option<ButtonId> {
 fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
     // Skip events OpenLogi itself synthesised ([`Action::execute`] stamps them),
     // so a remapped click we posted doesn't re-enter the hook as real input and,
-    // for a gesture button, get misread as a fresh hold.
-    if event.get_integer_value_field(EventField::EVENT_SOURCE_USER_DATA)
-        == openlogi_core::binding::SYNTHETIC_EVENT_USER_DATA
+    // for a gesture button, get misread as a fresh hold. Only button events are
+    // ever synthesised (`Action::execute` posts buttons, never moves/scroll), so
+    // gate the field read on button types — keeping the FFI call off the
+    // high-rate pointer-move stream.
+    let is_button = matches!(
+        etype,
+        CGEventType::LeftMouseDown
+            | CGEventType::LeftMouseUp
+            | CGEventType::RightMouseDown
+            | CGEventType::RightMouseUp
+            | CGEventType::OtherMouseDown
+            | CGEventType::OtherMouseUp
+    );
+    if is_button
+        && event.get_integer_value_field(EventField::EVENT_SOURCE_USER_DATA)
+            == openlogi_core::binding::SYNTHETIC_EVENT_USER_DATA
     {
         return None;
     }
@@ -168,11 +181,12 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             })
         }
         CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput => {
-            error!(
-                "CGEventTap disabled by OS (type={etype:?}); \
-                 hook will stop receiving events until re-enabled"
-            );
-            None
+            // The run-loop slice re-enables the tap (see `thread_main`); surface
+            // the interruption so the runtime cancels any in-progress hold — a
+            // button-up dropped during the gap must not later fire a phantom
+            // swipe off ordinary cursor motion.
+            warn!("CGEventTap disabled by OS (type={etype:?}); re-enabling, cancelling any hold");
+            Some(MouseEvent::CaptureInterrupted)
         }
         _ => None,
     }
@@ -304,6 +318,11 @@ fn thread_main(
             );
             break;
         }
+        // Recover from an OS-initiated disable (TapDisabledByTimeout/UserInput):
+        // re-enabling is idempotent while the tap is already live, so this brings
+        // a disabled tap back within one slice instead of the hook going
+        // permanently deaf. Only reached while Accessibility is still granted.
+        tap.enable();
     }
 
     // Detach the tap from the event stream synchronously before unwinding,

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -184,8 +184,10 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             // The run-loop slice re-enables the tap (see `thread_main`); surface
             // the interruption so the runtime cancels any in-progress hold — a
             // button-up dropped during the gap must not later fire a phantom
-            // swipe off ordinary cursor motion.
-            warn!("CGEventTap disabled by OS (type={etype:?}); re-enabling, cancelling any hold");
+            // swipe off ordinary cursor motion. Logged at debug, not warn:
+            // TapDisabledByUserInput fires during ordinary heavy input bursts and
+            // self-heals next slice, so it isn't worth a warning each time.
+            debug!("CGEventTap disabled by OS (type={etype:?}); re-enabling, cancelling any hold");
             Some(MouseEvent::CaptureInterrupted)
         }
         _ => None,

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -103,6 +103,14 @@ fn button_number_to_id(n: i64) -> Option<ButtonId> {
 /// Convert a `CGEvent` to our [`MouseEvent`] vocabulary. Returns `None`
 /// for event types we don't translate (e.g. move events, unknown buttons).
 fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
+    // Skip events OpenLogi itself synthesised ([`Action::execute`] stamps them),
+    // so a remapped click we posted doesn't re-enter the hook as real input and,
+    // for a gesture button, get misread as a fresh hold.
+    if event.get_integer_value_field(EventField::EVENT_SOURCE_USER_DATA)
+        == openlogi_core::binding::SYNTHETIC_EVENT_USER_DATA
+    {
+        return None;
+    }
     match etype {
         CGEventType::LeftMouseDown => Some(MouseEvent::Button {
             id: ButtonId::LeftClick,
@@ -139,6 +147,24 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             Some(MouseEvent::Scroll {
                 delta_x: dx as f32,
                 delta_y: dy as f32,
+            })
+        }
+        // Pointer movement feeds gesture-button swipe detection. While a button
+        // is physically held the OS reports *Dragged rather than MouseMoved, so
+        // a gesture button's hold-and-swipe arrives here as OtherMouseDragged.
+        CGEventType::MouseMoved
+        | CGEventType::LeftMouseDragged
+        | CGEventType::RightMouseDragged
+        | CGEventType::OtherMouseDragged => {
+            let dx = event.get_integer_value_field(EventField::MOUSE_EVENT_DELTA_X);
+            let dy = event.get_integer_value_field(EventField::MOUSE_EVENT_DELTA_Y);
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "per-event pointer deltas are small integers, far within i32"
+            )]
+            Some(MouseEvent::Moved {
+                delta_x: dx as i32,
+                delta_y: dy as i32,
             })
         }
         CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput => {
@@ -201,6 +227,14 @@ fn thread_main(
         CGEventType::OtherMouseDown,
         CGEventType::OtherMouseUp,
         CGEventType::ScrollWheel,
+        // Pointer movement, for gesture-button hold+swipe. A held button makes
+        // the OS emit *Dragged rather than MouseMoved, so all four are needed.
+        // The callback stays lock-light (see `hook_runtime`) so this high-rate
+        // stream can't stall the tap.
+        CGEventType::MouseMoved,
+        CGEventType::LeftMouseDragged,
+        CGEventType::RightMouseDragged,
+        CGEventType::OtherMouseDragged,
     ];
 
     let tap_result = CGEventTap::new(

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -31,6 +31,10 @@ fn mouse_event_clone_and_debug() {
             delta_x: 1.0,
             delta_y: -1.5,
         },
+        MouseEvent::Moved {
+            delta_x: 3,
+            delta_y: -2,
+        },
     ];
     for e in &events {
         let cloned = e.clone();


### PR DESCRIPTION
## Phase B — gesture buttons on the side buttons

Stacked on #187 (Phase A, the unified `Binding` model). **Base: `feat/unified-binding-model`** — review that first; this PR's diff is Phase B only.

Lets **Middle / Back / Forward** act as gesture buttons (hold + swipe → directional action) at the OS-hook layer, alongside the existing HID++ thumb-pad gesture button. At most one gesture button per device.

### What's here
- **Two capture paths, one swipe engine.** The dedicated thumb pad keeps its HID++ `0x1b04` raw-XY divert; Middle/Back/Forward are captured at the macOS `CGEventTap` (hold suppresses the click, pointer motion drives the swipe, a no-swipe release fires the plain click). Both share a single `SwipeAccumulator` in `openlogi-core` that commits mid-swipe, like Options+.
- **Explicit gesture-owner model.** `DeviceConfig.gesture_owner` (`Off | Button(id)`, absent = infer) is the single source of truth for which button gestures; switching it is non-destructive — every gesture-capable button keeps its full direction map, so changing the owner never loses customizations. A top-of-panel single-select in the GUI makes the one-gesture-button-per-device lock visible.
- **Runtime plumbing.** Per-thread hold state (no cross-device bleed on Linux); atomic publish of the hook maps; the thumb-pad divert is gated on ownership (no dead/swallowed control when gestures move off it); per-app overrides apply to OS-hook gesture buttons; the `CGEventTap` recovers from an OS-initiated disable and cancels a stale hold.

### Review
Two rounds of max-effort `/code-review` (9 finder angles + adversarial verification) ran against this branch. All confirmed findings are fixed — 8 fix commits; the residual items are documented as by-design or latent (hand-edit-only) in the commit messages.

### Testing
`cargo test` (core / agent-core / hid / hook) green; full-workspace `clippy -D warnings` clean (incl. GUI). Verified on-device on macOS: hold-and-swipe on the side buttons, plain click on a quick press, switching the gesture button, and turning gestures off.

Draft pending Phase A (#187) merging first.
