### PR TITLE
fix(gui): launch the agent helper via LaunchServices for a stable TCC identity

### DIFF
--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Bruger du Logi Options+? Afslut den først — begge apps konkurrerer om HID++-adgang."
 "Accessibility permission required": "Tilladelse til Tilgængelighed kræves"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi opfanger museknapper (Tilbage / Frem / bevægelsesknap) via systemets tilladelse til Tilgængelighed og udfører de handlinger, du tildeler. Funktioner, der kommunikerer direkte med enheden — DPI, SmartShift — påvirkes ikke."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Aktivér “OpenLogi Agent” på listen Tilgængelighed — det er baggrundsagenten, der ejer musekrogen, ikke OpenLogi-appen. Hvis den allerede vises som aktiveret, skal du fjerne den forældede post med knappen − og tilføje den igen."
 "Open System Settings to grant access": "Åbn Systemindstillinger for at give adgang"
 "Takes effect automatically once granted — no restart needed.": "Træder automatisk i kraft, når adgangen er givet — ingen genstart nødvendig."
 "Not now (use DPI and other features only)": "Ikke nu (brug kun DPI og andre funktioner)"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Verwendest du Logi Options+? Beende es zuerst – beide Apps konkurrieren um den HID++-Zugriff."
 "Accessibility permission required": "Berechtigung für Bedienungshilfen erforderlich"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi erfasst über die Systemberechtigung „Bedienungshilfen“ Maustasten (Zurück / Vor / Gestentaste) und führt die von dir zugewiesenen Aktionen aus. Funktionen, die direkt mit dem Gerät kommunizieren – DPI, SmartShift –, sind davon nicht betroffen."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Aktiviere “OpenLogi Agent” in der Bedienungshilfen-Liste — der Hintergrund-Agent besitzt den Maus-Hook, nicht die OpenLogi-App. Wird der Eintrag bereits als aktiviert angezeigt, entferne den veralteten Eintrag über die Taste − und füge ihn erneut hinzu."
 "Open System Settings to grant access": "Systemeinstellungen öffnen, um Zugriff zu gewähren"
 "Takes effect automatically once granted — no restart needed.": "Wird nach der Erteilung automatisch wirksam – kein Neustart erforderlich."
 "Not now (use DPI and other features only)": "Jetzt nicht (nur DPI und andere Funktionen verwenden)"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Χρησιμοποιείτε το Logi Options+; Κλείστε το πρώτα — και οι δύο εφαρμογές ανταγωνίζονται για πρόσβαση HID++."
 "Accessibility permission required": "Απαιτείται δικαίωμα Προσβασιμότητας"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "Το OpenLogi καταγράφει τα κουμπιά του ποντικιού (Πίσω / Εμπρός / κουμπί χειρονομιών) μέσω του δικαιώματος Προσβασιμότητας του συστήματος και εκτελεί τις ενέργειες που αντιστοιχίζετε. Οι λειτουργίες που επικοινωνούν απευθείας με τη συσκευή — DPI, SmartShift — δεν επηρεάζονται."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Ενεργοποιήστε το “OpenLogi Agent” στη λίστα Προσβασιμότητας — το άγκιστρο ποντικιού ανήκει στον παρασκηνιακό agent, όχι στην εφαρμογή OpenLogi. Αν εμφανίζεται ήδη ενεργοποιημένο, αφαιρέστε την παλιά καταχώριση με το κουμπί − και προσθέστε την ξανά."
 "Open System Settings to grant access": "Ανοίξτε τις Ρυθμίσεις συστήματος για παραχώρηση πρόσβασης"
 "Takes effect automatically once granted — no restart needed.": "Τίθεται αυτόματα σε ισχύ μόλις παραχωρηθεί — δεν απαιτείται επανεκκίνηση."
 "Not now (use DPI and other features only)": "Όχι τώρα (χρήση μόνο του DPI και άλλων λειτουργιών)"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Using Logi Options+? Quit it first — both apps compete for HID++ access."
 "Accessibility permission required": "Accessibility permission required"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back."
 "Open System Settings to grant access": "Open System Settings to grant access"
 "Takes effect automatically once granted — no restart needed.": "Takes effect automatically once granted — no restart needed."
 "Not now (use DPI and other features only)": "Not now (use DPI and other features only)"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "¿Usas Logi Options+? Ciérralo primero: ambas apps compiten por el acceso HID++."
 "Accessibility permission required": "Se requiere permiso de Accesibilidad"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi captura los botones del ratón (Atrás / Adelante / botón de gestos) mediante el permiso de Accesibilidad del sistema y ejecuta las acciones que asignes. Las funciones que se comunican directamente con el dispositivo, como DPI y SmartShift, no se ven afectadas."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Activa “OpenLogi Agent” en la lista de Accesibilidad — el agente en segundo plano es quien posee el hook del ratón, no la app OpenLogi. Si ya aparece como activado, elimina la entrada obsoleta con el botón − y vuelve a añadirla."
 "Open System Settings to grant access": "Abrir Ajustes del Sistema para conceder el acceso"
 "Takes effect automatically once granted — no restart needed.": "Se aplica automáticamente al concederlo: no es necesario reiniciar."
 "Not now (use DPI and other features only)": "Ahora no (usar solo DPI y otras funciones)"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Käytätkö Logi Options+ -sovellusta? Sulje se ensin — molemmat sovellukset kilpailevat HID++-yhteydestä."
 "Accessibility permission required": "Käyttöapu-oikeus vaaditaan"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi kaappaa hiiren painikkeet (Takaisin / Eteenpäin / eletoiminto) järjestelmän Käyttöapu-oikeuden kautta ja suorittaa määrittämäsi toiminnot. Suoraan laitteen kanssa kommunikoivat ominaisuudet — DPI, SmartShift — eivät häiriinny."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Ota “OpenLogi Agent” käyttöön Käyttöapu-luettelossa — hiirikoukun omistaa taustalla toimiva agentti, ei OpenLogi-sovellus. Jos se näkyy jo käytössä olevana, poista vanhentunut merkintä −-painikkeella ja lisää se uudelleen."
 "Open System Settings to grant access": "Avaa Järjestelmäasetukset ja myönnä oikeus"
 "Takes effect automatically once granted — no restart needed.": "Tulee voimaan automaattisesti, kun oikeus on myönnetty — uudelleenkäynnistystä ei tarvita."
 "Not now (use DPI and other features only)": "Ei nyt (käytä vain DPI:tä ja muita ominaisuuksia)"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Vous utilisez Logi Options+ ? Quittez-le d'abord — les deux applications se disputent l'accès HID++."
 "Accessibility permission required": "Autorisation d'accessibilité requise"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi capte les boutons de la souris (Précédent / Suivant / bouton de gestes) grâce à l'autorisation d'accessibilité du système et exécute les actions que vous attribuez. Les fonctionnalités qui communiquent directement avec l'appareil — DPI, SmartShift — ne sont pas affectées."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Activez “OpenLogi Agent” dans la liste Accessibilité — c'est l'agent en arrière-plan qui possède le hook souris, pas l'app OpenLogi. S'il apparaît déjà comme activé, supprimez l'entrée obsolète avec le bouton − puis ajoutez-la à nouveau."
 "Open System Settings to grant access": "Ouvrir Réglages Système pour accorder l'accès"
 "Takes effect automatically once granted — no restart needed.": "Prend effet automatiquement une fois accordé — aucun redémarrage nécessaire."
 "Not now (use DPI and other features only)": "Pas maintenant (utiliser uniquement le DPI et les autres fonctionnalités)"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Usi Logi Options+? Esci prima da lì — entrambe le app competono per l'accesso HID++."
 "Accessibility permission required": "Permesso di Accessibilità richiesto"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi cattura i pulsanti del mouse (Indietro / Avanti / pulsante gesture) tramite i permessi di Accessibilità del sistema ed esegue le azioni associate. Le funzionalità che comunicano direttamente con il dispositivo — DPI, SmartShift — non sono influenzate."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Abilita “OpenLogi Agent” nell'elenco Accessibilità — l'hook del mouse appartiene all'agente in background, non all'app OpenLogi. Se risulta già abilitato, rimuovi la voce obsoleta con il pulsante − e aggiungila di nuovo."
 "Open System Settings to grant access": "Apri Impostazioni di Sistema per concedere l'accesso"
 "Takes effect automatically once granted — no restart needed.": "Diventa effettivo automaticamente una volta concesso — nessun riavvio necessario."
 "Not now (use DPI and other features only)": "Non ora (usa solo DPI e altre funzionalità)"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Logi Options+ をお使いですか?まず終了してください — 両方のアプリが HID++ アクセスを奪い合います。"
 "Accessibility permission required": "アクセシビリティ権限が必要です"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi はシステムの「アクセシビリティ」権限を通じてマウスボタン(戻る / 進む / ジェスチャーボタン)を捕捉し、割り当てた操作を実行します。DPI、SmartShift などデバイスと直接通信する機能には影響しません。"
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "アクセシビリティのリストで“OpenLogi Agent”を有効にしてください — マウスフックを所有するのは OpenLogi アプリではなく、バックグラウンドのエージェントです。すでに有効と表示されている場合は、−ボタンで古い項目を削除してから追加し直してください。"
 "Open System Settings to grant access": "システム設定を開いて許可する"
 "Takes effect automatically once granted — no restart needed.": "許可すると自動的に反映されます — 再起動は不要です。"
 "Not now (use DPI and other features only)": "後で(DPI などの機能のみ使用)"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Logi Options+를 사용 중이신가요? 먼저 종료하세요 — 두 앱이 HID++ 접근 권한을 두고 경쟁합니다."
 "Accessibility permission required": "손쉬운 사용 권한이 필요합니다"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi는 시스템의 손쉬운 사용 권한을 통해 마우스 버튼(뒤로 / 앞으로 / 제스처 버튼)을 가로채어 사용자가 지정한 동작을 실행합니다. DPI, SmartShift처럼 기기와 직접 통신하는 기능에는 영향을 주지 않습니다."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "손쉬운 사용 목록에서 “OpenLogi Agent”를 활성화하세요 — 마우스 후크는 OpenLogi 앱이 아니라 백그라운드 에이전트가 소유합니다. 이미 활성화된 것으로 표시되면 − 버튼으로 오래된 항목을 제거한 뒤 다시 추가하세요."
 "Open System Settings to grant access": "시스템 설정을 열어 권한 부여"
 "Takes effect automatically once granted — no restart needed.": "권한을 부여하면 자동으로 적용됩니다 — 재시작이 필요 없습니다."
 "Not now (use DPI and other features only)": "나중에 (DPI 등 일부 기능만 사용)"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Bruker du Logi Options+? Avslutt den først — begge appene kjemper om HID++-tilgang."
 "Accessibility permission required": "Tilgjengelighetstillatelse kreves"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi fanger opp museknapper (Tilbake / Frem / bevegelsesknapp) via systemets Tilgjengelighet-tillatelse og kjører handlingene du tilordner. Funksjoner som kommuniserer direkte med enheten — DPI, SmartShift — påvirkes ikke."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Aktiver “OpenLogi Agent” i Tilgjengelighet-listen — det er bakgrunnsagenten som eier musekroken, ikke OpenLogi-appen. Hvis den allerede vises som aktivert, fjern den utdaterte oppføringen med −-knappen og legg den til på nytt."
 "Open System Settings to grant access": "Åpne Systeminnstillinger for å gi tilgang"
 "Takes effect automatically once granted — no restart needed.": "Trer i kraft automatisk når tilgang er gitt — ingen omstart nødvendig."
 "Not now (use DPI and other features only)": "Ikke nå (bruk kun DPI og andre funksjoner)"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Gebruik je Logi Options+? Sluit het eerst af — beide apps strijden om HID++-toegang."
 "Accessibility permission required": "Toegankelijkheidstoegang vereist"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi onderschept muisknoppen (Vorige / Volgende / gebarenknop) via de Toegankelijkheidstoegang van het systeem en voert de acties uit die je toewijst. Functies die rechtstreeks met het apparaat communiceren — DPI, SmartShift — worden niet beïnvloed."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Schakel “OpenLogi Agent” in in de lijst Toegankelijkheid — de achtergrondagent bezit de muis-hook, niet de OpenLogi-app. Staat deze al als ingeschakeld, verwijder dan het verouderde item met de −-knop en voeg het opnieuw toe."
 "Open System Settings to grant access": "Open Systeeminstellingen om toegang te verlenen"
 "Takes effect automatically once granted — no restart needed.": "Wordt automatisch van kracht zodra dit is verleend — herstarten is niet nodig."
 "Not now (use DPI and other features only)": "Niet nu (gebruik alleen DPI en andere functies)"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Używasz Logi Options+? Najpierw je zamknij — obie aplikacje rywalizują o dostęp HID++."
 "Accessibility permission required": "Wymagane uprawnienie Dostępność"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi przechwytuje przyciski myszy (Wstecz / Do przodu / przycisk gestów) za pomocą systemowego uprawnienia Dostępność i wykonuje przypisane działania. Funkcje komunikujące się bezpośrednio z urządzeniem — DPI, SmartShift — nie są tym objęte."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Włącz “OpenLogi Agent” na liście Dostępność — hak myszy należy do agenta działającego w tle, a nie do aplikacji OpenLogi. Jeśli wpis już widnieje jako włączony, usuń nieaktualny wpis przyciskiem − i dodaj go ponownie."
 "Open System Settings to grant access": "Otwórz Ustawienia systemowe, aby przyznać dostęp"
 "Takes effect automatically once granted — no restart needed.": "Po przyznaniu zacznie działać automatycznie — ponowne uruchomienie nie jest potrzebne."
 "Not now (use DPI and other features only)": "Nie teraz (używaj tylko DPI i pozostałych funkcji)"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Está usando o Logi Options+? Encerre-o primeiro — os dois apps disputam o acesso HID++."
 "Accessibility permission required": "Permissão de Acessibilidade necessária"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "O OpenLogi captura os botões do mouse (Voltar / Avançar / botão de gesto) por meio da permissão de Acessibilidade do sistema e executa as ações que você atribui. Os recursos que se comunicam diretamente com o dispositivo — DPI, SmartShift — não são afetados."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Ative “OpenLogi Agent” na lista de Acessibilidade — quem possui o hook do mouse é o agente em segundo plano, não o app OpenLogi. Se já aparecer como ativado, remova a entrada obsoleta com o botão − e adicione-a novamente."
 "Open System Settings to grant access": "Abrir os Ajustes do Sistema para conceder acesso"
 "Takes effect automatically once granted — no restart needed.": "Tem efeito automaticamente após a concessão — não é preciso reiniciar."
 "Not now (use DPI and other features only)": "Agora não (usar apenas DPI e outros recursos)"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "A utilizar o Logi Options+? Saia dele primeiro — ambas as aplicações competem pelo acesso HID++."
 "Accessibility permission required": "É necessária a permissão de Acessibilidade"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "O OpenLogi captura botões do rato (Retroceder / Avançar / botão de gesto) através da permissão de Acessibilidade do sistema e executa as ações que atribui. As funcionalidades que comunicam diretamente com o dispositivo — DPI, SmartShift — não são afetadas."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Ative “OpenLogi Agent” na lista de Acessibilidade — é o agente em segundo plano que detém o hook do rato, não a app OpenLogi. Se já aparecer como ativado, remova a entrada obsoleta com o botão − e volte a adicioná-la."
 "Open System Settings to grant access": "Abrir as Definições do Sistema para conceder acesso"
 "Takes effect automatically once granted — no restart needed.": "Tem efeito automaticamente assim que for concedida — não é necessário reiniciar."
 "Not now (use DPI and other features only)": "Agora não (utilizar apenas o DPI e outras funcionalidades)"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Используете Logi Options+? Сначала закройте его — оба приложения конкурируют за доступ к HID++."
 "Accessibility permission required": "Требуется разрешение Универсального доступа"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi перехватывает кнопки мыши (Назад / Вперёд / кнопку жестов) через системное разрешение Универсального доступа и выполняет назначенные вами действия. Функции, которые обращаются к устройству напрямую — DPI, SmartShift — не затрагиваются."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Включите “OpenLogi Agent” в списке «Универсальный доступ» — хук мыши принадлежит фоновому агенту, а не приложению OpenLogi. Если он уже отображается как включённый, удалите устаревшую запись кнопкой − и добавьте её заново."
 "Open System Settings to grant access": "Открыть системные настройки для выдачи доступа"
 "Takes effect automatically once granted — no restart needed.": "Вступит в силу автоматически после выдачи разрешения — перезапуск не нужен."
 "Not now (use DPI and other features only)": "Не сейчас (использовать только DPI и другие функции)"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "Använder du Logi Options+? Avsluta det först — båda apparna konkurrerar om HID++-åtkomst."
 "Accessibility permission required": "Behörighet för Hjälpmedel krävs"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi fångar upp musknappar (Bakåt / Framåt / gestknapp) via systemets behörighet för Hjälpmedel och kör de åtgärder du binder. Funktioner som kommunicerar direkt med enheten — DPI, SmartShift — påverkas inte."
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "Aktivera “OpenLogi Agent” i listan Hjälpmedel — det är bakgrundsagenten som äger mushooken, inte OpenLogi-appen. Om den redan visas som aktiverad tar du bort den inaktuella posten med −-knappen och lägger till den igen."
 "Open System Settings to grant access": "Öppna Systeminställningar för att ge åtkomst"
 "Takes effect automatically once granted — no restart needed.": "Tillämpas automatiskt när det beviljats — ingen omstart krävs."
 "Not now (use DPI and other features only)": "Inte nu (använd endast DPI och andra funktioner)"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "正在使用 Logi Options+?请先退出 —— 两个应用会争夺 HID++ 访问权限。"
 "Accessibility permission required": "需要「辅助功能」权限"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi 通过系统的「辅助功能」权限捕获鼠标按键(后退 / 前进 / 手势按钮)并执行你绑定的操作。DPI、SmartShift 等直接与设备通信的功能不受影响。"
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "请在“辅助功能”列表中启用“OpenLogi Agent”——鼠标钩子属于后台代理进程，而不是 OpenLogi 应用。如果它已显示为启用，请用 − 按钮移除失效条目后重新添加。"
 "Open System Settings to grant access": "打开系统设置授权"
 "Takes effect automatically once granted — no restart needed.": "授权后会自动生效,无需重启。"
 "Not now (use DPI and other features only)": "稍后再说(仅使用 DPI 等功能)"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "正在使用 Logi Options+?請先結束 —— 兩個應用會爭奪 HID++ 存取權限。"
 "Accessibility permission required": "需要「輔助使用」權限"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi 透過系統的「輔助使用」權限擷取滑鼠按鍵(後退 / 前進 / 手勢按鈕)並執行你綁定的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。"
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "請在「輔助使用」清單中啟用「OpenLogi Agent」——滑鼠掛鉤屬於背景代理程式，而非 OpenLogi 應用程式。如果它已顯示為啟用，請用 − 按鈕移除過時項目後重新加入。"
 "Open System Settings to grant access": "開啟系統設定授權"
 "Takes effect automatically once granted — no restart needed.": "授權後會自動生效,無需重新啟動。"
 "Not now (use DPI and other features only)": "稍後再說(僅使用 DPI 等功能)"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -50,6 +50,7 @@ _version: 1
 "Using Logi Options+? Quit it first — both apps compete for HID++ access.": "正在使用 Logi Options+？請先結束，兩個應用程式會爭用 HID++ 存取權限。"
 "Accessibility permission required": "需要「輔助使用」權限"
 "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.": "OpenLogi 會透過系統的「輔助使用」權限擷取滑鼠按鍵（後退 / 前進 / 手勢按鈕），並執行指派的操作。DPI、SmartShift 等直接與裝置通訊的功能不受影響。"
+"Enable “OpenLogi Agent” in the Accessibility list — the background agent owns the mouse hook, not the OpenLogi app. If it already shows as enabled, remove the stale entry with the − button and add it back.": "請在「輔助使用」清單中啟用「OpenLogi Agent」——滑鼠掛鉤屬於背景代理程式，而非 OpenLogi 應用程式。如果它已顯示為啟用，請用 − 按鈕移除過時項目後重新加入。"
 "Open System Settings to grant access": "開啟系統設定以授權"
 "Takes effect automatically once granted — no restart needed.": "授權後會自動生效，無需重新啟動。"
 "Not now (use DPI and other features only)": "稍後再說（僅使用 DPI 等功能）"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -295,6 +295,18 @@ impl AppView {
             )
             .child(
                 div()
+                    .max_w(px(440.))
+                    .text_sm()
+                    .text_color(pal.text_muted)
+                    .child(tr!(
+                        "Enable “OpenLogi Agent” in the Accessibility list — the \
+                         background agent owns the mouse hook, not the OpenLogi app. \
+                         If it already shows as enabled, remove the stale entry with \
+                         the − button and add it back."
+                    )),
+            )
+            .child(
+                div()
                     .id("open-accessibility")
                     .px_4()
                     .py_2()

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -504,11 +504,63 @@ fn spawn_agent() {
     };
     // Spawn the agent under its *own* macOS TCC identity, not the GUI's:
     // otherwise it inherits the GUI's responsibility and the Accessibility /
-    // Input-Monitoring grants the user gave the agent look missing (issue #214).
-    // `disclaim` is a no-op pass-through to `std::process::Command` off macOS.
-    match disclaim::Command::new(&path).spawn() {
-        Ok(_) => info!(path = %path.display(), "agent not running — launched it"),
+    // Input-Monitoring grants the user gave the agent look missing (#192, #214).
+    // The packaged helper goes through LaunchServices so it is its own TCC
+    // responsible process; everything else is a `disclaim` exec (a no-op
+    // pass-through to `std::process::Command` off macOS).
+    match launch_agent(&path) {
+        Ok(()) => info!(path = %path.display(), "agent not running — launched it"),
         Err(e) => warn!(error = %e, path = %path.display(), "could not launch the agent"),
+    }
+}
+
+/// Launch the agent binary at `path` under its own TCC identity.
+fn launch_agent(path: &std::path::Path) -> std::io::Result<()> {
+    // The packaged helper goes through LaunchServices so the agent is its own
+    // TCC responsible process; a direct exec attributes its Accessibility
+    // check to the parent GUI and the grant flips with the launch path (#192).
+    #[cfg(target_os = "macos")]
+    if let Some(bundle) = helper_bundle(path) {
+        return std::process::Command::new("/usr/bin/open")
+            .arg("-g")
+            .arg("-n")
+            .arg(bundle)
+            .spawn()
+            .map(|_| ());
+    }
+    // Any other layout (bare dev binary, Windows, Linux): exec the binary
+    // directly while disclaiming the GUI's TCC responsibility (#214).
+    disclaim::Command::new(path).spawn().map(|_| ())
+}
+
+/// The `OpenLogiAgent.app` root of a packaged helper binary, `None` for a bare dev binary.
+#[cfg(target_os = "macos")]
+fn helper_bundle(path: &std::path::Path) -> Option<&std::path::Path> {
+    let bundle = path.ancestors().nth(3)?;
+    (bundle.extension()? == "app").then_some(bundle)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use std::path::Path;
+
+    use super::helper_bundle;
+
+    #[test]
+    fn helper_bundle_resolves_only_the_packaged_layout() {
+        let packaged = Path::new(
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
+        );
+        assert_eq!(
+            helper_bundle(packaged),
+            Some(Path::new(
+                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app"
+            ))
+        );
+        assert_eq!(
+            helper_bundle(Path::new("target/debug/openlogi-agent")),
+            None
+        );
     }
 }
 


### PR DESCRIPTION
## Context
- fixes #192 — Accessibility toggle shows ON but the gate never clears
- the GUI exec'd the agent binary directly, so TCC attributed the agent's accessibility check to the GUI, while launchd starts attribute it to the agent itself — the grant silently depended on who launched the agent
- the packaged helper now launches via `open` (LaunchServices) so the agent is always its own responsible process
- the gate now names the "OpenLogi Agent" entry and explains removing a stale one

## Testing
- cargo test -p openlogi-gui passes (locale key parity + new helper_bundle test), clippy clean
- reproduced live with the packaged bundle layout: direct exec made the agent's responsible process the launching terminal and it reported granted off the terminal's grant, with no agent entry in TCC at all
- launched via open the agent is its own responsible process, prompts under its own "OpenLogi Agent" name
- end to end: granted that entry once, relaunched via open, agent logs accessibility granted and installs the hook
