### PR TITLE
fix(gui): don't show a multi-pid device twice in the carousel

### DIFF
--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -111,20 +111,37 @@ pub(super) fn build_device_list(
 }
 
 /// Append an offline placeholder for every known device not already present in
-/// `list` (matched by `config_key`). Split out from [`build_device_list`] so
-/// the union rule is unit-testable without an [`AssetResolver`].
+/// `list`. Split out from [`build_device_list`] so the union rule is
+/// unit-testable without an [`AssetResolver`].
+///
+/// A device is "already present" when its `config_key` matches **or** a record
+/// with the same (display name, kind) is already in the list. The second match
+/// is what stops a one-physical-device-two-cards phantom: a device with more
+/// than one model id resolves to a *different* `config_key` per transport (the
+/// MX Master 3S is pid `b034` over BTLE but `b043` via a Bolt receiver — #137),
+/// so a stale identity persisted under the other pid would otherwise show as a
+/// second card. The resolved display name is per-model, so it collapses those
+/// pid variants — both against a live record and among the placeholders
+/// themselves (a device persisted under both pids must still surface once).
 fn append_offline_known<'a>(
     list: &mut Vec<DeviceRecord>,
     known: impl Iterator<Item = (&'a str, &'a DeviceIdentity)>,
 ) {
-    let present: HashSet<&str> = list.iter().map(|r| r.config_key.as_str()).collect();
-    // Collect before extending: `present` borrows `list`, so the phantoms must
-    // be materialized before we can mutate it.
+    let present_keys: HashSet<&str> = list.iter().map(|r| r.config_key.as_str()).collect();
+    let mut seen: HashSet<(String, DeviceKind)> = list
+        .iter()
+        .map(|r| (r.display_name.clone(), r.kind))
+        .collect();
+    // Collect before extending: `present_keys` borrows `list`, so the phantoms
+    // must be materialized before we can mutate it.
     let phantoms: Vec<DeviceRecord> = known
-        .filter(|(key, _)| !present.contains(key))
+        .filter(|(key, identity)| {
+            !present_keys.contains(key)
+                && seen.insert((identity.display_name.clone(), identity.kind))
+        })
         .map(|(key, identity)| offline_record(key, identity))
         .collect();
-    drop(present);
+    drop(present_keys);
     list.extend(phantoms);
 }
 
@@ -388,6 +405,51 @@ mod tests {
         assert!(
             list.iter().any(|r| r.config_key == "B" && !r.online),
             "B is added back as a persisted offline placeholder"
+        );
+    }
+
+    #[test]
+    fn one_model_under_two_pids_is_not_duplicated() {
+        // The MX Master 3S resolves to a different `config_key` per transport
+        // (b034 BTLE / b043 Bolt, #137). A live record under one pid plus a
+        // stale persisted identity under the other must show ONE card, not two.
+        let mut list = vec![online_record("0b043")];
+        list[0].display_name = "MX Master 3S".into();
+        let stale = mouse_identity("MX Master 3S"); // persisted under the other pid
+        let other = mouse_identity("MX Mechanical Mini"); // a genuinely different device
+        append_offline_known(
+            &mut list,
+            [("0b034", &stale), ("0b367", &other)].into_iter(),
+        );
+
+        assert_eq!(
+            list.iter()
+                .filter(|r| r.display_name == "MX Master 3S")
+                .count(),
+            1,
+            "the same model under two pids must surface once"
+        );
+        assert!(
+            list.iter()
+                .any(|r| r.display_name == "MX Mechanical Mini" && !r.online),
+            "a genuinely different known device is still added"
+        );
+    }
+
+    #[test]
+    fn one_offline_model_persisted_under_two_pids_collapses_to_one_card() {
+        // Both pids persisted, neither live (device on another host): the
+        // dedupe must collapse the placeholders among themselves too, not only
+        // against a live record.
+        let mut list: Vec<DeviceRecord> = vec![];
+        let a = mouse_identity("MX Master 3S");
+        let b = mouse_identity("MX Master 3S");
+        append_offline_known(&mut list, [("0b034", &a), ("0b043", &b)].into_iter());
+
+        assert_eq!(
+            list.len(),
+            1,
+            "two persisted pids of one model collapse to one"
         );
     }
 


### PR DESCRIPTION
## Problem

On 0.6.12, after Easy-Switching an **MX Master 3S** to another host, the device carousel showed **two** "MX Master 3S" cards.

## Root cause

`config_key` is `format!("{:x}{:04x}", extended_model_id, model_ids[0])` — it keys on the device's *primary reported pid*. A device with more than one model id reports a different primary pid per transport: the MX Master 3S is **b034 over BTLE** but **b043 via a Bolt receiver** (exactly #137). So the same physical mouse resolves to a different `config_key` across connections.

#224's "keep asleep devices" union (`append_offline_known`) re-adds a persisted-identity placeholder for every known device *absent from the live list*, matched **only by `config_key`**. So when the 3S was seen under both pids — a live/cached record under one, a stale persisted identity under the other — neither matched the other's key, and both showed:

```
config_key 0b043  →  live/cached "MX Master 3S"      (current transport)
config_key 0b034  →  offline placeholder "MX Master 3S" (stale, other pid)
```

Switching the mouse to another host is what surfaced it: the live record went offline/cached while the placeholder under the other pid stayed.

## Fix

Dedup the offline-placeholder union by **(display name, kind)** as well as `config_key` — both against the live records *and* among the placeholders themselves (a device persisted under both pids must still surface once). The asset-resolved display name is per-model, so it collapses the pid variants. No schema change, no asset resolver needed in this hot path (the function stays testable in isolation, as its doc comment requires).

The edge case — two physically distinct devices of the *same* model, one online and one offline-elsewhere — collapses to one card while the second is away (it carries `route: None`, so it's unconfigurable until it returns anyway, at which point it gets its own live record). That's a far rarer and milder outcome than a phantom duplicate of one device.

## Tests (`cargo test -p openlogi-gui state::devices`, 9 pass)

- `one_model_under_two_pids_is_not_duplicated` — live record under one pid + stale identity under the other → one card; a genuinely different known device is still added.
- `one_offline_model_persisted_under_two_pids_collapses_to_one_card` — both pids persisted, neither live → one card (placeholder-vs-placeholder dedup).
- existing `known_devices_are_appended_only_when_absent_from_live` still passes.

`cargo fmt --all -- --check` clean, `cargo clippy -p openlogi-gui --all-targets -- -D warnings` clean.

## Verification

Found and reproduced live on 0.6.12 (macOS 27 beta, MX Master 3S on a Bolt receiver). Refs #137, #224.
