### PR TITLE
fix(hid): bound the Bolt per-slot probe so one hung device can't drop the whole receiver (#218)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,7 +5014,7 @@ version = "0.6.20"
 dependencies = [
  "async-hid",
  "bincode",
- "futures-lite 2.6.1",
+ "futures-lite",
  "interprocess",
  "openlogi-core",
  "openlogi-hid",

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -57,6 +57,21 @@ const PROBE_BUDGET: Duration = Duration::from_secs(5);
 /// just lacks capabilities / battery until the next tick.
 const UNIFYING_SLOT_PROBE: Duration = Duration::from_millis(3500);
 
+/// Per-slot budget for the HID++ 2.0 feature walk on a Bolt paired device.
+///
+/// The whole receiver shares one [`PROBE_BUDGET`]; without a per-slot cap a
+/// single online device that stops answering its feature-walk reads (seen on a
+/// recent macOS IOHID stack with a new MX Master 4) burns the entire budget, so
+/// `probe_one` times out and the receiver yields *nothing* — every paired device
+/// drops to "No devices" even though its pairing-register identity read fine
+/// (#218). Capping each slot lets a hung device fall back to its cached /
+/// identity-only data while the rest of the receiver still enumerates, mirroring
+/// [`UNIFYING_SLOT_PROBE`]. Bolt BTLE round-trips are fast (a healthy walk is
+/// well under a second), so 1 s is generous headroom yet small enough that three
+/// online slots can hang at once and still fit `PROBE_BUDGET` after the 1.5 s
+/// arrival drain (1.5 + 3×1 = 4.5 s).
+const BOLT_SLOT_PROBE: Duration = Duration::from_secs(1);
+
 /// Errors raised while enumerating HID++ devices.
 #[derive(Debug, Error)]
 pub enum InventoryError {

--- a/crates/openlogi-hid/src/inventory/cache.rs
+++ b/crates/openlogi-hid/src/inventory/cache.rs
@@ -63,7 +63,7 @@ pub(super) enum CacheOutcome {
 }
 
 /// `Seen` when the device has a stable key, else `Unkeyed`.
-fn seen(id: Option<CacheKey>) -> CacheOutcome {
+pub(super) fn seen(id: Option<CacheKey>) -> CacheOutcome {
     id.map_or(CacheOutcome::Unkeyed, CacheOutcome::Seen)
 }
 

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -21,9 +21,9 @@ use tracing::{debug, warn};
 use crate::mappings::{map_kind, map_unifying_kind, resolve_device_kind};
 use crate::route::DIRECT_DEVICE_INDEX;
 
-use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse};
+use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
-use super::{ARRIVAL_DRAIN, MAX_BOLT_SLOTS, UNIFYING_SLOT_PROBE};
+use super::{ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_SLOT_PROBE};
 
 /// One probed node's contribution this tick: its inventory (if any), whether
 /// the node actually answered — the ledger replays the last snapshot when it
@@ -253,7 +253,24 @@ async fn probe_bolt_slot(
     let cached = id.as_ref().and_then(|i| cache.get(i));
     let register_kind = map_kind(bolt_kind);
 
-    let (probe, outcome) = probe_or_reuse(channel, slot, id, cached, online, tick).await;
+    // Cap the feature walk per slot so one device that stops answering can't
+    // burn the whole receiver's `PROBE_BUDGET` and time out `probe_one` — which
+    // would drop *every* device on the receiver. A timed-out slot falls back to
+    // its cached probe (its pairing-register identity above already read fine),
+    // mirroring the Unifying path (#218).
+    let probe_result = timeout(
+        BOLT_SLOT_PROBE,
+        probe_or_reuse(channel, slot, id.clone(), cached, online, tick),
+    )
+    .await;
+    let (probe, outcome) = if let Ok(r) = probe_result {
+        r
+    } else {
+        debug!(slot, budget = ?BOLT_SLOT_PROBE,
+            "Bolt slot probe timed out; using cached data if available");
+        let probe = cached.map_or_else(ProbedFeatures::default, |c| c.probe.clone());
+        (probe, seen(id))
+    };
     if matches!(outcome, CacheOutcome::Fresh(..))
         && let Some(probed) = probe.kind
         && probed != DeviceKind::Unknown


### PR DESCRIPTION
## Context

Live re-testing #218 on the repro rig (macOS 27 beta, MX Master 4 + MX Master 3S + MX Mechanical Mini on one Bolt receiver) showed that #222 (`NodeLedger`) and #237 (one-shot retry) fix the *short transient* misses, but a **sustained** failure still drops the device list to "No devices" — details in [#218](https://github.com/AprilNEA/OpenLogi/issues/218). This PR fixes that remaining case.

## Root cause

A single paired **online** device's deep feature walk (`probe_features` / `Device::new`) hangs on every cycle, burning the whole 5 s `PROBE_BUDGET`. Each failing cycle still reads `pairing_count=Some(3)` and all three slot codenames — only the deep walk hangs — but because `probe_one` is the unit wrapped in `timeout(PROBE_BUDGET)`, when it fires the **entire node** is discarded, including the pairing-register reads that succeeded. The receiver yields nothing → GUI `inventory refreshed count=0`.

The tell: the **Unifying** slot probe already guards exactly this with `UNIFYING_SLOT_PROBE` (a per-slot cap, so a slow walk returns partial instead of starving the budget). The **Bolt** slot probe had no equivalent — `probe_or_reuse` was awaited bare in `probe_bolt_slot`, so one hung Bolt device blew the whole-receiver budget.

## Fix

Mirror the Unifying guard onto the Bolt path: a new `BOLT_SLOT_PROBE` (1.5 s) wraps the Bolt slot's `probe_or_reuse`; on timeout the slot falls back to its cached / identity-only data (codename + kind + online come from the pairing register, which reads fine every cycle) instead of letting the whole `probe_one` time out. A hung device keeps showing with its last-known capabilities while the rest of the receiver still enumerates.

1.5 s is well above a healthy BTLE walk (sub-second) yet small enough that **two** simultaneously-hung slots still fit `PROBE_BUDGET` after the 1.5 s arrival drain; the rare all-slots-hung case degrades to the existing per-node ledger replay (#222).

## Verification

```
cargo fmt --all -- --check                                   # clean
cargo clippy -p openlogi-hid --all-targets -- -D warnings     # clean
cargo test  -p openlogi-hid                                   # 61 pass
```

I couldn't add a unit test (the per-slot timeout needs a live/mock HID++ channel, same as the existing Unifying guard, which also has none). The change mirrors that proven pattern exactly.

**Manual hardware verification still recommended:** I have the repro rig but the wedge cleared on a receiver replug and I can't trigger the sustained hang on demand. The expected behaviour with this patch: when a device's deep probe hangs, the agent logs `Bolt slot probe timed out; using cached data if available` and the device list **stays populated** (the hung device keeps its last-known card) instead of dropping to "No devices".

Refs #218, #222.
