### PR TITLE
feat(linux): sign .deb/.rpm with minisign and add arm64 packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,8 +534,18 @@ jobs:
           path: .release/RELEASE_NOTES.md
 
   linux-packages:
-    name: Linux packages (.deb / .rpm)
-    runs-on: ubuntu-latest
+    name: Linux packages (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            nfpm_sha256: "d6417f99d5fa32bba7a4e007084615d3897651498c2e443118c26b9ec3b698a8"
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            nfpm_sha256: "dc63aa7228ec70490bae67ad3146883055a055639dcf0dffc82fa965bac75a31"
     permissions:
       contents: read
     steps:
@@ -545,16 +555,31 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # The nfpm `arch` and the runner's native arch must agree — the packages
+      # are built natively, not cross-compiled, so a mismatched runner would
+      # silently ship a wrongly-labelled binary.
+      - name: Verify runner architecture
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          case "$(uname -m)" in
+            x86_64) got=amd64 ;;
+            aarch64) got=arm64 ;;
+            *) echo "unexpected machine $(uname -m)" >&2; exit 1 ;;
+          esac
+          test "$got" = "$EXPECTED_ARCH"
+
       - name: Install system dependencies and nfpm
         env:
           NFPM_VERSION: "2.46.3"
-          NFPM_SHA256: "d6417f99d5fa32bba7a4e007084615d3897651498c2e443118c26b9ec3b698a8"
+          NFPM_ARCH: ${{ matrix.arch }}
+          NFPM_SHA256: ${{ matrix.nfpm_sha256 }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libfontconfig1-dev libfreetype-dev libxcb1-dev libxkbcommon-dev
           curl -fsSLo /tmp/nfpm.deb \
-            "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_amd64.deb"
+            "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_${NFPM_ARCH}.deb"
           echo "${NFPM_SHA256}  /tmp/nfpm.deb" | sha256sum -c
           sudo dpkg -i /tmp/nfpm.deb
 
@@ -562,6 +587,8 @@ jobs:
         run: cargo run -p xtask -- package-linux
 
       - name: Collect packages
+        env:
+          PKG_ARCH: ${{ matrix.arch }}
         run: |
           mkdir -p dist
           ref_name="${GITHUB_REF_NAME:-dev}"
@@ -569,12 +596,12 @@ jobs:
           for pkg in target/release/*.deb target/release/*.rpm; do
             [ -f "$pkg" ] || continue
             ext="${pkg##*.}"
-            cp "$pkg" "dist/openlogi-${ref_name}-linux-amd64.${ext}"
+            cp "$pkg" "dist/openlogi-${ref_name}-linux-${PKG_ARCH}.${ext}"
           done
 
       - uses: actions/upload-artifact@v8
         with:
-          name: OpenLogi-linux-packages
+          name: OpenLogi-linux-packages-${{ matrix.arch }}
           path: dist/*
 
   # Single owner of the GitHub Release. softprops/action-gh-release@v3 creates the
@@ -630,8 +657,9 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: OpenLogi-linux-packages
+          pattern: OpenLogi-linux-packages-*
           path: dist
+          merge-multiple: true
 
       - name: Generate checksums
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,14 +715,15 @@ jobs:
           # newline mangled to a space — see the GitHub App key note above).
           # `tr -d` drops any wrapping whitespace before decoding.
           printf '%s' "$OPENLOGI_UPDATE_MINISIGN_SECRET_KEY" | tr -d '[:space:]' | base64 -d > "$key_file"
-          # The Windows binaries get the same minisign treatment as the DMGs:
-          # manual verification today, and the future Windows auto-updater
-          # needs the detached signatures to exist for every shipped version.
-          # nullglob: the exe/msi sets are best-effort per arch leg, so the
-          # globs may match nothing; the DMGs are guaranteed by the publish
+          # The Windows binaries and Linux packages get the same minisign
+          # treatment as the DMGs: manual verification today, and the future
+          # auto-updaters need the detached signatures to exist for every
+          # shipped version.
+          # nullglob: the exe/msi/deb/rpm sets are best-effort per arch leg, so
+          # the globs may match nothing; the DMGs are guaranteed by the publish
           # gate.
           shopt -s nullglob
-          for artifact in dist/*.dmg dist/*.exe dist/*.msi; do
+          for artifact in dist/*.dmg dist/*.exe dist/*.msi dist/*.deb dist/*.rpm; do
             minisign -S -m "$artifact" -s "$key_file" -x "$artifact.minisig" -W
             minisign -V -m "$artifact" -P "$OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY" -x "$artifact.minisig"
           done

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -3,13 +3,13 @@
 # Build with the xtask:
 #   cargo run -p xtask -- package-linux
 #
-# Or directly (requires nfpm in PATH and VERSION env var set):
-#   VERSION=0.6.0 nfpm package --packager deb --target target/release
-#   VERSION=0.6.0 nfpm package --packager rpm --target target/release
+# Or directly (requires nfpm in PATH; set VERSION and PKG_ARCH):
+#   VERSION=0.6.0 PKG_ARCH=amd64 nfpm package --packager deb --target target/release
+#   VERSION=0.6.0 PKG_ARCH=arm64 nfpm package --packager rpm --target target/release
 
 name: openlogi
 version: "${VERSION}"
-arch: amd64
+arch: "${PKG_ARCH}"
 maintainer: OpenLogi Contributors <dev@aprilnea.me>
 description: |-
   Logitech HID++ device control — remap buttons, DPI, and SmartShift.

--- a/xtask/src/linux.rs
+++ b/xtask/src/linux.rs
@@ -44,14 +44,24 @@ pub(crate) fn package_linux(args: &PackageLinux) -> Result<()> {
     let output = absolutize(&root, &args.output);
     let config = root.join("packaging/linux/nfpm.yaml");
 
+    // nfpm stamps this into the package metadata and filename. The release CI
+    // builds natively on an amd64 and an arm64 runner, so the host arch is the
+    // package arch — map Rust's arch names to nfpm's.
+    let pkg_arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => anyhow::bail!("unsupported Linux package architecture: {other}"),
+    };
+
     for packager in ["deb", "rpm"] {
-        println!("==> nfpm {packager}");
+        println!("==> nfpm {packager} ({pkg_arch})");
         run(ProcessCommand::new("nfpm")
             .args(["package", "--packager", packager, "--config"])
             .arg(&config)
             .arg("--target")
             .arg(&output)
             .env("VERSION", env!("CARGO_PKG_VERSION"))
+            .env("PKG_ARCH", pkg_arch)
             .current_dir(&root))?;
     }
 


### PR DESCRIPTION
Follow-up to the Linux packaging from #179/#182. Closes the two gaps that left Linux behind macOS and Windows: the packages were unsigned and amd64-only.

## Changes

**Sign .deb/.rpm with minisign**
The signing loop covered only the DMGs and Windows binaries, so Linux packages shipped with no detached signature. Add them to the loop so each ships a verifiable `.minisig` against the release public key — the same scheme already used for every other artifact. They were already in the release upload globs and the R2 sync.

**Build arm64 packages**
The `linux-packages` job ran only on amd64. Matrix it over native amd64 (`ubuntu-latest`) and arm64 (`ubuntu-24.04-arm`, GA + free for public repos) runners. nfpm's `arch` is now driven by `PKG_ARCH`, which xtask derives from the host it builds on; collected-package and upload-artifact names are per-arch so the `publish` job merges both sets. `fail-fast: false` + the existing `!cancelled()` publish gate keep the arm64 leg best-effort, so a broken arm64 build never blocks a release.

## Validation

`release.yml` runs only on tags / `workflow_dispatch`, so PR CI does not exercise it. To validate before merging, run a publish-free `workflow_dispatch` of this workflow on this branch — it builds and signs both arches without cutting a release, the same way the Windows arm64 leg was proven. The build is native (no cross-compile), so the main thing to confirm is that the GUI (gpui) builds on the arm64 runner.

Not done here: native GPG package signatures (`rpm --addsign` / dpkg-sig). minisign is consistent with the rest of the project and needs no new key material; native GPG can follow if there's demand.