### PR TITLE
fix(gui): avoid RefCell panic when applying theme on OS appearance change

### DIFF
--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -142,7 +142,17 @@ pub fn apply_from_settings(window: Option<&mut Window>, cx: &mut App) {
     // `System` branch below reads the *real* OS appearance rather than a stale
     // forced override.
     crate::platform::os::set_app_appearance(appearance);
-    let os_appearance = cx.window_appearance();
+    // Read the OS appearance from the window in hand (a borrow-free field read)
+    // rather than `cx.window_appearance()`. On Linux the latter routes through
+    // the platform client's `RefCell` (`with_common`), and this is called from
+    // the window-appearance observer, which gpui fires from inside its
+    // xdg-desktop-portal handler while that same `RefCell` is already borrowed —
+    // querying it there panics with "RefCell already borrowed". With no window
+    // (a settings edit), the platform query is safe and gives every window's
+    // shared appearance.
+    let os_appearance = window
+        .as_ref()
+        .map_or_else(|| cx.window_appearance(), |w| w.appearance());
 
     // Pull the chosen configs out of the registry before borrowing the Theme
     // mutably (both live as globals).


### PR DESCRIPTION
## Problem

`openlogi-gui` panics on launch on Linux (both Wayland and X11) with:

```
thread 'main' panicked at .../gpui_linux/src/linux/wayland/client.rs:924:23:
RefCell already borrowed
```

(equivalently `x11/client.rs:1529` on the X11 backend). The CLI is unaffected — only the GUI crashes, immediately, on essentially every launch. Reproduced against the shipped `v0.6.18` build (gpui rev `eb2223c`).

## Root cause

`theme::apply_from_settings` reads the OS appearance via `cx.window_appearance()`. On Linux that routes through the platform client's `RefCell`:

```
cx.window_appearance()
  → LinuxPlatform::window_appearance()
  → self.inner.with_common(...)        // gpui_linux platform.rs
  → self.0.borrow_mut().common         // gpui_linux .../client.rs  ← panics
```

`apply_from_settings` is invoked from the window-appearance observer wired up in `open_main_window` (`main.rs`). gpui fires that observer from inside its **xdg-desktop-portal handler**, which holds the platform client's `RefCell` mutably borrowed across the dispatch:

```rust
// gpui_linux .../wayland/client.rs — XDPEvent::WindowAppearance
let mut client = client.borrow_mut();          // borrows self.0 ...
for window in client.windows.values_mut() {
    window.set_appearance(appearance);          // ... fires our observer here
}
```

So when the portal reports the initial colour scheme at startup, the observer re-enters the platform via `cx.window_appearance()` while the same `RefCell` is already borrowed → panic. (Deferring the work doesn't help: gpui flushes the deferred effect before that borrow is released.)

This almost certainly never surfaced on macOS, where appearance dispatch doesn't hold a `RefCell` across the callback.

## Fix

Read the OS appearance from the `Window` already in hand — a borrow-free field access (`Window::appearance()`) — instead of querying the platform. The platform query (`cx.window_appearance()`) is kept only for the no-window case (a live settings edit), which never runs inside the portal borrow.

## Verification

- Release build (matching the shipped `v0.6.18` gpui rev `eb2223c`) compiles clean; `cargo clippy -p openlogi-gui` is clean.
- Before: panicked on nearly every launch. After: **0 panics across repeated launches**, and the window stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)