### PR TITLE
fix(agent): prefer online device for input capture

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -320,10 +320,11 @@ impl Orchestrator {
     /// Apply a fresh inventory snapshot. Always refreshes the snapshot the IPC
     /// `inventory()` poll serves (battery / online state changes without
     /// altering the device *set*), but only re-picks the selection and rebuilds
-    /// the shared maps when the device set actually changed — `rebuild()` is
-    /// driven solely by `config_key` + route and resets the live DPI-cycle
-    /// index, so running it every 2s tick on an unchanged set would snap DPI
-    /// back to `preset[0]` (and burn three `RwLock` writes) for nothing.
+    /// the shared maps when the device set or runtime selection changed —
+    /// `rebuild()` is driven by `config_key` + route and resets the live
+    /// DPI-cycle index, so running it every 2s tick on a steady selection
+    /// would snap DPI back to `preset[0]` (and burn three `RwLock` writes)
+    /// for nothing.
     pub fn refresh_inventory(
         &mut self,
         inventories: &[DeviceInventory],
@@ -354,7 +355,8 @@ impl Orchestrator {
         for idx in targets {
             self.reapply_volatile_settings(&devices[idx]);
         }
-        let changed = devices.len() != self.devices.len()
+        let changed = next_current != self.current
+            || devices.len() != self.devices.len()
             || devices.iter().zip(&self.devices).any(|(a, b)| {
                 a.config_key != b.config_key
                     || a.route != b.route
@@ -366,8 +368,9 @@ impl Orchestrator {
             self.current = next_current;
             self.rebuild();
         } else {
-            // Same set and routes — but keep the fresh `online` flags, or a
-            // device that woke this tick would read as a transition forever.
+            // Same set, routes, and runtime selection — but keep the fresh
+            // `online` flags, or a device that woke this tick would read as a
+            // transition forever.
             self.devices = devices;
             self.sync_current_route();
             write_value(
@@ -886,17 +889,26 @@ fn plan_reapply(
     (targets, next_followup)
 }
 
-/// Index of the selected HID++ input device: the saved selection when it is an
-/// input route, otherwise the first input route. Standalone raw-HID devices
-/// participate in inventory and settings re-apply but must never replace the
-/// mouse/keyboard capture target when selected in the GUI.
+/// Index of the selected HID++ input device. Prefer the saved selection while
+/// it is an online input route, otherwise the first online input route. If
+/// every input device is offline, preserve the saved selection (or the first
+/// input route) so its configuration remains stable. Standalone raw-HID
+/// devices participate in inventory and settings re-apply but must never
+/// replace the mouse/keyboard capture target when selected in the GUI.
 fn pick_current(devices: &[AgentDevice], saved: Option<&str>) -> usize {
+    let saved = saved.and_then(|key| {
+        devices
+            .iter()
+            .position(|device| device.config_key == key && is_hidpp_device(device))
+    });
     saved
-        .and_then(|key| {
+        .filter(|&idx| devices[idx].online)
+        .or_else(|| {
             devices
                 .iter()
-                .position(|device| device.config_key == key && is_hidpp_device(device))
+                .position(|device| device.online && is_hidpp_device(device))
         })
+        .or(saved)
         .or_else(|| devices.iter().position(is_hidpp_device))
         .unwrap_or(0)
 }

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -81,6 +81,39 @@ fn direct_inventory(serial_number: Option<&str>, unit_id: [u8; 4]) -> DeviceInve
     }
 }
 
+fn direct_inventory_state(
+    product_id: u16,
+    serial_number: Option<&str>,
+    unit_id: [u8; 4],
+    online: bool,
+) -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "MX Master 3S".to_string(),
+            vendor_id: 0x046d,
+            product_id,
+            unique_id: None,
+        },
+        paired: vec![PairedDevice {
+            slot: DIRECT_DEVICE_INDEX,
+            codename: Some("MX Master 3S".to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online,
+            battery: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 1,
+                serial_number: serial_number.map(str::to_string),
+                unit_id,
+                transports: DeviceTransports::default(),
+                model_ids: [product_id, 0, 0],
+                extended_model_id: 2,
+            }),
+            capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+        }],
+    }
+}
+
 #[test]
 fn build_devices_skips_transient_zero_unit_direct_identity() {
     assert!(build_devices(&[direct_inventory(None, [0; 4])], &[]).is_empty());
@@ -136,6 +169,54 @@ fn standalone_selection_never_replaces_the_hidpp_capture_target() {
 
     assert_eq!(pick_current(&devices, Some("light")), 1);
     assert_eq!(pick_current(&devices, None), 1);
+}
+
+#[test]
+fn runtime_selection_falls_back_from_saved_offline_device_to_online_device() {
+    let devices = [dev("saved", 1, false), dev("online", 2, true)];
+
+    assert_eq!(pick_current(&devices, Some("saved")), 1);
+}
+
+#[test]
+fn runtime_selection_keeps_saved_device_when_it_is_online() {
+    let devices = [dev("other", 1, true), dev("saved", 2, true)];
+
+    assert_eq!(pick_current(&devices, Some("saved")), 1);
+}
+
+#[test]
+fn runtime_selection_keeps_saved_device_when_all_devices_are_offline() {
+    let devices = [dev("other", 1, false), dev("saved", 2, false)];
+
+    assert_eq!(pick_current(&devices, Some("saved")), 1);
+}
+
+#[test]
+fn runtime_selection_tracks_online_transition_without_device_set_change() {
+    let saved_key = "direct:046d:b023:unit:01000000";
+    let other_key = "direct:046d:b034:unit:02000000";
+    let mut config = Config::default();
+    config.set_selected_device(Some(saved_key.to_string()));
+    let mut orchestrator = Orchestrator::new(config);
+
+    orchestrator.refresh_inventory(
+        &[
+            direct_inventory_state(0xb023, None, [1, 0, 0, 0], true),
+            direct_inventory_state(0xb034, None, [2, 0, 0, 0], false),
+        ],
+        &[],
+    );
+    assert_eq!(orchestrator.current_key(), Some(saved_key));
+
+    orchestrator.refresh_inventory(
+        &[
+            direct_inventory_state(0xb023, None, [1, 0, 0, 0], false),
+            direct_inventory_state(0xb034, None, [2, 0, 0, 0], true),
+        ],
+        &[],
+    );
+    assert_eq!(orchestrator.current_key(), Some(other_key));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Keep programmable input capture on a usable device when the persisted GUI selection is offline.

## Changes

- `openlogi-agent-core`: prefer the saved GUI selection while it is online, otherwise use the first online device, and preserve the saved selection when every device is offline.
- Rebuild the live bindings and HID++ capture target when an online-state transition changes the runtime selection without changing device keys or routes.
- Add regression coverage for saved online, saved offline, all-offline, and online-only transition cases.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Hardware-tested on macOS 26.5.2 with an MX Master 3S over Bluetooth direct while an offline Unifying device was selected; programmable buttons remained active through the online fallback.

Fixes #452