### PR TITLE
feat: add LIGHTSPEED G305 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Remap buttons, drive DPI and SmartShift, and switch profiles per app — without
 
 ## What it is
 
-OpenLogi talks to Logitech HID++ peripherals over Logi Bolt and Unifying
-receivers, Bluetooth-direct connections, or USB cables — without running Logi
-Options+. It consists of three components:
+OpenLogi talks to Logitech HID++ peripherals over Logi Bolt, Unifying, and
+LIGHTSPEED receivers, Bluetooth-direct connections, or USB cables — without
+running Logi Options+. It consists of three components:
 
 - **[OpenLogi GUI](crates/openlogi-gui)** — a GPUI desktop app: an interactive mouse diagram with clickable hotspots, a per-button action picker (built-in actions plus custom keyboard shortcuts authored in the TOML config), DPI presets, SmartShift, per-device scroll inversion, RGB keyboard lighting, per-application profiles, a live device carousel, and a Settings window localized into 20 languages.
 - **[OpenLogi agent](crates/openlogi-agent)** — the background service that owns the input hook and all device I/O. The GUI is a pure IPC client and starts the agent when needed.
@@ -77,6 +77,7 @@ Things OpenLogi does that Options+ won't:
 |---|---|
 | Discover Bolt receivers + list paired devices (CLI + GUI) | ✅ |
 | Unifying receivers (older protocol, replaced by Bolt) | ✅ |
+| LIGHTSPEED gaming receivers (G305 / `046d:c53f` certified) | ✅ |
 | Bluetooth-direct / wired devices (no receiver) | ✅ |
 | Battery percentage / charge state | ✅ (online devices) |
 | Interactive GUI: carousel, mouse diagram, action picker | ✅ macOS + Linux + Windows |

--- a/crates/openlogi-agent-core/src/device_order.rs
+++ b/crates/openlogi-agent-core/src/device_order.rs
@@ -70,7 +70,8 @@ impl DeviceStableId {
         match route {
             Some(
                 DeviceRoute::Bolt { receiver_uid, slot }
-                | DeviceRoute::Unifying { receiver_uid, slot },
+                | DeviceRoute::Unifying { receiver_uid, slot }
+                | DeviceRoute::Lightspeed { receiver_uid, slot },
             ) => Self::Bolt {
                 receiver_uid: receiver_uid.to_ascii_lowercase(),
                 slot: *slot,
@@ -263,6 +264,20 @@ mod tests {
         assert_eq!(
             DeviceStableId::from_parts(Some(&bolt), 1, None, [0; 4]),
             DeviceStableId::from_parts(Some(&unifying), 1, None, [0; 4]),
+        );
+    }
+
+    #[test]
+    fn lightspeed_uses_receiver_backed_stable_identity() {
+        let route = DeviceRoute::Lightspeed {
+            receiver_uid: "G305-RX".into(),
+            slot: 1,
+        };
+        assert_eq!(
+            DeviceStableId::from_parts(Some(&route), 1, None, [0; 4])
+                .physical_key()
+                .map(PhysicalDeviceKey::into_string),
+            Some("receiver:g305-rx:slot:1".to_string())
         );
     }
 

--- a/crates/openlogi-agent-core/src/ipc.rs
+++ b/crates/openlogi-agent-core/src/ipc.rs
@@ -28,7 +28,8 @@ use serde::{Deserialize, Serialize};
 /// v8: [`WriteError`] carries typed HID++ operation failures.
 /// v9: `poll_event_monitor` appended + [`MonitorEvent`] (live event monitor).
 /// v10: `Capabilities::hires_wheel` appended.
-pub const PROTOCOL_VERSION: u32 = 10;
+/// v11: `DeviceRoute::Lightspeed` + `Capabilities::native_button_capture`.
+pub const PROTOCOL_VERSION: u32 = 11;
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -61,7 +61,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 10);
+    assert_eq!(PROTOCOL_VERSION, 11);
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is
@@ -174,6 +174,7 @@ fn device_inventory() {
             }),
             capabilities: Some(Capabilities {
                 buttons: true,
+                native_button_capture: true,
                 pointer: true,
                 lighting: false,
                 scroll_inversion: false,
@@ -183,7 +184,7 @@ fn device_inventory() {
     }];
     assert_wire(
         &inventory,
-        "010d426f6c74205265636569766572fb6d04fb48c501084630304443414645010101094d58204d535452335301fb34b000010150020001030106323134304c5a0102030400010100fb34b0fb8240000b010101000001",
+        "010d426f6c74205265636569766572fb6d04fb48c501084630304443414645010101094d58204d535452335301fb34b000010150020001030106323134304c5a0102030400010100fb34b0fb8240000b01010101000001",
     );
 }
 
@@ -224,6 +225,13 @@ fn pairing_updates() {
 
 #[test]
 fn device_settings_payloads() {
+    assert_wire(
+        &DeviceRoute::Lightspeed {
+            receiver_uid: "G305-RX".into(),
+            slot: 1,
+        },
+        "0207473330352d525801",
+    );
     let dpi: Result<DpiInfo, WriteError> = Ok(DpiInfo {
         current: 1600,
         capabilities: DpiCapabilities::new(vec![800, 1600, 3200]).expect("non-empty list"),

--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -20,8 +20,8 @@ pub async fn run(_args: ListArgs) -> Result<()> {
              permission: System Settings → Privacy & Security → Input Monitoring."
         );
         println!(
-            "  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other \
-             receivers (Unifying) aren't surfaced yet."
+            "  - Supported receiver families are Logi Bolt, Unifying, and Logitech \
+             LIGHTSPEED (including the G305 receiver, PID 0xC53F)."
         );
         std::process::exit(2);
     }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -891,6 +891,7 @@ mod tests {
             kind: DeviceKind::Mouse,
             capabilities: Capabilities {
                 buttons: true,
+                native_button_capture: true,
                 pointer: true,
                 lighting: false,
                 scroll_inversion: false,

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -86,8 +86,16 @@ impl DeviceKind {
     reason = "capabilities is a serialized feature-bit DTO; independent booleans keep the IPC/config shape explicit"
 )]
 pub struct Capabilities {
-    /// Reprogrammable buttons — HID++ `0x1b00`–`0x1b04` (ReprogControls).
+    /// A Buttons panel is useful. This includes native HID++ reprogrammable
+    /// controls (`0x1b00`–`0x1b04`) and gaming control tables (`0x8100` /
+    /// `0x8110`) whose standard middle/back/forward events can be remapped by
+    /// the host input hook.
     pub buttons: bool,
+    /// The device exposes a HID++ ReprogControls capture feature, allowing
+    /// controls beyond the OS-visible middle/back/forward buttons to be
+    /// diverted and remapped.
+    #[serde(default)]
+    pub native_button_capture: bool,
     /// Adjustable pointer resolution — HID++ `0x2201` / `0x2202` (AdjustableDpi).
     pub pointer: bool,
     /// Solid-colour RGB the lighting panel can actually drive — HID++
@@ -109,7 +117,8 @@ impl Capabilities {
     /// Membership of a driving feature ID flips the corresponding flag.
     #[must_use]
     pub fn from_feature_ids(ids: &[u16]) -> Self {
-        const BUTTONS: [u16; 5] = [0x1b00, 0x1b01, 0x1b02, 0x1b03, 0x1b04];
+        const NATIVE_BUTTONS: [u16; 5] = [0x1b00, 0x1b01, 0x1b02, 0x1b03, 0x1b04];
+        const GAMING_BUTTONS: [u16; 2] = [0x8100, 0x8110];
         const POINTER: [u16; 2] = [0x2201, 0x2202];
         // PerKeyLighting (0x8080) and ColorLedEffects (0x8070) — both now driven
         // by `set_keyboard_color` (it prefers 0x8070's fixed effect to override a
@@ -118,9 +127,15 @@ impl Capabilities {
         const LIGHTING: [u16; 2] = [0x8080, 0x8070];
         let has = |family: &[u16]| ids.iter().any(|id| family.contains(id));
         Self {
-            buttons: has(&BUTTONS),
+            buttons: has(&NATIVE_BUTTONS) || has(&GAMING_BUTTONS),
+            native_button_capture: has(&NATIVE_BUTTONS),
             pointer: has(&POINTER),
-            lighting: has(&LIGHTING),
+            // Gaming mice may advertise ColorLedEffects for indicator/profile
+            // LEDs, but OpenLogi's current lighting panel is keyboard-focused;
+            // gaming-mouse RGB is explicitly deferred. Keep wired G-series
+            // keyboards eligible by applying the exclusion only to devices
+            // that also advertise an adjustable pointer.
+            lighting: has(&LIGHTING) && !(has(&GAMING_BUTTONS) && has(&POINTER)),
             scroll_inversion: false,
             hires_wheel: ids.contains(&0x2121),
         }
@@ -136,6 +151,7 @@ impl Capabilities {
         match kind {
             DeviceKind::Mouse | DeviceKind::Trackball => Self {
                 buttons: true,
+                native_button_capture: false,
                 pointer: true,
                 lighting: false,
                 scroll_inversion: false,
@@ -367,6 +383,7 @@ mod tests {
                 }),
                 capabilities: Some(Capabilities {
                     buttons: true,
+                    native_button_capture: true,
                     pointer: true,
                     lighting: false,
                     scroll_inversion: false,
@@ -430,6 +447,7 @@ mod tests {
             mouse,
             Capabilities {
                 buttons: true,
+                native_button_capture: true,
                 pointer: true,
                 lighting: false,
                 scroll_inversion: false,
@@ -442,6 +460,7 @@ mod tests {
             keyboard,
             Capabilities {
                 buttons: false,
+                native_button_capture: false,
                 pointer: false,
                 lighting: true,
                 scroll_inversion: false,
@@ -453,6 +472,12 @@ mod tests {
             Capabilities::from_feature_ids(&[0x0000, 0x0003]),
             Capabilities::default()
         );
+
+        let gaming_mouse =
+            Capabilities::from_feature_ids(&[0x0005, 0x1000, 0x2201, 0x8070, 0x8100, 0x8110]);
+        assert!(gaming_mouse.buttons && gaming_mouse.pointer);
+        assert!(!gaming_mouse.native_button_capture);
+        assert!(!gaming_mouse.lighting, "gaming-mouse RGB remains deferred");
     }
 
     #[test]
@@ -470,6 +495,7 @@ mod tests {
         )?;
 
         assert!(!capabilities.hires_wheel);
+        assert!(!capabilities.native_button_capture);
         assert!(capabilities.scroll_inversion);
         Ok(())
     }

--- a/crates/openlogi-core/src/diagnostics.rs
+++ b/crates/openlogi-core/src/diagnostics.rs
@@ -26,6 +26,8 @@ pub enum ConnectionKind {
     BoltReceiver,
     /// Paired through a legacy Unifying receiver.
     UnifyingReceiver,
+    /// Paired through a Logitech LIGHTSPEED gaming receiver.
+    LightspeedReceiver,
     /// Connected directly over Bluetooth — no receiver involved.
     BluetoothDirect,
     /// Connected over a USB cable.
@@ -419,6 +421,7 @@ fn connection_label(connection: ConnectionKind) -> &'static str {
     match connection {
         ConnectionKind::BoltReceiver => "Logi Bolt receiver",
         ConnectionKind::UnifyingReceiver => "Logi Unifying receiver",
+        ConnectionKind::LightspeedReceiver => "Logitech LIGHTSPEED receiver",
         ConnectionKind::BluetoothDirect => "Bluetooth (direct)",
         ConnectionKind::Wired => "Wired (USB)",
         ConnectionKind::Unknown => "unknown",
@@ -590,6 +593,7 @@ mod tests {
                     battery: None,
                     capabilities: Some(Capabilities {
                         buttons: true,
+                        native_button_capture: true,
                         pointer: true,
                         lighting: false,
                         scroll_inversion: false,

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Batterifejl"
 "Bolt receiver": "Bolt-modtager"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED-modtager"
 "Direct connection": "Direkte forbindelse"
 "Unavailable": "Ikke tilgængelig"
 "Mouse": "Mus"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Akkufehler"
 "Bolt receiver": "Bolt-Empfänger"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED-Empfänger"
 "Direct connection": "Direktverbindung"
 "Unavailable": "Nicht verfügbar"
 "Mouse": "Maus"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Σφάλμα μπαταρίας"
 "Bolt receiver": "Δέκτης Bolt"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "Δέκτης LIGHTSPEED"
 "Direct connection": "Απευθείας σύνδεση"
 "Unavailable": "Μη διαθέσιμο"
 "Mouse": "Ποντίκι"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Battery error"
 "Bolt receiver": "Bolt receiver"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED receiver"
 "Direct connection": "Direct connection"
 "Unavailable": "Unavailable"
 "Mouse": "Mouse"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Error de batería"
 "Bolt receiver": "Receptor Bolt"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "Receptor LIGHTSPEED"
 "Direct connection": "Conexión directa"
 "Unavailable": "No disponible"
 "Mouse": "Ratón"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Akkuvirhe"
 "Bolt receiver": "Bolt-vastaanotin"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED-vastaanotin"
 "Direct connection": "Suora yhteys"
 "Unavailable": "Ei käytettävissä"
 "Mouse": "Hiiri"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Erreur de batterie"
 "Bolt receiver": "Récepteur Bolt"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "Récepteur LIGHTSPEED"
 "Direct connection": "Connexion directe"
 "Unavailable": "Indisponible"
 "Mouse": "Souris"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Errore batteria"
 "Bolt receiver": "Ricevitore Bolt"
 "Unifying receiver": "Ricevitore Unifying"
+"LIGHTSPEED receiver": "Ricevitore LIGHTSPEED"
 "Direct connection": "Connessione diretta"
 "Unavailable": "Non disponibile"
 "Mouse": "Mouse"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "バッテリーエラー"
 "Bolt receiver": "Bolt レシーバー"
 "Unifying receiver": "Unifying レシーバー"
+"LIGHTSPEED receiver": "LIGHTSPEED レシーバー"
 "Direct connection": "直接接続"
 "Unavailable": "利用不可"
 "Mouse": "マウス"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "배터리 오류"
 "Bolt receiver": "Bolt 수신기"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED 수신기"
 "Direct connection": "직접 연결"
 "Unavailable": "사용 불가"
 "Mouse": "마우스"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Batterifeil"
 "Bolt receiver": "Bolt-mottaker"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED-mottaker"
 "Direct connection": "Direkte tilkobling"
 "Unavailable": "Utilgjengelig"
 "Mouse": "Mus"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Batterijfout"
 "Bolt receiver": "Bolt-ontvanger"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED-ontvanger"
 "Direct connection": "Directe verbinding"
 "Unavailable": "Niet beschikbaar"
 "Mouse": "Muis"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Błąd baterii"
 "Bolt receiver": "Odbiornik Bolt"
 "Unifying receiver": "Odbiornik Unifying"
+"LIGHTSPEED receiver": "Odbiornik LIGHTSPEED"
 "Direct connection": "Połączenie bezpośrednie"
 "Unavailable": "Niedostępne"
 "Mouse": "Mysz"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Erro de bateria"
 "Bolt receiver": "Receptor Bolt"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "Receptor LIGHTSPEED"
 "Direct connection": "Conexão direta"
 "Unavailable": "Indisponível"
 "Mouse": "Mouse"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Erro de bateria"
 "Bolt receiver": "Recetor Bolt"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "Recetor LIGHTSPEED"
 "Direct connection": "Ligação direta"
 "Unavailable": "Indisponível"
 "Mouse": "Rato"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Ошибка батареи"
 "Bolt receiver": "Приёмник Bolt"
 "Unifying receiver": "Приёмник Unifying"
+"LIGHTSPEED receiver": "Приёмник LIGHTSPEED"
 "Direct connection": "Прямое подключение"
 "Unavailable": "Недоступно"
 "Mouse": "Мышь"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "Batterifel"
 "Bolt receiver": "Bolt-mottagare"
 "Unifying receiver": "Unifying receiver"
+"LIGHTSPEED receiver": "LIGHTSPEED-mottagare"
 "Direct connection": "Direktanslutning"
 "Unavailable": "Otillgänglig"
 "Mouse": "Mus"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "电池错误"
 "Bolt receiver": "Bolt 接收器"
 "Unifying receiver": "Unifying 接收器"
+"LIGHTSPEED receiver": "LIGHTSPEED 接收器"
 "Direct connection": "直接连接"
 "Unavailable": "不可用"
 "Mouse": "鼠标"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "電池錯誤"
 "Bolt receiver": "Bolt 接收器"
 "Unifying receiver": "Unifying 接收器"
+"LIGHTSPEED receiver": "LIGHTSPEED 接收器"
 "Direct connection": "直接連線"
 "Unavailable": "不可用"
 "Mouse": "滑鼠"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -34,6 +34,7 @@ _version: 1
 "Battery error": "電池錯誤"
 "Bolt receiver": "Bolt 接收器"
 "Unifying receiver": "Unifying 接收器"
+"LIGHTSPEED receiver": "LIGHTSPEED 接收器"
 "Direct connection": "直接連線"
 "Unavailable": "無法使用"
 "Mouse": "滑鼠"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -483,6 +483,10 @@ mod tests {
             receiver_uid: "r".into(),
             slot: 1,
         };
+        let lightspeed = DeviceRoute::Lightspeed {
+            receiver_uid: "r".into(),
+            slot: 1,
+        };
         let direct = DeviceRoute::Direct {
             vendor_id: 0x046d,
             product_id: 0xb019,
@@ -508,6 +512,10 @@ mod tests {
         );
         assert_eq!(
             connection_icon_path(Some(&uni), None),
+            "action-icons/unifying.svg"
+        );
+        assert_eq!(
+            connection_icon_path(Some(&lightspeed), None),
             "action-icons/unifying.svg"
         );
         // Direct + radio-less firmware = the cable is the only possible link.
@@ -578,6 +586,7 @@ mod tests {
     fn tabs_follow_capabilities_not_kind() {
         let caps = Some(Capabilities {
             buttons: true,
+            native_button_capture: true,
             pointer: true,
             lighting: false,
             scroll_inversion: false,
@@ -597,6 +606,7 @@ mod tests {
     fn keyboard_without_asset_hides_buttons_tab() {
         let caps = Some(Capabilities {
             buttons: true,
+            native_button_capture: true,
             pointer: false,
             lighting: true,
             scroll_inversion: false,

--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -362,6 +362,7 @@ pub(super) fn connection_icon_path(
     match route {
         Some(DeviceRoute::Bolt { .. }) => "action-icons/bolt.svg",
         Some(DeviceRoute::Unifying { .. }) => "action-icons/unifying.svg",
+        Some(DeviceRoute::Lightspeed { .. }) => "action-icons/unifying.svg",
         // Explicit arms (not `_`) so a new DeviceRoute variant trips the
         // compiler here, matching the exhaustive sibling `route_label`.
         Some(DeviceRoute::Direct { .. }) | None => match transports {

--- a/crates/openlogi-gui/src/app/widgets.rs
+++ b/crates/openlogi-gui/src/app/widgets.rs
@@ -192,6 +192,7 @@ pub(super) fn route_label(route: Option<&DeviceRoute>) -> String {
     match route {
         Some(DeviceRoute::Bolt { .. }) => tr!("Bolt receiver").to_string(),
         Some(DeviceRoute::Unifying { .. }) => tr!("Unifying receiver").to_string(),
+        Some(DeviceRoute::Lightspeed { .. }) => tr!("LIGHTSPEED receiver").to_string(),
         Some(DeviceRoute::Direct { .. }) => tr!("Direct connection").to_string(),
         None => tr!("Unavailable").to_string(),
     }

--- a/crates/openlogi-gui/src/diagnostics.rs
+++ b/crates/openlogi-gui/src/diagnostics.rs
@@ -159,6 +159,7 @@ fn connection_for(
     match route {
         Some(DeviceRoute::Bolt { .. }) => ConnectionKind::BoltReceiver,
         Some(DeviceRoute::Unifying { .. }) => ConnectionKind::UnifyingReceiver,
+        Some(DeviceRoute::Lightspeed { .. }) => ConnectionKind::LightspeedReceiver,
         Some(DeviceRoute::Direct { .. }) => match transports {
             Some(t) if t.bluetooth || t.btle => ConnectionKind::BluetoothDirect,
             Some(t) if t.usb => ConnectionKind::Wired,

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -90,7 +90,7 @@ impl MouseModelView {
 
 impl Render for MouseModelView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let (asset, active, bindings, gesture_owner, glow) = cx
+        let (asset, active, bindings, gesture_owner, glow, native_button_capture) = cx
             .try_global::<AppState>()
             .map(|s| {
                 (
@@ -99,6 +99,15 @@ impl Render for MouseModelView {
                     s.button_bindings.clone(),
                     s.current_gesture_owner(),
                     s.current_record().and_then(|r| keyboard_glow(s, r)),
+                    s.current_record()
+                        .and_then(|r| r.capabilities)
+                        .unwrap_or_else(|| {
+                            s.current_record()
+                                .map_or_else(openlogi_core::device::Capabilities::default, |r| {
+                                    openlogi_core::device::Capabilities::presumed_from_kind(r.kind)
+                                })
+                        })
+                        .native_button_capture,
                 )
             })
             .unwrap_or_default();
@@ -118,7 +127,7 @@ impl Render for MouseModelView {
             (viewport_w - MODEL_HORIZONTAL_RESERVE).clamp(MODEL_MIN_CONTENT_W, MODEL_CONTENT_MAX_W);
         let max_image_w = (content_w - gutter).max(MODEL_MIN_CONTENT_W / 2.);
         let (mouse_w, mouse_h, hotspots, labels) =
-            scaled_model(asset.as_ref(), target_h, max_image_w);
+            scaled_model(asset.as_ref(), target_h, max_image_w, native_button_capture);
 
         let canvas_w = gutter + mouse_w;
         let canvas_h = mouse_h;
@@ -215,15 +224,17 @@ fn scaled_model(
     asset: Option<&ResolvedAsset>,
     target_h: f32,
     max_w: f32,
+    native_button_capture: bool,
 ) -> (f32, f32, Vec<Hotspot>, Vec<Label>) {
     if let Some(a) = asset {
         let (w, h) = asset_dimensions_for_png(a, target_h, max_w);
-        let hotspots = asset_hotspots_for_png(a, w, h);
+        let mut hotspots = asset_hotspots_for_png(a, w, h);
+        retain_remappable_hotspots(&mut hotspots, native_button_capture);
         let labels = labels_from_hotspots(&hotspots, h);
         (w, h, hotspots, labels)
     } else {
         let scale = (target_h / MOUSE_MODEL_SIZE.1).min(max_w / MOUSE_MODEL_SIZE.0);
-        let hotspots = default_hotspots()
+        let mut hotspots = default_hotspots()
             .into_iter()
             .map(|hs| Hotspot {
                 x: hs.x * scale,
@@ -233,8 +244,10 @@ fn scaled_model(
                 ..hs
             })
             .collect();
+        retain_remappable_hotspots(&mut hotspots, native_button_capture);
         let labels = default_labels()
             .into_iter()
+            .filter(|label| hotspots.iter().any(|hotspot| hotspot.id == label.id))
             .map(|l| Label {
                 y: l.y * scale,
                 ..l
@@ -246,6 +259,12 @@ fn scaled_model(
             hotspots,
             labels,
         )
+    }
+}
+
+fn retain_remappable_hotspots(hotspots: &mut Vec<Hotspot>, native_button_capture: bool) {
+    if !native_button_capture {
+        hotspots.retain(|hotspot| hotspot.id.is_os_hook_button());
     }
 }
 
@@ -826,6 +845,24 @@ mod tests {
         assert_eq!(
             gesture_owner_label(ButtonId::GestureButton),
             "Gesture Button"
+        );
+    }
+
+    #[test]
+    fn host_only_mouse_exposes_only_os_visible_hotspots() {
+        let mut hotspots = default_hotspots();
+        retain_remappable_hotspots(&mut hotspots, false);
+        assert_eq!(
+            hotspots
+                .iter()
+                .map(|hotspot| hotspot.id)
+                .collect::<Vec<_>>(),
+            [ButtonId::MiddleClick, ButtonId::Back, ButtonId::Forward]
+        );
+        assert!(
+            !hotspots
+                .iter()
+                .any(|hotspot| matches!(hotspot.id, ButtonId::DpiToggle | ButtonId::GestureButton))
         );
     }
 }

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -517,6 +517,7 @@ mod tests {
             kind: DeviceKind::Mouse,
             capabilities: Capabilities {
                 buttons: true,
+                native_button_capture: true,
                 pointer: true,
                 lighting: false,
                 scroll_inversion: false,

--- a/crates/openlogi-hid/src/inventory/cache.rs
+++ b/crates/openlogi-hid/src/inventory/cache.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use hidpp::channel::HidppChannel;
 
-use super::features::{ProbedFeatures, probe_features, read_battery};
+use super::features::{BatteryFeatureIndex, ProbedFeatures, probe_features, read_battery_at};
 
 /// How many `enumerate` ticks a device's probe is reused before a fresh read.
 /// The expensive part of a probe (the `enumerate_features` feature-table walk)
@@ -26,6 +26,9 @@ pub(super) enum CacheKey {
     /// two receivers whose serials share a common prefix (e.g. "DA2699E1" and
     /// "DA2604F2" share "DA2").
     UnifyingSlot { receiver_uid: String, slot: u8 },
+    /// LIGHTSPEED: receiver serial + slot keeps identical gaming receivers and
+    /// devices isolated while remaining stable across sleep/reconnect.
+    LightspeedSlot { receiver_uid: String, slot: u8 },
     /// Direct (Bluetooth/USB): the OS-assigned HID node id (macOS registry-entry
     /// id, Linux dev path, Windows interface path). Unique *per node*, so two
     /// units of the same model never collide, and stable while connected so the
@@ -46,7 +49,7 @@ pub(super) struct Cached {
     /// table, captured by the full probe. Lets cache hits re-read the volatile
     /// battery in one round-trip — no `Device::new` ping, no table walk.
     /// `None` when the device exposes no `0x1004`.
-    pub(super) battery_index: Option<u8>,
+    pub(super) battery_index: Option<BatteryFeatureIndex>,
     pub(super) probed_tick: u64,
 }
 
@@ -119,7 +122,7 @@ pub(super) async fn probe_or_reuse(
             if online
                 && let Some(feature_index) = c.battery_index
                 && let Some(key) = id.clone()
-                && let Some(battery) = read_battery(channel, index, feature_index).await
+                && let Some(battery) = read_battery_at(channel, index, feature_index).await
             {
                 let mut entry = c.clone();
                 entry.probe.battery = Some(battery);

--- a/crates/openlogi-hid/src/inventory/features.rs
+++ b/crates/openlogi-hid/src/inventory/features.rs
@@ -5,12 +5,14 @@ use hidpp::{
     device::Device,
     feature::hires_wheel::HiResWheelFeature,
     feature::{
-        CreatableFeature, device_information::DeviceInformationFeature,
+        CreatableFeature, battery_status::BatteryStatus as LegacyBatteryStatus,
+        battery_status::BatteryStatusFeature, device_information::DeviceInformationFeature,
         device_type_and_name::DeviceTypeAndNameFeature, unified_battery::UnifiedBatteryFeature,
     },
 };
 use openlogi_core::device::{
-    BatteryInfo, Capabilities, DeviceKind, DeviceModelInfo, DeviceTransports,
+    BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceKind, DeviceModelInfo,
+    DeviceTransports,
 };
 use tracing::debug;
 
@@ -28,6 +30,15 @@ pub(super) struct ProbedFeatures {
     pub(super) kind: Option<DeviceKind>,
     /// Configuration capabilities derived from the device's feature table.
     pub(super) capabilities: Option<Capabilities>,
+    /// Marketing name from `0x0005`, used when the receiver codename is absent.
+    pub(super) marketing_name: Option<String>,
+}
+
+/// Runtime feature-table address used for cheap battery refreshes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BatteryFeatureIndex {
+    Unified(u8),
+    Legacy(u8),
 }
 
 /// Read just the battery by addressing the `UnifiedBattery` feature at its
@@ -52,15 +63,69 @@ pub(super) async fn read_battery(
         })
 }
 
+async fn read_legacy_battery(
+    channel: &Arc<HidppChannel>,
+    slot: u8,
+    feature_index: u8,
+) -> Option<BatteryInfo> {
+    let feature = BatteryStatusFeature::new(Arc::clone(channel), slot, feature_index);
+    feature.get_battery_level_status().await.ok().map(|info| {
+        let level = battery_level_from_percentage(info.percentage);
+        let status = match info.status {
+            LegacyBatteryStatus::Discharging => BatteryStatus::Discharging,
+            LegacyBatteryStatus::Charging | LegacyBatteryStatus::ChargingNearlyFull => {
+                BatteryStatus::Charging
+            }
+            LegacyBatteryStatus::Full => BatteryStatus::Full,
+            LegacyBatteryStatus::ChargingSlow => BatteryStatus::ChargingSlow,
+            LegacyBatteryStatus::InvalidBattery
+            | LegacyBatteryStatus::ThermalError
+            | LegacyBatteryStatus::ChargingError => BatteryStatus::Error,
+            _ => BatteryStatus::Unknown,
+        };
+        BatteryInfo {
+            percentage: info.percentage,
+            level,
+            status,
+        }
+    })
+}
+
+fn battery_level_from_percentage(percentage: u8) -> BatteryLevel {
+    match percentage {
+        100 => BatteryLevel::Full,
+        20..=99 => BatteryLevel::Good,
+        5..=19 => BatteryLevel::Low,
+        _ => BatteryLevel::Critical,
+    }
+}
+
+pub(super) async fn read_battery_at(
+    channel: &Arc<HidppChannel>,
+    slot: u8,
+    index: BatteryFeatureIndex,
+) -> Option<BatteryInfo> {
+    match index {
+        BatteryFeatureIndex::Unified(index) => read_battery(channel, slot, index).await,
+        BatteryFeatureIndex::Legacy(index) => read_legacy_battery(channel, slot, index).await,
+    }
+}
+
 /// Runtime index of the `UnifiedBattery` feature in an enumerated feature-ID
 /// table, for [`read_battery`]. The table is 1-based (index 0 is the implicit
 /// root feature, which enumeration omits).
-pub(super) fn battery_feature_index(ids: impl IntoIterator<Item = u16>) -> Option<u8> {
-    ids.into_iter()
-        .position(|id| id == UnifiedBatteryFeature::ID)
-        // A feature table holds at most `u8::MAX` entries (its count is a u8),
-        // so the 1-based index always fits.
-        .and_then(|pos| u8::try_from(pos + 1).ok())
+pub(super) fn battery_feature_index(
+    ids: impl IntoIterator<Item = u16>,
+) -> Option<BatteryFeatureIndex> {
+    let ids = ids.into_iter().collect::<Vec<_>>();
+    let index_of = |feature_id| {
+        ids.iter()
+            .position(|id| *id == feature_id)
+            .and_then(|pos| u8::try_from(pos + 1).ok())
+    };
+    index_of(UnifiedBatteryFeature::ID)
+        .map(BatteryFeatureIndex::Unified)
+        .or_else(|| index_of(BatteryStatusFeature::ID).map(BatteryFeatureIndex::Legacy))
 }
 
 /// Open a HID++ session for `slot` and read everything we care about (battery,
@@ -77,7 +142,7 @@ pub(super) fn battery_feature_index(ids: impl IntoIterator<Item = u16>) -> Optio
 pub(super) async fn probe_features(
     channel: &Arc<HidppChannel>,
     slot: u8,
-) -> (ProbedFeatures, Option<u8>) {
+) -> (ProbedFeatures, Option<BatteryFeatureIndex>) {
     let mut device = match Device::new(Arc::clone(channel), slot).await {
         Ok(d) => d,
         Err(e) => {
@@ -110,7 +175,7 @@ pub(super) async fn probe_features(
     }
 
     let battery = match battery_index {
-        Some(feature_index) => read_battery(channel, slot, feature_index).await,
+        Some(feature_index) => read_battery_at(channel, slot, feature_index).await,
         None => None,
     };
 
@@ -154,15 +219,23 @@ pub(super) async fn probe_features(
     // the authoritative kind signal. On the direct path it's the only one; on
     // the Bolt path it corrects a pairing register that reported the wrong (or
     // `Unknown`) kind.
-    let kind = match device.get_feature::<DeviceTypeAndNameFeature>() {
-        Some(feature) => match feature.get_device_type().await {
-            Ok(ty) => Some(map_device_type(ty)),
-            Err(e) => {
-                debug!(slot, error = ?e, "DeviceType read failed");
-                None
-            }
-        },
-        None => None,
+    let (kind, marketing_name) = match device.get_feature::<DeviceTypeAndNameFeature>() {
+        Some(feature) => {
+            let kind = match feature.get_device_type().await {
+                Ok(ty) => Some(map_device_type(ty)),
+                Err(e) => {
+                    debug!(slot, error = ?e, "DeviceType read failed");
+                    None
+                }
+            };
+            let name = feature
+                .get_whole_device_name()
+                .await
+                .ok()
+                .filter(|name| !name.trim().is_empty());
+            (kind, name)
+        }
+        None => (None, None),
     };
 
     (
@@ -171,6 +244,7 @@ pub(super) async fn probe_features(
             model_info,
             kind,
             capabilities,
+            marketing_name,
         },
         battery_index,
     )
@@ -180,17 +254,21 @@ pub(super) async fn probe_features(
 mod tests {
     use hidpp::feature::{CreatableFeature as _, unified_battery::UnifiedBatteryFeature};
 
-    use super::battery_feature_index;
+    use super::{BatteryFeatureIndex, battery_feature_index, battery_level_from_percentage};
+    use openlogi_core::device::BatteryLevel;
 
     #[test]
     fn battery_index_is_one_based_in_the_enumerated_table() {
         // `enumerate_features` omits the root feature (index 0), so the first
         // enumerated entry sits at runtime index 1.
         let table = [0x0001, UnifiedBatteryFeature::ID, 0x2201];
-        assert_eq!(battery_feature_index(table), Some(2));
+        assert_eq!(
+            battery_feature_index(table),
+            Some(BatteryFeatureIndex::Unified(2))
+        );
         assert_eq!(
             battery_feature_index([UnifiedBatteryFeature::ID]),
-            Some(1),
+            Some(BatteryFeatureIndex::Unified(1)),
             "first entry maps to index 1, not 0"
         );
     }
@@ -199,5 +277,29 @@ mod tests {
     fn no_battery_feature_means_no_index() {
         assert_eq!(battery_feature_index([0x0001, 0x2201, 0x1b04]), None);
         assert_eq!(battery_feature_index([]), None);
+    }
+
+    #[test]
+    fn legacy_battery_is_used_when_unified_is_absent() {
+        assert_eq!(
+            battery_feature_index([0x0001, 0x1000, 0x2201]),
+            Some(BatteryFeatureIndex::Legacy(2))
+        );
+        assert_eq!(
+            battery_feature_index([0x1000, 0x1004]),
+            Some(BatteryFeatureIndex::Unified(2)),
+            "0x1004 is preferred when both generations are advertised"
+        );
+    }
+
+    #[test]
+    fn legacy_percentage_maps_to_openlogi_levels() {
+        assert_eq!(battery_level_from_percentage(100), BatteryLevel::Full);
+        assert_eq!(battery_level_from_percentage(99), BatteryLevel::Good);
+        assert_eq!(battery_level_from_percentage(20), BatteryLevel::Good);
+        assert_eq!(battery_level_from_percentage(19), BatteryLevel::Low);
+        assert_eq!(battery_level_from_percentage(5), BatteryLevel::Low);
+        assert_eq!(battery_level_from_percentage(4), BatteryLevel::Critical);
+        assert_eq!(battery_level_from_percentage(0), BatteryLevel::Critical);
     }
 }

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -8,6 +8,10 @@ use hidpp::{
         bolt::{
             DeviceConnection as BoltDeviceConnection, Event as BoltEvent, Receiver as BoltReceiver,
         },
+        lightspeed::{
+            DeviceConnection as LightspeedDeviceConnection, Event as LightspeedEvent,
+            Receiver as LightspeedReceiver,
+        },
         unifying::{
             DeviceConnection as UnifyingDeviceConnection, Event as UnifyingEvent,
             Receiver as UnifyingReceiver,
@@ -18,7 +22,7 @@ use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverI
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
-use crate::mappings::{map_kind, map_unifying_kind, resolve_device_kind};
+use crate::mappings::{map_kind, map_lightspeed_kind, map_unifying_kind, resolve_device_kind};
 use crate::route::DIRECT_DEVICE_INDEX;
 
 use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
@@ -61,6 +65,9 @@ pub(super) async fn probe_one(
         Some(Receiver::Unifying(unifying)) => {
             probe_unifying_receiver(channel, info, unifying, cache, tick).await
         }
+        Some(Receiver::Lightspeed(lightspeed)) => {
+            probe_lightspeed_receiver(channel, info, lightspeed, cache, tick).await
+        }
         None | Some(_) => {
             // No recognised receiver — this might be a directly-paired device
             // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
@@ -69,6 +76,124 @@ pub(super) async fn probe_one(
             probe_direct(channel, &info, cache, tick).await
         }
     }
+}
+
+async fn probe_lightspeed_receiver(
+    channel: Arc<HidppChannel>,
+    info: async_hid::DeviceInfo,
+    receiver: LightspeedReceiver,
+    cache: &HashMap<CacheKey, Cached>,
+    tick: u64,
+) -> NodeProbe {
+    let receiver_info = receiver.get_receiver_info().await.ok();
+    let unique_id = receiver_info
+        .as_ref()
+        .and_then(|info| stable_receiver_uid(&info.serial_number));
+    let pairing_count = receiver.count_pairings().await.ok();
+    let connections = drain_device_arrival_lightspeed(&receiver).await;
+    let by_slot: HashMap<u8, LightspeedDeviceConnection> = connections
+        .into_iter()
+        .map(|event| (event.index, event))
+        .collect();
+
+    let uid_fallback;
+    let receiver_uid = if let Some(uid) = unique_id.as_deref() {
+        uid
+    } else {
+        // Keep immutable feature-cache entries isolated even though a missing
+        // receiver identity deliberately disables write routing.
+        uid_fallback = format!("node:{:?}", info.id);
+        &uid_fallback
+    };
+    let capacity = receiver_info
+        .as_ref()
+        .map_or(6, |info| info.pairing_slots.clamp(1, 6));
+    let mut paired = Vec::new();
+    let mut outcomes = Vec::new();
+    for slot in 1..=capacity {
+        if let Some((device, outcome)) = probe_lightspeed_slot(
+            &channel,
+            &receiver,
+            by_slot.get(&slot),
+            receiver_uid,
+            slot,
+            cache,
+            tick,
+        )
+        .await
+        {
+            paired.push(device);
+            outcomes.push(outcome);
+        }
+    }
+    let complete = pairing_count.is_some_and(|count| paired.len() == usize::from(count));
+    if !complete {
+        debug!(
+            ?pairing_count,
+            found = paired.len(),
+            "LIGHTSPEED pairing walk incomplete"
+        );
+    }
+    NodeProbe {
+        inventory: Some(DeviceInventory {
+            receiver: ReceiverInfo {
+                name: "LIGHTSPEED Receiver".to_string(),
+                vendor_id: info.vendor_id,
+                product_id: info.product_id,
+                unique_id,
+            },
+            paired,
+        }),
+        healthy: complete,
+        complete,
+        outcomes,
+    }
+}
+
+fn stable_receiver_uid(serial: &str) -> Option<String> {
+    let serial = serial.trim();
+    (!serial.is_empty() && serial.bytes().any(|byte| byte != b'0')).then(|| serial.to_string())
+}
+
+async fn probe_lightspeed_slot(
+    channel: &Arc<HidppChannel>,
+    receiver: &LightspeedReceiver,
+    event: Option<&LightspeedDeviceConnection>,
+    receiver_uid: &str,
+    slot: u8,
+    cache: &HashMap<CacheKey, Cached>,
+    tick: u64,
+) -> Option<(PairedDevice, CacheOutcome)> {
+    let pairing = receiver.get_device_pairing_information(slot).await.ok()?;
+    // LIGHTSPEED's persistent 0x2N pairing record has no connection-state
+    // bit. An arrival notification is authoritative when present; otherwise
+    // optimistically address the paired slot (the same behavior Solaar uses)
+    // so an awake G-series device can answer its HID++ 2.0 feature probe.
+    let online = event.is_none_or(|event| event.online);
+    let register_kind = map_lightspeed_kind(event.map_or(pairing.kind, |event| event.kind));
+    let id = CacheKey::LightspeedSlot {
+        receiver_uid: receiver_uid.to_string(),
+        slot,
+    };
+    let cached = cache.get(&id);
+    let (probe, outcome) = probe_or_reuse(channel, slot, Some(id), cached, online, tick).await;
+    let receiver_name = receiver.get_device_codename(slot).await.ok();
+    let codename = receiver_name.or_else(|| probe.marketing_name.clone());
+    let wpid = event.map_or(pairing.wpid, |event| event.wpid);
+    debug!(slot, online, wpid = format_args!("{wpid:04x}"), codename = ?codename, "LIGHTSPEED paired slot");
+    Some((
+        PairedDevice {
+            slot,
+            codename,
+            wpid: Some(wpid),
+            kind: resolve_device_kind(probe.kind, register_kind),
+            online,
+            battery: probe.battery,
+            model_info: probe.model_info,
+            capabilities: probe.capabilities,
+        },
+        outcome,
+    ))
 }
 
 async fn probe_bolt_receiver(
@@ -384,7 +509,10 @@ async fn walk_bolt_slot(
 
     let device = PairedDevice {
         slot,
-        codename: identity.codename.clone(),
+        codename: identity
+            .codename
+            .clone()
+            .or_else(|| probe.marketing_name.clone()),
         wpid,
         // Prefer the device's own `0x0005` type; the register kind is the
         // offline fallback.
@@ -468,7 +596,10 @@ async fn probe_direct(
         },
         paired: vec![PairedDevice {
             slot: DIRECT_DEVICE_INDEX,
-            codename: Some(info.name.clone()),
+            codename: probe
+                .marketing_name
+                .clone()
+                .or_else(|| Some(info.name.clone())),
             wpid: None,
             // No receiver pairing register here, so `0x0005` is the only kind
             // hint — but kind is just identity now; the UI gates on the
@@ -536,6 +667,25 @@ async fn drain_device_arrival_unifying(
     Some(out)
 }
 
+async fn drain_device_arrival_lightspeed(
+    receiver: &LightspeedReceiver,
+) -> Vec<LightspeedDeviceConnection> {
+    let rx = receiver.listen();
+    if let Err(error) = receiver.trigger_device_arrival().await {
+        debug!(?error, "LIGHTSPEED trigger_device_arrival failed");
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    loop {
+        match timeout(ARRIVAL_DRAIN, rx.recv()).await {
+            Ok(Ok(LightspeedEvent::DeviceConnection(connection))) => out.push(connection),
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(_) => break,
+        }
+    }
+    out
+}
+
 /// Probe a Unifying slot from a live device-connection event.
 ///
 /// Device-arrival events carry the slot index, kind, wpid, and online status —
@@ -594,7 +744,7 @@ async fn probe_unifying_slot(
 
     let device = PairedDevice {
         slot,
-        codename,
+        codename: codename.or_else(|| probe.marketing_name.clone()),
         wpid: Some(event.wpid),
         kind: resolve_device_kind(probe.kind, register_kind),
         // Reachable on this receiver iff the feature walk got through this tick.
@@ -651,4 +801,16 @@ async fn read_codename(channel: &HidppChannel, slot: u8) -> Option<String> {
     core::str::from_utf8(&response[3..3 + len])
         .ok()
         .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::stable_receiver_uid;
+
+    #[test]
+    fn lightspeed_receiver_uid_rejects_missing_identity() {
+        assert_eq!(stable_receiver_uid("A1B2C3D4").as_deref(), Some("A1B2C3D4"));
+        assert_eq!(stable_receiver_uid("00000000"), None);
+        assert_eq!(stable_receiver_uid("  "), None);
+    }
 }

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -280,3 +280,21 @@ fn codename_clamps_overlong_len() {
 fn codename_rejects_short_response() {
     assert_eq!(parse_codename_unifying(&[0x40]), None);
 }
+
+#[test]
+fn lightspeed_cache_is_scoped_to_receiver_and_slot() {
+    let first = CacheKey::LightspeedSlot {
+        receiver_uid: "RX-A".into(),
+        slot: 1,
+    };
+    let other_receiver = CacheKey::LightspeedSlot {
+        receiver_uid: "RX-B".into(),
+        slot: 1,
+    };
+    let other_slot = CacheKey::LightspeedSlot {
+        receiver_uid: "RX-A".into(),
+        slot: 2,
+    };
+    assert_ne!(first, other_receiver);
+    assert_ne!(first, other_slot);
+}

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -41,7 +41,7 @@ pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
 };
-pub use route::{BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
+pub use route::{BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, UNIFYING_PIDS};
 pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus};
 pub use write::{
     DpiCapabilities, DpiInfo, FeatureEntry, HidppFeatureErrorKind, HidppOperation, LightingMethod,

--- a/crates/openlogi-hid/src/mappings.rs
+++ b/crates/openlogi-hid/src/mappings.rs
@@ -8,6 +8,7 @@ use hidpp::feature::unified_battery::{
     BatteryLevel as HidppBatteryLevel, BatteryStatus as HidppBatteryStatus,
 };
 use hidpp::receiver::bolt::DeviceKind as BoltDeviceKind;
+use hidpp::receiver::lightspeed::DeviceKind as LightspeedDeviceKind;
 use hidpp::receiver::unifying::DeviceKind as UnifyingDeviceKind;
 use openlogi_core::device::{BatteryLevel, BatteryStatus, DeviceKind};
 
@@ -46,6 +47,20 @@ pub(crate) fn map_unifying_kind(k: UnifyingDeviceKind) -> DeviceKind {
         UnifyingDeviceKind::Remote => DeviceKind::Remote,
         UnifyingDeviceKind::Trackball => DeviceKind::Trackball,
         UnifyingDeviceKind::Touchpad => DeviceKind::Touchpad,
+        _ => DeviceKind::Unknown,
+    }
+}
+
+/// Map a LIGHTSPEED pairing-register device kind to our [`DeviceKind`].
+pub(crate) fn map_lightspeed_kind(k: LightspeedDeviceKind) -> DeviceKind {
+    match k {
+        LightspeedDeviceKind::Keyboard => DeviceKind::Keyboard,
+        LightspeedDeviceKind::Mouse => DeviceKind::Mouse,
+        LightspeedDeviceKind::Numpad => DeviceKind::Numpad,
+        LightspeedDeviceKind::Presenter => DeviceKind::Presenter,
+        LightspeedDeviceKind::Remote => DeviceKind::Remote,
+        LightspeedDeviceKind::Trackball => DeviceKind::Trackball,
+        LightspeedDeviceKind::Touchpad => DeviceKind::Touchpad,
         _ => DeviceKind::Unknown,
     }
 }

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -5,6 +5,8 @@
 //!
 //! - [`DeviceRoute::Bolt`] — a device paired to a Logi Bolt receiver, reached
 //!   through the receiver channel at a pairing slot.
+//! - [`DeviceRoute::Lightspeed`] — a gaming device paired to a LIGHTSPEED
+//!   receiver, also reached through the receiver channel at its slot.
 //! - [`DeviceRoute::Direct`] — a device attached straight to the host over a
 //!   USB cable or Bluetooth, reached on its own channel at the HID++
 //!   self-index [`DIRECT_DEVICE_INDEX`].
@@ -53,6 +55,13 @@ pub enum DeviceRoute {
         /// Pairing slot of the target device on that receiver.
         slot: u8,
     },
+    /// Paired to a Logitech LIGHTSPEED gaming receiver.
+    Lightspeed {
+        /// Stable receiver serial used to reopen the same physical receiver.
+        receiver_uid: String,
+        /// Pairing slot of the target device on that receiver.
+        slot: u8,
+    },
     /// Attached straight to the host over USB cable or Bluetooth, addressed at
     /// the HID++ self-index. Re-found by matching the HID node's vendor/product
     /// id — two identical mice on one host are indistinguishable here, so the
@@ -72,13 +81,20 @@ pub const BOLT_PIDS: &[u16] = &[0xc548];
 /// need to construct the correct [`DeviceRoute`] variant from a raw inventory.
 pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532];
 
+/// USB product IDs that identify Logitech LIGHTSPEED gaming receivers.
+pub const LIGHTSPEED_PIDS: &[u16] = &[
+    0xc539, 0xc53a, 0xc53d, 0xc53f, 0xc541, 0xc545, 0xc547, 0xc54d,
+];
+
 impl DeviceRoute {
     /// The HID++ device index features are addressed at for this route: the
     /// pairing slot for a Bolt device, the self-index for a direct one.
     #[must_use]
     pub fn device_index(&self) -> u8 {
         match self {
-            Self::Bolt { slot, .. } | Self::Unifying { slot, .. } => *slot,
+            Self::Bolt { slot, .. }
+            | Self::Unifying { slot, .. }
+            | Self::Lightspeed { slot, .. } => *slot,
             Self::Direct { .. } => DIRECT_DEVICE_INDEX,
         }
     }
@@ -100,6 +116,12 @@ impl DeviceRoute {
                 receiver_uid: uid.clone(),
                 slot,
             }),
+            Some(uid) if LIGHTSPEED_PIDS.contains(&inv.receiver.product_id) => {
+                Some(Self::Lightspeed {
+                    receiver_uid: uid.clone(),
+                    slot,
+                })
+            }
             Some(uid) => {
                 // Default to Bolt for any receiver whose PID is not in
                 // UNIFYING_PIDS. This covers both known Bolt PIDs (BOLT_PIDS)
@@ -128,7 +150,9 @@ impl DeviceRoute {
 impl fmt::Display for DeviceRoute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Bolt { receiver_uid, slot } | Self::Unifying { receiver_uid, slot } => {
+            Self::Bolt { receiver_uid, slot }
+            | Self::Unifying { receiver_uid, slot }
+            | Self::Lightspeed { receiver_uid, slot } => {
                 write!(f, "slot {slot} on receiver {receiver_uid}")
             }
             Self::Direct {
@@ -188,6 +212,17 @@ pub(crate) async fn open_route_channel(
                     return Ok(Some(channel));
                 }
             }
+            DeviceRoute::Lightspeed { receiver_uid, .. } => {
+                let Some(Receiver::Lightspeed(lightspeed)) = receiver::detect(Arc::clone(&channel))
+                else {
+                    continue;
+                };
+                if let Ok(uid) = lightspeed.get_unique_id().await
+                    && uid.eq_ignore_ascii_case(receiver_uid)
+                {
+                    return Ok(Some(channel));
+                }
+            }
             DeviceRoute::Direct { .. } => return Ok(Some(channel)),
         }
     }
@@ -200,7 +235,7 @@ mod tests {
 
     use openlogi_core::device::{DeviceInventory, ReceiverInfo};
 
-    use super::{DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
+    use super::{DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, UNIFYING_PIDS};
 
     fn inv(product_id: u16, unique_id: Option<&str>) -> DeviceInventory {
         DeviceInventory {
@@ -237,6 +272,18 @@ mod tests {
     }
 
     #[test]
+    fn device_route_for_lightspeed_pids_creates_lightspeed_route() {
+        for &pid in LIGHTSPEED_PIDS {
+            let route = DeviceRoute::device_route_for(&inv(pid, Some("G305-RX")), 1);
+            assert!(matches!(
+                route,
+                Some(DeviceRoute::Lightspeed { ref receiver_uid, slot: 1 })
+                    if receiver_uid == "G305-RX"
+            ));
+        }
+    }
+
+    #[test]
     fn device_route_for_direct_when_no_uid_and_direct_slot() {
         let route = DeviceRoute::device_route_for(&inv(0xb025, None), DIRECT_DEVICE_INDEX);
         assert_matches!(
@@ -261,6 +308,15 @@ mod tests {
             slot: 4,
         };
         assert_eq!(route.device_index(), 4);
+    }
+
+    #[test]
+    fn lightspeed_device_index_is_the_slot() {
+        let route = DeviceRoute::Lightspeed {
+            receiver_uid: "X".into(),
+            slot: 1,
+        };
+        assert_eq!(route.device_index(), 1);
     }
 
     #[test]

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -190,6 +190,7 @@ fn is_receiver_child_sysfs_path(path: &str) -> bool {
     crate::BOLT_PIDS
         .iter()
         .chain(crate::UNIFYING_PIDS.iter())
+        .chain(crate::LIGHTSPEED_PIDS.iter())
         .any(|&pid| {
             let marker = format!(":{LOGITECH_VID:04X}:{pid:04X}.");
             // A parent component contains the marker followed by at least one

--- a/crates/openlogi-hid/src/transport/tests.rs
+++ b/crates/openlogi-hid/src/transport/tests.rs
@@ -77,6 +77,11 @@ const UNIFYING_RECEIVER: &str = "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-5/3
 // Sysfs path: child of Bolt receiver
 const BOLT_CHILD: &str = "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-5/\
      0003:046D:C548.0001/0003:046D:B037.0002";
+// Sysfs path: G305 child created below its LIGHTSPEED receiver
+const LIGHTSPEED_CHILD: &str = "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-6/\
+     0003:046D:C53F.0003/0003:046D:4074.0004";
+const LIGHTSPEED_RECEIVER: &str = "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-6/\
+     0003:046D:C53F.0003";
 // Sysfs path: unrelated non-Logitech device
 const UNRELATED: &str = "/sys/devices/pci0000:00/0000:00:15.0/i2c-0/0018:06CB:CE67.0001";
 
@@ -93,6 +98,12 @@ fn unifying_receiver_itself_is_not_a_child() {
 #[test]
 fn child_of_bolt_receiver_is_detected() {
     assert!(is_receiver_child_sysfs_path(BOLT_CHILD));
+}
+
+#[test]
+fn child_of_lightspeed_receiver_is_detected() {
+    assert!(is_receiver_child_sysfs_path(LIGHTSPEED_CHILD));
+    assert!(!is_receiver_child_sysfs_path(LIGHTSPEED_RECEIVER));
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/feature/battery_status/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/battery_status/mod.rs
@@ -1,0 +1,80 @@
+//! Implements the legacy `BatteryStatus` feature (ID `0x1000`).
+
+use std::sync::Arc;
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use crate::{
+    channel::HidppChannel,
+    feature::{CreatableFeature, Feature, FeatureEndpoint},
+    protocol::v20::Hidpp20Error,
+};
+
+/// Legacy HID++ 2.0 battery status feature used by devices such as the G305.
+#[derive(Clone)]
+pub struct BatteryStatusFeature {
+    endpoint: FeatureEndpoint,
+}
+
+impl CreatableFeature for BatteryStatusFeature {
+    const ID: u16 = 0x1000;
+    const STARTING_VERSION: u8 = 0;
+
+    fn new(chan: Arc<HidppChannel>, device_index: u8, feature_index: u8) -> Self {
+        Self {
+            endpoint: FeatureEndpoint::new(chan, device_index, feature_index),
+        }
+    }
+}
+
+impl Feature for BatteryStatusFeature {}
+
+impl BatteryStatusFeature {
+    /// Reads the current percentage and charge status.
+    pub async fn get_battery_level_status(&self) -> Result<BatteryInfo, Hidpp20Error> {
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
+        Ok(BatteryInfo {
+            percentage: payload[0],
+            next_level: payload[1],
+            status: BatteryStatus::try_from(payload[2])
+                .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
+        })
+    }
+}
+
+/// Legacy battery information returned by function 0.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct BatteryInfo {
+    /// Current charge percentage.
+    pub percentage: u8,
+    /// Percentage threshold for the next coarser battery level.
+    pub next_level: u8,
+    /// Charging/discharging state.
+    pub status: BatteryStatus,
+}
+
+/// Charge state used by the legacy battery feature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum BatteryStatus {
+    /// The battery is discharging.
+    Discharging = 0,
+    /// The battery is charging.
+    Charging = 1,
+    /// Charging is in its final stage.
+    ChargingNearlyFull = 2,
+    /// Charging is complete.
+    Full = 3,
+    /// Charging is slower than optimal.
+    ChargingSlow = 4,
+    /// The reported battery type is invalid.
+    InvalidBattery = 5,
+    /// Charging stopped because of a thermal condition.
+    ThermalError = 6,
+    /// Another charging error occurred.
+    ChargingError = 7,
+}

--- a/crates/openlogi-hidpp/src/feature/battery_status/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/battery_status/mod.rs
@@ -36,8 +36,7 @@ impl BatteryStatusFeature {
         Ok(BatteryInfo {
             percentage: payload[0],
             next_level: payload[1],
-            status: BatteryStatus::try_from(payload[2])
-                .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
+            status: BatteryStatus::from_raw(payload[2]),
         })
     }
 }
@@ -77,4 +76,23 @@ pub enum BatteryStatus {
     ThermalError = 6,
     /// Another charging error occurred.
     ChargingError = 7,
+    /// The device reported an unrecognized charge state.
+    Unknown = 0xff,
+}
+
+impl BatteryStatus {
+    fn from_raw(value: u8) -> Self {
+        Self::try_from(value).unwrap_or(Self::Unknown)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BatteryStatus;
+
+    #[test]
+    fn unknown_status_byte_preserves_battery_read() {
+        assert_eq!(BatteryStatus::from_raw(8), BatteryStatus::Unknown);
+        assert_eq!(BatteryStatus::from_raw(0xff), BatteryStatus::Unknown);
+    }
 }

--- a/crates/openlogi-hidpp/src/feature/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 
 pub mod adjustable_dpi;
 pub mod backlight;
+pub mod battery_status;
 pub mod brightness_control;
 pub mod change_host;
 pub mod color_led_effects;

--- a/crates/openlogi-hidpp/src/receiver/lightspeed.rs
+++ b/crates/openlogi-hidpp/src/receiver/lightspeed.rs
@@ -1,0 +1,353 @@
+//! Implements Logitech LIGHTSPEED gaming receivers.
+//!
+//! LIGHTSPEED receivers use the same HID++ 1.0 receiver registers as the
+//! Unifying family for inventory and address paired HID++ 2.0 devices by slot.
+//! They are kept as a separate receiver family because their USB product IDs,
+//! pairing behavior, and supported device population are distinct.
+
+use std::sync::Arc;
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use crate::{
+    channel::{HidppChannel, MessageListenerGuard},
+    event::EventEmitter,
+    protocol::v10::{self, Hidpp10Error},
+    receiver::{RECEIVER_DEVICE_INDEX, ReceiverError},
+};
+
+/// All USB vendor/product pairs known to identify LIGHTSPEED receivers.
+pub const VPID_PAIRS: &[(u16, u16)] = &[
+    (0x046d, 0xc539),
+    (0x046d, 0xc53a),
+    (0x046d, 0xc53d),
+    (0x046d, 0xc53f),
+    (0x046d, 0xc541),
+    (0x046d, 0xc545),
+    (0x046d, 0xc547),
+    (0x046d, 0xc54d),
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+#[repr(u8)]
+enum Register {
+    Connections = 0x02,
+    ReceiverInfo = 0xb5,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+#[repr(u8)]
+enum InfoSubRegister {
+    ReceiverInfo = 0x03,
+    DevicePairingInformation = 0x20,
+    ExtendedPairingInformation = 0x30,
+    DeviceCodename = 0x40,
+}
+
+/// A Logitech LIGHTSPEED receiver.
+#[derive(Clone)]
+pub struct Receiver {
+    chan: Arc<HidppChannel>,
+    emitter: Arc<EventEmitter<Event>>,
+    _listener: Arc<MessageListenerGuard>,
+}
+
+impl Receiver {
+    /// Creates a LIGHTSPEED receiver for a channel with a known VID/PID.
+    pub fn new(chan: Arc<HidppChannel>) -> Result<Self, ReceiverError> {
+        if !VPID_PAIRS.contains(&(chan.vendor_id, chan.product_id)) {
+            return Err(ReceiverError::UnknownReceiver);
+        }
+
+        let emitter = Arc::new(EventEmitter::new());
+        let listener = chan.add_msg_listener_guarded({
+            let emitter = Arc::clone(&emitter);
+            move |raw, matched| {
+                if matched {
+                    return;
+                }
+                if let Some(connection) = parse_connection_notification(v10::Message::from(raw)) {
+                    emitter.emit(Event::DeviceConnection(connection));
+                }
+            }
+        });
+
+        Ok(Self {
+            chan,
+            emitter,
+            _listener: Arc::new(listener),
+        })
+    }
+
+    /// Creates a listener for receiver events.
+    pub fn listen(&self) -> async_channel::Receiver<Event> {
+        self.emitter.create_receiver()
+    }
+
+    /// Returns the number of persistent pairings on the receiver.
+    pub async fn count_pairings(&self) -> Result<u8, ReceiverError> {
+        let response = self
+            .chan
+            .read_register(RECEIVER_DEVICE_INDEX, Register::Connections.into(), [0; 3])
+            .await?;
+        Ok(response[1])
+    }
+
+    /// Requests a `0x41` notification from every connected paired device.
+    pub async fn trigger_device_arrival(&self) -> Result<(), ReceiverError> {
+        self.chan
+            .write_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::Connections.into(),
+                [0x02, 0x00, 0x00],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Reads receiver serial identity and pairing capacity.
+    pub async fn get_receiver_info(&self) -> Result<ReceiverInfo, ReceiverError> {
+        let response = self
+            .chan
+            .read_long_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::ReceiverInfo.into(),
+                [InfoSubRegister::ReceiverInfo.into(), 0, 0],
+            )
+            .await?;
+        Ok(ReceiverInfo {
+            serial_number: hex::encode_upper(&response[1..=4]),
+            pairing_slots: response[6],
+        })
+    }
+
+    /// Reads persistent pairing metadata for a 1-based receiver slot.
+    pub async fn get_device_pairing_information(
+        &self,
+        device_index: u8,
+    ) -> Result<DevicePairingInformation, ReceiverError> {
+        let pairing = self
+            .chan
+            .read_long_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::ReceiverInfo.into(),
+                [
+                    u8::from(InfoSubRegister::DevicePairingInformation)
+                        .saturating_add(device_index.saturating_sub(1)),
+                    0,
+                    0,
+                ],
+            )
+            .await?;
+        let extended = self
+            .chan
+            .read_long_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::ReceiverInfo.into(),
+                [
+                    u8::from(InfoSubRegister::ExtendedPairingInformation)
+                        .saturating_add(device_index.saturating_sub(1)),
+                    0,
+                    0,
+                ],
+            )
+            .await
+            .ok();
+        decode_pairing_information(&pairing, extended.as_ref()).map_err(ReceiverError::from)
+    }
+
+    /// Reads the receiver-provided codename for a paired device.
+    pub async fn get_device_codename(&self, device_index: u8) -> Result<String, ReceiverError> {
+        let response = self
+            .chan
+            .read_long_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::ReceiverInfo.into(),
+                [
+                    u8::from(InfoSubRegister::DeviceCodename)
+                        .saturating_add(device_index.saturating_sub(1)),
+                    0,
+                    0,
+                ],
+            )
+            .await?;
+        decode_codename(&response)
+            .map(str::to_string)
+            .ok_or_else(|| ReceiverError::from(Hidpp10Error::UnsupportedResponse))
+    }
+
+    /// Returns the stable receiver serial number.
+    pub async fn get_unique_id(&self) -> Result<String, ReceiverError> {
+        self.get_receiver_info()
+            .await
+            .map(|info| info.serial_number)
+    }
+}
+
+fn parse_connection_notification(message: v10::Message) -> Option<DeviceConnection> {
+    let header = message.header();
+    if header.sub_id != 0x41 || header.device_index == RECEIVER_DEVICE_INDEX {
+        return None;
+    }
+    let payload = message.extend_payload();
+    Some(DeviceConnection {
+        index: header.device_index,
+        kind: DeviceKind::try_from(payload[1] & 0x0f).ok()?,
+        encrypted: payload[1] & (1 << 5) != 0 || payload[0] == 0x10,
+        online: payload[1] & (1 << 6) == 0,
+        wpid: u16::from_le_bytes([payload[2], payload[3]]),
+    })
+}
+
+fn decode_pairing_information(
+    response: &[u8; 16],
+    extended: Option<&[u8; 16]>,
+) -> Result<DevicePairingInformation, Hidpp10Error> {
+    Ok(DevicePairingInformation {
+        wpid: u16::from_be_bytes([response[3], response[4]]),
+        kind: DeviceKind::try_from(response[7] & 0x0f)
+            .map_err(|_| Hidpp10Error::UnsupportedResponse)?,
+        encrypted: false,
+        // Pairing registers are persistent and carry no live connection bit;
+        // a `0x41` notification overrides this when the device is awake.
+        online: false,
+        unit_id: extended.map_or([0; 4], |info| info[1..=4].try_into().unwrap()),
+    })
+}
+
+fn decode_codename(response: &[u8; 16]) -> Option<&str> {
+    let len = usize::from(response[1]).min(14);
+    core::str::from_utf8(&response[2..2 + len]).ok()
+}
+
+/// General LIGHTSPEED receiver information.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct ReceiverInfo {
+    /// Stable receiver serial number.
+    pub serial_number: String,
+    /// Number of pairing slots supported by the receiver.
+    pub pairing_slots: u8,
+}
+
+/// Persistent metadata for one paired device.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct DevicePairingInformation {
+    /// Wireless product ID.
+    pub wpid: u16,
+    /// Receiver-reported device type.
+    pub kind: DeviceKind,
+    /// Whether the wireless link is encrypted.
+    pub encrypted: bool,
+    /// Whether the paired device is currently connected.
+    pub online: bool,
+    /// Device unit identifier stored by the receiver.
+    pub unit_id: [u8; 4],
+}
+
+/// Device-kind encoding used by LIGHTSPEED pairing registers.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum DeviceKind {
+    /// Unidentified device.
+    Unknown = 0x00,
+    /// Keyboard.
+    Keyboard = 0x01,
+    /// Mouse.
+    Mouse = 0x02,
+    /// Numeric keypad.
+    Numpad = 0x03,
+    /// Presenter.
+    Presenter = 0x04,
+    /// Remote control.
+    Remote = 0x05,
+    /// Trackball.
+    Trackball = 0x06,
+    /// Touchpad.
+    Touchpad = 0x07,
+}
+
+/// A parsed `0x41` device connection notification.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct DeviceConnection {
+    /// Receiver slot index.
+    pub index: u8,
+    /// Receiver-reported device type.
+    pub kind: DeviceKind,
+    /// Whether the wireless link is encrypted.
+    pub encrypted: bool,
+    /// Whether the device is online.
+    pub online: bool,
+    /// Wireless product ID.
+    pub wpid: u16,
+}
+
+/// Events emitted by a LIGHTSPEED receiver.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub enum Event {
+    /// A paired device connected, disconnected, or answered an arrival query.
+    DeviceConnection(DeviceConnection),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol::v10::{Message, MessageHeader};
+
+    use super::{
+        DeviceKind, VPID_PAIRS, decode_pairing_information, parse_connection_notification,
+    };
+
+    #[test]
+    fn known_pid_family_is_complete() {
+        let pids: Vec<u16> = VPID_PAIRS.iter().map(|(_, pid)| *pid).collect();
+        assert_eq!(
+            pids,
+            [
+                0xc539, 0xc53a, 0xc53d, 0xc53f, 0xc541, 0xc545, 0xc547, 0xc54d
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_g305_connection_notification() {
+        let message = Message::Short(
+            MessageHeader {
+                device_index: 1,
+                sub_id: 0x41,
+            },
+            [0, 0x22, 0x74, 0x40],
+        );
+        let connection = parse_connection_notification(message).unwrap();
+        assert_eq!(connection.index, 1);
+        assert_eq!(connection.kind, DeviceKind::Mouse);
+        assert!(connection.encrypted && connection.online);
+        assert_eq!(connection.wpid, 0x4074);
+    }
+
+    #[test]
+    fn decodes_pairing_register_metadata() {
+        let mut response = [0u8; 16];
+        response[3..=4].copy_from_slice(&0x4074u16.to_be_bytes());
+        response[7] = 0x02;
+        let mut extended = [0u8; 16];
+        extended[1..=4].copy_from_slice(&[1, 2, 3, 4]);
+        let pairing = decode_pairing_information(&response, Some(&extended)).unwrap();
+        assert_eq!(pairing.wpid, 0x4074);
+        assert_eq!(pairing.kind, DeviceKind::Mouse);
+        assert!(!pairing.encrypted && !pairing.online);
+        assert_eq!(pairing.unit_id, [1, 2, 3, 4]);
+    }
+}

--- a/crates/openlogi-hidpp/src/receiver/mod.rs
+++ b/crates/openlogi-hidpp/src/receiver/mod.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 use crate::{channel::HidppChannel, protocol::v10::Hidpp10Error};
 
 pub mod bolt;
+pub mod lightspeed;
 pub mod unifying;
 
 /// The index to use when communicating with the receiver on any HID++ channel.
@@ -35,6 +36,11 @@ pub fn detect(chan: Arc<HidppChannel>) -> Option<Receiver> {
     if unifying::VPID_PAIRS.contains(vpid_pair) {
         return unifying::Receiver::new(chan).ok().map(Receiver::Unifying);
     }
+    if lightspeed::VPID_PAIRS.contains(vpid_pair) {
+        return lightspeed::Receiver::new(chan)
+            .ok()
+            .map(Receiver::Lightspeed);
+    }
     None
 }
 
@@ -46,6 +52,8 @@ pub enum Receiver {
     Bolt(bolt::Receiver),
     /// Logitech Unifying receiver.
     Unifying(unifying::Receiver),
+    /// Logitech LIGHTSPEED gaming receiver.
+    Lightspeed(lightspeed::Receiver),
 }
 
 impl Receiver {
@@ -54,6 +62,7 @@ impl Receiver {
         match self {
             Self::Bolt(_) => "Logi Bolt Receiver",
             Self::Unifying(_) => "Unifying Receiver",
+            Self::Lightspeed(_) => "LIGHTSPEED Receiver",
         }
         .to_string()
     }
@@ -66,6 +75,7 @@ impl Receiver {
         match self {
             Self::Bolt(bolt) => bolt.get_unique_id().await,
             Self::Unifying(unifying) => unifying.get_unique_id().await,
+            Self::Lightspeed(lightspeed) => lightspeed.get_unique_id().await,
         }
     }
 }

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -2,8 +2,9 @@
 
 > [!NOTE]
 > Linux support is in active development. HID++ device enumeration supports
-> **Logi Bolt** (USB PID `0xC548`) and **Logi Unifying** (PID `0xC52B` and
-> others) receivers, as well as Bluetooth-direct devices.
+> **Logi Bolt** (USB PID `0xC548`), **Logi Unifying** (`0xC52B`, `0xC532`), and
+> **Logitech LIGHTSPEED** gaming receivers (including G305 receiver `0xC53F`),
+> as well as Bluetooth-direct devices.
 
 ## Prerequisites
 
@@ -40,8 +41,8 @@ OpenLogi needs:
 
 - **Write access to `/dev/uinput`** — to create the virtual input device for
   button remapping.
-- **Read/write access to `/dev/hidraw*`** — to send HID++ commands to the Bolt
-  receiver.
+- **Read/write access to `/dev/hidraw*`** — to send HID++ commands to a
+  supported receiver or directly connected device.
 
 Install the bundled udev rules to grant access to the active-seat user without
 requiring `sudo` or group membership (requires `systemd-logind`):


### PR DESCRIPTION
## Summary

- add LIGHTSPEED as a first-class HID++ receiver family with canonical receiver PIDs, receiver identity, pairing-slot inventory, connection notifications, and stable slot routing
- add G305-compatible legacy `0x1000` battery support with cached refreshes, live `0x2201` DPI access, and marketing-name fallback
- expose gaming-mouse Buttons support through host-side middle/back/forward remapping while hiding HID++-only DPI/gesture controls when no `0x1b0x` capture feature exists
- update Linux receiver-child filtering, IPC wire fixtures/protocol version, CLI guidance, and documentation

## Why

OpenLogi previously treated `046d:c53f` as an unrecognized HID++ node, so the connected G305 receiver could not surface its paired slot or route feature operations to device index 1. LIGHTSPEED uses Unifying-style HID++ 1.0 receiver registers (`0x2N` pairing information, `0x3N` extended information, and `0x4N` names), while the paired mouse exposes HID++ 2.0 features at its receiver slot.

This change models that receiver family explicitly and keeps hardware writes disabled when a stable receiver identity is unavailable.

## User impact

The G305 now appears as a named mouse with WPID, battery, pointer, and Buttons panels. DPI reads/writes target the paired slot, and standard middle/back/forward controls remain remappable through the OS input hook. Gaming-only DPI button capture, onboard profiles, persistent hardware mappings, and gaming RGB remain deferred.

## Validation

- `cargo test --workspace --no-fail-fast`
- `cargo fmt --all -- --check`
- `git diff --check`
- connected G305 inventory:
  - receiver `046d:c53f`
  - receiver ID `D686CB5E`
  - slot 1 `G305`
  - WPID `4074`
  - legacy battery `90%`, discharging
- feature diagnostics found `0x1000`, `0x2201`, `0x8100`, and `0x8110` on slot 1
- DPI hardware round-trip: read `3200`, write/read back `3250`, restore `3200`
