### PR TITLE
fix: divert thumbwheel for rotation rebinds even without single-tap capability

### DIFF
--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -13,7 +13,8 @@
 //! it, mirroring how the CGEventTap hook handles the side buttons. The thumb
 //! wheel is special: diverting it stops native horizontal scroll, so the GUI
 //! re-synthesises scroll from the [`CapturedInput::Scroll`] deltas — the wheel
-//! is therefore only diverted when its click is actually bound.
+//! is therefore only diverted when the user's thumbwheel config leaves its
+//! defaults (click bound, rotation rebound, or sensitivity changed).
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
@@ -44,8 +45,8 @@ pub enum CapturedInput {
     /// ([`ButtonId::Thumbwheel`]).
     ButtonPressed(ButtonId),
     /// Thumb-wheel rotation to re-synthesise as horizontal scroll, in the
-    /// wheel's `diverted_res` increments. Emitted only while the wheel is
-    /// diverted to capture its click.
+    /// wheel's `diverted_res` increments. Emitted while the wheel is diverted
+    /// (click bound, rotation rebound, or sensitivity changed).
     Scroll(i16),
 }
 

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -206,8 +206,8 @@ impl ArmedControls {
 
 /// Resolve features off the device's root and divert the controls we capture:
 /// the gesture button (raw-XY) and DPI/ModeShift buttons over `0x1b04`, and —
-/// when `capture_thumbwheel` and the wheel reports a single tap — the thumb
-/// wheel over `0x2150`. The root-feature lookup mirrors `write::open_feature`,
+/// when `capture_thumbwheel` — the thumb wheel over `0x2150`. The
+/// root-feature lookup mirrors `write::open_feature`,
 /// since hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
 async fn arm_controls(
     chan: &Arc<HidppChannel>,
@@ -273,14 +273,17 @@ async fn arm_controls(
                 false
             }
         };
-        if supports_single_tap {
-            tw.set_reporting(true, false)
-                .await
-                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-            thumb = Some((tw, info.index));
-        } else {
+        // Divert whenever capture was requested: rotation rebinds and the
+        // sensitivity multiplier need the diverted event stream even on wheels
+        // that report no single-tap capability (e.g. MX Master 4) — lacking the
+        // tap only means a bound click can never fire.
+        if !supports_single_tap {
             debug!("thumb wheel reports no single tap — click not capturable");
         }
+        tw.set_reporting(true, false)
+            .await
+            .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+        thumb = Some((tw, info.index));
     }
 
     if !gesture_diverted && dpi_cids.is_empty() && thumb.is_none() {

--- a/crates/openlogi-hid/src/thumbwheel.rs
+++ b/crates/openlogi-hid/src/thumbwheel.rs
@@ -4,7 +4,8 @@
 //!
 //! The wheel only has two reporting modes — Native (HID scroll) or Diverted
 //! (HID++ events) — there is no "report taps but keep scrolling" mode. So the
-//! capture session diverts the wheel only when the user has bound its click,
+//! capture session diverts the wheel whenever the user's thumbwheel config
+//! leaves its defaults (click bound, rotation rebound, or sensitivity changed),
 //! and re-synthesises horizontal scroll from the rotation deltas to keep
 //! scrolling working.
 //!


### PR DESCRIPTION
## Problem

On an MX Master 4, rebinding the thumbwheel rotation (`ThumbwheelScrollUp` / `ThumbwheelScrollDown`) or changing the thumbwheel sensitivity has no effect — silently. The GUI accepts and persists the config, `reload_config` goes through, the capture session restarts, but the wheel keeps scrolling natively in both directions.

## Root cause

`arm_controls` in `openlogi-hid/src/gesture.rs` only diverts the thumb wheel over `0x2150` when `getThumbwheelInfo` reports the single-tap capability:

```rust
if supports_single_tap {
    tw.set_reporting(true, false).await?;
    thumb = Some((tw, info.index));
} else {
    debug!("thumb wheel reports no single tap — click not capturable");
}
```

The MX Master 4 does not set that capability bit (verified on hardware — Bolt receiver, feature `0x2150` v0 present at index 19; getInfo byte 5 has `0x08` clear). Its thumb area was reworked into a haptic pad, which already behaves differently over HID++ elsewhere (see #313), so the missing bit is plausibly genuine rather than a firmware reporting bug.

But single-tap support only matters for capturing the wheel's *click*. Rotation rebinds and the sensitivity multiplier need the diverted event stream too — `thumbwheel_armed()` in `openlogi-agent-core` correctly requests capture for them — and the arming side then silently refuses. The user gets no error anywhere: just a debug-level line, and settings that appear to do nothing. This affects every platform equally; it just hasn't been visible because MX Master 3/3S report the bit and arm fine.

## Fix

Divert whenever capture was requested, regardless of the single-tap capability. A missing single tap now only means a bound click can never fire (the `single_tap` event bit simply never arrives), which is the accurate scope of the limitation. Doc comments updated to match.

Behavior is unchanged for wheels that do report single tap.

If the original gate was intentional (avoid suppressing native scroll on wheels where re-synthesis was considered untested), I'd argue the inconsistency should then be fixed on the `thumbwheel_armed()` side instead — requesting capture and silently not arming is the worst of both. Happy to rework in that direction if preferred.

## Verification

On real hardware (MX Master 4, slot 2 on a Bolt receiver, Linux/Wayland):

Before — with `ThumbwheelScrollUp = "HorizontalScrollLeft"` saved and reloaded:

```
DEBUG openlogi_hid::gesture: thumb wheel reports no single tap — click not capturable
INFO  openlogi_hid::gesture: control capture active index=2 gesture=false dpi_buttons=1 thumbwheel=false
```

After:

```
INFO  openlogi_hid::gesture: control capture active index=2 gesture=false dpi_buttons=1 thumbwheel=true
```

and the wheel behaves as configured (both rotation rebinds and the sensitivity multiplier now apply).

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N76prZoUHMrHZajXq4jET1