### PR TITLE
test(core): add hires_wheel to the inventory equality test helper

### DIFF
--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -370,6 +370,7 @@ mod tests {
                     pointer: true,
                     lighting: false,
                     scroll_inversion: false,
+                    hires_wheel: false,
                 }),
             }],
         }


### PR DESCRIPTION
## Summary

Master's test build is broken: `cargo test` fails to compile `openlogi-core` with `missing field hires_wheel in initializer of Capabilities`.

`#287` was branched before the wheel-resolution work (`feat(gui): expose wheel resolution setting`) added `hires_wheel` to `Capabilities`. The two never conflicted textually, so `#287` stayed mergeable and its branch CI was green — but squash-merging its stale diff onto the newer master left the `inventory()` test helper it added missing the new field, a semantic merge break that neither branch CI nor the mergeability check catches.

## Changes

- **openlogi-core**: add `hires_wheel: false` to the `Capabilities` literal in the `inventory()` test helper.

## Testing

- `cargo test -p openlogi-core` — 94 passed (was: compile error).

Un-breaks the default branch.