### PR TITLE
feat(hid): recognise Lightspeed nano receivers (G-series, e.g. G305)

### DIFF
--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -254,7 +254,7 @@ async fn probe_unifying_receiver(
     NodeProbe {
         inventory: Some(DeviceInventory {
             receiver: ReceiverInfo {
-                name: "Unifying Receiver".to_string(),
+                name: crate::route::receiver_display_name(info.product_id).to_string(),
                 vendor_id: info.vendor_id,
                 product_id: info.product_id,
                 unique_id,

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -59,7 +59,10 @@ pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
 };
-pub use route::{BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
+pub use route::{
+    BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, UNIFYING_PIDS,
+    receiver_display_name, speaks_unifying_protocol,
+};
 pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus};
 pub use standalone::enumerate_standalone;
 pub use write::{

--- a/crates/openlogi-hid/src/pairing.rs
+++ b/crates/openlogi-hid/src/pairing.rs
@@ -78,7 +78,8 @@ impl From<ReceiverFamily> for PairingPhase {
 fn family_for(product_id: u16) -> Option<ReceiverFamily> {
     if crate::BOLT_PIDS.contains(&product_id) {
         Some(ReceiverFamily::Bolt)
-    } else if crate::UNIFYING_PIDS.contains(&product_id) {
+    } else if crate::speaks_unifying_protocol(product_id) {
+        // Unifying proper plus protocol-compatible Lightspeed receivers.
         Some(ReceiverFamily::Unifying)
     } else {
         None

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -91,6 +91,34 @@ pub const BOLT_PIDS: &[u16] = &[0xc548];
 /// Unifying, so it routes as [`DeviceRoute::Unifying`].
 pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532, 0xc539];
 
+/// USB product IDs that identify Logitech Lightspeed nano receivers — the
+/// receivers bundled with G-series wireless mice such as the G305. They speak
+/// the same HID++ 1.0 receiver register protocol as Unifying, so they are
+/// enumerated, routed, and paired through the Unifying code path; only the
+/// user-facing receiver name (see [`receiver_display_name`]) differs.
+pub const LIGHTSPEED_PIDS: &[u16] = &[0xc53f];
+
+/// Whether `product_id` is a receiver that speaks the Unifying HID++ 1.0
+/// register protocol — a Unifying receiver proper, or a protocol-compatible
+/// Lightspeed receiver. Such receivers are addressed with
+/// [`DeviceRoute::Unifying`].
+#[must_use]
+pub fn speaks_unifying_protocol(product_id: u16) -> bool {
+    UNIFYING_PIDS.contains(&product_id) || LIGHTSPEED_PIDS.contains(&product_id)
+}
+
+/// Human-readable name for a receiver identified by `product_id`, used to label
+/// it in the inventory. Lightspeed receivers share the Unifying protocol path
+/// but are surfaced under their own name.
+#[must_use]
+pub fn receiver_display_name(product_id: u16) -> &'static str {
+    if LIGHTSPEED_PIDS.contains(&product_id) {
+        "Lightspeed Receiver"
+    } else {
+        "Unifying Receiver"
+    }
+}
+
 impl DeviceRoute {
     /// Whether two receiver routes use the same physical HID transport.
     /// Direct routes cannot prove identity because they carry only VID/PID.
@@ -132,25 +160,29 @@ impl DeviceRoute {
     /// Build the route that reaches a paired device from a receiver inventory.
     ///
     /// Picks [`DeviceRoute::Unifying`] or [`DeviceRoute::Bolt`] based on the
-    /// receiver's product ID using the canonical `UNIFYING_PIDS` / `BOLT_PIDS`
-    /// lists. Any receiver PID not in `UNIFYING_PIDS` — including future Bolt
-    /// variants whose PID isn't yet in `BOLT_PIDS` — defaults to
-    /// [`DeviceRoute::Bolt`] so writes keep working rather than silently
-    /// dropping. [`DeviceRoute::Direct`] is used for directly-attached devices
+    /// receiver's product ID via [`speaks_unifying_protocol`] (Unifying proper
+    /// plus protocol-compatible Lightspeed receivers). Any receiver that does
+    /// not speak the Unifying protocol — including future Bolt variants whose
+    /// PID isn't yet in `BOLT_PIDS` — defaults to [`DeviceRoute::Bolt`] so
+    /// writes keep working rather than silently dropping.
+    /// [`DeviceRoute::Direct`] is used for directly-attached devices
     /// (slot == [`DIRECT_DEVICE_INDEX`] with no receiver UID). Returns `None`
     /// when the receiver UID is unknown (writes are skipped, not mis-routed).
     #[must_use]
     pub fn device_route_for(inv: &DeviceInventory, slot: u8) -> Option<Self> {
         match &inv.receiver.unique_id {
-            Some(uid) if UNIFYING_PIDS.contains(&inv.receiver.product_id) => Some(Self::Unifying {
-                receiver_uid: uid.clone(),
-                slot,
-            }),
+            Some(uid) if speaks_unifying_protocol(inv.receiver.product_id) => {
+                Some(Self::Unifying {
+                    receiver_uid: uid.clone(),
+                    slot,
+                })
+            }
             Some(uid) => {
-                // Default to Bolt for any receiver whose PID is not in
-                // UNIFYING_PIDS. This covers both known Bolt PIDs (BOLT_PIDS)
-                // and any future Bolt-compatible receiver with a new PID —
-                // returning None would silently drop writes for such receivers.
+                // Default to Bolt for any receiver that does not speak the
+                // Unifying protocol. This covers both known Bolt PIDs
+                // (BOLT_PIDS) and any future Bolt-compatible receiver with a new
+                // PID — returning None would silently drop writes for such
+                // receivers.
                 if !BOLT_PIDS.contains(&inv.receiver.product_id) {
                     tracing::debug!(
                         pid = format_args!("{:04x}", inv.receiver.product_id),
@@ -260,7 +292,9 @@ mod tests {
 
     use openlogi_core::device::{DeviceInventory, ReceiverInfo};
 
-    use super::{DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
+    use super::{
+        DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, UNIFYING_PIDS, receiver_display_name,
+    };
 
     fn inv(product_id: u16, unique_id: Option<&str>) -> DeviceInventory {
         DeviceInventory {
@@ -283,6 +317,26 @@ mod tests {
                 "pid {pid:#06x} should produce Unifying route"
             );
         }
+    }
+
+    #[test]
+    fn device_route_for_lightspeed_pids_create_unifying_route() {
+        // Lightspeed nano receivers (e.g. the G305's) speak the Unifying
+        // protocol, so writes must be routed through DeviceRoute::Unifying —
+        // not defaulted to Bolt, which would address the pairing slot wrong.
+        for &pid in LIGHTSPEED_PIDS {
+            let route = DeviceRoute::device_route_for(&inv(pid, Some("A1B2")), 2);
+            assert!(
+                matches!(route, Some(DeviceRoute::Unifying { ref receiver_uid, slot: 2 }) if receiver_uid == "A1B2"),
+                "lightspeed pid {pid:#06x} should produce a Unifying route"
+            );
+        }
+    }
+
+    #[test]
+    fn lightspeed_receiver_has_its_own_display_name() {
+        assert_eq!(receiver_display_name(0xc53f), "Lightspeed Receiver");
+        assert_eq!(receiver_display_name(0xc52b), "Unifying Receiver");
     }
 
     #[test]

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -22,10 +22,18 @@ use crate::{
 /// All USB vendor & product ID pairs that are known to identify Unifying
 /// receivers.
 ///
-/// `046d:c539` is the Lightspeed gaming receiver, which answers the same
-/// HID++ 1.0 registers (pairing count, connection state, pairing information)
-/// as Unifying receivers.
-pub const VPID_PAIRS: &[(u16, u16)] = &[(0x046d, 0xc52b), (0x046d, 0xc532), (0x046d, 0xc539)];
+/// `046d:c539` is the Lightspeed gaming receiver; `046d:c53f` is the Lightspeed
+/// nano receiver (bundled with G-series wireless mice such as the G305). Both
+/// answer the same HID++ 1.0 registers (pairing count, connection state, pairing
+/// information) as Unifying receivers. Callers that surface a user-facing
+/// receiver name label Lightspeed PIDs separately (see `openlogi-hid`).
+/// `0xc53f` was verified against a G305 (paired device wpid `0x4074`).
+pub const VPID_PAIRS: &[(u16, u16)] = &[
+    (0x046d, 0xc52b),
+    (0x046d, 0xc532),
+    (0x046d, 0xc539),
+    (0x046d, 0xc53f),
+];
 
 /// All known registers of the Unifying receiver.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, TryFromPrimitive)]


### PR DESCRIPTION
## Summary

Adds recognition for the **Logitech Lightspeed nano receiver** (`046d:c53f`) — the receiver bundled with G-series wireless mice such as the **G305**. Before this change, `receiver::detect()` only matched Bolt (`c548`) and Unifying (`c52b`, `c532`) receivers; a Lightspeed receiver fell through to `None`, so any mouse paired to it was completely invisible (the mouse never appeared in `list` / the GUI, even though the keyboard on a Unifying receiver did).

A Lightspeed nano receiver is **not** a Unifying receiver, but it exposes the same HID++ 1.0 receiver registers (`0x02` connections, `0xB5/0x5N` pairing info) that this codebase already drives for Unifying. So the cleanest fix is to route it through the existing Unifying code path and differentiate it only where it's user-visible: the receiver's display name.

## Changes

- **`openlogi-hidpp` / `receiver::unifying::VPID_PAIRS`** — add `046d:c53f` so `detect()` builds the (Unifying-protocol) receiver for it. Documented that this is a protocol-compat Lightspeed receiver, not Unifying proper.
- **`openlogi-hid` / `route.rs`** — new `LIGHTSPEED_PIDS` list plus two small helpers: `speaks_unifying_protocol(pid)` (Unifying ∪ Lightspeed) and `receiver_display_name(pid)`. `device_route_for` now routes Lightspeed receivers as `DeviceRoute::Unifying` (they were previously defaulting to `Bolt`, which would address pairing slots with the wrong register flow on the write path).
- **`openlogi-hid` / `pairing.rs`** — `family_for` classifies Lightspeed as `ReceiverFamily::Unifying` via the shared helper.
- **`openlogi-hid` / `inventory/probe.rs`** — the enumerated receiver is now labelled via `receiver_display_name`, so a Lightspeed receiver surfaces as **"Lightspeed Receiver"** while Unifying stays "Unifying Receiver".
- Tests: added coverage that Lightspeed PIDs route as Unifying and that the display name resolves correctly.

## Testing

Verified on macOS with a real **Logitech G305** (paired device wpid `0x4074`) on its Lightspeed nano receiver:

```
# before
$ openlogi list        # G305 receiver not recognised — mouse invisible

# after
Lightspeed Receiver (E93B9602, vid=046d pid=c53f)
  └─ slot 1 ● mouse, wpid=4074 ... transports=equad
Unifying Receiver (E3C15593, vid=046d pid=c52b)
  └─ slot 1 ● keyboard, wpid=408a ...
```

- `cargo test -p openlogi-hid -p openlogi-hidpp` — all pass (incl. the new tests).
- `cargo clippy` / `cargo fmt` clean on the touched crates.

## Notes / scope

- I could only test `0xc53f` (the receiver that shipped with my G305). Other Lightspeed receiver PIDs (`0xc539`, `0xc541`, `0xc545`, `0xc547`, …) almost certainly work through the same path, but I've deliberately **not** added PIDs I couldn't verify — they can be appended to `LIGHTSPEED_PIDS` as people confirm them.
- Naming lives in the app layer (`openlogi-hid`) rather than the vendored `hidpp` fork, keeping the protocol layer's notion of "this is the Unifying register protocol" intact.
- The GUI's per-device "connected via … receiver" label (derived from `DeviceRoute::Unifying`) still reads "Unifying"; the primary receiver name shown in the inventory/carousel is correct. Happy to extend the GUI label too if you'd prefer a follow-up.
