### PR TITLE
fix(gui): refresh the macOS device menu when inventory changes

### DIFF
--- a/crates/openlogi-gui/src/app_menu.rs
+++ b/crates/openlogi-gui/src/app_menu.rs
@@ -223,10 +223,13 @@ fn device_menu_items(cx: &App) -> Vec<MenuItem> {
                     Some(battery) => format!("{} · {}%", record.display_name, battery.percentage),
                     None => record.display_name.clone(),
                 };
-                items.push(MenuItem::action(title, OpenSettings).disabled(true));
+                items.push(MenuItem::action(title, gpui::NoAction).disabled(true));
             }
         }
-        _ => items.push(MenuItem::action(tr!("No devices connected"), OpenSettings).disabled(true)),
+        _ => {
+            items
+                .push(MenuItem::action(tr!("No devices connected"), gpui::NoAction).disabled(true));
+        }
     }
 
     items

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -340,9 +340,10 @@ fn main() -> Result<()> {
                                 )
                             });
                             // The steady poll mostly repeats an identical snapshot;
-                            // skip the full-window invalidation for those.
+                            // skip the full-window invalidation and menu rebuild for those.
                             if changed {
                                 cx.refresh_windows();
+                                app_menu::rebuild(cx);
                             }
                             (auto_download, asset_source, models)
                         });

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -312,7 +312,7 @@ fn main() -> Result<()> {
                         // Scanning window overlaps the first sync's completion).
                         let force_refresh = inventory_ready && std::mem::take(&mut assets_dirty);
                         let (auto_download, asset_source, models) = cx.update(|cx| {
-                            let (changed, auto_download, asset_source, models) = cx.update_global::<AppState, _>(|state, _| {
+                            let (changed, merged, auto_download, asset_source, models) = cx.update_global::<AppState, _>(|state, _| {
                                 // Merge only *completed* enumerations. A not-yet-ready
                                 // agent can only serve an empty pre-enumeration list, and
                                 // counting those as misses would wipe the device list (and
@@ -334,6 +334,7 @@ fn main() -> Result<()> {
                                 let settings = state.app_settings();
                                 (
                                     changed,
+                                    merged,
                                     settings.auto_download_assets,
                                     settings.asset_source,
                                     state.asset_models(),
@@ -343,6 +344,8 @@ fn main() -> Result<()> {
                             // skip the full-window invalidation and menu rebuild for those.
                             if changed {
                                 cx.refresh_windows();
+                            }
+                            if merged {
                                 app_menu::rebuild(cx);
                             }
                             (auto_download, asset_source, models)


### PR DESCRIPTION
## Summary

Keep the native macOS Device menu synchronized with the device records shown by the GUI.

## Changes

- `openlogi-gui`: rebuild the application menu when an agent update changes the displayed state, without rebuilding it for unchanged polling snapshots.
- Use `NoAction` for informational disabled menu entries instead of routing them through Settings actions.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Hardware-tested on macOS 26.5.2 with an MX Master 3 over Unifying; after inventory loading, the native Device menu listed the active device records instead of remaining on `No devices connected`.

Fixes #455