### PR TITLE
fix(hidpp): correct UnifiedBattery (0x1004) charging status codes

### DIFF
--- a/crates/openlogi-hid/src/mappings.rs
+++ b/crates/openlogi-hid/src/mappings.rs
@@ -104,10 +104,14 @@ pub(crate) fn map_battery_level(level: HidppBatteryLevel) -> BatteryLevel {
 pub(crate) fn map_battery_status(status: HidppBatteryStatus) -> BatteryStatus {
     match status {
         HidppBatteryStatus::Discharging => BatteryStatus::Discharging,
-        HidppBatteryStatus::Charging => BatteryStatus::Charging,
+        HidppBatteryStatus::Charging | HidppBatteryStatus::ChargingNearlyFull => {
+            BatteryStatus::Charging
+        }
         HidppBatteryStatus::ChargingSlow => BatteryStatus::ChargingSlow,
         HidppBatteryStatus::Full => BatteryStatus::Full,
-        HidppBatteryStatus::Error => BatteryStatus::Error,
+        HidppBatteryStatus::InvalidBattery
+        | HidppBatteryStatus::ThermalError
+        | HidppBatteryStatus::ChargingError => BatteryStatus::Error,
         _ => BatteryStatus::Unknown,
     }
 }

--- a/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
@@ -183,7 +183,8 @@ pub enum BatteryLevel {
     Full = 1 << 3,
 }
 
-/// Represents the charging status of the battery.
+/// Represents the charging status of the battery, as reported in the `0x1004`
+/// `getStatus` battery-status byte.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
@@ -193,12 +194,18 @@ pub enum BatteryStatus {
     Discharging = 0,
     /// Battery is charging.
     Charging = 1,
-    /// Battery is charging slowly.
-    ChargingSlow = 2,
-    /// Battery is full.
+    /// Battery is charging and in its final stage (nearly full).
+    ChargingNearlyFull = 2,
+    /// Battery charge is complete.
     Full = 3,
-    /// Battery subsystem reported an error.
-    Error = 4,
+    /// Battery is recharging below optimal speed.
+    ChargingSlow = 4,
+    /// The battery type is invalid.
+    InvalidBattery = 5,
+    /// The battery subsystem reported a thermal error.
+    ThermalError = 6,
+    /// The battery subsystem reported a charging error.
+    ChargingError = 7,
 }
 
 /// Represents an event emitted by the [`UnifiedBatteryFeature`] feature.


### PR DESCRIPTION
## Summary

The `UnifiedBattery` (`0x1004`) `getStatus` "battery status" byte (`payload[2]`)
is decoded into `BatteryStatus`, but two values were mislabeled and three were
missing:

- `2` was `ChargingSlow` — it is actually the **final charging stage** (nearly
  full), still charging.
- `4` was `Error` — it is actually a **below-optimal-speed recharge** (the real
  "slow charge"), not an error.
- `5`/`6`/`7` (invalid battery, thermal error, charging error) had **no
  variants** at all.

Because the enum stopped at `4`, a device reporting `5`–`7` failed
`BatteryStatus::try_from` and `get_battery_info` returned
`UnsupportedResponse` — i.e. a thermal/charging-error state broke the whole
battery read rather than surfacing the error. A nearly-full charging device
showed "slow", and a genuinely slow charge showed "error".

## Evidence

Cross-checked against two independent sources, which agree:

**Linux `drivers/hid/hid-logitech-hidpp.c`** (unified-battery `switch (data[2])`):

| byte | kernel | this PR |
|---|---|---|
| 0 | discharging | `Discharging` |
| 1 | recharging | `Charging` |
| 2 | charge in final stage | `ChargingNearlyFull` |
| 3 | charge complete | `Full` |
| 4 | recharging below optimal speed | `ChargingSlow` |
| 5 | invalid battery type | `InvalidBattery` |
| 6 | thermal error | `ThermalError` |
| 7 | other charging error | `ChargingError` |

**Solaar** (`common.py` `BatteryStatus`): `0 DISCHARGING, 1 RECHARGING,
2 ALMOST_FULL, 3 FULL, 4 SLOW_RECHARGE, 5 INVALID_BATTERY, 6 THERMAL_ERROR`.

## Changes

- `openlogi-hidpp` (`feature/unified_battery`): rename `2` → `ChargingNearlyFull`,
  `4` → `ChargingSlow`, add `InvalidBattery` / `ThermalError` / `ChargingError`
  (`5`–`7`).
- `openlogi-hid` (`mappings::map_battery_status`): map the corrected variants to
  the existing core `BatteryStatus` — nearly-full → `Charging`, `5`–`7` →
  `Error`.

The `openlogi-core` domain `BatteryStatus` and all GUI/diagnostics code are
**unchanged**; this only corrects the wire decode and the bridge to it.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p openlogi-hid -- -D warnings`
- `cargo test -p openlogi-hidpp` (152) and `cargo test -p openlogi-hid` (60)

The full-workspace `clippy`/`test` gate was not run locally (it builds GPUI);
the change doesn't touch `openlogi-gui`, and the only cross-crate consumer of
the wire enum is `openlogi-hid::mappings`, which is covered above. CI will run
the full gate.

## Note

This lands in the vendored `openlogi-hidpp` fork (0BSD, kept close to
`lus/logy`). The same fix likely applies upstream — happy to send it there too
if you'd prefer to keep the fork in lockstep.
