### PR TITLE
ci: fix SignTool timestamp URL and add a signing dry-run workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,9 +252,12 @@ jobs:
           certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
           files: ${{ github.workspace }}\target\release\openlogi.exe
           # Timestamping is mandatory: without it the signature expires after
-          # 3 days. https beats the action's http default; the file/timestamp
-          # digests stay on the action's SHA256 defaults.
-          timestamp-rfc3161: https://timestamp.acs.microsoft.com
+          # 3 days. The URL must stay http — SignTool rejects an https /tr up
+          # front ("SignTool Error: Invalid Timestamp URL", v0.6.5) before
+          # even contacting Azure. The RFC3161 response is itself signed, so
+          # http transport does not weaken it. The file/timestamp digests stay
+          # on the action's SHA256 defaults.
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
           # Tag-only workflow: the action's four dependency caches save to
           # per-tag refs no future run can restore, so skip them.
           cache-dependencies: false

--- a/.github/workflows/windows-sign-dryrun.yml
+++ b/.github/workflows/windows-sign-dryrun.yml
@@ -1,0 +1,98 @@
+name: Windows signing dry-run
+
+# Manual, publish-free end-to-end test of the Azure Artifact Signing path:
+# 1Password config → build → OIDC login → sign → verify. Exists because
+# release.yml only runs on v* tags, so validating a signing-config change
+# used to cost a release (v0.6.4: missing role assignment; v0.6.5: https
+# timestamp URL). Keep these steps in sync with release.yml's `windows` job.
+
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  sign:
+    name: Windows signing dry-run (x86_64)
+    runs-on: windows-2025
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    # Same environment as the release job so the OIDC subject matches the
+    # federated credential (repo:AprilNEA/OpenLogi:environment:release).
+    environment: release
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Load Azure signing config from 1Password
+        id: azure_config
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AZURE_CLIENT_ID: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_CLIENT_ID
+          AZURE_TENANT_ID: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_TENANT_ID
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_SUBSCRIPTION_ID
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_SIGNING_ENDPOINT
+          AZURE_SIGNING_ACCOUNT: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_SIGNING_ACCOUNT
+          AZURE_CERT_PROFILE: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_CERT_PROFILE
+
+      - name: Validate Azure signing config
+        shell: bash
+        env:
+          AZURE_CLIENT_ID: ${{ steps.azure_config.outputs.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
+          AZURE_SIGNING_ENDPOINT: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
+          AZURE_CERT_PROFILE: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
+        run: |
+          set -euo pipefail
+          : "${AZURE_CLIENT_ID:?Configure AZURE_CLIENT_ID in the Azure 1Password item}"
+          : "${AZURE_TENANT_ID:?Configure AZURE_TENANT_ID in the Azure 1Password item}"
+          : "${AZURE_SUBSCRIPTION_ID:?Configure AZURE_SUBSCRIPTION_ID in the Azure 1Password item}"
+          : "${AZURE_SIGNING_ENDPOINT:?Configure AZURE_SIGNING_ENDPOINT in the Azure 1Password item}"
+          : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
+          : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
+
+      - name: Build OpenLogi CLI
+        run: cargo build --release -p openlogi
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ steps.azure_config.outputs.AZURE_CLIENT_ID }}
+          tenant-id: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
+          subscription-id: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign openlogi.exe with Artifact Signing
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\target\release\openlogi.exe
+          # Must stay http — SignTool rejects an https /tr ("Invalid Timestamp
+          # URL", v0.6.5). The RFC3161 response is itself signed.
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          cache-dependencies: false
+
+      - name: Verify the binary is signed
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature target\release\openlogi.exe
+          $sig | Format-List
+          # NotSigned and HashMismatch are trust-store independent and always
+          # ship-blockers; NotTrusted/UnknownError depend on the runner's
+          # trust store, so they stay log-only.
+          if ($null -eq $sig.SignerCertificate -or
+              "$($sig.Status)" -in 'NotSigned', 'HashMismatch') {
+            Write-Error "openlogi.exe Authenticode signature is invalid: $($sig.Status)"
+            exit 1
+          }


### PR DESCRIPTION
## What

1. **Revert the RFC3161 timestamp endpoint to `http`** (undoes dbb2b36, which adopted a review suggestion to upgrade it to https).
2. **Add `windows-sign-dryrun.yml`** — a `workflow_dispatch` job that mirrors `release.yml`'s `windows` job up through signature verification, so signing config can be validated without burning a release tag.

## Why

v0.6.5's windows job ([run](https://github.com/AprilNEA/OpenLogi/actions/runs/27293673093/job/80620645045)) failed at the signing step:

```
SignTool Error: Invalid Timestamp URL: https://timestamp.acs.microsoft.com
```

SignTool (SDK 10.0.26100) validates the `/tr` URL scheme **up front** and rejects `https` — it never reached Azure. The https endpoint being TLS-reachable (what was verified when adopting the suggestion) was not the relevant check; signtool's own input validation was.

> **Note for reviewers:** please don't re-suggest https here. `http://timestamp.acs.microsoft.com` is the action's default and the only scheme signtool accepts for `/tr`. This is not a security downgrade: RFC3161 timestamp responses are signed by the TSA, so their integrity does not depend on transport security. Comments at both sites now document this.

## Dry-run workflow

Both signing failures so far (v0.6.4: missing RBAC role; v0.6.5: timestamp URL) were only discoverable at a real tag, costing a release each. The new workflow runs the identical step sequence — 1Password load → validation → CLI build → OIDC login → Artifact Signing → Authenticode verify — under the same `release` environment (so the OIDC subject matches the federated credential), minus artifact collection/upload. A "keep in sync" header ties it to `release.yml`.

## Status after this PR

End-to-end signing (Azure cert fetch + actual signing + timestamp) is **still unvalidated** — v0.6.5 failed before contacting Azure. Next step: run the dry-run workflow from this branch's merge to validate before the next tag.

v0.6.5 itself shipped DMG-only by design (decoupling worked); the exe ships with the next tag. Its release is immutable — do not re-run its failed jobs.