### PR TITLE
fix(gui): keep asleep devices and their panels in the device list

### DIFF
--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::binding::{Action, Binding, ButtonId, GestureDirection, default_binding_for};
+use crate::device::{Capabilities, DeviceKind};
 use crate::paths::{self, PathsError};
 
 /// The schema version the current build produces. Bumped on breaking layout
@@ -263,6 +264,31 @@ where
     Ok(button.map(GestureOwner::Button))
 }
 
+/// Last-known identity of a device, captured while it was online so the UI can
+/// render its card and the *correct* config panels before any live HID++ probe
+/// completes — or while the device is asleep and can't be probed at all.
+///
+/// Every field is a **static property of the model**, not of the current
+/// connection: an MX Master 3S has adjustable DPI whether or not it is awake.
+/// That is what makes this safe to persist — it never goes stale. It is also
+/// free of any per-unit identifier (no serial number, no unit id), so caching
+/// it adds no privacy surface beyond the `config_key` already used as the map
+/// key. Persisting identity is what stops a sleeping/just-booted mouse from
+/// vanishing from the device list (and losing its Pointer/Buttons panels)
+/// until a cold probe happens to win its race — see issue #159.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceIdentity {
+    /// The name shown in the carousel, as resolved from the asset registry the
+    /// last time the device was online.
+    pub display_name: String,
+    /// The device's resolved [`DeviceKind`] (asset registry preferred, HID++
+    /// classification as fallback).
+    pub kind: DeviceKind,
+    /// Configuration capabilities measured from the device's HID++ feature
+    /// table. This is the field that keeps a sleeping mouse's panels visible.
+    pub capabilities: Capabilities,
+}
+
 /// Settings scoped to a single physical device (keyed by HID++ model+ext).
 ///
 /// Deserialization goes through [`RawDeviceConfig`] (`#[serde(from)]`) so
@@ -279,6 +305,12 @@ pub struct DeviceConfig {
     /// as a scalar ahead of the `bindings` sub-table.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gesture_owner: Option<GestureOwner>,
+    /// Last-known identity (name / kind / capabilities), captured while the
+    /// device was online. Lets the UI render this device — with the right
+    /// config panels — on a cold start before any probe, or while it sleeps.
+    /// `None` for configs written before this field existed or by hand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<DeviceIdentity>,
     /// Every rebindable button's binding: a single [`Action`], or — for the
     /// gesture button (and, later, any raw-XY-capable button) — a
     /// [`Binding::Gesture`] per-direction map.
@@ -316,6 +348,8 @@ struct RawDeviceConfig {
     /// [`deserialize_gesture_owner`].
     #[serde(default, deserialize_with = "deserialize_gesture_owner")]
     gesture_owner: Option<GestureOwner>,
+    #[serde(default)]
+    identity: Option<DeviceIdentity>,
     /// v2 shape — present on already-migrated files; wins on any key collision.
     #[serde(default)]
     bindings: BTreeMap<ButtonId, Binding>,
@@ -366,6 +400,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
 
         DeviceConfig {
             gesture_owner: raw.gesture_owner,
+            identity: raw.identity,
             bindings,
             per_app_bindings: raw.per_app_bindings,
             dpi_presets: raw.dpi_presets,
@@ -711,6 +746,34 @@ impl Config {
             .dpi_presets = presets;
     }
 
+    /// The last-known [`DeviceIdentity`] for `device_key`, or `None` if the
+    /// device has never been seen online (or was configured before identities
+    /// were recorded).
+    #[must_use]
+    pub fn device_identity(&self, device_key: &str) -> Option<&DeviceIdentity> {
+        self.devices
+            .get(device_key)
+            .and_then(|d| d.identity.as_ref())
+    }
+
+    /// Record (or refresh) the identity captured for `device_key` while it was
+    /// online, creating the device entry if needed.
+    pub fn set_device_identity(&mut self, device_key: &str, identity: DeviceIdentity) {
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .identity = Some(identity);
+    }
+
+    /// Iterate every device we've recorded an identity for, as
+    /// `(config_key, identity)`. Used to seed offline placeholder cards so a
+    /// known device stays visible (with its panels) before any live probe.
+    pub fn known_identities(&self) -> impl Iterator<Item = (&str, &DeviceIdentity)> {
+        self.devices
+            .iter()
+            .filter_map(|(k, d)| d.identity.as_ref().map(|i| (k.as_str(), i)))
+    }
+
     /// The lighting config for `device_key`, or `None` if unset.
     #[must_use]
     pub fn lighting(&self, device_key: &str) -> Option<Lighting> {
@@ -889,6 +952,42 @@ mod tests {
         assert!(
             !body.contains("dpi_presets"),
             "empty dpi_presets should be omitted: {body}"
+        );
+    }
+
+    #[test]
+    fn device_identity_roundtrips_and_is_iterable() {
+        use crate::device::{Capabilities, DeviceKind};
+
+        let mut cfg = Config::default();
+        let mouse = DeviceIdentity {
+            display_name: "MX Master 3S".to_string(),
+            kind: DeviceKind::Mouse,
+            capabilities: Capabilities {
+                buttons: true,
+                pointer: true,
+                lighting: false,
+            },
+        };
+        cfg.set_device_identity("2b034", mouse.clone());
+        // Recording an identity must not disturb unrelated per-device state.
+        cfg.set_binding(
+            "2b034",
+            ButtonId::Back,
+            Binding::Single(Action::BrowserBack),
+        );
+
+        let parsed = write_and_read(&cfg);
+        assert_eq!(parsed.device_identity("2b034"), Some(&mouse));
+        assert_eq!(parsed.device_identity("absent"), None);
+        assert_eq!(
+            parsed.bindings_for("2b034").get(&ButtonId::Back),
+            Some(&Binding::Single(Action::BrowserBack)),
+            "identity must coexist with bindings on the same device block"
+        );
+        assert_eq!(
+            parsed.known_identities().collect::<Vec<_>>(),
+            vec![("2b034", &mouse)]
         );
     }
 

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use gpui::{App, Global};
-use openlogi_core::config::{AppSettings, Config, Lighting};
+use openlogi_core::config::{AppSettings, Config, DeviceIdentity, Lighting};
 use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{
     DeviceRoute, DpiCapabilities, DpiInfo, SmartShiftMode, SmartShiftStatus, WriteError,
@@ -212,12 +212,14 @@ impl AppState {
     /// builds the `Arc` first and uses [`Self::with_runtime_shared`] instead.
     #[must_use]
     pub fn with_runtime(
-        config: Config,
+        mut config: Config,
         inventories: &[DeviceInventory],
         cache: &AssetResolver,
         ipc_commands: mpsc::UnboundedSender<crate::ipc_client::Command>,
     ) -> Self {
-        let device_list = build_device_list(inventories, cache);
+        let device_list = build_device_list(inventories, cache, &config);
+        // Record any device probed at launch so it survives the next cold start.
+        persist_identities(&mut config, &device_list);
         let current_device = pick_initial_device(&device_list, config.selected_device());
         let mut state = Self {
             current_device,
@@ -309,7 +311,7 @@ impl AppState {
         BTreeMap<GestureDirection, Action>,
         DpiCycleState,
     ) {
-        let device_list = build_device_list(inventories, cache);
+        let device_list = build_device_list(inventories, cache, config);
         let current_device = pick_initial_device(&device_list, config.selected_device());
         let record = device_list.get(current_device);
         let config_key = record.map(|r| r.config_key.as_str());
@@ -398,17 +400,29 @@ impl AppState {
         cache: &AssetResolver,
         force: bool,
     ) -> bool {
-        let new_list = build_device_list(inventories, cache);
+        let new_list = build_device_list(inventories, cache, &self.config);
         let merged_list = self.merge_inventory_snapshot(new_list);
-        // Compare routes too, not just config_key: a device can reconnect on a
-        // new HID++ index while keeping its model-derived config_key, and the
-        // fresh route must replace the stale one so reads/writes don't target a
-        // dead index.
+        // Capture any newly-probed identity before the unchanged-check can early
+        // out: a device whose capabilities just resolved keeps the same
+        // config_key + route, so that guard would otherwise skip the write.
+        persist_identities(&mut self.config, &merged_list);
+        // Compare more than config_key: a device can reconnect on a new HID++
+        // index while keeping its model-derived config_key, and the fresh route
+        // must replace the stale one so reads/writes don't target a dead index.
+        // `online` and `capabilities` are compared too, so a device waking up or
+        // a probe that resolves its feature table on a stable route still
+        // refreshes the carousel (and its config panels) instead of being
+        // swallowed by this guard.
         let unchanged = merged_list.len() == self.device_list.len()
             && merged_list
                 .iter()
                 .zip(self.device_list.iter())
-                .all(|(a, b)| a.config_key == b.config_key && a.route == b.route);
+                .all(|(a, b)| {
+                    a.config_key == b.config_key
+                        && a.route == b.route
+                        && a.online == b.online
+                        && a.capabilities == b.capabilities
+                });
         if unchanged && !force {
             return false;
         }
@@ -1176,6 +1190,40 @@ impl AppState {
         }
         // The agent owns the gesture watcher; have it rebuild from config.
         self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+    }
+}
+
+/// Record the identity (name / kind / capabilities) of every currently online,
+/// fully-probed device into `config`, persisting to disk only when something
+/// actually changed.
+///
+/// This is the write half of the identity-driven device list: it is what lets
+/// [`build_device_list`] resurrect a sleeping device on the next launch. Only
+/// online devices with *measured* capabilities are recorded — never a presumed
+/// or carried-forward `None` — so a placeholder never persists empty panels.
+/// The change-guard keeps quiet inventory ticks off the disk; the agent does
+/// not consume identities, so no `ReloadConfig` is sent.
+fn persist_identities(config: &mut Config, list: &[DeviceRecord]) {
+    let mut changed = false;
+    for record in list {
+        if !record.online {
+            continue;
+        }
+        let Some(capabilities) = record.capabilities else {
+            continue;
+        };
+        let identity = DeviceIdentity {
+            display_name: record.display_name.clone(),
+            kind: record.kind,
+            capabilities,
+        };
+        if config.device_identity(&record.config_key) != Some(&identity) {
+            config.set_device_identity(&record.config_key, identity);
+            changed = true;
+        }
+    }
+    if changed && let Err(e) = config.save_atomic() {
+        warn!(error = %e, "could not persist device identities to config.toml");
     }
 }
 

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -1,6 +1,9 @@
 //! Device-list construction and selection helpers for [`super::AppState`].
 
+use std::collections::HashSet;
+
 use openlogi_agent_core::device_order::DeviceStableId;
+use openlogi_core::config::{Config, DeviceIdentity};
 use openlogi_core::device::{BatteryInfo, Capabilities, DeviceInventory, DeviceKind};
 use openlogi_hid::DeviceRoute;
 use tracing::debug;
@@ -37,9 +40,21 @@ pub struct DeviceRecord {
     pub battery: Option<BatteryInfo>,
 }
 
+/// Build the carousel's device list as the **union** of the live inventory and
+/// the persisted set of devices we've seen before.
+///
+/// Live devices come from `inventories` (the agent's current HID++ probe).
+/// Every device the user has previously seen online but that is *absent* from
+/// this snapshot — asleep, or not yet re-probed after a cold start — is added
+/// back as an offline placeholder from [`Config::known_identities`]. This is
+/// what makes the list independent of whether a probe wins its timing race: a
+/// known device (with its Pointer/Buttons panels) is always shown, and the live
+/// probe only *enriches* it (online state, battery, asset photo) rather than
+/// *gating* whether it appears at all. See issue #159.
 pub(super) fn build_device_list(
     inventories: &[DeviceInventory],
     cache: &AssetResolver,
+    config: &Config,
 ) -> Vec<DeviceRecord> {
     let mut list = Vec::new();
     for inv in inventories {
@@ -90,8 +105,51 @@ pub(super) fn build_device_list(
     if std::env::var_os("OPENLOGI_DEMO_KEYBOARD").is_some() {
         list.push(demo_keyboard());
     }
+    append_offline_known(&mut list, config.known_identities());
     sort_device_list(&mut list);
     list
+}
+
+/// Append an offline placeholder for every known device not already present in
+/// `list` (matched by `config_key`). Split out from [`build_device_list`] so
+/// the union rule is unit-testable without an [`AssetResolver`].
+fn append_offline_known<'a>(
+    list: &mut Vec<DeviceRecord>,
+    known: impl Iterator<Item = (&'a str, &'a DeviceIdentity)>,
+) {
+    let present: HashSet<&str> = list.iter().map(|r| r.config_key.as_str()).collect();
+    // Collect before extending: `present` borrows `list`, so the phantoms must
+    // be materialized before we can mutate it.
+    let phantoms: Vec<DeviceRecord> = known
+        .filter(|(key, _)| !present.contains(key))
+        .map(|(key, identity)| offline_record(key, identity))
+        .collect();
+    drop(present);
+    list.extend(phantoms);
+}
+
+/// Synthesize an offline placeholder from a persisted [`DeviceIdentity`].
+///
+/// `route: None` keeps every hardware write a no-op until the live inventory
+/// supplies the real route when the device wakes; `capabilities: Some(..)` from
+/// the persisted measurement is what keeps the device's config panels visible
+/// while it sleeps. The asset photo is left to the live record (we don't
+/// re-resolve it here), so an offline card shows the synthetic silhouette until
+/// the device comes back online.
+fn offline_record(config_key: &str, identity: &DeviceIdentity) -> DeviceRecord {
+    DeviceRecord {
+        config_key: config_key.to_string(),
+        display_name: identity.display_name.clone(),
+        asset: None,
+        serial_number: None,
+        unit_id: [0; 4],
+        route: None,
+        kind: identity.kind,
+        capabilities: Some(identity.capabilities),
+        slot: 0,
+        online: false,
+        battery: None,
+    }
 }
 
 /// Order the carousel by physical route. HID enumeration order can change as
@@ -207,11 +265,15 @@ fn prettify_codename(raw: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
+    use openlogi_core::config::Config;
+    use openlogi_core::device::{DeviceInventory, PairedDevice, ReceiverInfo};
 
     use crate::asset::AssetResolver;
 
-    use super::{build_device_list, effective_kind};
+    use super::{
+        Capabilities, DeviceIdentity, DeviceKind, DeviceRecord, append_offline_known,
+        build_device_list, effective_kind, offline_record,
+    };
 
     fn paired_device_no_model_info(slot: u8, wpid: Option<u16>) -> PairedDevice {
         PairedDevice {
@@ -238,11 +300,39 @@ mod tests {
         }
     }
 
+    fn online_record(key: &str) -> DeviceRecord {
+        DeviceRecord {
+            config_key: key.to_string(),
+            display_name: format!("live {key}"),
+            asset: None,
+            serial_number: None,
+            unit_id: [1; 4],
+            route: None,
+            kind: DeviceKind::Mouse,
+            capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+            slot: 1,
+            online: true,
+            battery: None,
+        }
+    }
+
+    fn mouse_identity(name: &str) -> DeviceIdentity {
+        DeviceIdentity {
+            display_name: name.to_string(),
+            kind: DeviceKind::Mouse,
+            capabilities: Capabilities {
+                buttons: true,
+                pointer: true,
+                lighting: false,
+            },
+        }
+    }
+
     #[test]
     fn no_model_info_uses_wpid_as_config_key() {
         let inv = inventory_with(vec![paired_device_no_model_info(1, Some(0x4076))]);
         let cache = AssetResolver::new();
-        let list = build_device_list(&[inv], &cache);
+        let list = build_device_list(&[inv], &cache, &Config::default());
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].config_key, "wpid4076");
         assert!(list[0].serial_number.is_none());
@@ -253,7 +343,7 @@ mod tests {
     fn no_model_info_falls_back_to_slot_when_no_wpid() {
         let inv = inventory_with(vec![paired_device_no_model_info(3, None)]);
         let cache = AssetResolver::new();
-        let list = build_device_list(&[inv], &cache);
+        let list = build_device_list(&[inv], &cache, &Config::default());
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].config_key, "slot3");
     }
@@ -262,8 +352,43 @@ mod tests {
     fn no_model_info_display_name_falls_back_to_slot() {
         let inv = inventory_with(vec![paired_device_no_model_info(2, Some(0x4051))]);
         let cache = AssetResolver::new();
-        let list = build_device_list(&[inv], &cache);
+        let list = build_device_list(&[inv], &cache, &Config::default());
         assert_eq!(list[0].display_name, "Slot 2");
+    }
+
+    #[test]
+    fn offline_record_is_present_but_inert() {
+        // A persisted identity renders as an offline card that still carries its
+        // measured capabilities (so its panels show) but no route (so writes are
+        // no-ops until it wakes).
+        let id = mouse_identity("MX Master 3S");
+        let rec = offline_record("2b034", &id);
+        assert_eq!(rec.config_key, "2b034");
+        assert_eq!(rec.display_name, "MX Master 3S");
+        assert!(!rec.online);
+        assert!(rec.route.is_none());
+        assert_eq!(rec.capabilities, Some(id.capabilities));
+    }
+
+    #[test]
+    fn known_devices_are_appended_only_when_absent_from_live() {
+        // "A" is live; "B" is known-but-asleep. The union keeps the live "A"
+        // untouched and adds "B" back as an offline placeholder — the core of
+        // the #159 fix: a sleeping device never drops out of the list.
+        let mut list = vec![online_record("A")];
+        let a = mouse_identity("live A overwritten?");
+        let b = mouse_identity("asleep B");
+        append_offline_known(&mut list, [("A", &a), ("B", &b)].into_iter());
+
+        assert_eq!(list.len(), 2);
+        assert!(
+            list.iter().any(|r| r.config_key == "A" && r.online),
+            "the live record for A must win over its identity"
+        );
+        assert!(
+            list.iter().any(|r| r.config_key == "B" && !r.online),
+            "B is added back as a persisted offline placeholder"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The device list was rebuilt purely from the live inventory snapshot. A device that is asleep at GUI launch — or simply hasn't won its probe race yet — doesn't appear in that snapshot, so its card (and its Pointer/Buttons config panels) vanish until a cold probe happens to complete. Users read this as "my mouse disappeared from the app" (#159).

## Fix

Persist a per-device **identity** and build the list as the **union of live and known** devices:

- New `DeviceIdentity { display_name, kind, capabilities }` persisted under the device's config block. Every field is a static property of the *model* (an MX Master 3S has adjustable DPI whether or not it's awake), so it never goes stale; it carries no per-unit identifier beyond the `config_key` already used as the map key.
- `persist_identities` records the identity of every online, fully-probed device on each snapshot (change-guarded, so quiet ticks don't touch the disk). Only *measured* capabilities are recorded — never a presumed fallback — so a placeholder can't persist empty panels.
- `build_device_list` appends an **offline placeholder** for every known device absent from the live snapshot: `capabilities` from the persisted measurement (keeps the config panels visible), `route: None` (keeps every hardware write a no-op until the device wakes and the live inventory supplies the real route).
- The refresh guard now also compares `online` and `capabilities`, so a device waking up — or a probe resolving its feature table on a stable route — refreshes the carousel instead of being swallowed by the unchanged-check.

Rebased onto current master: the identity field is threaded through the `RawDeviceConfig` deserialization shim introduced by the binding unification, and the list-refresh logic is merged with the asset-sync `force` rebuild.

Fixes #159

## Tests

- Config round-trip + iteration test for `DeviceIdentity` (also proves the `RawDeviceConfig` mapping).
- Union-rule tests: offline placeholder is present-but-inert; known devices are appended only when absent from live.
- `cargo fmt` / `clippy --workspace --all-targets -D warnings` / full test suite green.