### PR TITLE
fix(agent): apply per-app gesture button clicks

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -115,7 +115,7 @@ pub fn plan_for_device(
     // One direction map per HID++ source in gesture mode — several may
     // gesture at once, each armed with its own raw-XY divert (the capture
     // target below derives the CIDs to divert from this map's keys).
-    let gesture_bindings = hidpp_gesture_maps_for(config, Some(config_key));
+    let gesture_bindings = hidpp_gesture_maps_for(config, Some(config_key), app);
     let divert_gesture_buttons = if os_mouse_hook_available {
         DIVERTABLE_STANDARD_BUTTONS
             .into_iter()

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -6,7 +6,7 @@ use super::{
     pick_current, plan_reapply, reapply_targets, stable_id,
 };
 use openlogi_core::app::ForegroundApp;
-use openlogi_core::binding::{Action, Binding, ButtonId};
+use openlogi_core::binding::{Action, Binding, ButtonId, GestureDirection};
 use openlogi_core::config::{
     Config, DeviceConfig, LightSettings, LinkConfig, ScrollResolution, VerticalScrollSensitivity,
 };
@@ -895,6 +895,18 @@ fn published_back_binding(orch: &Orchestrator) -> Option<Action> {
     })
 }
 
+/// The published dedicated HID++ gesture button's plain-click action.
+fn published_gesture_click(orch: &Orchestrator) -> Option<Action> {
+    let plans = orch.shared.capture_plans.borrow();
+    plans.first().and_then(|plan| {
+        plan.dispatch
+            .gesture_bindings
+            .get(&ButtonId::GestureButton)
+            .and_then(|map| map.get(&GestureDirection::Click))
+            .cloned()
+    })
+}
+
 #[test]
 fn app_switch_republishes_capture_plans() {
     // HID++ dispatch reads `plan.dispatch.bindings` at event time, so a
@@ -908,6 +920,12 @@ fn app_switch_republishes_capture_plans() {
         ButtonId::Back,
         Some(Action::Undo),
     );
+    config.set_per_app_binding(
+        "a",
+        "com.example.editor",
+        ButtonId::GestureButton,
+        Some(Action::BrowserBack),
+    );
     let mut orch = orchestrator(config);
     orch.devices = vec![dev("a", 1, true)];
     orch.rebuild();
@@ -916,8 +934,12 @@ fn app_switch_republishes_capture_plans() {
         Some(Action::Undo),
         "no per-app overlay while no app is in front"
     );
+    assert_ne!(published_gesture_click(&orch), Some(Action::BrowserBack));
     orch.set_current_app(Some(ForegroundApp::unnamed("com.example.editor".into())));
     assert_eq!(published_back_binding(&orch), Some(Action::Undo));
+    assert_eq!(published_gesture_click(&orch), Some(Action::BrowserBack));
+    orch.set_current_app(None);
+    assert_ne!(published_gesture_click(&orch), Some(Action::BrowserBack));
 }
 
 #[test]

--- a/crates/openlogi-core/src/bindings.rs
+++ b/crates/openlogi-core/src/bindings.rs
@@ -66,16 +66,20 @@ pub fn button_bindings_for(
 /// keyed by the button its captured swipes dispatch as. Each map is seeded
 /// via [`Binding::fill_gesture_defaults`] — the one canonical seeding rule —
 /// so the watcher always dispatches the full five-direction set the GUI
-/// shows. Empty when no HID++ source gestures (or `config_key` is `None`).
+/// shows. A per-app single-action override replaces only that source's Click
+/// arm; its global swipe arms and gesture mode remain intact. Empty when no
+/// HID++ source gestures (or `config_key` is `None`).
 #[must_use]
 pub fn hidpp_gesture_maps_for(
     config: &Config,
     config_key: Option<&str>,
+    app_bundle: Option<&str>,
 ) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
     let Some(key) = config_key else {
         return BTreeMap::new();
     };
     let stored = config.bindings_for(key);
+    let effective = app_bundle.map(|app| config.effective_bindings(key, Some(app)));
     ButtonId::ALL
         .iter()
         .copied()
@@ -89,7 +93,17 @@ pub fn hidpp_gesture_maps_for(
                 .unwrap_or_else(|| default_binding_for(button));
             binding.fill_gesture_defaults();
             match binding {
-                Binding::Gesture(map) => Some((button, map)),
+                Binding::Gesture(mut map) => {
+                    // HID++ gesture sources never reach the OS hook. Keep the
+                    // global gesture shape armed and apply an app's single
+                    // override to the plain press only, preserving swipes.
+                    if let Some(Binding::Single(action)) =
+                        effective.as_ref().and_then(|map| map.get(&button))
+                    {
+                        map.insert(GestureDirection::Click, action.clone());
+                    }
+                    Some((button, map))
+                }
                 Binding::Single(_) | Binding::LongPress(_) => None,
             }
         })
@@ -274,7 +288,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.set_gesture_mode("2b042", ButtonId::HapticPanel, true);
 
-        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"));
+        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"), None);
         // The dedicated button gestures by default...
         let dedicated = maps
             .get(&ButtonId::GestureButton)
@@ -327,7 +341,7 @@ mod tests {
         // Default device: the dedicated HID++ gesture button gestures, with its
         // defaults seeded.
         let mut cfg = Config::default();
-        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"));
+        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"), None);
         assert_eq!(
             maps.get(&ButtonId::GestureButton)
                 .and_then(|m| m.get(&GestureDirection::Up)),
@@ -340,8 +354,45 @@ mod tests {
         cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
         cfg.set_gesture_mode("2b042", ButtonId::Back, true);
         assert!(
-            hidpp_gesture_maps_for(&cfg, Some("2b042")).is_empty(),
+            hidpp_gesture_maps_for(&cfg, Some("2b042"), None).is_empty(),
             "a demoted dedicated button must dispatch nothing over HID++"
         );
+    }
+
+    #[test]
+    fn hidpp_source_applies_per_app_click_and_preserves_swipes() {
+        let mut cfg = Config::default();
+        cfg.set_per_app_binding(
+            "2b042",
+            "com.apple.Safari",
+            ButtonId::GestureButton,
+            Some(Action::BrowserBack),
+        );
+
+        let global = hidpp_gesture_maps_for(&cfg, Some("2b042"), None);
+        let safari = hidpp_gesture_maps_for(&cfg, Some("2b042"), Some("com.apple.Safari"));
+        let global_map = global
+            .get(&ButtonId::GestureButton)
+            .expect("default HID++ gesture map");
+        let safari_map = safari
+            .get(&ButtonId::GestureButton)
+            .expect("app override must keep gesture mode armed");
+
+        assert_eq!(
+            safari_map.get(&GestureDirection::Click),
+            Some(&Action::BrowserBack)
+        );
+        for direction in [
+            GestureDirection::Up,
+            GestureDirection::Down,
+            GestureDirection::Left,
+            GestureDirection::Right,
+        ] {
+            assert_eq!(
+                safari_map.get(&direction),
+                global_map.get(&direction),
+                "per-app click override changed {direction:?}"
+            );
+        }
     }
 }

--- a/crates/openlogi-desktop/src/state/bindings.rs
+++ b/crates/openlogi-desktop/src/state/bindings.rs
@@ -88,7 +88,7 @@ fn gesture_maps_for(
     let Some(key) = persistent_key else {
         return BTreeMap::new();
     };
-    let mut maps = hidpp_gesture_maps_for(config, Some(key));
+    let mut maps = hidpp_gesture_maps_for(config, Some(key), None);
     maps.extend(oshook_gestures_for(config, Some(key), None));
     maps
 }


### PR DESCRIPTION
## Summary

Apply per-app single-action overrides to the Click arm of dedicated HID++ gesture sources while keeping their global swipe directions and gesture mode intact.

This revision is rebased onto current `master` at OpenLogi 0.8.3 and adapts the fix to the current multi-source, per-button gesture architecture, including long-press capture behavior. It supports the dedicated gesture button and other HID++ gesture sources such as the MX Master 4 haptic panel.

## Root cause

Capture plans already rebuild ordinary bindings for the foreground app, but `hidpp_gesture_maps_for` projected only the global gesture maps. A dedicated HID++ gesture press therefore kept dispatching its global Click action after the foreground app changed.

## Changes

- pass the foreground app into `hidpp_gesture_maps_for`
- build gesture mode and swipe arms from the global binding shape
- overlay an effective per-app `Binding::Single` onto only `GestureDirection::Click`
- preserve current long-press exclusion and side-gesture diversion behavior
- pass the app through each device capture plan while keeping the desktop editing view global
- cover click override, swipe preservation, app exit fallback, and foreground-app capture-plan republishing

## Testing

- `RUSTFLAGS=-D warnings cargo fmt --all -- --check`
- `RUSTFLAGS=-D warnings cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTFLAGS=-D warnings cargo test --workspace --locked`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci wasm`

Previously hardware-validated with an MX Master 2S using Safari and Chrome per-app navigation actions. The rebased implementation has full workspace coverage; hardware behavior will be revalidated in the combined local 0.8.3 patch build.
