### PR TITLE
fix(hid): enable Win32_System_IO so WriteFile resolves

### DIFF
--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -34,6 +34,9 @@ windows-sys = { workspace = true, features = [
     # exposed when Win32_Security is also enabled.
     "Win32_Security",
     "Win32_Storage_FileSystem",
+    # WriteFile's signature references OVERLAPPED, so it is only exposed when
+    # Win32_System_IO is also enabled.
+    "Win32_System_IO",
 ] }
 
 [lints]


### PR DESCRIPTION
## Summary

`cargo build` fails on Windows in `openlogi-hid`, so the workspace cannot be built from source on that platform:

```
error[E0432]: unresolved import `windows_sys::Win32::Storage::FileSystem::WriteFile`
  --> crates\openlogi-hid\src\windows_hid.rs:19:9
```

`WriteFile`'s signature references `System::IO::OVERLAPPED`, so windows-sys gates it behind the `Win32_System_IO` feature:

```rust
#[cfg(feature = "Win32_System_IO")]
windows_link::link!("kernel32.dll" "system" fn WriteFile(...));
```

The features list already handles the identical situation for `CreateFileW` (gated behind `Win32_Security` because of `PSECURITY_ATTRIBUTES`, with a comment explaining why). This adds the equivalent entry for `WriteFile`.

## Changes

- `openlogi-hid`: add `Win32_System_IO` to the `windows-sys` features list, with a comment matching the existing `Win32_Security` note.

## Testing

```
cargo build -p openlogi-agent            # fails before, succeeds after
cargo build --release -p openlogi-agent  # succeeds
cargo fmt --all -- --check               # clean
cargo clippy -p openlogi-core -p openlogi-hid -p openlogi-agent-core --all-targets -- -D warnings   # clean
cargo test -p openlogi-core -p openlogi-hid -p openlogi-agent-core                                  # 228 passed
```

Environment: Windows 11 (26200), Rust 1.96.0, windows-sys 0.61.2.

Runtime-tested on hardware: yes — the resulting agent runs and drives a Logitech Lift over Bluetooth.
