### PR TITLE
feat: keyboard F-row key remapping and fn-lock over HID++

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -222,6 +222,55 @@ pub fn write_smartshift_in_background(
     });
 }
 
+/// Spawn an OS thread that writes the keyboard Fn-lock state to the device at
+/// `target` via [`openlogi_hid::set_fn_lock_on`]. Returns immediately; failures
+/// (incl. keyboards that expose neither `0x40a3` nor `0x40a2` fn inversion)
+/// are logged.
+///
+/// `target == None` is a no-op (dev environment without a real device).
+pub fn write_fn_lock_in_background(
+    capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
+    target: Option<DeviceRoute>,
+    on: bool,
+) {
+    let Some(target) = target else {
+        debug!(on, "no target device — Fn-lock write skipped");
+        return;
+    };
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — Fn-lock write skipped");
+        return;
+    };
+    let receiver_access = receiver_access.clone();
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                warn!(error = %e, "tokio runtime init failed; Fn-lock write skipped");
+                return;
+            }
+        };
+        let result = rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
+            tokio::time::timeout(WRITE_BUDGET, openlogi_hid::set_fn_lock_on(&shared, on)).await
+        });
+        let index = target.device_index();
+        match result {
+            Ok(Ok(())) => debug!(index, on, "Fn-lock written"),
+            Ok(Err(e)) => warn!(error = ?e, "Fn-lock write failed"),
+            Err(_) => warn!(
+                index,
+                "Fn-lock write timed out (device asleep/unresponsive)"
+            ),
+        }
+    });
+}
+
 /// Desired SmartShift values for a reconnect re-apply.
 #[derive(Debug, Clone, Copy)]
 pub struct SmartShiftApply {

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -200,14 +200,22 @@ impl Orchestrator {
         }
     }
 
-    /// The keyboard key-capture spec for the first online keyboard, or `None`
-    /// when no keyboard is online or none of its capturable keys carries a
+    /// The keyboard key-capture spec for the first known keyboard, or `None`
+    /// when no keyboard is paired or none of its capturable keys carries a
     /// real binding (an unbound key must never be diverted).
+    ///
+    /// Deliberately does NOT require the keyboard to be online: an idle
+    /// keyboard sleeps within minutes and probe timeouts can flap it offline,
+    /// and tearing the capture session down on every nap would hand the
+    /// diverted keys back to the firmware (dead bindings) until the re-arm
+    /// races through. The session instead stays up across sleeps — its
+    /// channel is to the always-present receiver — and re-arms diversion on
+    /// the device's `0x1d4b` reconnection broadcast.
     fn keyboard_spec_for(&self) -> Option<KeyboardSpec> {
         let dev = self
             .devices
             .iter()
-            .find(|d| d.kind == DeviceKind::Keyboard && d.online && d.route.is_some())?;
+            .find(|d| d.kind == DeviceKind::Keyboard && d.route.is_some())?;
         let bindings = bindings_for(
             &self.config,
             Some(&dev.config_key),

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -14,9 +14,10 @@ use std::collections::{BTreeMap, HashSet};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, RwLock};
 
+use openlogi_core::binding::Action;
 use openlogi_core::config::{Config, ScrollResolution};
-use openlogi_core::device::{Capabilities, DeviceInventory};
-use openlogi_hid::{CaptureChannel, ChannelPool, ChannelRegistry, DeviceRoute};
+use openlogi_core::device::{Capabilities, DeviceInventory, DeviceKind};
+use openlogi_hid::{CaptureChannel, ChannelPool, ChannelRegistry, DeviceRoute, KEYBOARD_KEY_CIDS};
 use tracing::warn;
 
 use crate::DpiCycleState;
@@ -27,6 +28,7 @@ use crate::ipc::InventoryHealth;
 use crate::receiver_access::ReceiverAccess;
 use crate::watchers::gesture::GestureBindings;
 use crate::watchers::host_switch::{HostSwitchLink, HostSwitchLinks};
+use crate::watchers::keyboard::{KeyboardSpec, SharedKeyboardSpec};
 
 /// The minimal per-device facts the agent needs: the config key (binding /
 /// preset lookup), the HID++ route (DPI/SmartShift writes + capture target), and
@@ -40,6 +42,10 @@ struct AgentDevice {
     serial: Option<String>,
     unit_id: [u8; 4],
     capabilities: Option<Capabilities>,
+    /// HID++-reported device kind — identity only (capability decisions come
+    /// from the feature table). Used to find the keyboard the key-capture
+    /// watcher should target.
+    kind: DeviceKind,
     /// Live link state from the inventory snapshot. An offline→online
     /// transition is a reconnect — the device may have power-cycled, so its
     /// volatile settings need re-applying (#189).
@@ -63,8 +69,14 @@ pub struct SharedRuntime {
     pub channel_registry: ChannelRegistry,
     /// Shared transport pool used by long-running host-switch sessions.
     pub channel_pool: ChannelPool,
-    /// Receiver access shared by HID++ sessions and pairing. Pairing is
-    /// exclusive; capture/host-switch sessions share under read leases.
+    /// The keyboard key-capture watcher's target + bindings, `None` while no
+    /// online keyboard has bound keys.
+    pub keyboard_spec: SharedKeyboardSpec,
+    /// The keyboard capture session's open channel, reused by Fn-lock writes
+    /// (the mouse-oriented [`Self::capture_channel`] points elsewhere).
+    pub keyboard_channel: CaptureChannel,
+    /// Receiver access shared by HID++ sessions and pairing. Pairing/host
+    /// transitions are exclusive; capture sessions share under read leases.
     pub receiver_access: ReceiverAccess,
     /// Keyboard → pointing-device routes resolved from `config.toml`.
     pub host_switch_links: HostSwitchLinks,
@@ -120,6 +132,8 @@ impl Orchestrator {
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
             channel_pool: ChannelPool::default(),
+            keyboard_spec: Arc::new(RwLock::new(None)),
+            keyboard_channel: Arc::new(RwLock::new(None)),
             receiver_access: ReceiverAccess::default(),
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
         };
@@ -186,6 +200,38 @@ impl Orchestrator {
         }
     }
 
+    /// The keyboard key-capture spec for the first online keyboard, or `None`
+    /// when no keyboard is online or none of its capturable keys carries a
+    /// real binding (an unbound key must never be diverted).
+    fn keyboard_spec_for(&self) -> Option<KeyboardSpec> {
+        let dev = self
+            .devices
+            .iter()
+            .find(|d| d.kind == DeviceKind::Keyboard && d.online && d.route.is_some())?;
+        let bindings = bindings_for(
+            &self.config,
+            Some(&dev.config_key),
+            self.current_app.as_deref(),
+        );
+        let wanted: BTreeMap<u16, _> = KEYBOARD_KEY_CIDS
+            .iter()
+            .filter(|(_, button)| {
+                bindings
+                    .get(button)
+                    .is_some_and(|action| *action != Action::None)
+            })
+            .copied()
+            .collect();
+        if wanted.is_empty() {
+            return None;
+        }
+        Some(KeyboardSpec {
+            route: dev.route.clone()?,
+            wanted,
+            bindings,
+        })
+    }
+
     /// Rewrite every shared map from the current config + selected device.
     fn rebuild(&self) {
         let key = self.current_key();
@@ -219,6 +265,11 @@ impl Orchestrator {
             &self.shared.host_switch_links,
             host_switch_links(&self.config, &self.devices),
             "host_switch_links",
+        );
+        write_value(
+            &self.shared.keyboard_spec,
+            self.keyboard_spec_for(),
+            "keyboard_spec",
         );
     }
 
@@ -318,9 +369,18 @@ impl Orchestrator {
                 Some(&self.shared.capture_channel),
                 &self.shared.channel_registry,
                 &self.shared.receiver_access,
-                Some(route),
+                Some(route.clone()),
                 &lighting,
             );
+        }
+        if let Some(fn_lock) = self.config.fn_lock(key) {
+            crate::hardware::write_fn_lock_in_background(
+                Some(&self.shared.keyboard_channel),
+                &self.shared.channel_registry,
+                &self.shared.receiver_access,
+                Some(route),
+                fn_lock,
+                );
         }
     }
 
@@ -404,6 +464,12 @@ impl Orchestrator {
             self.hook_maps_for(self.current_key(), self.current_app.as_deref()),
             "hook_maps",
         );
+        // The keyboard's effective bindings are app-scoped too.
+        write_value(
+            &self.shared.keyboard_spec,
+            self.keyboard_spec_for(),
+            "keyboard_spec",
+        );
     }
 
     /// Replace the config (after `config.toml` changed) and rebuild everything.
@@ -412,6 +478,29 @@ impl Orchestrator {
         self.current = pick_current(&self.devices, self.config.selected_device());
         self.rebuild();
         self.apply_native_wheel_modes();
+        self.apply_fn_locks();
+    }
+
+    /// Push the saved Fn-lock state to every online keyboard that has one.
+    /// Runs on config reloads (the reconnect path is
+    /// [`Self::reapply_volatile_settings`]); the write is a single HID++ call,
+    /// so re-applying an unchanged state is cheap.
+    fn apply_fn_locks(&self) {
+        for dev in self
+            .devices
+            .iter()
+            .filter(|dev| dev.online && dev.route.is_some())
+        {
+            if let Some(fn_lock) = self.config.fn_lock(&dev.config_key) {
+                crate::hardware::write_fn_lock_in_background(
+                    Some(&self.shared.keyboard_channel),
+                    &self.shared.channel_registry,
+                    &self.shared.receiver_access,
+                    dev.route.clone(),
+                    fn_lock,
+                    );
+            }
+        }
     }
 }
 
@@ -463,6 +552,7 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
                 serial: model.serial_number.clone(),
                 unit_id: model.unit_id,
                 capabilities: paired.capabilities,
+                kind: paired.kind,
                 online: paired.online,
             });
         }
@@ -619,6 +709,7 @@ mod tests {
             serial: None,
             unit_id: [0; 4],
             capabilities: None,
+            kind: openlogi_core::device::DeviceKind::Mouse,
             online,
         }
     }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -388,7 +388,7 @@ impl Orchestrator {
                 &self.shared.receiver_access,
                 Some(route),
                 fn_lock,
-                );
+            );
         }
     }
 
@@ -506,7 +506,7 @@ impl Orchestrator {
                     &self.shared.receiver_access,
                     dev.route.clone(),
                     fn_lock,
-                    );
+                );
             }
         }
     }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -182,7 +182,7 @@ fn thumbwheel_armed(hook_maps: &SharedHookMaps, sensitivity: i32) -> bool {
 /// respawn when it is the *current* one (not a stale session already superseded
 /// by a deliberate restart, whose epoch no longer matches) and a target is still
 /// set (not a deliberate stop-to-idle, e.g. while pairing owns the receiver).
-fn should_rearm(done_epoch: u64, live_epoch: u64, has_target: bool) -> bool {
+pub(crate) fn should_rearm(done_epoch: u64, live_epoch: u64, has_target: bool) -> bool {
     done_epoch == live_epoch && has_target
 }
 

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -1,0 +1,195 @@
+//! Background HID++ key-capture watcher for a bound keyboard.
+//!
+//! Runs [`openlogi_hid::run_keyboard_capture_session`] on a dedicated thread
+//! for the keyboard the orchestrator publishes in [`SharedKeyboardSpec`],
+//! restarts it when the keyboard (or the set of bound keys) changes, and
+//! dispatches each captured key press through the common action path
+//! ([`crate::hook_runtime::dispatch_action`]).
+//!
+//! The mouse capture watcher ([`super::gesture`]) and this one hold *shared*
+//! receiver leases, so both run concurrently; pairing still waits for (and
+//! excludes) both. Like the gesture watcher, this needs no macOS Accessibility
+//! permission — the key events arrive over HID++.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::Duration;
+
+use openlogi_core::binding::{Action, ButtonId};
+use openlogi_hid::{
+    CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute, run_keyboard_capture_session,
+};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, info, warn};
+
+use crate::DpiCycleState;
+use crate::hook_runtime;
+use crate::receiver_access::ReceiverAccess;
+use crate::watchers::gesture::should_rearm;
+
+/// Everything the watcher needs to capture one keyboard: where it is, which
+/// `0x1b04` controls to divert (only keys carrying a real binding), and the
+/// per-key action map presses dispatch through. Rebuilt by the orchestrator on
+/// config / inventory / foreground-app changes.
+#[derive(Clone)]
+pub struct KeyboardSpec {
+    /// HID++ route of the keyboard.
+    pub route: DeviceRoute,
+    /// `0x1b04` control ID → button, for exactly the bound keys.
+    pub wanted: BTreeMap<u16, ButtonId>,
+    /// Effective per-key single-action map (per-app overlay applied).
+    pub bindings: BTreeMap<ButtonId, Action>,
+}
+
+/// Shared keyboard-capture spec, `None` when no online keyboard has bound
+/// keys. Written by the orchestrator, read by the watcher.
+pub type SharedKeyboardSpec = Arc<RwLock<Option<KeyboardSpec>>>;
+
+/// How often to re-read the spec so a config edit, per-app overlay change, or
+/// keyboard reconnect re-points the capture session.
+const TARGET_POLL: Duration = Duration::from_secs(1);
+
+/// Spawn the keyboard-capture manager thread. It owns a current-thread tokio
+/// runtime that keeps one capture session pointed at the bound keyboard and
+/// dispatches each captured key press.
+pub fn spawn(
+    spec: SharedKeyboardSpec,
+    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    mouse_capture: CaptureChannel,
+    keyboard_channel: CaptureChannel,
+    receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
+) {
+    thread::spawn(move || {
+        let runtime = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                warn!(error = %e, "keyboard watcher: could not build tokio runtime");
+                return;
+            }
+        };
+        runtime.block_on(manage(
+            spec,
+            dpi_cycle,
+            mouse_capture,
+            keyboard_channel,
+            receiver_access,
+            registry,
+        ));
+    });
+}
+
+/// Keep one keyboard capture session alive for the published spec, restarting
+/// it when the keyboard or its bound-key set changes, and dispatch incoming
+/// presses. Runs for the lifetime of the process.
+async fn manage(
+    spec: SharedKeyboardSpec,
+    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    mouse_capture: CaptureChannel,
+    keyboard_channel: CaptureChannel,
+    receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
+) {
+    let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
+    let mut current: Option<(DeviceRoute, BTreeMap<u16, ButtonId>)> = None;
+    let mut stop: Option<oneshot::Sender<()>> = None;
+    let mut ticker = tokio::time::interval(TARGET_POLL);
+    // Sessions report completion tagged with their start epoch, so an
+    // unexpected exit of the *current* session re-arms while stale completions
+    // are ignored — same pacing/starvation reasoning as the gesture watcher.
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<u64>();
+    let mut epoch: u64 = 0;
+
+    loop {
+        tokio::select! {
+            Some(input) = rx.recv() => {
+                // The keyboard session only emits ButtonPressed; other inputs
+                // (gesture/scroll) never originate here.
+                let CapturedInput::ButtonPressed(button) = input else {
+                    continue;
+                };
+                let action = spec
+                    .read()
+                    .ok()
+                    .and_then(|guard| {
+                        guard.as_ref().and_then(|s| s.bindings.get(&button).cloned())
+                    });
+                if let Some(action) = action {
+                    info!(button = %button, action = %action.label(), "keyboard key → executing bound action");
+                    hook_runtime::dispatch_action(
+                        &action,
+                        &dpi_cycle,
+                        &mouse_capture,
+                        Some(&registry),
+                        &receiver_access,
+                    );
+                } else {
+                    debug!(?button, "keyboard key with no binding — ignored");
+                }
+            }
+            _ = ticker.tick() => {
+                // While pairing is waiting or active, release the capture
+                // session so run_pairing can own the receiver's HID node.
+                let want = if receiver_access.exclusive_requested() {
+                    None
+                } else {
+                    spec.read()
+                        .ok()
+                        .and_then(|guard| guard.clone())
+                        .map(|s| (s.route, s.wanted))
+                };
+                if want == current {
+                    continue;
+                }
+                // Spec changed (or first tick): stop the old session and start
+                // one for the new state. Sending on the oneshot lets the old
+                // session restore the diverted controls.
+                if let Some(stop) = stop.take() {
+                    let _ = stop.send(());
+                }
+                if current.is_some() {
+                    current = None;
+                    continue;
+                }
+                if let Some((route, wanted)) = want {
+                    let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
+                        current = None;
+                        continue;
+                    };
+                    current = Some((route.clone(), wanted.clone()));
+                    let (stop_tx, stop_rx) = oneshot::channel();
+                    let sink = tx.clone();
+                    let slot = Arc::clone(&keyboard_channel);
+                    epoch = epoch.wrapping_add(1);
+                    let session_epoch = epoch;
+                    let done = done_tx.clone();
+                    tokio::spawn(async move {
+                        let _receiver_lease = receiver_lease;
+                        if let Err(e) =
+                            run_keyboard_capture_session(route, wanted, sink, stop_rx, slot).await
+                        {
+                            debug!(error = %e, "keyboard capture session ended");
+                        }
+                        let _ = done.send(session_epoch);
+                    });
+                    stop = Some(stop_tx);
+                } else {
+                    current = None;
+                }
+            }
+            Some(done_epoch) = done_rx.recv() => {
+                // A capture session ended on its own; re-arm only the live one
+                // (see gesture watcher for the epoch/pacing rationale).
+                if should_rearm(done_epoch, epoch, current.is_some()) {
+                    warn!("keyboard capture session ended unexpectedly, re-arming");
+                    current = None;
+                    stop = None;
+                }
+            }
+        }
+    }
+}

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -1,10 +1,10 @@
 //! Background HID++ key-capture watcher for a bound keyboard.
 //!
-//! Runs [`openlogi_hid::run_keyboard_capture_session`] on a dedicated thread
-//! for the keyboard the orchestrator publishes in [`SharedKeyboardSpec`],
-//! restarts it when the keyboard (or the set of bound keys) changes, and
-//! dispatches each captured key press through the common action path
-//! ([`crate::hook_runtime::dispatch_action`]).
+//! Runs [`openlogi_hid::run_keyboard_capture_session_with_registry`] on a
+//! dedicated thread for the keyboard the orchestrator publishes in
+//! [`SharedKeyboardSpec`], restarts it when the keyboard (or the set of bound
+//! keys) changes, and dispatches each captured key press through the common
+//! action path ([`crate::hook_runtime::dispatch_action`]).
 //!
 //! The mouse capture watcher ([`super::gesture`]) and this one hold *shared*
 //! receiver leases, so both run concurrently; pairing still waits for (and
@@ -18,7 +18,8 @@ use std::time::Duration;
 
 use openlogi_core::binding::{Action, ButtonId};
 use openlogi_hid::{
-    CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute, run_keyboard_capture_session,
+    CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute,
+    run_keyboard_capture_session_with_registry,
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
@@ -109,7 +110,7 @@ async fn manage(
             Some(input) = rx.recv() => {
                 // The keyboard session only emits ButtonPressed; other inputs
                 // (gesture/scroll) never originate here.
-                let CapturedInput::ButtonPressed(button) = input else {
+                let CapturedInput::ButtonPressed(button, _) = input else {
                     continue;
                 };
                 let action = spec
@@ -164,13 +165,21 @@ async fn manage(
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let sink = tx.clone();
                     let slot = Arc::clone(&keyboard_channel);
+                    let session_registry = registry.clone();
                     epoch = epoch.wrapping_add(1);
                     let session_epoch = epoch;
                     let done = done_tx.clone();
                     tokio::spawn(async move {
                         let _receiver_lease = receiver_lease;
-                        if let Err(e) =
-                            run_keyboard_capture_session(route, wanted, sink, stop_rx, slot).await
+                        if let Err(e) = run_keyboard_capture_session_with_registry(
+                            route,
+                            wanted,
+                            sink,
+                            stop_rx,
+                            slot,
+                            &session_registry,
+                        )
+                        .await
                         {
                             debug!(error = %e, "keyboard capture session ended");
                         }

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -7,4 +7,5 @@ pub mod foreground_app;
 pub mod gesture;
 pub mod host_switch;
 pub mod inventory;
+pub mod keyboard;
 pub mod pairing;

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -32,7 +32,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use openlogi_agent_core::event_monitor::EventMonitor;
-use openlogi_agent_core::orchestrator::Orchestrator;
+use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::{hook_runtime, watchers};
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
@@ -120,6 +120,32 @@ fn main() {
     }
 }
 
+/// Start the HID++ background sessions that do not need Accessibility.
+fn spawn_hidpp_watchers(shared: &SharedRuntime) {
+    watchers::gesture::spawn_with_registry(
+        shared.hook_maps.clone(),
+        shared.gesture_bindings.clone(),
+        shared.dpi_cycle.clone(),
+        shared.capture_channel.clone(),
+        shared.thumbwheel_sensitivity.clone(),
+        shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
+    );
+    watchers::host_switch::spawn(
+        shared.host_switch_links.clone(),
+        shared.channel_pool.clone(),
+        shared.receiver_access.clone(),
+    );
+    watchers::keyboard::spawn(
+        shared.keyboard_spec.clone(),
+        shared.dpi_cycle.clone(),
+        shared.capture_channel.clone(),
+        shared.keyboard_channel.clone(),
+        shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
+    );
+}
+
 async fn run(config: Config) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
     // LaunchAgent, before `config` moves into the orchestrator.
@@ -158,37 +184,8 @@ async fn run(config: Config) {
     // Pairing runs in the agent (it owns device I/O); the GUI drives it over IPC.
     let pairing = Arc::new(pairing::PairingManager::new(shared.clone()));
 
-    // The HID++ control watcher (gesture button, DPI/ModeShift button, thumb
-    // wheel) needs no Accessibility permission — start it up front. It reads the
-    // shared maps and dispatches bound actions itself; the two pairing flags let
-    // it release its capture session while a pairing session owns the receiver.
-    watchers::gesture::spawn_with_registry(
-        shared.hook_maps.clone(),
-        shared.gesture_bindings.clone(),
-        shared.dpi_cycle.clone(),
-        shared.capture_channel.clone(),
-        shared.thumbwheel_sensitivity.clone(),
-        shared.receiver_access.clone(),
-        shared.channel_registry.clone(),
-    );
-    watchers::host_switch::spawn(
-        shared.host_switch_links.clone(),
-        shared.channel_pool.clone(),
-        shared.receiver_access.clone(),
-    );
-
-    // The keyboard key-capture watcher: diverts bound F-row controls on the
-    // keyboard the orchestrator publishes and dispatches their presses. Holds
-    // a shared receiver lease alongside the gesture watcher; also needs no
-    // Accessibility permission.
-    watchers::keyboard::spawn(
-        shared.keyboard_spec.clone(),
-        shared.dpi_cycle.clone(),
-        shared.capture_channel.clone(),
-        shared.keyboard_channel.clone(),
-        shared.receiver_access.clone(),
-        shared.channel_registry.clone(),
-    );
+    // HID++ watchers need no Accessibility permission — start them up front.
+    spawn_hidpp_watchers(&shared);
 
     let mut inventory_rx = watchers::inventory::spawn_with_registry(
         Duration::from_secs(2),

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -177,6 +177,19 @@ async fn run(config: Config) {
         shared.receiver_access.clone(),
     );
 
+    // The keyboard key-capture watcher: diverts bound F-row controls on the
+    // keyboard the orchestrator publishes and dispatches their presses. Holds
+    // a shared receiver lease alongside the gesture watcher; also needs no
+    // Accessibility permission.
+    watchers::keyboard::spawn(
+        shared.keyboard_spec.clone(),
+        shared.dpi_cycle.clone(),
+        shared.capture_channel.clone(),
+        shared.keyboard_channel.clone(),
+        shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
+    );
+
     let mut inventory_rx = watchers::inventory::spawn_with_registry(
         Duration::from_secs(2),
         shared.channel_registry.clone(),

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -274,6 +274,8 @@ mod tests {
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
             channel_pool: openlogi_hid::ChannelPool::default(),
+            keyboard_spec: Arc::new(RwLock::new(None)),
+            keyboard_channel: Arc::new(RwLock::new(None)),
             receiver_access: ReceiverAccess::default(),
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
         }

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -51,6 +51,29 @@ pub enum ButtonId {
     /// The HID++ gesture button on MX-line devices. The press itself
     /// fires the bound action; swipe directions are P1.5 territory.
     GestureButton,
+    /// Keyboard F-row "Search" control (`0x1b04` CID `0x00d4`,
+    /// `MultiPlatform_Search`) — F4 on the Signature series.
+    KeySearch,
+    /// Keyboard "Dictation" control (CID `0x0103`) — F5 on the Signature series.
+    KeyDictation,
+    /// Keyboard "Emoji" control (CID `0x0108`) — F6 on the Signature series.
+    KeyEmoji,
+    /// Keyboard "Screen Capture" control (CID `0x010a`) — F7 on the Signature
+    /// series.
+    KeyScreenCapture,
+    /// Keyboard "Mute Microphone" control (CID `0x011c`) — F8 on the Signature
+    /// series.
+    KeyMicMute,
+    /// Keyboard "Play/Pause" control (CID `0x00e5`) — F9 on the Signature series.
+    KeyPlayPause,
+    /// Keyboard "Mute" control (CID `0x00e7`) — F10 on the Signature series.
+    KeyMute,
+    /// Keyboard "Volume Down" control (CID `0x00e8`) — F11 on the Signature
+    /// series.
+    KeyVolumeDown,
+    /// Keyboard "Volume Up" control (CID `0x00e9`) — F12 on the Signature
+    /// series.
+    KeyVolumeUp,
 }
 
 impl ButtonId {
@@ -68,6 +91,22 @@ impl ButtonId {
         ButtonId::ThumbwheelScrollUp,
         ButtonId::ThumbwheelScrollDown,
         ButtonId::GestureButton,
+    ];
+
+    /// The divertable keyboard F-row controls, in F-row order. Kept out of
+    /// [`ButtonId::ALL`]: that array seeds mouse defaults and the mouse
+    /// popover trigger list, while keyboard keys stay native unless the user
+    /// binds them (an unbound key is never diverted).
+    pub const KEYBOARD_KEYS: [ButtonId; 9] = [
+        ButtonId::KeySearch,
+        ButtonId::KeyDictation,
+        ButtonId::KeyEmoji,
+        ButtonId::KeyScreenCapture,
+        ButtonId::KeyMicMute,
+        ButtonId::KeyPlayPause,
+        ButtonId::KeyMute,
+        ButtonId::KeyVolumeDown,
+        ButtonId::KeyVolumeUp,
     ];
 
     /// Whether this button is one the OS hook (macOS `CGEventTap` / Linux evdev)
@@ -99,6 +138,15 @@ impl ButtonId {
             ButtonId::ThumbwheelScrollUp => "Thumb Wheel Up",
             ButtonId::ThumbwheelScrollDown => "Thumb Wheel Down",
             ButtonId::GestureButton => "Gesture Button",
+            ButtonId::KeySearch => "Search Key",
+            ButtonId::KeyDictation => "Dictation Key",
+            ButtonId::KeyEmoji => "Emoji Key",
+            ButtonId::KeyScreenCapture => "Screen Capture Key",
+            ButtonId::KeyMicMute => "Mic Mute Key",
+            ButtonId::KeyPlayPause => "Play/Pause Key",
+            ButtonId::KeyMute => "Mute Key",
+            ButtonId::KeyVolumeDown => "Volume Down Key",
+            ButtonId::KeyVolumeUp => "Volume Up Key",
         }
     }
 }
@@ -363,6 +411,12 @@ pub enum Action {
     /// The `display` field is used by [`Action::label`] so the popover
     /// shows the user-friendly chord name.
     CustomShortcut(KeyCombo),
+
+    // ── System (appended) ────────────────────────────────────────────────────
+    /// Put the computer to sleep. Appended after `CustomShortcut` because the
+    /// serde variant index is the wire format (see the stability contract
+    /// above) — new variants only ever go at the end.
+    Sleep,
 }
 
 /// A modifier + virtual-key keystroke captured by the P1.3 recorder UI or
@@ -609,6 +663,7 @@ impl Action {
             Action::HorizontalScrollLeft => "Scroll Left".into(),
             Action::HorizontalScrollRight => "Scroll Right".into(),
             Action::CustomShortcut(combo) => combo.rendered_label(),
+            Action::Sleep => "Sleep".into(),
         }
     }
 
@@ -646,9 +701,11 @@ impl Action {
             | Action::NextDesktop
             | Action::ShowDesktop
             | Action::LaunchpadShow => Category::Navigation,
-            Action::None | Action::LockScreen | Action::Screenshot | Action::CaptureRegion => {
-                Category::System
-            }
+            Action::None
+            | Action::LockScreen
+            | Action::Screenshot
+            | Action::CaptureRegion
+            | Action::Sleep => Category::System,
             Action::PlayPause
             | Action::NextTrack
             | Action::PrevTrack
@@ -708,6 +765,7 @@ impl Action {
             Action::LockScreen,
             Action::Screenshot,
             Action::CaptureRegion,
+            Action::Sleep,
             // Media
             Action::PlayPause,
             Action::NextTrack,
@@ -758,6 +816,18 @@ pub fn default_binding(button: ButtonId) -> Action {
         ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollRight,
         ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollLeft,
         ButtonId::GestureButton => Action::MissionControl,
+        // Keyboard keys stay on their native firmware function until the user
+        // explicitly binds them; an unbound key is never diverted, so a
+        // `None` default keeps the projection total without capturing anything.
+        ButtonId::KeySearch
+        | ButtonId::KeyDictation
+        | ButtonId::KeyEmoji
+        | ButtonId::KeyScreenCapture
+        | ButtonId::KeyMicMute
+        | ButtonId::KeyPlayPause
+        | ButtonId::KeyMute
+        | ButtonId::KeyVolumeDown
+        | ButtonId::KeyVolumeUp => Action::None,
     }
 }
 

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -597,6 +597,13 @@ impl Config {
         self.devices.get(device_key).and_then(|d| d.smartshift)
     }
 
+    /// The persisted keyboard Fn-lock state for `device_key`, or `None` when
+    /// the user never set one (the keyboard keeps its own state).
+    #[must_use]
+    pub fn fn_lock(&self, device_key: &str) -> Option<bool> {
+        self.devices.get(device_key).and_then(|d| d.fn_lock)
+    }
+
     /// Record the SmartShift wheel config for `device_key`, so the agent can
     /// re-apply it when the device reconnects (#189).
     pub fn set_smartshift(&mut self, device_key: &str, smartshift: SmartShift) {

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -130,6 +130,12 @@ pub struct DeviceConfig {
     /// lets the keyboard leave the current host.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub host_switch_targets: Vec<String>,
+    /// Keyboard Fn-lock state (HID++ fn inversion, `0x40a2`/`0x40a3`): `true`
+    /// means the F-row sends F1–F12 without holding Fn. The state lives in
+    /// device RAM per host, so the agent re-applies it on reconnect like
+    /// [`Self::dpi`]. `None` means "never set — leave the keyboard alone".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fn_lock: Option<bool>,
 }
 
 /// `skip_serializing_if` helper for plain `bool` fields whose default is
@@ -188,6 +194,8 @@ struct RawDeviceConfig {
     scroll_resolution: Option<ScrollResolution>,
     #[serde(default)]
     host_switch_targets: Vec<String>,
+    #[serde(default)]
+    fn_lock: Option<bool>,
 }
 
 impl From<RawDeviceConfig> for DeviceConfig {
@@ -236,6 +244,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
             invert_scroll: raw.invert_scroll,
             scroll_resolution: raw.scroll_resolution,
             host_switch_targets: raw.host_switch_targets,
+            fn_lock: raw.fn_lock,
         }
     }
 }

--- a/crates/openlogi-gui/action-icons/moon.svg
+++ b/crates/openlogi-gui/action-icons/moon.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+</svg>

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Lås skærm"
 "Screenshot": "Skærmbillede"
+"Sleep": "Slumre"
 "Capture Region": "Optag område"
 "Play / Pause": "Afspil / pause"
 "Next Track": "Næste nummer"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Bildschirm sperren"
 "Screenshot": "Bildschirmfoto"
+"Sleep": "Ruhezustand"
 "Capture Region": "Bereich aufnehmen"
 "Play / Pause": "Wiedergabe / Pause"
 "Next Track": "Nächster Titel"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Κλείδωμα οθόνης"
 "Screenshot": "Στιγμιότυπο οθόνης"
+"Sleep": "Ύπνωση"
 "Capture Region": "Λήψη περιοχής"
 "Play / Pause": "Αναπαραγωγή / Παύση"
 "Next Track": "Επόμενο κομμάτι"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Lock Screen"
 "Screenshot": "Screenshot"
+"Sleep": "Sleep"
 "Capture Region": "Capture Region"
 "Play / Pause": "Play / Pause"
 "Next Track": "Next Track"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Bloquear pantalla"
 "Screenshot": "Captura de pantalla"
+"Sleep": "Reposo"
 "Capture Region": "Capturar región"
 "Play / Pause": "Reproducir / Pausar"
 "Next Track": "Pista siguiente"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Lukitse näyttö"
 "Screenshot": "Kuvakaappaus"
+"Sleep": "Lepotila"
 "Capture Region": "Kaappaa alue"
 "Play / Pause": "Toista / Keskeytä"
 "Next Track": "Seuraava kappale"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Verrouiller l'écran"
 "Screenshot": "Capture d'écran"
+"Sleep": "Suspendre l'activité"
 "Capture Region": "Capturer une zone"
 "Play / Pause": "Lecture / Pause"
 "Next Track": "Piste suivante"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Blocca schermo"
 "Screenshot": "Istantanea schermo"
+"Sleep": "Stop"
 "Capture Region": "Cattura area"
 "Play / Pause": "Riproduci / Pausa"
 "Next Track": "Traccia successiva"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "画面をロック"
 "Screenshot": "スクリーンショット"
+"Sleep": "スリープ"
 "Capture Region": "範囲をキャプチャ"
 "Play / Pause": "再生 / 一時停止"
 "Next Track": "次の曲"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "런치패드"
 "Lock Screen": "화면 잠금"
 "Screenshot": "스크린샷"
+"Sleep": "잠자기"
 "Capture Region": "영역 캡처"
 "Play / Pause": "재생 / 일시정지"
 "Next Track": "다음 트랙"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Lås skjerm"
 "Screenshot": "Skjermbilde"
+"Sleep": "Dvale"
 "Capture Region": "Ta opp område"
 "Play / Pause": "Spill av / pause"
 "Next Track": "Neste spor"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Scherm vergrendelen"
 "Screenshot": "Schermafbeelding"
+"Sleep": "Sluimer"
 "Capture Region": "Gebied vastleggen"
 "Play / Pause": "Afspelen / pauzeren"
 "Next Track": "Volgend nummer"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Zablokuj ekran"
 "Screenshot": "Zrzut ekranu"
+"Sleep": "Uśpij"
 "Capture Region": "Przechwyć obszar"
 "Play / Pause": "Odtwarzaj / Wstrzymaj"
 "Next Track": "Następny utwór"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Bloquear Tela"
 "Screenshot": "Captura de Tela"
+"Sleep": "Repouso"
 "Capture Region": "Capturar Região"
 "Play / Pause": "Reproduzir / Pausar"
 "Next Track": "Próxima Faixa"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Bloquear ecrã"
 "Screenshot": "Captura de ecrã"
+"Sleep": "Pausa"
 "Capture Region": "Capturar região"
 "Play / Pause": "Reproduzir / Pausa"
 "Next Track": "Faixa seguinte"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Заблокировать экран"
 "Screenshot": "Снимок экрана"
+"Sleep": "Режим сна"
 "Capture Region": "Снимок области"
 "Play / Pause": "Воспроизведение / пауза"
 "Next Track": "Следующий трек"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "Launchpad"
 "Lock Screen": "Lås skärmen"
 "Screenshot": "Skärmavbild"
+"Sleep": "Vila"
 "Capture Region": "Fånga område"
 "Play / Pause": "Spela upp / Pausa"
 "Next Track": "Nästa spår"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "启动台"
 "Lock Screen": "锁定屏幕"
 "Screenshot": "截屏"
+"Sleep": "睡眠"
 "Capture Region": "截取区域"
 "Play / Pause": "播放 / 暂停"
 "Next Track": "下一首"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "啟動台"
 "Lock Screen": "鎖定螢幕"
 "Screenshot": "截圖"
+"Sleep": "睡眠"
 "Capture Region": "擷取區域"
 "Play / Pause": "播放 / 暫停"
 "Next Track": "下一首"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -188,6 +188,7 @@ _version: 1
 "Launchpad": "啟動台"
 "Lock Screen": "鎖定螢幕"
 "Screenshot": "截圖"
+"Sleep": "睡眠"
 "Capture Region": "擷取區域"
 "Play / Pause": "播放 / 暫停"
 "Next Track": "下一首"

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -331,6 +331,7 @@ pub(crate) fn action_icon_path(action: &Action) -> &'static str {
         Action::LaunchpadShow => "action-icons/grid-3x3.svg",
         Action::LockScreen => "action-icons/lock.svg",
         Action::Screenshot | Action::CaptureRegion => "action-icons/camera.svg",
+        Action::Sleep => "action-icons/moon.svg",
         Action::PlayPause => "action-icons/play.svg",
         Action::NextTrack => "action-icons/skip-forward.svg",
         Action::PrevTrack => "action-icons/skip-back.svg",

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -581,15 +581,17 @@ async fn divert_candidate_cids(
 }
 
 /// Log (don't propagate) a failure to hand a control back to the firmware.
-fn restore<E: std::fmt::Display>(result: Result<(), E>, what: &str) {
+/// Shared with the keyboard capture session (`crate::keyboard`).
+pub(crate) fn restore<E: std::fmt::Display>(result: Result<(), E>, what: &str) {
     if let Err(e) = result {
         warn!(error = %e, control = what, "failed to restore control mapping on shutdown");
     }
 }
 
 /// Read the device's full reprogrammable-control table in one pass, so we can
-/// test several CIDs without rescanning per control.
-async fn enumerate_controls(
+/// test several CIDs without rescanning per control. Shared with the keyboard
+/// capture session (`crate::keyboard`).
+pub(crate) async fn enumerate_controls(
     rc: &ReprogControlsV4,
 ) -> Result<Vec<reprog_controls::CtrlIdInfo>, GestureError> {
     let count = rc

--- a/crates/openlogi-hid/src/keyboard.rs
+++ b/crates/openlogi-hid/src/keyboard.rs
@@ -1,0 +1,154 @@
+//! Live key capture for one keyboard: divert the bound F-row controls over
+//! HID++ `0x1b04` and turn their presses into [`CapturedInput`] the agent can
+//! dispatch.
+//!
+//! [`run_keyboard_capture_session`] is the keyboard counterpart of
+//! [`crate::gesture::run_capture_session`]: one open channel, diversion armed
+//! on exactly the controls the caller asks for (an unbound key is never
+//! diverted, so it keeps its native firmware function), one message listener,
+//! and every diverted control handed back to the firmware on shutdown.
+//!
+//! Diversion works on the key's *control* — the printed media/shortcut
+//! function — so it fires when Fn-lock is off (or via Fn+key when it is on).
+//! The plain F1–F12 codes of an Fn-locked row travel the ordinary HID keyboard
+//! interface and never reach `0x1b04`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use hidpp::{device::Device, protocol::v20};
+use openlogi_core::binding::ButtonId;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, info};
+
+use crate::gesture::{CaptureChannel, CapturedInput, GestureError, enumerate_controls, restore};
+use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
+use crate::route::{DeviceRoute, open_route_channel};
+use crate::write::SharedChannel;
+
+/// The divertable keyboard F-row controls OpenLogi models, as
+/// `(0x1b04 control ID, ButtonId)` pairs. CID values match Logitech's control
+/// catalog (cross-checked against Solaar's `special_keys.py`); the F-row
+/// positions are the Signature-series layout.
+pub const KEYBOARD_KEY_CIDS: [(u16, ButtonId); 9] = [
+    (0x00d4, ButtonId::KeySearch),
+    (0x0103, ButtonId::KeyDictation),
+    (0x0108, ButtonId::KeyEmoji),
+    (0x010a, ButtonId::KeyScreenCapture),
+    (0x011c, ButtonId::KeyMicMute),
+    (0x00e5, ButtonId::KeyPlayPause),
+    (0x00e7, ButtonId::KeyMute),
+    (0x00e8, ButtonId::KeyVolumeDown),
+    (0x00e9, ButtonId::KeyVolumeUp),
+];
+
+/// Capture the requested keyboard controls on `route` until `shutdown`
+/// resolves, forwarding a [`CapturedInput::ButtonPressed`] on each press
+/// (rising edge) to `sink`.
+///
+/// `wanted` maps `0x1b04` control IDs to the [`ButtonId`] they dispatch as —
+/// the caller passes only the keys that carry a real binding. Controls the
+/// device doesn't expose (or can't divert) are skipped with a debug log, so a
+/// partially-supported keyboard degrades per key rather than failing whole.
+pub async fn run_keyboard_capture_session(
+    route: DeviceRoute,
+    wanted: BTreeMap<u16, ButtonId>,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let chan = open_route_channel(&route)
+        .await?
+        .ok_or(GestureError::DeviceNotFound)?;
+    let device_index = route.device_index();
+    let device = Device::new(Arc::clone(&chan), device_index)
+        .await
+        .map_err(|_| GestureError::DeviceUnreachable(device_index))?;
+
+    let info = device
+        .root()
+        .get_feature(reprog_controls::FEATURE_ID)
+        .await
+        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
+        .ok_or_else(|| GestureError::Hidpp("keyboard exposes no 0x1b04 reprog controls".into()))?;
+    let rc = ReprogControlsV4::new(Arc::clone(&chan), device_index, info.index);
+    let controls = enumerate_controls(&rc).await?;
+
+    let mut diverted: BTreeMap<u16, ButtonId> = BTreeMap::new();
+    for (&cid, &button) in &wanted {
+        if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+            rc.set_cid_reporting(cid, true, false)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            diverted.insert(cid, button);
+        } else {
+            debug!(
+                cid = format_args!("{cid:#06x}"),
+                "bound key not divertable on this keyboard — left native"
+            );
+        }
+    }
+
+    // Rising-edge press state per CID. Behind a `Mutex` because the channel's
+    // read thread invokes the listener by shared reference.
+    let held: Arc<Mutex<BTreeSet<u16>>> = Arc::new(Mutex::new(BTreeSet::new()));
+    let feature_index = info.index;
+    let listener = chan.add_msg_listener_guarded({
+        let held = Arc::clone(&held);
+        let diverted = diverted.clone();
+        let sink = sink.clone();
+        move |raw, matched| {
+            if matched {
+                return;
+            }
+            let msg = v20::Message::from(raw);
+            let Some(RawControlEvent::DivertedButtons(cids)) =
+                reprog_controls::decode_event(&msg, device_index, feature_index)
+            else {
+                return;
+            };
+            // Recover the guard even if a prior holder panicked — the critical
+            // section is panic-free, so the data is consistent.
+            let mut down = held.lock().unwrap_or_else(PoisonError::into_inner);
+            for (&cid, &button) in &diverted {
+                let now = cids.contains(&cid);
+                let was = down.contains(&cid);
+                if now && !was {
+                    let _ = sink.send(CapturedInput::ButtonPressed(button));
+                }
+                if now {
+                    down.insert(cid);
+                } else {
+                    down.remove(&cid);
+                }
+            }
+        }
+    });
+
+    // Publish this keyboard's open channel so hardware writes (Fn-lock)
+    // reuse it instead of opening the same HID node a second time. Cleared
+    // on the way out.
+    if let Ok(mut slot) = channel_slot.write() {
+        *slot = Some(SharedChannel::new(Arc::clone(&chan), route.clone()));
+    }
+
+    info!(
+        index = device_index,
+        keys = diverted.len(),
+        "keyboard key capture active"
+    );
+    let _ = shutdown.await;
+
+    drop(listener);
+    if let Ok(mut slot) = channel_slot.write() {
+        *slot = None;
+    }
+    for &cid in diverted.keys() {
+        restore(
+            rc.set_cid_reporting(cid, false, false).await,
+            "keyboard key",
+        );
+    }
+    debug!(index = device_index, "keyboard key capture stopped");
+    Ok(())
+}

--- a/crates/openlogi-hid/src/keyboard.rs
+++ b/crates/openlogi-hid/src/keyboard.rs
@@ -16,10 +16,17 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, PoisonError};
 
-use hidpp::{device::Device, protocol::v20};
+use hidpp::{
+    device::Device,
+    feature::{
+        CreatableFeature, EmittingFeature,
+        wireless_device_status::{WirelessDeviceStatusEvent, WirelessDeviceStatusFeature},
+    },
+    protocol::v20,
+};
 use openlogi_core::binding::ButtonId;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::gesture::{CaptureChannel, CapturedInput, GestureError, enumerate_controls, restore};
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
@@ -74,20 +81,7 @@ pub async fn run_keyboard_capture_session(
     let rc = ReprogControlsV4::new(Arc::clone(&chan), device_index, info.index);
     let controls = enumerate_controls(&rc).await?;
 
-    let mut diverted: BTreeMap<u16, ButtonId> = BTreeMap::new();
-    for (&cid, &button) in &wanted {
-        if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-            rc.set_cid_reporting(cid, true, false)
-                .await
-                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-            diverted.insert(cid, button);
-        } else {
-            debug!(
-                cid = format_args!("{cid:#06x}"),
-                "bound key not divertable on this keyboard — left native"
-            );
-        }
-    }
+    let diverted = arm_keys(&rc, &controls, &wanted).await?;
 
     // Rising-edge press state per CID. Behind a `Mutex` because the channel's
     // read thread invokes the listener by shared reference.
@@ -125,6 +119,20 @@ pub async fn run_keyboard_capture_session(
         }
     });
 
+    // Wireless keyboards drop their diverted-control state when they
+    // power-cycle (idle sleep, power switch, Easy-Switch host change) — the
+    // reconnection broadcast on `0x1d4b` is the firmware asking the host to
+    // reconfigure. Re-arm the diversion on every broadcast, or the bound keys
+    // silently revert to their native functions after the first nap.
+    let wireless = device
+        .root()
+        .get_feature(WirelessDeviceStatusFeature::ID)
+        .await
+        .ok()
+        .flatten()
+        .map(|info| WirelessDeviceStatusFeature::new(Arc::clone(&chan), device_index, info.index));
+    let wake_events = wireless.as_ref().map(EmittingFeature::listen);
+
     // Publish this keyboard's open channel so hardware writes (Fn-lock)
     // reuse it instead of opening the same HID node a second time. Cleared
     // on the way out.
@@ -135,9 +143,30 @@ pub async fn run_keyboard_capture_session(
     info!(
         index = device_index,
         keys = diverted.len(),
+        wake_rearm = wake_events.is_some(),
         "keyboard key capture active"
     );
-    let _ = shutdown.await;
+    let mut shutdown = shutdown;
+    match wake_events {
+        None => {
+            let _ = shutdown.await;
+        }
+        Some(wake_events) => loop {
+            tokio::select! {
+                _ = &mut shutdown => break,
+                event = wake_events.recv() => {
+                    let Ok(WirelessDeviceStatusEvent::StatusBroadcast(broadcast)) = event else {
+                        // Emitter gone (feature dropped) — nothing left to
+                        // watch; fall back to a plain shutdown wait.
+                        let _ = shutdown.await;
+                        break;
+                    };
+                    info!(?broadcast, "keyboard reconnected — re-arming key diversion");
+                    rearm_keys(&rc, &diverted).await;
+                }
+            }
+        },
+    }
 
     drop(listener);
     if let Ok(mut slot) = channel_slot.write() {
@@ -151,4 +180,48 @@ pub async fn run_keyboard_capture_session(
     }
     debug!(index = device_index, "keyboard key capture stopped");
     Ok(())
+}
+
+/// Divert every wanted control the keyboard exposes as divertable, returning
+/// the armed `CID → ButtonId` subset. Missing / non-divertable controls are
+/// skipped with a debug log, so a partially-supported keyboard degrades per
+/// key rather than failing whole.
+async fn arm_keys(
+    rc: &ReprogControlsV4,
+    controls: &[reprog_controls::CtrlIdInfo],
+    wanted: &BTreeMap<u16, ButtonId>,
+) -> Result<BTreeMap<u16, ButtonId>, GestureError> {
+    let mut diverted = BTreeMap::new();
+    for (&cid, &button) in wanted {
+        if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+            rc.set_cid_reporting(cid, true, false)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            diverted.insert(cid, button);
+        } else {
+            debug!(
+                cid = format_args!("{cid:#06x}"),
+                "bound key not divertable on this keyboard — left native"
+            );
+        }
+    }
+    Ok(diverted)
+}
+
+/// Re-issue diversion for every armed control after a device power-cycle.
+/// Failures are logged, not propagated — the next reconnection broadcast
+/// retries.
+async fn rearm_keys(rc: &ReprogControlsV4, diverted: &BTreeMap<u16, ButtonId>) {
+    // A settling pause: the broadcast arrives the instant the link is back,
+    // occasionally before the device accepts feature writes again.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    for &cid in diverted.keys() {
+        if let Err(e) = rc.set_cid_reporting(cid, true, false).await {
+            warn!(
+                cid = format_args!("{cid:#06x}"),
+                error = ?e,
+                "re-divert after wake failed — key stays native until next wake"
+            );
+        }
+    }
 }

--- a/crates/openlogi-hid/src/keyboard.rs
+++ b/crates/openlogi-hid/src/keyboard.rs
@@ -28,6 +28,7 @@ use openlogi_core::binding::ButtonId;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
+use crate::channel_registry::ChannelRegistry;
 use crate::gesture::{CaptureChannel, CapturedInput, GestureError, enumerate_controls, restore};
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::route::{DeviceRoute, open_route_channel};
@@ -67,6 +68,38 @@ pub async fn run_keyboard_capture_session(
     let chan = open_route_channel(&route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
+    let shared = SharedChannel::new(chan, route.clone());
+    run_keyboard_capture_session_on(route, shared, wanted, sink, shutdown, channel_slot).await
+}
+
+/// Run keyboard capture on the exact channel currently published by `registry`.
+///
+/// A registry miss returns [`GestureError::DeviceNotFound`] without falling
+/// back to route enumeration/opening; the agent watcher retries after a later
+/// inventory publication.
+pub async fn run_keyboard_capture_session_with_registry(
+    route: DeviceRoute,
+    wanted: BTreeMap<u16, ButtonId>,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+    registry: &ChannelRegistry,
+) -> Result<(), GestureError> {
+    let shared = registry
+        .lookup(&route)
+        .ok_or(GestureError::DeviceNotFound)?;
+    run_keyboard_capture_session_on(route, shared, wanted, sink, shutdown, channel_slot).await
+}
+
+async fn run_keyboard_capture_session_on(
+    route: DeviceRoute,
+    shared: SharedChannel,
+    wanted: BTreeMap<u16, ButtonId>,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let chan = Arc::clone(shared.channel());
     let device_index = route.device_index();
     let device = Device::new(Arc::clone(&chan), device_index)
         .await
@@ -108,7 +141,7 @@ pub async fn run_keyboard_capture_session(
                 let now = cids.contains(&cid);
                 let was = down.contains(&cid);
                 if now && !was {
-                    let _ = sink.send(CapturedInput::ButtonPressed(button));
+                    let _ = sink.send(CapturedInput::ButtonPressed(button, None));
                 }
                 if now {
                     down.insert(cid);
@@ -137,7 +170,7 @@ pub async fn run_keyboard_capture_session(
     // reuse it instead of opening the same HID node a second time. Cleared
     // on the way out.
     if let Ok(mut slot) = channel_slot.write() {
-        *slot = Some(SharedChannel::new(Arc::clone(&chan), route.clone()));
+        *slot = Some(shared);
     }
 
     info!(

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -27,6 +27,7 @@ pub mod gesture;
 mod hires_wheel;
 pub mod hotplug;
 pub mod inventory;
+pub mod keyboard;
 pub mod pairing;
 pub mod reprog_controls;
 pub mod smartshift;
@@ -50,6 +51,7 @@ pub use host_switch::{
 };
 pub use hotplug::{HotplugEvent, watch_hotplug};
 pub use inventory::{Enumerator, InventoryError, enumerate};
+pub use keyboard::{KEYBOARD_KEY_CIDS, run_keyboard_capture_session};
 pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
@@ -61,7 +63,7 @@ pub use write::{
     ReprogControlEntry, SharedChannel, WriteError, dump_features, dump_reprog_controls,
     get_backlight, get_dpi, get_dpi_info, get_dpi_info_on, get_smartshift_status,
     get_smartshift_status_on, read_battery_raw, set_backlight_enabled, set_dpi, set_dpi_on,
-    set_keyboard_color, set_keyboard_color_on, set_keyboard_color_with, set_keyboard_color_with_on,
-    set_smartshift, set_smartshift_on, set_smartshift_sensitivity, toggle_smartshift,
-    toggle_smartshift_on,
+    set_fn_lock, set_fn_lock_on, set_keyboard_color, set_keyboard_color_on,
+    set_keyboard_color_with, set_keyboard_color_with_on, set_smartshift, set_smartshift_on,
+    set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -51,7 +51,9 @@ pub use host_switch::{
 };
 pub use hotplug::{HotplugEvent, watch_hotplug};
 pub use inventory::{Enumerator, InventoryError, enumerate};
-pub use keyboard::{KEYBOARD_KEY_CIDS, run_keyboard_capture_session};
+pub use keyboard::{
+    KEYBOARD_KEY_CIDS, run_keyboard_capture_session, run_keyboard_capture_session_with_registry,
+};
 pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -18,6 +18,7 @@ mod backlight;
 mod diagnostics;
 mod dpi;
 mod error;
+mod fn_lock;
 mod lighting;
 mod shared;
 mod smartshift;
@@ -28,10 +29,11 @@ pub use diagnostics::{
 };
 pub use dpi::{DpiCapabilities, DpiInfo, get_dpi, get_dpi_info, set_dpi};
 pub use error::{HidppFeatureErrorKind, HidppOperation, WriteError};
+pub use fn_lock::set_fn_lock;
 pub use lighting::{LightingMethod, set_keyboard_color, set_keyboard_color_with};
 pub use shared::{
-    SharedChannel, get_dpi_info_on, get_smartshift_status_on, set_dpi_on, set_keyboard_color_on,
-    set_keyboard_color_with_on, set_smartshift_on, toggle_smartshift_on,
+    SharedChannel, get_dpi_info_on, get_smartshift_status_on, set_dpi_on, set_fn_lock_on,
+    set_keyboard_color_on, set_keyboard_color_with_on, set_smartshift_on, toggle_smartshift_on,
 };
 pub use smartshift::{
     get_smartshift_status, set_smartshift, set_smartshift_sensitivity, toggle_smartshift,

--- a/crates/openlogi-hid/src/write/error.rs
+++ b/crates/openlogi-hid/src/write/error.rs
@@ -104,6 +104,9 @@ pub enum HidppOperation {
     ReadBacklight,
     /// Write the keyboard backlight config.
     WriteBacklight,
+    /// Write keyboard Fn-lock (fn inversion). Appended last — variant order
+    /// is wire format.
+    WriteFnLock,
 }
 
 /// HID++ feature error kind in a serializable wire-safe form.

--- a/crates/openlogi-hid/src/write/fn_lock.rs
+++ b/crates/openlogi-hid/src/write/fn_lock.rs
@@ -1,0 +1,105 @@
+//! HID++ keyboard Fn-lock writes — fn inversion `0x40a3` (multi-host), with
+//! the single-host `0x40a2` as fallback.
+//!
+//! "Fn-lock on" means the F-row sends plain F1–F12 without holding Fn
+//! ([`FnInversionState::On`]); off restores the printed media/shortcut
+//! functions, with Fn+key producing the F-keys. Multi-host keyboards store the
+//! state per Easy-Switch slot, so the `0x40a3` path addresses
+//! [`HostIndex::Current`] — the slot the keyboard is talking to right now.
+
+use std::sync::Arc;
+
+use hidpp::{
+    channel::HidppChannel,
+    device::Device,
+    feature::{
+        fn_inversion::{
+            FnInversionMultiHostFeature, FnInversionState, FnInversionWithDefaultStateFeature,
+        },
+        hosts_info::HostIndex,
+    },
+};
+use tracing::debug;
+
+use crate::route::DeviceRoute;
+
+use super::{HidppOperation, WriteError, classify_hidpp_error, open_feature, with_route};
+
+/// Whether a failure to open the `0x40a3` multi-host feature should trigger
+/// the `0x40a2` single-host fallback. Only a missing-`0x40a3` feature
+/// qualifies; transport and protocol errors propagate unchanged.
+fn is_missing_multi_host(err: &WriteError) -> bool {
+    matches!(
+        err,
+        WriteError::FeatureUnsupported { feature_hex } if *feature_hex == 0x40a3
+    )
+}
+
+/// Whichever fn-inversion feature the keyboard exposes, normalised onto one
+/// setter. Multi-host boards (Easy-Switch) carry `0x40a3`; single-host boards
+/// carry `0x40a2`.
+enum FnInversion {
+    /// `0x40a3 FnInversionForMultiHostDevices`.
+    MultiHost(Arc<FnInversionMultiHostFeature>),
+    /// `0x40a2 FnInversionWithDefaultState`.
+    SingleHost(Arc<FnInversionWithDefaultStateFeature>),
+}
+
+impl FnInversion {
+    /// Open whichever fn-inversion feature the device exposes. Tries `0x40a3`
+    /// first; on a missing-`0x40a3` error (and only that), retries with
+    /// `0x40a2`.
+    async fn open(device: &mut Device) -> Result<Self, WriteError> {
+        match open_feature::<FnInversionMultiHostFeature>(device).await {
+            Ok(feature) => Ok(Self::MultiHost(feature)),
+            Err(err) if is_missing_multi_host(&err) => {
+                let feature = open_feature::<FnInversionWithDefaultStateFeature>(device).await?;
+                Ok(Self::SingleHost(feature))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Write the inversion state (for the current host on `0x40a3`).
+    async fn set(&self, state: FnInversionState) -> Result<(), WriteError> {
+        match self {
+            Self::MultiHost(feature) => {
+                feature
+                    .set_global_fn_inversion(HostIndex::Current, state)
+                    .await
+                    .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteFnLock, 0x40a3))?;
+            }
+            Self::SingleHost(feature) => {
+                feature
+                    .set_global_fn_inversion(state)
+                    .await
+                    .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteFnLock, 0x40a2))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Write the keyboard's Fn-lock state: `true` = F-row sends F1–F12 directly.
+pub async fn set_fn_lock(route: &DeviceRoute, on: bool) -> Result<(), WriteError> {
+    let index = route.device_index();
+    with_route(route, move |channel| async move {
+        set_fn_lock_on_channel(&channel, index, on).await
+    })
+    .await
+}
+
+/// The Fn-lock write itself, on an already-open channel at HID++ `index`.
+pub(super) async fn set_fn_lock_on_channel(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+    on: bool,
+) -> Result<(), WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let fn_inversion = FnInversion::open(&mut device).await?;
+    fn_inversion.set(FnInversionState::from(on)).await?;
+    debug!(index, on, "fn-lock written");
+    Ok(())
+}

--- a/crates/openlogi-hid/src/write/shared.rs
+++ b/crates/openlogi-hid/src/write/shared.rs
@@ -8,6 +8,7 @@ use crate::smartshift::SmartShiftStatus;
 
 use super::WriteError;
 use super::dpi::{DpiInfo, get_dpi_info_on_channel, set_dpi_on_channel};
+use super::fn_lock::set_fn_lock_on_channel;
 use super::lighting::{LightingMethod, set_keyboard_color_with_on_channel};
 use super::smartshift::{
     get_smartshift_status_on_channel, set_smartshift_on_channel, toggle_smartshift_on_channel,
@@ -69,6 +70,12 @@ pub async fn get_smartshift_status_on(
     shared: &SharedChannel,
 ) -> Result<SmartShiftStatus, WriteError> {
     get_smartshift_status_on_channel(&shared.channel, shared.route.device_index()).await
+}
+
+/// Write keyboard Fn-lock on an already-open [`SharedChannel`] — the fast
+/// path that skips enumeration and channel setup.
+pub async fn set_fn_lock_on(shared: &SharedChannel, on: bool) -> Result<(), WriteError> {
+    set_fn_lock_on_channel(&shared.channel, shared.route.device_index(), on).await
 }
 
 /// Write a full SmartShift configuration on an already-open [`SharedChannel`]

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -64,6 +64,8 @@ pub(super) fn execute(action: &Action) {
         // ── System ────────────────────────────────────────────────────────
         // logind LockSessions() via the system bus; falls back to Super+L.
         Action::LockScreen => lock_screen(),
+        // logind Suspend() via the system bus.
+        Action::Sleep => sleep_system(),
         // Region vs full-screen capture depends on the desktop environment's
         // screenshot handler for Print Screen, so both map to the same key.
         Action::Screenshot | Action::CaptureRegion => press_key(&[], KeyCode::KEY_SYSRQ),
@@ -412,6 +414,27 @@ fn lock_screen() {
     // Super+L is the standard lock shortcut on GNOME and KDE.
     tracing::debug!("LockScreen via Super+L key combo");
     press_key(&[KeyCode::KEY_LEFTMETA], KeyCode::KEY_L);
+}
+
+/// Suspend the system via logind's `Suspend()` on the system bus. The
+/// `false` argument declines the "interactive" polkit prompt — if the
+/// session isn't allowed to suspend, the call fails and is logged rather
+/// than popping an authentication dialog from a background agent.
+fn sleep_system() {
+    let Some(conn) = SYSTEM_BUS.as_ref() else {
+        tracing::warn!("no system bus — Sleep skipped");
+        return;
+    };
+    match conn.call_method(
+        Some("org.freedesktop.login1"),
+        "/org/freedesktop/login1",
+        Some("org.freedesktop.login1.Manager"),
+        "Suspend",
+        &(false,),
+    ) {
+        Ok(_) => tracing::debug!("Sleep via logind Suspend"),
+        Err(e) => tracing::warn!("logind Suspend failed: {e}"),
+    }
 }
 
 /// Send `command` to the first MPRIS-capable media player on the session bus,

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -293,13 +293,20 @@ fn post_media_key(nx_key: i32) {
 
 /// Put the system to sleep via `pmset sleepnow` — sleep has no CGEvent
 /// equivalent, and `pmset` performs the console user's sleep request
-/// without privileges. Fire-and-forget; a spawn failure is logged.
+/// without privileges. Fire-and-forget; a spawn failure is logged. The
+/// child is reaped on a detached thread so it can't linger as a zombie
+/// in this long-running agent.
 fn sleep_system() {
     match std::process::Command::new("/usr/bin/pmset")
         .arg("sleepnow")
         .spawn()
     {
-        Ok(_) => tracing::debug!("Sleep via pmset sleepnow"),
+        Ok(mut child) => {
+            tracing::debug!("Sleep via pmset sleepnow");
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
         Err(e) => tracing::warn!(error = %e, "pmset sleepnow spawn failed"),
     }
 }

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -99,6 +99,10 @@ pub(super) fn execute(action: &Action) {
         Action::Screenshot => post_key(0x14, cmd | shift),
         // Capture region to clipboard = Cmd+Shift+Ctrl+4 (kVK_ANSI_4 = 0x15)
         Action::CaptureRegion => post_key(0x15, cmd | shift | ctrl),
+        // Sleep has no CGEvent equivalent (the WindowServer ignores a
+        // synthesised power key), so ask powermanagement directly. `pmset
+        // sleepnow` works for the console user without privileges.
+        Action::Sleep => sleep_system(),
         // ── Media ─────────────────────────────────────────────────────────
         // Media/volume controls are NX system-defined keys, not ordinary
         // keyboard virtual-key events. Posting kVK_Volume* through
@@ -285,6 +289,19 @@ fn post_media_key(nx_key: i32) {
             CGEvent::post(CGEventTapLocation::HIDEventTap, Some(&cg_event));
         }
     });
+}
+
+/// Put the system to sleep via `pmset sleepnow` — sleep has no CGEvent
+/// equivalent, and `pmset` performs the console user's sleep request
+/// without privileges. Fire-and-forget; a spawn failure is logged.
+fn sleep_system() {
+    match std::process::Command::new("/usr/bin/pmset")
+        .arg("sleepnow")
+        .spawn()
+    {
+        Ok(_) => tracing::debug!("Sleep via pmset sleepnow"),
+        Err(e) => tracing::warn!(error = %e, "pmset sleepnow spawn failed"),
+    }
 }
 
 /// Post a synthetic scroll event for `action` (one of the `Scroll*` variants).

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -107,6 +107,12 @@ pub(super) fn execute(action: &Action) {
         Action::Screenshot | Action::CaptureRegion => {
             post_key(VK_S, &[VK_LWIN, VK_SHIFT]);
         }
+        // Suspending reliably needs `SetSuspendState` (powrprof.dll), which
+        // hibernates instead when hibernation is enabled — no clean win from
+        // a background agent, so the action is skipped on Windows for now.
+        Action::Sleep => {
+            tracing::debug!("Sleep has no Windows synthesis yet — action skipped");
+        }
         Action::PlayPause => post_key(VK_MEDIA_PLAY_PAUSE, &[]),
         Action::NextTrack => post_key(VK_MEDIA_NEXT_TRACK, &[]),
         Action::PrevTrack => post_key(VK_MEDIA_PREV_TRACK, &[]),

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,6 +37,9 @@ MX Master 4):
   be paired on corresponding channels. The keyboard's host controls and every
   target must expose the HID++ features needed for host switching. Configure
   the link on every computer from which the keyboard may initiate a switch.
+- `fn_lock` — keyboards only: `true` makes the F-row send F1–F12 without
+  holding Fn, `false` keeps the printed media/shortcut functions. Absent
+  means the keyboard's own state is left alone. Re-applied on reconnect.
 
 The app-wide `[app_settings]` block holds `launch_at_login`,
 `check_for_updates`, and `auto_install_updates` (all off by default);
@@ -97,6 +100,18 @@ Back = "Undo"
 enabled = true
 color = "ff0000"
 brightness = 80
+
+# Keyboard F-row keys (Signature-series layout): a bound key is diverted
+# over HID++ and dispatches its action; an unbound key keeps its native
+# firmware function. Key names: KeySearch, KeyDictation, KeyEmoji,
+# KeyScreenCapture, KeyMicMute, KeyPlayPause, KeyMute, KeyVolumeDown,
+# KeyVolumeUp.
+[devices.2b372]
+fn_lock = false
+
+[devices.2b372.bindings]
+KeySearch = "MissionControl"
+KeyScreenCapture = "Sleep"
 ```
 
 Action names are the catalog's variant names (`LeftClick`, `MouseBack`,


### PR DESCRIPTION
## Summary

Keyboards are currently detection-only. This adds native key remapping for keyboard F-row controls via `0x1b04` diversion — the same mechanism behind the MX gesture button — plus fn-lock control via `0x40a3` (multi-host, with `0x40a2` single-host fallback). Bound keys are diverted and dispatched through the existing action path; unbound keys keep their native firmware functions and are never diverted.

Wireless keyboards clear their diverted-control state on every power cycle (idle sleep, power switch, host switch), so the capture session also watches the `0x1d4b` WirelessDeviceStatus reconnection broadcast and re-arms diversion on each one — without this the bindings silently die after the keyboard's first nap.

Config schema stays append-only: new `ButtonId` variants and the `Sleep` action are appended, `fn_lock` is a new optional device field, and the IPC wire-format goldens pass unchanged.

## Changes

- **core**: keyboard `ButtonId` variants (`KeySearch`, `KeyDictation`, `KeyEmoji`, `KeyScreenCapture`, `KeyMicMute`, `KeyPlayPause`, `KeyMute`, `KeyVolumeDown`, `KeyVolumeUp`), `Sleep` action, `fn_lock` device-config field
- **hid**: keyboard capture session (`0x1b04` divert, rising-edge press dispatch, `0x1d4b` wake re-arm), fn-lock writes, CID → ButtonId table cross-checked against Solaar's control catalog
- **agent-core**: keyboard key-capture watcher alongside the gesture watcher; receiver capture leases become shared (pairing stays exclusive); fn-lock reapplied on reconnect and config reload
- **agent**: spawn the keyboard watcher
- **inject**: `Sleep` synthesis (`pmset sleepnow` on macOS, logind `Suspend()` on Linux, skipped on Windows for now)
- **gui**: Sleep action icon (lucide moon) + entries in all 20 locales

## Testing

- `cargo test --workspace` (415 passed), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check` — all green
- Hardware-verified on macOS (arm64) with a Signature K855 on a Bolt receiver: all five bound keys dispatch their actions, `fn_lock = false` is written on connect (Fn+key still produces real F-keys), and diversion re-arms after both idle sleep and a power-switch cycle (`SoftwareReconfigurationNeeded` broadcast observed in logs)
- Not runtime-tested on Linux or Windows hardware

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)