### PR TITLE
feat(ipc): poll agent snapshots

### DIFF
--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -2,9 +2,9 @@
 //!
 //! tarpc generates the `AgentClient` and the `serve` glue from this trait. tarpc
 //! is strict request/response — no server push — so the streaming needs become
-//! polling: the GUI polls [`Agent::inventory`]/[`Agent::status`] on a timer, and
-//! the Add Device flow long-polls [`Agent::next_pairing`], which the agent holds
-//! open until a pairing event arrives or the request deadline elapses.
+//! polling: the GUI polls [`Agent::snapshot`] on a timer, and the Add Device
+//! flow long-polls [`Agent::next_pairing`], which the agent holds open until a
+//! pairing event arrives or the request deadline elapses.
 
 use openlogi_core::config::Lighting;
 use openlogi_core::device::DeviceInventory;
@@ -21,13 +21,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// v2: `AgentStatus::inventory_ready` added.
 /// v3: `inventory_ready` widened to [`InventoryHealth`] (adds `Unavailable`).
-pub const PROTOCOL_VERSION: u32 = 3;
+/// v4: [`Agent::snapshot`] added for atomic status + inventory polling.
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Where the agent's device enumeration stands. The distinction matters
-/// because an empty [`Agent::inventory`] is ambiguous on its own: the GUI must
-/// keep its scanning state while the answer simply isn't in yet, show the
-/// empty state only for a *completed* scan that found nothing, and surface an
-/// error — rather than scan forever — when enumeration itself is broken.
+/// because an empty inventory list is ambiguous on its own: the GUI must keep
+/// its scanning state while the answer simply isn't in yet, show the empty
+/// state only for a *completed* scan that found nothing, and surface an error —
+/// rather than scan forever — when enumeration itself is broken.
 ///
 /// bincode encodes the variant *index*, so variants are append-only, like the
 /// [`Agent`] trait methods.
@@ -35,7 +36,7 @@ pub const PROTOCOL_VERSION: u32 = 3;
 pub enum InventoryHealth {
     /// The first enumeration hasn't completed yet — the device set is unknown.
     Scanning,
-    /// At least one enumeration has completed; [`Agent::inventory`] is
+    /// At least one enumeration has completed; the inventory list is
     /// authoritative (an empty list really means no devices).
     Ready,
     /// Enumeration has never succeeded and has stopped being retried as a
@@ -55,6 +56,15 @@ pub struct AgentStatus {
     pub inventory: InventoryHealth,
     pub protocol_version: u32,
     pub agent_version: String,
+}
+
+/// Status and inventory as one poll result. Kept together so the GUI never
+/// pairs inventory readiness from one orchestrator state with the inventory
+/// list from another.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSnapshot {
+    pub status: AgentStatus,
+    pub inventory: Vec<DeviceInventory>,
 }
 
 /// A nearby unpaired device surfaced during Bolt discovery, in the minimal form
@@ -141,4 +151,9 @@ pub trait Agent {
     /// window elapses with no event (the GUI simply re-polls); the GUI drives
     /// this in a loop while the Add Device window is open.
     async fn next_pairing() -> Option<PairingUpdate>;
+    /// Atomically fetch status and the latest inventory for the GUI poll loop.
+    ///
+    /// Appended for protocol v4. Keep future methods append-only; method order
+    /// is wire-sensitive (see [`Self::protocol_version`]).
+    async fn snapshot() -> AgentSnapshot;
 }

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -23,7 +23,8 @@ use std::fmt::Write;
 
 use bincode::Options;
 use openlogi_agent_core::ipc::{
-    AgentRequest, AgentStatus, FoundDevice, InventoryHealth, PROTOCOL_VERSION, PairingUpdate,
+    AgentRequest, AgentSnapshot, AgentStatus, FoundDevice, InventoryHealth, PROTOCOL_VERSION,
+    PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{
@@ -60,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 3);
+    assert_eq!(PROTOCOL_VERSION, 4);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -80,6 +81,7 @@ fn request_variant_order() {
         "040008463030444341464501fb4006",
     );
     assert_wire(&AgentRequest::NextPairing {}, "0d");
+    assert_wire(&AgentRequest::Snapshot {}, "0e");
 }
 
 #[test]
@@ -99,6 +101,22 @@ fn agent_status() {
     assert_wire(&InventoryHealth::Scanning, "00");
     assert_wire(&InventoryHealth::Ready, "01");
     assert_wire(&InventoryHealth::Unavailable, "02");
+}
+
+#[test]
+fn agent_snapshot() {
+    let snapshot = AgentSnapshot {
+        status: AgentStatus {
+            accessibility_granted: true,
+            hook_installed: false,
+            launch_at_login: true,
+            inventory: InventoryHealth::Ready,
+            protocol_version: 7,
+            agent_version: "0.6.6".into(),
+        },
+        inventory: Vec::new(),
+    };
+    assert_wire(&snapshot, "010001010705302e362e3600");
 }
 
 #[test]

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -3,13 +3,15 @@
 //! (a Unix-domain socket on Unix, a named pipe on Windows).
 //!
 //! The agent owns all device I/O, so the GUI never opens a device — it routes
-//! "apply now" / "read" commands here, and polls inventory/status.
+//! "apply now" / "read" commands here, and polls snapshots.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures::StreamExt as _;
-use openlogi_agent_core::ipc::{Agent, AgentStatus, PROTOCOL_VERSION, PairingUpdate};
+use openlogi_agent_core::ipc::{
+    Agent, AgentSnapshot, AgentStatus, PROTOCOL_VERSION, PairingUpdate,
+};
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::{hardware, transport};
 use openlogi_core::config::{Config, Lighting};
@@ -135,6 +137,28 @@ impl Agent for AgentServer {
 
     async fn next_pairing(self, _: Context) -> Option<PairingUpdate> {
         self.pairing.next_update().await
+    }
+
+    async fn snapshot(self, _: Context) -> AgentSnapshot {
+        let (launch_at_login, inventory_health, inventory) = {
+            let orch = self.orchestrator.lock().await;
+            (
+                orch.launch_at_login(),
+                orch.inventory_health(),
+                orch.inventory(),
+            )
+        };
+        AgentSnapshot {
+            status: AgentStatus {
+                accessibility_granted: Hook::has_accessibility(),
+                hook_installed: self.hook_installed.load(Ordering::Relaxed),
+                launch_at_login,
+                inventory: inventory_health,
+                protocol_version: PROTOCOL_VERSION,
+                agent_version: env!("CARGO_PKG_VERSION").to_string(),
+            },
+            inventory,
+        }
     }
 }
 

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -2,8 +2,8 @@
 //!
 //! The agent owns all device I/O, so the GUI never opens a device — it connects
 //! to the agent's Unix socket and (a) polls status + inventory snapshots on a
-//! timer to drive the device list and the Accessibility gate, and (b) forwards "apply
-//! now" / "read" device commands. Both run on one dedicated OS thread with a
+//! timer to drive the device list and the Accessibility gate, and (b) forwards
+//! "apply now" / "read" device commands. Both run on one dedicated OS thread with a
 //! tokio runtime (the GPUI thread owns no async runtime), mirroring the old
 //! watcher pattern: results cross back over `mpsc` to the GPUI loop.
 //!

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -1,8 +1,8 @@
 //! Client side of the agent IPC.
 //!
 //! The agent owns all device I/O, so the GUI never opens a device — it connects
-//! to the agent's Unix socket and (a) polls status + inventory on a timer to
-//! drive the device list and the Accessibility gate, and (b) forwards "apply
+//! to the agent's Unix socket and (a) polls status + inventory snapshots on a
+//! timer to drive the device list and the Accessibility gate, and (b) forwards "apply
 //! now" / "read" device commands. Both run on one dedicated OS thread with a
 //! tokio runtime (the GPUI thread owns no async runtime), mirroring the old
 //! watcher pattern: results cross back over `mpsc` to the GPUI loop.
@@ -41,7 +41,7 @@ const SPAWN_RETRY_PERIOD: Duration = Duration::from_secs(30);
 /// ([`InventoryHealth::Ready`]). The steady `poll_period` is tuned for quiet
 /// background refresh; at startup it would leave the window on its loading
 /// frame for up to a full period *after* the agent already knows the devices.
-/// A status+inventory round every 250 ms is noise for the agent and gets the
+/// A snapshot round every 250 ms is noise for the agent and gets the
 /// gallery up moments after enumeration lands.
 const STARTUP_POLL_PERIOD: Duration = Duration::from_millis(250);
 
@@ -129,7 +129,7 @@ pub fn spawn(poll_period: Duration) -> IpcClient {
             };
             rt.block_on(async move {
                 // Pairing events stream on their own connection + long-poll so
-                // a held next_pairing never delays the status/inventory poll.
+                // a held next_pairing never delays the snapshot poll.
                 tokio::spawn(pairing_poll(pairing_tx));
                 poll_loop(poll_period, &update_tx, &mut cmd_rx).await;
             });
@@ -655,8 +655,8 @@ enum PollOutcome {
     NewerAgent,
 }
 
-/// Poll status + inventory and push a snapshot. `Err` means a live connection
-/// dropped (the caller reconnects fast); the no-agent cases come back as
+/// Poll status + inventory as one agent snapshot and push it. `Err` means a
+/// live connection dropped (the caller reconnects fast); the no-agent cases come back as
 /// [`PollOutcome`] so the caller can tell them apart from a delivery.
 async fn poll(
     client: &mut Option<AgentClient>,
@@ -667,15 +667,11 @@ async fn poll(
         Err(ConnectFailure::Unreachable) => return Ok(PollOutcome::NoAgent),
         Err(ConnectFailure::NewerAgent) => return Ok(PollOutcome::NewerAgent),
     };
-    // Status strictly before inventory: status carries the readiness the
-    // inventory is interpreted under. Fetched the other way around, the
-    // agent's first enumeration could land *between* the two RPCs and pair an
-    // empty pre-enumeration inventory with "ready" — exactly the "No devices"
-    // flash this poll exists to prevent. The inverse pairing (fresh inventory
-    // under a stale not-ready status) is benign: devices render regardless of
-    // the scanning state, and readiness lands next tick.
-    let status = client.status(context::current()).await.map_err(|_| ())?;
-    let inventory = client.inventory(context::current()).await.map_err(|_| ())?;
+    // Fetch status + inventory in one RPC so inventory readiness and the list
+    // are interpreted from the same orchestrator state.
+    let snapshot = client.snapshot(context::current()).await.map_err(|_| ())?;
+    let status = snapshot.status;
+    let inventory = snapshot.inventory;
     let ready = status.inventory == InventoryHealth::Ready;
     let _ = update_tx.send(GuiUpdate::Snapshot(PollUpdate { inventory, status }));
     Ok(PollOutcome::Delivered { ready })


### PR DESCRIPTION
## Summary
- add AgentSnapshot and append a v4 snapshot RPC to the tarpc Agent service
- return inventory health and inventory from one orchestrator-state read on the agent
- update the GUI IPC poll loop to use snapshot() instead of separate status()+inventory() RPCs
- pin the new protocol version and request variant in wire-format tests

## Validation
- cargo fmt --check
- cargo test -p openlogi-agent-core -p openlogi-agent -p openlogi-gui
- cargo clippy -p openlogi-agent-core -p openlogi-agent -p openlogi-gui --all-targets -- -D warnings
- pre-push cargo clippy --workspace --all-targets -- -D warnings

Stacked on #299.