### PR TITLE
fix(release): re-register PSGallery before Windows Artifact Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,18 @@ jobs:
           tenant-id: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
           subscription-id: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
 
+      # artifact-signing-action installs its ArtifactSigning module from PSGallery,
+      # which is intermittently missing on hosted windows runners (the action then
+      # dies with "Unable to find repository 'PSGallery'" — actions/runner-images#13758).
+      # That flake silently dropped the arm64 exe + msi from v0.6.14. Re-register the
+      # default PSGallery so a mis-provisioned runner can't lose an artifact again.
+      - name: Ensure PSGallery is registered
+        shell: pwsh
+        run: |
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+
       # Authenticode-signs via Artifact Signing (ex-Trusted Signing). The action only
       # runs on Windows runners. azure/login leaves an az CLI session that the action's
       # default AzureCliCredential picks up, so no azure-* secret inputs are needed.
@@ -430,6 +442,14 @@ jobs:
           client-id: ${{ steps.azure_config.outputs.AZURE_CLIENT_ID }}
           tenant-id: ${{ steps.azure_config.outputs.AZURE_TENANT_ID }}
           subscription-id: ${{ steps.azure_config.outputs.AZURE_SUBSCRIPTION_ID }}
+
+      # Same PSGallery flake guard as the exe job — see that step's comment.
+      - name: Ensure PSGallery is registered
+        shell: pwsh
+        run: |
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
 
       - name: Sign OpenLogi.msi with Artifact Signing
         uses: azure/artifact-signing-action@v2


### PR DESCRIPTION
## Problem

The `v0.6.14` Release run failed two jobs — **Windows EXE (arm64)** and **Windows MSI (arm64)** — so those two assets are missing from the published release. Everything else (macOS, Linux, Windows x86_64) shipped, and the GitHub Release published (the publish job is best-effort over Windows artifacts).

The arm64 EXE build succeeded; the **signing step** failed:

```
Install-Module -Name ArtifactSigning -RequiredVersion 0.1.8 -Force -Repository PSGallery
Get-PackageSource: Unable to find repository 'PSGallery'.
##[error]Process completed with exit code 1.
```

`azure/artifact-signing-action@v2` installs its `ArtifactSigning` module from PSGallery at runtime. PSGallery is **intermittently not registered** on hosted `windows` runners (actions/runner-images#13758), so the action dies on a mis-provisioned VM. x86_64 landed on a healthy runner and signed fine — this is a transient infra flake, not a config bug.

The MSI (arm64) failure is a downstream cascade: it couldn't download the missing arm64 EXE artifact.

## Fix

Re-register the default PSGallery before each `azure/artifact-signing-action@v2` call (both the EXE and MSI Windows jobs):

```pwsh
if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
  Register-PSRepository -Default
}
```

This is the workaround recommended in the runner-images issue. A mis-provisioned runner can no longer silently drop a release artifact.

## Scope

- Does **not** retroactively fix v0.6.14 — releases are immutable; the Windows arm64 assets return on the next tagged release.
- YAML-only; no Rust touched.