### PR TITLE
fix(gui): defer window focus to fix Linux crash

### DIFF
--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -158,7 +158,13 @@ impl AppView {
     ) -> Self {
         let cache = AssetResolver::new();
         let focus_handle = cx.focus_handle();
-        focus_handle.focus(window, cx);
+        // Defer the initial focus: focusing during view construction re-enters
+        // the platform window handler and panics ("RefCell already borrowed")
+        // on the Linux Wayland/X11 gpui backends.
+        cx.defer_in(window, {
+            let focus_handle = focus_handle.clone();
+            move |_, window, cx| focus_handle.focus(window, cx)
+        });
         // `AppState` is installed as a global by `main` (with the IPC command
         // sender) before any window opens; downstream reads use `try_global`
         // and tolerate its absence, so there's no fallback construction here.

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -154,7 +154,13 @@ pub struct AddDeviceView {
 impl AddDeviceView {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
-        focus_handle.focus(window, cx);
+        // Defer the initial focus: focusing during view construction re-enters
+        // the platform window handler and panics ("RefCell already borrowed")
+        // on the Linux Wayland/X11 gpui backends.
+        cx.defer_in(window, {
+            let focus_handle = focus_handle.clone();
+            move |_, window, cx| focus_handle.focus(window, cx)
+        });
         let state_obs = cx.observe_global::<PairingUi>(|_, cx| cx.notify());
         Self {
             focus_handle,

--- a/crates/openlogi-gui/src/windows/settings.rs
+++ b/crates/openlogi-gui/src/windows/settings.rs
@@ -128,7 +128,13 @@ impl SettingsView {
     )]
     fn new(initial_page: SettingsPage, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
-        focus_handle.focus(window, cx);
+        // Defer the initial focus: focusing during view construction re-enters
+        // the platform window handler and panics ("RefCell already borrowed")
+        // on the Linux Wayland/X11 gpui backends.
+        cx.defer_in(window, {
+            let focus_handle = focus_handle.clone();
+            move |_, window, cx| focus_handle.focus(window, cx)
+        });
         // Reuse the app-wide shared updater installed at launch, so a launch-time
         // check result is already visible. Fall back to a fresh one if it somehow
         // wasn't installed.

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -31,7 +31,13 @@ pub struct UpdateConsentView {
 impl UpdateConsentView {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
-        focus_handle.focus(window, cx);
+        // Defer the initial focus: focusing during view construction re-enters
+        // the platform window handler and panics ("RefCell already borrowed")
+        // on the Linux Wayland/X11 gpui backends.
+        cx.defer_in(window, {
+            let focus_handle = focus_handle.clone();
+            move |_, window, cx| focus_handle.focus(window, cx)
+        });
         Self {
             focus_handle,
             appearance_obs: None,


### PR DESCRIPTION
## Summary

The Linux GUI panics with `RefCell already borrowed` immediately on startup and
is unusable on both Wayland and X11. This defers the initial window focus so it
no longer re-enters the gpui platform handler during view construction.

## Changes

- **openlogi-gui**: focus the view's `FocusHandle` via `cx.defer_in(window, …)`
  instead of calling `focus_handle.focus(window, cx)` synchronously inside the
  constructor. Applied to every view that focused at construction time: the root
  app view (`app.rs`) and the settings, add-device, and update-consent windows.

## Root cause

`b58699b` ("fix(gui): focus window roots for shortcuts") added
`focus_handle.focus(window, cx)` inside the view constructors. On the Linux gpui
backends the focus call re-enters the platform window handler while the client
state `RefCell` is still borrowed for the in-progress window open, so it panics:

- Wayland: `gpui_linux::linux::wayland::client` (`activation token received with
  no pending activation`, then the borrow panic)
- X11: `gpui_linux::linux::x11::client` (during window/colormap creation)

Deferring the focus with `cx.defer_in` runs it at the end of the current effect
cycle, after the window is open and the borrow is released. The macOS/Windows
behaviour is unchanged (focus still happens once the window is up).

## Testing

Commands (from the repo root):

- `cargo build -p openlogi-gui` — builds clean, 0 warnings
- `cargo fmt -p openlogi-gui -- --check` — clean
- `cargo clippy -p openlogi-gui --all-targets -- -D warnings` — clean
- Ran the built binary against a running agent on **Wayland (native)** and on
  **X11 (forced with `env -u WAYLAND_DISPLAY`)**: the window opens and reaches
  the steady-state agent-poll loop with no panic. Before this change, v0.6.19
  crashed on the first frame on both backends.

Hardware: AMD Radeon (RADV, GFX1200), KDE Plasma Wayland session. **Not
runtime-tested on macOS or Windows**; the change is platform-agnostic and only
moves the focus one effect cycle later.

Fixes #368
Relates to #364 (same panic reported on X11)
