### PR TITLE
fix(gui): give the bundled agent the OpenLogi app icon

### DIFF
--- a/crates/openlogi-agent/macos/Info.plist
+++ b/crates/openlogi-agent/macos/Info.plist
@@ -23,6 +23,8 @@
   <string>OpenLogi Agent</string>
   <key>CFBundleExecutable</key>
   <string>openlogi-agent</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
   <key>CFBundleIdentifier</key>
   <string>org.openlogi.agent</string>
   <key>CFBundlePackageType</key>

--- a/scripts/cargo-run-macos.sh
+++ b/scripts/cargo-run-macos.sh
@@ -89,10 +89,14 @@ if [ "${OPENLOGI_DEV_AGENT:-1}" != "0" ]; then
     cargo build -p openlogi-agent --manifest-path "$ROOT/Cargo.toml"
   fi
   helper="$APP/Contents/Library/LoginItems/OpenLogiAgent.app"
-  mkdir -p "$helper/Contents/MacOS"
+  mkdir -p "$helper/Contents/MacOS" "$helper/Contents/Resources"
   ln -f "$agent_dir/openlogi-agent" "$helper/Contents/MacOS/openlogi-agent" 2>/dev/null \
     || cp -f "$agent_dir/openlogi-agent" "$helper/Contents/MacOS/openlogi-agent"
   cp -f "$ROOT/crates/openlogi-agent/macos/Info.plist" "$helper/Contents/Info.plist"
+  # Share the GUI's "e" icon (Info.plist CFBundleIconFile = AppIcon) so the
+  # agent isn't a blank entry in the Accessibility list. ICON_SRC was generated
+  # / verified above.
+  cp -f "$ICON_SRC" "$helper/Contents/Resources/AppIcon.icns"
 fi
 
 exec "$MACOS/openlogi-gui" "$@"

--- a/xtask/src/macos.rs
+++ b/xtask/src/macos.rs
@@ -187,6 +187,18 @@ fn embed_agent_helper(root: &Path, app: &Path, xcode_env: &[(String, String)]) -
     let info_dst = helper.join("Contents/Info.plist");
     fs::copy(&info_src, &info_dst)
         .with_context(|| "could not write the helper Info.plist".to_string())?;
+    // Share the GUI's app icon so the agent shows the OpenLogi mark (not a
+    // generic blank) in System Settings → Accessibility, where the grant now
+    // lives under "OpenLogi Agent". `bundle_macos` runs `generate_macos_icns`
+    // first, so the icns is already on disk. Matches the Info.plist
+    // CFBundleIconFile = "AppIcon".
+    let icon_src = root.join("crates/openlogi-gui/icon/AppIcon.icns");
+    ensure_file(&icon_src)?;
+    let resources = helper.join("Contents/Resources");
+    fs::create_dir_all(&resources)
+        .with_context(|| format!("could not create {}", resources.display()))?;
+    fs::copy(&icon_src, resources.join("AppIcon.icns"))
+        .with_context(|| "could not copy the app icon into the helper bundle".to_string())?;
     // The template ships the 0.0.0 dev version (the hand-bundled dev flow
     // copies it verbatim); stamp the workspace version (= xtask's own,
     // inherited) over it so Finder and update scanners see the real one.


### PR DESCRIPTION
## Context

The nested login-item helper `OpenLogiAgent.app` shipped with **no icon**: `embed_agent_helper` (xtask) only wrote `Contents/MacOS` + `Contents/Info.plist`, the helper's `Info.plist` had no `CFBundleIconFile`, and no `Resources/` was created. As a result the agent appeared as a **blank/generic entry** in *System Settings → Privacy & Security → Accessibility* — the exact list users are told to find and enable **"OpenLogi Agent"** in to grant the mouse hook.

This is the UX flip side of the TCC-identity work (#192 / #214, and #207): now that the grant lives under the agent's own identity, that entry needs to be recognizable. A blank icon next to the GUI's branded **"e"** entry makes it easy to enable the wrong one.

## Change

Share the GUI's existing `AppIcon.icns` with the agent bundle (same "e" mark, no new asset):

- `crates/openlogi-agent/macos/Info.plist` — add `CFBundleIconFile = AppIcon`.
- `xtask/src/macos.rs` (`embed_agent_helper`) — create `OpenLogiAgent.app/Contents/Resources/` and copy `crates/openlogi-gui/icon/AppIcon.icns` into it. `bundle_macos` runs `generate_macos_icns` first, so the icns is already on disk; the copy happens before code-signing.
- `scripts/cargo-run-macos.sh` — mirror the same into the dev-run helper bundle so dev builds aren't blank either.

The agent now shows the OpenLogi "e" instead of a generic placeholder. Sharing the GUI icon is intentional — branding the entry matters more than distinguishing the two.

## Testing

- `cargo run -p xtask -- bundle-macos` (full release bundle) — agent bundle now contains `Contents/Resources/AppIcon.icns` (sha256 identical to the GUI source) and `CFBundleIconFile = AppIcon`; rendered icon is the OpenLogi "e".
- `cargo clippy -p xtask --all-targets -- -D warnings` clean; `plutil -lint` on the helper `Info.plist` OK; `bash -n` on the dev script OK.