### PR TITLE
refactor(gui): introduce a HIG-based typography scale

### DIFF
--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -1,8 +1,7 @@
 use gpui::{
     AnyElement, App, AppContext as _, BorrowAppContext as _, Context, Entity, FocusHandle,
-    FontWeight, InteractiveElement, IntoElement, ParentElement, Render,
-    StatefulInteractiveElement as _, Styled, Subscription, Window, div,
-    prelude::FluentBuilder as _, px, rgb,
+    InteractiveElement, IntoElement, ParentElement, Render, StatefulInteractiveElement as _,
+    Styled, Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::{
     Icon, IconName, TitleBar,
@@ -21,7 +20,7 @@ use crate::components::lighting_panel::LightingPanel;
 use crate::components::smartshift_panel::SmartShiftPanel;
 use crate::mouse_model::view::MouseModelView;
 use crate::state::{AgentLink, AppState, DeviceRecord};
-use crate::theme::{self, Palette};
+use crate::theme::{self, Palette, Typography as _};
 
 mod detail;
 mod home;
@@ -246,14 +245,13 @@ impl AppView {
             )
             .child(
                 div()
-                    .text_xl()
-                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_title()
                     .child(tr!("Accessibility permission required")),
             )
             .child(
                 div()
                     .max_w(px(440.))
-                    .text_sm()
+                    .text_body()
                     .text_color(pal.text_muted)
                     .child(tr!(
                         "OpenLogi captures mouse buttons (Back / Forward / gesture button) \
@@ -265,7 +263,7 @@ impl AppView {
             .child(
                 div()
                     .max_w(px(440.))
-                    .text_sm()
+                    .text_body()
                     .text_color(pal.text_muted)
                     .child(tr!(
                         "Enable “OpenLogi Agent” in the Accessibility list — the \
@@ -281,13 +279,13 @@ impl AppView {
                     .label(tr!("Open System Settings to grant access"))
                     .on_click(|_, _, cx| request_accessibility(cx)),
             )
-            .child(div().text_xs().text_color(pal.text_muted).child(tr!(
+            .child(div().text_caption().text_color(pal.text_muted).child(tr!(
                 "Takes effect automatically once granted — no restart needed."
             )))
             .child(
                 div()
                     .id("skip-accessibility")
-                    .text_xs()
+                    .text_caption()
                     .text_color(pal.text_muted)
                     .cursor_pointer()
                     .hover(|s| s.text_color(pal.text_primary))
@@ -326,7 +324,7 @@ fn app_title_bar(pal: Palette) -> impl IntoElement {
             .flex()
             .items_center()
             .justify_center()
-            .text_sm()
+            .text_body()
             .text_color(pal.text_muted)
             .child("OpenLogi"),
     )

--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -2,8 +2,8 @@
 //! four section bodies (Buttons, Pointer, Lighting, Device).
 
 use gpui::{
-    AnyElement, BorrowAppContext as _, Context, FontWeight, InteractiveElement, IntoElement,
-    ParentElement, StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
+    AnyElement, BorrowAppContext as _, Context, InteractiveElement, IntoElement, ParentElement,
+    StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     IconName,
@@ -27,7 +27,7 @@ use crate::components::lighting_panel::LightingPanel;
 use crate::components::smartshift_panel::SmartShiftPanel;
 use crate::mouse_model::view::MouseModelView;
 use crate::state::{AppState, DeviceRecord};
-use crate::theme::{HEADER_H, Palette, SCREEN_PAD, SelectableStyle as _};
+use crate::theme::{HEADER_H, Palette, SCREEN_PAD, SelectableStyle as _, Typography as _};
 
 /// Device-detail top bar, in three zones: a back affordance + device name
 /// (leading), the section tabs as a centred segmented control (middle), and the
@@ -66,8 +66,7 @@ pub(super) fn detail_header(
         .child(
             div()
                 .min_w_0()
-                .text_lg()
-                .font_weight(FontWeight::SEMIBOLD)
+                .text_heading()
                 .child(name),
         )
         // Flexible spacers on either side centre the segmented tabs in the space
@@ -221,13 +220,13 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
             v_flex()
                 .child(
                     div()
-                        .text_sm()
+                        .text_body()
                         .text_color(pal.text_primary)
                         .child(tr!("Invert scroll direction")),
                 )
                 .child(
                     div()
-                        .text_xs()
+                        .text_caption()
                         .text_color(pal.text_muted)
                         .child(inversion_description),
                 ),
@@ -250,13 +249,13 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
             v_flex()
                 .child(
                     div()
-                        .text_sm()
+                        .text_body()
                         .text_color(pal.text_primary)
                         .child(tr!("Wheel resolution")),
                 )
                 .child(
                     div()
-                        .text_xs()
+                        .text_caption()
                         .text_color(pal.text_muted)
                         .child(resolution_description),
                 ),
@@ -329,7 +328,7 @@ fn wheel_resolution_segment(
         .py_1()
         .rounded(pal.control_radius)
         .text_center()
-        .text_xs()
+        .text_caption()
         .selected_fill(active)
         .text_color(if enabled {
             if active {
@@ -366,7 +365,7 @@ fn invert_scroll_toggle(on: bool, enabled: bool, pal: Palette) -> AnyElement {
             .rounded(pal.control_radius)
             .border_1()
             .border_color(pal.border)
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_muted)
             .child(tr!("Unavailable"))
             .into_any_element();
@@ -378,7 +377,7 @@ fn invert_scroll_toggle(on: bool, enabled: bool, pal: Palette) -> AnyElement {
         .rounded(pal.control_radius)
         .selected_border(on, pal)
         .selected_fill(on)
-        .text_xs()
+        .text_caption()
         .text_color(if on { pal.text_primary } else { pal.text_muted })
         .cursor_pointer()
         .child(label)
@@ -437,7 +436,7 @@ fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElem
         .map_or_else(
             || {
                 div()
-                    .text_sm()
+                    .text_body()
                     .text_color(pal.text_muted)
                     .child(tr!("No active device"))
                     .into_any_element()
@@ -529,15 +528,10 @@ fn device_summary(name: &str, kind: DeviceKind, online: bool, pal: Palette) -> i
             v_flex()
                 .gap_1()
                 .min_w_0()
+                .child(div().text_subheading().child(name.to_string()))
                 .child(
                     div()
-                        .text_sm()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .child(name.to_string()),
-                )
-                .child(
-                    div()
-                        .text_xs()
+                        .text_caption()
                         .text_color(pal.text_muted)
                         .child(kind_label(kind)),
                 ),

--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -25,7 +25,7 @@ use super::widgets::{add_device_button, kind_label, settings_button};
 use crate::asset::GlowGeometry;
 use crate::components::carousel::Carousel;
 use crate::state::{AppState, DeviceRecord};
-use crate::theme::{self, HEADER_H, Palette, SelectableStyle as _};
+use crate::theme::{self, HEADER_H, Palette, SelectableStyle as _, Typography as _};
 
 /// Home (gallery) top bar: the "Devices" title, a Settings gear, and the
 /// Add-Device button — the entry points the old carousel header used to carry.
@@ -42,8 +42,7 @@ pub(super) fn home_header(pal: Palette) -> impl IntoElement {
             div()
                 .flex_1()
                 .min_w_0()
-                .text_lg()
-                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_heading()
                 .child(tr!("Devices")),
         )
         .child(settings_button())
@@ -220,8 +219,7 @@ fn device_card(
                             div()
                                 .min_w_0()
                                 .truncate()
-                                .text_sm()
-                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                .text_subheading()
                                 .child(record.display_name.clone()),
                         )
                         .child(status_dot(record.online)),
@@ -236,7 +234,7 @@ fn device_card(
                             div()
                                 .min_w_0()
                                 .truncate()
-                                .text_xs()
+                                .text_caption()
                                 .text_color(pal.text_muted)
                                 .child(format!(
                                     "{} · slot {}",
@@ -323,7 +321,7 @@ fn battery_view(b: &BatteryInfo, pal: Palette) -> AnyElement {
     h_flex()
         .gap_1()
         .items_center()
-        .text_xs()
+        .text_caption()
         .text_color(pal.text_muted)
         .child(Icon::new(battery_icon(b)).size_3())
         .child(format!("{}%", b.percentage))
@@ -430,14 +428,13 @@ pub(super) fn device_empty_state(pal: Palette) -> AnyElement {
         )
         .child(
             div()
-                .text_xl()
-                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_title()
                 .child(tr!("No devices connected")),
         )
         .child(
             div()
                 .max_w(px(440.))
-                .text_sm()
+                .text_body()
                 .text_center()
                 .child(tr!(
                     "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings."
@@ -450,7 +447,7 @@ pub(super) fn device_empty_state(pal: Palette) -> AnyElement {
                 .label(tr!("Add Device"))
                 .on_click(|_, _, cx| crate::windows::add_device::open(cx)),
         )
-        .child(div().mt_1().max_w(px(440.)).text_xs().text_center().text_color(pal.text_muted).child(tr!(
+        .child(div().mt_1().max_w(px(440.)).text_caption().text_center().text_color(pal.text_muted).child(tr!(
             "Using Logi Options+? Quit it first — both apps compete for HID++ access."
         )))
         .into_any_element()

--- a/crates/openlogi-gui/src/app/status.rs
+++ b/crates/openlogi-gui/src/app/status.rs
@@ -2,9 +2,7 @@
 //! pre-connection / unreachable / outdated-build frames rendered in place of
 //! the real UI, and the footer status bar shown once it's up.
 
-use gpui::{
-    AnyElement, Div, FontWeight, IntoElement, ParentElement, SharedString, Styled, div, px, rgb,
-};
+use gpui::{AnyElement, Div, IntoElement, ParentElement, SharedString, Styled, div, px, rgb};
 use gpui_component::{
     Icon, IconName, Sizable as _,
     button::{Button, ButtonVariants as _},
@@ -13,7 +11,7 @@ use gpui_component::{
     v_flex,
 };
 
-use crate::theme::{self, FOOTER_H, Palette};
+use crate::theme::{self, FOOTER_H, Palette, Typography as _};
 
 /// Centered spinner over a muted one-line caption — the quiet "still working"
 /// body shared by the pre-connection frame and the scanning state, so the two
@@ -29,7 +27,7 @@ pub(super) fn loading_body(caption: SharedString, pal: Palette) -> Div {
         .justify_center()
         .gap_3()
         .child(Spinner::new().large().color(pal.text_muted))
-        .child(div().text_sm().text_color(pal.text_muted).child(caption))
+        .child(div().text_body().text_color(pal.text_muted).child(caption))
 }
 
 /// Static centered notice — icon, headline, muted caption — for the
@@ -48,16 +46,11 @@ pub(super) fn notice_body(headline: SharedString, caption: SharedString, pal: Pa
                 .size_8()
                 .text_color(rgb(theme::STATUS_CONNECTING)),
         )
-        .child(
-            div()
-                .text_xl()
-                .font_weight(FontWeight::SEMIBOLD)
-                .child(headline),
-        )
+        .child(div().text_title().child(headline))
         .child(
             div()
                 .max_w(px(440.))
-                .text_sm()
+                .text_body()
                 .text_center()
                 .text_color(pal.text_muted)
                 .child(caption),
@@ -136,7 +129,7 @@ pub(super) fn footer(pal: Palette, granted: bool) -> impl IntoElement {
         })
         .child(
             div()
-                .text_xs()
+                .text_caption()
                 .text_color(pal.text_muted)
                 .child(concat!("v", env!("CARGO_PKG_VERSION"))),
         )
@@ -158,7 +151,7 @@ fn accessibility_status(pal: Palette, granted: bool) -> AnyElement {
         h_flex()
             .gap_1p5()
             .items_center()
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_muted)
             .child(
                 div()
@@ -175,7 +168,7 @@ fn accessibility_status(pal: Palette, granted: bool) -> AnyElement {
             .id("footer-accessibility")
             .gap_2()
             .items_center()
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_primary)
             .cursor_pointer()
             .child(

--- a/crates/openlogi-gui/src/app/widgets.rs
+++ b/crates/openlogi-gui/src/app/widgets.rs
@@ -3,7 +3,7 @@
 //! screens.
 
 use gpui::{
-    AnyElement, Context, FontWeight, IntoElement, ParentElement, SharedString, Styled, div,
+    AnyElement, Context, IntoElement, ParentElement, SharedString, Styled, div,
     prelude::FluentBuilder as _, px, relative, rgb,
 };
 use gpui_component::{
@@ -16,7 +16,7 @@ use openlogi_hid::DeviceRoute;
 
 use super::AppView;
 use crate::state::AppState;
-use crate::theme::{self, Palette};
+use crate::theme::{self, Palette, Typography as _};
 
 /// "← Back" affordance on the detail screen; returns to the gallery without
 /// changing the active-device selection.
@@ -105,12 +105,7 @@ fn panel_card_inner(
                             .gap_2()
                             .text_color(pal.text_primary)
                             .child(Icon::new(icon).size_4().text_color(pal.text_muted))
-                            .child(
-                                div()
-                                    .text_sm()
-                                    .font_weight(FontWeight::SEMIBOLD)
-                                    .child(title),
-                            ),
+                            .child(div().text_subheading().child(title)),
                     )
                 })
                 .child(content),
@@ -131,7 +126,7 @@ pub(super) fn status_badge(online: bool, pal: Palette) -> impl IntoElement {
         .border_color(pal.border)
         .px_2()
         .py_1()
-        .text_xs()
+        .text_caption()
         .text_color(pal.text_muted)
         .child(div().size_1p5().rounded_full().bg(rgb(color)))
         .child(label)
@@ -149,7 +144,7 @@ pub(super) fn battery_summary(battery: &BatteryInfo, pal: Palette) -> impl IntoE
         .child(
             h_flex()
                 .justify_between()
-                .text_xs()
+                .text_caption()
                 .text_color(pal.text_muted)
                 .child(status)
                 .child(format!("{}%", battery.percentage)),

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 use crate::components::device_read::issue_device_read;
 use crate::components::status::{retry_line, status_line};
 use crate::state::{AppState, DpiStatus};
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
 
 pub struct DpiPanel {
     slider_state: Option<Entity<SliderState>>,
@@ -225,10 +225,15 @@ impl Render for DpiPanel {
                 h_flex()
                     .justify_between()
                     .items_baseline()
-                    .child(div().text_sm().text_color(pal.text_muted).child(tr!("DPI")))
                     .child(
                         div()
-                            .text_sm()
+                            .text_body()
+                            .text_color(pal.text_muted)
+                            .child(tr!("DPI")),
+                    )
+                    .child(
+                        div()
+                            .text_body()
                             .text_color(rgb(ACCENT_BLUE))
                             .child(format!("{}", snapshot.dpi)),
                     ),
@@ -236,7 +241,7 @@ impl Render for DpiPanel {
             .child(slider)
             .child(
                 div()
-                    .text_xs()
+                    .text_caption()
                     .text_color(pal.text_muted)
                     .child(range_label),
             )
@@ -245,7 +250,7 @@ impl Render for DpiPanel {
                     .gap_2()
                     .child(
                         div()
-                            .text_xs()
+                            .text_caption()
                             .text_color(pal.text_muted)
                             .child(tr!("PRESETS")),
                     )
@@ -364,7 +369,7 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
         .child(
             div()
                 .id(("dpi-preset-apply", idx))
-                .text_sm()
+                .text_body()
                 .text_color(pal.text_primary)
                 .child(format!("{value}"))
                 .on_click(move |_event, _window, cx| {
@@ -384,7 +389,7 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
         .child(
             div()
                 .id(("dpi-preset-remove", idx))
-                .text_xs()
+                .text_caption()
                 .text_color(pal.text_muted)
                 .child(Icon::new(IconName::Close).size_3())
                 .on_click(move |_event, _window, cx| {
@@ -415,7 +420,7 @@ fn add_preset_chip(pal: Palette) -> AnyElement {
             h_flex()
                 .gap_1()
                 .items_center()
-                .text_sm()
+                .text_body()
                 .text_color(pal.text_muted)
                 .child(Icon::new(IconName::Plus).size_3())
                 .child(tr!("Add")),

--- a/crates/openlogi-gui/src/components/lighting_panel.rs
+++ b/crates/openlogi-gui/src/components/lighting_panel.rs
@@ -18,7 +18,7 @@ use openlogi_core::color::Rgb;
 use openlogi_core::config::Lighting;
 
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
 
 const SWATCH: f32 = 28.;
 
@@ -117,7 +117,7 @@ impl Render for LightingPanel {
                     .items_center()
                     .child(
                         div()
-                            .text_sm()
+                            .text_body()
                             .text_color(pal.text_muted)
                             .child(tr!("LIGHTING")),
                     )
@@ -130,13 +130,13 @@ impl Render for LightingPanel {
                     .items_baseline()
                     .child(
                         div()
-                            .text_xs()
+                            .text_caption()
                             .text_color(pal.text_muted)
                             .child(tr!("BRIGHTNESS")),
                     )
                     .child(
                         div()
-                            .text_xs()
+                            .text_caption()
                             .text_color(rgb(ACCENT_BLUE))
                             .child(format!("{}%", lighting.brightness)),
                     ),
@@ -182,7 +182,7 @@ fn toggle(current: &Lighting, pal: Palette) -> AnyElement {
         .rounded(pal.control_radius)
         .selected_border(on, pal)
         .selected_fill(on)
-        .text_xs()
+        .text_caption()
         .text_color(if on { pal.text_primary } else { pal.text_muted })
         .cursor_pointer()
         .child(if on { tr!("On") } else { tr!("Off") })

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -28,7 +28,7 @@ use openlogi_hid::{AUTO_DISENGAGE_PERMANENT, DeviceRoute, SmartShiftMode, SmartS
 use crate::components::device_read::issue_device_read;
 use crate::components::status::{retry_line, status_line};
 use crate::state::{AppState, SmartShiftLoad};
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
 
 /// Friendly slider range for the `autoDisengage` threshold. The wire field is
 /// `0x01`–`0xFE` (0.25 turn/s steps); the slider exposes the usable band
@@ -216,7 +216,7 @@ impl SmartShiftPanel {
                     .child(section_label(tr!("Sensitivity"), pal))
                     .child(
                         div()
-                            .text_sm()
+                            .text_body()
                             .text_color(value_color)
                             .child(format!("{display}")),
                     ),
@@ -226,7 +226,7 @@ impl SmartShiftPanel {
             } else {
                 disabled_track(pal)
             })
-            .child(div().text_xs().text_color(pal.text_muted).child(tr!(
+            .child(div().text_caption().text_color(pal.text_muted).child(tr!(
                 "Higher keeps the ratchet engaged longer before free-spin."
             )));
 
@@ -238,7 +238,7 @@ impl SmartShiftPanel {
                     .child(section_label(tr!("Permanent ratchet"), pal))
                     .child(
                         div()
-                            .text_xs()
+                            .text_caption()
                             .text_color(pal.text_muted)
                             .child(tr!("Never auto-switch to free-spin.")),
                     ),
@@ -314,7 +314,7 @@ fn smartshift_load_target(cx: &mut Context<SmartShiftPanel>) -> Option<(String, 
 /// A small muted section heading.
 fn section_label(text: SharedString, pal: Palette) -> AnyElement {
     div()
-        .text_sm()
+        .text_body()
         .text_color(pal.text_muted)
         .child(text)
         .into_any_element()
@@ -342,7 +342,7 @@ fn mode_pill(
         .selected_border(selected, pal)
         .bg(pal.surface)
         .selected_fill(selected)
-        .text_sm()
+        .text_body()
         .text_color(pal.text_primary)
         .cursor_pointer()
         .hover(|s| s.bg(pal.surface_hover))
@@ -373,7 +373,7 @@ fn permanent_toggle(
             .rounded(pal.control_radius)
             .border_1()
             .border_color(pal.border)
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_muted)
             .child(label)
             .into_any_element();
@@ -385,7 +385,7 @@ fn permanent_toggle(
         .rounded(pal.control_radius)
         .selected_border(on, pal)
         .selected_fill(on)
-        .text_xs()
+        .text_caption()
         .text_color(if on { pal.text_primary } else { pal.text_muted })
         .cursor_pointer()
         .child(label)

--- a/crates/openlogi-gui/src/components/status.rs
+++ b/crates/openlogi-gui/src/components/status.rs
@@ -11,7 +11,7 @@ use gpui::{
     StatefulInteractiveElement as _, Styled, div, px,
 };
 
-use crate::theme::{self, Palette};
+use crate::theme::{self, Palette, Typography as _};
 
 /// Fixed height for a status / retry row, so swapping a slider out for a status
 /// message (or back) doesn't make the panel jump.
@@ -22,7 +22,7 @@ const ROW_H: f32 = 28.;
 pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
     div()
         .h(px(ROW_H))
-        .text_sm()
+        .text_body()
         .text_color(pal.text_muted)
         .child(text.into())
         .into_any_element()
@@ -42,7 +42,7 @@ pub fn retry_line(
     div()
         .id(id)
         .h(px(ROW_H))
-        .text_sm()
+        .text_body()
         .text_color(theme::accent())
         .hover(|s| s.text_color(pal.text_primary))
         .child(text.into())

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -22,8 +22,8 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use gpui::{
-    AnyElement, App, BorrowAppContext as _, Context, Entity, FontWeight, InteractiveElement,
-    IntoElement, ParentElement, StatefulInteractiveElement as _, Styled, Window, div,
+    AnyElement, App, BorrowAppContext as _, Context, Entity, InteractiveElement, IntoElement,
+    ParentElement, StatefulInteractiveElement as _, Styled, Window, div,
     prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_component::{Icon, IconName, h_flex, popover::PopoverState, v_flex};
@@ -33,7 +33,7 @@ use crate::data::mouse_buttons::{
 };
 use crate::mouse_model::view::MouseModelView;
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
 
 /// Floor width for the [`action_picker`] popover. The action labels drive the
 /// actual width; this only stops the list from collapsing too narrow. Matches
@@ -206,10 +206,10 @@ fn direction_cell(
         .selected_border(active, pal)
         .selected_fill(active)
         .hover(move |s| s.bg(pal.surface_hover))
-        .child(div().text_xs().text_color(pal.text_muted).child(header))
+        .child(div().text_caption().text_color(pal.text_muted).child(header))
         .child(
             div()
-                .text_sm()
+                .text_body()
                 .text_color(if is_default {
                     pal.text_muted
                 } else {
@@ -415,7 +415,7 @@ fn menu_row(
         .px_2()
         .py_1p5()
         .rounded(pal.control_radius)
-        .text_sm()
+        .text_body()
         .text_color(pal.text_primary)
         .selected_fill(selected)
         .hover(move |s| {
@@ -434,8 +434,7 @@ fn section_header(label: &str, pal: Palette) -> AnyElement {
         .px_2()
         .pt_2()
         .pb_0p5()
-        .text_xs()
-        .font_weight(FontWeight::SEMIBOLD)
+        .text_caption()
         .text_color(pal.text_muted)
         .child(label.to_uppercase())
         .into_any_element()
@@ -446,8 +445,7 @@ fn title(text: impl Into<gpui::SharedString>, pal: Palette) -> impl IntoElement 
     div()
         .px_2()
         .pb_1()
-        .text_xs()
-        .font_weight(FontWeight::SEMIBOLD)
+        .text_subheading()
         .text_color(pal.text_muted)
         .child(text.into())
 }

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -25,7 +25,7 @@ use crate::mouse_model::picker::{
     GESTURE_BUTTON_ICON, action_icon_path, action_picker, gesture_overview,
 };
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle};
+use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
 
 const SIDE_W: f32 = 180.;
 const SIDE_GAP: f32 = 24.;
@@ -290,7 +290,7 @@ fn gesture_owner_selector(
         .pl(px(SIDE_W + SIDE_GAP))
         .child(
             div()
-                .text_xs()
+                .text_caption()
                 .text_color(pal.text_muted)
                 .child(tr!("Gesture Button")),
         )
@@ -324,7 +324,7 @@ fn owner_chip(
         .rounded(pal.control_radius)
         .selected_border(selected, pal)
         .selected_fill(selected)
-        .text_xs()
+        .text_caption()
         .text_color(if selected {
             pal.text_primary
         } else {
@@ -591,7 +591,7 @@ impl RenderOnce for LabelTrigger {
             // popover title and category headers it shares the binding flow with.
             .child(
                 div()
-                    .text_xs()
+                    .text_caption()
                     .text_color(pal.text_muted)
                     .child(tr!(self.label.id.label())),
             )
@@ -623,7 +623,7 @@ impl RenderOnce for LabelTrigger {
                             .overflow_hidden()
                             .text_ellipsis()
                             .whitespace_nowrap()
-                            .text_sm()
+                            .text_body()
                             .text_color(binding_color)
                             .child(binding),
                     )

--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -12,7 +12,7 @@
 //!   own widgets — which is what keeps a popover from rendering white under
 //!   an otherwise dark UI (see `main.rs`'s appearance wiring).
 
-use gpui::{App, Hsla, Pixels, Styled, Window, hsla, px, rgb};
+use gpui::{App, FontWeight, Hsla, Pixels, Styled, Window, hsla, px, relative, rgb};
 use gpui_component::{ActiveTheme as _, Theme, ThemeMode, ThemeRegistry};
 use openlogi_core::config::Appearance;
 
@@ -269,6 +269,60 @@ pub trait SelectableStyle: Styled + Sized {
 }
 
 impl<E: Styled> SelectableStyle for E {}
+
+/// The app's type ramp as semantic roles, so a heading is `.text_heading()`
+/// everywhere instead of each call site re-picking a `text_*` size and a
+/// `font_weight`. Sizes, weights, and line heights live here once — an
+/// Apple-HIG-inspired scale, more generous and higher-contrast than the raw
+/// Tailwind steps it replaces — and every screen re-skins by editing this trait.
+///
+/// Blanket-implemented for every [`Styled`] element, the same way
+/// [`SelectableStyle`] extends styling. Colour stays a separate axis (the caller
+/// still picks `pal.text_primary` / `text_muted`); this trait only fixes size,
+/// weight, and leading.
+pub trait Typography: Styled + Sized {
+    /// Page / dialog hero title (empty states, connection notices). The
+    /// heaviest, largest step — the one place Bold is used.
+    #[must_use]
+    fn text_title(self) -> Self {
+        self.text_size(px(26.))
+            .font_weight(FontWeight::BOLD)
+            .line_height(relative(1.2))
+    }
+
+    /// Screen / section heading — the Home title, a device name, a window's
+    /// primary heading.
+    #[must_use]
+    fn text_heading(self) -> Self {
+        self.text_size(px(20.))
+            .font_weight(FontWeight::SEMIBOLD)
+            .line_height(relative(1.3))
+    }
+
+    /// Card / group title and item names — a heading one rung down, sitting
+    /// inside a card rather than titling a screen.
+    #[must_use]
+    fn text_subheading(self) -> Self {
+        self.text_size(px(15.))
+            .font_weight(FontWeight::SEMIBOLD)
+            .line_height(relative(1.4))
+    }
+
+    /// Default body copy — control labels, descriptions, values.
+    #[must_use]
+    fn text_body(self) -> Self {
+        self.text_size(px(15.)).line_height(relative(1.45))
+    }
+
+    /// De-emphasised metadata and helper text — the muted line under a label,
+    /// battery readouts, hints. Pair with `pal.text_muted`.
+    #[must_use]
+    fn text_caption(self) -> Self {
+        self.text_size(px(12.)).line_height(relative(1.4))
+    }
+}
+
+impl<E: Styled> Typography for E {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/openlogi-gui/src/windows.rs
+++ b/crates/openlogi-gui/src/windows.rs
@@ -13,6 +13,7 @@ pub mod add_device;
 pub mod settings;
 pub mod update_consent;
 
+use crate::theme::Typography as _;
 use gpui::{
     App, AppContext as _, Bounds, Context, Global, IntoElement, ParentElement as _, Pixels, Render,
     SharedString, Size, Styled as _, Subscription, TitlebarOptions, WindowBounds, WindowHandle,
@@ -69,7 +70,7 @@ pub fn aux_title_bar(title: impl Into<SharedString>, cx: &App) -> impl IntoEleme
             .flex()
             .items_center()
             .justify_center()
-            .text_sm()
+            .text_body()
             .text_color(cx.theme().muted_foreground)
             .child(title),
     )

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -29,7 +29,7 @@ use openlogi_hid::{Click, PasskeyMethod, ReceiverSelector};
 use crate::app_menu::{CloseWindow, Minimize, Zoom};
 use crate::ipc_client::Command;
 use crate::state::AppState;
-use crate::theme::{self, Palette};
+use crate::theme::{self, Palette, Typography as _};
 use crate::windows::{self, AuxWindow};
 
 /// The pairing flow's current UI state. Mirrors the [`PairingUpdate`] stream.
@@ -200,8 +200,7 @@ impl Render for AddDeviceView {
                     .gap_5()
                     .child(
                         div()
-                            .text_lg()
-                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_heading()
                             .child(tr!("Add Device")),
                     )
                     .child(body(&state, pal)),
@@ -305,7 +304,7 @@ fn device_row(idx: usize, device: &FoundDevice, pal: Palette) -> impl IntoElemen
         .hover(|s| s.bg(pal.surface_hover))
         .child(
             div()
-                .text_sm()
+                .text_body()
                 .child(SharedString::from(device.name.clone())),
         )
         .on_click(move |_, _, cx| {
@@ -324,12 +323,7 @@ fn passkey_panel(method: &PasskeyMethod, pal: Palette) -> impl IntoElement {
                     tr!("Type this passkey on the new keyboard, then press Enter:"),
                     pal,
                 ))
-                .child(
-                    div()
-                        .text_xl()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .child(SharedString::from(digits.clone())),
-                );
+                .child(div().text_title().child(SharedString::from(digits.clone())));
         }
         PasskeyMethod::Pointer { clicks, .. } => {
             let sequence: String = clicks
@@ -345,12 +339,7 @@ fn passkey_panel(method: &PasskeyMethod, pal: Palette) -> impl IntoElement {
                     tr!("On the new mouse, click in this order, then press both buttons together:"),
                     pal,
                 ))
-                .child(
-                    div()
-                        .text_xl()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .child(SharedString::from(sequence)),
-                );
+                .child(div().text_title().child(SharedString::from(sequence)));
         }
     }
     col
@@ -358,14 +347,14 @@ fn passkey_panel(method: &PasskeyMethod, pal: Palette) -> impl IntoElement {
 
 fn status_line(text: impl Into<SharedString>, _pal: Palette) -> impl IntoElement {
     div()
-        .text_sm()
+        .text_body()
         .font_weight(FontWeight::MEDIUM)
         .child(text.into())
 }
 
 fn hint(text: impl Into<SharedString>, pal: Palette) -> impl IntoElement {
     div()
-        .text_xs()
+        .text_caption()
         .text_color(pal.text_muted)
         .child(text.into())
 }

--- a/crates/openlogi-gui/src/windows/settings/about.rs
+++ b/crates/openlogi-gui/src/windows/settings/about.rs
@@ -6,6 +6,7 @@ use super::{
     SettingItem, SettingPage, SettingsView, SharedString, Sizable, Styled, div, h_flex, img, px,
     v_flex,
 };
+use crate::theme::Typography as _;
 
 /// The About page: a hero card with the build identity and outbound links, the
 /// on-disk config location, and a trademark disclaimer.
@@ -16,7 +17,7 @@ pub(super) fn about_page(view: Entity<SettingsView>, copied: bool, pal: Palette)
     let config = SettingGroup::new().item(SettingItem::render(move |_, _, _| about_config(pal)));
     let footer = SettingGroup::new().item(SettingItem::render(move |_, _, _| {
         div()
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_muted)
             .child(tr!(
                 "Not affiliated with Logitech. \"Logitech\", \"MX Master\", and \"Options+\" are trademarks of Logitech International S.A."
@@ -65,7 +66,7 @@ fn about_hero(view: &Entity<SettingsView>, copied: bool, pal: Palette, _: &mut A
                         )
                         .child(
                             div()
-                                .text_sm()
+                                .text_body()
                                 .text_color(pal.text_muted)
                                 .child(env!("CARGO_PKG_VERSION")),
                         ),
@@ -158,7 +159,7 @@ fn about_config(pal: Palette) -> AnyElement {
                 .child(div().font_weight(FontWeight::MEDIUM).child("config.toml"))
                 .child(
                     div()
-                        .text_xs()
+                        .text_caption()
                         .text_color(pal.text_muted)
                         .truncate()
                         .child(path),

--- a/crates/openlogi-gui/src/windows/settings/appearance.rs
+++ b/crates/openlogi-gui/src/windows/settings/appearance.rs
@@ -9,6 +9,7 @@ use super::{
     Styled, Theme, ThemeColor, ThemeConfig, ThemeFilter, ThemeMode, ThemeRegistry, div, h_flex, px,
     rgb, theme, v_flex,
 };
+use crate::theme::Typography as _;
 
 /// The Appearance page: light/dark mode, the theme grid, corner radius, and the
 /// interface language. Every theme here re-skins the whole app — the bespoke
@@ -189,7 +190,7 @@ fn mode_card(
                 .items_center()
                 .gap(px(6.))
                 .child(radio_dot(selected, accent, pal))
-                .child(div().text_sm().child(label)),
+                .child(div().text_body().child(label)),
         )
         .on_click(move |_, _, cx| on_click(cx))
 }
@@ -337,7 +338,7 @@ fn theme_picker(
 
     let grid = if themes.is_empty() {
         div()
-            .text_sm()
+            .text_body()
             .text_color(pal.text_muted)
             .child(tr!("No themes match “%{query}”.", query => query))
             .into_any_element()
@@ -496,7 +497,7 @@ fn theme_card(
                 .child(
                     div()
                         .overflow_hidden()
-                        .text_xs()
+                        .text_caption()
                         .text_color(pal.text_primary)
                         .child(name),
                 )
@@ -547,7 +548,7 @@ fn filter_chip(
         .py_1()
         .rounded_full()
         .border_1()
-        .text_xs()
+        .text_caption()
         .cursor_pointer()
         .map(|this| {
             if selected {

--- a/crates/openlogi-gui/src/windows/settings/assets.rs
+++ b/crates/openlogi-gui/src/windows/settings/assets.rs
@@ -1,5 +1,6 @@
 //! Assets (device-image cache) settings page.
 
+use crate::theme::Typography as _;
 use std::time::Duration;
 
 use super::{
@@ -213,7 +214,7 @@ fn action_button(
         .rounded(pal.control_radius)
         .border_1()
         .border_color(pal.border)
-        .text_xs()
+        .text_caption()
         .cursor_pointer()
         .hover(move |s| s.bg(pal.surface_hover))
         .child(label)

--- a/crates/openlogi-gui/src/windows/settings/diagnostics.rs
+++ b/crates/openlogi-gui/src/windows/settings/diagnostics.rs
@@ -2,6 +2,7 @@
 //! event stream — a common pointer-lag cause — and, in debug builds, dumps the
 //! full event-tap list plus a live event monitor.
 
+use crate::theme::Typography as _;
 #[cfg(not(debug_assertions))]
 use openlogi_hook::Hook;
 
@@ -57,14 +58,14 @@ fn input_conflict_field(pal: Palette, cx: &mut App) -> AnyElement {
     if conflicts.is_empty() {
         col = col.child(
             div()
-                .text_xs()
+                .text_caption()
                 .text_color(rgb(theme::STATUS_CONNECTED))
                 .child(tr!("No other app is intercepting mouse input.")),
         );
     } else {
         col = col.child(
             div()
-                .text_sm()
+                .text_body()
                 .text_color(rgb(theme::STATUS_CONNECTING))
                 .child(tr!(
                     "Another app is intercepting mouse input, which can cause pointer lag or duplicated button actions: %{apps}",
@@ -124,20 +125,25 @@ fn monitor_list(pal: Palette, cx: &mut App) -> impl IntoElement {
 
     let mut col = v_flex().w_full().mt_2().gap_1().child(
         div()
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_muted)
             .child("Live events (newest first)"),
     );
     if lines.is_empty() {
         col = col.child(
             div()
-                .text_xs()
+                .text_caption()
                 .text_color(pal.text_muted)
                 .child("(click or scroll to see what the hook receives)"),
         );
     } else {
         for line in lines {
-            col = col.child(div().text_xs().text_color(pal.text_primary).child(line));
+            col = col.child(
+                div()
+                    .text_caption()
+                    .text_color(pal.text_primary)
+                    .child(line),
+            );
         }
     }
     col
@@ -164,7 +170,7 @@ fn format_monitor_event(event: &openlogi_agent_core::ipc::MonitorEvent) -> Strin
 fn debug_tap_list(taps: &[openlogi_hook::EventTapInfo], pal: Palette) -> impl IntoElement {
     let mut col = v_flex().w_full().mt_2().gap_1().child(
         div()
-            .text_xs()
+            .text_caption()
             .text_color(pal.text_muted)
             .child(format!("{} event tap(s)", taps.len())),
     );
@@ -175,7 +181,7 @@ fn debug_tap_list(taps: &[openlogi_hook::EventTapInfo], pal: Palette) -> impl In
             "{owner} (pid {}) — {:?} {mode} enabled={}",
             tap.owner_pid, tap.location, tap.enabled
         );
-        let row = div().text_xs().child(line);
+        let row = div().text_caption().child(line);
         let row = if tap.gates_input() {
             row.text_color(rgb(theme::STATUS_CONNECTING))
         } else {

--- a/crates/openlogi-gui/src/windows/settings/general.rs
+++ b/crates/openlogi-gui/src/windows/settings/general.rs
@@ -5,6 +5,7 @@ use super::{
     FluentBuilder, IconName, IntoElement, ParentElement, SettingField, SettingGroup, SettingItem,
     SettingPage, Slider, SliderState, Styled, div, h_flex, px, theme, v_flex,
 };
+use crate::theme::Typography as _;
 
 pub(super) fn general_page(sensitivity_slider: Entity<SliderState>) -> SettingPage {
     let group = SettingGroup::new()
@@ -100,7 +101,7 @@ fn sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
                 .child(
                     div()
                         .w(px(72.))
-                        .text_sm()
+                        .text_body()
                         .text_color(pal.text_muted)
                         .child(value.to_string()),
                 ),
@@ -108,7 +109,7 @@ fn sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
         .when(is_default, |this| {
             this.child(
                 div()
-                    .text_xs()
+                    .text_caption()
                     .text_color(pal.text_muted)
                     .whitespace_nowrap()
                     .child(format!("({})", rust_i18n::t!("Default"))),

--- a/crates/openlogi-gui/src/windows/settings/permissions.rs
+++ b/crates/openlogi-gui/src/windows/settings/permissions.rs
@@ -1,6 +1,5 @@
 //! Permissions settings page (macOS / Linux).
 
-#[cfg(target_os = "macos")]
 use super::{
     App, AppState, InteractiveElement, Permission, SharedString, StatefulInteractiveElement, h_flex,
 };
@@ -12,6 +11,8 @@ use super::{
 };
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use crate::platform::permissions;
+#[cfg(target_os = "macos")]
+use crate::theme::Typography as _;
 
 #[cfg_attr(
     not(any(target_os = "macos", target_os = "linux")),
@@ -83,7 +84,7 @@ pub(super) fn permissions_page(pal: Palette) -> SettingPage {
                     PermissionStatus::Granted => None,
                 };
                 if let Some(text) = hint {
-                    field.child(div().text_xs().text_color(pal.text_muted).child(text))
+                    field.child(div().text_caption().text_color(pal.text_muted).child(text))
                 } else {
                     field
                 }
@@ -118,7 +119,7 @@ fn status_badge(status: PermissionStatus) -> impl IntoElement {
         PermissionStatus::Denied => (tr!("Not granted"), theme::STATUS_CONNECTING),
         PermissionStatus::Unknown => (tr!("Unknown"), theme::STATUS_OFFLINE),
     };
-    div().text_xs().text_color(rgb(color)).child(label)
+    div().text_caption().text_color(rgb(color)).child(label)
 }
 
 /// The right-side field for one permission row: live status, plus (macOS only)
@@ -145,7 +146,7 @@ fn permission_field(
             .rounded(pal.control_radius)
             .border_1()
             .border_color(pal.border)
-            .text_xs()
+            .text_caption()
             .cursor_pointer()
             .hover(move |s| s.bg(pal.surface_hover))
             .child(tr!("Open"))

--- a/crates/openlogi-gui/src/windows/settings/permissions.rs
+++ b/crates/openlogi-gui/src/windows/settings/permissions.rs
@@ -1,5 +1,6 @@
 //! Permissions settings page (macOS / Linux).
 
+#[cfg(target_os = "macos")]
 use super::{
     App, AppState, InteractiveElement, Permission, SharedString, StatefulInteractiveElement, h_flex,
 };
@@ -11,7 +12,6 @@ use super::{
 };
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use crate::platform::permissions;
-#[cfg(target_os = "macos")]
 use crate::theme::Typography as _;
 
 #[cfg_attr(

--- a/crates/openlogi-gui/src/windows/settings/updates.rs
+++ b/crates/openlogi-gui/src/windows/settings/updates.rs
@@ -6,6 +6,7 @@ use super::{
     SettingGroup, SettingItem, SettingPage, Sizable, Styled, Tag, UpdateStatus, Updater, div,
     h_flex, img, px, v_flex,
 };
+use crate::theme::Typography as _;
 
 /// The Updates page: a hero card with the running build, its update status, and
 /// the contextual check / install / restart action; the opt-in auto-check and
@@ -178,7 +179,7 @@ fn update_hero(updater: &Entity<Updater>, pal: Palette, cx: &mut App) -> AnyElem
                         )
                         .child(
                             div()
-                                .text_xs()
+                                .text_caption()
                                 .text_color(pal.text_muted)
                                 .truncate()
                                 .child(message.unwrap_or_else(|| tr!("Stable channel"))),
@@ -214,7 +215,7 @@ fn update_source(pal: Palette) -> AnyElement {
                         )
                         .child(
                             div()
-                                .text_xs()
+                                .text_caption()
                                 .text_color(pal.text_muted)
                                 .truncate()
                                 .child("github.com/AprilNEA/OpenLogi/releases"),
@@ -232,7 +233,7 @@ fn update_source(pal: Palette) -> AnyElement {
         )
         .child(
             div()
-                .text_xs()
+                .text_caption()
                 .text_color(pal.text_muted)
                 .child(tr!(
                     "No background updater — OpenLogi only connects when you turn on automatic checks or click Check for Updates."

--- a/crates/openlogi-gui/src/windows/update_consent.rs
+++ b/crates/openlogi-gui/src/windows/update_consent.rs
@@ -6,8 +6,9 @@
 //! is how a user opts in on first launch. Either choice marks the prompt seen
 //! so it never reappears; "Enable" also runs one check immediately.
 
+use crate::theme::Typography as _;
 use gpui::{
-    App, BorrowAppContext as _, Context, FocusHandle, FontWeight, InteractiveElement, IntoElement,
+    App, BorrowAppContext as _, Context, FocusHandle, InteractiveElement, IntoElement,
     ParentElement as _, Render, Size, Styled as _, Subscription, Window, div,
     prelude::FluentBuilder as _, px,
 };
@@ -94,14 +95,13 @@ impl Render for UpdateConsentView {
                     .p_6()
                     .child(
                         div()
-                            .text_lg()
-                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_heading()
                             .child(tr!("Check for updates?")),
                     )
                     .child(
                         div()
                             .max_w(px(320.))
-                            .text_sm()
+                            .text_body()
                             .text_center()
                             .text_color(pal.text_muted)
                             .child(tr!(


### PR DESCRIPTION
## Summary

Stacked on #440 (design tokens). Text across the GUI re-picked a raw Tailwind
`text_*` size and a `font_weight` at each call site, so the type had no named
hierarchy and drifted (a card title and a section heading were both
`text_sm + semibold`; body was sometimes `sm`, sometimes `xs`). This adds a
semantic type ramp and routes every screen through it, for a more spacious,
higher-contrast hierarchy inspired by Apple's HIG.

## Changes

**openlogi-gui**
- **theme**: a `Typography` blanket-trait (same shape as `SelectableStyle`) with
  five roles, each fixing size, weight, and line height in one place:
  - `text_title` — 26 / Bold
  - `text_heading` — 20 / Semibold
  - `text_subheading` — 15 / Semibold
  - `text_body` — 15 / Regular
  - `text_caption` — 12 / Regular
- Routed every screen's text through the roles: `text_xl + semibold` → title,
  `text_lg + semibold` → heading, `text_sm + semibold` → subheading, bare
  `text_sm` → body, `text_xs` → caption. Colour stays a separate axis (callers
  still pick `pal.text_muted` / `text_primary`). The About wordmark keeps its
  bespoke `text_lg` Bold sizing.
- Net effect: body 14→15, heading 18→20, title 20→26 (now Bold) — the type reads
  more generous with clearer steps.

## Constraints

- gpui's `TextStyle` has no letter-spacing field, so HIG *tracking* is not
  implementable on the current pin — this delivers size, weight, and line height
  only.
- All five role sizes/weights/leadings live in the one trait, so the exact scale
  is a five-line tweak if it wants adjusting after review.

## Testing

- `cargo clippy --workspace --all-targets -- -D warnings` — clean on macOS.
- `cargo test -p openlogi-gui` — 52 pass.
- Ran the app: the Home "Devices" heading, device names, and metadata show the
  new, clearer hierarchy.
- Cross-platform: the macOS-only Diagnostics page and the macOS/Linux-only
  Permissions page use the roles only on the platforms they compile for (checked
  by hand — gpui doesn't cross-compile for a headless GUI lint).

Base: `refactor/gui-design-tokens` (#440) — retargets to `master` once that merges.
