### PR TITLE
feat(hook): Wayland frontmost-window backends (wlroots + GNOME Shell)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,8 +5177,11 @@ dependencies = [
  "openlogi-inject",
  "thiserror 2.0.18",
  "tracing",
+ "wayland-client",
+ "wayland-protocols-wlr",
  "windows-sys 0.61.2",
  "x11rb",
+ "zbus",
 ]
 
 [[package]]

--- a/crates/openlogi-core/src/brand.rs
+++ b/crates/openlogi-core/src/brand.rs
@@ -14,6 +14,15 @@ pub const HELP_URL: &str = "https://github.com/AprilNEA/OpenLogi#readme";
 /// The "latest release" page.
 pub const RELEASES_URL: &str = "https://github.com/AprilNEA/OpenLogi/releases/latest";
 
+/// The application identifier: the Wayland xdg-toplevel `app_id` (and X11
+/// `WM_CLASS`) the GUI advertises, the root of the macOS bundle-id family
+/// (`org.openlogi.agent`, `org.openlogi.openlogi.dev`), and the value the Linux
+/// `.desktop` file pins as `StartupWMClass`. Defined once here so the window the
+/// compositor sees, the launcher that groups it, and the frontmost backend that
+/// self-identifies OpenLogi can never disagree. The `.desktop` file carries its
+/// own literal copy (it can't reference Rust) — keep the two in sync.
+pub const APP_ID: &str = "org.openlogi.openlogi";
+
 /// The release page for a specific version tag (e.g. the running build).
 #[must_use]
 pub fn release_tag_url(version: &str) -> String {

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -58,7 +58,7 @@ use gpui::{
     AppContext, BorrowAppContext as _, Bounds, Size, Styled, WindowBounds, WindowOptions, px,
 };
 use gpui_component::{ActiveTheme, Root};
-use openlogi_core::brand::DeeplinkCommand;
+use openlogi_core::brand::{APP_ID, DeeplinkCommand};
 use openlogi_core::config::Config;
 use openlogi_core::device::DeviceInventory;
 use tracing::{info, warn};
@@ -507,13 +507,13 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
         // the window ships no app_id, so GNOME's `get_wm_class()` returns empty
         // and our own `gnome_shell` frontmost backend reports OpenLogi as `None`
         // (and the dash can't group the window under its launcher icon). The id
-        // matches the bundle identifier and the desktop file's `StartupWMClass`.
-        app_id: Some("org.openlogi.openlogi".into()),
+        // is the shared `brand::APP_ID`, matching the desktop file's
+        // `StartupWMClass` and the macOS bundle-id family.
+        app_id: Some(APP_ID.into()),
         // Min height keeps the buttons tab's mouse model above its scale floor
         // (`MODEL_MIN_H` + the chrome/padding reserve) so its side labels never
         // overlap; below this the model can't shrink further without crowding.
         window_min_size: Some(Size::new(px(720.), px(680.))),
-        app_id: Some("openlogi".to_string()),
         // Linux: transparent chrome so `AppView::render` can draw a client-side
         // `TitleBar` (the compositor declines server-side decorations and gpui's
         // fallback is unpainted). macOS/Windows keep their native titlebar.

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -503,6 +503,12 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
     let bounds = Bounds::centered(None, Size::new(px(1100.), px(750.)), cx);
     WindowOptions {
         window_bounds: Some(WindowBounds::Windowed(bounds)),
+        // Advertise a Wayland xdg-toplevel app_id (and X11 WM_CLASS). Without it
+        // the window ships no app_id, so GNOME's `get_wm_class()` returns empty
+        // and our own `gnome_shell` frontmost backend reports OpenLogi as `None`
+        // (and the dash can't group the window under its launcher icon). The id
+        // matches the bundle identifier and the desktop file's `StartupWMClass`.
+        app_id: Some("org.openlogi.openlogi".into()),
         // Min height keeps the buttons tab's mouse model above its scale floor
         // (`MODEL_MIN_H` + the chrome/padding reserve) so its side labels never
         // overlap; below this the model can't shrink further without crowding.

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -17,7 +17,10 @@ tracing = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 evdev = { workspace = true }
 libc = "0.2"
+wayland-client = "0.31"
+wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 x11rb = "0.13"
+zbus = "5"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 ctrlc = "3"

--- a/crates/openlogi-hook/gnome-shell-extension/README.md
+++ b/crates/openlogi-hook/gnome-shell-extension/README.md
@@ -1,0 +1,59 @@
+# OpenLogi Frontmost Window — GNOME Shell extension
+
+GNOME (Mutter) does not let ordinary clients see which window is focused on
+Wayland, and it implements neither `wlr-foreign-toplevel` nor a focused-window
+portal. This minimal extension bridges that gap: it exports the WM_CLASS of the
+focused window over D-Bus so OpenLogi's `gnome-shell` frontmost backend can
+drive per-app mouse-profile switching.
+
+It reads only `global.display.focus_window.get_wm_class()`. No titles, no window
+contents, no input, no UI.
+
+## D-Bus surface
+
+- name: `org.openlogi.Frontmost`
+- path: `/org/openlogi/Frontmost`
+- method: `GetFocusedWmClass() -> s` (empty string when nothing is focused)
+
+## Install
+
+```sh
+UUID=openlogi-frontmost@openlogi.dev
+DEST="$HOME/.local/share/gnome-shell/extensions/$UUID"
+mkdir -p "$DEST"
+cp metadata.json extension.js "$DEST"/
+```
+
+On Wayland the shell cannot be reloaded in place, so **log out and back in** to
+let GNOME pick up the newly added extension, then enable it:
+
+```sh
+gnome-extensions enable "$UUID"
+gnome-extensions info "$UUID"   # State should be ACTIVE
+```
+
+## Verify
+
+```sh
+# Introspect the service:
+busctl --user introspect org.openlogi.Frontmost /org/openlogi/Frontmost
+
+# Focus a window, then query it:
+gdbus call --session \
+  -d org.openlogi.Frontmost \
+  -o /org/openlogi/Frontmost \
+  -m org.openlogi.Frontmost.GetFocusedWmClass
+```
+
+If `gdbus call` prints the focused window's WM_CLASS, OpenLogi's GNOME backend
+will pick it up automatically the next time the hook starts.
+
+## Notes
+
+- The `shell-version` list in `metadata.json` covers GNOME 45–50. Newer GNOME
+  releases may need an added entry; the API used here (`Gio.DBusExportedObject`,
+  `global.display.focus_window`, `Meta.Window.get_wm_class`) has been stable
+  across these versions.
+- The extension name/UUID and the D-Bus name (`org.openlogi.*`) are placeholders
+  that should track the project's namespace; if they change, update the matching
+  constants in `crates/openlogi-hook/src/linux/gnome_shell.rs`.

--- a/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/extension.js
+++ b/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/extension.js
@@ -1,0 +1,55 @@
+// OpenLogi Frontmost Window — GNOME Shell extension.
+//
+// Exports a tiny D-Bus service that returns the WM_CLASS of the currently
+// focused window. OpenLogi's `gnome_shell` frontmost backend polls this to
+// drive per-app mouse-profile switching on GNOME Wayland, where the focused
+// window is otherwise not visible to ordinary clients.
+//
+// It reads only `global.display.focus_window.get_wm_class()` — no titles, no
+// window contents, no input. ESM module style; targets GNOME Shell 45+.
+
+import Gio from 'gi://Gio';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const DBUS_NAME = 'org.openlogi.Frontmost';
+const DBUS_PATH = '/org/openlogi/Frontmost';
+const DBUS_INTERFACE = `
+<node>
+  <interface name="org.openlogi.Frontmost">
+    <method name="GetFocusedWmClass">
+      <arg type="s" direction="out" name="wmClass"/>
+    </method>
+  </interface>
+</node>`;
+
+export default class OpenLogiFrontmostExtension extends Extension {
+    enable() {
+        this._dbus = Gio.DBusExportedObject.wrapJSObject(DBUS_INTERFACE, this);
+        this._dbus.export(Gio.DBus.session, DBUS_PATH);
+        this._nameId = Gio.bus_own_name_on_connection(
+            Gio.DBus.session,
+            DBUS_NAME,
+            Gio.BusNameOwnerFlags.NONE,
+            null,
+            null);
+    }
+
+    disable() {
+        if (this._nameId) {
+            Gio.bus_unown_name(this._nameId);
+            this._nameId = 0;
+        }
+        if (this._dbus) {
+            this._dbus.unexport();
+            this._dbus = null;
+        }
+    }
+
+    // D-Bus method org.openlogi.Frontmost.GetFocusedWmClass.
+    GetFocusedWmClass() {
+        const win = global.display.focus_window;
+        if (!win)
+            return '';
+        return win.get_wm_class() || '';
+    }
+}

--- a/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/metadata.json
+++ b/crates/openlogi-hook/gnome-shell-extension/openlogi-frontmost@openlogi.dev/metadata.json
@@ -1,0 +1,8 @@
+{
+  "uuid": "openlogi-frontmost@openlogi.dev",
+  "name": "OpenLogi Frontmost Window",
+  "description": "Exposes the focused window's WM_CLASS over D-Bus so OpenLogi can switch per-app mouse profiles on GNOME Wayland. Read-only; no UI, no window contents.",
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
+  "url": "https://github.com/AprilNEA/OpenLogi",
+  "version": 1
+}

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -464,70 +464,220 @@ fn device_thread(
 
 // ── frontmost_bundle_id ──────────────────────────────────────────────────────
 
-struct X11State {
+// The frontmost-app reader is backend-driven so that Wayland support can be
+// added without touching callers. Exactly one backend is selected at startup
+// from the session environment (see `detect_frontmost_source`) and cached in
+// `FRONTMOST_SOURCE` for the process lifetime. Today only the X11 backend
+// exists; Wayland-native backends slot into `wayland_candidates`.
+
+mod gnome_shell;
+mod wlr_foreign_toplevel;
+
+/// A backend that reports which application is currently frontmost.
+///
+/// Implementations are display-server / desktop specific. The string returned
+/// by `frontmost_bundle_id` is compared against per-app profile keys by exact
+/// match (`openlogi_core::Config::effective_bindings`), so its exact form
+/// matters and is backend-specific. The X11 and gnome-shell backends both
+/// return the `WM_CLASS` class component (e.g. "Firefox"); the wlr backend
+/// returns the xdg-shell `app_id` (e.g. "org.mozilla.firefox"). These two
+/// namespaces do not map onto each other by any simple string rule, so a
+/// per-app profile created under wlroots will not match under GNOME/X11 and
+/// vice versa. This is a known limitation: reconciling it needs a canonical-id
+/// scheme or per-profile aliases rather than naive normalization, and is
+/// deliberately out of scope for the backends themselves.
+trait FrontmostSource: Send + Sync {
+    /// Opaque identifier of the frontmost application, or `None` when there is
+    /// no frontmost window or it cannot be read.
+    fn frontmost_bundle_id(&self) -> Option<String>;
+
+    /// Short backend identifier, for diagnostics / logging only.
+    fn name(&self) -> &'static str;
+}
+
+/// Frontmost backend backed by X11 `_NET_ACTIVE_WINDOW` + `WM_CLASS`.
+///
+/// Works on an X11 session, and on a Wayland session for XWayland windows;
+/// native Wayland windows are invisible through this path and yield `None`.
+struct X11Source {
     conn: RustConnection,
     root: Window,
     net_active_window: Atom,
 }
 
-static X11_STATE: LazyLock<Option<X11State>> = LazyLock::new(|| {
-    let (conn, screen_num) = RustConnection::connect(None)
-        .map_err(|e| debug!("X11 not available, frontmost_bundle_id will return None: {e}"))
-        .ok()?;
-    let root = conn.setup().roots[screen_num].root;
-    let net_active_window = conn
-        .intern_atom(false, b"_NET_ACTIVE_WINDOW")
-        .ok()?
-        .reply()
-        .ok()?
-        .atom;
-    Some(X11State {
-        conn,
-        root,
-        net_active_window,
-    })
-});
+impl X11Source {
+    /// Connect to the X server and resolve the `_NET_ACTIVE_WINDOW` atom.
+    /// Returns `None` when no X display is reachable (a Wayland session without
+    /// XWayland, or `$DISPLAY` unset).
+    fn connect() -> Option<Self> {
+        let (conn, screen_num) = RustConnection::connect(None)
+            .map_err(|e| debug!("X11 not available, frontmost will return None: {e}"))
+            .ok()?;
+        let root = conn.setup().roots[screen_num].root;
+        let net_active_window = conn
+            .intern_atom(false, b"_NET_ACTIVE_WINDOW")
+            .ok()?
+            .reply()
+            .ok()?
+            .atom;
+        Some(Self {
+            conn,
+            root,
+            net_active_window,
+        })
+    }
+}
 
-/// Return the X11 `WM_CLASS` class component of the currently active window,
-/// e.g. `"Firefox"` or `"Code"`.
-///
-/// Returns `None` when there is no active window, when the X11 display is
-/// unavailable (Wayland-only session without XWayland), or on read error.
-/// Native Wayland windows are not visible through this path.
-pub(crate) fn frontmost_bundle_id() -> Option<String> {
-    let state = X11_STATE.as_ref()?;
+impl FrontmostSource for X11Source {
+    fn frontmost_bundle_id(&self) -> Option<String> {
+        // _NET_ACTIVE_WINDOW on the root window holds the focused window's XID.
+        let window: Window = self
+            .conn
+            .get_property(
+                false,
+                self.root,
+                self.net_active_window,
+                AtomEnum::WINDOW,
+                0,
+                1,
+            )
+            .ok()?
+            .reply()
+            .ok()?
+            .value32()?
+            .next()?;
+        if window == 0 {
+            return None;
+        }
 
-    // _NET_ACTIVE_WINDOW on the root window holds the focused window's XID.
-    let window: Window = state
-        .conn
-        .get_property(
-            false,
-            state.root,
-            state.net_active_window,
-            AtomEnum::WINDOW,
-            0,
-            1,
-        )
-        .ok()?
-        .reply()
-        .ok()?
-        .value32()?
-        .next()?;
-    if window == 0 {
-        return None;
+        // WM_CLASS is instance_name\0class_name\0; the class component is more
+        // stable across window instances and is what profiles should key on
+        // (e.g. "Firefox", not "Navigator").
+        let wm = WmClass::get(&self.conn, window)
+            .ok()?
+            .reply_unchecked()
+            .ok()??;
+        std::str::from_utf8(wm.class())
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
     }
 
-    // WM_CLASS is instance_name\0class_name\0; the class component is more
-    // stable across window instances and is what profiles should key on
-    // (e.g. "Firefox", not "Navigator").
-    let wm = WmClass::get(&state.conn, window)
-        .ok()?
-        .reply_unchecked()
-        .ok()??;
-    std::str::from_utf8(wm.class())
-        .ok()
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
+    fn name(&self) -> &'static str {
+        "x11"
+    }
+}
+
+/// Fallback used when no backend is available (e.g. a pure Wayland session
+/// before any Wayland backend lands). Always reports `None`, so per-app
+/// profile switching simply no-ops rather than erroring.
+struct NullSource;
+
+impl FrontmostSource for NullSource {
+    fn frontmost_bundle_id(&self) -> Option<String> {
+        None
+    }
+
+    fn name(&self) -> &'static str {
+        "null"
+    }
+}
+
+/// Coarse classification of the graphical session, used to order the frontmost
+/// backend candidates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionKind {
+    X11,
+    Wayland,
+    Unknown,
+}
+
+/// Classify the session from the environment. `XDG_SESSION_TYPE` is
+/// authoritative when set to `x11` or `wayland`; otherwise fall back to the
+/// presence of `WAYLAND_DISPLAY` / `DISPLAY`.
+fn detect_session_kind() -> SessionKind {
+    if let Ok(kind) = std::env::var("XDG_SESSION_TYPE") {
+        match kind.as_str() {
+            "wayland" => return SessionKind::Wayland,
+            "x11" => return SessionKind::X11,
+            _ => {}
+        }
+    }
+    if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+        SessionKind::Wayland
+    } else if std::env::var_os("DISPLAY").is_some() {
+        SessionKind::X11
+    } else {
+        SessionKind::Unknown
+    }
+}
+
+/// A backend constructor: returns the backend if it can initialize on this
+/// system, or `None` to fall through to the next candidate.
+type Candidate = fn() -> Option<Box<dyn FrontmostSource>>;
+
+fn x11_candidate() -> Option<Box<dyn FrontmostSource>> {
+    X11Source::connect().map(|s| Box::new(s) as Box<dyn FrontmostSource>)
+}
+
+/// Wayland-native frontmost backends, in priority order: the wlroots
+/// foreign-toplevel protocol (sway, Hyprland, river, …) and the GNOME Shell
+/// D-Bus extension (Mutter). AT-SPI remains a future fallback. Compositors that
+/// support none of these fall through to the X11/XWayland path (which resolves
+/// XWayland windows, `None` for native Wayland apps).
+fn wayland_candidates() -> Vec<Candidate> {
+    vec![
+        wlr_foreign_toplevel::candidate,
+        gnome_shell::candidate,
+    ]
+}
+
+/// Pick the frontmost backend for this session, trying each candidate in order
+/// and keeping the first that initializes. Called once, lazily, per process.
+fn detect_frontmost_source() -> Box<dyn FrontmostSource> {
+    let session = detect_session_kind();
+    debug!("frontmost: session kind = {session:?}");
+
+    let mut candidates: Vec<Candidate> = match session {
+        SessionKind::Wayland => wayland_candidates(),
+        SessionKind::X11 | SessionKind::Unknown => Vec::new(),
+    };
+    // X11 / XWayland: the primary path on an X11 session and the universal
+    // fallback everywhere else.
+    candidates.push(x11_candidate);
+
+    for candidate in candidates {
+        if let Some(source) = candidate() {
+            debug!("frontmost: using '{}' backend", source.name());
+            // On Wayland, landing on the X11 backend means no native Wayland
+            // frontmost source was available, so native Wayland windows will
+            // report None (only XWayland windows resolve). Hint at the fix.
+            if session == SessionKind::Wayland && source.name() == "x11" {
+                debug!(
+                    "frontmost: on Wayland but using the X11/XWayland backend; \
+                     native Wayland windows will report None. Install the OpenLogi \
+                     GNOME Shell extension (GNOME) or use a wlroots compositor."
+                );
+            }
+            return source;
+        }
+    }
+
+    debug!("frontmost: no usable backend; frontmost_bundle_id will return None");
+    Box::new(NullSource)
+}
+
+static FRONTMOST_SOURCE: LazyLock<Box<dyn FrontmostSource>> =
+    LazyLock::new(detect_frontmost_source);
+
+/// Return an opaque identifier of the currently frontmost application, or
+/// `None` when unavailable. Dispatches to the backend chosen at startup.
+///
+/// On an X11 session this is the `WM_CLASS` class component (e.g. "Firefox").
+/// On a pure Wayland session it is currently `None` until a Wayland backend is
+/// added; XWayland windows are still resolved via the X11 backend.
+pub(crate) fn frontmost_bundle_id() -> Option<String> {
+    FRONTMOST_SOURCE.frontmost_bundle_id()
 }
 
 #[cfg(test)]

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -626,10 +626,7 @@ fn x11_candidate() -> Option<Box<dyn FrontmostSource>> {
 /// support none of these fall through to the X11/XWayland path (which resolves
 /// XWayland windows, `None` for native Wayland apps).
 fn wayland_candidates() -> Vec<Candidate> {
-    vec![
-        wlr_foreign_toplevel::candidate,
-        gnome_shell::candidate,
-    ]
+    vec![wlr_foreign_toplevel::candidate, gnome_shell::candidate]
 }
 
 /// Pick the frontmost backend for this session, trying each candidate in order

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -467,8 +467,8 @@ fn device_thread(
 // The frontmost-app reader is backend-driven so that Wayland support can be
 // added without touching callers. Exactly one backend is selected at startup
 // from the session environment (see `detect_frontmost_source`) and cached in
-// `FRONTMOST_SOURCE` for the process lifetime. Today only the X11 backend
-// exists; Wayland-native backends slot into `wayland_candidates`.
+// `FRONTMOST_SOURCE` for the process lifetime. The X11, wlr-foreign-toplevel,
+// and gnome-shell backends are all available; see `wayland_candidates`.
 
 mod gnome_shell;
 mod wlr_foreign_toplevel;
@@ -671,8 +671,8 @@ static FRONTMOST_SOURCE: LazyLock<Box<dyn FrontmostSource>> =
 /// `None` when unavailable. Dispatches to the backend chosen at startup.
 ///
 /// On an X11 session this is the `WM_CLASS` class component (e.g. "Firefox").
-/// On a pure Wayland session it is currently `None` until a Wayland backend is
-/// added; XWayland windows are still resolved via the X11 backend.
+/// On a Wayland session the wlr-foreign-toplevel or gnome-shell backend is used
+/// when available; XWayland windows fall back to the X11 backend.
 pub(crate) fn frontmost_bundle_id() -> Option<String> {
     FRONTMOST_SOURCE.frontmost_bundle_id()
 }

--- a/crates/openlogi-hook/src/linux/gnome_shell.rs
+++ b/crates/openlogi-hook/src/linux/gnome_shell.rs
@@ -1,0 +1,97 @@
+//! Frontmost backend for GNOME Shell (Wayland and X11), via a small companion
+//! GNOME Shell extension that exports the focused window's WM_CLASS over D-Bus.
+//!
+//! GNOME (Mutter) implements neither wlr-foreign-toplevel nor any portal for
+//! the focused window, and `org.gnome.Shell.Eval` is disabled by default, so a
+//! privileged GNOME Shell extension is the only way to read the focused window
+//! on a GNOME Wayland session. The extension lives in `gnome-shell-extension/`
+//! in this crate and must be installed and enabled for this backend to
+//! activate. When it is absent, [`GnomeShellSource::connect`] fails and backend
+//! selection falls through to the next candidate (XWayland via X11).
+//!
+//! The extension returns the WM_CLASS — not the `.desktop` id — so the
+//! identifier matches the X11 backend's, keeping per-app profile keys
+//! consistent across X11, XWayland, and GNOME Wayland sessions.
+//!
+//! Only the session-bus connection is held in the backend; a lightweight proxy
+//! is built per poll (no extra D-Bus traffic beyond the method call itself).
+
+use std::time::Duration;
+
+use tracing::debug;
+use zbus::blocking::Connection;
+use zbus::blocking::connection::Builder;
+use zbus::proxy;
+
+use super::FrontmostSource;
+
+/// Cap on every D-Bus call to the extension. Without it, a stalled GNOME Shell
+/// would block the polling thread forever (the probe runs inside the
+/// `FRONTMOST_SOURCE` initializer, so a stall there would block every thread
+/// that touches it).
+const METHOD_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// D-Bus proxy for the OpenLogi GNOME Shell extension. Only the blocking proxy
+/// is generated (`gen_async = false`), matching the synchronous poll contract.
+#[proxy(
+    interface = "org.openlogi.Frontmost",
+    default_service = "org.openlogi.Frontmost",
+    default_path = "/org/openlogi/Frontmost",
+    gen_async = false
+)]
+trait Frontmost {
+    /// WM_CLASS of the focused window, or "" when nothing is focused.
+    #[zbus(name = "GetFocusedWmClass")]
+    fn get_focused_wm_class(&self) -> zbus::Result<String>;
+}
+
+/// Frontmost backend talking to the OpenLogi GNOME Shell extension over the
+/// session bus.
+struct GnomeShellSource {
+    conn: Connection,
+}
+
+impl GnomeShellSource {
+    fn connect() -> Option<Self> {
+        let conn = Builder::session()
+            .map_err(|e| debug!("gnome-shell: no session bus: {e}"))
+            .ok()?
+            .method_timeout(METHOD_TIMEOUT)
+            .build()
+            .map_err(|e| debug!("gnome-shell: connection build failed: {e}"))
+            .ok()?;
+        // Probe reachability: a successful call (even an empty result) means the
+        // OpenLogi extension is installed and exporting the service. An error
+        // means it is absent/disabled, so this backend must not be selected.
+        let proxy = FrontmostProxy::new(&conn)
+            .map_err(|e| debug!("gnome-shell: proxy build failed: {e}"))
+            .ok()?;
+        proxy
+            .get_focused_wm_class()
+            .map_err(|e| debug!("gnome-shell: OpenLogi extension not reachable: {e}"))
+            .ok()?;
+        Some(Self { conn })
+    }
+}
+
+impl FrontmostSource for GnomeShellSource {
+    fn frontmost_bundle_id(&self) -> Option<String> {
+        let proxy = FrontmostProxy::new(&self.conn)
+            .map_err(|e| debug!("gnome-shell: proxy build failed: {e}"))
+            .ok()?;
+        let wm_class = proxy
+            .get_focused_wm_class()
+            .map_err(|e| debug!("gnome-shell: poll failed (extension gone or bus down?): {e}"))
+            .ok()?;
+        (!wm_class.is_empty()).then_some(wm_class)
+    }
+
+    fn name(&self) -> &'static str {
+        "gnome-shell"
+    }
+}
+
+/// Candidate constructor registered in [`super::wayland_candidates`].
+pub(super) fn candidate() -> Option<Box<dyn FrontmostSource>> {
+    GnomeShellSource::connect().map(|s| Box::new(s) as Box<dyn FrontmostSource>)
+}

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -1,0 +1,269 @@
+//! Frontmost backend using the wlroots `zwlr_foreign_toplevel_management_v1`
+//! protocol.
+//!
+//! The manager hands out one handle per toplevel window; each handle reports
+//! its `app_id` and a `state` set. The frontmost window is the toplevel whose
+//! state set contains `activated`, and its `app_id` is what we return.
+//!
+//! Note on the returned identifier: this is the xdg-shell `app_id` (e.g.
+//! "org.mozilla.firefox", "Alacritty", "foot"), which is a *different namespace*
+//! from the `WM_CLASS` returned by the X11 and gnome-shell backends (e.g.
+//! "Firefox"). Because profile lookup is an exact match, a per-app profile
+//! created under wlroots will not match under GNOME/X11 and vice versa. We
+//! deliberately return the native `app_id` rather than a lossy WM_CLASS
+//! approximation (stripping reverse-DNS and capitalizing guesses wrong for many
+//! apps); reconciling the two namespaces belongs in a single normalization
+//! layer, not here. See the `FrontmostSource` trait doc in `linux.rs`.
+//!
+//! This protocol is implemented by wlroots-based compositors (sway, Hyprland,
+//! river, Wayfire, …). GNOME (Mutter) and KDE (KWin) do not advertise it, so
+//! [`connect`](WlrForeignToplevelSource::connect) returns `None` there and the
+//! caller falls through to the next backend candidate.
+//!
+//! The protocol is event-driven, but the [`super::FrontmostSource`] contract is
+//! a synchronous poll (~1 Hz from `openlogi-gui::app_watcher`). To bridge that,
+//! the connection, event queue, and accumulated state are kept alive in the
+//! backend and a `roundtrip` is performed on each poll to drain pending events
+//! (focus changes, new / closed windows) before reading the active toplevel.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tracing::{debug, warn};
+use wayland_client::backend::ObjectId;
+use wayland_client::protocol::wl_registry::{self, WlRegistry};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, event_created_child};
+use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_handle_v1::{
+    self, ZwlrForeignToplevelHandleV1,
+};
+use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_manager_v1::{
+    self, ZwlrForeignToplevelManagerV1,
+};
+
+use super::FrontmostSource;
+
+/// Highest protocol version this backend understands. The events it relies on
+/// (`app_id`, `state`, `done`, `closed`) exist since v1, so binding is capped
+/// here to stay within what `wayland-protocols-wlr` generates.
+const MANAGER_MAX_VERSION: u32 = 3;
+
+/// Accumulated per-toplevel data. wlr sends individual property events and then
+/// a `done` marking a consistent snapshot, so updates are staged in `pending_*`
+/// and committed on `done`.
+#[derive(Default)]
+struct Toplevel {
+    app_id: Option<String>,
+    activated: bool,
+    pending_app_id: Option<String>,
+    pending_activated: bool,
+}
+
+/// Dispatch state: the bound manager plus the toplevels seen so far.
+#[derive(Default)]
+struct State {
+    manager: Option<ZwlrForeignToplevelManagerV1>,
+    toplevels: HashMap<ObjectId, Toplevel>,
+    /// Set when the compositor sends `finished`; the manager is then defunct.
+    finished: bool,
+}
+
+impl Dispatch<WlRegistry, ()> for State {
+    fn event(
+        state: &mut Self,
+        registry: &WlRegistry,
+        event: wl_registry::Event,
+        (): &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            if interface == ZwlrForeignToplevelManagerV1::interface().name {
+                let version = version.min(MANAGER_MAX_VERSION);
+                let manager =
+                    registry.bind::<ZwlrForeignToplevelManagerV1, (), Self>(name, version, qh, ());
+                state.manager = Some(manager);
+            }
+        }
+    }
+}
+
+impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &ZwlrForeignToplevelManagerV1,
+        event: zwlr_foreign_toplevel_manager_v1::Event,
+        (): &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_foreign_toplevel_manager_v1::Event::Toplevel { toplevel } => {
+                state.toplevels.insert(toplevel.id(), Toplevel::default());
+            }
+            zwlr_foreign_toplevel_manager_v1::Event::Finished => {
+                // sway emits this on config reload and compositor restart. The
+                // manager is now defunct and the backend is cached for the
+                // process lifetime, so per-app profiles stay disabled until the
+                // hook is restarted.
+                warn!(
+                    "wlr-foreign-toplevel: compositor sent Finished — per-app \
+                     profiles disabled until the hook restarts"
+                );
+                state.finished = true;
+                state.manager = None;
+            }
+            _ => {}
+        }
+    }
+
+    // The `toplevel` event creates a new handle object; tell the backend to
+    // route its events to this same `State` with `()` user data.
+    event_created_child!(State, ZwlrForeignToplevelManagerV1, [
+        zwlr_foreign_toplevel_manager_v1::EVT_TOPLEVEL_OPCODE => (ZwlrForeignToplevelHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for State {
+    fn event(
+        state: &mut Self,
+        handle: &ZwlrForeignToplevelHandleV1,
+        event: zwlr_foreign_toplevel_handle_v1::Event,
+        (): &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        use zwlr_foreign_toplevel_handle_v1::Event;
+
+        let id = handle.id();
+        match event {
+            Event::AppId { app_id } => {
+                if let Some(toplevel) = state.toplevels.get_mut(&id) {
+                    toplevel.pending_app_id = Some(app_id);
+                }
+            }
+            Event::State { state: states } => {
+                let activated = is_activated(&states);
+                if let Some(toplevel) = state.toplevels.get_mut(&id) {
+                    toplevel.pending_activated = activated;
+                }
+            }
+            Event::Done => {
+                if let Some(toplevel) = state.toplevels.get_mut(&id) {
+                    // app_id is sent only when it changes, and a compositor may
+                    // emit State + Done before the first AppId. Committing
+                    // `pending_app_id` unconditionally would clobber a known id
+                    // (or the initial one) with None, so only overwrite when a
+                    // value is actually pending. `activated` defaults to false,
+                    // which is the correct state for a window that sent none.
+                    if toplevel.pending_app_id.is_some() {
+                        toplevel.app_id = toplevel.pending_app_id.clone();
+                    }
+                    toplevel.activated = toplevel.pending_activated;
+                }
+            }
+            Event::Closed => {
+                state.toplevels.remove(&id);
+                handle.destroy();
+            }
+            // Title, output enter/leave, and parent are not needed for frontmost.
+            _ => {}
+        }
+    }
+}
+
+/// The `state` event carries a `wl_array` of native-endian `u32` state values.
+/// A toplevel is frontmost iff the `activated` value is present in that set.
+fn is_activated(states: &[u8]) -> bool {
+    use zwlr_foreign_toplevel_handle_v1::State;
+
+    states.chunks_exact(4).any(|chunk| {
+        let value = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        State::try_from(value).is_ok_and(|s| s == State::Activated)
+    })
+}
+
+/// Wayland frontmost backend. Holds the connection, event queue, and dispatch
+/// state alive for the process; each poll drains events and reads the active
+/// toplevel's `app_id`.
+struct WlrForeignToplevelSource {
+    // Kept alive so the protocol objects owned by the queue stay valid.
+    #[allow(dead_code)]
+    conn: Connection,
+    // Behind a mutex because the trait polls through `&self` while `roundtrip`
+    // needs `&mut`. The queue is only ever touched here, at ~1 Hz.
+    dispatcher: Mutex<Dispatcher>,
+}
+
+struct Dispatcher {
+    queue: EventQueue<State>,
+    state: State,
+}
+
+impl WlrForeignToplevelSource {
+    fn connect() -> Option<Self> {
+        let conn = Connection::connect_to_env()
+            .map_err(|e| debug!("wlr-foreign-toplevel: no Wayland connection: {e}"))
+            .ok()?;
+        let mut queue = conn.new_event_queue();
+        let qh = queue.handle();
+
+        // Registering the registry triggers `global` events on the next
+        // round-trip, where the manager is bound if the compositor advertises
+        // it. The registry handle is only needed for that round-trip.
+        let _registry = conn.display().get_registry(&qh, ());
+        let mut state = State::default();
+        queue
+            .roundtrip(&mut state)
+            .map_err(|e| debug!("wlr-foreign-toplevel: registry roundtrip failed: {e}"))
+            .ok()?;
+        if state.manager.is_none() {
+            debug!("wlr-foreign-toplevel: compositor does not advertise the protocol");
+            return None;
+        }
+
+        // Second round-trip: receive the initial toplevel list and properties,
+        // so the first poll already has the active window.
+        queue
+            .roundtrip(&mut state)
+            .map_err(|e| debug!("wlr-foreign-toplevel: initial roundtrip failed: {e}"))
+            .ok()?;
+
+        Some(Self {
+            conn,
+            dispatcher: Mutex::new(Dispatcher { queue, state }),
+        })
+    }
+}
+
+impl FrontmostSource for WlrForeignToplevelSource {
+    fn frontmost_bundle_id(&self) -> Option<String> {
+        let mut guard = self.dispatcher.lock().ok()?;
+        let Dispatcher { queue, state } = &mut *guard;
+
+        // Drain focus changes and new / closed windows since the last poll.
+        queue.roundtrip(state).ok()?;
+        if state.finished {
+            return None;
+        }
+
+        state
+            .toplevels
+            .values()
+            .find(|toplevel| toplevel.activated)
+            .and_then(|toplevel| toplevel.app_id.clone())
+    }
+
+    fn name(&self) -> &'static str {
+        "wlr-foreign-toplevel"
+    }
+}
+
+/// Candidate constructor registered in [`super::wayland_candidates`].
+pub(super) fn candidate() -> Option<Box<dyn FrontmostSource>> {
+    WlrForeignToplevelSource::connect().map(|s| Box::new(s) as Box<dyn FrontmostSource>)
+}

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -29,7 +29,7 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_registry::{self, WlRegistry};
 use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, event_created_child};
@@ -63,7 +63,8 @@ struct Toplevel {
 struct State {
     manager: Option<ZwlrForeignToplevelManagerV1>,
     toplevels: HashMap<ObjectId, Toplevel>,
-    /// Set when the compositor sends `finished`; the manager is then defunct.
+    /// Set when the compositor sends `finished`; triggers a reconnect on the
+    /// next poll instead of permanently disabling the backend.
     finished: bool,
 }
 
@@ -106,13 +107,11 @@ impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for State {
                 state.toplevels.insert(toplevel.id(), Toplevel::default());
             }
             zwlr_foreign_toplevel_manager_v1::Event::Finished => {
-                // sway emits this on config reload and compositor restart. The
-                // manager is now defunct and the backend is cached for the
-                // process lifetime, so per-app profiles stay disabled until the
-                // hook is restarted.
+                // The compositor is reloading or restarting. Mark the session
+                // finished; the next poll will reconnect automatically.
                 warn!(
-                    "wlr-foreign-toplevel: compositor sent Finished — per-app \
-                     profiles disabled until the hook restarts"
+                    "wlr-foreign-toplevel: compositor sent Finished — \
+                     will reconnect on next poll"
                 );
                 state.finished = true;
                 state.manager = None;
@@ -187,25 +186,23 @@ fn is_activated(states: &[u8]) -> bool {
     })
 }
 
-/// Wayland frontmost backend. Holds the connection, event queue, and dispatch
-/// state alive for the process; each poll drains events and reads the active
-/// toplevel's `app_id`.
-struct WlrForeignToplevelSource {
-    // Kept alive so the protocol objects owned by the queue stay valid.
-    #[allow(dead_code)]
-    conn: Connection,
-    // Behind a mutex because the trait polls through `&self` while `roundtrip`
-    // needs `&mut`. The queue is only ever touched here, at ~1 Hz.
-    dispatcher: Mutex<Dispatcher>,
-}
-
-struct Dispatcher {
+/// One live Wayland session: connection + event queue + dispatch state.
+///
+/// Grouping all three behind a single mutex means the whole session can be
+/// dropped and rebuilt atomically when the compositor sends `Finished`.
+struct Session {
+    // Held for RAII — even though `Connection` is Arc-backed, keeping an
+    // explicit handle here ensures the connection outlives the queue.
+    _conn: Connection,
     queue: EventQueue<State>,
     state: State,
 }
 
-impl WlrForeignToplevelSource {
-    fn connect() -> Option<Self> {
+impl Session {
+    /// Open a fresh connection, bind the manager, and do the initial two
+    /// round-trips to populate the toplevel list. Returns `None` when the
+    /// compositor doesn't advertise the protocol or the connection fails.
+    fn open() -> Option<Self> {
         let conn = Connection::connect_to_env()
             .map_err(|e| debug!("wlr-foreign-toplevel: no Wayland connection: {e}"))
             .ok()?;
@@ -234,20 +231,49 @@ impl WlrForeignToplevelSource {
             .ok()?;
 
         Some(Self {
-            conn,
-            dispatcher: Mutex::new(Dispatcher { queue, state }),
+            _conn: conn,
+            queue,
+            state,
+        })
+    }
+}
+
+/// Wayland frontmost backend. Holds the session behind a mutex so the whole
+/// connection can be rebuilt on compositor restart without touching callers.
+struct WlrForeignToplevelSource {
+    // Active session, or `None` when the last reconnect attempt failed.
+    // The mutex bridges the event-driven Wayland runtime to the synchronous
+    // poll contract; the session is only ever touched here, at ~1 Hz.
+    session: Mutex<Option<Session>>,
+}
+
+impl WlrForeignToplevelSource {
+    fn connect() -> Option<Self> {
+        Session::open().map(|s| Self {
+            session: Mutex::new(Some(s)),
         })
     }
 }
 
 impl FrontmostSource for WlrForeignToplevelSource {
     fn frontmost_bundle_id(&self) -> Option<String> {
-        let mut guard = self.dispatcher.lock().ok()?;
-        let Dispatcher { queue, state } = &mut *guard;
+        let mut guard = self.session.lock().ok()?;
 
-        // Drain focus changes and new / closed windows since the last poll.
+        // Reconnect when the compositor sent `Finished` (compositor reload /
+        // restart) or when a prior reconnect attempt failed.
+        let needs_reconnect = guard.as_ref().map_or(true, |s| s.state.finished);
+        if needs_reconnect {
+            *guard = Session::open();
+            match &*guard {
+                Some(_) => info!("wlr-foreign-toplevel: reconnected"),
+                None => debug!("wlr-foreign-toplevel: reconnect pending, retrying next poll"),
+            }
+        }
+
+        let Session { queue, state, .. } = guard.as_mut()?;
         queue.roundtrip(state).ok()?;
         if state.finished {
+            // `Finished` arrived during this poll; reconnect on the next call.
             return None;
         }
 

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -20,17 +20,34 @@
 //! [`connect`](WlrForeignToplevelSource::connect) returns `None` there and the
 //! caller falls through to the next backend candidate.
 //!
+//! ## Dispatch model
+//!
 //! The protocol is event-driven, but the [`super::FrontmostSource`] contract is
-//! a synchronous poll (~1 Hz from `openlogi-gui::app_watcher`). To bridge that,
-//! the connection, event queue, and accumulated state are kept alive in the
-//! backend and a `roundtrip` is performed on each poll to drain pending events
-//! (focus changes, new / closed windows) before reading the active toplevel.
+//! a synchronous poll (~1 Hz from `openlogi-gui::app_watcher`). Two primitives
+//! bridge that gap:
+//!
+//! - **`drain_events`** (poll path) — flushes pending writes, then attempts a
+//!   non-blocking `prepare_read` + `read` with a short 25 ms `poll(2)` cap.
+//!   If nothing arrives in time the last known state is returned unchanged;
+//!   millisecond-stale frontmost data is acceptable by design.
+//!
+//! - **`timed_roundtrip`** (init path) — sends `wl_display.sync`, then loops
+//!   `flush` → `poll(2)` → `read` → `dispatch_pending` until the sync callback
+//!   fires or `INIT_TIMEOUT` (5 s) expires. If the deadline is hit the candidate
+//!   returns `None` so backend selection falls through — the same contract as
+//!   every other backend.
+//!
+//! Both helpers use `poll(2)` via the `libc` crate (already a Linux dependency)
+//! with `Instant`-based remaining-time accounting and `EINTR` retry.
 
 use std::collections::HashMap;
+use std::os::unix::io::AsRawFd;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use tracing::{debug, info, warn};
 use wayland_client::backend::ObjectId;
+use wayland_client::protocol::wl_callback;
 use wayland_client::protocol::wl_registry::{self, WlRegistry};
 use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle, event_created_child};
 use wayland_protocols_wlr::foreign_toplevel::v1::client::zwlr_foreign_toplevel_handle_v1::{
@@ -46,6 +63,15 @@ use super::FrontmostSource;
 /// (`app_id`, `state`, `done`, `closed`) exist since v1, so binding is capped
 /// here to stay within what `wayland-protocols-wlr` generates.
 const MANAGER_MAX_VERSION: u32 = 3;
+
+/// Deadline for the two `wl_display.sync` round-trips in `Session::open`.
+/// Mirrors `gnome_shell::METHOD_TIMEOUT`: both guard the `FRONTMOST_SOURCE`
+/// `LazyLock` initializer against a stalled compositor socket.
+const INIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum time the poll-path drain will wait for new Wayland events. Stale
+/// frontmost data within this window is acceptable by design.
+const POLL_CAP_MS: u64 = 25;
 
 /// Accumulated per-toplevel data. wlr sends individual property events and then
 /// a `done` marking a consistent snapshot, so updates are staged in `pending_*`
@@ -66,6 +92,9 @@ struct State {
     /// Set when the compositor sends `finished`; triggers a reconnect on the
     /// next poll instead of permanently disabling the backend.
     finished: bool,
+    /// Flipped to `true` by the `wl_callback::Done` handler; used by
+    /// `timed_roundtrip` to detect that the sync echo arrived.
+    sync_done: bool,
 }
 
 impl Dispatch<WlRegistry, ()> for State {
@@ -175,6 +204,21 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for State {
     }
 }
 
+impl Dispatch<wl_callback::WlCallback, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &wl_callback::WlCallback,
+        event: wl_callback::Event,
+        (): &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_callback::Event::Done { .. } = event {
+            state.sync_done = true;
+        }
+    }
+}
+
 /// The `state` event carries a `wl_array` of native-endian `u32` state values.
 /// A toplevel is frontmost iff the `activated` value is present in that set.
 fn is_activated(states: &[u8]) -> bool {
@@ -184,6 +228,116 @@ fn is_activated(states: &[u8]) -> bool {
         let value = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
         State::try_from(value).is_ok_and(|s| s == State::Activated)
     })
+}
+
+/// Returns the milliseconds remaining until `deadline`, clamped to `[0, i32::MAX]`
+/// for use as a `libc::poll` timeout. Returns 0 when the deadline has passed.
+fn millis_until(deadline: Instant) -> i32 {
+    i32::try_from(
+        deadline
+            .saturating_duration_since(Instant::now())
+            .as_millis()
+            .min(i32::MAX as u128),
+    )
+    .unwrap_or(i32::MAX)
+}
+
+/// Calls `poll(2)` on `fd` (waiting for `POLLIN | POLLERR`) with a deadline.
+/// Retries on `EINTR` with the remaining time. Returns `true` if the fd became
+/// readable, `false` on timeout or error.
+fn poll_fd(fd: libc::c_int, deadline: Instant) -> bool {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN | libc::POLLERR,
+        revents: 0,
+    };
+    loop {
+        let timeout_ms = millis_until(deadline);
+        if timeout_ms == 0 {
+            return false;
+        }
+        let r = unsafe { libc::poll(&raw mut pfd, 1, timeout_ms) };
+        if r > 0 {
+            return true;
+        }
+        if r == 0 {
+            return false;
+        }
+        // r < 0 — check errno
+        let e = unsafe { *libc::__errno_location() };
+        if e != libc::EINTR {
+            return false;
+        }
+        // EINTR: retry with remaining deadline
+    }
+}
+
+/// Sends `wl_display.sync` and spins `flush → poll → read → dispatch_pending`
+/// until the sync callback fires or `deadline` is reached. Returns `true` on
+/// success, `false` on timeout or connection error.
+fn timed_roundtrip(
+    conn: &Connection,
+    queue: &mut EventQueue<State>,
+    state: &mut State,
+    deadline: Instant,
+) -> bool {
+    state.sync_done = false;
+    let qh = queue.handle();
+    conn.display().sync(&qh, ());
+
+    loop {
+        if queue.flush().is_err() {
+            return false;
+        }
+        if queue.dispatch_pending(state).is_err() {
+            return false;
+        }
+        if state.sync_done {
+            return true;
+        }
+        if millis_until(deadline) == 0 {
+            return false;
+        }
+
+        match queue.prepare_read() {
+            None => {
+                // Events are already buffered; loop back to dispatch.
+            }
+            Some(guard) => {
+                let fd = guard.connection_fd().as_raw_fd();
+                if !poll_fd(fd, deadline) {
+                    // Timed out or error — candidate falls through.
+                    return false;
+                }
+                if guard.read().is_err() {
+                    return false;
+                }
+            }
+        }
+    }
+}
+
+/// Drains pending compositor events without blocking longer than `POLL_CAP_MS`.
+/// Used on every frontmost poll. Stale data within the cap is acceptable by
+/// design; errors are silently ignored so the last known state is returned.
+fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
+    let _ = queue.flush();
+    let _ = queue.dispatch_pending(state);
+
+    let deadline = Instant::now() + Duration::from_millis(POLL_CAP_MS);
+    match queue.prepare_read() {
+        None => {
+            // Already had buffered events; dispatch_pending above handled them.
+        }
+        Some(guard) => {
+            let fd = guard.connection_fd().as_raw_fd();
+            if poll_fd(fd, deadline) {
+                let _ = guard.read();
+                let _ = queue.dispatch_pending(state);
+            }
+            // If poll timed out, guard is dropped here and we return stale state.
+        }
+    }
 }
 
 /// One live Wayland session: connection + event queue + dispatch state.
@@ -200,8 +354,9 @@ struct Session {
 
 impl Session {
     /// Open a fresh connection, bind the manager, and do the initial two
-    /// round-trips to populate the toplevel list. Returns `None` when the
-    /// compositor doesn't advertise the protocol or the connection fails.
+    /// timed round-trips to populate the toplevel list. Returns `None` when
+    /// the compositor doesn't advertise the protocol, the connection fails,
+    /// or either round-trip exceeds `INIT_TIMEOUT`.
     fn open() -> Option<Self> {
         let conn = Connection::connect_to_env()
             .map_err(|e| debug!("wlr-foreign-toplevel: no Wayland connection: {e}"))
@@ -209,15 +364,15 @@ impl Session {
         let mut queue = conn.new_event_queue();
         let qh = queue.handle();
 
-        // Registering the registry triggers `global` events on the next
-        // round-trip, where the manager is bound if the compositor advertises
-        // it. The registry handle is only needed for that round-trip.
+        // Registering the registry triggers `global` events on the first
+        // round-trip, where the manager is bound if the compositor advertises it.
         let _registry = conn.display().get_registry(&qh, ());
         let mut state = State::default();
-        queue
-            .roundtrip(&mut state)
-            .map_err(|e| debug!("wlr-foreign-toplevel: registry roundtrip failed: {e}"))
-            .ok()?;
+
+        if !timed_roundtrip(&conn, &mut queue, &mut state, Instant::now() + INIT_TIMEOUT) {
+            debug!("wlr-foreign-toplevel: registry round-trip timed out or failed");
+            return None;
+        }
         if state.manager.is_none() {
             debug!("wlr-foreign-toplevel: compositor does not advertise the protocol");
             return None;
@@ -225,10 +380,10 @@ impl Session {
 
         // Second round-trip: receive the initial toplevel list and properties,
         // so the first poll already has the active window.
-        queue
-            .roundtrip(&mut state)
-            .map_err(|e| debug!("wlr-foreign-toplevel: initial roundtrip failed: {e}"))
-            .ok()?;
+        if !timed_roundtrip(&conn, &mut queue, &mut state, Instant::now() + INIT_TIMEOUT) {
+            debug!("wlr-foreign-toplevel: initial toplevel round-trip timed out or failed");
+            return None;
+        }
 
         Some(Self {
             _conn: conn,
@@ -261,19 +416,20 @@ impl FrontmostSource for WlrForeignToplevelSource {
 
         // Reconnect when the compositor sent `Finished` (compositor reload /
         // restart) or when a prior reconnect attempt failed.
-        let needs_reconnect = guard.as_ref().map_or(true, |s| s.state.finished);
+        let needs_reconnect = guard.as_ref().is_none_or(|s| s.state.finished);
         if needs_reconnect {
             *guard = Session::open();
-            match &*guard {
-                Some(_) => info!("wlr-foreign-toplevel: reconnected"),
-                None => debug!("wlr-foreign-toplevel: reconnect pending, retrying next poll"),
+            if guard.is_some() {
+                info!("wlr-foreign-toplevel: reconnected");
+            } else {
+                debug!("wlr-foreign-toplevel: reconnect pending, retrying next poll");
             }
         }
 
         let Session { queue, state, .. } = guard.as_mut()?;
-        queue.roundtrip(state).ok()?;
+        drain_events(queue, state);
         if state.finished {
-            // `Finished` arrived during this poll; reconnect on the next call.
+            // `Finished` arrived during this drain; reconnect on the next call.
             return None;
         }
 
@@ -292,4 +448,27 @@ impl FrontmostSource for WlrForeignToplevelSource {
 /// Candidate constructor registered in [`super::wayland_candidates`].
 pub(super) fn candidate() -> Option<Box<dyn FrontmostSource>> {
     WlrForeignToplevelSource::connect().map(|s| Box::new(s) as Box<dyn FrontmostSource>)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::millis_until;
+
+    #[test]
+    fn millis_until_elapsed_deadline_is_zero() {
+        // `deadline` is captured before the call; by the time `millis_until`
+        // reads `Instant::now()` the deadline is at or before now, so
+        // `saturating_duration_since` returns `Duration::ZERO` → 0 ms.
+        let deadline = Instant::now();
+        assert_eq!(millis_until(deadline), 0);
+    }
+
+    #[test]
+    fn millis_until_future_deadline_is_positive() {
+        let future = Instant::now() + Duration::from_secs(10);
+        let ms = millis_until(future);
+        assert!(ms > 0 && ms <= 10_000);
+    }
 }

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -327,7 +327,9 @@ fn timed_roundtrip(
 /// returning stale state forever.
 fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
     if queue.flush().is_err() || queue.dispatch_pending(state).is_err() {
-        warn!("wlr-foreign-toplevel: connection error while draining — will reconnect on next poll");
+        warn!(
+            "wlr-foreign-toplevel: connection error while draining — will reconnect on next poll"
+        );
         state.finished = true;
         return;
     }
@@ -339,7 +341,9 @@ fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
         }
         Some(guard) => {
             let fd = guard.connection_fd().as_raw_fd();
-            if poll_fd(fd, deadline) && (guard.read().is_err() || queue.dispatch_pending(state).is_err()) {
+            if poll_fd(fd, deadline)
+                && (guard.read().is_err() || queue.dispatch_pending(state).is_err())
+            {
                 warn!(
                     "wlr-foreign-toplevel: connection error while draining — will reconnect on next poll"
                 );

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -29,7 +29,10 @@
 //! - **`drain_events`** (poll path) — flushes pending writes, then attempts a
 //!   non-blocking `prepare_read` + `read` with a short 25 ms `poll(2)` cap.
 //!   If nothing arrives in time the last known state is returned unchanged;
-//!   millisecond-stale frontmost data is acceptable by design.
+//!   millisecond-stale frontmost data is acceptable by design. A genuine
+//!   connection error here (as opposed to a timeout) marks the session
+//!   finished so the next poll reconnects, the same as an explicit
+//!   `Finished` event.
 //!
 //! - **`timed_roundtrip`** (init path) — sends `wl_display.sync`, then loops
 //!   `flush` → `poll(2)` → `read` → `dispatch_pending` until the sync callback
@@ -318,10 +321,16 @@ fn timed_roundtrip(
 
 /// Drains pending compositor events without blocking longer than `POLL_CAP_MS`.
 /// Used on every frontmost poll. Stale data within the cap is acceptable by
-/// design; errors are silently ignored so the last known state is returned.
+/// design; a genuine connection error (e.g. the compositor crashing and
+/// closing the socket, rather than sending a graceful `Finished`) marks
+/// `state.finished` so the caller reconnects on the next poll instead of
+/// returning stale state forever.
 fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
-    let _ = queue.flush();
-    let _ = queue.dispatch_pending(state);
+    if queue.flush().is_err() || queue.dispatch_pending(state).is_err() {
+        warn!("wlr-foreign-toplevel: connection error while draining — will reconnect on next poll");
+        state.finished = true;
+        return;
+    }
 
     let deadline = Instant::now() + Duration::from_millis(POLL_CAP_MS);
     match queue.prepare_read() {
@@ -330,9 +339,11 @@ fn drain_events(queue: &mut EventQueue<State>, state: &mut State) {
         }
         Some(guard) => {
             let fd = guard.connection_fd().as_raw_fd();
-            if poll_fd(fd, deadline) {
-                let _ = guard.read();
-                let _ = queue.dispatch_pending(state);
+            if poll_fd(fd, deadline) && (guard.read().is_err() || queue.dispatch_pending(state).is_err()) {
+                warn!(
+                    "wlr-foreign-toplevel: connection error while draining — will reconnect on next poll"
+                );
+                state.finished = true;
             }
             // If poll timed out, guard is dropped here and we return stale state.
         }

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -367,8 +367,9 @@ impl Session {
         // round-trip, where the manager is bound if the compositor advertises it.
         let _registry = conn.display().get_registry(&qh, ());
         let mut state = State::default();
+        let deadline = Instant::now() + INIT_TIMEOUT;
 
-        if !timed_roundtrip(&conn, &mut queue, &mut state, Instant::now() + INIT_TIMEOUT) {
+        if !timed_roundtrip(&conn, &mut queue, &mut state, deadline) {
             debug!("wlr-foreign-toplevel: registry round-trip timed out or failed");
             return None;
         }
@@ -379,7 +380,7 @@ impl Session {
 
         // Second round-trip: receive the initial toplevel list and properties,
         // so the first poll already has the active window.
-        if !timed_roundtrip(&conn, &mut queue, &mut state, Instant::now() + INIT_TIMEOUT) {
+        if !timed_roundtrip(&conn, &mut queue, &mut state, deadline) {
             debug!("wlr-foreign-toplevel: initial toplevel round-trip timed out or failed");
             return None;
         }

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -111,13 +111,12 @@ impl Dispatch<WlRegistry, ()> for State {
             interface,
             version,
         } = event
+            && interface == ZwlrForeignToplevelManagerV1::interface().name
         {
-            if interface == ZwlrForeignToplevelManagerV1::interface().name {
-                let version = version.min(MANAGER_MAX_VERSION);
-                let manager =
-                    registry.bind::<ZwlrForeignToplevelManagerV1, (), Self>(name, version, qh, ());
-                state.manager = Some(manager);
-            }
+            let version = version.min(MANAGER_MAX_VERSION);
+            let manager =
+                registry.bind::<ZwlrForeignToplevelManagerV1, (), Self>(name, version, qh, ());
+            state.manager = Some(manager);
         }
     }
 }

--- a/packaging/linux/desktop/openlogi.desktop
+++ b/packaging/linux/desktop/openlogi.desktop
@@ -5,6 +5,10 @@ Comment=Logitech HID++ device control — remap buttons, DPI, SmartShift
 Exec=openlogi-gui
 Icon=openlogi
 Terminal=false
+# Ties the running window (Wayland xdg-toplevel app_id / X11 WM_CLASS, set in
+# main_window_options) back to this launcher so GNOME groups it under the
+# OpenLogi icon instead of a generic one.
+StartupWMClass=org.openlogi.openlogi
 Categories=Settings;HardwareSettings;
 Keywords=logitech;mouse;hid;remap;dpi;
 StartupNotify=true

--- a/packaging/linux/desktop/openlogi.desktop
+++ b/packaging/linux/desktop/openlogi.desktop
@@ -5,9 +5,9 @@ Comment=Logitech HID++ device control — remap buttons, DPI, SmartShift
 Exec=openlogi-gui
 Icon=openlogi
 Terminal=false
-# Ties the running window (Wayland xdg-toplevel app_id / X11 WM_CLASS, set in
-# main_window_options) back to this launcher so GNOME groups it under the
-# OpenLogi icon instead of a generic one.
+# Ties the running window (Wayland xdg-toplevel app_id / X11 WM_CLASS) back to
+# this launcher so GNOME groups it under the OpenLogi icon instead of a generic
+# one. Must match `openlogi_core::brand::APP_ID`, the value the GUI advertises.
 StartupWMClass=org.openlogi.openlogi
 Categories=Settings;HardwareSettings;
 Keywords=logitech;mouse;hid;remap;dpi;


### PR DESCRIPTION
## Summary

`frontmost_bundle_id()` is X11-only today, so on a Wayland session it returns
`None` for native windows and per-app profiles never fire (XWayland windows
aside). This adds two Wayland backends behind the existing selection, keeping
the X11 path as the universal fallback — **no behavior change off Wayland, and
macOS/Windows untouched**:

- **wlroots** — `zwlr_foreign_toplevel_management_v1` (sway, Hyprland, river, Wayfire)
- **GNOME Shell** — a minimal, read-only companion extension that exports the
  focused window's `WM_CLASS` over D-Bus (Mutter offers no protocol/portal for this)

Implements the Wayland half of #95; complements the X11 backend from #122.

## Backend selection

`detect_session_kind()` (`XDG_SESSION_TYPE`, falling back to
`WAYLAND_DISPLAY`/`DISPLAY`) sets the candidate order; the first that
initializes wins:

- **Wayland** → wlroots → GNOME extension → X11/XWayland
- **X11 / unknown** → X11

A candidate returns `None` when it can't initialize (wlr manager absent on
GNOME, extension not installed, …), so unsupported compositors fall through to
X11 exactly as today. Selection is once-per-process; landing on X11 while on
Wayland logs a hint to install the extension.

## Compositor coverage

| Compositor | Backend | Identifier |
|---|---|---|
| wlroots (sway, Hyprland, river, Wayfire) | wlr foreign-toplevel | xdg `app_id` (`org.mozilla.firefox`) |
| GNOME / Mutter | companion extension (D-Bus) | `WM_CLASS` (`org.gnome.Nautilus`, `firefox_firefox`) |
| KDE/KWin, others | X11/XWayland fallback | X11 `WM_CLASS` (XWayland windows only) |

## Files

- `src/linux/wlr_foreign_toplevel.rs` — binds the foreign-toplevel manager,
  roundtrips per poll, returns the `activated` toplevel's `app_id`. Also
  reconnects on a genuine connection error during the poll-path drain (socket
  closed by a compositor crash), not just on a graceful `Finished` event —
  fixed per Greptile's review.
- `src/linux/gnome_shell.rs` — blocking `zbus` proxy onto `org.openlogi.Frontmost`,
  with a per-call timeout so a stalled Shell can't wedge the poll thread.
- `gnome-shell-extension/openlogi-frontmost@openlogi.dev/` — the extension. Reads
  only `global.display.focus_window.get_wm_class()`; no titles, contents, input,
  or UI. Targets GNOME Shell 45–50.
- `src/linux.rs` — dispatch refactored to a `FrontmostSource` trait + ordered
  candidate list. New deps (`wayland-client`, `wayland-protocols-wlr`, `zbus`)
  under the existing `cfg(target_os = "linux")` target.

## Identifier semantics — resolved

GNOME and X11 both return `WM_CLASS`, so a profile created on X11 carries over to
GNOME/Wayland unchanged. wlroots returns the native xdg `app_id`, a **different
namespace** — and since profile lookup is an exact match, a profile created under
wlroots won't match one created under GNOME/X11.

Decision: keep returning each compositor's native identifier rather than a lossy
`WM_CLASS` guess (stripping reverse-DNS and re-capitalizing is wrong for many
apps). No normalization layer is added in this PR; the cross-namespace mismatch
is documented as a known, deliberate limitation on the `FrontmostSource` trait
in `linux.rs` (a canonical-id scheme or per-profile aliases would be the right
fix, as a separate follow-up if it's ever needed in practice).

## Testing

Validated end-to-end on Ubuntu 26.04, GNOME Shell 50.1, Wayland, rustc 1.96:

- Extension `State: ACTIVE`; `gdbus call … GetFocusedWmClass` returns and tracks
  the focused window's `WM_CLASS`.
- `cargo run --example frontmost_app -p openlogi-hook` follows focus live across
  native-Wayland apps (Ptyxis → `org.gnome.Ptyxis`, Nautilus → `org.gnome.Nautilus`)
  and Firefox (`firefox_firefox`) — windows the X11 backend reports as `None`.

**wlroots backend validated on sway 1.11 (headless):** `frontmost_bundle_id()`
correctly returned `Some("foot")` and `Some("org.gnome.TextEditor")` as focus
switched between two Wayland windows — matching each window's native xdg `app_id`
exactly as reported by `swaymsg -t get_tree`.

## Install (GNOME)

```sh
UUID=openlogi-frontmost@openlogi.dev
DEST="$HOME/.local/share/gnome-shell/extensions/$UUID"
mkdir -p "$DEST"
cp crates/openlogi-hook/gnome-shell-extension/$UUID/{metadata.json,extension.js} "$DEST"/
# Wayland can't hot-reload the shell — log out/in, then:
gnome-extensions enable "$UUID"
```

## Open questions

1. ~~Extension UUID / D-Bus name use `openlogi.*` as placeholders — what
   namespace do you want?~~ **Resolved**: settled on `org.openlogi.*`
   throughout — D-Bus name/path (`org.openlogi.Frontmost` /
   `/org/openlogi/Frontmost`), extension UUID
   (`openlogi-frontmost@openlogi.dev`), and the app identifier
   (`brand::APP_ID = "org.openlogi.openlogi"`, added later in this PR) all
   agree. No placeholders remain.
2. **Still open** — extension distribution: bundle-and-document (current),
   ship to extensions.gnome.org, or auto-install from the app? #173/#179
   (nfpm packaging) have since merged, which was the blocker for the
   bundle-and-document follow-up (shipping
   `openlogi-frontmost@openlogi.dev/` as an nfpm `contents:` entry under
   `/usr/share/gnome-shell/extensions/<UUID>/`), but that follow-up hasn't
   been done yet — `packaging/linux/nfpm.yaml` currently has no entry for the
   extension. Happy to add it here or as a separate follow-up PR once we
   agree on distribution.

## Checklist

- [x] Linux-only (`cfg(target_os = "linux")`); macOS/Windows untouched.
- [x] Falls through to X11 when no Wayland backend initializes.
- [x] GNOME backend validated on real hardware (Ubuntu 26.04 / GNOME 50.1 / Wayland).
- [x] wlroots backend validated on a wlroots compositor (sway 1.11, headless).
- [x] Reconnects on wlr compositor crash (socket close), not just a graceful `Finished`.
- [x] Synced with `master` as of 2026-07-03 — clean, no conflicts.
