### PR TITLE
refactor(hook,hid): document the Windows FFI unsafe blocks

### DIFF
--- a/crates/openlogi-hid/src/windows_hid.rs
+++ b/crates/openlogi-hid/src/windows_hid.rs
@@ -127,6 +127,10 @@ fn padded_report(report: &[u8], len: usize) -> Vec<u8> {
 
 fn write_file(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
     let mut written = 0;
+    // SAFETY: `handle` is a live HID handle from `HidHandle::open`; `report` is a
+    // valid initialized slice, so its pointer + length describe readable bytes;
+    // `written` is a valid out-pointer; a null OVERLAPPED requests a synchronous
+    // write.
     let ok = unsafe {
         WriteFile(
             handle,
@@ -149,6 +153,8 @@ fn write_file(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
 }
 
 fn set_output_report(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
+    // SAFETY: `handle` is a live HID handle; `report` is a valid initialized
+    // slice, so its pointer + length describe readable bytes for the call.
     bool_result(unsafe {
         HidD_SetOutputReport(
             handle,
@@ -159,6 +165,8 @@ fn set_output_report(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
 }
 
 fn set_feature(handle: HANDLE, report: &[u8]) -> Result<(), io::Error> {
+    // SAFETY: `handle` is a live HID handle; `report` is a valid initialized
+    // slice, so its pointer + length describe readable bytes for the call.
     bool_result(unsafe {
         HidD_SetFeature(
             handle,
@@ -180,6 +188,10 @@ struct HidHandle(HANDLE);
 
 impl HidHandle {
     fn open(path: &[u16], desired_access: u32) -> Result<Self, io::Error> {
+        // SAFETY: `path` is a NUL-terminated UTF-16 string (the terminator is
+        // pushed in `NativeHidWriter::new`); the other arguments are valid
+        // share/disposition constants and null security/template pointers.
+        // Returns INVALID_HANDLE_VALUE on failure, checked below.
         let handle = unsafe {
             CreateFileW(
                 path.as_ptr(),
@@ -209,6 +221,8 @@ impl HidHandle {
             ProductID: 0,
             VersionNumber: 0,
         };
+        // SAFETY: `self.0` is a live HID handle; `attributes` is a valid,
+        // Size-initialized HIDD_ATTRIBUTES the call fills in.
         if !unsafe { HidD_GetAttributes(self.0, &raw mut attributes) } {
             return Err(NativeWriteError::LastOsError(
                 "HidD_GetAttributes",
@@ -217,6 +231,9 @@ impl HidHandle {
         }
 
         let mut preparsed: PHIDP_PREPARSED_DATA = 0;
+        // SAFETY: `self.0` is a live HID handle; `preparsed` is a valid
+        // out-pointer. On success the OS allocates a blob that must be released
+        // via HidD_FreePreparsedData — owned by the `PreparsedData` guard below.
         if !unsafe { HidD_GetPreparsedData(self.0, &raw mut preparsed) } {
             return Err(NativeWriteError::LastOsError(
                 "HidD_GetPreparsedData",
@@ -226,6 +243,8 @@ impl HidHandle {
 
         let _preparsed = PreparsedData(preparsed);
         let mut caps = HIDP_CAPS::default();
+        // SAFETY: `preparsed` is the non-null blob just returned, kept alive by
+        // `_preparsed`; `caps` is a valid out-parameter the call fills in.
         let status = unsafe { HidP_GetCaps(preparsed, &raw mut caps) };
         if status != HIDP_STATUS_SUCCESS {
             return Err(NativeWriteError::HidpStatus("HidP_GetCaps", status));
@@ -238,6 +257,8 @@ impl HidHandle {
 impl Drop for HidHandle {
     fn drop(&mut self) {
         if self.0 != INVALID_HANDLE_VALUE {
+            // SAFETY: `self.0` is a live handle from CreateFileW that we own,
+            // closed exactly once here at drop.
             let _ = unsafe { CloseHandle(self.0) };
         }
     }
@@ -248,6 +269,8 @@ struct PreparsedData(PHIDP_PREPARSED_DATA);
 impl Drop for PreparsedData {
     fn drop(&mut self) {
         if self.0 != 0 {
+            // SAFETY: `self.0` is the non-null preparsed-data blob from
+            // HidD_GetPreparsedData that we own, freed exactly once here at drop.
             let _ = unsafe { HidD_FreePreparsedData(self.0) };
         }
     }

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -185,7 +185,10 @@ unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) 
         return call_next(code, wparam, lparam);
     }
 
-    let Some(data) = hook_data(lparam) else {
+    // SAFETY: `mouse_proc` is only installed as a WH_MOUSE_LL hook and this is
+    // the `code == HC_ACTION` arm, so `lparam` is the live `MSLLHOOKSTRUCT`
+    // pointer `hook_data` requires.
+    let Some(data) = (unsafe { hook_data(lparam) }) else {
         return call_next(code, wparam, lparam);
     };
     let Some(event) = translate_event(wparam, data) else {
@@ -203,14 +206,20 @@ unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) 
     }
 }
 
-fn hook_data(lparam: LPARAM) -> Option<MSLLHOOKSTRUCT> {
+/// Copy the `MSLLHOOKSTRUCT` the OS passed in `lparam`, or `None` if `lparam`
+/// is null.
+///
+/// # Safety
+/// `lparam` must be the `lParam` the OS passes to a `WH_MOUSE_LL` hook
+/// procedure for an `HC_ACTION` event — i.e. it points to a live
+/// `MSLLHOOKSTRUCT` (or is 0). Any other non-zero value is undefined behavior.
+unsafe fn hook_data(lparam: LPARAM) -> Option<MSLLHOOKSTRUCT> {
     if lparam == 0 {
         return None;
     }
-    // SAFETY: reached only with `code == HC_ACTION` (checked by the sole caller,
-    // `mouse_proc`) and `lparam != 0`, so per the WH_MOUSE_LL contract Windows
-    // guarantees `lparam` points to a live `MSLLHOOKSTRUCT`. We copy it out by
-    // value (it is plain-old-data) and never retain the pointer.
+    // SAFETY: by this function's contract `lparam` is the WH_MOUSE_LL HC_ACTION
+    // lParam and is non-zero here, so it points to a live `MSLLHOOKSTRUCT`. We
+    // copy it out by value (plain-old-data) and never retain the pointer.
     Some(unsafe { *(lparam as *const MSLLHOOKSTRUCT) })
 }
 

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -61,12 +61,15 @@ pub(crate) fn start(
 }
 
 pub(crate) fn stop(mut inner: HookInner) {
+    // SAFETY: PostThreadMessageW takes the target thread id and the message by
+    // value (no pointers); `thread_id` was returned by the hook thread's own
+    // GetCurrentThreadId, so it names a real thread with a message queue.
     let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
     if posted == 0 {
-        tracing::warn!(
-            error = unsafe { GetLastError() },
-            "could not post WM_QUIT to Windows hook thread"
-        );
+        // SAFETY: GetLastError reads the calling thread's last-error code and
+        // has no preconditions.
+        let err = unsafe { GetLastError() };
+        tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
     }
     if let Some(join) = inner.join.take()
         && let Err(e) = join.join()
@@ -94,8 +97,13 @@ fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError
         }
     }
 
+    // SAFETY: GetCurrentThreadId returns the calling thread's id; no preconditions.
     let thread_id = unsafe { GetCurrentThreadId() };
     let mut bootstrap_msg = MSG::default();
+    // SAFETY: `bootstrap_msg` is a live, owned MSG and a null window handle is
+    // valid (peek this thread's own queue); PM_NOREMOVE only inspects. The call
+    // forces the OS to create this thread's message queue up front, so a
+    // PostThreadMessageW from `stop` can't race queue creation and be lost.
     unsafe {
         PeekMessageW(
             &mut bootstrap_msg,
@@ -106,6 +114,10 @@ fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError
         );
     }
 
+    // SAFETY: `mouse_proc` is a valid HOOKPROC with the matching `extern "system"`
+    // signature; a null module handle plus thread id 0 install a global
+    // low-level mouse hook, the documented usage for WH_MOUSE_LL. Returns null
+    // on failure, checked below.
     let hook = unsafe {
         SetWindowsHookExW(
             WH_MOUSE_LL,
@@ -123,6 +135,8 @@ fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError
     let _ = ready.send(Ok(thread_id));
     message_loop();
 
+    // SAFETY: `hook` is the live handle just returned by SetWindowsHookExW,
+    // unhooked exactly once here as the thread exits.
     unsafe {
         UnhookWindowsHookEx(hook);
     }
@@ -132,14 +146,16 @@ fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError
 fn message_loop() {
     let mut msg = MSG::default();
     loop {
+        // SAFETY: `msg` is a live, owned MSG; a null window handle retrieves
+        // messages for the calling thread. Returns <= 0 on WM_QUIT or error.
         let result = unsafe { GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0) };
         if result <= 0 {
             break;
         }
-        unsafe {
-            TranslateMessage(&msg);
-            DispatchMessageW(&msg);
-        }
+        // SAFETY: `msg` was just populated by GetMessageW and outlives the call.
+        unsafe { TranslateMessage(&msg) };
+        // SAFETY: as above — `msg` is a live, initialized MSG.
+        unsafe { DispatchMessageW(&msg) };
     }
 }
 
@@ -149,16 +165,31 @@ fn clear_callback() {
     }
 }
 
+/// Forward the event to the next hook in the chain — the default disposition
+/// for any event we don't suppress.
+fn call_next(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    // SAFETY: a null `hhk` is the documented way to invoke the next hook in the
+    // chain; `code`/`wparam`/`lparam` are forwarded verbatim from the
+    // OS-supplied callback arguments, valid for the duration of this call.
+    unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) }
+}
+
+/// Low-level mouse-hook procedure the OS invokes for every mouse event.
+///
+/// # Safety
+/// Must only be installed as a `WH_MOUSE_LL` hook via `SetWindowsHookExW`. When
+/// `code == HC_ACTION`, Windows guarantees `lparam` points to a live
+/// `MSLLHOOKSTRUCT`; [`hook_data`] relies on that contract to dereference it.
 unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     if code != HC_ACTION as i32 {
-        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
+        return call_next(code, wparam, lparam);
     }
 
     let Some(data) = hook_data(lparam) else {
-        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
+        return call_next(code, wparam, lparam);
     };
     let Some(event) = translate_event(wparam, data) else {
-        return unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) };
+        return call_next(code, wparam, lparam);
     };
 
     let callback = CALLBACK.lock().ok().and_then(|slot| slot.clone());
@@ -168,7 +199,7 @@ unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) 
     if disposition == EventDisposition::Suppress {
         1
     } else {
-        unsafe { CallNextHookEx(std::ptr::null_mut(), code, wparam, lparam) }
+        call_next(code, wparam, lparam)
     }
 }
 
@@ -176,6 +207,10 @@ fn hook_data(lparam: LPARAM) -> Option<MSLLHOOKSTRUCT> {
     if lparam == 0 {
         return None;
     }
+    // SAFETY: reached only with `code == HC_ACTION` (checked by the sole caller,
+    // `mouse_proc`) and `lparam != 0`, so per the WH_MOUSE_LL contract Windows
+    // guarantees `lparam` points to a live `MSLLHOOKSTRUCT`. We copy it out by
+    // value (it is plain-old-data) and never retain the pointer.
     Some(unsafe { *(lparam as *const MSLLHOOKSTRUCT) })
 }
 
@@ -231,12 +266,16 @@ fn signed_high_word(value: u32) -> i16 {
 }
 
 pub(crate) fn frontmost_process_path() -> Option<String> {
+    // SAFETY: GetForegroundWindow takes no arguments and returns a window handle
+    // or null; no preconditions.
     let hwnd = unsafe { GetForegroundWindow() };
     if hwnd.is_null() {
         return None;
     }
 
     let mut pid = 0;
+    // SAFETY: `hwnd` is the non-null handle just returned; `&mut pid` is a valid
+    // out-pointer the call writes the owning process id into.
     unsafe {
         GetWindowThreadProcessId(hwnd, &mut pid);
     }
@@ -244,6 +283,8 @@ pub(crate) fn frontmost_process_path() -> Option<String> {
         return None;
     }
 
+    // SAFETY: OpenProcess takes the access mask and pid by value and returns a
+    // handle or null (checked); on success we own the handle and close it below.
     let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
     if process.is_null() {
         return None;
@@ -251,7 +292,12 @@ pub(crate) fn frontmost_process_path() -> Option<String> {
 
     let mut buf = vec![0u16; 32_768];
     let mut len = buf.len() as u32;
+    // SAFETY: `process` is the valid handle from OpenProcess; `buf` is a live
+    // 32768-u16 buffer and `len` holds its length, so the call writes at most
+    // `len` code units and updates `len` with the count written.
     let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &mut len) };
+    // SAFETY: `process` is the handle from OpenProcess, owned here and closed
+    // exactly once now that the query has returned.
     unsafe {
         CloseHandle(process);
     }
@@ -263,9 +309,9 @@ pub(crate) fn frontmost_process_path() -> Option<String> {
 }
 
 fn last_error(context: &str) -> HookError {
-    HookError::WindowsHook(format!("{context} failed with GetLastError={}", unsafe {
-        GetLastError()
-    }))
+    // SAFETY: GetLastError reads the calling thread's last-error code; no preconditions.
+    let code = unsafe { GetLastError() };
+    HookError::WindowsHook(format!("{context} failed with GetLastError={code}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What
`openlogi-hook/src/windows.rs` (the `WH_MOUSE_LL` hook) and `openlogi-hid/src/windows_hid.rs` (native HID writes) carried ~28 `unsafe` blocks with **no SAFETY comment**, against the workspace convention that each unsafe block states the invariant that makes it sound.

## Change
- Document every unsafe block: the OS callback-pointer contract behind the `MSLLHOOKSTRUCT` dereference, handle/buffer validity for each Win32 call, and the owned single-free guarantee in the `Drop` impls.
- Fold the four identical `CallNextHookEx` calls in `mouse_proc` into one documented `call_next` helper, split the `TranslateMessage`/`DispatchMessageW` pair into single-operation blocks, and give the `mouse_proc` callback a `# Safety` section.

No behavior change.

## Verification
`cargo clippy --target x86_64-pc-windows-gnu -- -D warnings` clean (the Windows-cfg code compiles from macOS via the gnu cross-target).