### PR TITLE
fix: make one-shot enumerate() retry transport-agnostic so Unifying partial drains recover

### DIFF
--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -180,7 +180,7 @@ pub enum BatteryStatus {
 }
 
 /// Battery snapshot for one paired device, as last polled over HID++.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BatteryInfo {
     /// Reported charge percentage (`0..=100`).
     pub percentage: u8,
@@ -193,7 +193,7 @@ pub struct BatteryInfo {
 /// Identity of an enumerated receiver — no paired-device state (that lives
 /// in [`DeviceInventory::paired`]). For a direct (Bluetooth/wired) device,
 /// a synthetic entry mirroring the device's own HID identity fills this role.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReceiverInfo {
     /// Product string from the HID enumeration (e.g. `"Logi Bolt Receiver"`).
     pub name: String,
@@ -275,7 +275,7 @@ pub struct DeviceTransports {
 /// or a direct (Bluetooth/wired) attachment under its synthetic
 /// [`ReceiverInfo`]. Embedded in [`DeviceInventory`], so its field order is
 /// IPC wire format — see that type's contract.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PairedDevice {
     /// Receiver-assigned slot (1..=6 for Bolt).
     pub slot: u8,
@@ -310,7 +310,7 @@ pub struct PairedDevice {
 /// field and variant *order*, so reordering, retyping, or wrapping any field
 /// in this tree is a wire-format change and requires a `PROTOCOL_VERSION`
 /// bump (guarded by `openlogi-agent-core/tests/wire_format.rs`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeviceInventory {
     /// The receiver's identity — synthetic (mirroring the device itself)
     /// for a direct Bluetooth/wired attachment.
@@ -322,7 +322,74 @@ pub struct DeviceInventory {
 
 #[cfg(test)]
 mod tests {
-    use super::DeviceKind;
+    use super::{
+        BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
+        DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+    };
+
+    fn inventory(slot: u8, wpid: Option<u16>, battery_percentage: u8) -> DeviceInventory {
+        DeviceInventory {
+            receiver: ReceiverInfo {
+                name: "Logi Bolt Receiver".to_string(),
+                vendor_id: 0x046d,
+                product_id: 0xc548,
+                unique_id: Some("receiver-1".to_string()),
+            },
+            paired: vec![PairedDevice {
+                slot,
+                codename: Some("MX Test".to_string()),
+                wpid,
+                kind: DeviceKind::Mouse,
+                online: true,
+                battery: Some(BatteryInfo {
+                    percentage: battery_percentage,
+                    level: BatteryLevel::Good,
+                    status: BatteryStatus::Discharging,
+                }),
+                model_info: Some(DeviceModelInfo {
+                    entity_count: 1,
+                    serial_number: Some("serial-1".to_string()),
+                    unit_id: [1, 2, 3, 4],
+                    transports: DeviceTransports {
+                        usb: true,
+                        equad: true,
+                        btle: false,
+                        bluetooth: false,
+                    },
+                    model_ids: [0xb023, 0, 0],
+                    extended_model_id: 0x02,
+                }),
+                capabilities: Some(Capabilities {
+                    buttons: true,
+                    pointer: true,
+                    lighting: false,
+                    scroll_inversion: false,
+                }),
+            }],
+        }
+    }
+
+    #[test]
+    fn device_inventory_equality_includes_nested_device_fields() {
+        let base = inventory(1, Some(0xb023), 86);
+        assert_eq!(base, base.clone());
+
+        assert_ne!(
+            base,
+            inventory(2, Some(0xb023), 86),
+            "slot changes must affect inventory equality"
+        );
+        assert_ne!(
+            base,
+            inventory(1, Some(0xb024), 86),
+            "wireless product id changes must affect inventory equality"
+        );
+        assert_ne!(
+            base,
+            inventory(1, Some(0xb023), 87),
+            "nested battery changes must affect inventory equality"
+        );
+    }
 
     #[test]
     fn registry_type_is_case_folded() {

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -135,25 +135,63 @@ pub async fn enumerate() -> Result<Vec<DeviceInventory>, InventoryError> {
     // few times instead, reusing the same enumerator so its ledger accumulates a
     // snapshot a later attempt can replay and the opened channel stays warm.
     // #226's 5 s request timeout inside `HidppChannel::send` makes a dead probe
-    // fail fast, so a short bounded retry is cheap.
+    // fail fast, so a short bounded retry is cheap. Some transports can answer
+    // while still yielding a short device set (for example, a Unifying arrival
+    // event landing just after the drain window). When every node answered this
+    // cycle but that healthy pass is still short, two identical inventories mean
+    // the expected stable Unifying offline drain has settled. A failed/timed-out
+    // probe must keep using the full retry budget so the next attempt can reopen
+    // the channel and recover.
     let mut enumerator = Enumerator::default();
+    let mut previous_inventories: Option<Vec<DeviceInventory>> = None;
     let mut attempt = 1u8;
     loop {
-        let (inventories, all_healthy) = enumerator.enumerate_reporting_health().await?;
-        if all_healthy || attempt >= ONESHOT_ATTEMPTS {
+        let (inventories, all_complete, all_healthy) =
+            enumerator.enumerate_reporting_completeness().await?;
+        if one_shot_should_stop(
+            previous_inventories.as_deref(),
+            &inventories,
+            all_complete,
+            all_healthy,
+            attempt,
+        ) {
             return Ok(inventories);
         }
         debug!(
             attempt,
-            "one-shot enumerate saw an unhealthy node — retrying"
+            all_complete,
+            all_healthy,
+            "one-shot enumerate inventory incomplete or still changing — retrying"
         );
+        // Only a healthy pass is valid evidence for the unchanged-inventory
+        // stop, so the equality check below only ever compares two consecutive
+        // healthy snapshots. A failed/timed-out probe (replayed last-good or
+        // partial live result) is cleared so it can't count as one of the two
+        // "stable" reads and short-circuit a later healthy-but-short pass.
+        previous_inventories = if all_healthy { Some(inventories) } else { None };
         tokio::time::sleep(ONESHOT_RETRY_DELAY).await;
         attempt += 1;
     }
 }
 
+/// Stop the one-shot retry loop when the snapshot is complete, when a healthy
+/// but short pass has stabilized (the expected Unifying offline-drain case), or
+/// when the explicit attempt cap is reached. An unchanged inventory from a
+/// failed probe is not stable evidence; it must keep retrying until the cap.
+fn one_shot_should_stop(
+    previous: Option<&[DeviceInventory]>,
+    current: &[DeviceInventory],
+    all_complete: bool,
+    all_healthy: bool,
+    attempt: u8,
+) -> bool {
+    all_complete
+        || (all_healthy && previous.is_some_and(|previous| previous == current))
+        || attempt >= ONESHOT_ATTEMPTS
+}
+
 /// Attempts a one-shot [`enumerate`] makes before returning whatever it last
-/// read, when a node keeps coming back unhealthy.
+/// read, when an inventory keeps coming back incomplete or changing.
 const ONESHOT_ATTEMPTS: u8 = 4;
 
 /// Delay between one-shot [`enumerate`] retries. A first probe usually wakes an
@@ -172,19 +210,22 @@ impl Enumerator {
     /// channel is reopened, so a transient HID++ glitch can't masquerade as
     /// "no devices" (#218) — see the node ledger.
     pub async fn enumerate(&mut self) -> Result<Vec<DeviceInventory>, InventoryError> {
-        self.enumerate_reporting_health().await.map(|(inv, _)| inv)
+        self.enumerate_reporting_completeness()
+            .await
+            .map(|(inv, _, _)| inv)
     }
 
-    /// [`Self::enumerate`] plus whether every probed node answered cleanly this
-    /// pass — `false` if any probe timed out, failed to open, or read short of a
-    /// receiver's pairing count. The polling watcher ignores the flag (the ledger
-    /// already replays a node through a transient miss), but the one-shot
-    /// [`enumerate`] free fn uses it to retry: a fresh `Enumerator` has no ledger
-    /// history to replay, so a transient miss would otherwise surface as an
-    /// empty/partial list (#218).
-    async fn enumerate_reporting_health(
+    /// [`Self::enumerate`] plus whether every probed node produced a complete
+    /// enough snapshot for the one-shot caller to stop early, and whether every
+    /// probed node answered this cycle. Completeness is separate from per-node
+    /// health: a node can answer cleanly enough for the ledger to accept its
+    /// live inventory while still reporting a known count/list shortfall that
+    /// the one-shot retry should give one more chance to settle. Only healthy
+    /// shortfalls can use the unchanged-inventory early stop; failed probes must
+    /// run through the retry budget so a later attempt can recover.
+    async fn enumerate_reporting_completeness(
         &mut self,
-    ) -> Result<(Vec<DeviceInventory>, bool), InventoryError> {
+    ) -> Result<(Vec<DeviceInventory>, bool, bool), InventoryError> {
         self.tick = self.tick.wrapping_add(1);
         let tick = self.tick;
         let candidates = enumerate_hidpp_devices().await?;
@@ -251,8 +292,11 @@ impl Enumerator {
 
         let mut inventories = Vec::new();
         let mut outcomes = Vec::new();
-        // Whether every node answered cleanly this pass. Drives the one-shot
-        // `enumerate` retry; the ledger's own per-node replay is unaffected.
+        // Aggregates for the one-shot retry. `all_complete` can stop
+        // immediately; `all_healthy` gates the unchanged-inventory shortcut so
+        // failed probes keep retrying. The ledger's own per-node replay is
+        // governed by `probe.healthy`.
+        let mut all_complete = true;
         let mut all_healthy = true;
         for (node, result) in results {
             let probe = if let Ok(probe) = result {
@@ -265,6 +309,7 @@ impl Enumerator {
                 warn!(budget = ?PROBE_BUDGET, "device probe timed out — treating as a failed probe");
                 NodeProbe::failed()
             };
+            all_complete &= probe.complete;
             all_healthy &= probe.healthy;
             outcomes.extend(probe.outcomes);
             let settled = self.ledger.settle(&node, probe.healthy, probe.inventory);
@@ -276,6 +321,7 @@ impl Enumerator {
         // Nodes that wouldn't open this tick still replay their last snapshot
         // (they have no cached channel to evict).
         for node in open_failures {
+            all_complete = false;
             all_healthy = false;
             let settled = self.ledger.settle(&node, false, None);
             inventories.extend(settled.inventory);
@@ -296,7 +342,7 @@ impl Enumerator {
             }
         }
         self.evict_unseen(&seen_keys);
-        Ok((inventories, all_healthy))
+        Ok((inventories, all_complete, all_healthy))
     }
 
     /// Drop cache entries for devices not seen this tick, after a short grace so

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -27,11 +27,13 @@ use super::{ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_SLOT_PROBE}
 
 /// One probed node's contribution this tick: its inventory (if any), whether
 /// the node actually answered — the ledger replays the last snapshot when it
-/// didn't (see [`crate::node_ledger::NodeLedger::settle`]) — and each device's
-/// cache contribution, for the caller to apply and to drive eviction.
+/// didn't (see [`crate::node_ledger::NodeLedger::settle`]) — whether the
+/// one-shot retry can stop early, and each device's cache contribution for the
+/// caller to apply and to drive eviction.
 pub(super) struct NodeProbe {
     pub(super) inventory: Option<DeviceInventory>,
     pub(super) healthy: bool,
+    pub(super) complete: bool,
     pub(super) outcomes: Vec<CacheOutcome>,
 }
 
@@ -41,6 +43,7 @@ impl NodeProbe {
         Self {
             inventory: None,
             healthy: false,
+            complete: false,
             outcomes: Vec::new(),
         }
     }
@@ -122,6 +125,7 @@ async fn probe_bolt_receiver(
             paired,
         }),
         healthy: complete,
+        complete,
         outcomes,
     }
 }
@@ -189,12 +193,18 @@ async fn probe_unifying_receiver(
         );
     }
     // Unlike Bolt, a count/list shortfall is *expected* here (offline paired
-    // devices aren't enumerable yet), so completeness can't ride on it. The
-    // health signal is the pairing-count register answering at all: that
+    // devices aren't enumerable yet), so ledger health can't ride on it. The
+    // ledger health signal is the pairing-count register answering at all: that
     // proves the receiver round-trip worked this cycle, while `None` (e.g. a
     // parked channel) is "couldn't fully check" — the ledger then replays the
     // last good snapshot instead of presenting a possibly-empty list (#218).
+    //
+    // The one-shot CLI path still needs a retry when the count says more
+    // devices may appear after a late arrival drain. Report that separately as
+    // `complete = false`; the unchanged-inventory fallback stops expected
+    // offline Unifying shortfalls after they stabilize.
     let healthy = pairing_count.is_some();
+    let complete = pairing_count.is_some_and(|count| paired.len() == usize::from(count));
 
     NodeProbe {
         inventory: Some(DeviceInventory {
@@ -207,6 +217,7 @@ async fn probe_unifying_receiver(
             paired,
         }),
         healthy,
+        complete,
         outcomes,
     }
 }
@@ -353,6 +364,7 @@ async fn probe_direct(
         return NodeProbe {
             inventory: None,
             healthy: walk_succeeded,
+            complete: walk_succeeded,
             outcomes: vec![CacheOutcome::Unkeyed],
         };
     }
@@ -385,6 +397,7 @@ async fn probe_direct(
     NodeProbe {
         inventory: Some(inventory),
         healthy: true,
+        complete: true,
         outcomes: vec![outcome],
     }
 }

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 
-use super::Enumerator;
+use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
+
 use super::cache::{CACHE_MISS_GRACE, CacheKey, Cached, REFRESH_TICKS, is_stale};
+use super::{Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop};
 use crate::inventory::features::ProbedFeatures;
 
 fn cache_entry(probed_tick: u64) -> Cached {
@@ -69,5 +71,96 @@ fn cached_probe_is_reused_until_refresh_ticks() {
     assert!(
         is_stale(&cached, 10 + REFRESH_TICKS),
         "at the window the probe is refreshed"
+    );
+}
+
+fn inventory(slots: &[u8]) -> Vec<DeviceInventory> {
+    vec![DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "Unifying Receiver".to_string(),
+            vendor_id: 0x046d,
+            product_id: 0xc52b,
+            unique_id: Some("receiver-1".to_string()),
+        },
+        paired: slots
+            .iter()
+            .copied()
+            .map(|slot| PairedDevice {
+                slot,
+                codename: Some(format!("device-{slot}")),
+                wpid: Some(0xb000 + u16::from(slot)),
+                kind: DeviceKind::Mouse,
+                online: true,
+                battery: None,
+                model_info: None,
+                capabilities: None,
+            })
+            .collect(),
+    }]
+}
+
+#[test]
+fn one_shot_retry_stops_when_first_attempt_is_complete() {
+    let current = inventory(&[1, 2]);
+
+    assert!(
+        one_shot_should_stop(None, &current, true, true, 1),
+        "complete inventories keep the one-pass happy path"
+    );
+}
+
+#[test]
+fn one_shot_retry_waits_for_healthy_incomplete_inventory_to_stabilize() {
+    let partial = inventory(&[1]);
+    let full = inventory(&[1, 2]);
+
+    assert!(
+        !one_shot_should_stop(None, &partial, false, true, 1),
+        "the first incomplete pass has no previous inventory to compare"
+    );
+    assert!(
+        !one_shot_should_stop(Some(partial.as_slice()), &full, false, true, 2),
+        "a changed inventory should get another retry window"
+    );
+    assert!(
+        one_shot_should_stop(Some(full.as_slice()), &full, false, true, 3),
+        "once the returned inventory stabilizes, retrying stops"
+    );
+}
+
+#[test]
+fn one_shot_retry_stops_on_unchanged_incomplete_inventory() {
+    let partial = inventory(&[1]);
+
+    assert!(
+        one_shot_should_stop(Some(partial.as_slice()), &partial, false, true, 2),
+        "stable partial inventories should not burn every retry attempt"
+    );
+}
+
+#[test]
+fn one_shot_retry_keeps_unchanged_inventory_after_unhealthy_probe() {
+    let partial = inventory(&[1]);
+
+    assert!(
+        !one_shot_should_stop(Some(partial.as_slice()), &partial, false, false, 2),
+        "unchanged replay after a failed probe must keep retrying before the cap"
+    );
+}
+
+#[test]
+fn one_shot_retry_stops_at_attempt_cap_when_inventory_keeps_changing() {
+    let previous = inventory(&[1]);
+    let current = inventory(&[1, 2]);
+
+    assert!(
+        one_shot_should_stop(
+            Some(previous.as_slice()),
+            &current,
+            false,
+            false,
+            ONESHOT_ATTEMPTS
+        ),
+        "the retry loop must remain bounded even if the inventory changes every time"
     );
 }


### PR DESCRIPTION
## Summary

The one-shot `enumerate()` free fn (used by the CLI `list` / `diag` paths) retries through a transient probe miss, but its early-exit never tripped for a Unifying receiver, so a late-arriving device was silently dropped and the CLI returned a short device set.

The retry loop stopped on `all_healthy`, the AND of each probed node's `probe.healthy`. The two receiver kinds define `healthy` differently: a Bolt receiver sets `healthy = paired.len() == pairing_count` (a missing device makes it false and the retry fires), while a Unifying receiver sets `healthy = pairing_count.is_some()` because offline Unifying devices aren't enumerable yet. A Unifying device whose arrival event lands just after the ~1.5s drain window is dropped, yet `pairing_count.is_some()` stays true, so `all_healthy` stays true and the retry never fires. The continuous GUI/agent watcher is unaffected because it re-enumerates every ~2s.

Fixes #277.

## Why this matters

`openlogi list` and `openlogi diag` are the CLI's primary read paths, and a one-shot caller builds a fresh `Enumerator` with an empty ledger, so it has no prior snapshot to replay a transient miss against. The retry loop was added precisely to recover from that, but for a Unifying receiver it was a no-op: a device whose arrival event lands after the drain window is dropped while `pairing_count.is_some()` keeps `all_healthy` true, so the loop returns a short device set on the first pass. Users on Unifying hardware intermittently see fewer devices than are actually paired, with no recovery, while Bolt users (whose `healthy` rides on the count) are unaffected.

## Approach

Make the one-shot early-exit transport-agnostic by separating the retry signal from per-node ledger health:

- Add a `complete` flag to `NodeProbe`, reported alongside the existing `healthy`. For Unifying, `complete` requires `paired.len() == pairing_count`, so a partial drain now reports `complete = false` and the retry fires. `healthy` (which drives the ledger's per-node replay) is unchanged, so the watcher and the `#218` replay behavior are preserved.
- The retry loop stops on `all_complete`, on an unchanged inventory between two consecutive **healthy** passes (the expected stable Unifying offline-drain case, so a chronically-short set stabilizes instead of burning every attempt), or on the attempt cap. The unchanged-inventory shortcut is gated on `all_healthy` and the previous snapshot is only retained from a healthy pass, so a failed/timed-out/open-failed probe keeps using the full retry budget to reopen its channel and recover.
- Add `PartialEq` / `Eq` derives to the inventory device structs (`BatteryInfo`, `ReceiverInfo`, `DeviceModelInfo`, `DeviceTransports`, `PairedDevice`, `DeviceInventory`) so successive attempts can be diffed. These are additive derives only; field order is untouched, so the bincode wire format is unchanged (`openlogi-agent-core/tests/wire_format.rs` still passes).

As a side benefit, this also stops a chronically-unhealthy node (e.g. an asleep BT-direct device that never answers) from forcing every one-shot call to burn all attempts.

## Tests

Added unit tests in `openlogi-core` (structural equality across nested device fields) and `openlogi-hid`:

- Happy path: a complete inventory on attempt 1 returns after a single pass.
- Healthy partial drain stabilizes: the loop keeps retrying while the set grows, then stops once it stabilizes.
- Stabilization stop: a stable healthy-but-short set stops on "unchanged" rather than burning every attempt.
- Failed probe keeps retrying: an unchanged replay from an unhealthy pass does **not** stop early (regression guard).
- Bounded retries: a set that keeps changing still exits at the attempt cap.

`cargo fmt`, `cargo clippy`, and `cargo test` pass across the workspace.
