### PR TITLE
fix(gui): draw a client-side titlebar on Linux for window controls

### DIFF
--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -1,9 +1,10 @@
 use gpui::{
     AnyElement, App, AppContext as _, BorrowAppContext as _, Context, Entity, FocusHandle,
     FontWeight, InteractiveElement, IntoElement, ParentElement, Render,
-    StatefulInteractiveElement as _, Styled, Subscription, Window, div, px, rgb,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, div,
+    prelude::FluentBuilder as _, px, rgb,
 };
-use gpui_component::{Icon, IconName, h_flex, v_flex};
+use gpui_component::{Icon, IconName, TitleBar, h_flex, v_flex};
 use openlogi_core::device::{Capabilities, DeviceInventory, DeviceKind};
 use tracing::info;
 
@@ -320,6 +321,25 @@ fn request_accessibility(cx: &mut App) {
     permissions::open_pane(Permission::Accessibility);
 }
 
+/// Client-side main-window titlebar: window controls (minimize / maximize /
+/// close on Linux + Windows), the drag region, and the app name centred.
+/// Replaces the native titlebar so Linux — where the compositor declines
+/// server-side decorations and gpui falls back to client-side ones it doesn't
+/// paint — still gets a titlebar and window controls. On macOS the widget
+/// reserves the traffic-light space.
+fn app_title_bar(pal: Palette) -> impl IntoElement {
+    TitleBar::new().child(
+        div()
+            .flex_1()
+            .flex()
+            .items_center()
+            .justify_center()
+            .text_sm()
+            .text_color(pal.text_muted)
+            .child("OpenLogi"),
+    )
+}
+
 impl Render for AppView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
@@ -334,7 +354,14 @@ impl Render for AppView {
             .track_focus(&self.focus_handle)
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
-            .on_action(|_: &Zoom, window, _| window.zoom_window());
+            .on_action(|_: &Zoom, window, _| window.zoom_window())
+            // Linux only: a client-side titlebar (window controls + drag region)
+            // as the first row of every frame — including the pre-connection and
+            // error frames — so the chrome is present from the first frame on.
+            // macOS / Windows keep their native titlebar.
+            .when(cfg!(target_os = "linux"), |this| {
+                this.child(app_title_bar(pal))
+            });
 
         // The agent is the source of truth for both the permission state and
         // the device list; `AgentLink` is everything the GUI knows about it.

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -55,8 +55,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use gpui::{
-    AppContext, BorrowAppContext as _, Bounds, SharedString, Size, Styled, TitlebarOptions,
-    WindowBounds, WindowOptions, px,
+    AppContext, BorrowAppContext as _, Bounds, Size, Styled, WindowBounds, WindowOptions, px,
 };
 use gpui_component::{ActiveTheme, Root};
 use openlogi_core::brand::DeeplinkCommand;
@@ -489,11 +488,10 @@ fn main_window_options(cx: &mut gpui::App) -> WindowOptions {
         // overlap; below this the model can't shrink further without crowding.
         window_min_size: Some(Size::new(px(720.), px(680.))),
         app_id: Some("openlogi".to_string()),
-        titlebar: Some(TitlebarOptions {
-            title: Some(SharedString::from("OpenLogi")),
-            appears_transparent: false,
-            traffic_light_position: None,
-        }),
+        // Linux: transparent chrome so `AppView::render` can draw a client-side
+        // `TitleBar` (the compositor declines server-side decorations and gpui's
+        // fallback is unpainted). macOS/Windows keep their native titlebar.
+        titlebar: Some(windows::titlebar_options("OpenLogi")),
         ..WindowOptions::default()
     }
 }

--- a/crates/openlogi-gui/src/windows.rs
+++ b/crates/openlogi-gui/src/windows.rs
@@ -14,10 +14,11 @@ pub mod settings;
 pub mod update_consent;
 
 use gpui::{
-    App, AppContext as _, Bounds, Context, Global, Pixels, Render, SharedString, Size, Styled as _,
-    Subscription, TitlebarOptions, WindowBounds, WindowHandle, WindowOptions,
+    App, AppContext as _, Bounds, Context, Global, IntoElement, ParentElement as _, Pixels, Render,
+    SharedString, Size, Styled as _, Subscription, TitlebarOptions, WindowBounds, WindowHandle,
+    WindowOptions, div,
 };
-use gpui_component::{ActiveTheme as _, Root};
+use gpui_component::{ActiveTheme as _, Root, TitleBar};
 use tracing::warn;
 
 /// One live handle per auxiliary window, stored as a GPUI global so the menu
@@ -34,6 +35,45 @@ pub struct WindowRegistry {
 }
 
 impl Global for WindowRegistry {}
+
+/// Titlebar options for an app window.
+///
+/// On Linux this returns transparent options so the view can draw a client-side
+/// [`TitleBar`] (see [`aux_title_bar`]); the compositor declines server-side
+/// decorations there and gpui's client-side fallback is otherwise unpainted,
+/// leaving the window with no titlebar or controls. On macOS / Windows it keeps
+/// the native titlebar carrying `title`, unchanged.
+pub fn titlebar_options(title: impl Into<SharedString>) -> TitlebarOptions {
+    if cfg!(target_os = "linux") {
+        TitleBar::title_bar_options()
+    } else {
+        TitlebarOptions {
+            title: Some(title.into()),
+            appears_transparent: false,
+            traffic_light_position: None,
+        }
+    }
+}
+
+/// Client-side window titlebar for auxiliary windows: window controls
+/// (minimize / maximize / close on Linux + Windows), the drag region, and the
+/// window `title` centred. Each auxiliary view renders this as the top of its
+/// layout so the window has a titlebar and controls on Linux, where the
+/// compositor declines server-side decorations and gpui's client-side fallback
+/// is otherwise unpainted. On macOS the widget reserves the traffic-light space.
+pub fn aux_title_bar(title: impl Into<SharedString>, cx: &App) -> impl IntoElement {
+    let title = title.into();
+    TitleBar::new().child(
+        div()
+            .flex_1()
+            .flex()
+            .items_center()
+            .justify_center()
+            .text_sm()
+            .text_color(cx.theme().muted_foreground)
+            .child(title),
+    )
+}
 
 /// Implemented by every auxiliary root view so [`open_or_focus`] can hand it
 /// the appearance observer to hold onto — dropping the [`Subscription`] would
@@ -73,11 +113,7 @@ pub fn open_or_focus<V: AuxWindow + 'static>(
     let options = WindowOptions {
         window_bounds: Some(WindowBounds::Windowed(bounds)),
         app_id: Some("openlogi".to_string()),
-        titlebar: Some(TitlebarOptions {
-            title: Some(title.clone()),
-            appears_transparent: false,
-            traffic_light_position: None,
-        }),
+        titlebar: Some(titlebar_options(title.clone())),
         ..WindowOptions::default()
     };
 

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -17,7 +17,7 @@
 use gpui::{
     App, Context, FocusHandle, FontWeight, Global, InteractiveElement, IntoElement,
     ParentElement as _, Render, SharedString, Size, StatefulInteractiveElement as _, Styled as _,
-    Subscription, Window, div, px, rgb,
+    Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::v_flex;
 use openlogi_agent_core::ipc::{FoundDevice, PairingFailure, PairingUpdate};
@@ -183,15 +183,26 @@ impl Render for AddDeviceView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            .p_6()
-            .gap_5()
+            // Linux only: a client-side titlebar at the top of the window; the
+            // padded content sits in the flex-column below it. macOS / Windows
+            // keep their native titlebar.
+            .when(cfg!(target_os = "linux"), |this| {
+                this.child(windows::aux_title_bar(tr!("Add Device"), cx))
+            })
             .child(
-                div()
-                    .text_lg()
-                    .font_weight(FontWeight::SEMIBOLD)
-                    .child(tr!("Add Device")),
+                v_flex()
+                    .flex_1()
+                    .w_full()
+                    .p_6()
+                    .gap_5()
+                    .child(
+                        div()
+                            .text_lg()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(tr!("Add Device")),
+                    )
+                    .child(body(&state, pal)),
             )
-            .child(body(&state, pal))
     }
 }
 

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -18,8 +18,8 @@ pub(super) use gpui::{
     prelude::FluentBuilder, px, rgb,
 };
 pub(super) use gpui_component::{
-    ActiveTheme, Disableable, Icon, IconName, IndexPath, Selectable, Sizable, Theme, ThemeColor,
-    ThemeMode, ThemeRegistry,
+    ActiveTheme, Disableable, Icon, IconName, IndexPath, Selectable, Sizable, TITLE_BAR_HEIGHT,
+    Theme, ThemeColor, ThemeMode, ThemeRegistry,
     button::{Button, ButtonGroup, ButtonVariants},
     group_box::GroupBoxVariant,
     h_flex,
@@ -291,7 +291,7 @@ pub fn open(cx: &mut App) {
 pub fn open_at(page: SettingsPage, cx: &mut App) {
     windows::open_or_focus(
         |reg| &mut reg.settings,
-        "Settings",
+        tr!("Settings"),
         Size::new(px(840.), px(600.)),
         move |window, cx| SettingsView::new(page, window, cx),
         cx,
@@ -333,12 +333,27 @@ impl Render for SettingsView {
 
         div()
             .size_full()
+            .relative()
             .bg(pal.bg)
             .text_color(pal.text_primary)
             .track_focus(&self.focus_handle)
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
+            // Linux only: a client-side titlebar as an absolute overlay (with
+            // matching top padding) rather than a flex-column row — the
+            // `Settings` sidebar uses `h_resizable` percentage sizing, which a
+            // flex column would break. macOS / Windows keep their native titlebar.
+            .when(cfg!(target_os = "linux"), |this| {
+                this.pt(TITLE_BAR_HEIGHT).child(
+                    div()
+                        .absolute()
+                        .top_0()
+                        .left_0()
+                        .right_0()
+                        .child(windows::aux_title_bar(tr!("Settings"), cx)),
+                )
+            })
             .child(settings)
     }
 }

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -8,7 +8,8 @@
 
 use gpui::{
     App, BorrowAppContext as _, Context, FocusHandle, FontWeight, InteractiveElement, IntoElement,
-    ParentElement as _, Render, Size, Styled as _, Subscription, Window, div, px,
+    ParentElement as _, Render, Size, Styled as _, Subscription, Window, div,
+    prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     button::{Button, ButtonVariants as _},
@@ -77,43 +78,54 @@ impl Render for UpdateConsentView {
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())
-            .items_center()
-            .justify_center()
-            .gap_4()
-            .p_6()
+            // Linux only: a client-side titlebar at the top of the window; the
+            // centred content sits in the flex-column below it. macOS / Windows
+            // keep their native titlebar.
+            .when(cfg!(target_os = "linux"), |this| {
+                this.child(windows::aux_title_bar(tr!("OpenLogi"), cx))
+            })
             .child(
-                div()
-                    .text_lg()
-                    .font_weight(FontWeight::SEMIBOLD)
-                    .child(tr!("Check for updates?")),
-            )
-            .child(
-                div()
-                    .max_w(px(320.))
-                    .text_sm()
-                    .text_center()
-                    .text_color(pal.text_muted)
-                    .child(tr!(
-                        "OpenLogi can check GitHub once per launch for a new version — query \
-                         only, no automatic download or telemetry. You can change this anytime \
-                         in Settings."
-                    )),
-            )
-            .child(
-                h_flex()
-                    .gap_3()
-                    .pt_2()
+                v_flex()
+                    .flex_1()
+                    .w_full()
+                    .items_center()
+                    .justify_center()
+                    .gap_4()
+                    .p_6()
                     .child(
-                        Button::new("update-consent-decline")
-                            .outline()
-                            .label(tr!("Not now"))
-                            .on_click(|_, window, cx| answer(false, window, cx)),
+                        div()
+                            .text_lg()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .child(tr!("Check for updates?")),
                     )
                     .child(
-                        Button::new("update-consent-accept")
-                            .primary()
-                            .label(tr!("Enable"))
-                            .on_click(|_, window, cx| answer(true, window, cx)),
+                        div()
+                            .max_w(px(320.))
+                            .text_sm()
+                            .text_center()
+                            .text_color(pal.text_muted)
+                            .child(tr!(
+                                "OpenLogi can check GitHub once per launch for a new version — query \
+                                 only, no automatic download or telemetry. You can change this anytime \
+                                 in Settings."
+                            )),
+                    )
+                    .child(
+                        h_flex()
+                            .gap_3()
+                            .pt_2()
+                            .child(
+                                Button::new("update-consent-decline")
+                                    .outline()
+                                    .label(tr!("Not now"))
+                                    .on_click(|_, window, cx| answer(false, window, cx)),
+                            )
+                            .child(
+                                Button::new("update-consent-accept")
+                                    .primary()
+                                    .label(tr!("Enable"))
+                                    .on_click(|_, window, cx| answer(true, window, cx)),
+                            ),
                     ),
             )
     }


### PR DESCRIPTION
## Problem

On Linux every window opens with **no titlebar and no window controls** (minimize / maximize / close). All windows use `appears_transparent: false`, but on Linux the compositor declines server-side decorations and gpui falls back to client-side decorations it does not paint — so there's nothing to drag and no controls. macOS and Windows are unaffected (their native titlebar works), so this is a Linux-only gap.

Startup log on Wayland:

```
gpui_linux::linux::wayland::window: Server-side decorations requested, but the
Wayland server does not support them. Falling back to client-side decorations.
```

## Fix

Draw gpui-component's `TitleBar` (window controls + drag region) on Linux, scoped behind `cfg!(target_os = "linux")` so **macOS and Windows keep their native titlebar unchanged**:

- Window options go through a shared `windows::titlebar_options()` helper: on Linux it returns `TitleBar::title_bar_options()` (transparent native chrome); on macOS/Windows it returns the original native options. Used by the main window (`main.rs`) and the aux-window opener (`windows/mod.rs`).
- The main view (`app.rs`) and each auxiliary view — Settings, Add Device, Update Consent — render a `TitleBar` at the top via a shared `windows::aux_title_bar()` helper, each gated on Linux.
- The Settings window uses an **absolute-overlay** titlebar (with matching top padding) rather than a flex-column row, because its `h_resizable` sidebar uses percentage sizing that a flex column would break.

## Scope & testing

- **macOS / Windows: byte-for-byte unchanged** — the native titlebar options and render paths are preserved; the `TitleBar` is only added under `cfg!(target_os = "linux")`. (The one non-gated change, an inner `flex_1` wrapper in two aux views, is visually neutral.)
- **Linux: verified** — builds clean, `clippy` clean, the app launches and the window stays up with the client-side titlebar on the CSD path.

> Note: this is independent of the appearance-observer crash fix (#337) — it touches different files and neither depends on the other. But `master` currently panics on launch on Linux (that's #337), so to *run* this branch in isolation you'll want #337's one-line fix present; reviewing the diff needs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)