### PR TITLE
fix(gui): avoid RefCell panic on Linux startup

### DIFF
--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -142,7 +142,16 @@ pub fn apply_from_settings(window: Option<&mut Window>, cx: &mut App) {
     // `System` branch below reads the *real* OS appearance rather than a stale
     // forced override.
     crate::platform::os::set_app_appearance(appearance);
-    let os_appearance = cx.window_appearance();
+    // Read the OS appearance from the window's own cached value when we have a
+    // window in hand. This runs inside `observe_window_appearance`, where the
+    // Wayland/X11 client state is already borrowed for the appearance-change
+    // dispatch; re-querying the platform via `cx.window_appearance()` re-enters
+    // that borrow and panics ("RefCell already borrowed"). The cached value was
+    // just refreshed by the same dispatch, so it is the live OS appearance.
+    let os_appearance = match &window {
+        Some(window) => window.appearance(),
+        None => cx.window_appearance(),
+    };
 
     // Pull the chosen configs out of the registry before borrowing the Theme
     // mutably (both live as globals).


### PR DESCRIPTION
## Summary

`openlogi-gui` panics with `RefCell already borrowed` on startup on Linux
(Wayland and X11) and is unusable. The panic is a re-entrant borrow of the gpui
platform client state, triggered from the window-appearance observer.

## Changes

- **openlogi-gui** (`theme.rs`): in `apply_from_settings`, read the OS appearance
  from the window's own cached value (`Window::appearance`) when a window is in
  hand, and only fall back to `cx.window_appearance()` on the windowless
  settings-edit path.

## Root cause

The main and auxiliary windows register a window-appearance observer that
re-applies the theme:

```rust
window.observe_window_appearance(|window, cx| theme::apply_from_settings(Some(window), cx));
```

`apply_from_settings` read the OS appearance via `cx.window_appearance()`, which
on Linux goes `LinuxClient::with_common` → `self.0.borrow_mut()`. That observer
fires from `Window::appearance_changed`, which is dispatched while the
Wayland/X11 client state is **already borrowed** — so re-querying the platform
re-enters the borrow and panics (`crates/gpui_linux/.../client.rs`, `with_common`).

`appearance_changed` refreshes `Window::appearance` *before* invoking observers,
so the window's cached value is the live OS appearance and reading it needs no
second client borrow.

The panic only reproduces in optimized (release) builds; a debug build never
hits the re-entrant timing, which is why it can look fine in `cargo run`.

## Testing

Commands (from the repo root):

- `cargo clippy -p openlogi-gui --all-targets -- -D warnings` — clean
- `cargo build --release -p openlogi-gui` — clean

Because the crash is release-only, it was verified against a **release** binary
with a running agent:

- Before: the release build panics on every launch (Wayland and X11).
- After: launched the release binary repeatedly on **Wayland (native)**; it
  reaches the steady-state agent-poll loop with no panic (0 crashes across
  repeated runs). Also confirmed the re-entrant path via a symbolized backtrace
  (`observe_window_appearance` → `apply_from_settings` → `window_appearance` →
  `with_common` → `borrow_mut`).

Hardware: AMD Radeon (RADV, GFX1200), KDE Plasma Wayland session. **Not
runtime-tested on macOS or Windows.** On those platforms the change only swaps
`cx.window_appearance()` for the window's cached appearance when a window is
passed; the value is equivalent and the windowless path is unchanged.

Fixes #368
Relates to #364 (same panic reported on X11)
