### PR TITLE
fix(hid): probe Bolt slots concurrently so slow devices finish enumerating

### DIFF
--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -40,10 +40,11 @@ const MAX_BOLT_SLOTS: u8 = 6;
 ///
 /// Kept short so a snapshot settles quickly: a timed-out node is skipped and
 /// re-probed on the next watcher tick (~2 s), and the first probe usually wakes
-/// the device so the retry succeeds fast. Comfortably above a healthy device's
-/// probe time (the Bolt arrival drain alone is 1.5 s), so awake devices never
-/// trip it.
-const PROBE_BUDGET: Duration = Duration::from_secs(5);
+/// the device so the retry succeeds fast. Slots are probed concurrently on both
+/// receiver paths, so a healthy receiver's worst case is the 1.5 s arrival drain
+/// plus a single slot's [`BOLT_SLOT_PROBE`] / [`UNIFYING_SLOT_PROBE`] — not their
+/// sum — which this stays comfortably above, so awake devices never trip it.
+const PROBE_BUDGET: Duration = Duration::from_secs(6);
 
 /// Per-slot budget for the HID++ 2.0 feature walk on a Unifying paired device.
 ///
@@ -59,18 +60,22 @@ const UNIFYING_SLOT_PROBE: Duration = Duration::from_millis(3500);
 
 /// Per-slot budget for the HID++ 2.0 feature walk on a Bolt paired device.
 ///
-/// The whole receiver shares one [`PROBE_BUDGET`]; without a per-slot cap a
-/// single online device that stops answering its feature-walk reads (seen on a
-/// recent macOS IOHID stack with a new MX Master 4) burns the entire budget, so
+/// Without a per-slot cap a single online device that stops answering its
+/// feature-walk reads burns the whole receiver's [`PROBE_BUDGET`], so
 /// `probe_one` times out and the receiver yields *nothing* — every paired device
 /// drops to "No devices" even though its pairing-register identity read fine
 /// (#218). Capping each slot lets a hung device fall back to its cached /
 /// identity-only data while the rest of the receiver still enumerates, mirroring
-/// [`UNIFYING_SLOT_PROBE`]. Bolt BTLE round-trips are fast (a healthy walk is
-/// well under a second), so 1 s is generous headroom yet small enough that three
-/// online slots can hang at once and still fit `PROBE_BUDGET` after the 1.5 s
-/// arrival drain (1.5 + 3×1 = 4.5 s).
-const BOLT_SLOT_PROBE: Duration = Duration::from_secs(1);
+/// [`UNIFYING_SLOT_PROBE`].
+///
+/// Bolt slots are probed concurrently (see `probe_bolt_receiver`), so this cap
+/// bounds each slot independently and does *not* sum across slots — the receiver
+/// cycle is the arrival drain plus the single slowest slot. 3 s is generous
+/// headroom for a healthy walk: a feature-rich device enumerates a large table
+/// one round-trip per feature, and the MX Master 4 (45 features over Bolt) takes
+/// ~1–1.6 s even awake. The previous 1 s cap cut that walk off every tick, so
+/// the device surfaced permanently with no capabilities or battery.
+const BOLT_SLOT_PROBE: Duration = Duration::from_secs(3);
 
 /// Errors raised while enumerating HID++ devices.
 #[derive(Debug, Error)]

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -87,16 +87,42 @@ async fn probe_bolt_receiver(
     let by_slot: HashMap<u8, BoltDeviceConnection> =
         connections.into_iter().map(|c| (c.index, c)).collect();
 
-    let mut paired = Vec::new();
-    let mut outcomes = Vec::new();
-    for slot in 1u8..=MAX_BOLT_SLOTS {
-        if let Some((device, outcome)) =
-            probe_bolt_slot(&channel, &bolt, by_slot.get(&slot), slot, cache, tick).await
-        {
-            paired.push(device);
-            outcomes.push(outcome);
-        }
-    }
+    // Probe every slot concurrently so one slow or hung device's feature walk
+    // can't push the next slot past `PROBE_BUDGET` — each slot's walk is bounded
+    // independently by `BOLT_SLOT_PROBE`. Mirrors the Unifying path. The slot
+    // range is ordered and `join` preserves input order, so the device list
+    // stays stable across ticks without an explicit sort.
+    let slot_results = (1u8..=MAX_BOLT_SLOTS)
+        .map(|slot| probe_bolt_slot(&channel, &bolt, by_slot.get(&slot), slot, cache, tick))
+        .collect::<Vec<_>>()
+        .join()
+        .await;
+
+    let receiver = ReceiverInfo {
+        name: "Logi Bolt Receiver".to_string(),
+        vendor_id: info.vendor_id,
+        product_id: info.product_id,
+        unique_id,
+    };
+    assemble_bolt_probe(receiver, pairing_count, slot_results)
+}
+
+/// Fold a Bolt receiver's per-slot probe results into a [`NodeProbe`].
+///
+/// `slot_results` holds one entry per pairing slot in slot order; `None` is an
+/// empty slot or one whose pairing register didn't read this tick. The probe is
+/// `complete`/`healthy` only when the pairing-count register answered AND every
+/// counted slot was readable — `None` (the receiver didn't answer, e.g. a parked
+/// channel) or a shortfall is "couldn't fully check", so the ledger replays the
+/// last good snapshot instead of presenting the partial walk as the new truth
+/// (#218). A slot whose *feature walk* merely timed out still counts here: it
+/// falls back to cached/identity data in [`probe_bolt_slot`] and returns `Some`.
+pub(super) fn assemble_bolt_probe(
+    receiver: ReceiverInfo,
+    pairing_count: Option<u8>,
+    slot_results: Vec<Option<(PairedDevice, CacheOutcome)>>,
+) -> NodeProbe {
+    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().flatten().unzip();
 
     if let Some(count) = pairing_count
         && paired.len() != usize::from(count)
@@ -107,23 +133,10 @@ async fn probe_bolt_receiver(
             "paired-device count mismatch — some slots may be unreadable"
         );
     }
-    // Authoritative only when the pairing-count register answered AND every
-    // counted slot was readable. `None` (the receiver didn't answer — e.g. a
-    // parked channel) or a shortfall is "couldn't fully check": the ledger
-    // then replays the last good snapshot instead of presenting the partial
-    // walk as the new truth (#218).
     let complete = pairing_count.is_some_and(|count| paired.len() == usize::from(count));
 
     NodeProbe {
-        inventory: Some(DeviceInventory {
-            receiver: ReceiverInfo {
-                name: "Logi Bolt Receiver".to_string(),
-                vendor_id: info.vendor_id,
-                product_id: info.product_id,
-                unique_id,
-            },
-            paired,
-        }),
+        inventory: Some(DeviceInventory { receiver, paired }),
         healthy: complete,
         complete,
         outcomes,

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -87,13 +87,30 @@ async fn probe_bolt_receiver(
     let by_slot: HashMap<u8, BoltDeviceConnection> =
         connections.into_iter().map(|c| (c.index, c)).collect();
 
-    // Probe every slot concurrently so one slow or hung device's feature walk
-    // can't push the next slot past `PROBE_BUDGET` — each slot's walk is bounded
-    // independently by `BOLT_SLOT_PROBE`. Mirrors the Unifying path. The slot
-    // range is ordered and `join` preserves input order, so the device list
-    // stays stable across ticks without an explicit sort.
-    let slot_results = (1u8..=MAX_BOLT_SLOTS)
-        .map(|slot| probe_bolt_slot(&channel, &bolt, by_slot.get(&slot), slot, cache, tick))
+    // Phase 1 — read each occupied slot's identity from the receiver,
+    // sequentially. These reads all address the receiver (index 0xff), and the
+    // channel correlates responses by register, not by the slot in the request
+    // payload, so overlapping them could hand one slot's response to another
+    // (wrong unit id / online / kind). They are cheap register reads, so
+    // serializing them costs little.
+    let mut identities = Vec::new();
+    for slot in 1u8..=MAX_BOLT_SLOTS {
+        if let Some(identity) =
+            read_bolt_slot_identity(&bolt, &channel, by_slot.get(&slot), slot).await
+        {
+            identities.push(identity);
+        }
+    }
+
+    // Phase 2 — walk each occupied slot's feature table concurrently. Every walk
+    // addresses its own device index, so responses route by index (no
+    // cross-talk), and this per-device walk is the slow part a laggy device
+    // would otherwise serialize the rest of the receiver behind. Each is bounded
+    // independently by `BOLT_SLOT_PROBE`; the ordered identity list keeps the
+    // device list stable across ticks without an explicit sort.
+    let slot_results = identities
+        .iter()
+        .map(|identity| walk_bolt_slot(&channel, identity, cache, tick))
         .collect::<Vec<_>>()
         .join()
         .await;
@@ -107,22 +124,23 @@ async fn probe_bolt_receiver(
     assemble_bolt_probe(receiver, pairing_count, slot_results)
 }
 
-/// Fold a Bolt receiver's per-slot probe results into a [`NodeProbe`].
+/// Fold a Bolt receiver's per-slot results into a [`NodeProbe`].
 ///
-/// `slot_results` holds one entry per pairing slot in slot order; `None` is an
-/// empty slot or one whose pairing register didn't read this tick. The probe is
-/// `complete`/`healthy` only when the pairing-count register answered AND every
-/// counted slot was readable — `None` (the receiver didn't answer, e.g. a parked
-/// channel) or a shortfall is "couldn't fully check", so the ledger replays the
-/// last good snapshot instead of presenting the partial walk as the new truth
-/// (#218). A slot whose *feature walk* merely timed out still counts here: it
-/// falls back to cached/identity data in [`probe_bolt_slot`] and returns `Some`.
+/// `slot_results` holds one entry per *occupied* slot in slot order — empty or
+/// unreadable slots are dropped in phase 1 ([`read_bolt_slot_identity`]) and
+/// never reach here. The probe is `complete`/`healthy` only when the
+/// pairing-count register answered AND every counted slot was readable: `None`
+/// (the receiver didn't answer, e.g. a parked channel) or a shortfall is
+/// "couldn't fully check", so the ledger replays the last good snapshot instead
+/// of presenting the partial walk as the new truth (#218). A slot whose feature
+/// walk merely timed out still counts here — it falls back to cached/identity
+/// data in [`walk_bolt_slot`].
 pub(super) fn assemble_bolt_probe(
     receiver: ReceiverInfo,
     pairing_count: Option<u8>,
-    slot_results: Vec<Option<(PairedDevice, CacheOutcome)>>,
+    slot_results: Vec<(PairedDevice, CacheOutcome)>,
 ) -> NodeProbe {
-    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().flatten().unzip();
+    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().unzip();
 
     if let Some(count) = pairing_count
         && paired.len() != usize::from(count)
@@ -248,16 +266,31 @@ async fn probe_unifying_receiver(
     }
 }
 
-/// Probe a single Bolt pairing slot. Returns `None` when the slot is empty or
-/// unreadable, otherwise the device plus its cache contribution this tick.
-async fn probe_bolt_slot(
-    channel: &Arc<HidppChannel>,
+/// Identity read from the receiver's registers for one occupied Bolt slot
+/// (phase 1). Both reads address the receiver at index `0xff`, and the channel
+/// correlates responses by register — not by the slot encoded in the request
+/// payload — so they must be issued sequentially, never overlapped across slots.
+struct BoltSlotIdentity {
+    slot: u8,
+    codename: Option<String>,
+    /// Cache key from the pairing register's unit id. `None` = all-zero id
+    /// (unidentifiable): don't cache; always probe when online.
+    id: Option<CacheKey>,
+    online: bool,
+    register_kind: DeviceKind,
+    wpid: Option<u16>,
+}
+
+/// Read one Bolt slot's identity from the receiver's pairing + codename
+/// registers. Returns `None` when the slot is empty or its pairing register
+/// didn't read this tick. Must be called sequentially across slots — see
+/// [`probe_bolt_receiver`].
+async fn read_bolt_slot_identity(
     bolt: &BoltReceiver,
+    channel: &Arc<HidppChannel>,
     event: Option<&BoltDeviceConnection>,
     slot: u8,
-    cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
-) -> Option<(PairedDevice, CacheOutcome)> {
+) -> Option<BoltSlotIdentity> {
     let pairing = match bolt.get_device_pairing_information(slot).await {
         Ok(p) => p,
         Err(e) => {
@@ -287,13 +320,40 @@ async fn probe_bolt_slot(
     let id = (pairing.unit_id != [0u8; 4]).then_some(CacheKey::Bolt {
         unit_id: pairing.unit_id,
     });
+    Some(BoltSlotIdentity {
+        slot,
+        codename,
+        id,
+        online,
+        register_kind: map_kind(bolt_kind),
+        wpid,
+    })
+}
+
+/// Walk one identified Bolt slot's HID++ feature table (phase 2). Addresses the
+/// device at its own index, so this is safe to run concurrently across slots.
+/// Always yields the device — a timed-out or failed walk falls back to the
+/// slot's cached / identity-only data — plus its cache contribution this tick.
+async fn walk_bolt_slot(
+    channel: &Arc<HidppChannel>,
+    identity: &BoltSlotIdentity,
+    cache: &HashMap<CacheKey, Cached>,
+    tick: u64,
+) -> (PairedDevice, CacheOutcome) {
+    let &BoltSlotIdentity {
+        slot,
+        online,
+        register_kind,
+        wpid,
+        ..
+    } = identity;
+    let id = identity.id.clone();
     let cached = id.as_ref().and_then(|i| cache.get(i));
-    let register_kind = map_kind(bolt_kind);
 
     // Cap the feature walk per slot so one device that stops answering can't
     // burn the whole receiver's `PROBE_BUDGET` and time out `probe_one` — which
     // would drop *every* device on the receiver. A timed-out slot falls back to
-    // its cached probe (its pairing-register identity above already read fine),
+    // its cached probe (its pairing-register identity read fine in phase 1),
     // mirroring the Unifying path (#218).
     let probe_result = timeout(
         BOLT_SLOT_PROBE,
@@ -324,7 +384,7 @@ async fn probe_bolt_slot(
 
     let device = PairedDevice {
         slot,
-        codename,
+        codename: identity.codename.clone(),
         wpid,
         // Prefer the device's own `0x0005` type; the register kind is the
         // offline fallback.
@@ -334,7 +394,7 @@ async fn probe_bolt_slot(
         model_info: probe.model_info,
         capabilities: probe.capabilities,
     };
-    Some((device, outcome))
+    (device, outcome)
 }
 
 /// Probe a HID++ channel that doesn't host a Bolt receiver — for

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -2,8 +2,8 @@ use std::collections::HashSet;
 
 use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
 
-use super::cache::{CACHE_MISS_GRACE, CacheKey, Cached, REFRESH_TICKS, is_stale};
-use super::probe::parse_codename_unifying;
+use super::cache::{CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, is_stale};
+use super::probe::{NodeProbe, assemble_bolt_probe, parse_codename_unifying};
 use super::{Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop};
 use crate::inventory::features::ProbedFeatures;
 
@@ -164,6 +164,107 @@ fn one_shot_retry_stops_at_attempt_cap_when_inventory_keeps_changing() {
         ),
         "the retry loop must remain bounded even if the inventory changes every time"
     );
+}
+
+fn bolt_receiver_info() -> ReceiverInfo {
+    ReceiverInfo {
+        name: "Logi Bolt Receiver".to_string(),
+        vendor_id: 0x046d,
+        product_id: 0xc548,
+        unique_id: Some("bolt-1".to_string()),
+    }
+}
+
+/// A readable slot's probe result. `Seen` models the fallback a feature-walk
+/// timeout produces (#251): the device still surfaces from its pairing-register
+/// identity, so a timed-out slot counts as readable here.
+fn bolt_slot(slot: u8) -> (PairedDevice, CacheOutcome) {
+    (
+        PairedDevice {
+            slot,
+            codename: Some(format!("device-{slot}")),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: None,
+            capabilities: None,
+        },
+        CacheOutcome::Seen(CacheKey::Bolt {
+            unit_id: [0, 0, 0, slot],
+        }),
+    )
+}
+
+fn paired_slots(probe: &NodeProbe) -> Vec<u8> {
+    let Some(inventory) = probe.inventory.as_ref() else {
+        panic!("expected an inventory");
+    };
+    inventory.paired.iter().map(|d| d.slot).collect()
+}
+
+#[test]
+fn bolt_probe_is_complete_when_count_matches_readable_slots() {
+    // Two paired slots, both readable, and the pairing-count register agrees.
+    // The `None` gaps are empty slots; `join` yields results in slot order, so
+    // the surfaced devices must come out ordered without an explicit sort.
+    let probe = assemble_bolt_probe(
+        bolt_receiver_info(),
+        Some(2),
+        vec![
+            Some(bolt_slot(1)),
+            None,
+            Some(bolt_slot(2)),
+            None,
+            None,
+            None,
+        ],
+    );
+    assert!(probe.complete, "count matches the readable slots");
+    assert!(probe.healthy, "a complete Bolt walk is authoritative");
+    assert_eq!(paired_slots(&probe), vec![1, 2], "slots surface in order");
+    assert_eq!(
+        probe.outcomes.len(),
+        2,
+        "one cache outcome per readable slot"
+    );
+}
+
+#[test]
+fn bolt_probe_is_incomplete_when_a_counted_slot_is_unreadable() {
+    // The receiver reports two paired devices but only one slot's pairing
+    // register read this tick. Presenting that partial walk as the new truth is
+    // the #218 regression: it must stay incomplete so the ledger replays the
+    // last good snapshot instead of dropping the missing device.
+    let probe = assemble_bolt_probe(bolt_receiver_info(), Some(2), vec![Some(bolt_slot(1))]);
+    assert_eq!(
+        paired_slots(&probe),
+        vec![1],
+        "only the readable slot surfaces"
+    );
+    assert!(!probe.complete, "a count shortfall is not complete");
+    assert!(
+        !probe.healthy,
+        "an incomplete Bolt walk is not authoritative"
+    );
+}
+
+#[test]
+fn bolt_probe_is_incomplete_when_the_count_register_is_unanswered() {
+    // A parked/unresponsive receiver channel returns no pairing count. Even with
+    // slots surfaced from arrival events, the walk can't be trusted as the whole
+    // truth, so it stays incomplete and the ledger keeps the prior snapshot.
+    let probe = assemble_bolt_probe(
+        bolt_receiver_info(),
+        None,
+        vec![Some(bolt_slot(1)), Some(bolt_slot(2))],
+    );
+    assert_eq!(paired_slots(&probe), vec![1, 2]);
+    assert!(
+        !probe.complete,
+        "no count register means we couldn't fully check"
+    );
+    assert!(!probe.healthy);
 }
 
 #[test]

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -206,19 +206,13 @@ fn paired_slots(probe: &NodeProbe) -> Vec<u8> {
 #[test]
 fn bolt_probe_is_complete_when_count_matches_readable_slots() {
     // Two paired slots, both readable, and the pairing-count register agrees.
-    // The `None` gaps are empty slots; `join` yields results in slot order, so
-    // the surfaced devices must come out ordered without an explicit sort.
+    // Empty slots are dropped in phase 1, so only occupied slots reach here;
+    // `join` yields them in slot order, so the devices must come out ordered
+    // without an explicit sort.
     let probe = assemble_bolt_probe(
         bolt_receiver_info(),
         Some(2),
-        vec![
-            Some(bolt_slot(1)),
-            None,
-            Some(bolt_slot(2)),
-            None,
-            None,
-            None,
-        ],
+        vec![bolt_slot(1), bolt_slot(2)],
     );
     assert!(probe.complete, "count matches the readable slots");
     assert!(probe.healthy, "a complete Bolt walk is authoritative");
@@ -236,7 +230,7 @@ fn bolt_probe_is_incomplete_when_a_counted_slot_is_unreadable() {
     // register read this tick. Presenting that partial walk as the new truth is
     // the #218 regression: it must stay incomplete so the ledger replays the
     // last good snapshot instead of dropping the missing device.
-    let probe = assemble_bolt_probe(bolt_receiver_info(), Some(2), vec![Some(bolt_slot(1))]);
+    let probe = assemble_bolt_probe(bolt_receiver_info(), Some(2), vec![bolt_slot(1)]);
     assert_eq!(
         paired_slots(&probe),
         vec![1],
@@ -254,11 +248,7 @@ fn bolt_probe_is_incomplete_when_the_count_register_is_unanswered() {
     // A parked/unresponsive receiver channel returns no pairing count. Even with
     // slots surfaced from arrival events, the walk can't be trusted as the whole
     // truth, so it stays incomplete and the ledger keeps the prior snapshot.
-    let probe = assemble_bolt_probe(
-        bolt_receiver_info(),
-        None,
-        vec![Some(bolt_slot(1)), Some(bolt_slot(2))],
-    );
+    let probe = assemble_bolt_probe(bolt_receiver_info(), None, vec![bolt_slot(1), bolt_slot(2)]);
     assert_eq!(paired_slots(&probe), vec![1, 2]);
     assert!(
         !probe.complete,


### PR DESCRIPTION
## Summary

The MX Master 4 on a Logi Bolt receiver surfaced permanently as a bare mouse — correct name and kind, but no capabilities, battery, or config panels. Root cause: the 1 s per-slot `BOLT_SLOT_PROBE` cap added in #251 is shorter than the device's HID++ feature walk. The MX Master 4 enumerates 45 features over Bolt and takes ~1.0–1.6 s even when awake, so its walk was cancelled on every enumeration tick; the cancelled future cached nothing, so the fallback served empty capabilities forever.

#251 copied the Unifying path's per-slot timeout but not its concurrency. Bolt probed slots sequentially, so per-slot budgets summed and forced the too-tight 1 s cap to fit several hung slots inside `PROBE_BUDGET`. This PR probes Bolt slots concurrently (the same `futures-concurrency` join the Unifying path already uses), so each slot's walk is bounded independently — the receiver cycle is now the 1.5 s arrival drain plus the single slowest slot, not their sum — which makes a generous per-slot budget affordable.

## Changes

**openlogi-hid**
- `probe_bolt_receiver`: replace the sequential per-slot loop with a concurrent `futures-concurrency` join, mirroring `probe_unifying_receiver`. The ordered slot range keeps the device list stable across ticks without an explicit sort.
- Raise `BOLT_SLOT_PROBE` 1 s → 3 s (headroom over a healthy feature-rich walk) and `PROBE_BUDGET` 5 s → 6 s (covers the 1.5 s arrival drain plus one slot on either receiver path).
- Extract the per-slot fold into `assemble_bolt_probe` and document why a pairing-count shortfall or an unanswered count register keeps the probe incomplete — the #218 invariant that lets the ledger replay the last good snapshot instead of presenting a partial walk as the new truth.
- Add partial-failure regression tests: count matches readable slots → complete/healthy with slots in order; count shortfall → incomplete; unanswered count register → incomplete.

## Testing

- `cargo clippy -p openlogi-hid --all-targets -- -D warnings` — clean
- `cargo test --workspace --exclude openlogi-gui` — pass (openlogi-hid: 79 tests, including 3 new)
- `cargo fmt --all -- --check` — clean
- Hardware (MX Master 4 on a Bolt receiver, slot 2, macOS): with the fix, `openlogi list` reads `battery=95% full` and full capabilities on three consecutive runs; before the fix it read `battery=—` with no capabilities. This exercises the shared `openlogi-hid::enumerate` probe path via the CLI — not runtime-tested through a packaged agent build.

Regression from #251; hardens the #218 partial-failure arc.
