### PR TITLE
fix: prevent unintended thumbwheel tap actions

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -39,6 +39,15 @@ pub struct DeviceCapturePlan {
     /// Whether any thumbwheel binding leaves its default. Combined with the
     /// sensitivity to decide thumb-wheel diversion.
     pub thumbwheel_bindings_nondefault: bool,
+    /// Whether the thumb-wheel *tap* is explicitly bound for this device/app.
+    ///
+    /// Presence in the stored effective bindings, never equality against
+    /// `default_binding`: the tap's default is `AppExpose`, so a user who binds
+    /// `Single(AppExpose)` on purpose is indistinguishable from an unset tap
+    /// under a value comparison. Diversion can stay value-based (it only has to
+    /// be conservative), but tap *delivery* must not drop an explicitly bound
+    /// tap that happens to match the seed.
+    pub thumbwheel_tap_bound: bool,
     /// This device's effective thumb-wheel sensitivity (device override or the
     /// app-wide default).
     pub thumbwheel_sensitivity: ThumbwheelSensitivity,
@@ -92,6 +101,9 @@ pub fn plan_for_device(
             })
         })
         .collect();
+    let thumbwheel_tap_bound = config
+        .effective_bindings(config_key, app)
+        .contains_key(&ButtonId::Thumbwheel);
     let thumbwheel_bindings_nondefault = [
         ButtonId::Thumbwheel,
         ButtonId::ThumbwheelScrollUp,
@@ -110,6 +122,7 @@ pub fn plan_for_device(
         gesture_bindings,
         divert_buttons,
         thumbwheel_bindings_nondefault,
+        thumbwheel_tap_bound,
         thumbwheel_sensitivity: config.thumbwheel_sensitivity(config_key),
         rearm_generation,
     }
@@ -127,6 +140,42 @@ mod tests {
             receiver_uid: "cafe".into(),
             slot: 2,
         }
+    }
+
+    #[test]
+    fn an_explicit_tap_binding_equal_to_the_default_still_counts_as_bound() {
+        // The thumb wheel's seeded default is AppExpose, so a user who binds
+        // AppExpose on purpose produces a binding that is byte-identical to the
+        // seed. Value comparison against `default_binding` cannot tell the two
+        // apart and silently drops the explicitly bound tap; presence in the
+        // stored effective bindings can.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b042",
+            ButtonId::Thumbwheel,
+            Binding::Single(default_binding(ButtonId::Thumbwheel)),
+        );
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+
+        assert!(
+            plan.thumbwheel_tap_bound,
+            "an explicit tap binding must be bound even when it equals the seed"
+        );
+        assert!(
+            !plan.thumbwheel_bindings_nondefault,
+            "value comparison cannot see this binding, which is exactly the bug"
+        );
+    }
+
+    #[test]
+    fn an_unset_tap_is_not_bound() {
+        let cfg = Config::default();
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            !plan.thumbwheel_tap_bound,
+            "an untouched thumb wheel must not report an explicit tap binding"
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -88,6 +88,8 @@ impl ActionDispatcher {
 pub struct HookMaps {
     /// Per-button single action — the single-action dispatch path.
     pub bindings: BTreeMap<ButtonId, Action>,
+    /// Whether the effective thumb-wheel tap binding was explicitly configured.
+    pub thumbwheel_tap_bound: bool,
     /// Per-direction maps for the OS-hook gesture buttons (Middle/Back/Forward in
     /// gesture mode), so a hold+swipe resolves to a bound action. The dedicated
     /// HID++ gesture button (0x00c3) uses the gesture watcher's separate map
@@ -796,6 +798,7 @@ mod tests {
                 (ButtonId::ThumbwheelScrollDown, Action::PrevTab),
             ]),
             gestures: BTreeMap::new(),
+            thumbwheel_tap_bound: false,
         };
         assert_eq!(
             rebound_thumbwheel_action(&maps, 1.0),
@@ -822,6 +825,7 @@ mod tests {
                 ),
             ]),
             gestures: BTreeMap::new(),
+            thumbwheel_tap_bound: false,
         };
         assert_eq!(rebound_thumbwheel_action(&maps, 1.0), None);
         assert_eq!(rebound_thumbwheel_action(&maps, -1.0), None);

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -14,7 +14,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
-use openlogi_core::binding::Action;
+use openlogi_core::binding::{Action, ButtonId};
 use openlogi_core::bindings::{bindings_for, oshook_gestures_for};
 use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
@@ -249,6 +249,11 @@ impl Orchestrator {
         }
         HookMaps {
             bindings: bindings_for(&self.config, key, app),
+            thumbwheel_tap_bound: key.is_some_and(|key| {
+                self.config
+                    .effective_bindings(key, app)
+                    .contains_key(&ButtonId::Thumbwheel)
+            }),
             gestures: oshook_gestures_for(&self.config, key, app),
         }
     }

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -1,18 +1,21 @@
 //! Orchestrator inventory/reapply/camera tests.
 
+use std::sync::{Arc, RwLock};
+
+use crate::watchers::gesture::{captured_button_action, thumbwheel_capture_mode};
+
 use super::{
     AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
     any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
     pick_current, plan_reapply, reapply_targets,
 };
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Action, Binding, ButtonId, default_binding};
 use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
-use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
-use std::sync::Arc;
+use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute, ThumbwheelCaptureMode};
 
 use crate::observable::ObservableState;
 
@@ -774,4 +777,146 @@ fn app_switch_republishes_capture_plans() {
     );
     orch.set_current_app(Some("com.example.editor".into()));
     assert_eq!(published_back_binding(&orch), Some(Action::Undo));
+}
+
+fn thumbwheel_policy(config: Config) -> (Action, bool, ThumbwheelCaptureMode) {
+    let orchestrator = orchestrator(config);
+    let maps = orchestrator.hook_maps_for(Some("mouse"), None);
+    let tap_action = maps
+        .bindings
+        .get(&ButtonId::Thumbwheel)
+        .cloned()
+        .unwrap_or_else(|| default_binding(ButtonId::Thumbwheel));
+    let tap_bound = maps.thumbwheel_tap_bound;
+    let shared = Arc::new(RwLock::new(maps));
+    (
+        tap_action,
+        tap_bound,
+        thumbwheel_capture_mode(
+            &shared,
+            openlogi_core::config::ThumbwheelSensitivity::DEFAULT,
+        ),
+    )
+}
+
+#[test]
+fn thumbwheel_capture_policy_preserves_config_provenance() {
+    let mut rebound = Config::default();
+    rebound.set_binding(
+        "mouse",
+        ButtonId::Thumbwheel,
+        Binding::Single(Action::MissionControl),
+    );
+    assert_eq!(
+        thumbwheel_policy(rebound),
+        (
+            Action::MissionControl,
+            true,
+            ThumbwheelCaptureMode::Diverted
+        ),
+        "an explicitly rebound tap is delivered"
+    );
+
+    let mut explicit_default = Config::default();
+    explicit_default.set_binding(
+        "mouse",
+        ButtonId::Thumbwheel,
+        Binding::Single(default_binding(ButtonId::Thumbwheel)),
+    );
+    assert_eq!(
+        thumbwheel_policy(explicit_default),
+        (
+            default_binding(ButtonId::Thumbwheel),
+            true,
+            ThumbwheelCaptureMode::Diverted,
+        ),
+        "an explicitly stored default retains tap intent"
+    );
+
+    assert_eq!(
+        thumbwheel_policy(Config::default()),
+        (
+            default_binding(ButtonId::Thumbwheel),
+            false,
+            ThumbwheelCaptureMode::Native,
+        ),
+        "an unset tap inherits the visible default without arming tap delivery"
+    );
+}
+
+#[test]
+fn live_app_switch_updates_thumbwheel_tap_delivery_in_place() {
+    const DEVICE: &str = "mouse";
+    const BOUND_APP: &str = "com.example.bound";
+    const UNBOUND_APP: &str = "com.example.unbound";
+
+    let mut config = Config::default();
+    config.set_per_app_binding(
+        DEVICE,
+        BOUND_APP,
+        ButtonId::Thumbwheel,
+        Some(Action::MissionControl),
+    );
+    config.set_binding(
+        DEVICE,
+        ButtonId::ThumbwheelScrollUp,
+        Binding::Single(Action::MissionControl),
+    );
+    let mut orchestrator = orchestrator(config);
+    orchestrator.devices = vec![dev(DEVICE, 1, true)];
+    orchestrator.rebuild();
+
+    let live_maps = Arc::clone(&orchestrator.shared.hook_maps);
+    assert!(
+        orchestrator
+            .shared
+            .dpi_cycle
+            .read()
+            .is_ok_and(|state| state.selected.is_some()),
+        "the capture manager has a live device target"
+    );
+
+    orchestrator.set_current_app(Some(BOUND_APP.to_string()));
+    assert!(Arc::ptr_eq(&live_maps, &orchestrator.shared.hook_maps));
+    let live_session_mode = thumbwheel_capture_mode(
+        &live_maps,
+        openlogi_core::config::ThumbwheelSensitivity::DEFAULT,
+    );
+    assert_eq!(live_session_mode, ThumbwheelCaptureMode::Diverted);
+    assert_eq!(
+        captured_button_action(&live_maps, ButtonId::Thumbwheel),
+        Some(Action::MissionControl)
+    );
+
+    orchestrator.set_current_app(Some(UNBOUND_APP.to_string()));
+    assert!(Arc::ptr_eq(&live_maps, &orchestrator.shared.hook_maps));
+    assert_eq!(
+        thumbwheel_capture_mode(
+            &live_maps,
+            openlogi_core::config::ThumbwheelSensitivity::DEFAULT,
+        ),
+        live_session_mode,
+        "the rotation rebind keeps the same diverted capture session live"
+    );
+    assert_eq!(
+        captured_button_action(&live_maps, ButtonId::Thumbwheel),
+        None,
+        "a tap emitted by the still-live diverted session must be dropped"
+    );
+
+    orchestrator.set_current_app(Some(BOUND_APP.to_string()));
+    assert!(Arc::ptr_eq(&live_maps, &orchestrator.shared.hook_maps));
+    assert_eq!(
+        thumbwheel_capture_mode(
+            &live_maps,
+            openlogi_core::config::ThumbwheelSensitivity::DEFAULT,
+        ),
+        live_session_mode,
+        "restoring tap intent does not restart the diverted capture session"
+    );
+    assert_eq!(
+        captured_button_action(&live_maps, ButtonId::Thumbwheel),
+        Some(Action::MissionControl),
+        "the same live consumer observes the republished bound profile"
+    );
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -3,7 +3,7 @@
 //! Runs [`openlogi_hid::run_capture_session`] concurrently for every device in
 //! the shared capture-plan list (not just the GUI's selection), restarts a
 //! session when its device's plan — route, diverted controls, thumb-wheel
-//! arming — changes, and dispatches each captured input against the binding
+//! capture mode — changes, and dispatches each captured input against the binding
 //! maps of the device it arrived on:
 //!
 //! - a gesture swipe through the gesture binding map,
@@ -27,17 +27,20 @@ use std::time::{Duration, Instant};
 use openlogi_core::binding::{Action, ButtonId, default_binding};
 use openlogi_core::config::ThumbwheelSensitivity;
 use openlogi_hid::session::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
-use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
+use openlogi_hid::{
+    CaptureChannel, CapturedInput, DeviceRoute, ThumbwheelCaptureMode, run_capture_session,
+};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
 use crate::hook_runtime::ActionDispatcher;
+#[cfg(test)]
+use crate::hook_runtime::SharedHookMaps;
 use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
 
-/// How often to re-read the active device target + thumb-wheel arming so a
-/// carousel switch or a binding/sensitivity edit re-points / re-arms capture.
-/// It also paces the respawn of a session that ended on its own (see `manage`).
+/// How often to re-read the device capture plans. It also paces the respawn of
+/// a session that ended on its own (see `manage`).
 const TARGET_POLL: Duration = Duration::from_secs(1);
 
 /// Idle gap after which a partly-accumulated *custom* wheel action is forgotten,
@@ -49,8 +52,7 @@ const ACTION_DECAY: Duration = Duration::from_millis(300);
 const ACTION_COOLDOWN: Duration = Duration::from_millis(200);
 
 /// Spawn the capture-manager thread. It owns a current-thread tokio runtime that
-/// keeps one capture session pointed at the active device and dispatches each
-/// captured input.
+/// keeps one capture session alive per online device and dispatches each input.
 pub fn spawn(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
@@ -86,10 +88,64 @@ fn thumbwheel_armed(plan: &DeviceCapturePlan) -> bool {
         || plan.thumbwheel_bindings_nondefault
 }
 
+/// Select the thumb wheel's hardware reporting state from the live hook maps.
+///
+/// Test-only mirror of [`thumbwheel_capture_mode_for_plan`] that reads the
+/// published maps instead of a capture plan, so the orchestrator tests can
+/// assert the whole `Config -> hook maps -> capture policy` path rather than a
+/// hand-built plan. Tap provenance comes from `thumbwheel_tap_bound`, which is
+/// presence in the stored bindings, so an explicit binding equal to the seeded
+/// default still diverts.
+#[cfg(test)]
+pub(crate) fn thumbwheel_capture_mode(
+    hook_maps: &SharedHookMaps,
+    sensitivity: ThumbwheelSensitivity,
+) -> ThumbwheelCaptureMode {
+    let sensitivity_changed = sensitivity != ThumbwheelSensitivity::DEFAULT;
+    let Ok(maps) = hook_maps.read() else {
+        return if sensitivity_changed {
+            ThumbwheelCaptureMode::Diverted
+        } else {
+            ThumbwheelCaptureMode::Native
+        };
+    };
+    let binding_changed = |button| {
+        maps.bindings
+            .get(&button)
+            .is_some_and(|action| *action != default_binding(button))
+    };
+
+    if maps.thumbwheel_tap_bound
+        || sensitivity_changed
+        || [ButtonId::ThumbwheelScrollUp, ButtonId::ThumbwheelScrollDown]
+            .iter()
+            .any(|&button| binding_changed(button))
+    {
+        ThumbwheelCaptureMode::Diverted
+    } else {
+        ThumbwheelCaptureMode::Native
+    }
+}
+
+/// Whether this device's thumb wheel must leave its native HID reporting mode.
+///
+/// Only the two physical states exist. Tap intent is deliberately NOT encoded
+/// here: both "diverted for rotation" and "diverted for rotation and tap" arm
+/// the identical `set_reporting(true, false)`, so folding tap policy into the
+/// mode would restart an otherwise-identical session on every app/profile
+/// switch. The agent decides tap delivery from the live binding map instead.
+fn thumbwheel_capture_mode_for_plan(plan: &DeviceCapturePlan) -> ThumbwheelCaptureMode {
+    if thumbwheel_armed(plan) {
+        ThumbwheelCaptureMode::Diverted
+    } else {
+        ThumbwheelCaptureMode::Native
+    }
+}
+
 /// The [`CaptureSpec`] one device's session should run with right now.
 fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
     CaptureSpec {
-        capture_thumbwheel: thumbwheel_armed(plan),
+        thumbwheel_mode: thumbwheel_capture_mode_for_plan(plan),
         // Derived from the dispatch maps, so the armed diverts and the maps
         // resolving their events can never drift apart.
         divert_gesture_sources: GESTURE_SOURCE_BUTTONS
@@ -124,6 +180,35 @@ enum DoneAction {
     Remove { unexpected: bool },
 }
 
+/// Resolve a captured button press against the latest published hook maps.
+///
+/// A diverted thumb wheel can keep reporting taps while an app/profile switch
+/// removes its click binding. The provenance bit gates those stale in-flight
+/// reports; other captured buttons use the effective action map directly.
+#[cfg(test)]
+pub(crate) fn captured_button_action(
+    hook_maps: &SharedHookMaps,
+    button: ButtonId,
+) -> Option<Action> {
+    hook_maps.read().ok().and_then(|maps| {
+        if button == ButtonId::Thumbwheel && !maps.thumbwheel_tap_bound {
+            return None;
+        }
+        maps.bindings.get(&button).cloned()
+    })
+}
+
+/// Resolve a captured button press against one device's latest plan.
+fn captured_button_action_for_plan(plan: &DeviceCapturePlan, button: ButtonId) -> Option<Action> {
+    // Tap delivery follows the binding's provenance, not the session mode:
+    // an explicit tap stays deliverable while rotation or sensitivity keeps the
+    // wheel diverted for other reasons.
+    if button == ButtonId::Thumbwheel && !plan.thumbwheel_tap_bound {
+        return None;
+    }
+    plan.bindings.get(&button).cloned()
+}
+
 /// Decide the [`DoneAction`] for a completion report carrying `done_epoch`,
 /// given the session the manager currently tracks for that device (if any).
 ///
@@ -132,7 +217,6 @@ enum DoneAction {
 /// gone was stopped deliberately and is merely draining — its report frees the
 /// key quietly. One still holding its stop sender exited on its own and
 /// warrants a warning alongside the re-arm.
-/// Whether a finished session should be re-armed after completion.
 pub(crate) fn should_rearm(done_epoch: u64, live_epoch: u64, has_target: bool) -> bool {
     done_epoch == live_epoch && has_target
 }
@@ -404,9 +488,9 @@ fn dispatch(
             }
         }
         CapturedInput::ButtonPressed(button, _) => {
-            if let Some(action) = plan.bindings.get(&button) {
+            if let Some(action) = captured_button_action_for_plan(plan, button) {
                 debug!(key, ?button, action = %action.label(), "HID++ button → action");
-                dispatcher.dispatch(action, Some(key));
+                dispatcher.dispatch(&action, Some(key));
             } else {
                 debug!(key, ?button, "HID++ button with no binding — ignored");
             }
@@ -512,6 +596,112 @@ fn advance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn default_thumbwheel_plan() -> DeviceCapturePlan {
+        let bindings = [
+            ButtonId::Thumbwheel,
+            ButtonId::ThumbwheelScrollUp,
+            ButtonId::ThumbwheelScrollDown,
+        ]
+        .into_iter()
+        .map(|button| (button, default_binding(button)))
+        .collect();
+        DeviceCapturePlan {
+            config_key: "test-device".into(),
+            route: DeviceRoute::Direct {
+                vendor_id: 0x046d,
+                product_id: 0xc548,
+            },
+            bindings,
+            gesture_bindings: Default::default(),
+            divert_buttons: Vec::new(),
+            thumbwheel_bindings_nondefault: false,
+            thumbwheel_tap_bound: false,
+            thumbwheel_sensitivity: ThumbwheelSensitivity::DEFAULT,
+            rearm_generation: 0,
+        }
+    }
+
+    fn set_binding(plan: &mut DeviceCapturePlan, button: ButtonId, action: Action) {
+        plan.bindings.insert(button, action);
+        plan.thumbwheel_bindings_nondefault = true;
+        if button == ButtonId::Thumbwheel {
+            // Mirrors plan_for: an explicitly stored tap binding is present in
+            // the effective map regardless of the action it carries.
+            plan.thumbwheel_tap_bound = true;
+        }
+    }
+
+    #[test]
+    fn default_thumbwheel_bindings_use_native_reporting() {
+        assert_eq!(
+            thumbwheel_capture_mode_for_plan(&default_thumbwheel_plan()),
+            ThumbwheelCaptureMode::Native
+        );
+    }
+
+    #[test]
+    fn swapped_rotation_bindings_divert_the_hardware() {
+        let mut plan = default_thumbwheel_plan();
+        set_binding(
+            &mut plan,
+            ButtonId::ThumbwheelScrollUp,
+            default_binding(ButtonId::ThumbwheelScrollDown),
+        );
+        set_binding(
+            &mut plan,
+            ButtonId::ThumbwheelScrollDown,
+            default_binding(ButtonId::ThumbwheelScrollUp),
+        );
+
+        assert_eq!(
+            thumbwheel_capture_mode_for_plan(&plan),
+            ThumbwheelCaptureMode::Diverted
+        );
+        assert!(
+            !plan.thumbwheel_tap_bound,
+            "swapped rotation diverts the wheel without arming tap delivery"
+        );
+    }
+
+    #[test]
+    fn custom_sensitivity_diverts_the_hardware() {
+        let mut plan = default_thumbwheel_plan();
+        plan.thumbwheel_sensitivity = ThumbwheelSensitivity::MAX;
+        assert_eq!(
+            thumbwheel_capture_mode_for_plan(&plan),
+            ThumbwheelCaptureMode::Diverted
+        );
+        assert!(
+            !plan.thumbwheel_tap_bound,
+            "a sensitivity change diverts the wheel without arming tap delivery"
+        );
+    }
+
+    #[test]
+    fn rebound_thumbwheel_click_enables_tap_delivery() {
+        let mut plan = default_thumbwheel_plan();
+        set_binding(&mut plan, ButtonId::Thumbwheel, Action::MissionControl);
+
+        assert_eq!(
+            thumbwheel_capture_mode_for_plan(&plan),
+            ThumbwheelCaptureMode::Diverted
+        );
+        assert!(
+            plan.thumbwheel_tap_bound,
+            "an explicitly rebound tap stays deliverable"
+        );
+    }
+
+    #[test]
+    fn missing_default_bindings_do_not_divert() {
+        let mut plan = default_thumbwheel_plan();
+        plan.bindings.clear();
+        assert_eq!(
+            thumbwheel_capture_mode_for_plan(&plan),
+            ThumbwheelCaptureMode::Native
+        );
+    }
 
     #[test]
     fn multiplier_is_unity_at_default_sensitivity() {

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -48,8 +48,8 @@ pub use pairing::{
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
 };
 pub use session::gesture::{
-    CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
-    run_capture_session_with_stop_reason,
+    CaptureChannel, CaptureStop, CapturedInput, GestureError, ThumbwheelCaptureMode,
+    run_capture_session, run_capture_session_with_stop_reason,
 };
 pub use session::host_switch::{
     HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -10,12 +10,14 @@
 //! its input-report stream, so all captured controls share this session.
 //!
 //! The session is transport-only — it has no opinion on what an input *does*.
-//! The GUI maps each [`CapturedInput`] to the user's bound action and dispatches
+//! The agent maps each [`CapturedInput`] to the user's bound action and dispatches
 //! it, mirroring how the CGEventTap hook handles the side buttons. The thumb
-//! wheel is special: diverting it stops native horizontal scroll, so the GUI
+//! wheel is special: diverting it stops native horizontal scroll, so the agent
 //! re-synthesises scroll from the [`CapturedInput::Scroll`] deltas — the wheel
 //! is therefore only diverted when the user's thumbwheel config leaves its
-//! defaults (click bound, rotation rebound, or sensitivity changed).
+//! defaults (click bound, rotation rebound, or sensitivity changed). While
+//! diverted, the transport forwards every report; the agent applies the current
+//! app/profile policy before dispatching a tap.
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
@@ -31,7 +33,7 @@ use crate::backend::{BackendError, HidBackend};
 use crate::channel::route::{DeviceRoute, open_route_channel};
 
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
-use crate::thumbwheel::{self, Thumbwheel};
+use crate::thumbwheel::{self, Thumbwheel, ThumbwheelEvent};
 
 /// How often the capture session pings its device to prove the channel still
 /// delivers input reports. Cheap: one HID++ round-trip per interval.
@@ -54,6 +56,16 @@ pub enum CaptureStop {
     Graceful,
     /// Lease revoked / channel dying — skip restore writes.
     Revoked,
+}
+
+/// How a capture session handles the thumb wheel.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ThumbwheelCaptureMode {
+    /// Leave the wheel in its native HID reporting mode.
+    #[default]
+    Native,
+    /// Divert the wheel to HID++ and forward all decoded reports to the agent.
+    Diverted,
 }
 
 /// One input captured from the active device.
@@ -146,9 +158,10 @@ pub const GESTURE_SOURCE_BUTTONS: [(u16, ButtonId); 2] = [
 /// Which of one device's controls a capture session should divert.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CaptureSpec {
-    /// Divert the thumb wheel over `0x2150` (rotation rebind / sensitivity /
-    /// click bound).
-    pub capture_thumbwheel: bool,
+    /// Whether to leave the thumb wheel native or divert it over `0x2150`.
+    /// Either diverted mode arms the same physical reporting state; tap intent
+    /// is filtered against the latest binding map by the agent.
+    pub thumbwheel_mode: ThumbwheelCaptureMode,
     /// Gesture-source CIDs ([`GESTURE_SOURCE_BUTTONS`] members) to divert
     /// with raw-XY — one per source in gesture mode; empty when no HID++
     /// control gestures.
@@ -219,12 +232,7 @@ pub async fn run_capture_session(
             if let Some(idx) = thumb_index
                 && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
             {
-                if event.single_tap {
-                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None));
-                }
-                if event.rotation != 0 {
-                    let _ = sink.send(CapturedInput::Scroll(event.rotation));
-                }
+                forward_thumbwheel_event(event, &sink);
             }
         }
     });
@@ -305,6 +313,19 @@ pub async fn run_capture_session(
     Ok(())
 }
 
+/// Forward every actionable part of a decoded diverted thumb-wheel report.
+///
+/// Tap intent is deliberately not captured here: app/profile changes update the
+/// agent's live policy without restarting this hardware session.
+fn forward_thumbwheel_event(event: ThumbwheelEvent, sink: &mpsc::UnboundedSender<CapturedInput>) {
+    if event.single_tap {
+        let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None));
+    }
+    if event.rotation != 0 {
+        let _ = sink.send(CapturedInput::Scroll(event.rotation));
+    }
+}
+
 /// Reason-aware capture: maps stop reasons onto a unit oneshot shutdown.
 pub async fn run_capture_session_with_stop_reason(
     backend: &dyn HidBackend,
@@ -321,7 +342,11 @@ pub async fn run_capture_session_with_stop_reason(
         let _ = tx.send(());
     });
     let spec = CaptureSpec {
-        capture_thumbwheel,
+        thumbwheel_mode: if capture_thumbwheel {
+            ThumbwheelCaptureMode::Diverted
+        } else {
+            ThumbwheelCaptureMode::Native
+        },
         // The bool-era API only ever meant the dedicated gesture button; the
         // haptic panel is reachable through [`CaptureSpec`] itself.
         divert_gesture_sources: divert_gesture_button
@@ -376,7 +401,8 @@ impl ArmedControls {
 
 /// Resolve features off the device's root and divert the controls `spec`
 /// selects: the gesture sources (raw-XY), DPI/ModeShift buttons and rebindable
-/// standard buttons over `0x1b04`, and the thumb wheel over `0x2150`. The
+/// standard buttons over `0x1b04`, and — when `spec.thumbwheel_mode` is
+/// diverted — the thumb wheel over `0x2150`. The
 /// root-feature lookup mirrors `write::open_feature`,
 /// since hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
 ///
@@ -460,7 +486,7 @@ async fn arm_controls_into(
         }
     }
 
-    if spec.capture_thumbwheel
+    if spec.thumbwheel_mode != ThumbwheelCaptureMode::Native
         && let Some(info) = device
             .root()
             .get_feature(thumbwheel::FEATURE_ID)

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+use std::error::Error;
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use hidpp::channel::{LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel};
+
 const GESTURE: &[u16] = &[reprog_controls::GESTURE_BUTTON_CID];
 const PANEL: &[u16] = &[reprog_controls::HAPTIC_PANEL_CID];
 const BOTH: &[u16] = &[
@@ -70,6 +77,15 @@ fn both_press() -> RawControlEvent {
 
 fn release() -> RawControlEvent {
     RawControlEvent::DivertedButtons([0, 0, 0, 0])
+}
+
+fn thumbwheel_event(rotation: i16, single_tap: bool) -> ThumbwheelEvent {
+    ThumbwheelEvent {
+        rotation,
+        single_tap,
+        touch: single_tap,
+        proxy: false,
+    }
 }
 
 #[test]
@@ -525,4 +541,230 @@ fn a_dpi_button_re_presses_after_a_release() {
         rx.try_recv().is_err(),
         "press → release → press emits exactly two presses"
     );
+}
+
+#[test]
+fn diverted_report_forwards_tap_and_rotation_for_live_agent_policy() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    forward_thumbwheel_event(thumbwheel_event(-4, true), &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None))
+    );
+    assert_eq!(rx.try_recv(), Ok(CapturedInput::Scroll(-4)));
+    assert!(
+        rx.try_recv().is_err(),
+        "one report must emit exactly one tap and one rotation"
+    );
+}
+
+#[test]
+fn zero_motion_without_a_tap_emits_nothing() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    forward_thumbwheel_event(thumbwheel_event(0, false), &tx);
+
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn partial_arm_failure_restores_every_diverted_control() {
+    let (raw, mut written_reports) = ArmRawHidChannel::new();
+    let Ok(channel) = HidppChannel::from_raw_channel(raw).await else {
+        panic!("mock must support HID++");
+    };
+    let channel = Arc::new(channel);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        arm_controls(
+            &channel,
+            1,
+            &CaptureSpec {
+                thumbwheel_mode: ThumbwheelCaptureMode::Diverted,
+                divert_gesture_sources: vec![reprog_controls::GESTURE_BUTTON_CID],
+                divert_buttons: Vec::new(),
+            },
+        ),
+    )
+    .await;
+    let Ok(result) = result else {
+        panic!("scripted arm sequence timed out");
+    };
+    assert!(matches!(result, Err(GestureError::Hidpp(_))));
+
+    let reports: Vec<_> = std::iter::from_fn(|| written_reports.try_recv().ok()).collect();
+    let changes: Vec<_> = reports
+        .iter()
+        .filter_map(|report| {
+            (report.len() == LONG_REPORT_LENGTH
+                && report[0] == LONG_REPORT_ID
+                && report[2] == 5
+                && report[3] >> 4 == 3)
+                .then(|| {
+                    (
+                        u16::from_be_bytes([report[4], report[5]]),
+                        report[6] & 0x01 != 0,
+                        report[6] & 0x10 != 0,
+                    )
+                })
+        })
+        .collect();
+    assert_eq!(
+        changes,
+        vec![
+            (reprog_controls::GESTURE_BUTTON_CID, true, true),
+            (reprog_controls::DPI_MODE_SHIFT_CIDS[0], true, false),
+            (reprog_controls::DPI_MODE_SHIFT_CIDS[1], true, false),
+            (reprog_controls::DPI_MODE_SHIFT_CIDS[2], true, false),
+            (reprog_controls::GESTURE_BUTTON_CID, false, false),
+            (reprog_controls::DPI_MODE_SHIFT_CIDS[0], false, false),
+            (reprog_controls::DPI_MODE_SHIFT_CIDS[1], false, false),
+            (reprog_controls::DPI_MODE_SHIFT_CIDS[2], false, false),
+        ],
+        "the retained reprog accessor must hand back the gesture and every DPI CID"
+    );
+
+    let thumbwheel_modes: Vec<_> = reports
+        .iter()
+        .filter(|report| {
+            report.len() == LONG_REPORT_LENGTH
+                && report[0] == LONG_REPORT_ID
+                && report[2] == 6
+                && report[3] >> 4 == 2
+        })
+        .map(|report| report[4])
+        .collect();
+    assert_eq!(
+        thumbwheel_modes,
+        vec![1, 0],
+        "a possibly-applied failing thumbwheel arm is also handed back"
+    );
+}
+
+struct ArmRawHidChannel {
+    incoming_tx: mpsc::UnboundedSender<Vec<u8>>,
+    incoming_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
+    written_tx: mpsc::UnboundedSender<Vec<u8>>,
+    fail_thumbwheel_arm: AtomicBool,
+}
+
+impl ArmRawHidChannel {
+    fn new() -> (Self, mpsc::UnboundedReceiver<Vec<u8>>) {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let (written_tx, written_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                incoming_tx,
+                incoming_rx: tokio::sync::Mutex::new(incoming_rx),
+                written_tx,
+                fail_thumbwheel_arm: AtomicBool::new(true),
+            },
+            written_rx,
+        )
+    }
+
+    fn response_for(report: &[u8]) -> Vec<u8> {
+        let mut response = report.to_vec();
+        let feature = report[2];
+        let function = report[3] >> 4;
+        match (feature, function) {
+            // Root ping: advertise HID++ 2.0.
+            (0, 1) => response[4..7].copy_from_slice(&[2, 0, 0]),
+            // Root getFeature: expose reprog controls and thumbwheel.
+            (0, 0) => {
+                response[4..7].fill(0);
+                response[4] = match u16::from_be_bytes([report[4], report[5]]) {
+                    reprog_controls::FEATURE_ID => 5,
+                    thumbwheel::FEATURE_ID => 6,
+                    _ => 0,
+                };
+            }
+            // Reprog getCount: gesture plus every supported DPI/ModeShift CID.
+            (5, 0) => response[4] = 4,
+            // Reprog getCidInfo.
+            (5, 1) => {
+                response[4..].fill(0);
+                let index = usize::from(report[4]);
+                let cids = [
+                    reprog_controls::GESTURE_BUTTON_CID,
+                    reprog_controls::DPI_MODE_SHIFT_CIDS[0],
+                    reprog_controls::DPI_MODE_SHIFT_CIDS[1],
+                    reprog_controls::DPI_MODE_SHIFT_CIDS[2],
+                ];
+                let cid = cids[index].to_be_bytes();
+                response[4..6].copy_from_slice(&cid);
+                response[8] = 0x20; // DIVERTABLE
+                if index == 0 {
+                    response[12] = 0x01; // RAW_XY (the high flags byte)
+                }
+            }
+            // Thumbwheel getInfo: report single-tap support.
+            (6, 0) => {
+                response[4..].fill(0);
+                response[9] = 0x08;
+            }
+            // setCidReporting / setThumbwheelReporting responses echo the request.
+            (5, 3) | (6, 2) => {}
+            _ => {}
+        }
+        response
+    }
+}
+
+#[hidpp::async_trait]
+impl RawHidChannel for ArmRawHidChannel {
+    fn vendor_id(&self) -> u16 {
+        0x046d
+    }
+
+    fn product_id(&self) -> u16 {
+        0xc548
+    }
+
+    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Sync + Send>> {
+        let report = src.to_vec();
+        if self.written_tx.send(report.clone()).is_err() {
+            return Err(arm_mock_error("written-report receiver closed"));
+        }
+        let fails_after_reprog_arming = report.len() == LONG_REPORT_LENGTH
+            && report[0] == LONG_REPORT_ID
+            && report[2] == 6
+            && report[3] >> 4 == 2
+            && report[4] == 1
+            && self.fail_thumbwheel_arm.swap(false, Ordering::SeqCst);
+        if fails_after_reprog_arming {
+            return Err(arm_mock_error("injected thumbwheel arm failure"));
+        }
+        if self.incoming_tx.send(Self::response_for(&report)).is_err() {
+            return Err(arm_mock_error("incoming-report receiver closed"));
+        }
+        Ok(src.len())
+    }
+
+    async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Sync + Send>> {
+        let Some(report) = self.incoming_rx.lock().await.recv().await else {
+            return std::future::pending().await;
+        };
+        let len = report.len().min(buf.len());
+        buf[..len].copy_from_slice(&report[..len]);
+        Ok(len)
+    }
+
+    fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
+        Some((true, true))
+    }
+
+    async fn get_report_descriptor(
+        &self,
+        _buf: &mut [u8],
+    ) -> Result<usize, Box<dyn Error + Sync + Send>> {
+        Err(arm_mock_error("descriptor should not be requested"))
+    }
+}
+
+fn arm_mock_error(message: &str) -> Box<dyn Error + Sync + Send> {
+    Box::new(io::Error::other(message.to_string()))
 }


### PR DESCRIPTION
## Summary

Replace the watcher's single thumb-wheel armed flag with a typed capture mode that distinguishes native reporting, diverted rotation only, and diverted rotation with tap delivery; derive it from sensitivity plus the effective click and rotation bindings. Thread that mode through `run_capture_session`, export it from `openlogi-hid`, and include it in the manager's desired/current session state so changing the thumb-wheel click binding restarts capture with the correct behavior. Keep rotation decoding and re-synthesis unchanged, but have the HID listener emit `ButtonPressed(Thumbwheel)` only when the mode explicitly includes taps, preventing rotation inversion from activating the seeded App Exposé default.

## Why

On an MX Master 3S, swapping the horizontal thumb-wheel directions causes touching the wheel to launch App Exposé even though only rotation was edited. The current watcher diverts HID++ Thumbwheel feature `0x2150` whenever either rotation binding differs from its default, and the diverted listener then forwards every reported single tap as `ButtonId::Thumbwheel`. The effective binding map always seeds that button with App Exposé, so rotation-only customization unintentionally activates a dormant default tap action. This path remains present on current `master`, and there are no open or previously closed cross-referenced PRs for the issue.

## Testing

- Happy path: swap `ThumbwheelScrollUp` and `ThumbwheelScrollDown` while the thumb-wheel click remains at its seeded default; the watcher selects rotation-only capture, wheel rotation scrolls in the inverted direction, and a tap/touch report emits no App Exposé action.
- Edge cases: a non-default thumb-wheel sensitivity still selects rotation-only capture, while explicitly rebinding `Thumbwheel` selects rotation-plus-tap and continues to deliver exactly one button event alongside any nonzero rotation in the same HID++ report.
- Error paths: at default sensitivity, an unavailable or poisoned effective binding map falls back to no diversion instead of enabling tap capture, and unrelated, response, or zero-motion HID++ messages without a tap continue to produce no captured input.

Fixes #435

AI was used for assistance.


Fixes #477
