### PR TITLE
fix(windows): resolve the update check and fix the unreadable Update-failed badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,7 @@ jobs:
             --dist dist \
             --tag "$GITHUB_REF_NAME" \
             --base-url "$OPENLOGI_UPDATE_BASE_URL" \
+            --include-windows \
             --output dist/latest.json
 
       - name: Upload static updater assets to R2
@@ -282,22 +283,18 @@ jobs:
           release_prefix="s3://${R2_BUCKET}/releases/${GITHUB_REF_NAME}"
           channel_manifest="s3://${R2_BUCKET}/channels/stable/latest.json"
 
-          # The Windows binaries' distribution channel is the GitHub Release;
-          # latest.json is still dmg-only, so nothing in the updater bucket
-          # references the zip/msi or their minisigs — keep them all out of
-          # the immutable releases/ prefix until the Windows auto-updater
-          # lands (#347 PR 4). SHA256SUMS still lists them — it describes the
-          # GitHub Release's asset set. *.exe stays excluded defensively even
-          # though no bare exe ships anymore.
+          # latest.json now carries the Windows msi/zip entries (notify-only:
+          # a Windows check resolves and routes to the GitHub Release for the
+          # download — the client's install flow stays off, INSTALL_SUPPORTED
+          # is false). Their asset + signature URLs point into this prefix, so
+          # the zip/msi and their minisigs must ship here too or the manifest
+          # would reference 404s. *.exe stays excluded defensively — no bare
+          # exe ships anymore.
           aws s3 cp dist/ "$release_prefix/" \
             --recursive \
             --exclude latest.json \
             --exclude "*.exe" \
             --exclude "*.exe.minisig" \
-            --exclude "*.zip" \
-            --exclude "*.zip.minisig" \
-            --exclude "*.msi" \
-            --exclude "*.msi.minisig" \
             --cache-control "public, max-age=31536000, immutable" \
             --endpoint-url "$endpoint"
 

--- a/crates/openlogi-gui/themes/openlogi.json
+++ b/crates/openlogi-gui/themes/openlogi.json
@@ -129,7 +129,7 @@
         "chart_bullish": "green-600",
         "chart_bearish": "red-600",
         "danger.background": "#ef4444",
-        "danger.foreground": "red-600",
+        "danger.foreground": "neutral-50",
         "description_list_label.background": "#171717",
         "description_list_label.foreground": "#f5f5f5",
         "drag_border": "#3b82f6",

--- a/xtask/src/commands/release/latest_json.rs
+++ b/xtask/src/commands/release/latest_json.rs
@@ -30,8 +30,10 @@ pub(crate) struct Args {
     base_url: String,
     /// Also emit the per-arch Windows `.msi`/`.zip` entries. Off by default so
     /// the manifest can never reference objects the release workflow's R2
-    /// upload step doesn't ship: flip this in the same workflow change that
-    /// stops excluding the zip/msi from the `releases/` prefix (#347 PR 4).
+    /// upload step doesn't ship. The release workflow passes it and ships the
+    /// zip/msi to the `releases/` prefix; the entries are notify-only (the
+    /// Windows client resolves a check but installs from the GitHub Release —
+    /// `INSTALL_SUPPORTED` is false).
     #[arg(long)]
     include_windows: bool,
 }


### PR DESCRIPTION
## Summary

Fixes two Windows-facing bugs in the Updates page:

1. **The update check always fails.** The Windows client fetches `channels/stable/latest.json` and matches `os=windows` / `arch=x86_64` / `format=msi`, but the published manifest was dmg-only — so the check errored with *"no release asset matched the current platform (windows/x86_64)"* instead of resolving. The manifest omitted Windows because `xtask release latest-json` was invoked without `--include-windows` and the R2 upload excluded the zip/msi.
2. **The "Update failed" status pill is unreadable.** The OpenLogi Dark theme set `danger.foreground` to `red-600` over a `danger.background` of `#ef4444` (red-500) — dark-red text on a red fill.

This keeps Windows **notify-only** (the client stays `INSTALL_SUPPORTED=false`): a resolved check surfaces "Update available" and routes to the GitHub Release for the download rather than auto-installing. The in-app MSI install flow (`gpui-updater`'s staged `msiexec`) remains switched off — that's separate work.

## Changes

**release / xtask** — `.github/workflows/release.yml`, `xtask/src/commands/release/latest_json.rs`:

- Pass `--include-windows` to `xtask release latest-json` so the manifest carries the per-arch `.msi`/`.zip` entries.
- Stop the R2 upload from excluding `*.zip`/`*.msi` and their `.minisig`s, so the asset + signature URLs the manifest now advertises resolve instead of 404ing (`*.exe` stays excluded defensively — no bare exe ships).
- Refresh the now-stale `--include-windows` doc comment.

**gui** — `crates/openlogi-gui/themes/openlogi.json`:

- Dark-theme `danger.foreground` `red-600` → `neutral-50`, matching the light theme's danger treatment.

## Testing

Not runtime-tested — these are release-pipeline and theme-data changes:

- The manifest fix only takes effect on the **next tagged release**; the currently-published `latest.json` is unaffected. It can be validated before tagging by running the generator against a populated `dist/` and confirming the `windows/x86_64/msi` entry appears: `cargo run -p xtask -- release latest-json --dist dist --tag vX.Y.Z --base-url https://updates.openlogi.org --include-windows --output dist/latest.json`
- The theme change is a JSON data edit (validated as well-formed); the pill renders near-white on red in dark mode.
