### PR TITLE
Feat/linked host switching

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -242,6 +242,10 @@ pub struct SmartShiftApply {
 /// stream while correlating responses only by software id — they cross-talk and
 /// produce the intermittent SmartShift `InvalidArgument` seen in #485. One
 /// sequential writer removes that self-race.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "background reapply keeps one device write lifecycle together"
+)]
 pub fn reapply_mouse_volatile_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -20,6 +20,8 @@ use openlogi_hid::{
 };
 use tracing::{debug, warn};
 
+use crate::receiver_access::ReceiverAccess;
+
 /// Upper bound on a single HID++ write. `hidpp` has no request timeout of its
 /// own, so without this an asleep / unresponsive device would hang (and leak)
 /// this background thread forever; a write to a live device completes in well
@@ -88,6 +90,7 @@ fn choose_authoritative<T>(
 pub fn toggle_smartshift_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
 ) {
     let Some(target) = target else {
@@ -98,6 +101,7 @@ pub fn toggle_smartshift_in_background(
         debug!(route = %target, "no inventory channel — SmartShift toggle skipped");
         return;
     };
+    let receiver_access = receiver_access.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -110,6 +114,7 @@ pub fn toggle_smartshift_in_background(
             }
         };
         let result = rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
             tokio::time::timeout(WRITE_BUDGET, async {
                 openlogi_hid::toggle_smartshift_on(&shared).await
             })
@@ -166,6 +171,7 @@ pub fn read_smartshift_status_blocking(
 pub fn write_smartshift_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
     mode: SmartShiftMode,
     auto_disengage: u8,
@@ -179,6 +185,7 @@ pub fn write_smartshift_in_background(
         debug!(route = %target, "no inventory channel — SmartShift write skipped");
         return;
     };
+    let receiver_access = receiver_access.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -191,6 +198,7 @@ pub fn write_smartshift_in_background(
             }
         };
         let result = rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
             tokio::time::timeout(WRITE_BUDGET, async {
                 openlogi_hid::set_smartshift_on(&shared, mode, auto_disengage, tunable_torque).await
             })
@@ -237,6 +245,7 @@ pub struct SmartShiftApply {
 pub fn reapply_mouse_volatile_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     target: DeviceRoute,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
@@ -247,6 +256,7 @@ pub fn reapply_mouse_volatile_in_background(
         debug!(route = %target, "no inventory channel — volatile reapply skipped");
         return;
     };
+    let receiver_access = receiver_access.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -260,6 +270,7 @@ pub fn reapply_mouse_volatile_in_background(
         };
         let index = target.device_index();
         rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
             if resolution.is_some() || inverted.is_some() {
                 let result = tokio::time::timeout(WRITE_BUDGET, async {
                     apply_wheel_mode(&shared, resolution, inverted).await
@@ -371,6 +382,7 @@ fn log_wheel_result(
 pub fn write_dpi_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
     dpi: u32,
 ) {
@@ -382,6 +394,7 @@ pub fn write_dpi_in_background(
         debug!(route = %target, "no inventory channel — DPI write skipped");
         return;
     };
+    let receiver_access = receiver_access.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -400,6 +413,7 @@ pub fn write_dpi_in_background(
             return;
         };
         let result = rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
             tokio::time::timeout(WRITE_BUDGET, async {
                 openlogi_hid::set_dpi_on(&shared, dpi_u16).await
             })
@@ -439,6 +453,7 @@ enum ScrollWheelModeChange {
 pub fn write_scroll_wheel_mode_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
@@ -467,6 +482,7 @@ pub fn write_scroll_wheel_mode_in_background(
         debug!(route = %target, "no inventory channel — wheel mode write skipped");
         return;
     };
+    let receiver_access = receiver_access.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -479,6 +495,7 @@ pub fn write_scroll_wheel_mode_in_background(
             }
         };
         let result = rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
             tokio::time::timeout(WRITE_BUDGET, async {
                 match change {
                     ScrollWheelModeChange::ResolutionAndInversion {
@@ -530,6 +547,7 @@ pub fn write_scroll_wheel_mode_in_background(
 pub fn set_lighting_in_background(
     capture: Option<&CaptureChannel>,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
     lighting: &Lighting,
 ) {
@@ -542,6 +560,7 @@ pub fn set_lighting_in_background(
         return;
     };
     let (r, g, b) = lighting_rgb(lighting);
+    let receiver_access = receiver_access.clone();
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -553,7 +572,11 @@ pub fn set_lighting_in_background(
                 return;
             }
         };
-        match rt.block_on(openlogi_hid::set_keyboard_color_on(&shared, r, g, b)) {
+        let result = rt.block_on(async {
+            let _lease = receiver_access.acquire_for_io().await;
+            openlogi_hid::set_keyboard_color_on(&shared, r, g, b).await
+        });
+        match result {
             Ok(()) => debug!(r, g, b, "lighting written to keyboard"),
             Err(e) => warn!(error = ?e, "lighting write failed"),
         }
@@ -582,6 +605,7 @@ fn lighting_rgb(lighting: &Lighting) -> (u8, u8, u8) {
 pub async fn apply_dpi(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     route: &DeviceRoute,
     dpi: u32,
 ) -> Result<(), WriteError> {
@@ -592,6 +616,7 @@ pub async fn apply_dpi(
         feature_hex: 0x2201,
         kind: HidppFeatureErrorKind::OutOfRange,
     })?;
+    let _lease = receiver_access.acquire_for_io().await;
     let shared = authoritative_channel(Some(capture), registry, route)?;
     timed(
         HidppOperation::WriteDpi,
@@ -604,11 +629,13 @@ pub async fn apply_dpi(
 pub async fn apply_smartshift(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     route: &DeviceRoute,
     mode: SmartShiftMode,
     auto_disengage: u8,
     tunable_torque: u8,
 ) -> Result<(), WriteError> {
+    let _lease = receiver_access.acquire_for_io().await;
     let shared = authoritative_channel(Some(capture), registry, route)?;
     timed(
         HidppOperation::WriteSmartShift,
@@ -621,9 +648,11 @@ pub async fn apply_smartshift(
 pub async fn apply_lighting(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     route: &DeviceRoute,
     lighting: &Lighting,
 ) -> Result<(), WriteError> {
+    let _lease = receiver_access.acquire_for_io().await;
     let shared = authoritative_channel(Some(capture), registry, route)?;
     let (r, g, b) = lighting_rgb(lighting);
     timed(
@@ -637,8 +666,10 @@ pub async fn apply_lighting(
 pub async fn read_dpi(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     route: &DeviceRoute,
 ) -> Result<DpiInfo, WriteError> {
+    let _lease = receiver_access.acquire_for_io().await;
     let shared = authoritative_channel(Some(capture), registry, route)?;
     timed(
         HidppOperation::ReadDpiCapabilities,
@@ -651,8 +682,10 @@ pub async fn read_dpi(
 pub async fn read_smartshift(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
+    receiver_access: &ReceiverAccess,
     route: &DeviceRoute,
 ) -> Result<SmartShiftStatus, WriteError> {
+    let _lease = receiver_access.acquire_for_io().await;
     let shared = authoritative_channel(Some(capture), registry, route)?;
     timed(
         HidppOperation::ReadSmartShift,

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -20,6 +20,7 @@ use tracing::{info, warn};
 use crate::DpiCycleState;
 use crate::event_monitor::SharedEventMonitor;
 use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
+use crate::receiver_access::ReceiverAccess;
 
 /// The two button maps the OS-hook callback reads, kept behind ONE lock so a
 /// config rebuild publishes both atomically — a press during an owner switch can
@@ -104,6 +105,7 @@ pub fn start(
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture: CaptureChannel,
     registry: ChannelRegistry,
+    receiver_access: ReceiverAccess,
     monitor: SharedEventMonitor,
 ) -> Option<Hook> {
     if !Hook::has_accessibility() {
@@ -159,7 +161,7 @@ pub fn start(
                                 .map(|m| resolve_gesture_click(&m.gestures, id));
                             if let Some(action) = action {
                                 info!(button = %id, action = %action.label(), "gesture click → executing bound action");
-                                dispatch_action(&action, &dpi_cycle, &capture, Some(&registry));
+                                dispatch_action(&action, &dpi_cycle, &capture, Some(&registry), &receiver_access);
                             }
                         }
                         return EventDisposition::Suppress;
@@ -182,7 +184,7 @@ pub fn start(
 
                 if pressed {
                     info!(button = %id, action = %action.label(), "button → executing bound action");
-                    dispatch_action(&action, &dpi_cycle, &capture, Some(&registry));
+                    dispatch_action(&action, &dpi_cycle, &capture, Some(&registry), &receiver_access);
                 }
                 EventDisposition::Suppress
             }
@@ -208,7 +210,7 @@ pub fn start(
                     });
                     if let Some(action) = action {
                         info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
-                        dispatch_action(&action, &dpi_cycle, &capture, Some(&registry));
+                        dispatch_action(&action, &dpi_cycle, &capture, Some(&registry), &receiver_access);
                     }
                 }
                 EventDisposition::PassThrough
@@ -315,6 +317,7 @@ pub fn dispatch_action(
     dpi_cycle: &Arc<RwLock<DpiCycleState>>,
     capture: &CaptureChannel,
     registry: Option<&ChannelRegistry>,
+    receiver_access: &ReceiverAccess,
 ) {
     let next = match action {
         Action::CycleDpiPresets => match dpi_cycle.write() {
@@ -335,7 +338,7 @@ pub fn dispatch_action(
             let target = dpi_cycle.read().ok().and_then(|g| g.target.clone());
             info!("SmartShift toggle → flipping wheel mode");
             if let Some(registry) = registry {
-                toggle_smartshift_in_background(Some(capture), registry, target);
+                toggle_smartshift_in_background(Some(capture), registry, receiver_access, target);
             } else {
                 warn!("no inventory registry — SmartShift toggle skipped");
             }
@@ -365,7 +368,7 @@ pub fn dispatch_action(
     if let Some((dpi, target)) = next {
         info!(dpi, "DPI action → writing to device");
         if let Some(registry) = registry {
-            write_dpi_in_background(Some(capture), registry, target, dpi);
+            write_dpi_in_background(Some(capture), registry, receiver_access, target, dpi);
         } else {
             warn!("no inventory registry — DPI action skipped");
         }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -161,7 +161,13 @@ pub fn start(
                                 .map(|m| resolve_gesture_click(&m.gestures, id));
                             if let Some(action) = action {
                                 info!(button = %id, action = %action.label(), "gesture click → executing bound action");
-                                dispatch_action(&action, &dpi_cycle, &capture, Some(&registry), &receiver_access);
+                                dispatch_action(
+                                    &action,
+                                    &dpi_cycle,
+                                    &capture,
+                                    Some(&registry),
+                                    &receiver_access,
+                                );
                             }
                         }
                         return EventDisposition::Suppress;
@@ -184,7 +190,13 @@ pub fn start(
 
                 if pressed {
                     info!(button = %id, action = %action.label(), "button → executing bound action");
-                    dispatch_action(&action, &dpi_cycle, &capture, Some(&registry), &receiver_access);
+                    dispatch_action(
+                        &action,
+                        &dpi_cycle,
+                        &capture,
+                        Some(&registry),
+                        &receiver_access,
+                    );
                 }
                 EventDisposition::Suppress
             }
@@ -210,7 +222,13 @@ pub fn start(
                     });
                     if let Some(action) = action {
                         info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
-                        dispatch_action(&action, &dpi_cycle, &capture, Some(&registry), &receiver_access);
+                        dispatch_action(
+                            &action,
+                            &dpi_cycle,
+                            &capture,
+                            Some(&registry),
+                            &receiver_access,
+                        );
                     }
                 }
                 EventDisposition::PassThrough

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -26,6 +26,7 @@ use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::ipc::InventoryHealth;
 use crate::receiver_access::ReceiverAccess;
 use crate::watchers::gesture::GestureBindings;
+use crate::watchers::host_switch::{HostSwitchLink, HostSwitchLinks};
 
 /// The minimal per-device facts the agent needs: the config key (binding /
 /// preset lookup), the HID++ route (DPI/SmartShift writes + capture target), and
@@ -63,6 +64,8 @@ pub struct SharedRuntime {
     /// Exclusive receiver access shared by HID++ capture and pairing. Capture
     /// and pairing must never open the same receiver HID node concurrently.
     pub receiver_access: ReceiverAccess,
+    /// Keyboard → pointing-device routes resolved from `config.toml`.
+    pub host_switch_links: HostSwitchLinks,
 }
 
 /// Owns the config + device selection and keeps [`SharedRuntime`] in sync.
@@ -115,6 +118,7 @@ impl Orchestrator {
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
             receiver_access: ReceiverAccess::default(),
+            host_switch_links: Arc::new(RwLock::new(Vec::new())),
         };
         let orch = Self {
             config,
@@ -186,6 +190,11 @@ impl Orchestrator {
             self.config.app_settings.thumbwheel_sensitivity,
             Ordering::Relaxed,
         );
+        write_value(
+            &self.shared.host_switch_links,
+            host_switch_links(&self.config, &self.devices),
+            "host_switch_links",
+        );
     }
 
     /// Apply a fresh inventory snapshot. Always refreshes the snapshot the IPC
@@ -225,6 +234,11 @@ impl Orchestrator {
             // Same set and routes — but keep the fresh `online` flags, or a
             // device that woke this tick would read as a transition forever.
             self.devices = devices;
+            write_value(
+                &self.shared.host_switch_links,
+                host_switch_links(&self.config, &self.devices),
+                "host_switch_links",
+            );
             return;
         }
         self.devices = devices;
@@ -436,6 +450,31 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
     devices
 }
 
+fn host_switch_links(config: &Config, devices: &[AgentDevice]) -> Vec<HostSwitchLink> {
+    config
+        .devices
+        .iter()
+        .filter_map(|(keyboard_key, settings)| {
+            let keyboard = devices
+                .iter()
+                .find(|device| device.config_key == *keyboard_key && device.online)?
+                .route
+                .clone()?;
+            let targets = settings
+                .host_switch_targets
+                .iter()
+                .filter_map(|target_key| {
+                    devices
+                        .iter()
+                        .find(|device| device.config_key == *target_key)
+                        .and_then(|device| device.route.clone())
+                })
+                .collect::<Vec<_>>();
+            (!targets.is_empty()).then_some(HostSwitchLink { keyboard, targets })
+        })
+        .collect()
+}
+
 /// The canonical identity of one device: what the GUI carousel orders by, what
 /// the config key is derived from, and what [`reapply_targets`] matches a device
 /// against across inventory ticks.
@@ -529,7 +568,7 @@ fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentDevice, InventoryHealth, Orchestrator, build_devices, configured_wheel_mode,
+        AgentDevice, InventoryHealth, Orchestrator, configured_wheel_mode, host_switch_links,
         plan_reapply, reapply_targets,
     };
     use openlogi_core::config::{Config, ScrollResolution};
@@ -631,6 +670,45 @@ mod tests {
         });
 
         assert_eq!(configured_wheel_mode(&config, &device), (None, None));
+    }
+
+    #[test]
+    fn host_switch_links_keep_sleeping_targets_but_require_online_keyboard() {
+        let mut config = Config::default();
+        config
+            .devices
+            .entry("keyboard".into())
+            .or_default()
+            .host_switch_targets = vec!["mouse".into(), "offline".into(), "missing".into()];
+        let devices = [
+            dev("keyboard", 1, true),
+            dev("mouse", 2, true),
+            dev("offline", 3, false),
+        ];
+
+        let links = host_switch_links(&config, &devices);
+
+        assert_eq!(links.len(), 1);
+        assert_eq!(
+            links[0].keyboard,
+            DeviceRoute::Bolt {
+                receiver_uid: "AA00".into(),
+                slot: 1,
+            }
+        );
+        assert_eq!(
+            links[0].targets,
+            vec![
+                DeviceRoute::Bolt {
+                    receiver_uid: "AA00".into(),
+                    slot: 2,
+                },
+                DeviceRoute::Bolt {
+                    receiver_uid: "AA00".into(),
+                    slot: 3,
+                }
+            ]
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, RwLock};
 
 use openlogi_core::config::{Config, ScrollResolution};
 use openlogi_core::device::{Capabilities, DeviceInventory};
-use openlogi_hid::{CaptureChannel, ChannelRegistry, DeviceRoute};
+use openlogi_hid::{CaptureChannel, ChannelPool, ChannelRegistry, DeviceRoute};
 use tracing::warn;
 
 use crate::DpiCycleState;
@@ -61,8 +61,10 @@ pub struct SharedRuntime {
     pub capture_channel: CaptureChannel,
     /// Exact-route channels owned and published by the inventory enumerator.
     pub channel_registry: ChannelRegistry,
-    /// Exclusive receiver access shared by HID++ capture and pairing. Capture
-    /// and pairing must never open the same receiver HID node concurrently.
+    /// Shared transport pool used by long-running host-switch sessions.
+    pub channel_pool: ChannelPool,
+    /// Receiver access shared by HID++ sessions and pairing. Pairing is
+    /// exclusive; capture/host-switch sessions share under read leases.
     pub receiver_access: ReceiverAccess,
     /// Keyboard → pointing-device routes resolved from `config.toml`.
     pub host_switch_links: HostSwitchLinks,
@@ -117,6 +119,7 @@ impl Orchestrator {
             )),
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: ChannelRegistry::default(),
+            channel_pool: ChannelPool::default(),
             receiver_access: ReceiverAccess::default(),
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
         };
@@ -591,8 +594,8 @@ fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentDevice, InventoryHealth, Orchestrator, build_devices, configured_wheel_mode, host_switch_links,
-        plan_reapply, reapply_targets,
+        AgentDevice, InventoryHealth, Orchestrator, build_devices, configured_wheel_mode,
+        host_switch_links, plan_reapply, reapply_targets,
     };
     use openlogi_core::config::{Config, ScrollResolution};
     use openlogi_core::device::{

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -591,7 +591,7 @@ fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentDevice, InventoryHealth, Orchestrator, configured_wheel_mode, host_switch_links,
+        AgentDevice, InventoryHealth, Orchestrator, build_devices, configured_wheel_mode, host_switch_links,
         plan_reapply, reapply_targets,
     };
     use openlogi_core::config::{Config, ScrollResolution};

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -305,6 +305,7 @@ impl Orchestrator {
             crate::hardware::reapply_mouse_volatile_in_background(
                 Some(&self.shared.capture_channel),
                 &self.shared.channel_registry,
+                &self.shared.receiver_access,
                 route.clone(),
                 resolution,
                 inverted,
@@ -316,6 +317,7 @@ impl Orchestrator {
             crate::hardware::set_lighting_in_background(
                 Some(&self.shared.capture_channel),
                 &self.shared.channel_registry,
+                &self.shared.receiver_access,
                 Some(route),
                 &lighting,
             );
@@ -339,6 +341,7 @@ impl Orchestrator {
             crate::hardware::write_scroll_wheel_mode_in_background(
                 Some(&self.shared.capture_channel),
                 &self.shared.channel_registry,
+                &self.shared.receiver_access,
                 (resolution.is_some() || inverted.is_some())
                     .then(|| dev.route.clone())
                     .flatten(),

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -760,21 +760,27 @@ mod tests {
         orch.devices = vec![dev("mouse", 1, true)];
         orch.rebuild();
         {
-            let mut dpi = orch.shared.dpi_cycle.write().unwrap();
+            let Ok(mut dpi) = orch.shared.dpi_cycle.write() else {
+                panic!("DPI cycle lock should not be poisoned");
+            };
             dpi.index = 3;
         }
 
         orch.devices[0].online = false;
         orch.sync_current_route();
         {
-            let dpi = orch.shared.dpi_cycle.read().unwrap();
+            let Ok(dpi) = orch.shared.dpi_cycle.read() else {
+                panic!("DPI cycle lock should not be poisoned");
+            };
             assert_eq!(dpi.target, None);
             assert_eq!(dpi.index, 3);
         }
 
         orch.devices[0].online = true;
         orch.sync_current_route();
-        let dpi = orch.shared.dpi_cycle.read().unwrap();
+        let Ok(dpi) = orch.shared.dpi_cycle.read() else {
+            panic!("DPI cycle lock should not be poisoned");
+        };
         assert_eq!(dpi.target, orch.devices[0].route);
         assert_eq!(dpi.index, 3);
     }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -147,7 +147,29 @@ impl Orchestrator {
     }
 
     fn current_route(&self) -> Option<DeviceRoute> {
-        self.devices.get(self.current).and_then(|d| d.route.clone())
+        self.devices
+            .get(self.current)
+            .filter(|device| device.online)
+            .and_then(|device| device.route.clone())
+    }
+
+    /// Keep the capture/DPI write target aligned with the selected device's
+    /// live connection state without rebuilding the rest of the DPI cycle.
+    ///
+    /// Inventory-only online transitions do not warrant [`Self::rebuild`]
+    /// (which intentionally resets the cycle index), but they do have to stop
+    /// and restart HID++ capture. Easy-Switch preserves the receiver route
+    /// while the device is away, and its volatile control diversion is lost;
+    /// publishing `None` while offline and the route again on return makes the
+    /// capture watcher open a fresh session and re-arm those controls.
+    fn sync_current_route(&self) {
+        let target = self.current_route();
+        match self.shared.dpi_cycle.write() {
+            Ok(mut state) => state.target = target,
+            Err(error) => {
+                warn!(%error, lock = "dpi_cycle", "lock poisoned — keeping stale value");
+            }
+        }
     }
 
     /// Build the OS-hook callback's maps for `key` + foreground `app`. Both hook
@@ -234,6 +256,7 @@ impl Orchestrator {
             // Same set and routes — but keep the fresh `online` flags, or a
             // device that woke this tick would read as a transition forever.
             self.devices = devices;
+            self.sync_current_route();
             write_value(
                 &self.shared.host_switch_links,
                 host_switch_links(&self.config, &self.devices),
@@ -729,6 +752,31 @@ mod tests {
         );
         // Going to sleep (online → offline) → nothing.
         assert!(reapply_targets(&[dev("a", 1, true)], &[dev("a", 1, false)], false).is_empty());
+    }
+
+    #[test]
+    fn capture_target_tracks_online_state_without_resetting_dpi_cycle() {
+        let mut orch = Orchestrator::new(Config::default());
+        orch.devices = vec![dev("mouse", 1, true)];
+        orch.rebuild();
+        {
+            let mut dpi = orch.shared.dpi_cycle.write().unwrap();
+            dpi.index = 3;
+        }
+
+        orch.devices[0].online = false;
+        orch.sync_current_route();
+        {
+            let dpi = orch.shared.dpi_cycle.read().unwrap();
+            assert_eq!(dpi.target, None);
+            assert_eq!(dpi.index, 3);
+        }
+
+        orch.devices[0].online = true;
+        orch.sync_current_route();
+        let dpi = orch.shared.dpi_cycle.read().unwrap();
+        assert_eq!(dpi.target, orch.devices[0].route);
+        assert_eq!(dpi.index, 3);
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -79,6 +79,16 @@ impl ReceiverAccess {
         Some(SessionReceiverLease { _guard: guard })
     }
 
+    /// Wait for shared access for a bounded device-I/O operation.
+    ///
+    /// Unlike long-running sessions, ordinary reads and writes must not be
+    /// dropped merely because an exclusive operation is queued. Tokio's fair
+    /// lock ordering makes them wait behind that operation instead.
+    pub async fn acquire_for_io(&self) -> SessionReceiverLease {
+        let guard = Arc::clone(&self.inner.lease).read_owned().await;
+        SessionReceiverLease { _guard: guard }
+    }
+
     /// Request and acquire exclusive receiver access for `reason`.
     ///
     /// If the returned future is cancelled while waiting, the pairing request is
@@ -185,5 +195,22 @@ mod tests {
         assert!(access.try_acquire_for_session().is_none());
         drop(transition);
         assert!(access.try_acquire_for_session().is_some());
+    }
+
+    #[tokio::test]
+    async fn bounded_io_waits_for_host_transition() {
+        let access = ReceiverAccess::default();
+        let transition = access
+            .acquire_exclusive(ExclusiveAccessReason::HostTransition)
+            .await;
+        let waiting = tokio::spawn({
+            let access = access.clone();
+            async move { access.acquire_for_io().await }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished());
+        drop(transition);
+        assert!(waiting.await.is_ok());
     }
 }

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -1,11 +1,11 @@
-//! Exclusive receiver access coordination between HID++ capture and pairing.
+//! Shared and exclusive access coordination for receiver HID++ sessions.
 //!
 //! Long-running HID++ sessions share pooled receiver channels under read leases.
-//! Pairing first announces its intent so those sessions stop, then waits for an
-//! exclusive write lease before opening the receiver itself.
+//! Pairing and coordinated host transitions announce their intent so those
+//! sessions stop, then wait for an exclusive write lease.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
@@ -18,7 +18,25 @@ pub struct ReceiverAccess {
 #[derive(Default)]
 struct ReceiverAccessInner {
     lease: Arc<RwLock<()>>,
-    pairing_requested: Arc<AtomicBool>,
+    exclusive_requests: Arc<AtomicU8>,
+}
+
+/// Operation requiring sole ownership of a receiver transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExclusiveAccessReason {
+    /// Receiver discovery and pairing.
+    Pairing,
+    /// Coordinated movement of linked devices to another host.
+    HostTransition,
+}
+
+impl ExclusiveAccessReason {
+    const fn bit(self) -> u8 {
+        match self {
+            Self::Pairing => 1 << 0,
+            Self::HostTransition => 1 << 1,
+        }
+    }
 }
 
 /// Shared receiver lease held by a long-running HID++ session.
@@ -26,23 +44,23 @@ pub struct SessionReceiverLease {
     _guard: OwnedRwLockReadGuard<()>,
 }
 
-/// Exclusive receiver lease held by a pairing session.
-pub struct PairingReceiverLease {
+/// Exclusive receiver lease held by a pairing or host-transition operation.
+pub struct ExclusiveReceiverLease {
     _guard: OwnedRwLockWriteGuard<()>,
-    pairing_requested: Arc<AtomicBool>,
-}
-
-impl Drop for PairingReceiverLease {
-    fn drop(&mut self) {
-        self.pairing_requested.store(false, Ordering::Release);
-    }
+    _request: ExclusiveRequest,
 }
 
 impl ReceiverAccess {
-    /// Whether a pairing session is waiting for or holding receiver access.
+    /// Whether any exclusive operation is waiting for or holding receiver access.
     #[must_use]
-    pub fn pairing_requested(&self) -> bool {
-        self.inner.pairing_requested.load(Ordering::Acquire)
+    pub fn exclusive_requested(&self) -> bool {
+        self.inner.exclusive_requests.load(Ordering::Acquire) != 0
+    }
+
+    /// Whether `reason` is waiting for or holding receiver access.
+    #[must_use]
+    pub fn requested(&self, reason: ExclusiveAccessReason) -> bool {
+        self.inner.exclusive_requests.load(Ordering::Acquire) & reason.bit() != 0
     }
 
     /// Try to acquire receiver access for a pooled HID++ session.
@@ -51,55 +69,46 @@ impl ReceiverAccess {
     /// stay idle and retry on its next management tick.
     #[must_use]
     pub fn try_acquire_for_session(&self) -> Option<SessionReceiverLease> {
-        if self.pairing_requested() {
+        if self.exclusive_requested() {
             return None;
         }
         let guard = Arc::clone(&self.inner.lease).try_read_owned().ok()?;
-        if self.pairing_requested() {
+        if self.exclusive_requested() {
             return None;
         }
         Some(SessionReceiverLease { _guard: guard })
     }
 
-    /// Request and acquire exclusive receiver access for pairing.
+    /// Request and acquire exclusive receiver access for `reason`.
     ///
     /// If the returned future is cancelled while waiting, the pairing request is
     /// withdrawn automatically so capture can resume.
-    pub async fn acquire_for_pairing(&self) -> PairingReceiverLease {
-        let request = PairingRequest::new(Arc::clone(&self.inner.pairing_requested));
+    pub async fn acquire_exclusive(&self, reason: ExclusiveAccessReason) -> ExclusiveReceiverLease {
+        let request = ExclusiveRequest::new(Arc::clone(&self.inner.exclusive_requests), reason);
         let guard = Arc::clone(&self.inner.lease).write_owned().await;
-        request.disarm();
-        PairingReceiverLease {
+        ExclusiveReceiverLease {
             _guard: guard,
-            pairing_requested: Arc::clone(&self.inner.pairing_requested),
+            _request: request,
         }
     }
 }
 
-struct PairingRequest {
-    pairing_requested: Arc<AtomicBool>,
-    armed: bool,
+struct ExclusiveRequest {
+    requests: Arc<AtomicU8>,
+    reason: ExclusiveAccessReason,
 }
 
-impl PairingRequest {
-    fn new(pairing_requested: Arc<AtomicBool>) -> Self {
-        pairing_requested.store(true, Ordering::Release);
-        Self {
-            pairing_requested,
-            armed: true,
-        }
-    }
-
-    fn disarm(mut self) {
-        self.armed = false;
+impl ExclusiveRequest {
+    fn new(requests: Arc<AtomicU8>, reason: ExclusiveAccessReason) -> Self {
+        requests.fetch_or(reason.bit(), Ordering::AcqRel);
+        Self { requests, reason }
     }
 }
 
-impl Drop for PairingRequest {
+impl Drop for ExclusiveRequest {
     fn drop(&mut self) {
-        if self.armed {
-            self.pairing_requested.store(false, Ordering::Release);
-        }
+        self.requests
+            .fetch_and(!self.reason.bit(), Ordering::AcqRel);
     }
 }
 
@@ -111,14 +120,17 @@ mod tests {
     async fn pairing_request_blocks_new_capture_until_pairing_lease_drops() {
         let access = ReceiverAccess::default();
 
-        let pairing = access.acquire_for_pairing().await;
+        let pairing = access
+            .acquire_exclusive(ExclusiveAccessReason::Pairing)
+            .await;
 
-        assert!(access.pairing_requested());
+        assert!(access.requested(ExclusiveAccessReason::Pairing));
+        assert!(access.exclusive_requested());
         assert!(access.try_acquire_for_session().is_none());
 
         drop(pairing);
 
-        assert!(!access.pairing_requested());
+        assert!(!access.exclusive_requested());
         assert!(access.try_acquire_for_session().is_some());
     }
 
@@ -145,15 +157,33 @@ mod tests {
 
         let waiting = tokio::spawn({
             let access = access.clone();
-            async move { access.acquire_for_pairing().await }
+            async move {
+                access
+                    .acquire_exclusive(ExclusiveAccessReason::Pairing)
+                    .await
+            }
         });
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        assert!(access.pairing_requested());
+        assert!(access.requested(ExclusiveAccessReason::Pairing));
 
         waiting.abort();
         let _ = waiting.await;
-        assert!(!access.pairing_requested());
+        assert!(!access.exclusive_requested());
         drop(capture);
+        assert!(access.try_acquire_for_session().is_some());
+    }
+
+    #[tokio::test]
+    async fn host_transition_blocks_shared_sessions() {
+        let access = ReceiverAccess::default();
+
+        let transition = access
+            .acquire_exclusive(ExclusiveAccessReason::HostTransition)
+            .await;
+
+        assert!(access.requested(ExclusiveAccessReason::HostTransition));
+        assert!(access.try_acquire_for_session().is_none());
+        drop(transition);
         assert!(access.try_acquire_for_session().is_some());
     }
 }

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -1,15 +1,13 @@
 //! Exclusive receiver access coordination between HID++ capture and pairing.
 //!
-//! The active-device capture session and a pairing session cannot both open the
-//! same receiver HID node. This small arbiter makes that ownership explicit: the
-//! capture watcher may run only while it holds a capture lease, and pairing first
-//! announces its intent (so capture stops) before awaiting an exclusive pairing
-//! lease.
+//! Long-running HID++ sessions share pooled receiver channels under read leases.
+//! Pairing first announces its intent so those sessions stop, then waits for an
+//! exclusive write lease before opening the receiver itself.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use tokio::sync::{Mutex, OwnedMutexGuard};
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
 /// Coordinates exclusive access to the receiver HID node.
 #[derive(Clone, Default)]
@@ -19,18 +17,18 @@ pub struct ReceiverAccess {
 
 #[derive(Default)]
 struct ReceiverAccessInner {
-    lease: Arc<Mutex<()>>,
+    lease: Arc<RwLock<()>>,
     pairing_requested: Arc<AtomicBool>,
 }
 
-/// Exclusive receiver lease held by the capture watcher.
-pub struct CaptureReceiverLease {
-    _guard: OwnedMutexGuard<()>,
+/// Shared receiver lease held by a long-running HID++ session.
+pub struct SessionReceiverLease {
+    _guard: OwnedRwLockReadGuard<()>,
 }
 
 /// Exclusive receiver lease held by a pairing session.
 pub struct PairingReceiverLease {
-    _guard: OwnedMutexGuard<()>,
+    _guard: OwnedRwLockWriteGuard<()>,
     pairing_requested: Arc<AtomicBool>,
 }
 
@@ -47,20 +45,20 @@ impl ReceiverAccess {
         self.inner.pairing_requested.load(Ordering::Acquire)
     }
 
-    /// Try to acquire receiver access for the capture watcher.
+    /// Try to acquire receiver access for a pooled HID++ session.
     ///
     /// Capture is opportunistic: if pairing is waiting or active, capture should
     /// stay idle and retry on its next management tick.
     #[must_use]
-    pub fn try_acquire_for_capture(&self) -> Option<CaptureReceiverLease> {
+    pub fn try_acquire_for_session(&self) -> Option<SessionReceiverLease> {
         if self.pairing_requested() {
             return None;
         }
-        let guard = Arc::clone(&self.inner.lease).try_lock_owned().ok()?;
+        let guard = Arc::clone(&self.inner.lease).try_read_owned().ok()?;
         if self.pairing_requested() {
             return None;
         }
-        Some(CaptureReceiverLease { _guard: guard })
+        Some(SessionReceiverLease { _guard: guard })
     }
 
     /// Request and acquire exclusive receiver access for pairing.
@@ -69,7 +67,7 @@ impl ReceiverAccess {
     /// withdrawn automatically so capture can resume.
     pub async fn acquire_for_pairing(&self) -> PairingReceiverLease {
         let request = PairingRequest::new(Arc::clone(&self.inner.pairing_requested));
-        let guard = Arc::clone(&self.inner.lease).lock_owned().await;
+        let guard = Arc::clone(&self.inner.lease).write_owned().await;
         request.disarm();
         PairingReceiverLease {
             _guard: guard,
@@ -116,18 +114,32 @@ mod tests {
         let pairing = access.acquire_for_pairing().await;
 
         assert!(access.pairing_requested());
-        assert!(access.try_acquire_for_capture().is_none());
+        assert!(access.try_acquire_for_session().is_none());
 
         drop(pairing);
 
         assert!(!access.pairing_requested());
-        assert!(access.try_acquire_for_capture().is_some());
+        assert!(access.try_acquire_for_session().is_some());
+    }
+
+    #[tokio::test]
+    async fn pooled_sessions_share_access_before_pairing() {
+        let access = ReceiverAccess::default();
+
+        let first = access.try_acquire_for_session().unwrap_or_else(|| {
+            panic!("fresh receiver access should grant first session lease");
+        });
+        let second = access.try_acquire_for_session().unwrap_or_else(|| {
+            panic!("pooled sessions should share receiver access");
+        });
+
+        drop((first, second));
     }
 
     #[tokio::test]
     async fn cancelled_pairing_wait_withdraws_request() {
         let access = ReceiverAccess::default();
-        let capture = access.try_acquire_for_capture().unwrap_or_else(|| {
+        let capture = access.try_acquire_for_session().unwrap_or_else(|| {
             panic!("fresh receiver access should grant capture lease");
         });
 
@@ -142,6 +154,6 @@ mod tests {
         let _ = waiting.await;
         assert!(!access.pairing_requested());
         drop(capture);
-        assert!(access.try_acquire_for_capture().is_some());
+        assert!(access.try_acquire_for_session().is_some());
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -35,7 +35,7 @@ use tracing::{debug, warn};
 
 use crate::DpiCycleState;
 use crate::hook_runtime::{self, SharedHookMaps};
-use crate::receiver_access::{CaptureReceiverLease, ReceiverAccess};
+use crate::receiver_access::{SessionReceiverLease, ReceiverAccess};
 
 /// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
 /// direction). The watcher reads it to map a captured swipe to a bound action.
@@ -228,7 +228,7 @@ struct CaptureLaunch {
     divert_gesture_button: bool,
     sink: mpsc::UnboundedSender<CapturedInput>,
     channel_slot: CaptureChannel,
-    receiver_lease: CaptureReceiverLease,
+    receiver_lease: SessionReceiverLease,
     registry: Option<ChannelRegistry>,
     done: mpsc::UnboundedSender<u64>,
     epoch: u64,
@@ -362,7 +362,7 @@ async fn manage(
                     continue;
                 }
                 if let Some((route, capture_thumbwheel, divert_gesture_button)) = want {
-                    let Some(receiver_lease) = receiver_access.try_acquire_for_capture() else {
+                    let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
                         current = None;
                         continue;
                     };

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -324,7 +324,7 @@ async fn manage(
                 // While pairing is waiting or active, release the capture
                 // session so run_pairing can own the receiver's HID node (one
                 // process can't read it through two channels).
-                let want = if receiver_access.pairing_requested() {
+                let want = if receiver_access.exclusive_requested() {
                     None
                 } else {
                     let target = dpi_cycle.read().ok().and_then(|guard| guard.target.clone());

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -35,7 +35,7 @@ use tracing::{debug, warn};
 
 use crate::DpiCycleState;
 use crate::hook_runtime::{self, SharedHookMaps};
-use crate::receiver_access::{SessionReceiverLease, ReceiverAccess};
+use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
 
 /// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
 /// direction). The watcher reads it to map a captured swipe to a bound action.
@@ -316,6 +316,7 @@ async fn manage(
                         dpi_cycle: &dpi_cycle,
                         capture: &capture_channel,
                         registry: registry.as_ref(),
+                        receiver_access: &receiver_access,
                     },
                     &thumbwheel_sensitivity,
                 );
@@ -450,6 +451,7 @@ struct DispatchHardware<'a> {
     dpi_cycle: &'a Arc<RwLock<DpiCycleState>>,
     capture: &'a CaptureChannel,
     registry: Option<&'a ChannelRegistry>,
+    receiver_access: &'a ReceiverAccess,
 }
 
 fn dispatch(
@@ -473,6 +475,7 @@ fn dispatch(
                     hardware.dpi_cycle,
                     hardware.capture,
                     hardware.registry,
+                    hardware.receiver_access,
                 );
             } else {
                 debug!(?direction, "gesture with no binding — ignored");
@@ -500,6 +503,7 @@ fn dispatch(
                         hardware.dpi_cycle,
                         hardware.capture,
                         hardware.registry,
+                        hardware.receiver_access,
                     );
                 }
             } else {
@@ -538,6 +542,7 @@ fn dispatch(
                         hardware.dpi_cycle,
                         hardware.capture,
                         hardware.registry,
+                        hardware.receiver_access,
                     );
                 }
             }

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -4,9 +4,11 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
-use openlogi_hid::{DeviceRoute, run_host_switch_session};
+use openlogi_hid::{ChannelPool, DeviceRoute, run_host_switch_session};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
+
+use crate::receiver_access::ReceiverAccess;
 
 /// One resolved link. Config keys are converted to live routes by the
 /// orchestrator so the transport watcher never needs to understand inventory.
@@ -22,7 +24,7 @@ pub struct HostSwitchLink {
 pub type HostSwitchLinks = Arc<RwLock<Vec<HostSwitchLink>>>;
 
 /// Spawn the host switch session manager.
-pub fn spawn(links: HostSwitchLinks) {
+pub fn spawn(links: HostSwitchLinks, channel_pool: ChannelPool, receiver_access: ReceiverAccess) {
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -34,11 +36,15 @@ pub fn spawn(links: HostSwitchLinks) {
                 return;
             }
         };
-        runtime.block_on(manage(links));
+        runtime.block_on(manage(links, channel_pool, receiver_access));
     });
 }
 
-async fn manage(links: HostSwitchLinks) {
+async fn manage(
+    links: HostSwitchLinks,
+    channel_pool: ChannelPool,
+    receiver_access: ReceiverAccess,
+) {
     let mut current = Vec::new();
     let mut stops = Vec::new();
     let (done_tx, mut done_rx) = mpsc::unbounded_channel();
@@ -47,7 +53,11 @@ async fn manage(links: HostSwitchLinks) {
     loop {
         tokio::select! {
             _ = ticker.tick() => {
-                let wanted = links.read().map_or_else(|_| Vec::new(), |guard| guard.clone());
+                let wanted = if receiver_access.pairing_requested() {
+                    Vec::new()
+                } else {
+                    links.read().map_or_else(|_| Vec::new(), |guard| guard.clone())
+                };
                 if wanted == current {
                     continue;
                 }
@@ -57,10 +67,16 @@ async fn manage(links: HostSwitchLinks) {
                     let (stop_tx, stop_rx) = oneshot::channel();
                     stops.push(stop_tx);
                     let done = done_tx.clone();
+                    let pool = channel_pool.clone();
+                    let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
+                        current.clear();
+                        break;
+                    };
                     tokio::spawn(async move {
+                        let _receiver_lease = receiver_lease;
                         let keyboard = link.keyboard.clone();
                         if let Err(error) =
-                            run_host_switch_session(link.keyboard, link.targets, stop_rx).await
+                            run_host_switch_session(link.keyboard, link.targets, stop_rx, pool).await
                         {
                             debug!(%error, route = %keyboard, "host switch session ended");
                         }

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -46,8 +46,9 @@ async fn manage(
     receiver_access: ReceiverAccess,
 ) {
     let mut current = Vec::new();
-    let mut stops = Vec::new();
-    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let mut sessions = Vec::new();
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<u64>();
+    let mut generation = 0_u64;
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
 
     loop {
@@ -61,18 +62,19 @@ async fn manage(
                 if wanted == current {
                     continue;
                 }
-                stop_all(&mut stops);
+                stop_all(&mut sessions).await;
                 current.clone_from(&wanted);
+                generation = generation.wrapping_add(1);
                 for link in wanted {
                     let (stop_tx, stop_rx) = oneshot::channel();
-                    stops.push(stop_tx);
                     let done = done_tx.clone();
                     let pool = channel_pool.clone();
                     let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
                         current.clear();
                         break;
                     };
-                    tokio::spawn(async move {
+                    let session_generation = generation;
+                    let task = tokio::spawn(async move {
                         let _receiver_lease = receiver_lease;
                         let keyboard = link.keyboard.clone();
                         if let Err(error) =
@@ -80,23 +82,40 @@ async fn manage(
                         {
                             debug!(%error, route = %keyboard, "host switch session ended");
                         }
-                        let _ = done.send(());
+                        let _ = done.send(session_generation);
+                    });
+                    sessions.push(RunningSession {
+                        stop: stop_tx,
+                        task,
                     });
                 }
             }
-            Some(()) = done_rx.recv() => {
+            Some(done_generation) = done_rx.recv() => {
                 // A host switch intentionally disconnects the keyboard. Clear
                 // the local snapshot so the next tick attempts to arm it again;
                 // this also recovers transient setup/read failures.
-                stop_all(&mut stops);
-                current.clear();
+                if done_generation == generation && !sessions.is_empty() {
+                    stop_all(&mut sessions).await;
+                    current.clear();
+                }
             }
         }
     }
 }
 
-fn stop_all(stops: &mut Vec<oneshot::Sender<()>>) {
-    for stop in stops.drain(..) {
+struct RunningSession {
+    stop: oneshot::Sender<()>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+async fn stop_all(sessions: &mut Vec<RunningSession>) {
+    let running = std::mem::take(sessions);
+    let mut tasks = Vec::with_capacity(running.len());
+    for RunningSession { stop, task } in running {
         let _ = stop.send(());
+        tasks.push(task);
+    }
+    for task in tasks {
+        let _ = task.await;
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -50,10 +50,9 @@ async fn manage(
     channel_pool: ChannelPool,
     receiver_access: ReceiverAccess,
 ) {
-    let mut current = Vec::new();
     let mut sessions = Vec::new();
     let (done_tx, mut done_rx) = mpsc::unbounded_channel::<SessionCompletion>();
-    let mut generation = 0_u64;
+    let mut next_generation = 0_u64;
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
 
     loop {
@@ -64,21 +63,20 @@ async fn manage(
                 } else {
                     links.read().map_or_else(|_| Vec::new(), |guard| guard.clone())
                 };
-                if wanted == current {
-                    continue;
-                }
-                stop_all(&mut sessions, HostSwitchStopReason::Graceful).await;
-                current.clone_from(&wanted);
-                generation = generation.wrapping_add(1);
+                stop_unwanted(&mut sessions, &wanted).await;
                 for link in wanted {
+                    if sessions.iter().any(|session| session.link == link) {
+                        continue;
+                    }
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let done = done_tx.clone();
                     let pool = channel_pool.clone();
                     let Some(receiver_lease) = receiver_access.try_acquire_for_session() else {
-                        current.clear();
                         break;
                     };
-                    let session_generation = generation;
+                    next_generation = next_generation.wrapping_add(1);
+                    let session_generation = next_generation;
+                    let session_link = link.clone();
                     let task = tokio::spawn(async move {
                         let _receiver_lease = receiver_lease;
                         let keyboard = link.keyboard.clone();
@@ -101,19 +99,22 @@ async fn manage(
                         });
                     });
                     sessions.push(RunningSession {
+                        link: session_link,
+                        generation: session_generation,
                         stop: stop_tx,
                         task,
                     });
                 }
             }
             Some(completion) = done_rx.recv() => {
-                // A host switch intentionally disconnects the keyboard. Clear
-                // the local snapshot so the next tick attempts to arm it again;
-                // this also recovers transient setup/read failures.
-                if completion.generation == generation && !sessions.is_empty() {
-                    stop_all(&mut sessions, HostSwitchStopReason::Graceful).await;
-                    current.clear();
+                if let Some(index) = sessions
+                    .iter()
+                    .position(|session| session.generation == completion.generation)
+                {
+                    let completed = sessions.remove(index);
+                    let _ = completed.task.await;
                     if let Some((link, host)) = completion.request {
+                        stop_all(&mut sessions, HostSwitchStopReason::Graceful).await;
                         run_transition(&links, &channel_pool, &receiver_access, link, host).await;
                     }
                 }
@@ -123,6 +124,8 @@ async fn manage(
 }
 
 struct RunningSession {
+    link: HostSwitchLink,
+    generation: u64,
     stop: oneshot::Sender<HostSwitchStopReason>,
     task: tokio::task::JoinHandle<()>,
 }
@@ -135,11 +138,24 @@ struct SessionCompletion {
 async fn stop_all(sessions: &mut Vec<RunningSession>, reason: HostSwitchStopReason) {
     let running = std::mem::take(sessions);
     let mut tasks = Vec::with_capacity(running.len());
-    for RunningSession { stop, task } in running {
+    for RunningSession { stop, task, .. } in running {
         let _ = stop.send(reason);
         tasks.push(task);
     }
     for task in tasks {
+        let _ = task.await;
+    }
+}
+
+async fn stop_unwanted(sessions: &mut Vec<RunningSession>, wanted: &[HostSwitchLink]) {
+    let mut index = 0;
+    while index < sessions.len() {
+        if wanted.contains(&sessions[index].link) {
+            index += 1;
+            continue;
+        }
+        let RunningSession { stop, task, .. } = sessions.remove(index);
+        let _ = stop.send(HostSwitchStopReason::Graceful);
         let _ = task.await;
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -2,13 +2,18 @@
 
 use std::sync::{Arc, RwLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use openlogi_hid::{ChannelPool, DeviceRoute, run_host_switch_session};
+use openlogi_hid::{
+    ChannelPool, DeviceRoute, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
+};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
-use crate::receiver_access::ReceiverAccess;
+use crate::receiver_access::{ExclusiveAccessReason, ReceiverAccess};
+
+const DEPARTURE_TIMEOUT: Duration = Duration::from_secs(10);
+const DEPARTURE_POLL: Duration = Duration::from_millis(100);
 
 /// One resolved link. Config keys are converted to live routes by the
 /// orchestrator so the transport watcher never needs to understand inventory.
@@ -47,7 +52,7 @@ async fn manage(
 ) {
     let mut current = Vec::new();
     let mut sessions = Vec::new();
-    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<u64>();
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel::<SessionCompletion>();
     let mut generation = 0_u64;
     let mut ticker = tokio::time::interval(Duration::from_secs(1));
 
@@ -62,7 +67,7 @@ async fn manage(
                 if wanted == current {
                     continue;
                 }
-                stop_all(&mut sessions).await;
+                stop_all(&mut sessions, HostSwitchStopReason::Graceful).await;
                 current.clone_from(&wanted);
                 generation = generation.wrapping_add(1);
                 for link in wanted {
@@ -77,12 +82,23 @@ async fn manage(
                     let task = tokio::spawn(async move {
                         let _receiver_lease = receiver_lease;
                         let keyboard = link.keyboard.clone();
-                        if let Err(error) =
-                            run_host_switch_session(link.keyboard, link.targets, stop_rx, pool).await
+                        let request = match run_host_switch_session(
+                            link.keyboard.clone(),
+                            stop_rx,
+                            pool,
+                        )
+                        .await
                         {
-                            debug!(%error, route = %keyboard, "host switch session ended");
-                        }
-                        let _ = done.send(session_generation);
+                            Ok(host) => host.map(|host| (link, host)),
+                            Err(error) => {
+                                debug!(%error, route = %keyboard, "host switch session ended");
+                                None
+                            }
+                        };
+                        let _ = done.send(SessionCompletion {
+                            generation: session_generation,
+                            request,
+                        });
                     });
                     sessions.push(RunningSession {
                         stop: stop_tx,
@@ -90,13 +106,16 @@ async fn manage(
                     });
                 }
             }
-            Some(done_generation) = done_rx.recv() => {
+            Some(completion) = done_rx.recv() => {
                 // A host switch intentionally disconnects the keyboard. Clear
                 // the local snapshot so the next tick attempts to arm it again;
                 // this also recovers transient setup/read failures.
-                if done_generation == generation && !sessions.is_empty() {
-                    stop_all(&mut sessions).await;
+                if completion.generation == generation && !sessions.is_empty() {
+                    stop_all(&mut sessions, HostSwitchStopReason::Graceful).await;
                     current.clear();
+                    if let Some((link, host)) = completion.request {
+                        run_transition(&links, &channel_pool, &receiver_access, link, host).await;
+                    }
                 }
             }
         }
@@ -104,18 +123,56 @@ async fn manage(
 }
 
 struct RunningSession {
-    stop: oneshot::Sender<()>,
+    stop: oneshot::Sender<HostSwitchStopReason>,
     task: tokio::task::JoinHandle<()>,
 }
 
-async fn stop_all(sessions: &mut Vec<RunningSession>) {
+struct SessionCompletion {
+    generation: u64,
+    request: Option<(HostSwitchLink, u8)>,
+}
+
+async fn stop_all(sessions: &mut Vec<RunningSession>, reason: HostSwitchStopReason) {
     let running = std::mem::take(sessions);
     let mut tasks = Vec::with_capacity(running.len());
     for RunningSession { stop, task } in running {
-        let _ = stop.send(());
+        let _ = stop.send(reason);
         tasks.push(task);
     }
     for task in tasks {
         let _ = task.await;
     }
+}
+
+async fn run_transition(
+    links: &HostSwitchLinks,
+    channel_pool: &ChannelPool,
+    receiver_access: &ReceiverAccess,
+    link: HostSwitchLink,
+    host: u8,
+) {
+    let _lease = receiver_access
+        .acquire_exclusive(ExclusiveAccessReason::HostTransition)
+        .await;
+    match switch_linked_hosts(&link.keyboard, &link.targets, host, channel_pool).await {
+        Ok(true) => wait_for_departure(links, &link.keyboard).await,
+        Ok(false) => {}
+        Err(error) => {
+            debug!(%error, route = %link.keyboard, host, "keyboard host switch failed");
+        }
+    }
+}
+
+async fn wait_for_departure(links: &HostSwitchLinks, keyboard: &DeviceRoute) {
+    let deadline = Instant::now() + DEPARTURE_TIMEOUT;
+    while Instant::now() < deadline {
+        let departed = links.read().map_or(true, |current| {
+            !current.iter().any(|link| link.keyboard == *keyboard)
+        });
+        if departed {
+            return;
+        }
+        tokio::time::sleep(DEPARTURE_POLL).await;
+    }
+    warn!(route = %keyboard, "host transition departure was not observed");
 }

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -1,0 +1,86 @@
+//! Keep configured keyboard → pointing-device host-switch links armed.
+
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::Duration;
+
+use openlogi_hid::{DeviceRoute, run_host_switch_session};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, warn};
+
+/// One resolved link. Config keys are converted to live routes by the
+/// orchestrator so the transport watcher never needs to understand inventory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostSwitchLink {
+    /// Keyboard whose host switch keys initiate the transition.
+    pub keyboard: DeviceRoute,
+    /// Pointing devices that follow the keyboard.
+    pub targets: Vec<DeviceRoute>,
+}
+
+/// Shared resolved links, refreshed with config and inventory.
+pub type HostSwitchLinks = Arc<RwLock<Vec<HostSwitchLink>>>;
+
+/// Spawn the host switch session manager.
+pub fn spawn(links: HostSwitchLinks) {
+    thread::spawn(move || {
+        let runtime = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                warn!(%error, "host switch watcher: could not build tokio runtime");
+                return;
+            }
+        };
+        runtime.block_on(manage(links));
+    });
+}
+
+async fn manage(links: HostSwitchLinks) {
+    let mut current = Vec::new();
+    let mut stops = Vec::new();
+    let (done_tx, mut done_rx) = mpsc::unbounded_channel();
+    let mut ticker = tokio::time::interval(Duration::from_secs(1));
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                let wanted = links.read().map_or_else(|_| Vec::new(), |guard| guard.clone());
+                if wanted == current {
+                    continue;
+                }
+                stop_all(&mut stops);
+                current.clone_from(&wanted);
+                for link in wanted {
+                    let (stop_tx, stop_rx) = oneshot::channel();
+                    stops.push(stop_tx);
+                    let done = done_tx.clone();
+                    tokio::spawn(async move {
+                        let keyboard = link.keyboard.clone();
+                        if let Err(error) =
+                            run_host_switch_session(link.keyboard, link.targets, stop_rx).await
+                        {
+                            debug!(%error, route = %keyboard, "host switch session ended");
+                        }
+                        let _ = done.send(());
+                    });
+                }
+            }
+            Some(()) = done_rx.recv() => {
+                // A host switch intentionally disconnects the keyboard. Clear
+                // the local snapshot so the next tick attempts to arm it again;
+                // this also recovers transient setup/read failures.
+                stop_all(&mut stops);
+                current.clear();
+            }
+        }
+    }
+}
+
+fn stop_all(stops: &mut Vec<oneshot::Sender<()>>) {
+    for stop in stops.drain(..) {
+        let _ = stop.send(());
+    }
+}

--- a/crates/openlogi-agent-core/src/watchers/host_switch.rs
+++ b/crates/openlogi-agent-core/src/watchers/host_switch.rs
@@ -54,7 +54,7 @@ async fn manage(
     loop {
         tokio::select! {
             _ = ticker.tick() => {
-                let wanted = if receiver_access.pairing_requested() {
+                let wanted = if receiver_access.exclusive_requested() {
                     Vec::new()
                 } else {
                     links.read().map_or_else(|_| Vec::new(), |guard| guard.clone())

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -5,5 +5,6 @@
 pub mod accessibility;
 pub mod foreground_app;
 pub mod gesture;
+pub mod host_switch;
 pub mod inventory;
 pub mod pairing;

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -243,6 +243,7 @@ async fn run(config: Config) {
                             shared.dpi_cycle.clone(),
                             shared.capture_channel.clone(),
                             shared.channel_registry.clone(),
+                            shared.receiver_access.clone(),
                             Arc::clone(&event_monitor),
                         );
                         hook_installed.store(hook.is_some(), Ordering::Relaxed);

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -171,6 +171,7 @@ async fn run(config: Config) {
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
     );
+    watchers::host_switch::spawn(shared.host_switch_links.clone());
 
     let mut inventory_rx = watchers::inventory::spawn_with_registry(
         Duration::from_secs(2),

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -171,7 +171,11 @@ async fn run(config: Config) {
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
     );
-    watchers::host_switch::spawn(shared.host_switch_links.clone());
+    watchers::host_switch::spawn(
+        shared.host_switch_links.clone(),
+        shared.channel_pool.clone(),
+        shared.receiver_access.clone(),
+    );
 
     let mut inventory_rx = watchers::inventory::spawn_with_registry(
         Duration::from_secs(2),

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -272,6 +272,7 @@ mod tests {
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
             receiver_access: ReceiverAccess::default(),
+            host_switch_links: Arc::new(RwLock::new(Vec::new())),
         }
     }
 

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -271,6 +271,7 @@ mod tests {
             thumbwheel_sensitivity: Arc::new(0.into()),
             capture_channel: Arc::new(RwLock::new(None)),
             channel_registry: openlogi_hid::ChannelRegistry::default(),
+            channel_pool: openlogi_hid::ChannelPool::default(),
             receiver_access: ReceiverAccess::default(),
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
         }
@@ -303,7 +304,7 @@ mod tests {
             manager
                 .shared
                 .receiver_access
-                .try_acquire_for_capture()
+                .try_acquire_for_session()
                 .is_some()
         );
     }
@@ -344,7 +345,7 @@ mod tests {
             manager
                 .shared
                 .receiver_access
-                .try_acquire_for_capture()
+                .try_acquire_for_session()
                 .is_some()
         );
     }

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use openlogi_agent_core::ipc::{FoundDevice, PairingCommandError, PairingUpdate};
 use openlogi_agent_core::orchestrator::SharedRuntime;
-use openlogi_agent_core::receiver_access::PairingReceiverLease;
+use openlogi_agent_core::receiver_access::{ExclusiveAccessReason, ExclusiveReceiverLease};
 use openlogi_agent_core::watchers::pairing::{self, Control};
 use openlogi_hid::{DiscoveredDevice, PairingEvent, ReceiverSelector};
 use tokio::sync::{Mutex, mpsc};
@@ -36,7 +36,7 @@ const RECEIVER_LEASE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Address-keyed cache of the full discovered devices, so the GUI can pair by
 /// address without round-tripping the non-serializable `DiscoveredDevice`.
 type DeviceCache = Arc<StdMutex<HashMap<[u8; 6], DiscoveredDevice>>>;
-type ReceiverLeaseSlot = Arc<StdMutex<Option<PairingReceiverLease>>>;
+type ReceiverLeaseSlot = Arc<StdMutex<Option<ExclusiveReceiverLease>>>;
 
 /// Owns the pairing watcher and translates its event stream for the IPC layer.
 pub struct PairingManager {
@@ -96,7 +96,9 @@ impl PairingManager {
         }
         let Ok(receiver_lease) = tokio::time::timeout(
             RECEIVER_LEASE_TIMEOUT,
-            self.shared.receiver_access.acquire_for_pairing(),
+            self.shared
+                .receiver_access
+                .acquire_exclusive(ExclusiveAccessReason::Pairing),
         )
         .await
         else {
@@ -159,7 +161,7 @@ impl PairingManager {
 
 fn with_receiver_lease_slot<T>(
     receiver_lease: &ReceiverLeaseSlot,
-    f: impl FnOnce(&mut Option<PairingReceiverLease>) -> T,
+    f: impl FnOnce(&mut Option<ExclusiveReceiverLease>) -> T,
 ) -> T {
     match receiver_lease.lock() {
         Ok(mut slot) => f(&mut slot),
@@ -299,7 +301,7 @@ mod tests {
 
         assert_eq!(result, Err(PairingCommandError::WatcherUnavailable));
         assert_eq!(manager.sessions.load(Ordering::Acquire), 0);
-        assert!(!manager.shared.receiver_access.pairing_requested());
+        assert!(!manager.shared.receiver_access.exclusive_requested());
         assert!(
             manager
                 .shared
@@ -324,11 +326,20 @@ mod tests {
     async fn release_receiver_lease_recovers_poisoned_slot() {
         let (ctrl_tx, _ctrl_rx) = mpsc::unbounded_channel();
         let manager = manager_with_ctrl(ctrl_tx);
-        let receiver_lease = manager.shared.receiver_access.acquire_for_pairing().await;
+        let receiver_lease = manager
+            .shared
+            .receiver_access
+            .acquire_exclusive(ExclusiveAccessReason::Pairing)
+            .await;
         with_receiver_lease_slot(&manager.receiver_lease, |slot| {
             *slot = Some(receiver_lease);
         });
-        assert!(manager.shared.receiver_access.pairing_requested());
+        assert!(
+            manager
+                .shared
+                .receiver_access
+                .requested(ExclusiveAccessReason::Pairing)
+        );
 
         let slot = Arc::clone(&manager.receiver_lease);
         let _ = std::panic::catch_unwind(move || {
@@ -340,7 +351,7 @@ mod tests {
 
         manager.release_receiver_lease();
 
-        assert!(!manager.shared.receiver_access.pairing_requested());
+        assert!(!manager.shared.receiver_access.exclusive_requested());
         assert!(
             manager
                 .shared

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -83,6 +83,7 @@ impl Agent for AgentServer {
         hardware::apply_dpi(
             &self.shared.capture_channel,
             &self.shared.channel_registry,
+            &self.shared.receiver_access,
             &route,
             dpi,
         )
@@ -98,6 +99,7 @@ impl Agent for AgentServer {
         hardware::apply_lighting(
             &self.shared.capture_channel,
             &self.shared.channel_registry,
+            &self.shared.receiver_access,
             &route,
             &lighting,
         )
@@ -115,6 +117,7 @@ impl Agent for AgentServer {
         hardware::apply_smartshift(
             &self.shared.capture_channel,
             &self.shared.channel_registry,
+            &self.shared.receiver_access,
             &route,
             mode,
             auto_disengage,
@@ -127,6 +130,7 @@ impl Agent for AgentServer {
         hardware::read_dpi(
             &self.shared.capture_channel,
             &self.shared.channel_registry,
+            &self.shared.receiver_access,
             &route,
         )
         .await
@@ -140,6 +144,7 @@ impl Agent for AgentServer {
         hardware::read_smartshift(
             &self.shared.capture_channel,
             &self.shared.channel_registry,
+            &self.shared.receiver_access,
             &route,
         )
         .await

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -113,6 +113,12 @@ pub struct DeviceConfig {
     /// current resolution unmanaged and omits the field from `config.toml`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scroll_resolution: Option<ScrollResolution>,
+    /// Physical config keys of pointing devices that follow this keyboard's
+    /// host switch channel. The relationship is keyboard-initiated: pressing
+    /// one of this device's host keys switches every listed target first, then
+    /// lets the keyboard leave the current host.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub host_switch_targets: Vec<String>,
 }
 
 /// `skip_serializing_if` helper for plain `bool` fields whose default is
@@ -163,6 +169,8 @@ struct RawDeviceConfig {
     invert_scroll: bool,
     #[serde(default)]
     scroll_resolution: Option<ScrollResolution>,
+    #[serde(default)]
+    host_switch_targets: Vec<String>,
 }
 
 impl From<RawDeviceConfig> for DeviceConfig {
@@ -207,6 +215,30 @@ impl From<RawDeviceConfig> for DeviceConfig {
             smartshift: raw.smartshift,
             invert_scroll: raw.invert_scroll,
             scroll_resolution: raw.scroll_resolution,
+            host_switch_targets: raw.host_switch_targets,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeviceConfig;
+
+    #[test]
+    fn host_switch_targets_round_trip_as_physical_keys() -> Result<(), Box<dyn std::error::Error>> {
+        let config: DeviceConfig = toml::from_str(
+            r#"host_switch_targets = [
+  "receiver:keyboard:slot:1",
+  "receiver:mouse:slot:2",
+]"#,
+        )?;
+
+        assert_eq!(
+            config.host_switch_targets,
+            ["receiver:keyboard:slot:1", "receiver:mouse:slot:2"]
+        );
+        let serialized = toml::to_string(&config)?;
+        assert!(serialized.contains("host_switch_targets"));
+        Ok(())
     }
 }

--- a/crates/openlogi-hid/src/channel_pool.rs
+++ b/crates/openlogi-hid/src/channel_pool.rs
@@ -1,0 +1,47 @@
+//! Shared HID++ channels for long-running agent sessions.
+
+use std::sync::{Arc, Weak};
+
+use hidpp::channel::HidppChannel;
+use tokio::sync::Mutex;
+
+use crate::route::{DeviceRoute, open_route_channel};
+
+/// Reuses one open HID++ channel for routes on the same receiver.
+#[derive(Clone, Default)]
+pub struct ChannelPool {
+    entries: Arc<Mutex<Vec<PoolEntry>>>,
+}
+
+struct PoolEntry {
+    route: DeviceRoute,
+    channel: Weak<HidppChannel>,
+}
+
+impl ChannelPool {
+    /// Return a shared channel reaching `route`, opening it when necessary.
+    pub async fn open(
+        &self,
+        route: &DeviceRoute,
+    ) -> Result<Option<Arc<HidppChannel>>, async_hid::HidError> {
+        let mut entries = self.entries.lock().await;
+        entries.retain(|entry| entry.channel.strong_count() > 0);
+        if let Some(channel) = entries.iter().find_map(|entry| {
+            entry
+                .route
+                .shares_transport(route)
+                .then(|| entry.channel.upgrade())
+                .flatten()
+        }) {
+            return Ok(Some(channel));
+        }
+        let Some(channel) = open_route_channel(route).await? else {
+            return Ok(None);
+        };
+        entries.push(PoolEntry {
+            route: route.clone(),
+            channel: Arc::downgrade(&channel),
+        });
+        Ok(Some(channel))
+    }
+}

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -55,6 +55,7 @@ struct ArmedControl {
     cid: u16,
     host: u8,
     mode: ReportingMode,
+    original: reprog_controls::CidReporting,
 }
 
 /// Failure while arming or running a host-switch link.
@@ -208,6 +209,10 @@ async fn arm_host_controls_inner(
             None
         };
         if let Some(mode) = mode {
+            let original = controls
+                .get_cid_reporting(info.cid)
+                .await
+                .map_err(hidpp_error)?;
             // Record the rollback before issuing the write: a transport timeout
             // can mean that the device applied the request but its response was
             // lost, so the failing control must be restored as well.
@@ -215,6 +220,7 @@ async fn arm_host_controls_inner(
                 cid: info.cid,
                 host,
                 mode,
+                original,
             });
             match mode {
                 ReportingMode::Diverted => controls
@@ -241,19 +247,10 @@ async fn arm_host_controls_inner(
 
 async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {
     for control in armed {
-        let restored = match control.mode {
-            ReportingMode::Diverted => controls.set_cid_reporting(control.cid, false, false).await,
-            ReportingMode::Analytics => controls
-                .set_cid_reporting_full(
-                    control.cid,
-                    reprog_controls::CidReportingChange {
-                        analytics_key_events: Some(false),
-                        ..reprog_controls::CidReportingChange::default()
-                    },
-                )
-                .await
-                .map(|_echo| ()),
-        };
+        let restored = controls
+            .set_cid_reporting_full(control.cid, restoration_change(control))
+            .await
+            .map(|_echo| ());
         if let Err(error) = restored {
             debug!(
                 ?error,
@@ -261,6 +258,20 @@ async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedCont
                 "could not restore host switch control"
             );
         }
+    }
+}
+
+fn restoration_change(control: ArmedControl) -> reprog_controls::CidReportingChange {
+    match control.mode {
+        ReportingMode::Diverted => reprog_controls::CidReportingChange {
+            diverted: Some(control.original.diverted),
+            raw_xy: Some(control.original.raw_xy),
+            ..reprog_controls::CidReportingChange::default()
+        },
+        ReportingMode::Analytics => reprog_controls::CidReportingChange {
+            analytics_key_events: Some(control.original.analytics_key_events),
+            ..reprog_controls::CidReportingChange::default()
+        },
     }
 }
 
@@ -369,10 +380,26 @@ fn event_host(
 #[cfg(test)]
 mod tests {
     use super::{
-        ArmedControl, ReportingMode, event_host, host_change_required, host_channel, shares_channel,
+        ArmedControl, ReportingMode, event_host, host_change_required, host_channel,
+        restoration_change, shares_channel,
     };
     use crate::DeviceRoute;
-    use crate::reprog_controls::{AnalyticsKeyEvent, ControlId, CtrlIdInfo, ReprogControlsEvent};
+    use crate::reprog_controls::{
+        AnalyticsKeyEvent, CidReporting, ControlId, CtrlIdInfo, ReprogControlsEvent,
+    };
+
+    fn reporting(diverted: bool, raw_xy: bool, analytics_key_events: bool) -> CidReporting {
+        CidReporting {
+            cid: ControlId(0x00d3),
+            diverted,
+            persistently_diverted: true,
+            force_raw_xy: true,
+            raw_xy,
+            remap: Some(ControlId(0x1234)),
+            analytics_key_events,
+            raw_wheel: true,
+        }
+    }
 
     #[test]
     fn receiver_slots_share_one_channel() {
@@ -412,6 +439,7 @@ mod tests {
             cid: 0x00d3,
             host: 2,
             mode: ReportingMode::Analytics,
+            original: reporting(false, false, false),
         }];
         let mut events = [AnalyticsKeyEvent::default(); 5];
         events[0] = AnalyticsKeyEvent {
@@ -437,5 +465,35 @@ mod tests {
     #[test]
     fn host_outside_device_range_is_rejected() {
         assert!(host_change_required(0, 2, 2).is_err());
+    }
+
+    #[test]
+    fn diverted_cleanup_restores_only_the_original_temporary_bits() {
+        let change = restoration_change(ArmedControl {
+            cid: 0x00d3,
+            host: 2,
+            mode: ReportingMode::Diverted,
+            original: reporting(true, true, false),
+        });
+
+        assert_eq!(change.diverted, Some(true));
+        assert_eq!(change.raw_xy, Some(true));
+        assert_eq!(change.analytics_key_events, None);
+        assert_eq!(change.persistently_diverted, None);
+        assert_eq!(change.remap, None);
+    }
+
+    #[test]
+    fn analytics_cleanup_restores_the_original_analytics_bit() {
+        let change = restoration_change(ArmedControl {
+            cid: 0x00d3,
+            host: 2,
+            mode: ReportingMode::Analytics,
+            original: reporting(false, false, true),
+        });
+
+        assert_eq!(change.analytics_key_events, Some(true));
+        assert_eq!(change.diverted, None);
+        assert_eq!(change.raw_xy, None);
     }
 }

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -167,15 +167,19 @@ pub async fn switch_linked_hosts(
     let channel = open_channel(channel_pool, keyboard, "opening keyboard channel")
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
-    let mut prepared_targets = Vec::with_capacity(targets.len());
     for target in targets {
-        prepared_targets
-            .push(prepare_host_change(target, host, keyboard, &channel, channel_pool).await?);
+        match prepare_host_change(target, host, keyboard, &channel, channel_pool).await {
+            Ok(change) => {
+                if let Err(error) = apply_host_change(change).await {
+                    debug!(%error, route = %target, host, "linked device host switch failed");
+                }
+            }
+            Err(error) => {
+                debug!(%error, route = %target, host, "linked device host switch preparation failed");
+            }
+        }
     }
     let keyboard_change = prepare_host_change_on(&channel, keyboard.device_index(), host).await?;
-    for change in prepared_targets {
-        apply_host_change(change).await?;
-    }
     let changed = apply_host_change(keyboard_change).await?;
     if changed {
         debug!(host, route = %keyboard, "keyboard host switched");
@@ -267,12 +271,10 @@ async fn arm_host_controls_inner(
 
 async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {
     for control in armed {
-        let restored = timed_hidpp(
-            "restoring host control reporting",
-            controls.set_cid_reporting_full(control.cid, restoration_change(control)),
-        )
-        .await
-        .map(|_echo| ());
+        let mut restored = restore_host_control(controls, control).await;
+        if restored.is_err() {
+            restored = restore_host_control(controls, control).await;
+        }
         if let Err(error) = restored {
             debug!(
                 ?error,
@@ -281,6 +283,18 @@ async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedCont
             );
         }
     }
+}
+
+async fn restore_host_control(
+    controls: &ReprogControlsV4,
+    control: ArmedControl,
+) -> Result<(), HostSwitchError> {
+    timed_hidpp(
+        "restoring host control reporting",
+        controls.set_cid_reporting_full(control.cid, restoration_change(control)),
+    )
+    .await
+    .map(|_echo| ())
 }
 
 fn restoration_change(control: ArmedControl) -> reprog_controls::CidReportingChange {
@@ -385,7 +399,7 @@ where
     timeout(HIDPP_OPERATION_TIMEOUT, future)
         .await
         .map_err(|_| HostSwitchError::TimedOut { operation })?
-        .map_err(hidpp_error)
+        .map_err(|error| hidpp_error(operation, error))
 }
 
 fn host_change_required(
@@ -405,8 +419,8 @@ fn shares_channel(left: &DeviceRoute, right: &DeviceRoute) -> bool {
     left.shares_transport(right)
 }
 
-fn hidpp_error(error: impl std::fmt::Debug) -> HostSwitchError {
-    HostSwitchError::Hidpp(format!("{error:?}"))
+fn hidpp_error(operation: &'static str, error: impl std::fmt::Debug) -> HostSwitchError {
+    HostSwitchError::Hidpp(format!("{operation}: {error:?}"))
 }
 
 fn host_channel(info: reprog_controls::CtrlIdInfo) -> Option<u8> {

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -1,0 +1,382 @@
+//! Keyboard-initiated host-switch synchronization.
+//!
+//! A session temporarily diverts the keyboard's three host controls, observes
+//! which channel was pressed, switches the linked pointing devices, and then
+//! switches the keyboard itself. Ordering matters: once the keyboard leaves
+//! this host its HID++ channel can no longer command a mouse sharing the same
+//! receiver.
+
+use std::sync::Arc;
+
+use hidpp::{
+    channel::HidppChannel,
+    device::Device,
+    feature::{CreatableFeature, change_host::ChangeHostFeature},
+    protocol::v20,
+};
+use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, info, warn};
+
+use crate::{
+    reprog_controls::{self, ReprogControlsV4},
+    route::{DeviceRoute, open_route_channel},
+};
+
+const HOST_CONTROL_IDS: [(reprog_controls::ControlId, u8); 3] = [
+    (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_1, 0),
+    (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_2, 1),
+    (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_3, 2),
+];
+const HOST_TASK_IDS: [(reprog_controls::TaskId, u8); 3] = [
+    (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_1, 0),
+    (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_2, 1),
+    (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_3, 2),
+];
+
+#[derive(Clone, Copy)]
+enum ReportingMode {
+    Diverted,
+    Analytics,
+}
+
+#[derive(Clone, Copy)]
+struct ArmedControl {
+    cid: u16,
+    host: u8,
+    mode: ReportingMode,
+}
+
+/// Failure while arming or running a host-switch link.
+#[derive(Debug, Error)]
+pub enum HostSwitchError {
+    /// HID transport-level failure.
+    #[error("HID transport error")]
+    Hid(#[from] async_hid::HidError),
+    /// The configured keyboard is not currently reachable.
+    #[error("configured keyboard is not connected")]
+    KeyboardNotFound,
+    /// A configured target is not currently reachable.
+    #[error("configured linked device is not connected")]
+    TargetNotFound,
+    /// A required HID++ operation failed.
+    #[error("HID++ protocol error: {0}")]
+    Hidpp(String),
+    /// The keyboard cannot report its host switch controls to software.
+    #[error("keyboard exposes no reportable host switch controls")]
+    UnsupportedKeyboard,
+}
+
+/// Capture host switch keys on `keyboard` and make `targets` follow it until
+/// `shutdown` resolves.
+pub async fn run_host_switch_session(
+    keyboard: DeviceRoute,
+    targets: Vec<DeviceRoute>,
+    shutdown: oneshot::Receiver<()>,
+) -> Result<(), HostSwitchError> {
+    let channel = open_route_channel(&keyboard)
+        .await?
+        .ok_or(HostSwitchError::KeyboardNotFound)?;
+    let keyboard_index = keyboard.device_index();
+    let device = Device::new(Arc::clone(&channel), keyboard_index)
+        .await
+        .map_err(hidpp_error)?;
+    let feature = device
+        .root()
+        .get_feature(reprog_controls::FEATURE_ID)
+        .await
+        .map_err(hidpp_error)?
+        .ok_or(HostSwitchError::UnsupportedKeyboard)?;
+    let controls = ReprogControlsV4::new(Arc::clone(&channel), keyboard_index, feature.index);
+
+    let armed = arm_host_controls(&controls).await?;
+    if armed.is_empty() {
+        return Err(HostSwitchError::UnsupportedKeyboard);
+    }
+
+    let (press_tx, mut press_rx) = mpsc::unbounded_channel();
+    let feature_index = controls.feature_index();
+    let event_controls = armed.clone();
+    let listener = channel.add_msg_listener_guarded(move |raw, matched| {
+        if matched {
+            return;
+        }
+        let message = v20::Message::from(raw);
+        let Some(event) =
+            reprog_controls::decode_full_event(&message, keyboard_index, feature_index)
+        else {
+            return;
+        };
+        if let Some(host) = event_host(&event_controls, event) {
+            let _ = press_tx.send(host);
+        }
+    });
+
+    info!(
+        route = %keyboard,
+        controls = armed.len(),
+        targets = targets.len(),
+        "host switch link active"
+    );
+    let result = tokio::select! {
+        _ = shutdown => Ok(()),
+        Some(host) = press_rx.recv() => {
+            for target in &targets {
+                if let Err(error) = set_host(target, host, &keyboard, &channel).await {
+                    warn!(%error, route = %target, host, "linked device host switch failed");
+                }
+            }
+            // Always switch the keyboard last. This normally severs the channel,
+            // so the session ends and the manager reconnects if this host becomes
+            // active again.
+            let result = set_host_on(&channel, keyboard_index, host).await;
+            if result.is_ok() {
+                debug!(host, route = %keyboard, "keyboard host switched");
+            }
+            result
+        }
+    };
+
+    drop(listener);
+    restore_host_controls(&controls, armed).await;
+    result
+}
+
+async fn arm_host_controls(
+    controls: &ReprogControlsV4,
+) -> Result<Vec<ArmedControl>, HostSwitchError> {
+    let count = controls.get_count().await.map_err(hidpp_error)?;
+    let mut armed = Vec::new();
+    for index in 0..count {
+        let info = controls
+            .get_ctrl_id_info(index)
+            .await
+            .map_err(hidpp_error)?;
+        let Some(host) = host_channel(info) else {
+            continue;
+        };
+        debug!(
+            cid = format_args!("{:#06x}", info.cid),
+            task_id = format_args!("{:#06x}", info.task_id),
+            host,
+            divertable = info.is_divertable(),
+            analytics = info.supports_analytics_events(),
+            "host switch control discovered"
+        );
+        let mode = if info.is_divertable() {
+            controls
+                .set_cid_reporting(info.cid, true, false)
+                .await
+                .map_err(hidpp_error)?;
+            Some(ReportingMode::Diverted)
+        } else if info.supports_analytics_events() {
+            controls
+                .set_cid_reporting_full(
+                    info.cid,
+                    reprog_controls::CidReportingChange {
+                        analytics_key_events: Some(true),
+                        ..reprog_controls::CidReportingChange::default()
+                    },
+                )
+                .await
+                .map_err(hidpp_error)?;
+            Some(ReportingMode::Analytics)
+        } else {
+            None
+        };
+        if let Some(mode) = mode {
+            armed.push(ArmedControl {
+                cid: info.cid,
+                host,
+                mode,
+            });
+        }
+    }
+    Ok(armed)
+}
+
+async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {
+    for control in armed {
+        let restored = match control.mode {
+            ReportingMode::Diverted => controls.set_cid_reporting(control.cid, false, false).await,
+            ReportingMode::Analytics => controls
+                .set_cid_reporting_full(
+                    control.cid,
+                    reprog_controls::CidReportingChange {
+                        analytics_key_events: Some(false),
+                        ..reprog_controls::CidReportingChange::default()
+                    },
+                )
+                .await
+                .map(|_echo| ()),
+        };
+        if let Err(error) = restored {
+            debug!(
+                ?error,
+                cid = control.cid,
+                "could not restore host switch control"
+            );
+        }
+    }
+}
+
+async fn set_host(
+    target: &DeviceRoute,
+    host: u8,
+    keyboard: &DeviceRoute,
+    keyboard_channel: &Arc<HidppChannel>,
+) -> Result<(), HostSwitchError> {
+    if shares_channel(target, keyboard) {
+        set_host_on(keyboard_channel, target.device_index(), host).await
+    } else {
+        let channel = open_route_channel(target)
+            .await?
+            .ok_or(HostSwitchError::TargetNotFound)?;
+        set_host_on(&channel, target.device_index(), host).await
+    }
+}
+
+async fn set_host_on(
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
+    host: u8,
+) -> Result<(), HostSwitchError> {
+    let mut device = Device::new(Arc::clone(channel), device_index)
+        .await
+        .map_err(hidpp_error)?;
+    let info = device
+        .root()
+        .get_feature(ChangeHostFeature::ID)
+        .await
+        .map_err(hidpp_error)?
+        .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
+    let change_host = device.add_feature::<ChangeHostFeature>(info.index);
+    let state = change_host.get_host_info().await.map_err(hidpp_error)?;
+    if host >= state.host_count {
+        return Err(HostSwitchError::Hidpp(format!(
+            "host {host} is outside device host count {}",
+            state.host_count
+        )));
+    }
+    change_host
+        .set_current_host(host)
+        .await
+        .map_err(hidpp_error)
+}
+
+fn shares_channel(left: &DeviceRoute, right: &DeviceRoute) -> bool {
+    match (left, right) {
+        (
+            DeviceRoute::Bolt {
+                receiver_uid: left, ..
+            },
+            DeviceRoute::Bolt {
+                receiver_uid: right,
+                ..
+            },
+        )
+        | (
+            DeviceRoute::Unifying {
+                receiver_uid: left, ..
+            },
+            DeviceRoute::Unifying {
+                receiver_uid: right,
+                ..
+            },
+        ) => left.eq_ignore_ascii_case(right),
+        _ => false,
+    }
+}
+
+fn hidpp_error(error: impl std::fmt::Debug) -> HostSwitchError {
+    HostSwitchError::Hidpp(format!("{error:?}"))
+}
+
+fn host_channel(info: reprog_controls::CtrlIdInfo) -> Option<u8> {
+    HOST_CONTROL_IDS
+        .iter()
+        .find_map(|(cid, host)| (info.cid == cid.0).then_some(*host))
+        .or_else(|| {
+            HOST_TASK_IDS
+                .iter()
+                .find_map(|(task, host)| (info.task_id == task.0).then_some(*host))
+        })
+}
+
+fn event_host(
+    controls: &[ArmedControl],
+    event: reprog_controls::ReprogControlsEvent,
+) -> Option<u8> {
+    match event {
+        reprog_controls::ReprogControlsEvent::DivertedButtons(cids) => controls
+            .iter()
+            .find_map(|control| cids.contains(&control.cid.into()).then_some(control.host)),
+        reprog_controls::ReprogControlsEvent::AnalyticsKeyEvents(events) => {
+            controls.iter().find_map(|control| {
+                events
+                    .iter()
+                    .any(|event| event.cid.0 == control.cid)
+                    .then_some(control.host)
+            })
+        }
+        reprog_controls::ReprogControlsEvent::DivertedRawMouseXy { .. }
+        | reprog_controls::ReprogControlsEvent::DivertedRawWheel { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ArmedControl, ReportingMode, event_host, host_channel, shares_channel};
+    use crate::DeviceRoute;
+    use crate::reprog_controls::{AnalyticsKeyEvent, ControlId, CtrlIdInfo, ReprogControlsEvent};
+
+    #[test]
+    fn receiver_slots_share_one_channel() {
+        let keyboard = DeviceRoute::Bolt {
+            receiver_uid: "AABB".into(),
+            slot: 1,
+        };
+        let mouse = DeviceRoute::Bolt {
+            receiver_uid: "aabb".into(),
+            slot: 2,
+        };
+        assert!(shares_channel(&keyboard, &mouse));
+    }
+
+    #[test]
+    fn direct_devices_do_not_share_channels() {
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb025,
+        };
+        assert!(!shares_channel(&route, &route));
+    }
+
+    #[test]
+    fn host_controls_are_recognized_by_task_when_cid_varies() {
+        let info = CtrlIdInfo {
+            cid: 0x1234,
+            task_id: 0x00af,
+            flags: 0,
+        };
+        assert_eq!(host_channel(info), Some(1));
+    }
+
+    #[test]
+    fn analytics_event_selects_the_matching_host() {
+        let controls = [ArmedControl {
+            cid: 0x00d3,
+            host: 2,
+            mode: ReportingMode::Analytics,
+        }];
+        let mut events = [AnalyticsKeyEvent::default(); 5];
+        events[0] = AnalyticsKeyEvent {
+            cid: ControlId(0x00d3),
+            event: 1,
+        };
+        assert_eq!(
+            event_host(&controls, ReprogControlsEvent::AnalyticsKeyEvents(events)),
+            Some(2)
+        );
+    }
+}

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -6,7 +6,7 @@
 //! this host its HID++ channel can no longer command a mouse sharing the same
 //! receiver.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc, time::Duration};
 
 use hidpp::{
     channel::HidppChannel,
@@ -15,7 +15,10 @@ use hidpp::{
     protocol::v20,
 };
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::timeout,
+};
 use tracing::{debug, info};
 
 use crate::{
@@ -43,6 +46,7 @@ const HOST_TASK_IDS: [(reprog_controls::TaskId, u8); 3] = [
     (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_2, 1),
     (reprog_controls::task_ids::HOST_SWITCH_CHANNEL_3, 2),
 ];
+const HIDPP_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy)]
 enum ReportingMode {
@@ -73,6 +77,12 @@ pub enum HostSwitchError {
     /// A required HID++ operation failed.
     #[error("HID++ protocol error: {0}")]
     Hidpp(String),
+    /// A required HID++ operation did not complete within its budget.
+    #[error("HID++ operation timed out while {operation}")]
+    TimedOut {
+        /// Description of the operation that exceeded its budget.
+        operation: &'static str,
+    },
     /// The keyboard cannot report its host switch controls to software.
     #[error("keyboard exposes no reportable host switch controls")]
     UnsupportedKeyboard,
@@ -85,20 +95,21 @@ pub async fn run_host_switch_session(
     shutdown: oneshot::Receiver<HostSwitchStopReason>,
     channel_pool: ChannelPool,
 ) -> Result<Option<u8>, HostSwitchError> {
-    let channel = channel_pool
-        .open(&keyboard)
+    let channel = open_channel(&channel_pool, &keyboard, "opening keyboard channel")
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
     let keyboard_index = keyboard.device_index();
-    let device = Device::new(Arc::clone(&channel), keyboard_index)
-        .await
-        .map_err(hidpp_error)?;
-    let feature = device
-        .root()
-        .get_feature(reprog_controls::FEATURE_ID)
-        .await
-        .map_err(hidpp_error)?
-        .ok_or(HostSwitchError::UnsupportedKeyboard)?;
+    let device = timed_hidpp(
+        "opening keyboard device",
+        Device::new(Arc::clone(&channel), keyboard_index),
+    )
+    .await?;
+    let feature = timed_hidpp(
+        "locating host controls",
+        device.root().get_feature(reprog_controls::FEATURE_ID),
+    )
+    .await?
+    .ok_or(HostSwitchError::UnsupportedKeyboard)?;
     let controls = ReprogControlsV4::new(Arc::clone(&channel), keyboard_index, feature.index);
 
     let armed = arm_host_controls(&controls).await?;
@@ -153,16 +164,19 @@ pub async fn switch_linked_hosts(
     host: u8,
     channel_pool: &ChannelPool,
 ) -> Result<bool, HostSwitchError> {
-    let channel = channel_pool
-        .open(keyboard)
+    let channel = open_channel(channel_pool, keyboard, "opening keyboard channel")
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
+    let mut prepared_targets = Vec::with_capacity(targets.len());
     for target in targets {
-        if let Err(error) = set_host(target, host, keyboard, &channel, channel_pool).await {
-            debug!(%error, route = %target, host, "linked device host switch failed");
-        }
+        prepared_targets
+            .push(prepare_host_change(target, host, keyboard, &channel, channel_pool).await?);
     }
-    let changed = set_host_on(&channel, keyboard.device_index(), host).await?;
+    let keyboard_change = prepare_host_change_on(&channel, keyboard.device_index(), host).await?;
+    for change in prepared_targets {
+        apply_host_change(change).await?;
+    }
+    let changed = apply_host_change(keyboard_change).await?;
     if changed {
         debug!(host, route = %keyboard, "keyboard host switched");
     }
@@ -184,12 +198,13 @@ async fn arm_host_controls_inner(
     controls: &ReprogControlsV4,
     armed: &mut Vec<ArmedControl>,
 ) -> Result<(), HostSwitchError> {
-    let count = controls.get_count().await.map_err(hidpp_error)?;
+    let count = timed_hidpp("reading host control count", controls.get_count()).await?;
     for index in 0..count {
-        let info = controls
-            .get_ctrl_id_info(index)
-            .await
-            .map_err(hidpp_error)?;
+        let info = timed_hidpp(
+            "reading host control information",
+            controls.get_ctrl_id_info(index),
+        )
+        .await?;
         let Some(host) = host_channel(info) else {
             continue;
         };
@@ -209,10 +224,11 @@ async fn arm_host_controls_inner(
             None
         };
         if let Some(mode) = mode {
-            let original = controls
-                .get_cid_reporting(info.cid)
-                .await
-                .map_err(hidpp_error)?;
+            let original = timed_hidpp(
+                "reading host control reporting",
+                controls.get_cid_reporting(info.cid),
+            )
+            .await?;
             // Record the rollback before issuing the write: a transport timeout
             // can mean that the device applied the request but its response was
             // lost, so the failing control must be restored as well.
@@ -223,21 +239,25 @@ async fn arm_host_controls_inner(
                 original,
             });
             match mode {
-                ReportingMode::Diverted => controls
-                    .set_cid_reporting(info.cid, true, false)
-                    .await
-                    .map_err(hidpp_error)?,
+                ReportingMode::Diverted => {
+                    timed_hidpp(
+                        "diverting host control",
+                        controls.set_cid_reporting(info.cid, true, false),
+                    )
+                    .await?;
+                }
                 ReportingMode::Analytics => {
-                    controls
-                        .set_cid_reporting_full(
+                    timed_hidpp(
+                        "enabling host control analytics",
+                        controls.set_cid_reporting_full(
                             info.cid,
                             reprog_controls::CidReportingChange {
                                 analytics_key_events: Some(true),
                                 ..reprog_controls::CidReportingChange::default()
                             },
-                        )
-                        .await
-                        .map_err(hidpp_error)?;
+                        ),
+                    )
+                    .await?;
                 }
             }
         }
@@ -247,10 +267,12 @@ async fn arm_host_controls_inner(
 
 async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {
     for control in armed {
-        let restored = controls
-            .set_cid_reporting_full(control.cid, restoration_change(control))
-            .await
-            .map(|_echo| ());
+        let restored = timed_hidpp(
+            "restoring host control reporting",
+            controls.set_cid_reporting_full(control.cid, restoration_change(control)),
+        )
+        .await
+        .map(|_echo| ());
         if let Err(error) = restored {
             debug!(
                 ?error,
@@ -275,53 +297,95 @@ fn restoration_change(control: ArmedControl) -> reprog_controls::CidReportingCha
     }
 }
 
-async fn set_host(
+struct PreparedHostChange {
+    feature: Arc<ChangeHostFeature>,
+    device_index: u8,
+    host: u8,
+    required: bool,
+}
+
+async fn prepare_host_change(
     target: &DeviceRoute,
     host: u8,
     keyboard: &DeviceRoute,
     keyboard_channel: &Arc<HidppChannel>,
     channel_pool: &ChannelPool,
-) -> Result<(), HostSwitchError> {
+) -> Result<PreparedHostChange, HostSwitchError> {
     if shares_channel(target, keyboard) {
-        set_host_on(keyboard_channel, target.device_index(), host)
-            .await
-            .map(|_| ())
+        prepare_host_change_on(keyboard_channel, target.device_index(), host).await
     } else {
-        let channel = channel_pool
-            .open(target)
+        let channel = open_channel(channel_pool, target, "opening linked device channel")
             .await?
             .ok_or(HostSwitchError::TargetNotFound)?;
-        set_host_on(&channel, target.device_index(), host)
-            .await
-            .map(|_| ())
+        prepare_host_change_on(&channel, target.device_index(), host).await
     }
 }
 
-async fn set_host_on(
+async fn prepare_host_change_on(
     channel: &Arc<HidppChannel>,
     device_index: u8,
     host: u8,
-) -> Result<bool, HostSwitchError> {
-    let mut device = Device::new(Arc::clone(channel), device_index)
-        .await
-        .map_err(hidpp_error)?;
-    let info = device
-        .root()
-        .get_feature(ChangeHostFeature::ID)
-        .await
-        .map_err(hidpp_error)?
-        .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
+) -> Result<PreparedHostChange, HostSwitchError> {
+    let mut device = timed_hidpp(
+        "opening host-change device",
+        Device::new(Arc::clone(channel), device_index),
+    )
+    .await?;
+    let info = timed_hidpp(
+        "locating host-change feature",
+        device.root().get_feature(ChangeHostFeature::ID),
+    )
+    .await?
+    .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
     let change_host = device.add_feature::<ChangeHostFeature>(info.index);
-    let state = change_host.get_host_info().await.map_err(hidpp_error)?;
-    if !host_change_required(state.current_host, state.host_count, host)? {
+    let state = timed_hidpp("reading current host", change_host.get_host_info()).await?;
+    let required = host_change_required(state.current_host, state.host_count, host)?;
+    Ok(PreparedHostChange {
+        feature: change_host,
+        device_index,
+        host,
+        required,
+    })
+}
+
+async fn apply_host_change(change: PreparedHostChange) -> Result<bool, HostSwitchError> {
+    if !change.required {
+        let PreparedHostChange {
+            device_index, host, ..
+        } = change;
         debug!(device_index, host, "device already uses requested host");
         return Ok(false);
     }
-    change_host
-        .set_current_host(host)
-        .await
-        .map_err(hidpp_error)?;
+    timed_hidpp(
+        "writing current host",
+        change.feature.set_current_host(change.host),
+    )
+    .await?;
     Ok(true)
+}
+
+async fn open_channel(
+    channel_pool: &ChannelPool,
+    route: &DeviceRoute,
+    operation: &'static str,
+) -> Result<Option<Arc<HidppChannel>>, HostSwitchError> {
+    timeout(HIDPP_OPERATION_TIMEOUT, channel_pool.open(route))
+        .await
+        .map_err(|_| HostSwitchError::TimedOut { operation })?
+        .map_err(HostSwitchError::Hid)
+}
+
+async fn timed_hidpp<T, E>(
+    operation: &'static str,
+    future: impl Future<Output = Result<T, E>>,
+) -> Result<T, HostSwitchError>
+where
+    E: std::fmt::Debug,
+{
+    timeout(HIDPP_OPERATION_TIMEOUT, future)
+        .await
+        .map_err(|_| HostSwitchError::TimedOut { operation })?
+        .map_err(hidpp_error)
 }
 
 fn host_change_required(

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -19,8 +19,9 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
 use crate::{
+    ChannelPool,
     reprog_controls::{self, ReprogControlsV4},
-    route::{DeviceRoute, open_route_channel},
+    route::DeviceRoute,
 };
 
 const HOST_CONTROL_IDS: [(reprog_controls::ControlId, u8); 3] = [
@@ -73,8 +74,10 @@ pub async fn run_host_switch_session(
     keyboard: DeviceRoute,
     targets: Vec<DeviceRoute>,
     shutdown: oneshot::Receiver<()>,
+    channel_pool: ChannelPool,
 ) -> Result<(), HostSwitchError> {
-    let channel = open_route_channel(&keyboard)
+    let channel = channel_pool
+        .open(&keyboard)
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
     let keyboard_index = keyboard.device_index();
@@ -122,7 +125,7 @@ pub async fn run_host_switch_session(
         _ = shutdown => Ok(()),
         Some(host) = press_rx.recv() => {
             for target in &targets {
-                if let Err(error) = set_host(target, host, &keyboard, &channel).await {
+                if let Err(error) = set_host(target, host, &keyboard, &channel, &channel_pool).await {
                     warn!(%error, route = %target, host, "linked device host switch failed");
                 }
             }
@@ -236,11 +239,13 @@ async fn set_host(
     host: u8,
     keyboard: &DeviceRoute,
     keyboard_channel: &Arc<HidppChannel>,
+    channel_pool: &ChannelPool,
 ) -> Result<(), HostSwitchError> {
     if shares_channel(target, keyboard) {
         set_host_on(keyboard_channel, target.device_index(), host).await
     } else {
-        let channel = open_route_channel(target)
+        let channel = channel_pool
+            .open(target)
             .await?
             .ok_or(HostSwitchError::TargetNotFound)?;
         set_host_on(&channel, target.device_index(), host).await
@@ -276,27 +281,7 @@ async fn set_host_on(
 }
 
 fn shares_channel(left: &DeviceRoute, right: &DeviceRoute) -> bool {
-    match (left, right) {
-        (
-            DeviceRoute::Bolt {
-                receiver_uid: left, ..
-            },
-            DeviceRoute::Bolt {
-                receiver_uid: right,
-                ..
-            },
-        )
-        | (
-            DeviceRoute::Unifying {
-                receiver_uid: left, ..
-            },
-            DeviceRoute::Unifying {
-                receiver_uid: right,
-                ..
-            },
-        ) => left.eq_ignore_ascii_case(right),
-        _ => false,
-    }
+    left.shares_transport(right)
 }
 
 fn hidpp_error(error: impl std::fmt::Debug) -> HostSwitchError {

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -145,8 +145,19 @@ pub async fn run_host_switch_session(
 async fn arm_host_controls(
     controls: &ReprogControlsV4,
 ) -> Result<Vec<ArmedControl>, HostSwitchError> {
-    let count = controls.get_count().await.map_err(hidpp_error)?;
     let mut armed = Vec::new();
+    if let Err(error) = arm_host_controls_inner(controls, &mut armed).await {
+        restore_host_controls(controls, armed).await;
+        return Err(error);
+    }
+    Ok(armed)
+}
+
+async fn arm_host_controls_inner(
+    controls: &ReprogControlsV4,
+    armed: &mut Vec<ArmedControl>,
+) -> Result<(), HostSwitchError> {
+    let count = controls.get_count().await.map_err(hidpp_error)?;
     for index in 0..count {
         let info = controls
             .get_ctrl_id_info(index)
@@ -192,7 +203,7 @@ async fn arm_host_controls(
             });
         }
     }
-    Ok(armed)
+    Ok(())
 }
 
 async fn restore_host_controls(controls: &ReprogControlsV4, armed: Vec<ArmedControl>) {

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -201,32 +201,39 @@ async fn arm_host_controls_inner(
             "host switch control discovered"
         );
         let mode = if info.is_divertable() {
-            controls
-                .set_cid_reporting(info.cid, true, false)
-                .await
-                .map_err(hidpp_error)?;
             Some(ReportingMode::Diverted)
         } else if info.supports_analytics_events() {
-            controls
-                .set_cid_reporting_full(
-                    info.cid,
-                    reprog_controls::CidReportingChange {
-                        analytics_key_events: Some(true),
-                        ..reprog_controls::CidReportingChange::default()
-                    },
-                )
-                .await
-                .map_err(hidpp_error)?;
             Some(ReportingMode::Analytics)
         } else {
             None
         };
         if let Some(mode) = mode {
+            // Record the rollback before issuing the write: a transport timeout
+            // can mean that the device applied the request but its response was
+            // lost, so the failing control must be restored as well.
             armed.push(ArmedControl {
                 cid: info.cid,
                 host,
                 mode,
             });
+            match mode {
+                ReportingMode::Diverted => controls
+                    .set_cid_reporting(info.cid, true, false)
+                    .await
+                    .map_err(hidpp_error)?,
+                ReportingMode::Analytics => {
+                    controls
+                        .set_cid_reporting_full(
+                            info.cid,
+                            reprog_controls::CidReportingChange {
+                                analytics_key_events: Some(true),
+                                ..reprog_controls::CidReportingChange::default()
+                            },
+                        )
+                        .await
+                        .map_err(hidpp_error)?;
+                }
+            }
         }
     }
     Ok(())

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -16,7 +16,7 @@ use hidpp::{
 };
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::{
     ChannelPool,
@@ -126,7 +126,7 @@ pub async fn run_host_switch_session(
         Some(host) = press_rx.recv() => {
             for target in &targets {
                 if let Err(error) = set_host(target, host, &keyboard, &channel, &channel_pool).await {
-                    warn!(%error, route = %target, host, "linked device host switch failed");
+                    debug!(%error, route = %target, host, "linked device host switch failed");
                 }
             }
             // Always switch the keyboard last. This normally severs the channel,
@@ -268,16 +268,27 @@ async fn set_host_on(
         .ok_or_else(|| HostSwitchError::Hidpp("ChangeHost is unsupported".into()))?;
     let change_host = device.add_feature::<ChangeHostFeature>(info.index);
     let state = change_host.get_host_info().await.map_err(hidpp_error)?;
-    if host >= state.host_count {
-        return Err(HostSwitchError::Hidpp(format!(
-            "host {host} is outside device host count {}",
-            state.host_count
-        )));
+    if !host_change_required(state.current_host, state.host_count, host)? {
+        debug!(device_index, host, "device already uses requested host");
+        return Ok(());
     }
     change_host
         .set_current_host(host)
         .await
         .map_err(hidpp_error)
+}
+
+fn host_change_required(
+    current_host: u8,
+    host_count: u8,
+    requested_host: u8,
+) -> Result<bool, HostSwitchError> {
+    if requested_host >= host_count {
+        return Err(HostSwitchError::Hidpp(format!(
+            "host {requested_host} is outside device host count {host_count}"
+        )));
+    }
+    Ok(current_host != requested_host)
 }
 
 fn shares_channel(left: &DeviceRoute, right: &DeviceRoute) -> bool {
@@ -322,7 +333,9 @@ fn event_host(
 
 #[cfg(test)]
 mod tests {
-    use super::{ArmedControl, ReportingMode, event_host, host_channel, shares_channel};
+    use super::{
+        ArmedControl, ReportingMode, event_host, host_change_required, host_channel, shares_channel,
+    };
     use crate::DeviceRoute;
     use crate::reprog_controls::{AnalyticsKeyEvent, ControlId, CtrlIdInfo, ReprogControlsEvent};
 
@@ -374,5 +387,20 @@ mod tests {
             event_host(&controls, ReprogControlsEvent::AnalyticsKeyEvents(events)),
             Some(2)
         );
+    }
+
+    #[test]
+    fn current_host_does_not_require_a_change() {
+        assert!(matches!(host_change_required(1, 3, 1), Ok(false)));
+    }
+
+    #[test]
+    fn different_valid_host_requires_a_change() {
+        assert!(matches!(host_change_required(0, 3, 2), Ok(true)));
+    }
+
+    #[test]
+    fn host_outside_device_range_is_rejected() {
+        assert!(host_change_required(0, 2, 2).is_err());
     }
 }

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -24,6 +24,15 @@ use crate::{
     route::DeviceRoute,
 };
 
+/// Why an armed host-switch session is being stopped externally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostSwitchStopReason {
+    /// The keyboard remains reachable, so its controls must be restored.
+    Graceful,
+    /// The keyboard disappeared, so only local resources can be released.
+    DeviceLost,
+}
+
 const HOST_CONTROL_IDS: [(reprog_controls::ControlId, u8); 3] = [
     (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_1, 0),
     (reprog_controls::control_ids::HOST_SWITCH_CHANNEL_2, 1),
@@ -68,14 +77,13 @@ pub enum HostSwitchError {
     UnsupportedKeyboard,
 }
 
-/// Capture host switch keys on `keyboard` and make `targets` follow it until
-/// `shutdown` resolves.
+/// Capture host switch keys on `keyboard` until one is pressed or `shutdown`
+/// resolves. Controls are restored before a requested host is returned.
 pub async fn run_host_switch_session(
     keyboard: DeviceRoute,
-    targets: Vec<DeviceRoute>,
-    shutdown: oneshot::Receiver<()>,
+    shutdown: oneshot::Receiver<HostSwitchStopReason>,
     channel_pool: ChannelPool,
-) -> Result<(), HostSwitchError> {
+) -> Result<Option<u8>, HostSwitchError> {
     let channel = channel_pool
         .open(&keyboard)
         .await?
@@ -118,31 +126,46 @@ pub async fn run_host_switch_session(
     info!(
         route = %keyboard,
         controls = armed.len(),
-        targets = targets.len(),
         "host switch link active"
     );
-    let result = tokio::select! {
-        _ = shutdown => Ok(()),
-        Some(host) = press_rx.recv() => {
-            for target in &targets {
-                if let Err(error) = set_host(target, host, &keyboard, &channel, &channel_pool).await {
-                    debug!(%error, route = %target, host, "linked device host switch failed");
-                }
-            }
-            // Always switch the keyboard last. This normally severs the channel,
-            // so the session ends and the manager reconnects if this host becomes
-            // active again.
-            let result = set_host_on(&channel, keyboard_index, host).await;
-            if result.is_ok() {
-                debug!(host, route = %keyboard, "keyboard host switched");
-            }
-            result
-        }
+    let outcome = tokio::select! {
+        reason = shutdown => {
+            let reason = reason.unwrap_or(HostSwitchStopReason::DeviceLost);
+            (None, reason == HostSwitchStopReason::Graceful)
+        },
+        Some(host) = press_rx.recv() => (Some(host), true),
     };
 
     drop(listener);
-    restore_host_controls(&controls, armed).await;
-    result
+    if outcome.1 {
+        restore_host_controls(&controls, armed).await;
+    }
+    Ok(outcome.0)
+}
+
+/// Move reachable targets to `host`, then move the keyboard last.
+///
+/// Returns whether the keyboard actually changed hosts.
+pub async fn switch_linked_hosts(
+    keyboard: &DeviceRoute,
+    targets: &[DeviceRoute],
+    host: u8,
+    channel_pool: &ChannelPool,
+) -> Result<bool, HostSwitchError> {
+    let channel = channel_pool
+        .open(keyboard)
+        .await?
+        .ok_or(HostSwitchError::KeyboardNotFound)?;
+    for target in targets {
+        if let Err(error) = set_host(target, host, keyboard, &channel, channel_pool).await {
+            debug!(%error, route = %target, host, "linked device host switch failed");
+        }
+    }
+    let changed = set_host_on(&channel, keyboard.device_index(), host).await?;
+    if changed {
+        debug!(host, route = %keyboard, "keyboard host switched");
+    }
+    Ok(changed)
 }
 
 async fn arm_host_controls(
@@ -242,13 +265,17 @@ async fn set_host(
     channel_pool: &ChannelPool,
 ) -> Result<(), HostSwitchError> {
     if shares_channel(target, keyboard) {
-        set_host_on(keyboard_channel, target.device_index(), host).await
+        set_host_on(keyboard_channel, target.device_index(), host)
+            .await
+            .map(|_| ())
     } else {
         let channel = channel_pool
             .open(target)
             .await?
             .ok_or(HostSwitchError::TargetNotFound)?;
-        set_host_on(&channel, target.device_index(), host).await
+        set_host_on(&channel, target.device_index(), host)
+            .await
+            .map(|_| ())
     }
 }
 
@@ -256,7 +283,7 @@ async fn set_host_on(
     channel: &Arc<HidppChannel>,
     device_index: u8,
     host: u8,
-) -> Result<(), HostSwitchError> {
+) -> Result<bool, HostSwitchError> {
     let mut device = Device::new(Arc::clone(channel), device_index)
         .await
         .map_err(hidpp_error)?;
@@ -270,12 +297,13 @@ async fn set_host_on(
     let state = change_host.get_host_info().await.map_err(hidpp_error)?;
     if !host_change_required(state.current_host, state.host_count, host)? {
         debug!(device_index, host, "device already uses requested host");
-        return Ok(());
+        return Ok(false);
     }
     change_host
         .set_current_host(host)
         .await
-        .map_err(hidpp_error)
+        .map_err(hidpp_error)?;
+    Ok(true)
 }
 
 fn host_change_required(

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 mod channel_registry;
+pub mod host_switch;
 mod mappings;
 mod node_ledger;
 mod route;
@@ -42,6 +43,7 @@ pub use hires_wheel::{
     get_scroll_wheel_mode_on, set_scroll_inversion, set_scroll_inversion_on, set_scroll_resolution,
     set_scroll_resolution_on, set_scroll_wheel_mode, set_scroll_wheel_mode_on,
 };
+pub use host_switch::{HostSwitchError, run_host_switch_session};
 pub use hotplug::{HotplugEvent, watch_hotplug};
 pub use inventory::{Enumerator, InventoryError, enumerate};
 pub use pairing::{

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(rustdoc::bare_urls)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+mod channel_pool;
 mod channel_registry;
 pub mod host_switch;
 mod mappings;
@@ -33,6 +34,7 @@ pub mod thumbwheel;
 pub mod write;
 
 pub use backlight::{BacklightMode, BacklightState, BacklightStatus};
+pub use channel_pool::ChannelPool;
 pub use channel_registry::ChannelRegistry;
 pub use gesture::{
     CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -45,7 +45,9 @@ pub use hires_wheel::{
     get_scroll_wheel_mode_on, set_scroll_inversion, set_scroll_inversion_on, set_scroll_resolution,
     set_scroll_resolution_on, set_scroll_wheel_mode, set_scroll_wheel_mode_on,
 };
-pub use host_switch::{HostSwitchError, run_host_switch_session};
+pub use host_switch::{
+    HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
+};
 pub use hotplug::{HotplugEvent, watch_hotplug};
 pub use inventory::{Enumerator, InventoryError, enumerate};
 pub use pairing::{

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -30,6 +30,7 @@ pub use hidpp_reprog::{
     ControlId, GroupMask, RawWheelResolution, ReprogControlsCapabilities, ReprogControlsEvent,
     TaskId, decode_event as decode_full_event,
 };
+pub use hidpp_reprog::{control_ids, task_ids};
 
 /// `ReprogControlsV4` HID++ feature ID.
 pub const FEATURE_ID: u16 = 0x1b04;

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -73,6 +73,33 @@ pub const BOLT_PIDS: &[u16] = &[0xc548];
 pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532];
 
 impl DeviceRoute {
+    /// Whether two receiver routes use the same physical HID transport.
+    /// Direct routes cannot prove identity because they carry only VID/PID.
+    #[must_use]
+    pub fn shares_transport(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Bolt {
+                    receiver_uid: left, ..
+                },
+                Self::Bolt {
+                    receiver_uid: right,
+                    ..
+                },
+            )
+            | (
+                Self::Unifying {
+                    receiver_uid: left, ..
+                },
+                Self::Unifying {
+                    receiver_uid: right,
+                    ..
+                },
+            ) => left.eq_ignore_ascii_case(right),
+            _ => false,
+        }
+    }
+
     /// The HID++ device index features are addressed at for this route: the
     /// pairing slot for a Bolt device, the self-index for a direct one.
     #[must_use]

--- a/crates/openlogi-hid/src/write/shared.rs
+++ b/crates/openlogi-hid/src/write/shared.rs
@@ -39,9 +39,6 @@ impl SharedChannel {
         self.route == *route
     }
 
-    pub(crate) fn same_channel(&self, channel: &Arc<HidppChannel>) -> bool {
-        Arc::ptr_eq(&self.channel, channel)
-    }
 
     pub(crate) fn channel(&self) -> &Arc<HidppChannel> {
         &self.channel

--- a/crates/openlogi-hid/src/write/shared.rs
+++ b/crates/openlogi-hid/src/write/shared.rs
@@ -39,6 +39,10 @@ impl SharedChannel {
         self.route == *route
     }
 
+    pub(crate) fn same_channel(&self, channel: &Arc<HidppChannel>) -> bool {
+        Arc::ptr_eq(&self.channel, channel)
+    }
+
     pub(crate) fn channel(&self) -> &Arc<HidppChannel> {
         &self.channel
     }

--- a/crates/openlogi-hid/src/write/shared.rs
+++ b/crates/openlogi-hid/src/write/shared.rs
@@ -39,7 +39,6 @@ impl SharedChannel {
         self.route == *route
     }
 
-
     pub(crate) fn channel(&self) -> &Arc<HidppChannel> {
         &self.channel
     }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -32,6 +32,11 @@ MX Master 4):
   RGB keyboards.
 - `gesture_owner` — which button owns the gesture role, when chosen
   explicitly (otherwise inferred).
+- `host_switch_targets` — on a compatible keyboard, physical config keys of
+  mice that should follow its Easy-Switch channel. Both devices must already
+  be paired on corresponding channels. The keyboard's host controls and every
+  target must expose the HID++ features needed for host switching. Configure
+  the link on every computer from which the keyboard may initiate a switch.
 
 The app-wide `[app_settings]` block holds `launch_at_login`,
 `check_for_updates`, and `auto_install_updates` (all off by default);
@@ -65,6 +70,12 @@ appearance = "system"
 
 [devices.2b042]
 dpi_presets = [800, 1600, 3200]
+
+# Put this on the keyboard's physical device entry. Values are the physical
+# keys of the mice that should follow it; use the exact keys already present
+# under [devices] in your generated config.
+[devices."receiver:aabbccdd:slot:1"]
+host_switch_targets = ["receiver:aabbccdd:slot:2"]
 
 [devices.2b042.bindings]
 Back = "BrowserBack"


### PR DESCRIPTION
## Summary

  Add keyboard-initiated Easy-Switch synchronization for linked Logitech pointing devices.

  When an Easy-Switch key is pressed on a compatible keyboard, OpenLogi switches every configured pointing device to the corresponding host channel before switching the keyboard. This allows the
  configured devices to move together between hosts.

  Implementing this feature also exposed a HID++ capture lifecycle issue: a device returning after an Easy-Switch transition retained its route but did not restart capture. The capture target now
  follows the device's online state without resetting its DPI-cycle position.

  ## Changes

  - `openlogi-core`
    - Add `host_switch_targets` to the per-device TOML configuration.
    - Support serialization and deserialization of physical target device keys.

  - `openlogi-hid`
    - Detect host-switch controls exposed through HID++ reprogrammable controls.
    - Support diverted-control and analytics-event reporting modes.
    - Switch configured pointing devices before switching the initiating keyboard.
    - Reuse the receiver channel when linked devices share a Bolt or Unifying receiver.
    - Restore temporarily modified control reporting when the session ends.

  - `openlogi-agent-core`
    - Resolve configured host-switch links against the current device inventory.
    - Rebuild links when the configuration or device availability changes.
    - Require the initiating keyboard to be online while preserving routes for sleeping target devices.
    - Restart HID++ capture when a device returns without resetting its DPI-cycle position.
    - Ignore missing targets and empty link configurations.
    - Add coverage for host-switch links and capture lifecycle transitions.

  - Documentation
    - Document `host_switch_targets` and provide a TOML configuration example.

  ## Testing

  Automated verification:

  - `devenv tasks run openlogi:check`

  OpenLogi hardware testing was performed on Linux using the OpenLogi 0.6.22 RPM package with:

  - MX Master 3S, firmware 22.1.6, linked to an MX Mechanical, firmware 71.3.21.
  - MX Master 3S, firmware 22.1.6, linked to an MX Mechanical Mini, firmware 72.3.14.

  Both combinations were tested with the new host-switch synchronization functionality.

  Cross-agent behavior was additionally checked using the official Logi Options+ 2.5 client:

  - Windows with a Bolt receiver.
  - macOS over Bluetooth.

  These checks confirmed that the devices can switch between corresponding host channels regardless of which agent manages them. OpenLogi itself was not runtime-tested on Windows or macOS as part
  of this change.

  ## Known limitations

  - Older keyboard firmware may not expose the HID++ controls or events required by this feature.
  - Every linked device must already be paired with the corresponding channel on each host.
  - The host-switch link must be configured on every computer from which the keyboard can initiate a switch.
  
  ## Note
  
  Depends on #453 for the online-aware input capture selection behavior. This branch will be rebased onto master after that PR merges, then re-tested before being marked ready for review.