### PR TITLE
fix(hid): declare Win32_System_IO feature for windows-sys WriteFile

### DIFF
--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -34,6 +34,9 @@ windows-sys = { workspace = true, features = [
     # exposed when Win32_Security is also enabled.
     "Win32_Security",
     "Win32_Storage_FileSystem",
+    # WriteFile's signature references OVERLAPPED, so windows-sys 0.61.2 gates
+    # it behind Win32_System_IO as well.
+    "Win32_System_IO",
 ] }
 
 [lints]


### PR DESCRIPTION
## Summary

`openlogi-hid` uses `WriteFile` (native HID report writes in `windows_hid.rs`) but does not enable the `windows-sys` feature that gates it. In `windows-sys` 0.61.2, `WriteFile`'s signature references `OVERLAPPED`, so the function is only exported when `Win32_System_IO` is enabled.

Workspace builds still compile because another workspace dependency enables `Win32_System_IO` and cargo unifies features across the graph — which is why CI stays green. But any package-scoped build on Windows fails:

```
$ cargo check -p openlogi-hid
error[E0432]: unresolved import `windows_sys::Win32::Storage::FileSystem::WriteFile`
```

This declares the feature the crate actually uses instead of relying on feature unification.

## Changes

- `openlogi-hid`: add `Win32_System_IO` to the `windows-sys` feature list, with a comment mirroring the existing `Win32_Security` note.

## Testing

On Windows 11 (windows-sys 0.61.2 from the committed `Cargo.lock`):

- `cargo check -p openlogi-hid` — fails with E0432 before, passes after
- `cargo check --workspace` — passes before and after (feature unification masks the bug in workspace builds)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all pass
