### PR TITLE
fix(hid): keep last-known-good devices when a receiver read is incomplete (#218)

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -35,6 +35,53 @@ pub enum InventoryEvent {
     Unavailable,
 }
 
+/// The watcher's cross-tick memory, factored out of the poll loop so the
+/// tick → event decision is unit-testable without spawning the thread or
+/// touching real HID.
+#[derive(Default)]
+struct WatchState {
+    /// Set once any enumeration has completed. After that, a failed tick keeps
+    /// the last good snapshot forever instead of ever reporting `Unavailable`.
+    succeeded: bool,
+    /// Consecutive failures, counted only before the first success.
+    initial_failures: u8,
+}
+
+impl WatchState {
+    /// Decide what (if anything) a watch tick emits.
+    ///
+    /// - `Ok(snapshot)` — a completed enumeration (an empty one included: that's
+    ///   a genuine disconnect) — is forwarded so the agent's device set tracks
+    ///   reality.
+    /// - `Err(..)` means "couldn't fully check" — a transient HID++ timeout or a
+    ///   partial receiver read ([`openlogi_hid::InventoryError::Incomplete`]):
+    ///   emit nothing, so the agent keeps its last good device set and live
+    ///   bindings instead of wiping them for ~one period — the flap behind #218.
+    ///   Before the *first* success there is no good set to keep, so persistent
+    ///   initial failure is reported once as [`InventoryEvent::Unavailable`]; the
+    ///   loop keeps retrying and a later success recovers.
+    fn classify(
+        &mut self,
+        result: Result<Vec<DeviceInventory>, openlogi_hid::InventoryError>,
+    ) -> Option<InventoryEvent> {
+        match result {
+            Ok(inv) => {
+                self.succeeded = true;
+                Some(InventoryEvent::Snapshot(inv))
+            }
+            Err(e) => {
+                warn!(error = ?e, "enumerate failed during watch tick — keeping last snapshot");
+                if self.succeeded {
+                    return None;
+                }
+                self.initial_failures = self.initial_failures.saturating_add(1);
+                (self.initial_failures == INITIAL_FAILURE_LIMIT)
+                    .then_some(InventoryEvent::Unavailable)
+            }
+        }
+    }
+}
+
 /// Spawn the watcher and return a receiver of inventory events. The
 /// channel is unbounded so a slow consumer cannot back-pressure the HID
 /// poll loop into stalling on a real device disconnect.
@@ -63,35 +110,14 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
             // across ticks — a known device's immutable data (model, features)
             // is reused instead of being re-handshaked every poll.
             let mut enumerator = openlogi_hid::Enumerator::default();
-            let mut succeeded = false;
-            let mut initial_failures: u8 = 0;
+            let mut state = WatchState::default();
             loop {
-                match rt.block_on(enumerator.enumerate()) {
-                    Ok(inv) => {
-                        succeeded = true;
-                        if worker_tx.send(InventoryEvent::Snapshot(inv)).is_err() {
-                            debug!("inventory watcher receiver dropped — exiting");
-                            return;
-                        }
-                    }
-                    // A failed enumerate means "couldn't check", NOT "no devices":
-                    // skip the tick so the agent keeps its last good device set
-                    // and live bindings instead of wiping them for ~one period. A
-                    // genuine disconnect comes back as an `Ok` empty snapshot,
-                    // which we DO forward. Before the *first* success there is no
-                    // good set to keep, so persistent failure is reported once —
-                    // the loop keeps retrying, and a later success recovers.
-                    Err(e) => {
-                        warn!(error = ?e, "enumerate failed during watch tick — keeping last snapshot");
-                        if !succeeded {
-                            initial_failures = initial_failures.saturating_add(1);
-                            if initial_failures == INITIAL_FAILURE_LIMIT
-                                && worker_tx.send(InventoryEvent::Unavailable).is_err()
-                            {
-                                return;
-                            }
-                        }
-                    }
+                let result = rt.block_on(enumerator.enumerate());
+                if let Some(event) = state.classify(result)
+                    && worker_tx.send(event).is_err()
+                {
+                    debug!("inventory watcher receiver dropped — exiting");
+                    return;
                 }
                 thread::sleep(period);
             }
@@ -105,4 +131,58 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
         let _ = tx.send(InventoryEvent::Unavailable);
     }
     rx
+}
+
+#[cfg(test)]
+mod tests {
+    use openlogi_hid::InventoryError;
+
+    use super::{INITIAL_FAILURE_LIMIT, InventoryEvent, WatchState};
+
+    #[test]
+    fn completed_enumeration_is_forwarded_even_when_empty() {
+        let mut state = WatchState::default();
+        // A genuine "checked, nothing there" still propagates as a disconnect —
+        // the resilience must not swallow a real empty.
+        assert!(matches!(
+            state.classify(Ok(vec![])),
+            Some(InventoryEvent::Snapshot(snap)) if snap.is_empty()
+        ));
+        assert!(state.succeeded);
+    }
+
+    #[test]
+    fn incomplete_read_after_a_success_keeps_the_last_snapshot() {
+        let mut state = WatchState::default();
+        // A good tick first, so there is a last-known-good set to preserve.
+        assert!(matches!(
+            state.classify(Ok(vec![])),
+            Some(InventoryEvent::Snapshot(_))
+        ));
+        // Then transient partial reads emit nothing — the agent keeps the last
+        // snapshot instead of flapping to "No devices" (#218).
+        assert!(state.classify(Err(InventoryError::Incomplete)).is_none());
+        assert!(state.classify(Err(InventoryError::Incomplete)).is_none());
+    }
+
+    #[test]
+    fn persistent_initial_failure_reports_unavailable_once_then_recovers() {
+        let mut state = WatchState::default();
+        // No snapshot has ever landed, so repeated failure must eventually stop
+        // looking like "still scanning".
+        for _ in 1..INITIAL_FAILURE_LIMIT {
+            assert!(state.classify(Err(InventoryError::Incomplete)).is_none());
+        }
+        assert!(matches!(
+            state.classify(Err(InventoryError::Incomplete)),
+            Some(InventoryEvent::Unavailable)
+        ));
+        // Reported once, not on every later failure.
+        assert!(state.classify(Err(InventoryError::Incomplete)).is_none());
+        // …and a later success recovers with a live snapshot.
+        assert!(matches!(
+            state.classify(Ok(vec![])),
+            Some(InventoryEvent::Snapshot(_))
+        ));
+    }
 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -64,6 +64,15 @@ const PROBE_BUDGET: Duration = Duration::from_secs(5);
 pub enum InventoryError {
     #[error("HID transport error")]
     Hid(#[from] async_hid::HidError),
+
+    /// A receiver answered, but its paired-device list came back short of the
+    /// count it reports this cycle — a pairing slot, the pairing count, or a
+    /// whole device probe failed to read (a transient HID++ register timeout,
+    /// common on recent macOS IOHID stacks). Surfaced as an error rather than an
+    /// empty `Ok` so the polling watcher keeps its last good snapshot instead of
+    /// publishing a truncated list that flaps the GUI to "No devices" (#218).
+    #[error("enumeration incomplete — some paired devices were unreadable this cycle")]
+    Incomplete,
 }
 
 /// How many `enumerate` ticks a device's probe is reused before a fresh read.
@@ -216,6 +225,18 @@ struct CachedChannel {
     channel: Arc<HidppChannel>,
 }
 
+/// Attempts a one-shot [`enumerate`] makes when a cycle comes back
+/// [`InventoryError::Incomplete`]. The polling [`Enumerator`] keeps its last
+/// good snapshot across ticks, but a one-shot caller has no prior state to fall
+/// back on, so it retries a transient partial read a few times before giving up
+/// — the #218 flap cleared on a retry (two back-to-back isolated runs read 3
+/// devices and 0 respectively).
+const ONESHOT_ATTEMPTS: u8 = 4;
+
+/// Delay between one-shot retries. A first probe usually wakes an asleep device,
+/// so a short pause lets the next attempt read it instead of timing out again.
+const ONESHOT_RETRY_DELAY: Duration = Duration::from_millis(300);
+
 /// Enumerate all Logitech HID++ receivers visible to the current process and
 /// the devices paired to each.
 ///
@@ -230,8 +251,26 @@ struct CachedChannel {
 ///
 /// We merge the two so an MX Master that's been asleep still shows up with
 /// its codename and kind even before you click it.
+///
+/// A one-shot caller (CLI, diagnostics) has no last-known-good to fall back on,
+/// so a transient [`InventoryError::Incomplete`] cycle is retried up to
+/// [`ONESHOT_ATTEMPTS`] times here; the polling watcher instead keeps its last
+/// snapshot.
 pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
-    Enumerator::default().enumerate().await
+    // Reuse one enumerator across attempts so a retry keeps the channel it just
+    // opened (and the probe cache it warmed) rather than re-handshaking the
+    // receiver from scratch. Only `Incomplete` retries — a clean `Ok` (even an
+    // empty one) and a hard transport error both return straight away.
+    let mut enumerator = Enumerator::default();
+    let mut result = enumerator.enumerate().await;
+    let mut attempt = 1u8;
+    while attempt < ONESHOT_ATTEMPTS && matches!(result, Err(InventoryError::Incomplete)) {
+        debug!(attempt, "enumeration incomplete — retrying");
+        tokio::time::sleep(ONESHOT_RETRY_DELAY).await;
+        result = enumerator.enumerate().await;
+        attempt += 1;
+    }
+    result
 }
 
 impl Enumerator {
@@ -296,19 +335,25 @@ impl Enumerator {
 
         let mut inventories = Vec::new();
         let mut outcomes = Vec::new();
+        // A probe that timed out, or a receiver whose paired list came back
+        // short of its own reported count, leaves the snapshot missing a device
+        // that is actually connected. Track that so the cycle is reported
+        // `Incomplete` instead of publishing a truncated list (#218).
+        let mut incomplete = false;
         for result in results {
-            match result {
-                Ok((inv, mut probed)) => {
-                    inventories.extend(inv);
-                    outcomes.append(&mut probed);
-                }
-                Err(_) => {
-                    warn!(budget = ?PROBE_BUDGET, "device probe timed out — skipping (asleep/unresponsive)");
-                }
+            if let Ok((inv, mut probed, complete)) = result {
+                incomplete |= !complete;
+                inventories.extend(inv);
+                outcomes.append(&mut probed);
+            } else {
+                warn!(budget = ?PROBE_BUDGET, "device probe timed out — skipping (asleep/unresponsive)");
+                incomplete = true;
             }
         }
 
-        // Apply fresh probes and record which devices were seen this tick.
+        // Apply fresh probes and record which devices were seen this tick. Done
+        // even on an incomplete cycle so the cache stays warm for the devices
+        // that did read.
         let mut seen_keys = HashSet::new();
         for outcome in outcomes {
             match outcome {
@@ -322,6 +367,16 @@ impl Enumerator {
                 CacheOutcome::Unkeyed => {}
             }
         }
+
+        if incomplete {
+            // Don't evict — a device merely unread this cycle must keep its cache
+            // entry through the existing grace — and don't publish a short list.
+            // The caller keeps its last good snapshot. A genuine disconnect
+            // instead reads cleanly as an `Ok` carrying the receiver's real,
+            // smaller count, and is forwarded.
+            return Err(InventoryError::Incomplete);
+        }
+
         self.evict_unseen(&seen_keys);
         Ok(inventories)
     }
@@ -349,22 +404,36 @@ impl Enumerator {
     }
 }
 
+/// Whether a Bolt receiver's per-cycle read is complete: we learned how many
+/// devices it has paired and read at least that many. An unreadable count
+/// (`None`) or a short read means a HID++ register read timed out this cycle, so
+/// the snapshot is missing a device that is actually there — a transient failure
+/// to preserve last-known-good against, not "no devices" (#218). Reading *more*
+/// than the reported count is still complete (nothing is missing).
+fn receiver_read_complete(pairing_count: Option<u8>, paired_len: usize) -> bool {
+    pairing_count.is_some_and(|count| paired_len >= usize::from(count))
+}
+
 /// Probe one open HID++ node (channel reused across ticks by the caller).
-/// Returns its inventory (if any) plus each device's cache contribution this
-/// tick, for the caller to apply and to drive eviction.
+/// Returns its inventory (if any), each device's cache contribution this tick
+/// (for the caller to apply and to drive eviction), and whether the read was
+/// *complete* — `false` flags a transient partial read the caller turns into
+/// [`InventoryError::Incomplete`].
 async fn probe_one(
     info: async_hid::DeviceInfo,
     channel: Arc<HidppChannel>,
     cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> (Option<DeviceInventory>, Vec<CacheOutcome>) {
+) -> (Option<DeviceInventory>, Vec<CacheOutcome>, bool) {
     let Some(Receiver::Bolt(bolt)) = receiver::detect(Arc::clone(&channel)) else {
         // No receiver detected — this might be a directly-paired device
         // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
         // addresses the device's own features. Probe in case it answers.
         // P2.4 — verified path; no Bolt-pairing slot indirection needed.
+        // The direct path has no receiver pairing count to fall short of, so a
+        // device that answers is always a complete read.
         let (inventory, outcome) = probe_direct(channel, &info, cache, tick).await;
-        return (inventory, vec![outcome]);
+        return (inventory, vec![outcome], true);
     };
 
     let unique_id = bolt.get_unique_id().await.ok();
@@ -387,13 +456,12 @@ async fn probe_one(
         }
     }
 
-    if let Some(count) = pairing_count
-        && paired.len() != usize::from(count)
-    {
+    let complete = receiver_read_complete(pairing_count, paired.len());
+    if !complete {
         warn!(
-            expected = count,
+            expected = ?pairing_count,
             found = paired.len(),
-            "paired-device count mismatch — some slots may be unreadable"
+            "receiver read incomplete this cycle — some slots unreadable; keeping last snapshot"
         );
     }
 
@@ -408,6 +476,7 @@ async fn probe_one(
             paired,
         }),
         outcomes,
+        complete,
     )
 }
 
@@ -831,7 +900,8 @@ mod tests {
 
     use super::{
         CACHE_MISS_GRACE, CacheKey, Cached, DeviceKind, Enumerator, ProbedFeatures, REFRESH_TICKS,
-        UnifiedBatteryFeature, battery_feature_index, is_stale, resolve_device_kind,
+        UnifiedBatteryFeature, battery_feature_index, is_stale, receiver_read_complete,
+        resolve_device_kind,
     };
     use hidpp::feature::CreatableFeature as _;
 
@@ -841,6 +911,30 @@ mod tests {
             battery_index: None,
             probed_tick,
         }
+    }
+
+    #[test]
+    fn read_is_complete_only_when_every_paired_device_was_read() {
+        // The healthy steady state: the receiver reports 3 pairings and all 3
+        // slots read (empty slots don't count toward the pairing count).
+        assert!(receiver_read_complete(Some(3), 3));
+        // Reading more than reported is still complete — nothing is missing.
+        assert!(receiver_read_complete(Some(2), 3));
+        // A receiver with no pairings, read cleanly, is a genuine empty.
+        assert!(receiver_read_complete(Some(0), 0));
+    }
+
+    #[test]
+    fn short_or_countless_read_is_incomplete() {
+        // The #218 flap: the receiver says 3 but a transient slot timeout left
+        // us with 2 (or 0) — a partial read, not "devices vanished".
+        assert!(!receiver_read_complete(Some(3), 2));
+        assert!(!receiver_read_complete(Some(3), 0));
+        // The pairing-count register itself failed to read: we can't even tell
+        // how many devices to expect, so treat the cycle as incomplete rather
+        // than trust a possibly-truncated list.
+        assert!(!receiver_read_complete(None, 0));
+        assert!(!receiver_read_complete(None, 3));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the **device-list flapping** half of #218: on a Logi Bolt receiver the GUI oscillated between showing all paired devices and "No devices connected" roughly every 2 s, so they never stayed long enough to configure. Reported on 0.6.6, macOS 27 beta, Apple Silicon, with an MX Master 4 + MX Master 3S + MX Mechanical Mini on one receiver.

This PR is scoped to the flap only. The **device-images** half of #218 is already addressed by #142 (Settings → Assets runtime sync, no CLI needed), #137 (match every `modelId`), and #140 (retry sync with backoff), so I've left it to those.

## Root cause

The agent's inventory resilience rests on one rule, stated in `watchers/inventory.rs`:

> `enumerate()` returning **`Err`** = "couldn't check" → keep the last good snapshot.
> `enumerate()` returning **`Ok`** = authoritative → forward it (an empty `Ok` is a genuine disconnect).

A transient HID++ register read broke that rule. `count_pairings()` and the per-slot `get_device_pairing_information()` are independent HID++ 1.0 register reads; on the macOS 27-beta IOHID stack (with the brand-new MX Master 4 adding notification traffic) they time out intermittently. A failed slot read was silently skipped, so `probe_one` returned `Ok` with a **truncated** `paired` list — possibly empty — and a whole-receiver probe timeout dropped the receiver entirely. `enumerate()` already *detected* the shortfall (`paired.len() != pairing_count`) but only logged a warning.

That truncated `Ok` reached `Orchestrator::refresh_inventory`, which unconditionally overwrites `InventoryState::Ready`; the IPC `inventory()` poll served the short/empty list and the GUI rendered "No devices connected" until the next good cycle ~2 s later. The GUI's own `INVENTORY_MISS_GRACE = 2` rides out 1–2 transient empties, but a run of ≥3 (plausible on this stack) drops the devices anyway — and the agent-side snapshot flapped regardless.

I also checked the duplicate-agent spawn race from #207's review (the `open -n` path in `ipc_client.rs`). It's bounded — `just_disconnected` skips the spawn gate on the drop tick, `SPAWN_RETRY_PERIOD = 30 s` rate-limits respawns, and the agent's `single_instance::acquire("agent.lock")` makes any duplicate exit — so it can't produce a 2 s flap, and the report's own evidence (one agent process; isolated *cold* agent runs flap) rules it out. This PR doesn't touch `ipc_client.rs`, so it won't conflict with #207.

## The fix

Make `enumerate()` honest about partial reads so the existing keep-last-snapshot machinery engages, instead of papering over it in every consumer.

- **`openlogi-hid/inventory.rs`**
  - New `InventoryError::Incomplete`.
  - `receiver_read_complete(pairing_count, paired_len)`: a Bolt read is complete only when `count_pairings()` succeeded **and** at least that many slots read. An unreadable count or a short read is incomplete; reading *more* than the count is still complete.
  - `probe_one` reports that completeness; a probe **timeout** counts as incomplete too.
  - On an incomplete cycle `enumerate()` **skips cache eviction** (a device merely unread this cycle keeps its entry) and returns `Incomplete` rather than publishing a truncated list.
  - The one-shot `enumerate()` free fn (CLI / `diag`) has no last-known-good to fall back on, so it **retries** an `Incomplete` cycle a few times before giving up — the report's two isolated runs read 3 devices and 0; a retry would have read 3 both times.
- **`openlogi-agent-core/watchers/inventory.rs`** — factor the tick→event decision into `WatchState::classify` (no behaviour change; the `Err` arm already kept the last snapshot) so it's unit-testable.

A genuine unpair/disconnect still reads cleanly as an `Ok` carrying the receiver's real, smaller count, so the list still shrinks when devices actually leave.

## Tests

New unit tests (host-only, no hardware):

- `receiver_read_complete`: `Some(3)/3` and `Some(0)/0` complete; `Some(3)/2`, `Some(3)/0`, `None/*` incomplete.
- `WatchState::classify`: an incomplete read after a success **keeps** the last snapshot; a clean empty `Ok` is still forwarded as a disconnect; persistent initial failure reports `Unavailable` once, then recovers.

```
cargo fmt --all -- --check                                                                          # clean
cargo clippy -p openlogi-hid -p openlogi-agent-core -p openlogi-cli --all-targets -- -D warnings    # clean
cargo test  -p openlogi-hid -p openlogi-agent-core                                                   # 46 + 21 pass
```

I couldn't build `openlogi-gui` locally (it compiles Metal shaders against a full Xcode toolchain I don't have), but the GUI is untouched, `InventoryError` has no exhaustive match anywhere, and the new variant is additive — so the GUI build is unaffected. CI covers it.

## Manual hardware verification still needed

I don't have the Bolt-receiver hardware, so the live repro needs a hand (ideally @buliwyf42, who filed it):

1. Build the agent from this branch and run it against the 3-device Bolt setup on macOS 27 beta.
2. Watch the Devices view / agent logs for ~60 s. Expected: the list stays populated; on a bad cycle the agent logs `receiver read incomplete this cycle … keeping last snapshot` and emits **no** snapshot, instead of flapping to "No devices".
3. Power one device off → it should drop from the list within a cycle or two (a clean `Ok` with the smaller count), confirming genuine disconnects still propagate.

Closes the flapping half of #218.
