### PR TITLE
refactor(hidpp): dedup the feature layer (registry data-macro + FeatureEndpoint)

### DIFF
--- a/crates/openlogi-hidpp/src/feature/adjustable_dpi/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/adjustable_dpi/mod.rs
@@ -5,22 +5,15 @@ use std::sync::Arc;
 
 use crate::{
     channel::HidppChannel,
-    feature::{CreatableFeature, Feature},
-    nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, Feature, FeatureEndpoint},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `AdjustableDpi` / `0x2201` feature.
 #[derive(Clone)]
 pub struct AdjustableDpiFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for AdjustableDpiFeature {
@@ -29,9 +22,7 @@ impl CreatableFeature for AdjustableDpiFeature {
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
         }
     }
 }
@@ -41,20 +32,7 @@ impl Feature for AdjustableDpiFeature {}
 impl AdjustableDpiFeature {
     /// Retrieves the number of sensors the device exposes.
     pub async fn get_sensor_count(&self) -> Result<u8, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        Ok(response.extend_payload()[0])
+        Ok(self.endpoint.call(0, [0; 3]).await?.extend_payload()[0])
     }
 
     /// Retrieves the supported DPI values for `sensor_index`.
@@ -67,39 +45,22 @@ impl AdjustableDpiFeature {
     /// start is the previous value and whose end is the next value. The returned
     /// list is sorted and deduplicated.
     pub async fn get_sensor_dpi_list(&self, sensor_index: u8) -> Result<Vec<u16>, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [sensor_index, 0x00, 0x00],
-            ))
-            .await?;
-
         // Skip the echoed sensor index in byte 0; the DPI values follow.
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(1, [sensor_index, 0x00, 0x00])
+            .await?
+            .extend_payload();
         parse_dpi_list_payload(&payload[1..])
     }
 
     /// Retrieves the currently configured DPI for `sensor_index`.
     pub async fn get_sensor_dpi(&self, sensor_index: u8) -> Result<u16, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(2),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [sensor_index, 0x00, 0x00],
-            ))
-            .await?;
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(2, [sensor_index, 0x00, 0x00])
+            .await?
+            .extend_payload();
 
         Ok(u16::from_be_bytes([payload[1], payload[2]]))
     }
@@ -107,17 +68,8 @@ impl AdjustableDpiFeature {
     /// Sets the DPI for `sensor_index`.
     pub async fn set_sensor_dpi(&self, sensor_index: u8, dpi: u16) -> Result<(), Hidpp20Error> {
         let [dpi_hi, dpi_lo] = dpi.to_be_bytes();
-        let _ = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(3),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [sensor_index, dpi_hi, dpi_lo],
-            ))
+        self.endpoint
+            .call(3, [sensor_index, dpi_hi, dpi_lo])
             .await?;
 
         Ok(())

--- a/crates/openlogi-hidpp/src/feature/device_friendly_name/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/device_friendly_name/mod.rs
@@ -5,22 +5,15 @@ use std::sync::Arc;
 
 use crate::{
     channel::HidppChannel,
-    feature::{CreatableFeature, Feature},
-    nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, Feature, FeatureEndpoint},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `DeviceFriendlyName` / `0x0007` feature.
 #[derive(Clone)]
 pub struct DeviceFriendlyNameFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for DeviceFriendlyNameFeature {
@@ -29,9 +22,7 @@ impl CreatableFeature for DeviceFriendlyNameFeature {
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
         }
     }
 }
@@ -41,20 +32,7 @@ impl Feature for DeviceFriendlyNameFeature {}
 impl DeviceFriendlyNameFeature {
     /// Retrieves the length data of the friendly device name feature.
     pub async fn get_friendly_name_length(&self) -> Result<DeviceFriendlyNameLength, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
         Ok(DeviceFriendlyNameLength {
             name_length: payload[0],
@@ -74,20 +52,13 @@ impl DeviceFriendlyNameFeature {
     /// A convenience wrapper implementing this functionality is provided as
     /// [`Self::get_whole_friendly_name`].
     pub async fn get_friendly_name(&self, index: u8) -> Result<[u8; 15], Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [index, 0x00, 0x00],
-            ))
-            .await?;
+        let payload = self
+            .endpoint
+            .call(1, [index, 0x00, 0x00])
+            .await?
+            .extend_payload();
 
-        Ok(response.extend_payload()[1..].try_into().unwrap())
+        Ok(payload[1..].try_into().unwrap())
     }
 
     /// Retrieves the whole friendly name of the device by first calling
@@ -118,20 +89,13 @@ impl DeviceFriendlyNameFeature {
     /// A convenience wrapper implementing this functionality is provided as
     /// [`Self::get_whole_default_friendly_name`].
     pub async fn get_default_friendly_name(&self, index: u8) -> Result<[u8; 15], Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(2),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [index, 0x00, 0x00],
-            ))
-            .await?;
+        let payload = self
+            .endpoint
+            .call(2, [index, 0x00, 0x00])
+            .await?
+            .extend_payload();
 
-        Ok(response.extend_payload()[1..].try_into().unwrap())
+        Ok(payload[1..].try_into().unwrap())
     }
 
     /// Retrieves the whole default friendly name of the device by first calling
@@ -167,20 +131,9 @@ impl DeviceFriendlyNameFeature {
         data[0] = index;
         data[1..].copy_from_slice(&chunk);
 
-        let response = self
-            .chan
-            .send_v20(v20::Message::Long(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(3),
-                    software_id: self.chan.get_sw_id(),
-                },
-                data,
-            ))
-            .await?;
+        let payload = self.endpoint.call_long(3, data).await?.extend_payload();
 
-        Ok(response.extend_payload()[0])
+        Ok(payload[0])
     }
 
     /// Sets the whole friendly device name, truncating the value to a maximum
@@ -218,20 +171,7 @@ impl DeviceFriendlyNameFeature {
     ///
     /// Returns the total length of the name after resetting it,
     pub async fn reset_friendly_name(&self) -> Result<u8, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(4),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        Ok(response.extend_payload()[0])
+        Ok(self.endpoint.call(4, [0; 3]).await?.extend_payload()[0])
     }
 }
 

--- a/crates/openlogi-hidpp/src/feature/device_information/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/device_information/mod.rs
@@ -8,22 +8,15 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{
     bcd,
     channel::HidppChannel,
-    feature::{CreatableFeature, Feature},
-    nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, Feature, FeatureEndpoint},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `DeviceInformation` / `0x0003` feature.
 #[derive(Clone)]
 pub struct DeviceInformationFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for DeviceInformationFeature {
@@ -32,9 +25,7 @@ impl CreatableFeature for DeviceInformationFeature {
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
         }
     }
 }
@@ -44,20 +35,7 @@ impl Feature for DeviceInformationFeature {}
 impl DeviceInformationFeature {
     /// Retrieves general information about the device and its capabilities.
     pub async fn get_device_info(&self) -> Result<DeviceInformation, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
         Ok(DeviceInformation {
             entity_count: payload[0],
@@ -80,20 +58,11 @@ impl DeviceInformationFeature {
         &self,
         entity_index: u8,
     ) -> Result<DeviceEntityFirmwareInfo, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [entity_index, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(1, [entity_index, 0x00, 0x00])
+            .await?
+            .extend_payload();
 
         Ok(DeviceEntityFirmwareInfo {
             entity_type: DeviceEntityType::try_from(payload[0])
@@ -115,24 +84,12 @@ impl DeviceInformationFeature {
     /// Retrieves the serial number of the device.
     ///
     /// This function was added in feature version 4 and will likely result in
-    /// an [`v20::ErrorType::InvalidFunctionId`] error for older versions,
-    /// so [`DeviceInformationCapabilities::serial_number`] should be
-    /// verified before calling.
+    /// an [`v20::ErrorType::InvalidFunctionId`](crate::protocol::v20::ErrorType::InvalidFunctionId)
+    /// error for older versions, so
+    /// [`DeviceInformationCapabilities::serial_number`] should be verified
+    /// before calling.
     pub async fn get_serial_number(&self) -> Result<String, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(2),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(2, [0; 3]).await?.extend_payload();
 
         String::from_utf8(payload[..12].to_vec()).map_err(|_| Hidpp20Error::UnsupportedResponse)
     }

--- a/crates/openlogi-hidpp/src/feature/device_type_and_name/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/device_type_and_name/mod.rs
@@ -7,22 +7,15 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
     channel::HidppChannel,
-    feature::{CreatableFeature, Feature},
-    nibble::U4,
+    feature::{CreatableFeature, Feature, FeatureEndpoint},
     protocol::v20::{self, Hidpp20Error},
 };
 
 /// Implements the `DeviceTypeAndName` / `0x0005` feature.
 #[derive(Clone)]
 pub struct DeviceTypeAndNameFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for DeviceTypeAndNameFeature {
@@ -31,9 +24,7 @@ impl CreatableFeature for DeviceTypeAndNameFeature {
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
         }
     }
 }
@@ -43,20 +34,7 @@ impl Feature for DeviceTypeAndNameFeature {}
 impl DeviceTypeAndNameFeature {
     /// Retrieves the amount of characters in the marketing name of the device.
     pub async fn get_device_name_count(&self) -> Result<u8, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        Ok(response.extend_payload()[0])
+        Ok(self.endpoint.call(0, [0; 3]).await?.extend_payload()[0])
     }
 
     /// Retrieves a chunk of characters of the marketing name of the device,
@@ -70,18 +48,7 @@ impl DeviceTypeAndNameFeature {
     /// A convenience wrapper implementing this functionality is provided as
     /// [`Self::get_whole_device_name`].
     pub async fn get_device_name(&self, index: u8) -> Result<Vec<u8>, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [index, 0x00, 0x00],
-            ))
-            .await?;
+        let response = self.endpoint.call(1, [index, 0x00, 0x00]).await?;
 
         match response {
             v20::Message::Long(_, payload) => Ok(payload.to_vec()),
@@ -108,20 +75,7 @@ impl DeviceTypeAndNameFeature {
 
     /// Retrieves the marketing type of the device.
     pub async fn get_device_type(&self) -> Result<DeviceType, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(2),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        DeviceType::try_from(response.extend_payload()[0])
+        DeviceType::try_from(self.endpoint.call(2, [0; 3]).await?.extend_payload()[0])
             .map_err(|_| Hidpp20Error::UnsupportedResponse)
     }
 }

--- a/crates/openlogi-hidpp/src/feature/feature_set/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/feature_set/mod.rs
@@ -5,9 +5,8 @@ use std::sync::Arc;
 
 use crate::{
     channel::HidppChannel,
-    feature::{CreatableFeature, Feature, FeatureType},
-    nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, Feature, FeatureEndpoint, FeatureType},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `FeatureSet` / `0x0001` feature.
@@ -19,14 +18,8 @@ use crate::{
 /// root feature is not allowed).
 #[derive(Clone)]
 pub struct FeatureSetFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for FeatureSetFeature {
@@ -35,9 +28,7 @@ impl CreatableFeature for FeatureSetFeature {
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
         }
     }
 }
@@ -48,20 +39,7 @@ impl FeatureSetFeature {
     /// Retrieves the amount of features supported by the device, not including
     /// the root feature.
     pub async fn count(&self) -> Result<u8, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        Ok(response.extend_payload()[0])
+        Ok(self.endpoint.call(0, [0; 3]).await?.extend_payload()[0])
     }
 
     /// Retrieves the information about a specific feature based on its index in
@@ -69,20 +47,11 @@ impl FeatureSetFeature {
     ///
     /// Feature index `0` for the root feature is not allowed.
     pub async fn get_feature(&self, index: u8) -> Result<FeatureInformation, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [index, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(1, [index, 0x00, 0x00])
+            .await?
+            .extend_payload();
 
         Ok(FeatureInformation {
             id: (payload[0] as u16) << 8 | payload[1] as u16,

--- a/crates/openlogi-hidpp/src/feature/hires_wheel/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/hires_wheel/mod.rs
@@ -8,9 +8,9 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{
     channel::HidppChannel,
     event::EventEmitter,
-    feature::{CreatableFeature, EmittingFeature, Feature},
+    feature::{CreatableFeature, EmittingFeature, Feature, FeatureEndpoint, event_payload},
     nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `HiResWheel` / `0x2121` feature.
@@ -18,14 +18,8 @@ use crate::{
 /// The analytics part of the feature is not implemented here as its data
 /// structure lacks any documentation.
 pub struct HiResWheelFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<HiResWheelEvent>>,
@@ -47,23 +41,14 @@ impl CreatableFeature for HiResWheelFeature {
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
-                if matched {
+                let Some((func, payload)) =
+                    event_payload(raw, matched, device_index, feature_index)
+                else {
                     return;
-                }
+                };
 
-                let msg = v20::Message::from(raw);
-
-                let header = msg.header();
-                if header.device_index != device_index
-                    || header.feature_index != feature_index
-                    || header.software_id.to_lo() != 0
-                {
-                    return;
-                }
-
-                let payload = msg.extend_payload();
-
-                let event = match header.function_id.to_lo() {
+                // HiResWheel dispatches on the sub-id: 0 = movement, 1 = ratchet switch.
+                let event = match func.to_lo() {
                     0 => {
                         let Ok(resolution) =
                             WheelResolution::try_from((payload[0] & (1 << 4)) >> 4)
@@ -92,9 +77,7 @@ impl CreatableFeature for HiResWheelFeature {
         });
 
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
             emitter,
             msg_listener_hdl: hdl,
         }
@@ -111,27 +94,16 @@ impl EmittingFeature<HiResWheelEvent> for HiResWheelFeature {
 
 impl Drop for HiResWheelFeature {
     fn drop(&mut self) {
-        self.chan.remove_msg_listener(self.msg_listener_hdl);
+        self.endpoint
+            .chan()
+            .remove_msg_listener(self.msg_listener_hdl);
     }
 }
 
 impl HiResWheelFeature {
     /// Retrieves the capabilities of the hi-res wheel and this feature.
     pub async fn get_wheel_capabilities(&self) -> Result<WheelCapabilities, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
         Ok(WheelCapabilities {
             multiplier: payload[0],
@@ -144,20 +116,7 @@ impl HiResWheelFeature {
 
     /// Retrieves the current mode of the hi-res wheel.
     pub async fn get_wheel_mode(&self) -> Result<WheelMode, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(1, [0; 3]).await?.extend_payload();
 
         Ok(WheelMode {
             inverted: payload[0] & (1 << 2) != 0,
@@ -188,20 +147,11 @@ impl HiResWheelFeature {
         mode_byte |= u8::from(resolution) << 1;
         mode_byte |= u8::from(target);
 
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(2),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [mode_byte, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(2, [mode_byte, 0x00, 0x00])
+            .await?
+            .extend_payload();
 
         Ok(WheelMode {
             inverted: payload[0] & (1 << 2) != 0,
@@ -214,20 +164,7 @@ impl HiResWheelFeature {
 
     /// Retrieves the current state of the ratchet switch.
     pub async fn get_ratchet_switch_state(&self) -> Result<WheelRatchetState, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(3),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(3, [0; 3]).await?.extend_payload();
 
         WheelRatchetState::try_from(payload[0] & 1).map_err(|_| Hidpp20Error::UnsupportedResponse)
     }

--- a/crates/openlogi-hidpp/src/feature/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/mod.rs
@@ -2,7 +2,11 @@
 
 use std::{any::Any, sync::Arc};
 
-use crate::channel::HidppChannel;
+use crate::{
+    channel::{HidppChannel, HidppMessage, LONG_REPORT_LENGTH},
+    nibble::U4,
+    protocol::v20::{self, Hidpp20Error},
+};
 
 pub mod adjustable_dpi;
 pub mod device_friendly_name;
@@ -37,6 +41,105 @@ pub trait EmittingFeature<T>: Feature {
     /// Creates a receiver that is being notified whenever a new event of type
     /// `T` is emitted by the feature.
     fn listen(&self) -> async_channel::Receiver<T>;
+}
+
+/// A feature's addressable `(device, feature)` endpoint on a channel.
+///
+/// Embedding this in a feature replaces the three loose `chan` / `device_index`
+/// / `feature_index` fields every implementation used to carry, and centralises
+/// the HID++2.0 request framing that was otherwise hand-written at every call
+/// site.
+#[derive(Clone)]
+pub(crate) struct FeatureEndpoint {
+    /// The underlying HID++ channel.
+    chan: Arc<HidppChannel>,
+
+    /// The index of the device the feature belongs to.
+    device_index: u8,
+
+    /// The index of the feature in the device's feature table.
+    feature_index: u8,
+}
+
+impl FeatureEndpoint {
+    /// Binds an endpoint to `feature_index` on `device_index` of `chan`.
+    pub(crate) fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
+        Self {
+            chan,
+            device_index,
+            feature_index,
+        }
+    }
+
+    /// The channel this endpoint talks over.
+    pub(crate) fn chan(&self) -> &HidppChannel {
+        &self.chan
+    }
+
+    /// The request header addressing `function` on this endpoint, stamped with
+    /// the channel's next software id.
+    fn header(&self, function: u8) -> v20::MessageHeader {
+        v20::MessageHeader {
+            device_index: self.device_index,
+            feature_index: self.feature_index,
+            function_id: U4::from_lo(function),
+            software_id: self.chan.get_sw_id(),
+        }
+    }
+
+    /// Calls `function` with a 3-byte short-report payload and waits for the
+    /// matching response.
+    pub(crate) async fn call(
+        &self,
+        function: u8,
+        args: [u8; 3],
+    ) -> Result<v20::Message, Hidpp20Error> {
+        self.chan
+            .send_v20(v20::Message::Short(self.header(function), args))
+            .await
+    }
+
+    /// Calls `function` with a 16-byte long-report payload and waits for the
+    /// matching response.
+    pub(crate) async fn call_long(
+        &self,
+        function: u8,
+        args: [u8; 16],
+    ) -> Result<v20::Message, Hidpp20Error> {
+        self.chan
+            .send_v20(v20::Message::Long(self.header(function), args))
+            .await
+    }
+}
+
+/// Shared prelude for a feature's event listener.
+///
+/// Drops reports already matched to an outgoing request, parses the raw report
+/// as a HID++2.0 message, and keeps only unsolicited broadcasts addressed to
+/// this `(device_index, feature_index)` with a zero software id. Returns the
+/// event's function id (its sub-id) and extended payload, leaving sub-id
+/// dispatch to the caller — so a multi-event feature filters its sub-ids
+/// explicitly rather than folding the check into the header guard.
+pub(crate) fn event_payload(
+    raw: HidppMessage,
+    matched: bool,
+    device_index: u8,
+    feature_index: u8,
+) -> Option<(U4, [u8; LONG_REPORT_LENGTH - 4])> {
+    if matched {
+        return None;
+    }
+
+    let msg = v20::Message::from(raw);
+    let header = msg.header();
+    if header.device_index != device_index
+        || header.feature_index != feature_index
+        || header.software_id.to_lo() != 0
+    {
+        return None;
+    }
+
+    Some((header.function_id, msg.extend_payload()))
 }
 
 /// A bitfield describing some properties of a feature.
@@ -108,5 +211,62 @@ impl From<FeatureType> for u8 {
         }
 
         raw
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::event_payload;
+    use crate::{
+        channel::HidppMessage,
+        nibble::U4,
+        protocol::v20::{Message, MessageHeader},
+    };
+
+    /// Builds a raw long report carrying a HID++2.0 broadcast with the given
+    /// header fields and a recognisable payload.
+    fn broadcast(device_index: u8, feature_index: u8, function: u8, software: u8) -> HidppMessage {
+        Message::Long(
+            MessageHeader {
+                device_index,
+                feature_index,
+                function_id: U4::from_lo(function),
+                software_id: U4::from_lo(software),
+            },
+            [0xab; 16],
+        )
+        .into()
+    }
+
+    #[test]
+    fn accepts_matching_broadcast_and_returns_sub_id() {
+        let (func, payload) =
+            event_payload(broadcast(2, 5, 1, 0), false, 2, 5).expect("broadcast should pass");
+        assert_eq!(func.to_lo(), 1);
+        assert_eq!(payload, [0xab; 16]);
+    }
+
+    #[test]
+    fn rejects_request_matched_report() {
+        // A report already matched to an outgoing request is a response, not an
+        // event.
+        assert!(event_payload(broadcast(2, 5, 0, 0), true, 2, 5).is_none());
+    }
+
+    #[test]
+    fn rejects_other_device_or_feature() {
+        assert!(event_payload(broadcast(9, 5, 0, 0), false, 2, 5).is_none());
+        assert!(event_payload(broadcast(2, 9, 0, 0), false, 2, 5).is_none());
+    }
+
+    #[test]
+    fn gates_on_software_id_only_not_sub_id() {
+        // Only the software id gates a broadcast: a nonzero one is rejected, but
+        // a nonzero function id is a valid event sub-id the caller dispatches on
+        // and must still pass. This is the invariant the old per-feature
+        // `nibble::combine(software_id, function_id) != 0` guard got right only
+        // by accident (those features happened to emit a single sub-id 0 event).
+        assert!(event_payload(broadcast(2, 5, 0, 1), false, 2, 5).is_none());
+        assert!(event_payload(broadcast(2, 5, 7, 0), false, 2, 5).is_some());
     }
 }

--- a/crates/openlogi-hidpp/src/feature/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/mod.rs
@@ -78,7 +78,15 @@ impl FeatureEndpoint {
 
     /// The request header addressing `function` on this endpoint, stamped with
     /// the channel's next software id.
+    ///
+    /// `function` is a HID++2.0 function id, which is 4-bit; only the low nibble
+    /// is sent. The assert keeps a stray out-of-range id from silently routing
+    /// to a different function in debug builds.
     fn header(&self, function: u8) -> v20::MessageHeader {
+        debug_assert!(
+            function < 16,
+            "HID++2.0 function id {function} exceeds 4 bits"
+        );
         v20::MessageHeader {
             device_index: self.device_index,
             feature_index: self.feature_index,

--- a/crates/openlogi-hidpp/src/feature/registry.rs
+++ b/crates/openlogi-hidpp/src/feature/registry.rs
@@ -79,824 +79,137 @@ fn new_dyn<F: CreatableFeature>(
     )
 }
 
+/// Builds [`KNOWN_FEATURES`]. Each row is `id "Name"` for a feature we only know
+/// by name, or `id "Name" => FeatureImpl` to also register a default
+/// implementation produced through [`new_dyn`].
+macro_rules! known_features {
+    ( $( $id:literal $name:literal $( => $feat:ty )? ),* $(,)? ) => {
+        HashMap::from([ $(
+            ($id, KnownFeature { name: $name, versions: known_features!(@versions $( $feat )?) }),
+        )* ])
+    };
+    (@versions) => { &[] };
+    (@versions $feat:ty) => {
+        &[FeatureVersion {
+            starting_version: <$feat>::STARTING_VERSION,
+            producer: new_dyn::<$feat>,
+        }]
+    };
+}
+
 static KNOWN_FEATURES: LazyLock<HashMap<u16, KnownFeature>> = LazyLock::new(|| {
-    HashMap::from([
-        (
-            0x0000,
-            KnownFeature {
-                name: "Root",
-                versions: &[FeatureVersion {
-                    starting_version: RootFeature::STARTING_VERSION,
-                    producer: new_dyn::<RootFeature>,
-                }],
-            },
-        ),
-        (
-            0x0001,
-            KnownFeature {
-                name: "FeatureSet",
-                versions: &[FeatureVersion {
-                    starting_version: FeatureSetFeature::STARTING_VERSION,
-                    producer: new_dyn::<FeatureSetFeature>,
-                }],
-            },
-        ),
-        (
-            0x0002,
-            KnownFeature {
-                name: "FeatureInfo",
-                versions: &[],
-            },
-        ),
-        (
-            0x0003,
-            KnownFeature {
-                name: "DeviceInformation",
-                versions: &[FeatureVersion {
-                    starting_version: DeviceInformationFeature::STARTING_VERSION,
-                    producer: new_dyn::<DeviceInformationFeature>,
-                }],
-            },
-        ),
-        (
-            0x0004,
-            KnownFeature {
-                name: "UnitId",
-                versions: &[],
-            },
-        ),
-        (
-            0x0005,
-            KnownFeature {
-                name: "DeviceTypeAndName",
-                versions: &[FeatureVersion {
-                    starting_version: DeviceTypeAndNameFeature::STARTING_VERSION,
-                    producer: new_dyn::<DeviceTypeAndNameFeature>,
-                }],
-            },
-        ),
-        (
-            0x0006,
-            KnownFeature {
-                name: "DeviceGroups",
-                versions: &[],
-            },
-        ),
-        (
-            0x0007,
-            KnownFeature {
-                name: "DeviceFriendlyName",
-                versions: &[FeatureVersion {
-                    starting_version: DeviceFriendlyNameFeature::STARTING_VERSION,
-                    producer: new_dyn::<DeviceFriendlyNameFeature>,
-                }],
-            },
-        ),
-        (
-            0x0008,
-            KnownFeature {
-                name: "KeepAlive",
-                versions: &[],
-            },
-        ),
-        (
-            0x0020,
-            KnownFeature {
-                name: "ConfigChange",
-                versions: &[],
-            },
-        ),
-        (
-            0x0021,
-            KnownFeature {
-                name: "UniqueRandomId",
-                versions: &[],
-            },
-        ),
-        (
-            0x0030,
-            KnownFeature {
-                name: "TargetSoftware",
-                versions: &[],
-            },
-        ),
-        (
-            0x0080,
-            KnownFeature {
-                name: "WirelessSignalStrength",
-                versions: &[],
-            },
-        ),
-        (
-            0x00c0,
-            KnownFeature {
-                name: "DfuControlLegacy",
-                versions: &[],
-            },
-        ),
-        (
-            0x00c1,
-            KnownFeature {
-                name: "DfuControlUnsigned",
-                versions: &[],
-            },
-        ),
-        (
-            0x00c2,
-            KnownFeature {
-                name: "DfuControlSigned",
-                versions: &[],
-            },
-        ),
-        (
-            0x00c3,
-            KnownFeature {
-                name: "DfuControlBolt",
-                versions: &[],
-            },
-        ),
-        (
-            0x00d0,
-            KnownFeature {
-                name: "Dfu",
-                versions: &[],
-            },
-        ),
-        (
-            0x00d1,
-            KnownFeature {
-                name: "DfuResumable",
-                versions: &[],
-            },
-        ),
-        (
-            0x1000,
-            KnownFeature {
-                name: "BatteryStatus",
-                versions: &[],
-            },
-        ),
-        (
-            0x1001,
-            KnownFeature {
-                name: "BatteryVoltage",
-                versions: &[],
-            },
-        ),
-        (
-            0x1004,
-            KnownFeature {
-                name: "UnifiedBattery",
-                versions: &[FeatureVersion {
-                    starting_version: UnifiedBatteryFeature::STARTING_VERSION,
-                    producer: new_dyn::<UnifiedBatteryFeature>,
-                }],
-            },
-        ),
-        (
-            0x1010,
-            KnownFeature {
-                name: "ChargingControl",
-                versions: &[],
-            },
-        ),
-        (
-            0x1300,
-            KnownFeature {
-                name: "LedControl",
-                versions: &[],
-            },
-        ),
-        (
-            0x1800,
-            KnownFeature {
-                name: "GenericTest",
-                versions: &[],
-            },
-        ),
-        (
-            0x1802,
-            KnownFeature {
-                name: "DeviceReset",
-                versions: &[],
-            },
-        ),
-        (
-            0x1805,
-            KnownFeature {
-                name: "OobState",
-                versions: &[],
-            },
-        ),
-        (
-            0x1806,
-            KnownFeature {
-                name: "ConfigDeviceProps",
-                versions: &[],
-            },
-        ),
-        (
-            0x1814,
-            KnownFeature {
-                name: "ChangeHost",
-                versions: &[],
-            },
-        ),
-        (
-            0x1815,
-            KnownFeature {
-                name: "HostsInfo",
-                versions: &[],
-            },
-        ),
-        (
-            0x1981,
-            KnownFeature {
-                name: "Backlight1",
-                versions: &[],
-            },
-        ),
-        (
-            0x1982,
-            KnownFeature {
-                name: "Backlight2",
-                versions: &[],
-            },
-        ),
-        (
-            0x1983,
-            KnownFeature {
-                name: "Backlight3",
-                versions: &[],
-            },
-        ),
-        (
-            0x1990,
-            KnownFeature {
-                name: "Illumination",
-                versions: &[],
-            },
-        ),
-        (
-            0x19b0,
-            KnownFeature {
-                name: "HapticFeedback",
-                versions: &[],
-            },
-        ),
-        (
-            0x19c0,
-            KnownFeature {
-                name: "ForceSensingButton",
-                versions: &[],
-            },
-        ),
-        (
-            0x1a00,
-            KnownFeature {
-                name: "PresenterControl",
-                versions: &[],
-            },
-        ),
-        (
-            0x1a01,
-            KnownFeature {
-                name: "Sensor3D",
-                versions: &[],
-            },
-        ),
-        (
-            0x1b00,
-            KnownFeature {
-                name: "ReprogControls",
-                versions: &[],
-            },
-        ),
-        (
-            0x1b01,
-            KnownFeature {
-                name: "ReprogControls2",
-                versions: &[],
-            },
-        ),
-        (
-            0x1b02,
-            KnownFeature {
-                name: "ReprogControls3",
-                versions: &[],
-            },
-        ),
-        (
-            0x1b03,
-            KnownFeature {
-                name: "ReprogControls4",
-                versions: &[],
-            },
-        ),
-        (
-            0x1b04,
-            KnownFeature {
-                name: "ReprogControls5",
-                versions: &[],
-            },
-        ),
-        (
-            0x1bc0,
-            KnownFeature {
-                name: "ReportHidUsages",
-                versions: &[],
-            },
-        ),
-        (
-            0x1c00,
-            KnownFeature {
-                name: "PersistentRemappableAction",
-                versions: &[],
-            },
-        ),
-        (
-            0x1d4b,
-            KnownFeature {
-                name: "WirelessDeviceStatus",
-                versions: &[FeatureVersion {
-                    starting_version: WirelessDeviceStatusFeature::STARTING_VERSION,
-                    producer: new_dyn::<WirelessDeviceStatusFeature>,
-                }],
-            },
-        ),
-        (
-            0x1df0,
-            KnownFeature {
-                name: "RemainingPairings",
-                versions: &[],
-            },
-        ),
-        (
-            0x1f1f,
-            KnownFeature {
-                name: "FirmwareProperties",
-                versions: &[],
-            },
-        ),
-        (
-            0x1f20,
-            KnownFeature {
-                name: "AdcMeasurement",
-                versions: &[],
-            },
-        ),
-        (
-            0x2001,
-            KnownFeature {
-                name: "SwapLeftRightButton",
-                versions: &[],
-            },
-        ),
-        (
-            0x2005,
-            KnownFeature {
-                name: "ButtonSwapCancel",
-                versions: &[],
-            },
-        ),
-        (
-            0x2006,
-            KnownFeature {
-                name: "PointerAxesOrientation",
-                versions: &[],
-            },
-        ),
-        (
-            0x2100,
-            KnownFeature {
-                name: "VerticalScrolling",
-                versions: &[],
-            },
-        ),
-        (
-            0x2110,
-            KnownFeature {
-                name: "SmartShiftWheel",
-                versions: &[FeatureVersion {
-                    starting_version: SmartShiftFeature::STARTING_VERSION,
-                    producer: new_dyn::<SmartShiftFeature>,
-                }],
-            },
-        ),
-        (
-            0x2111,
-            KnownFeature {
-                name: "SmartShiftWheelEnhanced",
-                versions: &[],
-            },
-        ),
-        (
-            0x2120,
-            KnownFeature {
-                name: "HighResolutionScrolling",
-                versions: &[],
-            },
-        ),
-        (
-            0x2121,
-            KnownFeature {
-                name: "HiResWheel",
-                versions: &[FeatureVersion {
-                    starting_version: HiResWheelFeature::STARTING_VERSION,
-                    producer: new_dyn::<HiResWheelFeature>,
-                }],
-            },
-        ),
-        (
-            0x2130,
-            KnownFeature {
-                name: "RatchetWheel",
-                versions: &[],
-            },
-        ),
-        (
-            0x2150,
-            KnownFeature {
-                name: "Thumbwheel",
-                versions: &[FeatureVersion {
-                    starting_version: ThumbwheelFeature::STARTING_VERSION,
-                    producer: new_dyn::<ThumbwheelFeature>,
-                }],
-            },
-        ),
-        (
-            0x2200,
-            KnownFeature {
-                name: "MousePointer",
-                versions: &[],
-            },
-        ),
-        (
-            0x2201,
-            KnownFeature {
-                name: "AdjustableDpi",
-                versions: &[FeatureVersion {
-                    starting_version: AdjustableDpiFeature::STARTING_VERSION,
-                    producer: new_dyn::<AdjustableDpiFeature>,
-                }],
-            },
-        ),
-        (
-            0x2202,
-            KnownFeature {
-                name: "ExtendedAdjustableDpi",
-                versions: &[],
-            },
-        ),
-        (
-            0x2205,
-            KnownFeature {
-                name: "PointerMotionScaling",
-                versions: &[],
-            },
-        ),
-        (
-            0x2230,
-            KnownFeature {
-                name: "SensorAngleSnapping",
-                versions: &[],
-            },
-        ),
-        (
-            0x2240,
-            KnownFeature {
-                name: "SurfaceTuning",
-                versions: &[],
-            },
-        ),
-        (
-            0x2250,
-            KnownFeature {
-                name: "XyStats",
-                versions: &[],
-            },
-        ),
-        (
-            0x2251,
-            KnownFeature {
-                name: "WheelStats",
-                versions: &[],
-            },
-        ),
-        (
-            0x2400,
-            KnownFeature {
-                name: "HybridTrackingEngine",
-                versions: &[],
-            },
-        ),
-        (
-            0x40a0,
-            KnownFeature {
-                name: "FnInversion",
-                versions: &[],
-            },
-        ),
-        (
-            0x40a2,
-            KnownFeature {
-                name: "FnInversionWithDefaultState",
-                versions: &[],
-            },
-        ),
-        (
-            0x40a3,
-            KnownFeature {
-                name: "FnInversionForMultiHostDevices",
-                versions: &[],
-            },
-        ),
-        (
-            0x4100,
-            KnownFeature {
-                name: "Encryption",
-                versions: &[],
-            },
-        ),
-        (
-            0x4220,
-            KnownFeature {
-                name: "LockKeyState",
-                versions: &[],
-            },
-        ),
-        (
-            0x4301,
-            KnownFeature {
-                name: "SolarKeyboardDashboard",
-                versions: &[],
-            },
-        ),
-        (
-            0x4520,
-            KnownFeature {
-                name: "KeyboardLayout",
-                versions: &[],
-            },
-        ),
-        (
-            0x4521,
-            KnownFeature {
-                name: "DisableKeys",
-                versions: &[],
-            },
-        ),
-        (
-            0x4522,
-            KnownFeature {
-                name: "DisableKeysByUsage",
-                versions: &[],
-            },
-        ),
-        (
-            0x4530,
-            KnownFeature {
-                name: "DualPlatform",
-                versions: &[],
-            },
-        ),
-        (
-            0x4531,
-            KnownFeature {
-                name: "MultiPlatform",
-                versions: &[],
-            },
-        ),
-        (
-            0x4540,
-            KnownFeature {
-                name: "KeyboardInternationalLayouts",
-                versions: &[],
-            },
-        ),
-        (
-            0x4600,
-            KnownFeature {
-                name: "Crown",
-                versions: &[],
-            },
-        ),
-        (
-            0x6010,
-            KnownFeature {
-                name: "TouchpadFwItems",
-                versions: &[],
-            },
-        ),
-        (
-            0x6011,
-            KnownFeature {
-                name: "TouchpadSwItems",
-                versions: &[],
-            },
-        ),
-        (
-            0x6012,
-            KnownFeature {
-                name: "TouchpadWin8FwItems",
-                versions: &[],
-            },
-        ),
-        (
-            0x6020,
-            KnownFeature {
-                name: "TapEnable",
-                versions: &[],
-            },
-        ),
-        (
-            0x6021,
-            KnownFeature {
-                name: "TapEnableExtended",
-                versions: &[],
-            },
-        ),
-        (
-            0x6030,
-            KnownFeature {
-                name: "CursorBallistic",
-                versions: &[],
-            },
-        ),
-        (
-            0x6040,
-            KnownFeature {
-                name: "TouchpadResolutionDivider",
-                versions: &[],
-            },
-        ),
-        (
-            0x6100,
-            KnownFeature {
-                name: "TouchpadRawXy",
-                versions: &[],
-            },
-        ),
-        (
-            0x6110,
-            KnownFeature {
-                name: "TouchMouseRawTouchPoints",
-                versions: &[],
-            },
-        ),
-        (
-            0x6120,
-            KnownFeature {
-                name: "BtTouchMouseSettings",
-                versions: &[],
-            },
-        ),
-        (
-            0x6500,
-            KnownFeature {
-                name: "Gestures1",
-                versions: &[],
-            },
-        ),
-        (
-            0x6501,
-            KnownFeature {
-                name: "Gestures2",
-                versions: &[],
-            },
-        ),
-        (
-            0x8010,
-            KnownFeature {
-                name: "GamingGKeys",
-                versions: &[],
-            },
-        ),
-        (
-            0x8020,
-            KnownFeature {
-                name: "GamingMKeys",
-                versions: &[],
-            },
-        ),
-        (
-            0x8030,
-            KnownFeature {
-                name: "MacroRecord",
-                versions: &[],
-            },
-        ),
-        (
-            0x8040,
-            KnownFeature {
-                name: "BrightnessControl",
-                versions: &[],
-            },
-        ),
-        (
-            0x8060,
-            KnownFeature {
-                name: "AdjustableReportRate",
-                versions: &[],
-            },
-        ),
-        (
-            0x8061,
-            KnownFeature {
-                name: "ExtendedAdjustableReportRate",
-                versions: &[],
-            },
-        ),
-        (
-            0x8070,
-            KnownFeature {
-                name: "ColorLedEffects",
-                versions: &[],
-            },
-        ),
-        (
-            0x8071,
-            KnownFeature {
-                name: "RgbEffects",
-                versions: &[],
-            },
-        ),
-        (
-            0x8080,
-            KnownFeature {
-                name: "PerKeyLighting",
-                versions: &[],
-            },
-        ),
-        (
-            0x8081,
-            KnownFeature {
-                name: "PerKeyLighting2",
-                versions: &[],
-            },
-        ),
-        (
-            0x8090,
-            KnownFeature {
-                name: "ModeStatus",
-                versions: &[],
-            },
-        ),
-        (
-            0x8100,
-            KnownFeature {
-                name: "OnboardProfiles",
-                versions: &[],
-            },
-        ),
-        (
-            0x8110,
-            KnownFeature {
-                name: "MouseButtonFilter",
-                versions: &[],
-            },
-        ),
-        (
-            0x8111,
-            KnownFeature {
-                name: "LatencyMonitoring",
-                versions: &[],
-            },
-        ),
-        (
-            0x8120,
-            KnownFeature {
-                name: "GamingAttachments",
-                versions: &[],
-            },
-        ),
-        (
-            0x8123,
-            KnownFeature {
-                name: "ForceFeedback",
-                versions: &[],
-            },
-        ),
-        (
-            0x8300,
-            KnownFeature {
-                name: "Sidetone",
-                versions: &[],
-            },
-        ),
-        (
-            0x8310,
-            KnownFeature {
-                name: "Equalizer",
-                versions: &[],
-            },
-        ),
-        (
-            0x8320,
-            KnownFeature {
-                name: "HeadsetOut",
-                versions: &[],
-            },
-        ),
-    ])
+    known_features! {
+    0x0000 "Root" => RootFeature,
+    0x0001 "FeatureSet" => FeatureSetFeature,
+    0x0002 "FeatureInfo",
+    0x0003 "DeviceInformation" => DeviceInformationFeature,
+    0x0004 "UnitId",
+    0x0005 "DeviceTypeAndName" => DeviceTypeAndNameFeature,
+    0x0006 "DeviceGroups",
+    0x0007 "DeviceFriendlyName" => DeviceFriendlyNameFeature,
+    0x0008 "KeepAlive",
+    0x0020 "ConfigChange",
+    0x0021 "UniqueRandomId",
+    0x0030 "TargetSoftware",
+    0x0080 "WirelessSignalStrength",
+    0x00c0 "DfuControlLegacy",
+    0x00c1 "DfuControlUnsigned",
+    0x00c2 "DfuControlSigned",
+    0x00c3 "DfuControlBolt",
+    0x00d0 "Dfu",
+    0x00d1 "DfuResumable",
+    0x1000 "BatteryStatus",
+    0x1001 "BatteryVoltage",
+    0x1004 "UnifiedBattery" => UnifiedBatteryFeature,
+    0x1010 "ChargingControl",
+    0x1300 "LedControl",
+    0x1800 "GenericTest",
+    0x1802 "DeviceReset",
+    0x1805 "OobState",
+    0x1806 "ConfigDeviceProps",
+    0x1814 "ChangeHost",
+    0x1815 "HostsInfo",
+    0x1981 "Backlight1",
+    0x1982 "Backlight2",
+    0x1983 "Backlight3",
+    0x1990 "Illumination",
+    0x19b0 "HapticFeedback",
+    0x19c0 "ForceSensingButton",
+    0x1a00 "PresenterControl",
+    0x1a01 "Sensor3D",
+    0x1b00 "ReprogControls",
+    0x1b01 "ReprogControls2",
+    0x1b02 "ReprogControls3",
+    0x1b03 "ReprogControls4",
+    0x1b04 "ReprogControls5",
+    0x1bc0 "ReportHidUsages",
+    0x1c00 "PersistentRemappableAction",
+    0x1d4b "WirelessDeviceStatus" => WirelessDeviceStatusFeature,
+    0x1df0 "RemainingPairings",
+    0x1f1f "FirmwareProperties",
+    0x1f20 "AdcMeasurement",
+    0x2001 "SwapLeftRightButton",
+    0x2005 "ButtonSwapCancel",
+    0x2006 "PointerAxesOrientation",
+    0x2100 "VerticalScrolling",
+    0x2110 "SmartShiftWheel" => SmartShiftFeature,
+    0x2111 "SmartShiftWheelEnhanced",
+    0x2120 "HighResolutionScrolling",
+    0x2121 "HiResWheel" => HiResWheelFeature,
+    0x2130 "RatchetWheel",
+    0x2150 "Thumbwheel" => ThumbwheelFeature,
+    0x2200 "MousePointer",
+    0x2201 "AdjustableDpi" => AdjustableDpiFeature,
+    0x2202 "ExtendedAdjustableDpi",
+    0x2205 "PointerMotionScaling",
+    0x2230 "SensorAngleSnapping",
+    0x2240 "SurfaceTuning",
+    0x2250 "XyStats",
+    0x2251 "WheelStats",
+    0x2400 "HybridTrackingEngine",
+    0x40a0 "FnInversion",
+    0x40a2 "FnInversionWithDefaultState",
+    0x40a3 "FnInversionForMultiHostDevices",
+    0x4100 "Encryption",
+    0x4220 "LockKeyState",
+    0x4301 "SolarKeyboardDashboard",
+    0x4520 "KeyboardLayout",
+    0x4521 "DisableKeys",
+    0x4522 "DisableKeysByUsage",
+    0x4530 "DualPlatform",
+    0x4531 "MultiPlatform",
+    0x4540 "KeyboardInternationalLayouts",
+    0x4600 "Crown",
+    0x6010 "TouchpadFwItems",
+    0x6011 "TouchpadSwItems",
+    0x6012 "TouchpadWin8FwItems",
+    0x6020 "TapEnable",
+    0x6021 "TapEnableExtended",
+    0x6030 "CursorBallistic",
+    0x6040 "TouchpadResolutionDivider",
+    0x6100 "TouchpadRawXy",
+    0x6110 "TouchMouseRawTouchPoints",
+    0x6120 "BtTouchMouseSettings",
+    0x6500 "Gestures1",
+    0x6501 "Gestures2",
+    0x8010 "GamingGKeys",
+    0x8020 "GamingMKeys",
+    0x8030 "MacroRecord",
+    0x8040 "BrightnessControl",
+    0x8060 "AdjustableReportRate",
+    0x8061 "ExtendedAdjustableReportRate",
+    0x8070 "ColorLedEffects",
+    0x8071 "RgbEffects",
+    0x8080 "PerKeyLighting",
+    0x8081 "PerKeyLighting2",
+    0x8090 "ModeStatus",
+    0x8100 "OnboardProfiles",
+    0x8110 "MouseButtonFilter",
+    0x8111 "LatencyMonitoring",
+    0x8120 "GamingAttachments",
+    0x8123 "ForceFeedback",
+    0x8300 "Sidetone",
+    0x8310 "Equalizer",
+    0x8320 "HeadsetOut",
+    }
 });

--- a/crates/openlogi-hidpp/src/feature/registry.rs
+++ b/crates/openlogi-hidpp/src/feature/registry.rs
@@ -80,20 +80,22 @@ fn new_dyn<F: CreatableFeature>(
 }
 
 /// Builds [`KNOWN_FEATURES`]. Each row is `id "Name"` for a feature we only know
-/// by name, or `id "Name" => FeatureImpl` to also register a default
-/// implementation produced through [`new_dyn`].
+/// by name, or `id "Name" => Impl, ...` to also register one or more default
+/// implementations through [`new_dyn`]. Listing several impls mirrors a feature
+/// that ships multiple versions, each contributing its own
+/// [`CreatableFeature::STARTING_VERSION`] in declaration order.
 macro_rules! known_features {
-    ( $( $id:literal $name:literal $( => $feat:ty )? ),* $(,)? ) => {
+    ( $( $id:literal $name:literal $( => $($feat:ty),+ )? ),* $(,)? ) => {
         HashMap::from([ $(
-            ($id, KnownFeature { name: $name, versions: known_features!(@versions $( $feat )?) }),
+            ($id, KnownFeature { name: $name, versions: known_features!(@versions $( $($feat),+ )?) }),
         )* ])
     };
     (@versions) => { &[] };
-    (@versions $feat:ty) => {
-        &[FeatureVersion {
+    (@versions $($feat:ty),+) => {
+        &[$(FeatureVersion {
             starting_version: <$feat>::STARTING_VERSION,
             producer: new_dyn::<$feat>,
-        }]
+        }),+]
     };
 }
 
@@ -213,3 +215,26 @@ static KNOWN_FEATURES: LazyLock<HashMap<u16, KnownFeature>> = LazyLock::new(|| {
     0x8320 "HeadsetOut",
     }
 });
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{FeatureVersion, KnownFeature, new_dyn};
+    use crate::feature::{CreatableFeature, feature_set::FeatureSetFeature, root::RootFeature};
+
+    #[test]
+    fn macro_registers_one_version_per_listed_impl() {
+        // The `=> A, B` form keeps the original table's ability to register
+        // several versioned implementations under a single feature id.
+        let map: HashMap<u16, KnownFeature> = known_features! {
+            0x0000 "NameOnly",
+            0x0001 "OneImpl" => RootFeature,
+            0xffff "TwoImpls" => RootFeature, FeatureSetFeature,
+        };
+
+        assert_eq!(map[&0x0000].versions.len(), 0);
+        assert_eq!(map[&0x0001].versions.len(), 1);
+        assert_eq!(map[&0xffff].versions.len(), 2);
+    }
+}

--- a/crates/openlogi-hidpp/src/feature/root.rs
+++ b/crates/openlogi-hidpp/src/feature/root.rs
@@ -3,12 +3,8 @@
 
 use std::sync::Arc;
 
-use super::{CreatableFeature, Feature, FeatureType};
-use crate::{
-    channel::HidppChannel,
-    nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
-};
+use super::{CreatableFeature, Feature, FeatureEndpoint, FeatureType};
+use crate::{channel::HidppChannel, protocol::v20::Hidpp20Error};
 
 /// Implements the `Root` / `0x0000` feature that every HID++2.0 device
 /// supports by default.
@@ -17,11 +13,9 @@ use crate::{
 /// created using [`crate::device::Device::new`].
 #[derive(Clone)]
 pub struct RootFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
+    /// The endpoint this feature talks to. The root feature always lives at
+    /// feature index 0.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for RootFeature {
@@ -29,7 +23,9 @@ impl CreatableFeature for RootFeature {
     const STARTING_VERSION: u8 = 0;
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, _: u8) -> Self {
-        Self { chan, device_index }
+        Self {
+            endpoint: FeatureEndpoint::new(chan, device_index, 0),
+        }
     }
 }
 
@@ -44,20 +40,11 @@ impl RootFeature {
     /// If the device only supports the root feature version 1, the
     /// [`FeatureInformation::version`] field will be `0` for all features.
     pub async fn get_feature(&self, id: u16) -> Result<Option<FeatureInformation>, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: 0,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [(id >> 8) as u8, id as u8, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(0, [(id >> 8) as u8, id as u8, 0x00])
+            .await?
+            .extend_payload();
         if payload[0] == 0 {
             return Ok(None);
         }
@@ -78,20 +65,11 @@ impl RootFeature {
     /// [`crate::protocol::determine_version`] function does so in a more
     /// general manner.
     pub async fn ping(&self, data: u8) -> Result<u8, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: 0,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, data],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self
+            .endpoint
+            .call(1, [0x00, 0x00, data])
+            .await?
+            .extend_payload();
         Ok(payload[2])
     }
 }

--- a/crates/openlogi-hidpp/src/feature/smartshift/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/smartshift/mod.rs
@@ -7,21 +7,14 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
     channel::HidppChannel,
-    feature::{CreatableFeature, Feature},
-    nibble::U4,
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, Feature, FeatureEndpoint},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `SmartShift` / `0x2110` feature.
 pub struct SmartShiftFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 }
 
 impl CreatableFeature for SmartShiftFeature {
@@ -30,9 +23,7 @@ impl CreatableFeature for SmartShiftFeature {
 
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
         }
     }
 }
@@ -46,20 +37,7 @@ impl SmartShiftFeature {
     /// either by software or the wheel mode button. It will not provide
     /// information about whether the wheel is in auto-disengaged mode.
     pub async fn get_ratchet_control_mode(&self) -> Result<RatchetControlMode, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
         Ok(RatchetControlMode {
             wheel_mode: WheelMode::try_from(payload[0])
@@ -87,20 +65,15 @@ impl SmartShiftFeature {
         auto_disengage: Option<u8>,
         auto_disengage_default: Option<u8>,
     ) -> Result<(), Hidpp20Error> {
-        self.chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
+        self.endpoint
+            .call(
+                1,
                 [
                     wheel_mode.map_or(0, u8::from),
                     auto_disengage.unwrap_or(0),
                     auto_disengage_default.unwrap_or(0),
                 ],
-            ))
+            )
             .await?;
 
         Ok(())

--- a/crates/openlogi-hidpp/src/feature/thumbwheel/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/thumbwheel/mod.rs
@@ -8,21 +8,14 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{
     channel::HidppChannel,
     event::EventEmitter,
-    feature::{CreatableFeature, EmittingFeature, Feature},
-    nibble::{self, U4},
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, EmittingFeature, Feature, FeatureEndpoint, event_payload},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `Thumbwheel` / `0x2150` feature.
 pub struct ThumbwheelFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<ThumbwheelEvent>>,
@@ -44,21 +37,16 @@ impl CreatableFeature for ThumbwheelFeature {
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
-                if matched {
+                let Some((func, payload)) =
+                    event_payload(raw, matched, device_index, feature_index)
+                else {
+                    return;
+                };
+                // The status update is the only event and carries sub-id 0.
+                if func.to_lo() != 0 {
                     return;
                 }
 
-                let msg = v20::Message::from(raw);
-
-                let header = msg.header();
-                if header.device_index != device_index
-                    || header.feature_index != feature_index
-                    || nibble::combine(header.software_id, header.function_id) != 0
-                {
-                    return;
-                }
-
-                let payload = msg.extend_payload();
                 let Ok(rotation_status) = ThumbwheelRotationStatus::try_from(payload[4]) else {
                     return;
                 };
@@ -75,9 +63,7 @@ impl CreatableFeature for ThumbwheelFeature {
         });
 
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
             emitter,
             msg_listener_hdl: hdl,
         }
@@ -94,27 +80,16 @@ impl EmittingFeature<ThumbwheelEvent> for ThumbwheelFeature {
 
 impl Drop for ThumbwheelFeature {
     fn drop(&mut self) {
-        self.chan.remove_msg_listener(self.msg_listener_hdl);
+        self.endpoint
+            .chan()
+            .remove_msg_listener(self.msg_listener_hdl);
     }
 }
 
 impl ThumbwheelFeature {
     /// Retrieves some information about the thumbwheel.
     pub async fn get_thumbwheel_info(&self) -> Result<ThumbwheelInfo, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
         Ok(ThumbwheelInfo {
             native_resolution: u16::from_be_bytes(payload[0..=1].try_into().unwrap()),
@@ -128,20 +103,7 @@ impl ThumbwheelFeature {
 
     /// Retrieves the custom status of the thumbwheel.
     pub async fn get_thumbwheel_status(&self) -> Result<ThumbwheelStatus, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(1, [0; 3]).await?.extend_payload();
 
         Ok(ThumbwheelStatus {
             reporting_mode: ThumbwheelReportingMode::try_from(payload[0])
@@ -164,16 +126,8 @@ impl ThumbwheelFeature {
         mode: ThumbwheelReportingMode,
         invert_direction: bool,
     ) -> Result<(), Hidpp20Error> {
-        self.chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(2),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [mode.into(), if invert_direction { 1 } else { 0 }, 0x00],
-            ))
+        self.endpoint
+            .call(2, [mode.into(), if invert_direction { 1 } else { 0 }, 0x00])
             .await?;
 
         Ok(())

--- a/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
@@ -8,21 +8,14 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{
     channel::HidppChannel,
     event::EventEmitter,
-    feature::{CreatableFeature, EmittingFeature, Feature},
-    nibble::{self, U4},
-    protocol::v20::{self, Hidpp20Error},
+    feature::{CreatableFeature, EmittingFeature, Feature, FeatureEndpoint, event_payload},
+    protocol::v20::Hidpp20Error,
 };
 
 /// Implements the `UnifiedBattery` / `0x1004` feature.
 pub struct UnifiedBatteryFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
-    /// The index of the device to implement the feature for.
-    device_index: u8,
-
-    /// The index of the feature in the feature table.
-    feature_index: u8,
+    /// The endpoint this feature talks to.
+    endpoint: FeatureEndpoint,
 
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<BatteryEvent>>,
@@ -44,25 +37,20 @@ impl CreatableFeature for UnifiedBatteryFeature {
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
-                if matched {
-                    return;
-                }
-
-                let msg = v20::Message::from(raw);
-
-                let header = msg.header();
-                if header.device_index != device_index
-                    || header.feature_index != feature_index
-                    || nibble::combine(header.software_id, header.function_id) != 0
-                {
-                    return;
-                }
-
-                let payload = msg.extend_payload();
-                let Ok(level) = BatteryLevel::try_from(payload[1]) else {
+                let Some((func, payload)) =
+                    event_payload(raw, matched, device_index, feature_index)
+                else {
                     return;
                 };
-                let Ok(status) = BatteryStatus::try_from(payload[2]) else {
+                // The battery broadcast is the only event and carries sub-id 0.
+                if func.to_lo() != 0 {
+                    return;
+                }
+
+                let (Ok(level), Ok(status)) = (
+                    BatteryLevel::try_from(payload[1]),
+                    BatteryStatus::try_from(payload[2]),
+                ) else {
                     return;
                 };
 
@@ -75,9 +63,7 @@ impl CreatableFeature for UnifiedBatteryFeature {
         });
 
         Self {
-            chan,
-            device_index,
-            feature_index,
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
             emitter,
             msg_listener_hdl: hdl,
         }
@@ -94,47 +80,25 @@ impl EmittingFeature<BatteryEvent> for UnifiedBatteryFeature {
 
 impl Drop for UnifiedBatteryFeature {
     fn drop(&mut self) {
-        self.chan.remove_msg_listener(self.msg_listener_hdl);
+        self.endpoint
+            .chan()
+            .remove_msg_listener(self.msg_listener_hdl);
     }
 }
 
 impl UnifiedBatteryFeature {
     /// Retrieves the capabilities of this feature and the battery in general.
     pub async fn get_battery_capabilities(&self) -> Result<BatteryCapabilities, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(0),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload: [u8; 2] = response.extend_payload()[..2].try_into().unwrap();
+        let payload: [u8; 2] = self.endpoint.call(0, [0; 3]).await?.extend_payload()[..2]
+            .try_into()
+            .unwrap();
 
         Ok(BatteryCapabilities::from(payload))
     }
 
     /// Retrieves the current information about the battery status.
     pub async fn get_battery_info(&self) -> Result<BatteryInfo, Hidpp20Error> {
-        let response = self
-            .chan
-            .send_v20(v20::Message::Short(
-                v20::MessageHeader {
-                    device_index: self.device_index,
-                    feature_index: self.feature_index,
-                    function_id: U4::from_lo(1),
-                    software_id: self.chan.get_sw_id(),
-                },
-                [0x00, 0x00, 0x00],
-            ))
-            .await?;
-
-        let payload = response.extend_payload();
+        let payload = self.endpoint.call(1, [0; 3]).await?.extend_payload();
 
         // payload[3] contains some kind of information about the status of the external
         // power source (maybe 0 = disconnected and 1 = connected, I don't have enough

--- a/crates/openlogi-hidpp/src/feature/wireless_device_status/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/wireless_device_status/mod.rs
@@ -8,9 +8,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{
     channel::HidppChannel,
     event::EventEmitter,
-    feature::{CreatableFeature, EmittingFeature, Feature},
-    nibble,
-    protocol::v20,
+    feature::{CreatableFeature, EmittingFeature, Feature, event_payload},
 };
 
 /// Implements the `WirelessDeviceStatus` / `0x1d4b` feature.
@@ -38,28 +36,21 @@ impl CreatableFeature for WirelessDeviceStatusFeature {
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
-                if matched {
+                let Some((func, payload)) =
+                    event_payload(raw, matched, device_index, feature_index)
+                else {
+                    return;
+                };
+                // The reconnection broadcast is the only event and carries sub-id 0.
+                if func.to_lo() != 0 {
                     return;
                 }
 
-                let msg = v20::Message::from(raw);
-
-                let header = msg.header();
-                if header.device_index != device_index
-                    || header.feature_index != feature_index
-                    || nibble::combine(header.software_id, header.function_id) != 0
-                {
-                    return;
-                }
-
-                let payload = msg.extend_payload();
-                let Ok(status) = WirelessDeviceStatus::try_from(payload[0]) else {
-                    return;
-                };
-                let Ok(request) = WirelessDeviceStatusRequest::try_from(payload[1]) else {
-                    return;
-                };
-                let Ok(reason) = WirelessDeviceStatusReason::try_from(payload[2]) else {
+                let (Ok(status), Ok(request), Ok(reason)) = (
+                    WirelessDeviceStatus::try_from(payload[0]),
+                    WirelessDeviceStatusRequest::try_from(payload[1]),
+                    WirelessDeviceStatusReason::try_from(payload[2]),
+                ) else {
                     return;
                 };
 


### PR DESCRIPTION
## What

Two mechanical, behaviour-preserving refactors of `openlogi-hidpp`'s feature layer that remove ~960 lines of duplication and bring `registry.rs` back under the 500-line guideline.

### 1. `registry.rs`: 820-line table → data macro (902 → 215 lines)

`KNOWN_FEATURES` was 112 seven-line `KnownFeature { .. }` struct literals — 101 of which encode nothing but an `(id, name)` pair. A small `known_features!` macro makes each row one line:

```rust
0x2110 "SmartShift" => SmartShiftFeature,  // id + name + default impl
0x2111 "SmartShiftWheelEnhanced",          // id + name only
```

Same 112 entries, same 11 producers — pure data change.

### 2. Per-feature request framing → `FeatureEndpoint` (feature/ net −271 lines)

Every feature carried the same `chan` / `device_index` / `feature_index` trio and hand-built a `v20::Message::Short(MessageHeader { .. }, ..)` at each of its **30 call sites**. The four event features additionally repeated an identical listener prelude.

- A `FeatureEndpoint` owns the trio and exposes `call(fn, args)` / `call_long(fn, args)`. Each feature now holds **one** `endpoint` field, and a 22-line `get_battery_info` collapses to 8.
- An `event_payload` helper folds the listener prelude.

### Drive-by fix: event-guard foot-gun

Three event features filtered broadcasts with `nibble::combine(software_id, function_id) != 0` — which rejects **any** nonzero sub-id and was correct only because each happens to emit a single sub-id-0 event. `event_payload` gates on the software id alone and returns the function id, so each feature dispatches its sub-ids **explicitly** (`if func.to_lo() != 0 { return }`). Behaviour is identical for today's features; the hazard for a future multi-event feature is gone. Four unit tests pin the filter (the listener path had zero coverage before).

## Verification

- No public API or wire-format change — `call(n, args)` builds a byte-identical `Message` to the old inline header (same `get_sw_id()` source), verified by inspection per call site.
- `cargo clippy -p openlogi-hidpp` clean under `-D warnings`.
- `cargo test -p openlogi-hidpp`: 21 pass (was 17; +4 new `event_payload` tests).
- `cargo build --workspace --exclude openlogi-gui` builds — all hidpp consumers (hid / cli / agent) compile unchanged.

## Not done (by design)

A `feature_skeleton!` macro for the struct + `CreatableFeature` impl (~95 more lines) was deliberately skipped — it would hide the 7 feature types from grep / go-to-def / rustdoc source links for the least bug-prone boilerplate. Embedding `FeatureEndpoint` already shrinks those structs to a single field without a macro.

> Cannot be runtime-tested without hardware; the substitution is mechanically wire-identical, so compile + clippy + the existing/added tests are the verification bar.