### PR TITLE
fix(unifying): enable wireless notifications so paired devices enumerate

### DIFF
--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -158,6 +158,19 @@ async fn probe_unifying_receiver(
     };
     debug!(events = connections.len(), "drained device-arrival events");
 
+    // The receiver can re-broadcast the same 0x41 for a slot more than once per
+    // trigger, so keep one connection per slot — otherwise the device is listed
+    // twice. Last write wins: a later event carries the freshest online flag.
+    let mut connections: Vec<_> = connections
+        .into_iter()
+        .map(|c| (c.index, c))
+        .collect::<HashMap<_, _>>()
+        .into_values()
+        .collect();
+    // HashMap iteration is unordered; sort by slot so the device list is stable
+    // across probe cycles instead of jittering.
+    connections.sort_by_key(|c| c.index);
+
     // Probe all online slots concurrently so a slow HID++ 2.0 feature walk on
     // one device doesn't push the next slot past the PROBE_BUDGET deadline.
     // Pass the receiver UID so each slot's cache key is scoped to this specific
@@ -427,6 +440,12 @@ async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> 
 async fn drain_device_arrival_unifying(
     unifying: &UnifyingReceiver,
 ) -> Option<Vec<UnifyingDeviceConnection>> {
+    // The receiver only re-broadcasts 0x41 arrival events while wireless
+    // notifications are on; without this the trigger below is ACK'd but emits
+    // nothing, so a paired online device never surfaces.
+    if let Err(e) = unifying.set_wireless_notifications(true).await {
+        debug!(error = ?e, "enable wireless notifications failed");
+    }
     let rx = unifying.listen();
     if let Err(e) = unifying.trigger_device_arrival().await {
         debug!(error = ?e, "trigger_device_arrival failed; receiver may report no devices");
@@ -460,7 +479,7 @@ async fn probe_unifying_slot(
     tick: u64,
 ) -> Option<(PairedDevice, CacheOutcome)> {
     let slot = event.index;
-    let codename = read_codename(channel, slot).await;
+    let codename = read_codename_unifying(channel, slot).await;
     debug!(
         slot,
         online = event.online,
@@ -479,9 +498,16 @@ async fn probe_unifying_slot(
     let cached = cache.get(&id);
     let register_kind = map_unifying_kind(event.kind);
 
+    // `trigger_device_arrival` re-broadcasts a 0x41 for *every* paired slot,
+    // online or not, and the crate's `event.online` reads the wrong notification
+    // byte (payload[1] bit6, always set here — wire-verified `04 62 69 40`), so
+    // neither tells us if the device is actually reachable on this receiver.
+    // We therefore always attempt the probe (passing `true`) and treat the
+    // feature walk succeeding as the real liveness signal below — a device that
+    // moved to Bluetooth answers `DeviceNotFound` and surfaces as offline.
     let probe_result = timeout(
         UNIFYING_SLOT_PROBE,
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, event.online, tick),
+        probe_or_reuse(channel, slot, Some(id.clone()), cached, true, tick),
     )
     .await;
     let (probe, outcome) = if let Ok(r) = probe_result {
@@ -498,12 +524,40 @@ async fn probe_unifying_slot(
         codename,
         wpid: Some(event.wpid),
         kind: resolve_device_kind(probe.kind, register_kind),
-        online: event.online,
+        // Reachable on this receiver iff the feature walk got through this tick.
+        // Caveat: a GUI cache hit can serve stale capabilities for up to
+        // REFRESH_TICKS after the device leaves for Bluetooth, briefly showing it
+        // online; self-heals on the next forced re-probe. Add a per-tick liveness
+        // ping if that window ever matters.
+        online: probe.capabilities.is_some(),
         battery: probe.battery,
         model_info: probe.model_info,
         capabilities: probe.capabilities,
     };
     Some((device, outcome))
+}
+
+/// Reads a Unifying paired device's name. Unifying stores names at
+/// sub-register base `0x40` (device `n` at `0x40 + (n-1)`), a different layout
+/// from Bolt's `0x60`: the long-register response is `[sub, len, data..]` with
+/// no chunk byte — wire-verified `40 0c "MX Master 2S"`. The name lives on the
+/// receiver, so it reads even while the device is offline (e.g. moved to BT).
+async fn read_codename_unifying(channel: &HidppChannel, slot: u8) -> Option<String> {
+    let response = channel
+        .read_long_register(0xFF, 0xB5, [0x40 + slot - 1, 0x00, 0x00])
+        .await
+        .ok()?;
+    parse_codename_unifying(&response)
+}
+
+/// Parse a Unifying name-register response `[sub, len, data..]` into a string.
+/// The device-reported `len` is clamped to the bytes actually present so a
+/// bogus length can't over-read the fixed long-register buffer.
+pub(super) fn parse_codename_unifying(response: &[u8]) -> Option<String> {
+    let len = usize::from(*response.get(1)?).min(response.len().saturating_sub(2));
+    core::str::from_utf8(response.get(2..2 + len)?)
+        .ok()
+        .map(str::to_string)
 }
 
 /// Reads a paired device's codename, working around a slicing bug in

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
 
 use super::cache::{CACHE_MISS_GRACE, CacheKey, Cached, REFRESH_TICKS, is_stale};
+use super::probe::parse_codename_unifying;
 use super::{Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop};
 use crate::inventory::features::ProbedFeatures;
 
@@ -163,4 +164,28 @@ fn one_shot_retry_stops_at_attempt_cap_when_inventory_keeps_changing() {
         ),
         "the retry loop must remain bounded even if the inventory changes every time"
     );
+}
+
+#[test]
+fn codename_reads_len_prefixed_name() {
+    // wire-verified MX Master 2S reply: `40 0c "MX Master 2S"` then padding.
+    let mut buf = vec![0x40, 0x0c];
+    buf.extend_from_slice(b"MX Master 2S");
+    buf.extend_from_slice(&[0u8; 2]); // trailing bytes of the 16-byte register
+    assert_eq!(
+        parse_codename_unifying(&buf).as_deref(),
+        Some("MX Master 2S")
+    );
+}
+
+#[test]
+fn codename_clamps_overlong_len() {
+    // a bogus length byte must not over-read past the buffer.
+    let buf = [0x40, 0xff, b'h', b'i'];
+    assert_eq!(parse_codename_unifying(&buf).as_deref(), Some("hi"));
+}
+
+#[test]
+fn codename_rejects_short_response() {
+    assert_eq!(parse_codename_unifying(&[0x40]), None);
 }

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -29,6 +29,11 @@ pub const VPID_PAIRS: &[(u16, u16)] = &[(0x046d, 0xc52b), (0x046d, 0xc532)];
 #[non_exhaustive]
 #[repr(u8)]
 pub enum Register {
+    /// Controls which notifications the receiver emits. Wireless device-arrival
+    /// (`0x41`) events are only re-broadcast while wireless notifications are
+    /// enabled here; see [`Receiver::set_wireless_notifications`].
+    Notifications = 0x00,
+
     /// Enables or disables wireless device-connection notifications; also used
     /// to read the pairing count and to trigger device-arrival events.
     Connections = 0x02,
@@ -57,6 +62,11 @@ pub enum InfoSubRegister {
 
     /// Provides the codename of a specific paired device. The device index (4
     /// bits) must be added: `0x60 | (device_index & 0x0f)`.
+    ///
+    /// NOTE: `0x60` is the *Bolt* base. Wire-verified Unifying receivers store
+    /// names at base `0x40 + (n-1)` instead, so name reads go directly through
+    /// `read_codename_unifying` in `inventory.rs` rather than this constant —
+    /// don't reuse `DeviceCodename` for Unifying name reads.
     DeviceCodename = 0x60,
 }
 
@@ -136,6 +146,41 @@ impl Receiver {
             .await?;
 
         Ok(response[1])
+    }
+
+    /// Enables or disables wireless device-connection notifications.
+    ///
+    /// The receiver only re-broadcasts `0x41` device-arrival events (the source
+    /// for [`Self::trigger_device_arrival`]) while this is on. With it off the
+    /// trigger write is ACK'd but emits nothing — which is why a paired, online
+    /// device can fail to enumerate. Solaar enables this before listing.
+    ///
+    /// Read-modify-write of just the `WIRELESS` bit so it can't clobber other
+    /// flags already set on register `0x00` — notably `SOFTWARE_PRESENT` (0x08),
+    /// which the pairing flow enables (`pairing.rs` writes `[0x00, 0x09, 0x00]`)
+    /// and a concurrent inventory poll would otherwise drop.
+    pub async fn set_wireless_notifications(&self, enabled: bool) -> Result<(), ReceiverError> {
+        // Notification flags are a 3-byte big-endian word; the receiver-reporting
+        // bits live in byte 1 (WIRELESS = 0x000100, SOFTWARE_PRESENT = 0x000800).
+        const WIRELESS: u8 = 0x01;
+        let mut flags = self
+            .chan
+            .read_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::Notifications.into(),
+                [0; 3],
+            )
+            .await?;
+        if enabled {
+            flags[1] |= WIRELESS;
+        } else {
+            flags[1] &= !WIRELESS;
+        }
+        self.chan
+            .write_register(RECEIVER_DEVICE_INDEX, Register::Notifications.into(), flags)
+            .await?;
+
+        Ok(())
     }
 
     /// Triggers device-arrival notifications for all currently connected


### PR DESCRIPTION
## Summary
A device on a Unifying receiver wouldn't show up even while connected. The
receiver only re-broadcasts arrival events while wireless notifications
(register 0x00) are on, and we never enabled it — so the trigger got ACK'd
but emitted nothing. Solaar does this before listing.

## Changes
- Enable wireless notifications before draining arrivals.
- Derive online from the feature walk succeeding (event.online was always
  "offline" here).
- Read device names at Unifying's 0x40 base instead of Bolt's 0x60, and
  clamp the reported length.
- Dedup repeated arrivals per slot.

## Testing
Tested on an MX Master 2S over a Unifying receiver. Added unit tests for the
name parser (normal, over-long length, short response).
