### PR TITLE
style: collapse nested ifs flagged by current stable clippy

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -49,10 +49,10 @@ pub async fn run(args: LightingArgs) -> Result<()> {
                     inv.receiver.vendor_id, inv.receiver.product_id
                 )
             });
-            if let Some(ref n) = needle {
-                if !name.to_lowercase().contains(n.as_str()) {
-                    return None;
-                }
+            if let Some(ref n) = needle
+                && !name.to_lowercase().contains(n.as_str())
+            {
+                return None;
             }
             let route = DeviceRoute::Direct {
                 vendor_id: inv.receiver.vendor_id,

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1820,10 +1820,10 @@ mod linux {
         let _ = &*VIRTUAL_INPUT;
         // Give udev a moment to create the /dev node.
         std::thread::sleep(std::time::Duration::from_millis(150));
-        if let Some(m) = &*VIRTUAL_INPUT {
-            if let Ok(mut guard) = m.lock() {
-                return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
-            }
+        if let Some(m) = &*VIRTUAL_INPUT
+            && let Ok(mut guard) = m.lock()
+        {
+            return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
         }
         None
     }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -627,11 +627,11 @@ impl Config {
             return BTreeMap::new();
         };
         let mut out = device.bindings.clone();
-        if let Some(bid) = bundle_id {
-            if let Some(overlay) = device.per_app_bindings.get(bid) {
-                for (k, v) in overlay {
-                    out.insert(*k, Binding::Single(v.clone()));
-                }
+        if let Some(bid) = bundle_id
+            && let Some(overlay) = device.per_app_bindings.get(bid)
+        {
+            for (k, v) in overlay {
+                out.insert(*k, Binding::Single(v.clone()));
             }
         }
         out

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -113,10 +113,10 @@ fn sync_depot(
     // points `device_buttons_image` at a distinct side view. Fetch it only
     // when the registry lists it so front-only devices don't 404; failure
     // is non-fatal (the GUI falls back to the hero render).
-    if let Some(side) = entry.preferred_file(&BUTTONS_RENDER_FILES) {
-        if let Err(e) = fetch_to_cache(client, &entry.asset_path, &dir, entry, side) {
-            warn!(depot, error = %e, "buttons render fetch failed");
-        }
+    if let Some(side) = entry.preferred_file(&BUTTONS_RENDER_FILES)
+        && let Err(e) = fetch_to_cache(client, &entry.asset_path, &dir, entry, side)
+    {
+        warn!(depot, error = %e, "buttons render fetch failed");
     }
 
     // Optional second pass: download the colour variant PNGs matching

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -343,14 +343,13 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
 /// a window closed while the app kept running can be brought back.
 fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
     let existing = cx.default_global::<windows::WindowRegistry>().main;
-    if let Some(handle) = existing {
-        if handle
+    if let Some(handle) = existing
+        && handle
             .update(cx, |_, window, _| window.activate_window())
             .is_ok()
-        {
-            cx.activate(true);
-            return;
-        }
+    {
+        cx.activate(true);
+        return;
     }
 
     let options = main_window_options(cx);

--- a/crates/openlogi-gui/src/windows/mod.rs
+++ b/crates/openlogi-gui/src/windows/mod.rs
@@ -62,13 +62,12 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
     // Already open? Focus it and bail. A closed window leaves a stale handle
     // whose `update` errors, falling through to a fresh open.
     let existing = *slot(cx.default_global::<WindowRegistry>());
-    if let Some(handle) = existing {
-        if handle
+    if let Some(handle) = existing
+        && handle
             .update(cx, |_, window, _| window.activate_window())
             .is_ok()
-        {
-            return;
-        }
+    {
+        return;
     }
 
     let bounds = Bounds::centered(None, size, cx);

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -55,10 +55,8 @@ pub fn open(cx: &mut App) {
 /// Persist the user's answer, run one check if they opted in, and close.
 fn answer(enabled: bool, window: &mut Window, cx: &mut App) {
     cx.update_global::<AppState, _>(|state, _| state.record_update_consent(enabled));
-    if enabled {
-        if let Some(updater) = crate::platform::updater::shared(cx) {
-            updater.update(cx, Updater::check);
-        }
+    if enabled && let Some(updater) = crate::platform::updater::shared(cx) {
+        updater.update(cx, Updater::check);
     }
     window.remove_window();
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -129,23 +129,23 @@ pub async fn run_capture_session(
                 return;
             }
             let msg = v20::Message::from(raw);
-            if let Some(idx) = reprog_index {
-                if let Some(event) = reprog_controls::decode_event(&msg, device_index, idx) {
-                    // Recover the guard even if a prior holder panicked — the
-                    // critical section is panic-free, so the data is consistent.
-                    let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                    handle_reprog(&mut acc, event, &dpi_set, &sink);
-                    return;
-                }
+            if let Some(idx) = reprog_index
+                && let Some(event) = reprog_controls::decode_event(&msg, device_index, idx)
+            {
+                // Recover the guard even if a prior holder panicked — the
+                // critical section is panic-free, so the data is consistent.
+                let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
+                handle_reprog(&mut acc, event, &dpi_set, &sink);
+                return;
             }
-            if let Some(idx) = thumb_index {
-                if let Some(event) = thumbwheel::decode_event(&msg, device_index, idx) {
-                    if event.single_tap {
-                        let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
-                    }
-                    if event.rotation != 0 {
-                        let _ = sink.send(CapturedInput::Scroll(event.rotation));
-                    }
+            if let Some(idx) = thumb_index
+                && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
+            {
+                if event.single_tap {
+                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
+                }
+                if event.rotation != 0 {
+                    let _ = sink.send(CapturedInput::Scroll(event.rotation));
                 }
             }
         }
@@ -254,32 +254,31 @@ async fn arm_controls(
     }
 
     let mut thumb: Option<(Thumbwheel, u8)> = None;
-    if capture_thumbwheel {
-        if let Some(info) = device
+    if capture_thumbwheel
+        && let Some(info) = device
             .root()
             .get_feature(thumbwheel::FEATURE_ID)
             .await
             .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
-        {
-            let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
-            // Consume the getInfo error here, before the next await: Hidpp20Error
-            // isn't Send, so holding it across an await would make this future
-            // (spawned on tokio) non-Send.
-            let supports_single_tap = match tw.get_info().await {
-                Ok(twinfo) => twinfo.supports_single_tap,
-                Err(e) => {
-                    warn!(error = ?e, "thumb wheel getInfo failed");
-                    false
-                }
-            };
-            if supports_single_tap {
-                tw.set_reporting(true, false)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                thumb = Some((tw, info.index));
-            } else {
-                debug!("thumb wheel reports no single tap — click not capturable");
+    {
+        let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
+        // Consume the getInfo error here, before the next await: Hidpp20Error
+        // isn't Send, so holding it across an await would make this future
+        // (spawned on tokio) non-Send.
+        let supports_single_tap = match tw.get_info().await {
+            Ok(twinfo) => twinfo.supports_single_tap,
+            Err(e) => {
+                warn!(error = ?e, "thumb wheel getInfo failed");
+                false
             }
+        };
+        if supports_single_tap {
+            tw.set_reporting(true, false)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            thumb = Some((tw, info.index));
+        } else {
+            debug!("thumb wheel reports no single tap — click not capturable");
         }
     }
 

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -68,10 +68,10 @@ pub(crate) fn stop(mut inner: HookInner) {
             "could not post WM_QUIT to Windows hook thread"
         );
     }
-    if let Some(join) = inner.join.take() {
-        if let Err(e) = join.join() {
-            tracing::warn!(?e, "Windows hook thread panicked while stopping");
-        }
+    if let Some(join) = inner.join.take()
+        && let Err(e) = join.join()
+    {
+        tracing::warn!(?e, "Windows hook thread panicked while stopping");
     }
 }
 


### PR DESCRIPTION
## Why

The current stable clippy extends `collapsible_if` to `if`/`if let` nests that can become let-chains. Under our global `-D warnings` this turned master's `clippy` and `clippy (windows)` jobs red (first seen on the v0.6.4 release commit), which blocks every open PR.

## What

Mechanical collapse of all flagged sites (`cargo clippy --fix` + two hand fixes), no behavior change:

- 9 host-visible sites across `openlogi-core` (config.rs), `openlogi-hid` (gesture.rs ×3), `openlogi-cli` (diag/lighting.rs), and `openlogi-gui` (×4)
- 2 sites in cfg'd code the host lint never compiles, which the truncated CI logs also don't show yet (cargo aborts at the first failing crate):
  - `openlogi-core/src/binding.rs` `device_node()` — Linux uinput module (from the linux CI job log)
  - `openlogi-hook/src/windows.rs` `stop()` — Windows hook join (caught by a local `x86_64-pc-windows-gnu` cross-lint of the ring-free crate subset)

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean (host)
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-hook -p openlogi-agent -p openlogi-agent-core --all-targets -- -D warnings` clean
- `cargo test -p openlogi-core -p openlogi-hid -p openlogi-cli` passes

The Linux-cfg site can't be linted locally (no linux rust-std in the devenv) — this PR's linux clippy job is the check.