### PR TITLE
fix: stop flashing the permission gate and empty state at startup

### DIFF
--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -18,15 +18,26 @@ use serde::{Deserialize, Serialize};
 /// independent of the crate version. The GUI checks it via
 /// [`Agent::protocol_version`] on connect and refuses to drive a mismatch
 /// (transient only: both binaries ship in one `.app` and update atomically).
-pub const PROTOCOL_VERSION: u32 = 1;
+///
+/// v2: [`AgentStatus::inventory_ready`] added.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Agent health the GUI surfaces: the Accessibility gate, whether the hook is
 /// live, and the autostart toggle state.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "a status snapshot of independent flags, not a state machine — folding them into enums would only complicate the wire format"
+)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentStatus {
     pub accessibility_granted: bool,
     pub hook_installed: bool,
     pub launch_at_login: bool,
+    /// Whether the agent's first device enumeration has completed. While
+    /// `false`, an empty [`Agent::inventory`] means "still scanning", not "no
+    /// devices" — the GUI keeps its scanning state instead of declaring the
+    /// device list empty.
+    pub inventory_ready: bool,
     pub protocol_version: u32,
     pub agent_version: String,
 }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -70,6 +70,11 @@ pub struct Orchestrator {
     /// GUI's `inventory()` polls without re-enumerating (the agent owns all
     /// device I/O).
     last_inventory: Vec<DeviceInventory>,
+    /// Whether [`Self::refresh_inventory`] has run at least once. Until then
+    /// [`Self::last_inventory`] is empty because nothing has been *checked*
+    /// yet, not because no devices exist — the IPC `status` reports this so
+    /// the GUI can tell the two apart.
+    enumerated: bool,
     shared: SharedRuntime,
 }
 
@@ -96,6 +101,7 @@ impl Orchestrator {
             current: 0,
             current_app: None,
             last_inventory: Vec::new(),
+            enumerated: false,
             shared,
         };
         orch.rebuild();
@@ -168,6 +174,9 @@ impl Orchestrator {
     /// index, so running it every 2s tick on an unchanged set would snap DPI
     /// back to `preset[0]` (and burn three `RwLock` writes) for nothing.
     pub fn refresh_inventory(&mut self, inventories: &[DeviceInventory]) {
+        // Even an empty snapshot is a *completed* enumeration — the watcher
+        // skips failed ticks — so the device set is now known either way.
+        self.enumerated = true;
         self.last_inventory = inventories.to_vec();
         let devices = build_devices(inventories);
         let changed = devices.len() != self.devices.len()
@@ -206,6 +215,13 @@ impl Orchestrator {
     #[must_use]
     pub fn inventory(&self) -> Vec<DeviceInventory> {
         self.last_inventory.clone()
+    }
+
+    /// Whether the first device enumeration has completed (for the IPC
+    /// `status` poll) — distinguishes "still scanning" from "no devices".
+    #[must_use]
+    pub fn inventory_ready(&self) -> bool {
+        self.enumerated
     }
 
     /// Whether autostart is enabled in the current config (for IPC `status`).
@@ -312,5 +328,23 @@ fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
     match lock.write() {
         Ok(mut guard) => *guard = value,
         Err(e) => warn!(error = %e, lock = name, "lock poisoned — keeping stale value"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Orchestrator;
+    use openlogi_core::config::Config;
+
+    /// An *empty* snapshot still flips `inventory_ready`: the watcher only
+    /// forwards completed enumerations, so "checked and found nothing" must not
+    /// be reported as "still scanning" — that's the whole distinction the flag
+    /// exists to carry.
+    #[test]
+    fn empty_refresh_marks_inventory_ready() {
+        let mut orch = Orchestrator::new(Config::default());
+        assert!(!orch.inventory_ready());
+        orch.refresh_inventory(&[]);
+        assert!(orch.inventory_ready());
     }
 }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -8,6 +8,7 @@
 
 mod launch_agent;
 mod pairing;
+mod self_restart;
 mod server;
 #[cfg(target_os = "macos")]
 mod status_item;
@@ -47,6 +48,11 @@ fn main() {
             return;
         }
     };
+
+    // Watch our own executable and restart as the new image when an app update
+    // replaces it — see `self_restart`. Only the lock-holding (real) agent
+    // watches, so a losing duplicate can't restart anything.
+    self_restart::spawn();
 
     let config = Config::load_or_default().unwrap_or_else(|e| {
         warn!(error = %e, "could not load config.toml; using defaults");

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -79,7 +79,10 @@ fn restart(path: &Path) -> ! {
         path = %path.display(),
         "executable changed on disk — restarting as the new binary"
     );
-    let err = std::process::Command::new(path).exec();
+    // Forward our argv (none today) so a future flag survives the restart.
+    let err = std::process::Command::new(path)
+        .args(std::env::args_os().skip(1))
+        .exec();
     warn!(error = %err, "exec of the updated agent failed — exiting for the respawner");
     std::process::exit(1);
 }

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -1,0 +1,98 @@
+//! Restart the agent when its on-disk executable is replaced.
+//!
+//! An app update (Homebrew cask, the in-app updater, a dev rebuild) swaps the
+//! bundle on disk while the old agent keeps running. launchd only restarts the
+//! process when it *exits*, so nothing would pick up the new binary until the
+//! next login — and a GUI launched from the new bundle refuses the old agent's
+//! IPC protocol on a version bump, sitting on its connecting screen with no way
+//! forward. Watching our own executable and replacing the process image the
+//! moment it changes keeps "the running agent is the installed binary" true
+//! within one tick, with no launchd or GUI involvement — remapping continues
+//! even in setups where nothing would respawn a plain exit (autostart off,
+//! GUI closed).
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use tracing::{info, warn};
+
+/// How often to stat the executable: one `metadata` call per tick — noise next
+/// to the 2 s HID enumerate — while keeping the update-to-restart window short.
+const PERIOD: Duration = Duration::from_secs(10);
+
+/// What "the binary changed" means: a different size or mtime at the same
+/// path. Every real update path rewrites the file, so content hashing would
+/// buy nothing.
+type Fingerprint = (u64, SystemTime);
+
+fn fingerprint(path: &Path) -> Option<Fingerprint> {
+    let meta = std::fs::metadata(path).ok()?;
+    Some((meta.len(), meta.modified().ok()?))
+}
+
+/// Spawn the watcher thread. The executable path and its baseline fingerprint
+/// are resolved once, up front; if either fails the watch is disabled (logged)
+/// rather than guessing at a path.
+pub fn spawn() {
+    let Ok(path) = std::env::current_exe() else {
+        warn!("could not resolve own executable — binary-update watch disabled");
+        return;
+    };
+    let Some(baseline) = fingerprint(&path) else {
+        warn!(
+            path = %path.display(),
+            "could not stat own executable — binary-update watch disabled"
+        );
+        return;
+    };
+    let spawn_result = std::thread::Builder::new()
+        .name("openlogi-binary-watch".into())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(PERIOD);
+                // A vanished file is *not* a change: mid-replace the old inode
+                // is unlinked before the new file lands, so wait for a readable
+                // replacement before acting.
+                if fingerprint(&path).is_some_and(|now| now != baseline) {
+                    restart(&path);
+                }
+            }
+        });
+    if let Err(e) = spawn_result {
+        warn!(error = %e, "could not spawn the binary-update watch thread");
+    }
+}
+
+/// Replace this process with the new binary at `path`.
+///
+/// `exec` keeps the pid, so launchd's bookkeeping — including the
+/// `SuccessfulExit: false` semantics that make the tray's Quit final — is
+/// untouched, and no external respawner is needed. The singleton file lock and
+/// the IPC socket close with the old image (Rust opens fds `CLOEXEC`) and are
+/// re-acquired by the new one; the listener unlinks the stale socket file on
+/// bind. If `exec` itself fails, exit non-zero so launchd's crash-respawn
+/// (where installed) starts the new binary instead.
+#[cfg(unix)]
+fn restart(path: &Path) -> ! {
+    use std::os::unix::process::CommandExt as _;
+    info!(
+        path = %path.display(),
+        "executable changed on disk — restarting as the new binary"
+    );
+    let err = std::process::Command::new(path).exec();
+    warn!(error = %err, "exec of the updated agent failed — exiting for the respawner");
+    std::process::exit(1);
+}
+
+/// Windows has no `exec`: exit cleanly and let the GUI's socket-down spawn
+/// retry (or the next login's autostart) start the replaced binary. A
+/// spawn-before-exit handover would lose the race against the singleton lock
+/// this process still holds.
+#[cfg(windows)]
+fn restart(path: &Path) -> ! {
+    info!(
+        path = %path.display(),
+        "executable changed on disk — exiting so the new binary can start"
+    );
+    std::process::exit(0);
+}

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -43,10 +43,15 @@ impl Agent for AgentServer {
     }
 
     async fn status(self, _: Context) -> AgentStatus {
+        let (launch_at_login, inventory_ready) = {
+            let orch = self.orchestrator.lock().await;
+            (orch.launch_at_login(), orch.inventory_ready())
+        };
         AgentStatus {
             accessibility_granted: Hook::has_accessibility(),
             hook_installed: self.hook_installed.load(Ordering::Relaxed),
-            launch_at_login: self.orchestrator.lock().await.launch_at_login(),
+            launch_at_login,
+            inventory_ready,
             protocol_version: PROTOCOL_VERSION,
             agent_version: env!("CARGO_PKG_VERSION").to_string(),
         }

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Nødvendig for at læse HID++-data, inklusive Bluetooth-direkte mus."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Tillader OpenLogi at bruge CoreBluetooth (ikke nødvendigt for HID-adgang)."
 "Scanning for devices…": "Søger efter enheder…"
+"Connecting to the background service…": "Opretter forbindelse til baggrundstjenesten…"
 "Thumb Wheel Up": "Tommelfingerhjul op"
 "Thumb Wheel Down": "Tommelfingerhjul ned"
 "Do Nothing": "Gør ingenting"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Erforderlich zum Lesen von HID++-Daten, einschließlich Bluetooth-Direktmäusen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Erlaubt OpenLogi die Nutzung von CoreBluetooth (für HID-Zugriff nicht erforderlich)."
 "Scanning for devices…": "Suche nach Geräten…"
+"Connecting to the background service…": "Verbindung zum Hintergrunddienst wird hergestellt…"
 "Thumb Wheel Up": "Daumenrad nach oben"
 "Thumb Wheel Down": "Daumenrad nach unten"
 "Do Nothing": "Nichts tun"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Απαιτείται για την ανάγνωση δεδομένων HID++, συμπεριλαμβανομένων ποντικιών απευθείας μέσω Bluetooth."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Επιτρέπει στο OpenLogi να χρησιμοποιεί το CoreBluetooth (δεν απαιτείται για πρόσβαση HID)."
 "Scanning for devices…": "Αναζήτηση συσκευών…"
+"Connecting to the background service…": "Σύνδεση με την υπηρεσία παρασκηνίου…"
 "Thumb Wheel Up": "Πλαϊνός τροχός πάνω"
 "Thumb Wheel Down": "Πλαϊνός τροχός κάτω"
 "Do Nothing": "Καμία ενέργεια"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Needed to read HID++ data, including Bluetooth-direct mice."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Allows OpenLogi to use CoreBluetooth (not required for HID access)."
 "Scanning for devices…": "Scanning for devices…"
+"Connecting to the background service…": "Connecting to the background service…"
 "Thumb Wheel Up": "Thumb Wheel Up"
 "Thumb Wheel Down": "Thumb Wheel Down"
 "Do Nothing": "Do Nothing"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necesario para leer datos HID++, incluidos los ratones Bluetooth directos."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permite que OpenLogi use CoreBluetooth (no es necesario para el acceso HID)."
 "Scanning for devices…": "Buscando dispositivos…"
+"Connecting to the background service…": "Conectando con el servicio en segundo plano…"
 "Thumb Wheel Up": "Rueda lateral hacia arriba"
 "Thumb Wheel Down": "Rueda lateral hacia abajo"
 "Do Nothing": "No hacer nada"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Tarvitaan HID++-tietojen lukemiseen, mukaan lukien suoraan Bluetoothiin liitetyt hiiret."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Sallii OpenLogin käyttää CoreBluetoothia (ei vaadita HID-käyttöön)."
 "Scanning for devices…": "Etsitään laitteita…"
+"Connecting to the background service…": "Yhdistetään taustapalveluun…"
 "Thumb Wheel Up": "Peukalorulla ylös"
 "Thumb Wheel Down": "Peukalorulla alas"
 "Do Nothing": "Älä tee mitään"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Requis pour lire les données HID++, y compris les souris Bluetooth directes."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permet à OpenLogi d'utiliser CoreBluetooth (non requis pour l'accès HID)."
 "Scanning for devices…": "Recherche d'appareils…"
+"Connecting to the background service…": "Connexion au service d'arrière-plan…"
 "Thumb Wheel Up": "Molette latérale vers le haut"
 "Thumb Wheel Down": "Molette latérale vers le bas"
 "Do Nothing": "Ne rien faire"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necessario per leggere i dati HID++, inclusi i mouse con connessione diretta Bluetooth."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Consente a OpenLogi di utilizzare CoreBluetooth (non richiesto per l'accesso HID)."
 "Scanning for devices…": "Scansione dispositivi in corso…"
+"Connecting to the background service…": "Connessione al servizio in background…"
 "Thumb Wheel Up": "Rotella pollice su"
 "Thumb Wheel Down": "Rotella pollice giù"
 "Do Nothing": "Non fare nulla"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Bluetooth 直結マウスを含む HID++ データの読み取りに必要です。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "OpenLogi が CoreBluetooth を使用できるようにします（HID アクセスには不要）。"
 "Scanning for devices…": "デバイスを検索中…"
+"Connecting to the background service…": "バックグラウンドサービスに接続中…"
 "Thumb Wheel Up": "サムホイール 上"
 "Thumb Wheel Down": "サムホイール 下"
 "Do Nothing": "何もしない"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "블루투스 직접 연결 마우스를 포함한 HID++ 데이터를 읽는 데 필요합니다."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "OpenLogi가 CoreBluetooth를 사용할 수 있도록 허용합니다(HID 접근에는 필요하지 않음)."
 "Scanning for devices…": "기기 검색 중…"
+"Connecting to the background service…": "백그라운드 서비스에 연결하는 중…"
 "Thumb Wheel Up": "썸휠 위로"
 "Thumb Wheel Down": "썸휠 아래로"
 "Do Nothing": "동작 없음"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Kreves for å lese HID++-data, inkludert Bluetooth-direkte mus."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Lar OpenLogi bruke CoreBluetooth (ikke nødvendig for HID-tilgang)."
 "Scanning for devices…": "Søker etter enheter…"
+"Connecting to the background service…": "Kobler til bakgrunnstjenesten…"
 "Thumb Wheel Up": "Tommelhjul opp"
 "Thumb Wheel Down": "Tommelhjul ned"
 "Do Nothing": "Gjør ingenting"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Vereist om HID++-gegevens te lezen, inclusief Bluetooth-directe muizen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Staat OpenLogi toe CoreBluetooth te gebruiken (niet vereist voor HID-toegang)."
 "Scanning for devices…": "Apparaten zoeken…"
+"Connecting to the background service…": "Verbinden met de achtergrondservice…"
 "Thumb Wheel Up": "Duimwiel omhoog"
 "Thumb Wheel Down": "Duimwiel omlaag"
 "Do Nothing": "Niets doen"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Wymagane do odczytu danych HID++, w tym myszy podłączonych bezpośrednio przez Bluetooth."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Pozwala aplikacji OpenLogi używać CoreBluetooth (niewymagane do dostępu HID)."
 "Scanning for devices…": "Wyszukiwanie urządzeń…"
+"Connecting to the background service…": "Łączenie z usługą działającą w tle…"
 "Thumb Wheel Up": "Rolka kciukowa w górę"
 "Thumb Wheel Down": "Rolka kciukowa w dół"
 "Do Nothing": "Nic nie rób"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necessário para ler dados HID++, incluindo mouses Bluetooth diretos."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permite que o OpenLogi use o CoreBluetooth (não necessário para acesso HID)."
 "Scanning for devices…": "Procurando dispositivos…"
+"Connecting to the background service…": "Conectando ao serviço em segundo plano…"
 "Thumb Wheel Up": "Roda do Polegar para Cima"
 "Thumb Wheel Down": "Roda do Polegar para Baixo"
 "Do Nothing": "Não Fazer Nada"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necessário para ler dados HID++, incluindo ratos Bluetooth diretos."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permite que o OpenLogi use o CoreBluetooth (não necessário para acesso HID)."
 "Scanning for devices…": "A procurar dispositivos…"
+"Connecting to the background service…": "A ligar ao serviço em segundo plano…"
 "Thumb Wheel Up": "Roda de polegar para cima"
 "Thumb Wheel Down": "Roda de polegar para baixo"
 "Do Nothing": "Não fazer nada"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Требуется для чтения данных HID++, включая мыши с прямым Bluetooth-подключением."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Позволяет OpenLogi использовать CoreBluetooth (не требуется для доступа к HID)."
 "Scanning for devices…": "Сканирование устройств…"
+"Connecting to the background service…": "Подключение к фоновой службе…"
 "Thumb Wheel Up": "Колесо большого пальца вверх"
 "Thumb Wheel Down": "Колесо большого пальца вниз"
 "Do Nothing": "Ничего не делать"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Krävs för att läsa HID++-data, inklusive Bluetooth-direktanslutna möss."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Tillåter OpenLogi att använda CoreBluetooth (krävs inte för HID-åtkomst)."
 "Scanning for devices…": "Söker efter enheter…"
+"Connecting to the background service…": "Ansluter till bakgrundstjänsten…"
 "Thumb Wheel Up": "Tumhjul upp"
 "Thumb Wheel Down": "Tumhjul ned"
 "Do Nothing": "Gör ingenting"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "读取 HID++ 数据所需，包括蓝牙直连鼠标。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "允许 OpenLogi 使用 CoreBluetooth（HID 访问不需要）。"
 "Scanning for devices…": "正在扫描设备…"
+"Connecting to the background service…": "正在连接后台服务…"
 "Thumb Wheel Up": "拇指滚轮向上"
 "Thumb Wheel Down": "拇指滚轮向下"
 "Do Nothing": "不执行任何操作"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "讀取 HID++ 數據所需，包括藍牙直連滑鼠。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。"
 "Scanning for devices…": "正在掃描裝置…"
+"Connecting to the background service…": "正在連接背景服務…"
 "Thumb Wheel Up": "拇指滾輪向上"
 "Thumb Wheel Down": "拇指滾輪向下"
 "Do Nothing": "不執行任何操作"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -193,6 +193,7 @@ _version: 1
 "Needed to read HID++ data, including Bluetooth-direct mice.": "需要此權限才能讀取 HID++ 資料，包括藍牙直連滑鼠。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。"
 "Scanning for devices…": "正在掃描裝置…"
+"Connecting to the background service…": "正在連線背景服務…"
 "Thumb Wheel Up": "拇指滾輪向上"
 "Thumb Wheel Down": "拇指滾輪向下"
 "Do Nothing": "不執行任何操作"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -7,10 +7,11 @@ use gpui::{
     prelude::FluentBuilder as _, px, relative, rgb,
 };
 use gpui_component::{
-    Icon, IconName,
+    Icon, IconName, Sizable as _,
     description_list::{DescriptionItem, DescriptionList},
     h_flex,
     scroll::ScrollableElement as _,
+    spinner::Spinner,
     tab::TabBar,
     tooltip::Tooltip,
     v_flex,
@@ -343,9 +344,20 @@ impl Render for AppView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
 
-        let granted = cx
+        // The agent is the source of truth for both the permission state and
+        // the device list, and neither is known until its first IPC snapshot
+        // lands. Hold a neutral connecting frame until then: rendering the
+        // permission gate (and then the empty state) off the assumed-denied
+        // defaults flashed both screens at every already-set-up user on
+        // launch. A missing global gets the same neutral frame — it's equally
+        // "nothing is known yet".
+        let Some(granted) = cx
             .try_global::<AppState>()
-            .is_none_or(|s| s.accessibility_granted);
+            .and_then(|s| s.accessibility_granted)
+        else {
+            window.set_window_title("OpenLogi");
+            return connecting_view(pal);
+        };
         if !granted && !self.accessibility_dismissed {
             window.set_window_title("OpenLogi");
             return Self::accessibility_gate(pal, cx);
@@ -1259,6 +1271,30 @@ fn relative_percent(value: u8) -> gpui::DefiniteLength {
 
 fn file_url(path: &std::path::Path) -> String {
     format!("file://{}", path.to_string_lossy().replace(' ', "%20"))
+}
+
+/// Whole-window placeholder shown from window-open until the agent's first
+/// IPC snapshot lands — normally a fraction of a second, or for as long as the
+/// agent is genuinely unreachable (crashed / not yet spawned), where "still
+/// connecting" is the only true statement. Deliberately neutral: no chrome, no
+/// claims about permissions or devices. The spinner's repeating animation only
+/// runs while this view is mounted, so it can't pin the render loop once the
+/// real UI replaces it.
+fn connecting_view(pal: Palette) -> AnyElement {
+    v_flex()
+        .size_full()
+        .bg(pal.bg)
+        .items_center()
+        .justify_center()
+        .gap_3()
+        .child(Spinner::new().large().color(pal.text_muted))
+        .child(
+            div()
+                .text_sm()
+                .text_color(pal.text_muted)
+                .child(tr!("Connecting to the background service…")),
+        )
+        .into_any_element()
 }
 
 /// Body shown when no device is connected. The inventory watcher keeps polling

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -261,9 +261,13 @@ fn main() -> Result<()> {
                             let cache = asset::AssetResolver::new();
                             cx.update_global::<AppState, _>(|state, _| {
                                 state.refresh_inventories(&update.inventory, &cache);
-                                state.scanning = false;
+                                // A freshly-(re)started agent serves an empty
+                                // inventory until its own first enumeration
+                                // completes; only its say-so downgrades the
+                                // empty state from "Scanning…" to "No devices".
+                                state.scanning = !update.status.inventory_ready;
                                 state.accessibility_granted =
-                                    update.status.accessibility_granted;
+                                    Some(update.status.accessibility_granted);
                             });
                             cx.refresh_windows();
                         });

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -103,14 +103,17 @@ pub struct AppState {
     /// The hotspot the user most recently armed by clicking. Drives the
     /// "selected button" outline on the mouse model and the popover content.
     pub active_button: Option<ButtonId>,
-    /// Whether the process holds macOS Accessibility permission. Drives the
-    /// permission gate; flipped by the accessibility watcher when the user
-    /// grants access. Always `true` on platforms without the concept.
-    pub accessibility_granted: bool,
-    /// Whether the first device enumeration is still in flight. Startup no
-    /// longer blocks on enumeration (see `main`); this drives the "Scanning…"
-    /// vs "No devices connected" empty state and is cleared once the inventory
-    /// watcher delivers its first snapshot.
+    /// Whether the *agent* holds macOS Accessibility permission, or `None`
+    /// until the first IPC status snapshot arrives. Drives the permission
+    /// gate — which must not flash "not granted" at an authorized user while
+    /// the answer is simply not in yet, so `None` renders as a connecting
+    /// placeholder instead (see `AppView::render`).
+    pub accessibility_granted: Option<bool>,
+    /// Whether the agent's first device enumeration is still in flight. Drives
+    /// the "Scanning…" vs "No devices connected" empty state; tracks
+    /// `AgentStatus::inventory_ready` on every IPC snapshot, so an empty
+    /// device list reads as "no devices" only once the agent has actually
+    /// completed an enumeration.
     pub scanning: bool,
     /// Bindings for the *currently selected* device. Reloaded whenever the
     /// carousel selection changes.
@@ -199,7 +202,10 @@ impl AppState {
             active_button: None,
             // Updated from the agent's IPC `status` poll; the GUI no longer runs
             // the hook, so it can't meaningfully query Accessibility itself.
-            accessibility_granted: false,
+            // `None` (not `false`) until that first poll lands: rendering the
+            // permission gate off an assumed denial flashed it at every
+            // already-authorized user on launch.
+            accessibility_granted: None,
             scanning: true,
             button_bindings: BTreeMap::new(),
             gesture_bindings: BTreeMap::new(),

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -249,13 +249,16 @@ fn permissions_page(pal: Palette) -> SettingPage {
                     tr!("Needed for gesture and button remapping (event tap)."),
                     Permission::Accessibility,
                     |cx| {
-                        if cx
+                        // The agent owns the hook, so this is *its* grant,
+                        // reported over IPC; before the first snapshot the
+                        // state is genuinely unknown, not denied.
+                        match cx
                             .try_global::<AppState>()
-                            .is_some_and(|s| s.accessibility_granted)
+                            .and_then(|s| s.accessibility_granted)
                         {
-                            PermissionStatus::Granted
-                        } else {
-                            PermissionStatus::Denied
+                            Some(true) => PermissionStatus::Granted,
+                            Some(false) => PermissionStatus::Denied,
+                            None => PermissionStatus::Unknown,
                         }
                     },
                     pal,


### PR DESCRIPTION
## Problem

On every launch the main window briefly flashes two screens that are both false for a set-up user:

1. **"Accessibility permission required"** — `AppState` starts with `accessibility_granted: false` and the window opens before the first agent IPC poll lands, so the gate renders for the first frames of every single launch.
2. **"No devices connected"** — the first poll cleared `scanning` unconditionally, but a freshly-(re)started agent serves an *empty* inventory until its own first HID enumeration completes, so users see "No devices connected" while their devices are about to appear.

## Fix

**GUI** — `accessibility_granted` becomes `Option<bool>`; until the first agent snapshot arrives the window holds a neutral connecting frame (spinner + "Connecting to the background service…") instead of rendering states it can't know yet. That frame is also the honest screen while the agent is genuinely unreachable. The Settings permission row maps the unknown state to `Unknown` rather than pretending denial.

**IPC (protocol v2)** — `AgentStatus` gains `inventory_ready`, set by the orchestrator's first `refresh_inventory` (an empty snapshot still counts — the watcher only forwards completed enumerations). The GUI's `scanning` now tracks it, so a fresh agent's empty list reads "Scanning for devices…", not "No devices connected".

**Agent self-restart** — what makes the first-ever protocol bump shippable: an app update replaces the bundle while the old agent keeps running, and launchd only restarts it on exit, so a v2 GUI would refuse the stale v1 agent and sit on the connecting screen until logout. The agent now stats its own executable every 10 s and `exec`s the new image when it changes — same pid, no respawner needed (covers autostart-off + GUI-closed setups), and the `SuccessfulExit: false` / tray-Quit semantics stay intact. Windows (no `exec`, no shipped agent today) exits cleanly and relies on the GUI's spawn retry or next login.

New i18n string added to all 21 locales at the same ordered position.

## Startup now

| Agent state | Before | After |
|---|---|---|
| running, devices paired | gate flash → empty flash → gallery | connecting (≪1 s) → gallery |
| just (re)started | gate flash → "No devices connected" | connecting → "Scanning for devices…" → gallery |
| unreachable | permanent fake gate + empty state | connecting frame, honest |
| permission really missing | gate (after flash) | connecting → gate |

## Verification

- `cargo test` (incl. new `empty_refresh_marks_inventory_ready`), full-workspace clippy, and the windows-gnu cross-lint all pass.
- Ran the v2 GUI against the running v1 agent (protocol refusal): the window holds the new connecting frame — centered spinner over the plain window background with the muted localized caption ("正在连接后台服务…" under zh-CN) — no permission gate, no empty state, while the production agent keeps serving the real instance untouched.