### PR TITLE
fix(gui): keep the diagnostics report truthful across agent restarts

### DIFF
--- a/crates/openlogi-core/src/diagnostics.rs
+++ b/crates/openlogi-core/src/diagnostics.rs
@@ -37,6 +37,19 @@ pub enum RenderState {
     Silhouette,
 }
 
+/// Agent-side device-enumeration health — explains an empty or stale device
+/// section (e.g. a report copied while the agent is still scanning).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InventoryState {
+    /// The first enumeration hasn't completed yet — the device set is unknown.
+    Scanning,
+    /// Enumeration completed; the device section is authoritative.
+    Ready,
+    /// Enumeration failed and is no longer retried; details in the agent log.
+    Unavailable,
+}
+
 /// A receiver, by model only — never its `unique_id`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReceiverDiag {
@@ -80,6 +93,9 @@ pub struct AppInfo {
     pub agent_version: Option<String>,
     pub protocol_gui: u32,
     pub protocol_agent: Option<u32>,
+    /// Enumeration health behind the device section, `None` when the agent
+    /// status is unavailable.
+    pub inventory: Option<InventoryState>,
     /// Raw `std::env::consts::OS` (`"macos"` / `"linux"` / `"windows"`).
     pub os: String,
     pub os_version: Option<String>,
@@ -154,6 +170,15 @@ impl DiagnosticsReport {
             None => format!("GUI {} / agent —", a.protocol_gui),
         };
         let _ = writeln!(out, "- IPC protocol: {proto}");
+        let inventory = match a.inventory {
+            Some(InventoryState::Ready) => "ready",
+            Some(InventoryState::Scanning) => "scanning (first enumeration in progress)",
+            Some(InventoryState::Unavailable) => {
+                "⚠️ unavailable (enumeration failed — see agent log)"
+            }
+            None => "—",
+        };
+        let _ = writeln!(out, "- Inventory: {inventory}");
         let os = match &a.os_version {
             Some(v) => format!("{} {} ({})", os_label(&a.os), v, a.arch),
             None => format!("{} ({})", os_label(&a.os), a.arch),
@@ -431,7 +456,7 @@ fn opt_num<T: std::fmt::Display>(value: Option<T>) -> String {
 mod tests {
     use super::{
         AppInfo, AssetInfo, AssetSource, ConnectionKind, DeviceDiag, DiagnosticsReport,
-        ReceiverDiag, RenderState,
+        InventoryState, ReceiverDiag, RenderState,
     };
     use crate::device::{
         BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceKind, DeviceTransports,
@@ -444,6 +469,7 @@ mod tests {
             agent_version: Some("0.6.6".to_string()),
             protocol_gui: 1,
             protocol_agent: Some(1),
+            inventory: Some(InventoryState::Ready),
             os: "macos".to_string(),
             os_version: Some("15.5".to_string()),
             arch: "arm64".to_string(),
@@ -546,6 +572,7 @@ mod tests {
         assert!(md.contains("- OpenLogi (GUI): v0.6.6 (release)"));
         assert!(md.contains("- Agent: v0.6.6 (connected)"));
         assert!(md.contains("- IPC protocol: GUI 1 / agent 1"));
+        assert!(md.contains("- Inventory: ready"));
         assert!(md.contains("- OS: macOS 15.5 (arm64)"));
         assert!(
             md.contains("- Source: app bundle · Index: loaded (142 models) · User cache: present")
@@ -624,11 +651,30 @@ mod tests {
         let mut report = sample();
         report.app.agent_version = None;
         report.app.protocol_agent = None;
+        report.app.inventory = None;
         report.app.hook_installed = None;
         report.app.launch_at_login = None;
         let md = report.to_markdown();
         assert!(md.contains("- Agent: not connected"));
         assert!(md.contains("GUI 1 / agent —"));
+        assert!(md.contains("- Inventory: —"));
         assert!(md.contains("Input hook: unknown"));
+    }
+
+    #[test]
+    fn incomplete_enumeration_is_flagged() {
+        let mut report = sample();
+        report.app.inventory = Some(InventoryState::Scanning);
+        assert!(
+            report
+                .to_markdown()
+                .contains("- Inventory: scanning (first enumeration in progress)")
+        );
+        report.app.inventory = Some(InventoryState::Unavailable);
+        assert!(
+            report
+                .to_markdown()
+                .contains("- Inventory: ⚠️ unavailable (enumeration failed — see agent log)")
+        );
     }
 }

--- a/crates/openlogi-gui/src/diagnostics.rs
+++ b/crates/openlogi-gui/src/diagnostics.rs
@@ -3,11 +3,11 @@
 use std::path::Path;
 
 use gpui::App;
-use openlogi_agent_core::ipc::PROTOCOL_VERSION;
+use openlogi_agent_core::ipc::{InventoryHealth, PROTOCOL_VERSION};
 use openlogi_core::device::{DeviceInventory, PairedDevice};
 use openlogi_core::diagnostics::{
-    AppInfo, AssetInfo, AssetSource, ConnectionKind, DeviceDiag, DiagnosticsReport, ReceiverDiag,
-    RenderState,
+    AppInfo, AssetInfo, AssetSource, ConnectionKind, DeviceDiag, DiagnosticsReport, InventoryState,
+    ReceiverDiag, RenderState,
 };
 use openlogi_hid::DeviceRoute;
 
@@ -34,7 +34,9 @@ pub fn collect(cx: &App) -> DiagnosticsReport {
 }
 
 fn app_info(state: Option<&AppState>, running_from_bundle: bool) -> AppInfo {
-    let status = state.and_then(AppState::last_status);
+    // The live agent link, not a retained copy: a report copied while the
+    // agent is down must say "not connected", not replay the last status.
+    let status = state.and_then(AppState::agent_status);
     let settings = state.map(AppState::app_settings);
     let config = state.map(AppState::config_summary);
     let build_profile = if cfg!(debug_assertions) {
@@ -48,6 +50,7 @@ fn app_info(state: Option<&AppState>, running_from_bundle: bool) -> AppInfo {
         agent_version: status.map(|s| s.agent_version.clone()),
         protocol_gui: PROTOCOL_VERSION,
         protocol_agent: status.map(|s| s.protocol_version),
+        inventory: status.map(|s| inventory_state(s.inventory)),
         os: std::env::consts::OS.to_string(),
         os_version: crate::platform::os::os_version(),
         arch: arch_label().to_string(),
@@ -62,6 +65,14 @@ fn app_info(state: Option<&AppState>, running_from_bundle: bool) -> AppInfo {
         config_schema_version: config.map(|(version, _)| version),
         configured_device_count: config.map(|(_, count)| count),
         running_from_bundle,
+    }
+}
+
+fn inventory_state(health: InventoryHealth) -> InventoryState {
+    match health {
+        InventoryHealth::Scanning => InventoryState::Scanning,
+        InventoryHealth::Ready => InventoryState::Ready,
+        InventoryHealth::Unavailable => InventoryState::Unavailable,
     }
 }
 

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -299,11 +299,16 @@ fn main() -> Result<()> {
                                 // counting those as misses would wipe the device list (and
                                 // pop an open detail page) on every agent restart: at the
                                 // 250 ms reconnect cadence the miss grace burns in ~750 ms
-                                // while a fresh enumeration takes 1.5–5 s.
-                                let merged = update.status.inventory
-                                    == openlogi_agent_core::ipc::InventoryHealth::Ready
+                                // while a fresh enumeration takes 1.5–5 s. The diagnostics
+                                // snapshot shares the gate so a report copied during that
+                                // window keeps the receivers the UI is still showing.
+                                let ready = update.status.inventory
+                                    == openlogi_agent_core::ipc::InventoryHealth::Ready;
+                                let merged = ready
                                     && state.refresh_inventories(&update.inventory, &cache, force_refresh);
-                                state.store_agent_snapshot(&update.inventory, &update.status);
+                                if ready {
+                                    state.store_inventory_snapshot(&update.inventory);
+                                }
                                 // Bitwise `|`: the link must be set even when the
                                 // merge already reported a change.
                                 merged | state.set_agent_link(state::AgentLink::Ready(update.status))

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -35,7 +35,6 @@ use crate::asset::AssetResolver;
 use crate::data::mouse_buttons::{Action, Binding, ButtonId, GestureDirection};
 use crate::state::devices::{build_device_list, pick_initial_device, sort_device_list};
 use openlogi_agent_core::bindings::{bindings_for, gesture_bindings_for};
-use openlogi_agent_core::ipc::AgentStatus;
 
 /// Default DPI value applied to a fresh AppState. Matches a common Logitech
 /// mid-range mouse and keeps the dot-preview visually obvious from frame one.
@@ -194,9 +193,11 @@ pub struct AppState {
     /// rebuild, and "apply now" device changes (DPI / SmartShift / lighting)
     /// go out as their own commands. The GUI never opens a device itself.
     ipc_commands: mpsc::UnboundedSender<crate::ipc_client::Command>,
-    /// Latest agent status snapshot from the IPC poll, kept for the diagnostics report.
-    last_status: Option<AgentStatus>,
-    /// Latest raw inventory snapshot from the IPC poll, kept for diagnostics transports and receivers.
+    /// Raw inventory from the last *completed* enumeration, kept for the
+    /// diagnostics report (receivers + transports). The poll path only stores
+    /// [`InventoryHealth::Ready`](openlogi_agent_core::ipc::InventoryHealth)
+    /// snapshots, so an agent restart's empty pre-enumeration list never
+    /// blanks a report copied during the reconnect window.
     last_inventory: Vec<DeviceInventory>,
 }
 
@@ -240,7 +241,6 @@ impl AppState {
             device_list,
             config,
             ipc_commands,
-            last_status: None,
             last_inventory: Vec::new(),
         };
         state.button_bindings = state.bindings_for_current();
@@ -263,19 +263,14 @@ impl AppState {
         self.ipc_commands.clone()
     }
 
-    /// Cache the latest IPC poll snapshot (raw inventory + agent status) for the diagnostics report.
-    pub fn store_agent_snapshot(&mut self, inventory: &[DeviceInventory], status: &AgentStatus) {
+    /// Cache a *completed* inventory snapshot for the diagnostics report.
+    /// Callers gate on [`InventoryHealth::Ready`](openlogi_agent_core::ipc::InventoryHealth) —
+    /// see [`Self::last_inventory`].
+    pub fn store_inventory_snapshot(&mut self, inventory: &[DeviceInventory]) {
         self.last_inventory = inventory.to_vec();
-        self.last_status = Some(status.clone());
     }
 
-    /// The latest agent status snapshot, or `None` before the first poll lands.
-    #[must_use]
-    pub fn last_status(&self) -> Option<&AgentStatus> {
-        self.last_status.as_ref()
-    }
-
-    /// The latest raw inventory snapshot, used by diagnostics for transports and receivers.
+    /// The last completed inventory snapshot, used by diagnostics for transports and receivers.
     #[must_use]
     pub fn last_inventory(&self) -> &[DeviceInventory] {
         &self.last_inventory


### PR DESCRIPTION
Follow-up to #206. The Copy Diagnostics feature was written before the startup-states rework (#213/#215) landed, and the rebase kept its original snapshot plumbing. Two of those seams could make a report disagree with reality exactly when users are most likely to file one — right after an agent restart.

## Changes

**Read the agent status from the live `AgentLink` instead of a never-cleared copy.** `AppState.last_status` was retained on every poll and never invalidated, while `AgentLink` already carries the full `AgentStatus` and flips to `Unreachable` on disconnect. A report copied while the agent was down would claim `Agent: v… (connected)` from the stale copy — misleading for exactly the "agent is unresponsive" class of bug report. The adapter now reads `AppState::agent_status()` (backed by `AgentLink`), and the duplicate field is gone.

**Gate the inventory snapshot on `InventoryHealth::Ready`.** The device-list merge already ignores pre-enumeration snapshots (an agent restart serves an empty list for the 1.5–5 s enumeration window), but the diagnostics snapshot was stored unconditionally. A report copied in that window lost its Receivers section and all per-device enrichment (codename, wpid, model-ids, transports — Connection degraded to `unknown`) while the UI still showed everything, because the visible list is protected by the gate. The snapshot now shares it, so report and UI follow the same staleness rule.

**Surface enumeration health in the report.** New `Inventory: ready / scanning (first enumeration in progress) / ⚠️ unavailable (enumeration failed — see agent log)` line in the App section, so a zero-device report is self-explaining.

## Testing

- Core rendering tests extended: the `app()` fixture pins `Inventory: ready`, the unreachable-agent test pins the `—` placeholder, and a new test covers the scanning/unavailable wording (9 tests total).
- `cargo test -p openlogi-core`, `cargo clippy -p openlogi-gui -p openlogi-core --all-targets` (zero warnings), and `cargo fmt --check` all pass locally; full-workspace clippy ran via the pre-push hook.