### PR TITLE
feat: per-device capture — every online device gets its own session, bindings, and settings

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -1,0 +1,187 @@
+//! Per-device capture plans: what each online device's HID++ capture session
+//! should divert, plus the device's own binding maps for dispatch.
+//!
+//! The orchestrator rebuilds the shared plan list from config + inventory for
+//! *every* online device (not just the GUI's selection), and the capture
+//! watcher diffs it into running sessions. Keeping the binding maps inside the
+//! plan is what makes dispatch per-device: an input is resolved against the
+//! plan of the session it arrived on, never against a global selected-device
+//! map.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
+use openlogi_core::config::Config;
+use openlogi_hid::DeviceRoute;
+use openlogi_hid::gesture::DIVERTABLE_STANDARD_BUTTONS;
+use openlogi_hid::reprog_controls::GESTURE_BUTTON_CID;
+
+use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
+
+/// Everything the capture watcher needs to run one device's session and
+/// dispatch its events.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeviceCapturePlan {
+    /// Stable per-device config key (binding / preset lookup).
+    pub config_key: String,
+    /// HID++ route the session opens.
+    pub route: DeviceRoute,
+    /// Per-button single actions for this device (per-app effective).
+    pub bindings: BTreeMap<ButtonId, Action>,
+    /// Per-direction map when the dedicated HID++ gesture button owns the
+    /// gesture role on this device; empty otherwise.
+    pub gesture_bindings: BTreeMap<GestureDirection, Action>,
+    /// Standard buttons whose binding leaves the default — divert over
+    /// `0x1b04`. A button at its default keeps its native HID behavior, so no
+    /// re-synthesis is ever needed.
+    pub divert_buttons: Vec<(u16, ButtonId)>,
+    /// Whether any thumbwheel binding leaves its default. Combined with the
+    /// sensitivity to decide thumb-wheel diversion.
+    pub thumbwheel_bindings_nondefault: bool,
+    /// This device's effective thumb-wheel sensitivity (device override or the
+    /// app-wide default).
+    pub thumbwheel_sensitivity: i32,
+    /// Capture re-arm generation from the orchestrator. Bumps on reconnect /
+    /// system wake so sessions restart even when route and divert set match.
+    pub rearm_generation: u64,
+}
+
+/// Shared plan list, rewritten by the orchestrator and read by the watcher.
+pub type SharedCapturePlans = Arc<RwLock<Vec<DeviceCapturePlan>>>;
+
+/// Build one device's plan from the config (per-app effective for `app`).
+#[must_use]
+pub fn plan_for_device(
+    config: &Config,
+    config_key: &str,
+    route: DeviceRoute,
+    app: Option<&str>,
+    rearm_generation: u64,
+) -> DeviceCapturePlan {
+    let bindings = bindings_for(config, Some(config_key), app);
+    let gesture_bindings = gesture_bindings_for(config, Some(config_key));
+    // A button acting as the OS-hook gesture owner must stay native: the hook
+    // needs to see its press to run hold+swipe detection, and diverting it
+    // would starve the hook of events.
+    let oshook = oshook_gestures_for(config, Some(config_key), app);
+    // The dedicated gesture button never reaches the OS hook, so a non-default
+    // single binding on it is deliverable only via a plain HID++ divert — but
+    // only while it does NOT own the gesture role (the raw-XY gesture divert
+    // owns CID 0x00c3 in that case, and `gesture_bindings` is how the watcher
+    // arms that divert).
+    let plain_gesture_button = gesture_bindings
+        .is_empty()
+        .then_some((GESTURE_BUTTON_CID, ButtonId::GestureButton));
+    let divert_buttons: Vec<(u16, ButtonId)> = DIVERTABLE_STANDARD_BUTTONS
+        .into_iter()
+        .chain(plain_gesture_button)
+        .filter(|(_, button)| !oshook.contains_key(button))
+        .filter(|(_, button)| {
+            bindings
+                .get(button)
+                .is_some_and(|action| *action != default_binding(*button))
+        })
+        .collect();
+    let thumbwheel_bindings_nondefault = [
+        ButtonId::Thumbwheel,
+        ButtonId::ThumbwheelScrollUp,
+        ButtonId::ThumbwheelScrollDown,
+    ]
+    .iter()
+    .any(|button| {
+        bindings
+            .get(button)
+            .is_some_and(|action| *action != default_binding(*button))
+    });
+    DeviceCapturePlan {
+        config_key: config_key.to_owned(),
+        route,
+        bindings,
+        gesture_bindings,
+        divert_buttons,
+        thumbwheel_bindings_nondefault,
+        thumbwheel_sensitivity: config.thumbwheel_sensitivity(config_key),
+        rearm_generation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openlogi_core::binding::Binding;
+    use openlogi_hid::reprog_controls::GESTURE_BUTTON_CID;
+
+    use super::*;
+
+    fn route() -> DeviceRoute {
+        DeviceRoute::Bolt {
+            receiver_uid: "cafe".into(),
+            slot: 2,
+        }
+    }
+
+    #[test]
+    fn gestures_off_single_bound_gesture_button_is_plain_diverted() {
+        // The dedicated gesture button (CID 0x00c3) never reaches the OS hook,
+        // so with gestures off a non-default single binding on it is only
+        // deliverable via a plain HID++ divert.
+        let mut cfg = Config::default();
+        cfg.disable_gestures("2b042");
+        cfg.set_binding(
+            "2b042",
+            ButtonId::GestureButton,
+            Binding::Single(Action::CycleDpiPresets),
+        );
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            plan.gesture_bindings.is_empty(),
+            "gestures are off — no raw-XY gesture divert"
+        );
+        assert!(
+            plan.divert_buttons
+                .contains(&(GESTURE_BUTTON_CID, ButtonId::GestureButton)),
+            "a single-bound gesture button must be plain-diverted, or the binding can never fire"
+        );
+    }
+
+    #[test]
+    fn gesture_owner_button_is_never_plain_diverted() {
+        // When the gesture button owns the gesture role, the raw-XY gesture
+        // divert owns CID 0x00c3 — a plain divert on top would strip raw-XY.
+        // (Its default Click projects to a non-default single action, so only
+        // the owner rule keeps it out of the plain list.)
+        let mut cfg = Config::default();
+        cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            !plan.gesture_bindings.is_empty(),
+            "the gesture button owns the gesture role"
+        );
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(cid, _)| cid == GESTURE_BUTTON_CID),
+            "the gesture owner is delivered via raw-XY divert, never a plain one"
+        );
+    }
+
+    #[test]
+    fn gestures_off_default_gesture_button_stays_native() {
+        // With gestures off and no explicit binding, the gesture button keeps
+        // its native HID behavior — same contract as the standard buttons.
+        let mut cfg = Config::default();
+        cfg.disable_gestures("2b042");
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(cid, _)| cid == GESTURE_BUTTON_CID),
+            "an unbound gesture button must not be captured"
+        );
+    }
+}

--- a/crates/openlogi-agent-core/src/dpi.rs
+++ b/crates/openlogi-agent-core/src/dpi.rs
@@ -1,6 +1,39 @@
 //! DPI-cycle state shared with background action dispatch.
 
+use std::collections::HashMap;
+
 use openlogi_hid::{DeviceRoute, DpiCapabilities};
+
+/// Per-device DPI-cycle states plus the GUI's current selection.
+///
+/// HID++ capture dispatch resolves against the device an event arrived on; the
+/// OS hook cannot attribute an event to a device, so it dispatches against the
+/// selection — the same behavior the runtime had when this was a single state.
+#[derive(Debug, Clone, Default)]
+pub struct DpiCycles {
+    /// Config key of the GUI-selected device (the OS hook's dispatch target).
+    pub selected: Option<String>,
+    /// One cycle state per online device, keyed by config key.
+    pub by_key: HashMap<String, DpiCycleState>,
+}
+
+impl DpiCycles {
+    /// The state for `key`, falling back to the selected device when `key` is
+    /// `None` (the OS hook path).
+    pub fn state_for(&mut self, key: Option<&str>) -> Option<&mut DpiCycleState> {
+        let key = key.or(self.selected.as_deref())?;
+        self.by_key.get_mut(key)
+    }
+
+    /// The write target for `key` (same fallback as [`Self::state_for`])
+    /// without a mutable borrow — for dispatch that only needs the route, like
+    /// the SmartShift toggle.
+    #[must_use]
+    pub fn target_for(&self, key: Option<&str>) -> Option<DeviceRoute> {
+        let key = key.or(self.selected.as_deref())?;
+        self.by_key.get(key).and_then(|state| state.target.clone())
+    }
+}
 
 /// Shared state consumed by the OS hook thread and the DPI panel UI to
 /// implement DPI preset cycling and direct preset selection actions.
@@ -45,5 +78,43 @@ impl DpiCycleState {
         self.capabilities
             .as_ref()
             .map_or(dpi, |caps| caps.snap(dpi))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cycles_with(key: &str, slot: u8) -> DpiCycles {
+        let mut cycles = DpiCycles::default();
+        cycles.by_key.insert(
+            key.to_string(),
+            DpiCycleState {
+                presets: vec![800, 1600],
+                index: 0,
+                target: Some(DeviceRoute::Bolt {
+                    receiver_uid: "AA00".to_string(),
+                    slot,
+                }),
+                capabilities: None,
+            },
+        );
+        cycles
+    }
+
+    #[test]
+    fn target_for_resolves_explicit_key_and_selection_fallback() {
+        let mut cycles = cycles_with("a", 1);
+        assert!(cycles.target_for(Some("a")).is_some());
+        assert!(cycles.target_for(Some("missing")).is_none());
+        // No key and no selection → nothing to target.
+        assert!(cycles.target_for(None).is_none());
+        // The OS-hook path (no key) follows the selection.
+        cycles.selected = Some("a".to_string());
+        assert!(cycles.target_for(None).is_some());
+        assert_eq!(
+            cycles.target_for(None),
+            cycles.state_for(None).and_then(|s| s.target.clone())
+        );
     }
 }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -22,10 +22,10 @@ use openlogi_hook::{
 };
 use tracing::{info, warn};
 
-use crate::DpiCycleState;
 use crate::event_monitor::SharedEventMonitor;
 use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 use crate::receiver_access::ReceiverAccess;
+use crate::{DpiCycleState, DpiCycles};
 
 /// The two button maps the OS-hook callback reads, kept behind ONE lock so a
 /// config rebuild publishes both atomically — a press during an owner switch can
@@ -146,7 +146,7 @@ fn button_source_may_remap(device: Option<&EventDevice>) -> bool {
 
 /// Off-thread worker for bound actions so the tap callback never injects input.
 fn spawn_action_worker(
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    dpi_cycle: Arc<RwLock<DpiCycles>>,
     capture: CaptureChannel,
     registry: ChannelRegistry,
     receiver_access: ReceiverAccess,
@@ -159,6 +159,7 @@ fn spawn_action_worker(
                 dispatch_action(
                     &action,
                     &dpi_cycle,
+                    None,
                     &capture,
                     Some(&registry),
                     &receiver_access,
@@ -293,7 +294,7 @@ fn handle_moved(
 pub fn start(
     hooks: SharedHookMaps,
     keyboard_bindings: SharedKeyboardBindings,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    dpi_cycle: Arc<RwLock<DpiCycles>>,
     capture: CaptureChannel,
     registry: ChannelRegistry,
     receiver_access: ReceiverAccess,
@@ -491,28 +492,31 @@ fn browser_nav_debounce_ok(action: &Action) -> bool {
 /// not provide a registry.
 pub fn dispatch_action(
     action: &Action,
-    dpi_cycle: &Arc<RwLock<DpiCycleState>>,
+    dpi_cycle: &Arc<RwLock<DpiCycles>>,
+    device_key: Option<&str>,
     capture: &CaptureChannel,
     registry: Option<&ChannelRegistry>,
     receiver_access: &ReceiverAccess,
 ) {
     let next = match action {
         Action::CycleDpiPresets => match dpi_cycle.write() {
-            Ok(mut guard) => guard.cycle(),
+            Ok(mut guard) => guard.state_for(device_key).and_then(DpiCycleState::cycle),
             Err(e) => {
                 warn!(error = %e, "dpi_cycle lock poisoned — cycle skipped");
                 None
             }
         },
         Action::SetDpiPreset(i) => match dpi_cycle.write() {
-            Ok(mut guard) => guard.set(usize::from(*i)),
+            Ok(mut guard) => guard
+                .state_for(device_key)
+                .and_then(|state| state.set(usize::from(*i))),
             Err(e) => {
                 warn!(error = %e, "dpi_cycle lock poisoned — set skipped");
                 None
             }
         },
         Action::ToggleSmartShift => {
-            let target = dpi_cycle.read().ok().and_then(|g| g.target.clone());
+            let target = dpi_cycle.read().ok().and_then(|g| g.target_for(device_key));
             info!("SmartShift toggle → flipping wheel mode");
             if let Some(registry) = registry {
                 toggle_smartshift_in_background(Some(capture), registry, receiver_access, target);

--- a/crates/openlogi-agent-core/src/lib.rs
+++ b/crates/openlogi-agent-core/src/lib.rs
@@ -7,6 +7,7 @@
 //! without linking gpui.
 
 pub mod bindings;
+pub mod capture_plan;
 pub mod device_order;
 mod dpi;
 pub mod event_monitor;
@@ -18,4 +19,4 @@ pub mod receiver_access;
 pub mod transport;
 pub mod watchers;
 
-pub use dpi::DpiCycleState;
+pub use dpi::{DpiCycleState, DpiCycles};

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -11,7 +11,7 @@
 //! (still valid) values — exactly the GUI's "window never opened" behaviour.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use openlogi_core::binding::Action;
@@ -25,8 +25,8 @@ use openlogi_hid::{
 };
 use tracing::{debug, info, warn};
 
-use crate::DpiCycleState;
 use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
+use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans, plan_for_device};
 use crate::device_order::DeviceStableId;
 use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::ipc::InventoryHealth;
@@ -34,6 +34,7 @@ use crate::receiver_access::ReceiverAccess;
 use crate::watchers::gesture::GestureBindings;
 use crate::watchers::host_switch::{HostSwitchLink, HostSwitchLinks};
 use crate::watchers::keyboard::{KeyboardSpec, SharedKeyboardSpec};
+use crate::{DpiCycleState, DpiCycles};
 
 /// The minimal per-device facts the agent needs: the config key (binding /
 /// preset lookup), the HID++ route (DPI/SmartShift writes + capture target), and
@@ -71,8 +72,11 @@ pub struct SharedRuntime {
     /// per-app-profile in M1 (spec non-goal), so a single shared map.
     pub keyboard_bindings: crate::hook_runtime::SharedKeyboardBindings,
     pub gesture_bindings: GestureBindings,
-    pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
-    pub thumbwheel_sensitivity: Arc<AtomicI32>,
+    pub dpi_cycle: Arc<RwLock<DpiCycles>>,
+    /// One capture plan per online device — what to divert and how to
+    /// dispatch, keyed by the device the events arrive on. Carries each
+    /// device's effective thumb-wheel sensitivity.
+    pub capture_plans: SharedCapturePlans,
     pub capture_channel: CaptureChannel,
     /// Exact-route channels owned and published by the inventory enumerator.
     pub channel_registry: ChannelRegistry,
@@ -84,9 +88,9 @@ pub struct SharedRuntime {
     /// The keyboard capture session's open channel, reused by Fn-lock writes
     /// (the mouse-oriented [`Self::capture_channel`] points elsewhere).
     pub keyboard_channel: CaptureChannel,
-    /// Incremented when the selected device reconnects or the system wakes, so
-    /// the gesture watcher re-arms volatile HID++ control diversion even when
-    /// the receiver route itself never changed.
+    /// Incremented when a device reconnects or the system wakes, so capture
+    /// sessions re-arm volatile HID++ control diversion even when route and
+    /// online flags look unchanged.
     pub capture_rearm_generation: Arc<AtomicU64>,
     /// Receiver access shared by HID++ sessions and pairing. Pairing/host
     /// transitions are exclusive; capture sessions share under read leases.
@@ -112,11 +116,8 @@ pub struct Orchestrator {
     /// set/route/online state looks identical across the sleep gap, so the
     /// next refresh re-applies volatile settings to every online device.
     reapply_all_next_refresh: bool,
-    /// Config keys of devices first sighted last refresh, mapped to a remaining
-    /// count of confirming re-applies. The first write can race the device's own
-    /// boot and be lost — a cold restart leaves the MX Master 3s slow to enumerate,
-    /// so the volatile write (DPI/SmartShift/wheel/lighting) is retried for a
-    /// bounded run of inventory ticks until the device finishes booting (#189).
+    /// Config keys of devices first sighted recently, with remaining confirming
+    /// re-apply budget: the first write can race the device's own boot and be lost.
     reapply_followup: HashMap<String, u8>,
     /// Last successful aggregate camera-use sample. `None` means the macOS
     /// watcher has not produced its first usable observation yet.
@@ -151,10 +152,8 @@ impl Orchestrator {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
-            dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
-            thumbwheel_sensitivity: Arc::new(AtomicI32::new(
-                config.app_settings.thumbwheel_sensitivity,
-            )),
+            dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
+            capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
             channel_pool: ChannelPool::default(),
@@ -193,37 +192,17 @@ impl Orchestrator {
             .map(|d| d.config_key.as_str())
     }
 
-    fn current_route(&self) -> Option<DeviceRoute> {
-        self.devices
-            .get(self.current)
-            .filter(|device| device.online && is_hidpp_device(device))
-            .and_then(|device| device.route.clone())
-    }
-
-    /// Keep the capture/DPI write target aligned with the selected device's
-    /// live connection state without rebuilding the rest of the DPI cycle.
-    ///
-    /// Inventory-only online transitions do not warrant [`Self::rebuild`]
-    /// (which intentionally resets the cycle index), but they do have to stop
-    /// and restart HID++ capture. Easy-Switch preserves the receiver route
-    /// while the device is away, and its volatile control diversion is lost;
-    /// publishing `None` while offline and the route again on return makes the
-    /// capture watcher open a fresh session and re-arm those controls.
-    fn sync_current_route(&self) {
-        let target = self.current_route();
-        match self.shared.dpi_cycle.write() {
-            Ok(mut state) => state.target = target,
-            Err(error) => {
-                warn!(%error, lock = "dpi_cycle", "lock poisoned — keeping stale value");
-            }
-        }
-    }
-
     /// Build the OS-hook callback's maps for `key` + foreground `app`. Both hook
     /// sub-maps are app-scoped (a per-app override can demote the gesture owner),
     /// so they're built together here and published under one lock — keeping
     /// `rebuild` and `set_current_app` from drifting into a half-populated write.
     fn hook_maps_for(&self, key: Option<&str>, app: Option<&str>) -> HookMaps {
+        // A disabled selected device gets empty maps: the OS hook then passes
+        // its events through untouched instead of applying remaps to a device
+        // the user asked OpenLogi to leave alone.
+        if key.is_some_and(|k| !self.config.device_enabled(k)) {
+            return HookMaps::default();
+        }
         HookMaps {
             bindings: bindings_for(&self.config, key, app),
             gestures: oshook_gestures_for(&self.config, key, app),
@@ -285,16 +264,21 @@ impl Orchestrator {
             gesture_bindings_for(&self.config, key),
             "gesture_bindings",
         );
+        self.publish_device_runtime();
+    }
+
+    /// Republish the runtime views derived from the device set + config: the
+    /// capture plans and the per-device DPI-cycle map. One method so the
+    /// inventory fast path (same set, fresh online flags) can't update one and
+    /// forget the other — a waking device needs both its capture session and
+    /// its DPI-cycle slot.
+    fn publish_device_runtime(&self) {
         write_value(
-            &self.shared.dpi_cycle,
-            DpiCycleState {
-                presets: key.map(|k| self.config.dpi_presets(k)).unwrap_or_default(),
-                index: 0,
-                target: self.current_route(),
-                capabilities: None,
-            },
-            "dpi_cycle",
+            &self.shared.capture_plans,
+            self.capture_plans_for(),
+            "capture_plans",
         );
+        self.rebuild_dpi_cycles(self.current_key());
         // Keyboard F-key bindings are global (not per-device), so they key off
         // the top-level config map rather than the selected device. Published
         // here so `reload_config` (GUI commit) takes effect live, not only on
@@ -303,10 +287,6 @@ impl Orchestrator {
             &self.shared.keyboard_bindings,
             self.config.keyboard.bindings.clone(),
             "keyboard_bindings",
-        );
-        self.shared.thumbwheel_sensitivity.store(
-            self.config.app_settings.thumbwheel_sensitivity,
-            Ordering::Relaxed,
         );
         write_value(
             &self.shared.host_switch_links,
@@ -318,6 +298,62 @@ impl Orchestrator {
             self.keyboard_spec_for(),
             "keyboard_spec",
         );
+    }
+
+    /// Rewrite the per-device DPI-cycle map for every online device,
+    /// preserving a device's live cycle index (and lazily discovered
+    /// capabilities) across rebuilds whose presets did not change — a config
+    /// reload must not snap DPI back to `preset[0]`.
+    fn rebuild_dpi_cycles(&self, selected: Option<&str>) {
+        let Ok(mut guard) = self.shared.dpi_cycle.write() else {
+            warn!("dpi_cycle lock poisoned — rebuild skipped");
+            return;
+        };
+        let mut by_key = std::collections::HashMap::new();
+        for dev in self
+            .devices
+            .iter()
+            .filter(|dev| dev.online && self.config.device_enabled(&dev.config_key))
+        {
+            let Some(route) = dev.route.clone() else {
+                continue;
+            };
+            let presets = self.config.dpi_presets(&dev.config_key);
+            let previous = guard
+                .by_key
+                .get(&dev.config_key)
+                .filter(|state| state.presets == presets);
+            by_key.insert(
+                dev.config_key.clone(),
+                DpiCycleState {
+                    index: previous.map_or(0, |state| state.index),
+                    capabilities: previous.and_then(|state| state.capabilities.clone()),
+                    presets,
+                    target: Some(route),
+                },
+            );
+        }
+        guard.selected = selected.map(str::to_owned);
+        guard.by_key = by_key;
+    }
+
+    /// One capture plan per online device, from the current config + app.
+    fn capture_plans_for(&self) -> Vec<DeviceCapturePlan> {
+        let rearm_generation = self.shared.capture_rearm_generation.load(Ordering::Relaxed);
+        self.devices
+            .iter()
+            .filter(|dev| dev.online && self.config.device_enabled(&dev.config_key))
+            .filter_map(|dev| {
+                let route = dev.route.clone()?;
+                Some(plan_for_device(
+                    &self.config,
+                    &dev.config_key,
+                    route,
+                    self.current_app.as_deref(),
+                    rearm_generation,
+                ))
+            })
+            .collect()
     }
 
     /// Apply a fresh inventory snapshot. Always refreshes the snapshot the IPC
@@ -349,8 +385,7 @@ impl Orchestrator {
         // flag — a system wake where none of those are observable.
         let reapply_all = std::mem::take(&mut self.reapply_all_next_refresh);
         let next_current = pick_current(&devices, self.config.selected_device());
-        let rearm_capture =
-            selected_needs_capture_rearm(&self.devices, &devices, next_current, reapply_all);
+        let rearm_capture = any_device_needs_capture_rearm(&self.devices, &devices, reapply_all);
         let followup = std::mem::take(&mut self.reapply_followup);
         let (targets, next_followup) =
             plan_reapply(&self.devices, &devices, &followup, reapply_all);
@@ -366,30 +401,28 @@ impl Orchestrator {
                     || a.capabilities != b.capabilities
                     || a.light_capabilities != b.light_capabilities
             });
-        if changed {
-            self.devices = devices;
-            self.current = next_current;
-            self.rebuild();
-        } else {
-            // Same set, routes, and runtime selection — but keep the fresh
-            // `online` flags, or a device that woke this tick would read as a
-            // transition forever.
-            self.devices = devices;
-            self.sync_current_route();
-            write_value(
-                &self.shared.host_switch_links,
-                host_switch_links(&self.config, &self.devices),
-                "host_switch_links",
-            );
-        }
         if rearm_capture {
             let generation = self
                 .shared
                 .capture_rearm_generation
                 .fetch_add(1, Ordering::Relaxed)
                 .wrapping_add(1);
-            debug!(generation, "selected device requires capture re-arm");
+            debug!(generation, "device(s) require capture re-arm");
         }
+        if !changed {
+            // Same set, routes, and runtime selection — but keep the fresh
+            // `online` flags, or a device that woke this tick would read as a
+            // transition forever. The runtime views key on `online`, so
+            // republish them even here or a woken device would get neither its
+            // capture session nor its DPI-cycle slot. A rearm generation bump
+            // also lands through this republish.
+            self.devices = devices;
+            self.publish_device_runtime();
+            return;
+        }
+        self.devices = devices;
+        self.current = next_current;
+        self.rebuild();
     }
 
     /// Force a volatile-settings re-apply for every online device on the next
@@ -407,6 +440,10 @@ impl Orchestrator {
     /// receiver cannot cross-talk (#485); lighting stays a separate path
     /// (keyboards / different feature).
     fn reapply_volatile_settings(&self, dev: &AgentDevice) {
+        // A disabled device is left fully native — no writes of any kind.
+        if !self.config.device_enabled(&dev.config_key) {
+            return;
+        }
         let Some(route) = dev.route.clone() else {
             return;
         };
@@ -600,11 +637,13 @@ impl Orchestrator {
         self.config.app_settings.launch_at_login
     }
 
-    /// Foreground-app change → re-overlay per-app bindings on the hook maps (DPI
-    /// and the dedicated HID++ gesture map are not app-scoped, so they're untouched).
-    /// Both hook maps are recomputed: a per-app override of the gesture owner
-    /// turns it into a single action for that app, dropping it from the OS-hook
-    /// gesture set — so the gesture map is app-scoped too.
+    /// Foreground-app change → re-overlay per-app bindings on the hook maps and
+    /// republish the capture plans, whose binding maps and divert sets are
+    /// per-app effective too (HID++ dispatch reads them at event time). Both
+    /// hook maps are recomputed: a per-app override of the gesture owner turns
+    /// it into a single action for that app, dropping it from the OS-hook
+    /// gesture set — so the gesture map is app-scoped too. The dedicated HID++
+    /// gesture map is not app-scoped and stays untouched.
     pub fn set_current_app(&mut self, bundle: Option<String>) {
         if bundle == self.current_app {
             return;
@@ -615,12 +654,9 @@ impl Orchestrator {
             self.hook_maps_for(self.current_key(), self.current_app.as_deref()),
             "hook_maps",
         );
-        // The keyboard's effective bindings are app-scoped too.
-        write_value(
-            &self.shared.keyboard_spec,
-            self.keyboard_spec_for(),
-            "keyboard_spec",
-        );
+        // Capture plans are app-scoped (per-app binding overlays); republish
+        // them with the keyboard's effective bindings.
+        self.publish_device_runtime();
     }
 
     /// Replace the config (after `config.toml` changed) and rebuild everything.
@@ -850,24 +886,22 @@ fn reapply_targets(prev: &[AgentDevice], next: &[AgentDevice], reapply_all: bool
         .collect()
 }
 
-/// Whether this refresh invalidated the selected device's volatile control
+/// Whether this refresh invalidated any online device's volatile control
 /// diversion. Receiver routes stay connected while a paired mouse sleeps, so
-/// route equality alone cannot tell the capture watcher to re-arm on wake.
-fn selected_needs_capture_rearm(
+/// route equality alone cannot tell capture sessions to re-arm on wake.
+fn any_device_needs_capture_rearm(
     prev: &[AgentDevice],
     next: &[AgentDevice],
-    selected: usize,
     reapply_all: bool,
 ) -> bool {
-    reapply_targets(prev, next, reapply_all).contains(&selected)
+    !reapply_targets(prev, next, reapply_all).is_empty()
 }
 
 /// How many inventory ticks a first-sighted device keeps re-applying its
 /// volatile settings after the initial write. A cold restart leaves a Bolt/
 /// Unifying mouse slow to enumerate, so the first write (and a single confirm)
 /// can both time out against a still-booting device; retrying for ~8s at the 2s
-/// cadence lets the write land once it finishes booting. Bounded rather than
-/// read-back-confirmed — see the note on [`plan_reapply`].
+/// cadence lets the write land once it finishes booting.
 const VOLATILE_REAPPLY_CONFIRM_RETRIES: u8 = 4;
 
 /// Plan this refresh's volatile-settings writes: the [`reapply_targets`] set
@@ -896,17 +930,14 @@ fn plan_reapply(
         })
         .collect();
     for (idx, dev) in next.iter().enumerate() {
-        if dev.online && dev.route.is_some() && !targets.contains(&idx) {
-            // ponytail: bounded retry, not read-back-confirmed. The upgrade is
-            // to confirm the write took (read DPI back via openlogi_hid and
-            // stop retrying on a match) instead of running out a fixed budget —
-            // that converges faster and drops the redundant writes on a device
-            // that accepted the first one.
-            if let Some(&remaining) = followup.get(&dev.config_key) {
-                targets.push(idx);
-                if remaining > 1 {
-                    next_followup.insert(dev.config_key.clone(), remaining - 1);
-                }
+        if dev.online
+            && dev.route.is_some()
+            && !targets.contains(&idx)
+            && let Some(&remaining) = followup.get(&dev.config_key)
+        {
+            targets.push(idx);
+            if remaining > 1 {
+                next_followup.insert(dev.config_key.clone(), remaining - 1);
             }
         }
     }

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -1,10 +1,11 @@
 //! Orchestrator inventory/reapply/camera tests.
 
 use super::{
-    AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES, build_devices,
-    configured_wheel_mode, host_switch_links, pick_current, plan_reapply, reapply_targets,
-    selected_needs_capture_rearm,
+    AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
+    any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
+    pick_current, plan_reapply, reapply_targets,
 };
+use openlogi_core::binding::{Action, ButtonId};
 use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
@@ -321,7 +322,7 @@ fn reapply_targets_new_arrivals_and_transitions() {
 }
 
 #[test]
-fn capture_target_tracks_online_state_without_resetting_dpi_cycle() {
+fn dpi_cycle_drops_offline_device_and_restores_on_return() {
     let mut orch = Orchestrator::new(Config::default());
     orch.devices = vec![dev("mouse", 1, true)];
     orch.rebuild();
@@ -329,26 +330,30 @@ fn capture_target_tracks_online_state_without_resetting_dpi_cycle() {
         let Ok(mut dpi) = orch.shared.dpi_cycle.write() else {
             panic!("DPI cycle lock should not be poisoned");
         };
-        dpi.index = 3;
+        if let Some(state) = dpi.by_key.get_mut("mouse") {
+            state.index = 3;
+        }
     }
 
     orch.devices[0].online = false;
-    orch.sync_current_route();
+    orch.publish_device_runtime();
     {
         let Ok(dpi) = orch.shared.dpi_cycle.read() else {
             panic!("DPI cycle lock should not be poisoned");
         };
-        assert_eq!(dpi.target, None);
-        assert_eq!(dpi.index, 3);
+        assert!(!dpi.by_key.contains_key("mouse"));
     }
 
     orch.devices[0].online = true;
-    orch.sync_current_route();
+    orch.publish_device_runtime();
     let Ok(dpi) = orch.shared.dpi_cycle.read() else {
         panic!("DPI cycle lock should not be poisoned");
     };
-    assert_eq!(dpi.target, orch.devices[0].route);
-    assert_eq!(dpi.index, 3);
+    assert_eq!(dpi.by_key.get("mouse").map(|s| s.index), Some(0));
+    assert_eq!(
+        dpi.by_key.get("mouse").and_then(|s| s.target.clone()),
+        orch.devices[0].route
+    );
 }
 
 #[test]
@@ -383,26 +388,30 @@ fn reapply_all_targets_every_online_device() {
 }
 
 #[test]
-fn selected_receiver_reconnect_requests_capture_rearm() {
+fn receiver_reconnect_requests_capture_rearm() {
     let prev = [dev("selected", 1, false), dev("other", 2, true)];
     let next = [dev("selected", 1, true), dev("other", 2, true)];
 
-    assert!(selected_needs_capture_rearm(&prev, &next, 0, false));
-    assert!(!selected_needs_capture_rearm(&prev, &next, 1, false));
+    assert!(any_device_needs_capture_rearm(&prev, &next, false));
+    assert!(!any_device_needs_capture_rearm(
+        &[dev("other", 2, true)],
+        &[dev("other", 2, true)],
+        false
+    ));
 }
 
 #[test]
-fn system_wake_requests_capture_rearm_for_selected_online_device() {
+fn system_wake_requests_capture_rearm_for_online_devices() {
     let devices = [dev("selected", 1, true), dev("other", 2, true)];
 
-    assert!(selected_needs_capture_rearm(&devices, &devices, 0, true));
+    assert!(any_device_needs_capture_rearm(&devices, &devices, true));
 }
 
 #[test]
 fn steady_inventory_does_not_cycle_capture() {
     let devices = [dev("selected", 1, true)];
 
-    assert!(!selected_needs_capture_rearm(&devices, &devices, 0, false));
+    assert!(!any_device_needs_capture_rearm(&devices, &devices, false));
 }
 
 #[test]
@@ -657,4 +666,38 @@ fn config_reload_clears_override_when_camera_mode_changes() {
             .map(|light| light.enabled),
         Some(true)
     );
+}
+
+/// The published capture plan's Back binding for the first device, if any.
+fn published_back_binding(orch: &Orchestrator) -> Option<Action> {
+    orch.shared.capture_plans.read().ok().and_then(|plans| {
+        plans
+            .first()
+            .and_then(|plan| plan.bindings.get(&ButtonId::Back).cloned())
+    })
+}
+
+#[test]
+fn app_switch_republishes_capture_plans() {
+    // HID++ dispatch reads `plan.bindings` at event time, so a
+    // foreground-app change must republish the capture plans — their
+    // binding maps and divert sets are per-app effective — or every
+    // diverted button keeps firing the previous app's actions.
+    let mut config = Config::default();
+    config.set_per_app_binding(
+        "a",
+        "com.example.editor",
+        ButtonId::Back,
+        Some(Action::Undo),
+    );
+    let mut orch = Orchestrator::new(config);
+    orch.devices = vec![dev("a", 1, true)];
+    orch.rebuild();
+    assert_ne!(
+        published_back_binding(&orch),
+        Some(Action::Undo),
+        "no per-app overlay while no app is in front"
+    );
+    orch.set_current_app(Some("com.example.editor".into()));
+    assert_eq!(published_back_binding(&orch), Some(Action::Undo));
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -1,9 +1,10 @@
-//! Background HID++ control-capture watcher for the active device.
+//! Background HID++ control-capture watcher, one session per online device.
 //!
-//! Runs [`openlogi_hid::run_capture_session`] on a dedicated thread for whichever
-//! device the DPI / SmartShift path currently targets
-//! ([`DpiCycleState::target`]), restarts it when the carousel selection — or the
-//! thumb-wheel arming — changes, and dispatches each captured input:
+//! Runs [`openlogi_hid::run_capture_session`] concurrently for every device in
+//! the shared capture-plan list (not just the GUI's selection), restarts a
+//! session when its device's plan — route, diverted controls, thumb-wheel
+//! arming — changes, and dispatches each captured input against the binding
+//! maps of the device it arrived on:
 //!
 //! - a gesture swipe through the gesture binding map,
 //! - a DPI/ModeShift or thumb-wheel-tap press through the button binding map,
@@ -18,32 +19,28 @@
 //! the events arrive over HID++, and the bound action is synthesised the same
 //! way regardless.
 
-use std::collections::BTreeMap;
-use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 use openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY;
+use openlogi_hid::gesture::CaptureSpec;
 use openlogi_hid::{
-    CaptureChannel, CaptureStop, CapturedInput, ChannelRegistry, DeviceRoute,
-    run_capture_session_with_registry, run_capture_session_with_stop_reason,
+    CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute, run_capture_session,
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
-use crate::DpiCycleState;
-use crate::hook_runtime::{self, SharedHookMaps};
+use crate::DpiCycles;
+use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
+use crate::hook_runtime;
 use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
 
 /// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
 /// direction). The watcher reads it to map a captured swipe to a bound action.
 pub type GestureBindings = Arc<RwLock<BTreeMap<GestureDirection, Action>>>;
-
-/// Shared thumb-wheel sensitivity, mirrored from `AppState`. Read on every wheel
-/// event; written only by `AppState::set_thumbwheel_sensitivity`.
-pub type ThumbwheelSensitivity = Arc<AtomicI32>;
 
 /// How often to re-read the active device target + thumb-wheel arming so a
 /// carousel switch or a binding/sensitivity edit re-points / re-arms capture.
@@ -78,66 +75,11 @@ fn action_threshold(sensitivity: i32) -> i32 {
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
 pub fn spawn(
-    hook_maps: SharedHookMaps,
-    gesture_bindings: GestureBindings,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    capture_plans: SharedCapturePlans,
+    dpi_cycle: Arc<RwLock<DpiCycles>>,
     capture_channel: CaptureChannel,
-    thumbwheel_sensitivity: ThumbwheelSensitivity,
-    capture_rearm_generation: Arc<AtomicU64>,
     receiver_access: ReceiverAccess,
-) {
-    spawn_inner(
-        hook_maps,
-        gesture_bindings,
-        dpi_cycle,
-        capture_channel,
-        thumbwheel_sensitivity,
-        capture_rearm_generation,
-        receiver_access,
-        None,
-    );
-}
-
-/// Spawn capture in Agent mode, reusing only inventory-published channels.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "agent mode needs maps, dpi, rearm, leases, and registry"
-)]
-pub fn spawn_with_registry(
-    hook_maps: SharedHookMaps,
-    gesture_bindings: GestureBindings,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
-    capture_channel: CaptureChannel,
-    thumbwheel_sensitivity: ThumbwheelSensitivity,
-    capture_rearm_generation: Arc<AtomicU64>,
-    receiver_access: ReceiverAccess,
-    registry: ChannelRegistry,
-) {
-    spawn_inner(
-        hook_maps,
-        gesture_bindings,
-        dpi_cycle,
-        capture_channel,
-        thumbwheel_sensitivity,
-        capture_rearm_generation,
-        receiver_access,
-        Some(registry),
-    );
-}
-
-#[expect(
-    clippy::too_many_arguments,
-    reason = "capture manager needs maps, dpi, rearm, leases, and registry"
-)]
-fn spawn_inner(
-    hook_maps: SharedHookMaps,
-    gesture_bindings: GestureBindings,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
-    capture_channel: CaptureChannel,
-    thumbwheel_sensitivity: ThumbwheelSensitivity,
-    capture_rearm_generation: Arc<AtomicU64>,
-    receiver_access: ReceiverAccess,
-    registry: Option<ChannelRegistry>,
+    channel_registry: ChannelRegistry,
 ) {
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -151,313 +93,266 @@ fn spawn_inner(
             }
         };
         runtime.block_on(manage(
-            hook_maps,
-            gesture_bindings,
+            capture_plans,
             dpi_cycle,
             capture_channel,
-            thumbwheel_sensitivity,
-            capture_rearm_generation,
             receiver_access,
-            registry,
+            channel_registry,
         ));
     });
 }
 
-/// Whether the thumb wheel must be diverted over HID++ (which suppresses native
-/// scroll) so we can re-synthesise its scroll or capture its tap.
-///
-/// We divert when the sensitivity leaves its default (so we can scale scroll
-/// ourselves) or when the click or either rotation direction is rebound away
-/// from its default; otherwise the OS scrolls the wheel natively.
-fn thumbwheel_armed(hook_maps: &SharedHookMaps, sensitivity: i32) -> bool {
-    if sensitivity != DEFAULT_THUMBWHEEL_SENSITIVITY {
-        return true;
-    }
-    hook_maps.read().ok().is_some_and(|maps| {
-        [
-            ButtonId::Thumbwheel,
-            ButtonId::ThumbwheelScrollUp,
-            ButtonId::ThumbwheelScrollDown,
-        ]
-        .iter()
-        .any(|&button| {
-            maps.bindings
-                .get(&button)
-                .is_some_and(|action| *action != default_binding(button))
-        })
-    })
+/// Whether one device's thumb wheel must be diverted over HID++ (which
+/// suppresses native scroll) so we can re-synthesise its scroll or capture its
+/// tap: its sensitivity leaves the default (so we scale scroll ourselves) or a
+/// thumbwheel binding does.
+fn thumbwheel_armed(plan: &DeviceCapturePlan) -> bool {
+    plan.thumbwheel_sensitivity != DEFAULT_THUMBWHEEL_SENSITIVITY
+        || plan.thumbwheel_bindings_nondefault
 }
 
-/// Whether a finished capture session should make the manager re-arm.
+/// The [`CaptureSpec`] one device's session should run with right now.
+fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
+    CaptureSpec {
+        capture_thumbwheel: thumbwheel_armed(plan),
+        divert_gesture_button: !plan.gesture_bindings.is_empty(),
+        divert_buttons: plan.divert_buttons.clone(),
+    }
+}
+
+/// One capture session tracked by the manager.
+struct RunningSession {
+    route: DeviceRoute,
+    spec: CaptureSpec,
+    rearm_generation: u64,
+    /// Present while the session runs; taken to request a stop. `None` means
+    /// the session is draining — deliberately stopped, but its task (and the
+    /// control-restore writes in its teardown) may still be in flight.
+    stop: Option<oneshot::Sender<()>>,
+    epoch: u64,
+}
+
+/// What the manager should do with one session-completion report.
+#[derive(Debug, PartialEq)]
+enum DoneAction {
+    /// A stale report from a session the manager no longer tracks — ignore it.
+    Ignore,
+    /// The tracked session's task has fully exited: drop its entry so the next
+    /// tick may arm a successor. `unexpected` is true when the exit wasn't a
+    /// deliberate stop and the drop deserves a warning.
+    Remove { unexpected: bool },
+}
+
+/// Decide the [`DoneAction`] for a completion report carrying `done_epoch`,
+/// given the session the manager currently tracks for that device (if any).
 ///
-/// `done_epoch` identifies the session that signalled completion; `live_epoch`
-/// is the session the manager currently believes is running; `has_target` is
-/// whether a device is currently targeted. A session ending only warrants a
-/// respawn when it is the *current* one (not a stale session already superseded
-/// by a deliberate restart, whose epoch no longer matches) and a target is still
-/// set (not a deliberate stop-to-idle, e.g. while pairing owns the receiver).
+/// Only the *current* session's report settles anything; a stale epoch belongs
+/// to a session already superseded. A tracked session whose stop sender is
+/// gone was stopped deliberately and is merely draining — its report frees the
+/// key quietly. One still holding its stop sender exited on its own and
+/// warrants a warning alongside the re-arm.
+/// Whether a finished session should be re-armed after completion.
 pub(crate) fn should_rearm(done_epoch: u64, live_epoch: u64, has_target: bool) -> bool {
     done_epoch == live_epoch && has_target
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CaptureTarget {
-    route: DeviceRoute,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    rearm_generation: u64,
-}
-
-/// Why to stop the current session when the desired target changes.
-fn stop_for_target_change(
-    want: Option<&CaptureTarget>,
-    current: Option<&CaptureTarget>,
-    connection_is_current: bool,
-) -> Option<CaptureStop> {
-    let cur = current?;
-    if want == Some(cur) {
-        return (!connection_is_current).then_some(CaptureStop::Revoked);
-    }
-    // Same route, new generation (reconnect/wake): skip restore — firmware already reset.
-    if want.is_some_and(|next| {
-        next.route == cur.route && next.rearm_generation != cur.rearm_generation
-    }) {
-        return Some(CaptureStop::Revoked);
-    }
-    Some(CaptureStop::Graceful)
-}
-
-#[cfg_attr(
-    not(test),
-    allow(dead_code, reason = "kept for unit tests of stop policy")
-)]
-fn stop_reason<T: PartialEq>(
-    want: Option<&T>,
-    current: Option<&T>,
-    connection_is_current: bool,
-) -> Option<CaptureStop> {
-    current?;
-    if want == current {
-        (!connection_is_current).then_some(CaptureStop::Revoked)
-    } else {
-        Some(CaptureStop::Graceful)
+fn on_done(done_epoch: u64, live: Option<&RunningSession>) -> DoneAction {
+    match live {
+        Some(session) if session.epoch == done_epoch => DoneAction::Remove {
+            unexpected: session.stop.is_some(),
+        },
+        _ => DoneAction::Ignore,
     }
 }
 
-fn acknowledge_stopping(stopping_epoch: &mut Option<u64>, done_epoch: u64) -> bool {
-    if *stopping_epoch == Some(done_epoch) {
-        *stopping_epoch = None;
-        true
-    } else {
-        false
-    }
-}
-
-fn capture_connection_is_current(
-    registry: Option<&ChannelRegistry>,
-    capture_channel: &CaptureChannel,
-) -> bool {
-    let Some(registry) = registry else {
-        return true;
-    };
-    capture_channel
-        .read()
-        .ok()
-        .and_then(|slot| slot.clone())
-        .is_some_and(|shared| registry.is_current(&shared))
-}
-
-struct CaptureLaunch {
-    route: DeviceRoute,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    sink: mpsc::UnboundedSender<CapturedInput>,
-    channel_slot: CaptureChannel,
-    receiver_lease: SessionReceiverLease,
-    registry: Option<ChannelRegistry>,
-    done: mpsc::UnboundedSender<u64>,
-    epoch: u64,
-}
-
-fn spawn_capture_session(launch: CaptureLaunch) -> oneshot::Sender<CaptureStop> {
-    let (stop_tx, stop_rx) = oneshot::channel();
-    tokio::spawn(async move {
-        let result = {
-            let receiver_lease = launch.receiver_lease;
-            let result = if let Some(registry) = launch.registry.as_ref() {
-                run_capture_session_with_registry(
-                    launch.route,
-                    launch.capture_thumbwheel,
-                    launch.divert_gesture_button,
-                    launch.sink,
-                    stop_rx,
-                    launch.channel_slot,
-                    registry,
-                )
-                .await
-            } else {
-                run_capture_session_with_stop_reason(
-                    launch.route,
-                    launch.capture_thumbwheel,
-                    launch.divert_gesture_button,
-                    launch.sink,
-                    stop_rx,
-                    launch.channel_slot,
-                )
-                .await
-            };
-            drop(receiver_lease);
-            result
-        };
-        if let Err(error) = result {
-            debug!(%error, "capture session ended");
-        }
-        // Completion is sent only after the capture future released its channel
-        // and the receiver lease above, so the manager can safely replace it.
-        let _ = launch.done.send(launch.epoch);
-    });
-    stop_tx
-}
-
-/// Keep one capture session alive for the active device, restarting it when the
-/// device or the thumb-wheel arming changes, and dispatch incoming inputs. Runs
-/// for the lifetime of the process.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "capture manager needs maps, dpi, rearm, leases, and registry"
-)]
+/// Keep one capture session alive per online device, restarting a session when
+/// its device's plan changes, and dispatch incoming inputs against the plan of
+/// the device they arrived on. Runs for the lifetime of the process.
 async fn manage(
-    hook_maps: SharedHookMaps,
-    gesture_bindings: GestureBindings,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    capture_plans: SharedCapturePlans,
+    dpi_cycle: Arc<RwLock<DpiCycles>>,
     capture_channel: CaptureChannel,
-    thumbwheel_sensitivity: ThumbwheelSensitivity,
-    capture_rearm_generation: Arc<AtomicU64>,
     receiver_access: ReceiverAccess,
-    registry: Option<ChannelRegistry>,
+    channel_registry: ChannelRegistry,
 ) {
-    let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
-    let mut current: Option<CaptureTarget> = None;
-    let mut stop: Option<oneshot::Sender<CaptureStop>> = None;
-    let mut stopping_epoch: Option<u64> = None;
+    let (tx, mut rx) = mpsc::unbounded_channel::<(String, CapturedInput)>();
+    let mut sessions: HashMap<String, RunningSession> = HashMap::new();
     let mut ticker = tokio::time::interval(TARGET_POLL);
-    let mut accumulators = WheelAccumulators::default();
+    let mut accumulators: HashMap<String, WheelAccumulators> = HashMap::new();
     // Capture sessions run as detached tasks, so an unexpected exit (a transient
     // HID++ read error, a sleep-wake glitch, brief radio loss) would otherwise go
-    // unnoticed: the tick below only restarts on a *changed* target, so a session
-    // that dies with the target unchanged leaves the gesture button and thumb
-    // wheel dead until the next carousel switch, config reload, or agent restart.
-    // Each session reports its completion here, tagged with the epoch it started
-    // under, so a dead *current* session can be re-armed while stale completions
-    // (from an already-superseded session) are ignored.
-    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<u64>();
+    // unnoticed. Each session reports its completion here, tagged with its device
+    // key and the epoch it started under: a dead *current* session re-arms on the
+    // next tick, a deliberately stopped one merely frees its key for the
+    // replacement once its teardown has drained, and stale completions are
+    // ignored (see `on_done`).
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<(String, u64)>();
     let mut epoch: u64 = 0;
+    // The capture-vs-pairing arbiter hands out one exclusive lease. All session
+    // tasks share it through an `Arc`; the manager keeps only a `Weak` so the
+    // lease frees itself when the last session exits (letting pairing proceed).
+    let mut lease: std::sync::Weak<SessionReceiverLease> = std::sync::Weak::new();
 
     loop {
         tokio::select! {
-            Some(input) = rx.recv() => {
+            Some((key, input)) = rx.recv() => {
                 dispatch(
+                    &key,
                     input,
                     &mut accumulators,
-                    &hook_maps,
-                    &gesture_bindings,
-                    DispatchHardware {
-                        dpi_cycle: &dpi_cycle,
-                        capture: &capture_channel,
-                        registry: registry.as_ref(),
-                        receiver_access: &receiver_access,
-                    },
-                    &thumbwheel_sensitivity,
+                    &capture_plans,
+                    &dpi_cycle,
+                    &capture_channel,
+                    &channel_registry,
+                    &receiver_access,
                 );
             }
             _ = ticker.tick() => {
-                // While pairing is waiting or active, release the capture
+                // While pairing is waiting or active, release every capture
                 // session so run_pairing can own the receiver's HID node (one
                 // process can't read it through two channels).
-                let want = if receiver_access.exclusive_requested() {
-                    None
-                } else {
-                    let target = dpi_cycle.read().ok().and_then(|guard| guard.target.clone());
-                    let sensitivity = thumbwheel_sensitivity.load(Ordering::Relaxed);
-                    // Divert the dedicated HID++ gesture button only while it owns the gesture role. The
-                    // shared gesture map is non-empty exactly then (gesture_bindings_for
-                    // gates on the owner), so it doubles as that signal — no need to
-                    // thread the full config in. Re-evaluated each tick, so a
-                    // ReloadConfig owner change restarts the session accordingly.
-                    let divert_gesture = gesture_bindings.read().is_ok_and(|g| !g.is_empty());
-                    let rearm_generation = capture_rearm_generation.load(Ordering::Relaxed);
-                    target.map(|route| CaptureTarget {
-                        route,
-                        capture_thumbwheel: thumbwheel_armed(&hook_maps, sensitivity),
-                        divert_gesture_button: divert_gesture,
-                        rearm_generation,
-                    })
-                };
-                if stopping_epoch.is_some() {
-                    continue;
-                }
-                let connection_is_current =
-                    capture_connection_is_current(registry.as_ref(), &capture_channel);
-                if let Some(reason) =
-                    stop_for_target_change(want.as_ref(), current.as_ref(), connection_is_current)
-                {
-                    if let Some(stop) = stop.take() {
-                        let _ = stop.send(reason);
-                    }
-                    stopping_epoch = Some(epoch);
-                    current = None;
-                    continue;
-                }
-                if want == current {
-                    continue;
-                }
-                if let Some(target) = want {
-                    let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
-                        current = None;
-                        continue;
+                let want: HashMap<String, (DeviceRoute, CaptureSpec, u64)> =
+                    if receiver_access.exclusive_requested() {
+                        HashMap::new()
+                    } else {
+                        capture_plans
+                            .read()
+                            .map(|plans| {
+                                plans
+                                    .iter()
+                                    .map(|plan| {
+                                        (
+                                            plan.config_key.clone(),
+                                            (
+                                                plan.route.clone(),
+                                                spec_for(plan),
+                                                plan.rearm_generation,
+                                            ),
+                                        )
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default()
                     };
-                    current = Some(target.clone());
+                // Stop sessions whose device disappeared or whose plan changed.
+                // Sending on the oneshot lets the session restore its controls.
+                // A stopped session stays tracked — stop sender taken — until
+                // its task reports completion below, and a tracked key is never
+                // re-armed: arming the replacement while the old task may still
+                // be mid-restore could interleave its divert writes with the
+                // restore writes on the same device, leaving a control
+                // un-diverted while the new session believes it owns it,
+                // however many ticks the restore takes.
+                for (key, session) in &mut sessions {
+                    let keep = want.get(key).is_some_and(|(route, spec, rearm)| {
+                        *route == session.route
+                            && *spec == session.spec
+                            && *rearm == session.rearm_generation
+                    });
+                    if !keep && let Some(stop) = session.stop.take() {
+                        let _ = stop.send(());
+                    }
+                }
+                accumulators.retain(|key, _| want.contains_key(key));
+                for (key, (route, spec, rearm_generation)) in want {
+                    if sessions.contains_key(&key) {
+                        continue;
+                    }
+                    // All sessions share one exclusive lease; acquire it with the
+                    // first session and ride the existing one afterwards.
+                    let session_lease = if let Some(existing) = lease.upgrade() {
+                        existing
+                    } else {
+                        let Some(fresh) = receiver_access.try_acquire_for_session() else {
+                            continue;
+                        };
+                        let fresh = Arc::new(fresh);
+                        lease = Arc::downgrade(&fresh);
+                        fresh
+                    };
                     epoch = epoch.wrapping_add(1);
-                    stop = Some(spawn_capture_session(CaptureLaunch {
-                        route: target.route,
-                        capture_thumbwheel: target.capture_thumbwheel,
-                        divert_gesture_button: target.divert_gesture_button,
-                        sink: tx.clone(),
-                        channel_slot: Arc::clone(&capture_channel),
-                        receiver_lease,
-                        registry: registry.clone(),
-                        done: done_tx.clone(),
+                    let session = spawn_session(
+                        key.clone(),
+                        route,
+                        spec,
+                        rearm_generation,
                         epoch,
-                    }));
-                } else {
-                    current = None;
+                        session_lease,
+                        &tx,
+                        &done_tx,
+                        &capture_channel,
+                    );
+                    sessions.insert(key, session);
                 }
             }
-            Some(done_epoch) = done_rx.recv() => {
-                if acknowledge_stopping(&mut stopping_epoch, done_epoch) {
-                    // The stopped task has cleared its slot, dropped the
-                    // listener/channel and released any receiver lease. A later
-                    // poll may now arm the desired replacement.
-                    stop = None;
-                    continue;
-                }
-                // A capture session ended on its own. Re-arm only when it is the
-                // session we currently believe is live for an active target;
-                // clearing `current` lets the next tick start a fresh session.
-                // The tick fires at most once per `TARGET_POLL`, which paces the
-                // respawn so a permanently failing device can't hot-loop. A stale
-                // epoch or a deliberate stop-to-idle is a no-op (see `should_rearm`).
-                if should_rearm(done_epoch, epoch, current.is_some()) {
-                    warn!("capture session for the active device ended unexpectedly, re-arming");
-                    current = None;
-                    // Keep the `stop`/`current` invariant: the session already
-                    // exited, so its stop receiver is gone and dropping the sender
-                    // here is a no-op, but it stops the next tick from signalling a
-                    // session that no longer exists.
-                    stop = None;
+            Some((key, done_epoch)) = done_rx.recv() => {
+                // A capture session's task has fully exited — its restore writes
+                // included — so dropping its entry lets the next tick start a
+                // fresh session for that device; the tick fires at most once per
+                // `TARGET_POLL`, which paces the respawn so a permanently failing
+                // device can't hot-loop. A stale epoch (an already-superseded
+                // session) is a no-op.
+                if let DoneAction::Remove { unexpected } = on_done(done_epoch, sessions.get(&key)) {
+                    if unexpected {
+                        warn!(key, "capture session ended unexpectedly, re-arming");
+                    }
+                    sessions.remove(&key);
                 }
             }
         }
+    }
+}
+
+/// Start one device's capture session plus its input-forwarding task, and
+/// return the manager's tracking entry for it.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "plumbing between the manager loop's channels; grouping them into \
+              a struct would only relabel the same eight values"
+)]
+fn spawn_session(
+    key: String,
+    route: DeviceRoute,
+    spec: CaptureSpec,
+    rearm_generation: u64,
+    epoch: u64,
+    lease: Arc<SessionReceiverLease>,
+    inputs: &mpsc::UnboundedSender<(String, CapturedInput)>,
+    done: &mpsc::UnboundedSender<(String, u64)>,
+    capture_channel: &CaptureChannel,
+) -> RunningSession {
+    let (stop_tx, stop_rx) = oneshot::channel();
+    // Tag this session's inputs with its device key so dispatch resolves them
+    // against the right plan.
+    let (session_tx, mut session_rx) = mpsc::unbounded_channel::<CapturedInput>();
+    let forward = inputs.clone();
+    let forward_key = key.clone();
+    tokio::spawn(async move {
+        while let Some(input) = session_rx.recv().await {
+            let _ = forward.send((forward_key.clone(), input));
+        }
+    });
+    let done = done.clone();
+    let session_route = route.clone();
+    let session_spec = spec.clone();
+    let slot = Arc::clone(capture_channel);
+    tokio::spawn(async move {
+        let _lease = lease;
+        if let Err(e) =
+            run_capture_session(session_route, session_spec, session_tx, stop_rx, slot).await
+        {
+            debug!(error = %e, "capture session ended");
+        }
+        // Report completion so the manager can re-arm if this exit was
+        // unexpected rather than a deliberate stop.
+        let _ = done.send((key, epoch));
+    });
+    RunningSession {
+        route,
+        spec,
+        rearm_generation,
+        stop: Some(stop_tx),
+        epoch,
     }
 }
 
@@ -494,69 +389,58 @@ enum WheelOutput {
     FireAction,
 }
 
-/// Route one captured input to its bound action (or re-synthesised scroll).
-#[derive(Clone, Copy)]
-struct DispatchHardware<'a> {
-    dpi_cycle: &'a Arc<RwLock<DpiCycleState>>,
-    capture: &'a CaptureChannel,
-    registry: Option<&'a ChannelRegistry>,
-    receiver_access: &'a ReceiverAccess,
-}
-
+/// Route one captured input from device `key` to its bound action (or
+/// re-synthesised scroll), using that device's own plan maps.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "per-device dispatch needs plan maps, dpi, capture, and registry handles"
+)]
 fn dispatch(
+    key: &str,
     input: CapturedInput,
-    accumulators: &mut WheelAccumulators,
-    hook_maps: &SharedHookMaps,
-    gesture_bindings: &GestureBindings,
-    hardware: DispatchHardware<'_>,
-    thumbwheel_sensitivity: &ThumbwheelSensitivity,
+    accumulators: &mut HashMap<String, WheelAccumulators>,
+    capture_plans: &SharedCapturePlans,
+    dpi_cycle: &Arc<RwLock<DpiCycles>>,
+    capture: &CaptureChannel,
+    registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
 ) {
+    let Ok(plans) = capture_plans.read() else {
+        return;
+    };
+    let Some(plan) = plans.iter().find(|plan| plan.config_key == key) else {
+        debug!(key, "input from a device with no capture plan — ignored");
+        return;
+    };
     match input {
         CapturedInput::Gesture(direction) => {
-            let action = gesture_bindings
-                .read()
-                .ok()
-                .and_then(|guard| guard.get(&direction).cloned());
-            if let Some(action) = action {
-                debug!(?direction, action = %action.label(), "gesture → action");
+            if let Some(action) = plan.gesture_bindings.get(&direction) {
+                debug!(key, ?direction, action = %action.label(), "gesture → action");
                 hook_runtime::dispatch_action(
-                    &action,
-                    hardware.dpi_cycle,
-                    hardware.capture,
-                    hardware.registry,
-                    hardware.receiver_access,
+                    action,
+                    dpi_cycle,
+                    Some(key),
+                    capture,
+                    Some(registry),
+                    receiver_access,
                 );
             } else {
-                debug!(?direction, "gesture with no binding — ignored");
+                debug!(key, ?direction, "gesture with no binding — ignored");
             }
         }
-        CapturedInput::ButtonPressed(button, frontmost_pid) => {
-            let action = hook_maps
-                .read()
-                .ok()
-                .and_then(|maps| maps.bindings.get(&button).cloned());
-            if let Some(action) = action {
-                debug!(?button, action = %action.label(), "HID++ button → action");
-                // For browser navigation, use the AX API with the PID captured
-                // at press time (before async dispatch could shift focus).
-                let ax_handled = matches!(action, Action::BrowserBack | Action::BrowserForward)
-                    && frontmost_pid.is_some_and(|pid| {
-                        openlogi_inject::ax_navigate_browser(
-                            pid,
-                            matches!(action, Action::BrowserForward),
-                        )
-                    });
-                if !ax_handled {
-                    hook_runtime::dispatch_action(
-                        &action,
-                        hardware.dpi_cycle,
-                        hardware.capture,
-                        hardware.registry,
-                        hardware.receiver_access,
-                    );
-                }
+        CapturedInput::ButtonPressed(button, _) => {
+            if let Some(action) = plan.bindings.get(&button) {
+                debug!(key, ?button, action = %action.label(), "HID++ button → action");
+                hook_runtime::dispatch_action(
+                    action,
+                    dpi_cycle,
+                    Some(key),
+                    capture,
+                    Some(registry),
+                    receiver_access,
+                );
             } else {
-                debug!(?button, "HID++ button with no binding — ignored");
+                debug!(key, ?button, "HID++ button with no binding — ignored");
             }
         }
         CapturedInput::Scroll(rotation) => {
@@ -567,17 +451,14 @@ fn dispatch(
             } else {
                 ButtonId::ThumbwheelScrollDown
             };
-            let action = hook_maps
-                .read()
-                .ok()
-                .and_then(|maps| maps.bindings.get(&button).cloned())
+            let action = plan
+                .bindings
+                .get(&button)
+                .cloned()
                 .unwrap_or_else(|| default_binding(button));
-            let sensitivity = thumbwheel_sensitivity.load(Ordering::Relaxed);
-            let dir = if up {
-                &mut accumulators.up
-            } else {
-                &mut accumulators.down
-            };
+            let sensitivity = plan.thumbwheel_sensitivity;
+            let wheels = accumulators.entry(key.to_owned()).or_default();
+            let dir = if up { &mut wheels.up } else { &mut wheels.down };
             let magnitude = i32::from(rotation).abs();
             match advance(dir, &action, magnitude, sensitivity, Instant::now()) {
                 WheelOutput::Idle => {}
@@ -585,13 +466,14 @@ fn dispatch(
                     openlogi_inject::post_horizontal_scroll(lines);
                 }
                 WheelOutput::FireAction => {
-                    debug!(?button, action = %action.label(), "thumb wheel → action");
+                    debug!(key, ?button, action = %action.label(), "thumb wheel → action");
                     hook_runtime::dispatch_action(
                         &action,
-                        hardware.dpi_cycle,
-                        hardware.capture,
-                        hardware.registry,
-                        hardware.receiver_access,
+                        dpi_cycle,
+                        Some(key),
+                        capture,
+                        Some(registry),
+                        receiver_access,
                     );
                 }
             }
@@ -668,9 +550,6 @@ fn advance(
 
 #[cfg(test)]
 mod tests {
-    use std::panic::{AssertUnwindSafe, catch_unwind};
-    use std::sync::PoisonError;
-
     use super::*;
 
     #[test]
@@ -805,77 +684,64 @@ mod tests {
         );
     }
 
+    /// A session whose stop sender is already gone (taken by a deliberate stop).
+    fn stopped_session_with_epoch(epoch: u64) -> RunningSession {
+        RunningSession {
+            route: DeviceRoute::Direct {
+                vendor_id: 0x046d,
+                product_id: 0xc548,
+            },
+            spec: CaptureSpec::default(),
+            rearm_generation: 0,
+            stop: None,
+            epoch,
+        }
+    }
+
+    /// A session still holding its stop sender (never asked to stop).
+    fn live_session_with_epoch(epoch: u64) -> RunningSession {
+        let (stop, _rx) = oneshot::channel();
+        RunningSession {
+            stop: Some(stop),
+            ..stopped_session_with_epoch(epoch)
+        }
+    }
+
     #[test]
-    fn rearms_when_the_current_session_dies_with_a_target() {
-        // The live session ended on its own while a device is still targeted.
-        assert!(should_rearm(7, 7, true));
+    fn rearms_when_the_current_session_dies() {
+        // The live session for this device ended on its own.
+        assert_eq!(
+            on_done(7, Some(&live_session_with_epoch(7))),
+            DoneAction::Remove { unexpected: true }
+        );
     }
 
     #[test]
     fn ignores_a_stale_session_superseded_by_a_restart() {
         // An older session reports completion after a deliberate restart already
         // bumped the epoch; re-arming would needlessly cycle the live session.
-        assert!(!should_rearm(6, 7, true));
-    }
-
-    #[test]
-    fn ignores_a_deliberate_stop_to_idle() {
-        // The session was stopped on purpose (pairing took the receiver, or no
-        // device is targeted): no target means there is nothing to re-arm.
-        assert!(!should_rearm(7, 7, false));
-    }
-
-    #[test]
-    fn unchanged_target_keeps_the_current_connection() {
         assert_eq!(
-            stop_reason(Some(&"device-a"), Some(&"device-a"), true),
-            None
+            on_done(6, Some(&live_session_with_epoch(7))),
+            DoneAction::Ignore
         );
     }
 
     #[test]
-    fn revoked_connection_stops_without_disarming_it() {
-        assert_eq!(
-            stop_reason(Some(&"device-a"), Some(&"device-a"), false),
-            Some(CaptureStop::Revoked)
-        );
+    fn ignores_a_completion_for_an_untracked_device() {
+        // The session's entry is already gone (a deliberate stop to idle, or a
+        // device that went away): there is nothing to settle or re-arm.
+        assert_eq!(on_done(7, None), DoneAction::Ignore);
     }
 
     #[test]
-    fn target_change_stops_gracefully_while_connection_is_current() {
+    fn settles_a_draining_session_quietly() {
+        // A deliberately stopped session stays tracked until its task — the
+        // control-restore writes included — actually exits, so its key cannot
+        // re-arm mid-restore. Its completion report frees the key without the
+        // unexpected-exit warning.
         assert_eq!(
-            stop_reason(Some(&"device-b"), Some(&"device-a"), true),
-            Some(CaptureStop::Graceful)
+            on_done(7, Some(&stopped_session_with_epoch(7))),
+            DoneAction::Remove { unexpected: false }
         );
-        assert_eq!(
-            stop_reason::<&str>(None, Some(&"device-a"), true),
-            Some(CaptureStop::Graceful)
-        );
-    }
-
-    #[test]
-    fn replacement_waits_for_the_stopped_epochs_acknowledgement() {
-        let mut stopping_epoch = Some(7);
-
-        assert!(!acknowledge_stopping(&mut stopping_epoch, 6));
-        assert_eq!(stopping_epoch, Some(7));
-
-        assert!(acknowledge_stopping(&mut stopping_epoch, 7));
-        assert_eq!(stopping_epoch, None);
-    }
-
-    #[test]
-    fn poisoned_capture_slot_fails_the_current_connection_check_closed() {
-        let capture: CaptureChannel = Arc::new(RwLock::new(None));
-        let poison = Arc::clone(&capture);
-        let _ = catch_unwind(AssertUnwindSafe(move || {
-            let _guard = poison.write().unwrap_or_else(PoisonError::into_inner);
-            panic!("poison capture slot");
-        }));
-
-        assert!(!capture_connection_is_current(
-            Some(&ChannelRegistry::default()),
-            &capture
-        ));
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -24,7 +24,7 @@ use openlogi_hid::{
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-use crate::DpiCycleState;
+use crate::DpiCycles;
 use crate::hook_runtime;
 use crate::receiver_access::ReceiverAccess;
 use crate::watchers::gesture::should_rearm;
@@ -56,7 +56,7 @@ const TARGET_POLL: Duration = Duration::from_secs(1);
 /// dispatches each captured key press.
 pub fn spawn(
     spec: SharedKeyboardSpec,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    dpi_cycle: Arc<RwLock<DpiCycles>>,
     mouse_capture: CaptureChannel,
     keyboard_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
@@ -89,7 +89,7 @@ pub fn spawn(
 /// presses. Runs for the lifetime of the process.
 async fn manage(
     spec: SharedKeyboardSpec,
-    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    dpi_cycle: Arc<RwLock<DpiCycles>>,
     mouse_capture: CaptureChannel,
     keyboard_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
@@ -124,6 +124,7 @@ async fn manage(
                     hook_runtime::dispatch_action(
                         &action,
                         &dpi_cycle,
+                        None,
                         &mouse_capture,
                         Some(&registry),
                         &receiver_access,

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -124,13 +124,10 @@ fn main() {
 
 /// Start the HID++ background sessions that do not need Accessibility.
 fn spawn_hidpp_watchers(shared: &SharedRuntime) {
-    watchers::gesture::spawn_with_registry(
-        shared.hook_maps.clone(),
-        shared.gesture_bindings.clone(),
+    watchers::gesture::spawn(
+        shared.capture_plans.clone(),
         shared.dpi_cycle.clone(),
         shared.capture_channel.clone(),
-        shared.thumbwheel_sensitivity.clone(),
-        shared.capture_rearm_generation.clone(),
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
     );

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -261,7 +261,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::RwLock;
 
-    use openlogi_agent_core::DpiCycleState;
+    use openlogi_agent_core::DpiCycles;
     use openlogi_agent_core::hook_runtime::HookMaps;
     use openlogi_agent_core::receiver_access::ReceiverAccess;
 
@@ -270,8 +270,8 @@ mod tests {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(std::collections::HashMap::new())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
-            dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
-            thumbwheel_sensitivity: Arc::new(0.into()),
+            dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
+            capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
             channel_pool: openlogi_hid::ChannelPool::default(),

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -699,6 +699,44 @@ impl Config {
             .or_default()
             .scroll_resolution = resolution;
     }
+
+    /// Whether OpenLogi manages `device_key` at all (capture + volatile
+    /// re-apply). Unconfigured devices are managed.
+    #[must_use]
+    pub fn device_enabled(&self, device_key: &str) -> bool {
+        self.devices.get(device_key).is_none_or(|d| d.enabled)
+    }
+
+    /// Enable or disable OpenLogi's management of `device_key`.
+    pub fn set_device_enabled(&mut self, device_key: &str, enabled: bool) {
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .enabled = enabled;
+    }
+
+    /// The effective thumb-wheel sensitivity for `device_key`: the device's
+    /// override when set, else the app-wide default.
+    #[must_use]
+    pub fn thumbwheel_sensitivity(&self, device_key: &str) -> i32 {
+        self.devices
+            .get(device_key)
+            .and_then(|d| d.thumbwheel_sensitivity)
+            .unwrap_or(self.app_settings.thumbwheel_sensitivity)
+    }
+
+    /// Set (or clear, with `None`) `device_key`'s thumb-wheel sensitivity
+    /// override.
+    pub fn set_device_thumbwheel_sensitivity(
+        &mut self,
+        device_key: &str,
+        sensitivity: Option<i32>,
+    ) {
+        self.devices
+            .entry(device_key.to_string())
+            .or_default()
+            .thumbwheel_sensitivity = sensitivity;
+    }
 }
 
 /// Write `bytes` to `path` atomically via a randomized temp file + rename,

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -65,9 +65,15 @@ pub struct DeviceIdentity {
 /// `gesture_bindings` — fold into the unified [`Self::bindings`] map. Only
 /// `bindings` is ever serialized, so a migrated file self-heals to the v2 shape
 /// on its next save.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(from = "RawDeviceConfig")]
 pub struct DeviceConfig {
+    /// Whether OpenLogi manages this device at all. `false` leaves the device
+    /// fully native: no capture session (no HID++ diversion of any control)
+    /// and no volatile-settings re-apply on reconnect. Defaults to `true` and
+    /// is only serialized when disabled.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub enabled: bool,
     /// Which button owns the device's single gesture role, once the user has
     /// chosen explicitly. Absent means "infer" (the dedicated HID++ gesture
     /// button owns gestures if present) — see
@@ -129,6 +135,11 @@ pub struct DeviceConfig {
     /// The camera profile last applied from the GUI, highlighted on reopen.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub camera_profile: Option<String>,
+    /// Per-device thumb-wheel sensitivity override. `None` falls back to the
+    /// app-wide
+    /// [`AppSettings::thumbwheel_sensitivity`](crate::config::AppSettings::thumbwheel_sensitivity).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumbwheel_sensitivity: Option<i32>,
     /// Invert this device's scroll-wheel direction relative to the OS setting
     /// (issue #126): on, a wheel tick scrolls the opposite way, so a user who
     /// keeps macOS "natural scrolling" for the trackpad can have a traditional
@@ -153,6 +164,47 @@ pub struct DeviceConfig {
     /// [`Self::dpi`]. `None` means "never set — leave the keyboard alone".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fn_lock: Option<bool>,
+}
+
+impl Default for DeviceConfig {
+    fn default() -> Self {
+        Self {
+            // A fresh entry (e.g. created by a first DPI write) must stay
+            // managed — `enabled: false` is an explicit user choice only.
+            enabled: true,
+            gesture_owner: None,
+            identity: None,
+            bindings: BTreeMap::new(),
+            per_app_bindings: BTreeMap::new(),
+            dpi_presets: Vec::new(),
+            dpi: None,
+            lighting: None,
+            light: None,
+            smartshift: None,
+            camera_controls: None,
+            camera_profiles: BTreeMap::new(),
+            camera_profile: None,
+            thumbwheel_sensitivity: None,
+            invert_scroll: false,
+            scroll_resolution: None,
+            host_switch_targets: Vec::new(),
+            fn_lock: None,
+        }
+    }
+}
+
+/// `serde(default)` helper for `bool` fields that default to `true`.
+fn default_true() -> bool {
+    true
+}
+
+/// `skip_serializing_if` helper for `bool` fields whose default is `true`.
+#[allow(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde's skip_serializing_if requires a fn(&T) -> bool signature"
+)]
+fn is_true(b: &bool) -> bool {
+    *b
 }
 
 /// `skip_serializing_if` helper for plain `bool` fields whose default is
@@ -208,6 +260,8 @@ struct RawDeviceConfig {
     #[serde(default)]
     camera_profile: Option<String>,
     #[serde(default)]
+    thumbwheel_sensitivity: Option<i32>,
+    #[serde(default)]
     invert_scroll: bool,
     #[serde(default)]
     scroll_resolution: Option<ScrollResolution>,
@@ -215,6 +269,8 @@ struct RawDeviceConfig {
     host_switch_targets: Vec<String>,
     #[serde(default)]
     fn_lock: Option<bool>,
+    #[serde(default = "default_true")]
+    enabled: bool,
 }
 
 impl From<RawDeviceConfig> for DeviceConfig {
@@ -249,6 +305,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
         }
 
         DeviceConfig {
+            enabled: raw.enabled,
             gesture_owner: raw.gesture_owner,
             identity: raw.identity,
             bindings,
@@ -261,6 +318,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
             camera_controls: raw.camera_controls,
             camera_profiles: raw.camera_profiles,
             camera_profile: raw.camera_profile,
+            thumbwheel_sensitivity: raw.thumbwheel_sensitivity,
             invert_scroll: raw.invert_scroll,
             scroll_resolution: raw.scroll_resolution,
             host_switch_targets: raw.host_switch_targets,

--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -11,6 +11,7 @@ use gpui_component::{
     description_list::{DescriptionItem, DescriptionList},
     h_flex,
     scroll::ScrollableElement as _,
+    switch::Switch,
     tab::TabBar,
     v_flex,
 };
@@ -579,6 +580,14 @@ fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElem
 }
 
 fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
+    let device_enabled = cx
+        .try_global::<AppState>()
+        .and_then(|state| {
+            state
+                .current_record()
+                .map(|r| state.device_enabled(&r.config_key))
+        })
+        .unwrap_or(true);
     let (binding_count, gesture_count, preset_count, app_profile) = cx
         .try_global::<AppState>()
         .map_or((0, 0, 0, tr!("Default profile").to_string()), |state| {
@@ -595,6 +604,32 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
 
     let content = v_flex()
         .gap_3()
+        .child(
+            h_flex()
+                .justify_between()
+                .items_center()
+                .child(
+                    v_flex()
+                        .child(div().text_sm().child(tr!("Manage this device")))
+                        .child(div().text_xs().text_color(pal.text_muted).child(tr!(
+                            "Off leaves every control native and stops re-applying settings."
+                        ))),
+                )
+                .child(
+                    Switch::new("device-enabled")
+                        .checked(device_enabled)
+                        .on_click(|checked, _window, cx| {
+                            let enabled = *checked;
+                            cx.update_global::<AppState, _>(|state, _| {
+                                let key = state.current_record().map(|r| r.config_key.clone());
+                                if let Some(key) = key {
+                                    state.set_device_enabled(&key, enabled);
+                                }
+                            });
+                            cx.refresh_windows();
+                        }),
+                ),
+        )
         .child(
             DescriptionList::new()
                 .columns(1)

--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -58,8 +58,10 @@ const GALLERY_GAP: f32 = 24.;
 /// cards (Logi Options+ style), via [`Carousel`]'s `uniform` mode. Each card
 /// floats the device photo on the window background above its name and battery;
 /// the row centres while the cards fit the viewport and scrolls once they don't.
-/// Clicking a card opens its detail screen and makes it the active device (whose
-/// bindings the hook uses); the active card wears an accent ring and tint.
+/// Clicking a card opens its detail screen and makes it the active device.
+/// Capture runs per device, so which card is current only decides what the
+/// detail screen shows; the active card wears an accent fill. A disabled
+/// device wears a persistent red ring so the unmanaged state stays visible.
 pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
     let (len, active_idx) = cx.try_global::<AppState>().map_or((0, 0), |s| {
         let len = s.device_list.len();
@@ -83,6 +85,9 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
                     return div().into_any_element();
                 };
                 let key = record.config_key.clone();
+                let enabled = cx
+                    .try_global::<AppState>()
+                    .is_some_and(|s| s.device_enabled(&record.config_key));
                 let light_enabled = cx.try_global::<AppState>().is_some_and(|state| {
                     record.kind == DeviceKind::Light && state.light_enabled_for(&record.config_key)
                 });
@@ -95,19 +100,27 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
                     .try_global::<AppState>()
                     .and_then(|s| keyboard_glow(s, &record));
                 let view = view.clone();
-                device_card(&record, focused, glow, light_enabled, light_settings, pal)
-                    .id(("device-card", idx))
-                    .active(gpui::Styled::shadow_2xs)
-                    .role(Role::Button)
-                    .aria_label(record.display_name.clone())
-                    .aria_description(device_accessibility_description(&record))
-                    .aria_selected(focused)
-                    .cursor_pointer()
-                    .hover(move |s| s.border_color(rgb(theme::ACCENT_BLUE)).shadow_sm())
-                    .on_click(move |_, _, cx| {
-                        view.update(cx, |this, cx| this.open_device(key.clone(), cx));
-                    })
-                    .into_any_element()
+                device_card(
+                    &record,
+                    enabled,
+                    focused,
+                    glow,
+                    light_enabled,
+                    light_settings,
+                    pal,
+                )
+                .id(("device-card", idx))
+                .active(gpui::Styled::shadow_2xs)
+                .role(Role::Button)
+                .aria_label(record.display_name.clone())
+                .aria_description(device_accessibility_description(&record))
+                .aria_selected(focused)
+                .cursor_pointer()
+                .hover(move |s| s.border_color(rgb(theme::ACCENT_BLUE)).shadow_sm())
+                .on_click(move |_, _, cx| {
+                    view.update(cx, |this, cx| this.open_device(key.clone(), cx));
+                })
+                .into_any_element()
             })
             .on_select(cx.listener(|_, ix: &usize, _, cx| {
                 cx.update_global::<AppState, _>(|state, _| state.set_current_device(*ix));
@@ -211,12 +224,22 @@ pub(crate) fn glow_canvas(geom: Arc<GlowGeometry>, color: Hsla) -> impl IntoElem
 /// the hover and click handlers.
 fn device_card(
     record: &DeviceRecord,
+    enabled: bool,
     active: bool,
     glow: Option<(Arc<GlowGeometry>, Hsla)>,
     light_enabled: bool,
     light_settings: LightSettings,
     pal: Palette,
 ) -> Div {
+    // Disabled devices get a persistent red ring; active managed devices keep
+    // the accent ring; otherwise transparent until hover (wired by the gallery).
+    let ring = if !enabled {
+        rgb(theme::STATUS_DISABLED).into()
+    } else if active {
+        theme::accent()
+    } else {
+        gpui::transparent_black()
+    };
     v_flex()
         .w(px(theme::GALLERY_CARD_W))
         .flex_shrink_0()
@@ -225,11 +248,7 @@ fn device_card(
         .p_3()
         .rounded(pal.card_radius)
         .border_1()
-        .border_color(if active {
-            theme::accent()
-        } else {
-            gpui::transparent_black()
-        })
+        .border_color(ring)
         .shadow_xs()
         .selected_fill(active)
         .child(

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -23,7 +23,10 @@ use gpui_component::{
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
 };
-use openlogi_core::config::{SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, SMARTSHIFT_MIN_AUTO_DISENGAGE};
+use openlogi_core::config::{
+    DEFAULT_THUMBWHEEL_SENSITIVITY, MAX_THUMBWHEEL_SENSITIVITY, MIN_THUMBWHEEL_SENSITIVITY,
+    SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, SMARTSHIFT_MIN_AUTO_DISENGAGE,
+};
 use openlogi_hid::{AUTO_DISENGAGE_PERMANENT, DeviceRoute, SmartShiftMode, SmartShiftStatus};
 
 use crate::components::device_read::issue_device_read;
@@ -53,6 +56,14 @@ pub struct SmartShiftPanel {
     /// The live drag value, shown in the numeric label until release commits.
     pending_threshold: Option<u8>,
     _threshold_sub: Subscription,
+    /// The per-device thumb-wheel sensitivity slider (device override; devices
+    /// without one follow the app-wide default from Settings → General).
+    wheel_sensitivity: Entity<SliderState>,
+    /// Last committed sensitivity, to re-seat the thumb on a device switch.
+    last_wheel_sensitivity: i32,
+    /// Live drag value shown in the numeric label until release commits.
+    pending_wheel_sensitivity: Option<i32>,
+    _wheel_sensitivity_sub: Subscription,
     _state_obs: Subscription,
 }
 
@@ -89,12 +100,52 @@ impl SmartShiftPanel {
                     }
                 },
             );
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "sensitivity bounds are small 1..=100 integers — exact in f32"
+        )]
+        let wheel_sensitivity = cx.new(|_| {
+            SliderState::new()
+                .min(MIN_THUMBWHEEL_SENSITIVITY as f32)
+                .max(MAX_THUMBWHEEL_SENSITIVITY as f32)
+                .step(1.)
+                .default_value(DEFAULT_THUMBWHEEL_SENSITIVITY as f32)
+        });
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "slider values are small integers well inside i32"
+        )]
+        let wheel_sensitivity_sub = cx.subscribe(
+            &wheel_sensitivity,
+            |panel, _slider, event: &SliderEvent, cx| match event {
+                SliderEvent::Change(value) => {
+                    panel.pending_wheel_sensitivity = Some(value.start().round() as i32);
+                    cx.notify();
+                }
+                SliderEvent::Release(value) => {
+                    let sensitivity = value.start().round() as i32;
+                    panel.pending_wheel_sensitivity = None;
+                    panel.last_wheel_sensitivity = sensitivity;
+                    cx.update_global::<AppState, _>(|state, _| {
+                        let key = state.current_record().map(|r| r.config_key.clone());
+                        if let Some(key) = key {
+                            state.set_device_thumbwheel_sensitivity(&key, sensitivity);
+                        }
+                    });
+                    cx.notify();
+                }
+            },
+        );
         let state_obs = cx.observe_global::<AppState>(|_, cx| cx.notify());
         Self {
             threshold,
             last_threshold: DEFAULT_THRESHOLD,
             pending_threshold: None,
             _threshold_sub: threshold_sub,
+            wheel_sensitivity,
+            last_wheel_sensitivity: DEFAULT_THUMBWHEEL_SENSITIVITY,
+            pending_wheel_sensitivity: None,
+            _wheel_sensitivity_sub: wheel_sensitivity_sub,
             _state_obs: state_obs,
         }
     }
@@ -245,26 +296,9 @@ impl SmartShiftPanel {
                 "Higher keeps the ratchet engaged longer before free-spin."
             )));
 
-        let permanent_row = h_flex()
-            .justify_between()
-            .items_center()
-            .child(
-                v_flex()
-                    .child(section_label(tr!("Permanent ratchet"), pal))
-                    .child(
-                        div()
-                            .text_caption()
-                            .text_color(pal.text_muted)
-                            .child(tr!("Never auto-switch to free-spin.")),
-                    ),
-            )
-            .child(permanent_toggle(
-                permanent,
-                ratchet,
-                restore_threshold,
-                torque,
-                pal,
-            ));
+        let wheel_row = self.wheel_sensitivity_row(window, pal, cx);
+
+        let permanent_row = permanent_row(permanent, ratchet, restore_threshold, torque, pal);
 
         v_flex()
             .gap_4()
@@ -272,6 +306,58 @@ impl SmartShiftPanel {
             .child(mode_row)
             .child(sensitivity_row)
             .child(permanent_row)
+            .child(wheel_row)
+            .into_any_element()
+    }
+}
+
+impl SmartShiftPanel {
+    /// The per-device thumb-wheel sensitivity row: label, live value, slider.
+    /// Reads the selected device's effective value and re-seats the thumb on a
+    /// device switch / external config change, never mid-drag.
+    fn wheel_sensitivity_row(
+        &mut self,
+        window: &mut Window,
+        pal: Palette,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let committed = cx
+            .try_global::<AppState>()
+            .and_then(|state| {
+                state
+                    .current_record()
+                    .map(|r| state.device_thumbwheel_sensitivity(&r.config_key))
+            })
+            .unwrap_or(DEFAULT_THUMBWHEEL_SENSITIVITY);
+        if self.pending_wheel_sensitivity.is_none() && committed != self.last_wheel_sensitivity {
+            self.last_wheel_sensitivity = committed;
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "sensitivity is a small 1..=100 integer — exact in f32"
+            )]
+            self.wheel_sensitivity
+                .update(cx, |s, cx| s.set_value(committed as f32, window, cx));
+        }
+        let display = self.pending_wheel_sensitivity.unwrap_or(committed);
+        v_flex()
+            .gap_2()
+            .child(
+                h_flex()
+                    .justify_between()
+                    .items_baseline()
+                    .child(section_label(tr!("Thumb Wheel Sensitivity"), pal))
+                    .child(
+                        div()
+                            .text_body()
+                            .text_color(rgb(ACCENT_BLUE))
+                            .child(format!("{display}")),
+                    ),
+            )
+            .child(
+                Slider::new(&self.wheel_sensitivity)
+                    .horizontal()
+                    .into_any_element(),
+            )
             .into_any_element()
     }
 }
@@ -359,6 +445,36 @@ fn smartshift_load_target(
         };
         Some((record.config_key.clone(), record.route.clone()?, write_id))
     })
+}
+
+/// The "Permanent ratchet" label + toggle row.
+fn permanent_row(
+    permanent: bool,
+    ratchet: bool,
+    restore_threshold: u8,
+    torque: u8,
+    pal: Palette,
+) -> gpui::Div {
+    h_flex()
+        .justify_between()
+        .items_center()
+        .child(
+            v_flex()
+                .child(section_label(tr!("Permanent ratchet"), pal))
+                .child(
+                    div()
+                        .text_caption()
+                        .text_color(pal.text_muted)
+                        .child(tr!("Never auto-switch to free-spin.")),
+                ),
+        )
+        .child(permanent_toggle(
+            permanent,
+            ratchet,
+            restore_threshold,
+            torque,
+            pal,
+        ))
 }
 
 /// A small muted section heading.

--- a/crates/openlogi-gui/src/state/settings.rs
+++ b/crates/openlogi-gui/src/state/settings.rs
@@ -97,9 +97,60 @@ impl AppState {
         self.config.app_settings.ui_radius = radius;
         self.persist_config("UI radius setting");
     }
-    /// Set the thumb-wheel sensitivity (clamped to the valid range), publish it
-    /// to the gesture watcher via the shared atomic, and persist it. No-op when
-    /// unchanged. Disk failures are logged, not propagated.
+    /// Whether OpenLogi manages `key` (capture + volatile re-apply).
+    #[must_use]
+    pub fn device_enabled(&self, key: &str) -> bool {
+        self.config.device_enabled(key)
+    }
+
+    /// Enable or disable OpenLogi's management of `key` and persist it. The
+    /// agent tears down or re-arms the device's capture session on reload.
+    pub fn set_device_enabled(&mut self, key: &str, enabled: bool) {
+        if self.config.device_enabled(key) == enabled {
+            return;
+        }
+        self.config.set_device_enabled(key, enabled);
+        self.persist_and_reload("device enabled");
+    }
+
+    /// The effective thumb-wheel sensitivity for `key` (its per-device
+    /// override, else the app-wide default).
+    #[must_use]
+    pub fn device_thumbwheel_sensitivity(&self, key: &str) -> i32 {
+        self.config.thumbwheel_sensitivity(key)
+    }
+
+    /// Set `key`'s per-device thumb-wheel sensitivity override (clamped to the
+    /// valid range) and persist it. Committing the app-wide default *clears*
+    /// the override — the slider is the device's only sensitivity control, so
+    /// landing on the default is the "no override" gesture, and the device
+    /// goes back to following Settings → General instead of pinning today's
+    /// default forever. The agent picks the change up through the reloaded
+    /// capture plans. No-op when the stored override would not change.
+    pub fn set_device_thumbwheel_sensitivity(&mut self, key: &str, sensitivity: i32) {
+        let sensitivity = sensitivity.clamp(
+            openlogi_core::config::MIN_THUMBWHEEL_SENSITIVITY,
+            openlogi_core::config::MAX_THUMBWHEEL_SENSITIVITY,
+        );
+        let override_value =
+            (sensitivity != self.config.app_settings.thumbwheel_sensitivity).then_some(sensitivity);
+        let stored = self
+            .config
+            .devices
+            .get(key)
+            .and_then(|d| d.thumbwheel_sensitivity);
+        if stored == override_value {
+            return;
+        }
+        self.config
+            .set_device_thumbwheel_sensitivity(key, override_value);
+        self.persist_and_reload("device thumbwheel sensitivity");
+    }
+
+    /// Set the app-wide default thumb-wheel sensitivity (clamped to the valid
+    /// range) and persist it — devices without a per-device override follow it
+    /// through the reloaded capture plans. No-op when unchanged. Disk failures
+    /// are logged, not propagated.
     pub fn set_thumbwheel_sensitivity(&mut self, sensitivity: i32) {
         let sensitivity = sensitivity.clamp(
             openlogi_core::config::MIN_THUMBWHEEL_SENSITIVITY,

--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -26,6 +26,8 @@ pub const ACCENT_BLUE: u32 = 0x003b_82f6;
 pub const STATUS_CONNECTED: u32 = 0x0022_c55e;
 pub const STATUS_CONNECTING: u32 = 0x00ea_b308;
 pub const STATUS_OFFLINE: u32 = 0x006b_7280;
+/// Ring color for a device the user disabled ("Manage this device" off).
+pub const STATUS_DISABLED: u32 = 0x00ef_4444;
 
 /// Sizes that several components need to agree on.
 pub const HEADER_H: f32 = 80.;

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -4,9 +4,7 @@
 //!
 //! [`run_capture_session`] holds a single HID++ channel open for one device,
 //! enables diversion on whichever of those controls it exposes, registers one
-//! message listener, and restores every control's default mapping on graceful
-//! shutdown. Registry revocation instead releases the stale channel without
-//! sending cleanup traffic through it.
+//! message listener, and restores every control's default mapping on shutdown.
 //! Using one channel matters: a second channel to the same device would split
 //! its input-report stream, so all captured controls share this session.
 //!
@@ -19,61 +17,30 @@
 //! defaults (click bound, rotation rebound, or sensitivity changed).
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
-use std::time::{Duration, Instant};
 
-use hidpp::{
-    channel::HidppChannel,
-    device::Device,
-    feature::{CreatableFeature, gestures2::Gestures2Feature},
-    protocol::v20,
-};
+use hidpp::{channel::HidppChannel, device::Device, protocol::v20};
 use openlogi_core::binding::{ButtonId, GestureDirection, SwipeAccumulator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-use crate::channel_registry::ChannelRegistry;
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::route::{DeviceRoute, open_route_channel};
 use crate::thumbwheel::{self, Thumbwheel};
 use crate::write::SharedChannel;
-
-/// Return the PID of the frontmost application at this instant.
-/// Called on the HID++ listener thread — before any async dispatch delay —
-/// so the PID reflects the app that was active when the button was pressed.
-/// Returns `None` on non-macOS platforms or if no frontmost app exists.
-fn frontmost_pid() -> Option<i32> {
-    #[cfg(target_os = "macos")]
-    {
-        use objc2::rc::autoreleasepool;
-        use objc2_app_kit::NSWorkspace;
-        autoreleasepool(|_| {
-            NSWorkspace::sharedWorkspace()
-                .frontmostApplication()
-                .map(|a| a.processIdentifier())
-        })
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        None
-    }
-}
 
 /// Shared slot holding the active capture session's open channel, so DPI /
 /// SmartShift writes can reuse it instead of opening a fresh one. `None`
 /// whenever no session is connected.
 pub type CaptureChannel = Arc<RwLock<Option<SharedChannel>>>;
 
-/// Why an active capture session is stopping.
+/// Why a capture session is shutting down.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CaptureStop {
-    /// The target/configuration changed while the channel is still current, so
-    /// diverted controls must be restored before the session exits.
+    /// Normal stop — restore diverted controls.
     Graceful,
-    /// Inventory revoked or replaced the underlying connection, or the
-    /// transport went down. Clear local ownership without restore writes —
-    /// the device has already discarded volatile diversion state.
+    /// Lease revoked / channel dying — skip restore writes.
     Revoked,
 }
 
@@ -84,11 +51,7 @@ pub enum CapturedInput {
     Gesture(GestureDirection),
     /// A diverted button was pressed — the DPI/ModeShift button
     /// ([`ButtonId::DpiToggle`]) or the thumb-wheel single tap
-    /// ([`ButtonId::Thumbwheel`]). The optional `frontmost_pid` is the
-    /// PID of the frontmost application at the instant the button was pressed
-    /// (captured on the listener thread to avoid timing races on dispatch).
-    /// The PID is skipped in serialization — it is a dispatch hint, not part
-    /// of the stable wire format.
+    /// ([`ButtonId::Thumbwheel`]).
     ButtonPressed(ButtonId, #[serde(skip)] Option<i32>),
     /// Thumb-wheel rotation to re-synthesise as horizontal scroll, in the
     /// wheel's `diverted_res` increments. Emitted while the wheel is diverted
@@ -111,40 +74,6 @@ pub enum GestureError {
     /// A HID++ feature call returned an error; inner string carries context.
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
-    /// An established HID channel disconnected while capture was active.
-    #[error("HID channel disconnected")]
-    ChannelDisconnected,
-}
-
-const CAPTURE_HEALTH_POLL: Duration = Duration::from_secs(1);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CaptureExit {
-    Stopped(CaptureStop),
-    Disconnected,
-}
-
-async fn wait_for_capture_exit<Shutdown>(
-    chan: &HidppChannel,
-    shutdown: Shutdown,
-    poll_period: Duration,
-) -> CaptureExit
-where
-    Shutdown: std::future::Future<Output = CaptureStop>,
-{
-    tokio::pin!(shutdown);
-    loop {
-        tokio::select! {
-            stop = &mut shutdown => {
-                return CaptureExit::Stopped(stop);
-            }
-            () = tokio::time::sleep(poll_period) => {
-                if !chan.is_connected() {
-                    return CaptureExit::Disconnected;
-                }
-            }
-        }
-    }
 }
 
 /// Movement + button state accumulated across messages. Lives behind a `Mutex`
@@ -156,53 +85,55 @@ struct CaptureAccum {
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
-    /// Whether any Back control was held in the last event.
-    back_down: bool,
-    /// Whether any Forward control was held in the last event.
-    forward_down: bool,
-    /// Timestamp of the last Back press dispatch — for debounce.
-    last_back: Option<Instant>,
-    /// Timestamp of the last Forward press dispatch — for debounce.
-    last_forward: Option<Instant>,
+    /// Diverted standard-button CIDs held in the last event.
+    buttons_down: Vec<u16>,
 }
 
-/// Minimum time between two Back or Forward dispatches from the same HID++
-/// CID. The MX Vertical sends multiple DivertedButtons frames per physical
-/// click as the CID flag bounces in/out within a single press (~50-100ms).
-/// 150ms suppresses intra-press bounce while allowing intentional rapid
-/// double-clicks (typically ≥200ms apart).
-///
-/// Note: on devices that expose buttons through both HID++ diversion and the
-/// OS CGEventTap path (e.g. MX Vertical), a single press can fire both the
-/// gesture watcher and the hook. The gesture watcher uses AXPress (Safari-safe);
-/// the hook path uses Cmd+[/] (Chrome-safe, no-op in Safari). This is harmless
-/// in practice — Safari only responds to AXPress, Chrome only responds to
-/// keyboard shortcuts, and the two actions don't double-navigate. A shared
-/// cross-path debounce (`TODO`) would be cleaner but is not required.
-const BACK_FORWARD_DEBOUNCE: Duration = Duration::from_millis(150);
+/// HID++-divertable standard buttons: the `0x1b04` control ID and the
+/// [`ButtonId`] its press dispatches as. A button is diverted per device only
+/// when its binding leaves the default, so an unbound button keeps its native
+/// HID behavior (no re-synthesis needed).
+pub const DIVERTABLE_STANDARD_BUTTONS: [(u16, ButtonId); 3] = [
+    (0x0052, ButtonId::MiddleClick),
+    (0x0053, ButtonId::Back),
+    (0x0056, ButtonId::Forward),
+];
 
-/// Capture the gesture button, DPI/ModeShift button, and (when
-/// `capture_thumbwheel`) the thumb wheel on `route` until `shutdown` resolves,
-/// forwarding each event to `sink`.
+/// Which of one device's controls a capture session should divert.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CaptureSpec {
+    /// Divert the thumb wheel over `0x2150` (rotation rebind / sensitivity /
+    /// click bound).
+    pub capture_thumbwheel: bool,
+    /// Divert the dedicated gesture button with raw-XY (it owns the gesture
+    /// role).
+    pub divert_gesture_button: bool,
+    /// Buttons to divert as plain presses (no raw-XY): the
+    /// [`DIVERTABLE_STANDARD_BUTTONS`] whose binding leaves the default, plus
+    /// the dedicated gesture button when it carries a non-default single
+    /// binding without owning the gesture role.
+    pub divert_buttons: Vec<(u16, ButtonId)>,
+}
+
+/// Capture the controls selected by `spec` on `route` until `shutdown`
+/// resolves, forwarding each event to `sink`.
 ///
-/// The dedicated gesture button (raw-XY) is diverted only when `divert_gesture_button` —
-/// i.e. it is the device's gesture owner. When the user moves the gesture role
-/// to an OS-hook button or turns gestures off, the HID++ gesture control is
-/// left undiverted so it keeps its native behavior instead of being
-/// captured-and-swallowed. The DPI/ModeShift capture and the channel-reuse slot
-/// are independent of this.
+/// The dedicated gesture button (raw-XY) is diverted only when
+/// `spec.divert_gesture_button` — i.e. it is the device's gesture owner. When
+/// the user moves the gesture role to an OS-hook button or turns gestures off,
+/// the HID++ gesture control keeps its native behavior — unless a non-default
+/// single binding puts it in `spec.divert_buttons`, in which case it is
+/// diverted as a plain button (the OS hook never sees CID `0x00c3`, so this is
+/// the binding's only delivery path). The DPI/ModeShift capture and the
+/// channel-reuse slot are independent of this.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
 /// device exposes, and listens. Returns once `shutdown` fires (or its sender is
-/// dropped), or when the established channel disconnects. A normal shutdown
-/// restores every diverted control; [`CaptureStop::Revoked`] and a disconnect
-/// skip restoration because the device has already reset its volatile mappings.
-/// Setup errors are returned; failures to restore on the way out are logged,
-/// not propagated.
+/// dropped), after restoring every diverted control. Setup errors are returned;
+/// failures to restore on the way out are logged, not propagated.
 pub async fn run_capture_session(
     route: DeviceRoute,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
+    spec: CaptureSpec,
     sink: mpsc::UnboundedSender<CapturedInput>,
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
@@ -210,127 +141,21 @@ pub async fn run_capture_session(
     let chan = open_route_channel(&route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
-    let shared = SharedChannel::new(chan, route.clone());
-    run_capture_session_on(
-        route,
-        shared,
-        capture_thumbwheel,
-        divert_gesture_button,
-        sink,
-        graceful_shutdown(shutdown),
-        channel_slot,
-    )
-    .await
-}
-
-/// Run standalone capture with an explicit graceful-or-revoked stop reason.
-///
-/// This is the reason-aware counterpart to [`run_capture_session`]. A
-/// [`CaptureStop::Graceful`] shutdown restores diverted controls;
-/// [`CaptureStop::Revoked`] releases local ownership without writing through
-/// the stale connection. Dropping the shutdown sender is treated as graceful.
-pub async fn run_capture_session_with_stop_reason(
-    route: DeviceRoute,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    sink: mpsc::UnboundedSender<CapturedInput>,
-    shutdown: oneshot::Receiver<CaptureStop>,
-    channel_slot: CaptureChannel,
-) -> Result<(), GestureError> {
-    let chan = open_route_channel(&route)
-        .await?
-        .ok_or(GestureError::DeviceNotFound)?;
-    let shared = SharedChannel::new(chan, route.clone());
-    run_capture_session_on(
-        route,
-        shared,
-        capture_thumbwheel,
-        divert_gesture_button,
-        sink,
-        explicit_shutdown(shutdown),
-        channel_slot,
-    )
-    .await
-}
-
-/// Run capture on the exact channel currently published by `registry`.
-///
-/// A registry miss returns [`GestureError::DeviceNotFound`] without falling
-/// back to route enumeration/opening; the Agent watcher retries after a later
-/// inventory publication.
-pub async fn run_capture_session_with_registry(
-    route: DeviceRoute,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    sink: mpsc::UnboundedSender<CapturedInput>,
-    shutdown: oneshot::Receiver<CaptureStop>,
-    channel_slot: CaptureChannel,
-    registry: &ChannelRegistry,
-) -> Result<(), GestureError> {
-    let shared = registry
-        .lookup(&route)
-        .ok_or(GestureError::DeviceNotFound)?;
-    run_capture_session_on(
-        route,
-        shared,
-        capture_thumbwheel,
-        divert_gesture_button,
-        sink,
-        explicit_shutdown(shutdown),
-        channel_slot,
-    )
-    .await
-}
-
-async fn graceful_shutdown(shutdown: oneshot::Receiver<()>) -> CaptureStop {
-    let _ = shutdown.await;
-    CaptureStop::Graceful
-}
-
-async fn explicit_shutdown(shutdown: oneshot::Receiver<CaptureStop>) -> CaptureStop {
-    shutdown.await.unwrap_or(CaptureStop::Graceful)
-}
-
-async fn run_capture_session_on<Shutdown>(
-    route: DeviceRoute,
-    shared: SharedChannel,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    sink: mpsc::UnboundedSender<CapturedInput>,
-    shutdown: Shutdown,
-    channel_slot: CaptureChannel,
-) -> Result<(), GestureError>
-where
-    Shutdown: std::future::Future<Output = CaptureStop>,
-{
-    let chan = Arc::clone(shared.channel());
     let device_index = route.device_index();
-    // Publish before the first setup await so the watcher can validate exact
-    // channel identity on its next poll, even while arming is still in flight.
-    replace_capture_slot(&channel_slot, Some(shared));
-    let armed = arm_controls(
-        &chan,
-        device_index,
-        capture_thumbwheel,
-        divert_gesture_button,
-        legacy_thumbwheel_trace_requested(),
-    )
-    .await;
-    let armed = match armed {
-        Ok(armed) => armed,
-        Err(error) => {
-            replace_capture_slot(&channel_slot, None);
-            return Err(error);
-        }
-    };
+    let armed = arm_controls(&chan, device_index, &spec).await?;
+
+    // Publish this device's open channel so DPI/SmartShift writes reuse it
+    // instead of opening their own. Cleared on the way out.
+    if let Ok(mut slot) = channel_slot.write() {
+        *slot = Some(SharedChannel::new(Arc::clone(&chan), route.clone()));
+    }
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
+    let gesture_diverted = armed.gesture_diverted;
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
-    let legacy_thumb_index = armed.legacy_thumb.as_ref().map(|legacy| legacy.index);
     let dpi_set = armed.dpi_cids.clone();
-    let back_set = armed.back_cids.clone();
-    let forward_set = armed.forward_cids.clone();
+    let button_set = armed.button_cids.clone();
     let listener = chan.add_msg_listener_guarded({
         let accum = Arc::clone(&accum);
         let sink = sink.clone();
@@ -339,16 +164,20 @@ where
                 return;
             }
             let msg = v20::Message::from(raw);
-            if log_legacy_thumbwheel_packet(&msg, device_index, legacy_thumb_index) {
-                return;
-            }
             if let Some(idx) = reprog_index
                 && let Some(event) = reprog_controls::decode_event(&msg, device_index, idx)
             {
                 // Recover the guard even if a prior holder panicked — the
                 // critical section is panic-free, so the data is consistent.
                 let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(&mut acc, event, &dpi_set, &back_set, &forward_set, &sink);
+                handle_reprog(
+                    &mut acc,
+                    event,
+                    gesture_diverted,
+                    &dpi_set,
+                    &button_set,
+                    &sink,
+                );
                 return;
             }
             if let Some(idx) = thumb_index
@@ -368,84 +197,71 @@ where
         index = device_index,
         gesture = armed.gesture_diverted,
         dpi_buttons = armed.dpi_cids.len(),
-        back_buttons = armed.back_cids.len(),
-        forward_buttons = armed.forward_cids.len(),
+        buttons = armed.button_cids.len(),
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
-    let exit = wait_for_capture_exit(&chan, shutdown, CAPTURE_HEALTH_POLL).await;
+    let _ = shutdown.await;
 
     drop(listener);
-    replace_capture_slot(&channel_slot, None);
-    match exit {
-        CaptureExit::Stopped(CaptureStop::Graceful) => {
-            armed.disarm().await;
-            debug!(index = device_index, "control capture stopped");
-            Ok(())
-        }
-        CaptureExit::Stopped(CaptureStop::Revoked) => {
-            debug!(
-                index = device_index,
-                "control capture abandoned after reconnect"
-            );
-            Ok(())
-        }
-        CaptureExit::Disconnected => {
-            debug!(index = device_index, "control capture channel disconnected");
-            Err(GestureError::ChannelDisconnected)
-        }
+    // The slot is one last-writer-wins cell shared by every session, so a
+    // sibling may have published its own channel after ours. Clear it only
+    // while it still holds *this* session's channel — evicting the sibling's
+    // would silently demote its DPI/SmartShift writes to the fresh-open slow
+    // path.
+    if let Ok(mut slot) = channel_slot.write()
+        && slot
+            .as_ref()
+            .is_some_and(|shared| Arc::ptr_eq(shared.channel(), &chan))
+    {
+        *slot = None;
     }
+    armed.disarm().await;
+    debug!(index = device_index, "control capture stopped");
+    Ok(())
 }
 
-fn replace_capture_slot(slot: &CaptureChannel, value: Option<SharedChannel>) {
-    *slot.write().unwrap_or_else(PoisonError::into_inner) = value;
-}
-
-#[cfg_attr(
-    not(test),
-    allow(dead_code, reason = "used by gesture session unit tests")
-)]
-async fn teardown_capture<Listener, Clear, Disarm, DisarmFuture>(
-    clear: Clear,
-    listener: Listener,
-    stop: CaptureStop,
-    disarm: Disarm,
-) where
-    Clear: FnOnce(),
-    Disarm: FnOnce() -> DisarmFuture,
-    DisarmFuture: std::future::Future<Output = ()>,
-{
-    clear();
-    drop(listener);
-    if stop == CaptureStop::Graceful {
-        disarm().await;
-    }
-}
-
-fn legacy_thumbwheel_trace_requested() -> bool {
-    std::env::var_os("OPENLOGI_TRACE_GESTURE2_THUMBWHEEL").is_some()
-}
-
-fn log_legacy_thumbwheel_packet(
-    msg: &v20::Message,
-    device_index: u8,
-    feature_index: Option<u8>,
-) -> bool {
-    let Some(feature_index) = feature_index else {
-        return false;
+/// Reason-aware capture: maps stop reasons onto a unit oneshot shutdown.
+pub async fn run_capture_session_with_stop_reason(
+    route: DeviceRoute,
+    capture_thumbwheel: bool,
+    divert_gesture_button: bool,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<CaptureStop>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let _ = shutdown.await;
+        let _ = tx.send(());
+    });
+    let spec = CaptureSpec {
+        capture_thumbwheel,
+        divert_gesture_button,
+        divert_buttons: Vec::new(),
     };
-    if msg.header().device_index != device_index || msg.header().feature_index != feature_index {
-        return false;
-    }
-    let header = msg.header();
-    info!(
-        feature_index = header.feature_index,
-        function_id = header.function_id.to_lo(),
-        software_id = header.software_id.to_lo(),
-        payload = ?msg.extend_payload(),
-        "legacy Gestures2 thumbwheel raw event"
-    );
-    true
+    run_capture_session(route, spec, sink, rx, channel_slot).await
+}
+
+/// Registry-aware capture: currently opens via route (inventory channel reuse TBD).
+pub async fn run_capture_session_with_registry(
+    route: DeviceRoute,
+    capture_thumbwheel: bool,
+    divert_gesture_button: bool,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<CaptureStop>,
+    channel_slot: CaptureChannel,
+    _registry: &crate::ChannelRegistry,
+) -> Result<(), GestureError> {
+    run_capture_session_with_stop_reason(
+        route,
+        capture_thumbwheel,
+        divert_gesture_button,
+        sink,
+        shutdown,
+        channel_slot,
+    )
+    .await
 }
 
 /// The set of controls a session has diverted, kept so they can be handed back
@@ -457,24 +273,12 @@ struct ArmedControls {
     gesture_diverted: bool,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
-    /// Back button CIDs diverted as plain buttons.
-    back_cids: Vec<u16>,
-    /// Forward button CIDs diverted as plain buttons.
-    forward_cids: Vec<u16>,
+    /// Standard-button CIDs diverted per the session's [`CaptureSpec`], with
+    /// the [`ButtonId`] each dispatches as.
+    button_cids: Vec<(u16, ButtonId)>,
     /// `0x2150` accessor + feature index, present when the thumb wheel is
     /// diverted.
     thumb: Option<(Thumbwheel, u8)>,
-    /// Diagnostic-only `0x6501` diversion for old MX thumb wheels. The packet
-    /// format is not decoded yet; this exists only while collecting real-device
-    /// traces for a native HID++ decoder.
-    legacy_thumb: Option<LegacyThumbwheelTrace>,
-}
-
-struct LegacyThumbwheelTrace {
-    feature: Gestures2Feature,
-    index: u8,
-    /// Restore only when this process changed the state.
-    restore_native: bool,
 }
 
 impl ArmedControls {
@@ -490,43 +294,85 @@ impl ArmedControls {
             for &cid in &self.dpi_cids {
                 restore(rc.set_cid_reporting(cid, false, false).await, "DPI button");
             }
-            for &cid in &self.back_cids {
-                restore(rc.set_cid_reporting(cid, false, false).await, "Back button");
-            }
-            for &cid in &self.forward_cids {
+            for &(cid, _) in &self.button_cids {
                 restore(
                     rc.set_cid_reporting(cid, false, false).await,
-                    "Forward button",
+                    "standard button",
                 );
             }
         }
         if let Some((tw, _)) = self.thumb.as_ref() {
             restore(tw.set_reporting(false, false).await, "thumb wheel");
         }
-        if let Some(legacy) = self.legacy_thumb.as_ref()
-            && legacy.restore_native
-        {
-            restore(
-                legacy
-                    .feature
-                    .set_thumbwheel_diverted(false)
-                    .await
-                    .map(|_| ()),
-                "legacy Gestures2 thumb wheel",
-            );
-        }
     }
 }
 
-/// Arm the dedicated HID++ `0x2150` thumbwheel when available.
-async fn arm_modern_thumbwheel(
-    device: &Device,
+/// Resolve features off the device's root and divert the controls `spec`
+/// selects: the gesture button (raw-XY), DPI/ModeShift buttons and rebindable
+/// standard buttons over `0x1b04`, and the thumb wheel over `0x2150`. The
+/// root-feature lookup mirrors `write::open_feature`,
+/// since hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
+async fn arm_controls(
     chan: &Arc<HidppChannel>,
     slot: u8,
-    capture_thumbwheel: bool,
-) -> Result<Option<(Thumbwheel, u8)>, GestureError> {
-    let mut thumb = None;
-    if capture_thumbwheel
+    spec: &CaptureSpec,
+) -> Result<ArmedControls, GestureError> {
+    let device = Device::new(Arc::clone(chan), slot)
+        .await
+        .map_err(|_| GestureError::DeviceUnreachable(slot))?;
+
+    let mut reprog: Option<(ReprogControlsV4, u8)> = None;
+    let mut gesture_diverted = false;
+    let mut dpi_cids: Vec<u16> = Vec::new();
+    let mut button_cids: Vec<(u16, ButtonId)> = Vec::new();
+    if let Some(info) = device
+        .root()
+        .get_feature(reprog_controls::FEATURE_ID)
+        .await
+        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
+    {
+        let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
+        let controls = enumerate_controls(&rc).await?;
+
+        // Only divert the gesture button when it owns the gesture role; otherwise
+        // leave it native (a non-owner HID++ control must not be captured-and-dropped).
+        if spec.divert_gesture_button
+            && controls
+                .iter()
+                .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
+        {
+            rc.set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, true, true)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            gesture_diverted = true;
+        }
+        for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
+            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+                rc.set_cid_reporting(cid, true, false)
+                    .await
+                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                dpi_cids.push(cid);
+            }
+        }
+        for &(cid, button) in &spec.divert_buttons {
+            // The plan never lists CID 0x00c3 while the raw-XY gesture divert
+            // owns it, but guard anyway: a plain (divert, no raw-XY) write here
+            // would strip the raw-XY reporting armed above.
+            if gesture_diverted && cid == reprog_controls::GESTURE_BUTTON_CID {
+                continue;
+            }
+            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+                rc.set_cid_reporting(cid, true, false)
+                    .await
+                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                button_cids.push((cid, button));
+            }
+        }
+        reprog = Some((rc, info.index));
+    }
+
+    let mut thumb: Option<(Thumbwheel, u8)> = None;
+    if spec.capture_thumbwheel
         && let Some(info) = device
             .root()
             .get_feature(thumbwheel::FEATURE_ID)
@@ -551,226 +397,25 @@ async fn arm_modern_thumbwheel(
         if !supports_single_tap {
             debug!("thumb wheel reports no single tap — click not capturable");
         }
-        // Use warn+continue rather than ? so a thumbwheel setup failure
-        // doesn't abort the whole session and leave already-diverted
-        // Back/Forward/DPI controls stuck with no capture session to
-        // restore them.
-        match tw.set_reporting(true, false).await {
-            Ok(()) => thumb = Some((tw, info.index)),
-            Err(e) => {
-                warn!(error = ?e, "thumb wheel set_reporting failed — skipping click capture");
-            }
-        }
+        tw.set_reporting(true, false)
+            .await
+            .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+        thumb = Some((tw, info.index));
     }
 
-    Ok(thumb)
-}
-
-/// Arm diagnostic-only diversion for the legacy `Gestures2` thumb wheel.
-async fn arm_legacy_thumbwheel_trace(
-    device: &Device,
-    chan: &Arc<HidppChannel>,
-    slot: u8,
-    enabled: bool,
-) -> Result<Option<LegacyThumbwheelTrace>, GestureError> {
-    if !enabled {
-        return Ok(None);
-    }
-    let Some(info) = device
-        .root()
-        .get_feature(Gestures2Feature::ID)
-        .await
-        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
-    else {
-        return Ok(None);
-    };
-
-    let feature = Gestures2Feature::new(Arc::clone(chan), slot, info.index);
-    match feature.thumbwheel_diverted().await {
-        Ok(Some(already_diverted)) => {
-            if !already_diverted {
-                feature
-                    .set_thumbwheel_diverted(true)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-            }
-            info!(
-                slot,
-                feature_index = info.index,
-                "legacy Gestures2 thumbwheel trace armed; rotate both directions now"
-            );
-            Ok(Some(LegacyThumbwheelTrace {
-                feature,
-                index: info.index,
-                restore_native: !already_diverted,
-            }))
-        }
-        Ok(None) => {
-            debug!(slot, "Gestures2 thumbwheel is absent or not divertable");
-            Ok(None)
-        }
-        Err(e) => {
-            warn!(error = ?e, "failed to inspect legacy Gestures2 thumbwheel diversion");
-            Ok(None)
-        }
-    }
-}
-
-/// Resolve features off the device's root and divert the controls we capture:
-/// the gesture button (raw-XY) and DPI/ModeShift buttons over `0x1b04`, and —
-/// when `capture_thumbwheel` — the thumb wheel over `0x2150`. Optional legacy
-/// `0x6501` tracing is isolated in [`arm_legacy_thumbwheel_trace`]. The
-/// root-feature lookup mirrors `write::open_feature`,
-/// since hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
-async fn arm_controls(
-    chan: &Arc<HidppChannel>,
-    slot: u8,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    trace_legacy_thumbwheel: bool,
-) -> Result<ArmedControls, GestureError> {
-    let device = Device::new(Arc::clone(chan), slot)
-        .await
-        .map_err(|_| GestureError::DeviceUnreachable(slot))?;
-
-    let mut reprog: Option<(ReprogControlsV4, u8)> = None;
-    let mut gesture_diverted = false;
-    let mut dpi_cids: Vec<u16> = Vec::new();
-    let mut back_cids: Vec<u16> = Vec::new();
-    let mut forward_cids: Vec<u16> = Vec::new();
-    if let Some(info) = device
-        .root()
-        .get_feature(reprog_controls::FEATURE_ID)
-        .await
-        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
-    {
-        let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
-        let controls = enumerate_controls(&rc).await?;
-
-        // Only divert the gesture button when it owns the gesture role; otherwise
-        // leave it native (a non-owner HID++ control must not be captured-and-dropped).
-        if divert_gesture_button
-            && controls
-                .iter()
-                .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
-        {
-            // No prior diversions to roll back at this point — gesture is first.
-            rc.set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, true, true)
-                .await
-                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-            gesture_diverted = true;
-        }
-        // Track every CID diverted so far (across DPI/Back/Forward groups) so a
-        // later group's failure can roll back everything already diverted —
-        // including this group's own partial progress — leaving no button stuck.
-        let mut diverted_cids: Vec<u16> = Vec::new();
-        dpi_cids = divert_candidate_cids(
-            &rc,
-            &controls,
-            &reprog_controls::DPI_MODE_SHIFT_CIDS,
-            &mut diverted_cids,
-            gesture_diverted,
-        )
-        .await?;
-        // Back/Forward buttons on MX Vertical and similar devices report via
-        // HID++ rather than as standard OS mouse buttons. Divert them so the
-        // capture session can synthesize the correct OS events.
-        back_cids = divert_candidate_cids(
-            &rc,
-            &controls,
-            &reprog_controls::BACK_CIDS,
-            &mut diverted_cids,
-            gesture_diverted,
-        )
-        .await?;
-        forward_cids = divert_candidate_cids(
-            &rc,
-            &controls,
-            &reprog_controls::FORWARD_CIDS,
-            &mut diverted_cids,
-            gesture_diverted,
-        )
-        .await?;
-        reprog = Some((rc, info.index));
-    }
-
-    let thumb = arm_modern_thumbwheel(&device, chan, slot, capture_thumbwheel).await?;
-
-    // MX Master 2S does not expose 0x2150. Its thumb wheel is Gestures2
-    // gesture 46. Trace mode diverts only that gesture and logs raw packets;
-    // normal builds continue using the native horizontal-wheel fallback.
-    let legacy_thumb = arm_legacy_thumbwheel_trace(
-        &device,
-        chan,
-        slot,
-        capture_thumbwheel && thumb.is_none() && trace_legacy_thumbwheel,
-    )
-    .await?;
-
-    if !gesture_diverted
-        && dpi_cids.is_empty()
-        && back_cids.is_empty()
-        && forward_cids.is_empty()
-        && thumb.is_none()
-        && legacy_thumb.is_none()
-    {
+    if !gesture_diverted && dpi_cids.is_empty() && button_cids.is_empty() && thumb.is_none() {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(ArmedControls {
         reprog,
         gesture_diverted,
         dpi_cids,
-        back_cids,
-        forward_cids,
+        button_cids,
         thumb,
-        legacy_thumb,
     })
 }
 
-/// Divert every CID in `candidates` that `controls` reports as divertable,
-/// appending each success to `diverted` (the running rollback list shared
-/// across all candidate groups in one [`arm_controls`] call) and returning
-/// the subset actually diverted from this group.
-///
-/// On failure, rolls back `gesture_diverted` (if set) plus everything already
-/// in `diverted` — including this group's own partial progress, since the
-/// failing CID's own diversion never got recorded — then returns the error.
-/// No calling group is left with a stuck-diverted button.
-async fn divert_candidate_cids(
-    rc: &ReprogControlsV4,
-    controls: &[reprog_controls::CtrlIdInfo],
-    candidates: &[u16],
-    diverted: &mut Vec<u16>,
-    gesture_diverted: bool,
-) -> Result<Vec<u16>, GestureError> {
-    let mut group = Vec::new();
-    for &cid in candidates {
-        if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-            if let Err(e) = rc.set_cid_reporting(cid, true, false).await {
-                if gesture_diverted {
-                    let _ = rc
-                        .set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, false, false)
-                        .await;
-                }
-                for &d in diverted.iter() {
-                    let _ = rc.set_cid_reporting(d, false, false).await;
-                }
-                // The failed enable may still have applied in firmware if only
-                // the acknowledgement was lost — best-effort revert this CID
-                // too, so a flaky response doesn't leave it silently diverted
-                // with no ArmedControls session ever created to restore it.
-                let _ = rc.set_cid_reporting(cid, false, false).await;
-                return Err(GestureError::Hidpp(format!("{e:?}")));
-            }
-            group.push(cid);
-            diverted.push(cid);
-        }
-    }
-    Ok(group)
-}
-
 /// Log (don't propagate) a failure to hand a control back to the firmware.
-/// Shared with the keyboard capture session (`crate::keyboard`).
 pub(crate) fn restore<E: std::fmt::Display>(result: Result<(), E>, what: &str) {
     if let Err(e) = result {
         warn!(error = %e, control = what, "failed to restore control mapping on shutdown");
@@ -778,8 +423,7 @@ pub(crate) fn restore<E: std::fmt::Display>(result: Result<(), E>, what: &str) {
 }
 
 /// Read the device's full reprogrammable-control table in one pass, so we can
-/// test several CIDs without rescanning per control. Shared with the keyboard
-/// capture session (`crate::keyboard`).
+/// test several CIDs without rescanning per control.
 pub(crate) async fn enumerate_controls(
     rc: &ReprogControlsV4,
 ) -> Result<Vec<reprog_controls::CtrlIdInfo>, GestureError> {
@@ -805,21 +449,27 @@ pub(crate) async fn enumerate_controls(
 fn handle_reprog(
     acc: &mut CaptureAccum,
     event: RawControlEvent,
+    gesture_diverted: bool,
     dpi_cids: &[u16],
-    back_cids: &[u16],
-    forward_cids: &[u16],
+    button_cids: &[(u16, ButtonId)],
     sink: &mpsc::UnboundedSender<CapturedInput>,
 ) {
     match event {
         RawControlEvent::DivertedButtons(cids) => {
-            let gesture_held = cids.contains(&reprog_controls::GESTURE_BUTTON_CID);
-            if gesture_held && !acc.swipe.is_holding() {
-                acc.swipe.begin();
-            } else if !gesture_held && acc.swipe.is_holding() {
-                // A press that never committed a direction is a plain click.
-                if acc.swipe.end() {
-                    debug!("gesture click");
-                    let _ = sink.send(CapturedInput::Gesture(GestureDirection::Click));
+            // The swipe accumulator belongs to the raw-XY gesture divert. When
+            // the gesture button is instead diverted as a plain button (it has
+            // a single binding but not the gesture role), its press must flow
+            // through the `button_cids` loop only — not also emit a click.
+            if gesture_diverted {
+                let gesture_held = cids.contains(&reprog_controls::GESTURE_BUTTON_CID);
+                if gesture_held && !acc.swipe.is_holding() {
+                    acc.swipe.begin();
+                } else if !gesture_held && acc.swipe.is_holding() {
+                    // A press that never committed a direction is a plain click.
+                    if acc.swipe.end() {
+                        debug!("gesture click");
+                        let _ = sink.send(CapturedInput::Gesture(GestureDirection::Click));
+                    }
                 }
             }
 
@@ -829,48 +479,16 @@ fn handle_reprog(
             }
             acc.dpi_down = dpi_down;
 
-            // Back/Forward: emit on the rising edge (first frame where the CID
-            // appears), matching the DPI button convention above.
-            let back_down = back_cids.iter().any(|cid| cids.contains(cid));
-            if back_down && !acc.back_down {
-                let now = Instant::now();
-                let elapsed = acc.last_back.map_or(BACK_FORWARD_DEBOUNCE, |t| now - t);
-                if elapsed >= BACK_FORWARD_DEBOUNCE {
-                    acc.last_back = Some(now);
-                    // Capture frontmost PID NOW on this listener thread — before
-                    // any async dispatch delay can shift focus away from the
-                    // target browser window.
-                    let _ = sink.send(CapturedInput::ButtonPressed(
-                        ButtonId::Back,
-                        frontmost_pid(),
-                    ));
-                } else {
-                    debug!(
-                        elapsed_ms = elapsed.as_millis(),
-                        "Back debounced — too soon after last dispatch"
-                    );
+            for &(cid, button) in button_cids {
+                let down = cids.contains(&cid);
+                let was_down = acc.buttons_down.contains(&cid);
+                if down && !was_down {
+                    let _ = sink.send(CapturedInput::ButtonPressed(button, None));
+                    acc.buttons_down.push(cid);
+                } else if !down && was_down {
+                    acc.buttons_down.retain(|&c| c != cid);
                 }
             }
-            acc.back_down = back_down;
-
-            let forward_down = forward_cids.iter().any(|cid| cids.contains(cid));
-            if forward_down && !acc.forward_down {
-                let now = Instant::now();
-                let elapsed = acc.last_forward.map_or(BACK_FORWARD_DEBOUNCE, |t| now - t);
-                if elapsed >= BACK_FORWARD_DEBOUNCE {
-                    acc.last_forward = Some(now);
-                    let _ = sink.send(CapturedInput::ButtonPressed(
-                        ButtonId::Forward,
-                        frontmost_pid(),
-                    ));
-                } else {
-                    debug!(
-                        elapsed_ms = elapsed.as_millis(),
-                        "Forward debounced — too soon after last dispatch"
-                    );
-                }
-            }
-            acc.forward_down = forward_down;
         }
         RawControlEvent::RawXy { dx, dy } => {
             // Commit the instant a clean direction emerges (mid-swipe, once per

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -1,97 +1,5 @@
 use super::*;
 
-use std::cell::RefCell;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::rc::Rc;
-
-struct DropRecorder(Rc<RefCell<Vec<&'static str>>>);
-
-impl Drop for DropRecorder {
-    fn drop(&mut self) {
-        self.0.borrow_mut().push("listener");
-    }
-}
-
-#[tokio::test]
-async fn graceful_teardown_clears_then_drops_listener_then_disarms() {
-    let events = Rc::new(RefCell::new(Vec::new()));
-    teardown_capture(
-        {
-            let events = Rc::clone(&events);
-            move || events.borrow_mut().push("clear")
-        },
-        DropRecorder(Rc::clone(&events)),
-        CaptureStop::Graceful,
-        {
-            let events = Rc::clone(&events);
-            move || async move { events.borrow_mut().push("disarm") }
-        },
-    )
-    .await;
-
-    assert_eq!(*events.borrow(), ["clear", "listener", "disarm"]);
-}
-
-#[tokio::test]
-async fn revoked_teardown_clears_then_drops_listener_without_disarm() {
-    let events = Rc::new(RefCell::new(Vec::new()));
-    teardown_capture(
-        {
-            let events = Rc::clone(&events);
-            move || events.borrow_mut().push("clear")
-        },
-        DropRecorder(Rc::clone(&events)),
-        CaptureStop::Revoked,
-        {
-            let events = Rc::clone(&events);
-            move || async move { events.borrow_mut().push("disarm") }
-        },
-    )
-    .await;
-
-    assert_eq!(*events.borrow(), ["clear", "listener"]);
-}
-
-#[test]
-fn capture_slot_cleanup_recovers_a_poisoned_writer() {
-    let slot: CaptureChannel = Arc::new(RwLock::new(None));
-    let poison = Arc::clone(&slot);
-    let _ = catch_unwind(AssertUnwindSafe(move || {
-        let _guard = poison.write().unwrap_or_else(PoisonError::into_inner);
-        panic!("poison capture slot");
-    }));
-
-    replace_capture_slot(&slot, None);
-
-    assert!(
-        slot.read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .is_none()
-    );
-}
-
-#[tokio::test]
-async fn registry_miss_does_not_fall_back_to_opening_the_route() {
-    let route = DeviceRoute::Direct {
-        vendor_id: 0x046d,
-        product_id: 0xb35b,
-    };
-    let registry = ChannelRegistry::default();
-    let (sink, _events) = mpsc::unbounded_channel();
-    let (_stop, shutdown) = oneshot::channel();
-    let slot: CaptureChannel = Arc::new(RwLock::new(None));
-
-    let result =
-        run_capture_session_with_registry(route, false, false, sink, shutdown, slot, &registry)
-            .await;
-
-    let Err(error) = result else {
-        panic!("an empty Agent registry must fail before any route open");
-    };
-
-    assert!(matches!(error, GestureError::DeviceNotFound));
-}
-
 fn press() -> RawControlEvent {
     RawControlEvent::DivertedButtons([reprog_controls::GESTURE_BUTTON_CID, 0, 0, 0])
 }
@@ -105,16 +13,16 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &[], &[], &[], &tx);
+    handle_reprog(&mut acc, press(), true, &[], &[], &tx);
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        &[],
+        true,
         &[],
         &[],
         &tx,
     );
-    handle_reprog(&mut acc, release(), &[], &[], &[], &tx);
+    handle_reprog(&mut acc, release(), true, &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -131,13 +39,13 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &[], &[], &[], &tx);
+    handle_reprog(&mut acc, press(), true, &[], &[], &tx);
     // Pretend the button has been held well past the swipe gate.
     acc.swipe.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        &[],
+        true,
         &[],
         &[],
         &tx,
@@ -148,10 +56,33 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
         Ok(CapturedInput::Gesture(GestureDirection::Right))
     );
 
-    handle_reprog(&mut acc, release(), &[], &[], &[], &tx);
+    handle_reprog(&mut acc, release(), true, &[], &[], &tx);
     assert!(
         rx.try_recv().is_err(),
         "a committed swipe must not also click on release"
+    );
+}
+
+#[test]
+fn a_plain_diverted_gesture_button_presses_without_gesturing() {
+    // A gesture button diverted as a plain button (it does NOT own the gesture
+    // role; its single binding needs delivery) must dispatch as a button press
+    // only — the swipe accumulator belongs to the raw-XY gesture divert and
+    // must not also emit a gesture click on release.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let buttons = [(reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)];
+
+    handle_reprog(&mut acc, press(), false, &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), false, &[], &buttons, &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::GestureButton, None))
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "a plain-diverted gesture button must not also emit a gesture click"
     );
 }
 
@@ -162,8 +93,8 @@ fn a_held_dpi_button_presses_once_on_the_rising_edge() {
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
 
-    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
-    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
+    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -183,9 +114,9 @@ fn a_dpi_button_re_presses_after_a_release() {
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
     let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
 
-    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
-    handle_reprog(&mut acc, up, &[dpi], &[], &[], &tx);
-    handle_reprog(&mut acc, down, &[dpi], &[], &[], &tx);
+    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, up, true, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -195,86 +126,6 @@ fn a_dpi_button_re_presses_after_a_release() {
         rx.try_recv(),
         Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle, None)),
         "a release re-arms the rising edge"
-    );
-    assert!(rx.try_recv().is_err());
-}
-
-// Back/Forward emit `ButtonPressed` with a real `frontmost_pid()` reading
-// (`Some` on macOS, `None` elsewhere — see `frontmost_pid`), unlike DPI's
-// hardcoded `None`, so these assertions match on the button only.
-
-#[test]
-fn a_held_back_button_presses_once_on_the_rising_edge() {
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let mut acc = CaptureAccum::default();
-    let back = reprog_controls::BACK_CIDS[0];
-    let down = RawControlEvent::DivertedButtons([back, 0, 0, 0]);
-
-    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
-    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
-
-    assert!(matches!(
-        rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::Back, _))
-    ));
-    assert!(rx.try_recv().is_err(), "a held Back button presses once");
-}
-
-#[test]
-fn a_forward_button_re_press_within_the_debounce_window_is_suppressed() {
-    // Unlike the DPI button, Back/Forward re-arm on release is gated by
-    // BACK_FORWARD_DEBOUNCE: the MX Vertical's firmware can report a single
-    // physical click as press/release/press within a few ms, and without the
-    // debounce that would fire twice. A press → release → press happening in
-    // a tight test loop is well within the 150ms window, so the second press
-    // must be suppressed.
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let mut acc = CaptureAccum::default();
-    let fwd = reprog_controls::FORWARD_CIDS[0];
-    let down = RawControlEvent::DivertedButtons([fwd, 0, 0, 0]);
-    let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
-
-    handle_reprog(&mut acc, down, &[], &[], &[fwd], &tx);
-    handle_reprog(&mut acc, up, &[], &[], &[fwd], &tx);
-    handle_reprog(&mut acc, down, &[], &[], &[fwd], &tx);
-
-    assert!(matches!(
-        rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::Forward, _))
-    ));
-    assert!(
-        rx.try_recv().is_err(),
-        "a re-press inside the debounce window must not re-fire"
-    );
-}
-
-#[test]
-fn a_back_button_re_press_after_the_debounce_window_fires_again() {
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let mut acc = CaptureAccum::default();
-    let back = reprog_controls::BACK_CIDS[0];
-    let down = RawControlEvent::DivertedButtons([back, 0, 0, 0]);
-    let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
-
-    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
-    handle_reprog(&mut acc, up, &[], &[back], &[], &tx);
-    // Backdate the last dispatch past the debounce window instead of
-    // sleeping in the test, mirroring `SwipeAccumulator::backdate_hold_for_test`.
-    acc.last_back = acc
-        .last_back
-        .and_then(|t| t.checked_sub(BACK_FORWARD_DEBOUNCE + Duration::from_millis(1)));
-    handle_reprog(&mut acc, down, &[], &[back], &[], &tx);
-
-    assert!(matches!(
-        rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::Back, _))
-    ));
-    assert!(
-        matches!(
-            rx.try_recv(),
-            Ok(CapturedInput::ButtonPressed(ButtonId::Back, _))
-        ),
-        "a re-press past the debounce window re-arms and fires"
     );
     assert!(rx.try_recv().is_err());
 }

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -150,6 +150,24 @@ fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 
 fn find_mouse_devices() -> Vec<(std::path::PathBuf, Device)> {
     evdev::enumerate()
+        // Only Logitech mice: the hook exists to remap devices OpenLogi
+        // manages, and grabbing an unrelated vendor's mouse would route its
+        // events through the virtual device and apply foreign remaps to it.
+        // `input_id().vendor()` is u16; crate::LOGITECH_VENDOR_ID is u32.
+        .filter(|(path, d)| {
+            let ours = u32::from(d.input_id().vendor()) == LOGITECH_VENDOR_ID;
+            if !ours
+                && d.supported_keys()
+                    .is_some_and(|keys| keys.contains(KeyCode::BTN_LEFT))
+            {
+                debug!(
+                    "not hooking {} ({}): not a Logitech device",
+                    path.display(),
+                    d.name().unwrap_or("unnamed"),
+                );
+            }
+            ours
+        })
         .filter(|(path, d)| {
             let vendor = u32::from(d.input_id().vendor());
             let hookable = is_hookable_mouse(

--- a/devenv.nix
+++ b/devenv.nix
@@ -25,19 +25,35 @@ in
   env = {
     GREET = "devenv";
     RUSTC_WRAPPER = "sccache";
-  } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+  }
+  // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
     DEVELOPER_DIR = xcodeDeveloperDir;
     SDKROOT = xcodeSdkRoot;
   };
 
-  packages = with pkgs; [
-    git
-    cmake
-    sccache
-    prek
-    create-dmg
-    crowdin-cli
-  ];
+  packages =
+    with pkgs;
+    [
+      git
+      cmake
+      sccache
+      prek
+      crowdin-cli
+    ]
+    # create-dmg is macOS-only (meta.platforms = darwin); an unconditional entry
+    # breaks evaluation of the shell on Linux.
+    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ create-dmg ]
+    # The Linux build links a handful of system libraries the shell must
+    # provide rather than rely on whatever the ambient user environment
+    # happens to expose: fontconfig via pkg-config (GPUI text rendering via
+    # yeslogic-fontconfig-sys), libxcb (x11rb in the hook and GPUI's X11
+    # backend), and libxkbcommon (GPUI keyboard handling).
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      pkg-config
+      fontconfig
+      xorg.libxcb
+      libxkbcommon
+    ];
 
   languages.rust = {
     enable = true;


### PR DESCRIPTION
## Problem

The runtime manages only the GUI-selected device. With more than one mouse connected this produces two real defects:

1. **The non-selected device's settings are dead.** Its thumbwheel rebinds, sensitivity, and button captures silently stop applying the moment you switch the carousel to another device.
2. **The Linux evdev hook applies the selected device's profile to every mouse it grabs** — including other vendors' mice and virtual pointers (e.g. keyd's). Side-button remaps configured for an MX Master land on whatever other pointing device you plug in.

## Design

Capture moves to the HID++ layer per device, where device identity is structural (one channel per device) instead of inferred:

- **`capture_plan` (agent-core, new):** the orchestrator rebuilds one `DeviceCapturePlan` per *online* device — route, per-device binding maps, divert set, effective thumbwheel sensitivity — on every config / app / inventory change, including pure online-flag flips.
- **Plan-driven sessions (`openlogi-hid`):** `run_capture_session` takes a `CaptureSpec`. Rebindable standard buttons (middle/back/forward, `0x0052/0x0053/0x0056`) divert over `0x1b04` and dispatch as `ButtonPressed`. A button at its default binding is **never diverted**, so native behavior needs no re-synthesis; the OS-hook gesture owner's button is likewise excluded so hold+swipe keeps its events.
- **Multi-session watcher:** sessions live in a map keyed by config key; inputs arrive tagged with their device and dispatch against that device's own plan (per-device thumbwheel accumulators included). The capture-vs-pairing lease is shared across sessions via an `Arc` and frees itself when the last session exits — pairing semantics unchanged.
- **Per-device settings:** `DeviceConfig.thumbwheel_sensitivity` overrides the app-wide default (which remains the fallback and keeps its Settings → General slider); the SmartShift panel gains a per-device sensitivity slider (existing localized label, no new i18n keys). `DpiCycles` replaces the single cycle state: HID++ dispatch cycles the device an event arrived on, the OS hook (which cannot attribute events) keeps targeting the selection, and a config reload no longer snaps an unchanged device's cycle index back to `preset[0]`.
- **Per-device manage toggle:** `DeviceConfig.enabled` (default `true`). A disabled device is left fully native — no capture session, no volatile re-apply, no DPI-cycle entry, empty hook maps. The Home gallery ring now shows managed state (accent blue = managed, red = disabled) instead of marking the selection, since capture no longer depends on it.
- **Linux hook:** grabs only Logitech (VID `046d`) mice, mirroring the macOS hook's vendor awareness.

## Verification

On real hardware (MX Master 4 + MX Master 3S on two Bolt receivers, Linux/Wayland):

- Both devices hold concurrent capture sessions; side buttons, gesture swipes/click, DPI button, thumbwheel rotation and (3S) single tap all arrive correctly attributed with no OS hook involved, and every diverted control restores on teardown.
- Independent per-device behavior confirmed live: different thumbwheel directions and sensitivities on each mouse simultaneously, regardless of carousel selection.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass.

HID++-layer changes are platform-neutral; runtime testing was on Linux (the OS-hook change is Linux-only).

## Notes

- The first two commits are #415 (thumbwheel divert fix) — this branch builds on it; if #415 merges first this PR rebases to just the five feature commits.
- Known limitation kept intentionally small: the OS hook still applies the selection's profile to the (now Logitech-only) devices it grabs; fully per-device hook dispatch would need evdev device attribution plumbed through the hook and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N76prZoUHMrHZajXq4jET1