### PR TITLE
feat(release): per-arch MSI installers + drop the GUI qualifier from Windows jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
           path: dist/*.dmg
 
   windows:
-    name: Windows GUI (${{ matrix.arch }})
+    name: Windows EXE (${{ matrix.arch }})
     # Both arches build on the x86_64 runner — arm64 as an MSVC cross-compile.
     # Native Arm runners are not an option: artifact-signing-action refuses to
     # run on them, while the signing itself is arch-agnostic over the PE file.
@@ -254,11 +254,12 @@ jobs:
           : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
           : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
 
-      # Windows ships the GUI as its single artifact, mirroring what the macOS
-      # DMG carries. The headless agent (ported in #167) joins the artifact set
-      # once it has been runtime-tested on a real Windows box; the CLI stays
-      # cargo-install-only, as on the other platforms.
-      - name: Build OpenLogi GUI
+      # The exe IS the product on Windows — no separate CLI artifact will ever
+      # ship there (cargo install covers that audience), so job and artifact
+      # names carry no GUI qualifier. The headless agent (ported in #167)
+      # joins the artifact set once it has been runtime-tested on a real
+      # Windows box.
+      - name: Build OpenLogi
         run: cargo build --release -p openlogi-gui --target ${{ matrix.target }}
 
       # Federated (passwordless) login. Requires an app registration whose federated
@@ -308,7 +309,7 @@ jobs:
             exit 1
           }
 
-      - name: Collect signed GUI artifact
+      - name: Collect signed exe artifact
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
@@ -322,6 +323,139 @@ jobs:
           path: dist/*.exe
           # 'warn' (the default) would let a no-exe job stay green, and publish
           # would then die at the by-name download instead of shipping DMG-only.
+          if-no-files-found: error
+
+  windows-msi:
+    name: Windows MSI (${{ matrix.arch }})
+    runs-on: windows-2025
+    needs: windows
+    # `needs` only orders the jobs; this gate runs the MSI legs even when the
+    # windows matrix AGGREGATE failed. The by-name artifact download below
+    # then fails exactly the leg whose exe never shipped, and the other arch
+    # keeps going.
+    if: ${{ !cancelled() }}
+    # No Rust build here — dotnet tool install + wix build + signing.
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            msi_platform: x64
+          - arch: arm64
+            msi_platform: arm64
+    permissions:
+      # Same OIDC setup as the windows job — the MSI is signed with the same
+      # Artifact Signing profile as the exe it wraps.
+      id-token: write
+      contents: read
+    environment: release
+    steps:
+      # Needed for packaging/windows/OpenLogi.wxs.
+      - uses: actions/checkout@v6
+
+      # The already-signed exe from this arch's windows leg.
+      - uses: actions/download-artifact@v8
+        with:
+          name: OpenLogi-windows-${{ matrix.arch }}
+          path: signed-exe
+
+      - name: Load Azure signing config from 1Password
+        id: azure_config
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AZURE_CLIENT_ID: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_CLIENT_ID
+          AZURE_TENANT_ID: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_TENANT_ID
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_SUBSCRIPTION_ID
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_SIGNING_ENDPOINT
+          AZURE_SIGNING_ACCOUNT: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_SIGNING_ACCOUNT
+          AZURE_CERT_PROFILE: ${{ secrets.OP_AZURE_SECRET_ITEM }}/AZURE_CERT_PROFILE
+
+      - name: Validate Azure signing config
+        shell: bash
+        env:
+          AZURE_CLIENT_ID: ${{ steps.azure_config.outputs.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
+          AZURE_SIGNING_ENDPOINT: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
+          AZURE_CERT_PROFILE: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
+        run: |
+          set -euo pipefail
+          : "${AZURE_CLIENT_ID:?Configure AZURE_CLIENT_ID in the Azure 1Password item}"
+          : "${AZURE_TENANT_ID:?Configure AZURE_TENANT_ID in the Azure 1Password item}"
+          : "${AZURE_SUBSCRIPTION_ID:?Configure AZURE_SUBSCRIPTION_ID in the Azure 1Password item}"
+          : "${AZURE_SIGNING_ENDPOINT:?Configure AZURE_SIGNING_ENDPOINT in the Azure 1Password item}"
+          : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
+          : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
+
+      - name: Install the WiX toolset
+        run: dotnet tool install --global wix --version "6.*"
+
+      - name: Build the MSI
+        shell: pwsh
+        run: |
+          # ProductVersion must be a numeric x.y.z; non-tag dispatches build a
+          # throwaway 0.0.0 package.
+          if ($env:GITHUB_REF_NAME -match '^v(\d+\.\d+\.\d+)$') {
+            $version = $Matches[1]
+          } else {
+            $version = '0.0.0'
+          }
+          $exe = Get-ChildItem signed-exe\*.exe | Select-Object -First 1
+          New-Item -ItemType Directory -Force -Path out | Out-Null
+          wix build packaging\windows\OpenLogi.wxs `
+            -arch ${{ matrix.msi_platform }} `
+            -d Version=$version `
+            -d ExeFile="$($exe.FullName)" `
+            -o out\OpenLogi.msi
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ steps.azure_config.outputs.AZURE_CLIENT_ID }}
+          tenant-id: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
+          subscription-id: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign OpenLogi.msi with Artifact Signing
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\out\OpenLogi.msi
+          # http on purpose — see the exe signing step.
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          cache-dependencies: false
+
+      - name: Verify the MSI is signed
+        shell: pwsh
+        run: |
+          $sig = Get-AuthenticodeSignature out\OpenLogi.msi
+          $sig | Format-List
+          # Same gate as the exe: NotSigned/HashMismatch are trust-store
+          # independent ship-blockers; NotTrusted/UnknownError stay log-only.
+          if ($null -eq $sig.SignerCertificate -or
+              "$($sig.Status)" -in 'NotSigned', 'HashMismatch') {
+            Write-Error "OpenLogi.msi Authenticode signature is invalid: $($sig.Status)"
+            exit 1
+          }
+
+      - name: Collect signed MSI artifact
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          # Renaming after signing is safe: the signature lives in the MSI.
+          $ref = $env:GITHUB_REF_NAME -replace '/', '-'
+          Copy-Item out\OpenLogi.msi "dist\OpenLogi-$ref-windows-${{ matrix.arch }}.msi"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: OpenLogi-windows-msi-${{ matrix.arch }}
+          path: dist/*.msi
           if-no-files-found: error
 
   release-notes:
@@ -396,11 +530,11 @@ jobs:
   publish:
     name: Publish release
     runs-on: ubuntu-latest
-    needs: [macos, windows, release-notes]
-    # Wait for the Windows job (so a successful .exe can be attached) but do NOT let
-    # its failure block the macOS release. `!cancelled()` removes the implicit
-    # "all needs succeeded" gate, so the required deps are checked explicitly here —
-    # windows is deliberately absent from this condition.
+    needs: [macos, windows, windows-msi, release-notes]
+    # Wait for the Windows jobs (so the successful .exe/.msi set can be attached)
+    # but do NOT let their failure block the macOS release. `!cancelled()` removes
+    # the implicit "all needs succeeded" gate, so the required deps are checked
+    # explicitly here — the windows jobs are deliberately absent from this condition.
     # NOTE: after such a partial publish, do NOT "re-run failed jobs" — publish
     # re-runs as windows' dependent and fails against the now-immutable release
     # (and would overwrite immutable-cached R2 objects). A missed .exe ships
@@ -449,18 +583,23 @@ jobs:
           # nothing instead of erroring on a literal pattern, so the DMGs are
           # hashed alone.
           shopt -s nullglob
-          sha256sum *.dmg *.exe > SHA256SUMS
+          sha256sum *.dmg *.exe *.msi > SHA256SUMS
 
       # softprops' `files` can't list a glob that matches nothing without
-      # tripping fail_on_unmatched_files, and the exe set now varies per arch
-      # leg — record whether any exe actually arrived.
+      # tripping fail_on_unmatched_files, and the exe/msi sets vary per arch
+      # leg — record what actually arrived.
       - name: Detect shipped Windows binaries
         id: windows_exes
         run: |
           if compgen -G 'dist/*.exe' > /dev/null; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "exe=true" >> "$GITHUB_OUTPUT"
           else
-            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "exe=false" >> "$GITHUB_OUTPUT"
+          fi
+          if compgen -G 'dist/*.msi' > /dev/null; then
+            echo "msi=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "msi=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Load static updater publishing config from 1Password
@@ -516,13 +655,14 @@ jobs:
           # newline mangled to a space — see the GitHub App key note above).
           # `tr -d` drops any wrapping whitespace before decoding.
           printf '%s' "$OPENLOGI_UPDATE_MINISIGN_SECRET_KEY" | tr -d '[:space:]' | base64 -d > "$key_file"
-          # The exes get the same minisign treatment as the DMGs: manual
-          # verification today, and the future Windows auto-updater needs the
-          # detached signatures to exist for every shipped version. nullglob:
-          # the exe set is best-effort per arch leg, so *.exe may match
-          # nothing; the DMGs are guaranteed by the publish gate.
+          # The Windows binaries get the same minisign treatment as the DMGs:
+          # manual verification today, and the future Windows auto-updater
+          # needs the detached signatures to exist for every shipped version.
+          # nullglob: the exe/msi sets are best-effort per arch leg, so the
+          # globs may match nothing; the DMGs are guaranteed by the publish
+          # gate.
           shopt -s nullglob
-          for artifact in dist/*.dmg dist/*.exe; do
+          for artifact in dist/*.dmg dist/*.exe dist/*.msi; do
             minisign -S -m "$artifact" -s "$key_file" -x "$artifact.minisig" -W
             minisign -V -m "$artifact" -P "$OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY" -x "$artifact.minisig"
           done
@@ -552,16 +692,19 @@ jobs:
           release_prefix="s3://${R2_BUCKET}/releases/${GITHUB_REF_NAME}"
           channel_manifest="s3://${R2_BUCKET}/channels/stable/latest.json"
 
-          # The exe's distribution channel is the GitHub Release; latest.json
-          # is still dmg-only, so nothing in the updater bucket references the
-          # exe or its minisig — keep both out of the immutable releases/
-          # prefix until the Windows auto-updater lands. SHA256SUMS still
-          # lists the exes — it describes the GitHub Release's asset set.
+          # The Windows binaries' distribution channel is the GitHub Release;
+          # latest.json is still dmg-only, so nothing in the updater bucket
+          # references the exe/msi or their minisigs — keep them all out of
+          # the immutable releases/ prefix until the Windows auto-updater
+          # lands. SHA256SUMS still lists them — it describes the GitHub
+          # Release's asset set.
           aws s3 cp dist/ "$release_prefix/" \
             --recursive \
             --exclude latest.json \
             --exclude "*.exe" \
             --exclude "*.exe.minisig" \
+            --exclude "*.msi" \
+            --exclude "*.msi.minisig" \
             --cache-control "public, max-age=31536000, immutable" \
             --endpoint-url "$endpoint"
 
@@ -584,7 +727,8 @@ jobs:
             dist/*.dmg
             dist/*.minisig
             dist/SHA256SUMS
-            ${{ steps.windows_exes.outputs.present == 'true' && 'dist/*.exe' || '' }}
+            ${{ steps.windows_exes.outputs.exe == 'true' && 'dist/*.exe' || '' }}
+            ${{ steps.windows_exes.outputs.msi == 'true' && 'dist/*.msi' || '' }}
           fail_on_unmatched_files: true
 
   homebrew-tap:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,7 +393,10 @@ jobs:
           : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
 
       - name: Install the WiX toolset
-        run: dotnet tool install --global wix --version "6.*"
+        # Pinned exactly: a WiX point release can silently change the produced
+        # MSI (validation, cab layout), and nothing in CI installs the MSI, so
+        # drift would only surface on end-user machines. Bump deliberately.
+        run: dotnet tool install --global wix --version 6.0.2
 
       - name: Build the MSI
         shell: pwsh
@@ -406,6 +409,14 @@ jobs:
             $version = '0.0.0'
           }
           $exe = Get-ChildItem signed-exe\*.exe | Select-Object -First 1
+          # Upstream invariants (upload's if-no-files-found: error, the
+          # by-name download) should make this unreachable; the guard turns a
+          # confusing "$null.FullName -> empty -d ExeFile" wix error into a
+          # named cause if those invariants ever shift.
+          if ($null -eq $exe) {
+            Write-Error "No signed exe found in signed-exe\ — nothing to package"
+            exit 1
+          }
           New-Item -ItemType Directory -Force -Path out | Out-Null
           wix build packaging\windows\OpenLogi.wxs `
             -arch ${{ matrix.msi_platform }} `

--- a/.github/workflows/windows-sign-dryrun.yml
+++ b/.github/workflows/windows-sign-dryrun.yml
@@ -74,7 +74,7 @@ jobs:
           : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
           : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
 
-      - name: Build OpenLogi GUI
+      - name: Build OpenLogi
         run: cargo build --release -p openlogi-gui --target ${{ matrix.target }}
 
       - name: Azure login (OIDC)

--- a/packaging/windows/OpenLogi.wxs
+++ b/packaging/windows/OpenLogi.wxs
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Windows Installer authoring for the OpenLogi MSI (built with the WiX
+  toolset v6 by release.yml's `windows-msi` job).
+
+  - Per-user scope: installs to %LocalAppData%\Programs\OpenLogi without
+    elevation; raw HID access and the input hook need no admin rights.
+  - The packaged exe is the already-Authenticode-signed build from the
+    `windows` job; the MSI itself is signed on top by the same job.
+  - Build-time defines (passed via `wix build -d`):
+      Version  numeric x.y.z ProductVersion (0.0.0 on non-tag dispatches)
+      ExeFile  path to the signed openlogi-gui exe to package
+-->
+
+<!--
+  One UpgradeCode per architecture, fixed forever: Windows Installer treats
+  x64 and arm64 packages both as "64-bit", so a shared UpgradeCode would let
+  FindRelatedProducts cross-grade one architecture over the other.
+-->
+<?if $(sys.BUILDARCH) = arm64 ?>
+  <?define UpgradeCode = "2A989A66-36FE-4999-ACE2-3E79AE02D12A" ?>
+<?else?>
+  <?define UpgradeCode = "981D0C70-179E-4EE8-8F1E-0EB6877EAE94" ?>
+<?endif?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="OpenLogi"
+           Manufacturer="AprilNEA"
+           Version="$(var.Version)"
+           UpgradeCode="$(var.UpgradeCode)"
+           Language="1033"
+           Scope="perUser"
+           Compressed="yes">
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of OpenLogi is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <StandardDirectory Id="LocalAppDataFolder">
+      <Directory Id="ProgramsFolder" Name="Programs">
+        <Directory Id="INSTALLFOLDER" Name="OpenLogi" />
+      </Directory>
+    </StandardDirectory>
+
+    <ComponentGroup Id="App" Directory="INSTALLFOLDER">
+      <Component Id="MainExecutable">
+        <!-- Installed as plain OpenLogi.exe: inside the install dir the file
+             name is the product name. -->
+        <File Id="OpenLogiExe" Name="OpenLogi.exe" Source="$(var.ExeFile)" KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <!-- Shortcuts cannot be a component KeyPath; the HKCU marker stands in,
+           which also fits the per-user scope. -->
+      <Component Id="StartMenuShortcut">
+        <Shortcut Id="OpenLogiShortcut"
+                  Name="OpenLogi"
+                  Target="[INSTALLFOLDER]OpenLogi.exe"
+                  WorkingDirectory="INSTALLFOLDER" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\OpenLogi"
+                       Name="Installed"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </StandardDirectory>
+
+    <Feature Id="Main">
+      <ComponentGroupRef Id="App" />
+      <ComponentRef Id="StartMenuShortcut" />
+    </Feature>
+
+    <Property Id="ARPURLINFOABOUT" Value="https://openlogi.org" />
+    <Property Id="ARPHELPLINK" Value="https://github.com/AprilNEA/OpenLogi" />
+  </Package>
+</Wix>


### PR DESCRIPTION
## What

The Windows side of the release pipeline becomes **four jobs**:

1. **Windows EXE (x86_64)** — was `Windows GUI (x86_64)`
2. **Windows EXE (arm64)** — was `Windows GUI (arm64)`
3. **Windows MSI (x86_64)** — new
4. **Windows MSI (arm64)** — new

The GUI qualifier is gone from job/step names: the exe **is** the product on Windows — no CLI artifact will ever ship there (cargo install covers that audience), so there is nothing to distinguish from.

## The MSI job

`windows-msi` (matrix over arch, `needs: windows`, `if: !cancelled()`) wraps each arch's **already-signed exe** in a WiX-built MSI and signs the MSI itself with the same Artifact Signing profile (signtool handles `.msi` via the MSI SIP). New authoring at `packaging/windows/OpenLogi.wxs`:

- **Per-user scope**: installs to `%LocalAppData%\Programs\OpenLogi` without elevation (raw HID + the input hook need no admin); Start Menu shortcut; `MajorUpgrade` with downgrade guard; ARP links.
- Installed file is plain **`OpenLogi.exe`** — inside the install dir the filename is the product name.
- **Distinct UpgradeCode per arch**: Windows Installer treats x64 and arm64 both as "64-bit", so a shared UpgradeCode would let `FindRelatedProducts` cross-grade one architecture over the other.
- `ProductVersion` parses from the `v*` tag; non-tag dispatches build a throwaway `0.0.0` package, so the publish-free manual dispatch validates the MSI path too.
- Toolchain: `dotnet tool install --global wix` (v6, in the runner's preinstalled .NET) + `wix build -arch x64|arm64`. No commercial packagers needed for a one-file package.

Per-leg semantics match the exes: a failed exe leg fails only that arch's MSI leg (the by-name artifact download is the cut-out); whatever was built+signed+verified ships.

## publish changes

- `needs` gains `windows-msi` (so the MSI artifacts exist before download) — but the gate still doesn't depend on any windows result; DMGs publish regardless.
- `SHA256SUMS` and the minisign loop cover `*.msi`; softprops attaches exes and MSIs independently, presence-gated; R2 excludes `*.msi`/`*.msi.minisig` like the exes (latest.json is still dmg-only).

## Not validated yet

WiX authoring is CI-validated only from Linux/macOS (`xmllint` well-formedness); the real check is a **manual release dispatch** after merge — it now exercises EXE *and* MSI on both arches, publish-free, and the run artifacts are installable for VM testing (per-user MSI on the ARM box is the original repro environment). Known polish gaps, deliberate: no app icon / VERSIONINFO in the exe yet (tracked follow-up), no embedded license dialog, agent not yet packaged (joins the MSI once runtime-tested, with a `StartupTask`-equivalent autostart entry).

Relation to #209: a signed MSI sidesteps MSIX's container constraints (no registry/file virtualization, no read-only install dir, no Publisher-DN coupling), so it can ship well before the MSIX work.