### PR TITLE
fix: don't flash the empty-state screen while the agent is still scanning

### DIFF
--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -73,6 +73,16 @@ pub enum PairingUpdate {
 #[tarpc::service]
 pub trait Agent {
     /// Wire-protocol version, for the connect handshake.
+    ///
+    /// Method *order* is part of the wire format: tarpc generates one request
+    /// enum from this trait and bincode encodes the variant index, so this
+    /// method must stay **first** — and new methods must be appended at the
+    /// end, never inserted — or the handshake itself stops decoding across a
+    /// version skew and a mismatch can no longer be detected and reported.
+    /// There is deliberately no minor version / compat negotiation: GUI and
+    /// agent ship in one bundle and the agent re-execs itself when its binary
+    /// is replaced, so strict equality plus a clean refusal is the whole
+    /// contract (see [`PROTOCOL_VERSION`]).
     async fn protocol_version() -> u32;
     /// Accessibility / hook / autostart state for the GUI gate + settings.
     async fn status() -> AgentStatus;

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -425,8 +425,10 @@ impl Render for AppView {
                 home_header(pal).into_any_element(),
                 if has_device {
                     device_gallery(cx).into_any_element()
+                } else if scanning {
+                    device_scanning_state(pal)
                 } else {
-                    device_empty_state(pal, scanning)
+                    device_empty_state(pal)
                 },
             )
         };
@@ -1273,34 +1275,51 @@ fn file_url(path: &std::path::Path) -> String {
     format!("file://{}", path.to_string_lossy().replace(' ', "%20"))
 }
 
-/// Whole-window placeholder shown from window-open until the agent's first
-/// IPC snapshot lands — normally a fraction of a second, or for as long as the
-/// agent is genuinely unreachable (crashed / not yet spawned), where "still
-/// connecting" is the only true statement. Deliberately neutral: no chrome, no
-/// claims about permissions or devices. The spinner's repeating animation only
-/// runs while this view is mounted, so it can't pin the render loop once the
-/// real UI replaces it.
-fn connecting_view(pal: Palette) -> AnyElement {
+/// Centered spinner over a muted one-line caption — the quiet "still working"
+/// body shared by the pre-connection frame and the scanning state, so the two
+/// loading phases render as one continuous frame with only the caption
+/// changing. The spinner's repeating animation only runs while a loading view
+/// is mounted, so it can't pin the render loop once the real UI replaces it.
+fn loading_body(caption: SharedString, pal: Palette) -> Div {
     v_flex()
-        .size_full()
-        .bg(pal.bg)
         .items_center()
         .justify_center()
         .gap_3()
         .child(Spinner::new().large().color(pal.text_muted))
-        .child(
-            div()
-                .text_sm()
-                .text_color(pal.text_muted)
-                .child(tr!("Connecting to the background service…")),
-        )
+        .child(div().text_sm().text_color(pal.text_muted).child(caption))
+}
+
+/// Whole-window placeholder shown from window-open until the agent's first
+/// IPC snapshot lands — normally a fraction of a second, or for as long as the
+/// agent is genuinely unreachable (crashed / not yet spawned), where "still
+/// connecting" is the only true statement. Deliberately neutral: no chrome, no
+/// claims about permissions or devices.
+fn connecting_view(pal: Palette) -> AnyElement {
+    loading_body(tr!("Connecting to the background service…"), pal)
+        .size_full()
+        .bg(pal.bg)
+        .text_color(pal.text_primary)
         .into_any_element()
 }
 
-/// Body shown when no device is connected. The inventory watcher keeps polling
-/// (every 2 s) and `AppView`'s `AppState` observer swaps the device UI back in
-/// the moment one appears, so this is purely a wait-and-pair placeholder.
-fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
+/// Home body while the agent's first enumeration is still in flight: the
+/// device set is *unknown*, not empty, so this keeps the quiet loading frame
+/// rather than flashing the add-device empty state (icon, headline, CTA) at a
+/// user whose devices are about to appear. Swaps to the gallery or to
+/// [`device_empty_state`] the moment the agent reports a completed scan.
+fn device_scanning_state(pal: Palette) -> AnyElement {
+    loading_body(tr!("Scanning for devices…"), pal)
+        .flex_1()
+        .w_full()
+        .min_h_0()
+        .into_any_element()
+}
+
+/// Body shown when the agent has completed an enumeration and found no
+/// devices. The polling keeps running and `AppView`'s `AppState` observer
+/// swaps the device UI back in the moment one appears, so this is purely a
+/// wait-and-pair placeholder.
+fn device_empty_state(pal: Palette) -> AnyElement {
     v_flex()
         .flex_1()
         .w_full()
@@ -1318,11 +1337,7 @@ fn device_empty_state(pal: Palette, scanning: bool) -> AnyElement {
             div()
                 .text_xl()
                 .font_weight(FontWeight::SEMIBOLD)
-                .child(if scanning {
-                    tr!("Scanning for devices…")
-                } else {
-                    tr!("No devices connected")
-                }),
+                .child(tr!("No devices connected")),
         )
         .child(
             div()

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -124,7 +124,14 @@ pub fn spawn(poll_period: Duration) -> IpcClient {
                             match poll(&mut client, &update_tx).await {
                                 Ok(Some(true)) if !steady => {
                                     steady = true;
-                                    interval = tokio::time::interval(poll_period);
+                                    // `interval_at`: a fresh `interval` ticks
+                                    // immediately, which would fire a redundant
+                                    // back-to-back poll right after the one
+                                    // that just confirmed readiness.
+                                    interval = tokio::time::interval_at(
+                                        tokio::time::Instant::now() + poll_period,
+                                        poll_period,
+                                    );
                                 }
                                 Ok(_) => {}
                                 Err(()) => {

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -29,6 +29,14 @@ use tracing::{debug, info, warn};
 /// tight loop, short enough that a quit / crashed agent is recovered promptly.
 const SPAWN_RETRY_PERIOD: Duration = Duration::from_secs(30);
 
+/// Poll cadence until the agent reports its first completed enumeration
+/// (`AgentStatus::inventory_ready`). The steady `poll_period` is tuned for
+/// quiet background refresh; at startup it would leave the window on its
+/// loading frame for up to a full period *after* the agent already knows the
+/// devices. A status+inventory round every 250 ms is noise for the agent and
+/// gets the gallery up moments after enumeration lands.
+const STARTUP_POLL_PERIOD: Duration = Duration::from_millis(250);
+
 /// A poll snapshot pushed to the GPUI loop every `poll_period`.
 pub struct PollUpdate {
     pub inventory: Vec<DeviceInventory>,
@@ -104,12 +112,28 @@ pub fn spawn(poll_period: Duration) -> IpcClient {
                 // tight respawn loop, while a crashed / quit agent is still
                 // recovered without restarting the GUI.
                 let mut last_spawn_attempt: Option<Instant> = None;
-                let mut interval = tokio::time::interval(poll_period);
+                // Fast cadence until the agent's first completed enumeration
+                // reaches the GUI, then drop to the steady period; back to
+                // fast whenever the connection is lost, so an agent restart
+                // (binary-update exec, crash) re-converges just as quickly.
+                let mut interval = tokio::time::interval(STARTUP_POLL_PERIOD);
+                let mut steady = false;
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
-                            if poll(&mut client, &update_tx).await.is_err() {
-                                client = None; // drop a dead connection; reconnect next tick
+                            match poll(&mut client, &update_tx).await {
+                                Ok(Some(true)) if !steady => {
+                                    steady = true;
+                                    interval = tokio::time::interval(poll_period);
+                                }
+                                Ok(_) => {}
+                                Err(()) => {
+                                    client = None; // drop a dead connection; reconnect next tick
+                                    if steady {
+                                        steady = false;
+                                        interval = tokio::time::interval(STARTUP_POLL_PERIOD);
+                                    }
+                                }
                             }
                             if client.is_none()
                                 && last_spawn_attempt
@@ -255,18 +279,22 @@ async fn ensure(client: &mut Option<AgentClient>) -> std::io::Result<&AgentClien
     }
 }
 
-/// Poll inventory + status and push a snapshot. `Err` on a dropped connection.
+/// Poll inventory + status and push a snapshot. `Ok(Some(inventory_ready))`
+/// when a snapshot was delivered — the caller uses the readiness to pick its
+/// poll cadence — `Ok(None)` when the agent isn't reachable yet, and `Err` on
+/// a dropped connection.
 async fn poll(
     client: &mut Option<AgentClient>,
     update_tx: &mpsc::UnboundedSender<PollUpdate>,
-) -> Result<(), ()> {
+) -> Result<Option<bool>, ()> {
     let Ok(client) = ensure(client).await else {
-        return Ok(()); // agent not up yet; try again next tick (keep `client` None)
+        return Ok(None); // agent not up yet; try again next tick (keep `client` None)
     };
     let inventory = client.inventory(context::current()).await.map_err(|_| ())?;
     let status = client.status(context::current()).await.map_err(|_| ())?;
+    let ready = status.inventory_ready;
     let _ = update_tx.send(PollUpdate { inventory, status });
-    Ok(())
+    Ok(Some(ready))
 }
 
 /// Run one device command. `Err` signals a dropped connection so the caller


### PR DESCRIPTION
Follow-up to #212 — the startup sequence still flashed the device empty-state screen for users with paired devices.

## Problem

While the agent's first enumeration is in flight (`inventory_ready == false`), the home body rendered the **full empty-state screen** — search icon, headline, Add-Device CTA, pairing hints — with only the headline swapped to "Scanning for devices…". For a user whose devices are about to appear that is still a "no devices" flash. And since the GUI polls on a 2 s timer, the gallery could lag a full period behind the agent actually knowing the devices.

## Fix

- **Scanning is unknown, not empty**: while `scanning` is set, the home body shows the same quiet spinner frame as the pre-connection view (caption "Scanning for devices…", string already in all locales). The empty-state screen with its Add-Device CTA is reserved for a *completed* scan that genuinely found nothing. The two loading phases share one layout (`loading_body`), so startup renders as a single continuous frame whose caption changes, resolving into the gallery.
- **Fast startup polling**: the IPC client polls every 250 ms until the first `inventory_ready` snapshot arrives, then drops to the steady 2 s cadence; it falls back to fast when the connection is lost so an agent restart (binary-update exec, crash) re-converges just as quickly. A status+inventory round every 250 ms is noise for the agent.
- **Docs**: recorded the tarpc/bincode invariant that method *order* is part of the wire format — `protocol_version` stays first, new methods append-only — and why the protocol deliberately has no minor version (single-bundle shipping + agent self-exec make strict equality the whole contract).

## Startup now (cold, devices paired)

connecting spinner (≈agent boot) → scanning spinner (≈one enumeration, sub-second with fast polling) → gallery. No empty-state flash at any point.

## Verification

`cargo test`, full-workspace clippy pass; the scanning frame reuses the connecting-frame layout verified in #212.