### PR TITLE
refactor(gui): fold duplicated DPI/SmartShift code into shared abstractions

### DIFF
--- a/crates/openlogi-gui/src/components/device_read.rs
+++ b/crates/openlogi-gui/src/components/device_read.rs
@@ -1,0 +1,61 @@
+//! The lazy device-read skeleton shared by the DPI and SmartShift panels.
+//!
+//! Both panels resolve their state by sending a one-shot read request to the
+//! agent over IPC and awaiting the typed reply off the render thread, then
+//! storing the result — or clearing the loading marker if the reply never
+//! comes. Only the command, the store action, and the clear action differ; the
+//! panels inject them as their own `AppState` method references.
+
+use gpui::{BorrowAppContext as _, Context};
+use openlogi_hid::DeviceRoute;
+use tokio::sync::oneshot;
+
+use crate::ipc_client::Command;
+use crate::state::AppState;
+
+/// Issue a one-shot device read over IPC and apply its typed result to
+/// [`AppState`], off the render thread.
+///
+/// `make_command` builds the read [`Command`] from the route and reply channel
+/// (e.g. [`Command::ReadDpi`]); `store` applies a delivered result (e.g.
+/// [`AppState::store_dpi_info`]); `clear` resets the loading marker when the
+/// reply is dropped (e.g. [`AppState::clear_dpi_loading`]). The caller marks the
+/// loading state first for an initial load, or skips it for a post-write confirm
+/// re-read so the optimistic value stays on screen until the real one lands.
+pub fn issue_device_read<P, T>(
+    cx: &mut Context<P>,
+    key: String,
+    route: DeviceRoute,
+    make_command: impl FnOnce(DeviceRoute, oneshot::Sender<T>) -> Command,
+    store: impl FnOnce(&mut AppState, String, &DeviceRoute, T) + 'static,
+    clear: impl Fn(&mut AppState, &str) + 'static,
+) where
+    P: 'static,
+    T: 'static,
+{
+    let sender = cx.global::<AppState>().ipc_sender();
+    let (tx, rx) = oneshot::channel();
+    if sender.send(make_command(route.clone(), tx)).is_err() {
+        cx.update_global::<AppState, _>(|state, _| clear(state, &key));
+        return;
+    }
+    cx.spawn(async move |_panel, cx| {
+        match rx.await {
+            Ok(result) => {
+                cx.update_global::<AppState, _>(|state, cx| {
+                    store(state, key, &route, result);
+                    cx.refresh_windows();
+                });
+            }
+            // The client thread dropped the reply (it's gone). Reset the loading
+            // marker so the device isn't stuck on "Reading…".
+            Err(_) => {
+                cx.update_global::<AppState, _>(|state, cx| {
+                    clear(state, &key);
+                    cx.refresh_windows();
+                });
+            }
+        }
+    })
+    .detach();
+}

--- a/crates/openlogi-gui/src/components/device_read.rs
+++ b/crates/openlogi-gui/src/components/device_read.rs
@@ -36,7 +36,14 @@ pub fn issue_device_read<P, T>(
     let sender = cx.global::<AppState>().ipc_sender();
     let (tx, rx) = oneshot::channel();
     if sender.send(make_command(route.clone(), tx)).is_err() {
-        cx.update_global::<AppState, _>(|state, _| clear(state, &key));
+        // Repaint here too: the async branches below refresh after clearing the
+        // marker, so a channel that's already broken when the read is issued
+        // must not leave the panel stuck on "Reading…" until an unrelated event
+        // redraws it. (Both original panels missed this on the send-error path.)
+        cx.update_global::<AppState, _>(|state, cx| {
+            clear(state, &key);
+            cx.refresh_windows();
+        });
         return;
     }
     cx.spawn(async move |_panel, cx| {

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -17,8 +17,10 @@ use gpui_component::{
 use openlogi_hid::{DeviceRoute, DpiCapabilities};
 use tracing::debug;
 
+use crate::components::device_read::issue_device_read;
+use crate::components::status::{retry_line, status_line};
 use crate::state::{AppState, DpiStatus};
-use crate::theme::{self, ACCENT_BLUE, Palette};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
 
 /// Slider column width. Matches the right-column layout in `app.rs`.
 const PANEL_W: f32 = 300.;
@@ -82,39 +84,18 @@ impl DpiPanel {
         };
 
         cx.update_global::<AppState, _>(|state, _| state.mark_dpi_loading(&key));
-        // The agent owns device I/O; request the DPI read over IPC and await the
-        // reply rather than opening the device from the GUI process. The agent
-        // returns the typed `WriteError`, so a permanent `FeatureUnsupported` /
-        // `EmptyDpiList` reaches `store_dpi_info` intact and the panel stops
-        // re-probing instead of retrying a doomed read on every reselect.
-        let sender = cx.global::<AppState>().ipc_sender();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        if sender
-            .send(crate::ipc_client::Command::ReadDpi(route.clone(), tx))
-            .is_err()
-        {
-            cx.update_global::<AppState, _>(|state, _| state.clear_dpi_loading(&key));
-            return;
-        }
-        cx.spawn(async move |_panel, cx| {
-            match rx.await {
-                Ok(result) => {
-                    cx.update_global::<AppState, _>(|state, cx| {
-                        state.store_dpi_info(key, &route, result);
-                        cx.refresh_windows();
-                    });
-                }
-                // The client thread dropped the reply (it's gone). Reset the
-                // `Loading` marker so the device isn't stuck on "Reading…".
-                Err(_) => {
-                    cx.update_global::<AppState, _>(|state, cx| {
-                        state.clear_dpi_loading(&key);
-                        cx.refresh_windows();
-                    });
-                }
-            }
-        })
-        .detach();
+        // The agent owns device I/O: request the DPI read over IPC and store the
+        // typed reply off the render thread. The typed `WriteError` reaches
+        // `store_dpi_info` intact, so a permanent `FeatureUnsupported` /
+        // `EmptyDpiList` stops the panel re-probing on every reselect.
+        issue_device_read(
+            cx,
+            key,
+            route,
+            crate::ipc_client::Command::ReadDpi,
+            AppState::store_dpi_info,
+            AppState::clear_dpi_loading,
+        );
     }
 
     fn ensure_slider(
@@ -333,57 +314,33 @@ fn slider_element(
     match (status, slider_state) {
         // A device with one supported DPI has nothing to drag — show the value.
         (DpiStatus::Ready(info), _) if info.capabilities.min() == info.capabilities.max() => {
-            dpi_status_line(
-                tr!("Fixed DPI: %{dpi}", dpi => info.capabilities.min()),
-                pal,
-            )
+            status_line(tr!("Fixed DPI: %{dpi}", dpi => info.capabilities.min()), pal)
         }
         (DpiStatus::Ready(_), Some(slider_state)) => {
             Slider::new(slider_state).horizontal().into_any_element()
         }
-        (DpiStatus::Ready(_), None) => dpi_status_line(tr!("Preparing DPI slider…"), pal),
+        (DpiStatus::Ready(_), None) => status_line(tr!("Preparing DPI slider…"), pal),
         (DpiStatus::Unknown | DpiStatus::Loading, _) if !reachable => {
-            dpi_status_line(tr!("Device offline — DPI unavailable."), pal)
+            status_line(tr!("Device offline — DPI unavailable."), pal)
         }
         (DpiStatus::Unknown | DpiStatus::Loading, _) => {
-            dpi_status_line(tr!("Reading supported DPI values…"), pal)
+            status_line(tr!("Reading supported DPI values…"), pal)
         }
         // Clickable: reselecting is a no-op for a single-device carousel, so the
         // retry must work in place.
-        (DpiStatus::Failed(_), _) => {
-            dpi_retry_line(tr!("Couldn't read DPI — click to retry."), pal)
-        }
-        (DpiStatus::Unsupported(_), _) => dpi_status_line(
-            tr!("This device did not report Adjustable DPI support."),
+        (DpiStatus::Failed(_), _) => retry_line(
+            "dpi-retry",
+            tr!("Couldn't read DPI — click to retry."),
             pal,
+            |cx| {
+                cx.update_global::<AppState, _>(|state, _| state.retry_active_dpi());
+                cx.refresh_windows();
+            },
         ),
+        (DpiStatus::Unsupported(_), _) => {
+            status_line(tr!("This device did not report Adjustable DPI support."), pal)
+        }
     }
-}
-
-fn dpi_status_line(message: SharedString, pal: Palette) -> AnyElement {
-    div()
-        .h(px(CHIP_H))
-        .text_sm()
-        .text_color(pal.text_muted)
-        .child(message)
-        .into_any_element()
-}
-
-/// A `Failed`-state line that re-arms DPI discovery for the active device on
-/// click. Backs the only recovery path when the carousel holds one device.
-fn dpi_retry_line(message: SharedString, pal: Palette) -> AnyElement {
-    div()
-        .id("dpi-retry")
-        .h(px(CHIP_H))
-        .text_sm()
-        .text_color(rgb(ACCENT_BLUE))
-        .hover(|s| s.text_color(pal.text_primary))
-        .child(message)
-        .on_click(|_event, _window, cx| {
-            cx.update_global::<AppState, _>(|state, _| state.retry_active_dpi());
-            cx.refresh_windows();
-        })
-        .into_any_element()
 }
 
 const CHIP_H: f32 = 28.;
@@ -399,27 +356,15 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
         .gap_2()
         .items_center()
         .rounded_md()
-        .border_1()
-        .border_color(if active {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.border
-        })
-        .bg(if active {
-            pal.surface_hover
-        } else {
-            pal.surface
-        })
+        .selected_border(active, pal)
+        .bg(pal.surface)
+        .selected_fill(active)
         .hover(|s| s.bg(pal.surface_hover))
         .child(
             div()
                 .id(("dpi-preset-apply", idx))
                 .text_sm()
-                .text_color(if active {
-                    rgb(ACCENT_BLUE).into()
-                } else {
-                    pal.text_primary
-                })
+                .text_color(pal.text_primary)
                 .child(format!("{value}"))
                 .on_click(move |_event, _window, cx| {
                     // Only apply once the supported DPI list is known, so the

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -314,7 +314,10 @@ fn slider_element(
     match (status, slider_state) {
         // A device with one supported DPI has nothing to drag — show the value.
         (DpiStatus::Ready(info), _) if info.capabilities.min() == info.capabilities.max() => {
-            status_line(tr!("Fixed DPI: %{dpi}", dpi => info.capabilities.min()), pal)
+            status_line(
+                tr!("Fixed DPI: %{dpi}", dpi => info.capabilities.min()),
+                pal,
+            )
         }
         (DpiStatus::Ready(_), Some(slider_state)) => {
             Slider::new(slider_state).horizontal().into_any_element()
@@ -337,9 +340,10 @@ fn slider_element(
                 cx.refresh_windows();
             },
         ),
-        (DpiStatus::Unsupported(_), _) => {
-            status_line(tr!("This device did not report Adjustable DPI support."), pal)
-        }
+        (DpiStatus::Unsupported(_), _) => status_line(
+            tr!("This device did not report Adjustable DPI support."),
+            pal,
+        ),
     }
 }
 

--- a/crates/openlogi-gui/src/components/lighting_panel.rs
+++ b/crates/openlogi-gui/src/components/lighting_panel.rs
@@ -17,7 +17,7 @@ use gpui_component::{
 use openlogi_core::config::Lighting;
 
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
 
 const SWATCH: f32 = 28.;
 
@@ -145,7 +145,7 @@ fn swatch(idx: usize, hex: &'static str, current: &Lighting, pal: Palette) -> An
         .rounded_md()
         .border_2()
         .border_color(if selected {
-            rgb(ACCENT_BLUE).into()
+            theme::accent()
         } else {
             pal.border
         })
@@ -171,18 +171,10 @@ fn toggle(current: &Lighting, pal: Palette) -> AnyElement {
         .px_2()
         .py_1()
         .rounded_md()
-        .border_1()
-        .border_color(if on {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.border
-        })
+        .selected_border(on, pal)
+        .selected_fill(on)
         .text_xs()
-        .text_color(if on {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.text_muted
-        })
+        .text_color(if on { pal.text_primary } else { pal.text_muted })
         .cursor_pointer()
         .child(if on { tr!("On") } else { tr!("Off") })
         .on_click(|_event, _window, cx| {

--- a/crates/openlogi-gui/src/components/mod.rs
+++ b/crates/openlogi-gui/src/components/mod.rs
@@ -5,6 +5,8 @@
 //! [`crate::state::AppState`].
 
 pub mod carousel;
+pub mod device_read;
 pub mod dpi_panel;
 pub mod lighting_panel;
 pub mod smartshift_panel;
+pub mod status;

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -23,8 +23,10 @@ use gpui_component::{
 };
 use openlogi_hid::{AUTO_DISENGAGE_PERMANENT, DeviceRoute, SmartShiftMode, SmartShiftStatus};
 
+use crate::components::device_read::issue_device_read;
+use crate::components::status::{retry_line, status_line};
 use crate::state::{AppState, SmartShiftLoad};
-use crate::theme::{self, ACCENT_BLUE, Palette};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
 
 /// Friendly slider range for the `autoDisengage` threshold. The wire field is
 /// `0x01`–`0xFE` (0.25 turn/s steps), but realistic scroll speeds sit well
@@ -122,33 +124,14 @@ impl SmartShiftPanel {
     /// so a permanent `FeatureUnsupported` reaches `store_smartshift_status`
     /// intact and the panel stops re-probing instead of retrying every reselect.
     fn issue_smartshift_read(key: String, route: DeviceRoute, cx: &mut Context<Self>) {
-        let sender = cx.global::<AppState>().ipc_sender();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        if sender
-            .send(crate::ipc_client::Command::ReadSmartShift(
-                route.clone(),
-                tx,
-            ))
-            .is_err()
-        {
-            cx.update_global::<AppState, _>(|state, _| state.clear_smartshift_loading(&key));
-            return;
-        }
-        cx.spawn(async move |_panel, cx| match rx.await {
-            Ok(result) => {
-                cx.update_global::<AppState, _>(|state, cx| {
-                    state.store_smartshift_status(key, &route, result);
-                    cx.refresh_windows();
-                });
-            }
-            Err(_) => {
-                cx.update_global::<AppState, _>(|state, cx| {
-                    state.clear_smartshift_loading(&key);
-                    cx.refresh_windows();
-                });
-            }
-        })
-        .detach();
+        issue_device_read(
+            cx,
+            key,
+            route,
+            crate::ipc_client::Command::ReadSmartShift,
+            AppState::store_smartshift_status,
+            AppState::clear_smartshift_loading,
+        );
     }
 
     /// The interactive body shown once the device's SmartShift config resolves.
@@ -296,9 +279,15 @@ impl Render for SmartShiftPanel {
             SmartShiftLoad::Loading | SmartShiftLoad::Unknown => {
                 status_line(tr!("Reading SmartShift settings…"), pal)
             }
-            SmartShiftLoad::Failed(_) => {
-                retry_line(tr!("Couldn't read SmartShift — click to retry."), pal)
-            }
+            SmartShiftLoad::Failed(_) => retry_line(
+                "smartshift-retry",
+                tr!("Couldn't read SmartShift — click to retry."),
+                pal,
+                |cx| {
+                    cx.update_global::<AppState, _>(|state, _| state.retry_active_smartshift());
+                    cx.refresh_windows();
+                },
+            ),
             SmartShiftLoad::Unsupported(_) => {
                 status_line(tr!("This device does not support SmartShift."), pal)
             }
@@ -346,23 +335,11 @@ fn mode_pill(
         .px_3()
         .py_1()
         .rounded_md()
-        .border_1()
-        .border_color(if selected {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.border
-        })
-        .bg(if selected {
-            pal.surface_hover
-        } else {
-            pal.surface
-        })
+        .selected_border(selected, pal)
+        .bg(pal.surface)
+        .selected_fill(selected)
         .text_sm()
-        .text_color(if selected {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.text_primary
-        })
+        .text_color(pal.text_primary)
         .cursor_pointer()
         .hover(|s| s.bg(pal.surface_hover))
         .child(label)
@@ -402,18 +379,10 @@ fn permanent_toggle(
         .px_2()
         .py_1()
         .rounded_md()
-        .border_1()
-        .border_color(if on {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.border
-        })
+        .selected_border(on, pal)
+        .selected_fill(on)
         .text_xs()
-        .text_color(if on {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.text_muted
-        })
+        .text_color(if on { pal.text_primary } else { pal.text_muted })
         .cursor_pointer()
         .child(label)
         .on_click(move |_event, _window, cx| {
@@ -437,30 +406,6 @@ fn disabled_track(pal: Palette) -> AnyElement {
         .h(px(6.))
         .rounded_full()
         .bg(pal.border)
-        .into_any_element()
-}
-
-fn status_line(text: SharedString, pal: Palette) -> AnyElement {
-    div()
-        .text_sm()
-        .text_color(pal.text_muted)
-        .child(text)
-        .into_any_element()
-}
-
-/// A `Failed`-state line that re-arms the SmartShift read on click — the only
-/// recovery path when the carousel holds a single device.
-fn retry_line(text: SharedString, pal: Palette) -> AnyElement {
-    div()
-        .id("smartshift-retry")
-        .text_sm()
-        .text_color(rgb(ACCENT_BLUE))
-        .hover(|s| s.text_color(pal.text_primary))
-        .child(text)
-        .on_click(|_event, _window, cx| {
-            cx.update_global::<AppState, _>(|state, _| state.retry_active_smartshift());
-            cx.refresh_windows();
-        })
         .into_any_element()
 }
 

--- a/crates/openlogi-gui/src/components/status.rs
+++ b/crates/openlogi-gui/src/components/status.rs
@@ -1,0 +1,51 @@
+//! Shared status / retry lines for the lazily-loaded device-config panels.
+//!
+//! The DPI and SmartShift panels both resolve their device state in the
+//! background and surface the same handful of non-`Ready` states — "reading…",
+//! "offline", "unsupported", and a clickable "retry". This module is the single
+//! rendering of those rows so they read identically across panels; only the
+//! retry action differs, injected by the caller.
+
+use gpui::{
+    AnyElement, App, ElementId, InteractiveElement, IntoElement, ParentElement, SharedString,
+    StatefulInteractiveElement as _, Styled, div, px,
+};
+
+use crate::theme::{self, Palette};
+
+/// Fixed height for a status / retry row, so swapping a slider out for a status
+/// message (or back) doesn't make the panel jump.
+const ROW_H: f32 = 28.;
+
+/// A muted, non-interactive status line — "Reading…", "offline", "unsupported".
+/// The text is pre-localized by the caller (panels hold their own `tr!` keys).
+pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
+    div()
+        .h(px(ROW_H))
+        .text_sm()
+        .text_color(pal.text_muted)
+        .child(text.into())
+        .into_any_element()
+}
+
+/// A clickable accent line that re-arms a failed read on click. `on_retry` runs
+/// the panel's retry (e.g. [`AppState::retry_active_dpi`]) — the only recovery
+/// path when the carousel holds a single device, where re-selecting is a no-op.
+///
+/// [`AppState::retry_active_dpi`]: crate::state::AppState::retry_active_dpi
+pub fn retry_line(
+    id: impl Into<ElementId>,
+    text: impl Into<SharedString>,
+    pal: Palette,
+    on_retry: impl Fn(&mut App) + 'static,
+) -> AnyElement {
+    div()
+        .id(id)
+        .h(px(ROW_H))
+        .text_sm()
+        .text_color(theme::accent())
+        .hover(|s| s.text_color(pal.text_primary))
+        .child(text.into())
+        .on_click(move |_event, _window, cx| on_retry(cx))
+        .into_any_element()
+}

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -23,7 +23,7 @@ use std::rc::Rc;
 
 use gpui::{
     AnyElement, App, BorrowAppContext as _, Context, Entity, FontWeight, InteractiveElement,
-    IntoElement, ParentElement, StatefulInteractiveElement as _, Styled, Window, div, hsla,
+    IntoElement, ParentElement, StatefulInteractiveElement as _, Styled, Window, div,
     prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_component::{Icon, IconName, h_flex, popover::PopoverState, v_flex};
@@ -33,7 +33,7 @@ use crate::data::mouse_buttons::{
 };
 use crate::mouse_model::view::MouseModelView;
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
 
 /// Floor width for the [`action_picker`] popover. The action labels drive the
 /// actual width; this only stops the list from collapsing too narrow. Matches
@@ -203,13 +203,8 @@ fn direction_cell(
         .px_2()
         .py_1p5()
         .rounded_md()
-        .border_1()
-        .border_color(if active {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.border
-        })
-        .when(active, |s| s.bg(hsla(0.6, 0.9, 0.6, 0.10)))
+        .selected_border(active, pal)
+        .selected_fill(active)
         .hover(move |s| s.bg(pal.surface_hover))
         .child(div().text_xs().text_color(pal.text_muted).child(header))
         .child(
@@ -411,10 +406,6 @@ fn menu_row(
     pal: Palette,
     selected: bool,
 ) -> gpui::Stateful<gpui::Div> {
-    // Accent fill derived from ACCENT_BLUE (≈ hue 0.6 / sat 0.9 / light 0.6),
-    // kept low-alpha so the row reads as tinted, not painted.
-    let tint = hsla(0.6, 0.9, 0.6, 0.12);
-    let tint_hover = hsla(0.6, 0.9, 0.6, 0.18);
     h_flex()
         .id(id)
         .w_full()
@@ -426,10 +417,10 @@ fn menu_row(
         .rounded_md()
         .text_sm()
         .text_color(pal.text_primary)
-        .when(selected, |s| s.bg(tint))
+        .selected_fill(selected)
         .hover(move |s| {
             s.bg(if selected {
-                tint_hover
+                theme::accent_tint_hover()
             } else {
                 pal.surface_hover
             })

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -21,7 +21,7 @@ use crate::mouse_model::picker::{
     GESTURE_BUTTON_ICON, action_icon_path, action_picker, gesture_overview,
 };
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
 
 const SIDE_W: f32 = 180.;
 const SIDE_GAP: f32 = 24.;
@@ -291,23 +291,20 @@ fn owner_chip(
         None => tr!("Off"),
     };
     let id_part = btn.map_or(0usize, |b| b as usize + 1);
-    let tint = hsla(0.6, 0.9, 0.6, 0.12);
-    let tint_border = hsla(0.6, 0.9, 0.6, 0.5);
     let view = view.clone();
     div()
         .id(("gesture-owner", id_part))
         .px_2()
         .py_1()
         .rounded_md()
-        .border_1()
-        .border_color(if selected { tint_border } else { pal.border })
+        .selected_border(selected, pal)
+        .selected_fill(selected)
         .text_xs()
         .text_color(if selected {
             pal.text_primary
         } else {
             pal.text_muted
         })
-        .when(selected, |s| s.bg(tint))
         .when(!selected, |s| s.hover(|s| s.bg(pal.surface_hover)))
         .cursor_pointer()
         .child(text)

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -70,49 +70,188 @@ pub enum AgentLink {
 /// disappear mid-interaction.
 const INVENTORY_MISS_GRACE: u8 = 2;
 
-/// How many times to retry DPI capability discovery after a transient HID++
-/// error (read timeout, busy device) before marking the device unsupported. A
-/// genuine "feature not supported" reply is permanent and never retried.
-const DPI_LOAD_MAX_ATTEMPTS: u8 = 3;
+/// How many times to retry a device read (DPI capability discovery or a
+/// SmartShift read) after a transient HID++ error (read timeout, busy device)
+/// before giving up. A genuine "feature not supported" reply is permanent and
+/// never retried.
+const LOAD_MAX_ATTEMPTS: u8 = 3;
 
-/// Per-device DPI capability loading state.
+/// Lazy per-device load state for a background HID++ read: unqueried, in flight,
+/// resolved, transiently failed (retryable on re-select), or permanently
+/// unsupported. Shared by DPI capability discovery and SmartShift reads through
+/// [`LazyDeviceData`]; the two differ only in payload type `T` and in which
+/// errors count as permanent.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DpiStatus {
+pub enum Load<T> {
     /// The selected device has not been queried yet.
     Unknown,
     /// A background HID++ read is in flight.
     Loading,
-    /// The device reported its current DPI and supported values.
-    Ready(DpiInfo),
-    /// Transient discovery errors (read timeouts, busy device) exhausted the
-    /// retry budget. Distinct from [`Self::Unsupported`] because the device may
-    /// well support DPI — re-selecting it (see [`AppState::set_current_device`])
+    /// The device reported its value.
+    Ready(T),
+    /// Transient errors (read timeouts, busy device) exhausted the retry budget.
+    /// Distinct from [`Self::Unsupported`] because the device may well support
+    /// the feature — re-selecting it (see [`AppState::set_current_device`])
     /// grants a fresh attempt.
     Failed(String),
-    /// The device genuinely does not support the AdjustableDpi feature; never
-    /// retried.
+    /// The device genuinely does not support the feature; never retried.
     Unsupported(String),
 }
 
-/// Per-device SmartShift (`0x2111`) loading state. Mirrors [`DpiStatus`]:
-/// lazily loaded because the HID++ read must not block device switching or
-/// rendering. Unlike DPI presets, the resolved config is *not* persisted to
-/// `config.toml` — the device stores wheel mode / threshold / torque in its
-/// own non-volatile memory, so the GUI only ever reads and writes the device.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SmartShiftLoad {
-    /// The selected device has not been queried yet.
-    Unknown,
-    /// A background HID++ read is in flight.
-    Loading,
-    /// The device reported its current SmartShift configuration.
-    Ready(SmartShiftStatus),
-    /// Transient read errors exhausted the retry budget; retryable on
-    /// re-select.
-    Failed(String),
-    /// The device genuinely does not expose SmartShift (`0x2111`); never
-    /// retried.
-    Unsupported(String),
+/// Per-device DPI capability load state. See [`Load`].
+pub type DpiStatus = Load<DpiInfo>;
+
+/// Per-device SmartShift (`0x2111`) config load state. See [`Load`]. Unlike DPI
+/// presets, the resolved config is *not* persisted to `config.toml` — the device
+/// stores wheel mode / threshold / torque in its own non-volatile memory, so the
+/// GUI only ever reads and writes the device.
+pub type SmartShiftLoad = Load<SmartShiftStatus>;
+
+/// Per-device lazy-load cache for a background HID++ read, keyed by
+/// [`DeviceRecord::config_key`]. Holds each device's [`Load`] state plus its
+/// transient-retry counter, and carries the stale-route guard + retry-budget
+/// policy once, for both DPI and SmartShift.
+struct LazyDeviceData<T> {
+    by_device: BTreeMap<String, Load<T>>,
+    /// Consecutive transient read failures per device, capped by
+    /// [`LOAD_MAX_ATTEMPTS`] before the device settles on [`Load::Failed`].
+    attempts: BTreeMap<String, u8>,
+}
+
+// Manual `Default` (not derived): a derive would demand `T: Default`, but the
+// empty maps need nothing of `T`.
+impl<T> Default for LazyDeviceData<T> {
+    fn default() -> Self {
+        Self {
+            by_device: BTreeMap::new(),
+            attempts: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T: Clone> LazyDeviceData<T> {
+    /// The recorded state for `key`, or [`Load::Unknown`] if never queried.
+    fn status(&self, key: &str) -> Load<T> {
+        self.by_device.get(key).cloned().unwrap_or(Load::Unknown)
+    }
+
+    /// The raw recorded entry for `key`, for callers that match on `Ready`
+    /// without cloning the payload.
+    fn get(&self, key: &str) -> Option<&Load<T>> {
+        self.by_device.get(key)
+    }
+
+    /// Whether `key` still needs a read (nothing recorded yet). Cheaper than
+    /// cloning [`status`](Self::status) on the per-frame render path.
+    fn unqueried(&self, key: &str) -> bool {
+        !self.by_device.contains_key(key)
+    }
+
+    /// Mark a read as in flight for `key`.
+    fn mark_loading(&mut self, key: &str) {
+        self.by_device.insert(key.to_string(), Load::Loading);
+    }
+
+    /// Reset a stuck `Loading` for `key` back to unqueried — the read worker
+    /// vanished (e.g. panicked) without delivering a result, so the next render
+    /// re-issues instead of wedging the device on "Reading…".
+    fn clear_loading(&mut self, key: &str) {
+        if matches!(self.by_device.get(key), Some(Load::Loading)) {
+            self.by_device.remove(key);
+        }
+    }
+
+    /// Drop `key`'s recorded state and retry budget so the next render re-reads.
+    /// Backs the "click to retry" affordance and the re-select-grants-a-retry
+    /// rule for a [`Load::Failed`] device.
+    fn retry(&mut self, key: &str) {
+        self.by_device.remove(key);
+        self.attempts.remove(key);
+    }
+
+    /// Forget `key` entirely — the device disappeared, or reconnected on a new
+    /// route, so its cached state (keyed to the dead route) is stale.
+    fn remove(&mut self, key: &str) {
+        self.by_device.remove(key);
+        self.attempts.remove(key);
+    }
+
+    /// Forget every device the `present` predicate rejects (not in the live set).
+    fn retain_present(&mut self, present: impl Fn(&str) -> bool) {
+        self.by_device.retain(|key, _| present(key.as_str()));
+        self.attempts.retain(|key, _| present(key.as_str()));
+    }
+
+    /// Optimistically record a resolved value with no read involved — e.g. a
+    /// just-written SmartShift config, shown until a confirming re-read replaces
+    /// it. Leaves the retry budget untouched.
+    fn set_ready(&mut self, key: String, value: T) {
+        self.by_device.insert(key, Load::Ready(value));
+    }
+
+    /// Store a read result under the stale-route guard and the transient-retry /
+    /// permanent-unsupported policy. `matches_route` is whether a live device
+    /// still holds `key` *on the route the read targeted*; `still_present` is
+    /// whether `key` exists at all. Returns the resolved value when the result
+    /// settled to [`Load::Ready`], so the caller can run a side effect (the DPI
+    /// panel seeds the shared current value). `label` tags the debug logs.
+    fn store(
+        &mut self,
+        key: String,
+        result: Result<T, WriteError>,
+        is_permanent: impl Fn(&WriteError) -> bool,
+        matches_route: bool,
+        still_present: bool,
+        label: &'static str,
+    ) -> Option<T> {
+        if !matches_route {
+            debug!(key, label, "stale device read result ignored");
+            // The device reconnected on a different route mid-read: drop the
+            // orphaned `Loading` marker so the next render re-reads against the
+            // live route instead of spinning on "Reading…" forever.
+            if still_present {
+                self.by_device.remove(&key);
+            }
+            return None;
+        }
+
+        let status = match result {
+            Ok(value) => {
+                self.attempts.remove(&key);
+                Load::Ready(value)
+            }
+            // A genuine "feature not supported" reply never changes — record it
+            // and stop probing.
+            Err(error) if is_permanent(&error) => {
+                self.attempts.remove(&key);
+                Load::Unsupported(error.to_string())
+            }
+            // Transient failures get a few more tries: clear the status so the
+            // next render re-reads, until the budget runs out, then settle on
+            // `Failed` (retryable on re-select) rather than `Unsupported`.
+            Err(error) => {
+                let attempts = self.attempts.entry(key.clone()).or_insert(0);
+                *attempts = attempts.saturating_add(1);
+                if *attempts < LOAD_MAX_ATTEMPTS {
+                    debug!(key, attempts = *attempts, error = %error, label, "transient device read error — will retry");
+                    self.by_device.remove(&key);
+                    return None;
+                }
+                self.attempts.remove(&key);
+                Load::Failed(error.to_string())
+            }
+        };
+
+        // Clone out the resolved value (cheap; once per completed read) before
+        // the status moves into the map, so the caller can seed derived state
+        // without re-borrowing `self`.
+        let resolved = match &status {
+            Load::Ready(value) => Some(value.clone()),
+            _ => None,
+        };
+        self.by_device.insert(key, status);
+        resolved
+    }
 }
 
 pub struct AppState {
@@ -144,28 +283,18 @@ pub struct AppState {
     /// [`DeviceConfig::bindings`]: openlogi_core::config::DeviceConfig::bindings
     pub gesture_bindings: BTreeMap<GestureDirection, Action>,
     pub dpi: u32,
-    /// DPI capability state keyed by [`DeviceRecord::config_key`]. Loaded
+    /// DPI capability load state keyed by [`DeviceRecord::config_key`]. Loaded
     /// lazily because HID++ reads must not block device switching or rendering.
-    pub dpi_by_device: BTreeMap<String, DpiStatus>,
+    dpi_data: LazyDeviceData<DpiInfo>,
     /// Consecutive inventory snapshots that omitted a previously-known device,
     /// keyed by [`DeviceRecord::config_key`]. Used to debounce transient HID++
     /// probe misses without hiding a real disconnect forever.
     inventory_misses: BTreeMap<String, u8>,
-    /// Consecutive failed DPI discovery attempts, keyed by
-    /// [`DeviceRecord::config_key`]. Lets a transient read error retry a few
-    /// times (see [`DPI_LOAD_MAX_ATTEMPTS`]) instead of sticking the device on
-    /// [`DpiStatus::Unsupported`] forever.
-    dpi_load_attempts: BTreeMap<String, u8>,
-    /// SmartShift (`0x2111`) configuration state keyed by
+    /// SmartShift (`0x2111`) config load state keyed by
     /// [`DeviceRecord::config_key`]. Loaded lazily on the same pattern as
-    /// [`Self::dpi_by_device`]; the device persists the values itself, so this
-    /// is a read/write cache, not a source of truth saved to disk. Private so
-    /// all access goes through the accessor methods below (`current_smartshift_*`,
-    /// `store_smartshift_status`), which enforce the stale-result and retry rules.
-    smartshift_by_device: BTreeMap<String, SmartShiftLoad>,
-    /// Consecutive failed SmartShift read attempts, keyed by
-    /// [`DeviceRecord::config_key`] — mirrors [`Self::dpi_load_attempts`].
-    smartshift_load_attempts: BTreeMap<String, u8>,
+    /// [`Self::dpi_data`]; the device persists the values itself, so this is a
+    /// read/write cache, not a source of truth saved to disk.
+    smartshift_data: LazyDeviceData<SmartShiftStatus>,
     /// Glow-overlay cache paths we've already spawned generation for, so each
     /// `(depot, colour)` is attempted exactly once — even when the depot ships
     /// no mask and no file is ever written (otherwise the worker's
@@ -232,11 +361,9 @@ impl AppState {
             button_bindings: BTreeMap::new(),
             gesture_bindings: BTreeMap::new(),
             dpi: DEFAULT_DPI,
-            dpi_by_device: BTreeMap::new(),
+            dpi_data: LazyDeviceData::default(),
             inventory_misses: BTreeMap::new(),
-            dpi_load_attempts: BTreeMap::new(),
-            smartshift_by_device: BTreeMap::new(),
-            smartshift_load_attempts: BTreeMap::new(),
+            smartshift_data: LazyDeviceData::default(),
             glow_attempted: HashSet::new(),
             glow_ready: HashSet::new(),
             smartshift_pending_confirm: std::collections::BTreeSet::new(),
@@ -303,7 +430,7 @@ impl AppState {
     /// The cached DPI-discovery status for `key`, for the diagnostics report.
     #[must_use]
     pub fn dpi_status_for(&self, key: &str) -> Option<DpiStatus> {
-        self.dpi_by_device.get(key).cloned()
+        self.dpi_data.get(key).cloned()
     }
 
     /// Ask the agent to fire the macOS Accessibility prompt. The agent owns the
@@ -472,19 +599,16 @@ impl AppState {
 
         self.device_list = merged_list;
         for key in &rerouted {
-            self.dpi_by_device.remove(key);
-            self.dpi_load_attempts.remove(key);
-            self.smartshift_by_device.remove(key);
-            self.smartshift_load_attempts.remove(key);
+            self.dpi_data.remove(key);
+            self.smartshift_data.remove(key);
         }
-        self.dpi_by_device
-            .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
-        self.dpi_load_attempts
-            .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
-        self.smartshift_by_device
-            .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
-        self.smartshift_load_attempts
-            .retain(|key, _| self.device_list.iter().any(|r| r.config_key == *key));
+        let present = |key: &str| {
+            self.device_list
+                .iter()
+                .any(|r| r.config_key.as_str() == key)
+        };
+        self.dpi_data.retain_present(present);
+        self.smartshift_data.retain_present(present);
         self.current_device = new_index;
         // The active device may have changed (selection fell back to index 0
         // when the previous one vanished); re-seed the displayed DPI so it
@@ -552,16 +676,11 @@ impl AppState {
         // A device left in `Failed` (transient read errors exhausted its retry
         // budget) gets one fresh attempt each time it is re-selected.
         if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
-            if matches!(self.dpi_by_device.get(&key), Some(DpiStatus::Failed(_))) {
-                self.dpi_by_device.remove(&key);
-                self.dpi_load_attempts.remove(&key);
+            if matches!(self.dpi_data.get(&key), Some(Load::Failed(_))) {
+                self.dpi_data.retry(&key);
             }
-            if matches!(
-                self.smartshift_by_device.get(&key),
-                Some(SmartShiftLoad::Failed(_))
-            ) {
-                self.smartshift_by_device.remove(&key);
-                self.smartshift_load_attempts.remove(&key);
+            if matches!(self.smartshift_data.get(&key), Some(Load::Failed(_))) {
+                self.smartshift_data.retry(&key);
             }
         }
         // `self.dpi` is the active device's value; adopt the newly-selected
@@ -605,9 +724,9 @@ impl AppState {
     /// DPI capability status for the active device.
     #[must_use]
     pub fn current_dpi_status(&self) -> DpiStatus {
-        self.current_record()
-            .and_then(|record| self.dpi_by_device.get(&record.config_key).cloned())
-            .unwrap_or(DpiStatus::Unknown)
+        self.current_record().map_or(DpiStatus::Unknown, |record| {
+            self.dpi_data.status(&record.config_key)
+        })
     }
 
     /// Whether the active device still needs a DPI read (no status recorded —
@@ -616,7 +735,7 @@ impl AppState {
     #[must_use]
     pub fn current_dpi_unqueried(&self) -> bool {
         self.current_record()
-            .is_some_and(|record| !self.dpi_by_device.contains_key(&record.config_key))
+            .is_some_and(|record| self.dpi_data.unqueried(&record.config_key))
     }
 
     /// The active device's known DPI, falling back to [`DEFAULT_DPI`] until its
@@ -624,7 +743,7 @@ impl AppState {
     #[must_use]
     fn dpi_for_current(&self) -> u32 {
         self.current_record()
-            .and_then(|record| self.dpi_by_device.get(&record.config_key))
+            .and_then(|record| self.dpi_data.get(&record.config_key))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(u32::from(info.current)),
                 _ => None,
@@ -634,17 +753,14 @@ impl AppState {
 
     /// Mark DPI capability discovery as in flight for `key`.
     pub fn mark_dpi_loading(&mut self, key: &str) {
-        self.dpi_by_device
-            .insert(key.to_string(), DpiStatus::Loading);
+        self.dpi_data.mark_loading(key);
     }
 
     /// Reset a stuck `Loading` for `key` back to `Unknown`. Called when the
     /// discovery worker vanished without delivering a result (e.g. it panicked),
     /// so the device isn't wedged on "Reading…" with no path to retry.
     pub fn clear_dpi_loading(&mut self, key: &str) {
-        if matches!(self.dpi_by_device.get(key), Some(DpiStatus::Loading)) {
-            self.dpi_by_device.remove(key);
-        }
+        self.dpi_data.clear_loading(key);
     }
 
     /// Drop the active device's recorded DPI status so the next render
@@ -653,8 +769,7 @@ impl AppState {
     /// carousel has a single device (re-selecting it is a no-op).
     pub fn retry_active_dpi(&mut self) {
         if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
-            self.dpi_by_device.remove(&key);
-            self.dpi_load_attempts.remove(&key);
+            self.dpi_data.retry(&key);
         }
     }
 
@@ -667,73 +782,36 @@ impl AppState {
         route: &DeviceRoute,
         result: Result<DpiInfo, WriteError>,
     ) {
-        let still_matches = self
+        let is_active = self.current_record().map(|r| r.config_key.as_str()) == Some(key.as_str());
+        let matches_route = self
             .device_list
             .iter()
             .any(|record| record.config_key == key && record.route.as_ref() == Some(route));
-        if !still_matches {
-            debug!(key, ?route, "stale DPI capability result ignored");
-            // If the device is still present but on a different route (it
-            // reconnected mid-read), drop the orphaned `Loading` marker so the
-            // next render re-discovers against the live route instead of
-            // spinning on "Reading…" forever.
-            if self
-                .device_list
-                .iter()
-                .any(|record| record.config_key == key)
-            {
-                self.dpi_by_device.remove(&key);
-            }
-            return;
+        let still_present = self
+            .device_list
+            .iter()
+            .any(|record| record.config_key == key);
+        // Only the active device owns the shared `self.dpi`; a result landing for
+        // a background device after a carousel switch must not clobber the
+        // visible value.
+        if let Some(info) = self.dpi_data.store(
+            key,
+            result,
+            dpi_error_is_permanent,
+            matches_route,
+            still_present,
+            "DPI",
+        ) && is_active
+        {
+            self.dpi = u32::from(info.current);
         }
-
-        let is_active = self.current_record().map(|r| r.config_key.as_str()) == Some(key.as_str());
-        let status = match result {
-            Ok(info) => {
-                // Only the active device owns the shared `self.dpi`; a result
-                // landing for a background device after a carousel switch must
-                // not clobber the visible value.
-                if is_active {
-                    self.dpi = u32::from(info.current);
-                }
-                self.dpi_load_attempts.remove(&key);
-                DpiStatus::Ready(info)
-            }
-            // A genuine "feature not supported" reply will never change — record
-            // it and stop probing.
-            Err(error) if dpi_error_is_permanent(&error) => {
-                self.dpi_load_attempts.remove(&key);
-                DpiStatus::Unsupported(error.to_string())
-            }
-            // Timeouts and other transient failures get a few more tries: clear
-            // the status back to `Unknown` so the next render re-triggers the
-            // read, until the attempt budget runs out, then settle on `Failed`
-            // (retryable on re-select) rather than the permanent `Unsupported`.
-            Err(error) => {
-                let attempts = self.dpi_load_attempts.entry(key.clone()).or_insert(0);
-                *attempts = attempts.saturating_add(1);
-                if *attempts < DPI_LOAD_MAX_ATTEMPTS {
-                    debug!(
-                        key,
-                        attempts = *attempts,
-                        error = %error,
-                        "transient DPI read error — will retry"
-                    );
-                    self.dpi_by_device.remove(&key);
-                    return;
-                }
-                self.dpi_load_attempts.remove(&key);
-                DpiStatus::Failed(error.to_string())
-            }
-        };
-        self.dpi_by_device.insert(key, status);
     }
 
     /// DPI capabilities for the active device, if discovery succeeded.
     #[must_use]
     pub fn active_dpi_capabilities(&self) -> Option<&DpiCapabilities> {
         self.current_record()
-            .and_then(|record| self.dpi_by_device.get(&record.config_key))
+            .and_then(|record| self.dpi_data.get(&record.config_key))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(&info.capabilities),
                 DpiStatus::Unknown
@@ -754,8 +832,9 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_status(&self) -> SmartShiftLoad {
         self.current_record()
-            .and_then(|record| self.smartshift_by_device.get(&record.config_key).cloned())
-            .unwrap_or(SmartShiftLoad::Unknown)
+            .map_or(SmartShiftLoad::Unknown, |record| {
+                self.smartshift_data.status(&record.config_key)
+            })
     }
 
     /// Whether the active device still needs a SmartShift read (no status
@@ -764,7 +843,7 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_unqueried(&self) -> bool {
         self.current_record()
-            .is_some_and(|record| !self.smartshift_by_device.contains_key(&record.config_key))
+            .is_some_and(|record| self.smartshift_data.unqueried(&record.config_key))
     }
 
     /// The active device's resolved SmartShift config, if the read succeeded.
@@ -773,7 +852,7 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_ready(&self) -> Option<SmartShiftStatus> {
         self.current_record()
-            .and_then(|record| self.smartshift_by_device.get(&record.config_key))
+            .and_then(|record| self.smartshift_data.get(&record.config_key))
             .and_then(|status| match status {
                 SmartShiftLoad::Ready(s) => Some(*s),
                 SmartShiftLoad::Unknown
@@ -785,19 +864,13 @@ impl AppState {
 
     /// Mark SmartShift discovery as in flight for `key`.
     pub fn mark_smartshift_loading(&mut self, key: &str) {
-        self.smartshift_by_device
-            .insert(key.to_string(), SmartShiftLoad::Loading);
+        self.smartshift_data.mark_loading(key);
     }
 
     /// Reset a stuck `Loading` for `key` back to `Unknown` — called when the
     /// read worker vanished without delivering a result.
     pub fn clear_smartshift_loading(&mut self, key: &str) {
-        if matches!(
-            self.smartshift_by_device.get(key),
-            Some(SmartShiftLoad::Loading)
-        ) {
-            self.smartshift_by_device.remove(key);
-        }
+        self.smartshift_data.clear_loading(key);
     }
 
     /// Drop the active device's recorded SmartShift status so the next render
@@ -805,8 +878,7 @@ impl AppState {
     /// [`SmartShiftLoad::Failed`] device.
     pub fn retry_active_smartshift(&mut self) {
         if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
-            self.smartshift_by_device.remove(&key);
-            self.smartshift_load_attempts.remove(&key);
+            self.smartshift_data.retry(&key);
         }
     }
 
@@ -819,48 +891,22 @@ impl AppState {
         route: &DeviceRoute,
         result: Result<SmartShiftStatus, WriteError>,
     ) {
-        let still_matches = self
+        let matches_route = self
             .device_list
             .iter()
             .any(|record| record.config_key == key && record.route.as_ref() == Some(route));
-        if !still_matches {
-            debug!(key, ?route, "stale SmartShift result ignored");
-            if self.device_list.iter().any(|r| r.config_key == key) {
-                self.smartshift_by_device.remove(&key);
-            }
-            return;
-        }
-
-        let status = match result {
-            Ok(status) => {
-                self.smartshift_load_attempts.remove(&key);
-                SmartShiftLoad::Ready(status)
-            }
-            Err(error) if smartshift_error_is_permanent(&error) => {
-                self.smartshift_load_attempts.remove(&key);
-                SmartShiftLoad::Unsupported(error.to_string())
-            }
-            Err(error) => {
-                let attempts = self
-                    .smartshift_load_attempts
-                    .entry(key.clone())
-                    .or_insert(0);
-                *attempts = attempts.saturating_add(1);
-                if *attempts < DPI_LOAD_MAX_ATTEMPTS {
-                    debug!(
-                        key,
-                        attempts = *attempts,
-                        error = %error,
-                        "transient SmartShift read error — will retry"
-                    );
-                    self.smartshift_by_device.remove(&key);
-                    return;
-                }
-                self.smartshift_load_attempts.remove(&key);
-                SmartShiftLoad::Failed(error.to_string())
-            }
-        };
-        self.smartshift_by_device.insert(key, status);
+        let still_present = self
+            .device_list
+            .iter()
+            .any(|record| record.config_key == key);
+        self.smartshift_data.store(
+            key,
+            result,
+            smartshift_error_is_permanent,
+            matches_route,
+            still_present,
+            "SmartShift",
+        );
     }
 
     /// Write a full SmartShift configuration to the active device (best-effort,
@@ -902,13 +948,13 @@ impl AppState {
         // re-read: the write is fire-and-forget, so a sleeping device that
         // rejected or timed it out would otherwise leave this optimistic value
         // showing as "applied" forever (Ready blocks any further read).
-        self.smartshift_by_device.insert(
+        self.smartshift_data.set_ready(
             key.clone(),
-            SmartShiftLoad::Ready(SmartShiftStatus {
+            SmartShiftStatus {
                 mode,
                 auto_disengage,
                 tunable_torque,
-            }),
+            },
         );
         self.smartshift_pending_confirm.insert(key);
     }

--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -166,4 +166,19 @@ mod tests {
         assert!((a.s - t.s).abs() < 0.05, "sat {} vs {}", a.s, t.s);
         assert!((a.l - t.l).abs() < 0.05, "light {} vs {}", a.l, t.l);
     }
+
+    /// `accent_tint_hover` is also a hand-written `hsla`; pin that it stays
+    /// derived from `ACCENT_BLUE` and sits deeper than the resting `accent_tint`.
+    #[test]
+    fn accent_tint_hover_matches_accent() {
+        let a = accent();
+        let th = accent_tint_hover();
+        assert!((a.h - th.h).abs() < 0.02, "hue {} vs {}", a.h, th.h);
+        assert!((a.s - th.s).abs() < 0.05, "sat {} vs {}", a.s, th.s);
+        assert!((a.l - th.l).abs() < 0.05, "light {} vs {}", a.l, th.l);
+        assert!(
+            th.a > accent_tint().a,
+            "hover tint should sit deeper than the resting tint"
+        );
+    }
 }

--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -12,7 +12,7 @@
 //!   own widgets — which is what keeps a popover from rendering white under
 //!   an otherwise dark UI (see `main.rs`'s appearance wiring).
 
-use gpui::{App, Hsla, rgb};
+use gpui::{App, Hsla, Styled, hsla, rgb};
 use gpui_component::ActiveTheme as _;
 
 /// Primary action / selection blue. Brand colour, identical in both modes —
@@ -97,5 +97,73 @@ pub fn palette(cx: &App) -> Palette {
         Palette::dark()
     } else {
         Palette::light()
+    }
+}
+
+/// [`ACCENT_BLUE`] as an [`Hsla`] — the selection accent for borders and fills
+/// on selectable controls, so callers stop re-`rgb()`-ing the brand constant.
+#[must_use]
+pub fn accent() -> Hsla {
+    rgb(ACCENT_BLUE).into()
+}
+
+/// Faint accent fill marking a *selected* row / chip — tinted, not painted, so
+/// it reads on both palettes while the label stays in `text_primary` (a blue
+/// label fails AA contrast on the light surface). Hand-matched to [`accent`]
+/// (hue 0.6 / sat 0.9 / light 0.6); [`tests::accent_tint_matches_accent`] pins
+/// that it stays derived from the brand colour.
+#[must_use]
+pub fn accent_tint() -> Hsla {
+    hsla(0.6, 0.9, 0.6, 0.12)
+}
+
+/// [`accent_tint`] deepened for hover on an already-selected row.
+#[must_use]
+pub fn accent_tint_hover() -> Hsla {
+    hsla(0.6, 0.9, 0.6, 0.18)
+}
+
+/// Chaining helpers expressing the single "selected" decision — accent border
+/// plus a faint accent fill — instead of every pill / chip / row hand-rolling
+/// the `if selected { accent } else { border }` ternary (which had drifted into
+/// three inconsistent dialects, one of them blue-on-white). Blanket-implemented
+/// for every [`Styled`] element, the way gpui-component extends styling.
+pub trait SelectableStyle: Styled + Sized {
+    /// A 1px accent border when `selected`, the neutral hairline otherwise.
+    #[must_use]
+    fn selected_border(self, selected: bool, pal: Palette) -> Self {
+        self.border_1()
+            .border_color(if selected { accent() } else { pal.border })
+    }
+
+    /// A faint accent fill when `selected`; leaves the background untouched
+    /// otherwise so the caller's resting fill shows through.
+    #[must_use]
+    fn selected_fill(self, selected: bool) -> Self {
+        if selected {
+            self.bg(accent_tint())
+        } else {
+            self
+        }
+    }
+}
+
+impl<E: Styled> SelectableStyle for E {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `accent_tint` is hand-written `hsla` (gpui's `rgb→hsla` isn't `const`),
+    /// so pin that it stays derived from `ACCENT_BLUE` rather than drifting into
+    /// an arbitrary blue — selected chips must match the accent borders and text
+    /// they sit beside.
+    #[test]
+    fn accent_tint_matches_accent() {
+        let a = accent();
+        let t = accent_tint();
+        assert!((a.h - t.h).abs() < 0.02, "hue {} vs {}", a.h, t.h);
+        assert!((a.s - t.s).abs() < 0.05, "sat {} vs {}", a.s, t.s);
+        assert!((a.l - t.l).abs() < 0.05, "light {} vs {}", a.l, t.l);
     }
 }


### PR DESCRIPTION
## What

DPI and SmartShift are the same shape — a lazily-loaded, per-device HID++ read with a three-state lifecycle and a retry budget — that had been duplicated across three layers. This folds each layer into one place. **No behavior change.**

## Why

The triplication (surfaced in a code-quality pass):

- **state.rs** — two isomorphic enums (`DpiStatus` / `SmartShiftLoad`) + 8 twin accessor methods + two copies of the stale-route-guard / retry-budget `store`.
- **panels** — the lazy-read spawn/await/error-cleanup skeleton was copy-pasted in `dpi_panel` and `smartshift_panel` (whose comment literally read "same lazy pattern as DpiPanel").
- **styling** — the selected-pill border/fill/text decision was hand-rolled in 7 places across 3 inconsistent dialects, one of which (blue-on-white text) failed AA contrast on the light theme.

## Changes

- **`state.rs`** — `Load<T>` + `LazyDeviceData<T>` carry the stale-route guard and retry-budget policy once. `DpiStatus` / `SmartShiftLoad` become `type` aliases of `Load<DpiInfo>` / `Load<SmartShiftStatus>`, so every panel/diagnostics `::Ready(..)` match arm is untouched. ~150 lines of twins collapse into one generic.
- **`components/device_read.rs`** — `issue_device_read<T>` folds the lazy-read skeleton; panels inject `Command::ReadDpi` / `AppState::store_dpi_info` / `AppState::clear_dpi_loading` as plain fn/method references.
- **`components/status.rs`** — one `status_line` / `retry_line` shared by both panels, with the retry action injected as a closure.
- **`theme.rs`** — `accent()` / `accent_tint()` / `accent_tint_hover()` tokens (removing 5 hand-computed `hsla` approximations of `ACCENT_BLUE`) + a `SelectableStyle` extension trait. The 4 panel pills and the gesture owner chip now use it, unified onto the existing tint dialect, which also fixes the light-theme AA contrast.
- **i18n** — the DPI panel's status strings now go through `tr!()` instead of being hardcoded English; the new keys are added to `en.yml` (Crowdin source) and all 19 translated locales.

## Test

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p openlogi-gui` (32 tests, including i18n key-parity and a new `accent_tint_matches_accent` token test) all pass.

## Out of scope

`state.rs`'s stale `#![allow(dead_code)]` ("UI.md phases 2–4") is pre-existing and left untouched.
