### PR TITLE
refactor(agent): arbitrate receiver access with leases

### DIFF
--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -9,8 +9,8 @@
 use openlogi_core::config::Lighting;
 use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{
-    DeviceRoute, DpiInfo, PasskeyMethod, ReceiverSelector, SmartShiftMode, SmartShiftStatus,
-    WriteError,
+    DeviceRoute, DpiInfo, PairingError, PasskeyMethod, ReceiverSelector, SmartShiftMode,
+    SmartShiftStatus, WriteError,
 };
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,8 @@ use serde::{Deserialize, Serialize};
 /// v2: `AgentStatus::inventory_ready` added.
 /// v3: `inventory_ready` widened to [`InventoryHealth`] (adds `Unavailable`).
 /// v4: [`Agent::snapshot`] added for atomic status + inventory polling.
-pub const PROTOCOL_VERSION: u32 = 4;
+/// v5: [`PairingUpdate::Failed`] carries a typed [`PairingFailure`].
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep
@@ -78,9 +79,54 @@ pub struct FoundDevice {
     pub name: String,
 }
 
+/// Terminal failure reason for a pairing session.
+///
+/// Kept typed across the agent↔GUI boundary so the GUI can choose recovery UI,
+/// telemetry, and localized copy without matching human-readable strings.
+///
+/// bincode encodes the variant *index*, so variants are append-only, like the
+/// [`Agent`] trait methods.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PairingFailure {
+    /// The HID transport returned an error.
+    Hid { message: String },
+    /// No connected receiver supports pairing.
+    ReceiverNotFound,
+    /// HID++ receiver register access failed.
+    Register { message: String },
+    /// The device or receiver did not complete pairing before its deadline.
+    Timeout,
+    /// The receiver reported a protocol-level pairing error code.
+    Device { code: u8 },
+    /// The user cancelled the pairing session.
+    Cancelled,
+    /// The agent could not obtain exclusive receiver ownership for pairing.
+    ReceiverBusy,
+    /// The pairing watcher is unavailable inside the agent process.
+    WatcherUnavailable,
+    /// The background agent restarted during an active pairing session.
+    AgentRestarted,
+    /// The agent could not store its exclusive receiver ownership lease.
+    ReceiverAccessUnavailable,
+}
+
+impl From<PairingError> for PairingFailure {
+    fn from(error: PairingError) -> Self {
+        match error {
+            PairingError::Hid(message) => Self::Hid { message },
+            PairingError::ReceiverNotFound => Self::ReceiverNotFound,
+            PairingError::Register(message) => Self::Register { message },
+            PairingError::Timeout => Self::Timeout,
+            PairingError::Device(code) => Self::Device { code },
+            PairingError::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
 /// One step of a pairing session, streamed to the GUI via [`Agent::next_pairing`].
 /// Mirrors `openlogi_hid::PairingEvent` but in a wire-safe form — the discovered
-/// device collapses to [`FoundDevice`] and the terminal error to a string.
+/// device collapses to [`FoundDevice`] and terminal failures to
+/// [`PairingFailure`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PairingUpdate {
     /// Discovery (Bolt) / the pairing lock (Unifying) is open.
@@ -91,8 +137,8 @@ pub enum PairingUpdate {
     Passkey(PasskeyMethod),
     /// A device paired into `slot`.
     Paired { slot: u8 },
-    /// The flow ended without pairing a device (carries a human-readable detail).
-    Failed(String),
+    /// The flow ended without pairing a device.
+    Failed(PairingFailure),
 }
 
 #[tarpc::service]

--- a/crates/openlogi-agent-core/src/lib.rs
+++ b/crates/openlogi-agent-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hardware;
 pub mod hook_runtime;
 pub mod ipc;
 pub mod orchestrator;
+pub mod receiver_access;
 pub mod transport;
 pub mod watchers;
 

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -24,6 +24,7 @@ use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
 use crate::device_order::DeviceStableId;
 use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::ipc::InventoryHealth;
+use crate::receiver_access::ReceiverAccess;
 use crate::watchers::gesture::GestureBindings;
 
 /// The minimal per-device facts the agent needs: the config key (binding /
@@ -61,14 +62,9 @@ pub struct SharedRuntime {
     /// setting rather than applying per-device simultaneously.
     pub invert_scroll: Arc<AtomicBool>,
     pub capture_channel: CaptureChannel,
-    /// Set while a pairing session runs: the gesture watcher then releases its
-    /// capture session so `run_pairing` can own the receiver's HID node (one
-    /// process still can't read the same node through two channels).
-    pub pairing_active: Arc<AtomicBool>,
-    /// Published by the gesture watcher: `true` when it holds no capture
-    /// session, so the pairing manager can wait for capture to actually release
-    /// before opening the receiver.
-    pub capture_idle: Arc<AtomicBool>,
+    /// Exclusive receiver access shared by HID++ capture and pairing. Capture
+    /// and pairing must never open the same receiver HID node concurrently.
+    pub receiver_access: ReceiverAccess,
 }
 
 /// Owns the config + device selection and keeps [`SharedRuntime`] in sync.
@@ -119,8 +115,7 @@ impl Orchestrator {
             // device's real setting once devices are known.
             invert_scroll: Arc::new(AtomicBool::new(false)),
             capture_channel: Arc::new(RwLock::new(None)),
-            pairing_active: Arc::new(AtomicBool::new(false)),
-            capture_idle: Arc::new(AtomicBool::new(true)),
+            receiver_access: ReceiverAccess::default(),
         };
         let orch = Self {
             config,

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -1,0 +1,147 @@
+//! Exclusive receiver access coordination between HID++ capture and pairing.
+//!
+//! The active-device capture session and a pairing session cannot both open the
+//! same receiver HID node. This small arbiter makes that ownership explicit: the
+//! capture watcher may run only while it holds a capture lease, and pairing first
+//! announces its intent (so capture stops) before awaiting an exclusive pairing
+//! lease.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+/// Coordinates exclusive access to the receiver HID node.
+#[derive(Clone, Default)]
+pub struct ReceiverAccess {
+    inner: Arc<ReceiverAccessInner>,
+}
+
+#[derive(Default)]
+struct ReceiverAccessInner {
+    lease: Arc<Mutex<()>>,
+    pairing_requested: Arc<AtomicBool>,
+}
+
+/// Exclusive receiver lease held by the capture watcher.
+pub struct CaptureReceiverLease {
+    _guard: OwnedMutexGuard<()>,
+}
+
+/// Exclusive receiver lease held by a pairing session.
+pub struct PairingReceiverLease {
+    _guard: OwnedMutexGuard<()>,
+    pairing_requested: Arc<AtomicBool>,
+}
+
+impl Drop for PairingReceiverLease {
+    fn drop(&mut self) {
+        self.pairing_requested.store(false, Ordering::Release);
+    }
+}
+
+impl ReceiverAccess {
+    /// Whether a pairing session is waiting for or holding receiver access.
+    #[must_use]
+    pub fn pairing_requested(&self) -> bool {
+        self.inner.pairing_requested.load(Ordering::Acquire)
+    }
+
+    /// Try to acquire receiver access for the capture watcher.
+    ///
+    /// Capture is opportunistic: if pairing is waiting or active, capture should
+    /// stay idle and retry on its next management tick.
+    #[must_use]
+    pub fn try_acquire_for_capture(&self) -> Option<CaptureReceiverLease> {
+        if self.pairing_requested() {
+            return None;
+        }
+        let guard = Arc::clone(&self.inner.lease).try_lock_owned().ok()?;
+        if self.pairing_requested() {
+            return None;
+        }
+        Some(CaptureReceiverLease { _guard: guard })
+    }
+
+    /// Request and acquire exclusive receiver access for pairing.
+    ///
+    /// If the returned future is cancelled while waiting, the pairing request is
+    /// withdrawn automatically so capture can resume.
+    pub async fn acquire_for_pairing(&self) -> PairingReceiverLease {
+        let request = PairingRequest::new(Arc::clone(&self.inner.pairing_requested));
+        let guard = Arc::clone(&self.inner.lease).lock_owned().await;
+        request.disarm();
+        PairingReceiverLease {
+            _guard: guard,
+            pairing_requested: Arc::clone(&self.inner.pairing_requested),
+        }
+    }
+}
+
+struct PairingRequest {
+    pairing_requested: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl PairingRequest {
+    fn new(pairing_requested: Arc<AtomicBool>) -> Self {
+        pairing_requested.store(true, Ordering::Release);
+        Self {
+            pairing_requested,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PairingRequest {
+    fn drop(&mut self) {
+        if self.armed {
+            self.pairing_requested.store(false, Ordering::Release);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pairing_request_blocks_new_capture_until_pairing_lease_drops() {
+        let access = ReceiverAccess::default();
+
+        let pairing = access.acquire_for_pairing().await;
+
+        assert!(access.pairing_requested());
+        assert!(access.try_acquire_for_capture().is_none());
+
+        drop(pairing);
+
+        assert!(!access.pairing_requested());
+        assert!(access.try_acquire_for_capture().is_some());
+    }
+
+    #[tokio::test]
+    async fn cancelled_pairing_wait_withdraws_request() {
+        let access = ReceiverAccess::default();
+        let capture = access.try_acquire_for_capture().unwrap_or_else(|| {
+            panic!("fresh receiver access should grant capture lease");
+        });
+
+        let waiting = tokio::spawn({
+            let access = access.clone();
+            async move { access.acquire_for_pairing().await }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        assert!(access.pairing_requested());
+
+        waiting.abort();
+        let _ = waiting.await;
+        assert!(!access.pairing_requested());
+        drop(capture);
+        assert!(access.try_acquire_for_capture().is_some());
+    }
+}

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -19,7 +19,7 @@
 //! way regardless.
 
 use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -32,6 +32,7 @@ use tracing::{debug, warn};
 
 use crate::DpiCycleState;
 use crate::hook_runtime::{self, SharedHookMaps};
+use crate::receiver_access::ReceiverAccess;
 
 /// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
 /// direction). The watcher reads it to map a captured swipe to a bound action.
@@ -79,8 +80,7 @@ pub fn spawn(
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture_channel: CaptureChannel,
     thumbwheel_sensitivity: ThumbwheelSensitivity,
-    pairing_active: Arc<AtomicBool>,
-    capture_idle: Arc<AtomicBool>,
+    receiver_access: ReceiverAccess,
 ) {
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -99,8 +99,7 @@ pub fn spawn(
             dpi_cycle,
             capture_channel,
             thumbwheel_sensitivity,
-            pairing_active,
-            capture_idle,
+            receiver_access,
         ));
     });
 }
@@ -151,8 +150,7 @@ async fn manage(
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture_channel: CaptureChannel,
     thumbwheel_sensitivity: ThumbwheelSensitivity,
-    pairing_active: Arc<AtomicBool>,
-    capture_idle: Arc<AtomicBool>,
+    receiver_access: ReceiverAccess,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
     // (route, capture_thumbwheel, divert_gesture_button)
@@ -185,10 +183,10 @@ async fn manage(
                 );
             }
             _ = ticker.tick() => {
-                // While pairing, release the capture session so run_pairing can
-                // own the receiver's HID node (one process can't read it through
-                // two channels). The pairing manager waits on `capture_idle`.
-                let want = if pairing_active.load(Ordering::Relaxed) {
+                // While pairing is waiting or active, release the capture
+                // session so run_pairing can own the receiver's HID node (one
+                // process can't read it through two channels).
+                let want = if receiver_access.pairing_requested() {
                     None
                 } else {
                     let target = dpi_cycle.read().ok().and_then(|guard| guard.target.clone());
@@ -216,9 +214,16 @@ async fn manage(
                 if let Some(stop) = stop.take() {
                     let _ = stop.send(());
                 }
-                current.clone_from(&want);
-                capture_idle.store(want.is_none(), Ordering::Relaxed);
+                if current.is_some() {
+                    current = None;
+                    continue;
+                }
                 if let Some((route, capture_thumbwheel, divert_gesture_button)) = want {
+                    let Some(receiver_lease) = receiver_access.try_acquire_for_capture() else {
+                        current = None;
+                        continue;
+                    };
+                    current = Some((route.clone(), capture_thumbwheel, divert_gesture_button));
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let sink = tx.clone();
                     let slot = Arc::clone(&capture_channel);
@@ -226,6 +231,7 @@ async fn manage(
                     let session_epoch = epoch;
                     let done = done_tx.clone();
                     tokio::spawn(async move {
+                        let _receiver_lease = receiver_lease;
                         if let Err(e) = run_capture_session(
                             route,
                             capture_thumbwheel,
@@ -243,6 +249,8 @@ async fn manage(
                         let _ = done.send(session_epoch);
                     });
                     stop = Some(stop_tx);
+                } else {
+                    current = None;
                 }
             }
             Some(done_epoch) = done_rx.recv() => {
@@ -260,11 +268,6 @@ async fn manage(
                     // here is a no-op, but it stops the next tick from signalling a
                     // session that no longer exists.
                     stop = None;
-                    // No session owns the receiver now, so mark capture idle: the
-                    // tick's `want == current` short-circuit (None == None while
-                    // pairing wants None) would otherwise skip this update and a
-                    // pairing session waiting on `capture_idle` could stall.
-                    capture_idle.store(true, Ordering::Relaxed);
                 }
             }
         }

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -24,7 +24,7 @@ use std::fmt::Write;
 use bincode::Options;
 use openlogi_agent_core::ipc::{
     AgentRequest, AgentSnapshot, AgentStatus, FoundDevice, InventoryHealth, PROTOCOL_VERSION,
-    PairingUpdate,
+    PairingFailure, PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{
@@ -61,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 4);
+    assert_eq!(PROTOCOL_VERSION, 5);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -187,9 +187,10 @@ fn pairing_updates() {
         "0201023132020001",
     );
     assert_wire(&PairingUpdate::Paired { slot: 2 }, "0302");
+    assert_wire(&PairingUpdate::Failed(PairingFailure::Timeout), "0403");
     assert_wire(
-        &PairingUpdate::Failed("timed out".into()),
-        "040974696d6564206f7574",
+        &PairingUpdate::Failed(PairingFailure::Device { code: 0x1f }),
+        "04041f",
     );
 }
 

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -137,8 +137,7 @@ async fn run(config: Config) {
         shared.dpi_cycle.clone(),
         shared.capture_channel.clone(),
         shared.thumbwheel_sensitivity.clone(),
-        shared.pairing_active.clone(),
-        shared.capture_idle.clone(),
+        shared.receiver_access.clone(),
     );
 
     let mut inventory_rx = watchers::inventory::spawn(Duration::from_secs(2));

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -7,19 +7,20 @@
 //! (`start_pairing` / `pair_device` / `cancel_pairing` + a `next_pairing`
 //! long-poll for the event stream).
 //!
-//! While a session runs, the agent pauses its own capture via
-//! [`SharedRuntime::pairing_active`] and waits for [`SharedRuntime::capture_idle`]
-//! so `run_pairing` can own the receiver's HID node, then resumes capture when
-//! the session ends (every end — including cancel — emits a terminal event).
+//! While a session runs, the agent holds an exclusive receiver lease through
+//! [`SharedRuntime::receiver_access`], so `run_pairing` can own the receiver's
+//! HID node. Dropping that lease lets HID++ capture resume when the session ends
+//! (every end — including cancel — emits a terminal event).
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
 use openlogi_agent_core::orchestrator::SharedRuntime;
+use openlogi_agent_core::receiver_access::PairingReceiverLease;
 use openlogi_agent_core::watchers::pairing::{self, Control};
 use openlogi_hid::{DiscoveredDevice, PairingEvent, ReceiverSelector};
 use tokio::sync::{Mutex, mpsc};
@@ -29,6 +30,9 @@ use tracing::warn;
 /// Comfortably under the client's request deadline so the agent answers first.
 const HOLD: Duration = Duration::from_secs(20);
 
+/// How long pairing waits for HID++ capture to release the receiver lease.
+const RECEIVER_LEASE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Address-keyed cache of the full discovered devices, so the GUI can pair by
 /// address without round-tripping the non-serializable `DiscoveredDevice`.
 type DeviceCache = Arc<StdMutex<HashMap<[u8; 6], DiscoveredDevice>>>;
@@ -36,14 +40,15 @@ type DeviceCache = Arc<StdMutex<HashMap<[u8; 6], DiscoveredDevice>>>;
 /// Owns the pairing watcher and translates its event stream for the IPC layer.
 pub struct PairingManager {
     ctrl: mpsc::UnboundedSender<Control>,
+    update_tx: mpsc::UnboundedSender<PairingUpdate>,
     updates: Mutex<mpsc::UnboundedReceiver<PairingUpdate>>,
     devices: DeviceCache,
     /// Count of outstanding pairing sessions. The watcher is single-session,
-    /// so `start` atomically transitions this 0 → 1 (and sets
-    /// `pairing_active`); the translator decrements it on each terminal event
-    /// and lifts the capture pause when it returns to zero. Balanced: one
-    /// accepted `start` ⇒ exactly one terminal.
+    /// so `start` atomically transitions this 0 → 1. The translator decrements
+    /// it on each terminal event and releases the receiver lease when it returns
+    /// to zero. Balanced: one accepted `start` ⇒ exactly one terminal.
     sessions: Arc<AtomicUsize>,
+    receiver_lease: Arc<StdMutex<Option<PairingReceiverLease>>>,
     shared: SharedRuntime,
 }
 
@@ -56,18 +61,21 @@ impl PairingManager {
         let (upd_tx, upd_rx) = mpsc::unbounded_channel();
         let devices: DeviceCache = Arc::new(StdMutex::new(HashMap::new()));
         let sessions = Arc::new(AtomicUsize::new(0));
+        let receiver_lease = Arc::new(StdMutex::new(None));
         tokio::spawn(translate(
             raw_events,
-            upd_tx,
+            upd_tx.clone(),
             Arc::clone(&devices),
             Arc::clone(&sessions),
-            Arc::clone(&shared.pairing_active),
+            Arc::clone(&receiver_lease),
         ));
         Self {
             ctrl,
+            update_tx: upd_tx,
             updates: Mutex::new(upd_rx),
             devices,
             sessions,
+            receiver_lease,
             shared,
         }
     }
@@ -82,17 +90,41 @@ impl PairingManager {
             warn!("pairing start requested while a session is already active");
             return;
         }
+        let admission = SessionAdmission::new(Arc::clone(&self.sessions));
 
         if let Ok(mut devices) = self.devices.lock() {
             devices.clear();
         }
-        self.shared.pairing_active.store(true, Ordering::Relaxed);
-        self.wait_capture_idle().await;
-        if let Err(e) = self.ctrl.send(Control::Start(selector)) {
-            self.sessions.store(0, Ordering::Release);
-            self.shared.pairing_active.store(false, Ordering::Relaxed);
-            warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
+        let Ok(receiver_lease) = tokio::time::timeout(
+            RECEIVER_LEASE_TIMEOUT,
+            self.shared.receiver_access.acquire_for_pairing(),
+        )
+        .await
+        else {
+            let _ = self.update_tx.send(PairingUpdate::Failed(
+                "Timed out waiting for receiver capture to stop.".to_string(),
+            ));
+            warn!("timed out waiting for receiver capture to stop; pairing not started");
+            return;
+        };
+        if let Ok(mut slot) = self.receiver_lease.lock() {
+            *slot = Some(receiver_lease);
+        } else {
+            let _ = self.update_tx.send(PairingUpdate::Failed(
+                "Pairing is unavailable because receiver access could not be recorded.".to_string(),
+            ));
+            warn!("pairing receiver lease lock poisoned; aborting start");
+            return;
         }
+        if let Err(e) = self.ctrl.send(Control::Start(selector)) {
+            self.release_receiver_lease();
+            let _ = self.update_tx.send(PairingUpdate::Failed(
+                "Pairing is unavailable because the pairing watcher is not running.".to_string(),
+            ));
+            warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
+            return;
+        }
+        admission.commit();
     }
 
     /// Pair with a previously discovered device by address.
@@ -110,7 +142,7 @@ impl PairingManager {
     }
 
     /// Cancel the in-progress session. The resulting `Failed(Cancelled)` event
-    /// resumes capture via the translator — don't clear `pairing_active` here, or
+    /// releases the receiver lease via the translator — don't release it here, or
     /// capture could re-acquire the receiver while `run_pairing` still holds it.
     pub fn cancel(&self) {
         let _ = self.ctrl.send(Control::Cancel);
@@ -122,16 +154,36 @@ impl PairingManager {
         tokio::time::timeout(HOLD, rx.recv()).await.ok().flatten()
     }
 
-    /// Wait (bounded, ~3s at the watcher's ~1s re-evaluation cadence) for the
-    /// capture watcher to drop its session before opening the receiver.
-    async fn wait_capture_idle(&self) {
-        for _ in 0..30 {
-            if self.shared.capture_idle.load(Ordering::Relaxed) {
-                return;
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+    fn release_receiver_lease(&self) {
+        if let Ok(mut slot) = self.receiver_lease.lock() {
+            *slot = None;
         }
-        warn!("capture did not release before pairing — proceeding anyway");
+    }
+}
+
+struct SessionAdmission {
+    sessions: Arc<AtomicUsize>,
+    committed: bool,
+}
+
+impl SessionAdmission {
+    fn new(sessions: Arc<AtomicUsize>) -> Self {
+        Self {
+            sessions,
+            committed: false,
+        }
+    }
+
+    fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for SessionAdmission {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.sessions.store(0, Ordering::Release);
+        }
     }
 }
 
@@ -143,7 +195,7 @@ async fn translate(
     upd_tx: mpsc::UnboundedSender<PairingUpdate>,
     devices: DeviceCache,
     sessions: Arc<AtomicUsize>,
-    pairing_active: Arc<AtomicBool>,
+    receiver_lease: Arc<StdMutex<Option<PairingReceiverLease>>>,
 ) {
     while let Some(event) = raw.recv().await {
         let update = match event {
@@ -169,8 +221,10 @@ async fn translate(
             // Lift the capture pause when the accepted single session ends.
             // Balanced: `start()` admits one active session, and that session
             // emits exactly one terminal event.
-            if sessions.fetch_sub(1, Ordering::Relaxed) == 1 {
-                pairing_active.store(false, Ordering::Relaxed);
+            if sessions.fetch_sub(1, Ordering::Relaxed) == 1
+                && let Ok(mut lease) = receiver_lease.lock()
+            {
+                *lease = None;
             }
         }
         if upd_tx.send(update).is_err() {
@@ -179,11 +233,13 @@ async fn translate(
     }
     // The watcher channel closed — its thread exited, most likely because
     // run_pairing panicked and unwound the watcher thread, dropping evt_tx before
-    // any terminal event. Don't leave capture permanently paused: reset the pause
-    // so gesture / DPI-cycle / thumbwheel remapping keeps working (only pairing
+    // any terminal event. Don't leave the receiver lease held: release it so
+    // gesture / DPI-cycle / thumbwheel remapping keeps working (only pairing
     // itself is then unavailable until the agent restarts).
     sessions.store(0, Ordering::Relaxed);
-    pairing_active.store(false, Ordering::Relaxed);
+    if let Ok(mut lease) = receiver_lease.lock() {
+        *lease = None;
+    }
 }
 
 #[cfg(test)]
@@ -192,9 +248,11 @@ mod tests {
 
     use std::collections::BTreeMap;
     use std::sync::RwLock;
+    use std::sync::atomic::AtomicBool;
 
     use openlogi_agent_core::DpiCycleState;
     use openlogi_agent_core::hook_runtime::HookMaps;
+    use openlogi_agent_core::receiver_access::ReceiverAccess;
 
     fn shared_runtime() -> SharedRuntime {
         SharedRuntime {
@@ -204,18 +262,19 @@ mod tests {
             thumbwheel_sensitivity: Arc::new(0.into()),
             invert_scroll: Arc::new(AtomicBool::new(false)),
             capture_channel: Arc::new(RwLock::new(None)),
-            pairing_active: Arc::new(AtomicBool::new(false)),
-            capture_idle: Arc::new(AtomicBool::new(true)),
+            receiver_access: ReceiverAccess::default(),
         }
     }
 
     fn manager_with_ctrl(ctrl: mpsc::UnboundedSender<Control>) -> PairingManager {
-        let (_upd_tx, upd_rx) = mpsc::unbounded_channel();
+        let (upd_tx, upd_rx) = mpsc::unbounded_channel();
         PairingManager {
             ctrl,
+            update_tx: upd_tx,
             updates: Mutex::new(upd_rx),
             devices: Arc::new(StdMutex::new(HashMap::new())),
             sessions: Arc::new(AtomicUsize::new(0)),
+            receiver_lease: Arc::new(StdMutex::new(None)),
             shared: shared_runtime(),
         }
     }
@@ -229,7 +288,18 @@ mod tests {
         manager.start(ReceiverSelector::First).await;
 
         assert_eq!(manager.sessions.load(Ordering::Acquire), 0);
-        assert!(!manager.shared.pairing_active.load(Ordering::Relaxed));
+        assert!(!manager.shared.receiver_access.pairing_requested());
+        assert!(
+            manager
+                .shared
+                .receiver_access
+                .try_acquire_for_capture()
+                .is_some()
+        );
+        assert!(matches!(
+            manager.next_update().await,
+            Some(PairingUpdate::Failed(_))
+        ));
     }
 
     #[tokio::test]
@@ -237,7 +307,6 @@ mod tests {
         let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
         let manager = manager_with_ctrl(ctrl_tx);
         manager.sessions.store(1, Ordering::Release);
-        manager.shared.pairing_active.store(true, Ordering::Relaxed);
         {
             let Ok(mut devices) = manager.devices.lock() else {
                 panic!("test device cache lock should not be poisoned");
@@ -256,7 +325,6 @@ mod tests {
         manager.start(ReceiverSelector::First).await;
 
         assert_eq!(manager.sessions.load(Ordering::Acquire), 1);
-        assert!(manager.shared.pairing_active.load(Ordering::Relaxed));
         let Ok(devices) = manager.devices.lock() else {
             panic!("test device cache lock should not be poisoned");
         };

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -36,6 +36,7 @@ const RECEIVER_LEASE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Address-keyed cache of the full discovered devices, so the GUI can pair by
 /// address without round-tripping the non-serializable `DiscoveredDevice`.
 type DeviceCache = Arc<StdMutex<HashMap<[u8; 6], DiscoveredDevice>>>;
+type ReceiverLeaseSlot = Arc<StdMutex<Option<PairingReceiverLease>>>;
 
 /// Owns the pairing watcher and translates its event stream for the IPC layer.
 pub struct PairingManager {
@@ -48,7 +49,7 @@ pub struct PairingManager {
     /// it on each terminal event and releases the receiver lease when it returns
     /// to zero. Balanced: one accepted `start` ⇒ exactly one terminal.
     sessions: Arc<AtomicUsize>,
-    receiver_lease: Arc<StdMutex<Option<PairingReceiverLease>>>,
+    receiver_lease: ReceiverLeaseSlot,
     shared: SharedRuntime,
 }
 
@@ -107,15 +108,9 @@ impl PairingManager {
             warn!("timed out waiting for receiver capture to stop; pairing not started");
             return;
         };
-        if let Ok(mut slot) = self.receiver_lease.lock() {
+        with_receiver_lease_slot(&self.receiver_lease, |slot| {
             *slot = Some(receiver_lease);
-        } else {
-            let _ = self.update_tx.send(PairingUpdate::Failed(
-                PairingFailure::ReceiverAccessUnavailable,
-            ));
-            warn!("pairing receiver lease lock poisoned; aborting start");
-            return;
-        }
+        });
         if let Err(e) = self.ctrl.send(Control::Start(selector)) {
             self.release_receiver_lease();
             let _ = self
@@ -155,8 +150,22 @@ impl PairingManager {
     }
 
     fn release_receiver_lease(&self) {
-        if let Ok(mut slot) = self.receiver_lease.lock() {
+        with_receiver_lease_slot(&self.receiver_lease, |slot| {
             *slot = None;
+        });
+    }
+}
+
+fn with_receiver_lease_slot<T>(
+    receiver_lease: &ReceiverLeaseSlot,
+    f: impl FnOnce(&mut Option<PairingReceiverLease>) -> T,
+) -> T {
+    match receiver_lease.lock() {
+        Ok(mut slot) => f(&mut slot),
+        Err(poisoned) => {
+            warn!("pairing receiver lease lock poisoned; recovering lease slot");
+            let mut slot = poisoned.into_inner();
+            f(&mut slot)
         }
     }
 }
@@ -195,7 +204,7 @@ async fn translate(
     upd_tx: mpsc::UnboundedSender<PairingUpdate>,
     devices: DeviceCache,
     sessions: Arc<AtomicUsize>,
-    receiver_lease: Arc<StdMutex<Option<PairingReceiverLease>>>,
+    receiver_lease: ReceiverLeaseSlot,
 ) {
     while let Some(event) = raw.recv().await {
         let update = match event {
@@ -221,10 +230,10 @@ async fn translate(
             // Lift the capture pause when the accepted single session ends.
             // Balanced: `start()` admits one active session, and that session
             // emits exactly one terminal event.
-            if sessions.fetch_sub(1, Ordering::Relaxed) == 1
-                && let Ok(mut lease) = receiver_lease.lock()
-            {
-                *lease = None;
+            if sessions.fetch_sub(1, Ordering::Relaxed) == 1 {
+                with_receiver_lease_slot(&receiver_lease, |lease| {
+                    *lease = None;
+                });
             }
         }
         if upd_tx.send(update).is_err() {
@@ -237,9 +246,9 @@ async fn translate(
     // gesture / DPI-cycle / thumbwheel remapping keeps working (only pairing
     // itself is then unavailable until the agent restarts).
     sessions.store(0, Ordering::Relaxed);
-    if let Ok(mut lease) = receiver_lease.lock() {
+    with_receiver_lease_slot(&receiver_lease, |lease| {
         *lease = None;
-    }
+    });
 }
 
 #[cfg(test)]
@@ -300,6 +309,36 @@ mod tests {
             manager.next_update().await,
             Some(PairingUpdate::Failed(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn release_receiver_lease_recovers_poisoned_slot() {
+        let (ctrl_tx, _ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        let receiver_lease = manager.shared.receiver_access.acquire_for_pairing().await;
+        with_receiver_lease_slot(&manager.receiver_lease, |slot| {
+            *slot = Some(receiver_lease);
+        });
+        assert!(manager.shared.receiver_access.pairing_requested());
+
+        let slot = Arc::clone(&manager.receiver_lease);
+        let _ = std::panic::catch_unwind(move || {
+            let Ok(_guard) = slot.lock() else {
+                panic!("test receiver lease slot should start unpoisoned");
+            };
+            panic!("poison receiver lease slot");
+        });
+
+        manager.release_receiver_lease();
+
+        assert!(!manager.shared.receiver_access.pairing_requested());
+        assert!(
+            manager
+                .shared
+                .receiver_access
+                .try_acquire_for_capture()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
+use openlogi_agent_core::ipc::{FoundDevice, PairingFailure, PairingUpdate};
 use openlogi_agent_core::orchestrator::SharedRuntime;
 use openlogi_agent_core::receiver_access::PairingReceiverLease;
 use openlogi_agent_core::watchers::pairing::{self, Control};
@@ -101,9 +101,9 @@ impl PairingManager {
         )
         .await
         else {
-            let _ = self.update_tx.send(PairingUpdate::Failed(
-                "Timed out waiting for receiver capture to stop.".to_string(),
-            ));
+            let _ = self
+                .update_tx
+                .send(PairingUpdate::Failed(PairingFailure::ReceiverBusy));
             warn!("timed out waiting for receiver capture to stop; pairing not started");
             return;
         };
@@ -111,16 +111,16 @@ impl PairingManager {
             *slot = Some(receiver_lease);
         } else {
             let _ = self.update_tx.send(PairingUpdate::Failed(
-                "Pairing is unavailable because receiver access could not be recorded.".to_string(),
+                PairingFailure::ReceiverAccessUnavailable,
             ));
             warn!("pairing receiver lease lock poisoned; aborting start");
             return;
         }
         if let Err(e) = self.ctrl.send(Control::Start(selector)) {
             self.release_receiver_lease();
-            let _ = self.update_tx.send(PairingUpdate::Failed(
-                "Pairing is unavailable because the pairing watcher is not running.".to_string(),
-            ));
+            let _ = self
+                .update_tx
+                .send(PairingUpdate::Failed(PairingFailure::WatcherUnavailable));
             warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
             return;
         }
@@ -212,7 +212,7 @@ async fn translate(
             }
             PairingEvent::Passkey(method) => PairingUpdate::Passkey(method),
             PairingEvent::Paired { slot } => PairingUpdate::Paired { slot },
-            PairingEvent::Failed(error) => PairingUpdate::Failed(error.to_string()),
+            PairingEvent::Failed(error) => PairingUpdate::Failed(error.into()),
         };
         if matches!(
             update,

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use openlogi_agent_core::ipc::{
-    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingUpdate,
+    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingFailure, PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::DeviceInventory;
@@ -452,9 +452,7 @@ async fn pairing_poll(tx: mpsc::UnboundedSender<PairingUpdate>) {
                 client = None; // connection dropped (agent restart) — reconnect
                 if session_active {
                     session_active = false;
-                    let _ = tx.send(PairingUpdate::Failed(
-                        tr!("The background service restarted — try pairing again.").to_string(),
-                    ));
+                    let _ = tx.send(PairingUpdate::Failed(PairingFailure::AgentRestarted));
                 }
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -20,7 +20,7 @@ use gpui::{
     px, rgb,
 };
 use gpui_component::v_flex;
-use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
+use openlogi_agent_core::ipc::{FoundDevice, PairingFailure, PairingUpdate};
 use openlogi_hid::{Click, PasskeyMethod, ReceiverSelector};
 
 use crate::app_menu::{CloseWindow, Minimize, Zoom};
@@ -45,7 +45,7 @@ pub enum PairingUi {
     Passkey(PasskeyMethod),
     /// A device paired into `slot`.
     Paired { slot: u8 },
-    /// The session ended without pairing; carries a human-readable detail.
+    /// The session ended without pairing; carries localized display copy.
     Failed(String),
 }
 
@@ -90,9 +90,40 @@ pub fn apply_update(cx: &mut App, update: PairingUpdate) {
         }
         PairingUpdate::Passkey(method) => PairingUi::Passkey(method),
         PairingUpdate::Paired { slot } => PairingUi::Paired { slot },
-        PairingUpdate::Failed(detail) => PairingUi::Failed(detail),
+        PairingUpdate::Failed(failure) => PairingUi::Failed(pairing_failure_text(failure)),
     };
     cx.set_global(next);
+}
+
+fn pairing_failure_text(failure: PairingFailure) -> String {
+    match failure {
+        PairingFailure::Hid { message } => {
+            tr!("HID transport error: %{message}", message => message).to_string()
+        }
+        PairingFailure::ReceiverNotFound => {
+            tr!("No supported pairing-capable receiver was found.").to_string()
+        }
+        PairingFailure::Register { message } => {
+            tr!("Receiver register access failed: %{message}", message => message).to_string()
+        }
+        PairingFailure::Timeout => tr!("Pairing timed out.").to_string(),
+        PairingFailure::Device { code } => tr!(
+            "The receiver reported pairing error %{code}.",
+            code => format!("0x{code:02x}"),
+        )
+        .to_string(),
+        PairingFailure::Cancelled => tr!("Pairing was cancelled.").to_string(),
+        PairingFailure::ReceiverBusy => tr!("The receiver is busy. Try pairing again.").to_string(),
+        PairingFailure::WatcherUnavailable => {
+            tr!("Pairing is unavailable because the background service is not ready.").to_string()
+        }
+        PairingFailure::AgentRestarted => {
+            tr!("The background service restarted — try pairing again.").to_string()
+        }
+        PairingFailure::ReceiverAccessUnavailable => {
+            tr!("Pairing is unavailable because receiver access could not be recorded.").to_string()
+        }
+    }
 }
 
 fn send(cx: &App, command: Command) {


### PR DESCRIPTION
## Summary
- replace pairing/capture coordination atomics with an explicit ReceiverAccess lease arbiter
- make capture opportunistically hold receiver ownership and make pairing await exclusive ownership before starting
- release pairing ownership only on terminal watcher events or watcher shutdown, and surface startup failures instead of opening the receiver concurrently

## Validation
- cargo fmt --check
- cargo test -p openlogi-agent-core receiver_access::tests
- cargo test -p openlogi-agent pairing::tests
- cargo test -p openlogi-agent-core -p openlogi-agent
- cargo clippy -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings