### PR TITLE
fix: allow local dev without devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,6 @@
-eval "$(devenv direnvrc)"
-use devenv
+if has devenv; then
+  eval "$(devenv direnvrc)"
+  use devenv
+else
+  echo "devenv not found; using system toolchain (see docs/DEVELOPMENT.md)"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,28 +39,37 @@ sits beneath both.
 
 ## Build, run, verify
 
-The toolchain lives in a devenv (Nix) shell — **cargo is not on the bare PATH**. Run
-everything through direnv from the repo root, including git (the hooks need cargo):
+Nix/devenv is optional. rustup + `rust-toolchain.toml` is enough. If devenv is
+installed, direnv loads it; otherwise `.envrc` prints a notice and leaves PATH
+alone — use system `cargo`.
+
+With devenv active, cargo may only be on PATH inside the shell; run commands
+from the repo root (or via `direnv exec . …`), including git (hooks need cargo):
 
 ```sh
+cargo clippy --workspace --all-targets -- -D warnings
+# or, when cargo is only inside devenv:
 direnv exec . cargo clippy --workspace --all-targets -- -D warnings
 direnv exec . git commit …
 ```
 
-- Full local gate (same as CI): `devenv tasks run openlogi:check` = `fmt --check` +
-  `clippy -D warnings` + workspace tests. It must pass before every commit.
+- Full local gate (same as CI): `cargo fmt --all -- --check` +
+  `cargo clippy --workspace --all-targets -- -D warnings` +
+  `cargo test --workspace` (or `devenv tasks run openlogi:check`). It must pass
+  before every commit.
 - prek hooks (`prek.toml`): `cargo fmt` at commit; full-workspace clippy at push
   (rust-scoped, so non-Rust pushes skip it).
-- The macOS GUI build needs full Xcode for GPUI's Metal shaders; devenv sets
-  `DEVELOPER_DIR`/`SDKROOT`. If the shader compile fails, `direnv reload` first.
+- The macOS GUI build needs full Xcode for GPUI's Metal shaders. devenv sets
+  `DEVELOPER_DIR`/`SDKROOT` when present; without it, use system Xcode. If the
+  shader compile fails under devenv, `direnv reload` first.
 - Dev-run the app with `cargo run -p openlogi-gui` — a cargo runner wraps it into
   `target/dev/OpenLogi.app`. `cargo build` does NOT refresh that bundle, and a second
   instance exits on the singleton lock: quit the old instance and re-`run` before
   judging a UI change "not applied".
 - macOS-green proves nothing about cfg-gated code. CI's linux/windows jobs are the
   authoritative check (`RUSTFLAGS=-D warnings` globally, so plain warnings fail too);
-  `devenv tasks run openlogi:check-windows` cross-lints the ring-free subset locally.
-  Don't claim cross-platform success without CI.
+  with devenv, `devenv tasks run openlogi:check-windows` cross-lints the ring-free
+  subset locally. Don't claim cross-platform success without CI.
 
 ## Rust standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ sits beneath both.
 Nix/devenv is optional — rustup + `rust-toolchain.toml` is enough. If devenv is
 installed, direnv loads it; otherwise `.envrc` prints a notice and leaves PATH
 alone so system `cargo` works. With devenv active, cargo may only be on PATH
-inside the shell — run from the repo root (or `direnv exec . …`), including git
-(the hooks need cargo):
+inside the shell — run from the repo root (or `direnv exec . …`), including
+git (the hooks need cargo):
 
 ```sh
 cargo clippy --workspace --all-targets -- -D warnings
@@ -54,17 +54,17 @@ direnv exec . git commit …
 
 - Full local gate (same as CI): `cargo fmt --all -- --check` +
   `cargo clippy --workspace --all-targets -- -D warnings` +
-  `cargo test --workspace` (or `devenv tasks run openlogi:check`). Must pass
-  before every commit.
+  `cargo test --workspace` (or `devenv tasks run openlogi:check`). Must
+  pass before every commit.
 - prek hooks (`prek.toml`): `cargo fmt` at commit; full-workspace clippy at push
   (rust-scoped, so non-Rust pushes skip it).
 - The macOS GUI build needs full Xcode for GPUI's Metal shaders. devenv sets
   `DEVELOPER_DIR`/`SDKROOT` when present; without it, use system Xcode. If the
   shader compile fails under devenv, `direnv reload` first.
-- Dev-run the app with `cargo run -p openlogi-gui` — a cargo runner wraps it into
-  `target/dev/OpenLogi.app`. `cargo build` does NOT refresh that bundle, and a
-  second instance exits on the singleton lock: quit the old instance and re-`run`
-  before judging a UI change "not applied".
+- Dev-run the app with `cargo run -p openlogi-gui` — a cargo runner wraps it
+  into `target/dev/OpenLogi.app`. `cargo build` does NOT refresh that bundle,
+  and a second instance exits on the singleton lock: quit the old instance and
+  re-`run` before judging a UI change "not applied".
 - macOS-green proves nothing about cfg-gated code. CI's linux/windows jobs are the
   authoritative check (`RUSTFLAGS=-D warnings` globally, so plain warnings fail
   too); with devenv, `devenv tasks run openlogi:check-windows` cross-lints the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,23 +39,22 @@ sits beneath both.
 
 ## Build, run, verify
 
-Nix/devenv is optional. rustup + `rust-toolchain.toml` is enough. If devenv is
+Nix/devenv is optional — rustup + `rust-toolchain.toml` is enough. If devenv is
 installed, direnv loads it; otherwise `.envrc` prints a notice and leaves PATH
-alone — use system `cargo`.
-
-With devenv active, cargo may only be on PATH inside the shell; run commands
-from the repo root (or via `direnv exec . …`), including git (hooks need cargo):
+alone so system `cargo` works. With devenv active, cargo may only be on PATH
+inside the shell — run from the repo root (or `direnv exec . …`), including git
+(the hooks need cargo):
 
 ```sh
 cargo clippy --workspace --all-targets -- -D warnings
-# or, when cargo is only inside devenv:
+# when cargo is only inside devenv:
 direnv exec . cargo clippy --workspace --all-targets -- -D warnings
 direnv exec . git commit …
 ```
 
 - Full local gate (same as CI): `cargo fmt --all -- --check` +
   `cargo clippy --workspace --all-targets -- -D warnings` +
-  `cargo test --workspace` (or `devenv tasks run openlogi:check`). It must pass
+  `cargo test --workspace` (or `devenv tasks run openlogi:check`). Must pass
   before every commit.
 - prek hooks (`prek.toml`): `cargo fmt` at commit; full-workspace clippy at push
   (rust-scoped, so non-Rust pushes skip it).
@@ -63,13 +62,13 @@ direnv exec . git commit …
   `DEVELOPER_DIR`/`SDKROOT` when present; without it, use system Xcode. If the
   shader compile fails under devenv, `direnv reload` first.
 - Dev-run the app with `cargo run -p openlogi-gui` — a cargo runner wraps it into
-  `target/dev/OpenLogi.app`. `cargo build` does NOT refresh that bundle, and a second
-  instance exits on the singleton lock: quit the old instance and re-`run` before
-  judging a UI change "not applied".
+  `target/dev/OpenLogi.app`. `cargo build` does NOT refresh that bundle, and a
+  second instance exits on the singleton lock: quit the old instance and re-`run`
+  before judging a UI change "not applied".
 - macOS-green proves nothing about cfg-gated code. CI's linux/windows jobs are the
-  authoritative check (`RUSTFLAGS=-D warnings` globally, so plain warnings fail too);
-  with devenv, `devenv tasks run openlogi:check-windows` cross-lints the ring-free
-  subset locally. Don't claim cross-platform success without CI.
+  authoritative check (`RUSTFLAGS=-D warnings` globally, so plain warnings fail
+  too); with devenv, `devenv tasks run openlogi:check-windows` cross-lints the
+  ring-free subset locally. Don't claim cross-platform success without CI.
 
 ## Rust standards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,1 @@
-@AGENTS.md
-
-## Claude Code specifics
-
-- Path-scoped deep rules live in `.claude/rules/` and load automatically when you touch
-  matching files; the index is at the bottom of AGENTS.md.
-- GPUI and gpui-component reference skills may be present locally under `.agents/skills/`
-  (`gpui`, `gpui-component`, `gpui-entity`, `gpui-layout-and-style`, …; gitignored,
-  per-developer). When they are available, consult them for GUI work instead of guessing
-  gpui APIs from training data — the gpui pin moves and APIs drift.
-- `crates/openlogi-gui/src/platform/CLAUDE.md` imports that directory's `AGENTS.md`
-  (the macOS ObjC FFI contract) when you work in that subtree.
+AGENTS.md

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,19 +15,51 @@ build instructions, see the [README](../README.md).
 
 ## Building from source
 
-CLI:
+Nix/devenv is optional. A normal Rust toolchain is enough.
+
+### Without Nix
 
 ```sh
+# rustup installs the stable toolchain pinned in rust-toolchain.toml
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# macOS: full Xcode 16+ with the Metal Toolchain (not only Command Line Tools)
+# Linux: see system libraries under Toolchain above
+# optional helpers: brew install cmake create-dmg sccache
 git clone https://github.com/AprilNEA/OpenLogi
 cd OpenLogi
 cargo run -p openlogi --release -- list
-```
-
-Desktop app:
-
-```sh
 cargo run -p openlogi-gui --release
 ```
+
+If you use [direnv](https://direnv.net) without devenv installed, `.envrc`
+prints a notice and leaves your shell alone. Install rustup/cargo yourself
+and keep working.
+
+### With devenv (optional)
+
+`devenv.nix` provisions sccache, the stable Rust toolchain, packaging helpers,
+and the macOS env overrides GPUI needs (`DEVELOPER_DIR` / `SDKROOT`). Tasks:
+
+```sh
+devenv tasks run openlogi:gui      # run the desktop app
+devenv tasks run openlogi:check    # fmt + clippy + tests (run before committing)
+devenv tasks run openlogi:dmg      # build the macOS DMG
+devenv tasks run openlogi:i18n-upload    # upload English source strings to Crowdin
+devenv tasks run openlogi:i18n-download  # download translations and run i18n tests
+```
+
+After a `devenv.nix` change, reload direnv so the new env takes effect:
+
+```sh
+direnv reload    # or: exit your shell and `cd` back in
+```
+
+Without that, GPUI's `gpui_macos` build script can't find Apple's `metal`
+shader compiler, and link errors about missing `_write` / `_sysconf` /
+`_waitpid` symbols show up because the Nix `apple-sdk-14.4` stub doesn't
+expose `libSystem` the way Apple's real linker wants.
+
+### Dev app bundle (macOS)
 
 On macOS the desktop binary is launched from inside a throwaway
 `target/dev/OpenLogi.app` — a Cargo `runner` wired in `.cargo/config.toml`
@@ -45,33 +77,6 @@ To install the CLI binary on `PATH`:
 ```sh
 cargo install --path .
 ```
-
-## Using devenv (macOS)
-
-The repo's `devenv.nix` provisions a Nix-based dev shell with sccache, the
-stable Rust toolchain, and the env overrides GPUI needs. It exposes tasks that
-mirror CI and packaging:
-
-```sh
-devenv tasks run openlogi:gui      # run the desktop app
-devenv tasks run openlogi:check    # fmt + clippy + tests (run before committing)
-devenv tasks run openlogi:dmg      # build the macOS DMG
-devenv tasks run openlogi:i18n-upload    # upload English source strings to Crowdin
-devenv tasks run openlogi:i18n-download  # download translations and run i18n tests
-```
-
-The first time you `cd` into the repo after pulling a change to `devenv.nix`,
-**reload direnv** so the new env vars (`DEVELOPER_DIR`, `SDKROOT`, the PATH
-filter that strips Nix's `xcbuild` xcrun stub) take effect:
-
-```sh
-direnv reload    # or: exit your shell and `cd` back in
-```
-
-Without that, GPUI's `gpui_macos` build script can't find Apple's `metal`
-shader compiler, and link errors about missing `_write` / `_sysconf` /
-`_waitpid` symbols show up because the Nix `apple-sdk-14.4` stub doesn't
-expose `libSystem` the way Apple's real linker wants.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary
Stop direnv from failing when Nix/devenv is not installed. Document rustup as a supported contributor path; devenv stays optional.

## Changes
- `.envrc`: load devenv only when present
- `docs/DEVELOPMENT.md`: without-Nix bootstrap + optional devenv section
- `AGENTS.md`: treat devenv as optional

## Testing
- `direnv allow .` then `direnv exec . bash -c 'echo OK'` with no devenv → notice + success
- no code/CI changes