### PR TITLE
feat(hidpp): add level-gated wire tracing for HID++ requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5143,6 +5143,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -41,3 +41,6 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 hex = "0.4.3"
 derive_builder = "0.20.2"
 bitflags = { version = "2", features = ["serde"] }
+# OpenLogi-specific: request-level wire tracing at trace!. Off by default
+# (level-gated); enable with OPENLOGI_LOG=hidpp=trace. Not in upstream hidpp.
+tracing = { workspace = true }

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -18,6 +18,7 @@ use futures::{FutureExt, channel::oneshot, select};
 use hidreport::{Field, Report, ReportDescriptor, Usage, UsageId, UsagePage};
 use rand::Rng;
 use thiserror::Error;
+use tracing::trace;
 
 use crate::nibble::U4;
 
@@ -215,6 +216,17 @@ impl HidppMessage {
                 LONG_REPORT_LENGTH
             }
         }
+    }
+
+    /// The HID++ addressing header `(device_index, feature_index, function)` —
+    /// the first three payload bytes, present on both report kinds. Used only
+    /// for wire tracing (OpenLogi-specific; not in upstream hidpp).
+    fn header(&self) -> (u8, u8, u8) {
+        let payload: &[u8] = match self {
+            Self::Short(payload) => payload,
+            Self::Long(payload) => payload,
+        };
+        (payload[0], payload[1], payload[2])
     }
 }
 
@@ -501,6 +513,12 @@ impl HidppChannel {
             return Err(ChannelError::MessageTypeNotSupported);
         }
 
+        // Wire trace (off by default; `OPENLOGI_LOG=hidpp=trace`). Capture the
+        // header before `msg` is moved into the send future so the outcome line
+        // below can name the same request.
+        let (dev, feat, func) = msg.header();
+        trace!(dev, feat, func, "hidpp request");
+
         let (sender, receiver) = oneshot::channel::<HidppMessage>();
         let pending_id = self.pending_message_id.fetch_add(1, Ordering::SeqCst);
 
@@ -537,6 +555,11 @@ impl HidppChannel {
             result = request => result,
             _ = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
         };
+
+        match &result {
+            Ok(_) => trace!(dev, feat, "hidpp response"),
+            Err(e) => trace!(dev, feat, error = ?e, "hidpp no response"),
+        }
 
         if result.is_err() {
             // A timeout or write failure leaves the entry queued — remove it

--- a/crates/openlogi-hidpp/src/device.rs
+++ b/crates/openlogi-hidpp/src/device.rs
@@ -3,6 +3,7 @@
 use std::{any::TypeId, collections::HashMap, sync::Arc};
 
 use thiserror::Error;
+use tracing::trace;
 
 use crate::{
     channel::{ChannelError, HidppChannel},
@@ -138,9 +139,20 @@ impl Device {
         let feature_set_feature = self.add_feature::<FeatureSetFeature>(feature_set_info.index);
 
         let count = feature_set_feature.count().await?;
+        trace!(
+            index = self.device_index,
+            count, "enumerating feature table"
+        );
         let mut features = Vec::with_capacity(count as usize);
         for i in 1..=count {
             let info = feature_set_feature.get_feature(i).await?;
+            trace!(
+                index = self.device_index,
+                slot = i,
+                id = format_args!("{:#06x}", info.id),
+                version = info.version,
+                "feature",
+            );
             features.push(info);
 
             if i == feature_set_info.index {


### PR DESCRIPTION
## Summary

The vendored `hidpp` channel had no tracing, so diagnosing why a device stalls mid feature-walk — e.g. the MX Master 4 in #438, whose 45-feature walk overran the per-slot budget — meant adding throwaway `eprintln!` instrumentation and building a custom binary. This adds `trace!` at the two points that matter for that class of bug, gated at the trace level so it is off by default and costs effectively nothing until switched on.

## Changes

**openlogi-hidpp**
- `HidppChannel::send_with_timeout`: log each request (`device index / feature index / function`) and its outcome (`response` vs `no response` on timeout/write failure). This captures every HID++ round-trip, so a stall shows as a `request` with no matching `response`.
- `Device::enumerate_features`: log the feature-table size and each resolved `index → id/version` — the decoded view a raw wire trace can't give.
- Add `tracing` (workspace dependency) to the crate. Documented inline as an OpenLogi-specific addition (not in upstream hidpp).

## Gating

Runtime level, not compile-time. Off at the default `info` level; enable per-run with `OPENLOGI_LOG=hidpp=trace` (or `hidpp::channel=trace` for just the wire). Disabled `trace!` callsites are near-free, and runtime gating means a shipped **release** build can be traced in place — the exact situation that made #438 hard to diagnose — without a debug rebuild. (Builds wanting zero release cost can additionally set tracing's `release_max_level_info` feature to compile the callsites out.)

## Testing

- `cargo clippy -p openlogi-hidpp -p openlogi-hid -p openlogi-cli --all-targets -- -D warnings` — clean
- `cargo test -p openlogi-hidpp -p openlogi-hid` — pass (157 + 76)
- Behavior: `openlogi list` with no env emits zero hidpp trace lines; with `OPENLOGI_LOG=hidpp=trace` it prints the per-request wire trace and the `enumerating feature table … / feature index=… id=0x… ` walk (verified on hardware, MX Master 4 on a Bolt receiver).

Motivated by #438.
