### PR TITLE
feat(assets): race Cloudflare and npm mirrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,8 @@ devenv.local.yaml
 # macOS finder metadata
 .DS_Store
 
-# Bundle-time asset payload — fetched fresh from assets.openlogi.org by the
-# macOS bundle task before `cargo bundle`, not checked in.
+# Bundle-time asset payload — fetched fresh from OpenLogi's asset mirrors by
+# the macOS bundle task before `cargo bundle`, not checked in.
 /crates/openlogi-gui/assets/
 
 # Packaging output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ sits beneath both.
 | `crates/openlogi-core` | Pure types: TOML config, device model, action catalog. No I/O, no async |
 | `crates/openlogi-hidpp` | Vendored fork of the `hidpp` protocol crate (**lib name `hidpp`**, 0BSD) |
 | `crates/openlogi-hid` | Device discovery + HID++ writes over `async-hid` |
-| `crates/openlogi-assets` | Device-render registry + cached fetch from assets.openlogi.org |
+| `crates/openlogi-assets` | Device-render registry + cached fetch from OpenLogi asset mirrors |
 | `crates/openlogi-cli` | `clap` command tree: `list`, `assets`, `diag` |
 | `crates/openlogi-hook` | OS input capture: CGEventTap / evdev+uinput / WH_MOUSE_LL |
 | `crates/openlogi-inject` | OS input synthesis: CGEvent / uinput+MPRIS / SendInput |

--- a/crates/openlogi-assets/Cargo.toml
+++ b/crates/openlogi-assets/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-description = "Asset registry schema + blocking HTTP fetch helpers for the assets.openlogi.org device asset host. Shared by the openlogi CLI (bundle sync) and openlogi-gui (runtime cache)."
+description = "Asset registry schema, mirror discovery, and blocking HTTP fetch helpers. Shared by the openlogi CLI (bundle sync) and openlogi-gui (runtime cache)."
 keywords = ["logitech", "openlogi", "assets", "hid"]
 categories = ["hardware-support"]
 

--- a/crates/openlogi-assets/src/error.rs
+++ b/crates/openlogi-assets/src/error.rs
@@ -72,7 +72,7 @@ pub enum AssetError {
     SourcesUnavailable {
         /// Failure from the production custom domain.
         production: Box<AssetError>,
-        /// Failure from the immutable Cloudflare Pages deployment.
+        /// Failure from the versioned Cloudflare Pages branch alias.
         pages: Box<AssetError>,
         /// Failure from the versioned jsDelivr npm mirror.
         jsdelivr: Box<AssetError>,

--- a/crates/openlogi-assets/src/error.rs
+++ b/crates/openlogi-assets/src/error.rs
@@ -65,4 +65,47 @@ pub enum AssetError {
         /// The offending value.
         component: String,
     },
+    /// Every built-in asset mirror failed its catalog probe.
+    #[error(
+        "all asset sources are unavailable (assets.openlogi.org: {production}; Pages: {pages}; jsDelivr: {jsdelivr})"
+    )]
+    SourcesUnavailable {
+        /// Failure from the production custom domain.
+        production: Box<AssetError>,
+        /// Failure from the immutable Cloudflare Pages deployment.
+        pages: Box<AssetError>,
+        /// Failure from the versioned jsDelivr npm mirror.
+        jsdelivr: Box<AssetError>,
+    },
+    /// Probe workers ended without reporting every source.
+    #[error("asset source probe workers stopped before reporting all results")]
+    SourceProbeInterrupted,
+    /// The npm routing catalog uses a schema this client does not understand.
+    #[error("unsupported npm route schema {found}; expected {expected}")]
+    UnsupportedNpmRoutesSchema {
+        /// Schema version required by this OpenLogi build.
+        expected: u32,
+        /// Schema version returned by the catalog.
+        found: u32,
+    },
+    /// The npm routing catalog does not describe the pinned package release.
+    #[error("npm route version {found} does not match pinned asset version {expected}")]
+    NpmRoutesVersionMismatch {
+        /// Asset package version required by this OpenLogi build.
+        expected: String,
+        /// Asset package version returned by the catalog.
+        found: String,
+    },
+    /// A depot in `index.json` has no matching npm shard route.
+    #[error("npm routes contain no package for asset depot {depot}")]
+    MissingNpmRoute {
+        /// Depot whose files cannot be resolved to an npm package.
+        depot: String,
+    },
+    /// A requested asset path was not present when npm routes were validated.
+    #[error("npm routes contain no package for asset path {asset_path}")]
+    MissingNpmAssetPath {
+        /// Registry asset path with no npm package mapping.
+        asset_path: String,
+    },
 }

--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -10,6 +10,7 @@
 //! The free functions below are stateless hash / local-file helpers with
 //! no relation to a host, so they stay off the client.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
@@ -51,9 +52,20 @@ const RETRY_MIN_DELAY: Duration = Duration::from_millis(200);
 /// pulls a sync makes against the same host share one keep-alive connection
 /// instead of paying a fresh TCP + TLS handshake each time.
 pub struct AssetClient {
-    /// Normalised origin, trailing slash trimmed once at construction.
-    base: String,
+    location: AssetLocation,
     agent: Agent,
+}
+
+enum AssetLocation {
+    Uniform {
+        base: String,
+    },
+    JsDelivr {
+        catalog_base: String,
+        package_root: String,
+        package_version: String,
+        package_by_asset_path: HashMap<String, String>,
+    },
 }
 
 /// Outcome of a cache-checked fetch ([`AssetClient::fetch_entry_if_stale`]).
@@ -69,15 +81,37 @@ impl AssetClient {
     /// Build a client for `base` (e.g. `https://assets.openlogi.org`).
     #[must_use]
     pub fn new(base: &str) -> Self {
-        let agent: Agent = Agent::config_builder()
+        Self {
+            location: AssetLocation::Uniform {
+                base: base.trim_end_matches('/').to_owned(),
+            },
+            agent: Self::agent(),
+        }
+    }
+
+    pub(crate) fn new_jsdelivr(
+        catalog_base: &str,
+        package_root: &str,
+        package_version: &str,
+        package_by_asset_path: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            location: AssetLocation::JsDelivr {
+                catalog_base: catalog_base.trim_end_matches('/').to_owned(),
+                package_root: package_root.trim_end_matches('/').to_owned(),
+                package_version: package_version.to_owned(),
+                package_by_asset_path,
+            },
+            agent: Self::agent(),
+        }
+    }
+
+    fn agent() -> Agent {
+        Agent::config_builder()
             .user_agent(USER_AGENT)
             .timeout_connect(Some(CONNECT_TIMEOUT))
             .build()
-            .into();
-        Self {
-            base: base.trim_end_matches('/').to_owned(),
-            agent,
-        }
+            .into()
     }
 
     /// GET `<base>/index.json` and parse it.
@@ -88,7 +122,7 @@ impl AssetClient {
     /// GET `<base>/index.json`, returning both the raw bytes (so callers can
     /// persist them verbatim) and the parsed struct.
     pub fn fetch_index_raw(&self) -> Result<(Vec<u8>, Index), AssetError> {
-        let url = format!("{}/{INDEX_NAME}", self.base);
+        let url = self.index_url();
         debug!(%url, "fetching index.json");
         let body = self.get_bytes(&url)?;
         let parsed: Index =
@@ -109,10 +143,39 @@ impl AssetClient {
     /// GET a per-depot file, e.g.
     /// `fetch_file("v1/devices/mx_master_4/", "front_core.png")`.
     fn fetch_file(&self, asset_path: &str, name: &str) -> Result<Vec<u8>, AssetError> {
-        let asset_path = asset_path.trim_start_matches('/');
-        let url = format!("{}/{asset_path}{name}", self.base);
+        let url = self.asset_url(asset_path, name)?;
         debug!(%url, "fetching file");
         self.get_bytes(&url)
+    }
+
+    fn index_url(&self) -> String {
+        let base = match &self.location {
+            AssetLocation::Uniform { base } => base,
+            AssetLocation::JsDelivr { catalog_base, .. } => catalog_base,
+        };
+        format!("{base}/{INDEX_NAME}")
+    }
+
+    pub(crate) fn asset_url(&self, asset_path: &str, name: &str) -> Result<String, AssetError> {
+        let asset_path = asset_path.trim_start_matches('/');
+        match &self.location {
+            AssetLocation::Uniform { base } => Ok(format!("{base}/{asset_path}{name}")),
+            AssetLocation::JsDelivr {
+                package_root,
+                package_version,
+                package_by_asset_path,
+                ..
+            } => {
+                let package = package_by_asset_path.get(asset_path).ok_or_else(|| {
+                    AssetError::MissingNpmAssetPath {
+                        asset_path: asset_path.to_owned(),
+                    }
+                })?;
+                Ok(format!(
+                    "{package_root}/{package}@{package_version}/{asset_path}{name}"
+                ))
+            }
+        }
     }
 
     /// Fetch `file` into `dir` unless a file already there matches its
@@ -157,7 +220,7 @@ impl AssetClient {
     /// The backoff sleeps block the calling thread, which is fine: every
     /// caller runs on the sync's dedicated background thread, never the
     /// async runtime. `backon` defaults to `std::thread::sleep` here.
-    fn get_bytes(&self, url: &str) -> Result<Vec<u8>, AssetError> {
+    pub(crate) fn get_bytes(&self, url: &str) -> Result<Vec<u8>, AssetError> {
         let policy = ExponentialBuilder::default()
             .with_min_delay(RETRY_MIN_DELAY)
             .with_factor(2.0)
@@ -250,7 +313,7 @@ pub fn safe_component_path(
 /// The temporary file is created in the destination directory and committed via
 /// rename, so a concurrent reader sees the old file or the new one, never a
 /// half-written one. A planted symlink at `dst` is replaced, not followed.
-fn write_replace(dst: &Path, bytes: &[u8]) -> Result<(), AssetError> {
+pub(crate) fn write_replace(dst: &Path, bytes: &[u8]) -> Result<(), AssetError> {
     use std::io::Write as _;
 
     let fail = |source| AssetError::WriteFile {
@@ -290,9 +353,23 @@ pub fn cached_matches(path: &Path, expected_sha: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_retryable, safe_component_path, write_replace};
+    use super::{AssetClient, is_retryable, safe_component_path, write_replace};
     use std::path::Path;
     use ureq::Error;
+
+    #[test]
+    fn uniform_source_preserves_the_cloudflare_path() {
+        let client = AssetClient::new("https://assets.openlogi.org/");
+
+        assert_eq!(client.index_url(), "https://assets.openlogi.org/index.json");
+        assert_eq!(
+            client
+                .asset_url("v1/devices/mx_master_3s/", "front_core.png")
+                .ok()
+                .as_deref(),
+            Some("https://assets.openlogi.org/v1/devices/mx_master_3s/front_core.png")
+        );
+    }
 
     #[test]
     #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]

--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -3,7 +3,7 @@
     reason = "full schema parsed; only a subset is consumed by today's callers"
 )]
 
-//! Parses the `index.json` shipped by assets.openlogi.org.
+//! Parses the `index.json` shared by OpenLogi's asset mirrors.
 //!
 //! Schema mirrors the file the assets repo's `stage_assets.py` emits:
 //!

--- a/crates/openlogi-assets/src/lib.rs
+++ b/crates/openlogi-assets/src/lib.rs
@@ -1,4 +1,4 @@
-//! Shared asset registry types + HTTP fetch helpers for assets.openlogi.org.
+//! Shared asset registry types + HTTP fetch helpers for OpenLogi's asset mirrors.
 //!
 //! Consumers:
 //!
@@ -15,6 +15,7 @@ pub mod http;
 pub mod index;
 pub mod manifest;
 pub mod metadata;
+mod source;
 
 pub use error::AssetError;
 pub use http::{AssetClient, FetchOutcome, cached_matches, read_bytes, sha256_hex, sha256_of_file};
@@ -23,3 +24,4 @@ pub use index::{
 };
 pub use manifest::{DepotManifest, ManifestDevice, ManifestResource, variant_model_id};
 pub use metadata::{Assignment, Direction, ImageEntry, Metadata, Origin, Point};
+pub use source::{AssetRegistry, AssetSource};

--- a/crates/openlogi-assets/src/source.rs
+++ b/crates/openlogi-assets/src/source.rs
@@ -1,7 +1,7 @@
 //! Built-in asset mirror discovery and npm shard routing.
 //!
-//! A synchronization run races the production custom domain, its immutable
-//! Cloudflare Pages deployment, and the fixed jsDelivr npm release. The first
+//! A synchronization run races the production custom domain, its versioned
+//! Cloudflare Pages alias, and the fixed jsDelivr npm release. The first
 //! source with a complete valid catalog supplies both `index.json` and every
 //! subsequent file URL for that run, so caches never mix mirrors mid-sync.
 
@@ -23,8 +23,8 @@ const INDEX_NAME: &str = "index.json";
 /// Mutable production endpoint behind the OpenLogi custom domain.
 const PRODUCTION_BASE: &str = "https://assets.openlogi.org";
 
-/// Immutable Cloudflare Pages deployment for asset release 0.0.1.
-const PAGES_BASE: &str = "https://18259774.openlogi-assets.pages.dev";
+/// Stable Cloudflare Pages branch alias for asset release 0.0.1.
+const PAGES_BASE: &str = "https://v0-0-1.openlogi-assets.pages.dev";
 
 /// Exact jsDelivr catalog package for asset release 0.0.1.
 const JSDELIVR_CATALOG_BASE: &str = "https://cdn.jsdelivr.net/npm/@logi-assets/catalog@0.0.1";
@@ -44,7 +44,7 @@ const NPM_ROUTES_SCHEMA: u32 = 1;
 pub enum AssetSource {
     /// Mutable production custom domain.
     Production,
-    /// Immutable Cloudflare Pages deployment matching the npm release.
+    /// Versioned Cloudflare Pages branch alias matching the npm release.
     Pages,
     /// Versioned npm packages served through jsDelivr.
     JsDelivr,
@@ -74,7 +74,7 @@ impl AssetRegistry {
     /// Load a registry into `dir`.
     ///
     /// An explicit `base` uses that uniform origin. Without an override, the
-    /// production domain, immutable Pages deployment, and versioned jsDelivr
+    /// production domain, versioned Pages alias, and versioned jsDelivr
     /// mirror are probed concurrently; the first complete valid catalog wins.
     pub fn load(base: Option<&str>, dir: &Path) -> Result<Self, AssetError> {
         if let Some(base) = base {

--- a/crates/openlogi-assets/src/source.rs
+++ b/crates/openlogi-assets/src/source.rs
@@ -1,0 +1,335 @@
+//! Built-in asset mirror discovery and npm shard routing.
+//!
+//! A synchronization run races the production custom domain, its immutable
+//! Cloudflare Pages deployment, and the fixed jsDelivr npm release. The first
+//! source with a complete valid catalog supplies both `index.json` and every
+//! subsequent file URL for that run, so caches never mix mirrors mid-sync.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+
+use crate::error::AssetError;
+use crate::http::{AssetClient, write_replace};
+use crate::index::Index;
+
+const INDEX_NAME: &str = "index.json";
+
+/// Mutable production endpoint behind the OpenLogi custom domain.
+const PRODUCTION_BASE: &str = "https://assets.openlogi.org";
+
+/// Immutable Cloudflare Pages deployment for asset release 0.0.1.
+const PAGES_BASE: &str = "https://18259774.openlogi-assets.pages.dev";
+
+/// Exact jsDelivr catalog package for asset release 0.0.1.
+const JSDELIVR_CATALOG_BASE: &str = "https://cdn.jsdelivr.net/npm/@logi-assets/catalog@0.0.1";
+
+/// jsDelivr prefix shared by every npm asset shard.
+const JSDELIVR_PACKAGE_ROOT: &str = "https://cdn.jsdelivr.net/npm";
+
+/// npm asset release this OpenLogi build understands.
+const ASSET_VERSION: &str = "0.0.1";
+
+/// Filename and schema of the depot-to-package routing catalog.
+const NPM_ROUTES_NAME: &str = "npm-routes.json";
+const NPM_ROUTES_SCHEMA: u32 = 1;
+
+/// Asset endpoint selected for one synchronization run.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AssetSource {
+    /// Mutable production custom domain.
+    Production,
+    /// Immutable Cloudflare Pages deployment matching the npm release.
+    Pages,
+    /// Versioned npm packages served through jsDelivr.
+    JsDelivr,
+    /// Explicit `OPENLOGI_ASSETS` or CLI `--base` override.
+    Override(String),
+}
+
+impl fmt::Display for AssetSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Production => formatter.write_str(PRODUCTION_BASE),
+            Self::Pages => formatter.write_str(PAGES_BASE),
+            Self::JsDelivr => formatter.write_str(JSDELIVR_CATALOG_BASE),
+            Self::Override(base) => formatter.write_str(base),
+        }
+    }
+}
+
+/// A parsed registry and the client pinned to the mirror that supplied it.
+pub struct AssetRegistry {
+    client: AssetClient,
+    index: Index,
+    source: AssetSource,
+}
+
+impl AssetRegistry {
+    /// Load a registry into `dir`.
+    ///
+    /// An explicit `base` uses that uniform origin. Without an override, the
+    /// production domain, immutable Pages deployment, and versioned jsDelivr
+    /// mirror are probed concurrently; the first complete valid catalog wins.
+    pub fn load(base: Option<&str>, dir: &Path) -> Result<Self, AssetError> {
+        if let Some(base) = base {
+            let client = AssetClient::new(base);
+            let index = client.fetch_index_to_dir(dir)?;
+            let source = AssetSource::Override(base.to_owned());
+            info!(%source, "asset source selected");
+            return Ok(Self {
+                client,
+                index,
+                source,
+            });
+        }
+        probe_default_sources(dir)
+    }
+
+    /// Client pinned to the selected mirror for the lifetime of this registry.
+    #[must_use]
+    pub fn client(&self) -> &AssetClient {
+        &self.client
+    }
+
+    /// Parsed `index.json` returned by the selected mirror.
+    #[must_use]
+    pub fn index(&self) -> &Index {
+        &self.index
+    }
+
+    /// Mirror selected by the source probes.
+    #[must_use]
+    pub fn source(&self) -> &AssetSource {
+        &self.source
+    }
+}
+
+#[derive(Deserialize)]
+struct NpmRoutes {
+    schema_version: u32,
+    package_version: String,
+    devices: HashMap<String, String>,
+}
+
+struct ProbeSuccess {
+    client: AssetClient,
+    index_bytes: Vec<u8>,
+    index: Index,
+}
+
+fn probe_default_sources(dir: &Path) -> Result<AssetRegistry, AssetError> {
+    let (sender, receiver) = mpsc::channel();
+
+    for (source, base) in [
+        (AssetSource::Production, PRODUCTION_BASE),
+        (AssetSource::Pages, PAGES_BASE),
+    ] {
+        let sender = sender.clone();
+        thread::spawn(move || {
+            let result = probe_uniform(base);
+            if sender.send((source.clone(), result)).is_err() {
+                debug!(%source, "asset source probe finished after a winner was selected");
+            }
+        });
+    }
+    let jsdelivr_sender = sender.clone();
+    thread::spawn(move || {
+        let result = probe_jsdelivr();
+        if jsdelivr_sender
+            .send((AssetSource::JsDelivr, result))
+            .is_err()
+        {
+            debug!("jsDelivr probe finished after a winner was selected");
+        }
+    });
+    drop(sender);
+
+    let mut production_error = None;
+    let mut pages_error = None;
+    let mut jsdelivr_error = None;
+    while let Ok((source, result)) = receiver.recv() {
+        match result {
+            Ok(probe) => {
+                write_replace(&dir.join(INDEX_NAME), &probe.index_bytes)?;
+                info!(%source, "asset source selected");
+                return Ok(AssetRegistry {
+                    client: probe.client,
+                    index: probe.index,
+                    source,
+                });
+            }
+            Err(error) => {
+                warn!(%source, error = ?error, "asset source probe failed");
+                match source {
+                    AssetSource::Production => production_error = Some(error),
+                    AssetSource::Pages => pages_error = Some(error),
+                    AssetSource::JsDelivr => jsdelivr_error = Some(error),
+                    AssetSource::Override(_) => return Err(AssetError::SourceProbeInterrupted),
+                }
+            }
+        }
+        if production_error.is_some() && pages_error.is_some() && jsdelivr_error.is_some() {
+            break;
+        }
+    }
+    match (production_error, pages_error, jsdelivr_error) {
+        (Some(production), Some(pages), Some(jsdelivr)) => Err(AssetError::SourcesUnavailable {
+            production: Box::new(production),
+            pages: Box::new(pages),
+            jsdelivr: Box::new(jsdelivr),
+        }),
+        _ => Err(AssetError::SourceProbeInterrupted),
+    }
+}
+
+fn probe_uniform(base: &str) -> Result<ProbeSuccess, AssetError> {
+    let client = AssetClient::new(base);
+    let (index_bytes, index) = client.fetch_index_raw()?;
+    Ok(ProbeSuccess {
+        client,
+        index_bytes,
+        index,
+    })
+}
+
+fn probe_jsdelivr() -> Result<ProbeSuccess, AssetError> {
+    let catalog_client = AssetClient::new(JSDELIVR_CATALOG_BASE);
+    let (index_bytes, index) = catalog_client.fetch_index_raw()?;
+    let routes_url = format!("{JSDELIVR_CATALOG_BASE}/{NPM_ROUTES_NAME}");
+    let routes_bytes = catalog_client.get_bytes(&routes_url)?;
+    let routes: NpmRoutes =
+        serde_json::from_slice(&routes_bytes).map_err(|source| AssetError::ParseJson {
+            what: "fetched npm-routes.json".to_owned(),
+            source,
+        })?;
+    let client = build_jsdelivr_client(&index, &routes)?;
+    Ok(ProbeSuccess {
+        client,
+        index_bytes,
+        index,
+    })
+}
+
+fn build_jsdelivr_client(index: &Index, routes: &NpmRoutes) -> Result<AssetClient, AssetError> {
+    if routes.schema_version != NPM_ROUTES_SCHEMA {
+        return Err(AssetError::UnsupportedNpmRoutesSchema {
+            expected: NPM_ROUTES_SCHEMA,
+            found: routes.schema_version,
+        });
+    }
+    if routes.package_version != ASSET_VERSION {
+        return Err(AssetError::NpmRoutesVersionMismatch {
+            expected: ASSET_VERSION.to_owned(),
+            found: routes.package_version.clone(),
+        });
+    }
+    let mut package_by_asset_path = HashMap::with_capacity(index.devices.len());
+    for (depot, entry) in &index.devices {
+        let package = routes
+            .devices
+            .get(depot)
+            .ok_or_else(|| AssetError::MissingNpmRoute {
+                depot: depot.clone(),
+            })?;
+        package_by_asset_path.insert(
+            entry.asset_path.trim_start_matches('/').to_owned(),
+            package.clone(),
+        );
+    }
+    Ok(AssetClient::new_jsdelivr(
+        JSDELIVR_CATALOG_BASE,
+        JSDELIVR_PACKAGE_ROOT,
+        ASSET_VERSION,
+        package_by_asset_path,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{AssetError, DeviceEntry, Index};
+
+    use super::{ASSET_VERSION, NPM_ROUTES_SCHEMA, NpmRoutes, build_jsdelivr_client};
+
+    fn one_device_index() -> Index {
+        Index {
+            schema_version: 1,
+            devices: HashMap::from([(
+                "mx_master_3s".to_owned(),
+                DeviceEntry {
+                    model_id: "2b043".to_owned(),
+                    model_ids: vec!["2b043".to_owned(), "2b034".to_owned()],
+                    display_name: "MX Master 3S".to_owned(),
+                    kind: "MOUSE".to_owned(),
+                    asset_path: "v1/devices/mx_master_3s/".to_owned(),
+                    files: Vec::new(),
+                },
+            )]),
+        }
+    }
+
+    fn routes_for(package_version: &str) -> NpmRoutes {
+        NpmRoutes {
+            schema_version: NPM_ROUTES_SCHEMA,
+            package_version: package_version.to_owned(),
+            devices: HashMap::from([(
+                "mx_master_3s".to_owned(),
+                "@logi-assets/pointing".to_owned(),
+            )]),
+        }
+    }
+
+    #[test]
+    fn npm_route_preserves_the_cloudflare_path_inside_its_shard() {
+        let index = one_device_index();
+        let routes = routes_for(ASSET_VERSION);
+
+        let url = build_jsdelivr_client(&index, &routes)
+            .ok()
+            .and_then(|client| {
+                client
+                    .asset_url("v1/devices/mx_master_3s/", "front_core.png")
+                    .ok()
+            });
+
+        assert_eq!(
+            url.as_deref(),
+            Some(
+                "https://cdn.jsdelivr.net/npm/@logi-assets/pointing@0.0.1/v1/devices/mx_master_3s/front_core.png"
+            )
+        );
+    }
+
+    #[test]
+    fn npm_routes_must_match_the_pinned_asset_version() {
+        let index = one_device_index();
+        let routes = routes_for("0.0.2");
+
+        assert!(matches!(
+            build_jsdelivr_client(&index, &routes),
+            Err(AssetError::NpmRoutesVersionMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn every_catalog_depot_requires_an_npm_route() {
+        let index = one_device_index();
+        let routes = NpmRoutes {
+            schema_version: NPM_ROUTES_SCHEMA,
+            package_version: ASSET_VERSION.to_owned(),
+            devices: HashMap::new(),
+        };
+
+        assert!(matches!(
+            build_jsdelivr_client(&index, &routes),
+            Err(AssetError::MissingNpmRoute { depot }) if depot == "mx_master_3s"
+        ));
+    }
+}

--- a/crates/openlogi-assets/src/source.rs
+++ b/crates/openlogi-assets/src/source.rs
@@ -23,17 +23,17 @@ const INDEX_NAME: &str = "index.json";
 /// Mutable production endpoint behind the OpenLogi custom domain.
 const PRODUCTION_BASE: &str = "https://assets.openlogi.org";
 
-/// Stable Cloudflare Pages branch alias for asset release 0.0.1.
-const PAGES_BASE: &str = "https://v0-0-1.openlogi-assets.pages.dev";
+/// Stable Cloudflare Pages branch alias for asset release 0.1.0.
+const PAGES_BASE: &str = "https://v0-1-0.openlogi-assets.pages.dev";
 
-/// Exact jsDelivr catalog package for asset release 0.0.1.
-const JSDELIVR_CATALOG_BASE: &str = "https://cdn.jsdelivr.net/npm/@logi-assets/catalog@0.0.1";
+/// Exact jsDelivr catalog package for asset release 0.1.0.
+const JSDELIVR_CATALOG_BASE: &str = "https://cdn.jsdelivr.net/npm/@logi-assets/catalog@0.1.0";
 
 /// jsDelivr prefix shared by every npm asset shard.
 const JSDELIVR_PACKAGE_ROOT: &str = "https://cdn.jsdelivr.net/npm";
 
 /// npm asset release this OpenLogi build understands.
-const ASSET_VERSION: &str = "0.0.1";
+const ASSET_VERSION: &str = "0.1.0";
 
 /// Filename and schema of the depot-to-package routing catalog.
 const NPM_ROUTES_NAME: &str = "npm-routes.json";
@@ -302,7 +302,7 @@ mod tests {
         assert_eq!(
             url.as_deref(),
             Some(
-                "https://cdn.jsdelivr.net/npm/@logi-assets/pointing@0.0.1/v1/devices/mx_master_3s/front_core.png"
+                "https://cdn.jsdelivr.net/npm/@logi-assets/pointing@0.1.0/v1/devices/mx_master_3s/front_core.png"
             )
         );
     }

--- a/crates/openlogi-assets/src/source.rs
+++ b/crates/openlogi-assets/src/source.rs
@@ -156,6 +156,7 @@ fn probe_default_sources(dir: &Path) -> Result<AssetRegistry, AssetError> {
     while let Ok((source, result)) = receiver.recv() {
         match result {
             Ok(probe) => {
+                // A local persistence failure is independent of the selected mirror.
                 write_replace(&dir.join(INDEX_NAME), &probe.index_bytes)?;
                 info!(%source, "asset source selected");
                 return Ok(AssetRegistry {
@@ -170,7 +171,9 @@ fn probe_default_sources(dir: &Path) -> Result<AssetRegistry, AssetError> {
                     AssetSource::Production => production_error = Some(error),
                     AssetSource::Pages => pages_error = Some(error),
                     AssetSource::JsDelivr => jsdelivr_error = Some(error),
-                    AssetSource::Override(_) => return Err(AssetError::SourceProbeInterrupted),
+                    AssetSource::Override(_) => {
+                        unreachable!("override is not sent by source probes")
+                    }
                 }
             }
         }

--- a/crates/openlogi-cli/src/cmd/assets/mod.rs
+++ b/crates/openlogi-cli/src/cmd/assets/mod.rs
@@ -7,7 +7,7 @@ pub mod sync;
 
 #[derive(Debug, Subcommand)]
 pub enum AssetsCmd {
-    /// Download every device's bundle-required files from assets.openlogi.org.
+    /// Download every device's bundle-required files from the fastest available mirror.
     Sync(sync::SyncArgs),
 }
 

--- a/crates/openlogi-cli/src/cmd/assets/sync.rs
+++ b/crates/openlogi-cli/src/cmd/assets/sync.rs
@@ -1,10 +1,11 @@
 //! `openlogi assets sync` — pull every device's bundle-required files
 //! into the openlogi-gui crate so `cargo bundle` can pick them up.
 //!
-//! Fetches `index.json`, writes per-device files (skipping cache hits via
-//! sha256 compare), and prunes depots that no longer appear in the
-//! registry. Default `--out` matches the cargo-bundle resources path so
-//! the workflow is `openlogi assets sync && cargo bundle --release`.
+//! Probes OpenLogi's asset mirrors, fetches `index.json`, writes per-device
+//! files (skipping cache hits via sha256 compare), and prunes depots that no
+//! longer appear in the registry. Default `--out` matches the cargo-bundle
+//! resources path so the workflow is
+//! `openlogi assets sync && cargo bundle --release`.
 
 use std::collections::HashSet;
 use std::fs;
@@ -12,10 +13,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
 use clap::Args;
-use openlogi_assets::{FRONT_RENDER_FILES, FetchOutcome, METADATA_FILES, http};
-
-/// Default origin. Overridable via `--base` / `OPENLOGI_ASSETS`.
-const DEFAULT_BASE: &str = "https://assets.openlogi.org";
+use openlogi_assets::{AssetRegistry, FRONT_RENDER_FILES, FetchOutcome, METADATA_FILES, http};
 
 /// Returns true when `name` is an *optional* asset OpenLogi fetches when the
 /// registry lists it but never warns about when it's absent:
@@ -44,9 +42,9 @@ fn is_optional_asset(name: &str) -> bool {
 
 #[derive(Debug, Args)]
 pub struct SyncArgs {
-    /// Origin of the asset host.
-    #[arg(long, default_value = DEFAULT_BASE, env = "OPENLOGI_ASSETS")]
-    base: String,
+    /// Override automatic mirror discovery with one uniform asset origin.
+    #[arg(long, env = "OPENLOGI_ASSETS")]
+    base: Option<String>,
     /// Destination directory. Default matches the cargo-bundle
     /// resources path declared in openlogi-gui/Cargo.toml.
     #[arg(long, default_value = "crates/openlogi-gui/assets")]
@@ -57,8 +55,10 @@ pub fn run(args: SyncArgs) -> Result<()> {
     let SyncArgs { base, out } = args;
     fs::create_dir_all(&out).with_context(|| format!("create {}", out.display()))?;
 
-    let client = http::AssetClient::new(&base);
-    let index = client.fetch_index_to_dir(&out)?;
+    let registry = AssetRegistry::load(base.as_deref(), &out)?;
+    let client = registry.client();
+    let index = registry.index();
+    println!("asset source: {}", registry.source());
     println!("index.json: {} devices", index.devices.len());
 
     // Prune orphans so the bundle stays in sync with the registry.

--- a/crates/openlogi-cli/src/cmd/mod.rs
+++ b/crates/openlogi-cli/src/cmd/mod.rs
@@ -9,7 +9,7 @@ pub mod list;
 pub enum Command {
     /// List connected Logitech HID++ devices.
     List(list::ListArgs),
-    /// Manage assets fetched from assets.openlogi.org.
+    /// Manage assets fetched from OpenLogi's asset mirrors.
     #[command(subcommand)]
     Assets(assets::AssetsCmd),
     /// Real-device round-trip smoke tests against the HID++ write path.

--- a/crates/openlogi-gui/src/asset/sync.rs
+++ b/crates/openlogi-gui/src/asset/sync.rs
@@ -1,4 +1,4 @@
-//! Background HTTP sync against `assets.openlogi.org`.
+//! Background HTTP sync against OpenLogi's asset mirrors.
 //!
 //! Always fetches `index.json` first — even with no devices connected, so
 //! the registry is on disk before the first device needs resolving. Then,
@@ -15,13 +15,11 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use backon::{BackoffBuilder, ExponentialBuilder};
 use openlogi_assets::http;
-use openlogi_assets::{BUTTONS_RENDER_FILES, DepotManifest, DeviceEntry, FetchOutcome};
+use openlogi_assets::{
+    AssetRegistry, BUTTONS_RENDER_FILES, DepotManifest, DeviceEntry, FetchOutcome,
+};
 use openlogi_core::device::{DeviceInventory, DeviceModelInfo};
 use tracing::{debug, info, warn};
-
-/// Default origin for asset fetches. Overridable via `OPENLOGI_ASSETS`
-/// so dev / staging deployments can point elsewhere without a rebuild.
-pub const DEFAULT_BASE: &str = "https://assets.openlogi.org";
 
 /// Whether the startup HTTP sync should run on this launch.
 ///
@@ -43,7 +41,8 @@ pub fn should_run(has_bundle: bool) -> bool {
     !has_bundle
 }
 
-/// Refresh the local cache: the shared `index.json` unconditionally, then
+/// Refresh the local cache: probe the built-in mirrors (or use the explicit
+/// `server` override), persist the selected source's `index.json`, then sync
 /// the depots for every model in `models`. An empty `models` is a valid
 /// call — it prefetches just the index so device resolution works the
 /// moment a device first appears.
@@ -51,21 +50,19 @@ pub fn should_run(has_bundle: bool) -> bool {
 /// Each entry pairs a device's HID++ model info with its firmware `codename`,
 /// so the depot match can fall back to the registry `displayName` for devices
 /// whose live PID isn't in the registry (e.g. an MX Master 3S over BTLE).
-pub fn sync(server: &str, models: &[(DeviceModelInfo, Option<String>)]) -> Result<()> {
+pub fn sync(server: Option<&str>, models: &[(DeviceModelInfo, Option<String>)]) -> Result<()> {
     let cache_root = super::paths::user_cache_root();
     fs::create_dir_all(&cache_root)
         .with_context(|| format!("create cache root {}", cache_root.display()))?;
 
-    let client = http::AssetClient::new(server);
+    let registry = AssetRegistry::load(server, &cache_root).context("fetch asset index")?;
+    let client = registry.client();
+    let index = registry.index();
     // The index is the critical shared resource — if it can't be fetched
     // (after the HTTP layer's own retries) bail with an error so the caller
     // retries the whole sync on a later device snapshot, rather than latching
     // success off a run that downloaded nothing. Per-depot failures below stay
     // best-effort: an optional colour variant 404 shouldn't block everything.
-    let index = client
-        .fetch_index_to_dir(&cache_root)
-        .context("fetch asset index")?;
-
     // Each target carries the HID++ `extended_model_id` byte so the
     // depot sync can fetch the right colour variant. `OPENLOGI_FORCE_DEPOT`
     // doesn't correspond to a physical device, so we pass `ext = 0`
@@ -77,7 +74,7 @@ pub fn sync(server: &str, models: &[(DeviceModelInfo, Option<String>)]) -> Resul
         targets.push((forced, entry.clone(), 0));
     }
     for (model, codename) in models {
-        if let Some((depot, entry)) = super::resolve_in_index(&index, model, codename.as_deref()) {
+        if let Some((depot, entry)) = super::resolve_in_index(index, model, codename.as_deref()) {
             targets.push((depot.to_string(), entry.clone(), model.extended_model_id));
         }
     }
@@ -90,7 +87,7 @@ pub fn sync(server: &str, models: &[(DeviceModelInfo, Option<String>)]) -> Resul
     }
 
     for (depot, entry, ext) in &targets {
-        if let Err(e) = sync_depot(&client, &cache_root, depot, entry, *ext) {
+        if let Err(e) = sync_depot(client, &cache_root, depot, entry, *ext) {
             warn!(depot, error = %e, "depot sync failed");
         }
     }
@@ -258,8 +255,8 @@ pub(crate) fn sync_retry_delay(attempts: u32) -> Duration {
 /// actions always fetch, even in a release build that would otherwise serve
 /// only bundled art.)
 pub(crate) fn run_asset_sync(models: &[(DeviceModelInfo, Option<String>)]) -> bool {
-    let server = std::env::var("OPENLOGI_ASSETS").unwrap_or_else(|_| DEFAULT_BASE.to_string());
-    match sync(&server, models) {
+    let server = std::env::var("OPENLOGI_ASSETS").ok();
+    match sync(server.as_deref(), models) {
         Ok(()) => true,
         Err(e) => {
             warn!(error = ?e, "asset sync failed — will retry with backoff");

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -82,7 +82,7 @@ crates/
   openlogi-inject/  OS input synthesis: CGEvent, uinput/MPRIS, and SendInput
   openlogi-hidpp/   vendored HID++ protocol crate (lib name `hidpp`)
   openlogi-hid/     device discovery, HID++ reads/writes, and control capture over async-hid
-  openlogi-assets/  device-render registry schema + cached HTTP fetch from assets.openlogi.org
+  openlogi-assets/  device-render registry schema + cached HTTP fetch from OpenLogi asset mirrors
   openlogi-cli/     CLI implementation: command tree + `run()`, called by the `openlogi` binary
   openlogi-agent-core/  shared orchestration + the agent/GUI IPC contract
   openlogi-agent/   the `openlogi-agent` binary — background agent owning device I/O and the hook

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,8 +16,8 @@ openlogi diag lighting ff0000 # solid colour for a wired RGB keyboard (any RRGGB
 Running `openlogi` with no subcommand defaults to `list`. Set
 `OPENLOGI_LOG=debug` for verbose tracing in the CLI, GUI, or agent.
 
-Asset synchronization probes `assets.openlogi.org`, the immutable Cloudflare
-Pages release, and the pinned jsDelivr npm release concurrently. The first
+Asset synchronization probes `assets.openlogi.org`, the versioned Cloudflare
+Pages release alias, and the pinned jsDelivr npm release concurrently. The first
 mirror with a valid catalog supplies every file for that synchronization run.
 Set `OPENLOGI_ASSETS` or pass `openlogi assets sync --base <URL>` to use one
 uniform asset origin instead of automatic mirror selection.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -5,7 +5,7 @@ The `openlogi` command-line tool. For install and configuration, see the
 
 ```sh
 openlogi list                 # paired devices: slot, codename, kind, online, battery
-openlogi assets sync          # pre-fetch device renders from assets.openlogi.org
+openlogi assets sync          # pre-fetch device renders from the fastest available mirror
 openlogi diag features        # dump every HID++ feature the active device reports
 openlogi diag controls        # dump reprogrammable controls and capability flags
 openlogi diag dpi             # read → write → read-back → restore DPI (smoke test)
@@ -15,3 +15,9 @@ openlogi diag lighting ff0000 # solid colour for a wired RGB keyboard (any RRGGB
 
 Running `openlogi` with no subcommand defaults to `list`. Set
 `OPENLOGI_LOG=debug` for verbose tracing in the CLI, GUI, or agent.
+
+Asset synchronization probes `assets.openlogi.org`, the immutable Cloudflare
+Pages release, and the pinned jsDelivr npm release concurrently. The first
+mirror with a valid catalog supplies every file for that synchronization run.
+Set `OPENLOGI_ASSETS` or pass `openlogi assets sync --base <URL>` to use one
+uniform asset origin instead of automatic mirror selection.


### PR DESCRIPTION
## Summary

OpenLogi now discovers an asset source once per synchronization run instead of always using `assets.openlogi.org`.

- race three independent catalog probes concurrently:
  - `https://assets.openlogi.org`
  - `https://v0-1-0.openlogi-assets.pages.dev`
  - `https://cdn.jsdelivr.net/npm/@logi-assets/catalog@0.1.0`
- return as soon as the first complete valid catalog succeeds, so a blocked `pages.dev` probe does not delay the other sources
- pin the selected client for the entire synchronization run; files never mix sources mid-sync
- route jsDelivr device paths through the validated `npm-routes.json` package map
- validate npm route schema, package version, and complete depot coverage before selecting jsDelivr
- retain `OPENLOGI_ASSETS` and CLI `--base` as explicit single-origin overrides
- share source selection between the CLI and GUI through `openlogi-assets`

## Release alignment

The fixed versioned sources both target asset release `0.1.0`:

- Pages alias: https://v0-1-0.openlogi-assets.pages.dev
- npm catalog: https://cdn.jsdelivr.net/npm/@logi-assets/catalog@0.1.0
- asset release: https://github.com/openlogi-org/assets/releases/tag/v0.1.0

## Verification

- `devenv tasks run openlogi:check`
- `cargo test -p openlogi-assets --lib` — 21 passed
- `cargo clippy -p openlogi-assets --all-targets -- -D warnings`
- full jsDelivr validation — 210 manifest URLs succeeded
- full Pages alias validation — 210 manifest URLs succeeded
- live catalog-only source race selected `v0-1-0.openlogi-assets.pages.dev` and parsed 210 devices
- explicit `assets.openlogi.org` override parsed 210 devices without running source discovery
