### PR TITLE
fix: set app_id on GUI windows so GNOME Wayland matches the .desktop icon and decorations

### DIFF
--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -557,6 +557,7 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
         // (`MODEL_MIN_H` + the chrome/padding reserve) so its side labels never
         // overlap; below this the model can't shrink further without crowding.
         window_min_size: Some(Size::new(px(720.), px(680.))),
+        app_id: Some("openlogi".to_string()),
         titlebar: Some(TitlebarOptions {
             title: Some(SharedString::from("OpenLogi")),
             appears_transparent: false,

--- a/crates/openlogi-gui/src/windows/mod.rs
+++ b/crates/openlogi-gui/src/windows/mod.rs
@@ -73,6 +73,7 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
     let bounds = Bounds::centered(None, size, cx);
     let options = WindowOptions {
         window_bounds: Some(WindowBounds::Windowed(bounds)),
+        app_id: Some("openlogi".to_string()),
         titlebar: Some(TitlebarOptions {
             title: Some(title.clone()),
             appears_transparent: false,


### PR DESCRIPTION
## Summary

Sets `app_id: Some("openlogi".to_string())` on the two `gpui::WindowOptions` literals that previously omitted it: the main window in `main_window_options()` (`crates/openlogi-gui/src/main.rs`) and the auxiliary windows in `open_or_focus()` (`crates/openlogi-gui/src/windows/mod.rs`).

The value `"openlogi"` matches the packaged desktop basename `packaging/linux/desktop/openlogi.desktop` and its `Icon=openlogi`, so GNOME can associate the live window with its `.desktop` entry and icon.

## Why this matters

On GNOME Wayland the GUI window is created without an xdg-toplevel `app_id`, so GNOME reports `wmclass: null` for the running window (#319). That single root cause produces two cosmetic regressions: a generic dock/overview icon (even though the `.desktop` and app-grid icon are correct) and missing server-side window decorations (square corners instead of GNOME's rounded ones). Because the window class is `null`, no `StartupWMClass=` in the `.desktop` can fix it; the `app_id` has to be set on the GPUI window itself, which is what this change does.

The change is additive (one field per literal) and inert on macOS/Windows, where `app_id` is unused.

## Testing

- `cargo fmt -p openlogi-gui --check` — clean.
- `cargo clippy -p openlogi-gui` — clean (only a pre-existing future-incompat warning from the `block` transitive dep, unrelated to this change).
- `cargo check -p openlogi-gui` — compiles; the `app_id: Option<String>` field is present on the pinned gpui rev (`eb2223c`), so a wrong field name would be a compile error.
- GNOME Wayland window association (live `wmclass: openlogi`, correct dock icon, standard decorations) is not unit-testable headless and would need a maintainer check on a Wayland session.

Fixes #319
