### PR TITLE
feat(scroll): per-device inverted scrolling

### DIFF
--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -7,6 +7,7 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use openlogi_core::binding::{
@@ -101,6 +102,7 @@ pub fn start(
     hooks: SharedHookMaps,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture: CaptureChannel,
+    invert_scroll: Arc<AtomicBool>,
 ) -> Option<Hook> {
     if !Hook::has_accessibility() {
         warn!(
@@ -210,7 +212,26 @@ pub fn start(
             HOLD.with_borrow_mut(HoldState::cancel);
             EventDisposition::PassThrough
         }
-        MouseEvent::Scroll { .. } => EventDisposition::PassThrough,
+        MouseEvent::Scroll {
+            delta_x,
+            delta_y,
+            is_continuous,
+        } => {
+            // Invert only a discrete mouse-wheel tick, and only when the active
+            // device opted in (#126). A continuous trackpad / Magic Mouse gesture
+            // passes through so its native (e.g. natural) scrolling is left alone.
+            // The tap reads the merged HID stream and can't attribute a scroll to
+            // a physical device, so `invert_scroll` reflects the *selected*
+            // device — the same active-device compromise as `thumbwheel_sensitivity`.
+            if !is_continuous && delta_y != 0.0 && invert_scroll.load(Ordering::Relaxed) {
+                EventDisposition::ReplaceScroll {
+                    delta_x,
+                    delta_y: -delta_y,
+                }
+            } else {
+                EventDisposition::PassThrough
+            }
+        }
     });
 
     match result {

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -54,6 +54,12 @@ pub struct SharedRuntime {
     pub gesture_bindings: GestureBindings,
     pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
     pub thumbwheel_sensitivity: Arc<AtomicI32>,
+    /// Whether the active device's scroll wheel is inverted (issue #126). The
+    /// OS-hook callback reads it on every discrete scroll. The tap sees the
+    /// merged HID stream with no device-of-origin, so — like
+    /// [`Self::thumbwheel_sensitivity`] — this tracks the *selected* device's
+    /// setting rather than applying per-device simultaneously.
+    pub invert_scroll: Arc<AtomicBool>,
     pub capture_channel: CaptureChannel,
     /// Set while a pairing session runs: the gesture watcher then releases its
     /// capture session so `run_pairing` can own the receiver's HID node (one
@@ -109,6 +115,9 @@ impl Orchestrator {
             thumbwheel_sensitivity: Arc::new(AtomicI32::new(
                 config.app_settings.thumbwheel_sensitivity,
             )),
+            // Seeded false; `rebuild` (called below) fills in the selected
+            // device's real setting once devices are known.
+            invert_scroll: Arc::new(AtomicBool::new(false)),
             capture_channel: Arc::new(RwLock::new(None)),
             pairing_active: Arc::new(AtomicBool::new(false)),
             capture_idle: Arc::new(AtomicBool::new(true)),
@@ -180,6 +189,10 @@ impl Orchestrator {
         );
         self.shared.thumbwheel_sensitivity.store(
             self.config.app_settings.thumbwheel_sensitivity,
+            Ordering::Relaxed,
+        );
+        self.shared.invert_scroll.store(
+            key.is_some_and(|k| self.config.invert_scroll(k)),
             Ordering::Relaxed,
         );
     }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -201,6 +201,7 @@ async fn run(config: Config) {
                         shared.hook_maps.clone(),
                         shared.dpi_cycle.clone(),
                         shared.capture_channel.clone(),
+                        shared.invert_scroll.clone(),
                     );
                     hook_installed.store(hook.is_some(), Ordering::Relaxed);
                 }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -371,6 +371,24 @@ pub struct DeviceConfig {
     /// the same reason as [`Self::dpi`]. `None` until the user changes it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub smartshift: Option<SmartShift>,
+    /// Invert this device's scroll-wheel direction relative to the OS setting
+    /// (issue #126): on, a wheel tick scrolls the opposite way, so a user who
+    /// keeps macOS "natural scrolling" for the trackpad can have a traditional
+    /// "reverse" wheel on the mouse. Vertical only; the agent applies it in the
+    /// OS hook and leaves continuous trackpad scrolling untouched. `false`
+    /// (default) is the native direction, and is omitted from `config.toml`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub invert_scroll: bool,
+}
+
+/// `skip_serializing_if` helper for plain `bool` fields whose default is
+/// `false`: keeps an unset toggle out of `config.toml` entirely.
+#[allow(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde's skip_serializing_if requires a fn(&T) -> bool signature"
+)]
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// Deserialize-only shim that folds the pre-v2 `button_bindings` +
@@ -406,6 +424,8 @@ struct RawDeviceConfig {
     lighting: Option<Lighting>,
     #[serde(default)]
     smartshift: Option<SmartShift>,
+    #[serde(default)]
+    invert_scroll: bool,
 }
 
 impl From<RawDeviceConfig> for DeviceConfig {
@@ -448,6 +468,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
             dpi: raw.dpi,
             lighting: raw.lighting,
             smartshift: raw.smartshift,
+            invert_scroll: raw.invert_scroll,
         }
     }
 }
@@ -860,6 +881,24 @@ impl Config {
             .or_default()
             .smartshift = Some(smartshift);
     }
+
+    /// Whether `device_key`'s scroll wheel is inverted (issue #126). `false`
+    /// (the native direction) for an unconfigured or absent device.
+    #[must_use]
+    pub fn invert_scroll(&self, device_key: &str) -> bool {
+        self.devices
+            .get(device_key)
+            .is_some_and(|d| d.invert_scroll)
+    }
+
+    /// Set whether `device_key`'s scroll wheel is inverted. The agent reads this
+    /// on the next `ReloadConfig` and applies it in the OS hook.
+    pub fn set_invert_scroll(&mut self, device_key: &str, invert: bool) {
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .invert_scroll = invert;
+    }
 }
 
 fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
@@ -966,6 +1005,31 @@ mod tests {
             })
         );
         assert_eq!(restored.smartshift("absent"), None);
+    }
+
+    #[test]
+    fn invert_scroll_roundtrips_per_device() {
+        let mut cfg = Config::default();
+        // Default is the native direction for any device, present or not.
+        assert!(!cfg.invert_scroll("2b042"));
+        cfg.set_invert_scroll("2b042", true);
+        let restored = write_and_read(&cfg);
+        assert!(restored.invert_scroll("2b042"));
+        assert!(!restored.invert_scroll("absent"));
+    }
+
+    #[test]
+    fn default_invert_scroll_is_omitted_from_toml() {
+        // A device block with only the default (false) invert_scroll must not
+        // emit the field — `skip_serializing_if` keeps configs clean.
+        let mut cfg = Config::default();
+        cfg.set_binding("2b042", ButtonId::Back, Binding::Single(Action::Copy));
+        cfg.set_invert_scroll("2b042", false);
+        let body = toml::to_string_pretty(&cfg).expect("serialize");
+        assert!(
+            !body.contains("invert_scroll"),
+            "default invert_scroll should be omitted: {body}"
+        );
     }
 
     #[test]

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Rulning"
+"Invert scroll direction": "Vend rulleretning om"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Vend musens rullehjul om. Din pegeplade beholder systemets rulleretning."

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Scrollen"
+"Invert scroll direction": "Scrollrichtung umkehren"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Kehrt das Scrollrad dieser Maus um. Dein Trackpad behält die Scrollrichtung des Systems."

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Κύλιση"
+"Invert scroll direction": "Αντιστροφή κατεύθυνσης κύλισης"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Αντιστρέφει τον τροχό κύλισης αυτού του ποντικιού. Το trackpad διατηρεί την κατεύθυνση κύλισης του συστήματος."

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Scrolling"
+"Invert scroll direction": "Invert scroll direction"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction."

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Desplazamiento"
+"Invert scroll direction": "Invertir dirección de desplazamiento"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Invierte la rueda de desplazamiento de este ratón. Tu trackpad conserva la dirección de desplazamiento del sistema."

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Vieritys"
+"Invert scroll direction": "Käännä vierityssuunta"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Kääntää tämän hiiren vierityspyörän. Ohjauslevy säilyttää järjestelmän vierityssuunnan."

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Défilement"
+"Invert scroll direction": "Inverser le sens de défilement"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverse la molette de cette souris. Votre trackpad conserve le sens de défilement du système."

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Scorrimento"
+"Invert scroll direction": "Inverti direzione di scorrimento"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverte la rotellina di questo mouse. Il trackpad mantiene la direzione di scorrimento del sistema."

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "スクロール"
+"Invert scroll direction": "スクロール方向を反転"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "このマウスのスクロールホイールを反転します。トラックパッドはシステムのスクロール方向を維持します。"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "스크롤"
+"Invert scroll direction": "스크롤 방향 반전"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "이 마우스의 스크롤 휠을 반전합니다. 트랙패드는 시스템 스크롤 방향을 유지합니다."

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Rulling"
+"Invert scroll direction": "Inverter rulleretning"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverterer rullehjulet på denne musen. Styreplaten beholder systemets rulleretning."

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Scrollen"
+"Invert scroll direction": "Scrollrichting omkeren"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Keert het scrollwiel van deze muis om. Je trackpad behoudt de scrollrichting van het systeem."

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Przewijanie"
+"Invert scroll direction": "Odwróć kierunek przewijania"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Odwraca kółko przewijania tej myszy. Gładzik zachowuje systemowy kierunek przewijania."

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Rolagem"
+"Invert scroll direction": "Inverter direção de rolagem"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverte a roda de rolagem deste mouse. Seu trackpad mantém a direção de rolagem do sistema."

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Deslocação"
+"Invert scroll direction": "Inverter direção de deslocação"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverte a roda de deslocação deste rato. O seu trackpad mantém a direção de deslocação do sistema."

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Прокрутка"
+"Invert scroll direction": "Инвертировать направление прокрутки"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Инвертирует колёсико прокрутки этой мыши. Трекпад сохраняет системное направление прокрутки."

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "Rullning"
+"Invert scroll direction": "Invertera rullningsriktning"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverterar mushjulet på den här musen. Din styrplatta behåller systemets rullningsriktning."

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "滚动"
+"Invert scroll direction": "反转滚动方向"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "反转这只鼠标的滚轮方向。触控板仍保持系统的滚动方向。"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "捲動"
+"Invert scroll direction": "反轉捲動方向"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "反轉此滑鼠的滾輪方向。觸控板會維持系統的捲動方向。"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -249,3 +249,6 @@ _version: 1
 "Reading supported DPI values…": "Reading supported DPI values…"
 "Couldn't read DPI — click to retry.": "Couldn't read DPI — click to retry."
 "This device did not report Adjustable DPI support.": "This device did not report Adjustable DPI support."
+"Scrolling": "捲動"
+"Invert scroll direction": "反轉捲動方向"
+"Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "反轉此滑鼠的滾輪方向。觸控板會維持系統的捲動方向。"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -32,7 +32,7 @@ use crate::components::lighting_panel::LightingPanel;
 use crate::components::smartshift_panel::SmartShiftPanel;
 use crate::mouse_model::view::MouseModelView;
 use crate::state::{AgentLink, AppState, DeviceRecord};
-use crate::theme::{self, FOOTER_H, HEADER_H, Palette};
+use crate::theme::{self, FOOTER_H, HEADER_H, Palette, SelectableStyle as _};
 
 /// Which screen the root view is showing.
 ///
@@ -887,7 +887,7 @@ fn detail_content(
 ) -> impl IntoElement {
     match active {
         DetailTab::Buttons => buttons_tab(mouse_model).into_any_element(),
-        DetailTab::Pointer => pointer_tab(dpi_panel, smartshift_panel, pal).into_any_element(),
+        DetailTab::Pointer => pointer_tab(dpi_panel, smartshift_panel, pal, cx).into_any_element(),
         DetailTab::Lighting => lighting_tab(lighting_panel, pal).into_any_element(),
         DetailTab::Device => device_tab(pal, cx).into_any_element(),
     }
@@ -934,12 +934,13 @@ fn buttons_tab(mouse_model: &Entity<MouseModelView>) -> impl IntoElement {
         .child(div().w_full().max_w(px(760.)).child(mouse_model.clone()))
 }
 
-/// Pointer tab: the DPI panel and the SmartShift wheel controls, each in a
-/// titled card, stacked.
+/// Pointer tab: the DPI panel, the SmartShift wheel controls, and the
+/// scroll-wheel preferences, each in a titled card, stacked.
 fn pointer_tab(
     dpi_panel: &Entity<DpiPanel>,
     smartshift_panel: &Entity<SmartShiftPanel>,
     pal: Palette,
+    cx: &mut Context<AppView>,
 ) -> impl IntoElement {
     v_flex()
         .flex_1()
@@ -961,6 +962,67 @@ fn pointer_tab(
             pal,
             smartshift_panel.clone().into_any_element(),
         )))
+        .child(
+            div()
+                .w_full()
+                .max_w(px(560.))
+                .child(scrolling_card(pal, cx)),
+        )
+}
+
+/// Scrolling card: a per-device "invert scroll direction" toggle (#126). Pure
+/// config — no hardware read — so it is a plain switch row rather than an
+/// `Entity` panel like DPI / SmartShift.
+fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
+    let inverted = cx
+        .try_global::<AppState>()
+        .is_some_and(AppState::current_invert_scroll);
+    let row = h_flex()
+        .justify_between()
+        .items_center()
+        .gap_4()
+        .child(
+            v_flex()
+                .child(
+                    div()
+                        .text_sm()
+                        .text_color(pal.text_primary)
+                        .child(tr!("Invert scroll direction")),
+                )
+                .child(div().text_xs().text_color(pal.text_muted).child(tr!(
+                    "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction."
+                ))),
+        )
+        .child(invert_scroll_toggle(inverted, pal));
+    panel_card(
+        tr!("Scrolling"),
+        IconName::Settings,
+        pal,
+        row.into_any_element(),
+    )
+}
+
+/// On/Off pill that flips the active device's scroll-wheel inversion, mirroring
+/// the SmartShift permanent-ratchet toggle.
+fn invert_scroll_toggle(on: bool, pal: Palette) -> impl IntoElement {
+    let label = if on { tr!("On") } else { tr!("Off") };
+    div()
+        .id("invert-scroll-toggle")
+        .px_2()
+        .py_1()
+        .rounded_md()
+        .selected_border(on, pal)
+        .selected_fill(on)
+        .text_xs()
+        .text_color(if on { pal.text_primary } else { pal.text_muted })
+        .cursor_pointer()
+        .child(label)
+        .on_click(move |_event, _window, cx| {
+            cx.update_global::<AppState, _>(|state, _| {
+                state.commit_invert_scroll(!on);
+            });
+            cx.refresh_windows();
+        })
 }
 
 /// Lighting tab: the RGB controls (swatches, on/off, brightness) in a titled

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -948,6 +948,27 @@ impl AppState {
         self.smartshift_pending_confirm.insert(key);
     }
 
+    /// Whether the active device's scroll wheel is inverted (issue #126).
+    /// `false` when no device is selected or the device hasn't opted in.
+    #[must_use]
+    pub fn current_invert_scroll(&self) -> bool {
+        self.current_record()
+            .is_some_and(|r| self.config.invert_scroll(&r.config_key))
+    }
+
+    /// Set the active device's scroll-wheel inversion, persist it, and reload
+    /// the agent so the OS hook applies it on the next scroll. No-op when no
+    /// device is selected. Pure config — there is no hardware write, so (unlike
+    /// DPI / SmartShift) no optimistic cache or confirming re-read is needed.
+    pub fn commit_invert_scroll(&mut self, invert: bool) {
+        let Some(key) = self.current_record().map(|r| r.config_key.clone()) else {
+            debug!("no active device — invert-scroll change ignored");
+            return;
+        };
+        self.config.set_invert_scroll(&key, invert);
+        self.persist_and_reload("invert scroll");
+    }
+
     /// Take the active device's pending SmartShift confirm, if any. Returns the
     /// `(config_key, route)` for a one-shot re-read that replaces the optimistic
     /// value with the device's real state; consumed once so it doesn't re-fire.

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -37,6 +37,7 @@ objc2-app-kit = { version = "0.3.2", features = ["NSWorkspace", "NSRunningApplic
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_WindowsAndMessaging",
 ] }
 

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -43,6 +43,13 @@ pub enum MouseEvent {
         delta_x: f32,
         /// Positive = down, negative = up.
         delta_y: f32,
+        /// `true` for a smooth, momentum-carrying scroll — a trackpad or Magic
+        /// Mouse gesture (macOS `kCGScrollWheelEventIsContinuous`); `false` for a
+        /// discrete mouse-wheel detent. Lets a consumer transform the wheel while
+        /// leaving native trackpad scrolling alone (issue #126). Always `false`
+        /// on Linux/Windows, where the wheel and trackpad arrive as distinct
+        /// event types rather than one flagged stream.
+        is_continuous: bool,
     },
     /// Pointer movement, in device units. Emitted so a held gesture button can
     /// accumulate a swipe; the callback passes these through (the cursor keeps
@@ -62,12 +69,25 @@ pub enum MouseEvent {
 }
 
 /// What the hook callback wants the OS to do with the captured event.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EventDisposition {
     /// Let the event reach its original target unchanged.
     PassThrough,
     /// Drop the event; the target application never sees it.
     Suppress,
+    /// Deliver a [`MouseEvent::Scroll`] carrying these deltas in place of the
+    /// captured one — the hook rewrites the live event's axes (and scales its
+    /// smooth-scroll companion fields to match) rather than re-synthesising it,
+    /// so momentum/phase survive. Only meaningful in response to a `Scroll`
+    /// event; the value is the same `(delta_x, delta_y)` units the callback was
+    /// handed. Used to invert the wheel (issue #126): pure negation is exact in
+    /// these units, so no precision is lost.
+    ReplaceScroll {
+        /// Positive = right, negative = left.
+        delta_x: f32,
+        /// Positive = down, negative = up.
+        delta_y: f32,
+    },
 }
 
 /// Errors that [`Hook::start`] and related functions can produce.

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -21,7 +21,7 @@ use std::sync::{
 use std::thread;
 
 use evdev::uinput::VirtualDevice;
-use evdev::{Device, EventSummary, KeyCode, RelativeAxisCode};
+use evdev::{Device, EventSummary, EventType, InputEvent, KeyCode, RelativeAxisCode};
 use tracing::{debug, error, warn};
 use x11rb::connection::Connection as _;
 use x11rb::properties::WmClass;
@@ -211,7 +211,39 @@ fn wait_readable(device_fd: i32, stop_fd: i32) -> bool {
 }
 
 fn scroll(delta_x: f32, delta_y: f32) -> MouseEvent {
-    MouseEvent::Scroll { delta_x, delta_y }
+    // evdev delivers the wheel and the trackpad as distinct devices/axes rather
+    // than one flagged stream, so there is no continuous-scroll flag to carry.
+    MouseEvent::Scroll {
+        delta_x,
+        delta_y,
+        is_continuous: false,
+    }
+}
+
+/// Re-encode a transformed scroll back into one evdev axis event for re-injection
+/// (an [`EventDisposition::ReplaceScroll`]). The captured `event` is a single
+/// wheel axis; `horizontal`/`vertical` are the replacement deltas in the same
+/// units [`translate`] produced, so the relevant axis is mapped back through the
+/// inverse of `translate` (×[`HIRES_UNITS_PER_TICK`] for the hi-res axes). A
+/// non-wheel event is returned unchanged — it is never the target of a
+/// `ReplaceScroll`.
+fn reinject_scroll(event: &InputEvent, horizontal: f32, vertical: f32) -> InputEvent {
+    let EventSummary::RelativeAxis(_, axis, _) = event.destructure() else {
+        return *event;
+    };
+    let units = match axis {
+        RelativeAxisCode::REL_WHEEL => vertical,
+        RelativeAxisCode::REL_WHEEL_HI_RES => vertical * HIRES_UNITS_PER_TICK,
+        RelativeAxisCode::REL_HWHEEL => horizontal,
+        RelativeAxisCode::REL_HWHEEL_HI_RES => horizontal * HIRES_UNITS_PER_TICK,
+        _ => return *event,
+    };
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "re-injected wheel ticks are small integer counts; negation is exact"
+    )]
+    let raw = units.round() as i32;
+    InputEvent::new(EventType::RELATIVE.0, axis.0, raw)
 }
 
 fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent> {
@@ -366,8 +398,16 @@ fn device_thread(
                     }
                     None => EventDisposition::PassThrough,
                 };
-                if matches!(disposition, EventDisposition::PassThrough) {
-                    pending.push(event);
+                match disposition {
+                    EventDisposition::PassThrough => pending.push(event),
+                    // Re-inject the wheel tick with transformed deltas (e.g. an
+                    // inverted wheel, #126). uinput events go to the desktop, not
+                    // back into this grabbed device's reader, so there is no
+                    // re-capture loop to guard against.
+                    EventDisposition::ReplaceScroll { delta_x, delta_y } => {
+                        pending.push(reinject_scroll(&event, delta_x, delta_y));
+                    }
+                    EventDisposition::Suppress => {}
                 }
             }
         }
@@ -575,7 +615,7 @@ mod tests {
         let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_WHEEL.0, 3);
         let result = translate(&event, false);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
                 if delta_x.abs() < f32::EPSILON && (delta_y - 3.0).abs() < f32::EPSILON),
             "expected Scroll {{ delta_x: 0.0, delta_y: 3.0 }}, got {result:?}"
         );
@@ -586,7 +626,7 @@ mod tests {
         let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_HWHEEL.0, -2);
         let result = translate(&event, false);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
                 if (delta_x - -2.0).abs() < f32::EPSILON && delta_y.abs() < f32::EPSILON),
             "expected Scroll {{ delta_x: -2.0, delta_y: 0.0 }}, got {result:?}"
         );
@@ -604,7 +644,7 @@ mod tests {
         );
         let result = translate(&event, true);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
                 if delta_x.abs() < f32::EPSILON && (delta_y - 0.5).abs() < f32::EPSILON),
             "expected Scroll {{ delta_x: 0.0, delta_y: 0.5 }}, got {result:?}"
         );
@@ -619,7 +659,7 @@ mod tests {
         );
         let result = translate(&event, true);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y })
+            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
                 if (delta_x - -1.0).abs() < f32::EPSILON && delta_y.abs() < f32::EPSILON),
             "expected Scroll {{ delta_x: -1.0, delta_y: 0.0 }}, got {result:?}"
         );

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -7,7 +7,7 @@ use core_foundation::runloop::{
     CFRunLoop, CFRunLoopRunResult, kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
 };
 use core_graphics::event::{
-    CGEvent, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement,
+    CGEvent, CGEventField, CGEventTap, CGEventTapLocation, CGEventTapOptions, CGEventTapPlacement,
     CGEventTapProxy, CGEventType, CallbackResult, EventField,
 };
 use tracing::{debug, error, warn};
@@ -153,6 +153,11 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             // axis 1 = vertical scroll; axis 2 = horizontal scroll.
             let dy = event.get_double_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1);
             let dx = event.get_double_value_field(EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2);
+            // Continuous events come from a trackpad / Magic Mouse gesture; a
+            // notched mouse wheel is discrete. The consumer uses this to invert
+            // the wheel without disturbing native trackpad scrolling (#126).
+            let is_continuous =
+                event.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0;
             #[allow(
                 clippy::cast_possible_truncation,
                 reason = "scroll deltas are small fractional values that fit comfortably in f32"
@@ -160,6 +165,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             Some(MouseEvent::Scroll {
                 delta_x: dx as f32,
                 delta_y: dy as f32,
+                is_continuous,
             })
         }
         // Pointer movement feeds gesture-button swipe detection. While a button
@@ -191,6 +197,54 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             Some(MouseEvent::CaptureInterrupted)
         }
         _ => None,
+    }
+}
+
+/// Rewrite a live `ScrollWheel` event so its deltas become `(new_dx, new_dy)`
+/// in the line units the tap reports. macOS hands modern apps a pixel-precise
+/// delta and a fixed-point delta *alongside* the integer line delta, and an app
+/// with smooth scrolling reads those, not the line field — so flipping only the
+/// line delta would leave such apps scrolling the original way. Each axis scales
+/// all three companion fields by the same factor (`-1` for the inversion in
+/// #126, which is exact), keeping the smooth-scroll path consistent with the
+/// notched one.
+fn rewrite_scroll(event: &CGEvent, horizontal: f64, vertical: f64) {
+    // Vertical = axis 1, horizontal = axis 2 (mirrors `translate`).
+    rewrite_scroll_axis(
+        event,
+        vertical,
+        EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1,
+        EventField::SCROLL_WHEEL_EVENT_FIXED_POINT_DELTA_AXIS_1,
+        EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1,
+    );
+    rewrite_scroll_axis(
+        event,
+        horizontal,
+        EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2,
+        EventField::SCROLL_WHEEL_EVENT_FIXED_POINT_DELTA_AXIS_2,
+        EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2,
+    );
+}
+
+/// Rewrite one scroll axis: set its line delta to `new_line` and scale the
+/// fixed-point + pixel companions by `new_line / old_line` so they agree. A
+/// zero original delta means no scroll on this axis, so the companions are left
+/// untouched (and the division avoided).
+fn rewrite_scroll_axis(
+    event: &CGEvent,
+    new_line: f64,
+    line_field: CGEventField,
+    fixed_field: CGEventField,
+    point_field: CGEventField,
+) {
+    let old_line = event.get_double_value_field(line_field);
+    event.set_double_value_field(line_field, new_line);
+    if old_line != 0.0 {
+        let scale = new_line / old_line;
+        let fixed = event.get_double_value_field(fixed_field);
+        event.set_double_value_field(fixed_field, fixed * scale);
+        let point = event.get_double_value_field(point_field);
+        event.set_double_value_field(point_field, point * scale);
     }
 }
 
@@ -265,6 +319,10 @@ fn thread_main(
             match cb(mouse_event) {
                 EventDisposition::PassThrough => CallbackResult::Keep,
                 EventDisposition::Suppress => CallbackResult::Drop,
+                EventDisposition::ReplaceScroll { delta_x, delta_y } => {
+                    rewrite_scroll(event, f64::from(delta_x), f64::from(delta_y));
+                    CallbackResult::Keep
+                }
             }
         },
     );

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -30,6 +30,7 @@ fn mouse_event_clone_and_debug() {
         MouseEvent::Scroll {
             delta_x: 1.0,
             delta_y: -1.5,
+            is_continuous: false,
         },
         MouseEvent::Moved {
             delta_x: 3,
@@ -49,6 +50,27 @@ fn event_disposition_equality() {
     assert_eq!(EventDisposition::PassThrough, EventDisposition::PassThrough);
     assert_eq!(EventDisposition::Suppress, EventDisposition::Suppress);
     assert_ne!(EventDisposition::PassThrough, EventDisposition::Suppress);
+    // The scroll-transform variant compares by its deltas.
+    assert_eq!(
+        EventDisposition::ReplaceScroll {
+            delta_x: 0.0,
+            delta_y: 3.0,
+        },
+        EventDisposition::ReplaceScroll {
+            delta_x: 0.0,
+            delta_y: 3.0,
+        },
+    );
+    assert_ne!(
+        EventDisposition::ReplaceScroll {
+            delta_x: 0.0,
+            delta_y: 3.0,
+        },
+        EventDisposition::ReplaceScroll {
+            delta_x: 0.0,
+            delta_y: -3.0,
+        },
+    );
 }
 
 /// On unsupported targets (not macOS, not Linux), `Hook::start` returns `Unsupported`.

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -199,7 +199,15 @@ unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) 
     let disposition = callback
         .as_ref()
         .map_or(EventDisposition::PassThrough, |cb| cb(event));
-    if disposition == EventDisposition::Suppress {
+    let suppress = match disposition {
+        EventDisposition::Suppress => true,
+        // Scroll inversion (#126) is not wired on Windows yet: re-injecting a
+        // wheel event via SendInput would re-enter this WH_MOUSE_LL hook, which
+        // needs an injected-event guard (LLMHF_INJECTED) this port doesn't carry
+        // yet. Until then a ReplaceScroll is delivered unchanged.
+        EventDisposition::ReplaceScroll { .. } | EventDisposition::PassThrough => false,
+    };
+    if suppress {
         1
     } else {
         call_next(code, wparam, lparam)
@@ -254,13 +262,18 @@ fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
         // every platform — matching macOS (`SCROLL_WHEEL_EVENT_DELTA_AXIS_1`) and
         // Linux (`REL_WHEEL`), whose deltas feed the same direction-sensitive
         // bindings. Negating here flipped scroll-up/-down only on Windows.
+        // `is_continuous` is always false on Windows: the wheel arrives as
+        // WM_MOUSEWHEEL and precision-touchpad scrolling as separate input, so
+        // there is no single flagged stream to disambiguate (unlike macOS).
         WM_MOUSEWHEEL => Some(MouseEvent::Scroll {
             delta_x: 0.0,
             delta_y: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
+            is_continuous: false,
         }),
         WM_MOUSEHWHEEL => Some(MouseEvent::Scroll {
             delta_x: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
             delta_y: 0.0,
+            is_continuous: false,
         }),
         _ => None,
     }
@@ -349,8 +362,9 @@ mod tests {
             mouseData: 120u32 << 16,
             ..MSLLHOOKSTRUCT::default()
         };
-        let Some(MouseEvent::Scroll { delta_x, delta_y }) =
-            translate_event(WM_MOUSEWHEEL as WPARAM, forward)
+        let Some(MouseEvent::Scroll {
+            delta_x, delta_y, ..
+        }) = translate_event(WM_MOUSEWHEEL as WPARAM, forward)
         else {
             panic!("expected a scroll event");
         };

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -7,12 +7,16 @@
     reason = "Win32 FFI uses raw pointer parameters and fixed-width message values"
 )]
 
+use std::mem::size_of;
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
 use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, LPARAM, LRESULT, WPARAM};
 use windows_sys::Win32::System::Threading::{
     GetCurrentThreadId, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
+    INPUT, INPUT_0, INPUT_MOUSE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_WHEEL, MOUSEINPUT, SendInput,
 };
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     CallNextHookEx, DispatchMessageW, GetForegroundWindow, GetMessageW, GetWindowThreadProcessId,
@@ -199,18 +203,16 @@ unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) 
     let disposition = callback
         .as_ref()
         .map_or(EventDisposition::PassThrough, |cb| cb(event));
-    let suppress = match disposition {
-        EventDisposition::Suppress => true,
-        // Scroll inversion (#126) is not wired on Windows yet: re-injecting a
-        // wheel event via SendInput would re-enter this WH_MOUSE_LL hook, which
-        // needs an injected-event guard (LLMHF_INJECTED) this port doesn't carry
-        // yet. Until then a ReplaceScroll is delivered unchanged.
-        EventDisposition::ReplaceScroll { .. } | EventDisposition::PassThrough => false,
-    };
-    if suppress {
-        1
-    } else {
-        call_next(code, wparam, lparam)
+    match disposition {
+        EventDisposition::PassThrough => call_next(code, wparam, lparam),
+        EventDisposition::Suppress => 1,
+        // Invert the wheel (#126): drop the original and re-inject the transformed
+        // tick. `SendInput` stamps it `LLMHF_INJECTED`, which `translate_event`
+        // skips, so it reaches the foreground app without looping back here.
+        EventDisposition::ReplaceScroll { delta_x, delta_y } => {
+            inject_scroll(delta_x, delta_y);
+            1
+        }
     }
 }
 
@@ -276,6 +278,63 @@ fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
             is_continuous: false,
         }),
         _ => None,
+    }
+}
+
+/// Re-inject a scroll carrying `(delta_x, delta_y)` via `SendInput`, used to
+/// deliver an inverted wheel (#126). The synthetic events are flagged
+/// `LLMHF_INJECTED`, which [`translate_event`] skips, so they reach the
+/// foreground app without looping back through this hook. A `SendInput`
+/// `mouseData` carries the wheel delta directly (a multiple of `WHEEL_DELTA`),
+/// unlike the high-word packing the hook reads off an incoming `MSLLHOOKSTRUCT`.
+fn inject_scroll(delta_x: f32, delta_y: f32) {
+    let mut inputs: Vec<INPUT> = Vec::with_capacity(2);
+    if delta_y != 0.0 {
+        inputs.push(wheel_input(MOUSEEVENTF_WHEEL, delta_y));
+    }
+    if delta_x != 0.0 {
+        inputs.push(wheel_input(MOUSEEVENTF_HWHEEL, delta_x));
+    }
+    let (Ok(count), Ok(size)) = (
+        u32::try_from(inputs.len()),
+        i32::try_from(size_of::<INPUT>()),
+    ) else {
+        tracing::warn!("SendInput contract violated for re-injected scroll");
+        return;
+    };
+    if count == 0 {
+        return;
+    }
+    // SAFETY: `inputs` is a live, initialized slice of `count` `INPUT`s; SendInput
+    // copies it and returns how many it injected.
+    let sent = unsafe { SendInput(count, inputs.as_ptr(), size) };
+    if sent != count {
+        tracing::warn!(
+            requested = count,
+            sent,
+            "SendInput dropped re-injected scroll"
+        );
+    }
+}
+
+/// Build one wheel `INPUT`. `delta` is in the hook's wheel-tick units (the same
+/// [`MouseEvent::Scroll`] units), converted back to the Win32 `mouseData`
+/// multiple of `WHEEL_DELTA`. Pure negation is exact, so an inverted tick
+/// round-trips cleanly.
+fn wheel_input(flags: u32, delta: f32) -> INPUT {
+    let data = (delta * WHEEL_DELTA).round() as i32;
+    INPUT {
+        r#type: INPUT_MOUSE,
+        Anonymous: INPUT_0 {
+            mi: MOUSEINPUT {
+                dx: 0,
+                dy: 0,
+                mouseData: u32::from_ne_bytes(data.to_ne_bytes()),
+                dwFlags: flags,
+                time: 0,
+                dwExtraInfo: 0,
+            },
+        },
     }
 }
 
@@ -373,5 +432,24 @@ mod tests {
             delta_y > 0.0,
             "wheel-forward should scroll up, got {delta_y}"
         );
+    }
+
+    /// The re-injected wheel `mouseData` carries the delta directly (a multiple
+    /// of `WHEEL_DELTA`), and inversion is an exact negation — so an inverted
+    /// tick is the original's sign flipped, no rounding drift.
+    #[test]
+    fn wheel_input_reconstructs_exact_signed_delta() {
+        let up = wheel_input(MOUSEEVENTF_WHEEL, 1.0);
+        let down = wheel_input(MOUSEEVENTF_WHEEL, -1.0);
+        // SAFETY: both were just built as INPUT_MOUSE, so the `mi` arm is active.
+        let (up_data, down_data) = unsafe {
+            (
+                i32::from_ne_bytes(up.Anonymous.mi.mouseData.to_ne_bytes()),
+                i32::from_ne_bytes(down.Anonymous.mi.mouseData.to_ne_bytes()),
+            )
+        };
+        assert_eq!(up_data, 120);
+        assert_eq!(down_data, -120);
+        assert_eq!(up_data, -down_data, "inversion is an exact negation");
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in, **per-device "Invert scroll direction"** toggle. A user can keep
macOS natural scrolling on the trackpad while running a traditional (reversed)
wheel on the mouse — which the native setting can't do.

Closes #126.

### Why the native option isn't enough

macOS scroll direction is a single global default (`com.apple.swipescrolldirection`);
the Mouse and Trackpad panes both reflect that *same* value. So "natural trackpad
+ reversed mouse" is impossible natively — exactly the case #126 describes, and the
reason tools like Scroll Reverser / LinearMouse exist. The toggle here inverts
*relative to* whatever the OS produces, so it composes correctly with the global
setting.

## Design — layered so each crate keeps its own job

- **openlogi-core** (data model): a per-device `invert_scroll` flag on `DeviceConfig`
  with accessors; omitted from `config.toml` when false.
- **openlogi-hook** (pure OS mechanism, no policy): `MouseEvent::Scroll` gains
  `is_continuous` (a trackpad/Magic-Mouse gesture vs. a discrete wheel detent), and
  a new `EventDisposition::ReplaceScroll` that re-emits the wheel with transformed
  deltas. Each platform's hook owns its own re-emission:
  - **macOS** mutates the `CGEvent` in place and scales its smooth-scroll companion
    fields (fixed-point + pixel deltas), so pixel-precise apps invert too — not just
    line-based ones.
  - **Linux** re-injects the flipped tick via uinput.
  - **Windows** re-injects via `SendInput`; the hook already drops `LLMHF_INJECTED`
    events, so the synthetic tick can't loop back.
- **openlogi-agent-core** (policy): the orchestrator publishes the active device's
  flag into a shared `AtomicBool`; the hook runtime inverts only a **discrete** wheel
  and passes continuous trackpad scrolling through untouched.
- **openlogi-gui**: a "Scrolling" card in the Pointer tab with an On/Off toggle
  (pure config — no hardware read). New strings translated across all 20 locales.

### Known limitation (documented in code)

The macOS `CGEventTap` reads the merged HID stream and can't attribute a scroll to a
physical device, so the flag applies to the **selected** device — the same
active-device compromise as `thumbwheel_sensitivity`. The trackpad-vs-wheel split is
done via `is_continuous`, which is what makes #126's actual scenario work. On Linux
(thread-per-device evdev) true per-device is structurally possible later.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean (macOS)
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hook -p openlogi-inject -p openlogi-agent-core --all-targets -- -D warnings` — clean (Windows code cross-linted)
- `cargo fmt --all --check` — clean
- Tests pass: openlogi-core, openlogi-hook, openlogi-agent-core (incl. `wire_format`
  — **no IPC protocol bump**, the flag travels via config + `ReloadConfig`), and
  openlogi-gui (incl. the i18n ordered-key parity test)
