### PR TITLE
feat(windows): ship the signed GUI as the Windows release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,10 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      # openlogi-gui's GPUI backend doesn't build on Windows yet — restrict to
-      # the platform-agnostic crates so the workspace stays green on push. clippy
-      # subsumes `cargo check` and additionally lints the Windows-only code paths
-      # (the WH_MOUSE_LL hook, SendInput synthesis, native HID writer, the
-      # composite HID++ channel, and the agent's HKCU-Run autostart) that the
-      # Linux/macOS clippy jobs never compile.
-      - run: cargo clippy -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-assets -p openlogi-cli -p openlogi -p openlogi-hook -p openlogi-agent -p openlogi-agent-core --all-targets -- -D warnings
+      # Whole workspace, matching the Linux jobs — GPUI's DirectX backend
+      # covers the GUI on Windows. clippy subsumes `cargo check` and
+      # additionally lints the Windows-only code paths (the WH_MOUSE_LL hook,
+      # SendInput synthesis, native HID writer, the composite HID++ channel,
+      # and the agent's HKCU-Run autostart) that the Linux/macOS clippy jobs
+      # never compile.
+      - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,13 +160,15 @@ jobs:
           path: dist/*.dmg
 
   windows:
-    name: Windows CLI (x86_64)
+    name: Windows GUI (x86_64)
     runs-on: windows-2025
     # A hung signing/login call must become a normal failure (which publish
     # tolerates), not a 6-hour stall: publish waits for this job to reach a
-    # terminal state before its own gate is even evaluated. Healthy runs take
-    # ~8 minutes (v0.6.4 measured ~4.6 min up to the signing step).
-    timeout-minutes: 30
+    # terminal state before its own gate is even evaluated. The GUI release
+    # build (thin LTO, codegen-units=1, the whole GPUI stack) dominates the
+    # runtime on the 4-core runner, hence a looser budget than the ~8-minute
+    # CLI-only runs needed.
+    timeout-minutes: 60
     permissions:
       # Mint an OIDC token so azure/login can exchange it for an Azure access token
       # via a federated credential — no client secret is stored in GitHub.
@@ -225,11 +227,12 @@ jobs:
           : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
           : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
 
-      # Only the `openlogi` CLI compiles on Windows from master today — the agent and
-      # GUI are excluded from the Windows build (see ci.yml's `clippy (windows)`), so
-      # this signs and ships `openlogi.exe` alone until the Windows agent/GUI land.
-      - name: Build OpenLogi CLI
-        run: cargo build --release -p openlogi
+      # Windows ships the GUI as its single artifact, mirroring what the macOS
+      # DMG carries. The headless agent (ported in #167) joins the artifact set
+      # once it has been runtime-tested on a real Windows box; the CLI stays
+      # cargo-install-only, as on the other platforms.
+      - name: Build OpenLogi GUI
+        run: cargo build --release -p openlogi-gui
 
       # Federated (passwordless) login. Requires an app registration whose federated
       # credential subject is `repo:AprilNEA/OpenLogi:environment:release`, granted the
@@ -244,13 +247,13 @@ jobs:
       # Authenticode-signs via Artifact Signing (ex-Trusted Signing). The action only
       # runs on Windows runners. azure/login leaves an az CLI session that the action's
       # default AzureCliCredential picks up, so no azure-* secret inputs are needed.
-      - name: Sign openlogi.exe with Artifact Signing
+      - name: Sign openlogi-gui.exe with Artifact Signing
         uses: azure/artifact-signing-action@v2
         with:
           endpoint: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
-          files: ${{ github.workspace }}\target\release\openlogi.exe
+          files: ${{ github.workspace }}\target\release\openlogi-gui.exe
           # Timestamping is mandatory: without it the signature expires after
           # 3 days. The URL must stay http — SignTool rejects an https /tr up
           # front ("SignTool Error: Invalid Timestamp URL", v0.6.5) before
@@ -265,7 +268,7 @@ jobs:
       - name: Verify the binary is signed
         shell: pwsh
         run: |
-          $sig = Get-AuthenticodeSignature target\release\openlogi.exe
+          $sig = Get-AuthenticodeSignature target\release\openlogi-gui.exe
           $sig | Format-List
           # The signing step above already fails on error; this guards against it
           # silently producing an unsigned or corrupted binary. NotSigned and
@@ -274,16 +277,17 @@ jobs:
           # on the runner's trust store, so they stay log-only.
           if ($null -eq $sig.SignerCertificate -or
               "$($sig.Status)" -in 'NotSigned', 'HashMismatch') {
-            Write-Error "openlogi.exe Authenticode signature is invalid: $($sig.Status)"
+            Write-Error "openlogi-gui.exe Authenticode signature is invalid: $($sig.Status)"
             exit 1
           }
 
-      - name: Collect signed CLI artifact
+      - name: Collect signed GUI artifact
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
+          # Renaming after signing is safe: Authenticode lives in the PE file.
           $ref = $env:GITHUB_REF_NAME -replace '/', '-'
-          Copy-Item target\release\openlogi.exe "dist\OpenLogi-$ref-windows-x86_64.exe"
+          Copy-Item target\release\openlogi-gui.exe "dist\OpenLogi-$ref-windows-x86_64.exe"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/windows-sign-dryrun.yml
+++ b/.github/workflows/windows-sign-dryrun.yml
@@ -17,7 +17,8 @@ jobs:
   sign:
     name: Windows signing dry-run (x86_64)
     runs-on: windows-2025
-    timeout-minutes: 30
+    # Matches release.yml's windows job: the GUI release build dominates.
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read
@@ -61,8 +62,8 @@ jobs:
           : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
           : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
 
-      - name: Build OpenLogi CLI
-        run: cargo build --release -p openlogi
+      - name: Build OpenLogi GUI
+        run: cargo build --release -p openlogi-gui
 
       - name: Azure login (OIDC)
         uses: azure/login@v3
@@ -71,13 +72,13 @@ jobs:
           tenant-id: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
           subscription-id: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Sign openlogi.exe with Artifact Signing
+      - name: Sign openlogi-gui.exe with Artifact Signing
         uses: azure/artifact-signing-action@v2
         with:
           endpoint: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
-          files: ${{ github.workspace }}\target\release\openlogi.exe
+          files: ${{ github.workspace }}\target\release\openlogi-gui.exe
           # Must stay http — SignTool rejects an https /tr ("Invalid Timestamp
           # URL", v0.6.5). The RFC3161 response is itself signed.
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
@@ -86,13 +87,13 @@ jobs:
       - name: Verify the binary is signed
         shell: pwsh
         run: |
-          $sig = Get-AuthenticodeSignature target\release\openlogi.exe
+          $sig = Get-AuthenticodeSignature target\release\openlogi-gui.exe
           $sig | Format-List
           # NotSigned and HashMismatch are trust-store independent and always
           # ship-blockers; NotTrusted/UnknownError depend on the runner's
           # trust store, so they stay log-only.
           if ($null -eq $sig.SignerCertificate -or
               "$($sig.Status)" -in 'NotSigned', 'HashMismatch') {
-            Write-Error "openlogi.exe Authenticode signature is invalid: $($sig.Status)"
+            Write-Error "openlogi-gui.exe Authenticode signature is invalid: $($sig.Status)"
             exit 1
           }

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -4,6 +4,13 @@
 //! the main thread, so we can't move it onto a tokio runtime). Live polling
 //! lands when there's something to react to.
 
+// Without this Windows runs the exe as a console app and pops a terminal
+// window behind the UI. Debug builds keep the console so logs stay visible.
+#![cfg_attr(
+    all(target_os = "windows", not(debug_assertions)),
+    windows_subsystem = "windows"
+)]
+
 /// Translate `key` (an English msgid) to the current locale and wrap it as a
 /// [`gpui::SharedString`], ready for `.child(...)` / `.label(...)` / menu items.
 /// Forwards `rust_i18n` interpolation, e.g. `tr!("Bind %{name}", name => x)`.


### PR DESCRIPTION
## What

The Windows release job now builds, signs, and ships **`openlogi-gui.exe`** (as `OpenLogi-<tag>-windows-x86_64.exe`) instead of the bare CLI — mirroring what the macOS DMG carries. The GUI is the product; the CLI stays cargo-install-only on every platform.

- `release.yml`: job renamed **Windows GUI (x86_64)**; builds `-p openlogi-gui`; signs/verifies/collects the GUI exe; `timeout-minutes: 30 → 60` (the GUI release build — thin LTO, codegen-units=1, the whole GPUI stack — dominates on the 4-core runner).
- `windows-sign-dryrun.yml`: tracks the same steps, per its keep-in-sync contract.
- `ci.yml`: the Windows clippy job goes **`--workspace`**, matching the Linux jobs. Its package list predated GPUI's Windows support (the agent already joined in #167; xtask is dependency-portable), so the GUI now lints on Windows too and nothing can silently drop out of coverage again.
- `openlogi-gui/src/main.rs`: `windows_subsystem = "windows"` on release builds so the exe doesn't pop a console window behind the UI (debug builds keep the console for tracing output).

## The load-bearing check

**`clippy (windows)` on this PR is the first time the GUI compiles on a Windows toolchain** — our own code's non-macOS paths are already proven by the Linux workspace builds, so the open question is the pinned gpui / gpui-component stack on windows-msvc. If it fails, this PR is where it gets fixed.

## What this PR does NOT validate

- **Runtime behavior on Windows.** The exe is compile- and signing-validated only. The GUI talks to the headless agent over IPC, and nothing ships or starts the agent on Windows yet — first launch is expected to come up in a disconnected/empty state until the agent (#167, also runtime-untested) joins the artifact set.
- **Release-build wall-clock.** After merging, dispatch *Windows signing dry-run* (now building the GUI) once to confirm the 60-minute budget and re-validate signing end to end — that's one button instead of a burned tag. The signing path itself is already proven by [run 27294937410](https://github.com/AprilNEA/OpenLogi/actions/runs/27294937410).

## Follow-ups (not this PR)

- Embed a VERSIONINFO resource + icon (winresource build script): Task Manager / file-properties product naming and a non-generic exe icon. Filename alone doesn't control those surfaces.
- Ship `openlogi-agent.exe` (+ autostart wiring) once runtime-tested on a real Windows box; revisit an installer (MSIX/Inno) at that point.