### PR TITLE
refactor(ipc): type pairing failure reasons

### DIFF
--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -9,8 +9,8 @@
 use openlogi_core::config::Lighting;
 use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{
-    DeviceRoute, DpiInfo, PasskeyMethod, ReceiverSelector, SmartShiftMode, SmartShiftStatus,
-    WriteError,
+    DeviceRoute, DpiInfo, PairingError, PasskeyMethod, ReceiverSelector, SmartShiftMode,
+    SmartShiftStatus, WriteError,
 };
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,8 @@ use serde::{Deserialize, Serialize};
 /// v2: `AgentStatus::inventory_ready` added.
 /// v3: `inventory_ready` widened to [`InventoryHealth`] (adds `Unavailable`).
 /// v4: [`Agent::snapshot`] added for atomic status + inventory polling.
-pub const PROTOCOL_VERSION: u32 = 4;
+/// v5: [`PairingUpdate::Failed`] carries a typed [`PairingFailure`].
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep
@@ -78,9 +79,54 @@ pub struct FoundDevice {
     pub name: String,
 }
 
+/// Terminal failure reason for a pairing session.
+///
+/// Kept typed across the agent↔GUI boundary so the GUI can choose recovery UI,
+/// telemetry, and localized copy without matching human-readable strings.
+///
+/// bincode encodes the variant *index*, so variants are append-only, like the
+/// [`Agent`] trait methods.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PairingFailure {
+    /// The HID transport returned an error.
+    Hid { message: String },
+    /// No connected receiver supports pairing.
+    ReceiverNotFound,
+    /// HID++ receiver register access failed.
+    Register { message: String },
+    /// The device or receiver did not complete pairing before its deadline.
+    Timeout,
+    /// The receiver reported a protocol-level pairing error code.
+    Device { code: u8 },
+    /// The user cancelled the pairing session.
+    Cancelled,
+    /// The agent could not obtain exclusive receiver ownership for pairing.
+    ReceiverBusy,
+    /// The pairing watcher is unavailable inside the agent process.
+    WatcherUnavailable,
+    /// The background agent restarted during an active pairing session.
+    AgentRestarted,
+    /// The agent could not store its exclusive receiver ownership lease.
+    ReceiverAccessUnavailable,
+}
+
+impl From<PairingError> for PairingFailure {
+    fn from(error: PairingError) -> Self {
+        match error {
+            PairingError::Hid(message) => Self::Hid { message },
+            PairingError::ReceiverNotFound => Self::ReceiverNotFound,
+            PairingError::Register(message) => Self::Register { message },
+            PairingError::Timeout => Self::Timeout,
+            PairingError::Device(code) => Self::Device { code },
+            PairingError::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
 /// One step of a pairing session, streamed to the GUI via [`Agent::next_pairing`].
 /// Mirrors `openlogi_hid::PairingEvent` but in a wire-safe form — the discovered
-/// device collapses to [`FoundDevice`] and the terminal error to a string.
+/// device collapses to [`FoundDevice`] and terminal failures to
+/// [`PairingFailure`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PairingUpdate {
     /// Discovery (Bolt) / the pairing lock (Unifying) is open.
@@ -91,8 +137,8 @@ pub enum PairingUpdate {
     Passkey(PasskeyMethod),
     /// A device paired into `slot`.
     Paired { slot: u8 },
-    /// The flow ended without pairing a device (carries a human-readable detail).
-    Failed(String),
+    /// The flow ended without pairing a device.
+    Failed(PairingFailure),
 }
 
 #[tarpc::service]

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -24,7 +24,7 @@ use std::fmt::Write;
 use bincode::Options;
 use openlogi_agent_core::ipc::{
     AgentRequest, AgentSnapshot, AgentStatus, FoundDevice, InventoryHealth, PROTOCOL_VERSION,
-    PairingUpdate,
+    PairingFailure, PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{
@@ -61,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 4);
+    assert_eq!(PROTOCOL_VERSION, 5);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -187,9 +187,10 @@ fn pairing_updates() {
         "0201023132020001",
     );
     assert_wire(&PairingUpdate::Paired { slot: 2 }, "0302");
+    assert_wire(&PairingUpdate::Failed(PairingFailure::Timeout), "0403");
     assert_wire(
-        &PairingUpdate::Failed("timed out".into()),
-        "040974696d6564206f7574",
+        &PairingUpdate::Failed(PairingFailure::Device { code: 0x1f }),
+        "04041f",
     );
 }
 

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
+use openlogi_agent_core::ipc::{FoundDevice, PairingFailure, PairingUpdate};
 use openlogi_agent_core::orchestrator::SharedRuntime;
 use openlogi_agent_core::receiver_access::PairingReceiverLease;
 use openlogi_agent_core::watchers::pairing::{self, Control};
@@ -101,9 +101,9 @@ impl PairingManager {
         )
         .await
         else {
-            let _ = self.update_tx.send(PairingUpdate::Failed(
-                "Timed out waiting for receiver capture to stop.".to_string(),
-            ));
+            let _ = self
+                .update_tx
+                .send(PairingUpdate::Failed(PairingFailure::ReceiverBusy));
             warn!("timed out waiting for receiver capture to stop; pairing not started");
             return;
         };
@@ -111,16 +111,16 @@ impl PairingManager {
             *slot = Some(receiver_lease);
         } else {
             let _ = self.update_tx.send(PairingUpdate::Failed(
-                "Pairing is unavailable because receiver access could not be recorded.".to_string(),
+                PairingFailure::ReceiverAccessUnavailable,
             ));
             warn!("pairing receiver lease lock poisoned; aborting start");
             return;
         }
         if let Err(e) = self.ctrl.send(Control::Start(selector)) {
             self.release_receiver_lease();
-            let _ = self.update_tx.send(PairingUpdate::Failed(
-                "Pairing is unavailable because the pairing watcher is not running.".to_string(),
-            ));
+            let _ = self
+                .update_tx
+                .send(PairingUpdate::Failed(PairingFailure::WatcherUnavailable));
             warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
             return;
         }
@@ -212,7 +212,7 @@ async fn translate(
             }
             PairingEvent::Passkey(method) => PairingUpdate::Passkey(method),
             PairingEvent::Paired { slot } => PairingUpdate::Paired { slot },
-            PairingEvent::Failed(error) => PairingUpdate::Failed(error.to_string()),
+            PairingEvent::Failed(error) => PairingUpdate::Failed(error.into()),
         };
         if matches!(
             update,

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use openlogi_agent_core::ipc::{
-    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingUpdate,
+    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingFailure, PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::DeviceInventory;
@@ -452,9 +452,7 @@ async fn pairing_poll(tx: mpsc::UnboundedSender<PairingUpdate>) {
                 client = None; // connection dropped (agent restart) — reconnect
                 if session_active {
                     session_active = false;
-                    let _ = tx.send(PairingUpdate::Failed(
-                        tr!("The background service restarted — try pairing again.").to_string(),
-                    ));
+                    let _ = tx.send(PairingUpdate::Failed(PairingFailure::AgentRestarted));
                 }
                 tokio::time::sleep(Duration::from_secs(1)).await;
             }

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -20,7 +20,7 @@ use gpui::{
     px, rgb,
 };
 use gpui_component::v_flex;
-use openlogi_agent_core::ipc::{FoundDevice, PairingUpdate};
+use openlogi_agent_core::ipc::{FoundDevice, PairingFailure, PairingUpdate};
 use openlogi_hid::{Click, PasskeyMethod, ReceiverSelector};
 
 use crate::app_menu::{CloseWindow, Minimize, Zoom};
@@ -45,7 +45,7 @@ pub enum PairingUi {
     Passkey(PasskeyMethod),
     /// A device paired into `slot`.
     Paired { slot: u8 },
-    /// The session ended without pairing; carries a human-readable detail.
+    /// The session ended without pairing; carries localized display copy.
     Failed(String),
 }
 
@@ -90,9 +90,40 @@ pub fn apply_update(cx: &mut App, update: PairingUpdate) {
         }
         PairingUpdate::Passkey(method) => PairingUi::Passkey(method),
         PairingUpdate::Paired { slot } => PairingUi::Paired { slot },
-        PairingUpdate::Failed(detail) => PairingUi::Failed(detail),
+        PairingUpdate::Failed(failure) => PairingUi::Failed(pairing_failure_text(failure)),
     };
     cx.set_global(next);
+}
+
+fn pairing_failure_text(failure: PairingFailure) -> String {
+    match failure {
+        PairingFailure::Hid { message } => {
+            tr!("HID transport error: %{message}", message => message).to_string()
+        }
+        PairingFailure::ReceiverNotFound => {
+            tr!("No supported pairing-capable receiver was found.").to_string()
+        }
+        PairingFailure::Register { message } => {
+            tr!("Receiver register access failed: %{message}", message => message).to_string()
+        }
+        PairingFailure::Timeout => tr!("Pairing timed out.").to_string(),
+        PairingFailure::Device { code } => tr!(
+            "The receiver reported pairing error %{code}.",
+            code => format!("0x{code:02x}"),
+        )
+        .to_string(),
+        PairingFailure::Cancelled => tr!("Pairing was cancelled.").to_string(),
+        PairingFailure::ReceiverBusy => tr!("The receiver is busy. Try pairing again.").to_string(),
+        PairingFailure::WatcherUnavailable => {
+            tr!("Pairing is unavailable because the background service is not ready.").to_string()
+        }
+        PairingFailure::AgentRestarted => {
+            tr!("The background service restarted — try pairing again.").to_string()
+        }
+        PairingFailure::ReceiverAccessUnavailable => {
+            tr!("Pairing is unavailable because receiver access could not be recorded.").to_string()
+        }
+    }
 }
 
 fn send(cx: &App, command: Command) {


### PR DESCRIPTION
## Summary
- replace stringly typed pairing failures on the IPC wire with a serializable PairingFailure enum
- bump PROTOCOL_VERSION and pin the new wire encoding in golden tests
- map typed pairing failures to localized GUI copy only at the presentation layer

## Validation
- cargo fmt --check
- cargo test -p openlogi-agent-core --test wire_format
- cargo test -p openlogi-agent pairing::tests
- cargo check -p openlogi-agent -p openlogi-gui
- cargo test -p openlogi-agent-core -p openlogi-agent
- cargo clippy -p openlogi-agent-core -p openlogi-agent -p openlogi-gui --all-targets -- -D warnings