### PR TITLE
feat: wheel tilt-left/right as bindable buttons (verified on MX Ergo)

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -6,7 +6,8 @@
 //! thumb-wheel arming — changes, and dispatches each captured input:
 //!
 //! - a gesture swipe through the gesture binding map,
-//! - a DPI/ModeShift or thumb-wheel-tap press through the button binding map,
+//! - a DPI/ModeShift, wheel-tilt, or thumb-wheel-tap press through the button
+//!   binding map,
 //! - thumb-wheel rotation through the [`ButtonId::ThumbwheelScrollUp`] /
 //!   [`ButtonId::ThumbwheelScrollDown`] bindings — either re-synthesised as
 //!   continuous, sensitivity-scaled horizontal scroll or accumulated into a

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -235,6 +235,7 @@ async fn manage(
                         if let Err(e) = run_capture_session(
                             route,
                             capture_thumbwheel,
+                            false,
                             divert_gesture_button,
                             sink,
                             stop_rx,

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -129,6 +129,24 @@ fn thumbwheel_armed(hook_maps: &SharedHookMaps, sensitivity: i32) -> bool {
     })
 }
 
+/// Whether either wheel-tilt control must be diverted over HID++ (which
+/// suppresses native horizontal scroll) so we can run a custom action.
+///
+/// We divert only when a tilt is rebound away from its default horizontal
+/// scroll; otherwise the OS scrolls the wheel natively. Mirrors
+/// [`thumbwheel_armed`].
+fn tilt_armed(hook_maps: &SharedHookMaps) -> bool {
+    hook_maps.read().ok().is_some_and(|maps| {
+        [ButtonId::TiltLeft, ButtonId::TiltRight]
+            .iter()
+            .any(|&button| {
+                maps.bindings
+                    .get(&button)
+                    .is_some_and(|action| *action != default_binding(button))
+            })
+    })
+}
+
 /// Whether a finished capture session should make the manager re-arm.
 ///
 /// `done_epoch` identifies the session that signalled completion; `live_epoch`
@@ -153,8 +171,8 @@ async fn manage(
     receiver_access: ReceiverAccess,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
-    // (route, capture_thumbwheel, divert_gesture_button)
-    let mut current: Option<(DeviceRoute, bool, bool)> = None;
+    // (route, capture_thumbwheel, capture_tilt, divert_gesture_button)
+    let mut current: Option<(DeviceRoute, bool, bool, bool)> = None;
     let mut stop: Option<oneshot::Sender<()>> = None;
     let mut ticker = tokio::time::interval(TARGET_POLL);
     let mut accumulators = WheelAccumulators::default();
@@ -201,6 +219,7 @@ async fn manage(
                         (
                             t,
                             thumbwheel_armed(&hook_maps, sensitivity),
+                            tilt_armed(&hook_maps),
                             divert_gesture,
                         )
                     })
@@ -218,12 +237,17 @@ async fn manage(
                     current = None;
                     continue;
                 }
-                if let Some((route, capture_thumbwheel, divert_gesture_button)) = want {
+                if let Some((route, capture_thumbwheel, capture_tilt, divert_gesture_button)) = want {
                     let Some(receiver_lease) = receiver_access.try_acquire_for_capture() else {
                         current = None;
                         continue;
                     };
-                    current = Some((route.clone(), capture_thumbwheel, divert_gesture_button));
+                    current = Some((
+                        route.clone(),
+                        capture_thumbwheel,
+                        capture_tilt,
+                        divert_gesture_button,
+                    ));
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let sink = tx.clone();
                     let slot = Arc::clone(&capture_channel);
@@ -235,7 +259,7 @@ async fn manage(
                         if let Err(e) = run_capture_session(
                             route,
                             capture_thumbwheel,
-                            false,
+                            capture_tilt,
                             divert_gesture_button,
                             sink,
                             stop_rx,
@@ -598,5 +622,28 @@ mod tests {
         // The session was stopped on purpose (pairing took the receiver, or no
         // device is targeted): no target means there is nothing to re-arm.
         assert!(!should_rearm(7, 7, false));
+    }
+
+    #[test]
+    fn tilt_armed_false_at_defaults_true_when_rebound() {
+        use crate::hook_runtime::HookMaps;
+        use openlogi_core::binding::Action;
+        use std::sync::{Arc, RwLock};
+
+        let maps: SharedHookMaps = Arc::new(RwLock::new(HookMaps::default()));
+        assert!(!tilt_armed(&maps), "no bindings → not armed");
+
+        // The default binding is not "armed".
+        if let Ok(mut m) = maps.write() {
+            m.bindings
+                .insert(ButtonId::TiltLeft, default_binding(ButtonId::TiltLeft));
+        }
+        assert!(!tilt_armed(&maps), "default binding → not armed");
+
+        // A non-default binding on either tilt arms capture.
+        if let Ok(mut m) = maps.write() {
+            m.bindings.insert(ButtonId::TiltRight, Action::Copy);
+        }
+        assert!(tilt_armed(&maps), "a rebound tilt → armed");
     }
 }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -51,13 +51,21 @@ pub enum ButtonId {
     /// The HID++ gesture button on MX-line devices. The press itself
     /// fires the bound action; swipe directions are P1.5 territory.
     GestureButton,
+    /// The scroll wheel tilted left — a divertable HID++ `0x1b04` control
+    /// (CID `0x5b`) on tilt-wheel devices like the MX Ergo. Bound to horizontal
+    /// scroll by default; captured over HID++ only when rebound (see agent-core
+    /// `watchers::gesture`), so native tilt-scroll is preserved otherwise.
+    TiltLeft,
+    /// The scroll wheel tilted right — divertable HID++ `0x1b04` control
+    /// (CID `0x5d`). See [`ButtonId::TiltLeft`].
+    TiltRight,
 }
 
 impl ButtonId {
     /// Every rebindable button in declaration (physical front-to-side) order —
     /// the iteration source for default-binding seeding and the popover
     /// trigger list.
-    pub const ALL: [ButtonId; 10] = [
+    pub const ALL: [ButtonId; 12] = [
         ButtonId::LeftClick,
         ButtonId::RightClick,
         ButtonId::MiddleClick,
@@ -67,6 +75,8 @@ impl ButtonId {
         ButtonId::Thumbwheel,
         ButtonId::ThumbwheelScrollUp,
         ButtonId::ThumbwheelScrollDown,
+        ButtonId::TiltLeft,
+        ButtonId::TiltRight,
         ButtonId::GestureButton,
     ];
 
@@ -98,6 +108,8 @@ impl ButtonId {
             ButtonId::Thumbwheel => "Thumb Wheel",
             ButtonId::ThumbwheelScrollUp => "Thumb Wheel Up",
             ButtonId::ThumbwheelScrollDown => "Thumb Wheel Down",
+            ButtonId::TiltLeft => "Tilt Left",
+            ButtonId::TiltRight => "Tilt Right",
             ButtonId::GestureButton => "Gesture Button",
         }
     }
@@ -742,6 +754,10 @@ impl Action {
 /// hook map, scroll defaults, labels) stay total.
 #[must_use]
 pub fn default_binding(button: ButtonId) -> Action {
+    #[allow(
+        clippy::match_same_arms,
+        reason = "tilt arms mirror the thumbwheel horizontal-scroll actions but are kept separate and documented per physical control"
+    )]
     match button {
         ButtonId::LeftClick => Action::LeftClick,
         ButtonId::RightClick => Action::RightClick,
@@ -757,6 +773,12 @@ pub fn default_binding(button: ButtonId) -> Action {
         // would get (see `watchers::gesture`).
         ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollRight,
         ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollLeft,
+        // The scroll wheel tilts to scroll horizontally: tilt-left → scroll
+        // left, tilt-right → scroll right. Dispatched as a discrete per-press
+        // horizontal scroll (openlogi_inject::execute) via the generic button
+        // path — see agent-core watchers::gesture.
+        ButtonId::TiltLeft => Action::HorizontalScrollLeft,
+        ButtonId::TiltRight => Action::HorizontalScrollRight,
         ButtonId::GestureButton => Action::MissionControl,
     }
 }
@@ -1105,5 +1127,25 @@ mod tests {
             default_binding(ButtonId::DpiToggle),
             Action::CycleDpiPresets
         );
+    }
+
+    #[test]
+    fn tilt_buttons_default_to_horizontal_scroll() {
+        assert_eq!(
+            default_binding(ButtonId::TiltLeft),
+            Action::HorizontalScrollLeft
+        );
+        assert_eq!(
+            default_binding(ButtonId::TiltRight),
+            Action::HorizontalScrollRight
+        );
+    }
+
+    #[test]
+    fn tilt_buttons_are_in_all_and_have_labels() {
+        assert!(ButtonId::ALL.contains(&ButtonId::TiltLeft));
+        assert!(ButtonId::ALL.contains(&ButtonId::TiltRight));
+        assert_eq!(ButtonId::TiltLeft.label(), "Tilt Left");
+        assert_eq!(ButtonId::TiltRight.label(), "Tilt Right");
     }
 }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -18,9 +18,10 @@ pub use swipe::{
     detect_swipe,
 };
 
-/// One of the user-rebindable hotspots on a Logi mouse. The order matches the
-/// physical layout from front to side; [`ButtonId::ALL`] is consumed by the
-/// default-binding generator and the popover trigger list.
+/// One of the user-rebindable hotspots on a Logi mouse. New variants are
+/// appended (the identifiers are TOML-stable config keys); [`ButtonId::ALL`]
+/// lists them in physical layout order (front to side) and is what the
+/// default-binding generator and the popover trigger list consume.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum ButtonId {
     /// The primary button. Rebindable in the config schema, but the OS hook

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI-skift"
 "Thumb Wheel": "Tommelfingerhjul"
 "Gesture Button": "Bevægelsesknap"
+"Tilt Left": "Vip til venstre"
+"Tilt Right": "Vip til højre"
 "Up": "Op"
 "Down": "Ned"
 "Left": "Venstre"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI-Umschaltung"
 "Thumb Wheel": "Daumenrad"
 "Gesture Button": "Gestentaste"
+"Tilt Left": "Nach links kippen"
+"Tilt Right": "Nach rechts kippen"
 "Up": "Oben"
 "Down": "Unten"
 "Left": "Links"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Εναλλαγή DPI"
 "Thumb Wheel": "Πλαϊνός τροχός"
 "Gesture Button": "Κουμπί χειρονομιών"
+"Tilt Left": "Κλίση αριστερά"
+"Tilt Right": "Κλίση δεξιά"
 "Up": "Πάνω"
 "Down": "Κάτω"
 "Left": "Αριστερά"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI Toggle"
 "Thumb Wheel": "Thumb Wheel"
 "Gesture Button": "Gesture Button"
+"Tilt Left": "Tilt Left"
+"Tilt Right": "Tilt Right"
 "Up": "Up"
 "Down": "Down"
 "Left": "Left"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Cambiar DPI"
 "Thumb Wheel": "Rueda lateral"
 "Gesture Button": "Botón de gestos"
+"Tilt Left": "Inclinar a la izquierda"
+"Tilt Right": "Inclinar a la derecha"
 "Up": "Arriba"
 "Down": "Abajo"
 "Left": "Izquierda"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI-vaihto"
 "Thumb Wheel": "Peukalorulla"
 "Gesture Button": "Eletoiminto"
+"Tilt Left": "Kallista vasemmalle"
+"Tilt Right": "Kallista oikealle"
 "Up": "Ylös"
 "Down": "Alas"
 "Left": "Vasen"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Bascule DPI"
 "Thumb Wheel": "Molette latérale"
 "Gesture Button": "Bouton de gestes"
+"Tilt Left": "Incliner à gauche"
+"Tilt Right": "Incliner à droite"
 "Up": "Haut"
 "Down": "Bas"
 "Left": "Gauche"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Cambia DPI"
 "Thumb Wheel": "Volante da pollice"
 "Gesture Button": "Pulsante gesture"
+"Tilt Left": "Inclina a sinistra"
+"Tilt Right": "Inclina a destra"
 "Up": "Su"
 "Down": "Giù"
 "Left": "Sinistra"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI 切り替え"
 "Thumb Wheel": "サムホイール"
 "Gesture Button": "ジェスチャーボタン"
+"Tilt Left": "左チルト"
+"Tilt Right": "右チルト"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI 전환"
 "Thumb Wheel": "썸휠"
 "Gesture Button": "제스처 버튼"
+"Tilt Left": "왼쪽 틸트"
+"Tilt Right": "오른쪽 틸트"
 "Up": "위"
 "Down": "아래"
 "Left": "왼쪽"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI-veksling"
 "Thumb Wheel": "Tommelhjul"
 "Gesture Button": "Bevegelsesknapp"
+"Tilt Left": "Vipp til venstre"
+"Tilt Right": "Vipp til høyre"
 "Up": "Opp"
 "Down": "Ned"
 "Left": "Venstre"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI wisselen"
 "Thumb Wheel": "Duimwiel"
 "Gesture Button": "Gebarenknop"
+"Tilt Left": "Naar links kantelen"
+"Tilt Right": "Naar rechts kantelen"
 "Up": "Omhoog"
 "Down": "Omlaag"
 "Left": "Links"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Przełącznik DPI"
 "Thumb Wheel": "Rolka kciukowa"
 "Gesture Button": "Przycisk gestów"
+"Tilt Left": "Przechył w lewo"
+"Tilt Right": "Przechył w prawo"
 "Up": "W górę"
 "Down": "W dół"
 "Left": "W lewo"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Alternar DPI"
 "Thumb Wheel": "Roda do Polegar"
 "Gesture Button": "Botão de Gesto"
+"Tilt Left": "Inclinar para a esquerda"
+"Tilt Right": "Inclinar para a direita"
 "Up": "Cima"
 "Down": "Baixo"
 "Left": "Esquerda"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Alternar DPI"
 "Thumb Wheel": "Roda de polegar"
 "Gesture Button": "Botão de gesto"
+"Tilt Left": "Inclinar para a esquerda"
+"Tilt Right": "Inclinar para a direita"
 "Up": "Cima"
 "Down": "Baixo"
 "Left": "Esquerda"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "Переключение DPI"
 "Thumb Wheel": "Колесо под большой палец"
 "Gesture Button": "Кнопка жестов"
+"Tilt Left": "Наклон влево"
+"Tilt Right": "Наклон вправо"
 "Up": "Вверх"
 "Down": "Вниз"
 "Left": "Влево"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "DPI-växling"
 "Thumb Wheel": "Tumhjul"
 "Gesture Button": "Gestknapp"
+"Tilt Left": "Luta åt vänster"
+"Tilt Right": "Luta åt höger"
 "Up": "Upp"
 "Down": "Ned"
 "Left": "Vänster"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "灵敏度切换"
 "Thumb Wheel": "拇指滚轮"
 "Gesture Button": "手势按钮"
+"Tilt Left": "向左倾斜"
+"Tilt Right": "向右倾斜"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "靈敏度切換"
 "Thumb Wheel": "拇指滾輪"
 "Gesture Button": "手勢按鈕"
+"Tilt Left": "向左傾斜"
+"Tilt Right": "向右傾斜"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -156,6 +156,8 @@ _version: 1
 "DPI Toggle": "靈敏度切換"
 "Thumb Wheel": "拇指滾輪"
 "Gesture Button": "手勢按鈕"
+"Tilt Left": "向左傾斜"
+"Tilt Right": "向右傾斜"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/src/mouse_model/geometry.rs
+++ b/crates/openlogi-gui/src/mouse_model/geometry.rs
@@ -212,6 +212,8 @@ fn map_slot_name(name: &str) -> Option<ButtonId> {
         "SLOT_NAME_LEFT_BUTTON" => Some(ButtonId::LeftClick),
         "SLOT_NAME_RIGHT_BUTTON" => Some(ButtonId::RightClick),
         "SLOT_NAME_MIDDLE_BUTTON" => Some(ButtonId::MiddleClick),
+        "SLOT_NAME_SCROLL_LEFT" => Some(ButtonId::TiltLeft),
+        "SLOT_NAME_SCROLL_RIGHT" => Some(ButtonId::TiltRight),
         "SLOT_NAME_BACK_BUTTON" => Some(ButtonId::Back),
         "SLOT_NAME_FORWARD_BUTTON" => Some(ButtonId::Forward),
         "SLOT_NAME_MODESHIFT_BUTTON" => Some(ButtonId::DpiToggle),
@@ -290,5 +292,17 @@ mod tests {
         ys.sort_by(f32::total_cmp);
         ys.dedup();
         assert_eq!(ys.len(), labels.len(), "each label gets a distinct slot");
+    }
+
+    #[test]
+    fn scroll_slots_map_to_tilt_buttons() {
+        assert_eq!(
+            map_slot_name("SLOT_NAME_SCROLL_LEFT"),
+            Some(ButtonId::TiltLeft)
+        );
+        assert_eq!(
+            map_slot_name("SLOT_NAME_SCROLL_RIGHT"),
+            Some(ButtonId::TiltRight)
+        );
     }
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -1,6 +1,6 @@
 //! Live control capture for one device: divert the MX dedicated gesture button, the
-//! DPI/ModeShift button, and the thumb wheel over HID++ and turn their events
-//! into [`CapturedInput`] the GUI can dispatch.
+//! DPI/ModeShift button, the wheel-tilt buttons, and the thumb wheel over HID++
+//! and turn their events into [`CapturedInput`] the GUI can dispatch.
 //!
 //! [`run_capture_session`] holds a single HID++ channel open for one device,
 //! enables diversion on whichever of those controls it exposes, registers one
@@ -75,11 +75,15 @@ struct CaptureAccum {
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
+    /// Whether the left tilt control was held in the last event.
+    tilt_left_down: bool,
+    /// Whether the right tilt control was held in the last event.
+    tilt_right_down: bool,
 }
 
-/// Capture the gesture button, DPI/ModeShift button, and (when
-/// `capture_thumbwheel`) the thumb wheel on `route` until `shutdown` resolves,
-/// forwarding each event to `sink`.
+/// Capture the gesture button, DPI/ModeShift button, (when `capture_tilt`)
+/// the wheel-tilt buttons, and (when `capture_thumbwheel`) the thumb wheel on
+/// `route` until `shutdown` resolves, forwarding each event to `sink`.
 ///
 /// The dedicated gesture button (raw-XY) is diverted only when `divert_gesture_button` —
 /// i.e. it is the device's gesture owner. When the user moves the gesture role
@@ -95,6 +99,7 @@ struct CaptureAccum {
 pub async fn run_capture_session(
     route: DeviceRoute,
     capture_thumbwheel: bool,
+    capture_tilt: bool,
     divert_gesture_button: bool,
     sink: mpsc::UnboundedSender<CapturedInput>,
     shutdown: oneshot::Receiver<()>,
@@ -108,6 +113,7 @@ pub async fn run_capture_session(
         &chan,
         device_index,
         capture_thumbwheel,
+        capture_tilt,
         divert_gesture_button,
     )
     .await?;
@@ -156,6 +162,7 @@ pub async fn run_capture_session(
         index = device_index,
         gesture = armed.gesture_diverted,
         dpi_buttons = armed.dpi_cids.len(),
+        tilt_buttons = armed.tilt_cids.len(),
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
@@ -179,6 +186,8 @@ struct ArmedControls {
     gesture_diverted: bool,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
+    /// Wheel tilt CIDs diverted as plain buttons.
+    tilt_cids: Vec<u16>,
     /// `0x2150` accessor + feature index, present when the thumb wheel is
     /// diverted.
     thumb: Option<(Thumbwheel, u8)>,
@@ -197,6 +206,9 @@ impl ArmedControls {
             for &cid in &self.dpi_cids {
                 restore(rc.set_cid_reporting(cid, false, false).await, "DPI button");
             }
+            for &cid in &self.tilt_cids {
+                restore(rc.set_cid_reporting(cid, false, false).await, "tilt button");
+            }
         }
         if let Some((tw, _)) = self.thumb.as_ref() {
             restore(tw.set_reporting(false, false).await, "thumb wheel");
@@ -205,14 +217,16 @@ impl ArmedControls {
 }
 
 /// Resolve features off the device's root and divert the controls we capture:
-/// the gesture button (raw-XY) and DPI/ModeShift buttons over `0x1b04`, and —
-/// when `capture_thumbwheel` and the wheel reports a single tap — the thumb
-/// wheel over `0x2150`. The root-feature lookup mirrors `write::open_feature`,
-/// since hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
+/// the gesture button (raw-XY), DPI/ModeShift buttons, and (when
+/// `capture_tilt`) the wheel-tilt buttons, all over `0x1b04`, and — when
+/// `capture_thumbwheel` and the wheel reports a single tap — the thumb wheel
+/// over `0x2150`. The root-feature lookup mirrors `write::open_feature`, since
+/// hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
 async fn arm_controls(
     chan: &Arc<HidppChannel>,
     slot: u8,
     capture_thumbwheel: bool,
+    capture_tilt: bool,
     divert_gesture_button: bool,
 ) -> Result<ArmedControls, GestureError> {
     let device = Device::new(Arc::clone(chan), slot)
@@ -222,6 +236,7 @@ async fn arm_controls(
     let mut reprog: Option<(ReprogControlsV4, u8)> = None;
     let mut gesture_diverted = false;
     let mut dpi_cids: Vec<u16> = Vec::new();
+    let mut tilt_cids: Vec<u16> = Vec::new();
     if let Some(info) = device
         .root()
         .get_feature(reprog_controls::FEATURE_ID)
@@ -249,6 +264,19 @@ async fn arm_controls(
                     .await
                     .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
                 dpi_cids.push(cid);
+            }
+        }
+        if capture_tilt {
+            for &cid in &[
+                reprog_controls::TILT_LEFT_CID,
+                reprog_controls::TILT_RIGHT_CID,
+            ] {
+                if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+                    rc.set_cid_reporting(cid, true, false)
+                        .await
+                        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                    tilt_cids.push(cid);
+                }
             }
         }
         reprog = Some((rc, info.index));
@@ -283,13 +311,14 @@ async fn arm_controls(
         }
     }
 
-    if !gesture_diverted && dpi_cids.is_empty() && thumb.is_none() {
+    if !gesture_diverted && dpi_cids.is_empty() && tilt_cids.is_empty() && thumb.is_none() {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(ArmedControls {
         reprog,
         gesture_diverted,
         dpi_cids,
+        tilt_cids,
         thumb,
     })
 }
@@ -349,6 +378,18 @@ fn handle_reprog(
                 let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::DpiToggle));
             }
             acc.dpi_down = dpi_down;
+
+            let tilt_left_down = cids.contains(&reprog_controls::TILT_LEFT_CID);
+            if tilt_left_down && !acc.tilt_left_down {
+                let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::TiltLeft));
+            }
+            acc.tilt_left_down = tilt_left_down;
+
+            let tilt_right_down = cids.contains(&reprog_controls::TILT_RIGHT_CID);
+            if tilt_right_down && !acc.tilt_right_down {
+                let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::TiltRight));
+            }
+            acc.tilt_right_down = tilt_right_down;
         }
         RawControlEvent::RawXy { dx, dy } => {
             // Commit the instant a clean direction emerges (mid-swipe, once per

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -40,7 +40,8 @@ pub enum CapturedInput {
     /// A completed gesture-button swipe.
     Gesture(GestureDirection),
     /// A diverted button was pressed — the DPI/ModeShift button
-    /// ([`ButtonId::DpiToggle`]) or the thumb-wheel single tap
+    /// ([`ButtonId::DpiToggle`]), a wheel-tilt button ([`ButtonId::TiltLeft`] /
+    /// [`ButtonId::TiltRight`]), or the thumb-wheel single tap
     /// ([`ButtonId::Thumbwheel`]).
     ButtonPressed(ButtonId),
     /// Thumb-wheel rotation to re-synthesise as horizontal scroll, in the

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -102,3 +102,40 @@ fn a_dpi_button_re_presses_after_a_release() {
     );
     assert!(rx.try_recv().is_err());
 }
+
+#[test]
+fn a_held_tilt_left_presses_once_on_the_rising_edge() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let down = RawControlEvent::DivertedButtons([reprog_controls::TILT_LEFT_CID, 0, 0, 0]);
+
+    handle_reprog(&mut acc, down, &[], &tx);
+    handle_reprog(&mut acc, down, &[], &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::TiltLeft))
+    );
+    assert!(rx.try_recv().is_err(), "a held tilt presses once");
+}
+
+#[test]
+fn tilt_left_and_right_emit_independent_presses() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let left = RawControlEvent::DivertedButtons([reprog_controls::TILT_LEFT_CID, 0, 0, 0]);
+    let right = RawControlEvent::DivertedButtons([reprog_controls::TILT_RIGHT_CID, 0, 0, 0]);
+
+    handle_reprog(&mut acc, left, &[], &tx);
+    handle_reprog(&mut acc, right, &[], &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::TiltLeft))
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::TiltRight))
+    );
+    assert!(rx.try_recv().is_err());
+}

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -51,6 +51,15 @@ pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 /// cross-checked against Solaar `special_keys.py`.
 pub const DPI_MODE_SHIFT_CIDS: [u16; 3] = [0x00c4, 0x00ed, 0x00fd];
 
+/// Control IDs of the scroll wheel's horizontal tilt on tilt-wheel devices
+/// (e.g. MX Ergo): left = `0x5b`, right = `0x5d`. These are classic mouse CIDs
+/// (below `0xB8`, so absent from `control_ids.rs`); values cross-checked against
+/// Solaar `special_keys.py` and the MX Ergo asset depot slotIds (`c91`/`c93`).
+/// Their default on-device task is horizontal scroll left/right.
+pub const TILT_LEFT_CID: u16 = 0x005b;
+/// See [`TILT_LEFT_CID`].
+pub const TILT_RIGHT_CID: u16 = 0x005d;
+
 /// Identity and capabilities of one reprogrammable control, as returned by
 /// `getCtrlIdInfo`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## What

Adds the scroll-wheel **tilt-left / tilt-right** controls as first-class bindable buttons. These horizontal-tilt controls (HID++ `0x1b04` reprogrammable controls, CIDs `0x5b`/`0x5d`) weren't detected or configurable before; they now appear on the mouse diagram with an action picker and default to horizontal scroll.

Addresses #100 (wheel tilt not detected / not configurable). That issue is filed against the **M500S**; this implements the general mechanism and is verified end-to-end on an **MX Ergo** (same standard Logitech tilt CIDs). I don't have an M500S to confirm, but the capture path and slot-name mapping are device-agnostic.

## How (mirrors existing patterns)

- `ButtonId::TiltLeft` / `TiltRight` (appended, TOML-stable), default-bound to `HorizontalScrollLeft` / `HorizontalScrollRight`.
- Captured over HID++ via the same diverted-button rising-edge path as the DPI button; diverted **only when a tilt is rebound** (mirrors `thumbwheel_armed`), so native horizontal scrolling is untouched otherwise.
- GUI hotspots come from the existing asset markers by mapping `SLOT_NAME_SCROLL_LEFT` / `SLOT_NAME_SCROLL_RIGHT` — no asset-registry change.
- Localized across all 20 locales.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace -D warnings`, and `cargo test --workspace` (417 passed, 0 failed) all green.
- New unit tests: the capture rising-edge for both tilt CIDs, `tilt_armed` gating, and the slot-name mapping.
- **On-device (MX Ergo, Bluetooth):** `diag controls` reports `0x5b`/`0x5d` as `divertable`, and a live capture session recorded 142 physical tilt events correctly mapped to `TiltLeft` / `TiltRight` (not swapped).

## Not in scope

- The MX Ergo's Virtual Gesture Button (`0xd7`).
- Label-layout changes — the right gutter is intentionally reserved for the DPI/gesture column per existing code comments, so the tilt labels stay in the left column.

Fixes #100