### PR TITLE
fix(hidpp): prune abandoned event receivers

### DIFF
--- a/crates/openlogi-hidpp/src/event.rs
+++ b/crates/openlogi-hidpp/src/event.rs
@@ -17,6 +17,7 @@ impl<T: Clone> EventEmitter<T> {
     /// list.
     pub fn create_receiver(&self) -> async_channel::Receiver<T> {
         let mut senders = self.senders.lock().unwrap();
+        senders.retain(|sender| sender.receiver_count() > 0);
         let (tx, rx) = async_channel::unbounded();
         senders.push(tx);
         rx
@@ -26,6 +27,39 @@ impl<T: Clone> EventEmitter<T> {
     /// removed from the list.
     pub fn emit(&self, event: T) {
         let mut senders = self.senders.lock().unwrap();
-        senders.retain(|sender| sender.send_blocking(event.clone()).is_ok());
+        senders.retain(|sender| {
+            sender.receiver_count() > 0 && sender.send_blocking(event.clone()).is_ok()
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_receiver_prunes_abandoned_senders_without_waiting_for_emit() {
+        let emitter = EventEmitter::<u8>::new();
+
+        let rx = emitter.create_receiver();
+        drop(rx);
+
+        let _rx = emitter.create_receiver();
+
+        assert_eq!(emitter.senders.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn emit_prunes_abandoned_senders() {
+        let emitter = EventEmitter::<u8>::new();
+
+        let live = emitter.create_receiver();
+        let dropped = emitter.create_receiver();
+        drop(dropped);
+
+        emitter.emit(7);
+
+        assert_eq!(live.recv_blocking().unwrap(), 7);
+        assert_eq!(emitter.senders.lock().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- prune dropped async-channel receivers before registering a new EventEmitter receiver
- keep emit-time pruning explicit before sending to live receivers
- add regression coverage for abandoned receiver cleanup

## Validation
- cargo fmt --check
- cargo test -p openlogi-hidpp
- cargo clippy -p openlogi-hidpp --all-targets -- -D warnings
- pre-push cargo clippy --workspace --all-targets -- -D warnings