### PR TITLE
refactor(hid): type write error causes

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -17,8 +17,8 @@ use std::time::Duration;
 
 use openlogi_core::config::Lighting;
 use openlogi_hid::{
-    CaptureChannel, DeviceRoute, DpiInfo, SharedChannel, SmartShiftMode, SmartShiftStatus,
-    WriteError,
+    CaptureChannel, DeviceRoute, DpiInfo, HidppOperation, SharedChannel, SmartShiftMode,
+    SmartShiftStatus, WriteError,
 };
 use tracing::{debug, warn};
 
@@ -36,12 +36,16 @@ pub fn read_dpi_info_blocking(target: &DeviceRoute) -> Result<DpiInfo, WriteErro
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .map_err(|e| WriteError::Hidpp(format!("tokio runtime init failed: {e}")))?;
+        .map_err(|e| WriteError::RuntimeInit {
+            message: e.to_string(),
+        })?;
 
     rt.block_on(async {
         tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_dpi_info(target))
             .await
-            .map_err(|_| WriteError::Hidpp("DPI info read timed out".into()))?
+            .map_err(|_| WriteError::RequestTimedOut {
+                operation: HidppOperation::ReadDpiCapabilities,
+            })?
     })
 }
 
@@ -116,12 +120,16 @@ pub fn read_smartshift_status_blocking(
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .map_err(|e| WriteError::Hidpp(format!("tokio runtime init failed: {e}")))?;
+        .map_err(|e| WriteError::RuntimeInit {
+            message: e.to_string(),
+        })?;
 
     rt.block_on(async {
         tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_smartshift_status(target))
             .await
-            .map_err(|_| WriteError::Hidpp("SmartShift status read timed out".into()))?
+            .map_err(|_| WriteError::RequestTimedOut {
+                operation: HidppOperation::ReadSmartShift,
+            })?
     })
 }
 
@@ -316,7 +324,7 @@ pub async fn apply_dpi(
 ) -> Result<(), WriteError> {
     let dpi = u16::try_from(dpi).unwrap_or(u16::MAX);
     let shared = reusable_channel(Some(capture), route);
-    timed(async {
+    timed(HidppOperation::WriteDpi, async {
         match &shared {
             Some(shared) => openlogi_hid::set_dpi_on(shared, dpi).await,
             None => openlogi_hid::set_dpi(route, dpi).await,
@@ -334,7 +342,7 @@ pub async fn apply_smartshift(
     tunable_torque: u8,
 ) -> Result<(), WriteError> {
     let shared = reusable_channel(Some(capture), route);
-    timed(async {
+    timed(HidppOperation::WriteSmartShift, async {
         match &shared {
             Some(shared) => {
                 openlogi_hid::set_smartshift_on(shared, mode, auto_disengage, tunable_torque).await
@@ -348,23 +356,38 @@ pub async fn apply_smartshift(
 /// Apply a lighting config to the keyboard at `route`.
 pub async fn apply_lighting(route: &DeviceRoute, lighting: &Lighting) -> Result<(), WriteError> {
     let (r, g, b) = lighting_rgb(lighting);
-    timed(openlogi_hid::set_keyboard_color(route, r, g, b)).await
+    timed(
+        HidppOperation::Lighting,
+        openlogi_hid::set_keyboard_color(route, r, g, b),
+    )
+    .await
 }
 
 /// Read the current DPI + supported values from `route`.
 pub async fn read_dpi(route: &DeviceRoute) -> Result<DpiInfo, WriteError> {
-    timed(openlogi_hid::get_dpi_info(route)).await
+    timed(
+        HidppOperation::ReadDpiCapabilities,
+        openlogi_hid::get_dpi_info(route),
+    )
+    .await
 }
 
 /// Read the current SmartShift config from `route`.
 pub async fn read_smartshift(route: &DeviceRoute) -> Result<SmartShiftStatus, WriteError> {
-    timed(openlogi_hid::get_smartshift_status(route)).await
+    timed(
+        HidppOperation::ReadSmartShift,
+        openlogi_hid::get_smartshift_status(route),
+    )
+    .await
 }
 
 /// Bound any single HID++ call by [`WRITE_BUDGET`] so an asleep / unresponsive
 /// device can't hang the awaiting IPC handler indefinitely.
-async fn timed<T>(fut: impl Future<Output = Result<T, WriteError>>) -> Result<T, WriteError> {
-    tokio::time::timeout(WRITE_BUDGET, fut).await.map_err(|_| {
-        WriteError::Hidpp("HID++ request timed out (device asleep/unresponsive)".into())
-    })?
+async fn timed<T>(
+    operation: HidppOperation,
+    fut: impl Future<Output = Result<T, WriteError>>,
+) -> Result<T, WriteError> {
+    tokio::time::timeout(WRITE_BUDGET, fut)
+        .await
+        .map_err(|_| WriteError::RequestTimedOut { operation })?
 }

--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -24,7 +24,8 @@ use serde::{Deserialize, Serialize};
 /// v4: [`Agent::snapshot`] added for atomic status + inventory polling.
 /// v5: [`PairingUpdate::Failed`] carries a typed [`PairingFailure`].
 /// v6: pairing commands return typed acceptance errors.
-pub const PROTOCOL_VERSION: u32 = 6;
+/// v7: [`WriteError`] carries typed HID++ operation failures.
+pub const PROTOCOL_VERSION: u32 = 7;
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -32,8 +32,8 @@ use openlogi_core::device::{
     DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
 };
 use openlogi_hid::{
-    Click, DeviceRoute, DpiCapabilities, DpiInfo, PasskeyMethod, ReceiverSelector, SmartShiftMode,
-    SmartShiftStatus, WriteError,
+    Click, DeviceRoute, DpiCapabilities, DpiInfo, HidppFeatureErrorKind, HidppOperation,
+    PasskeyMethod, ReceiverSelector, SmartShiftMode, SmartShiftStatus, WriteError,
 };
 
 /// Serialize exactly as the transport does (`tokio_serde::formats::Bincode`
@@ -61,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 6);
+    assert_eq!(PROTOCOL_VERSION, 7);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -214,6 +214,35 @@ fn device_settings_payloads() {
         feature_hex: 0x2201,
     });
     assert_wire(&unsupported, "0103fb0122");
+
+    assert_wire(
+        &WriteError::RequestTimedOut {
+            operation: HidppOperation::WriteDpi,
+        },
+        "0804",
+    );
+    assert_wire(
+        &WriteError::HidppFeature {
+            operation: HidppOperation::WriteDpi,
+            feature_hex: 0x2201,
+            kind: HidppFeatureErrorKind::OutOfRange,
+        },
+        "0604fb012203",
+    );
+    assert_wire(
+        &WriteError::UnsupportedResponse {
+            operation: HidppOperation::Lighting,
+            feature_hex: 0x8070,
+        },
+        "0707fb7080",
+    );
+    assert_wire(
+        &WriteError::RuntimeInit {
+            message: "boom".into(),
+        },
+        "0904626f6f6d",
+    );
+    assert_wire(&WriteError::AgentUnavailable, "0a");
 
     // serde encodes SmartShiftMode's variant *index* (Free=0, Ratchet=1), not
     // the `#[repr(u8)]` firmware discriminants (1/2) — pinned here because it

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -761,15 +761,14 @@ fn rpc_result<T>(r: Result<T, tarpc::client::RpcError>) -> Result<T, ()> {
     reason = "the two read arms send the same disconnect error to differently-typed reply channels, so they can't be merged"
 )]
 fn reply_disconnected(pairing_tx: &mpsc::UnboundedSender<PairingUpdate>, cmd: Command) {
-    // Transient (Hidpp), not a permanent feature error: the agent is just
-    // restarting, so the panel should keep retrying, not latch "unsupported".
-    let unreachable = || WriteError::Hidpp("background agent not running".to_string());
+    // Transient, not a permanent feature error: the agent is just restarting,
+    // so the panel should keep retrying, not latch "unsupported".
     match cmd {
         Command::ReadDpi(_, reply) => {
-            let _ = reply.send(Err(unreachable()));
+            let _ = reply.send(Err(WriteError::AgentUnavailable));
         }
         Command::ReadSmartShift(_, reply) => {
-            let _ = reply.send(Err(unreachable()));
+            let _ = reply.send(Err(WriteError::AgentUnavailable));
         }
         Command::StartPairing(_) | Command::PairDevice(_) => {
             let _ = pairing_tx.send(PairingUpdate::Failed(PairingFailure::AgentRestarted));

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -32,8 +32,8 @@ pub use pairing::{
 pub use route::{BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
 pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus};
 pub use write::{
-    DpiCapabilities, DpiInfo, FeatureEntry, LightingMethod, SharedChannel, WriteError,
-    dump_features, get_dpi, get_dpi_info, get_smartshift_status, set_dpi, set_dpi_on,
-    set_keyboard_color, set_keyboard_color_with, set_smartshift, set_smartshift_on,
-    set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
+    DpiCapabilities, DpiInfo, FeatureEntry, HidppFeatureErrorKind, HidppOperation, LightingMethod,
+    SharedChannel, WriteError, dump_features, get_dpi, get_dpi_info, get_smartshift_status,
+    set_dpi, set_dpi_on, set_keyboard_color, set_keyboard_color_with, set_smartshift,
+    set_smartshift_on, set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -50,11 +50,97 @@ pub enum WriteError {
     EmptyDpiList,
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
+    #[error("HID++ feature error during {operation:?} for feature {feature_hex:#06x}: {kind:?}")]
+    HidppFeature {
+        operation: HidppOperation,
+        feature_hex: u16,
+        kind: HidppFeatureErrorKind,
+    },
+    #[error("HID++ unsupported response during {operation:?} for feature {feature_hex:#06x}")]
+    UnsupportedResponse {
+        operation: HidppOperation,
+        feature_hex: u16,
+    },
+    #[error("HID++ request timed out during {operation:?}")]
+    RequestTimedOut { operation: HidppOperation },
+    #[error("tokio runtime init failed: {message}")]
+    RuntimeInit { message: String },
+    #[error("background agent is unavailable")]
+    AgentUnavailable,
+}
+
+/// HID++ operation being performed when a device write/read failed.
+///
+/// Variant order is wire format because this travels inside [`WriteError`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HidppOperation {
+    ResolveFeature,
+    DumpFeatures,
+    ReadDpi,
+    ReadDpiCapabilities,
+    WriteDpi,
+    ReadSmartShift,
+    WriteSmartShift,
+    Lighting,
+}
+
+/// HID++ feature error kind in a serializable wire-safe form.
+///
+/// Variant order is wire format because this travels inside [`WriteError`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HidppFeatureErrorKind {
+    NoError,
+    Unknown,
+    InvalidArgument,
+    OutOfRange,
+    HwError,
+    LogitechInternal,
+    InvalidFeatureIndex,
+    InvalidFunctionId,
+    Busy,
+    Unsupported,
+    Unrecognized,
 }
 
 impl From<async_hid::HidError> for WriteError {
     fn from(e: async_hid::HidError) -> Self {
         Self::Hid(e.to_string())
+    }
+}
+
+fn hidpp_feature_error_kind(kind: ErrorType) -> HidppFeatureErrorKind {
+    match kind {
+        ErrorType::NoError => HidppFeatureErrorKind::NoError,
+        ErrorType::Unknown => HidppFeatureErrorKind::Unknown,
+        ErrorType::InvalidArgument => HidppFeatureErrorKind::InvalidArgument,
+        ErrorType::OutOfRange => HidppFeatureErrorKind::OutOfRange,
+        ErrorType::HwError => HidppFeatureErrorKind::HwError,
+        ErrorType::LogitechInternal => HidppFeatureErrorKind::LogitechInternal,
+        ErrorType::InvalidFeatureIndex => HidppFeatureErrorKind::InvalidFeatureIndex,
+        ErrorType::InvalidFunctionId => HidppFeatureErrorKind::InvalidFunctionId,
+        ErrorType::Busy => HidppFeatureErrorKind::Busy,
+        ErrorType::Unsupported => HidppFeatureErrorKind::Unsupported,
+        _ => HidppFeatureErrorKind::Unrecognized,
+    }
+}
+
+fn classify_hidpp_error(
+    error: Hidpp20Error,
+    operation: HidppOperation,
+    feature_hex: u16,
+) -> WriteError {
+    match error {
+        Hidpp20Error::Feature(kind) => WriteError::HidppFeature {
+            operation,
+            feature_hex,
+            kind: hidpp_feature_error_kind(kind),
+        },
+        Hidpp20Error::UnsupportedResponse => WriteError::UnsupportedResponse {
+            operation,
+            feature_hex,
+        },
+        Hidpp20Error::Channel(error) => WriteError::Hidpp(format!("{error:?}")),
+        _ => WriteError::Hidpp(format!("{error:?}")),
     }
 }
 
@@ -191,21 +277,21 @@ pub async fn dump_features(route: &DeviceRoute) -> Result<Vec<FeatureEntry>, Wri
             .root()
             .get_feature(FeatureSetFeature::ID)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?
+            .map_err(|e| {
+                classify_hidpp_error(e, HidppOperation::DumpFeatures, FeatureSetFeature::ID)
+            })?
             .ok_or(WriteError::FeatureUnsupported {
                 feature_hex: FeatureSetFeature::ID,
             })?;
         let feature_set = device.add_feature::<FeatureSetFeature>(feature_set_info.index);
-        let count = feature_set
-            .count()
-            .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+        let count = feature_set.count().await.map_err(|e| {
+            classify_hidpp_error(e, HidppOperation::DumpFeatures, FeatureSetFeature::ID)
+        })?;
         let mut entries = Vec::with_capacity(usize::from(count));
         for i in 0..=count {
-            let info = feature_set
-                .get_feature(i)
-                .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+            let info = feature_set.get_feature(i).await.map_err(|e| {
+                classify_hidpp_error(e, HidppOperation::DumpFeatures, FeatureSetFeature::ID)
+            })?;
             entries.push(FeatureEntry {
                 id: info.id,
                 version: info.version,
@@ -231,7 +317,7 @@ async fn open_feature<F: CreatableFeature + 'static>(
         .root()
         .get_feature(F::ID)
         .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, F::ID))?
         .ok_or(WriteError::FeatureUnsupported { feature_hex: F::ID })?;
     Ok(device.add_feature::<F>(info.index))
 }
@@ -299,15 +385,13 @@ impl SmartShift {
     /// `tunable_torque` is reported as `0` per [`SmartShiftStatus`]'s contract.
     async fn status(&self) -> Result<SmartShiftStatus, WriteError> {
         match self {
-            Self::Enhanced(feature) => feature
-                .get_status()
-                .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+            Self::Enhanced(feature) => feature.get_status().await.map_err(|e| {
+                classify_hidpp_error(e, HidppOperation::ReadSmartShift, SmartShiftFeatureV0::ID)
+            }),
             Self::Legacy(feature) => {
-                let rcm = feature
-                    .get_ratchet_control_mode()
-                    .await
-                    .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+                let rcm = feature.get_ratchet_control_mode().await.map_err(|e| {
+                    classify_hidpp_error(e, HidppOperation::ReadSmartShift, SmartShiftFeature::ID)
+                })?;
                 Ok(SmartShiftStatus {
                     mode: wheel_mode_to_smartshift(rcm.wheel_mode),
                     auto_disengage: rcm.auto_disengage,
@@ -335,7 +419,13 @@ impl SmartShift {
             Self::Enhanced(feature) => feature
                 .set_status(mode, auto_disengage, tunable_torque)
                 .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+                .map_err(|e| {
+                    classify_hidpp_error(
+                        e,
+                        HidppOperation::WriteSmartShift,
+                        SmartShiftFeatureV0::ID,
+                    )
+                }),
             Self::Legacy(feature) => feature
                 .set_ratchet_control_mode(
                     Some(smartshift_to_wheel(mode)),
@@ -343,7 +433,9 @@ impl SmartShift {
                     None,
                 )
                 .await
-                .map_err(|e| WriteError::Hidpp(format!("{e:?}"))),
+                .map_err(|e| {
+                    classify_hidpp_error(e, HidppOperation::WriteSmartShift, SmartShiftFeature::ID)
+                }),
         }
     }
 
@@ -375,7 +467,7 @@ pub async fn get_dpi(route: &DeviceRoute) -> Result<u16, WriteError> {
         feature
             .get_sensor_dpi(0)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))
+            .map_err(|e| classify_hidpp_error(e, HidppOperation::ReadDpi, AdjustableDpiFeature::ID))
     })
     .await
 }
@@ -384,15 +476,19 @@ pub async fn get_dpi(route: &DeviceRoute) -> Result<u16, WriteError> {
 /// announces `0x2201` but rejects a function (`Unsupported` /
 /// `InvalidFunctionId`) or returns a structurally invalid DPI list
 /// (`UnsupportedResponse`) will keep doing so, so these map to the permanent
-/// [`WriteError::FeatureUnsupported`]; channel/timeout errors stay transient
-/// [`WriteError::Hidpp`] so callers may retry.
+/// [`WriteError::FeatureUnsupported`]; channel/timeout and other errors are
+/// forwarded through [`classify_hidpp_error`] as transient so callers may retry.
 fn classify_dpi_error(error: Hidpp20Error) -> WriteError {
     match error {
         Hidpp20Error::Feature(ErrorType::Unsupported | ErrorType::InvalidFunctionId)
         | Hidpp20Error::UnsupportedResponse => WriteError::FeatureUnsupported {
             feature_hex: AdjustableDpiFeature::ID,
         },
-        other => WriteError::Hidpp(format!("{other:?}")),
+        other => classify_hidpp_error(
+            other,
+            HidppOperation::ReadDpiCapabilities,
+            AdjustableDpiFeature::ID,
+        ),
     }
 }
 
@@ -591,7 +687,7 @@ async fn resolve_feature_index(
             .root()
             .get_feature(feature_id)
             .await
-            .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+            .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, feature_id))?;
         Ok(info.map(|i| i.index))
     })
     .await
@@ -706,7 +802,7 @@ async fn set_dpi_on_channel(
     feature
         .set_sensor_dpi(0, dpi)
         .await
-        .map_err(|e| WriteError::Hidpp(format!("{e:?}")))?;
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteDpi, AdjustableDpiFeature::ID))?;
     // Read back to confirm the firmware accepted the value. A mismatch is a
     // silent failure mode that's otherwise invisible — devices in low-power
     // states or with unsupported DPI ranges can ACK the write yet keep the old


### PR DESCRIPTION
## Summary
- add typed WriteError variants for HID++ feature errors, unsupported responses, request timeouts, runtime init failures, and agent unavailability
- preserve existing DPI permanent-error behavior and SmartShift fallback behavior
- keep Hidpp(String) only as a catch-all for lower-level channel/future unknown errors
- bump PROTOCOL_VERSION and pin new wire encodings

## Validation
- cargo fmt --check
- cargo test -p openlogi-agent-core --test wire_format
- cargo test -p openlogi-hid write::tests
- cargo check -p openlogi-agent -p openlogi-gui
- cargo test -p openlogi-agent-core -p openlogi-agent -p openlogi-hid
- cargo clippy -p openlogi-hid -p openlogi-agent-core -p openlogi-agent -p openlogi-gui --all-targets -- -D warnings