### PR TITLE
fix(pairing): keep session pause balanced

### DIFF
--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -38,11 +38,11 @@ pub struct PairingManager {
     ctrl: mpsc::UnboundedSender<Control>,
     updates: Mutex<mpsc::UnboundedReceiver<PairingUpdate>>,
     devices: DeviceCache,
-    /// Count of outstanding pairing sessions. `start` increments it (and sets
+    /// Count of outstanding pairing sessions. The watcher is single-session,
+    /// so `start` atomically transitions this 0 → 1 (and sets
     /// `pairing_active`); the translator decrements it on each terminal event
-    /// and lifts the capture pause only when it reaches zero — so a stale
-    /// terminal from a just-cancelled session can't clear the pause a rapidly
-    /// restarted session set. Balanced: one `start` ⇒ exactly one terminal.
+    /// and lifts the capture pause when it returns to zero. Balanced: one
+    /// accepted `start` ⇒ exactly one terminal.
     sessions: Arc<AtomicUsize>,
     shared: SharedRuntime,
 }
@@ -74,16 +74,25 @@ impl PairingManager {
 
     /// Begin a session: forget the previous discovery, pause capture, then start.
     pub async fn start(&self, selector: ReceiverSelector) {
+        if self
+            .sessions
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            warn!("pairing start requested while a session is already active");
+            return;
+        }
+
         if let Ok(mut devices) = self.devices.lock() {
             devices.clear();
         }
-        // Count this session before pausing, so a terminal event still in flight
-        // from a just-cancelled session can't lift the pause out from under it
-        // (the translator only clears when the count returns to zero).
-        self.sessions.fetch_add(1, Ordering::Relaxed);
         self.shared.pairing_active.store(true, Ordering::Relaxed);
         self.wait_capture_idle().await;
-        let _ = self.ctrl.send(Control::Start(selector));
+        if let Err(e) = self.ctrl.send(Control::Start(selector)) {
+            self.sessions.store(0, Ordering::Release);
+            self.shared.pairing_active.store(false, Ordering::Relaxed);
+            warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
+        }
     }
 
     /// Pair with a previously discovered device by address.
@@ -176,4 +185,83 @@ async fn translate(
     // itself is then unavailable until the agent restarts).
     sessions.store(0, Ordering::Relaxed);
     pairing_active.store(false, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+    use std::sync::RwLock;
+
+    use openlogi_agent_core::DpiCycleState;
+    use openlogi_agent_core::hook_runtime::HookMaps;
+
+    fn shared_runtime() -> SharedRuntime {
+        SharedRuntime {
+            hook_maps: Arc::new(RwLock::new(HookMaps::default())),
+            gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
+            dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
+            thumbwheel_sensitivity: Arc::new(0.into()),
+            invert_scroll: Arc::new(AtomicBool::new(false)),
+            capture_channel: Arc::new(RwLock::new(None)),
+            pairing_active: Arc::new(AtomicBool::new(false)),
+            capture_idle: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn manager_with_ctrl(ctrl: mpsc::UnboundedSender<Control>) -> PairingManager {
+        let (_upd_tx, upd_rx) = mpsc::unbounded_channel();
+        PairingManager {
+            ctrl,
+            updates: Mutex::new(upd_rx),
+            devices: Arc::new(StdMutex::new(HashMap::new())),
+            sessions: Arc::new(AtomicUsize::new(0)),
+            shared: shared_runtime(),
+        }
+    }
+
+    #[tokio::test]
+    async fn start_rolls_back_pause_when_watcher_send_fails() {
+        let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel();
+        drop(ctrl_rx);
+        let manager = manager_with_ctrl(ctrl_tx);
+
+        manager.start(ReceiverSelector::First).await;
+
+        assert_eq!(manager.sessions.load(Ordering::Acquire), 0);
+        assert!(!manager.shared.pairing_active.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn start_ignores_overlapping_session_without_clearing_or_sending() {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        manager.sessions.store(1, Ordering::Release);
+        manager.shared.pairing_active.store(true, Ordering::Relaxed);
+        {
+            let Ok(mut devices) = manager.devices.lock() else {
+                panic!("test device cache lock should not be poisoned");
+            };
+            devices.insert(
+                [1, 2, 3, 4, 5, 6],
+                DiscoveredDevice {
+                    address: [1, 2, 3, 4, 5, 6],
+                    authentication: 0,
+                    kind: openlogi_hid::pairing::BoltDeviceKind::Unknown,
+                    name: "existing".to_string(),
+                },
+            );
+        }
+
+        manager.start(ReceiverSelector::First).await;
+
+        assert_eq!(manager.sessions.load(Ordering::Acquire), 1);
+        assert!(manager.shared.pairing_active.load(Ordering::Relaxed));
+        let Ok(devices) = manager.devices.lock() else {
+            panic!("test device cache lock should not be poisoned");
+        };
+        assert_eq!(devices.len(), 1);
+        assert!(ctrl_rx.try_recv().is_err());
+    }
 }

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -166,10 +166,9 @@ async fn translate(
             update,
             PairingUpdate::Paired { .. } | PairingUpdate::Failed(_)
         ) {
-            // Lift the capture pause only when the last outstanding session ends;
-            // fetch_sub composes with start()'s fetch_add, so a session started
-            // during this one's teardown keeps the pause held. (Balanced: every
-            // session emits exactly one terminal, so the count never underflows.)
+            // Lift the capture pause when the accepted single session ends.
+            // Balanced: `start()` admits one active session, and that session
+            // emits exactly one terminal event.
             if sessions.fetch_sub(1, Ordering::Relaxed) == 1 {
                 pairing_active.store(false, Ordering::Relaxed);
             }

--- a/crates/openlogi-hid/src/pairing.rs
+++ b/crates/openlogi-hid/src/pairing.rs
@@ -408,7 +408,13 @@ pub async fn run_pairing(
     mut commands: mpsc::UnboundedReceiver<PairingCommand>,
     events: mpsc::UnboundedSender<PairingEvent>,
 ) -> Result<(), PairingError> {
-    let (channel, family) = open_receiver(&target).await?;
+    let (channel, family) = match open_receiver(&target).await {
+        Ok(receiver) => receiver,
+        Err(e) => {
+            let _ = events.send(PairingEvent::Failed(e.clone()));
+            return Err(e);
+        }
+    };
     let (listener, mut notifications) = subscribe(&channel);
 
     let result = drive(&channel, family, &mut commands, &mut notifications, &events).await;

--- a/crates/openlogi-hidpp/src/event.rs
+++ b/crates/openlogi-hidpp/src/event.rs
@@ -17,6 +17,7 @@ impl<T: Clone> EventEmitter<T> {
     /// list.
     pub fn create_receiver(&self) -> async_channel::Receiver<T> {
         let mut senders = self.senders.lock().unwrap();
+        senders.retain(|sender| sender.receiver_count() > 0);
         let (tx, rx) = async_channel::unbounded();
         senders.push(tx);
         rx
@@ -26,6 +27,39 @@ impl<T: Clone> EventEmitter<T> {
     /// removed from the list.
     pub fn emit(&self, event: T) {
         let mut senders = self.senders.lock().unwrap();
-        senders.retain(|sender| sender.send_blocking(event.clone()).is_ok());
+        senders.retain(|sender| {
+            sender.receiver_count() > 0 && sender.send_blocking(event.clone()).is_ok()
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_receiver_prunes_abandoned_senders_without_waiting_for_emit() {
+        let emitter = EventEmitter::<u8>::new();
+
+        let rx = emitter.create_receiver();
+        drop(rx);
+
+        let _rx = emitter.create_receiver();
+
+        assert_eq!(emitter.senders.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn emit_prunes_abandoned_senders() {
+        let emitter = EventEmitter::<u8>::new();
+
+        let live = emitter.create_receiver();
+        let dropped = emitter.create_receiver();
+        drop(dropped);
+
+        emitter.emit(7);
+
+        assert_eq!(live.recv_blocking().unwrap(), 7);
+        assert_eq!(emitter.senders.lock().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- accept at most one active pairing session so the watcher and manager agree on lifecycle
- roll back the capture pause if the pairing watcher command channel is closed
- emit a terminal pairing failure when receiver opening fails before the pairing driver starts
- add regression tests for send failure rollback and overlapping start handling

## Validation
- cargo fmt --check
- cargo test -p openlogi-agent
- cargo test -p openlogi-hid pairing::tests
- cargo clippy -p openlogi-agent --all-targets -- -D warnings
- cargo clippy -p openlogi-hid --all-targets -- -D warnings
- pre-push cargo clippy --workspace --all-targets -- -D warnings