### PR TITLE
fix(release): install the GUI's x11/wayland deps so Linux packaging links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -576,8 +576,17 @@ jobs:
           NFPM_SHA256: ${{ matrix.nfpm_sha256 }}
         run: |
           sudo apt-get update
+          # package-linux builds openlogi-gui, which links GPUI's full
+          # wayland / x11 stack — keep this in sync with ci.yml's Linux deps
+          # (the proven set). The previous short list was missing
+          # libxkbcommon-x11-dev / libwayland-dev / libx11-xcb-dev, so every
+          # tagged Linux build failed to link (`-lxkbcommon-x11`) and took the
+          # whole GitHub Release down with it.
           sudo apt-get install -y \
-            libfontconfig1-dev libfreetype-dev libxcb1-dev libxkbcommon-dev
+            libudev-dev \
+            gcc g++ clang libfontconfig-dev libwayland-dev \
+            libxkbcommon-x11-dev libx11-xcb-dev \
+            libssl-dev libzstd-dev pkg-config
           curl -fsSLo /tmp/nfpm.deb \
             "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_${NFPM_ARCH}.deb"
           echo "${NFPM_SHA256}  /tmp/nfpm.deb" | sha256sum -c
@@ -674,21 +683,21 @@ jobs:
           sha256sum *.dmg *.exe *.msi *.deb *.rpm > SHA256SUMS
 
       # softprops' `files` can't list a glob that matches nothing without
-      # tripping fail_on_unmatched_files, and the exe/msi sets vary per arch
-      # leg — record what actually arrived.
-      - name: Detect shipped Windows binaries
-        id: windows_exes
+      # tripping fail_on_unmatched_files. The Windows exe/msi (per arch leg)
+      # and the Linux deb/rpm are all best-effort — only the DMGs, SHA256SUMS
+      # and the .minisig set are guaranteed by the publish gate — so record
+      # what actually arrived. This is what lets a failing Windows or Linux
+      # leg degrade to a smaller release instead of blocking the macOS one.
+      - name: Detect best-effort artifacts
+        id: artifacts
         run: |
-          if compgen -G 'dist/*.exe' > /dev/null; then
-            echo "exe=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exe=false" >> "$GITHUB_OUTPUT"
-          fi
-          if compgen -G 'dist/*.msi' > /dev/null; then
-            echo "msi=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "msi=false" >> "$GITHUB_OUTPUT"
-          fi
+          for ext in exe msi deb rpm; do
+            if compgen -G "dist/*.$ext" > /dev/null; then
+              echo "$ext=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$ext=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
 
       - name: Load static updater publishing config from 1Password
         id: r2_config
@@ -814,12 +823,12 @@ jobs:
           body_path: .release/RELEASE_NOTES.md
           files: |
             dist/*.dmg
-            dist/*.deb
-            dist/*.rpm
             dist/*.minisig
             dist/SHA256SUMS
-            ${{ steps.windows_exes.outputs.exe == 'true' && 'dist/*.exe' || '' }}
-            ${{ steps.windows_exes.outputs.msi == 'true' && 'dist/*.msi' || '' }}
+            ${{ steps.artifacts.outputs.exe == 'true' && 'dist/*.exe' || '' }}
+            ${{ steps.artifacts.outputs.msi == 'true' && 'dist/*.msi' || '' }}
+            ${{ steps.artifacts.outputs.deb == 'true' && 'dist/*.deb' || '' }}
+            ${{ steps.artifacts.outputs.rpm == 'true' && 'dist/*.rpm' || '' }}
           fail_on_unmatched_files: true
 
   homebrew-tap:


### PR DESCRIPTION
## Problem

The `Release` workflow has failed on every tag since **v0.6.8** — v0.6.8, v0.6.9 and v0.6.10 have **no GitHub Release** (the releases page is stuck at v0.6.7), even though the macOS DMG and Windows exe/msi built and signed fine each time.

## Root cause

The `linux-packages` job landed in #179 (after v0.6.7) and has never succeeded on a real tag. It runs `xtask package-linux`, which builds **openlogi-gui**, but installed only a CLI-sized system-dep set (`libfontconfig1-dev libfreetype-dev libxcb1-dev libxkbcommon-dev`). The GUI link step then fails:

```
rust-lld: error: unable to find library -lxkbcommon-x11
error: could not compile `openlogi-gui` (bin "openlogi-gui")
```

No `.deb`/`.rpm` is produced. The `publish` job listed `dist/*.deb` and `dist/*.rpm` **unconditionally** under `fail_on_unmatched_files: true`, so the final `softprops/action-gh-release` step died with `Pattern 'dist/*.deb' does not match any files` — taking the entire GitHub Release down with it. (The macOS R2 upload had already run by then, so the updater channel advanced even though no GitHub Release ever appeared.)

## Fix

1. **Align the Linux apt set with `ci.yml`'s proven deps.** The clippy/check/test jobs already build `openlogi-gui` on Linux with this exact set; the release job had drifted from it. Adds `libxkbcommon-x11-dev`, `libwayland-dev`, `libx11-xcb-dev`, `libudev-dev`, etc.
2. **Make `.deb`/`.rpm` release assets best-effort, like the Windows exe/msi.** Detect what actually arrived and only glob those. A failing Linux leg now degrades to a smaller release instead of blocking macOS/Windows — matching the workflow's existing "macOS is the only hard gate" design.

## Notes

- v0.6.8–v0.6.10 remain unpublished on GitHub; the in-flight **v0.6.11** release rolls all of them forward. **Merge this PR before cutting v0.6.11**, or that tag fails the same way.
- Do not re-run the old failed release jobs — the R2 objects are immutable.