### PR TITLE
fix(release): derive macOS bundle versions from the workspace

### DIFF
--- a/crates/openlogi-agent/macos/Info.plist
+++ b/crates/openlogi-agent/macos/Info.plist
@@ -9,6 +9,11 @@
   runtime). A distinct CFBundleIdentifier (org.openlogi.agent) + a stable
   Developer-ID signature is what lets the Accessibility (TCC) grant persist
   across app updates — the agent, not the GUI, is the hook-trusted process.
+
+  The 0.0.0 version is a sentinel, not a release number: `xtask bundle-macos`
+  stamps the workspace version over it when embedding the helper, while the
+  hand-bundled dev flow (scripts/cargo-run-macos.sh) copies it as-is, so a
+  0.0.0 helper is by definition a dev build.
 -->
 <plist version="1.0">
 <dict>
@@ -23,9 +28,9 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.5.1</string>
+  <string>0.0.0</string>
   <key>CFBundleVersion</key>
-  <string>0.5.1</string>
+  <string>0.0.0</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>LSUIElement</key>

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -63,7 +63,8 @@ doc_markdown = "allow"
 [package.metadata.bundle]
 name = "OpenLogi"
 identifier = "org.openlogi.openlogi"
-version = "0.1.0"
+# No `version` override — cargo-bundle falls back to the crate version, which
+# is workspace-unified. A literal here goes stale the moment release-plz bumps.
 category = "public.app-category.utilities"
 short_description = "Lightweight local-first companion for Logitech HID++ peripherals."
 long_description = """\

--- a/crates/openlogi-gui/dev/Info.plist
+++ b/crates/openlogi-gui/dev/Info.plist
@@ -8,8 +8,10 @@
   <key>CFBundleIdentifier</key><string>org.openlogi.openlogi.dev</string>
   <key>CFBundleIconFile</key><string>AppIcon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.0.1</string>
-  <key>CFBundleVersion</key><string>0.0.1</string>
+  <!-- 0.0.0 = the repo-wide "unstamped dev build" sentinel (release versions
+       come from cargo-bundle / xtask stamping). -->
+  <key>CFBundleShortVersionString</key><string>0.0.0</string>
+  <key>CFBundleVersion</key><string>0.0.0</string>
   <key>LSMinimumSystemVersion</key><string>13.0</string>
   <key>NSHighResolutionCapable</key><true/>
   <!-- openlogi:// deep-link scheme. Mirror of [package.metadata.bundle]

--- a/xtask/src/macos.rs
+++ b/xtask/src/macos.rs
@@ -184,8 +184,20 @@ fn embed_agent_helper(root: &Path, app: &Path, xcode_env: &[(String, String)]) -
         .with_context(|| "could not copy the agent binary into the helper bundle".to_string())?;
     let info_src = root.join("crates/openlogi-agent/macos/Info.plist");
     ensure_file(&info_src)?;
-    fs::copy(&info_src, helper.join("Contents/Info.plist"))
+    let info_dst = helper.join("Contents/Info.plist");
+    fs::copy(&info_src, &info_dst)
         .with_context(|| "could not write the helper Info.plist".to_string())?;
+    // The template ships the 0.0.0 dev version (the hand-bundled dev flow
+    // copies it verbatim); stamp the workspace version (= xtask's own,
+    // inherited) over it so Finder and update scanners see the real one.
+    for key in ["CFBundleShortVersionString", "CFBundleVersion"] {
+        run(ProcessCommand::new("/usr/bin/plutil")
+            .arg("-replace")
+            .arg(key)
+            .arg("-string")
+            .arg(env!("CARGO_PKG_VERSION"))
+            .arg(&info_dst))?;
+    }
 
     println!("    embedded {}", helper.display());
     Ok(())


### PR DESCRIPTION
Fixes #216.

Finder's Get Info (and update scanners like MacUpdater) read `CFBundleShortVersionString` from the app bundle's Info.plist, which was stuck at **0.1.0**: `[package.metadata.bundle]` carried a hardcoded `version` that predates workspace-unified versioning and never got bumped.

- **OpenLogi.app** — drop the `version` override. cargo-bundle then falls back to the crate version, which is workspace-inherited, so release-plz bumps flow through automatically. (Fallback verified in the cargo-bundle 0.10.0 installed locally and in the 0.11.0 source that CI installs.)
- **OpenLogiAgent.app** (nested login-item helper) — the same rot one layer down: its hand-maintained Info.plist was stuck at 0.5.1. The template now ships a 0.0.0 dev version and `xtask bundle-macos` stamps the workspace version over it via `plutil -replace` (semantic, key-targeted — no string templating) when embedding. The hand-bundled dev flow (`scripts/cargo-run-macos.sh`) keeps copying it verbatim, so 0.0.0 doubles as the unstamped-dev-build marker — the same sentinel the Windows MSI uses for non-tag dispatches.
- The dev GUI plist moves 0.0.1 → 0.0.0 to match that convention.

A nested cargo-bundle run for the helper (which would make the fallback symmetric) was considered and rejected: cargo-bundle has no `LSUIElement` support, and restructuring the helper bundle risks the stable TCC identity its comments document.

### Verification

`cargo run -p xtask -- bundle-macos` end to end, then `plutil -p` on both produced plists:

| plist | before | after |
|---|---|---|
| OpenLogi.app | 0.1.0 | **0.6.6** |
| OpenLogiAgent.app | 0.5.1 | **0.6.6** (LSUIElement etc. intact) |

The source template keeps its 0.0.0 placeholders; `cargo test -p xtask`, fmt and full-workspace clippy pass.