### PR TITLE
fix(gui): keep the post-sync asset repaint until the inventory is Ready

### DIFF
--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -302,8 +302,15 @@ fn main() -> Result<()> {
                         // silhouettes were resolved: the resolver was rebuilt
                         // when its outcome landed; force this merge through
                         // the unchanged-list early-return so the fresh records
-                        // become visible.
-                        let force_refresh = std::mem::take(&mut assets_dirty);
+                        // become visible. Only consume the flag on a `Ready`
+                        // snapshot that will actually run the merge below —
+                        // `refresh_inventories` is skipped while the agent is
+                        // still `Scanning`, so taking it there would drop the
+                        // repaint and strand the device on its silhouette until
+                        // the next inventory change or a restart (seen after an
+                        // update relaunches GUI and agent together: the agent's
+                        // Scanning window overlaps the first sync's completion).
+                        let force_refresh = inventory_ready && std::mem::take(&mut assets_dirty);
                         let (auto_download, asset_source, models) = cx.update(|cx| {
                             let (changed, auto_download, asset_source, models) = cx.update_global::<AppState, _>(|state, _| {
                                 // Merge only *completed* enumerations. A not-yet-ready


### PR DESCRIPTION
## Summary

After an auto-update, a device's photo could stay a gray synthetic silhouette
until a full manual restart; a clean quit + relaunch never reproduced it.

A completed asset sync sets `assets_dirty` so the next inventory merge repaints
devices whose silhouette was resolved before the cache was populated. That merge
runs only on a `Ready` snapshot — and `refresh_inventories`' `unchanged` guard
compares `config_key`/`route`/`online`/`capabilities` but **not the asset**, so
only a forced merge swaps a fresh photo in for a stable device. The snapshot arm,
however, consumed the `assets_dirty` flag *unconditionally*: when it was taken on
a `Scanning` snapshot the forced merge was skipped and the flag was gone, so the
device stayed on its silhouette until an unrelated inventory change or a restart.

This surfaced specifically after an auto-update because the updater relaunches the
GUI **and** the agent together (the `.app` is ditto-swapped, so launchd restarts
the login-item agent). The agent's initial `Scanning` window then overlaps the
first sync's completion. A clean quit + relaunch leaves the already-`Ready` agent
running, which is why it didn't reproduce there.

`InventoryHealth` is monotonic (`Scanning` → `Ready`, never reverts), so holding
the flag until `Ready` cannot strand it — if HID stays broken there are no devices
to paint anyway.

## Changes

- `openlogi-gui` (`src/main.rs`): take `assets_dirty` into `force_refresh` only on
  a `Ready` snapshot that will actually run the merge, so the post-sync repaint
  survives the agent's `Scanning` window instead of being dropped.

## Testing

- `devenv tasks run openlogi:check` (fmt --check + clippy -D warnings + workspace
  tests + doctests) — green.
- Not runtime-tested on hardware: the failure is a startup timing race (agent
  `Scanning` overlapping the first sync's completion) and reproducing it live would
  mean stopping the running agent and wiping the asset cache. Verified by code
  trace: on the first `Ready` snapshot the carried-over flag forces
  `refresh_inventories`, which rebuilds the list from the freshly-synced resolver
  and swaps the real photo in for the silhouette.