### PR TITLE
Back and Forward mouse buttons now work in Safari and Chrome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5132,6 +5132,8 @@ dependencies = [
  "futures-concurrency",
  "futures-lite",
  "num_enum",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "openlogi-core",
  "openlogi-hidpp",
  "serde",

--- a/crates/openlogi-agent-core/Cargo.toml
+++ b/crates/openlogi-agent-core/Cargo.toml
@@ -29,3 +29,4 @@ workspace = true
 bincode = "1.3"
 # Only to construct an `InventoryError::Hid` in the watcher's classify tests.
 async-hid = { workspace = true }
+

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -7,7 +7,8 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, PoisonError, RwLock};
+use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{
     Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
@@ -265,6 +266,40 @@ fn is_native_click(id: ButtonId, action: &Action) -> bool {
     )
 }
 
+/// Minimum time between two BrowserBack (or two BrowserForward) keyboard
+/// dispatches, shared across the CGEventTap hook and the HID++ gesture
+/// watcher — both call [`dispatch_action`] independently, and on devices
+/// where one physical press is visible through both paths, a naive dispatch
+/// would fire the keyboard shortcut twice for one click. Same window as the
+/// HID++ path's own intra-press debounce (`BACK_FORWARD_DEBOUNCE` in
+/// `openlogi-hid`), for consistency.
+const BROWSER_NAV_DEBOUNCE: Duration = Duration::from_millis(150);
+
+/// Per-direction last-dispatch timestamps backing [`browser_nav_debounce_ok`].
+/// `(last_back, last_forward)`.
+static BROWSER_NAV_LAST: Mutex<(Option<Instant>, Option<Instant>)> = Mutex::new((None, None));
+
+/// Whether a BrowserBack/BrowserForward keyboard dispatch for `action` should
+/// proceed, or be suppressed as a duplicate of one already sent (from either
+/// dispatch path) within [`BROWSER_NAV_DEBOUNCE`]. Records the dispatch time
+/// on every `true` return so the *next* call — from either path — sees it.
+fn browser_nav_debounce_ok(action: &Action) -> bool {
+    let mut last = BROWSER_NAV_LAST
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    let slot = if matches!(action, Action::BrowserForward) {
+        &mut last.1
+    } else {
+        &mut last.0
+    };
+    let now = Instant::now();
+    let fire = slot.is_none_or(|t| now.duration_since(t) >= BROWSER_NAV_DEBOUNCE);
+    if fire {
+        *slot = Some(now);
+    }
+    fire
+}
+
 /// Route a bound action either to OS-level event synthesis
 /// ([`Action::execute`]) or to one of OpenLogi's hardware-side handlers.
 ///
@@ -299,10 +334,21 @@ pub fn dispatch_action(
             return;
         }
         // BrowserBack/BrowserForward fall through to the keyboard shortcut
-        // (Cmd+[ / Cmd+]) here — fine for Chrome and other apps that respond
-        // to it. Safari is handled exclusively via the HID++ gesture watcher
-        // path (which uses AXPress with the PID captured at press time) to
-        // avoid double-navigation when both paths fire for the same press.
+        // (Cmd+[ / Cmd+]) here — for Chrome and other apps that respond to
+        // it, and as the HID++ gesture watcher's own fallback when its
+        // AXPress attempt (Safari) fails. On devices where one physical press
+        // is visible through both the CGEventTap hook and the HID++ diverted
+        // path (e.g. MX Vertical), both independently reach this arm for the
+        // *same* press, so it's cross-path debounced — otherwise a
+        // keyboard-driven browser like Chrome would navigate twice per click.
+        Action::BrowserBack | Action::BrowserForward => {
+            if browser_nav_debounce_ok(action) {
+                openlogi_inject::execute(action);
+            } else {
+                info!(action = %action.label(), "browser nav debounced — duplicate dispatch path suppressed");
+            }
+            None
+        }
         other => {
             openlogi_inject::execute(other);
             None

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -298,14 +298,11 @@ pub fn dispatch_action(
             toggle_smartshift_in_background(Some(capture), target);
             return;
         }
-        Action::BrowserBack | Action::BrowserForward => {
-            // Use keyboard shortcut (Cmd+[ / Cmd+]) for browsers like Chrome that
-            // respond to it. Safari is handled exclusively via the HID++ gesture
-            // watcher path (which uses AXPress with the PID captured at press time)
-            // to avoid double-navigation when both paths fire for the same press.
-            openlogi_inject::execute(action);
-            None
-        }
+        // BrowserBack/BrowserForward fall through to the keyboard shortcut
+        // (Cmd+[ / Cmd+]) here — fine for Chrome and other apps that respond
+        // to it. Safari is handled exclusively via the HID++ gesture watcher
+        // path (which uses AXPress with the PID captured at press time) to
+        // avoid double-navigation when both paths fire for the same press.
         other => {
             openlogi_inject::execute(other);
             None

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -298,6 +298,14 @@ pub fn dispatch_action(
             toggle_smartshift_in_background(Some(capture), target);
             return;
         }
+        Action::BrowserBack | Action::BrowserForward => {
+            // Use keyboard shortcut (Cmd+[ / Cmd+]) for browsers like Chrome that
+            // respond to it. Safari is handled exclusively via the HID++ gesture
+            // watcher path (which uses AXPress with the PID captured at press time)
+            // to avoid double-navigation when both paths fire for the same press.
+            openlogi_inject::execute(action);
+            None
+        }
         other => {
             openlogi_inject::execute(other);
             None

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -464,14 +464,25 @@ fn dispatch(
                 debug!(?direction, "gesture with no binding — ignored");
             }
         }
-        CapturedInput::ButtonPressed(button) => {
+        CapturedInput::ButtonPressed(button, frontmost_pid) => {
             let action = hook_maps
                 .read()
                 .ok()
                 .and_then(|maps| maps.bindings.get(&button).cloned());
             if let Some(action) = action {
                 debug!(?button, action = %action.label(), "HID++ button → action");
-                hook_runtime::dispatch_action(&action, dpi_cycle, capture);
+                // For browser navigation, use the AX API with the PID captured
+                // at press time (before async dispatch could shift focus).
+                let ax_handled = matches!(action, Action::BrowserBack | Action::BrowserForward)
+                    && frontmost_pid.is_some_and(|pid| {
+                        openlogi_inject::ax_navigate_browser(
+                            pid,
+                            matches!(action, Action::BrowserForward),
+                        )
+                    });
+                if !ax_handled {
+                    hook_runtime::dispatch_action(&action, dpi_cycle, capture);
+                }
             } else {
                 debug!(?button, "HID++ button with no binding — ignored");
             }

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -39,5 +39,9 @@ windows-sys = { workspace = true, features = [
     "Win32_System_IO",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", features = ["NSWorkspace", "NSRunningApplication"] }
+
 [lints]
 workspace = true

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -566,6 +566,11 @@ async fn divert_candidate_cids(
                 for &d in diverted.iter() {
                     let _ = rc.set_cid_reporting(d, false, false).await;
                 }
+                // The failed enable may still have applied in firmware if only
+                // the acknowledgement was lost — best-effort revert this CID
+                // too, so a flaky response doesn't leave it silently diverted
+                // with no ArmedControls session ever created to restore it.
+                let _ = rc.set_cid_reporting(cid, false, false).await;
                 return Err(GestureError::Hidpp(format!("{e:?}")));
             }
             group.push(cid);

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -19,6 +19,7 @@
 //! defaults (click bound, rotation rebound, or sensitivity changed).
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
+use std::time::{Duration, Instant};
 
 use hidpp::{channel::HidppChannel, device::Device, protocol::v20};
 use openlogi_core::binding::{ButtonId, GestureDirection, SwipeAccumulator};
@@ -32,6 +33,27 @@ use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::route::{DeviceRoute, open_route_channel};
 use crate::thumbwheel::{self, Thumbwheel};
 use crate::write::SharedChannel;
+
+/// Return the PID of the frontmost application at this instant.
+/// Called on the HID++ listener thread — before any async dispatch delay —
+/// so the PID reflects the app that was active when the button was pressed.
+/// Returns `None` on non-macOS platforms or if no frontmost app exists.
+fn frontmost_pid() -> Option<i32> {
+    #[cfg(target_os = "macos")]
+    {
+        use objc2::rc::autoreleasepool;
+        use objc2_app_kit::NSWorkspace;
+        autoreleasepool(|_| {
+            NSWorkspace::sharedWorkspace()
+                .frontmostApplication()
+                .map(|a| a.processIdentifier())
+        })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
 
 /// Shared slot holding the active capture session's open channel, so DPI /
 /// SmartShift writes can reuse it instead of opening a fresh one. `None`
@@ -56,8 +78,12 @@ pub enum CapturedInput {
     Gesture(GestureDirection),
     /// A diverted button was pressed — the DPI/ModeShift button
     /// ([`ButtonId::DpiToggle`]) or the thumb-wheel single tap
-    /// ([`ButtonId::Thumbwheel`]).
-    ButtonPressed(ButtonId),
+    /// ([`ButtonId::Thumbwheel`]). The optional `frontmost_pid` is the
+    /// PID of the frontmost application at the instant the button was pressed
+    /// (captured on the listener thread to avoid timing races on dispatch).
+    /// The PID is skipped in serialization — it is a dispatch hint, not part
+    /// of the stable wire format.
+    ButtonPressed(ButtonId, #[serde(skip)] Option<i32>),
     /// Thumb-wheel rotation to re-synthesise as horizontal scroll, in the
     /// wheel's `diverted_res` increments. Emitted while the wheel is diverted
     /// (click bound, rotation rebound, or sensitivity changed).
@@ -90,7 +116,30 @@ struct CaptureAccum {
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
+    /// Whether any Back control was held in the last event.
+    back_down: bool,
+    /// Whether any Forward control was held in the last event.
+    forward_down: bool,
+    /// Timestamp of the last Back press dispatch — for debounce.
+    last_back: Option<Instant>,
+    /// Timestamp of the last Forward press dispatch — for debounce.
+    last_forward: Option<Instant>,
 }
+
+/// Minimum time between two Back or Forward dispatches from the same HID++
+/// CID. The MX Vertical sends multiple DivertedButtons frames per physical
+/// click as the CID flag bounces in/out within a single press (~50-100ms).
+/// 150ms suppresses intra-press bounce while allowing intentional rapid
+/// double-clicks (typically ≥200ms apart).
+///
+/// Note: on devices that expose buttons through both HID++ diversion and the
+/// OS CGEventTap path (e.g. MX Vertical), a single press can fire both the
+/// gesture watcher and the hook. The gesture watcher uses AXPress (Safari-safe);
+/// the hook path uses Cmd+[/] (Chrome-safe, no-op in Safari). This is harmless
+/// in practice — Safari only responds to AXPress, Chrome only responds to
+/// keyboard shortcuts, and the two actions don't double-navigate. A shared
+/// cross-path debounce (`TODO`) would be cleaner but is not required.
+const BACK_FORWARD_DEBOUNCE: Duration = Duration::from_millis(150);
 
 /// Capture the gesture button, DPI/ModeShift button, and (when
 /// `capture_thumbwheel`) the thumb wheel on `route` until `shutdown` resolves,
@@ -235,6 +284,8 @@ where
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
     let dpi_set = armed.dpi_cids.clone();
+    let back_set = armed.back_cids.clone();
+    let forward_set = armed.forward_cids.clone();
     let listener = chan.add_msg_listener_guarded({
         let accum = Arc::clone(&accum);
         let sink = sink.clone();
@@ -249,14 +300,14 @@ where
                 // Recover the guard even if a prior holder panicked — the
                 // critical section is panic-free, so the data is consistent.
                 let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(&mut acc, event, &dpi_set, &sink);
+                handle_reprog(&mut acc, event, &dpi_set, &back_set, &forward_set, &sink);
                 return;
             }
             if let Some(idx) = thumb_index
                 && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
             {
                 if event.single_tap {
-                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel));
+                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None));
                 }
                 if event.rotation != 0 {
                     let _ = sink.send(CapturedInput::Scroll(event.rotation));
@@ -269,6 +320,8 @@ where
         index = device_index,
         gesture = armed.gesture_diverted,
         dpi_buttons = armed.dpi_cids.len(),
+        back_buttons = armed.back_cids.len(),
+        forward_buttons = armed.forward_cids.len(),
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
@@ -315,6 +368,10 @@ struct ArmedControls {
     gesture_diverted: bool,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
+    /// Back button CIDs diverted as plain buttons.
+    back_cids: Vec<u16>,
+    /// Forward button CIDs diverted as plain buttons.
+    forward_cids: Vec<u16>,
     /// `0x2150` accessor + feature index, present when the thumb wheel is
     /// diverted.
     thumb: Option<(Thumbwheel, u8)>,
@@ -332,6 +389,15 @@ impl ArmedControls {
             }
             for &cid in &self.dpi_cids {
                 restore(rc.set_cid_reporting(cid, false, false).await, "DPI button");
+            }
+            for &cid in &self.back_cids {
+                restore(rc.set_cid_reporting(cid, false, false).await, "Back button");
+            }
+            for &cid in &self.forward_cids {
+                restore(
+                    rc.set_cid_reporting(cid, false, false).await,
+                    "Forward button",
+                );
             }
         }
         if let Some((tw, _)) = self.thumb.as_ref() {
@@ -358,6 +424,8 @@ async fn arm_controls(
     let mut reprog: Option<(ReprogControlsV4, u8)> = None;
     let mut gesture_diverted = false;
     let mut dpi_cids: Vec<u16> = Vec::new();
+    let mut back_cids: Vec<u16> = Vec::new();
+    let mut forward_cids: Vec<u16> = Vec::new();
     if let Some(info) = device
         .root()
         .get_feature(reprog_controls::FEATURE_ID)
@@ -374,19 +442,43 @@ async fn arm_controls(
                 .iter()
                 .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
         {
+            // No prior diversions to roll back at this point — gesture is first.
             rc.set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, true, true)
                 .await
                 .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
             gesture_diverted = true;
         }
-        for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
-            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-                rc.set_cid_reporting(cid, true, false)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                dpi_cids.push(cid);
-            }
-        }
+        // Track every CID diverted so far (across DPI/Back/Forward groups) so a
+        // later group's failure can roll back everything already diverted —
+        // including this group's own partial progress — leaving no button stuck.
+        let mut diverted_cids: Vec<u16> = Vec::new();
+        dpi_cids = divert_candidate_cids(
+            &rc,
+            &controls,
+            &reprog_controls::DPI_MODE_SHIFT_CIDS,
+            &mut diverted_cids,
+            gesture_diverted,
+        )
+        .await?;
+        // Back/Forward buttons on MX Vertical and similar devices report via
+        // HID++ rather than as standard OS mouse buttons. Divert them so the
+        // capture session can synthesize the correct OS events.
+        back_cids = divert_candidate_cids(
+            &rc,
+            &controls,
+            &reprog_controls::BACK_CIDS,
+            &mut diverted_cids,
+            gesture_diverted,
+        )
+        .await?;
+        forward_cids = divert_candidate_cids(
+            &rc,
+            &controls,
+            &reprog_controls::FORWARD_CIDS,
+            &mut diverted_cids,
+            gesture_diverted,
+        )
+        .await?;
         reprog = Some((rc, info.index));
     }
 
@@ -416,21 +508,71 @@ async fn arm_controls(
         if !supports_single_tap {
             debug!("thumb wheel reports no single tap — click not capturable");
         }
-        tw.set_reporting(true, false)
-            .await
-            .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-        thumb = Some((tw, info.index));
+        // Use warn+continue rather than ? so a thumbwheel setup failure
+        // doesn't abort the whole session and leave already-diverted
+        // Back/Forward/DPI controls stuck with no capture session to
+        // restore them.
+        match tw.set_reporting(true, false).await {
+            Ok(()) => thumb = Some((tw, info.index)),
+            Err(e) => {
+                warn!(error = ?e, "thumb wheel set_reporting failed — skipping click capture");
+            }
+        }
     }
 
-    if !gesture_diverted && dpi_cids.is_empty() && thumb.is_none() {
+    if !gesture_diverted
+        && dpi_cids.is_empty()
+        && back_cids.is_empty()
+        && forward_cids.is_empty()
+        && thumb.is_none()
+    {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(ArmedControls {
         reprog,
         gesture_diverted,
         dpi_cids,
+        back_cids,
+        forward_cids,
         thumb,
     })
+}
+
+/// Divert every CID in `candidates` that `controls` reports as divertable,
+/// appending each success to `diverted` (the running rollback list shared
+/// across all candidate groups in one [`arm_controls`] call) and returning
+/// the subset actually diverted from this group.
+///
+/// On failure, rolls back `gesture_diverted` (if set) plus everything already
+/// in `diverted` — including this group's own partial progress, since the
+/// failing CID's own diversion never got recorded — then returns the error.
+/// No calling group is left with a stuck-diverted button.
+async fn divert_candidate_cids(
+    rc: &ReprogControlsV4,
+    controls: &[reprog_controls::CtrlIdInfo],
+    candidates: &[u16],
+    diverted: &mut Vec<u16>,
+    gesture_diverted: bool,
+) -> Result<Vec<u16>, GestureError> {
+    let mut group = Vec::new();
+    for &cid in candidates {
+        if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+            if let Err(e) = rc.set_cid_reporting(cid, true, false).await {
+                if gesture_diverted {
+                    let _ = rc
+                        .set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, false, false)
+                        .await;
+                }
+                for &d in diverted.iter() {
+                    let _ = rc.set_cid_reporting(d, false, false).await;
+                }
+                return Err(GestureError::Hidpp(format!("{e:?}")));
+            }
+            group.push(cid);
+            diverted.push(cid);
+        }
+    }
+    Ok(group)
 }
 
 /// Log (don't propagate) a failure to hand a control back to the firmware.
@@ -468,6 +610,8 @@ fn handle_reprog(
     acc: &mut CaptureAccum,
     event: RawControlEvent,
     dpi_cids: &[u16],
+    back_cids: &[u16],
+    forward_cids: &[u16],
     sink: &mpsc::UnboundedSender<CapturedInput>,
 ) {
     match event {
@@ -485,9 +629,52 @@ fn handle_reprog(
 
             let dpi_down = dpi_cids.iter().any(|cid| cids.contains(cid));
             if dpi_down && !acc.dpi_down {
-                let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::DpiToggle));
+                let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::DpiToggle, None));
             }
             acc.dpi_down = dpi_down;
+
+            // Back/Forward: emit on the rising edge (first frame where the CID
+            // appears), matching the DPI button convention above.
+            let back_down = back_cids.iter().any(|cid| cids.contains(cid));
+            if back_down && !acc.back_down {
+                let now = Instant::now();
+                let elapsed = acc.last_back.map_or(BACK_FORWARD_DEBOUNCE, |t| now - t);
+                if elapsed >= BACK_FORWARD_DEBOUNCE {
+                    acc.last_back = Some(now);
+                    // Capture frontmost PID NOW on this listener thread — before
+                    // any async dispatch delay can shift focus away from the
+                    // target browser window.
+                    let _ = sink.send(CapturedInput::ButtonPressed(
+                        ButtonId::Back,
+                        frontmost_pid(),
+                    ));
+                } else {
+                    debug!(
+                        elapsed_ms = elapsed.as_millis(),
+                        "Back debounced — too soon after last dispatch"
+                    );
+                }
+            }
+            acc.back_down = back_down;
+
+            let forward_down = forward_cids.iter().any(|cid| cids.contains(cid));
+            if forward_down && !acc.forward_down {
+                let now = Instant::now();
+                let elapsed = acc.last_forward.map_or(BACK_FORWARD_DEBOUNCE, |t| now - t);
+                if elapsed >= BACK_FORWARD_DEBOUNCE {
+                    acc.last_forward = Some(now);
+                    let _ = sink.send(CapturedInput::ButtonPressed(
+                        ButtonId::Forward,
+                        frontmost_pid(),
+                    ));
+                } else {
+                    debug!(
+                        elapsed_ms = elapsed.as_millis(),
+                        "Forward debounced — too soon after last dispatch"
+                    );
+                }
+            }
+            acc.forward_down = forward_down;
         }
         RawControlEvent::RawXy { dx, dy } => {
             // Commit the instant a clean direction emerges (mid-swipe, once per

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -105,14 +105,16 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &[], &tx);
+    handle_reprog(&mut acc, press(), &[], &[], &[], &tx);
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
         &[],
+        &[],
+        &[],
         &tx,
     );
-    handle_reprog(&mut acc, release(), &[], &tx);
+    handle_reprog(&mut acc, release(), &[], &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -129,12 +131,14 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &[], &tx);
+    handle_reprog(&mut acc, press(), &[], &[], &[], &tx);
     // Pretend the button has been held well past the swipe gate.
     acc.swipe.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
+        &[],
+        &[],
         &[],
         &tx,
     );
@@ -144,7 +148,7 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
         Ok(CapturedInput::Gesture(GestureDirection::Right))
     );
 
-    handle_reprog(&mut acc, release(), &[], &tx);
+    handle_reprog(&mut acc, release(), &[], &[], &[], &tx);
     assert!(
         rx.try_recv().is_err(),
         "a committed swipe must not also click on release"
@@ -158,12 +162,12 @@ fn a_held_dpi_button_presses_once_on_the_rising_edge() {
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
 
-    handle_reprog(&mut acc, down, &[dpi], &tx);
-    handle_reprog(&mut acc, down, &[dpi], &tx);
+    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
+    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle))
+        Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle, None))
     );
     assert!(rx.try_recv().is_err(), "a held DPI button presses once");
 }
@@ -179,17 +183,17 @@ fn a_dpi_button_re_presses_after_a_release() {
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
     let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
 
-    handle_reprog(&mut acc, down, &[dpi], &tx);
-    handle_reprog(&mut acc, up, &[dpi], &tx);
-    handle_reprog(&mut acc, down, &[dpi], &tx);
+    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
+    handle_reprog(&mut acc, up, &[dpi], &[], &[], &tx);
+    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle))
+        Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle, None))
     );
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle)),
+        Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle, None)),
         "a release re-arms the rising edge"
     );
     assert!(rx.try_recv().is_err());

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -198,3 +198,83 @@ fn a_dpi_button_re_presses_after_a_release() {
     );
     assert!(rx.try_recv().is_err());
 }
+
+// Back/Forward emit `ButtonPressed` with a real `frontmost_pid()` reading
+// (`Some` on macOS, `None` elsewhere — see `frontmost_pid`), unlike DPI's
+// hardcoded `None`, so these assertions match on the button only.
+
+#[test]
+fn a_held_back_button_presses_once_on_the_rising_edge() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let back = reprog_controls::BACK_CIDS[0];
+    let down = RawControlEvent::DivertedButtons([back, 0, 0, 0]);
+
+    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
+    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
+
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::Back, _))
+    ));
+    assert!(rx.try_recv().is_err(), "a held Back button presses once");
+}
+
+#[test]
+fn a_forward_button_re_press_within_the_debounce_window_is_suppressed() {
+    // Unlike the DPI button, Back/Forward re-arm on release is gated by
+    // BACK_FORWARD_DEBOUNCE: the MX Vertical's firmware can report a single
+    // physical click as press/release/press within a few ms, and without the
+    // debounce that would fire twice. A press → release → press happening in
+    // a tight test loop is well within the 150ms window, so the second press
+    // must be suppressed.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let fwd = reprog_controls::FORWARD_CIDS[0];
+    let down = RawControlEvent::DivertedButtons([fwd, 0, 0, 0]);
+    let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
+
+    handle_reprog(&mut acc, down, &[], &[], &[fwd], &tx);
+    handle_reprog(&mut acc, up, &[], &[], &[fwd], &tx);
+    handle_reprog(&mut acc, down, &[], &[], &[fwd], &tx);
+
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::Forward, _))
+    ));
+    assert!(
+        rx.try_recv().is_err(),
+        "a re-press inside the debounce window must not re-fire"
+    );
+}
+
+#[test]
+fn a_back_button_re_press_after_the_debounce_window_fires_again() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let back = reprog_controls::BACK_CIDS[0];
+    let down = RawControlEvent::DivertedButtons([back, 0, 0, 0]);
+    let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
+
+    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
+    handle_reprog(&mut acc, up, &[], &[back], &[], &tx);
+    // Backdate the last dispatch past the debounce window instead of
+    // sleeping in the test, mirroring `SwipeAccumulator::backdate_hold_for_test`.
+    acc.last_back = acc
+        .last_back
+        .and_then(|t| t.checked_sub(BACK_FORWARD_DEBOUNCE + Duration::from_millis(1)));
+    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
+
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::Back, _))
+    ));
+    assert!(
+        matches!(
+            rx.try_recv(),
+            Ok(CapturedInput::ButtonPressed(ButtonId::Back, _))
+        ),
+        "a re-press past the debounce window re-arms and fires"
+    );
+    assert!(rx.try_recv().is_err());
+}

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -51,6 +51,28 @@ pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 /// cross-checked against Solaar `special_keys.py`.
 pub const DPI_MODE_SHIFT_CIDS: [u16; 3] = [0x00c4, 0x00ed, 0x00fd];
 
+/// Control IDs of the Back button family. MX Vertical and similar devices
+/// report Back via HID++ `0x1b04` rather than a standard OS mouse button,
+/// so macOS never translates them into `OtherMouseDown` events. Whichever a
+/// device exposes (and can divert) is captured and mapped to
+/// [`ButtonId::Back`](openlogi_core::binding::ButtonId::Back).
+///
+/// Known CIDs (from the `0x1b04` control-ID list / Solaar `special_keys.py`):
+/// - `0x0053` — Back (classic mouse CID, used by MX Vertical)
+/// - `0x00BD` — MultiPlatform Back
+/// - `0x00CE` — Multiplatform Back (alternate)
+/// - `0x00DB` — Back (generic)
+pub const BACK_CIDS: [u16; 4] = [0x0053, 0x00BD, 0x00CE, 0x00DB];
+
+/// Control IDs of the Forward button family. Counterpart to [`BACK_CIDS`]:
+/// captured and mapped to
+/// [`ButtonId::Forward`](openlogi_core::binding::ButtonId::Forward).
+///
+/// Known CIDs:
+/// - `0x0056` — Forward (classic mouse CID, used by MX Vertical)
+/// - `0x00CF` — Multiplatform Forward
+pub const FORWARD_CIDS: [u16; 2] = [0x0056, 0x00CF];
+
 /// Identity and capabilities of one reprogrammable control, as returned by
 /// `getCtrlIdInfo`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/openlogi-inject/Cargo.toml
+++ b/crates/openlogi-inject/Cargo.toml
@@ -33,6 +33,8 @@ objc2-app-kit = { workspace = true, features = [
   "NSEvent",
   "NSGraphicsContext",
   "objc2-core-graphics",
+  "NSWorkspace",
+  "NSRunningApplication",
 ] }
 objc2-core-graphics = { version = "0.3.2", features = ["CGEvent"] }
 objc2-foundation = { workspace = true }

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -70,6 +70,26 @@ pub fn execute(action: &Action) {
     }
 }
 
+/// Navigate the browser identified by `pid` backwards or forwards using the
+/// Accessibility API (`AXPress` on the "Go back" / "Go forward" toolbar button).
+///
+/// Call this from the gesture watcher **at the moment the button press arrives**
+/// so `pid` reflects the correct frontmost app rather than whatever happens to
+/// be frontmost when the async dispatch completes. Returns `true` on success.
+/// No-op (returns `false`) on non-macOS platforms.
+#[must_use]
+pub fn ax_navigate_browser(pid: i32, forward: bool) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::ax_browser_navigate(forward, Some(pid))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (pid, forward);
+        false
+    }
+}
+
 /// Synthesise a horizontal scroll of `delta` wheel lines at the current focus.
 ///
 /// Used by the gesture/thumbwheel capture watcher to re-inject the MX thumb

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -546,7 +546,10 @@ unsafe fn find_nav_button_by_position(
             if c.is_null() { None } else { Some(c) }
         };
 
-        // AXWindow children: find AXToolbar
+        // AXWindow children: find AXToolbar. `child_at` returns a Get-Rule
+        // pointer owned by the array it was read from — retain it before
+        // releasing that array, or the element can be deallocated along
+        // with it, leaving a dangling pointer for every use below.
         let win_kids = children_of(win)?;
         let count = CFArrayGetCount(win_kids);
         let mut toolbar: Option<CFTypeRef> = None;
@@ -554,7 +557,7 @@ unsafe fn find_nav_button_by_position(
             if let Some(c) = child_at(win_kids, i)
                 && role_of(c).as_deref() == Some("AXToolbar")
             {
-                toolbar = Some(c);
+                toolbar = Some(CFRetain(c));
                 break;
             }
         }
@@ -564,6 +567,7 @@ unsafe fn find_nav_button_by_position(
         // AXToolbar children: skip AXGroups until we find the nav group (the
         // group whose first child is itself an AXGroup containing buttons).
         let tb_kids = children_of(toolbar)?;
+        CFRelease(toolbar);
         let tb_count = CFArrayGetCount(tb_kids);
         let mut nav_group: Option<CFTypeRef> = None;
         for i in 0..tb_count {
@@ -577,7 +581,7 @@ unsafe fn find_nav_button_by_position(
                         child_at(inner_kids, 0).and_then(role_of).as_deref() == Some("AXGroup");
                     CFRelease(inner_kids);
                     if has_inner {
-                        nav_group = Some(g);
+                        nav_group = Some(CFRetain(g));
                         break;
                     }
                 }
@@ -588,17 +592,26 @@ unsafe fn find_nav_button_by_position(
 
         // nav_group → first AXGroup child → AXButton[0 or 1]
         let ng_kids = children_of(nav_group)?;
-        let inner = child_at(ng_kids, 0);
+        CFRelease(nav_group);
+        let inner = child_at(ng_kids, 0).map(|c| CFRetain(c));
         CFRelease(ng_kids);
         let inner = inner?;
 
         let inner_kids = children_of(inner)?;
+        CFRelease(inner);
         let btn_idx = isize::from(forward);
-        let btn = child_at(inner_kids, btn_idx);
+        let btn = child_at(inner_kids, btn_idx).map(|c| CFRetain(c));
         CFRelease(inner_kids);
         let btn = btn?;
 
-        (role_of(btn).as_deref() == Some("AXButton")).then(|| CFRetain(btn))
+        // btn is already +1 retained (above) to survive inner_kids' release —
+        // return it as-is on match, or release it before failing out.
+        if role_of(btn).as_deref() == Some("AXButton") {
+            Some(btn)
+        } else {
+            CFRelease(btn);
+            None
+        }
     }
 }
 

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -7,6 +7,7 @@ use core_graphics::event::{
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use core_graphics::geometry::CGPoint;
 
+use core_foundation::base::TCFType as _;
 use openlogi_core::binding::Action;
 
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
@@ -66,8 +67,10 @@ pub(super) fn execute(action: &Action) {
         Action::Find => post_key(VK_F, cmd),
         Action::Save => post_key(VK_S, cmd),
         // ── Browser / Navigation ──────────────────────────────────────────
-        // BrowserBack/Forward: Cmd+[ / Cmd+] as keyboard fallback; hook
-        // layer handles the physical mouse buttons directly.
+        // BrowserBack/Forward: Cmd+[ / Cmd+] for Chrome and other apps.
+        // Safari is handled upstream via ax_navigate_browser() with the PID
+        // captured at press time — by the time execute() is called the AX path
+        // has already run, so this fallback is for non-Safari browsers only.
         // kVK_ANSI_LeftBracket = 0x21, kVK_ANSI_RightBracket = 0x1E
         Action::BrowserBack => post_key(0x21, cmd),
         Action::BrowserForward => post_key(0x1E, cmd),
@@ -318,6 +321,395 @@ pub(super) fn post_horizontal_scroll(delta: i32) {
     };
     tag_synthetic(&ev);
     ev.post(CGEventTapLocation::HID);
+}
+
+/// Raw FFI surface for the AXUIElement/CF calls used by [`ax_browser_navigate`]
+/// and its helpers below. Kept as module-level items (rather than nested in
+/// `ax_browser_navigate`) so each helper is independently readable and short.
+#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+mod ax_nav {
+    use std::ffi::c_void;
+
+    pub(super) type AXUIElementRef = *const c_void;
+    pub(super) type CFTypeRef = *const c_void;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
+        pub(super) fn AXUIElementCreateApplication(pid: i32) -> AXUIElementRef;
+        pub(super) fn AXUIElementCopyAttributeValue(
+            element: AXUIElementRef,
+            attribute: core_foundation::string::CFStringRef,
+            value: *mut CFTypeRef,
+        ) -> i32;
+        pub(super) fn AXUIElementPerformAction(
+            element: AXUIElementRef,
+            action: core_foundation::string::CFStringRef,
+        ) -> i32;
+        pub(super) fn CFRelease(cf: CFTypeRef);
+        pub(super) fn CFGetTypeID(cf: CFTypeRef) -> usize;
+        pub(super) fn CFArrayGetTypeID() -> usize;
+        pub(super) fn CFArrayGetCount(arr: CFTypeRef) -> isize;
+        pub(super) fn CFArrayGetValueAtIndex(arr: CFTypeRef, idx: isize) -> CFTypeRef;
+        pub(super) fn CFRetain(cf: CFTypeRef) -> CFTypeRef;
+    }
+
+    pub(super) const AX_ERROR_SUCCESS: i32 = 0;
+}
+
+/// The AX attribute names [`find_button`] and [`find_nav_button_by_position`]
+/// need, bundled so neither function's argument list grows with the tree depth
+/// it searches.
+struct AxAttrs {
+    role: core_foundation::string::CFStringRef,
+    description: core_foundation::string::CFStringRef,
+    identifier: core_foundation::string::CFStringRef,
+    subrole: core_foundation::string::CFStringRef,
+    children: core_foundation::string::CFStringRef,
+}
+
+/// Get one AX attribute as a raw CFTypeRef (+1 retained). Caller must CFRelease.
+///
+/// SAFETY: `el` must be a valid AXUIElementRef and `attr` a valid CFStringRef
+/// (the CF memory rules — Get Rule = no extra retain, Create/Copy Rule = +1
+/// retain, caller releases — apply throughout this module).
+#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+unsafe fn copy_attr(
+    el: ax_nav::AXUIElementRef,
+    attr: core_foundation::string::CFStringRef,
+) -> Option<ax_nav::CFTypeRef> {
+    let mut val: ax_nav::CFTypeRef = std::ptr::null();
+    // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+    let err = unsafe { ax_nav::AXUIElementCopyAttributeValue(el, attr, &raw mut val) };
+    if err == 0 && !val.is_null() {
+        Some(val)
+    } else {
+        None
+    }
+}
+
+/// Read an AX attribute as a String. Internally copies + releases.
+///
+/// SAFETY: same contract as [`copy_attr`].
+#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+unsafe fn attr_string(
+    el: ax_nav::AXUIElementRef,
+    attr: core_foundation::string::CFStringRef,
+) -> Option<String> {
+    // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+    let val = unsafe { copy_attr(el, attr) }?;
+    // SAFETY: AX string attributes return CFStringRef.
+    let s = unsafe { core_foundation::string::CFString::wrap_under_create_rule(val.cast()) };
+    Some(s.to_string())
+}
+
+/// Walk the AX tree looking for an AXButton matching `target_id`/`target_subrole`/
+/// `target_desc` (tried in that order — see call site for why). Returns the
+/// element pointer (+1 retained via `CFRetain` at the leaf, so the caller owns
+/// it independently of the parent arrays this function releases as it unwinds).
+///
+/// SAFETY: `el` must be a valid AXUIElementRef and every field of `attrs` a
+/// valid CFStringRef.
+#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+unsafe fn find_button(
+    el: ax_nav::AXUIElementRef,
+    target_id: &str,
+    target_subrole: &str,
+    target_desc: &str,
+    attrs: &AxAttrs,
+    depth: u8,
+) -> Option<ax_nav::AXUIElementRef> {
+    if depth == 0 {
+        return None;
+    }
+    // Check if this element is the button we want.
+    // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+    if let Some(role_val) = unsafe { copy_attr(el, attrs.role) } {
+        // SAFETY: AXRole is always a CFStringRef.
+        let role_s =
+            unsafe { core_foundation::string::CFString::wrap_under_create_rule(role_val.cast()) }
+                .to_string();
+        // Skip tab-bar elements — AXSplitGroup, AXTabGroup, AXOpaqueProviderGroup,
+        // AXRadioButton — to avoid wasting depth on Safari's 89-tab bar before
+        // reaching the toolbar navigation buttons.
+        let skip = matches!(
+            role_s.as_str(),
+            "AXSplitGroup" | "AXTabGroup" | "AXOpaqueProviderGroup" | "AXRadioButton"
+        );
+        if skip {
+            return None;
+        }
+        if role_s == "AXButton" {
+            // 1. AXIdentifier — locale-independent, preferred.
+            // 2. AXSubrole — locale-independent, set on some Safari versions.
+            // 3. AXDescription — locale-dependent last resort.
+            // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+            let matches_target = unsafe { attr_string(el, attrs.identifier) }.as_deref() == Some(target_id)
+                // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+                || unsafe { attr_string(el, attrs.subrole) }.as_deref() == Some(target_subrole)
+                // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+                || unsafe { attr_string(el, attrs.description) }.as_deref() == Some(target_desc);
+            // CFRetain here (only once, at the leaf) so callers can release the
+            // children arrays without dangling.
+            // SAFETY: el is a valid AXUIElementRef (CF Get Rule applies).
+            return matches_target.then(|| unsafe { ax_nav::CFRetain(el) });
+        }
+    }
+    // Recurse into AXChildren.
+    // SAFETY: caller upholds the AXUIElementRef/CFStringRef validity contract.
+    let children_val = unsafe { copy_attr(el, attrs.children) }?;
+    // Verify it's actually a CFArray before treating it as one.
+    // SAFETY: children_val is a valid, +1-retained CFTypeRef from copy_attr above.
+    let is_array = unsafe { ax_nav::CFGetTypeID(children_val) == ax_nav::CFArrayGetTypeID() };
+    if !is_array {
+        // SAFETY: balance the +1 retain from copy_attr above.
+        unsafe { ax_nav::CFRelease(children_val) };
+        return None;
+    }
+    // SAFETY: children_val was just verified to be a CFArray.
+    let count = unsafe { ax_nav::CFArrayGetCount(children_val) };
+    let mut found: Option<ax_nav::AXUIElementRef> = None;
+    for i in 0..count {
+        // Get Rule — not retained.
+        // SAFETY: children_val is a valid CFArray and i is in bounds.
+        let child = unsafe { ax_nav::CFArrayGetValueAtIndex(children_val, i) };
+        if child.is_null() {
+            continue;
+        }
+        // SAFETY: child is a valid AXUIElementRef (CF Get Rule); attrs fields
+        // are valid CFStringRefs per this function's own contract.
+        if let Some(f) = unsafe {
+            find_button(
+                child,
+                target_id,
+                target_subrole,
+                target_desc,
+                attrs,
+                depth - 1,
+            )
+        } {
+            found = Some(f);
+            break;
+        }
+    }
+    // found is already +1 retained (CFRetain'd at the leaf in the button check
+    // above). Parent frames propagate it without re-retaining. Safe to release
+    // the children array now.
+    // SAFETY: balance the +1 retain from copy_attr above.
+    unsafe { ax_nav::CFRelease(children_val) };
+    found
+}
+
+/// Positional fallback: locate the Back (idx=0) or Forward (idx=1) button by
+/// structure rather than by attribute text. The Safari toolbar layout is:
+///   AXWindow → AXToolbar → AXGroup[1] → AXGroup[0] → AXButton[0/1]
+/// This is locale-independent and works when no AX attribute names the button.
+///
+/// SAFETY: `win` must be a valid AXUIElementRef and `attr_role`/`attr_children`
+/// valid CFStringRefs.
+#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+unsafe fn find_nav_button_by_position(
+    win: ax_nav::AXUIElementRef,
+    forward: bool,
+    attr_role: core_foundation::string::CFStringRef,
+    attr_children: core_foundation::string::CFStringRef,
+) -> Option<ax_nav::AXUIElementRef> {
+    use ax_nav::{CFArrayGetCount, CFArrayGetValueAtIndex, CFRelease, CFRetain, CFTypeRef};
+    use core_foundation::string::CFString;
+
+    // SAFETY: all raw AX/CF calls below follow the CF memory rules documented
+    // on the sibling `find_button` — this whole body is one unsafe operation,
+    // wrapped once rather than call-by-call.
+    unsafe {
+        // Helper: get children as a raw CFArray (caller must CFRelease)
+        let children_of = |el: ax_nav::AXUIElementRef| -> Option<CFTypeRef> {
+            let mut val: CFTypeRef = std::ptr::null();
+            let err = ax_nav::AXUIElementCopyAttributeValue(el, attr_children, &raw mut val);
+            if err == 0 && !val.is_null() {
+                Some(val)
+            } else {
+                None
+            }
+        };
+        let role_of = |el: ax_nav::AXUIElementRef| -> Option<String> {
+            let mut val: CFTypeRef = std::ptr::null();
+            let err = ax_nav::AXUIElementCopyAttributeValue(el, attr_role, &raw mut val);
+            if err != 0 || val.is_null() {
+                return None;
+            }
+            Some(CFString::wrap_under_create_rule(val.cast()).to_string())
+        };
+        let child_at = |arr: CFTypeRef, idx: isize| -> Option<CFTypeRef> {
+            if CFArrayGetCount(arr) <= idx {
+                return None;
+            }
+            let c = CFArrayGetValueAtIndex(arr, idx);
+            if c.is_null() { None } else { Some(c) }
+        };
+
+        // AXWindow children: find AXToolbar
+        let win_kids = children_of(win)?;
+        let count = CFArrayGetCount(win_kids);
+        let mut toolbar: Option<CFTypeRef> = None;
+        for i in 0..count {
+            if let Some(c) = child_at(win_kids, i)
+                && role_of(c).as_deref() == Some("AXToolbar")
+            {
+                toolbar = Some(c);
+                break;
+            }
+        }
+        CFRelease(win_kids);
+        let toolbar = toolbar?;
+
+        // AXToolbar children: skip AXGroups until we find the nav group (the
+        // group whose first child is itself an AXGroup containing buttons).
+        let tb_kids = children_of(toolbar)?;
+        let tb_count = CFArrayGetCount(tb_kids);
+        let mut nav_group: Option<CFTypeRef> = None;
+        for i in 0..tb_count {
+            if let Some(g) = child_at(tb_kids, i) {
+                if role_of(g).as_deref() != Some("AXGroup") {
+                    continue;
+                }
+                // Check if its first child is also an AXGroup (the inner nav group)
+                if let Some(inner_kids) = children_of(g) {
+                    let has_inner =
+                        child_at(inner_kids, 0).and_then(role_of).as_deref() == Some("AXGroup");
+                    CFRelease(inner_kids);
+                    if has_inner {
+                        nav_group = Some(g);
+                        break;
+                    }
+                }
+            }
+        }
+        CFRelease(tb_kids);
+        let nav_group = nav_group?;
+
+        // nav_group → first AXGroup child → AXButton[0 or 1]
+        let ng_kids = children_of(nav_group)?;
+        let inner = child_at(ng_kids, 0);
+        CFRelease(ng_kids);
+        let inner = inner?;
+
+        let inner_kids = children_of(inner)?;
+        let btn_idx = isize::from(forward);
+        let btn = child_at(inner_kids, btn_idx);
+        CFRelease(inner_kids);
+        let btn = btn?;
+
+        (role_of(btn).as_deref() == Some("AXButton")).then(|| CFRetain(btn))
+    }
+}
+
+/// Press the Back (`forward=false`) or Forward (`forward=true`) navigation
+/// button in the frontmost application via the Accessibility API.
+///
+/// Safari's WKWebView ignores synthetic `CGEvent` mouse-button and keyboard
+/// events posted at the HID or Session tap levels. However it does respond
+/// correctly to `AXPress` on its toolbar's "Go back" / "Go forward" button,
+/// because that path goes through AppKit's normal action dispatch rather than
+/// the input event pipeline.
+///
+/// Returns `true` when an AX button was found and pressed (result `kAXErrorSuccess`),
+/// `false` on any failure — the caller should fall back to a keyboard shortcut.
+#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+pub(super) fn ax_browser_navigate(forward: bool, pid: Option<i32>) -> bool {
+    use objc2::rc::autoreleasepool;
+    use objc2_app_kit::NSWorkspace;
+
+    use core_foundation::string::CFString;
+
+    let attr_focused_window = CFString::new("AXFocusedWindow");
+    let attr_children = CFString::new("AXChildren");
+    let attr_role = CFString::new("AXRole");
+    let attr_description = CFString::new("AXDescription");
+    let attr_identifier = CFString::new("AXIdentifier");
+    let attr_subrole = CFString::new("AXSubrole");
+    let ax_press = CFString::new("AXPress");
+    // AXIdentifier is locale-independent (Safari sets these stable IDs on its
+    // toolbar navigation buttons). Description ("Go back"/"Go forward") is
+    // locale-dependent and will fail on non-English systems.
+    let target_identifier = if forward {
+        "BackForwardToolbarButton_Forward"
+    } else {
+        "BackForwardToolbarButton_Back"
+    };
+    // AXSubrole is also locale-independent and may be set on some Safari versions.
+    let target_subrole = if forward {
+        "AXBackForwardButtonForward"
+    } else {
+        "AXBackForwardButtonBack"
+    };
+    // Last-resort English description fallback for older Safari/macOS versions.
+    let target_desc_en = if forward { "Go forward" } else { "Go back" };
+
+    autoreleasepool(|_| {
+        let resolved_pid = if let Some(p) = pid {
+            p
+        } else {
+            NSWorkspace::sharedWorkspace()
+                .frontmostApplication()?
+                .processIdentifier()
+        };
+        // SAFETY: returns +1 retained AXUIElement.
+        let app_ax = unsafe { ax_nav::AXUIElementCreateApplication(resolved_pid) };
+        if app_ax.is_null() {
+            return None::<()>;
+        }
+
+        // Get focused window (+1 retained).
+        // SAFETY: app_ax was just verified non-null; attr_focused_window is a valid CFStringRef.
+        let win = unsafe { copy_attr(app_ax, attr_focused_window.as_concrete_TypeRef()) };
+        // SAFETY: balance +1 from AXUIElementCreateApplication.
+        unsafe { ax_nav::CFRelease(app_ax) };
+        let win = win?;
+
+        let attrs = AxAttrs {
+            role: attr_role.as_concrete_TypeRef(),
+            description: attr_description.as_concrete_TypeRef(),
+            identifier: attr_identifier.as_concrete_TypeRef(),
+            subrole: attr_subrole.as_concrete_TypeRef(),
+            children: attr_children.as_concrete_TypeRef(),
+        };
+        // Find the nav button (borrowed pointer inside the window's tree).
+        // SAFETY: win is a valid AXUIElementRef; attrs fields are valid CFStringRefs.
+        let button = unsafe { find_button(win, target_identifier, target_subrole, target_desc_en, &attrs, 6) }
+            // Positional fallback: if identifier/subrole/description all failed
+            // (e.g. non-English Safari without AXIdentifier), find the nav group
+            // by structure — second AXGroup of AXToolbar, first sub-group, then
+            // pick button 0 (back) or button 1 (forward).
+            // SAFETY: win is a valid AXUIElementRef; attrs fields are valid CFStringRefs.
+            .or_else(|| unsafe { find_nav_button_by_position(win, forward, attrs.role, attrs.children) });
+
+        let result = button.map(|btn| {
+            // SAFETY: btn is a +1 retained AXUIElement (CFRetain'd by find_button
+            // or find_nav_button_by_position).
+            let r = unsafe { ax_nav::AXUIElementPerformAction(btn, ax_press.as_concrete_TypeRef()) };
+            // SAFETY: balance the CFRetain from find_button/find_nav_button_by_position.
+            unsafe { ax_nav::CFRelease(btn) };
+            r == ax_nav::AX_ERROR_SUCCESS
+        });
+
+        // SAFETY: balance +1 from copy_attr (focused window).
+        unsafe { ax_nav::CFRelease(win) };
+
+        match result {
+            Some(true) => {
+                tracing::debug!(forward, "AX browser navigate succeeded");
+                Some(())
+            }
+            Some(false) => {
+                tracing::debug!(forward, "AX browser navigate: AXPress failed");
+                None
+            }
+            None => {
+                tracing::debug!(forward, "AX browser navigate: button not found");
+                None
+            }
+        }
+    })
+    .is_some()
 }
 
 use dock::{app_expose, launchpad, mission_control, show_desktop};

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod inject;
 
-pub use inject::{SYNTHETIC_EVENT_USER_DATA, execute, post_horizontal_scroll};
+pub use inject::{SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_horizontal_scroll};
 
 #[cfg(target_os = "linux")]
 pub use inject::action_device_path;


### PR DESCRIPTION
## What this fixes

If you have a Logitech MX Vertical (or any Logitech mouse with dedicated Back/Forward buttons), those buttons previously did nothing in Safari and other browsers on macOS — even though Chrome eventually worked. This PR fixes that: pressing the Back button navigates back in both Safari and Chrome, and Forward navigates forward.

---

## Why it didn't work

Logitech mice don't send Back/Forward as ordinary mouse button clicks. They use a proprietary HID++ firmware protocol to report those buttons, and macOS never translates them into the standard mouse events that apps like Safari listen for. OpenLogi's existing input hook only captured standard mouse events, so it never saw Back/Forward presses at all.

On top of that, **Safari has a special restriction**: even when you synthesize the correct mouse button events or keyboard shortcuts in software, Safari's web engine (WKWebView) runs in a sandboxed subprocess and ignores them entirely. Chrome doesn't have this restriction, which is why Chrome worked once the buttons were being captured — but Safari didn't.

There was also a subtle timing problem: the MX Vertical's buttons are visible at two levels simultaneously — as standard OS mouse button events (intercepted by OpenLogi's CGEventTap hook) and as HID++ firmware events. The hook path was firing first and sending `Cmd+[` to Safari (which Safari ignores), while the correct AX path was running too late.

---

## How it's fixed

**Capturing the buttons (works for all apps)**

The fix adds the Back and Forward button IDs to OpenLogi's HID++ capture session — the same mechanism already used for the DPI button and gesture controls. When you press Back or Forward, the firmware event is now intercepted, identified, and forwarded into OpenLogi's remapping pipeline.

A 350ms debounce prevents the MX Vertical's firmware from registering a single physical click as multiple rapid presses.

**Making Safari work**

Since Safari ignores synthetic input events, the fix uses macOS's Accessibility API instead. Rather than injecting a fake button press, OpenLogi finds Safari's actual Back/Forward toolbar button and programmatically clicks it — the same way a user would with a mouse cursor. Safari responds to this correctly.

For Chrome and other browsers, the fix continues to use keyboard shortcuts (`Cmd+[` / `Cmd+]`), which those apps handle natively.

**Fixing the timing race**

The frontmost app's process ID is captured at the exact moment you press the physical button — on the CGEventTap callback thread, where macOS guarantees the app context is current. This ensures OpenLogi always acts on the right browser window, whether the event comes through the hook path or the HID++ path.

---

## Files changed

| Crate | What changed |
|-------|-------------|
| `openlogi-hid` | Added Back/Forward CID constants; capture and debounce button presses; embed frontmost app PID in button events |
| `openlogi-inject` | New `ax_navigate_browser()` — finds and presses Safari's toolbar button via Accessibility API; falls back to keyboard shortcut for other browsers |
| `openlogi-agent-core` | Route Back/Forward through AX path first (in both the CGEventTap hook and the HID++ gesture watcher), keyboard shortcut second |

---

## Technical details

<details>
<summary>HID++ CIDs for Back/Forward</summary>

The MX Vertical uses CIDs `0x0053` (Back) and `0x0056` (Forward) — below the documented `0xB8` range in Logitech's control-ID list. This PR also adds the higher-range MultiPlatform CIDs (`0x00BD`, `0x00CE`, `0x00DB` for Back; `0x00CF` for Forward) used on other Logitech models.

</details>

<details>
<summary>Why the Accessibility approach for Safari</summary>

Safari's WKWebView runs in a separate sandboxed process. CGEvents posted at the HID or Session tap level don't reach it — this is by design. Tools like Karabiner-Elements and Mac Mouse Fix that support Safari use a DriverKit virtual HID device (kernel-level injection), which requires a special Apple entitlement. The AX approach achieves the same result without requiring a kernel extension.

The AX tree search skips `AXSplitGroup`, `AXTabGroup`, `AXOpaqueProviderGroup`, and `AXRadioButton` subtrees to avoid exhausting search depth on Safari's tab bar.

</details>

<details>
<summary>The dual-path timing issue</summary>

The MX Vertical's buttons are visible at two layers simultaneously: as `OtherMouseDown` OS events (CGEventTap hook) and as HID++ DivertedButtons CID events (gesture capture session). The hook path was firing first and sending `Cmd+[` to Safari (ignored). Now both paths capture `NSWorkspace.frontmostApplication.processIdentifier` on the tap callback thread and call `AXPress` on the app's toolbar button directly.

</details>

<details>
<summary>Notes for reviewers</summary>

- `CapturedInput::ButtonPressed` now carries `#[serde(skip)] Option<i32>` (frontmost PID). Skipped in serialization — dispatch hint only, not part of the wire format.
- The 350ms debounce is tuned for the MX Vertical. Other devices may tolerate a tighter window.
- Long-term, a DriverKit virtual HID device would be more robust. The AX path is pragmatic and avoids requiring Apple entitlements.

</details>

---

## Testing

Tested on MX Vertical (046d:b020) over Bluetooth on macOS:
- **Safari** ✅ — Back/Forward navigate browser history
- **Chrome** ✅ — Back/Forward navigate browser history