### PR TITLE
refactor(ipc): acknowledge pairing commands

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use openlogi_core::config::Lighting;
 use openlogi_hid::{
-    CaptureChannel, DeviceRoute, DpiInfo, SharedChannel, SmartShiftMode, SmartShiftStatus,
-    WriteError,
+    CaptureChannel, DeviceRoute, DpiInfo, HidppOperation, SharedChannel, SmartShiftMode,
+    SmartShiftStatus, WriteError,
 };
 use tracing::{debug, warn};
 
@@ -36,12 +36,16 @@ pub fn read_dpi_info_blocking(target: &DeviceRoute) -> Result<DpiInfo, WriteErro
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .map_err(|e| WriteError::Hidpp(format!("tokio runtime init failed: {e}")))?;
+        .map_err(|e| WriteError::RuntimeInit {
+            message: e.to_string(),
+        })?;
 
     rt.block_on(async {
         tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_dpi_info(target))
             .await
-            .map_err(|_| WriteError::Hidpp("DPI info read timed out".into()))?
+            .map_err(|_| WriteError::RequestTimedOut {
+                operation: HidppOperation::ReadDpiCapabilities,
+            })?
     })
 }
 
@@ -116,12 +120,16 @@ pub fn read_smartshift_status_blocking(
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .map_err(|e| WriteError::Hidpp(format!("tokio runtime init failed: {e}")))?;
+        .map_err(|e| WriteError::RuntimeInit {
+            message: e.to_string(),
+        })?;
 
     rt.block_on(async {
         tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_smartshift_status(target))
             .await
-            .map_err(|_| WriteError::Hidpp("SmartShift status read timed out".into()))?
+            .map_err(|_| WriteError::RequestTimedOut {
+                operation: HidppOperation::ReadSmartShift,
+            })?
     })
 }
 
@@ -372,7 +380,7 @@ pub async fn apply_dpi(
 ) -> Result<(), WriteError> {
     let dpi = u16::try_from(dpi).unwrap_or(u16::MAX);
     let shared = reusable_channel(Some(capture), route);
-    timed(async {
+    timed(HidppOperation::WriteDpi, async {
         match &shared {
             Some(shared) => openlogi_hid::set_dpi_on(shared, dpi).await,
             None => openlogi_hid::set_dpi(route, dpi).await,
@@ -390,7 +398,7 @@ pub async fn apply_smartshift(
     tunable_torque: u8,
 ) -> Result<(), WriteError> {
     let shared = reusable_channel(Some(capture), route);
-    timed(async {
+    timed(HidppOperation::WriteSmartShift, async {
         match &shared {
             Some(shared) => {
                 openlogi_hid::set_smartshift_on(shared, mode, auto_disengage, tunable_torque).await
@@ -404,23 +412,38 @@ pub async fn apply_smartshift(
 /// Apply a lighting config to the keyboard at `route`.
 pub async fn apply_lighting(route: &DeviceRoute, lighting: &Lighting) -> Result<(), WriteError> {
     let (r, g, b) = lighting_rgb(lighting);
-    timed(openlogi_hid::set_keyboard_color(route, r, g, b)).await
+    timed(
+        HidppOperation::Lighting,
+        openlogi_hid::set_keyboard_color(route, r, g, b),
+    )
+    .await
 }
 
 /// Read the current DPI + supported values from `route`.
 pub async fn read_dpi(route: &DeviceRoute) -> Result<DpiInfo, WriteError> {
-    timed(openlogi_hid::get_dpi_info(route)).await
+    timed(
+        HidppOperation::ReadDpiCapabilities,
+        openlogi_hid::get_dpi_info(route),
+    )
+    .await
 }
 
 /// Read the current SmartShift config from `route`.
 pub async fn read_smartshift(route: &DeviceRoute) -> Result<SmartShiftStatus, WriteError> {
-    timed(openlogi_hid::get_smartshift_status(route)).await
+    timed(
+        HidppOperation::ReadSmartShift,
+        openlogi_hid::get_smartshift_status(route),
+    )
+    .await
 }
 
 /// Bound any single HID++ call by [`WRITE_BUDGET`] so an asleep / unresponsive
 /// device can't hang the awaiting IPC handler indefinitely.
-async fn timed<T>(fut: impl Future<Output = Result<T, WriteError>>) -> Result<T, WriteError> {
-    tokio::time::timeout(WRITE_BUDGET, fut).await.map_err(|_| {
-        WriteError::Hidpp("HID++ request timed out (device asleep/unresponsive)".into())
-    })?
+async fn timed<T>(
+    operation: HidppOperation,
+    fut: impl Future<Output = Result<T, WriteError>>,
+) -> Result<T, WriteError> {
+    tokio::time::timeout(WRITE_BUDGET, fut)
+        .await
+        .map_err(|_| WriteError::RequestTimedOut { operation })?
 }

--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -24,7 +24,8 @@ use serde::{Deserialize, Serialize};
 /// v4: [`Agent::snapshot`] added for atomic status + inventory polling.
 /// v5: [`PairingUpdate::Failed`] carries a typed [`PairingFailure`].
 /// v6: `Capabilities::scroll_inversion` added.
-pub const PROTOCOL_VERSION: u32 = 6;
+/// v7: pairing commands return typed acceptance errors.
+pub const PROTOCOL_VERSION: u32 = 7;
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep
@@ -109,6 +110,46 @@ pub enum PairingFailure {
     AgentRestarted,
     /// The agent could not store its exclusive receiver ownership lease.
     ReceiverAccessUnavailable,
+    /// A pairing session is already active.
+    AlreadyActive,
+    /// The GUI asked to pair an address that is not in the current discovery cache.
+    UnknownDevice,
+    /// There is no pairing session to receive this command.
+    NoActiveSession,
+}
+
+/// Immediate command-acceptance failure for pairing RPCs.
+///
+/// Progress after a command is accepted still arrives through
+/// [`PairingUpdate`]. This type only covers failures that prevent the agent from
+/// accepting the command in the first place.
+///
+/// bincode encodes the variant *index*, so variants are append-only, like the
+/// [`Agent`] trait methods.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PairingCommandError {
+    /// A pairing session is already active.
+    AlreadyActive,
+    /// The agent could not obtain exclusive receiver ownership for pairing.
+    ReceiverBusy,
+    /// The pairing watcher is unavailable inside the agent process.
+    WatcherUnavailable,
+    /// The GUI asked to pair an address that is not in the current discovery cache.
+    UnknownDevice,
+    /// There is no pairing session to receive this command.
+    NoActiveSession,
+}
+
+impl From<PairingCommandError> for PairingFailure {
+    fn from(error: PairingCommandError) -> Self {
+        match error {
+            PairingCommandError::AlreadyActive => Self::AlreadyActive,
+            PairingCommandError::ReceiverBusy => Self::ReceiverBusy,
+            PairingCommandError::WatcherUnavailable => Self::WatcherUnavailable,
+            PairingCommandError::UnknownDevice => Self::UnknownDevice,
+            PairingCommandError::NoActiveSession => Self::NoActiveSession,
+        }
+    }
 }
 
 impl From<PairingError> for PairingFailure {
@@ -188,12 +229,12 @@ pub trait Agent {
     /// I/O, so pairing (which opens the receiver) runs here, not in the GUI —
     /// the GUI opening a receiver channel would clash with the agent's live
     /// capture session on the same Bolt receiver.
-    async fn start_pairing(selector: ReceiverSelector);
+    async fn start_pairing(selector: ReceiverSelector) -> Result<(), PairingCommandError>;
     /// Bolt: pair with a discovered device by its address (from a prior
     /// [`PairingUpdate::DeviceFound`]).
-    async fn pair_device(address: [u8; 6]);
+    async fn pair_device(address: [u8; 6]) -> Result<(), PairingCommandError>;
     /// Abort the in-progress pairing session.
-    async fn cancel_pairing();
+    async fn cancel_pairing() -> Result<(), PairingCommandError>;
     /// Long-poll the next pairing step. Returns `None` when the agent's hold
     /// window elapses with no event (the GUI simply re-polls); the GUI drives
     /// this in a loop while the Add Device window is open.

--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -25,7 +25,8 @@ use serde::{Deserialize, Serialize};
 /// v5: [`PairingUpdate::Failed`] carries a typed [`PairingFailure`].
 /// v6: `Capabilities::scroll_inversion` added.
 /// v7: pairing commands return typed acceptance errors.
-pub const PROTOCOL_VERSION: u32 = 7;
+/// v8: [`WriteError`] carries typed HID++ operation failures.
+pub const PROTOCOL_VERSION: u32 = 8;
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -24,7 +24,7 @@ use std::fmt::Write;
 use bincode::Options;
 use openlogi_agent_core::ipc::{
     AgentRequest, AgentSnapshot, AgentStatus, FoundDevice, InventoryHealth, PROTOCOL_VERSION,
-    PairingFailure, PairingUpdate,
+    PairingCommandError, PairingFailure, PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{
@@ -61,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 6);
+    assert_eq!(PROTOCOL_VERSION, 7);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -193,6 +193,12 @@ fn pairing_updates() {
         &PairingUpdate::Failed(PairingFailure::Device { code: 0x1f }),
         "04041f",
     );
+    assert_wire(
+        &PairingUpdate::Failed(PairingFailure::UnknownDevice),
+        "040b",
+    );
+    assert_wire(&PairingCommandError::AlreadyActive, "00");
+    assert_wire(&PairingCommandError::UnknownDevice, "03");
 }
 
 #[test]

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -32,8 +32,8 @@ use openlogi_core::device::{
     DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
 };
 use openlogi_hid::{
-    Click, DeviceRoute, DpiCapabilities, DpiInfo, PasskeyMethod, ReceiverSelector, SmartShiftMode,
-    SmartShiftStatus, WriteError,
+    Click, DeviceRoute, DpiCapabilities, DpiInfo, HidppFeatureErrorKind, HidppOperation,
+    PasskeyMethod, ReceiverSelector, SmartShiftMode, SmartShiftStatus, WriteError,
 };
 
 /// Serialize exactly as the transport does (`tokio_serde::formats::Bincode`
@@ -61,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 7);
+    assert_eq!(PROTOCOL_VERSION, 8);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -215,6 +215,35 @@ fn device_settings_payloads() {
         feature_hex: 0x2201,
     });
     assert_wire(&unsupported, "0103fb0122");
+
+    assert_wire(
+        &WriteError::RequestTimedOut {
+            operation: HidppOperation::WriteDpi,
+        },
+        "0804",
+    );
+    assert_wire(
+        &WriteError::HidppFeature {
+            operation: HidppOperation::WriteDpi,
+            feature_hex: 0x2201,
+            kind: HidppFeatureErrorKind::OutOfRange,
+        },
+        "0604fb012203",
+    );
+    assert_wire(
+        &WriteError::UnsupportedResponse {
+            operation: HidppOperation::Lighting,
+            feature_hex: 0x8070,
+        },
+        "0707fb7080",
+    );
+    assert_wire(
+        &WriteError::RuntimeInit {
+            message: "boom".into(),
+        },
+        "0904626f6f6d",
+    );
+    assert_wire(&WriteError::AgentUnavailable, "0a");
 
     // serde encodes SmartShiftMode's variant *index* (Free=0, Ratchet=1), not
     // the `#[repr(u8)]` firmware discriminants (1/2) — pinned here because it

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use openlogi_agent_core::ipc::{FoundDevice, PairingFailure, PairingUpdate};
+use openlogi_agent_core::ipc::{FoundDevice, PairingCommandError, PairingUpdate};
 use openlogi_agent_core::orchestrator::SharedRuntime;
 use openlogi_agent_core::receiver_access::PairingReceiverLease;
 use openlogi_agent_core::watchers::pairing::{self, Control};
@@ -41,7 +41,6 @@ type ReceiverLeaseSlot = Arc<StdMutex<Option<PairingReceiverLease>>>;
 /// Owns the pairing watcher and translates its event stream for the IPC layer.
 pub struct PairingManager {
     ctrl: mpsc::UnboundedSender<Control>,
-    update_tx: mpsc::UnboundedSender<PairingUpdate>,
     updates: Mutex<mpsc::UnboundedReceiver<PairingUpdate>>,
     devices: DeviceCache,
     /// Count of outstanding pairing sessions. The watcher is single-session,
@@ -72,7 +71,6 @@ impl PairingManager {
         ));
         Self {
             ctrl,
-            update_tx: upd_tx,
             updates: Mutex::new(upd_rx),
             devices,
             sessions,
@@ -82,14 +80,14 @@ impl PairingManager {
     }
 
     /// Begin a session: forget the previous discovery, pause capture, then start.
-    pub async fn start(&self, selector: ReceiverSelector) {
+    pub async fn start(&self, selector: ReceiverSelector) -> Result<(), PairingCommandError> {
         if self
             .sessions
             .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
             warn!("pairing start requested while a session is already active");
-            return;
+            return Err(PairingCommandError::AlreadyActive);
         }
         let admission = SessionAdmission::new(Arc::clone(&self.sessions));
 
@@ -102,45 +100,48 @@ impl PairingManager {
         )
         .await
         else {
-            let _ = self
-                .update_tx
-                .send(PairingUpdate::Failed(PairingFailure::ReceiverBusy));
             warn!("timed out waiting for receiver capture to stop; pairing not started");
-            return;
+            return Err(PairingCommandError::ReceiverBusy);
         };
         with_receiver_lease_slot(&self.receiver_lease, |slot| {
             *slot = Some(receiver_lease);
         });
         if let Err(e) = self.ctrl.send(Control::Start(selector)) {
             self.release_receiver_lease();
-            let _ = self
-                .update_tx
-                .send(PairingUpdate::Failed(PairingFailure::WatcherUnavailable));
             warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
-            return;
+            return Err(PairingCommandError::WatcherUnavailable);
         }
         admission.commit();
+        Ok(())
     }
 
     /// Pair with a previously discovered device by address.
-    pub fn pair(&self, address: [u8; 6]) {
+    pub fn pair(&self, address: [u8; 6]) -> Result<(), PairingCommandError> {
         let device = self
             .devices
             .lock()
             .ok()
             .and_then(|devices| devices.get(&address).cloned());
         if let Some(device) = device {
-            let _ = self.ctrl.send(Control::Pair(device));
+            self.ctrl
+                .send(Control::Pair(device))
+                .map_err(|_| PairingCommandError::WatcherUnavailable)
         } else {
             warn!(?address, "pair requested for an unknown device");
+            Err(PairingCommandError::UnknownDevice)
         }
     }
 
     /// Cancel the in-progress session. The resulting `Failed(Cancelled)` event
     /// releases the receiver lease via the translator — don't release it here, or
     /// capture could re-acquire the receiver while `run_pairing` still holds it.
-    pub fn cancel(&self) {
-        let _ = self.ctrl.send(Control::Cancel);
+    pub fn cancel(&self) -> Result<(), PairingCommandError> {
+        if self.sessions.load(Ordering::Acquire) == 0 {
+            return Ok(());
+        }
+        self.ctrl
+            .send(Control::Cancel)
+            .map_err(|_| PairingCommandError::WatcherUnavailable)
     }
 
     /// Long-poll the next pairing step; `None` when the hold window elapses.
@@ -274,10 +275,9 @@ mod tests {
     }
 
     fn manager_with_ctrl(ctrl: mpsc::UnboundedSender<Control>) -> PairingManager {
-        let (upd_tx, upd_rx) = mpsc::unbounded_channel();
+        let (_, upd_rx) = mpsc::unbounded_channel();
         PairingManager {
             ctrl,
-            update_tx: upd_tx,
             updates: Mutex::new(upd_rx),
             devices: Arc::new(StdMutex::new(HashMap::new())),
             sessions: Arc::new(AtomicUsize::new(0)),
@@ -292,8 +292,9 @@ mod tests {
         drop(ctrl_rx);
         let manager = manager_with_ctrl(ctrl_tx);
 
-        manager.start(ReceiverSelector::First).await;
+        let result = manager.start(ReceiverSelector::First).await;
 
+        assert_eq!(result, Err(PairingCommandError::WatcherUnavailable));
         assert_eq!(manager.sessions.load(Ordering::Acquire), 0);
         assert!(!manager.shared.receiver_access.pairing_requested());
         assert!(
@@ -303,10 +304,17 @@ mod tests {
                 .try_acquire_for_capture()
                 .is_some()
         );
-        assert!(matches!(
-            manager.next_update().await,
-            Some(PairingUpdate::Failed(_))
-        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_without_active_session_is_a_noop_success() {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+
+        let result = manager.cancel();
+
+        assert_eq!(result, Ok(()));
+        assert!(ctrl_rx.try_recv().is_err());
     }
 
     #[tokio::test]
@@ -359,8 +367,9 @@ mod tests {
             );
         }
 
-        manager.start(ReceiverSelector::First).await;
+        let result = manager.start(ReceiverSelector::First).await;
 
+        assert_eq!(result, Err(PairingCommandError::AlreadyActive));
         assert_eq!(manager.sessions.load(Ordering::Acquire), 1);
         let Ok(devices) = manager.devices.lock() else {
             panic!("test device cache lock should not be poisoned");

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures::StreamExt as _;
 use openlogi_agent_core::ipc::{
-    Agent, AgentSnapshot, AgentStatus, PROTOCOL_VERSION, PairingUpdate,
+    Agent, AgentSnapshot, AgentStatus, PROTOCOL_VERSION, PairingCommandError, PairingUpdate,
 };
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::{hardware, transport};
@@ -123,16 +123,20 @@ impl Agent for AgentServer {
         Hook::prompt_accessibility();
     }
 
-    async fn start_pairing(self, _: Context, selector: ReceiverSelector) {
-        self.pairing.start(selector).await;
+    async fn start_pairing(
+        self,
+        _: Context,
+        selector: ReceiverSelector,
+    ) -> Result<(), PairingCommandError> {
+        self.pairing.start(selector).await
     }
 
-    async fn pair_device(self, _: Context, address: [u8; 6]) {
-        self.pairing.pair(address);
+    async fn pair_device(self, _: Context, address: [u8; 6]) -> Result<(), PairingCommandError> {
+        self.pairing.pair(address)
     }
 
-    async fn cancel_pairing(self, _: Context) {
-        self.pairing.cancel();
+    async fn cancel_pairing(self, _: Context) -> Result<(), PairingCommandError> {
+        self.pairing.cancel()
     }
 
     async fn next_pairing(self, _: Context) -> Option<PairingUpdate> {

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -779,15 +779,14 @@ fn rpc_result<T>(r: Result<T, tarpc::client::RpcError>) -> Result<T, ()> {
     reason = "the two read arms send the same disconnect error to differently-typed reply channels, so they can't be merged"
 )]
 fn reply_disconnected(pairing_tx: &mpsc::UnboundedSender<PairingUpdate>, cmd: Command) {
-    // Transient (Hidpp), not a permanent feature error: the agent is just
-    // restarting, so the panel should keep retrying, not latch "unsupported".
-    let unreachable = || WriteError::Hidpp("background agent not running".to_string());
+    // Transient, not a permanent feature error: the agent is just restarting,
+    // so the panel should keep retrying, not latch "unsupported".
     match cmd {
         Command::ReadDpi(_, reply) => {
-            let _ = reply.send(Err(unreachable()));
+            let _ = reply.send(Err(WriteError::AgentUnavailable));
         }
         Command::ReadSmartShift(_, reply) => {
-            let _ = reply.send(Err(unreachable()));
+            let _ = reply.send(Err(WriteError::AgentUnavailable));
         }
         Command::StartPairing(_) | Command::PairDevice(_) => {
             let _ = pairing_tx.send(PairingUpdate::Failed(PairingFailure::AgentRestarted));

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -20,7 +20,8 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use openlogi_agent_core::ipc::{
-    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingFailure, PairingUpdate,
+    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingCommandError,
+    PairingFailure, PairingUpdate,
 };
 use openlogi_core::config::Lighting;
 use openlogi_core::device::DeviceInventory;
@@ -130,8 +131,8 @@ pub fn spawn(poll_period: Duration) -> IpcClient {
             rt.block_on(async move {
                 // Pairing events stream on their own connection + long-poll so
                 // a held next_pairing never delays the snapshot poll.
-                tokio::spawn(pairing_poll(pairing_tx));
-                poll_loop(poll_period, &update_tx, &mut cmd_rx).await;
+                tokio::spawn(pairing_poll(pairing_tx.clone()));
+                poll_loop(poll_period, &update_tx, &pairing_tx, &mut cmd_rx).await;
             });
         });
     if let Err(e) = spawn_result {
@@ -151,6 +152,7 @@ pub fn spawn(poll_period: Duration) -> IpcClient {
 async fn poll_loop(
     poll_period: Duration,
     update_tx: &mpsc::UnboundedSender<GuiUpdate>,
+    pairing_tx: &mpsc::UnboundedSender<PairingUpdate>,
     cmd_rx: &mut mpsc::UnboundedReceiver<Command>,
 ) {
     let mut client: Option<AgentClient> = None;
@@ -217,7 +219,7 @@ async fn poll_loop(
             }
             cmd = cmd_rx.recv() => {
                 let Some(cmd) = cmd else { break }; // GUI dropped the sender → shut down
-                if handle(&mut client, cmd).await.is_err() {
+                if handle(&mut client, pairing_tx, cmd).await.is_err() {
                     // Same as a poll-detected drop: back to the fast cadence
                     // so the reconnect (agent self-exec, crash) re-converges
                     // just as quickly as at startup.
@@ -695,10 +697,14 @@ async fn poll(
 
 /// Run one device command. `Err` signals a dropped connection so the caller
 /// reconnects; the command's own failure is reported back over its oneshot.
-async fn handle(client: &mut Option<AgentClient>, cmd: Command) -> Result<(), ()> {
+async fn handle(
+    client: &mut Option<AgentClient>,
+    pairing_tx: &mpsc::UnboundedSender<PairingUpdate>,
+    cmd: Command,
+) -> Result<(), ()> {
     // keep `client` None on connect failure; that's not a dropped live connection
     let Ok(client) = ensure(client).await else {
-        reply_disconnected(cmd);
+        reply_disconnected(pairing_tx, cmd);
         return Ok(());
     };
     let ctx = context::current();
@@ -722,12 +728,29 @@ async fn handle(client: &mut Option<AgentClient>, cmd: Command) -> Result<(), ()
             .await
             .map_err(|_| ())?,
         Command::StartPairing(selector) => {
-            client.start_pairing(ctx, selector).await.map_err(|_| ())?;
+            pairing_command_result(pairing_tx, client.start_pairing(ctx, selector).await)?;
         }
-        Command::PairDevice(address) => client.pair_device(ctx, address).await.map_err(|_| ())?,
-        Command::CancelPairing => client.cancel_pairing(ctx).await.map_err(|_| ())?,
+        Command::PairDevice(address) => {
+            pairing_command_result(pairing_tx, client.pair_device(ctx, address).await)?;
+        }
+        Command::CancelPairing => {
+            pairing_command_result(pairing_tx, client.cancel_pairing(ctx).await)?;
+        }
     }
     Ok(())
+}
+
+fn pairing_command_result(
+    tx: &mpsc::UnboundedSender<PairingUpdate>,
+    result: Result<Result<(), PairingCommandError>, tarpc::client::RpcError>,
+) -> Result<(), ()> {
+    match result.map_err(|_| ())? {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = tx.send(PairingUpdate::Failed(PairingFailure::from(error)));
+            Ok(())
+        }
+    }
 }
 
 /// A fire-and-forget "apply now": `Err(())` (transport drop) propagates so the
@@ -755,7 +778,7 @@ fn rpc_result<T>(r: Result<T, tarpc::client::RpcError>) -> Result<T, ()> {
     clippy::match_same_arms,
     reason = "the two read arms send the same disconnect error to differently-typed reply channels, so they can't be merged"
 )]
-fn reply_disconnected(cmd: Command) {
+fn reply_disconnected(pairing_tx: &mpsc::UnboundedSender<PairingUpdate>, cmd: Command) {
     // Transient (Hidpp), not a permanent feature error: the agent is just
     // restarting, so the panel should keep retrying, not latch "unsupported".
     let unreachable = || WriteError::Hidpp("background agent not running".to_string());
@@ -766,6 +789,10 @@ fn reply_disconnected(cmd: Command) {
         Command::ReadSmartShift(_, reply) => {
             let _ = reply.send(Err(unreachable()));
         }
+        Command::StartPairing(_) | Command::PairDevice(_) => {
+            let _ = pairing_tx.send(PairingUpdate::Failed(PairingFailure::AgentRestarted));
+        }
+        Command::CancelPairing => {}
         _ => {}
     }
 }

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -123,6 +123,11 @@ fn pairing_failure_text(failure: PairingFailure) -> String {
         PairingFailure::ReceiverAccessUnavailable => {
             tr!("Pairing is unavailable because receiver access could not be recorded.").to_string()
         }
+        PairingFailure::AlreadyActive => tr!("A pairing session is already active.").to_string(),
+        PairingFailure::UnknownDevice => {
+            tr!("That device is no longer available. Search again and retry pairing.").to_string()
+        }
+        PairingFailure::NoActiveSession => tr!("No pairing session is active.").to_string(),
     }
 }
 

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -34,8 +34,8 @@ pub use pairing::{
 pub use route::{BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
 pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus};
 pub use write::{
-    DpiCapabilities, DpiInfo, FeatureEntry, LightingMethod, SharedChannel, WriteError,
-    dump_features, get_dpi, get_dpi_info, get_smartshift_status, set_dpi, set_dpi_on,
-    set_keyboard_color, set_keyboard_color_with, set_smartshift, set_smartshift_on,
-    set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
+    DpiCapabilities, DpiInfo, FeatureEntry, HidppFeatureErrorKind, HidppOperation, LightingMethod,
+    SharedChannel, WriteError, dump_features, get_dpi, get_dpi_info, get_smartshift_status,
+    set_dpi, set_dpi_on, set_keyboard_color, set_keyboard_color_with, set_smartshift,
+    set_smartshift_on, set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -50,11 +50,97 @@ pub enum WriteError {
     EmptyDpiList,
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
+    #[error("HID++ feature error during {operation:?} for feature {feature_hex:#06x}: {kind:?}")]
+    HidppFeature {
+        operation: HidppOperation,
+        feature_hex: u16,
+        kind: HidppFeatureErrorKind,
+    },
+    #[error("HID++ unsupported response during {operation:?} for feature {feature_hex:#06x}")]
+    UnsupportedResponse {
+        operation: HidppOperation,
+        feature_hex: u16,
+    },
+    #[error("HID++ request timed out during {operation:?}")]
+    RequestTimedOut { operation: HidppOperation },
+    #[error("tokio runtime init failed: {message}")]
+    RuntimeInit { message: String },
+    #[error("background agent is unavailable")]
+    AgentUnavailable,
+}
+
+/// HID++ operation being performed when a device write/read failed.
+///
+/// Variant order is wire format because this travels inside [`WriteError`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HidppOperation {
+    ResolveFeature,
+    DumpFeatures,
+    ReadDpi,
+    ReadDpiCapabilities,
+    WriteDpi,
+    ReadSmartShift,
+    WriteSmartShift,
+    Lighting,
+}
+
+/// HID++ feature error kind in a serializable wire-safe form.
+///
+/// Variant order is wire format because this travels inside [`WriteError`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HidppFeatureErrorKind {
+    NoError,
+    Unknown,
+    InvalidArgument,
+    OutOfRange,
+    HwError,
+    LogitechInternal,
+    InvalidFeatureIndex,
+    InvalidFunctionId,
+    Busy,
+    Unsupported,
+    Unrecognized,
 }
 
 impl From<async_hid::HidError> for WriteError {
     fn from(e: async_hid::HidError) -> Self {
         Self::Hid(e.to_string())
+    }
+}
+
+fn hidpp_feature_error_kind(kind: ErrorType) -> HidppFeatureErrorKind {
+    match kind {
+        ErrorType::NoError => HidppFeatureErrorKind::NoError,
+        ErrorType::Unknown => HidppFeatureErrorKind::Unknown,
+        ErrorType::InvalidArgument => HidppFeatureErrorKind::InvalidArgument,
+        ErrorType::OutOfRange => HidppFeatureErrorKind::OutOfRange,
+        ErrorType::HwError => HidppFeatureErrorKind::HwError,
+        ErrorType::LogitechInternal => HidppFeatureErrorKind::LogitechInternal,
+        ErrorType::InvalidFeatureIndex => HidppFeatureErrorKind::InvalidFeatureIndex,
+        ErrorType::InvalidFunctionId => HidppFeatureErrorKind::InvalidFunctionId,
+        ErrorType::Busy => HidppFeatureErrorKind::Busy,
+        ErrorType::Unsupported => HidppFeatureErrorKind::Unsupported,
+        _ => HidppFeatureErrorKind::Unrecognized,
+    }
+}
+
+fn classify_hidpp_error(
+    error: Hidpp20Error,
+    operation: HidppOperation,
+    feature_hex: u16,
+) -> WriteError {
+    match error {
+        Hidpp20Error::Feature(kind) => WriteError::HidppFeature {
+            operation,
+            feature_hex,
+            kind: hidpp_feature_error_kind(kind),
+        },
+        Hidpp20Error::UnsupportedResponse => WriteError::UnsupportedResponse {
+            operation,
+            feature_hex,
+        },
+        Hidpp20Error::Channel(error) => WriteError::Hidpp(format!("{error:?}")),
+        _ => WriteError::Hidpp(format!("{error:?}")),
     }
 }
 
@@ -191,21 +277,21 @@ pub async fn dump_features(route: &DeviceRoute) -> Result<Vec<FeatureEntry>, Wri
             .root()
             .get_feature(FeatureSetFeature::ID)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?
+            .map_err(|e| {
+                classify_hidpp_error(e, HidppOperation::DumpFeatures, FeatureSetFeature::ID)
+            })?
             .ok_or(WriteError::FeatureUnsupported {
                 feature_hex: FeatureSetFeature::ID,
             })?;
         let feature_set = device.add_feature::<FeatureSetFeature>(feature_set_info.index);
-        let count = feature_set
-            .count()
-            .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+        let count = feature_set.count().await.map_err(|e| {
+            classify_hidpp_error(e, HidppOperation::DumpFeatures, FeatureSetFeature::ID)
+        })?;
         let mut entries = Vec::with_capacity(usize::from(count));
         for i in 0..=count {
-            let info = feature_set
-                .get_feature(i)
-                .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+            let info = feature_set.get_feature(i).await.map_err(|e| {
+                classify_hidpp_error(e, HidppOperation::DumpFeatures, FeatureSetFeature::ID)
+            })?;
             entries.push(FeatureEntry {
                 id: info.id,
                 version: info.version,
@@ -231,7 +317,7 @@ pub(crate) async fn open_feature<F: CreatableFeature + 'static>(
         .root()
         .get_feature(F::ID)
         .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, F::ID))?
         .ok_or(WriteError::FeatureUnsupported { feature_hex: F::ID })?;
     Ok(device.add_feature::<F>(info.index))
 }
@@ -299,15 +385,13 @@ impl SmartShift {
     /// `tunable_torque` is reported as `0` per [`SmartShiftStatus`]'s contract.
     async fn status(&self) -> Result<SmartShiftStatus, WriteError> {
         match self {
-            Self::Enhanced(feature) => feature
-                .get_status()
-                .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+            Self::Enhanced(feature) => feature.get_status().await.map_err(|e| {
+                classify_hidpp_error(e, HidppOperation::ReadSmartShift, SmartShiftFeatureV0::ID)
+            }),
             Self::Legacy(feature) => {
-                let rcm = feature
-                    .get_ratchet_control_mode()
-                    .await
-                    .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+                let rcm = feature.get_ratchet_control_mode().await.map_err(|e| {
+                    classify_hidpp_error(e, HidppOperation::ReadSmartShift, SmartShiftFeature::ID)
+                })?;
                 Ok(SmartShiftStatus {
                     mode: wheel_mode_to_smartshift(rcm.wheel_mode),
                     auto_disengage: rcm.auto_disengage,
@@ -335,7 +419,13 @@ impl SmartShift {
             Self::Enhanced(feature) => feature
                 .set_status(mode, auto_disengage, tunable_torque)
                 .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+                .map_err(|e| {
+                    classify_hidpp_error(
+                        e,
+                        HidppOperation::WriteSmartShift,
+                        SmartShiftFeatureV0::ID,
+                    )
+                }),
             Self::Legacy(feature) => feature
                 .set_ratchet_control_mode(
                     Some(smartshift_to_wheel(mode)),
@@ -343,7 +433,9 @@ impl SmartShift {
                     None,
                 )
                 .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+                .map_err(|e| {
+                    classify_hidpp_error(e, HidppOperation::WriteSmartShift, SmartShiftFeature::ID)
+                }),
         }
     }
 
@@ -375,7 +467,7 @@ pub async fn get_dpi(route: &DeviceRoute) -> Result<u16, WriteError> {
         feature
             .get_sensor_dpi(0)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))
+            .map_err(|e| classify_hidpp_error(e, HidppOperation::ReadDpi, AdjustableDpiFeature::ID))
     })
     .await
 }
@@ -384,15 +476,19 @@ pub async fn get_dpi(route: &DeviceRoute) -> Result<u16, WriteError> {
 /// announces `0x2201` but rejects a function (`Unsupported` /
 /// `InvalidFunctionId`) or returns a structurally invalid DPI list
 /// (`UnsupportedResponse`) will keep doing so, so these map to the permanent
-/// [`WriteError::FeatureUnsupported`]; channel/timeout errors stay transient
-/// [`WriteError::Hidpp`] so callers may retry.
+/// [`WriteError::FeatureUnsupported`]; channel/timeout and other errors are
+/// forwarded through [`classify_hidpp_error`] as transient so callers may retry.
 fn classify_dpi_error(error: Hidpp20Error) -> WriteError {
     match error {
         Hidpp20Error::Feature(ErrorType::Unsupported | ErrorType::InvalidFunctionId)
         | Hidpp20Error::UnsupportedResponse => WriteError::FeatureUnsupported {
             feature_hex: AdjustableDpiFeature::ID,
         },
-        other => WriteError::Hidpp(format!("{other:?}")),
+        other => classify_hidpp_error(
+            other,
+            HidppOperation::ReadDpiCapabilities,
+            AdjustableDpiFeature::ID,
+        ),
     }
 }
 
@@ -591,7 +687,7 @@ async fn resolve_feature_index(
             .root()
             .get_feature(feature_id)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+            .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, feature_id))?;
         Ok(info.map(|i| i.index))
     })
     .await
@@ -706,7 +802,7 @@ async fn set_dpi_on_channel(
     feature
         .set_sensor_dpi(0, dpi)
         .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteDpi, AdjustableDpiFeature::ID))?;
     // Read back to confirm the firmware accepted the value. A mismatch is a
     // silent failure mode that's otherwise invisible — devices in low-power
     // states or with unsupported DPI ranges can ACK the write yet keep the old

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -21,7 +21,7 @@ use std::sync::{
 use std::thread;
 
 use evdev::uinput::VirtualDevice;
-use evdev::{Device, EventSummary, InputEvent, KeyCode, RelativeAxisCode};
+use evdev::{Device, EventSummary, KeyCode, RelativeAxisCode};
 use tracing::{debug, error, warn};
 use x11rb::connection::Connection as _;
 use x11rb::properties::WmClass;


### PR DESCRIPTION
## Summary
- make pairing command RPCs return typed command-acceptance errors instead of fire-and-forget unit results
- keep session progress on the pairing event stream, while command rejection is acknowledged immediately
- map command rejection to typed pairing failures in the GUI so Add Device never stays in an optimistic state after rejection
- bump PROTOCOL_VERSION and pin new wire variants

## Validation
- cargo fmt --check
- cargo test -p openlogi-agent pairing::tests
- cargo test -p openlogi-agent-core --test wire_format
- cargo check -p openlogi-agent -p openlogi-gui
- cargo clippy -p openlogi-agent-core -p openlogi-agent -p openlogi-gui --all-targets -- -D warnings
- cargo test -p openlogi-agent-core -p openlogi-agent