### PR TITLE
fix(hidpp): bound device-controlled name lengths in Bolt parsing

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -49,10 +49,10 @@ pub async fn run(args: LightingArgs) -> Result<()> {
                     inv.receiver.vendor_id, inv.receiver.product_id
                 )
             });
-            if let Some(ref n) = needle {
-                if !name.to_lowercase().contains(n.as_str()) {
-                    return None;
-                }
+            if let Some(ref n) = needle
+                && !name.to_lowercase().contains(n.as_str())
+            {
+                return None;
             }
             let route = DeviceRoute::Direct {
                 vendor_id: inv.receiver.vendor_id,

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1820,10 +1820,10 @@ mod linux {
         let _ = &*VIRTUAL_INPUT;
         // Give udev a moment to create the /dev node.
         std::thread::sleep(std::time::Duration::from_millis(150));
-        if let Some(m) = &*VIRTUAL_INPUT {
-            if let Ok(mut guard) = m.lock() {
-                return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
-            }
+        if let Some(m) = &*VIRTUAL_INPUT
+            && let Ok(mut guard) = m.lock()
+        {
+            return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
         }
         None
     }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -627,11 +627,11 @@ impl Config {
             return BTreeMap::new();
         };
         let mut out = device.bindings.clone();
-        if let Some(bid) = bundle_id {
-            if let Some(overlay) = device.per_app_bindings.get(bid) {
-                for (k, v) in overlay {
-                    out.insert(*k, Binding::Single(v.clone()));
-                }
+        if let Some(bid) = bundle_id
+            && let Some(overlay) = device.per_app_bindings.get(bid)
+        {
+            for (k, v) in overlay {
+                out.insert(*k, Binding::Single(v.clone()));
             }
         }
         out

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -113,10 +113,10 @@ fn sync_depot(
     // points `device_buttons_image` at a distinct side view. Fetch it only
     // when the registry lists it so front-only devices don't 404; failure
     // is non-fatal (the GUI falls back to the hero render).
-    if let Some(side) = entry.preferred_file(&BUTTONS_RENDER_FILES) {
-        if let Err(e) = fetch_to_cache(client, &entry.asset_path, &dir, entry, side) {
-            warn!(depot, error = %e, "buttons render fetch failed");
-        }
+    if let Some(side) = entry.preferred_file(&BUTTONS_RENDER_FILES)
+        && let Err(e) = fetch_to_cache(client, &entry.asset_path, &dir, entry, side)
+    {
+        warn!(depot, error = %e, "buttons render fetch failed");
     }
 
     // Optional second pass: download the colour variant PNGs matching

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -343,14 +343,13 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
 /// a window closed while the app kept running can be brought back.
 fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
     let existing = cx.default_global::<windows::WindowRegistry>().main;
-    if let Some(handle) = existing {
-        if handle
+    if let Some(handle) = existing
+        && handle
             .update(cx, |_, window, _| window.activate_window())
             .is_ok()
-        {
-            cx.activate(true);
-            return;
-        }
+    {
+        cx.activate(true);
+        return;
     }
 
     let options = main_window_options(cx);

--- a/crates/openlogi-gui/src/windows/mod.rs
+++ b/crates/openlogi-gui/src/windows/mod.rs
@@ -62,13 +62,12 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
     // Already open? Focus it and bail. A closed window leaves a stale handle
     // whose `update` errors, falling through to a fresh open.
     let existing = *slot(cx.default_global::<WindowRegistry>());
-    if let Some(handle) = existing {
-        if handle
+    if let Some(handle) = existing
+        && handle
             .update(cx, |_, window, _| window.activate_window())
             .is_ok()
-        {
-            return;
-        }
+    {
+        return;
     }
 
     let bounds = Bounds::centered(None, size, cx);

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -55,10 +55,8 @@ pub fn open(cx: &mut App) {
 /// Persist the user's answer, run one check if they opted in, and close.
 fn answer(enabled: bool, window: &mut Window, cx: &mut App) {
     cx.update_global::<AppState, _>(|state, _| state.record_update_consent(enabled));
-    if enabled {
-        if let Some(updater) = crate::platform::updater::shared(cx) {
-            updater.update(cx, Updater::check);
-        }
+    if enabled && let Some(updater) = crate::platform::updater::shared(cx) {
+        updater.update(cx, Updater::check);
     }
     window.remove_window();
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -129,23 +129,23 @@ pub async fn run_capture_session(
                 return;
             }
             let msg = v20::Message::from(raw);
-            if let Some(idx) = reprog_index {
-                if let Some(event) = reprog_controls::decode_event(&msg, device_index, idx) {
-                    // Recover the guard even if a prior holder panicked — the
-                    // critical section is panic-free, so the data is consistent.
-                    let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                    handle_reprog(&mut acc, event, &dpi_set, &sink);
-                    return;
-                }
+            if let Some(idx) = reprog_index
+                && let Some(event) = reprog_controls::decode_event(&msg, device_index, idx)
+            {
+                // Recover the guard even if a prior holder panicked — the
+                // critical section is panic-free, so the data is consistent.
+                let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
+                handle_reprog(&mut acc, event, &dpi_set, &sink);
+                return;
             }
-            if let Some(idx) = thumb_index {
-                if let Some(event) = thumbwheel::decode_event(&msg, device_index, idx) {
-                    if event.single_tap {
-                        let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
-                    }
-                    if event.rotation != 0 {
-                        let _ = sink.send(CapturedInput::Scroll(event.rotation));
-                    }
+            if let Some(idx) = thumb_index
+                && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
+            {
+                if event.single_tap {
+                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
+                }
+                if event.rotation != 0 {
+                    let _ = sink.send(CapturedInput::Scroll(event.rotation));
                 }
             }
         }
@@ -254,32 +254,31 @@ async fn arm_controls(
     }
 
     let mut thumb: Option<(Thumbwheel, u8)> = None;
-    if capture_thumbwheel {
-        if let Some(info) = device
+    if capture_thumbwheel
+        && let Some(info) = device
             .root()
             .get_feature(thumbwheel::FEATURE_ID)
             .await
             .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
-        {
-            let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
-            // Consume the getInfo error here, before the next await: Hidpp20Error
-            // isn't Send, so holding it across an await would make this future
-            // (spawned on tokio) non-Send.
-            let supports_single_tap = match tw.get_info().await {
-                Ok(twinfo) => twinfo.supports_single_tap,
-                Err(e) => {
-                    warn!(error = ?e, "thumb wheel getInfo failed");
-                    false
-                }
-            };
-            if supports_single_tap {
-                tw.set_reporting(true, false)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                thumb = Some((tw, info.index));
-            } else {
-                debug!("thumb wheel reports no single tap — click not capturable");
+    {
+        let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
+        // Consume the getInfo error here, before the next await: Hidpp20Error
+        // isn't Send, so holding it across an await would make this future
+        // (spawned on tokio) non-Send.
+        let supports_single_tap = match tw.get_info().await {
+            Ok(twinfo) => twinfo.supports_single_tap,
+            Err(e) => {
+                warn!(error = ?e, "thumb wheel getInfo failed");
+                false
             }
+        };
+        if supports_single_tap {
+            tw.set_reporting(true, false)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            thumb = Some((tw, info.index));
+        } else {
+            debug!("thumb wheel reports no single tap — click not capturable");
         }
     }
 

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -747,6 +747,16 @@ mod tests {
     }
 
     #[test]
+    fn discovery_name_rejects_invalid_utf8() {
+        let mut payload = [0u8; 17];
+        payload[3] = 2;
+        payload[4] = 0xff;
+        payload[5] = 0xfe;
+
+        assert_eq!(parse_discovery_name(&payload), None);
+    }
+
+    #[test]
     fn codename_with_oversized_length_clamps_to_available_chunk() {
         let mut response = [0u8; 16];
         response[2] = 200;

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -158,14 +158,12 @@ impl Receiver {
                             }
                             // Device name
                             1 => {
-                                let Ok(name) =
-                                    str::from_utf8(&payload[4..(4 + payload[3] as usize)])
-                                else {
+                                let Some((counter, name)) = parse_discovery_name(&payload) else {
                                     return;
                                 };
 
                                 emitter.emit(Event::DeviceDiscoveryDeviceName {
-                                    counter: payload[0] as u16 + payload[1] as u16 * 256,
+                                    counter,
                                     name: name.to_string(),
                                 });
                             }
@@ -413,9 +411,8 @@ impl Receiver {
             )
             .await?;
 
-        let end_idx = 3 + response[2] as usize;
-        Ok(str::from_utf8(&response[3..end_idx])
-            .map_err(|_| Hidpp10Error::UnsupportedResponse)?
+        Ok(parse_codename(&response)
+            .ok_or(Hidpp10Error::UnsupportedResponse)?
             .to_string())
     }
 
@@ -494,6 +491,31 @@ impl Receiver {
 
         Ok(())
     }
+}
+
+/// Parse a device-discovery name notification (sub-id `0x4f`, kind `1`).
+///
+/// `payload[3]` is the device-reported name length. The byte comes straight
+/// off the radio, so it must never index past the report: a length that does
+/// not fit the packet (or non-UTF-8 bytes) drops the event instead of
+/// panicking the listener.
+fn parse_discovery_name(payload: &[u8; 17]) -> Option<(u16, &str)> {
+    let len = usize::from(payload[3]);
+    let end = 4usize.checked_add(len)?;
+    let name = str::from_utf8(payload.get(4..end)?).ok()?;
+    Some((payload[0] as u16 + payload[1] as u16 * 256, name))
+}
+
+/// Extract the codename chunk from a `DeviceCodename` register read.
+///
+/// `response[2]` is the device-reported name length. A name longer than the
+/// 13 bytes one response carries is clamped to the chunk present (fetching
+/// the rest takes further reads with different parameters); a length byte
+/// pointing past the response must not panic. `None` for non-UTF-8 bytes.
+fn parse_codename(response: &[u8; 16]) -> Option<&str> {
+    let end = 3usize.saturating_add(usize::from(response[2]));
+    let raw = response.get(3..end.min(response.len()))?;
+    str::from_utf8(raw).ok()
 }
 
 impl Drop for Receiver {
@@ -700,4 +722,55 @@ pub enum PairingPasskeyPressType {
     Initialization = 0x00,
     Keypress = 0x01,
     Submit = 0x04,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovery_name_with_oversized_length_is_dropped() {
+        let mut payload = [0u8; 17];
+        payload[3] = 200;
+
+        assert_eq!(parse_discovery_name(&payload), None);
+    }
+
+    #[test]
+    fn discovery_name_within_bounds_parses() {
+        let mut payload = [0u8; 17];
+        payload[0] = 7;
+        payload[3] = 4;
+        payload[4..8].copy_from_slice(b"Casa");
+
+        assert_eq!(parse_discovery_name(&payload), Some((7, "Casa")));
+    }
+
+    #[test]
+    fn codename_with_oversized_length_clamps_to_available_chunk() {
+        let mut response = [0u8; 16];
+        response[2] = 200;
+        response[3..16].copy_from_slice(b"MX Anywhere 3");
+
+        assert_eq!(parse_codename(&response), Some("MX Anywhere 3"));
+    }
+
+    #[test]
+    fn codename_within_bounds_parses() {
+        let mut response = [0u8; 16];
+        response[2] = 5;
+        response[3..8].copy_from_slice(b"Casa!");
+
+        assert_eq!(parse_codename(&response), Some("Casa!"));
+    }
+
+    #[test]
+    fn codename_rejects_invalid_utf8() {
+        let mut response = [0u8; 16];
+        response[2] = 2;
+        response[3] = 0xff;
+        response[4] = 0xfe;
+
+        assert_eq!(parse_codename(&response), None);
+    }
 }

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -68,10 +68,10 @@ pub(crate) fn stop(mut inner: HookInner) {
             "could not post WM_QUIT to Windows hook thread"
         );
     }
-    if let Some(join) = inner.join.take() {
-        if let Err(e) = join.join() {
-            tracing::warn!(?e, "Windows hook thread panicked while stopping");
-        }
+    if let Some(join) = inner.join.take()
+        && let Err(e) = join.join()
+    {
+        tracing::warn!(?e, "Windows hook thread panicked while stopping");
     }
 }
 


### PR DESCRIPTION
## Why

Two Bolt receiver parse sites slice a fixed-size HID++ report by a length byte the device supplies, so a malicious or buggy device (or a fuzzed report) panics the parser — and since v0.6.0 that parser lives in the always-on agent:

1. **Discovery `DeviceName` notification** — `payload[3]` sliced `payload[4..4 + len]` out of a `[u8; 17]` extended payload.
2. **`get_device_codename`** — `response[2]` sliced `response[3..3 + len]` out of a `[u8; 16]` register read.

## What

Both sites now go through pure, bounded parse helpers (`parse_discovery_name` / `parse_codename`) that validate the length against the actual buffer and the bytes as UTF-8, dropping the event / returning `UnsupportedResponse` instead of panicking. The codename parser clamps to the available chunk — codenames longer than 13 bytes legitimately span multiple register reads.

Five unit tests cover the oversized-length, in-bounds, and invalid-UTF-8 cases.

## Credit

The discovery-name finding and the shape of its fix come from #66 by @cantorjf — the codename site turned up while re-deriving that patch on current master.

---
Stacked on #197 (the clippy unblock): merge that first and this diff collapses to the one `fix(hidpp)` commit.

Co-authored-by: Jason Cantor

## Verification

- `cargo test -p openlogi-hidpp` — 16 pass (5 new)
- `cargo clippy --workspace --all-targets -- -D warnings` clean