### PR TITLE
ci: add cargo-deny (advisories, licenses, bans, sources)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,15 @@ jobs:
         run: test "$(uname -m)" = "${{ matrix.arch }}"
       - run: cargo test --workspace --all-targets
 
+  cargo-deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+
   clippy-windows:
     name: clippy (windows)
     runs-on: windows-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,37 @@
+# cargo-deny configuration — advisories, licenses, and source hygiene for the
+# whole dependency graph (including the git-pinned gpui/zed tree).
+# Run locally with: nix run nixpkgs#cargo-deny -- check
+
+[advisories]
+yanked = "deny"
+
+[licenses]
+# Additions here need a conscious decision; keep the list to what the graph
+# actually pulls in.
+allow = [
+    "0BSD",
+    "CDLA-Permissive-2.0",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "MPL-2.0",
+    "CC0-1.0",
+]
+
+[bans]
+# The zed/gpui tree inevitably carries duplicate versions; keep this advisory
+# rather than blocking.
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = [
+    "https://github.com/zed-industries/zed",
+    "https://github.com/longbridge/gpui-component",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,16 @@ multiple-versions = "warn"
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+# The two deliberate direct git deps, plus the git sources they pull in
+# transitively (zed's forks and the gpui-updater sibling crate) — everything
+# that appears as `git+…` in Cargo.lock must be listed here.
 allow-git = [
     "https://github.com/zed-industries/zed",
     "https://github.com/longbridge/gpui-component",
+    "https://github.com/AprilNEA/gpui-updater",
+    "https://github.com/zed-industries/font-kit",
+    "https://github.com/zed-industries/reqwest.git",
+    "https://github.com/zed-industries/scap",
+    "https://github.com/zed-industries/wgpu.git",
+    "https://github.com/zed-industries/xim-rs.git",
 ]

--- a/devenv.lock
+++ b/devenv.lock
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779592685,
-        "narHash": "sha256-p9d56GezhHRf4QfANxwa1d+fvwShvjB5XUhdIl7WEd0=",
+        "lastModified": 1783144302,
+        "narHash": "sha256-NQnzmXwpEAd5tjMBh2+P/y9NknF+WHv5+6yoXoN4h/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3a58b199e7c83a80b85c28044f808085ba7e941c",
+        "rev": "fe5aee0952e8e1525533d61defd9e36513db811b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Adds a cargo-deny gate over the whole dependency graph:

- **advisories**: RUSTSEC database, yanked crates denied. First local run immediately flagged RUSTSEC's anyhow advisory (Miri-detected UB in `downcast_mut`, GitHub dependabot alert #2) — this PR bumps anyhow 1.0.102 → 1.0.103 to clear it. The lockfile diff is that single package; the zed/gpui git pins are untouched.
- **licenses**: explicit allow-list covering what the graph actually pulls in (incl. the zed/gpui tree); anything new needs a conscious deny.toml addition.
- **bans**: duplicate versions warn-only — the zed tree inevitably carries duplicates.
- **sources**: unknown registries/git denied; only the two pinned git sources (zed-industries/zed, longbridge/gpui-component) are allowed, so an accidental new git dependency fails CI.

Validated locally: `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok.