### PR TITLE
build(release): shrink artifacts with fat LTO, LZMA DMG, and high MSI compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,6 @@ missing_errors_doc = "allow"
 doc_markdown = "allow"
 
 [profile.release]
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 strip = "symbols"

--- a/packaging/windows/OpenLogi.wxs
+++ b/packaging/windows/OpenLogi.wxs
@@ -34,7 +34,7 @@
            Compressed="yes">
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of OpenLogi is already installed." />
-    <MediaTemplate EmbedCab="yes" />
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
 
     <StandardDirectory Id="LocalAppDataFolder">
       <Directory Id="ProgramsFolder" Name="Programs">

--- a/xtask/src/macos.rs
+++ b/xtask/src/macos.rs
@@ -253,7 +253,11 @@ pub(crate) fn dmg_macos(args: &DmgMacos) -> Result<()> {
     // Geometry is locked to the painted 760×480 background. `create-dmg` uses
     // outer window dimensions, so add the 32pt Finder title bar and keep icon
     // coordinates relative to the 760×480 content area.
+    // ULMO (LZMA) compresses ~20% smaller than the default UDZO (zlib) and
+    // mounts on macOS 10.15+, well under the bundle's 13.0 floor.
     run(ProcessCommand::new("create-dmg")
+        .arg("--format")
+        .arg("ULMO")
         .arg("--volname")
         .arg("OpenLogi")
         .arg("--background")


### PR DESCRIPTION
## Summary

Three independent release-packaging size optimizations:

| Change | Measured effect |
|---|---|
| DMG: `create-dmg --format ULMO` (LZMA instead of the default UDZO/zlib) | **12.61 → 10.02 MB (-20.5%)**, measured by repacking the shipped v0.6.7 arm64 DMG |
| `profile.release.lto`: `thin` → `fat` | openlogi-gui **-7.4%** (17,905,568 → 16,584,384 B), openlogi-agent **-7.2%** (3,439,856 → 3,191,696 B), A/B on the same tree (aarch64-darwin) |
| MSI: `MediaTemplate CompressionLevel="high"` | not measurable locally; WiX defaults to `medium` when unspecified ([CreateCabinetsCommand.cs](https://github.com/wixtoolset/wix/blob/main/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateCabinetsCommand.cs)) |

Combined, the DMG should land around ~9.5 MB (~-25% vs v0.6.7) and the Windows EXEs shrink ~7%.

## Notes

- **ULMO compatibility**: LZMA DMGs mount on macOS 10.15+; the bundle floor is 13.0 (`osx_minimum_system_version`). CI installs `create-dmg` via brew (≥1.2), which supports `--format`.
- **Fat LTO cost/risk**: no semantic change (unlike `panic = "abort"`). Peak link RSS measured at **3.6 GB**, comfortably inside the 7 GB macOS arm64 runners; release-profile builds only run on tags, where the slower fat-LTO link (+~2 min locally) is acceptable. `cargo install openlogi` also picks up the smaller/faster profile.
- **Testing**: DMG conversion verified with `hdiutil` on the real v0.6.7 artifact (the same conversion `create-dmg` performs). Fat-LTO binaries built locally for both packaged crates but not runtime-smoke-tested (a release agent would take over the running production agent); they ride the normal release verification. The MSI change is validated by the next release run.