### PR TITLE
fix(agent): persist DPI/SmartShift per device and reapply volatile settings on reconnect

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -350,23 +350,36 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
     // the GUI shows first rather than whatever HID node enumerated first.
     // `config_key` only breaks ties a unique `DeviceStableId` never produces.
     devices.sort_by(|a, b| {
-        DeviceStableId::from_parts(a.route.as_ref(), a.slot, a.serial.as_deref(), a.unit_id)
-            .cmp(&DeviceStableId::from_parts(
-                b.route.as_ref(),
-                b.slot,
-                b.serial.as_deref(),
-                b.unit_id,
-            ))
+        stable_id(a)
+            .cmp(&stable_id(b))
             .then_with(|| a.config_key.cmp(&b.config_key))
     });
     devices
 }
 
+/// The canonical identity of one device: what the GUI carousel orders by and
+/// what [`reapply_targets`] matches a device against across inventory ticks.
+/// Unlike `config_key` (derived from the model id), this stays unique for two
+/// physically distinct devices of the same model.
+fn stable_id(dev: &AgentDevice) -> DeviceStableId {
+    DeviceStableId::from_parts(
+        dev.route.as_ref(),
+        dev.slot,
+        dev.serial.as_deref(),
+        dev.unit_id,
+    )
+}
+
 /// Indices into `next` of devices whose volatile settings need re-applying:
-/// newly-appeared keys, route changes (a replug re-enumerating under a new
-/// node), offline→online transitions (a reconnect after device sleep), or —
-/// after a system wake — every device. Offline devices are never targeted
-/// (the write would just time out); they re-apply on their own transition.
+/// a device whose stable identity is newly present (a first sighting, or a
+/// replug that re-enumerated under a new identity — e.g. a Bolt device that
+/// moved slots), or an offline→online transition (a reconnect after device
+/// sleep); plus — after a system wake — every online device. Devices are
+/// matched across ticks by [`stable_id`], never `config_key`: two same-model
+/// devices share a `config_key`, so keying on it made the second device
+/// perpetually match the first, observe a different route, and re-apply on
+/// every tick. Offline devices are never targeted (the write would just time
+/// out); they re-apply on their own transition.
 fn reapply_targets(prev: &[AgentDevice], next: &[AgentDevice], reapply_all: bool) -> Vec<usize> {
     next.iter()
         .enumerate()
@@ -375,9 +388,13 @@ fn reapply_targets(prev: &[AgentDevice], next: &[AgentDevice], reapply_all: bool
             if reapply_all {
                 return true;
             }
-            match prev.iter().find(|p| p.config_key == dev.config_key) {
+            let id = stable_id(dev);
+            match prev.iter().find(|p| stable_id(p) == id) {
+                // A new identity (first sighting, or a replug under a new
+                // route/slot) needs a fresh apply; a known one only when it has
+                // just come back online.
                 None => true,
-                Some(p) => p.route != dev.route || !p.online,
+                Some(p) => !p.online,
             }
         })
         .map(|(idx, _)| idx)
@@ -442,6 +459,18 @@ mod tests {
         );
         // Going to sleep (online → offline) → nothing.
         assert!(reapply_targets(&[dev("a", 1, true)], &[dev("a", 1, false)], false).is_empty());
+    }
+
+    #[test]
+    fn reapply_targets_disambiguates_same_model_duplicates() {
+        // Two devices of the same model share a `config_key` but are distinct
+        // physical units at different Bolt slots, so they have distinct stable
+        // ids. A steady tick with both already online must target NEITHER —
+        // matching prev by `config_key` alone made the second device match the
+        // first, observe a different route, and re-apply on every 2s tick.
+        let prev = [dev("dup", 1, true), dev("dup", 2, true)];
+        let next = [dev("dup", 1, true), dev("dup", 2, true)];
+        assert!(reapply_targets(&prev, &next, false).is_empty());
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -36,6 +36,10 @@ struct AgentDevice {
     slot: u8,
     serial: Option<String>,
     unit_id: [u8; 4],
+    /// Live link state from the inventory snapshot. An offline→online
+    /// transition is a reconnect — the device may have power-cycled, so its
+    /// volatile settings need re-applying (#189).
+    online: bool,
 }
 
 /// The shared runtime handed to the hook and the gesture watcher. Every field
@@ -74,6 +78,10 @@ pub struct Orchestrator {
     /// the distinction (as [`InventoryHealth`]) so the GUI can tell them
     /// apart.
     inventory: InventoryState,
+    /// Set after a system wake: devices may have power-cycled while their
+    /// set/route/online state looks identical across the sleep gap, so the
+    /// next refresh re-applies volatile settings to every online device.
+    reapply_all_next_refresh: bool,
     shared: SharedRuntime,
 }
 
@@ -111,6 +119,7 @@ impl Orchestrator {
             current: 0,
             current_app: None,
             inventory: InventoryState::Pending,
+            reapply_all_next_refresh: false,
             shared,
         };
         orch.rebuild();
@@ -188,36 +197,68 @@ impl Orchestrator {
         // a recovered backend upgrades `Unavailable` back to live data).
         self.inventory = InventoryState::Ready(inventories.to_vec());
         let devices = build_devices(inventories);
+        // Volatile settings (lighting colour, sensor DPI, SmartShift) live in
+        // device RAM and reset on a power cycle, so every reconnect shape
+        // re-applies the persisted values (#189): a first sighting, a replug
+        // (new route), a wake from device sleep (offline→online), or — via the
+        // flag — a system wake where none of those are observable.
+        let reapply_all = std::mem::take(&mut self.reapply_all_next_refresh);
+        for idx in reapply_targets(&self.devices, &devices, reapply_all) {
+            self.reapply_volatile_settings(&devices[idx]);
+        }
         let changed = devices.len() != self.devices.len()
             || devices
                 .iter()
                 .zip(&self.devices)
                 .any(|(a, b)| a.config_key != b.config_key || a.route != b.route);
         if !changed {
+            // Same set and routes — but keep the fresh `online` flags, or a
+            // device that woke this tick would read as a transition forever.
+            self.devices = devices;
             return;
-        }
-        // Re-apply saved lighting to any device that just arrived — a first
-        // sighting at startup or a replug (which drops then re-adds it). A
-        // keyboard forgets its colour across a power cycle, so without this a
-        // replug goes dark until the user re-picks the colour.
-        for dev in &devices {
-            if self
-                .devices
-                .iter()
-                .any(|prev| prev.config_key == dev.config_key)
-            {
-                continue;
-            }
-            let Some(route) = dev.route.clone() else {
-                continue;
-            };
-            if let Some(lighting) = self.config.lighting(&dev.config_key).filter(|l| l.enabled) {
-                crate::hardware::set_lighting_in_background(Some(route), &lighting);
-            }
         }
         self.devices = devices;
         self.current = pick_current(&self.devices, self.config.selected_device());
         self.rebuild();
+    }
+
+    /// Force a volatile-settings re-apply for every online device on the next
+    /// inventory refresh. Called on a detected system wake: the devices were
+    /// likely power-cycled during the sleep, but the first post-wake snapshot
+    /// can look identical to the last pre-sleep one (same set, same routes,
+    /// already online), so the per-device transition triggers never fire.
+    pub fn reapply_volatile_on_next_refresh(&mut self) {
+        self.reapply_all_next_refresh = true;
+    }
+
+    /// Push the persisted volatile settings (lighting, sensor DPI, SmartShift)
+    /// to one device, fire-and-forget on background threads. Reuses the
+    /// capture session's channel when it already points at the device, like
+    /// every other hardware write.
+    fn reapply_volatile_settings(&self, dev: &AgentDevice) {
+        let Some(route) = dev.route.clone() else {
+            return;
+        };
+        let key = &dev.config_key;
+        if let Some(lighting) = self.config.lighting(key).filter(|l| l.enabled) {
+            crate::hardware::set_lighting_in_background(Some(route.clone()), &lighting);
+        }
+        if let Some(dpi) = self.config.dpi(key) {
+            crate::hardware::write_dpi_in_background(
+                Some(&self.shared.capture_channel),
+                Some(route.clone()),
+                dpi,
+            );
+        }
+        if let Some(smartshift) = self.config.smartshift(key) {
+            crate::hardware::write_smartshift_in_background(
+                Some(&self.shared.capture_channel),
+                Some(route),
+                smartshift.mode.into(),
+                smartshift.auto_disengage,
+                smartshift.tunable_torque,
+            );
+        }
     }
 
     /// The latest inventory snapshot (for the IPC `inventory()` poll). Empty
@@ -300,6 +341,7 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
                 slot: paired.slot,
                 serial: model.serial_number.clone(),
                 unit_id: model.unit_id,
+                online: paired.online,
             });
         }
     }
@@ -318,6 +360,28 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
             .then_with(|| a.config_key.cmp(&b.config_key))
     });
     devices
+}
+
+/// Indices into `next` of devices whose volatile settings need re-applying:
+/// newly-appeared keys, route changes (a replug re-enumerating under a new
+/// node), offline→online transitions (a reconnect after device sleep), or —
+/// after a system wake — every device. Offline devices are never targeted
+/// (the write would just time out); they re-apply on their own transition.
+fn reapply_targets(prev: &[AgentDevice], next: &[AgentDevice], reapply_all: bool) -> Vec<usize> {
+    next.iter()
+        .enumerate()
+        .filter(|(_, dev)| dev.online && dev.route.is_some())
+        .filter(|(_, dev)| {
+            if reapply_all {
+                return true;
+            }
+            match prev.iter().find(|p| p.config_key == dev.config_key) {
+                None => true,
+                Some(p) => p.route != dev.route || !p.online,
+            }
+        })
+        .map(|(idx, _)| idx)
+        .collect()
 }
 
 /// Index of the selected device: the one whose `config_key` matches the saved
@@ -342,8 +406,64 @@ fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{InventoryHealth, Orchestrator};
+    use super::{AgentDevice, InventoryHealth, Orchestrator, reapply_targets};
     use openlogi_core::config::Config;
+    use openlogi_hid::DeviceRoute;
+
+    fn dev(key: &str, slot: u8, online: bool) -> AgentDevice {
+        AgentDevice {
+            config_key: key.to_string(),
+            route: Some(DeviceRoute::Bolt {
+                receiver_uid: "AA00".to_string(),
+                slot,
+            }),
+            slot,
+            serial: None,
+            unit_id: [0; 4],
+            online,
+        }
+    }
+
+    #[test]
+    fn reapply_targets_new_arrivals_and_transitions() {
+        // First sighting of an online device → re-apply.
+        assert_eq!(reapply_targets(&[], &[dev("a", 1, true)], false), vec![0]);
+        // Steady state → nothing.
+        assert!(reapply_targets(&[dev("a", 1, true)], &[dev("a", 1, true)], false).is_empty());
+        // Replug under a new route (same key, new slot) → re-apply.
+        assert_eq!(
+            reapply_targets(&[dev("a", 1, true)], &[dev("a", 2, true)], false),
+            vec![0]
+        );
+        // Waking from device sleep (offline → online) → re-apply.
+        assert_eq!(
+            reapply_targets(&[dev("a", 1, false)], &[dev("a", 1, true)], false),
+            vec![0]
+        );
+        // Going to sleep (online → offline) → nothing.
+        assert!(reapply_targets(&[dev("a", 1, true)], &[dev("a", 1, false)], false).is_empty());
+    }
+
+    #[test]
+    fn reapply_targets_skip_offline_and_routeless_devices() {
+        // A paired-but-asleep new arrival waits for its online transition —
+        // writing now would only time out against a sleeping device.
+        assert!(reapply_targets(&[], &[dev("a", 1, false)], false).is_empty());
+        let routeless = AgentDevice {
+            route: None,
+            ..dev("b", 2, true)
+        };
+        assert!(reapply_targets(&[], &[routeless], false).is_empty());
+    }
+
+    #[test]
+    fn reapply_all_targets_every_online_device() {
+        let prev = [dev("a", 1, true), dev("b", 2, false)];
+        let next = [dev("a", 1, true), dev("b", 2, false)];
+        // The post-wake snapshot looks identical to the pre-sleep one; the
+        // flag still re-applies to the online device (and only that one).
+        assert_eq!(reapply_targets(&prev, &next, true), vec![0]);
+    }
 
     /// An *empty* snapshot still flips the health to `Ready`: the watcher only
     /// forwards completed enumerations, so "checked and found nothing" must not

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -12,11 +12,11 @@
 //! latency budget in PLAN.md.
 
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use openlogi_core::device::DeviceInventory;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Consecutive *initial* enumerate failures before the watcher declares
 /// enumeration [`InventoryEvent::Unavailable`]. Only counts before the first
@@ -24,6 +24,13 @@ use tracing::{debug, warn};
 /// the error arm below), and a later success upgrades `Unavailable` back to a
 /// live inventory.
 const INITIAL_FAILURE_LIMIT: u8 = 3;
+
+/// Wall-clock slack past `period` before a late tick is read as a sleep/wake
+/// gap. Generously above the worst honest iteration (period + a fully
+/// timed-out probe pass), so only a genuine suspend trips it; a rare false
+/// positive (e.g. a large NTP step) merely re-applies settings the devices
+/// already have.
+const WAKE_GAP: Duration = Duration::from_secs(60);
 
 /// What the watcher tells the agent.
 pub enum InventoryEvent {
@@ -33,6 +40,12 @@ pub enum InventoryEvent {
     /// starting" any longer; without this the GUI would show its scanning
     /// state forever on a broken HID backend.
     Unavailable,
+    /// The wall clock jumped far past the polling period — the system almost
+    /// certainly slept and woke. Devices may have power-cycled while their
+    /// set/route/online state looks unchanged across the gap, so the agent
+    /// re-applies volatile settings on the next snapshot (#189). Detected by
+    /// wall clock because the monotonic clock pauses during sleep on macOS.
+    SystemWake,
 }
 
 /// Spawn the watcher and return a receiver of inventory events. The
@@ -65,7 +78,21 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
             let mut enumerator = openlogi_hid::Enumerator::default();
             let mut succeeded = false;
             let mut initial_failures: u8 = 0;
+            let mut last_tick = SystemTime::now();
             loop {
+                // A tick arriving far past its period means the system slept;
+                // `duration_since` errs when the clock stepped backwards, in
+                // which case there is nothing to conclude — just re-anchor.
+                let now = SystemTime::now();
+                if let Ok(elapsed) = now.duration_since(last_tick)
+                    && elapsed > period + WAKE_GAP
+                {
+                    info!(?elapsed, "wall-clock gap — assuming a system wake");
+                    if worker_tx.send(InventoryEvent::SystemWake).is_err() {
+                        return;
+                    }
+                }
+                last_tick = now;
                 match rt.block_on(enumerator.enumerate()) {
                     Ok(inv) => {
                         succeeded = true;

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -174,6 +174,11 @@ async fn run(config: Config) {
                 Some(watchers::inventory::InventoryEvent::Unavailable) => {
                     orchestrator.lock().await.mark_inventory_unavailable();
                 }
+                Some(watchers::inventory::InventoryEvent::SystemWake) => {
+                    // Devices likely power-cycled during the sleep; the next
+                    // snapshot re-applies their volatile settings (#189).
+                    orchestrator.lock().await.reapply_volatile_on_next_refresh();
+                }
                 // Watcher thread death (e.g. a panic inside the HID backend's
                 // enumerate) — without a snapshot the GUI would scan forever.
                 None => {

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -214,6 +214,33 @@ where
     Ok(u8::deserialize(deserializer)?.min(100))
 }
 
+/// Scroll-wheel mode for [`SmartShift`]: free-spin or ratchet (clicky).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WheelMode {
+    Free,
+    Ratchet,
+}
+
+/// Per-device SmartShift wheel configuration, persisted so the agent can
+/// re-apply it when the device reconnects: the values are written to device
+/// RAM and do not survive a power cycle (#189), despite earlier assumptions
+/// that the device kept them in NVM.
+///
+/// Config-file only — never crosses the IPC (the agent reads it from
+/// `config.toml` on reload), so it is free to evolve without a
+/// `PROTOCOL_VERSION` bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmartShift {
+    pub mode: WheelMode,
+    /// SmartShift auto-disengage threshold (`0x01`–`0xFE`, in 0.25 turn/s
+    /// steps), or `0xFF` for a permanently engaged ratchet.
+    pub auto_disengage: u8,
+    /// Tunable-torque force percentage (`1`–`100`), `0` when the device
+    /// doesn't support tunable torque.
+    pub tunable_torque: u8,
+}
+
 /// Which control owns a device's single gesture role.
 ///
 /// Stored explicitly — rather than inferred from which button happens to carry a
@@ -298,10 +325,20 @@ pub struct DeviceConfig {
     /// the cycle action becomes a no-op until the user adds at least one.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dpi_presets: Vec<u32>,
+    /// The sensor DPI the user committed for this device. Persisted because
+    /// the value lives in device RAM and resets on a power cycle (#189); the
+    /// agent re-applies it when the device reconnects. `None` until the user
+    /// first changes DPI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dpi: Option<u32>,
     /// Per-device RGB lighting (static color + brightness + on/off). `None`
     /// until the user changes it, so it stays out of `config.toml` otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lighting: Option<Lighting>,
+    /// Per-device SmartShift wheel configuration, re-applied on reconnect for
+    /// the same reason as [`Self::dpi`]. `None` until the user changes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smartshift: Option<SmartShift>,
 }
 
 /// Deserialize-only shim that folds the pre-v2 `button_bindings` +
@@ -330,7 +367,11 @@ struct RawDeviceConfig {
     #[serde(default)]
     dpi_presets: Vec<u32>,
     #[serde(default)]
+    dpi: Option<u32>,
+    #[serde(default)]
     lighting: Option<Lighting>,
+    #[serde(default)]
+    smartshift: Option<SmartShift>,
 }
 
 impl From<RawDeviceConfig> for DeviceConfig {
@@ -369,7 +410,9 @@ impl From<RawDeviceConfig> for DeviceConfig {
             bindings,
             per_app_bindings: raw.per_app_bindings,
             dpi_presets: raw.dpi_presets,
+            dpi: raw.dpi,
             lighting: raw.lighting,
+            smartshift: raw.smartshift,
         }
     }
 }
@@ -726,6 +769,33 @@ impl Config {
             .or_default()
             .lighting = Some(lighting);
     }
+
+    /// The committed sensor DPI for `device_key`, or `None` if never set.
+    #[must_use]
+    pub fn dpi(&self, device_key: &str) -> Option<u32> {
+        self.devices.get(device_key).and_then(|d| d.dpi)
+    }
+
+    /// Record the committed sensor DPI for `device_key`, so the agent can
+    /// re-apply it when the device reconnects (#189).
+    pub fn set_dpi(&mut self, device_key: &str, dpi: u32) {
+        self.devices.entry(device_key.to_string()).or_default().dpi = Some(dpi);
+    }
+
+    /// The SmartShift wheel config for `device_key`, or `None` if never set.
+    #[must_use]
+    pub fn smartshift(&self, device_key: &str) -> Option<SmartShift> {
+        self.devices.get(device_key).and_then(|d| d.smartshift)
+    }
+
+    /// Record the SmartShift wheel config for `device_key`, so the agent can
+    /// re-apply it when the device reconnects (#189).
+    pub fn set_smartshift(&mut self, device_key: &str, smartshift: SmartShift) {
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .smartshift = Some(smartshift);
+    }
 }
 
 fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
@@ -800,6 +870,38 @@ mod tests {
             })
         );
         assert_eq!(restored.lighting("absent"), None);
+    }
+
+    #[test]
+    fn dpi_roundtrips_per_device() {
+        let mut cfg = Config::default();
+        cfg.set_dpi("2b042", 1600);
+        let restored = write_and_read(&cfg);
+        assert_eq!(restored.dpi("2b042"), Some(1600));
+        assert_eq!(restored.dpi("absent"), None);
+    }
+
+    #[test]
+    fn smartshift_roundtrips_per_device() {
+        let mut cfg = Config::default();
+        cfg.set_smartshift(
+            "2b042",
+            SmartShift {
+                mode: WheelMode::Ratchet,
+                auto_disengage: 16,
+                tunable_torque: 30,
+            },
+        );
+        let restored = write_and_read(&cfg);
+        assert_eq!(
+            restored.smartshift("2b042"),
+            Some(SmartShift {
+                mode: WheelMode::Ratchet,
+                auto_disengage: 16,
+                tunable_torque: 30,
+            })
+        );
+        assert_eq!(restored.smartshift("absent"), None);
     }
 
     #[test]

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -177,18 +177,11 @@ impl DpiPanel {
                     }
                     SliderEvent::Release(value) => {
                         let dpi = normalized_slider_dpi(value.start(), cx);
-                        // Resolve the target from AppState at fire-time so
+                        // `commit_dpi` resolves the target at fire-time, so
                         // carousel-driven device switches route the write to the
                         // now-current device, not whichever was active when this
                         // slider entity was constructed.
-                        let route = cx
-                            .try_global::<AppState>()
-                            .and_then(|s| s.current_record().and_then(|r| r.route.clone()));
-                        let sender = cx.try_global::<AppState>().map(AppState::ipc_sender);
-                        cx.update_global::<AppState, _>(|state, _| state.dpi = dpi);
-                        if let (Some(route), Some(sender)) = (route, sender) {
-                            let _ = sender.send(crate::ipc_client::Command::SetDpi(route, dpi));
-                        }
+                        cx.update_global::<AppState, _>(|state, _| state.commit_dpi(dpi));
                     }
                 },
             );
@@ -422,17 +415,13 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
                     // Only apply once the supported DPI list is known, so the
                     // click writes a snapped, device-valid value — and can't be
                     // clobbered by a discovery result that lands afterwards.
-                    let Some((route, dpi, sender)) = cx.try_global::<AppState>().and_then(|s| {
-                        let dpi = s.active_dpi_capabilities()?.snap(value);
-                        let route = s.current_record().and_then(|r| r.route.clone());
-                        Some((route, dpi, s.ipc_sender()))
-                    }) else {
+                    let Some(dpi) = cx
+                        .try_global::<AppState>()
+                        .and_then(|s| Some(s.active_dpi_capabilities()?.snap(value)))
+                    else {
                         return;
                     };
-                    cx.update_global::<AppState, _>(|state, _| state.dpi = dpi);
-                    if let Some(route) = route {
-                        let _ = sender.send(crate::ipc_client::Command::SetDpi(route, dpi));
-                    }
+                    cx.update_global::<AppState, _>(|state, _| state.commit_dpi(dpi));
                     cx.refresh_windows();
                 }),
         )

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -256,6 +256,22 @@ impl AppState {
         }
     }
 
+    /// Persist the in-memory config and — only if the write actually landed —
+    /// have the agent reload it. `what` names the setting for the failure log.
+    ///
+    /// The order matters: on a failed write the on-disk file still holds the
+    /// *previous* config, so a reload would hand the agent stale values and
+    /// (for volatile settings) silently re-apply the old DPI/SmartShift on the
+    /// next reconnect or wake. Skipping the reload keeps the agent on whatever
+    /// it already runs; the GUI keeps the new value in memory either way.
+    fn persist_and_reload(&self, what: &str) {
+        if let Err(e) = self.config.save_atomic() {
+            warn!(error = %e, what, "could not persist to config.toml — agent reload skipped");
+            return;
+        }
+        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+    }
+
     /// A clone of the IPC command sender, so views (the DPI / SmartShift panels)
     /// can issue device reads and writes through the agent themselves.
     #[must_use]
@@ -542,11 +558,8 @@ impl AppState {
         self.gesture_bindings = self.gesture_bindings_for_current();
         let key = self.current_record().map(|r| r.config_key.clone());
         self.config.set_selected_device(key);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist selected device");
-        }
         // The agent owns the hook + device I/O; have it switch devices too.
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("selected device");
     }
 
     /// Replace the DPI preset list for the currently selected device. The
@@ -563,10 +576,7 @@ impl AppState {
             return;
         };
         self.config.set_dpi_presets(&key, presets);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist DPI presets to config.toml");
-        }
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("DPI presets");
     }
 
     /// Read the DPI preset list for the active device, or an empty `Vec`
@@ -872,10 +882,7 @@ impl AppState {
                 tunable_torque,
             },
         );
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist SmartShift to config.toml");
-        }
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("SmartShift");
         // Reflect the write immediately so the panel doesn't flicker back to
         // the previous value before a re-read lands, but queue a confirming
         // re-read: the write is fire-and-forget, so a sleeping device that
@@ -952,13 +959,10 @@ impl AppState {
             ));
         }
         self.config.set_lighting(&key, lighting);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist lighting to config.toml");
-        }
         // Keep the agent's config copy fresh: it re-applies the saved colour
         // when the keyboard reconnects, and without the reload it would
         // replay whatever was saved the last time something *else* reloaded.
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("lighting");
     }
 
     /// Apply `dpi` to the active device (best-effort, via the agent) and
@@ -977,10 +981,7 @@ impl AppState {
             self.send_ipc(crate::ipc_client::Command::SetDpi(route, dpi));
         }
         self.config.set_dpi(&key, dpi);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist DPI to config.toml");
-        }
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("DPI");
     }
 
     /// App-wide settings backing the Settings window (launch-at-login,
@@ -1000,12 +1001,9 @@ impl AppState {
             return;
         }
         self.config.app_settings.launch_at_login = enabled;
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist launch-at-login setting");
-        }
         // The agent owns autostart now; it reconciles its LaunchAgent (which
         // points at the agent, not the GUI) when it reloads the config.
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("launch-at-login setting");
     }
 
     /// Toggle the menu-bar (status item) icon preference and persist it. The
@@ -1019,10 +1017,7 @@ impl AppState {
             return;
         }
         self.config.app_settings.show_in_menu_bar = enabled;
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist show-in-menu-bar setting");
-        }
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("show-in-menu-bar setting");
     }
 
     /// Toggle the opt-in update check and persist it. No immediate side
@@ -1050,10 +1045,7 @@ impl AppState {
             return;
         }
         self.config.app_settings.thumbwheel_sensitivity = sensitivity;
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist thumbwheel sensitivity");
-        }
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("thumbwheel sensitivity");
     }
 
     pub fn set_auto_download_assets(&mut self, enabled: bool) {
@@ -1120,11 +1112,8 @@ impl AppState {
         };
         self.config
             .set_binding(&key, button, Binding::Single(action));
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist binding to config.toml");
-        }
         // The agent owns the hook; have it rebuild its live map from config.
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("binding");
     }
 
     fn bindings_for_current(&self) -> BTreeMap<ButtonId, Action> {
@@ -1177,13 +1166,10 @@ impl AppState {
                 self.config.disable_gestures(&key);
             }
         }
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist gesture-button change to config.toml");
-        }
         // The owner change shuffles bindings between the single + gesture maps.
         self.button_bindings = self.bindings_for_current();
         self.gesture_bindings = self.gesture_bindings_for_current();
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("gesture-button change");
     }
 
     /// Update a single gesture-button sub-binding in memory, on disk, and in the
@@ -1210,11 +1196,8 @@ impl AppState {
         self.gesture_bindings.insert(direction, action.clone());
         self.config
             .set_gesture_direction(&key, owner, direction, action);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist gesture binding to config.toml");
-        }
         // The agent owns the gesture watcher; have it rebuild from config.
-        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        self.persist_and_reload("gesture binding");
     }
 }
 

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -840,8 +840,9 @@ impl AppState {
     }
 
     /// Write a full SmartShift configuration to the active device (best-effort,
-    /// on a background thread) and optimistically cache it. The device persists
-    /// the values in its own NVM, so nothing is written to `config.toml`.
+    /// on a background thread), optimistically cache it, and persist it to
+    /// `config.toml` — the values live in device RAM and reset on a power
+    /// cycle (#189), so the agent re-applies them when the device reconnects.
     /// No-op when no device is selected.
     pub fn commit_smartshift(
         &mut self,
@@ -863,6 +864,18 @@ impl AppState {
                 tunable_torque,
             ));
         }
+        self.config.set_smartshift(
+            &key,
+            openlogi_core::config::SmartShift {
+                mode: mode.into(),
+                auto_disengage,
+                tunable_torque,
+            },
+        );
+        if let Err(e) = self.config.save_atomic() {
+            warn!(error = %e, "could not persist SmartShift to config.toml");
+        }
+        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
         // Reflect the write immediately so the panel doesn't flicker back to
         // the previous value before a re-read lands, but queue a confirming
         // re-read: the write is fire-and-forget, so a sleeping device that
@@ -942,6 +955,32 @@ impl AppState {
         if let Err(e) = self.config.save_atomic() {
             warn!(error = %e, "could not persist lighting to config.toml");
         }
+        // Keep the agent's config copy fresh: it re-applies the saved colour
+        // when the keyboard reconnects, and without the reload it would
+        // replay whatever was saved the last time something *else* reloaded.
+        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+    }
+
+    /// Apply `dpi` to the active device (best-effort, via the agent) and
+    /// persist it per device — the sensor value lives in device RAM and resets
+    /// on a power cycle (#189), so the agent re-applies it on reconnect.
+    /// Updates the displayed value even with no device selected.
+    pub fn commit_dpi(&mut self, dpi: u32) {
+        self.dpi = dpi;
+        let Some(record) = self.current_record() else {
+            debug!("no active device — DPI change kept in memory only");
+            return;
+        };
+        let key = record.config_key.clone();
+        let route = record.route.clone();
+        if let Some(route) = route {
+            self.send_ipc(crate::ipc_client::Command::SetDpi(route, dpi));
+        }
+        self.config.set_dpi(&key, dpi);
+        if let Err(e) = self.config.save_atomic() {
+            warn!(error = %e, "could not persist DPI to config.toml");
+        }
+        self.send_ipc(crate::ipc_client::Command::ReloadConfig);
     }
 
     /// App-wide settings backing the Settings window (launch-at-login,

--- a/crates/openlogi-hid/src/smartshift.rs
+++ b/crates/openlogi-hid/src/smartshift.rs
@@ -57,6 +57,28 @@ impl SmartShiftMode {
     }
 }
 
+// The config file persists the wheel mode in its own representation
+// (`openlogi_core::config::WheelMode`, kept IPC-free); these conversions are
+// the single mapping between the persisted and the wire/firmware form, used by
+// the GUI when committing and by the agent when re-applying after a reconnect.
+impl From<openlogi_core::config::WheelMode> for SmartShiftMode {
+    fn from(mode: openlogi_core::config::WheelMode) -> Self {
+        match mode {
+            openlogi_core::config::WheelMode::Free => Self::Free,
+            openlogi_core::config::WheelMode::Ratchet => Self::Ratchet,
+        }
+    }
+}
+
+impl From<SmartShiftMode> for openlogi_core::config::WheelMode {
+    fn from(mode: SmartShiftMode) -> Self {
+        match mode {
+            SmartShiftMode::Free => Self::Free,
+            SmartShiftMode::Ratchet => Self::Ratchet,
+        }
+    }
+}
+
 /// `autoDisengage` value that keeps the ratchet engaged permanently — the
 /// wheel never auto-releases into free-spin, regardless of speed. Any other
 /// value (`0x01`–`0xFE`) is a SmartShift speed threshold.


### PR DESCRIPTION
## Problem

DPI (`0x2201`) and SmartShift (`0x2110`/`0x2111`) writes land in device RAM — they do **not** survive a power cycle. `commit_smartshift`'s doc comment even claimed NVM persistence, which is wrong. Only lighting was persisted to `config.toml`, and even that was only reapplied when the orchestrator saw a brand-new device key. Net effect: turn the mouse off and on (or sleep/wake the Mac) and DPI + SmartShift silently revert to hardware defaults (#189).

## Fix

**Persist** (config side):
- `DeviceConfig` gains `dpi: Option<u32>` and `smartshift: Option<SmartShift>` (`WheelMode` + `auto_disengage` + `tunable_torque`). Config-file only — nothing crosses IPC, no protocol bump.
- GUI `commit_dpi` / `commit_smartshift` now write the value to `config.toml` (atomic save) and send `ReloadConfig`, like the lighting path; `commit_lighting` now also sends `ReloadConfig` it was missing.

**Reapply** (agent side) — `reapply_targets` picks devices that are online with a live route and:
1. are new to the device map (cold start / new pairing), or
2. came back on a **different route** (re-enumerated on a new HID++ index), or
3. flipped **offline → online** (power cycle on a stable route), or
4. everything, once, after a **system wake**.

Wake detection: the inventory watcher compares wall-clock time across ticks (`SystemTime`, because the monotonic clock pauses during sleep on macOS) and emits `InventoryEvent::SystemWake` when the gap exceeds the period by 60 s; the agent then schedules a one-shot reapply-all on the next snapshot.

For each target the agent pushes lighting, DPI, and SmartShift from `config.toml` via the existing background write paths.

Fixes #189

## Tests

- Config round-trip tests for `dpi` and `smartshift` per device.
- 3 `reapply_targets` unit tests (new key, route change, offline→online, plus the reapply-all flag).
- `cargo fmt` / `clippy --workspace --all-targets -D warnings` / full test suite green.