### PR TITLE
test: characterize the hidpp v20 matcher and cover the CLI

### DIFF
--- a/crates/openlogi-cli/src/cmd/assets/sync.rs
+++ b/crates/openlogi-cli/src/cmd/assets/sync.rs
@@ -137,3 +137,50 @@ pub fn run(args: SyncArgs) -> Result<()> {
     );
     Ok(())
 }
+
+#[cfg(test)]
+mod is_optional_asset_tests {
+    use super::is_optional_asset;
+
+    #[test]
+    fn side_render_names_are_optional() {
+        assert!(is_optional_asset("side_core.png"));
+        assert!(is_optional_asset("side.png"));
+    }
+
+    #[test]
+    fn colour_variant_names_are_optional() {
+        assert!(is_optional_asset("front_ext1.png"));
+        assert!(is_optional_asset("front_ext_2.png"));
+        assert!(is_optional_asset("side_ext_3.png"));
+    }
+
+    #[test]
+    fn baseline_and_metadata_files_are_not_optional() {
+        assert!(!is_optional_asset("front_core.png"));
+        assert!(!is_optional_asset("front.png"));
+        assert!(!is_optional_asset("manifest.json"));
+        assert!(!is_optional_asset("core_metadata.json"));
+    }
+
+    #[test]
+    fn non_png_files_are_never_optional_even_with_a_matching_prefix() {
+        assert!(!is_optional_asset("front_ext.json"));
+    }
+
+    #[test]
+    fn prefix_match_is_loose_and_also_matches_unintended_names() {
+        // `starts_with("front_ext")` also matches names that merely begin the
+        // same way, not just the `front_extN` / `front_ext_N` schema —
+        // pinning this as current behaviour, not a spec.
+        assert!(is_optional_asset("front_extra_special.png"));
+    }
+
+    #[test]
+    fn prefix_match_is_case_sensitive_while_the_extension_check_is_not() {
+        // The extension check folds case (`eq_ignore_ascii_case`), but the
+        // prefix check is a plain `starts_with`, so an all-caps name fails
+        // the prefix half even though its extension would pass alone.
+        assert!(!is_optional_asset("FRONT_EXT1.PNG"));
+    }
+}

--- a/crates/openlogi-cli/src/cmd/diag/dpi.rs
+++ b/crates/openlogi-cli/src/cmd/diag/dpi.rs
@@ -107,3 +107,30 @@ fn summarize_dpi(capabilities: &openlogi_hid::DpiCapabilities) -> String {
         values.len()
     )
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+mod summarize_dpi_tests {
+    use openlogi_hid::DpiCapabilities;
+
+    use super::summarize_dpi;
+
+    #[test]
+    fn lists_values_verbatim_at_the_twelve_value_boundary() {
+        let values: Vec<u16> = (1..=12).map(|n| n * 100).collect();
+        let caps = DpiCapabilities::new(values).expect("non-empty");
+
+        assert_eq!(
+            summarize_dpi(&caps),
+            "100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200"
+        );
+    }
+
+    #[test]
+    fn switches_to_a_range_summary_past_twelve_values() {
+        let values: Vec<u16> = (1..=13).map(|n| n * 100).collect();
+        let caps = DpiCapabilities::new(values).expect("non-empty");
+
+        assert_eq!(summarize_dpi(&caps), "100..1300 (step ≈ 100, 13 values)");
+    }
+}

--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -97,3 +97,42 @@ pub async fn run(args: LightingArgs) -> Result<()> {
     println!("done — {name} should now be solid #{r:02x}{g:02x}{b:02x}");
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
+mod color_validation_tests {
+    use super::{LightingArgs, Method, run};
+
+    fn args(color: &str) -> LightingArgs {
+        LightingArgs {
+            color: color.to_string(),
+            device: None,
+            method: Method::Auto,
+        }
+    }
+
+    /// Invalid colours are rejected before any device I/O, so `run` is safe to
+    /// call in-process here. Valid colours proceed to hardware enumeration and
+    /// are deliberately not exercised.
+    #[tokio::test]
+    async fn rejects_malformed_colors_before_touching_hardware() {
+        for bad in ["zzz", "ff000", "ff00001", "gg0000", ""] {
+            let err = run(args(bad)).await.unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "color must be exactly 6 hex digits, e.g. ff0000"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn hash_prefix_is_stripped_before_validation() {
+        // `#zzzzzz` still fails, but with the same message — proving the `#`
+        // is stripped rather than counted toward the 6-digit length.
+        let err = run(args("#zzzzzz")).await.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "color must be exactly 6 hex digits, e.g. ff0000"
+        );
+    }
+}

--- a/crates/openlogi-cli/src/cmd/diag/mod.rs
+++ b/crates/openlogi-cli/src/cmd/diag/mod.rs
@@ -146,3 +146,59 @@ pub(crate) async fn select_device(
         .map(|c| (c.route, c.name))
         .ok_or_else(|| no_match_err(&[], None))
 }
+
+#[cfg(test)]
+mod no_match_err_tests {
+    use openlogi_hid::DeviceRoute;
+
+    use super::{Candidate, no_match_err};
+
+    fn candidate(name: &str) -> Candidate {
+        Candidate {
+            route: DeviceRoute::Direct {
+                vendor_id: 0x046d,
+                product_id: 0xc539,
+            },
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn no_devices_at_all_gives_a_generic_not_found_message() {
+        let err = no_match_err(&[], None).to_string();
+        assert_eq!(
+            err,
+            "no online HID++ device found — is a Logi device paired and awake?"
+        );
+    }
+
+    #[test]
+    fn no_devices_at_all_ignores_a_query_and_still_uses_the_generic_message() {
+        // `devices.is_empty()` short-circuits before `query` is inspected.
+        let err = no_match_err(&[], Some("mouse")).to_string();
+        assert_eq!(
+            err,
+            "no online HID++ device found — is a Logi device paired and awake?"
+        );
+    }
+
+    #[test]
+    fn unmatched_query_names_the_query_and_lists_online_devices() {
+        let devices = vec![candidate("MX Master 3S"), candidate("G Pro")];
+        let err = no_match_err(&devices, Some("keyboard")).to_string();
+
+        assert!(err.contains("no online device matches `--device keyboard`"));
+        assert!(err.contains("MX Master 3S"));
+        assert!(err.contains("G Pro"));
+    }
+
+    #[test]
+    fn no_query_suggests_the_device_flag_and_lists_online_devices() {
+        let devices = vec![candidate("MX Master 3S")];
+        let err = no_match_err(&devices, None).to_string();
+
+        assert!(err.contains("could not pick a device automatically"));
+        assert!(err.contains("pass --device <name> to choose one"));
+        assert!(err.contains("MX Master 3S"));
+    }
+}

--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -120,3 +120,108 @@ fn format_model(m: &DeviceModelInfo) -> String {
         m.extended_model_id
     )
 }
+
+#[cfg(test)]
+mod format_tests {
+    use openlogi_core::device::{BatteryLevel, BatteryStatus, DeviceKind, DeviceTransports};
+
+    use super::{BatteryInfo, DeviceModelInfo};
+    use super::{PairedDevice, format_battery, format_device, format_model};
+
+    fn base_device() -> PairedDevice {
+        PairedDevice {
+            slot: 1,
+            codename: Some("MX Master 3S".to_string()),
+            wpid: Some(0x4082),
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: None,
+            capabilities: None,
+        }
+    }
+
+    #[test]
+    fn online_device_uses_filled_dot_and_reports_fields() {
+        let d = base_device();
+        let out = format_device(&d);
+        assert_eq!(out, "slot 1 ● MX Master 3S (mouse, wpid=4082, battery=—)");
+    }
+
+    #[test]
+    fn offline_device_uses_hollow_dot() {
+        let mut d = base_device();
+        d.online = false;
+        let out = format_device(&d);
+        assert!(out.starts_with("slot 1 ○ "));
+    }
+
+    #[test]
+    fn missing_codename_and_wpid_fall_back_to_placeholders() {
+        let mut d = base_device();
+        d.codename = None;
+        d.wpid = None;
+        let out = format_device(&d);
+        assert_eq!(out, "slot 1 ● Unknown device (mouse, wpid=?, battery=—)");
+    }
+
+    #[test]
+    fn battery_info_is_embedded_when_present() {
+        let mut d = base_device();
+        d.battery = Some(BatteryInfo {
+            percentage: 42,
+            level: BatteryLevel::Low,
+            status: BatteryStatus::Discharging,
+        });
+        let out = format_device(&d);
+        assert!(out.contains("battery=42% low (discharging)"));
+    }
+
+    #[test]
+    fn battery_status_debug_names_are_lowercased_verbatim() {
+        // `ChargingSlow`'s Debug form has no separator; lowercasing alone
+        // yields "chargingslow", not "charging_slow" or "charging slow".
+        let b = BatteryInfo {
+            percentage: 10,
+            level: BatteryLevel::Critical,
+            status: BatteryStatus::ChargingSlow,
+        };
+        assert_eq!(format_battery(&b), "battery=10% critical (chargingslow)");
+    }
+
+    fn base_model() -> DeviceModelInfo {
+        DeviceModelInfo {
+            entity_count: 1,
+            serial_number: None,
+            unit_id: [0x00, 0x01, 0x02, 0x03],
+            transports: DeviceTransports::default(),
+            model_ids: [0xb042, 0, 0],
+            extended_model_id: 0x02,
+        }
+    }
+
+    #[test]
+    fn model_with_no_transports_shows_placeholder_and_missing_serial() {
+        let m = base_model();
+        let out = format_model(&m);
+        assert_eq!(
+            out,
+            "     model_ids=[b042,0000,0000] ext=02 serial=— unit_id=00010203 transports=—"
+        );
+    }
+
+    #[test]
+    fn model_transports_join_in_declared_field_order() {
+        let mut m = base_model();
+        m.transports = DeviceTransports {
+            usb: true,
+            equad: false,
+            btle: true,
+            bluetooth: true,
+        };
+        m.serial_number = Some("SN123".to_string());
+        let out = format_model(&m);
+        assert!(out.contains("transports=usb+btle+bt"));
+        assert!(out.contains("serial=SN123"));
+    }
+}

--- a/crates/openlogi-cli/src/lib.rs
+++ b/crates/openlogi-cli/src/lib.rs
@@ -35,3 +35,97 @@ pub async fn run() -> Result<()> {
         .unwrap_or(cmd::Command::List(cmd::list::ListArgs {}));
     command.run().await
 }
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+    use cmd::Command;
+    use cmd::diag::DiagCmd;
+    use cmd::diag::lighting::Method;
+
+    /// Clap's own structural validation (arg ID collisions, invalid
+    /// `conflicts_with` targets, etc.) — cheap and catches a broken derive
+    /// tree before it ever reaches a user.
+    #[test]
+    fn cli_command_tree_is_well_formed() {
+        Cli::command().debug_assert();
+    }
+
+    /// A bare `openlogi` invocation must remain valid — `run()` defaults the
+    /// missing subcommand to `list`.
+    #[test]
+    fn bare_invocation_has_no_subcommand() {
+        let cli = Cli::try_parse_from(["openlogi"]).expect("bare invocation parses");
+        assert!(cli.cmd.is_none());
+    }
+
+    #[test]
+    fn smartshift_leave_flipped_conflicts_with_sensitivity() {
+        let result = Cli::try_parse_from([
+            "openlogi",
+            "diag",
+            "smartshift",
+            "--leave-flipped",
+            "--sensitivity",
+            "10",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn smartshift_rejects_zero_sensitivity() {
+        // `--sensitivity` is a `NonZeroU8`; 0 must fail to parse rather than
+        // silently becoming "no change" downstream.
+        let result = Cli::try_parse_from(["openlogi", "diag", "smartshift", "--sensitivity", "0"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn dpi_target_and_device_flags_are_mapped() {
+        let cli = Cli::try_parse_from([
+            "openlogi",
+            "diag",
+            "dpi",
+            "--target",
+            "800",
+            "--device",
+            "MX Master",
+        ])
+        .expect("valid dpi invocation parses");
+
+        match cli.cmd.expect("subcommand present") {
+            Command::Diag(DiagCmd::Dpi(args)) => {
+                assert_eq!(args.target, Some(800));
+                assert_eq!(args.device.as_deref(), Some("MX Master"));
+            }
+            other => panic!("expected Diag(Dpi), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lighting_color_is_positional_and_method_is_a_flag() {
+        let cli = Cli::try_parse_from([
+            "openlogi", "diag", "lighting", "ff0000", "--method", "effects",
+        ])
+        .expect("valid lighting invocation parses");
+
+        match cli.cmd.expect("subcommand present") {
+            Command::Diag(DiagCmd::Lighting(args)) => {
+                assert_eq!(args.color, "ff0000");
+                assert!(matches!(args.method, Method::Effects));
+            }
+            other => panic!("expected Diag(Lighting), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lighting_rejects_unknown_method() {
+        let result = Cli::try_parse_from([
+            "openlogi", "diag", "lighting", "ff0000", "--method", "bogus",
+        ]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -979,6 +979,9 @@ mod tests {
             let (result, ()) = futures::join!(send_fut, feed_fut);
 
             assert_eq!(result.unwrap(), response);
+            // The oneshot resolves before the listener loop runs on the read
+            // thread; wait for both deliveries before asserting on them.
+            wait_for_event_count(&events, 2).await;
             let recorded = events.lock().unwrap().clone();
             assert_eq!(
                 recorded,

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -681,6 +681,11 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    use crate::{
+        nibble,
+        protocol::v20::{self, ErrorType, Hidpp20Error},
+    };
+
     #[test]
     fn short_payload_widens_preserving_header_and_padding() {
         // [device, feature, function|sw, p0, p1, p2]
@@ -866,6 +871,218 @@ mod tests {
 
             assert_eq!(removed_listener_calls.load(Ordering::SeqCst), 1);
         });
+    }
+
+    // --- HID++2.0 (v20) send/matcher characterization tests -----------------
+    //
+    // `HidppChannel::send`/`send_with_timeout` above are protocol-agnostic:
+    // they match on an arbitrary predicate over raw `HidppMessage`s. The
+    // v20-specific correlation logic (matching by header, splitting out error
+    // frames) lives in `protocol::v20::HidppChannel::send_v20`, which is built
+    // directly on top of `send`. These tests pin that logic's current
+    // behaviour using the same mock transport as the tests above.
+
+    #[test]
+    fn send_v20_matches_response_by_header_ignoring_unrelated_messages() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+
+            let header = v20::MessageHeader {
+                device_index: 0x01,
+                feature_index: 0x05,
+                function_id: U4::from_lo(0x2),
+                software_id: U4::from_lo(0x3),
+            };
+            let request = v20::Message::Short(header, [0x00, 0x00, 0x00]);
+            let response = v20::Message::Short(header, [0xaa, 0xbb, 0xcc]);
+
+            // Each decoy differs from the request in exactly one header field, so
+            // none of them may be mistaken for its response.
+            let wrong_device = v20::Message::Short(
+                v20::MessageHeader {
+                    device_index: 0x02,
+                    ..header
+                },
+                [0, 0, 0],
+            );
+            let wrong_feature = v20::Message::Short(
+                v20::MessageHeader {
+                    feature_index: 0x06,
+                    ..header
+                },
+                [0, 0, 0],
+            );
+            let wrong_sw_id = v20::Message::Short(
+                v20::MessageHeader {
+                    software_id: U4::from_lo(0x4),
+                    ..header
+                },
+                [0, 0, 0],
+            );
+
+            let send_fut = channel.send_v20(request);
+            let feed_fut = async {
+                handle.send_incoming(wrong_device.into()).await;
+                handle.send_incoming(wrong_feature.into()).await;
+                handle.send_incoming(wrong_sw_id.into()).await;
+                handle.send_incoming(response.into()).await;
+            };
+
+            let (result, ()) = futures::join!(send_fut, feed_fut);
+
+            assert_eq!(result.unwrap(), response);
+            assert_pending_empty(&channel);
+        });
+    }
+
+    #[test]
+    fn send_v20_broadcast_event_does_not_resolve_pending_request() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let listener_events = Arc::clone(&events);
+            channel.add_msg_listener(move |msg, matched| {
+                listener_events.lock().unwrap().push((msg, matched));
+            });
+
+            let header = v20::MessageHeader {
+                device_index: 0x01,
+                feature_index: 0x05,
+                function_id: U4::from_lo(0x2),
+                software_id: U4::from_lo(0x3),
+            };
+            let request = v20::Message::Short(header, [0, 0, 0]);
+            let response = v20::Message::Short(header, [0xaa, 0xbb, 0xcc]);
+
+            // Software ID 0 is reserved for unsolicited device notifications
+            // (see `feature::event_payload`). The request above uses a non-zero
+            // ID, so an incoming broadcast sharing device/feature but using ID 0
+            // must be routed to listeners, not consumed as this request's
+            // response.
+            let event = v20::Message::Short(
+                v20::MessageHeader {
+                    software_id: U4::from_lo(0x0),
+                    ..header
+                },
+                [0x01, 0x02, 0x03],
+            );
+
+            let send_fut = channel.send_v20(request);
+            let feed_fut = async {
+                handle.send_incoming(event.into()).await;
+                wait_for_event_count(&events, 1).await;
+                handle.send_incoming(response.into()).await;
+            };
+
+            let (result, ()) = futures::join!(send_fut, feed_fut);
+
+            assert_eq!(result.unwrap(), response);
+            let recorded = events.lock().unwrap().clone();
+            assert_eq!(
+                recorded,
+                vec![
+                    (HidppMessage::from(event), false),
+                    (HidppMessage::from(response), true),
+                ]
+            );
+            assert_pending_empty(&channel);
+        });
+    }
+
+    #[test]
+    fn send_v20_response_may_arrive_as_a_different_report_width() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+
+            let header = v20::MessageHeader {
+                device_index: 0x01,
+                feature_index: 0x05,
+                function_id: U4::from_lo(0x2),
+                software_id: U4::from_lo(0x3),
+            };
+            let request = v20::Message::Short(header, [0, 0, 0]);
+            // Quirk: `send_v20`'s response predicate compares only the parsed
+            // v20 header, not the underlying report width. A device replying
+            // with a long report to a short request — same header, wider
+            // payload — is still accepted as the response.
+            let response = v20::Message::Long(header, [0xaa; 16]);
+            handle.queue_response(response.into());
+
+            let result = channel.send_v20(request).await.unwrap();
+
+            assert_eq!(result, response);
+            assert_pending_empty(&channel);
+        });
+    }
+
+    #[test]
+    fn send_v20_error_frame_resolves_to_feature_error() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+
+            let header = v20::MessageHeader {
+                device_index: 0x01,
+                feature_index: 0x05,
+                function_id: U4::from_lo(0x2),
+                software_id: U4::from_lo(0x3),
+            };
+            let request = v20::Message::Short(header, [0, 0, 0]);
+            let error_response = v20_error_frame(header, ErrorType::InvalidArgument.into());
+            handle.queue_response(error_response.into());
+
+            let err = channel.send_v20(request).await.unwrap_err();
+
+            assert!(matches!(
+                err,
+                Hidpp20Error::Feature(ErrorType::InvalidArgument)
+            ));
+            assert_pending_empty(&channel);
+        });
+    }
+
+    #[test]
+    fn send_v20_error_frame_with_unmapped_code_is_unsupported_response() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+
+            let header = v20::MessageHeader {
+                device_index: 0x01,
+                feature_index: 0x05,
+                function_id: U4::from_lo(0x2),
+                software_id: U4::from_lo(0x3),
+            };
+            let request = v20::Message::Short(header, [0, 0, 0]);
+            // 0xfe is not a defined `ErrorType` variant.
+            let error_response = v20_error_frame(header, 0xfe);
+            handle.queue_response(error_response.into());
+
+            let err = channel.send_v20(request).await.unwrap_err();
+
+            assert!(matches!(err, Hidpp20Error::UnsupportedResponse));
+            assert_pending_empty(&channel);
+        });
+    }
+
+    /// Builds the HID++2.0 error-frame encoding for `request_header`: feature
+    /// index 0xFF, with the original feature index and function|software byte
+    /// shifted one byte to the right (see `v20::HidppChannel::send_v20`'s
+    /// `is_error` predicate for the reverse mapping).
+    fn v20_error_frame(request_header: v20::MessageHeader, error_code: u8) -> v20::Message {
+        let error_header = v20::MessageHeader {
+            device_index: request_header.device_index,
+            feature_index: 0xff,
+            function_id: U4::from_hi(request_header.feature_index),
+            software_id: U4::from_lo(request_header.feature_index),
+        };
+        let mut payload = [0u8; 3];
+        payload[0] = nibble::combine(request_header.function_id, request_header.software_id);
+        payload[1] = error_code;
+        v20::Message::Short(error_header, payload)
     }
 
     #[derive(Clone)]


### PR DESCRIPTION
## Summary

Closes the two long-standing test gaps flagged in the engineering audit: the HID++ 2.0 send/response-matcher path in the vendored hidpp fork had no characterization tests, and openlogi-cli had 2 tests for ~965 lines. All changes are purely additive `#[cfg(test)]` modules — zero production lines modified.

## Changes

- **hidpp**: characterization tests for the v20 correlation layer (`protocol/v20.rs::send_v20` over the predicate-based `HidppChannel::send`), reusing the existing `MockRawHidChannel` harness: header-field correlation against interleaved decoys, broadcast events not consuming pending requests, 0xFF error-frame decoding (mapped code → `Hidpp20Error::Feature`, unmapped code → `UnsupportedResponse`), and the width-agnostic matching quirk (a Long reply to a Short request is accepted) pinned as current behavior.
- **cli**: 30 tests covering clap parsing (`debug_assert`, arg conflicts, `NonZeroU8` bounds, value-enum mapping), `diag` message selection, DPI list-vs-range summarization, lighting color validation (rejects before any device I/O), optional-asset classification incl. two pinned quirks, and `list` output formatting. Pure dispatch glue and hardware-seam functions were deliberately left untested (tautological or requiring prod changes).

Found while writing tests, recorded here rather than fixed (test-only PR): the unreachable `map_err` in `diag/lighting.rs` color parsing, and `is_optional_asset`'s loose `front_ext*` prefix match.

## Testing

- `cargo test -p openlogi-hidpp -p openlogi-cli` — 157 + 30 passed, 0 failed
- `cargo clippy -p openlogi-cli --all-targets -- -D warnings` — clean
- Not runtime-tested on hardware (all tests run against mocks or pre-I/O validation paths).