### PR TITLE
feat(packaging): add Arch Linux release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -669,6 +669,11 @@ jobs:
             ext="${pkg##*.}"
             cp "$pkg" "dist/openlogi-${ref_name}-linux-${PKG_ARCH}.${ext}"
           done
+          # .pkg.tar.zst has a compound extension; handle it separately.
+          for pkg in target/release/*.pkg.tar.zst; do
+            [ -f "$pkg" ] || continue
+            cp "$pkg" "dist/openlogi-${ref_name}-linux-${PKG_ARCH}.pkg.tar.zst"
+          done
 
       - uses: actions/upload-artifact@v7
         with:
@@ -743,7 +748,7 @@ jobs:
           # hashed alone. The Windows portable artifact is a zip of the GUI +
           # agent exes (#347); no bare .exe ships anymore.
           shopt -s nullglob
-          sha256sum *.dmg *.zip *.msi *.deb *.rpm > SHA256SUMS
+          sha256sum -- *.dmg *.zip *.msi *.deb *.rpm *.pkg.tar.zst > SHA256SUMS
 
       # softprops' `files` can't list a glob that matches nothing without
       # tripping fail_on_unmatched_files. The Windows zip/msi (per arch leg)
@@ -761,6 +766,11 @@ jobs:
               echo "$ext=false" >> "$GITHUB_OUTPUT"
             fi
           done
+          if compgen -G "dist/*.pkg.tar.zst" > /dev/null; then
+            echo "pacman=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pacman=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Load static updater publishing config from 1Password
         id: r2_config
@@ -823,7 +833,7 @@ jobs:
           # the globs may match nothing; the DMGs are guaranteed by the publish
           # gate.
           shopt -s nullglob
-          for artifact in dist/*.dmg dist/*.zip dist/*.msi dist/*.deb dist/*.rpm; do
+          for artifact in dist/*.dmg dist/*.zip dist/*.msi dist/*.deb dist/*.rpm dist/*.pkg.tar.zst; do
             minisign -S -m "$artifact" -s "$key_file" -x "$artifact.minisig" -W
             minisign -V -m "$artifact" -P "$OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY" -x "$artifact.minisig"
           done
@@ -895,6 +905,7 @@ jobs:
             ${{ steps.artifacts.outputs.msi == 'true' && 'dist/*.msi' || '' }}
             ${{ steps.artifacts.outputs.deb == 'true' && 'dist/*.deb' || '' }}
             ${{ steps.artifacts.outputs.rpm == 'true' && 'dist/*.rpm' || '' }}
+            ${{ steps.artifacts.outputs.pacman == 'true' && 'dist/*.pkg.tar.zst' || '' }}
           fail_on_unmatched_files: true
 
   homebrew-tap:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ before the official cask autobump lands. Install either `openlogi` or
 
 ### Linux
 
-Download the `.deb` or `.rpm` from the [latest release](https://github.com/AprilNEA/OpenLogi/releases/latest):
+Download the package for your distribution from the
+[latest release](https://github.com/AprilNEA/OpenLogi/releases/latest):
 
 ```sh
 # Debian / Ubuntu
@@ -126,6 +127,9 @@ sudo dpkg -i openlogi_*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
+
+# Arch Linux
+sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 
 Packages are published for both `x86_64`/`amd64` and `arm64`/`aarch64`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -121,13 +121,14 @@ layout: a 760×480 background image in a 760×512 Finder window, with 128px icon
 positioned at `(212, 250)` for `OpenLogi.app` and `(548, 250)` for
 `Applications`.
 
-## Packaging Linux `.deb` / `.rpm`
+## Packaging Linux `.deb` / `.rpm` / `.pkg.tar.zst`
 
 Requires [nfpm](https://nfpm.goreleaser.com/) on `PATH`; the package arch is
 derived from the host (override with `PKG_ARCH`):
 
 ```sh
-cargo run -p xtask -- linux package    # → target/release/openlogi_*.deb / .rpm
+cargo run -p xtask -- linux package
+# → target/release/openlogi_*.deb / .rpm / .pkg.tar.zst
 ```
 
 The package contents (binaries, udev rules, systemd user unit, desktop entry,

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -91,10 +91,10 @@ fi
 SYSTEMD_UNIT_DIR=/usr/lib/systemd/user
 if [ -d "$SYSTEMD_UNIT_DIR" ] || command -v systemctl > /dev/null 2>&1; then
     echo "Installing systemd user unit …"
-    # Expand the @BINDIR@ placeholder to match the actual install prefix.
+    # Rewrite the packaged /usr/bin path to match the requested install prefix.
     # Escape the replacement so sed metacharacters (& \ |) in the path are literal.
     ESCAPED_BINDIR="$(printf '%s\n' "${BINDIR}" | sed 's|[&\\|]|\\&|g')"
-    sed "s|@BINDIR@|${ESCAPED_BINDIR}|g" \
+    sed "s|^ExecStart=/usr/bin/openlogi-agent$|ExecStart=${ESCAPED_BINDIR}/openlogi-agent|" \
         "${SCRIPT_DIR}/systemd/openlogi-agent.service" \
         | sudo tee "${SYSTEMD_UNIT_DIR}/openlogi-agent.service" > /dev/null
     # Best-effort daemon-reload for the invoking user so a reinstall picks up

--- a/packaging/linux/nfpm-scripts/postinstall.sh
+++ b/packaging/linux/nfpm-scripts/postinstall.sh
@@ -1,14 +1,6 @@
 #!/bin/sh
 set -eu
 
-# Expand the @BINDIR@ placeholder in the installed systemd unit.
-# Packages install binaries to /usr/bin; the template uses a placeholder so
-# install.sh can substitute a different prefix without a separate template.
-SERVICE=/usr/lib/systemd/user/openlogi-agent.service
-if [ -f "$SERVICE" ]; then
-    sed -i "s|@BINDIR@|/usr/bin|g" "$SERVICE"
-fi
-
 # Reload udev rules and wait for the new uaccess tags to be applied.
 # udevadm trigger is asynchronous — settle ensures the tags are in place
 # before the script exits so the agent can open /dev/hidraw* immediately.

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -1,4 +1,4 @@
-# nfpm package descriptor for OpenLogi Linux packages (.deb / .rpm).
+# nfpm package descriptor for OpenLogi Linux packages (.deb / .rpm / .pkg.tar.zst).
 #
 # Build with the xtask:
 #   cargo run -p xtask -- linux package
@@ -6,11 +6,12 @@
 # Or directly (requires nfpm in PATH; set VERSION and PKG_ARCH):
 #   VERSION=0.6.0 PKG_ARCH=amd64 nfpm package --packager deb --target target/release
 #   VERSION=0.6.0 PKG_ARCH=arm64 nfpm package --packager rpm --target target/release
+#   VERSION=0.6.0 PKG_ARCH=amd64 nfpm package --packager archlinux --target target/release
 
 name: openlogi
 version: "${VERSION}"
 arch: "${PKG_ARCH}"
-maintainer: OpenLogi Contributors <dev@aprilnea.me>
+maintainer: AprilNEA <dev@aprilnea.me>
 description: |-
   Logitech HID++ device control — remap buttons, DPI, and SmartShift.
   An open-source, local-first alternative to Logi Options+. No account,
@@ -58,6 +59,33 @@ contents:
     dst: /usr/share/icons/hicolor/512x512/apps/openlogi.png
     file_info:
       mode: 0644
+
+  - src: LICENSE-APACHE
+    dst: /usr/share/licenses/openlogi/LICENSE-APACHE
+    file_info:
+      mode: 0644
+
+  - src: LICENSE-MIT
+    dst: /usr/share/licenses/openlogi/LICENSE-MIT
+    file_info:
+      mode: 0644
+
+archlinux:
+  packager: "AprilNEA <dev@aprilnea.me>"
+
+overrides:
+  archlinux:
+    depends:
+      - dbus
+      - fontconfig
+      - gcc-libs
+      - glibc
+      - libglvnd
+      - libxcb
+      - libxkbcommon
+      - libxkbcommon-x11
+      - vulkan-icd-loader
+      - wayland
 
 scripts:
   postinstall: packaging/linux/nfpm-scripts/postinstall.sh

--- a/packaging/linux/systemd/openlogi-agent.service
+++ b/packaging/linux/systemd/openlogi-agent.service
@@ -1,8 +1,7 @@
 # OpenLogi background agent — packaged user unit.
 #
-# This file is a template — @BINDIR@ is substituted at install time:
-#   - nfpm (.deb/.rpm): postinstall.sh expands it to /usr/bin
-#   - install.sh: expanded to PREFIX/bin (default /usr/local/bin)
+# Packages use /usr/bin directly. install.sh rewrites ExecStart when installing
+# under a custom PREFIX (default: /usr/local).
 # The agent's launch_at_login setting writes its own copy to
 # $XDG_CONFIG_HOME/systemd/user/ using the current binary path — both coexist,
 # enabling either works.
@@ -16,7 +15,7 @@ After=graphical-session.target
 
 [Service]
 Type=simple
-ExecStart=@BINDIR@/openlogi-agent
+ExecStart=/usr/bin/openlogi-agent
 Restart=on-failure
 RestartSec=5
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -15,7 +15,8 @@ devenv shell -- cargo run -p xtask -- <command>
 - `macos bundle` — build the release `OpenLogi.app` and embed the agent helper.
 - `macos dmg` — package an existing app bundle into the branded DMG.
 - `macos package` — build the app bundle, optionally sign it, then create the branded DMG.
-- `linux package` — build release binaries and package `.deb` / `.rpm` artifacts with nfpm.
+- `linux package` — build release binaries and package `.deb`, `.rpm`, and
+  `.pkg.tar.zst` artifacts with nfpm.
 - `release latest-json` — generate the static updater manifest for the stable channel.
 
 The Cargo runner in `../scripts/cargo-run-macos.sh` stays outside xtask because

--- a/xtask/src/commands/linux/package.rs
+++ b/xtask/src/commands/linux/package.rs
@@ -8,7 +8,7 @@ use crate::support::fs::{absolutize, ensure_command, ensure_file, repo_root};
 
 #[derive(Parser)]
 pub(crate) struct Args {
-    /// Output directory for .deb and .rpm packages (default: target/release).
+    /// Output directory for .deb, .rpm, and .pkg.tar.zst packages (default: target/release).
     #[arg(long, default_value = "target/release")]
     output: PathBuf,
     /// Skip the cargo build step (binaries must already exist in target/release).
@@ -48,7 +48,7 @@ pub(crate) fn run(args: &Args) -> Result<()> {
         other => anyhow::bail!("unsupported Linux package architecture: {other}"),
     };
 
-    for packager in ["deb", "rpm"] {
+    for packager in ["deb", "rpm", "archlinux"] {
         println!("==> nfpm {packager} ({pkg_arch})");
         cmd!(
             sh,


### PR DESCRIPTION
## Summary

Add first-class Arch Linux packages to OpenLogi releases alongside the existing Debian and RPM artifacts.

AUR publishing is intentionally not automated here: `openlogi-bin` already exists and is maintained by Nilesh Kevlani (`njkevlani`). Issue #255 remains open for ownership/co-maintainer coordination before upstream CI writes to that package.

## Changes

- **xtask / nFPM**
  - Build `.pkg.tar.zst` packages for x86_64 and aarch64.
  - Use `AprilNEA <dev@aprilnea.me>` consistently for package metadata.
  - Declare the verified Arch runtime dependencies and include both license files.
  - Package a final `/usr/bin/openlogi-agent` systemd unit instead of modifying a package-owned file after installation.
- **Release CI**
  - Collect the compound `.pkg.tar.zst` extension correctly.
  - Include Arch packages in `SHA256SUMS`, minisign signatures, R2 uploads, and GitHub Release assets.
- **Documentation**
  - Document the Arch installation command and the additional xtask output.

## Testing

- `devenv tasks run openlogi:check`
- `actionlint .github/workflows/release.yml`
- `shellcheck packaging/linux/install.sh packaging/linux/uninstall.sh packaging/linux/nfpm-scripts/postinstall.sh packaging/linux/nfpm-scripts/postremove.sh`
- Generated `openlogi-0.6.20-1-x86_64.pkg.tar.zst` with nFPM v2.46.3.
- Inspected the generated metadata with `pacman -Qip` and verified the packaged licenses, install hooks, and systemd unit.
- Not runtime-tested on Arch Linux hardware.

Refs #255