### PR TITLE
refactor: unify device-kind precedence docs + drop the redundant caps carry-forward

### DIFF
--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -375,15 +375,8 @@ impl AppState {
         let mut merged = Vec::with_capacity(by_key.len().max(self.device_list.len()));
 
         for previous in &self.device_list {
-            if let Some(mut record) = by_key.remove(&previous.config_key) {
+            if let Some(record) = by_key.remove(&previous.config_key) {
                 self.inventory_misses.remove(&previous.config_key);
-                // Capabilities can only be measured while the device is online.
-                // When a known device goes offline (or a probe fails) the fresh
-                // record carries `None`; keep the last-known set so a sleeping
-                // mouse doesn't lose its button/pointer panels.
-                if record.capabilities.is_none() {
-                    record.capabilities = previous.capabilities;
-                }
                 merged.push(record);
                 continue;
             }

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -26,10 +26,11 @@ pub struct DeviceRecord {
     pub unit_id: [u8; 4],
     pub route: Option<DeviceRoute>,
     pub kind: DeviceKind,
-    /// Configuration capabilities from the device's HID++ feature table. `None`
-    /// when the device couldn't be probed (offline); the snapshot merge carries
-    /// the last-known value forward, and the UI falls back to
-    /// [`Capabilities::presumed_from_kind`] for a never-probed device.
+    /// Configuration capabilities from the device's HID++ feature table.
+    /// Continuity across sleep lives in the hid layer: its probe cache keeps
+    /// serving the last-known capabilities for a known-but-offline device, so
+    /// this is `None` only for a device never probed since the agent started —
+    /// and the UI then falls back to [`Capabilities::presumed_from_kind`].
     pub capabilities: Option<Capabilities>,
     pub slot: u8,
     pub online: bool,
@@ -145,16 +146,26 @@ fn device_route(inv: &DeviceInventory, slot: u8) -> Option<DeviceRoute> {
     }
 }
 
-/// Pick a device's [`DeviceKind`], preferring the asset registry's curated type
-/// over the runtime HID++ classification.
+/// Last step of the device-kind precedence chain:
 ///
-/// The registry type is per-model and human-maintained, so a device that
-/// matched a known depot is classified by what that model *is* — not by a Bolt
-/// pairing register that can misreport (the failure behind #127). We fall back
-/// to `hid_kind` when there is no asset or its type is `Unknown`. A genuine
-/// disagreement is logged at debug (the list rebuilds on every snapshot, so a
-/// louder level would spam); it flags a HID++ source we shouldn't trust for
-/// that device.
+/// > **asset registry** > HID++ `0x0005` > Bolt pairing register
+///
+/// The two HID++ sources are already folded into `hid_kind` by
+/// `resolve_device_kind` (`crates/openlogi-hid/src/inventory.rs`); this applies
+/// the final override. Adding a kind source means slotting it into this one
+/// chain — here if it should beat the HID++ sources, in `resolve_device_kind`
+/// otherwise — and updating both docs.
+///
+/// The registry type wins because it is per-model and human-maintained, so a
+/// device that matched a known depot is classified by what that model *is* —
+/// not by a Bolt pairing register that can misreport (the failure behind #127).
+/// We fall back to `hid_kind` when there is no asset or its type is `Unknown`.
+/// A genuine disagreement is logged at debug (the list rebuilds on every
+/// snapshot, so a louder level would spam); it flags a HID++ source we
+/// shouldn't trust for that device.
+///
+/// Kind is cosmetic (icon / label) since #127: config panels gate on
+/// [`Capabilities`], never on kind, so a wrong pick can't hide functionality.
 fn effective_kind(hid_kind: DeviceKind, asset_kind: Option<DeviceKind>) -> DeviceKind {
     let Some(asset_kind) = asset_kind.filter(|k| *k != DeviceKind::Unknown) else {
         return hid_kind;

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -674,8 +674,14 @@ fn map_device_type(ty: HidppDeviceType) -> DeviceKind {
     }
 }
 
-/// Resolve a device's kind, preferring the device's own HID++ `0x0005` report
-/// (`probed`) over the receiver-supplied `register` kind.
+/// First step of the device-kind precedence chain:
+///
+/// > asset registry > **HID++ `0x0005`** > **Bolt pairing register**
+///
+/// This folds the two HID++ sources; the GUI applies the final asset-registry
+/// override in `effective_kind` (`crates/openlogi-gui/src/state/devices.rs`).
+/// Adding a kind source means slotting it into this one chain — and updating
+/// both docs.
 ///
 /// `0x0005` is the device's self-reported marketing type and is authoritative;
 /// the Bolt pairing register is a coarser hint that can misreport (e.g. an


### PR DESCRIPTION
Addresses both halves of #154.

## One documented precedence chain

`kind` is resolved by two layers in two crates — `resolve_device_kind` (`0x0005` > register, `openlogi-hid`) and `effective_kind` (asset > hid, `openlogi-gui`) — with no cross-reference; a maintainer adding a kind source had to discover both and could insert into the wrong one. Both functions now document the **same** chain:

> asset registry > HID++ `0x0005` > Bolt pairing register

each marking its own step and pointing at the other, plus a note that kind has been cosmetic (icon/label) since #127 — panels gate on `Capabilities`.

A true single-function resolver was considered and rejected: the sources live at different layers by necessity (register + `0x0005` exist at probe time agent-side, the asset registry only GUI-side), so unifying the code would mean shipping two extra kind fields over IPC for a cosmetic pick. The existing per-layer precedence tests stay.

**The asset-over-`0x0005` override stays** — it's per-model, human-curated, covers misreporting HID++ sources (#127), and is 12 tested lines.

## Carry-forward deletion

**The `state.rs` capability carry-forward goes.** Since the hid-layer probe cache (c4fa9c1, hardened by a2eae95) keeps serving last-known capabilities for known-but-offline devices, the GUI-side copy of that logic is dead in steady state. Its only residual window — agent restart while a device sleeps — degrades to `Capabilities::presumed_from_kind`, which shows a sleeping mouse the same button/pointer panels, and self-heals on wake. Its `is_none` gate also silently missed the empty-`Some` shape (an empty probe would clobber rather than carry forward); deleting the branch beats widening it. `DeviceRecord::capabilities` docs now state where continuity actually lives.

Closes #154