### PR TITLE
fix(tray): stop the Windows tray launching the CLI instead of the GUI

### DIFF
--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -290,6 +290,12 @@ fn open_or_focus_gui() {
 /// same-user filter keeps other sessions (fast user switching) out of
 /// Show/Quit — their windows are invisible to `EnumWindows` and their
 /// processes unkillable anyway, but don't even consider them.
+///
+/// The `OpenLogi.exe` match is case-*sensitive*: the CLI binary is
+/// `openlogi.exe`, which case-insensitively equals the GUI's `OpenLogi.exe`.
+/// The two share a name on the case-insensitive filesystem (only the dev
+/// target dir ever holds both), so an `eq_ignore_ascii_case` match would take
+/// a transient CLI invocation for the GUI and then fail to find its window.
 fn gui_pids() -> Vec<u32> {
     use sysinfo::{Pid, Process, ProcessesToUpdate, System};
     let mut system = System::new();
@@ -302,8 +308,7 @@ fn gui_pids() -> Vec<u32> {
         .values()
         .filter(|p| {
             let name = p.name().to_string_lossy();
-            (name.eq_ignore_ascii_case("OpenLogi.exe")
-                || name.eq_ignore_ascii_case("openlogi-gui.exe"))
+            (name == "OpenLogi.exe" || name.eq_ignore_ascii_case("openlogi-gui.exe"))
                 && (own_user.is_none() || p.user_id() == own_user)
         })
         .map(|p| p.pid().as_u32())
@@ -354,9 +359,13 @@ fn spawn_gui() {
         return;
     };
     let Some(dir) = exe.parent() else { return };
-    // Installed/portable layout first (the product name), then the cargo
-    // target-dir name (dev) — the reverse of the GUI's agent sibling lookup.
-    let gui = ["OpenLogi.exe", "openlogi-gui.exe"]
+    // Dev target dir first: it holds both `openlogi.exe` (CLI) and
+    // `openlogi-gui.exe`, and the CLI shares `OpenLogi.exe`'s name on the
+    // case-insensitive filesystem — so `dir.join("OpenLogi.exe").exists()`
+    // there resolves to the CLI and would launch it. Probing the unambiguous
+    // `openlogi-gui.exe` first avoids that; the installed layout has only
+    // `OpenLogi.exe` and falls through to it.
+    let gui = ["openlogi-gui.exe", "OpenLogi.exe"]
         .iter()
         .map(|name| dir.join(name))
         .find(|p| p.exists());

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -290,12 +290,6 @@ fn open_or_focus_gui() {
 /// same-user filter keeps other sessions (fast user switching) out of
 /// Show/Quit — their windows are invisible to `EnumWindows` and their
 /// processes unkillable anyway, but don't even consider them.
-///
-/// The `OpenLogi.exe` match is case-*sensitive*: the CLI binary is
-/// `openlogi.exe`, which case-insensitively equals the GUI's `OpenLogi.exe`.
-/// The two share a name on the case-insensitive filesystem (only the dev
-/// target dir ever holds both), so an `eq_ignore_ascii_case` match would take
-/// a transient CLI invocation for the GUI and then fail to find its window.
 fn gui_pids() -> Vec<u32> {
     use sysinfo::{Pid, Process, ProcessesToUpdate, System};
     let mut system = System::new();
@@ -307,12 +301,20 @@ fn gui_pids() -> Vec<u32> {
         .processes()
         .values()
         .filter(|p| {
-            let name = p.name().to_string_lossy();
-            (name == "OpenLogi.exe" || name.eq_ignore_ascii_case("openlogi-gui.exe"))
+            is_gui_process_name(&p.name().to_string_lossy())
                 && (own_user.is_none() || p.user_id() == own_user)
         })
         .map(|p| p.pid().as_u32())
         .collect()
+}
+
+/// Whether a process image name is one of the GUI binaries.
+///
+/// `OpenLogi.exe` is matched case-*sensitively*: the CLI is `openlogi.exe`,
+/// which `eq_ignore_ascii_case` would accept, and the dev target dir holds
+/// both. Windows reports image names with their on-disk case, so this holds.
+fn is_gui_process_name(name: &str) -> bool {
+    name == "OpenLogi.exe" || name.eq_ignore_ascii_case("openlogi-gui.exe")
 }
 
 /// Bring the first visible top-level window owned by one of `pids` to the
@@ -411,4 +413,16 @@ fn quit(hwnd: HWND) {
 /// NUL-terminated UTF-16 for win32 W-APIs.
 fn wide(s: &str) -> Vec<u16> {
     s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_gui_process_name;
+
+    #[test]
+    fn the_cli_binary_is_not_the_gui() {
+        assert!(is_gui_process_name("OpenLogi.exe"));
+        assert!(is_gui_process_name("openlogi-gui.exe"));
+        assert!(!is_gui_process_name("openlogi.exe")); // the CLI
+    }
 }


### PR DESCRIPTION
## Summary

On Windows the tray's "Show Main Window" launched the **CLI** instead of the GUI, and
Show/Quit could report `GUI process is running but no window was found to focus`.

Root cause: `tray_windows.rs` identifies the GUI by filename — `OpenLogi.exe`
(installed) or `openlogi-gui.exe` (dev). The CLI binary is `openlogi.exe`, and two
independent things went wrong in a cargo target dir:

- `gui_pids()` compared process image names with `eq_ignore_ascii_case`, so a transient
  `openlogi.exe` CLI run counted as the GUI — hence the "no window to focus" report.
  This is the comparison's own doing, not the filesystem's.
- `spawn_gui()` probed `dir.join("OpenLogi.exe").exists()`. Win32 path lookup *is*
  case-insensitive, so that name resolved to the CLI's `openlogi.exe` and the tray
  launched it.

The installed layout ships only `OpenLogi.exe` + `openlogi-agent.exe` (no CLI), so this
only bites dev/portable layouts — but it's a real filename-collision bug.

## Changes

- **agent (tray)**: extract `is_gui_process_name()` and match the product GUI
  `OpenLogi.exe` case-*sensitively* — Windows reports image names with their on-disk
  case, so the lowercase CLI `openlogi.exe` no longer counts as the GUI.
- **agent (tray)**: probe the unambiguous `openlogi-gui.exe` first in `spawn_gui()`, so
  `.exists()` can't resolve `OpenLogi.exe` to the CLI on the case-insensitive filesystem.
- **agent (tray)**: add a unit test pinning all three binary names.

## Testing

`cargo clippy -p openlogi-agent --all-targets -- -D warnings` — clean.

Note the new `is_gui_process_name` test sits in a Windows-only module, so it runs only on
a Windows host — CI's test jobs are macOS/Linux, so they skip it. `clippy (windows)` is
the only CI job that compiles this file.

Windows-only tray behaviour, **not runtime-tested on hardware**: verify by rebuilding the
agent and clicking the tray — it should open the GUI window, not print a device list.

Fixes the wrong-binary launch reported on Windows dev builds.
