### PR TITLE
fix(macos): preserve Fn semantics for page navigation

### DIFF
--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -10,7 +10,8 @@ const MOD_COMMAND: u8 = 1 << 0;
 const MOD_SHIFT: u8 = 1 << 1;
 const MOD_CONTROL: u8 = 1 << 2;
 const MOD_OPTION: u8 = 1 << 3;
-const ALL_MODIFIERS: u8 = MOD_COMMAND | MOD_SHIFT | MOD_CONTROL | MOD_OPTION;
+const MOD_FUNCTION: u8 = 1 << 4;
+const ALL_MODIFIERS: u8 = MOD_COMMAND | MOD_SHIFT | MOD_CONTROL | MOD_OPTION | MOD_FUNCTION;
 
 /// USB HID keyboard usage supported by custom shortcuts.
 ///
@@ -191,10 +192,22 @@ impl KeyCombo {
         self.modifiers & MOD_OPTION != 0
     }
 
+    /// Whether the chord includes the macOS Fn/Globe modifier.
+    ///
+    /// Other injection backends currently ignore this platform-specific
+    /// modifier while still posting the ordinary key.
+    #[must_use]
+    pub const fn has_function(&self) -> bool {
+        self.modifiers & MOD_FUNCTION != 0
+    }
+
     /// Canonical user-facing chord label.
     #[must_use]
     pub fn rendered_label(&self) -> String {
         let mut parts = Vec::new();
+        if self.has_function() {
+            parts.push("Fn".to_string());
+        }
         if self.has_command() {
             parts.push("Cmd".to_string());
         }
@@ -270,6 +283,7 @@ fn parse_modifier(token: &str) -> Option<u8> {
         "shift" => Some(MOD_SHIFT),
         "ctrl" | "control" => Some(MOD_CONTROL),
         "alt" | "option" => Some(MOD_OPTION),
+        "fn" | "function" | "globe" => Some(MOD_FUNCTION),
         _ => None,
     }
 }
@@ -354,6 +368,35 @@ mod tests {
         let combo = "Cmd+A".parse::<KeyCombo>().expect("valid shortcut failed");
         assert_eq!(combo.key().code(), 0x04);
         assert_eq!(combo.rendered_label(), "Cmd+A");
+    }
+
+    #[test]
+    fn parses_and_renders_function_before_standard_modifiers() {
+        let combo = "Globe+Ctrl+Alt+Shift+Cmd+Down"
+            .parse::<KeyCombo>()
+            .expect("valid Fn shortcut failed");
+        assert!(combo.has_function());
+        assert!(combo.has_command());
+        assert!(combo.has_control());
+        assert!(combo.has_option());
+        assert!(combo.has_shift());
+        assert_eq!(combo.key().code(), 0x51);
+        assert_eq!(combo.rendered_label(), "Fn+Cmd+Ctrl+Alt+Shift+Down");
+    }
+
+    #[test]
+    fn function_shortcut_roundtrips_human_readable_toml() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Wrapper {
+            shortcut: KeyCombo,
+        }
+
+        let wrapper = Wrapper {
+            shortcut: "Fn+Up".parse().expect("valid Fn shortcut failed"),
+        };
+        let encoded = toml::to_string(&wrapper).expect("shortcut serialization failed");
+        assert_eq!(encoded, "shortcut = \"Fn+Up\"\n");
+        assert_eq!(toml::from_str::<Wrapper>(&encoded), Ok(wrapper));
     }
 
     #[test]

--- a/crates/openlogi-inject/examples/inject_action.rs
+++ b/crates/openlogi-inject/examples/inject_action.rs
@@ -180,15 +180,14 @@ fn print_usage() {
                   PlayPause NextTrack PrevTrack VolumeUp VolumeDown MuteVolume\n\
                   CycleDpiPresets ToggleSmartShift\n\
                   ScrollUp ScrollDown HorizontalScrollLeft HorizontalScrollRight\n\
-                  CustomShortcut:<mod_hex>:<key_hex>\n\
+                  CustomShortcut:<chord>\n\
          \n\
-         CustomShortcut modifier bits: 0x01=Cmd/Ctrl 0x02=Shift 0x04=Ctrl 0x08=Option/Alt\n\
-         CustomShortcut key_hex: macOS kVK_* code (e.g. 0x08=C, 0x09=V, 0x7E=Up)\n\
+         CustomShortcut chord examples: Cmd+C, Ctrl+Shift+P, Fn+Down (macOS)\n\
          \n\
          Examples:\n\
            inject_action --delay 3 Copy\n\
            inject_action --delay 2 --between 500 VolumeUp VolumeDown PlayPause\n\
            inject_action ScrollDown ScrollDown ScrollDown\n\
-           inject_action CustomShortcut:0x01:0x08   # Ctrl+C"
+           inject_action CustomShortcut:Fn+Down"
     );
 }

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -288,14 +288,14 @@ fn post_unicode(text: &str) {
 /// Press a key chord described by a `KeyCombo` modifier bitmask + virtual
 /// keycode. Used by the workflow sequencer's `PressKey` step.
 fn post_keycombo(combo: &KeyCombo) {
-    if let Some(vk) = hid_usage_to_macos(combo.key().code()) {
-        post_key(vk, combo_flags(combo));
-    } else {
+    let Some((vk, flags)) = keycombo_event(combo) else {
         tracing::warn!(
             usage = combo.key().code(),
             "shortcut usage has no macOS mapping"
         );
-    }
+        return;
+    };
+    post_key(vk, flags);
 }
 
 /// Emit the physical-key edges whose shared ownership changed, preserving the
@@ -383,6 +383,33 @@ fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
     flags
 }
 
+/// Translate a platform-neutral chord into the virtual key and flags macOS
+/// reports for the corresponding physical key press.
+///
+/// Fn+Arrow is not represented as an arrow with the Fn flag: macOS changes
+/// the virtual key to Home/End/Page Up/Page Down and preserves SecondaryFn.
+/// Direct Page Up/Page Down keys use that flag as well. Matching both pieces
+/// avoids the short-scroll behavior applications give flagged arrow events.
+fn keycombo_event(combo: &KeyCombo) -> Option<(u16, CGEventFlags)> {
+    let mut flags = combo_flags(combo);
+    let usage = combo.key().code();
+    if combo.has_function() || matches!(usage, 0x4b | 0x4e) {
+        flags |= CGEventFlags::CGEventFlagSecondaryFn;
+    }
+    let vk = if combo.has_function() {
+        match usage {
+            0x50 => 0x73, // Fn+Left -> Home
+            0x4f => 0x77, // Fn+Right -> End
+            0x52 => 0x74, // Fn+Up -> Page Up
+            0x51 => 0x79, // Fn+Down -> Page Down
+            _ => hid_usage_to_macos(usage)?,
+        }
+    } else {
+        hid_usage_to_macos(usage)?
+    };
+    Some((vk, flags))
+}
+
 /// Map a platform-neutral USB HID keyboard usage to a macOS virtual key.
 fn hid_usage_to_macos(usage: u8) -> Option<u16> {
     const LETTERS: [u16; 26] = [
@@ -431,9 +458,9 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use core_graphics::event::CGEventFlags;
-    use openlogi_core::binding::Shortcut;
+    use openlogi_core::binding::{KeyCombo, Shortcut};
 
-    use super::{combo, held_key_event, hid_usage_to_macos};
+    use super::{combo, held_key_event, hid_usage_to_macos, keycombo_event};
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
     #[test]
@@ -444,6 +471,30 @@ mod tests {
         assert_eq!(hid_usage_to_macos(0x3a), Some(0x7a));
         assert_eq!(hid_usage_to_macos(0x6f), Some(0x5a));
         assert_eq!(hid_usage_to_macos(0xff), None);
+    }
+
+    #[test]
+    fn function_arrows_use_native_navigation_events() {
+        for (chord, expected_vk) in [
+            ("Fn+Left", 0x73),
+            ("Fn+Right", 0x77),
+            ("Fn+Up", 0x74),
+            ("Fn+Down", 0x79),
+        ] {
+            let combo = chord.parse::<KeyCombo>().expect("valid Fn chord");
+            let (vk, flags) = keycombo_event(&combo).expect("mapped Fn chord");
+            assert_eq!(vk, expected_vk, "wrong virtual key for {chord}");
+            assert!(flags.contains(CGEventFlags::CGEventFlagSecondaryFn));
+        }
+    }
+
+    #[test]
+    fn page_keys_preserve_the_secondary_function_flag() {
+        for chord in ["PageUp", "PageDown"] {
+            let combo = chord.parse::<KeyCombo>().expect("valid page chord");
+            let (_, flags) = keycombo_event(&combo).expect("mapped page chord");
+            assert!(flags.contains(CGEventFlags::CGEventFlagSecondaryFn));
+        }
     }
 
     /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -117,6 +117,17 @@ in TOML. The GUI presents their `short` action; changing that button in the GUI
 replaces the whole pair with the selected single action. `per_app_bindings` and
 `keyboard.bindings` remain single-action maps.
 
+`CustomShortcut` modifiers are `Cmd`, `Ctrl`, `Alt`, `Shift`, and `Fn`; `Fn`
+is a macOS-specific modifier that other injection backends ignore. macOS
+reproduces the native navigation events for `Fn+Left`, `Fn+Right`, `Fn+Up`, and
+`Fn+Down`, including the SecondaryFn event flag. Direct `PageUp` and `PageDown`
+shortcuts also preserve that flag:
+
+```toml
+Back = { CustomShortcut = "Fn+Down" }
+Forward = { CustomShortcut = "Fn+Up" }
+```
+
 An Actions Ring entry wraps the action and may add an icon or literal label:
 
 ```toml


### PR DESCRIPTION
## Summary

Add macOS Fn/Globe support to the platform-neutral `KeyCombo` model and reproduce the native navigation-key event representation. Synthesized page navigation therefore matches physical Fn+Up/Fn+Down instead of the shorter scroll behavior produced by flagged arrow-key events.

This revision is rebased onto current `master` at OpenLogi 0.8.3 and preserves the newer `HoldShortcut` key lifecycle introduced since the PR was opened.

## Changes

- `openlogi-core`
  - add Fn/Globe as modifier bit `0x10` in the validated binary shortcut representation
  - parse `Fn`, `Function`, and `Globe` aliases and render the canonical modifier first
  - cover combined modifier ordering and human-readable TOML round trips
- `openlogi-inject`
  - map Fn to `CGEventFlagSecondaryFn` on macOS
  - normalize Fn+Left/Right/Up/Down HID usages to Home/End/Page Up/Page Down virtual key codes while preserving the flag
  - preserve current press/release handling for `HoldShortcut`; Fn remains a `CustomShortcut` modifier
  - update the injection example to the current `CustomShortcut:<chord>` syntax
- documentation
  - document `Fn+Down` / `Fn+Up` TOML shortcuts and macOS-only Fn behavior

## Testing

- `RUSTFLAGS=-D warnings cargo fmt --all -- --check`
- `RUSTFLAGS=-D warnings cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTFLAGS=-D warnings cargo test --workspace --locked`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci wasm`
- `cargo xtask ci clippy-windows` (repository cross-lint proxy; native Windows CI remains authoritative)

The original implementation was hardware-validated with an MX Master 2S in Safari and Chrome. The rebased implementation preserves the same macOS event behavior through the current HID-usage shortcut model.

Related to #101.
