### PR TITLE
fix: embed and sign the openlogi CLI in the macOS app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
           set -euo pipefail
           app="target/release/bundle/osx/OpenLogi.app"
           helper="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
+          cli="$app/Contents/MacOS/openlogi"
           # Inside-out signing: seal the nested agent helper with its own
           # signature first, then the outer app (which seals the signed helper).
           # --deep is deprecated and can't give the helper an independent
@@ -124,10 +125,18 @@ jobs:
             codesign --force --options runtime --timestamp \
               --sign "$APPLE_SIGNING_IDENTITY" "$helper"
           fi
+          # The embedded CLI is a second Mach-O under Contents/MacOS; sign it
+          # with the hardened runtime before the outer app or notarization
+          # rejects its as-built ad-hoc signature.
+          if [ -f "$cli" ]; then
+            codesign --force --options runtime --timestamp \
+              --sign "$APPLE_SIGNING_IDENTITY" "$cli"
+          fi
           codesign --force --options runtime --timestamp \
             --sign "$APPLE_SIGNING_IDENTITY" "$app"
           codesign --verify --strict --verbose=2 "$app"
           [ -d "$helper" ] && codesign --verify --strict --verbose=2 "$helper"
+          [ -f "$cli" ] && codesign --verify --strict --verbose=2 "$cli"
 
       - name: Create and sign DMG
         env:

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -219,10 +219,20 @@ pub(crate) fn sign_app(identity: &str) -> Result<()> {
     if helper.exists() {
         codesign_runtime(identity, &helper)?;
     }
+    // The embedded CLI is a second Mach-O under Contents/MacOS; sign it with the
+    // hardened runtime before the outer app so it carries a Developer ID
+    // signature (its as-built ad-hoc signature would fail notarization).
+    let cli = app.join("Contents/MacOS/openlogi");
+    if cli.exists() {
+        codesign_runtime(identity, &cli)?;
+    }
     codesign_runtime(identity, &app)?;
     cmd!(sh, "codesign --verify --strict {app}").run()?;
     if helper.exists() {
         cmd!(sh, "codesign --verify --strict {helper}").run()?;
+    }
+    if cli.exists() {
+        cmd!(sh, "codesign --verify --strict {cli}").run()?;
     }
     Ok(())
 }

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -99,6 +99,8 @@ pub(crate) fn run() -> Result<()> {
     let app = root.join("target/release/bundle/osx/OpenLogi.app");
     ensure_dir(&app)?;
     embed_agent_helper(&root, &app, &xcode_env)?;
+    embed_cli(&root, &app, &xcode_env)?;
+    verify_bundle_binaries(&app)?;
     println!();
     println!("Bundle ready: {}", app.display());
     Ok(())
@@ -147,6 +149,33 @@ fn embed_agent_helper(root: &Path, app: &Path, xcode_env: &[(String, String)]) -
     stamp_bundle_version(&info_dst, env!("CARGO_PKG_VERSION"))?;
 
     println!("    embedded {}", helper.display());
+    Ok(())
+}
+
+fn embed_cli(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
+    let sh = Shell::new()?;
+    let _repo = sh.push_dir(root);
+    println!("==> cli (build)");
+    cmd!(sh, "cargo build -p openlogi --release")
+        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+        .run()?;
+    let cli_bin = root.join("target/release/openlogi");
+    ensure_file(&cli_bin)?;
+
+    let macos = app.join("Contents/MacOS");
+    fs_err::copy(&cli_bin, macos.join("openlogi"))
+        .with_context(|| "could not copy the CLI binary into the app bundle".to_string())?;
+
+    println!("    embedded {}", macos.join("openlogi").display());
+    Ok(())
+}
+
+fn verify_bundle_binaries(app: &Path) -> Result<()> {
+    for binary in ["openlogi", "openlogi-gui"] {
+        let path = app.join("Contents/MacOS").join(binary);
+        ensure_file(&path)
+            .with_context(|| format!("missing required bundle binary {}", path.display()))?;
+    }
     Ok(())
 }
 
@@ -207,4 +236,45 @@ fn codesign_runtime(identity: &str, target: &Path) -> Result<()> {
     )
     .run()?;
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn app_with_binaries(binaries: &[&str]) -> tempfile::TempDir {
+        let app = tempfile::tempdir().unwrap();
+        let macos = app.path().join("Contents/MacOS");
+        fs_err::create_dir_all(&macos).unwrap();
+        for binary in binaries {
+            fs_err::write(macos.join(binary), b"").unwrap();
+        }
+        app
+    }
+
+    #[test]
+    fn verify_bundle_binaries_accepts_cli_and_gui() {
+        let app = app_with_binaries(&["openlogi", "openlogi-gui"]);
+
+        verify_bundle_binaries(app.path()).unwrap();
+    }
+
+    #[test]
+    fn verify_bundle_binaries_rejects_missing_cli() {
+        let app = app_with_binaries(&["openlogi-gui"]);
+
+        let error = verify_bundle_binaries(app.path()).unwrap_err();
+
+        assert!(error.to_string().contains("openlogi"));
+    }
+
+    #[test]
+    fn verify_bundle_binaries_rejects_missing_gui() {
+        let app = app_with_binaries(&["openlogi"]);
+
+        let error = verify_bundle_binaries(app.path()).unwrap_err();
+
+        assert!(error.to_string().contains("openlogi-gui"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #328. The macOS `.app` bundle now includes the `openlogi` CLI binary, so it is present in the release the same way it is in the Linux package and where the Homebrew cask's `binary` stanza expects it (`Contents/MacOS/openlogi`).

## Why this matters

The macOS bundle step only embedded `openlogi-gui`, so the CLI was absent from the shipped `.app`. Users installing the macOS release had no `openlogi` command, while Linux users did. The fix mirrors the existing agent-helper embedding so the CLI ships alongside the GUI.

## Changes

- `xtask/.../macos/bundle.rs`: add `embed_cli`, which builds `openlogi --release` and copies it into `Contents/MacOS/openlogi`, mirroring `embed_agent_helper`. Add `verify_bundle_binaries`, called at the end of `run()`, asserting both `openlogi` and `openlogi-gui` are present so a future regression fails the build loudly (unit-tested against a temp dir, no Xcode toolchain required).
- Signing: the embedded CLI is a second Mach-O under `Contents/MacOS`, so it needs its own hardened-runtime signature before the outer app or notarization rejects its as-built ad-hoc signature. `sign_app` now signs (and verifies) the CLI in the same inside-out order it uses for the agent helper, and the release workflow's signing step does the same, so tagged notarized builds stay valid.

## Testing

`cargo build -p xtask`, `cargo test -p xtask` (5 passing, including the new `verify_bundle_binaries` cases), and `cargo clippy -p xtask` all pass. Running `xtask macos bundle` locally produces an `OpenLogi.app` containing both `openlogi` and `openlogi-gui`. The codesign/notarization steps run only in the tagged release workflow (they need the signing certificate), so those were reviewed against the existing agent-helper signing pattern rather than executed here.
