### PR TITLE
fix(hidpp): guard message listener lifetimes

### DIFF
--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -38,11 +38,11 @@ pub struct PairingManager {
     ctrl: mpsc::UnboundedSender<Control>,
     updates: Mutex<mpsc::UnboundedReceiver<PairingUpdate>>,
     devices: DeviceCache,
-    /// Count of outstanding pairing sessions. `start` increments it (and sets
+    /// Count of outstanding pairing sessions. The watcher is single-session,
+    /// so `start` atomically transitions this 0 → 1 (and sets
     /// `pairing_active`); the translator decrements it on each terminal event
-    /// and lifts the capture pause only when it reaches zero — so a stale
-    /// terminal from a just-cancelled session can't clear the pause a rapidly
-    /// restarted session set. Balanced: one `start` ⇒ exactly one terminal.
+    /// and lifts the capture pause when it returns to zero. Balanced: one
+    /// accepted `start` ⇒ exactly one terminal.
     sessions: Arc<AtomicUsize>,
     shared: SharedRuntime,
 }
@@ -74,16 +74,25 @@ impl PairingManager {
 
     /// Begin a session: forget the previous discovery, pause capture, then start.
     pub async fn start(&self, selector: ReceiverSelector) {
+        if self
+            .sessions
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            warn!("pairing start requested while a session is already active");
+            return;
+        }
+
         if let Ok(mut devices) = self.devices.lock() {
             devices.clear();
         }
-        // Count this session before pausing, so a terminal event still in flight
-        // from a just-cancelled session can't lift the pause out from under it
-        // (the translator only clears when the count returns to zero).
-        self.sessions.fetch_add(1, Ordering::Relaxed);
         self.shared.pairing_active.store(true, Ordering::Relaxed);
         self.wait_capture_idle().await;
-        let _ = self.ctrl.send(Control::Start(selector));
+        if let Err(e) = self.ctrl.send(Control::Start(selector)) {
+            self.sessions.store(0, Ordering::Release);
+            self.shared.pairing_active.store(false, Ordering::Relaxed);
+            warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
+        }
     }
 
     /// Pair with a previously discovered device by address.
@@ -176,4 +185,83 @@ async fn translate(
     // itself is then unavailable until the agent restarts).
     sessions.store(0, Ordering::Relaxed);
     pairing_active.store(false, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+    use std::sync::RwLock;
+
+    use openlogi_agent_core::DpiCycleState;
+    use openlogi_agent_core::hook_runtime::HookMaps;
+
+    fn shared_runtime() -> SharedRuntime {
+        SharedRuntime {
+            hook_maps: Arc::new(RwLock::new(HookMaps::default())),
+            gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
+            dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
+            thumbwheel_sensitivity: Arc::new(0.into()),
+            invert_scroll: Arc::new(AtomicBool::new(false)),
+            capture_channel: Arc::new(RwLock::new(None)),
+            pairing_active: Arc::new(AtomicBool::new(false)),
+            capture_idle: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn manager_with_ctrl(ctrl: mpsc::UnboundedSender<Control>) -> PairingManager {
+        let (_upd_tx, upd_rx) = mpsc::unbounded_channel();
+        PairingManager {
+            ctrl,
+            updates: Mutex::new(upd_rx),
+            devices: Arc::new(StdMutex::new(HashMap::new())),
+            sessions: Arc::new(AtomicUsize::new(0)),
+            shared: shared_runtime(),
+        }
+    }
+
+    #[tokio::test]
+    async fn start_rolls_back_pause_when_watcher_send_fails() {
+        let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel();
+        drop(ctrl_rx);
+        let manager = manager_with_ctrl(ctrl_tx);
+
+        manager.start(ReceiverSelector::First).await;
+
+        assert_eq!(manager.sessions.load(Ordering::Acquire), 0);
+        assert!(!manager.shared.pairing_active.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn start_ignores_overlapping_session_without_clearing_or_sending() {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        manager.sessions.store(1, Ordering::Release);
+        manager.shared.pairing_active.store(true, Ordering::Relaxed);
+        {
+            let Ok(mut devices) = manager.devices.lock() else {
+                panic!("test device cache lock should not be poisoned");
+            };
+            devices.insert(
+                [1, 2, 3, 4, 5, 6],
+                DiscoveredDevice {
+                    address: [1, 2, 3, 4, 5, 6],
+                    authentication: 0,
+                    kind: openlogi_hid::pairing::BoltDeviceKind::Unknown,
+                    name: "existing".to_string(),
+                },
+            );
+        }
+
+        manager.start(ReceiverSelector::First).await;
+
+        assert_eq!(manager.sessions.load(Ordering::Acquire), 1);
+        assert!(manager.shared.pairing_active.load(Ordering::Relaxed));
+        let Ok(devices) = manager.devices.lock() else {
+            panic!("test device cache lock should not be poisoned");
+        };
+        assert_eq!(devices.len(), 1);
+        assert!(ctrl_rx.try_recv().is_err());
+    }
 }

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -166,10 +166,9 @@ async fn translate(
             update,
             PairingUpdate::Paired { .. } | PairingUpdate::Failed(_)
         ) {
-            // Lift the capture pause only when the last outstanding session ends;
-            // fetch_sub composes with start()'s fetch_add, so a session started
-            // during this one's teardown keeps the pause held. (Balanced: every
-            // session emits exactly one terminal, so the count never underflows.)
+            // Lift the capture pause when the accepted single session ends.
+            // Balanced: `start()` admits one active session, and that session
+            // emits exactly one terminal event.
             if sessions.fetch_sub(1, Ordering::Relaxed) == 1 {
                 pairing_active.store(false, Ordering::Relaxed);
             }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -121,7 +121,7 @@ pub async fn run_capture_session(
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
     let dpi_set = armed.dpi_cids.clone();
-    let hdl = chan.add_msg_listener({
+    let listener = chan.add_msg_listener_guarded({
         let accum = Arc::clone(&accum);
         let sink = sink.clone();
         move |raw, matched| {
@@ -160,7 +160,7 @@ pub async fn run_capture_session(
     );
     let _ = shutdown.await;
 
-    chan.remove_msg_listener(hdl);
+    drop(listener);
     if let Ok(mut slot) = channel_slot.write() {
         *slot = None;
     }

--- a/crates/openlogi-hid/src/pairing.rs
+++ b/crates/openlogi-hid/src/pairing.rs
@@ -408,7 +408,13 @@ pub async fn run_pairing(
     mut commands: mpsc::UnboundedReceiver<PairingCommand>,
     events: mpsc::UnboundedSender<PairingEvent>,
 ) -> Result<(), PairingError> {
-    let (channel, family) = open_receiver(&target).await?;
+    let (channel, family) = match open_receiver(&target).await {
+        Ok(receiver) => receiver,
+        Err(e) => {
+            let _ = events.send(PairingEvent::Failed(e.clone()));
+            return Err(e);
+        }
+    };
     let (listener, mut notifications) = subscribe(&channel);
 
     let result = drive(&channel, family, &mut commands, &mut notifications, &events).await;

--- a/crates/openlogi-hid/src/pairing.rs
+++ b/crates/openlogi-hid/src/pairing.rs
@@ -26,7 +26,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use hidpp::{
-    channel::{HidppChannel, HidppMessage},
+    channel::{HidppChannel, HidppMessage, MessageListenerGuard},
     receiver::{self, Receiver},
 };
 use serde::{Deserialize, Serialize};
@@ -379,16 +379,18 @@ fn parse_notification(sub_id: u8, device_index: u8, p: [u8; 17]) -> Option<Notif
 }
 
 /// Subscribes a listener that forwards unmatched messages to an async channel,
-/// and returns the listener handle plus the receiver end.
-fn subscribe(channel: &HidppChannel) -> (u32, mpsc::UnboundedReceiver<HidppMessage>) {
+/// and returns the listener guard plus the receiver end.
+fn subscribe(
+    channel: &HidppChannel,
+) -> (MessageListenerGuard, mpsc::UnboundedReceiver<HidppMessage>) {
     let (tx, rx) = mpsc::unbounded_channel();
-    let hdl = channel.add_msg_listener(move |msg, matched| {
+    let listener = channel.add_msg_listener_guarded(move |msg, matched| {
         // `matched` messages are responses to our own register writes.
         if !matched {
             let _ = tx.send(msg);
         }
     });
-    (hdl, rx)
+    (listener, rx)
 }
 
 /// Overall guard so a wedged receiver can't hang the session forever.
@@ -419,7 +421,7 @@ pub async fn run_pairing(
 
     let result = drive(&channel, family, &mut commands, &mut notifications, &events).await;
 
-    channel.remove_msg_listener(listener);
+    drop(listener);
     // Best-effort restore: clear notification flags we set.
     let _ = channel
         .write_register(RECEIVER_INDEX, reg::NOTIFICATIONS, [0, 0, 0])

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, VecDeque},
     error::Error,
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, Weak,
         atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
@@ -223,7 +223,28 @@ impl HidppMessage {
     }
 }
 
-type MessageListener = Box<dyn Fn(HidppMessage, bool) + Send>;
+type MessageListener = Arc<dyn Fn(HidppMessage, bool) + Send + Sync + 'static>;
+
+/// Removes a HID++ message listener when dropped.
+pub struct MessageListenerGuard {
+    message_listeners: Weak<Mutex<HashMap<u32, MessageListener>>>,
+    hdl: u32,
+}
+
+impl MessageListenerGuard {
+    /// Returns the raw listener handle managed by this guard.
+    pub fn handle(&self) -> u32 {
+        self.hdl
+    }
+}
+
+impl Drop for MessageListenerGuard {
+    fn drop(&mut self) {
+        if let Some(message_listeners) = self.message_listeners.upgrade() {
+            message_listeners.lock().unwrap().remove(&self.hdl);
+        }
+    }
+}
 
 /// Represents a HID communication channel supporting HID++.
 pub struct HidppChannel {
@@ -339,17 +360,25 @@ impl HidppChannel {
                             continue;
                         };
 
-                        let mut msgs = pending_messages.lock().unwrap();
                         let mut matched = false;
-                        if let Some(pos) =
-                            msgs.iter().position(|elem| (elem.response_predicate)(&msg))
                         {
-                            let waiting = msgs.remove(pos).unwrap();
-                            let _ = waiting.sender.send(msg);
-                            matched = true;
+                            let mut msgs = pending_messages.lock().unwrap();
+                            if let Some(pos) =
+                                msgs.iter().position(|elem| (elem.response_predicate)(&msg))
+                            {
+                                let waiting = msgs.remove(pos).unwrap();
+                                let _ = waiting.sender.send(msg);
+                                matched = true;
+                            }
                         }
 
-                        for listener in message_listeners.lock().unwrap().values() {
+                        let listeners: Vec<_> = message_listeners
+                            .lock()
+                            .unwrap()
+                            .values()
+                            .cloned()
+                            .collect();
+                        for listener in listeners {
                             listener(msg, matched);
                         }
                     }
@@ -561,7 +590,10 @@ impl HidppChannel {
     ///
     /// Returns a handle that can be used to remove the listener using a call to
     /// [`Self::remove_msg_listener`].
-    pub fn add_msg_listener(&self, listener: impl Fn(HidppMessage, bool) + Send + 'static) -> u32 {
+    pub fn add_msg_listener(
+        &self,
+        listener: impl Fn(HidppMessage, bool) + Send + Sync + 'static,
+    ) -> u32 {
         let mut listeners = self.message_listeners.lock().unwrap();
 
         let mut rng = rand::rng();
@@ -570,8 +602,21 @@ impl HidppChannel {
             hdl = rng.random::<u32>();
         }
 
-        listeners.insert(hdl, Box::new(listener));
+        listeners.insert(hdl, Arc::new(listener));
         hdl
+    }
+
+    /// Registers a listener that is automatically removed when the returned
+    /// guard is dropped.
+    pub fn add_msg_listener_guarded(
+        &self,
+        listener: impl Fn(HidppMessage, bool) + Send + Sync + 'static,
+    ) -> MessageListenerGuard {
+        let hdl = self.add_msg_listener(listener);
+        MessageListenerGuard {
+            message_listeners: Arc::downgrade(&self.message_listeners),
+            hdl,
+        }
     }
 
     /// Removes a previously registered message listener.
@@ -636,7 +681,10 @@ mod tests {
     use super::*;
     use std::{
         io,
-        sync::{Arc, Mutex},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::{Duration, Instant},
     };
 
@@ -796,6 +844,37 @@ mod tests {
         });
     }
 
+    #[test]
+    fn listener_can_remove_another_listener_during_dispatch() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = Arc::new(HidppChannel::from_raw_channel(raw).await.unwrap());
+            let removed_listener_calls = Arc::new(AtomicUsize::new(0));
+            let removing_listener_calls = Arc::new(AtomicUsize::new(0));
+
+            let removed_listener_calls_for_listener = Arc::clone(&removed_listener_calls);
+            let removed_hdl = channel.add_msg_listener(move |_, _| {
+                removed_listener_calls_for_listener.fetch_add(1, Ordering::SeqCst);
+            });
+
+            let channel_for_listener = Arc::clone(&channel);
+            let removing_listener_calls_for_listener = Arc::clone(&removing_listener_calls);
+            channel.add_msg_listener(move |_, _| {
+                removing_listener_calls_for_listener.fetch_add(1, Ordering::SeqCst);
+                channel_for_listener.remove_msg_listener(removed_hdl);
+            });
+
+            handle.send_incoming(short_msg(0x20)).await;
+            wait_for_atomic_count(&removing_listener_calls, 1).await;
+            wait_for_atomic_count(&removed_listener_calls, 1).await;
+
+            handle.send_incoming(short_msg(0x21)).await;
+            wait_for_atomic_count(&removing_listener_calls, 2).await;
+
+            assert_eq!(removed_listener_calls.load(Ordering::SeqCst), 1);
+        });
+    }
+
     #[derive(Clone)]
     struct MockRawHidHandle {
         incoming_tx: async_channel::Sender<Vec<u8>>,
@@ -914,6 +993,18 @@ mod tests {
         }
 
         panic!("timed out waiting for {count} listener events");
+    }
+
+    async fn wait_for_atomic_count(count: &AtomicUsize, expected: usize) {
+        let started = Instant::now();
+        while started.elapsed() < Duration::from_secs(1) {
+            if count.load(Ordering::SeqCst) >= expected {
+                return;
+            }
+            futures_timer::Delay::new(Duration::from_millis(10)).await;
+        }
+
+        panic!("timed out waiting for atomic count {expected}");
     }
 
     fn mock_error() -> Box<dyn Error + Sync + Send> {

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -231,13 +231,6 @@ pub struct MessageListenerGuard {
     hdl: u32,
 }
 
-impl MessageListenerGuard {
-    /// Returns the raw listener handle managed by this guard.
-    pub fn handle(&self) -> u32 {
-        self.hdl
-    }
-}
-
 impl Drop for MessageListenerGuard {
     fn drop(&mut self) {
         if let Some(message_listeners) = self.message_listeners.upgrade() {

--- a/crates/openlogi-hidpp/src/event.rs
+++ b/crates/openlogi-hidpp/src/event.rs
@@ -17,6 +17,7 @@ impl<T: Clone> EventEmitter<T> {
     /// list.
     pub fn create_receiver(&self) -> async_channel::Receiver<T> {
         let mut senders = self.senders.lock().unwrap();
+        senders.retain(|sender| sender.receiver_count() > 0);
         let (tx, rx) = async_channel::unbounded();
         senders.push(tx);
         rx
@@ -26,6 +27,39 @@ impl<T: Clone> EventEmitter<T> {
     /// removed from the list.
     pub fn emit(&self, event: T) {
         let mut senders = self.senders.lock().unwrap();
-        senders.retain(|sender| sender.send_blocking(event.clone()).is_ok());
+        senders.retain(|sender| {
+            sender.receiver_count() > 0 && sender.send_blocking(event.clone()).is_ok()
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_receiver_prunes_abandoned_senders_without_waiting_for_emit() {
+        let emitter = EventEmitter::<u8>::new();
+
+        let rx = emitter.create_receiver();
+        drop(rx);
+
+        let _rx = emitter.create_receiver();
+
+        assert_eq!(emitter.senders.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn emit_prunes_abandoned_senders() {
+        let emitter = EventEmitter::<u8>::new();
+
+        let live = emitter.create_receiver();
+        let dropped = emitter.create_receiver();
+        drop(dropped);
+
+        emitter.emit(7);
+
+        assert_eq!(live.recv_blocking().unwrap(), 7);
+        assert_eq!(emitter.senders.lock().unwrap().len(), 1);
     }
 }

--- a/crates/openlogi-hidpp/src/feature/hires_wheel/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/hires_wheel/mod.rs
@@ -6,7 +6,7 @@ use std::{hash::Hash, sync::Arc};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-    channel::HidppChannel,
+    channel::{HidppChannel, MessageListenerGuard},
     event::EventEmitter,
     feature::{CreatableFeature, EmittingFeature, Feature, FeatureEndpoint, event_payload},
     nibble::U4,
@@ -24,10 +24,8 @@ pub struct HiResWheelFeature {
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<HiResWheelEvent>>,
 
-    /// The handle assigned to the message listener registered via
-    /// [`HidppChannel::add_msg_listener`].
-    /// This is used to remove the listener when the feature is dropped.
-    msg_listener_hdl: u32,
+    /// Removes the message listener when the feature is dropped.
+    _msg_listener: MessageListenerGuard,
 }
 
 impl CreatableFeature for HiResWheelFeature {
@@ -37,7 +35,7 @@ impl CreatableFeature for HiResWheelFeature {
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         let emitter = Arc::new(EventEmitter::new());
 
-        let hdl = chan.add_msg_listener({
+        let listener = chan.add_msg_listener_guarded({
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
@@ -79,7 +77,7 @@ impl CreatableFeature for HiResWheelFeature {
         Self {
             endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
             emitter,
-            msg_listener_hdl: hdl,
+            _msg_listener: listener,
         }
     }
 }
@@ -89,14 +87,6 @@ impl Feature for HiResWheelFeature {}
 impl EmittingFeature<HiResWheelEvent> for HiResWheelFeature {
     fn listen(&self) -> async_channel::Receiver<HiResWheelEvent> {
         self.emitter.create_receiver()
-    }
-}
-
-impl Drop for HiResWheelFeature {
-    fn drop(&mut self) {
-        self.endpoint
-            .chan()
-            .remove_msg_listener(self.msg_listener_hdl);
     }
 }
 

--- a/crates/openlogi-hidpp/src/feature/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/mod.rs
@@ -71,11 +71,6 @@ impl FeatureEndpoint {
         }
     }
 
-    /// The channel this endpoint talks over.
-    pub(crate) fn chan(&self) -> &HidppChannel {
-        &self.chan
-    }
-
     /// The request header addressing `function` on this endpoint, stamped with
     /// the channel's next software id.
     ///

--- a/crates/openlogi-hidpp/src/feature/thumbwheel/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/thumbwheel/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-    channel::HidppChannel,
+    channel::{HidppChannel, MessageListenerGuard},
     event::EventEmitter,
     feature::{CreatableFeature, EmittingFeature, Feature, FeatureEndpoint, event_payload},
     protocol::v20::Hidpp20Error,
@@ -20,10 +20,8 @@ pub struct ThumbwheelFeature {
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<ThumbwheelEvent>>,
 
-    /// The handle assigned to the message listener registered via
-    /// [`HidppChannel::add_msg_listener`].
-    /// This is used to remove the listener when the feature is dropped.
-    msg_listener_hdl: u32,
+    /// Removes the message listener when the feature is dropped.
+    _msg_listener: MessageListenerGuard,
 }
 
 impl CreatableFeature for ThumbwheelFeature {
@@ -33,7 +31,7 @@ impl CreatableFeature for ThumbwheelFeature {
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         let emitter = Arc::new(EventEmitter::new());
 
-        let hdl = chan.add_msg_listener({
+        let listener = chan.add_msg_listener_guarded({
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
@@ -65,7 +63,7 @@ impl CreatableFeature for ThumbwheelFeature {
         Self {
             endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
             emitter,
-            msg_listener_hdl: hdl,
+            _msg_listener: listener,
         }
     }
 }
@@ -75,14 +73,6 @@ impl Feature for ThumbwheelFeature {}
 impl EmittingFeature<ThumbwheelEvent> for ThumbwheelFeature {
     fn listen(&self) -> async_channel::Receiver<ThumbwheelEvent> {
         self.emitter.create_receiver()
-    }
-}
-
-impl Drop for ThumbwheelFeature {
-    fn drop(&mut self) {
-        self.endpoint
-            .chan()
-            .remove_msg_listener(self.msg_listener_hdl);
     }
 }
 

--- a/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
@@ -6,7 +6,7 @@ use std::{collections::HashSet, hash::Hash, sync::Arc};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-    channel::HidppChannel,
+    channel::{HidppChannel, MessageListenerGuard},
     event::EventEmitter,
     feature::{CreatableFeature, EmittingFeature, Feature, FeatureEndpoint, event_payload},
     protocol::v20::Hidpp20Error,
@@ -20,10 +20,8 @@ pub struct UnifiedBatteryFeature {
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<BatteryEvent>>,
 
-    /// The handle assigned to the message listener registered via
-    /// [`HidppChannel::add_msg_listener`].
-    /// This is used to remove the listener when the feature is dropped.
-    msg_listener_hdl: u32,
+    /// Removes the message listener when the feature is dropped.
+    _msg_listener: MessageListenerGuard,
 }
 
 impl CreatableFeature for UnifiedBatteryFeature {
@@ -33,7 +31,7 @@ impl CreatableFeature for UnifiedBatteryFeature {
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         let emitter = Arc::new(EventEmitter::new());
 
-        let hdl = chan.add_msg_listener({
+        let listener = chan.add_msg_listener_guarded({
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
@@ -65,7 +63,7 @@ impl CreatableFeature for UnifiedBatteryFeature {
         Self {
             endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
             emitter,
-            msg_listener_hdl: hdl,
+            _msg_listener: listener,
         }
     }
 }
@@ -75,14 +73,6 @@ impl Feature for UnifiedBatteryFeature {}
 impl EmittingFeature<BatteryEvent> for UnifiedBatteryFeature {
     fn listen(&self) -> async_channel::Receiver<BatteryEvent> {
         self.emitter.create_receiver()
-    }
-}
-
-impl Drop for UnifiedBatteryFeature {
-    fn drop(&mut self) {
-        self.endpoint
-            .chan()
-            .remove_msg_listener(self.msg_listener_hdl);
     }
 }
 

--- a/crates/openlogi-hidpp/src/feature/wireless_device_status/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/wireless_device_status/mod.rs
@@ -6,23 +6,18 @@ use std::sync::Arc;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-    channel::HidppChannel,
+    channel::{HidppChannel, MessageListenerGuard},
     event::EventEmitter,
     feature::{CreatableFeature, EmittingFeature, Feature, event_payload},
 };
 
 /// Implements the `WirelessDeviceStatus` / `0x1d4b` feature.
 pub struct WirelessDeviceStatusFeature {
-    /// The underlying HID++ channel.
-    chan: Arc<HidppChannel>,
-
     /// The emitter used to emit events.
     emitter: Arc<EventEmitter<WirelessDeviceStatusEvent>>,
 
-    /// The handle assigned to the message listener registered via
-    /// [`HidppChannel::add_msg_listener`].
-    /// This is used to remove the listener when the feature is dropped.
-    msg_listener_hdl: u32,
+    /// Removes the message listener when the feature is dropped.
+    _msg_listener: MessageListenerGuard,
 }
 
 impl CreatableFeature for WirelessDeviceStatusFeature {
@@ -32,7 +27,7 @@ impl CreatableFeature for WirelessDeviceStatusFeature {
     fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
         let emitter = Arc::new(EventEmitter::new());
 
-        let hdl = chan.add_msg_listener({
+        let listener = chan.add_msg_listener_guarded({
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
@@ -65,9 +60,8 @@ impl CreatableFeature for WirelessDeviceStatusFeature {
         });
 
         Self {
-            chan,
             emitter,
-            msg_listener_hdl: hdl,
+            _msg_listener: listener,
         }
     }
 }
@@ -77,12 +71,6 @@ impl Feature for WirelessDeviceStatusFeature {}
 impl EmittingFeature<WirelessDeviceStatusEvent> for WirelessDeviceStatusFeature {
     fn listen(&self) -> async_channel::Receiver<WirelessDeviceStatusEvent> {
         self.emitter.create_receiver()
-    }
-}
-
-impl Drop for WirelessDeviceStatusFeature {
-    fn drop(&mut self) {
-        self.chan.remove_msg_listener(self.msg_listener_hdl);
     }
 }
 

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -12,14 +12,13 @@
 
 use std::sync::Arc;
 
-use crate::receiver::ListenerDropGuard;
 use derive_builder::Builder;
 use futures::{FutureExt, pin_mut, select};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use super::{RECEIVER_DEVICE_INDEX, ReceiverError};
 use crate::{
-    channel::HidppChannel,
+    channel::{HidppChannel, MessageListenerGuard},
     event::EventEmitter,
     protocol::v10::{self, Hidpp10Error},
 };
@@ -93,7 +92,7 @@ pub enum InfoSubRegister {
 pub struct Receiver {
     chan: Arc<HidppChannel>,
     emitter: Arc<EventEmitter<Event>>,
-    _listener: Arc<ListenerDropGuard>,
+    _listener: Arc<MessageListenerGuard>,
 }
 
 impl Receiver {
@@ -109,7 +108,7 @@ impl Receiver {
 
         let emitter = Arc::new(EventEmitter::new());
 
-        let hdl = chan.add_msg_listener({
+        let listener = chan.add_msg_listener_guarded({
             let emitter = Arc::clone(&emitter);
 
             move |raw, matched| {
@@ -230,10 +229,7 @@ impl Receiver {
         });
 
         Ok(Receiver {
-            _listener: Arc::new(ListenerDropGuard {
-                chan: Arc::clone(&chan),
-                hdl,
-            }),
+            _listener: Arc::new(listener),
             chan,
             emitter,
         })

--- a/crates/openlogi-hidpp/src/receiver/mod.rs
+++ b/crates/openlogi-hidpp/src/receiver/mod.rs
@@ -18,23 +18,6 @@ use thiserror::Error;
 
 use crate::{channel::HidppChannel, protocol::v10::Hidpp10Error};
 
-/// Removes a HID++ message listener when the last receiver clone is dropped.
-///
-/// Storing this inside an `Arc` on the receiver struct prevents the
-/// `#[derive(Clone)]` copy from sharing the raw `u32` handle: cloning a
-/// receiver increments the Arc refcount, and `remove_msg_listener` is called
-/// exactly once — when the last clone's Arc refcount reaches zero.
-pub(super) struct ListenerDropGuard {
-    pub(super) chan: Arc<HidppChannel>,
-    pub(super) hdl: u32,
-}
-
-impl Drop for ListenerDropGuard {
-    fn drop(&mut self) {
-        self.chan.remove_msg_listener(self.hdl);
-    }
-}
-
 pub mod bolt;
 pub mod unifying;
 

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-    channel::HidppChannel,
+    channel::{HidppChannel, MessageListenerGuard},
     event::EventEmitter,
     protocol::v10::{self, Hidpp10Error},
-    receiver::{ListenerDropGuard, RECEIVER_DEVICE_INDEX, ReceiverError},
+    receiver::{RECEIVER_DEVICE_INDEX, ReceiverError},
 };
 
 /// All USB vendor & product ID pairs that are known to identify Unifying
@@ -65,7 +65,7 @@ pub enum InfoSubRegister {
 pub struct Receiver {
     chan: Arc<HidppChannel>,
     emitter: Arc<EventEmitter<Event>>,
-    _listener: Arc<ListenerDropGuard>,
+    _listener: Arc<MessageListenerGuard>,
 }
 
 impl Receiver {
@@ -80,7 +80,7 @@ impl Receiver {
 
         let emitter = Arc::new(EventEmitter::new());
 
-        let hdl = chan.add_msg_listener({
+        let listener = chan.add_msg_listener_guarded({
             let emitter = Arc::clone(&emitter);
             move |raw, matched| {
                 if matched {
@@ -112,10 +112,7 @@ impl Receiver {
         });
 
         Ok(Receiver {
-            _listener: Arc::new(ListenerDropGuard {
-                chan: Arc::clone(&chan),
-                hdl,
-            }),
+            _listener: Arc::new(listener),
             chan,
             emitter,
         })


### PR DESCRIPTION
## Summary
- dispatch HID++ message listeners outside the pending-message and listener-map locks
- add a RAII MessageListenerGuard API that unregisters listeners on drop
- migrate internal receiver, feature, pairing, and gesture listeners to the guard
- add a regression test for listener removal during dispatch

## Validation
- cargo fmt --check
- cargo test -p openlogi-hidpp
- cargo test -p openlogi-hid
- cargo test -p openlogi-hid pairing::tests after rebasing onto PR #298
- cargo clippy -p openlogi-hidpp --all-targets -- -D warnings
- cargo clippy -p openlogi-hid --all-targets -- -D warnings
- pre-push cargo clippy --workspace --all-targets -- -D warnings

Stacked on #298.