### PR TITLE
fix(hid): show the 0x0005 device name when the receiver stores no codename

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ Things OpenLogi does that Options+ won't:
 
 ¹ Media key actions use D-Bus MPRIS on Linux; a handful of macOS-specific actions have no universal Linux equivalent and are no-ops. Windows maps platform actions to native equivalents where available.
 
+## Tested devices
+
+OpenLogi speaks generic HID++ 2.0, so most modern Logitech mice work without a
+per-model entry — if a device appears under `openlogi list`, button / DPI /
+SmartShift control will generally work. Confirmed on real hardware:
+
+| Device | Connection | Verified |
+|---|---|---|
+| **MX Master** (1st gen — reports `Wireless Mouse MX Master`, `wpid 4060`) | Unifying receiver | macOS 26 — enumeration, DPI (`0x2201`), SmartShift (`0x2110`), and Back / Forward / mode-shift button remapping. Thumb gesture button (`0x00c3`) is not yet captured on this model. |
+
+Don't see your device? Please [open an issue](https://github.com/AprilNEA/OpenLogi/issues)
+with your `openlogi list` output so it can be added here.
+
 ## Install
 
 > [!IMPORTANT]

--- a/crates/openlogi-hid/src/inventory/cache.rs
+++ b/crates/openlogi-hid/src/inventory/cache.rs
@@ -84,9 +84,10 @@ pub(super) async fn probe_or_reuse(
     cached: Option<&Cached>,
     online: bool,
     tick: u64,
+    want_name: bool,
 ) -> (ProbedFeatures, CacheOutcome) {
     if online && cached.is_none_or(|c| is_stale(c, tick)) {
-        let (fresh, battery_index) = probe_features(channel, index).await;
+        let (fresh, battery_index) = probe_features(channel, index, want_name).await;
         // `capabilities` is `Some` exactly when the feature-table walk succeeded;
         // only then is the probe worth caching.
         if fresh.capabilities.is_some() {

--- a/crates/openlogi-hid/src/inventory/features.rs
+++ b/crates/openlogi-hid/src/inventory/features.rs
@@ -26,6 +26,11 @@ pub(super) struct ProbedFeatures {
     pub(super) model_info: Option<DeviceModelInfo>,
     /// Marketing type from HID++ `0x0005` — an identity hint only.
     pub(super) kind: Option<DeviceKind>,
+    /// Marketing name from HID++ `0x0005` (e.g. `"MX Master"`). Used as the
+    /// display-name fallback when the receiver has no stored codename for the
+    /// slot (Unifying never stores one; some Bolt pairings don't either), so an
+    /// otherwise-recognised device isn't shown as "Unknown device".
+    pub(super) name: Option<String>,
     /// Configuration capabilities derived from the device's feature table.
     pub(super) capabilities: Option<Capabilities>,
 }
@@ -154,15 +159,30 @@ pub(super) async fn probe_features(
     // the authoritative kind signal. On the direct path it's the only one; on
     // the Bolt path it corrects a pairing register that reported the wrong (or
     // `Unknown`) kind.
-    let kind = match device.get_feature::<DeviceTypeAndNameFeature>() {
-        Some(feature) => match feature.get_device_type().await {
-            Ok(ty) => Some(map_device_type(ty)),
-            Err(e) => {
-                debug!(slot, error = ?e, "DeviceType read failed");
-                None
-            }
-        },
-        None => None,
+    let (kind, name) = match device.get_feature::<DeviceTypeAndNameFeature>() {
+        Some(feature) => {
+            let kind = match feature.get_device_type().await {
+                Ok(ty) => Some(map_device_type(ty)),
+                Err(e) => {
+                    debug!(slot, error = ?e, "DeviceType read failed");
+                    None
+                }
+            };
+            // The device's own marketing name, used as the display fallback
+            // when the receiver has no stored codename for this slot.
+            let name = match feature.get_whole_device_name().await {
+                Ok(n) => {
+                    let trimmed = n.trim();
+                    (!trimmed.is_empty()).then(|| trimmed.to_string())
+                }
+                Err(e) => {
+                    debug!(slot, error = ?e, "device name (0x0005) read failed");
+                    None
+                }
+            };
+            (kind, name)
+        }
+        None => (None, None),
     };
 
     (
@@ -170,6 +190,7 @@ pub(super) async fn probe_features(
             battery,
             model_info,
             kind,
+            name,
             capabilities,
         },
         battery_index,

--- a/crates/openlogi-hid/src/inventory/features.rs
+++ b/crates/openlogi-hid/src/inventory/features.rs
@@ -82,6 +82,7 @@ pub(super) fn battery_feature_index(ids: impl IntoIterator<Item = u16>) -> Optio
 pub(super) async fn probe_features(
     channel: &Arc<HidppChannel>,
     slot: u8,
+    want_name: bool,
 ) -> (ProbedFeatures, Option<u8>) {
     let mut device = match Device::new(Arc::clone(channel), slot).await {
         Ok(d) => d,
@@ -169,16 +170,23 @@ pub(super) async fn probe_features(
                 }
             };
             // The device's own marketing name, used as the display fallback
-            // when the receiver has no stored codename for this slot.
-            let name = match feature.get_whole_device_name().await {
-                Ok(n) => {
-                    let trimmed = n.trim();
-                    (!trimmed.is_empty()).then(|| trimmed.to_string())
+            // when the receiver has no stored codename for this slot. Skipped
+            // on the direct path (`want_name = false`), where the HID node name
+            // is already the codename — fetching it would be several HID++
+            // round-trips whose result is discarded.
+            let name = if want_name {
+                match feature.get_whole_device_name().await {
+                    Ok(n) => {
+                        let trimmed = n.trim();
+                        (!trimmed.is_empty()).then(|| trimmed.to_string())
+                    }
+                    Err(e) => {
+                        debug!(slot, error = ?e, "device name (0x0005) read failed");
+                        None
+                    }
                 }
-                Err(e) => {
-                    debug!(slot, error = ?e, "device name (0x0005) read failed");
-                    None
-                }
+            } else {
+                None
             };
             (kind, name)
         }

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -357,7 +357,7 @@ async fn walk_bolt_slot(
     // mirroring the Unifying path (#218).
     let probe_result = timeout(
         BOLT_SLOT_PROBE,
-        probe_or_reuse(channel, slot, id.clone(), cached, online, tick),
+        probe_or_reuse(channel, slot, id.clone(), cached, online, tick, true),
     )
     .await;
     let (probe, outcome) = if let Ok(r) = probe_result {
@@ -419,8 +419,16 @@ async fn probe_direct(
     let cached = cache.get(&id);
     // A direct device is always "present" (its HID node is the candidate), so
     // treat it as online: reuse the cached probe while fresh, otherwise probe.
-    let (probe, outcome) =
-        probe_or_reuse(&channel, DIRECT_DEVICE_INDEX, Some(id), cached, true, tick).await;
+    let (probe, outcome) = probe_or_reuse(
+        &channel,
+        DIRECT_DEVICE_INDEX,
+        Some(id),
+        cached,
+        true,
+        tick,
+        false,
+    )
+    .await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or exposes a
     // configuration feature (buttons / pointer / lighting). A Bolt receiver's
@@ -582,7 +590,7 @@ async fn probe_unifying_slot(
     // moved to Bluetooth answers `DeviceNotFound` and surfaces as offline.
     let probe_result = timeout(
         UNIFYING_SLOT_PROBE,
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, true, tick),
+        probe_or_reuse(channel, slot, Some(id.clone()), cached, true, tick, true),
     )
     .await;
     let (probe, outcome) = if let Ok(r) = probe_result {

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -384,7 +384,9 @@ async fn walk_bolt_slot(
 
     let device = PairedDevice {
         slot,
-        codename: identity.codename.clone(),
+        // Fall back to the device's own `0x0005` marketing name when the Bolt
+        // receiver has no stored codename for this slot.
+        codename: identity.codename.clone().or_else(|| probe.name.clone()),
         wpid,
         // Prefer the device's own `0x0005` type; the register kind is the
         // offline fallback.
@@ -594,7 +596,9 @@ async fn probe_unifying_slot(
 
     let device = PairedDevice {
         slot,
-        codename,
+        // Fall back to the device's own `0x0005` marketing name when the
+        // receiver has no stored codename for this slot.
+        codename: codename.or_else(|| probe.name.clone()),
         wpid: Some(event.wpid),
         kind: resolve_device_kind(probe.kind, register_kind),
         // Reachable on this receiver iff the feature walk got through this tick.


### PR DESCRIPTION
## Problem

On a Unifying receiver, a fully-recognised device shows up as **"Unknown device"** in `openlogi list` (and the GUI device list). The display name (`codename`) is read only from the receiver's stored codename register (`read_codename`), which a Unifying receiver doesn't populate per slot — so it is always `None` there, and some Bolt pairings lack it too.

## Fix

The slot probe already creates the HID++ `0x0005` (`DeviceTypeAndName`) feature to read the device *kind*. This change also reads the device's marketing **name** via `get_whole_device_name()` and uses it as the `codename` fallback **only when** the receiver register returns none. When a stored codename exists, behavior is unchanged.

Touched: `crates/openlogi-hid/src/inventory.rs` — `ProbedFeatures` gains a `name` field, populated in `probe_features`; `probe_unifying_slot` and `probe_bolt_slot` use `codename.or_else(|| probe.name.clone())`.

## Verification

Original **MX Master** (reports `Wireless Mouse MX Master`, `wpid 4060`) over a Unifying receiver, macOS 26:

Before:
```
slot 1 ● Unknown device (mouse, wpid=4060, ...)
```
After:
```
slot 1 ● Wireless Mouse MX Master (mouse, wpid=4060, ...)
```

`cargo fmt -p openlogi-hid -- --check`, `cargo clippy -p openlogi-hid --all-targets -- -D warnings`, and `cargo test -p openlogi-hid` (61 passed) are all clean.

## Notes

- Adds a short **Tested devices** section to the README documenting the MX Master result.
- Generic HID++ control on this device (DPI `0x2201`, SmartShift `0x2110`, and Back/Forward/mode-shift remapping) already works — this PR is purely about the display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)