### PR TITLE
fix(updater): bump gpui-updater to v0.0.5 (relaunch as GUI, not in Terminal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,8 +2643,8 @@ dependencies = [
 
 [[package]]
 name = "gpui-updater"
-version = "0.0.4"
-source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.4#d9b2872f373b23ab923268c18d8a59f42f4d76e9"
+version = "0.0.5"
+source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.5#dd592ac89c45a061ddc3a40160eecf1dfe7302fe"
 dependencies = [
  "gpui",
  "minisign-verify",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["png"] }
 rust-i18n = "4"
 sys-locale = "0.3.2"
-gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.4", features = ["gpui"] }
+gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.5", features = ["gpui"] }
 # Spawn the agent under its own macOS TCC identity (see ipc_client::spawn_agent).
 # Cross-platform: a no-op pass-through to std::process::Command off macOS.
 disclaim = "0.1"


### PR DESCRIPTION
Closes #68.

## Problem

After installing an update, OpenLogi relaunched **inside a Terminal window** instead of coming back as a normal GUI app. Closing that Terminal window killed the app (reported in #68).

## Cause

GPUI's macOS `restart` relaunches the staged update via `open "$path"`. `gpui-updater`'s installer was handing it the executable *inside* the bundle (`OpenLogi.app/Contents/MacOS/openlogi-gui`); `open` has no GUI handler for a bare Mach-O, so LaunchServices falls back to running it inside `Terminal.app`.

## Fix

Bump `gpui-updater` v0.0.4 → **v0.0.5** (AprilNEA/gpui-updater#4), which returns the `.app` bundle root as the restart path, so `open` launches the update detached as a GUI app.

No OpenLogi code changes: the crate's only public-API change is an internal `Installed::restart_binary` → `restart_path` rename, which OpenLogi never references (it uses the high-level `Updater` entity).

## Verification

- `cargo check -p openlogi-gui --locked` — compiles clean against v0.0.5
- Lockfile bump is surgical (gpui-updater version + tag/sha only); the pinned `gpui` rev `eb2223c0` is unchanged.