### PR TITLE
refactor: adopt newly stabilized std APIs across the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,12 +5039,12 @@ dependencies = [
 name = "openlogi-assets"
 version = "0.6.19"
 dependencies = [
- "anyhow",
  "atomic-write-file",
  "backon",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
  "tracing",
  "ureq",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 [workspace.package]
 version = "0.6.19"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.96"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AprilNEA/OpenLogi"
 authors = ["AprilNEA <dev@aprilnea.me>"]

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -33,6 +33,7 @@ const INITIAL_FAILURE_LIMIT: u8 = 3;
 const WAKE_GAP: Duration = Duration::from_secs(60);
 
 /// What the watcher tells the agent.
+#[derive(Debug)]
 pub enum InventoryEvent {
     /// A completed enumeration — empty means "checked, no devices".
     Snapshot(Vec<DeviceInventory>),
@@ -163,6 +164,8 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use openlogi_hid::InventoryError;
 
     use super::{INITIAL_FAILURE_LIMIT, InventoryEvent, WatchState};
@@ -178,10 +181,10 @@ mod tests {
         let mut state = WatchState::default();
         // A genuine "checked, nothing there" still propagates as a disconnect —
         // the resilience must not swallow a real empty.
-        assert!(matches!(
+        assert_matches!(
             state.classify(Ok(vec![])),
             Some(InventoryEvent::Snapshot(snap)) if snap.is_empty()
-        ));
+        );
         assert!(state.succeeded);
     }
 
@@ -189,10 +192,10 @@ mod tests {
     fn failure_after_a_success_keeps_the_last_snapshot() {
         let mut state = WatchState::default();
         // A good tick first, so there is a last-known-good set to preserve.
-        assert!(matches!(
+        assert_matches!(
             state.classify(Ok(vec![])),
             Some(InventoryEvent::Snapshot(_))
-        ));
+        );
         // Then transient enumerate failures emit nothing — the agent keeps the
         // last snapshot instead of flapping to "No devices" (#218).
         assert!(state.classify(Err(enumerate_failed())).is_none());
@@ -207,16 +210,16 @@ mod tests {
         for _ in 0..INITIAL_FAILURE_LIMIT - 1 {
             assert!(state.classify(Err(enumerate_failed())).is_none());
         }
-        assert!(matches!(
+        assert_matches!(
             state.classify(Err(enumerate_failed())),
             Some(InventoryEvent::Unavailable)
-        ));
+        );
         // Reported once, not on every later failure.
         assert!(state.classify(Err(enumerate_failed())).is_none());
         // …and a later success recovers with a live snapshot.
-        assert!(matches!(
+        assert_matches!(
             state.classify(Ok(vec![])),
             Some(InventoryEvent::Snapshot(_))
-        ));
+        );
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -30,7 +30,7 @@ const INITIAL_FAILURE_LIMIT: u8 = 3;
 /// timed-out probe pass), so only a genuine suspend trips it; a rare false
 /// positive (e.g. a large NTP step) merely re-applies settings the devices
 /// already have.
-const WAKE_GAP: Duration = Duration::from_secs(60);
+const WAKE_GAP: Duration = Duration::from_mins(1);
 
 /// What the watcher tells the agent.
 #[derive(Debug)]

--- a/crates/openlogi-assets/Cargo.toml
+++ b/crates/openlogi-assets/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 ureq = { workspace = true }
 sha2 = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 backon = { workspace = true }
 atomic-write-file = "0.3.0"

--- a/crates/openlogi-assets/src/error.rs
+++ b/crates/openlogi-assets/src/error.rs
@@ -1,0 +1,68 @@
+//! The crate-wide error type for registry fetch, parse, and cache writes.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Errors from asset-registry fetches, JSON parsing, and cache-file I/O.
+#[derive(Debug, Error)]
+pub enum AssetError {
+    /// A GET against the asset host failed, after the retry policy for
+    /// transient failures was exhausted.
+    #[error("GET {url}")]
+    Http {
+        /// Full URL of the failed request.
+        url: String,
+        /// The transport or HTTP-status failure.
+        #[source]
+        source: ureq::Error,
+    },
+    /// A registry or metadata JSON document failed to parse.
+    #[error("parse {what}")]
+    ParseJson {
+        /// What was being parsed — a local path or a description of a
+        /// just-fetched document.
+        what: String,
+        /// The underlying deserialization failure.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// Opening or reading a local file failed.
+    #[error("read {}", path.display())]
+    ReadFile {
+        /// The file that could not be read.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Writing a file (via the atomic write-and-rename) failed.
+    #[error("write {}", path.display())]
+    WriteFile {
+        /// The destination that could not be written.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+    /// A downloaded asset's SHA-256 did not match the registry entry, so it
+    /// was discarded before reaching the cache.
+    #[error("downloaded asset checksum mismatch for {name}: expected {expected}, got {actual}")]
+    ChecksumMismatch {
+        /// Registry file name of the asset.
+        name: String,
+        /// The SHA-256 the registry promised.
+        expected: String,
+        /// The SHA-256 of the bytes actually downloaded.
+        actual: String,
+    },
+    /// A remote-supplied name was not a single safe path component
+    /// (empty, contained separators, or was `.`/`..`).
+    #[error("{label} must be a single safe path component, got {component:?}")]
+    UnsafeComponent {
+        /// Which input was rejected (e.g. `"asset file name"`).
+        label: String,
+        /// The offending value.
+        component: String,
+    },
+}

--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -14,7 +14,6 @@ use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 
-use anyhow::{Context as _, Result, bail};
 use atomic_write_file::AtomicWriteFile;
 use backon::{BlockingRetryable, ExponentialBuilder};
 use serde::de::DeserializeOwned;
@@ -22,6 +21,7 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
 use ureq::Agent;
 
+use crate::error::AssetError;
 use crate::index::{FileEntry, Index};
 
 const USER_AGENT: &str = concat!(
@@ -81,22 +81,26 @@ impl AssetClient {
     }
 
     /// GET `<base>/index.json` and parse it.
-    pub fn fetch_index(&self) -> Result<Index> {
+    pub fn fetch_index(&self) -> Result<Index, AssetError> {
         Ok(self.fetch_index_raw()?.1)
     }
 
     /// GET `<base>/index.json`, returning both the raw bytes (so callers can
     /// persist them verbatim) and the parsed struct.
-    pub fn fetch_index_raw(&self) -> Result<(Vec<u8>, Index)> {
+    pub fn fetch_index_raw(&self) -> Result<(Vec<u8>, Index), AssetError> {
         let url = format!("{}/{INDEX_NAME}", self.base);
         debug!(%url, "fetching index.json");
         let body = self.get_bytes(&url)?;
-        let parsed: Index = serde_json::from_slice(&body).context("parse fetched index.json")?;
+        let parsed: Index =
+            serde_json::from_slice(&body).map_err(|source| AssetError::ParseJson {
+                what: "fetched index.json".to_owned(),
+                source,
+            })?;
         Ok((body, parsed))
     }
 
     /// Fetch `<base>/index.json`, write it into `dir`, and return the parsed index.
-    pub fn fetch_index_to_dir(&self, dir: &Path) -> Result<Index> {
+    pub fn fetch_index_to_dir(&self, dir: &Path) -> Result<Index, AssetError> {
         let (raw, index) = self.fetch_index_raw()?;
         write_replace(&dir.join(INDEX_NAME), &raw)?;
         Ok(index)
@@ -104,7 +108,7 @@ impl AssetClient {
 
     /// GET a per-depot file, e.g.
     /// `fetch_file("v1/devices/mx_master_4/", "front_core.png")`.
-    fn fetch_file(&self, asset_path: &str, name: &str) -> Result<Vec<u8>> {
+    fn fetch_file(&self, asset_path: &str, name: &str) -> Result<Vec<u8>, AssetError> {
         let asset_path = asset_path.trim_start_matches('/');
         let url = format!("{}/{asset_path}{name}", self.base);
         debug!(%url, "fetching file");
@@ -123,7 +127,7 @@ impl AssetClient {
         asset_path: &str,
         dir: &Path,
         file: &FileEntry,
-    ) -> Result<FetchOutcome> {
+    ) -> Result<FetchOutcome, AssetError> {
         // `name` comes from remote metadata; validate it down to a single
         // path component before any path is built.
         let dst = safe_component_path(dir, &file.name, "asset file name")?;
@@ -133,11 +137,11 @@ impl AssetClient {
         let bytes = self.fetch_file(asset_path, &file.name)?;
         let actual = sha256_hex(&bytes);
         if !actual.eq_ignore_ascii_case(&file.sha256) {
-            bail!(
-                "downloaded asset checksum mismatch for {}: expected {}, got {actual}",
-                file.name,
-                file.sha256
-            );
+            return Err(AssetError::ChecksumMismatch {
+                name: file.name.clone(),
+                expected: file.sha256.clone(),
+                actual,
+            });
         }
         write_replace(&dst, &bytes)?;
         Ok(FetchOutcome::Fetched { bytes: bytes.len() })
@@ -153,7 +157,7 @@ impl AssetClient {
     /// The backoff sleeps block the calling thread, which is fine: every
     /// caller runs on the sync's dedicated background thread, never the
     /// async runtime. `backon` defaults to `std::thread::sleep` here.
-    fn get_bytes(&self, url: &str) -> Result<Vec<u8>> {
+    fn get_bytes(&self, url: &str) -> Result<Vec<u8>, AssetError> {
         let policy = ExponentialBuilder::default()
             .with_min_delay(RETRY_MIN_DELAY)
             .with_factor(2.0)
@@ -166,7 +170,10 @@ impl AssetClient {
                 warn!(%url, backoff_ms = dur.as_millis(), error = ?e, "transient fetch error — retrying");
             })
             .call()
-            .map_err(|e| anyhow::Error::new(e).context(format!("GET {url}")))
+            .map_err(|source| AssetError::Http {
+                url: url.to_owned(),
+                source,
+            })
     }
 
     /// One GET + full body read, surfacing the typed [`ureq::Error`] so the
@@ -195,15 +202,21 @@ fn is_retryable(error: &ureq::Error) -> bool {
 }
 
 /// Load and parse a JSON document from disk.
-pub(crate) fn load_json<T: DeserializeOwned>(path: &Path) -> Result<T> {
+pub(crate) fn load_json<T: DeserializeOwned>(path: &Path) -> Result<T, AssetError> {
     let bytes = read_bytes(path)?;
-    serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))
+    serde_json::from_slice(&bytes).map_err(|source| AssetError::ParseJson {
+        what: path.display().to_string(),
+        source,
+    })
 }
 
 /// Raw bytes of `path`. Avoid for very large files — held entirely in
 /// memory.
-pub fn read_bytes(path: &Path) -> Result<Vec<u8>> {
-    fs::read(path).with_context(|| format!("read {}", path.display()))
+pub fn read_bytes(path: &Path) -> Result<Vec<u8>, AssetError> {
+    fs::read(path).map_err(|source| AssetError::ReadFile {
+        path: path.to_owned(),
+        source,
+    })
 }
 
 /// Join one untrusted registry component onto a trusted directory.
@@ -211,19 +224,24 @@ pub fn read_bytes(path: &Path) -> Result<Vec<u8>> {
 /// Remote asset metadata is expected to carry depot and file *names*, not
 /// paths. Rejecting separators, absolute prefixes, and `.`/`..` keeps every
 /// sync write inside the cache or bundle directory chosen by the caller.
-pub fn safe_component_path(base: &Path, component: &str, label: &str) -> Result<PathBuf> {
-    if component.is_empty() {
-        bail!("{label} is empty");
-    }
+pub fn safe_component_path(
+    base: &Path,
+    component: &str,
+    label: &str,
+) -> Result<PathBuf, AssetError> {
+    let reject = || AssetError::UnsafeComponent {
+        label: label.to_owned(),
+        component: component.to_owned(),
+    };
     // `Path::components` never yields separators on the platform that didn't
     // produce them, so reject both kinds explicitly before consulting it.
-    if component.contains('/') || component.contains('\\') {
-        bail!("{label} must be a single path component: {component}");
+    if component.is_empty() || component.contains('/') || component.contains('\\') {
+        return Err(reject());
     }
     let mut parts = Path::new(component).components();
     match (parts.next(), parts.next()) {
         (Some(Component::Normal(_)), None) => Ok(base.join(component)),
-        _ => bail!("{label} must be a safe relative path component: {component}"),
+        _ => Err(reject()),
     }
 }
 
@@ -232,15 +250,16 @@ pub fn safe_component_path(base: &Path, component: &str, label: &str) -> Result<
 /// The temporary file is created in the destination directory and committed via
 /// rename, so a concurrent reader sees the old file or the new one, never a
 /// half-written one. A planted symlink at `dst` is replaced, not followed.
-fn write_replace(dst: &Path, bytes: &[u8]) -> Result<()> {
+fn write_replace(dst: &Path, bytes: &[u8]) -> Result<(), AssetError> {
     use std::io::Write as _;
 
-    let mut file =
-        AtomicWriteFile::open(dst).with_context(|| format!("create {}", dst.display()))?;
-    file.write_all(bytes)
-        .with_context(|| format!("write {}", dst.display()))?;
-    file.commit()
-        .with_context(|| format!("replace {}", dst.display()))
+    let fail = |source| AssetError::WriteFile {
+        path: dst.to_owned(),
+        source,
+    };
+    let mut file = AtomicWriteFile::open(dst).map_err(fail)?;
+    file.write_all(bytes).map_err(fail)?;
+    file.commit().map_err(fail)
 }
 
 /// Hex SHA-256 of an in-memory blob.
@@ -250,10 +269,14 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 /// Streamed hex SHA-256 of `path`.
-pub fn sha256_of_file(path: &Path) -> Result<String> {
-    let mut file = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+pub fn sha256_of_file(path: &Path) -> Result<String, AssetError> {
+    let fail = |source| AssetError::ReadFile {
+        path: path.to_owned(),
+        source,
+    };
+    let mut file = fs::File::open(path).map_err(fail)?;
     let mut hasher = Sha256::new();
-    std::io::copy(&mut file, &mut hasher).with_context(|| format!("read {}", path.display()))?;
+    std::io::copy(&mut file, &mut hasher).map_err(fail)?;
     Ok(format!("{:x}", hasher.finalize()))
 }
 

--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -35,6 +35,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+use crate::error::AssetError;
 use crate::http;
 
 #[derive(Debug, Deserialize)]
@@ -121,7 +122,8 @@ impl DeviceEntry {
 }
 
 impl Index {
-    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+    /// Load and parse an `index.json` from disk.
+    pub fn load_from(path: &Path) -> Result<Self, AssetError> {
         http::load_json(path)
     }
 

--- a/crates/openlogi-assets/src/lib.rs
+++ b/crates/openlogi-assets/src/lib.rs
@@ -10,11 +10,13 @@
 //! No filesystem layout opinions live here — both consumers decide where
 //! files end up. This crate stays I/O-light: parsing, HTTP, hashing.
 
+mod error;
 pub mod http;
 pub mod index;
 pub mod manifest;
 pub mod metadata;
 
+pub use error::AssetError;
 pub use http::{AssetClient, FetchOutcome, cached_matches, read_bytes, sha256_hex, sha256_of_file};
 pub use index::{
     BUTTONS_RENDER_FILES, DeviceEntry, FRONT_RENDER_FILES, FileEntry, Index, METADATA_FILES,

--- a/crates/openlogi-assets/src/manifest.rs
+++ b/crates/openlogi-assets/src/manifest.rs
@@ -41,6 +41,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+use crate::error::AssetError;
 use crate::http;
 
 /// Top-level `manifest.json` document.
@@ -68,7 +69,7 @@ pub struct ManifestResource {
 
 impl DepotManifest {
     /// Load and parse a `manifest.json` from disk.
-    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+    pub fn load_from(path: &Path) -> Result<Self, AssetError> {
         http::load_json(path)
     }
 

--- a/crates/openlogi-assets/src/metadata.rs
+++ b/crates/openlogi-assets/src/metadata.rs
@@ -47,6 +47,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
+use crate::error::AssetError;
 use crate::http;
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -92,7 +93,8 @@ pub struct Direction {
 }
 
 impl Metadata {
-    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+    /// Load and parse a metadata JSON file from disk.
+    pub fn load_from(path: &Path) -> Result<Self, AssetError> {
         http::load_json(path)
     }
 

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -918,6 +918,7 @@ pub fn default_binding_for(button: ButtonId) -> Binding {
 #[cfg(test)]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
+    use std::assert_matches;
     use std::collections::BTreeMap;
 
     use serde::{Deserialize, Serialize};
@@ -994,10 +995,10 @@ mod tests {
             back[&ButtonId::DpiToggle],
             Binding::Single(Action::SetDpiPreset(2))
         );
-        assert!(matches!(
+        assert_matches!(
             back[&ButtonId::Forward],
             Binding::Single(Action::CustomShortcut(_))
-        ));
+        );
     }
 
     #[test]

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -1040,6 +1040,8 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
 #[cfg(test)]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use crate::binding::{default_binding, default_gesture_binding};
 
@@ -1528,10 +1530,10 @@ Back = \"BrowserBack\"
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("config.toml");
         fs::write(&path, "schema_version = 99\n").expect("write");
-        assert!(matches!(
+        assert_matches!(
             Config::load_from_path(&path).expect_err("v99 should fail"),
             ConfigError::UnsupportedSchemaVersion { found: 99, .. }
-        ));
+        );
 
         fs::write(&path, "schema_version = 1\n").expect("write");
         assert!(

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -527,7 +527,7 @@ fn sync_retry_delay(attempts: u32) -> Duration {
         .without_max_times()
         .build()
         .nth(attempts.saturating_sub(1).min(6) as usize)
-        .unwrap_or(Duration::from_secs(60))
+        .unwrap_or(Duration::from_mins(1))
 }
 
 /// Refresh the asset cache: the shared index always, plus the depots for
@@ -638,7 +638,7 @@ mod tests {
         assert_eq!(sync_retry_delay(3), Duration::from_secs(4));
         assert_eq!(sync_retry_delay(5), Duration::from_secs(16));
         // Caps at 60s and never overflows the shift for large attempt counts.
-        assert_eq!(sync_retry_delay(7), Duration::from_secs(60));
-        assert_eq!(sync_retry_delay(u32::MAX), Duration::from_secs(60));
+        assert_eq!(sync_retry_delay(7), Duration::from_mins(1));
+        assert_eq!(sync_retry_delay(u32::MAX), Duration::from_mins(1));
     }
 }

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -196,6 +196,8 @@ pub(crate) async fn open_route_channel(
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use openlogi_core::device::{DeviceInventory, ReceiverInfo};
 
     use super::{DIRECT_DEVICE_INDEX, DeviceRoute, UNIFYING_PIDS};
@@ -228,22 +230,22 @@ mod tests {
         // 0xC548 is Bolt; anything not in UNIFYING_PIDS defaults to Bolt so
         // future Bolt variants with unknown PIDs still work.
         let route = DeviceRoute::device_route_for(&inv(0xc548, Some("UID")), 1);
-        assert!(matches!(
+        assert_matches!(
             route,
             Some(DeviceRoute::Bolt { ref receiver_uid, slot: 1 }) if receiver_uid == "UID"
-        ));
+        );
     }
 
     #[test]
     fn device_route_for_direct_when_no_uid_and_direct_slot() {
         let route = DeviceRoute::device_route_for(&inv(0xb025, None), DIRECT_DEVICE_INDEX);
-        assert!(matches!(
+        assert_matches!(
             route,
             Some(DeviceRoute::Direct {
                 vendor_id: 0x046d,
                 product_id: 0xb025
             })
-        ));
+        );
     }
 
     #[test]

--- a/crates/openlogi-hid/src/write/dpi.rs
+++ b/crates/openlogi-hid/src/write/dpi.rs
@@ -82,8 +82,8 @@ impl DpiCapabilities {
     #[must_use]
     pub fn step_hint(&self) -> u16 {
         self.values
-            .windows(2)
-            .filter_map(|pair| pair[1].checked_sub(pair[0]))
+            .array_windows::<2>()
+            .filter_map(|&[low, high]| high.checked_sub(low))
             .filter(|step| *step > 0)
             .min()
             .unwrap_or(1)

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -1,3 +1,5 @@
+use std::assert_matches;
+
 use super::*;
 use hidpp::feature::smartshift::WheelMode;
 
@@ -18,10 +20,10 @@ fn capabilities_sort_and_deduplicate_values() -> Result<(), WriteError> {
 
 #[test]
 fn capabilities_reject_empty_list() {
-    assert!(matches!(
+    assert_matches!(
         DpiCapabilities::new(Vec::new()),
         Err(WriteError::EmptyDpiList)
-    ));
+    );
 }
 
 #[test]

--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -17,7 +17,7 @@ edition.workspace = true
 # Upstream HEAD uses std APIs stabilized in 1.87. Keep this explicit instead
 # of inheriting the workspace MSRV so future syncs can see the fork's own lower
 # bound.
-rust-version = "1.87"
+rust-version = "1.96"
 license = "0BSD"
 repository.workspace = true
 description = "OpenLogi's vendored fork of the `hidpp` crate (Logitech HID++ protocol)."

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -183,25 +183,20 @@ pub enum HidppMessage {
 impl HidppMessage {
     /// Tries to read a HID++ message from raw data.
     pub fn read_raw(data: &[u8]) -> Option<Self> {
-        if data.is_empty() {
-            return None;
+        let (&report_id, rest) = data.split_first()?;
+
+        // The empty-remainder patterns enforce the exact report lengths.
+        if report_id == SHORT_REPORT_ID
+            && let Some((&payload, [])) = rest.split_first_chunk()
+        {
+            Some(HidppMessage::Short(payload))
+        } else if report_id == LONG_REPORT_ID
+            && let Some((&payload, [])) = rest.split_first_chunk()
+        {
+            Some(HidppMessage::Long(payload))
+        } else {
+            None
         }
-
-        if data[0] == SHORT_REPORT_ID {
-            if data.len() != SHORT_REPORT_LENGTH {
-                return None;
-            }
-
-            return Some(HidppMessage::Short(data[1..].try_into().unwrap()));
-        } else if data[0] == LONG_REPORT_ID {
-            if data.len() != LONG_REPORT_LENGTH {
-                return None;
-            }
-
-            return Some(HidppMessage::Long(data[1..].try_into().unwrap()));
-        }
-
-        None
     }
 
     /// Writes a HID++ message in its raw byte form into a buffer.

--- a/crates/openlogi-hidpp/src/feature/adjustable_dpi/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/adjustable_dpi/mod.rs
@@ -126,6 +126,8 @@ fn parse_dpi_list_payload(bytes: &[u8]) -> Result<Vec<u16>, Hidpp20Error> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::parse_dpi_list_payload;
     use crate::protocol::v20::Hidpp20Error;
 
@@ -157,40 +159,40 @@ mod tests {
     fn rejects_range_marker_without_previous_value() {
         let payload = [0xe0, 0x32, 0x1f, 0x40, 0x00, 0x00];
 
-        assert!(matches!(
+        assert_matches!(
             parse_dpi_list_payload(&payload),
             Err(Hidpp20Error::UnsupportedResponse)
-        ));
+        );
     }
 
     #[test]
     fn rejects_range_marker_without_end_value() {
         let payload = [0x01, 0x90, 0xe0, 0x32];
 
-        assert!(matches!(
+        assert_matches!(
             parse_dpi_list_payload(&payload),
             Err(Hidpp20Error::UnsupportedResponse)
-        ));
+        );
     }
 
     #[test]
     fn rejects_zero_step_range_marker() {
         let payload = [0x01, 0x90, 0xe0, 0x00, 0x06, 0x40, 0x00, 0x00];
 
-        assert!(matches!(
+        assert_matches!(
             parse_dpi_list_payload(&payload),
             Err(Hidpp20Error::UnsupportedResponse)
-        ));
+        );
     }
 
     #[test]
     fn rejects_descending_range_marker() {
         let payload = [0x06, 0x40, 0xe0, 0x32, 0x01, 0x90, 0x00, 0x00];
 
-        assert!(matches!(
+        assert_matches!(
             parse_dpi_list_payload(&payload),
             Err(Hidpp20Error::UnsupportedResponse)
-        ));
+        );
     }
 
     #[test]
@@ -216,9 +218,9 @@ mod tests {
 
     #[test]
     fn rejects_payload_with_no_values() {
-        assert!(matches!(
+        assert_matches!(
             parse_dpi_list_payload(&[0x00, 0x00]),
             Err(Hidpp20Error::UnsupportedResponse)
-        ));
+        );
     }
 }

--- a/crates/openlogi-hidpp/src/feature/color_led_effects/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/color_led_effects/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `ColorLedEffects` payload parsing and event decoding.
 
+use std::assert_matches;
+
 use super::event::{ColorLedEffectsEvent, decode_event};
 use super::types::{
     ColorLedInfo, EffectId, EffectSettings, ExtCapabilities, LedBinIndex, LedBinInfo,
@@ -64,10 +66,10 @@ fn rejects_unknown_zone_location() {
     let mut payload = [0; 16];
     payload[1..3].copy_from_slice(&99u16.to_be_bytes());
 
-    assert!(matches!(
+    assert_matches!(
         ZoneInfo::from_payload(&payload),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
@@ -168,12 +170,12 @@ fn maps_effect_id_wire_values() {
 #[test]
 fn validates_single_nv_capability() {
     assert!(validate_single_nv_capability(NvCapabilities::BOOT_UP_EFFECT).is_ok());
-    assert!(matches!(
+    assert_matches!(
         validate_single_nv_capability(NvCapabilities::empty()),
         Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         validate_single_nv_capability(NvCapabilities::BOOT_UP_EFFECT | NvCapabilities::DEMO),
         Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-    ));
+    );
 }

--- a/crates/openlogi-hidpp/src/feature/crown/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/crown/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `Crown` mode parsing and event decoding.
 
+use std::assert_matches;
+
 use super::event::{
     ActivityState, ButtonState, CrownEvent, CrownGesture, RotationState, decode_event,
 };
@@ -27,10 +29,10 @@ fn rejects_unknown_mode_value() {
     let mut payload = [0; 16];
     payload[0] = 9;
 
-    assert!(matches!(
+    assert_matches!(
         CrownMode::from_payload(&payload),
         Err(crate::protocol::v20::Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/feature/disable_keys_by_usage/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/disable_keys_by_usage/mod.rs
@@ -101,6 +101,8 @@ fn usage_packets(usages: &[u8]) -> Vec<[u8; USAGES_PER_PACKET]> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::{usage_packets, validate_usages};
     use crate::protocol::v20::{ErrorType, Hidpp20Error};
 
@@ -120,10 +122,10 @@ mod tests {
 
     #[test]
     fn rejects_zero_usage_before_packetizing() {
-        assert!(matches!(
+        assert_matches!(
             validate_usages(&[0x39, 0, 0x3a]),
             Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-        ));
+        );
     }
 
     #[test]

--- a/crates/openlogi-hidpp/src/feature/extended_dpi/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/extended_dpi/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `ExtendedAdjustableDpi` payload parsing and event decoding.
 
+use std::assert_matches;
+
 use super::event::{ExtendedDpiEvent, decode_event};
 use super::types::{
     DpiCalibrationCorrection, DpiDirection, DpiRange, Lod, parse_dpi_list, parse_dpi_ranges,
@@ -120,20 +122,20 @@ fn parses_range_followed_by_fixed_value() {
 fn rejects_hyphen_without_preceding_value() {
     let stream = [0xe0, 0x01, 0x01, 0x90, 0x00, 0x00];
 
-    assert!(matches!(
+    assert_matches!(
         parse_dpi_ranges(&stream),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
 fn rejects_hyphen_without_following_value() {
     let stream = [0x01, 0x90, 0xe0, 0x01, 0x00, 0x00];
 
-    assert!(matches!(
+    assert_matches!(
         parse_dpi_ranges(&stream),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
@@ -141,30 +143,30 @@ fn rejects_zero_step_unused_marker() {
     // 0xe000 is the documented "unused" marker (step 0); it is not a valid range.
     let stream = [0x01, 0x90, 0xe0, 0x00, 0x04, 0xb0, 0x00, 0x00];
 
-    assert!(matches!(
+    assert_matches!(
         parse_dpi_ranges(&stream),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
 fn rejects_descending_stepped_range() {
     let stream = [0x06, 0x40, 0xe0, 0x32, 0x01, 0x90, 0x00, 0x00];
 
-    assert!(matches!(
+    assert_matches!(
         parse_dpi_ranges(&stream),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
 fn rejects_unterminated_dpi_ranges() {
     let stream = [0x01, 0x90, 0x03, 0x20];
 
-    assert!(matches!(
+    assert_matches!(
         parse_dpi_ranges(&stream),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
@@ -197,20 +199,20 @@ fn parses_lod_list() {
 fn rejects_unknown_lod_value() {
     let bytes = [9];
 
-    assert!(matches!(
+    assert_matches!(
         parse_lod_list(&bytes, 1),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
 fn rejects_lod_list_longer_than_payload() {
     let bytes = [1, 2];
 
-    assert!(matches!(
+    assert_matches!(
         parse_lod_list(&bytes, 3),
         Err(Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]
@@ -294,9 +296,9 @@ fn rejects_out_of_range_calibration_corrections() {
         DpiCalibrationCorrection::Adjust(1024),
         DpiCalibrationCorrection::Adjust(i16::MIN),
     ] {
-        assert!(matches!(
+        assert_matches!(
             correction.to_wire(),
             Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-        ));
+        );
     }
 }

--- a/crates/openlogi-hidpp/src/feature/extended_dpi/types.rs
+++ b/crates/openlogi-hidpp/src/feature/extended_dpi/types.rs
@@ -326,10 +326,10 @@ pub(super) fn parse_dpi_ranges(stream: &[u8]) -> Result<Vec<DpiRange>, Hidpp20Er
             offset += 4;
         } else {
             // A literal value: flush the previous standalone literal first.
-            if let Some(previous) = pending {
-                if !pending_is_range_end {
-                    ranges.push(DpiRange::Fixed(previous));
-                }
+            if let Some(previous) = pending
+                && !pending_is_range_end
+            {
+                ranges.push(DpiRange::Fixed(previous));
             }
             pending = Some(value);
             pending_is_range_end = false;
@@ -337,10 +337,10 @@ pub(super) fn parse_dpi_ranges(stream: &[u8]) -> Result<Vec<DpiRange>, Hidpp20Er
         }
     }
 
-    if let Some(previous) = pending {
-        if !pending_is_range_end {
-            ranges.push(DpiRange::Fixed(previous));
-        }
+    if let Some(previous) = pending
+        && !pending_is_range_end
+    {
+        ranges.push(DpiRange::Fixed(previous));
     }
 
     if ranges.is_empty() {

--- a/crates/openlogi-hidpp/src/feature/illumination/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/illumination/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `Illumination` payload parsing and event decoding.
 
+use std::assert_matches;
+
 use super::event::{IlluminationEvent, decode_event};
 use super::types::{
     BrightnessClampedSource, ControlCapabilities, ControlInfo, IlluminationState, LevelConfig,
@@ -160,10 +162,10 @@ fn rejects_invalid_non_linear_levels() {
             values: vec![1],
         },
     ] {
-        assert!(matches!(
+        assert_matches!(
             levels.to_payload(),
             Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-        ));
+        );
     }
 }
 

--- a/crates/openlogi-hidpp/src/feature/per_key_lighting/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/per_key_lighting/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `PerKeyLighting` request encoding.
 
+use std::assert_matches;
+
 use super::{
     FramePersistence, Rgb, RgbZone, RgbZoneRange, ZonePresencePage, consecutive_zones_args,
     delta_args, frame_end_args, individual_zones_args, range_zones_args, single_value_args,
@@ -49,31 +51,31 @@ fn individual_zones_caps_at_four() {
 #[test]
 fn rejects_reserved_zone_ids() {
     for zone_id in [0, 0xff] {
-        assert!(matches!(
+        assert_matches!(
             validate_zone_id(zone_id),
             Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-        ));
+        );
     }
 
-    assert!(matches!(
+    assert_matches!(
         validate_individual_zones(&[RgbZone {
             zone_id: 0,
             color: RED,
         }]),
         Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         validate_ranges(&[RgbZoneRange {
             first_zone_id: 1,
             last_zone_id: 0xff,
             color: RED,
         }]),
         Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-    ));
-    assert!(matches!(
+    );
+    assert_matches!(
         validate_single_value_zones(&[1, 0xff]),
         Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))
-    ));
+    );
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/feature/persistent_remappable_action/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/persistent_remappable_action/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `PersistentRemappableAction` payload parsing.
 
+use std::assert_matches;
+
 use super::{ActionId, HostMask, ModifierMask, PersistentAction, RemappableCapabilities};
 use crate::feature::{hosts_info::HostIndex, reprog_controls::ControlId};
 
@@ -58,10 +60,10 @@ fn rejects_unknown_action_id() {
     let mut payload = [0; 16];
     payload[3] = 0x55;
 
-    assert!(matches!(
+    assert_matches!(
         PersistentAction::from_payload(&payload),
         Err(crate::protocol::v20::Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/feature/touchpad_raw_xy/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/touchpad_raw_xy/tests.rs
@@ -1,5 +1,7 @@
 //! Unit tests for `TouchpadRawXy` info parsing and raw-event decoding.
 
+use std::assert_matches;
+
 use super::event::{TouchpadRawEvent, decode_event};
 use super::{Origin, RawReportFlags, TouchpadInfo};
 
@@ -34,10 +36,10 @@ fn rejects_reserved_origin() {
     let mut payload = [0; 16];
     payload[8] = 0; // 0x00 is reserved
 
-    assert!(matches!(
+    assert_matches!(
         TouchpadInfo::from_payload(&payload),
         Err(crate::protocol::v20::Hidpp20Error::UnsupportedResponse)
-    ));
+    );
 }
 
 #[test]

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -25,6 +25,8 @@
 //! hook.stop();
 //! ```
 
+use std::cfg_select;
+
 pub use openlogi_core::binding::ButtonId;
 
 /// Best-effort identity for the physical device that produced an OS event.
@@ -158,21 +160,7 @@ pub struct Hook {
 
 impl Drop for Hook {
     fn drop(&mut self) {
-        #[cfg(target_os = "macos")]
-        if let Some(inner) = self.inner.take() {
-            macos::stop(inner);
-        }
-        #[cfg(target_os = "linux")]
-        if let Some(inner) = self.inner.take() {
-            linux::stop(inner);
-        }
-        #[cfg(target_os = "windows")]
-        if let Some(inner) = self.inner.take() {
-            windows::stop(inner);
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-        // Unreachable: `never: Infallible` makes `Hook` uninhabited here.
-        {}
+        self.shutdown();
     }
 }
 
@@ -190,22 +178,20 @@ impl Hook {
     pub fn start(
         cb: impl Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static,
     ) -> Result<Self, HookError> {
-        #[cfg(target_os = "macos")]
-        {
-            macos::start(cb).map(|inner| Self { inner: Some(inner) })
-        }
-        #[cfg(target_os = "linux")]
-        {
-            linux::start(cb).map(|inner| Self { inner: Some(inner) })
-        }
-        #[cfg(target_os = "windows")]
-        {
-            windows::start(cb).map(|inner| Self { inner: Some(inner) })
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-        {
-            let _ = cb;
-            Err(HookError::Unsupported)
+        cfg_select! {
+            target_os = "macos" => {
+                macos::start(cb).map(|inner| Self { inner: Some(inner) })
+            }
+            target_os = "linux" => {
+                linux::start(cb).map(|inner| Self { inner: Some(inner) })
+            }
+            target_os = "windows" => {
+                windows::start(cb).map(|inner| Self { inner: Some(inner) })
+            }
+            _ => {
+                let _ = cb;
+                Err(HookError::Unsupported)
+            }
         }
     }
 
@@ -214,28 +200,34 @@ impl Hook {
     /// Signals background threads to exit and blocks until they join. Calling
     /// this explicitly is preferred over relying on `Drop` when errors in
     /// cleanup should be visible. `Drop` calls this automatically.
-    #[cfg_attr(
-        not(any(target_os = "macos", target_os = "linux", target_os = "windows")),
-        allow(
-            unused_mut,
-            reason = "`mut self` is only consumed by platform teardown paths"
-        )
-    )]
     pub fn stop(mut self) {
-        #[cfg(target_os = "macos")]
-        if let Some(inner) = self.inner.take() {
-            macos::stop(inner);
+        self.shutdown();
+    }
+
+    /// Tear down the platform hook if it is still running. Idempotent: the
+    /// first call takes `inner`, so the `Drop` after an explicit [`Self::stop`]
+    /// is a no-op.
+    fn shutdown(&mut self) {
+        cfg_select! {
+            target_os = "macos" => {
+                if let Some(inner) = self.inner.take() {
+                    macos::stop(inner);
+                }
+            }
+            target_os = "linux" => {
+                if let Some(inner) = self.inner.take() {
+                    linux::stop(inner);
+                }
+            }
+            target_os = "windows" => {
+                if let Some(inner) = self.inner.take() {
+                    windows::stop(inner);
+                }
+            }
+            _ => {
+                // Unreachable: `never: Infallible` makes `Hook` uninhabited here.
+            }
         }
-        #[cfg(target_os = "linux")]
-        if let Some(inner) = self.inner.take() {
-            linux::stop(inner);
-        }
-        #[cfg(target_os = "windows")]
-        if let Some(inner) = self.inner.take() {
-            windows::stop(inner);
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-        match self.never {}
     }
 
     /// Returns `true` when the process has the permissions required to install
@@ -247,13 +239,9 @@ impl Hook {
     /// Windows low-level hook needs no separate privacy grant).
     #[must_use]
     pub fn has_accessibility() -> bool {
-        #[cfg(target_os = "macos")]
-        {
-            macos::has_accessibility()
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            true
+        cfg_select! {
+            target_os = "macos" => { macos::has_accessibility() }
+            _ => { true }
         }
     }
 
@@ -267,9 +255,9 @@ impl Hook {
     /// its side effect; the resulting trust state is observed separately via
     /// [`Self::has_accessibility`]. No-op on non-macOS.
     pub fn prompt_accessibility() {
-        #[cfg(target_os = "macos")]
-        {
-            macos::prompt_accessibility();
+        cfg_select! {
+            target_os = "macos" => { macos::prompt_accessibility(); }
+            _ => {}
         }
     }
 }
@@ -288,21 +276,11 @@ impl Hook {
 /// `openlogi-gui::app_watcher`.
 #[must_use]
 pub fn frontmost_bundle_id() -> Option<String> {
-    #[cfg(target_os = "macos")]
-    {
-        macos::frontmost_bundle_id()
-    }
-    #[cfg(target_os = "linux")]
-    {
-        linux::frontmost_bundle_id()
-    }
-    #[cfg(target_os = "windows")]
-    {
-        windows::frontmost_process_path()
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        None
+    cfg_select! {
+        target_os = "macos" => { macos::frontmost_bundle_id() }
+        target_os = "linux" => { linux::frontmost_bundle_id() }
+        target_os = "windows" => { windows::frontmost_process_path() }
+        _ => { None }
     }
 }
 

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -455,6 +455,8 @@ pub(crate) fn frontmost_bundle_id() -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use evdev::{EventType, InputEvent, KeyCode, RelativeAxisCode};
 
     use super::*;
@@ -493,61 +495,61 @@ mod tests {
     #[test]
     fn translate_btn_left_down_returns_button_pressed() {
         let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_LEFT.0, 1);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::LeftClick,
                 pressed: true
             })
-        ));
+        );
     }
 
     #[test]
     fn translate_btn_left_up_returns_button_released() {
         let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_LEFT.0, 0);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::LeftClick,
                 pressed: false
             })
-        ));
+        );
     }
 
     #[test]
     fn translate_btn_back_returns_back() {
         let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_BACK.0, 1);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::Back,
                 pressed: true
             })
-        ));
+        );
     }
 
     #[test]
     fn translate_btn_side_returns_back() {
         let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_SIDE.0, 1);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::Back,
                 pressed: true
             })
-        ));
+        );
     }
 
     #[test]
     fn translate_btn_forward_returns_forward() {
         let event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_FORWARD.0, 1);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::Forward,
                 pressed: true
             })
-        ));
+        );
     }
 
     // ── movement ─────────────────────────────────────────────────────────────
@@ -555,25 +557,25 @@ mod tests {
     #[test]
     fn translate_rel_x_returns_horizontal_move() {
         let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_X.0, 7);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Moved {
                 delta_x: 7,
                 delta_y: 0
             })
-        ));
+        );
     }
 
     #[test]
     fn translate_rel_y_returns_vertical_move() {
         let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_Y.0, -4);
-        assert!(matches!(
+        assert_matches!(
             translate(&event, false),
             Some(MouseEvent::Moved {
                 delta_x: 0,
                 delta_y: -4
             })
-        ));
+        );
     }
 
     // ── scroll — standard ────────────────────────────────────────────────────

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -57,8 +57,11 @@ fn event_disposition_equality() {
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 #[test]
 fn unsupported_start_returns_unsupported() {
+    use std::assert_matches;
+
+    // Asserted via `.err()` because `Hook` itself has no `Debug` impl to print.
     let result = Hook::start(|_| EventDisposition::PassThrough);
-    assert!(matches!(result, Err(HookError::Unsupported)));
+    assert_matches!(result.err(), Some(HookError::Unsupported));
 }
 
 /// On Linux, `Hook::start` never returns `Unsupported` — it either succeeds or


### PR DESCRIPTION
## Summary

Adopts the Rust 1.89–1.96 std stabilizations the engineering audit identified as having real call sites. Shares two commits with #407 (the MSRV bump and the clippy-1.96 lint fixes) — identical hunks that dedupe at merge time; merge #407 first and this rebases clean.

## Changes

- **tests (workspace-wide)**: `assert!(matches!(…))` → std `assert_matches!` at 42 sites in 16 files — failures now print the actual value's Debug representation. Note for reviewers: on stable 1.96 the macro lives at the std crate root (`use std::assert_matches;`), not `std::assert_matches::assert_matches` as some docs suggest (verified empirically; the latter fails E0432). `InventoryEvent` gained a `Debug` derive to support it (not an IPC/serde type). Three sites in hidpp `channel.rs`'s test module were deliberately left for #406 to land first.
- **hid**: `step_hint` uses `array_windows::<2>()` (stable 1.94) with `&[low, high]` destructuring instead of indexed `windows(2)` pairs.
- **hidpp**: `read_raw` parses report frames with `split_first` + exact-length chunk patterns — both `try_into().unwrap()`s are gone; the invariant is now structural.
- **hook**: `cfg_select!` (stable 1.95) at 5 genuine dispatch points in lib.rs, including a new shared `Hook::shutdown` that folds the previously duplicated `Drop`/`stop` ladders (net −22 lines and one `cfg_attr` workaround deleted). Per-arm-field/attribute sites keep plain `#[cfg]` — cfg_select can't express those.
- **assets**: public API returns a typed `thiserror` `AssetError` (Http, ParseJson, ReadFile, WriteFile, ChecksumMismatch, UnsafeComponent) instead of `anyhow::Result`, matching the other lib crates' error design; anyhow dropped from the crate. Zero consumer changes — the CLI/GUI anyhow boundaries absorb the typed error.

## Testing

- `cargo test` across all 8 touched crates — 16 test targets, ~400 tests green (incl. the agent-core wire-format goldens)
- Full-workspace clippy `-D warnings` on 1.96.1 via the pre-push hook — clean
- Windows cross-lint: `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hook --all-targets -- -D warnings` — clean (compiles the windows cfg_select arms)
- Not locally checkable: Linux cfg surfaces (hook linux.rs test rewrites, cfg_select linux arms) — CI's linux jobs are authoritative
- The zed / gpui-component pins in Cargo.lock verified intact (including master's recent gpui pin bump)
- Not runtime-tested on hardware.