### PR TITLE
fix(assets): keep sync writes inside the cache root and verified

### DIFF
--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -97,8 +97,7 @@ impl AssetClient {
     /// Fetch `<base>/index.json`, write it into `dir`, and return the parsed index.
     pub fn fetch_index_to_dir(&self, dir: &Path) -> Result<Index> {
         let (raw, index) = self.fetch_index_raw()?;
-        let local = dir.join(INDEX_NAME);
-        fs::write(&local, &raw).with_context(|| format!("write {}", local.display()))?;
+        write_replace(&dir.join(INDEX_NAME), &raw)?;
         Ok(index)
     }
 
@@ -113,13 +112,11 @@ impl AssetClient {
 
     /// Fetch a per-depot file into `dir`, returning the number of bytes
     /// written. `name` comes from remote metadata, so it is validated down
-    /// to a single path component and the destination must not be a symlink
-    /// before anything touches the filesystem.
+    /// to a single path component before any path is built.
     fn fetch_file_to_dir(&self, asset_path: &str, dir: &Path, name: &str) -> Result<usize> {
         let dst = safe_component_path(dir, name, "asset file name")?;
-        reject_symlink(&dst)?;
         let bytes = self.fetch_file(asset_path, name)?;
-        fs::write(&dst, &bytes).with_context(|| format!("write {}", dst.display()))?;
+        write_replace(&dst, &bytes)?;
         Ok(bytes.len())
     }
 
@@ -231,16 +228,37 @@ pub fn safe_component_path(base: &Path, component: &str, label: &str) -> Result<
     }
 }
 
-/// Refuse to write through a symlink planted at `path`, which would redirect
-/// an asset write anywhere the process can reach.
-fn reject_symlink(path: &Path) -> Result<()> {
-    if fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
-        bail!(
-            "refusing to write asset through symlink: {}",
-            path.display()
-        );
+/// Write `bytes` beside `dst` and atomically rename into place.
+///
+/// `create_new` refuses to open through anything pre-planted at the temp
+/// path (`O_EXCL` never follows symlinks), and `rename` *replaces* a symlink
+/// sitting at `dst` instead of writing through it — together they close the
+/// check-to-write race a symlink check followed by a plain `fs::write` would
+/// leave open. The rename also means a concurrent reader sees the old file
+/// or the new one, never a half-written one.
+fn write_replace(dst: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+
+    let mut tmp_name = dst.as_os_str().to_owned();
+    tmp_name.push(".part");
+    let tmp = PathBuf::from(tmp_name);
+    // A stale `.part` from a crashed sync would fail `create_new`; it never
+    // holds verified data, so clear it.
+    let _ = fs::remove_file(&tmp);
+    let mut file = fs::File::options()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)
+        .with_context(|| format!("create {}", tmp.display()))?;
+    let written = file
+        .write_all(bytes)
+        .with_context(|| format!("write {}", tmp.display()));
+    drop(file);
+    if let Err(e) = written {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
     }
-    Ok(())
+    fs::rename(&tmp, dst).with_context(|| format!("replace {}", dst.display()))
 }
 
 /// Hex SHA-256 of an in-memory blob.
@@ -267,9 +285,46 @@ pub fn cached_matches(path: &Path, expected_sha: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_retryable, safe_component_path};
+    use super::{is_retryable, safe_component_path, write_replace};
     use std::path::Path;
     use ureq::Error;
+
+    #[test]
+    #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+    fn write_replace_overwrites_in_place() {
+        let dir = std::env::temp_dir().join(format!("openlogi-http-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let dst = dir.join("a.png");
+
+        write_replace(&dst, b"one").expect("first write");
+        write_replace(&dst, b"two").expect("replace");
+
+        assert_eq!(std::fs::read(&dst).expect("read back"), b"two");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+    fn write_replace_replaces_a_planted_symlink_instead_of_following_it() {
+        let dir =
+            std::env::temp_dir().join(format!("openlogi-http-symlink-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let victim = dir.join("victim.txt");
+        std::fs::write(&victim, b"untouched").expect("seed victim");
+        let dst = dir.join("b.png");
+        std::os::unix::fs::symlink(&victim, &dst).expect("plant symlink");
+
+        write_replace(&dst, b"payload").expect("write through planted link");
+
+        // The link target must be untouched, and the link itself must now be
+        // a regular file holding the payload.
+        assert_eq!(std::fs::read(&victim).expect("victim intact"), b"untouched");
+        let meta = std::fs::symlink_metadata(&dst).expect("stat dst");
+        assert!(meta.file_type().is_file());
+        assert_eq!(std::fs::read(&dst).expect("read dst"), b"payload");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn safe_component_path_accepts_plain_names() {

--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -11,10 +11,10 @@
 //! no relation to a host, so they stay off the client.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use backon::{BlockingRetryable, ExponentialBuilder};
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
@@ -104,35 +104,46 @@ impl AssetClient {
 
     /// GET a per-depot file, e.g.
     /// `fetch_file("v1/devices/mx_master_4/", "front_core.png")`.
-    pub fn fetch_file(&self, asset_path: &str, name: &str) -> Result<Vec<u8>> {
+    fn fetch_file(&self, asset_path: &str, name: &str) -> Result<Vec<u8>> {
         let asset_path = asset_path.trim_start_matches('/');
         let url = format!("{}/{asset_path}{name}", self.base);
         debug!(%url, "fetching file");
         self.get_bytes(&url)
     }
 
-    /// Fetch a per-depot file into `dir`, returning the number of bytes written.
-    pub fn fetch_file_to_dir(&self, asset_path: &str, dir: &Path, name: &str) -> Result<usize> {
-        let dst = dir.join(name);
+    /// Fetch a per-depot file into `dir`, returning the number of bytes
+    /// written. `name` comes from remote metadata, so it is validated down
+    /// to a single path component and the destination must not be a symlink
+    /// before anything touches the filesystem.
+    fn fetch_file_to_dir(&self, asset_path: &str, dir: &Path, name: &str) -> Result<usize> {
+        let dst = safe_component_path(dir, name, "asset file name")?;
+        reject_symlink(&dst)?;
         let bytes = self.fetch_file(asset_path, name)?;
         fs::write(&dst, &bytes).with_context(|| format!("write {}", dst.display()))?;
         Ok(bytes.len())
     }
 
     /// Fetch `file` into `dir` unless a file already there matches its
-    /// `sha256`. The cache-skip primitive shared by the CLI bundle sync and
-    /// the GUI runtime sync — callers branch on [`FetchOutcome`] to do their
-    /// own progress reporting.
+    /// `sha256`; a fresh download is verified against the same hash and
+    /// removed on mismatch, so nothing unverified survives on disk. The
+    /// cache-skip primitive shared by the CLI bundle sync and the GUI
+    /// runtime sync — callers branch on [`FetchOutcome`] to do their own
+    /// progress reporting.
     pub fn fetch_entry_if_stale(
         &self,
         asset_path: &str,
         dir: &Path,
         file: &FileEntry,
     ) -> Result<FetchOutcome> {
-        if cached_matches(&dir.join(&file.name), &file.sha256) {
+        let dst = safe_component_path(dir, &file.name, "asset file name")?;
+        if cached_matches(&dst, &file.sha256) {
             return Ok(FetchOutcome::CacheHit);
         }
         let bytes = self.fetch_file_to_dir(asset_path, dir, &file.name)?;
+        if !cached_matches(&dst, &file.sha256) {
+            let _ = fs::remove_file(&dst);
+            bail!("downloaded asset checksum mismatch: {}", dst.display());
+        }
         Ok(FetchOutcome::Fetched { bytes })
     }
 
@@ -199,6 +210,39 @@ pub fn read_bytes(path: &Path) -> Result<Vec<u8>> {
     fs::read(path).with_context(|| format!("read {}", path.display()))
 }
 
+/// Join one untrusted registry component onto a trusted directory.
+///
+/// Remote asset metadata is expected to carry depot and file *names*, not
+/// paths. Rejecting separators, absolute prefixes, and `.`/`..` keeps every
+/// sync write inside the cache or bundle directory chosen by the caller.
+pub fn safe_component_path(base: &Path, component: &str, label: &str) -> Result<PathBuf> {
+    if component.is_empty() {
+        bail!("{label} is empty");
+    }
+    // `Path::components` never yields separators on the platform that didn't
+    // produce them, so reject both kinds explicitly before consulting it.
+    if component.contains('/') || component.contains('\\') {
+        bail!("{label} must be a single path component: {component}");
+    }
+    let mut parts = Path::new(component).components();
+    match (parts.next(), parts.next()) {
+        (Some(Component::Normal(_)), None) => Ok(base.join(component)),
+        _ => bail!("{label} must be a safe relative path component: {component}"),
+    }
+}
+
+/// Refuse to write through a symlink planted at `path`, which would redirect
+/// an asset write anywhere the process can reach.
+fn reject_symlink(path: &Path) -> Result<()> {
+    if fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        bail!(
+            "refusing to write asset through symlink: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// Hex SHA-256 of an in-memory blob.
 #[must_use]
 pub fn sha256_hex(bytes: &[u8]) -> String {
@@ -223,8 +267,39 @@ pub fn cached_matches(path: &Path, expected_sha: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_retryable;
+    use super::{is_retryable, safe_component_path};
+    use std::path::Path;
     use ureq::Error;
+
+    #[test]
+    fn safe_component_path_accepts_plain_names() {
+        assert_eq!(
+            safe_component_path(Path::new("/cache"), "front_core.png", "asset").ok(),
+            Some(Path::new("/cache").join("front_core.png"))
+        );
+        assert_eq!(
+            safe_component_path(Path::new("/cache"), "mx_master_4", "depot").ok(),
+            Some(Path::new("/cache").join("mx_master_4"))
+        );
+    }
+
+    #[test]
+    fn safe_component_path_rejects_traversal_and_separators() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../LaunchAgents/x",
+            "nested/file.png",
+            "nested\\file.png",
+            "/etc/passwd",
+        ] {
+            assert!(
+                safe_component_path(Path::new("/cache"), name, "asset").is_err(),
+                "{name:?} should be rejected"
+            );
+        }
+    }
 
     #[test]
     fn retries_transient_failures_not_permanent_ones() {

--- a/crates/openlogi-cli/src/cmd/assets/sync.rs
+++ b/crates/openlogi-cli/src/cmd/assets/sync.rs
@@ -82,7 +82,7 @@ pub fn run(args: SyncArgs) -> Result<()> {
     depots.sort();
     for depot in depots {
         let entry = &index.devices[depot];
-        let dir = out.join(depot);
+        let dir = http::safe_component_path(&out, depot, "asset depot")?;
         fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
 
         // Per-depot baseline (metadata + manifest + hero render, either

--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -49,10 +49,10 @@ pub async fn run(args: LightingArgs) -> Result<()> {
                     inv.receiver.vendor_id, inv.receiver.product_id
                 )
             });
-            if let Some(ref n) = needle {
-                if !name.to_lowercase().contains(n.as_str()) {
-                    return None;
-                }
+            if let Some(ref n) = needle
+                && !name.to_lowercase().contains(n.as_str())
+            {
+                return None;
             }
             let route = DeviceRoute::Direct {
                 vendor_id: inv.receiver.vendor_id,

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -1820,10 +1820,10 @@ mod linux {
         let _ = &*VIRTUAL_INPUT;
         // Give udev a moment to create the /dev node.
         std::thread::sleep(std::time::Duration::from_millis(150));
-        if let Some(m) = &*VIRTUAL_INPUT {
-            if let Ok(mut guard) = m.lock() {
-                return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
-            }
+        if let Some(m) = &*VIRTUAL_INPUT
+            && let Ok(mut guard) = m.lock()
+        {
+            return guard.enumerate_dev_nodes_blocking().ok()?.flatten().next();
         }
         None
     }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -627,11 +627,11 @@ impl Config {
             return BTreeMap::new();
         };
         let mut out = device.bindings.clone();
-        if let Some(bid) = bundle_id {
-            if let Some(overlay) = device.per_app_bindings.get(bid) {
-                for (k, v) in overlay {
-                    out.insert(*k, Binding::Single(v.clone()));
-                }
+        if let Some(bid) = bundle_id
+            && let Some(overlay) = device.per_app_bindings.get(bid)
+        {
+            for (k, v) in overlay {
+                out.insert(*k, Binding::Single(v.clone()));
             }
         }
         out

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -609,7 +609,7 @@ fn lighting_overlay(record: &DeviceRecord, cx: &App) -> Option<PathBuf> {
         .filter(|l| l.enabled)?;
     let asset = record.asset.as_ref()?;
     asset.hero_image_path.as_ref()?;
-    let path = crate::asset::glow_path(&asset.depot, &lighting.color);
+    let path = crate::asset::glow_path(&asset.depot, &lighting.color)?;
     state.glow_is_ready(&path).then_some(path)
 }
 
@@ -633,7 +633,7 @@ fn glow_job(state: &AppState, record: &DeviceRecord) -> Option<GlowJob> {
     let asset = record.asset.as_ref()?;
     asset.hero_image_path.as_ref()?;
     Some(GlowJob {
-        cache: crate::asset::glow_path(&asset.depot, &lighting.color),
+        cache: crate::asset::glow_path(&asset.depot, &lighting.color)?,
         depot: asset.depot.clone(),
         hex: lighting.color,
     })

--- a/crates/openlogi-gui/src/asset/glow.rs
+++ b/crates/openlogi-gui/src/asset/glow.rs
@@ -50,7 +50,8 @@ struct MetaGlow {
 /// can't be written. Cached under the writable user dir keyed by `depot`, so it
 /// survives a read-only `.app` bundle.
 pub(crate) fn ensure_glow_png(depot: &str, hex: &str) -> Option<PathBuf> {
-    let out = glow_path(depot, hex);
+    let dir = depot_dir(depot)?;
+    let out = dir.join(format!("glow-{hex}.png"));
     if out.exists() {
         return Some(out);
     }
@@ -58,8 +59,7 @@ pub(crate) fn ensure_glow_png(depot: &str, hex: &str) -> Option<PathBuf> {
     let color = Rgba([r, g, b, 255]);
     let overlay = render_mask(&read_baked_mask(depot)?, color)?;
 
-    let dir = out.parent()?;
-    std::fs::create_dir_all(dir).ok()?;
+    std::fs::create_dir_all(&dir).ok()?;
     // Write atomically (temp + rename) so a concurrent render never loads a
     // half-written PNG; gpui caches an image-load *failure* permanently. For the
     // same reason we keep every colour variant on disk (bounded by the small
@@ -82,10 +82,23 @@ pub(crate) fn glow_path(depot: &str, hex: &str) -> PathBuf {
         .join(format!("glow-{hex}.png"))
 }
 
+/// Validated `<user_cache_root>/<depot>` — `None` (with a warn) when the
+/// index-supplied depot name isn't a single safe path component, so glow
+/// IO can never leave the cache root.
+fn depot_dir(depot: &str) -> Option<PathBuf> {
+    openlogi_assets::http::safe_component_path(
+        &super::paths::user_cache_root(),
+        depot,
+        "asset depot",
+    )
+    .map_err(|e| warn!(depot, error = %e, "glow: refusing depot dir"))
+    .ok()
+}
+
 /// Read the precomputed `glow` mask from the depot's metadata, ignoring every
 /// other field (so the keyboard-schema hotspot data is irrelevant here).
 fn read_baked_mask(depot: &str) -> Option<GlowMask> {
-    let dir = super::paths::user_cache_root().join(depot);
+    let dir = depot_dir(depot)?;
     META_FILES.iter().find_map(|name| {
         let text = std::fs::read_to_string(dir.join(name)).ok()?;
         serde_json::from_str::<MetaGlow>(&text).ok()?.glow

--- a/crates/openlogi-gui/src/asset/glow.rs
+++ b/crates/openlogi-gui/src/asset/glow.rs
@@ -75,11 +75,11 @@ pub(crate) fn ensure_glow_png(depot: &str, hex: &str) -> Option<PathBuf> {
     Some(out)
 }
 
-/// Cache path for a depot's glow overlay at colour `hex` (pure — no IO).
-pub(crate) fn glow_path(depot: &str, hex: &str) -> PathBuf {
-    super::paths::user_cache_root()
-        .join(depot)
-        .join(format!("glow-{hex}.png"))
+/// Cache path for a depot's glow overlay at colour `hex` (stat-only — no
+/// writes). `None` when the depot name isn't a safe single path component,
+/// so read-side lookups stay inside the cache root just like the writers.
+pub(crate) fn glow_path(depot: &str, hex: &str) -> Option<PathBuf> {
+    Some(depot_dir(depot)?.join(format!("glow-{hex}.png")))
 }
 
 /// Validated `<user_cache_root>/<depot>` — `None` (with a warn) when the

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -99,7 +99,7 @@ fn sync_depot(
     entry: &DeviceEntry,
     ext: u8,
 ) -> Result<()> {
-    let dir = cache_root.join(depot);
+    let dir = http::safe_component_path(cache_root, depot, "asset depot")?;
     fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
 
     // Baseline: hotspot metadata + manifest + hero render, in whichever
@@ -145,9 +145,9 @@ fn sync_depot(
 }
 
 /// Fetch a single named file from `<server>/<asset_path>/<name>` into
-/// `<dir>/<name>`. SHA-checked against `entry.files`; missing registry
-/// entry trips a warn but doesn't bail (some depots ship one-off files
-/// not yet rolled into the registry).
+/// `<dir>/<name>`. SHA-checked against `entry.files`; a name the registry
+/// doesn't list is skipped (warn) — everything written to the cache must
+/// carry a registry hash, so a tampered host can't plant unverified files.
 fn fetch_to_cache(
     client: &http::AssetClient,
     asset_path: &str,
@@ -163,10 +163,8 @@ fn fetch_to_cache(
     } else {
         warn!(
             file = name,
-            "registry lists no entry — fetching without sha verify"
+            "registry lists no entry — skipping unverified asset"
         );
-        let bytes = client.fetch_file_to_dir(asset_path, dir, name)?;
-        info!(file = name, bytes, "downloaded");
     }
     Ok(())
 }

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -113,10 +113,10 @@ fn sync_depot(
     // points `device_buttons_image` at a distinct side view. Fetch it only
     // when the registry lists it so front-only devices don't 404; failure
     // is non-fatal (the GUI falls back to the hero render).
-    if let Some(side) = entry.preferred_file(&BUTTONS_RENDER_FILES) {
-        if let Err(e) = fetch_to_cache(client, &entry.asset_path, &dir, entry, side) {
-            warn!(depot, error = %e, "buttons render fetch failed");
-        }
+    if let Some(side) = entry.preferred_file(&BUTTONS_RENDER_FILES)
+        && let Err(e) = fetch_to_cache(client, &entry.asset_path, &dir, entry, side)
+    {
+        warn!(depot, error = %e, "buttons render fetch failed");
     }
 
     // Optional second pass: download the colour variant PNGs matching

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -343,14 +343,13 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
 /// a window closed while the app kept running can be brought back.
 fn open_main_window(inventories: &[DeviceInventory], cx: &mut gpui::App) {
     let existing = cx.default_global::<windows::WindowRegistry>().main;
-    if let Some(handle) = existing {
-        if handle
+    if let Some(handle) = existing
+        && handle
             .update(cx, |_, window, _| window.activate_window())
             .is_ok()
-        {
-            cx.activate(true);
-            return;
-        }
+    {
+        cx.activate(true);
+        return;
     }
 
     let options = main_window_options(cx);

--- a/crates/openlogi-gui/src/windows/mod.rs
+++ b/crates/openlogi-gui/src/windows/mod.rs
@@ -62,13 +62,12 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
     // Already open? Focus it and bail. A closed window leaves a stale handle
     // whose `update` errors, falling through to a fresh open.
     let existing = *slot(cx.default_global::<WindowRegistry>());
-    if let Some(handle) = existing {
-        if handle
+    if let Some(handle) = existing
+        && handle
             .update(cx, |_, window, _| window.activate_window())
             .is_ok()
-        {
-            return;
-        }
+    {
+        return;
     }
 
     let bounds = Bounds::centered(None, size, cx);

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -55,10 +55,8 @@ pub fn open(cx: &mut App) {
 /// Persist the user's answer, run one check if they opted in, and close.
 fn answer(enabled: bool, window: &mut Window, cx: &mut App) {
     cx.update_global::<AppState, _>(|state, _| state.record_update_consent(enabled));
-    if enabled {
-        if let Some(updater) = crate::platform::updater::shared(cx) {
-            updater.update(cx, Updater::check);
-        }
+    if enabled && let Some(updater) = crate::platform::updater::shared(cx) {
+        updater.update(cx, Updater::check);
     }
     window.remove_window();
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -129,23 +129,23 @@ pub async fn run_capture_session(
                 return;
             }
             let msg = v20::Message::from(raw);
-            if let Some(idx) = reprog_index {
-                if let Some(event) = reprog_controls::decode_event(&msg, device_index, idx) {
-                    // Recover the guard even if a prior holder panicked — the
-                    // critical section is panic-free, so the data is consistent.
-                    let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                    handle_reprog(&mut acc, event, &dpi_set, &sink);
-                    return;
-                }
+            if let Some(idx) = reprog_index
+                && let Some(event) = reprog_controls::decode_event(&msg, device_index, idx)
+            {
+                // Recover the guard even if a prior holder panicked — the
+                // critical section is panic-free, so the data is consistent.
+                let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
+                handle_reprog(&mut acc, event, &dpi_set, &sink);
+                return;
             }
-            if let Some(idx) = thumb_index {
-                if let Some(event) = thumbwheel::decode_event(&msg, device_index, idx) {
-                    if event.single_tap {
-                        let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
-                    }
-                    if event.rotation != 0 {
-                        let _ = sink.send(CapturedInput::Scroll(event.rotation));
-                    }
+            if let Some(idx) = thumb_index
+                && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
+            {
+                if event.single_tap {
+                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
+                }
+                if event.rotation != 0 {
+                    let _ = sink.send(CapturedInput::Scroll(event.rotation));
                 }
             }
         }
@@ -254,32 +254,31 @@ async fn arm_controls(
     }
 
     let mut thumb: Option<(Thumbwheel, u8)> = None;
-    if capture_thumbwheel {
-        if let Some(info) = device
+    if capture_thumbwheel
+        && let Some(info) = device
             .root()
             .get_feature(thumbwheel::FEATURE_ID)
             .await
             .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
-        {
-            let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
-            // Consume the getInfo error here, before the next await: Hidpp20Error
-            // isn't Send, so holding it across an await would make this future
-            // (spawned on tokio) non-Send.
-            let supports_single_tap = match tw.get_info().await {
-                Ok(twinfo) => twinfo.supports_single_tap,
-                Err(e) => {
-                    warn!(error = ?e, "thumb wheel getInfo failed");
-                    false
-                }
-            };
-            if supports_single_tap {
-                tw.set_reporting(true, false)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                thumb = Some((tw, info.index));
-            } else {
-                debug!("thumb wheel reports no single tap — click not capturable");
+    {
+        let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
+        // Consume the getInfo error here, before the next await: Hidpp20Error
+        // isn't Send, so holding it across an await would make this future
+        // (spawned on tokio) non-Send.
+        let supports_single_tap = match tw.get_info().await {
+            Ok(twinfo) => twinfo.supports_single_tap,
+            Err(e) => {
+                warn!(error = ?e, "thumb wheel getInfo failed");
+                false
             }
+        };
+        if supports_single_tap {
+            tw.set_reporting(true, false)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            thumb = Some((tw, info.index));
+        } else {
+            debug!("thumb wheel reports no single tap — click not capturable");
         }
     }
 

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -68,10 +68,10 @@ pub(crate) fn stop(mut inner: HookInner) {
             "could not post WM_QUIT to Windows hook thread"
         );
     }
-    if let Some(join) = inner.join.take() {
-        if let Err(e) = join.join() {
-            tracing::warn!(?e, "Windows hook thread panicked while stopping");
-        }
+    if let Some(join) = inner.join.take()
+        && let Err(e) = join.join()
+    {
+        tracing::warn!(?e, "Windows hook thread panicked while stopping");
     }
 }
 


### PR DESCRIPTION
## Why

`index.json` depot keys, per-depot file names, and `manifest.json` variant names are remote data, but the sync paths joined them raw onto local directories. A tampered asset host (or poisoned cache/manifest) could:

- **write outside the cache root** — a depot key or file name like `../LaunchAgents/x` traverses on join (GUI runtime sync, CLI bundle sync, and the glow cache's depot dir)
- **redirect a write through a planted symlink**
- **plant unverified bytes** — the GUI's fallback fetched files the registry doesn't list, with no hash to check, and a fresh download was never re-verified against its registry `sha256`

## What

- `http::safe_component_path` validates every remote-named component down to a single normal path component (no separators, no `.`/`..`, non-empty) before any join; all sync joins go through it
- the destination is refused if a symlink sits there (`symlink_metadata` check at the single write chokepoint)
- `fetch_entry_if_stale` verifies a fresh download against the registry `sha256` and deletes it on mismatch — nothing unverified survives on disk
- the GUI now **skips** names the registry doesn't list instead of fetching them unverified; with that fallback gone, `fetch_file`/`fetch_file_to_dir` became private to `openlogi-assets`
- the glow cache (`ensure_glow_png` / `read_baked_mask`) gates its depot dir the same way — a write path beyond what #66 covered

## Credit

The path-traversal/symlink/checksum findings and the original patch shape are from #66 by @cantorjf, re-derived on current master.

---
Stacked on #197 (the clippy unblock): merge that first and this diff collapses to the one `fix(assets)` commit.

## Verification

- `cargo test -p openlogi-assets -p openlogi-gui -p openlogi-cli` — all pass (2 new traversal tests)
- `cargo clippy --workspace --all-targets -- -D warnings` clean