### PR TITLE
fix(deps): drop vulnerable opentelemetry_sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,7 +1726,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4451,7 +4451,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5208,38 +5208,22 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
-]
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "option-ext"
@@ -7300,8 +7284,6 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tarpc"
 version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cb86a4b5b941909e9896289c01b46ff0bec756b01f366b0d5490a5e8ed7871"
 dependencies = [
  "anyhow",
  "fnv",
@@ -7771,14 +7753,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
- "opentelemetry_sdk",
  "tracing",
  "tracing-core",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,15 @@ doc_markdown = "allow"
 lto = "fat"
 codegen-units = 1
 strip = "symbols"
+
+# tarpc 0.37 hard-pins opentelemetry 0.30 / tracing-opentelemetry 0.31, which
+# pulls vulnerable opentelemetry_sdk 0.30 (GHSA-w9wp-h8wv-79jx, fixed in
+# 0.32.1). Dependabot cannot bump it alone: the fixed SDK is semver-incompatible
+# with tarpc's pins, and no crates.io tarpc release allows the 0.32 line yet.
+# Patch a 0.37-compatible tree onto otel 0.32 / tracing-opentelemetry 0.33 so
+# opentelemetry_sdk drops out of the runtime graph. Remove when upstream tarpc
+# depends on tracing-opentelemetry >= 0.32.1 (or otherwise sheds the vulnerable
+# SDK). See third_party/tarpc/README.md.
+[patch.crates-io]
+tarpc = { path = "third_party/tarpc" }
+

--- a/third_party/tarpc/Cargo.toml
+++ b/third_party/tarpc/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "tarpc"
+version = "0.37.0"
+rust-version = "1.65.0"
+authors = [
+    "Adam Wright <adam.austin.wright@gmail.com>",
+    "Tim Kuehn <timothy.j.kuehn@gmail.com>",
+]
+edition = "2021"
+license = "MIT"
+documentation = "https://docs.rs/tarpc"
+homepage = "https://github.com/google/tarpc"
+repository = "https://github.com/google/tarpc"
+keywords = ["rpc", "network", "server", "api", "microservices"]
+categories = ["asynchronous", "network-programming"]
+readme = "README.md"
+description = "An RPC framework for Rust with a focus on ease of use."
+
+[features]
+default = []
+
+serde1 = ["tarpc-plugins/serde1", "serde", "serde/derive", "serde/rc"]
+tokio1 = ["tokio/rt"]
+serde-transport = ["serde1", "tokio1", "tokio-serde", "tokio-util/codec"]
+serde-transport-json = ["serde-transport", "tokio-serde/json"]
+serde-transport-bincode = ["serde-transport", "tokio-serde/bincode"]
+tcp = ["tokio/net"]
+unix = ["tokio/net"]
+
+full = [
+    "serde1",
+    "tokio1",
+    "serde-transport",
+    "serde-transport-json",
+    "serde-transport-bincode",
+    "tcp",
+    "unix",
+]
+
+[dependencies]
+anyhow = "1.0"
+fnv = "1.0"
+futures = "0.3"
+humantime = "2.0"
+pin-project = "1.0"
+rand = "0.8"
+serde = { optional = true, version = "1.0", features = ["derive"] }
+static_assertions = "1.1.0"
+tarpc-plugins = "0.14"
+thiserror = "2.0"
+tokio = { version = "1", features = ["time"] }
+tokio-util = { version = "0.7.3", features = ["time"] }
+tokio-serde = { optional = true, version = "0.9" }
+tracing = { version = "0.1", default-features = false, features = [
+    "attributes",
+    "log",
+] }
+tracing-opentelemetry = { version = "0.33", default-features = false }
+opentelemetry = { version = "0.32", default-features = false }
+opentelemetry-semantic-conventions = "0.32"
+

--- a/third_party/tarpc/LICENSE
+++ b/third_party/tarpc/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third_party/tarpc/README.md
+++ b/third_party/tarpc/README.md
@@ -1,0 +1,39 @@
+# Vendored tarpc (temporary security pin)
+
+This is google/tarpc **0.37.0** with a minimal dependency bump so OpenLogi no
+longer pulls the vulnerable `opentelemetry_sdk` 0.30 line
+([GHSA-w9wp-h8wv-79jx](https://github.com/advisories/GHSA-w9wp-h8wv-79jx) /
+CVE-2026-48504).
+
+## Why
+
+`tarpc` 0.37 on crates.io hard-depends on:
+
+- `opentelemetry ^0.30`
+- `tracing-opentelemetry ^0.31`
+
+`tracing-opentelemetry` 0.31 has a normal dependency on `opentelemetry_sdk
+^0.30`. The patched SDK is `0.32.1`, which is semver-incompatible with that
+range, so Dependabot reports `security_update_not_possible`.
+
+Upstream has not shipped a release that allows the 0.32 line yet (crates.io is
+still 0.37.0 / otel 0.30; `main` is only on otel 0.31). See
+[google/tarpc#564](https://github.com/google/tarpc/issues/564) and the open
+Dependabot bumps on that repo.
+
+## Delta from crates.io 0.37.0
+
+1. `Cargo.toml`: `opentelemetry` / `opentelemetry-semantic-conventions` → 0.32,
+   `tracing-opentelemetry` → 0.33 (0.33 no longer depends on
+   `opentelemetry_sdk` at runtime — it is dev-only).
+2. `src/context.rs`: ignore the `Result` from `OpenTelemetrySpanExt::set_parent`
+   (return type changed in `tracing-opentelemetry` 0.32+).
+
+No tarpc API used by OpenLogi was changed.
+
+## Remove this vendor when
+
+A crates.io `tarpc` release depends on `tracing-opentelemetry` ≥ 0.32.1 (or
+otherwise no longer pulls `opentelemetry_sdk` < 0.32.1). Then drop
+`[patch.crates-io].tarpc` from the workspace `Cargo.toml` and delete this
+directory.

--- a/third_party/tarpc/src/cancellations.rs
+++ b/third_party/tarpc/src/cancellations.rs
@@ -1,0 +1,49 @@
+use futures::{prelude::*, task::*};
+use std::pin::Pin;
+use tokio::sync::mpsc;
+
+/// Sends request cancellation signals.
+#[derive(Debug, Clone)]
+pub struct RequestCancellation(mpsc::UnboundedSender<u64>);
+
+/// A stream of IDs of requests that have been canceled.
+#[derive(Debug)]
+pub struct CanceledRequests(mpsc::UnboundedReceiver<u64>);
+
+/// Returns a channel to send request cancellation messages.
+pub fn cancellations() -> (RequestCancellation, CanceledRequests) {
+    // Unbounded because messages are sent in the drop fn. This is fine, because it's still
+    // bounded by the number of in-flight requests.
+    let (tx, rx) = mpsc::unbounded_channel();
+    (RequestCancellation(tx), CanceledRequests(rx))
+}
+
+impl RequestCancellation {
+    /// Cancels the request with ID `request_id`.
+    ///
+    /// No validation is done of `request_id`. There is no way to know if the request id provided
+    /// corresponds to a request actually tracked by the backing channel. `RequestCancellation` is
+    /// a one-way communication channel.
+    ///
+    /// Once request data is cleaned up, a response will never be received by the client. This is
+    /// useful primarily when request processing ends prematurely for requests with long deadlines
+    /// which would otherwise continue to be tracked by the backing channel—a kind of leak.
+    pub fn cancel(&self, request_id: u64) {
+        let _ = self.0.send(request_id);
+    }
+}
+
+impl CanceledRequests {
+    /// Polls for a cancelled request.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<u64>> {
+        self.0.poll_recv(cx)
+    }
+}
+
+impl Stream for CanceledRequests {
+    type Item = u64;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<u64>> {
+        self.poll_recv(cx)
+    }
+}

--- a/third_party/tarpc/src/client.rs
+++ b/third_party/tarpc/src/client.rs
@@ -1,0 +1,1162 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a client that connects to a server and sends multiplexed requests.
+
+mod in_flight_requests;
+pub mod stub;
+
+use crate::{
+    cancellations::{cancellations, CanceledRequests, RequestCancellation},
+    context, trace,
+    util::TimeUntil,
+    ChannelError, ClientMessage, Request, RequestName, Response, ServerError, Transport,
+};
+use futures::{prelude::*, ready, stream::Fuse, task::*};
+use in_flight_requests::InFlightRequests;
+use pin_project::pin_project;
+use std::{
+    any::Any,
+    convert::TryFrom,
+    fmt,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::SystemTime,
+};
+use tokio::sync::{mpsc, oneshot};
+use tracing::Span;
+
+/// Settings that control the behavior of the client.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Config {
+    /// The number of requests that can be in flight at once.
+    /// `max_in_flight_requests` controls the size of the map used by the client
+    /// for storing pending requests.
+    pub max_in_flight_requests: usize,
+    /// The number of requests that can be buffered client-side before being sent.
+    /// `pending_requests_buffer` controls the size of the channel clients use
+    /// to communicate with the request dispatch task.
+    pub pending_request_buffer: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            max_in_flight_requests: 1_000,
+            pending_request_buffer: 100,
+        }
+    }
+}
+
+/// A channel and dispatch pair. The dispatch drives the sending and receiving of requests
+/// and must be polled continuously or spawned.
+pub struct NewClient<C, D> {
+    /// The new client.
+    pub client: C,
+    /// The client's dispatch.
+    pub dispatch: D,
+}
+
+impl<C, D, E> NewClient<C, D>
+where
+    D: Future<Output = Result<(), E>> + Send + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    /// Helper method to spawn the dispatch on the default executor.
+    #[cfg(feature = "tokio1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
+    pub fn spawn(self) -> C {
+        let dispatch = self.dispatch.unwrap_or_else(move |e| {
+            let e = anyhow::Error::new(e);
+            tracing::warn!("Connection broken: {:?}", e);
+        });
+        tokio::spawn(dispatch);
+        self.client
+    }
+}
+
+impl<C, D> fmt::Debug for NewClient<C, D> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "NewClient")
+    }
+}
+
+const _CHECK_USIZE: () = assert!(
+    std::mem::size_of::<usize>() <= std::mem::size_of::<u64>(),
+    "usize is too big to fit in u64"
+);
+
+/// Handles communication from the client to request dispatch.
+#[derive(Debug)]
+pub struct Channel<Req, Resp> {
+    to_dispatch: mpsc::Sender<DispatchRequest<Req, Resp>>,
+    /// Channel to send a cancel message to the dispatcher.
+    cancellation: RequestCancellation,
+    /// The ID to use for the next request to stage.
+    next_request_id: Arc<AtomicUsize>,
+}
+
+impl<Req, Resp> Clone for Channel<Req, Resp> {
+    fn clone(&self) -> Self {
+        Self {
+            to_dispatch: self.to_dispatch.clone(),
+            cancellation: self.cancellation.clone(),
+            next_request_id: self.next_request_id.clone(),
+        }
+    }
+}
+
+impl<Req, Resp> Channel<Req, Resp>
+where
+    Req: RequestName,
+{
+    /// Sends a request to the dispatch task to forward to the server, returning a [`Future`] that
+    /// resolves to the response.
+    #[tracing::instrument(
+        name = "RPC",
+        skip(self, ctx, request),
+        fields(
+            rpc.trace_id = tracing::field::Empty,
+            rpc.deadline = %humantime::format_rfc3339(SystemTime::now() + ctx.deadline.time_until()),
+            otel.kind = "client",
+            otel.name = %request.name())
+        )]
+    pub async fn call(&self, mut ctx: context::Context, request: Req) -> Result<Resp, RpcError> {
+        let span = Span::current();
+        ctx.trace_context = trace::Context::try_from(&span).unwrap_or_else(|_| {
+            tracing::trace!(
+                "OpenTelemetry subscriber not installed; making unsampled child context."
+            );
+            ctx.trace_context.new_child()
+        });
+        span.record("rpc.trace_id", tracing::field::display(ctx.trace_id()));
+        let (response_completion, mut response) = oneshot::channel();
+        let request_id =
+            u64::try_from(self.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();
+
+        // ResponseGuard impls Drop to cancel in-flight requests. It should be created before
+        // sending out the request; otherwise, the response future could be dropped after the
+        // request is sent out but before ResponseGuard is created, rendering the cancellation
+        // logic inactive.
+        let response_guard = ResponseGuard {
+            response: &mut response,
+            request_id,
+            cancellation: &self.cancellation,
+            cancel: true,
+        };
+        self.to_dispatch
+            .send(DispatchRequest {
+                ctx,
+                span,
+                request_id,
+                request,
+                response_completion,
+            })
+            .await
+            .map_err(|mpsc::error::SendError(_)| RpcError::Shutdown)?;
+        response_guard.response().await
+    }
+}
+
+/// A server response that is completed by request dispatch when the corresponding response
+/// arrives off the wire.
+struct ResponseGuard<'a, Resp> {
+    response: &'a mut oneshot::Receiver<Result<Resp, RpcError>>,
+    cancellation: &'a RequestCancellation,
+    request_id: u64,
+    cancel: bool,
+}
+
+/// An error that can occur in the processing of an RPC. This is not request-specific errors but
+/// rather cross-cutting errors that can always occur.
+#[derive(thiserror::Error, Debug)]
+pub enum RpcError {
+    /// The client disconnected from the server.
+    #[error("the connection to the server was already shutdown")]
+    Shutdown,
+    /// The client failed to buffer the request in the underlying transport.
+    #[error("the client failed to buffer the request in the underlying transport")]
+    Send(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    /// The channel was disconnected due to a critical error.
+    #[error("the channel was disconnected due to a critical error")]
+    Channel(#[source] ChannelError<dyn std::error::Error + Send + Sync + 'static>),
+    /// The request exceeded its deadline.
+    #[error("the request exceeded its deadline")]
+    DeadlineExceeded,
+    /// The server aborted request processing.
+    #[error("the server aborted request processing")]
+    Server(#[from] ServerError),
+}
+
+impl<Resp> ResponseGuard<'_, Resp> {
+    async fn response(mut self) -> Result<Resp, RpcError> {
+        let response = (&mut self.response).await;
+        // Cancel drop logic once a response has been received.
+        self.cancel = false;
+        match response {
+            Ok(response) => response,
+            Err(oneshot::error::RecvError { .. }) => {
+                // The oneshot is Canceled when the dispatch task ends. In that case,
+                // there's nothing listening on the other side, so there's no point in
+                // propagating cancellation.
+                Err(RpcError::Shutdown)
+            }
+        }
+    }
+}
+
+// Cancels the request when dropped, if not already complete.
+impl<Resp> Drop for ResponseGuard<'_, Resp> {
+    fn drop(&mut self) {
+        // The receiver needs to be closed to handle the edge case that the request has not
+        // yet been received by the dispatch task. It is possible for the cancel message to
+        // arrive before the request itself, in which case the request could get stuck in the
+        // dispatch map forever if the server never responds (e.g. if the server dies while
+        // responding). Even if the server does respond, it will have unnecessarily done work
+        // for a client no longer waiting for a response. To avoid this, the dispatch task
+        // checks if the receiver is closed before inserting the request in the map. By
+        // closing the receiver before sending the cancel message, it is guaranteed that if the
+        // dispatch task misses an early-arriving cancellation message, then it will see the
+        // receiver as closed.
+        self.response.close();
+        if self.cancel {
+            self.cancellation.cancel(self.request_id);
+        }
+    }
+}
+
+/// Returns a channel and dispatcher that manages the lifecycle of requests initiated by the
+/// channel.
+pub fn new<Req, Resp, C>(
+    config: Config,
+    transport: C,
+) -> NewClient<Channel<Req, Resp>, RequestDispatch<Req, Resp, C>>
+where
+    C: Transport<ClientMessage<Req>, Response<Resp>>,
+{
+    let (to_dispatch, pending_requests) = mpsc::channel(config.pending_request_buffer);
+    let (cancellation, canceled_requests) = cancellations();
+
+    NewClient {
+        client: Channel {
+            to_dispatch,
+            cancellation,
+            next_request_id: Arc::new(AtomicUsize::new(0)),
+        },
+        dispatch: RequestDispatch {
+            config,
+            canceled_requests,
+            transport: transport.fuse(),
+            in_flight_requests: InFlightRequests::default(),
+            pending_requests,
+            terminal_error: None,
+        },
+    }
+}
+
+/// Handles the lifecycle of requests, writing requests to the wire, managing cancellations,
+/// and dispatching responses to the appropriate channel.
+#[must_use]
+#[pin_project()]
+#[derive(Debug)]
+pub struct RequestDispatch<Req, Resp, C> {
+    /// Writes requests to the wire and reads responses off the wire.
+    #[pin]
+    transport: Fuse<C>,
+    /// Requests waiting to be written to the wire.
+    pending_requests: mpsc::Receiver<DispatchRequest<Req, Resp>>,
+    /// Requests that were dropped.
+    canceled_requests: CanceledRequests,
+    /// Requests already written to the wire that haven't yet received responses.
+    in_flight_requests: InFlightRequests<Result<Resp, RpcError>>,
+    /// Configures limits to prevent unlimited resource usage.
+    config: Config,
+    /// Produces errors that can be sent in response to any unprocessed requests at the time
+    /// RequestDispatch is dropped. Correctness note: this field should only be populated by
+    /// RequestDispatch::poll, which relies on downcasting the Any to a concrete error type
+    /// determined within the poll function.
+    terminal_error: Option<ChannelError<dyn Any + Send + Sync + 'static>>,
+}
+
+impl<Req, Resp, C> RequestDispatch<Req, Resp, C>
+where
+    C: Transport<ClientMessage<Req>, Response<Resp>>,
+{
+    fn in_flight_requests<'a>(
+        self: &'a mut Pin<&mut Self>,
+    ) -> &'a mut InFlightRequests<Result<Resp, RpcError>> {
+        self.as_mut().project().in_flight_requests
+    }
+
+    fn transport_pin_mut<'a>(self: &'a mut Pin<&mut Self>) -> Pin<&'a mut Fuse<C>> {
+        self.as_mut().project().transport
+    }
+
+    fn poll_ready<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), ChannelError<C::Error>>> {
+        self.transport_pin_mut()
+            .poll_ready(cx)
+            .map_err(|e| ChannelError::Ready(Arc::new(e)))
+    }
+
+    fn start_send(self: &mut Pin<&mut Self>, message: ClientMessage<Req>) -> Result<(), C::Error> {
+        self.transport_pin_mut().start_send(message)
+    }
+
+    fn poll_flush<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), ChannelError<C::Error>>> {
+        self.transport_pin_mut()
+            .poll_flush(cx)
+            .map_err(|e| ChannelError::Flush(Arc::new(e)))
+    }
+
+    fn poll_close<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), ChannelError<C::Error>>> {
+        self.transport_pin_mut()
+            .poll_close(cx)
+            .map_err(|e| ChannelError::Close(Arc::new(e)))
+    }
+
+    fn canceled_requests_mut<'a>(self: &'a mut Pin<&mut Self>) -> &'a mut CanceledRequests {
+        self.as_mut().project().canceled_requests
+    }
+
+    fn pending_requests_mut<'a>(
+        self: &'a mut Pin<&mut Self>,
+    ) -> &'a mut mpsc::Receiver<DispatchRequest<Req, Resp>> {
+        self.as_mut().project().pending_requests
+    }
+
+    fn terminal_error_mut<'a>(
+        self: &'a mut Pin<&mut Self>,
+    ) -> &'a mut Option<ChannelError<dyn Any + Send + Sync + 'static>> {
+        self.as_mut().project().terminal_error
+    }
+
+    fn pump_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(), ChannelError<C::Error>>>> {
+        self.transport_pin_mut()
+            .poll_next(cx)
+            .map_err(|e| ChannelError::Read(Arc::new(e)))
+            .map_ok(|response| {
+                self.complete(response);
+            })
+    }
+
+    fn pump_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(), ChannelError<C::Error>>>> {
+        enum ReceiverStatus {
+            Pending,
+            Closed,
+        }
+
+        let pending_requests_status = match self.as_mut().poll_write_request(cx)? {
+            Poll::Ready(Some(())) => return Poll::Ready(Some(Ok(()))),
+            Poll::Ready(None) => ReceiverStatus::Closed,
+            Poll::Pending => ReceiverStatus::Pending,
+        };
+
+        let canceled_requests_status = match self.as_mut().poll_write_cancel(cx)? {
+            Poll::Ready(Some(())) => return Poll::Ready(Some(Ok(()))),
+            Poll::Ready(None) => ReceiverStatus::Closed,
+            Poll::Pending => ReceiverStatus::Pending,
+        };
+
+        // Receiving Poll::Ready(None) when polling expired requests never indicates "Closed",
+        // because there can temporarily be zero in-flight rquests. Therefore, there is no need to
+        // track the status like is done with pending and cancelled requests.
+        if let Poll::Ready(Some(_)) = self
+            .in_flight_requests()
+            .poll_expired(cx, || Err(RpcError::DeadlineExceeded))
+        {
+            // Expired requests are considered complete; there is no compelling reason to send a
+            // cancellation message to the server, since it will have already exhausted its
+            // allotted processing time.
+            return Poll::Ready(Some(Ok(())));
+        }
+
+        match (pending_requests_status, canceled_requests_status) {
+            (ReceiverStatus::Closed, ReceiverStatus::Closed) => {
+                ready!(self.poll_close(cx)?);
+                Poll::Ready(None)
+            }
+            (ReceiverStatus::Pending, _) | (_, ReceiverStatus::Pending) => {
+                // No more messages to process, so flush any messages buffered in the transport.
+                ready!(self.poll_flush(cx)?);
+
+                // Even if we fully-flush, we return Pending, because we have no more requests
+                // or cancellations right now.
+                Poll::Pending
+            }
+        }
+    }
+
+    /// Yields the next pending request, if one is ready to be sent.
+    ///
+    /// Note that a request will only be yielded if the transport is *ready* to be written to (i.e.
+    /// start_send would succeed).
+    ///
+    /// Side effect: will flush the transport if it is full.
+    fn poll_next_request(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<DispatchRequest<Req, Resp>, ChannelError<C::Error>>>> {
+        if self.in_flight_requests().len() >= self.config.max_in_flight_requests {
+            tracing::info!(
+                "At in-flight request capacity ({}/{}).",
+                self.in_flight_requests().len(),
+                self.config.max_in_flight_requests
+            );
+
+            // No need to schedule a wakeup, because timers and responses are responsible
+            // for clearing out in-flight requests.
+            return Poll::Pending;
+        }
+
+        ready!(self.ensure_writeable(cx)?);
+
+        loop {
+            match ready!(self.pending_requests_mut().poll_recv(cx)) {
+                Some(request) => {
+                    if request.response_completion.is_closed() {
+                        let _entered = request.span.enter();
+                        tracing::info!("AbortRequest");
+                        continue;
+                    }
+
+                    return Poll::Ready(Some(Ok(request)));
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+
+    /// Yields the next pending cancellation, and, if one is ready, cancels the associated request.
+    ///
+    /// Note that a request to cancel will only be yielded if the transport is *ready* to be
+    /// written to (i.e. start_send would succeed).
+    ///
+    /// Side effect: will flush the transport if it is full.
+    fn poll_next_cancellation(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(context::Context, Span, u64), ChannelError<C::Error>>>> {
+        ready!(self.ensure_writeable(cx)?);
+
+        loop {
+            match ready!(self.canceled_requests_mut().poll_next_unpin(cx)) {
+                Some(request_id) => {
+                    if let Some((ctx, span)) = self.in_flight_requests().cancel_request(request_id)
+                    {
+                        return Poll::Ready(Some(Ok((ctx, span, request_id))));
+                    }
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+
+    /// Returns Ready if writing a message to the transport (i.e. via write_request or
+    /// write_cancel) would not fail due to a full buffer. If the transport is not ready to be
+    /// written to, flushes it until it is ready.
+    fn ensure_writeable<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(), ChannelError<C::Error>>>> {
+        while self.poll_ready(cx)?.is_pending() {
+            ready!(self.poll_flush(cx)?);
+        }
+        Poll::Ready(Some(Ok(())))
+    }
+
+    /// Polls the next request and, if available, writes it to the transport.
+    ///
+    /// Note that a request will only be polled if the transport is *ready* to be written to (i.e.
+    /// start_send would succeed).
+    ///
+    /// Side effect: will flush the transport if it is full.
+    fn poll_write_request<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(), ChannelError<C::Error>>>> {
+        let DispatchRequest {
+            ctx,
+            span,
+            request_id,
+            request,
+            response_completion,
+        } = match ready!(self.as_mut().poll_next_request(cx)?) {
+            Some(dispatch_request) => dispatch_request,
+            None => return Poll::Ready(None),
+        };
+        let _entered = span.enter();
+        // poll_next_request only returns Ready if there is room to buffer another request.
+        // Therefore, we can call write_request without fear of erroring due to a full
+        // buffer.
+        let request = ClientMessage::Request(Request {
+            id: request_id,
+            message: request,
+            context: context::Context {
+                deadline: ctx.deadline,
+                trace_context: ctx.trace_context,
+            },
+        });
+        self.in_flight_requests()
+            .insert_request(request_id, ctx, span.clone(), response_completion)
+            .expect("Request IDs should be unique");
+        match self.start_send(request) {
+            Ok(()) => tracing::info!("SendRequest"),
+            Err(e) => {
+                self.in_flight_requests()
+                    .complete_request(request_id, Err(RpcError::Send(Box::new(e))));
+            }
+        }
+        Poll::Ready(Some(Ok(())))
+    }
+
+    /// Polls the next cancellation message and, if available, writes it to the transport.
+    ///
+    /// Note that a request will only be polled if the transport is *ready* to be written to (i.e.
+    /// start_send would succeed).
+    ///
+    /// Side effect: will flush the transport if it is full.
+    fn poll_write_cancel<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(), ChannelError<C::Error>>>> {
+        let (context, span, request_id) = match ready!(self.as_mut().poll_next_cancellation(cx)?) {
+            Some(triple) => triple,
+            None => return Poll::Ready(None),
+        };
+        let _entered = span.enter();
+
+        let cancel = ClientMessage::Cancel {
+            trace_context: context.trace_context,
+            request_id,
+        };
+        self.start_send(cancel)
+            .map_err(|e| ChannelError::Write(Arc::new(e)))?;
+        tracing::info!("CancelRequest");
+        Poll::Ready(Some(Ok(())))
+    }
+
+    /// Sends a server response to the client task that initiated the associated request.
+    fn complete(mut self: Pin<&mut Self>, response: Response<Resp>) -> bool {
+        if let Some(span) = self.in_flight_requests().complete_request(
+            response.request_id,
+            response.message.map_err(RpcError::Server),
+        ) {
+            let _entered = span.enter();
+            tracing::info!("ReceiveResponse");
+            return true;
+        }
+        false
+    }
+
+    /// Closes the pending requests channel and completes all pending and in-flight requests with
+    /// the given error.
+    fn shut_down_with_terminal_error(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        e: ChannelError<dyn std::error::Error + Send + Sync + 'static>,
+    ) -> Poll<()> {
+        self.pending_requests_mut().close();
+        for span in self
+            .in_flight_requests()
+            .complete_all_requests(|| Err(RpcError::Channel(e.clone())))
+        {
+            let _entered = span.enter();
+            tracing::warn!("RpcError::Channel");
+        }
+        loop {
+            match ready!(self.pending_requests_mut().poll_recv(cx)) {
+                Some(DispatchRequest {
+                    span,
+                    response_completion,
+                    ..
+                }) => {
+                    let _entered = span.enter();
+                    if response_completion.is_closed() {
+                        tracing::info!("AbortRequest");
+                    } else {
+                        tracing::warn!("RpcError::Channel");
+                        let _ = response_completion.send(Err(RpcError::Channel(e.clone())));
+                    }
+                }
+                None => return Poll::Ready(()),
+            }
+        }
+    }
+
+    fn run<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), ChannelError<C::Error>>> {
+        loop {
+            match (self.as_mut().pump_read(cx)?, self.as_mut().pump_write(cx)?) {
+                (Poll::Ready(None), _) => {
+                    tracing::info!("Shutdown: read half closed, so shutting down.");
+                    return Poll::Ready(Ok(()));
+                }
+                (read, Poll::Ready(None)) => {
+                    if self.in_flight_requests.is_empty() {
+                        tracing::info!("Shutdown: write half closed, and no requests in flight.");
+                        return Poll::Ready(Ok(()));
+                    }
+                    tracing::info!(
+                        "Shutdown: write half closed, and {} requests in flight.",
+                        self.in_flight_requests().len()
+                    );
+                    match read {
+                        Poll::Ready(Some(())) => continue,
+                        _ => return Poll::Pending,
+                    }
+                }
+                (Poll::Ready(Some(())), _) | (_, Poll::Ready(Some(()))) => {}
+                _ => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl<Req, Resp, C> Future for RequestDispatch<Req, Resp, C>
+where
+    C: Transport<ClientMessage<Req>, Response<Resp>>,
+{
+    type Output = Result<(), ChannelError<C::Error>>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), ChannelError<C::Error>>> {
+        loop {
+            if let Some(e) = self.terminal_error_mut() {
+                tracing::info!("RpcError::Channel");
+                let e: ChannelError<C::Error> = e
+                    .clone()
+                    .downcast()
+                    .expect("Invariant: ChannelError must store a C::Error");
+                ready!(self.shut_down_with_terminal_error(cx, e.clone().upcast_error()));
+                return Poll::Ready(Err(e));
+            }
+            let result = ready!(self.run(cx));
+            match result {
+                Ok(()) => return Poll::Ready(Ok(())),
+                Err(e) => *self.terminal_error_mut() = Some(e.upcast_any()),
+            }
+        }
+    }
+}
+
+/// A server-bound request sent from a [`Channel`] to request dispatch, which will then manage
+/// the lifecycle of the request.
+#[derive(Debug)]
+struct DispatchRequest<Req, Resp> {
+    pub ctx: context::Context,
+    pub span: Span,
+    pub request_id: u64,
+    pub request: Req,
+    pub response_completion: oneshot::Sender<Result<Resp, RpcError>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        cancellations, Channel, DispatchRequest, RequestDispatch, ResponseGuard, RpcError,
+    };
+    use crate::{
+        client::{in_flight_requests::InFlightRequests, Config},
+        context::{self, current},
+        transport::{self, channel::UnboundedChannel},
+        ChannelError, ClientMessage, Response,
+    };
+    use assert_matches::assert_matches;
+    use futures::{prelude::*, task::*};
+    use std::{
+        convert::TryFrom,
+        fmt::Display,
+        marker::PhantomData,
+        pin::Pin,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+    use thiserror::Error;
+    use tokio::sync::{
+        mpsc::{self},
+        oneshot,
+    };
+    use tracing::Span;
+
+    #[tokio::test]
+    async fn response_completes_request_future() {
+        let (mut dispatch, mut _channel, mut server_channel) = set_up();
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        let (tx, mut rx) = oneshot::channel();
+
+        dispatch
+            .in_flight_requests
+            .insert_request(0, context::current(), Span::current(), tx)
+            .unwrap();
+        server_channel
+            .send(Response {
+                request_id: 0,
+                message: Ok("Resp".into()),
+            })
+            .await
+            .unwrap();
+        assert_matches!(dispatch.as_mut().poll(cx), Poll::Pending);
+        assert_matches!(rx.try_recv(), Ok(Ok(resp)) if resp == "Resp");
+    }
+
+    #[tokio::test]
+    async fn dispatch_response_cancels_on_drop() {
+        let (cancellation, mut canceled_requests) = cancellations();
+        let (_, mut response) = oneshot::channel();
+        drop(ResponseGuard::<u32> {
+            response: &mut response,
+            cancellation: &cancellation,
+            request_id: 3,
+            cancel: true,
+        });
+        // resp's drop() is run, which should send a cancel message.
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        assert_eq!(canceled_requests.poll_recv(cx), Poll::Ready(Some(3)));
+    }
+
+    #[tokio::test]
+    async fn dispatch_response_doesnt_cancel_after_complete() {
+        let (cancellation, mut canceled_requests) = cancellations();
+        let (tx, mut response) = oneshot::channel();
+        tx.send(Ok(Response {
+            request_id: 0,
+            message: Ok("well done"),
+        }))
+        .unwrap();
+        // resp's drop() is run, but should not send a cancel message.
+        ResponseGuard {
+            response: &mut response,
+            cancellation: &cancellation,
+            request_id: 3,
+            cancel: true,
+        }
+        .response()
+        .await
+        .unwrap();
+        drop(cancellation);
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        assert_eq!(canceled_requests.poll_recv(cx), Poll::Ready(None));
+    }
+
+    #[tokio::test]
+    async fn stage_request() {
+        let (mut dispatch, mut channel, _server_channel) = set_up();
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        let (tx, mut rx) = oneshot::channel();
+
+        let _resp = send_request(&mut channel, "hi", tx, &mut rx).await;
+
+        #[allow(unstable_name_collisions)]
+        let req = dispatch.as_mut().poll_next_request(cx).ready();
+        assert!(req.is_some());
+
+        let req = req.unwrap();
+        assert_eq!(req.request_id, 0);
+        assert_eq!(req.request, "hi".to_string());
+    }
+
+    // Regression test for  https://github.com/google/tarpc/issues/220
+    #[tokio::test]
+    async fn stage_request_channel_dropped_doesnt_panic() {
+        let (mut dispatch, mut channel, mut server_channel) = set_up();
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        let (tx, mut rx) = oneshot::channel();
+
+        let _ = send_request(&mut channel, "hi", tx, &mut rx).await;
+        drop(channel);
+
+        assert!(dispatch.as_mut().poll(cx).is_ready());
+        send_response(
+            &mut server_channel,
+            Response {
+                request_id: 0,
+                message: Ok("hello".into()),
+            },
+        )
+        .await;
+        dispatch.await.unwrap();
+    }
+
+    #[allow(unstable_name_collisions)]
+    #[tokio::test]
+    async fn stage_request_response_future_dropped_is_canceled_before_sending() {
+        let (mut dispatch, mut channel, _server_channel) = set_up();
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        let (tx, mut rx) = oneshot::channel();
+
+        let _ = send_request(&mut channel, "hi", tx, &mut rx).await;
+
+        // Drop the channel so polling returns none if no requests are currently ready.
+        drop(channel);
+        // Test that a request future dropped before it's processed by dispatch will cause the request
+        // to not be added to the in-flight request map.
+        assert!(dispatch.as_mut().poll_next_request(cx).ready().is_none());
+    }
+
+    #[allow(unstable_name_collisions)]
+    #[tokio::test]
+    async fn stage_request_response_future_dropped_is_canceled_after_sending() {
+        let (mut dispatch, mut channel, _server_channel) = set_up();
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        let (tx, mut rx) = oneshot::channel();
+
+        let req = send_request(&mut channel, "hi", tx, &mut rx).await;
+
+        assert!(dispatch.as_mut().pump_write(cx).ready().is_some());
+        assert!(!dispatch.in_flight_requests.is_empty());
+
+        // Test that a request future dropped after it's processed by dispatch will cause the request
+        // to be removed from the in-flight request map.
+        drop(req);
+        assert_matches!(
+            dispatch.as_mut().poll_next_cancellation(cx),
+            Poll::Ready(Some(Ok(_)))
+        );
+        assert!(dispatch.in_flight_requests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stage_request_response_closed_skipped() {
+        let (mut dispatch, mut channel, _server_channel) = set_up();
+        let cx = &mut Context::from_waker(noop_waker_ref());
+        let (tx, mut rx) = oneshot::channel();
+
+        // Test that a request future that's closed its receiver but not yet canceled its request --
+        // i.e. still in `drop fn` -- will cause the request to not be added to the in-flight request
+        // map.
+        let resp = send_request(&mut channel, "hi", tx, &mut rx).await;
+        resp.response.close();
+
+        assert!(dispatch.as_mut().poll_next_request(cx).is_pending());
+    }
+
+    #[tokio::test]
+    async fn test_permit_before_transport_error() {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+        let (mut dispatch, mut channel, mut cx) = set_up_always_err(TransportError::Flush);
+        let (tx, mut rx) = oneshot::channel();
+        // reserve succeeds
+        let permit = reserve_for_send(&mut channel, tx, &mut rx).await;
+        // Since there's an outstanding permit, dispatch should not complete yet.
+        assert_matches!(dispatch.as_mut().poll(&mut cx), Poll::Pending);
+
+        let resp = permit("hi");
+
+        // errors from both the dispatch future and the request
+        assert_matches!(dispatch.as_mut().poll(&mut cx), Poll::Ready(Err(ChannelError::Flush(e))) if matches!(*e, TransportError::Flush));
+        assert_matches!(resp.response().await, Err(RpcError::Channel(_)));
+    }
+
+    #[tokio::test]
+    async fn test_shutdown() {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+        let (dispatch, channel, _server_channel) = set_up();
+        drop(dispatch);
+        // error on send
+        let resp = channel.call(current(), "hi".to_string()).await;
+        assert_matches!(resp, Err(RpcError::Shutdown));
+    }
+
+    #[tokio::test]
+    async fn test_transport_error_write() {
+        let cause = TransportError::Write;
+        let (mut dispatch, mut channel, mut cx) = set_up_always_err(cause);
+        let (tx, mut rx) = oneshot::channel();
+
+        let resp = send_request(&mut channel, "hi", tx, &mut rx).await;
+        assert!(dispatch.as_mut().poll(&mut cx).is_pending());
+        let res = resp.response().await;
+        assert_matches!(res, Err(RpcError::Send(_)));
+        let client_error: anyhow::Error = res.unwrap_err().into();
+        let mut chain = client_error.chain();
+        chain.next(); // original RpcError
+        assert_eq!(
+            chain.next().unwrap().downcast_ref::<TransportError>(),
+            Some(&cause)
+        );
+        assert_eq!(
+            client_error.root_cause().downcast_ref::<TransportError>(),
+            Some(&cause)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transport_error_read() {
+        let cause = TransportError::Read;
+        let (mut dispatch, mut channel, mut cx) = set_up_always_err(cause);
+        let (tx, mut rx) = oneshot::channel();
+        let resp = send_request(&mut channel, "hi", tx, &mut rx).await;
+        assert_eq!(
+            dispatch.as_mut().pump_write(&mut cx),
+            Poll::Ready(Some(Ok(())))
+        );
+        assert_eq!(
+            dispatch.as_mut().poll(&mut cx),
+            Poll::Ready(Err(ChannelError::Read(Arc::new(cause))))
+        );
+        assert_matches!(resp.response().await, Err(RpcError::Channel(_)));
+    }
+
+    #[tokio::test]
+    async fn test_transport_error_ready() {
+        let cause = TransportError::Ready;
+        let (mut dispatch, _, mut cx) = set_up_always_err(cause);
+        assert_eq!(
+            dispatch.as_mut().poll(&mut cx),
+            Poll::Ready(Err(ChannelError::Ready(Arc::new(cause))))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transport_error_flush() {
+        let cause = TransportError::Flush;
+        let (mut dispatch, _, mut cx) = set_up_always_err(cause);
+        assert_eq!(
+            dispatch.as_mut().poll(&mut cx),
+            Poll::Ready(Err(ChannelError::Flush(Arc::new(cause))))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transport_error_close() {
+        let cause = TransportError::Close;
+        let (mut dispatch, channel, mut cx) = set_up_always_err(cause);
+        drop(channel);
+        assert_eq!(
+            dispatch.as_mut().poll(&mut cx),
+            Poll::Ready(Err(ChannelError::Close(Arc::new(cause))))
+        );
+    }
+
+    /// Sets up a RequestDispatch with a transport that always errors.
+    fn set_up_always_err(
+        cause: TransportError,
+    ) -> (
+        Pin<Box<RequestDispatch<String, String, AlwaysErrorTransport<String>>>>,
+        Channel<String, String>,
+        Context<'static>,
+    ) {
+        let (to_dispatch, pending_requests) = mpsc::channel(1);
+        let (cancellation, canceled_requests) = cancellations();
+        let transport: AlwaysErrorTransport<String> = AlwaysErrorTransport(cause, PhantomData);
+        let dispatch = Box::pin(RequestDispatch::<String, String, _> {
+            transport: transport.fuse(),
+            pending_requests,
+            canceled_requests,
+            in_flight_requests: InFlightRequests::default(),
+            config: Config::default(),
+            terminal_error: None,
+        });
+        let channel = Channel {
+            to_dispatch,
+            cancellation,
+            next_request_id: Arc::new(AtomicUsize::new(0)),
+        };
+        let cx = Context::from_waker(noop_waker_ref());
+        (dispatch, channel, cx)
+    }
+
+    struct AlwaysErrorTransport<I>(TransportError, PhantomData<I>);
+
+    #[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
+    enum TransportError {
+        Read,
+        Ready,
+        Write,
+        Flush,
+        Close,
+    }
+
+    impl Display for TransportError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&format!("{self:?}"))
+        }
+    }
+
+    impl<I: Clone, S> Sink<S> for AlwaysErrorTransport<I> {
+        type Error = TransportError;
+        fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            match self.0 {
+                TransportError::Ready => Poll::Ready(Err(self.0)),
+                TransportError::Flush => Poll::Pending,
+                _ => Poll::Ready(Ok(())),
+            }
+        }
+        fn start_send(self: Pin<&mut Self>, _: S) -> Result<(), Self::Error> {
+            if matches!(self.0, TransportError::Write) {
+                Err(self.0)
+            } else {
+                Ok(())
+            }
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if matches!(self.0, TransportError::Flush) {
+                Poll::Ready(Err(self.0))
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if matches!(self.0, TransportError::Close) {
+                Poll::Ready(Err(self.0))
+            } else {
+                Poll::Ready(Ok(()))
+            }
+        }
+    }
+
+    impl<I: Clone> Stream for AlwaysErrorTransport<I> {
+        type Item = Result<Response<I>, TransportError>;
+        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            if matches!(self.0, TransportError::Read) {
+                Poll::Ready(Some(Err(self.0)))
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
+    fn set_up() -> (
+        Pin<
+            Box<
+                RequestDispatch<
+                    String,
+                    String,
+                    UnboundedChannel<Response<String>, ClientMessage<String>>,
+                >,
+            >,
+        >,
+        Channel<String, String>,
+        UnboundedChannel<ClientMessage<String>, Response<String>>,
+    ) {
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+
+        let (to_dispatch, pending_requests) = mpsc::channel(1);
+        let (cancellation, canceled_requests) = cancellations();
+        let (client_channel, server_channel) = transport::channel::unbounded();
+
+        let dispatch = RequestDispatch::<String, String, _> {
+            transport: client_channel.fuse(),
+            pending_requests,
+            canceled_requests,
+            in_flight_requests: InFlightRequests::default(),
+            config: Config::default(),
+            terminal_error: None,
+        };
+
+        let channel = Channel {
+            to_dispatch,
+            cancellation,
+            next_request_id: Arc::new(AtomicUsize::new(0)),
+        };
+
+        (Box::pin(dispatch), channel, server_channel)
+    }
+
+    async fn reserve_for_send<'a>(
+        channel: &'a mut Channel<String, String>,
+        response_completion: oneshot::Sender<Result<String, RpcError>>,
+        response: &'a mut oneshot::Receiver<Result<String, RpcError>>,
+    ) -> impl FnOnce(&str) -> ResponseGuard<'a, String> {
+        let permit = channel.to_dispatch.reserve().await.unwrap();
+        |request| {
+            let request_id =
+                u64::try_from(channel.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();
+            let request = DispatchRequest {
+                ctx: context::current(),
+                span: Span::current(),
+                request_id,
+                request: request.to_string(),
+                response_completion,
+            };
+            permit.send(request);
+            ResponseGuard {
+                response,
+                cancellation: &channel.cancellation,
+                request_id,
+                cancel: true,
+            }
+        }
+    }
+
+    async fn send_request<'a>(
+        channel: &'a mut Channel<String, String>,
+        request: &str,
+        response_completion: oneshot::Sender<Result<String, RpcError>>,
+        response: &'a mut oneshot::Receiver<Result<String, RpcError>>,
+    ) -> ResponseGuard<'a, String> {
+        let request_id =
+            u64::try_from(channel.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();
+        let request = DispatchRequest {
+            ctx: context::current(),
+            span: Span::current(),
+            request_id,
+            request: request.to_string(),
+            response_completion,
+        };
+        let response_guard = ResponseGuard {
+            response,
+            cancellation: &channel.cancellation,
+            request_id,
+            cancel: true,
+        };
+        channel.to_dispatch.send(request).await.unwrap();
+        response_guard
+    }
+
+    async fn send_response(
+        channel: &mut UnboundedChannel<ClientMessage<String>, Response<String>>,
+        response: Response<String>,
+    ) {
+        channel.send(response).await.unwrap();
+    }
+
+    trait PollTest {
+        type T;
+        fn ready(self) -> Self::T;
+    }
+
+    impl<T, E> PollTest for Poll<Option<Result<T, E>>>
+    where
+        E: ::std::fmt::Display,
+    {
+        type T = Option<T>;
+
+        fn ready(self) -> Option<T> {
+            match self {
+                Poll::Ready(Some(Ok(t))) => Some(t),
+                Poll::Ready(None) => None,
+                Poll::Ready(Some(Err(e))) => panic!("{}", e.to_string()),
+                Poll::Pending => panic!("Pending"),
+            }
+        }
+    }
+}

--- a/third_party/tarpc/src/client/in_flight_requests.rs
+++ b/third_party/tarpc/src/client/in_flight_requests.rs
@@ -1,0 +1,137 @@
+use crate::{
+    context,
+    util::{Compact, TimeUntil},
+};
+use fnv::FnvHashMap;
+use std::{
+    collections::hash_map,
+    task::{Context, Poll},
+};
+use tokio::sync::oneshot;
+use tokio_util::time::delay_queue::{self, DelayQueue};
+use tracing::Span;
+
+/// Requests already written to the wire that haven't yet received responses.
+#[derive(Debug)]
+pub struct InFlightRequests<Resp> {
+    request_data: FnvHashMap<u64, RequestData<Resp>>,
+    deadlines: DelayQueue<u64>,
+}
+
+impl<Resp> Default for InFlightRequests<Resp> {
+    fn default() -> Self {
+        Self {
+            request_data: Default::default(),
+            deadlines: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RequestData<Res> {
+    ctx: context::Context,
+    span: Span,
+    response_completion: oneshot::Sender<Res>,
+    /// The key to remove the timer for the request's deadline.
+    deadline_key: delay_queue::Key,
+}
+
+/// An error returned when an attempt is made to insert a request with an ID that is already in
+/// use.
+#[derive(Debug)]
+pub struct AlreadyExistsError;
+
+impl<Res> InFlightRequests<Res> {
+    /// Returns the number of in-flight requests.
+    pub fn len(&self) -> usize {
+        self.request_data.len()
+    }
+
+    /// Returns true iff there are no requests in flight.
+    pub fn is_empty(&self) -> bool {
+        self.request_data.is_empty()
+    }
+
+    /// Starts a request, unless a request with the same ID is already in flight.
+    pub fn insert_request(
+        &mut self,
+        request_id: u64,
+        ctx: context::Context,
+        span: Span,
+        response_completion: oneshot::Sender<Res>,
+    ) -> Result<(), AlreadyExistsError> {
+        match self.request_data.entry(request_id) {
+            hash_map::Entry::Vacant(vacant) => {
+                let timeout = ctx.deadline.time_until();
+                let deadline_key = self.deadlines.insert(request_id, timeout);
+                vacant.insert(RequestData {
+                    ctx,
+                    span,
+                    response_completion,
+                    deadline_key,
+                });
+                Ok(())
+            }
+            hash_map::Entry::Occupied(_) => Err(AlreadyExistsError),
+        }
+    }
+
+    /// Removes a request without aborting. Returns true iff the request was found.
+    pub fn complete_request(&mut self, request_id: u64, result: Res) -> Option<Span> {
+        if let Some(request_data) = self.request_data.remove(&request_id) {
+            self.request_data.compact(0.1);
+            self.deadlines.remove(&request_data.deadline_key);
+            let _ = request_data.response_completion.send(result);
+            return Some(request_data.span);
+        }
+
+        tracing::debug!("No in-flight request found for request_id = {request_id}.");
+
+        // If the response completion was absent, then the request was already canceled.
+        None
+    }
+
+    /// Completes all requests using the provided function.
+    /// Returns Spans for all completes requests.
+    pub fn complete_all_requests<'a>(
+        &'a mut self,
+        mut result: impl FnMut() -> Res + 'a,
+    ) -> impl Iterator<Item = Span> + 'a {
+        self.deadlines.clear();
+        self.request_data.drain().map(move |(_, request_data)| {
+            let _ = request_data.response_completion.send(result());
+            request_data.span
+        })
+    }
+
+    /// Cancels a request without completing (typically used when a request handle was dropped
+    /// before the request completed).
+    pub fn cancel_request(&mut self, request_id: u64) -> Option<(context::Context, Span)> {
+        if let Some(request_data) = self.request_data.remove(&request_id) {
+            self.request_data.compact(0.1);
+            self.deadlines.remove(&request_data.deadline_key);
+            Some((request_data.ctx, request_data.span))
+        } else {
+            None
+        }
+    }
+
+    /// Yields a request that has expired, completing it with a TimedOut error.
+    /// The caller should send cancellation messages for any yielded request ID.
+    pub fn poll_expired(
+        &mut self,
+        cx: &mut Context,
+        expired_error: impl Fn() -> Res,
+    ) -> Poll<Option<u64>> {
+        self.deadlines.poll_expired(cx).map(|expired| {
+            let request_id = expired?.into_inner();
+            if let Some(request_data) = self.request_data.remove(&request_id) {
+                let _entered = request_data.span.enter();
+                tracing::error!("DeadlineExceeded");
+                self.request_data.compact(0.1);
+                let _ = request_data.response_completion.send(expired_error());
+            }
+            Some(request_id)
+        })
+    }
+}

--- a/third_party/tarpc/src/client/stub.rs
+++ b/third_party/tarpc/src/client/stub.rs
@@ -1,0 +1,52 @@
+//! Provides a Stub trait, implemented by types that can call remote services.
+
+use crate::{
+    client::{Channel, RpcError},
+    context,
+    server::Serve,
+    RequestName,
+};
+
+pub mod load_balance;
+pub mod retry;
+
+#[cfg(test)]
+mod mock;
+
+/// A connection to a remote service.
+/// Calls the service with requests of type `Req` and receives responses of type `Resp`.
+#[allow(async_fn_in_trait)]
+pub trait Stub {
+    /// The service request type.
+    type Req: RequestName;
+
+    /// The service response type.
+    type Resp;
+
+    /// Calls a remote service.
+    async fn call(&self, ctx: context::Context, request: Self::Req)
+        -> Result<Self::Resp, RpcError>;
+}
+
+impl<Req, Resp> Stub for Channel<Req, Resp>
+where
+    Req: RequestName,
+{
+    type Req = Req;
+    type Resp = Resp;
+
+    async fn call(&self, ctx: context::Context, request: Req) -> Result<Self::Resp, RpcError> {
+        Self::call(self, ctx, request).await
+    }
+}
+
+impl<S> Stub for S
+where
+    S: Serve + Clone,
+{
+    type Req = S::Req;
+    type Resp = S::Resp;
+    async fn call(&self, ctx: context::Context, req: Self::Req) -> Result<Self::Resp, RpcError> {
+        self.clone().serve(ctx, req).await.map_err(RpcError::Server)
+    }
+}

--- a/third_party/tarpc/src/client/stub/load_balance.rs
+++ b/third_party/tarpc/src/client/stub/load_balance.rs
@@ -1,0 +1,277 @@
+//! Provides load-balancing [Stubs](crate::client::stub::Stub).
+
+pub use consistent_hash::ConsistentHash;
+pub use round_robin::RoundRobin;
+
+/// Provides a stub that load-balances with a simple round-robin strategy.
+mod round_robin {
+    use crate::{
+        client::{stub, RpcError},
+        context,
+    };
+    use cycle::AtomicCycle;
+
+    impl<Stub> stub::Stub for RoundRobin<Stub>
+    where
+        Stub: stub::Stub,
+    {
+        type Req = Stub::Req;
+        type Resp = Stub::Resp;
+
+        async fn call(
+            &self,
+            ctx: context::Context,
+            request: Self::Req,
+        ) -> Result<Stub::Resp, RpcError> {
+            let next = self.stubs.next();
+            next.call(ctx, request).await
+        }
+    }
+
+    /// A Stub that load-balances across backing stubs by round robin.
+    #[derive(Clone, Debug)]
+    pub struct RoundRobin<Stub> {
+        stubs: AtomicCycle<Stub>,
+    }
+
+    impl<Stub> RoundRobin<Stub>
+    where
+        Stub: stub::Stub,
+    {
+        /// Returns a new RoundRobin stub.
+        pub fn new(stubs: Vec<Stub>) -> Self {
+            Self {
+                stubs: AtomicCycle::new(stubs),
+            }
+        }
+    }
+
+    mod cycle {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        /// Cycles endlessly and atomically over a collection of elements of type T.
+        #[derive(Clone, Debug)]
+        pub struct AtomicCycle<T>(Arc<State<T>>);
+
+        #[derive(Debug)]
+        struct State<T> {
+            elements: Vec<T>,
+            next: AtomicUsize,
+        }
+
+        impl<T> AtomicCycle<T> {
+            pub fn new(elements: Vec<T>) -> Self {
+                Self(Arc::new(State {
+                    elements,
+                    next: Default::default(),
+                }))
+            }
+
+            pub fn next(&self) -> &T {
+                self.0.next()
+            }
+        }
+
+        impl<T> State<T> {
+            pub fn next(&self) -> &T {
+                let next = self.next.fetch_add(1, Ordering::Relaxed);
+                &self.elements[next % self.elements.len()]
+            }
+        }
+
+        #[test]
+        fn test_cycle() {
+            let cycle = AtomicCycle::new(vec![1, 2, 3]);
+            assert_eq!(cycle.next(), &1);
+            assert_eq!(cycle.next(), &2);
+            assert_eq!(cycle.next(), &3);
+            assert_eq!(cycle.next(), &1);
+        }
+    }
+}
+
+/// Provides a stub that load-balances with a consistent hashing strategy.
+///
+/// Each request is hashed, then mapped to a stub based on the hash. Equivalent requests will use
+/// the same stub.
+mod consistent_hash {
+    use crate::{
+        client::{stub, RpcError},
+        context,
+    };
+    use std::{
+        collections::hash_map::RandomState,
+        hash::{BuildHasher, Hash, Hasher},
+        num::TryFromIntError,
+    };
+
+    impl<Stub, S> stub::Stub for ConsistentHash<Stub, S>
+    where
+        Stub: stub::Stub,
+        Stub::Req: Hash,
+        S: BuildHasher,
+    {
+        type Req = Stub::Req;
+        type Resp = Stub::Resp;
+
+        async fn call(
+            &self,
+            ctx: context::Context,
+            request: Self::Req,
+        ) -> Result<Stub::Resp, RpcError> {
+            let index = usize::try_from(self.hash_request(&request) % self.stubs_len).expect(
+                "invariant broken: stubs_len is not larger than a usize, \
+                         so the hash modulo stubs_len should always fit in a usize",
+            );
+            let next = &self.stubs[index];
+            next.call(ctx, request).await
+        }
+    }
+
+    /// A Stub that load-balances across backing stubs by round robin.
+    #[derive(Clone, Debug)]
+    pub struct ConsistentHash<Stub, S = RandomState> {
+        stubs: Vec<Stub>,
+        stubs_len: u64,
+        hasher: S,
+    }
+
+    impl<Stub> ConsistentHash<Stub, RandomState>
+    where
+        Stub: stub::Stub,
+        Stub::Req: Hash,
+    {
+        /// Returns a new RoundRobin stub.
+        /// Returns an err if the length of `stubs` overflows a u64.
+        pub fn new(stubs: Vec<Stub>) -> Result<Self, TryFromIntError> {
+            Ok(Self {
+                stubs_len: stubs.len().try_into()?,
+                stubs,
+                hasher: RandomState::new(),
+            })
+        }
+    }
+
+    impl<Stub, S> ConsistentHash<Stub, S>
+    where
+        Stub: stub::Stub,
+        Stub::Req: Hash,
+        S: BuildHasher,
+    {
+        /// Returns a new RoundRobin stub.
+        /// Returns an err if the length of `stubs` overflows a u64.
+        pub fn with_hasher(stubs: Vec<Stub>, hasher: S) -> Result<Self, TryFromIntError> {
+            Ok(Self {
+                stubs_len: stubs.len().try_into()?,
+                stubs,
+                hasher,
+            })
+        }
+
+        fn hash_request(&self, req: &Stub::Req) -> u64 {
+            let mut hasher = self.hasher.build_hasher();
+            req.hash(&mut hasher);
+            hasher.finish()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::ConsistentHash;
+        use crate::{
+            client::stub::{mock::Mock, Stub},
+            context,
+        };
+        use std::{
+            collections::HashMap,
+            hash::{BuildHasher, Hash, Hasher},
+            rc::Rc,
+        };
+
+        #[tokio::test]
+        async fn test() -> anyhow::Result<()> {
+            let stub = ConsistentHash::<_, FakeHasherBuilder>::with_hasher(
+                vec![
+                    // For easier reading of the assertions made in this test, each Mock's response
+                    // value is equal to a hash value that should map to its index: 3 % 3 = 0, 1 %
+                    // 3 = 1, etc.
+                    Mock::new([('a', 3), ('b', 3), ('c', 3)]),
+                    Mock::new([('a', 1), ('b', 1), ('c', 1)]),
+                    Mock::new([('a', 2), ('b', 2), ('c', 2)]),
+                ],
+                FakeHasherBuilder::new([('a', 1), ('b', 2), ('c', 3)]),
+            )?;
+
+            for _ in 0..2 {
+                let resp = stub.call(context::current(), 'a').await?;
+                assert_eq!(resp, 1);
+
+                let resp = stub.call(context::current(), 'b').await?;
+                assert_eq!(resp, 2);
+
+                let resp = stub.call(context::current(), 'c').await?;
+                assert_eq!(resp, 3);
+            }
+
+            Ok(())
+        }
+
+        struct HashRecorder(Vec<u8>);
+        impl Hasher for HashRecorder {
+            fn write(&mut self, bytes: &[u8]) {
+                self.0 = Vec::from(bytes);
+            }
+            fn finish(&self) -> u64 {
+                0
+            }
+        }
+
+        struct FakeHasherBuilder {
+            recorded_hashes: Rc<HashMap<Vec<u8>, u64>>,
+        }
+
+        struct FakeHasher {
+            recorded_hashes: Rc<HashMap<Vec<u8>, u64>>,
+            output: u64,
+        }
+
+        impl BuildHasher for FakeHasherBuilder {
+            type Hasher = FakeHasher;
+
+            fn build_hasher(&self) -> Self::Hasher {
+                FakeHasher {
+                    recorded_hashes: self.recorded_hashes.clone(),
+                    output: 0,
+                }
+            }
+        }
+
+        impl FakeHasherBuilder {
+            fn new<T: Hash, const N: usize>(fake_hashes: [(T, u64); N]) -> Self {
+                let mut recorded_hashes = HashMap::new();
+                for (to_hash, fake_hash) in fake_hashes {
+                    let mut recorder = HashRecorder(vec![]);
+                    to_hash.hash(&mut recorder);
+                    recorded_hashes.insert(recorder.0, fake_hash);
+                }
+                Self {
+                    recorded_hashes: Rc::new(recorded_hashes),
+                }
+            }
+        }
+
+        impl Hasher for FakeHasher {
+            fn write(&mut self, bytes: &[u8]) {
+                if let Some(hash) = self.recorded_hashes.get(bytes) {
+                    self.output = *hash;
+                }
+            }
+            fn finish(&self) -> u64 {
+                self.output
+            }
+        }
+    }
+}

--- a/third_party/tarpc/src/client/stub/mock.rs
+++ b/third_party/tarpc/src/client/stub/mock.rs
@@ -1,0 +1,44 @@
+use crate::{
+    client::{stub::Stub, RpcError},
+    context, RequestName, ServerError,
+};
+use std::{collections::HashMap, hash::Hash, io};
+
+/// A mock stub that returns user-specified responses.
+pub struct Mock<Req, Resp> {
+    responses: HashMap<Req, Resp>,
+}
+
+impl<Req, Resp> Mock<Req, Resp>
+where
+    Req: Eq + Hash,
+{
+    /// Returns a new mock, mocking the specified (request, response) pairs.
+    pub fn new<const N: usize>(responses: [(Req, Resp); N]) -> Self {
+        Self {
+            responses: HashMap::from(responses),
+        }
+    }
+}
+
+impl<Req, Resp> Stub for Mock<Req, Resp>
+where
+    Req: Eq + Hash + RequestName,
+    Resp: Clone,
+{
+    type Req = Req;
+    type Resp = Resp;
+
+    async fn call(&self, _: context::Context, request: Self::Req) -> Result<Resp, RpcError> {
+        self.responses
+            .get(&request)
+            .cloned()
+            .map(Ok)
+            .unwrap_or_else(|| {
+                Err(RpcError::Server(ServerError {
+                    kind: io::ErrorKind::NotFound,
+                    detail: "mock (request, response) entry not found".into(),
+                }))
+            })
+    }
+}

--- a/third_party/tarpc/src/client/stub/retry.rs
+++ b/third_party/tarpc/src/client/stub/retry.rs
@@ -1,0 +1,53 @@
+//! Provides a stub that retries requests based on response contents..
+
+use crate::{
+    client::{stub, RpcError},
+    context, RequestName,
+};
+use std::sync::Arc;
+
+impl<Stub, Req, F> stub::Stub for Retry<F, Stub>
+where
+    Req: RequestName,
+    Stub: stub::Stub<Req = Arc<Req>>,
+    F: Fn(&Result<Stub::Resp, RpcError>, u32) -> bool,
+{
+    type Req = Req;
+    type Resp = Stub::Resp;
+
+    async fn call(
+        &self,
+        ctx: context::Context,
+        request: Self::Req,
+    ) -> Result<Stub::Resp, RpcError> {
+        let request = Arc::new(request);
+        for i in 1.. {
+            let result = self.stub.call(ctx, Arc::clone(&request)).await;
+            if (self.should_retry)(&result, i) {
+                tracing::trace!("Retrying on attempt {i}");
+                continue;
+            }
+            return result;
+        }
+        unreachable!("Wow, that was a lot of attempts!");
+    }
+}
+
+/// A Stub that retries requests based on response contents.
+/// Note: to use this stub with Serde serialization, the "rc" feature of Serde needs to be enabled.
+#[derive(Clone, Debug)]
+pub struct Retry<F, Stub> {
+    should_retry: F,
+    stub: Stub,
+}
+
+impl<Stub, Req, F> Retry<F, Stub>
+where
+    Stub: stub::Stub<Req = Arc<Req>>,
+    F: Fn(&Result<Stub::Resp, RpcError>, u32) -> bool,
+{
+    /// Creates a new Retry stub that delegates calls to the underlying `stub`.
+    pub fn new(stub: Stub, should_retry: F) -> Self {
+        Self { stub, should_retry }
+    }
+}

--- a/third_party/tarpc/src/context.rs
+++ b/third_party/tarpc/src/context.rs
@@ -1,0 +1,153 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a request context that carries a deadline and trace context. This context is sent from
+//! client to server and is used by the server to enforce response deadlines.
+
+use crate::trace::{self, TraceId};
+use opentelemetry::trace::TraceContextExt;
+use static_assertions::assert_impl_all;
+use std::{
+    convert::TryFrom,
+    time::{Duration, Instant},
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// A request context that carries request-scoped information like deadlines and trace information.
+/// It is sent from client to server and is used by the server to enforce response deadlines.
+///
+/// The context should not be stored directly in a server implementation, because the context will
+/// be different for each request in scope.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct Context {
+    /// When the client expects the request to be complete by. The server should cancel the request
+    /// if it is not complete by this time.
+    #[cfg_attr(feature = "serde1", serde(default = "ten_seconds_from_now"))]
+    // Serialized as a Duration to prevent clock skew issues.
+    #[cfg_attr(feature = "serde1", serde(with = "absolute_to_relative_time"))]
+    pub deadline: Instant,
+    /// Uniquely identifies requests originating from the same source.
+    /// When a service handles a request by making requests itself, those requests should
+    /// include the same `trace_id` as that included on the original request. This way,
+    /// users can trace related actions across a distributed system.
+    pub trace_context: trace::Context,
+}
+
+#[cfg(feature = "serde1")]
+mod absolute_to_relative_time {
+    pub use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    pub use std::time::{Duration, Instant};
+
+    pub fn serialize<S>(deadline: &Instant, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let deadline = deadline.duration_since(Instant::now());
+        deadline.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Instant, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let deadline = Duration::deserialize(deserializer)?;
+        Ok(Instant::now() + deadline)
+    }
+
+    #[cfg(test)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct AbsoluteToRelative(#[serde(with = "self")] Instant);
+
+    #[test]
+    fn test_serialize() {
+        let now = Instant::now();
+        let deadline = now + Duration::from_secs(10);
+        let serialized_deadline = bincode::serialize(&AbsoluteToRelative(deadline)).unwrap();
+        let deserialized_deadline: Duration = bincode::deserialize(&serialized_deadline).unwrap();
+        // TODO: how to avoid flakiness?
+        assert!(deserialized_deadline > Duration::from_secs(9));
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let deadline = Duration::from_secs(10);
+        let serialized_deadline = bincode::serialize(&deadline).unwrap();
+        let AbsoluteToRelative(deserialized_deadline) =
+            bincode::deserialize(&serialized_deadline).unwrap();
+        // TODO: how to avoid flakiness?
+        assert!(deserialized_deadline > Instant::now() + Duration::from_secs(9));
+    }
+}
+
+assert_impl_all!(Context: Send, Sync);
+
+fn ten_seconds_from_now() -> Instant {
+    Instant::now() + Duration::from_secs(10)
+}
+
+/// Returns the context for the current request, or a default Context if no request is active.
+pub fn current() -> Context {
+    Context::current()
+}
+
+#[derive(Clone)]
+struct Deadline(Instant);
+
+impl Default for Deadline {
+    fn default() -> Self {
+        Self(ten_seconds_from_now())
+    }
+}
+
+impl Context {
+    /// Returns the context for the current request, or a default Context if no request is active.
+    pub fn current() -> Self {
+        let span = tracing::Span::current();
+        Self {
+            trace_context: trace::Context::try_from(&span)
+                .unwrap_or_else(|_| trace::Context::default()),
+            deadline: span
+                .context()
+                .get::<Deadline>()
+                .cloned()
+                .unwrap_or_default()
+                .0,
+        }
+    }
+
+    /// Returns the ID of the request-scoped trace.
+    pub fn trace_id(&self) -> &TraceId {
+        &self.trace_context.trace_id
+    }
+}
+
+/// An extension trait for [`tracing::Span`] for propagating tarpc Contexts.
+pub(crate) trait SpanExt {
+    /// Sets the given context on this span. Newly-created spans will be children of the given
+    /// context's trace context.
+    fn set_context(&self, context: &Context);
+}
+
+impl SpanExt for tracing::Span {
+    fn set_context(&self, context: &Context) {
+        // Explicitly ignore the returned result because it either means that the span has
+        // already started, or the Otel layer is not present, so we don't mind if the result
+        // is an error we silently ignore.
+        let _ = self.set_parent(
+            opentelemetry::Context::new()
+                .with_remote_span_context(opentelemetry::trace::SpanContext::new(
+                    opentelemetry::trace::TraceId::from(context.trace_context.trace_id),
+                    opentelemetry::trace::SpanId::from(context.trace_context.span_id),
+                    opentelemetry::trace::TraceFlags::from(context.trace_context.sampling_decision),
+                    true,
+                    opentelemetry::trace::TraceState::default(),
+                ))
+                .with_value(Deadline(context.deadline)),
+        );
+    }
+}

--- a/third_party/tarpc/src/lib.rs
+++ b/third_party/tarpc/src/lib.rs
@@ -1,0 +1,557 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//! *Disclaimer*: This is not an official Google product.
+//!
+//! tarpc is an RPC framework for rust with a focus on ease of use. Defining a
+//! service can be done in just a few lines of code, and most of the boilerplate of
+//! writing a server is taken care of for you.
+//!
+//! [Documentation](https://docs.rs/crate/tarpc/)
+//!
+//! ## What is an RPC framework?
+//! "RPC" stands for "Remote Procedure Call," a function call where the work of
+//! producing the return value is being done somewhere else. When an rpc function is
+//! invoked, behind the scenes the function contacts some other process somewhere
+//! and asks them to evaluate the function instead. The original function then
+//! returns the value produced by the other process.
+//!
+//! RPC frameworks are a fundamental building block of most microservices-oriented
+//! architectures. Two well-known ones are [gRPC](http://www.grpc.io) and
+//! [Cap'n Proto](https://capnproto.org/).
+//!
+//! tarpc differentiates itself from other RPC frameworks by defining the schema in code,
+//! rather than in a separate language such as .proto. This means there's no separate compilation
+//! process, and no context switching between different languages.
+//!
+//! Some other features of tarpc:
+//! - Pluggable transport: any type implementing `Stream<Item = Request> + Sink<Response>` can be
+//!   used as a transport to connect the client and server.
+//! - `Send + 'static` optional: if the transport doesn't require it, neither does tarpc!
+//! - Cascading cancellation: dropping a request will send a cancellation message to the server.
+//!   The server will cease any unfinished work on the request, subsequently cancelling any of its
+//!   own requests, repeating for the entire chain of transitive dependencies.
+//! - Configurable deadlines and deadline propagation: request deadlines default to 10s if
+//!   unspecified. The server will automatically cease work when the deadline has passed. Any
+//!   requests sent by the server that use the request context will propagate the request deadline.
+//!   For example, if a server is handling a request with a 10s deadline, does 2s of work, then
+//!   sends a request to another server, that server will see an 8s deadline.
+//! - Distributed tracing: tarpc is instrumented with
+//!   [tracing](https://github.com/tokio-rs/tracing) primitives extended with
+//!   [OpenTelemetry](https://opentelemetry.io/) traces. Using a compatible tracing subscriber like
+//!   [OTLP](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp),
+//!   each RPC can be traced through the client, server, and other dependencies downstream of the
+//!   server. Even for applications not connected to a distributed tracing collector, the
+//!   instrumentation can also be ingested by regular loggers like
+//!   [env_logger](https://github.com/env-logger-rs/env_logger/).
+//! - Serde serialization: enabling the `serde1` Cargo feature will make service requests and
+//!   responses `Serialize + Deserialize`. It's entirely optional, though: in-memory transports can
+//!   be used, as well, so the price of serialization doesn't have to be paid when it's not needed.
+//!
+//! ## Usage
+//! Add to your `Cargo.toml` dependencies:
+//!
+//! ```toml
+//! tarpc = "0.37"
+//! ```
+//!
+//! The `tarpc::service` attribute expands to a collection of items that form an rpc service.
+//! These generated types make it easy and ergonomic to write servers with less boilerplate.
+//! Simply implement the generated service trait, and you're off to the races!
+//!
+//! ## Example
+//!
+//! This example uses [tokio](https://tokio.rs), so add the following dependencies to
+//! your `Cargo.toml`:
+//!
+//! ```toml
+//! anyhow = "1.0"
+//! futures = "0.3"
+//! tarpc = { version = "0.37", features = ["tokio1"] }
+//! tokio = { version = "1.0", features = ["macros"] }
+//! ```
+//!
+//! In the following example, we use an in-process channel for communication between
+//! client and server. In real code, you will likely communicate over the network.
+//! For a more real-world example, see [example-service](example-service).
+//!
+//! First, let's set up the dependencies and service definition.
+//!
+//! ```rust
+//! # extern crate futures;
+//!
+//! use futures::{
+//!     prelude::*,
+//! };
+//! use tarpc::{
+//!     client, context,
+//!     server::{self, incoming::Incoming, Channel},
+//! };
+//!
+//! // This is the service definition. It looks a lot like a trait definition.
+//! // It defines one RPC, hello, which takes one arg, name, and returns a String.
+//! #[tarpc::service]
+//! trait World {
+//!     /// Returns a greeting for name.
+//!     async fn hello(name: String) -> String;
+//! }
+//! ```
+//!
+//! This service definition generates a trait called `World`. Next we need to
+//! implement it for our Server struct.
+//!
+//! ```rust
+//! # extern crate futures;
+//! # use futures::{
+//! #     prelude::*,
+//! # };
+//! # use tarpc::{
+//! #     client, context,
+//! #     server::{self, incoming::Incoming},
+//! # };
+//! # // This is the service definition. It looks a lot like a trait definition.
+//! # // It defines one RPC, hello, which takes one arg, name, and returns a String.
+//! # #[tarpc::service]
+//! # trait World {
+//! #     /// Returns a greeting for name.
+//! #     async fn hello(name: String) -> String;
+//! # }
+//! // This is the type that implements the generated World trait. It is the business logic
+//! // and is used to start the server.
+//! #[derive(Clone)]
+//! struct HelloServer;
+//!
+//! impl World for HelloServer {
+//!     // Each defined rpc generates an async fn that serves the RPC
+//!     async fn hello(self, _: context::Context, name: String) -> String {
+//!         format!("Hello, {name}!")
+//!     }
+//! }
+//! ```
+//!
+//! Lastly let's write our `main` that will start the server. While this example uses an
+//! [in-process channel](transport::channel), tarpc also ships a generic [`serde_transport`]
+//! behind the `serde-transport` feature, with additional [TCP](serde_transport::tcp) functionality
+//! available behind the `tcp` feature.
+//!
+//! ```rust
+//! # extern crate futures;
+//! # use futures::{
+//! #     prelude::*,
+//! # };
+//! # use tarpc::{
+//! #     client, context,
+//! #     server::{self, Channel},
+//! # };
+//! # // This is the service definition. It looks a lot like a trait definition.
+//! # // It defines one RPC, hello, which takes one arg, name, and returns a String.
+//! # #[tarpc::service]
+//! # trait World {
+//! #     /// Returns a greeting for name.
+//! #     async fn hello(name: String) -> String;
+//! # }
+//! # // This is the type that implements the generated World trait. It is the business logic
+//! # // and is used to start the server.
+//! # #[derive(Clone)]
+//! # struct HelloServer;
+//! # impl World for HelloServer {
+//!     // Each defined rpc generates an async fn that serves the RPC
+//! #     async fn hello(self, _: context::Context, name: String) -> String {
+//! #         format!("Hello, {name}!")
+//! #     }
+//! # }
+//! # #[cfg(not(feature = "tokio1"))]
+//! # fn main() {}
+//! # #[cfg(feature = "tokio1")]
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let (client_transport, server_transport) = tarpc::transport::channel::unbounded();
+//!
+//!     let server = server::BaseChannel::with_defaults(server_transport);
+//!     tokio::spawn(
+//!         server.execute(HelloServer.serve())
+//!             // Handle all requests concurrently.
+//!             .for_each(|response| async move {
+//!                 tokio::spawn(response);
+//!             }));
+//!
+//!     // WorldClient is generated by the #[tarpc::service] attribute. It has a constructor `new`
+//!     // that takes a config and any Transport as input.
+//!     let mut client = WorldClient::new(client::Config::default(), client_transport).spawn();
+//!
+//!     // The client has an RPC method for each RPC defined in the annotated trait. It takes the same
+//!     // args as defined, with the addition of a Context, which is always the first arg. The Context
+//!     // specifies a deadline and trace information which can be helpful in debugging requests.
+//!     let hello = client.hello(context::current(), "Stim".to_string()).await?;
+//!
+//!     println!("{hello}");
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Service Documentation
+//!
+//! Use `cargo doc` as you normally would to see the documentation created for all
+//! items expanded by a `service!` invocation.
+
+#![deny(missing_docs)]
+#![allow(clippy::type_complexity)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(feature = "serde1")]
+#[doc(hidden)]
+pub use serde;
+
+#[cfg(feature = "serde-transport")]
+pub use {tokio_serde, tokio_util};
+
+#[cfg(feature = "serde-transport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-transport")))]
+pub mod serde_transport;
+
+pub mod trace;
+
+#[cfg(feature = "serde1")]
+pub use tarpc_plugins::derive_serde;
+
+/// The main macro that creates RPC services.
+///
+/// Rpc methods are specified, mirroring trait syntax:
+///
+/// ```
+/// #[tarpc::service]
+/// trait Service {
+/// /// Say hello
+/// async fn hello(name: String) -> String;
+/// }
+/// ```
+///
+/// Attributes can be attached to each rpc. These attributes
+/// will then be attached to the generated service traits'
+/// corresponding `fn`s, as well as to the client stubs' RPCs.
+///
+/// The following items are expanded in the enclosing module:
+///
+/// * `trait Service` -- defines the RPC service.
+///   * `fn serve` -- turns a service impl into a request handler.
+/// * `Client` -- a client stub with a fn for each RPC.
+///   * `fn new_stub` -- creates a new Client stub.
+pub use tarpc_plugins::service;
+
+pub(crate) mod cancellations;
+pub mod client;
+pub mod context;
+pub mod server;
+pub mod transport;
+pub(crate) mod util;
+
+pub use crate::transport::sealed::Transport;
+
+use std::{any::Any, error::Error, io, sync::Arc, time::Instant};
+
+/// A message from a client to a server.
+#[derive(Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum ClientMessage<T> {
+    /// A request initiated by a user. The server responds to a request by invoking a
+    /// service-provided request handler.  The handler completes with a [`response`](Response), which
+    /// the server sends back to the client.
+    Request(Request<T>),
+    /// A command to cancel an in-flight request, automatically sent by the client when a response
+    /// future is dropped.
+    ///
+    /// When received, the server will immediately cancel the main task (top-level future) of the
+    /// request handler for the associated request. Any tasks spawned by the request handler will
+    /// not be canceled, because the framework layer does not
+    /// know about them.
+    Cancel {
+        /// The trace context associates the message with a specific chain of causally-related actions,
+        /// possibly orchestrated across many distributed systems.
+        #[cfg_attr(feature = "serde1", serde(default))]
+        trace_context: trace::Context,
+        /// The ID of the request to cancel.
+        request_id: u64,
+    },
+}
+
+/// A request from a client to a server.
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct Request<T> {
+    /// Trace context, deadline, and other cross-cutting concerns.
+    pub context: context::Context,
+    /// Uniquely identifies the request across all requests sent over a single channel.
+    pub id: u64,
+    /// The request body.
+    pub message: T,
+}
+
+/// Implemented by the request types generated by tarpc::service.
+pub trait RequestName {
+    /// The name of a request.
+    fn name(&self) -> &str;
+}
+
+impl<Req> RequestName for Arc<Req>
+where
+    Req: RequestName,
+{
+    fn name(&self) -> &str {
+        self.as_ref().name()
+    }
+}
+
+impl<Req> RequestName for Box<Req>
+where
+    Req: RequestName,
+{
+    fn name(&self) -> &str {
+        self.as_ref().name()
+    }
+}
+
+/// Impls for common std types for testing.
+impl RequestName for String {
+    fn name(&self) -> &str {
+        "string"
+    }
+}
+
+impl RequestName for char {
+    fn name(&self) -> &str {
+        "char"
+    }
+}
+
+impl RequestName for () {
+    fn name(&self) -> &str {
+        "unit"
+    }
+}
+
+impl RequestName for i32 {
+    fn name(&self) -> &str {
+        "i32"
+    }
+}
+
+impl RequestName for u32 {
+    fn name(&self) -> &str {
+        "u32"
+    }
+}
+
+impl RequestName for i64 {
+    fn name(&self) -> &str {
+        "i64"
+    }
+}
+
+impl RequestName for u64 {
+    fn name(&self) -> &str {
+        "u64"
+    }
+}
+
+/// A response from a server to a client.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct Response<T> {
+    /// The ID of the request being responded to.
+    pub request_id: u64,
+    /// The response body, or an error if the request failed.
+    pub message: Result<T, ServerError>,
+}
+
+/// An error indicating the server aborted the request early, e.g., due to request throttling.
+#[derive(thiserror::Error, Clone, Debug, PartialEq, Eq, Hash)]
+#[error("{kind:?}: {detail}")]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct ServerError {
+    #[cfg_attr(
+        feature = "serde1",
+        serde(serialize_with = "util::serde::serialize_io_error_kind_as_u32")
+    )]
+    #[cfg_attr(
+        feature = "serde1",
+        serde(deserialize_with = "util::serde::deserialize_io_error_kind_from_u32")
+    )]
+    /// The type of error that occurred to fail the request.
+    pub kind: io::ErrorKind,
+    /// A message describing more detail about the error that occurred.
+    pub detail: String,
+}
+
+/// Critical errors that result in a Channel disconnecting.
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum ChannelError<E>
+where
+    E: ?Sized,
+{
+    /// Could not read from the transport.
+    #[error("could not read from the transport")]
+    Read(#[source] Arc<E>),
+    /// Could not ready the transport for writes.
+    #[error("could not ready the transport for writes")]
+    Ready(#[source] Arc<E>),
+    /// Could not write to the transport.
+    #[error("could not write to the transport")]
+    Write(#[source] Arc<E>),
+    /// Could not flush the transport.
+    #[error("could not flush the transport")]
+    Flush(#[source] Arc<E>),
+    /// Could not close the write end of the transport.
+    #[error("could not close the write end of the transport")]
+    Close(#[source] Arc<E>),
+}
+
+impl<E> Clone for ChannelError<E>
+where
+    E: ?Sized,
+{
+    fn clone(&self) -> Self {
+        use ChannelError::*;
+        match self {
+            Read(e) => Read(e.clone()),
+            Ready(e) => Ready(e.clone()),
+            Write(e) => Write(e.clone()),
+            Flush(e) => Flush(e.clone()),
+            Close(e) => Close(e.clone()),
+        }
+    }
+}
+
+impl<E> ChannelError<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    /// Converts the ChannelError's source error type to a dyn Error. This is useful in type-erased
+    /// contexts, for example, storing a ChannelError in a non-generic type like
+    /// [`client::RpcError`].
+    fn upcast_error(self) -> ChannelError<dyn Error + Send + Sync + 'static> {
+        use ChannelError::*;
+        match self {
+            Read(e) => Read(e),
+            Ready(e) => Ready(e),
+            Write(e) => Write(e),
+            Flush(e) => Flush(e),
+            Close(e) => Close(e),
+        }
+    }
+}
+
+impl<E> ChannelError<E>
+where
+    E: Send + Sync + 'static,
+{
+    /// Converts the ChannelError's source error type to a dyn Any. This is useful in type-erased
+    /// contexts, for example, storing a ChannelError in a non-generic type like
+    /// [`client::RpcError`].
+    fn upcast_any(self) -> ChannelError<dyn Any + Send + Sync + 'static> {
+        use ChannelError::*;
+        match self {
+            Read(e) => Read(e),
+            Ready(e) => Ready(e),
+            Write(e) => Write(e),
+            Flush(e) => Flush(e),
+            Close(e) => Close(e),
+        }
+    }
+}
+
+impl ChannelError<dyn Any + Send + Sync + 'static> {
+    /// Converts the ChannelError's source error type to a concrete type. This is useful in
+    /// type-erased contexts, for example, storing a ChannelError in a non-generic type like
+    /// [`Client::RpcError`].
+    fn downcast<E>(self) -> Result<ChannelError<E>, Self>
+    where
+        E: Any + Send + Sync,
+    {
+        use ChannelError::*;
+        match self {
+            Read(e) => e.downcast::<E>().map(Read).map_err(Read),
+            Ready(e) => e.downcast::<E>().map(Ready).map_err(Ready),
+            Write(e) => e.downcast::<E>().map(Write).map_err(Write),
+            Flush(e) => e.downcast::<E>().map(Flush).map_err(Flush),
+            Close(e) => e.downcast::<E>().map(Close).map_err(Close),
+        }
+    }
+}
+
+impl ServerError {
+    /// Returns a new server error with `kind` and `detail`.
+    pub fn new(kind: io::ErrorKind, detail: String) -> ServerError {
+        Self { kind, detail }
+    }
+}
+
+impl<T> Request<T> {
+    /// Returns the deadline for this request.
+    pub fn deadline(&self) -> &Instant {
+        &self.context.deadline
+    }
+}
+
+#[test]
+fn test_channel_any_casts() {
+    use assert_matches::assert_matches;
+    let any = ChannelError::Read(Arc::new("")).upcast_any();
+    assert_matches!(any, ChannelError::Read(_));
+    assert_matches!(any.downcast::<&'static str>(), Ok(ChannelError::Read(_)));
+
+    let any = ChannelError::Ready(Arc::new("")).upcast_any();
+    assert_matches!(any, ChannelError::Ready(_));
+    assert_matches!(any.downcast::<&'static str>(), Ok(ChannelError::Ready(_)));
+
+    let any = ChannelError::Write(Arc::new("")).upcast_any();
+    assert_matches!(any, ChannelError::Write(_));
+    assert_matches!(any.downcast::<&'static str>(), Ok(ChannelError::Write(_)));
+
+    let any = ChannelError::Flush(Arc::new("")).upcast_any();
+    assert_matches!(any, ChannelError::Flush(_));
+    assert_matches!(any.downcast::<&'static str>(), Ok(ChannelError::Flush(_)));
+
+    let any = ChannelError::Close(Arc::new("")).upcast_any();
+    assert_matches!(any, ChannelError::Close(_));
+    assert_matches!(any.downcast::<&'static str>(), Ok(ChannelError::Close(_)));
+}
+
+#[test]
+fn test_channel_error_upcast() {
+    use assert_matches::assert_matches;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct E;
+    impl fmt::Display for E {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "E")
+        }
+    }
+    impl Error for E {}
+    assert_matches!(
+        ChannelError::Read(Arc::new(E)).upcast_error(),
+        ChannelError::Read(_)
+    );
+    assert_matches!(
+        ChannelError::Ready(Arc::new(E)).upcast_error(),
+        ChannelError::Ready(_)
+    );
+    assert_matches!(
+        ChannelError::Write(Arc::new(E)).upcast_error(),
+        ChannelError::Write(_)
+    );
+    assert_matches!(
+        ChannelError::Flush(Arc::new(E)).upcast_error(),
+        ChannelError::Flush(_)
+    );
+    assert_matches!(
+        ChannelError::Close(Arc::new(E)).upcast_error(),
+        ChannelError::Close(_)
+    );
+}

--- a/third_party/tarpc/src/serde_transport.rs
+++ b/third_party/tarpc/src/serde_transport.rs
@@ -1,0 +1,737 @@
+// Copyright 2019 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! A generic Serde-based `Transport` that can serialize anything supported by `tokio-serde` via any medium that implements `AsyncRead` and `AsyncWrite`.
+
+#![deny(missing_docs)]
+
+use futures::{prelude::*, task::*};
+use pin_project::pin_project;
+use serde::{Deserialize, Serialize};
+use std::{error::Error, io, pin::Pin};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_serde::{Framed as SerdeFramed, *};
+use tokio_util::codec::{length_delimited::LengthDelimitedCodec, Framed};
+
+/// A transport that serializes to, and deserializes from, a byte stream.
+#[pin_project]
+pub struct Transport<S, Item, SinkItem, Codec> {
+    #[pin]
+    inner: SerdeFramed<Framed<S, LengthDelimitedCodec>, Item, SinkItem, Codec>,
+}
+
+impl<S, Item, SinkItem, Codec> Transport<S, Item, SinkItem, Codec> {
+    /// Returns the inner transport over which messages are sent and received.
+    pub fn get_ref(&self) -> &S {
+        self.inner.get_ref().get_ref()
+    }
+}
+
+impl<S, Item, SinkItem, Codec, CodecError> Stream for Transport<S, Item, SinkItem, Codec>
+where
+    S: AsyncWrite + AsyncRead,
+    Item: for<'a> Deserialize<'a>,
+    Codec: Deserializer<Item>,
+    CodecError: Into<Box<dyn std::error::Error + Send + Sync>>,
+    SerdeFramed<Framed<S, LengthDelimitedCodec>, Item, SinkItem, Codec>:
+        Stream<Item = Result<Item, CodecError>>,
+{
+    type Item = io::Result<Item>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<io::Result<Item>>> {
+        self.project()
+            .inner
+            .poll_next(cx)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+}
+
+impl<S, Item, SinkItem, Codec, CodecError> Sink<SinkItem> for Transport<S, Item, SinkItem, Codec>
+where
+    S: AsyncWrite,
+    SinkItem: Serialize,
+    Codec: Serializer<SinkItem>,
+    CodecError: Into<Box<dyn Error + Send + Sync>>,
+    SerdeFramed<Framed<S, LengthDelimitedCodec>, Item, SinkItem, Codec>:
+        Sink<SinkItem, Error = CodecError>,
+{
+    type Error = io::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project()
+            .inner
+            .poll_ready(cx)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: SinkItem) -> io::Result<()> {
+        self.project()
+            .inner
+            .start_send(item)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project()
+            .inner
+            .poll_flush(cx)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project()
+            .inner
+            .poll_close(cx)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+}
+
+/// Constructs a new transport from a framed transport and a serialization codec.
+pub fn new<S, Item, SinkItem, Codec>(
+    framed_io: Framed<S, LengthDelimitedCodec>,
+    codec: Codec,
+) -> Transport<S, Item, SinkItem, Codec>
+where
+    S: AsyncWrite + AsyncRead,
+    Item: for<'de> Deserialize<'de>,
+    SinkItem: Serialize,
+    Codec: Serializer<SinkItem> + Deserializer<Item>,
+{
+    Transport {
+        inner: SerdeFramed::new(framed_io, codec),
+    }
+}
+
+impl<S, Item, SinkItem, Codec> From<(S, Codec)> for Transport<S, Item, SinkItem, Codec>
+where
+    S: AsyncWrite + AsyncRead,
+    Item: for<'de> Deserialize<'de>,
+    SinkItem: Serialize,
+    Codec: Serializer<SinkItem> + Deserializer<Item>,
+{
+    fn from((io, codec): (S, Codec)) -> Self {
+        new(Framed::new(io, LengthDelimitedCodec::new()), codec)
+    }
+}
+
+#[cfg(feature = "tcp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tcp")))]
+/// TCP support for generic transport using Tokio.
+pub mod tcp {
+    use {
+        super::*,
+        futures::ready,
+        std::{marker::PhantomData, net::SocketAddr},
+        tokio::net::{TcpListener, TcpStream, ToSocketAddrs},
+        tokio_util::codec::length_delimited,
+    };
+
+    impl<Item, SinkItem, Codec> Transport<TcpStream, Item, SinkItem, Codec> {
+        /// Returns the peer address of the underlying TcpStream.
+        pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+            self.inner.get_ref().get_ref().peer_addr()
+        }
+        /// Returns the local address of the underlying TcpStream.
+        pub fn local_addr(&self) -> io::Result<SocketAddr> {
+            self.inner.get_ref().get_ref().local_addr()
+        }
+    }
+
+    /// A connection Future that also exposes the length-delimited framing config.
+    #[must_use]
+    #[pin_project]
+    pub struct TcpConnect<T, Item, SinkItem, CodecFn> {
+        #[pin]
+        inner: T,
+        codec_fn: CodecFn,
+        config: length_delimited::Builder,
+        ghost: PhantomData<(fn(SinkItem), fn() -> Item)>,
+    }
+
+    impl<T, Item, SinkItem, Codec, CodecFn> Future for TcpConnect<T, Item, SinkItem, CodecFn>
+    where
+        T: Future<Output = io::Result<TcpStream>>,
+        Item: for<'de> Deserialize<'de>,
+        SinkItem: Serialize,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        type Output = io::Result<Transport<TcpStream, Item, SinkItem, Codec>>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            let io = ready!(self.as_mut().project().inner.poll(cx))?;
+            Poll::Ready(Ok(new(self.config.new_framed(io), (self.codec_fn)())))
+        }
+    }
+
+    impl<T, Item, SinkItem, CodecFn> TcpConnect<T, Item, SinkItem, CodecFn> {
+        /// Returns an immutable reference to the length-delimited codec's config.
+        pub fn config(&self) -> &length_delimited::Builder {
+            &self.config
+        }
+
+        /// Returns a mutable reference to the length-delimited codec's config.
+        pub fn config_mut(&mut self) -> &mut length_delimited::Builder {
+            &mut self.config
+        }
+    }
+
+    /// Connects to `addr`, wrapping the connection in a TCP transport.
+    pub fn connect<A, Item, SinkItem, Codec, CodecFn>(
+        addr: A,
+        codec_fn: CodecFn,
+    ) -> TcpConnect<impl Future<Output = io::Result<TcpStream>>, Item, SinkItem, CodecFn>
+    where
+        A: ToSocketAddrs,
+        Item: for<'de> Deserialize<'de>,
+        SinkItem: Serialize,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        TcpConnect {
+            inner: TcpStream::connect(addr),
+            codec_fn,
+            config: LengthDelimitedCodec::builder(),
+            ghost: PhantomData,
+        }
+    }
+
+    /// Listens on `addr`, wrapping accepted connections in TCP transports.
+    pub async fn listen<A, Item, SinkItem, Codec, CodecFn>(
+        addr: A,
+        codec_fn: CodecFn,
+    ) -> io::Result<Incoming<Item, SinkItem, Codec, CodecFn>>
+    where
+        A: ToSocketAddrs,
+        Item: for<'de> Deserialize<'de>,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        listen_on(TcpListener::bind(addr).await?, codec_fn).await
+    }
+
+    /// Wrap accepted connections from `listener` in TCP transports.
+    pub async fn listen_on<Item, SinkItem, Codec, CodecFn>(
+        listener: TcpListener,
+        codec_fn: CodecFn,
+    ) -> io::Result<Incoming<Item, SinkItem, Codec, CodecFn>>
+    where
+        Item: for<'de> Deserialize<'de>,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        let local_addr = listener.local_addr()?;
+        Ok(Incoming {
+            listener,
+            codec_fn,
+            local_addr,
+            config: LengthDelimitedCodec::builder(),
+            ghost: PhantomData,
+        })
+    }
+
+    /// A [`TcpListener`] that wraps connections in [transports](Transport).
+    #[pin_project]
+    #[derive(Debug)]
+    pub struct Incoming<Item, SinkItem, Codec, CodecFn> {
+        listener: TcpListener,
+        local_addr: SocketAddr,
+        codec_fn: CodecFn,
+        config: length_delimited::Builder,
+        ghost: PhantomData<(fn() -> Item, fn(SinkItem), Codec)>,
+    }
+
+    impl<Item, SinkItem, Codec, CodecFn> Incoming<Item, SinkItem, Codec, CodecFn> {
+        /// Returns the address being listened on.
+        pub fn local_addr(&self) -> SocketAddr {
+            self.local_addr
+        }
+
+        /// Returns an immutable reference to the length-delimited codec's config.
+        pub fn config(&self) -> &length_delimited::Builder {
+            &self.config
+        }
+
+        /// Returns a mutable reference to the length-delimited codec's config.
+        pub fn config_mut(&mut self) -> &mut length_delimited::Builder {
+            &mut self.config
+        }
+    }
+
+    impl<Item, SinkItem, Codec, CodecFn> Stream for Incoming<Item, SinkItem, Codec, CodecFn>
+    where
+        Item: for<'de> Deserialize<'de>,
+        SinkItem: Serialize,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        type Item = io::Result<Transport<TcpStream, Item, SinkItem, Codec>>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let conn: TcpStream =
+                ready!(Pin::new(&mut self.as_mut().project().listener).poll_accept(cx)?).0;
+            Poll::Ready(Some(Ok(new(
+                self.config.new_framed(conn),
+                (self.codec_fn)(),
+            ))))
+        }
+    }
+}
+
+#[cfg(all(unix, feature = "unix"))]
+#[cfg_attr(docsrs, doc(cfg(all(unix, feature = "unix"))))]
+/// Unix Domain Socket support for generic transport using Tokio.
+pub mod unix {
+    use {
+        super::*,
+        futures::ready,
+        std::{marker::PhantomData, path::Path},
+        tokio::net::{unix::SocketAddr, UnixListener, UnixStream},
+        tokio_util::codec::length_delimited,
+    };
+
+    impl<Item, SinkItem, Codec> Transport<UnixStream, Item, SinkItem, Codec> {
+        /// Returns the socket address of the remote half of the underlying [`UnixStream`].
+        pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+            self.inner.get_ref().get_ref().peer_addr()
+        }
+        /// Returns the socket address of the local half of the underlying [`UnixStream`].
+        pub fn local_addr(&self) -> io::Result<SocketAddr> {
+            self.inner.get_ref().get_ref().local_addr()
+        }
+    }
+
+    /// A connection Future that also exposes the length-delimited framing config.
+    #[must_use]
+    #[pin_project]
+    pub struct UnixConnect<T, Item, SinkItem, CodecFn> {
+        #[pin]
+        inner: T,
+        codec_fn: CodecFn,
+        config: length_delimited::Builder,
+        ghost: PhantomData<(fn(SinkItem), fn() -> Item)>,
+    }
+
+    impl<T, Item, SinkItem, Codec, CodecFn> Future for UnixConnect<T, Item, SinkItem, CodecFn>
+    where
+        T: Future<Output = io::Result<UnixStream>>,
+        Item: for<'de> Deserialize<'de>,
+        SinkItem: Serialize,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        type Output = io::Result<Transport<UnixStream, Item, SinkItem, Codec>>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            let io = ready!(self.as_mut().project().inner.poll(cx))?;
+            Poll::Ready(Ok(new(self.config.new_framed(io), (self.codec_fn)())))
+        }
+    }
+
+    impl<T, Item, SinkItem, CodecFn> UnixConnect<T, Item, SinkItem, CodecFn> {
+        /// Returns an immutable reference to the length-delimited codec's config.
+        pub fn config(&self) -> &length_delimited::Builder {
+            &self.config
+        }
+
+        /// Returns a mutable reference to the length-delimited codec's config.
+        pub fn config_mut(&mut self) -> &mut length_delimited::Builder {
+            &mut self.config
+        }
+    }
+
+    /// Connects to socket named by `path`, wrapping the connection in a Unix Domain Socket
+    /// transport.
+    pub fn connect<P, Item, SinkItem, Codec, CodecFn>(
+        path: P,
+        codec_fn: CodecFn,
+    ) -> UnixConnect<impl Future<Output = io::Result<UnixStream>>, Item, SinkItem, CodecFn>
+    where
+        P: AsRef<Path>,
+        Item: for<'de> Deserialize<'de>,
+        SinkItem: Serialize,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        UnixConnect {
+            inner: UnixStream::connect(path),
+            codec_fn,
+            config: LengthDelimitedCodec::builder(),
+            ghost: PhantomData,
+        }
+    }
+
+    /// Listens on the socket named by `path`, wrapping accepted connections in Unix Domain Socket
+    /// transports.
+    pub async fn listen<P, Item, SinkItem, Codec, CodecFn>(
+        path: P,
+        codec_fn: CodecFn,
+    ) -> io::Result<Incoming<Item, SinkItem, Codec, CodecFn>>
+    where
+        P: AsRef<Path>,
+        Item: for<'de> Deserialize<'de>,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        listen_on(UnixListener::bind(path)?, codec_fn).await
+    }
+
+    /// Wrap accepted connections from `listener` in Unix Domain Socket transports.
+    pub async fn listen_on<Item, SinkItem, Codec, CodecFn>(
+        listener: UnixListener,
+        codec_fn: CodecFn,
+    ) -> io::Result<Incoming<Item, SinkItem, Codec, CodecFn>>
+    where
+        Item: for<'de> Deserialize<'de>,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        let local_addr = listener.local_addr()?;
+        Ok(Incoming {
+            listener,
+            codec_fn,
+            local_addr,
+            config: LengthDelimitedCodec::builder(),
+            ghost: PhantomData,
+        })
+    }
+
+    /// A [`UnixListener`] that wraps connections in [transports](Transport).
+    #[pin_project]
+    #[derive(Debug)]
+    pub struct Incoming<Item, SinkItem, Codec, CodecFn> {
+        listener: UnixListener,
+        local_addr: SocketAddr,
+        codec_fn: CodecFn,
+        config: length_delimited::Builder,
+        ghost: PhantomData<(fn() -> Item, fn(SinkItem), Codec)>,
+    }
+
+    impl<Item, SinkItem, Codec, CodecFn> Incoming<Item, SinkItem, Codec, CodecFn> {
+        /// Returns the the socket address being listened on.
+        pub fn local_addr(&self) -> &SocketAddr {
+            &self.local_addr
+        }
+
+        /// Returns an immutable reference to the length-delimited codec's config.
+        pub fn config(&self) -> &length_delimited::Builder {
+            &self.config
+        }
+
+        /// Returns a mutable reference to the length-delimited codec's config.
+        pub fn config_mut(&mut self) -> &mut length_delimited::Builder {
+            &mut self.config
+        }
+    }
+
+    impl<Item, SinkItem, Codec, CodecFn> Stream for Incoming<Item, SinkItem, Codec, CodecFn>
+    where
+        Item: for<'de> Deserialize<'de>,
+        SinkItem: Serialize,
+        Codec: Serializer<SinkItem> + Deserializer<Item>,
+        CodecFn: Fn() -> Codec,
+    {
+        type Item = io::Result<Transport<UnixStream, Item, SinkItem, Codec>>;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let conn: UnixStream = ready!(self.as_mut().project().listener.poll_accept(cx)?).0;
+            Poll::Ready(Some(Ok(new(
+                self.config.new_framed(conn),
+                (self.codec_fn)(),
+            ))))
+        }
+    }
+
+    /// A temporary `PathBuf` that lives in `std::env::temp_dir` and is removed on drop.
+    pub struct TempPathBuf(std::path::PathBuf);
+
+    impl TempPathBuf {
+        /// A named socket that results in `<tempdir>/<name>`
+        pub fn new<S: AsRef<str>>(name: S) -> Self {
+            let mut sock = std::env::temp_dir();
+            sock.push(name.as_ref());
+            Self(sock)
+        }
+
+        /// Appends a random hex string to the socket name resulting in
+        /// `<tempdir>/<name>_<xxxxx>`
+        pub fn with_random<S: AsRef<str>>(name: S) -> Self {
+            Self::new(format!("{}_{:016x}", name.as_ref(), rand::random::<u64>()))
+        }
+    }
+
+    impl AsRef<std::path::Path> for TempPathBuf {
+        fn as_ref(&self) -> &std::path::Path {
+            self.0.as_path()
+        }
+    }
+
+    impl Drop for TempPathBuf {
+        fn drop(&mut self) {
+            // This will remove the file pointed to by this PathBuf if it exists, however Err's can
+            // be returned such as attempting to remove a non-existing file, or one which we don't
+            // have permission to remove. In these cases the Err is swallowed
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use tokio_serde::formats::SymmetricalJson;
+
+        #[test]
+        fn temp_path_buf_non_random() {
+            let sock = TempPathBuf::new("test");
+            let mut good = std::env::temp_dir();
+            good.push("test");
+            assert_eq!(sock.as_ref(), good);
+            assert_eq!(sock.as_ref().file_name().unwrap(), "test");
+        }
+
+        #[test]
+        fn temp_path_buf_random() {
+            let sock = TempPathBuf::with_random("test");
+            let good = std::env::temp_dir();
+            assert!(sock.as_ref().starts_with(good));
+            // Since there are 16 random characters we just assert the file_name has the right name
+            // and starts with the correct string 'test_'
+            // file name: test_xxxxxxxxxxxxxxxx
+            // test  = 4
+            // _     = 1
+            // <hex> = 16
+            // total = 21
+            let fname = sock.as_ref().file_name().unwrap().to_string_lossy();
+            assert!(fname.starts_with("test_"));
+            assert_eq!(fname.len(), 21);
+        }
+
+        #[test]
+        fn temp_path_buf_non_existing() {
+            let sock = TempPathBuf::with_random("test");
+            let sock_path = std::path::PathBuf::from(sock.as_ref());
+
+            // No actual file has been created yet
+            assert!(!sock_path.exists());
+            // Should not panic
+            std::mem::drop(sock);
+            assert!(!sock_path.exists());
+        }
+
+        #[test]
+        fn temp_path_buf_existing_file() {
+            let sock = TempPathBuf::with_random("test");
+            let sock_path = std::path::PathBuf::from(sock.as_ref());
+            let _file = std::fs::File::create(&sock).unwrap();
+            assert!(sock_path.exists());
+            std::mem::drop(sock);
+            assert!(!sock_path.exists());
+        }
+
+        #[test]
+        fn temp_path_buf_preexisting_file() {
+            let mut pre_existing = std::env::temp_dir();
+            pre_existing.push("test");
+            let _file = std::fs::File::create(&pre_existing).unwrap();
+            let sock = TempPathBuf::new("test");
+            let sock_path = std::path::PathBuf::from(sock.as_ref());
+            assert!(sock_path.exists());
+            std::mem::drop(sock);
+            assert!(!sock_path.exists());
+        }
+
+        #[tokio::test]
+        async fn temp_path_buf_for_socket() {
+            let sock = TempPathBuf::with_random("test");
+            // Save path for testing after drop
+            let sock_path = std::path::PathBuf::from(sock.as_ref());
+            // create the actual socket
+            let _ = listen(&sock, SymmetricalJson::<String>::default).await;
+            assert!(sock_path.exists());
+            std::mem::drop(sock);
+            assert!(!sock_path.exists());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Transport;
+    use assert_matches::assert_matches;
+    use futures::{task::*, Sink, Stream};
+    #[cfg(any(feature = "tcp", all(unix, feature = "unix")))]
+    use futures::{SinkExt, StreamExt};
+    use pin_utils::pin_mut;
+    use std::{
+        io::{self, Cursor},
+        pin::Pin,
+    };
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+    use tokio_serde::formats::SymmetricalJson;
+
+    fn ctx() -> Context<'static> {
+        Context::from_waker(noop_waker_ref())
+    }
+
+    struct TestIo(Cursor<Vec<u8>>);
+
+    impl AsyncRead for TestIo {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            AsyncRead::poll_read(Pin::new(&mut self.0), cx, buf)
+        }
+    }
+
+    impl AsyncWrite for TestIo {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            AsyncWrite::poll_write(Pin::new(&mut self.0), cx, buf)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            AsyncWrite::poll_flush(Pin::new(&mut self.0), cx)
+        }
+
+        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            AsyncWrite::poll_shutdown(Pin::new(&mut self.0), cx)
+        }
+    }
+
+    #[test]
+    fn close() {
+        let (tx, _rx) = crate::transport::channel::bounded::<(), ()>(0);
+        pin_mut!(tx);
+        assert_matches!(tx.as_mut().poll_close(&mut ctx()), Poll::Ready(Ok(())));
+        assert_matches!(tx.as_mut().start_send(()), Err(_));
+    }
+
+    #[test]
+    fn test_stream() {
+        let data: &[u8] = b"\x00\x00\x00\x18\"Test one, check check.\"";
+        let transport = Transport::from((
+            TestIo(Cursor::new(Vec::from(data))),
+            SymmetricalJson::<String>::default(),
+        ));
+        pin_mut!(transport);
+
+        assert_matches!(
+            transport.as_mut().poll_next(&mut ctx()),
+            Poll::Ready(Some(Ok(ref s))) if s == "Test one, check check.");
+        assert_matches!(transport.as_mut().poll_next(&mut ctx()), Poll::Ready(None));
+    }
+
+    #[test]
+    fn test_sink() {
+        let writer = Cursor::new(vec![]);
+        let mut transport = Box::pin(Transport::from((
+            TestIo(writer),
+            SymmetricalJson::<String>::default(),
+        )));
+
+        assert_matches!(
+            transport.as_mut().poll_ready(&mut ctx()),
+            Poll::Ready(Ok(()))
+        );
+        assert_matches!(
+            transport
+                .as_mut()
+                .start_send("Test one, check check.".into()),
+            Ok(())
+        );
+        assert_matches!(
+            transport.as_mut().poll_flush(&mut ctx()),
+            Poll::Ready(Ok(()))
+        );
+        assert_eq!(
+            transport.get_ref().0.get_ref(),
+            b"\x00\x00\x00\x18\"Test one, check check.\""
+        );
+    }
+
+    #[cfg(feature = "tcp")]
+    #[tokio::test]
+    async fn tcp() -> io::Result<()> {
+        use super::tcp;
+
+        let mut listener = tcp::listen("0.0.0.0:0", SymmetricalJson::<String>::default).await?;
+        let addr = listener.local_addr();
+        tokio::spawn(async move {
+            let mut transport = listener.next().await.unwrap().unwrap();
+            let message = transport.next().await.unwrap().unwrap();
+            transport.send(message).await.unwrap();
+        });
+        let mut transport = tcp::connect(addr, SymmetricalJson::<String>::default).await?;
+        transport.send(String::from("test")).await?;
+        assert_matches!(transport.next().await, Some(Ok(s)) if s == "test");
+        assert_matches!(transport.next().await, None);
+        Ok(())
+    }
+
+    #[cfg(feature = "tcp")]
+    #[tokio::test]
+    async fn tcp_on_existing_transport() -> io::Result<()> {
+        use super::tcp;
+
+        let transport = tokio::net::TcpListener::bind("0.0.0.0:0").await?;
+        let mut listener = tcp::listen_on(transport, SymmetricalJson::<String>::default).await?;
+        let addr = listener.local_addr();
+        tokio::spawn(async move {
+            let mut transport = listener.next().await.unwrap().unwrap();
+            let message = transport.next().await.unwrap().unwrap();
+            transport.send(message).await.unwrap();
+        });
+        let mut transport = tcp::connect(addr, SymmetricalJson::<String>::default).await?;
+        transport.send(String::from("test")).await?;
+        assert_matches!(transport.next().await, Some(Ok(s)) if s == "test");
+        assert_matches!(transport.next().await, None);
+        Ok(())
+    }
+
+    #[cfg(all(unix, feature = "unix"))]
+    #[tokio::test]
+    async fn uds() -> io::Result<()> {
+        use super::unix;
+
+        let sock = unix::TempPathBuf::with_random("uds");
+        let mut listener = unix::listen(&sock, SymmetricalJson::<String>::default).await?;
+        tokio::spawn(async move {
+            let mut transport = listener.next().await.unwrap().unwrap();
+            let message = transport.next().await.unwrap().unwrap();
+            transport.send(message).await.unwrap();
+        });
+        let mut transport = unix::connect(&sock, SymmetricalJson::<String>::default).await?;
+        transport.send(String::from("test")).await?;
+        assert_matches!(transport.next().await, Some(Ok(s)) if s == "test");
+        assert_matches!(transport.next().await, None);
+        Ok(())
+    }
+
+    #[cfg(all(unix, feature = "unix"))]
+    #[tokio::test]
+    async fn uds_on_existing_transport() -> io::Result<()> {
+        use super::unix;
+
+        let sock = unix::TempPathBuf::with_random("uds");
+        let transport = tokio::net::UnixListener::bind(&sock)?;
+        let mut listener = unix::listen_on(transport, SymmetricalJson::<String>::default).await?;
+        tokio::spawn(async move {
+            let mut transport = listener.next().await.unwrap().unwrap();
+            let message = transport.next().await.unwrap().unwrap();
+            transport.send(message).await.unwrap();
+        });
+        let mut transport = unix::connect(&sock, SymmetricalJson::<String>::default).await?;
+        transport.send(String::from("test")).await?;
+        assert_matches!(transport.next().await, Some(Ok(s)) if s == "test");
+        assert_matches!(transport.next().await, None);
+        Ok(())
+    }
+}

--- a/third_party/tarpc/src/server.rs
+++ b/third_party/tarpc/src/server.rs
@@ -1,0 +1,1451 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a server that concurrently handles many connections sending multiplexed requests.
+
+use crate::{
+    cancellations::{cancellations, CanceledRequests, RequestCancellation},
+    context::{self, SpanExt},
+    trace,
+    util::TimeUntil,
+    ChannelError, ClientMessage, Request, RequestName, Response, ServerError, Transport,
+};
+use ::tokio::sync::mpsc;
+use futures::{
+    future::{AbortRegistration, Abortable},
+    prelude::*,
+    ready,
+    stream::Fuse,
+    task::*,
+};
+use in_flight_requests::{AlreadyExistsError, InFlightRequests};
+use pin_project::pin_project;
+use std::{
+    convert::TryFrom, error::Error, fmt, marker::PhantomData, pin::Pin, sync::Arc, time::SystemTime,
+};
+use tracing::{info_span, instrument::Instrument, Span};
+
+mod in_flight_requests;
+pub mod request_hook;
+#[cfg(test)]
+mod testing;
+
+/// Provides functionality to apply server limits.
+pub mod limits;
+
+/// Provides helper methods for streams of Channels.
+pub mod incoming;
+
+/// Settings that control the behavior of [channels](Channel).
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// Controls the buffer size of the in-process channel over which a server's handlers send
+    /// responses to the [`Channel`]. In other words, this is the number of responses that can sit
+    /// in the outbound queue before request handlers begin blocking.
+    pub pending_response_buffer: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            pending_response_buffer: 100,
+        }
+    }
+}
+
+impl Config {
+    /// Returns a channel backed by `transport` and configured with `self`.
+    pub fn channel<Req, Resp, T>(self, transport: T) -> BaseChannel<Req, Resp, T>
+    where
+        T: Transport<Response<Resp>, ClientMessage<Req>>,
+    {
+        BaseChannel::new(self, transport)
+    }
+}
+
+/// Equivalent to a `FnOnce(Req) -> impl Future<Output = Resp>`.
+#[allow(async_fn_in_trait)]
+pub trait Serve {
+    /// Type of request.
+    type Req: RequestName;
+
+    /// Type of response.
+    type Resp;
+
+    /// Responds to a single request.
+    async fn serve(self, ctx: context::Context, req: Self::Req) -> Result<Self::Resp, ServerError>;
+}
+
+/// A Serve wrapper around a Fn.
+#[derive(Debug)]
+pub struct ServeFn<Req, Resp, F> {
+    f: F,
+    data: PhantomData<fn(Req) -> Resp>,
+}
+
+impl<Req, Resp, F> Clone for ServeFn<Req, Resp, F>
+where
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: self.f.clone(),
+            data: PhantomData,
+        }
+    }
+}
+
+impl<Req, Resp, F> Copy for ServeFn<Req, Resp, F> where F: Copy {}
+
+/// Creates a [`Serve`] wrapper around a `FnOnce(context::Context, Req) -> impl Future<Output =
+/// Result<Resp, ServerError>>`.
+pub fn serve<Req, Resp, Fut, F>(f: F) -> ServeFn<Req, Resp, F>
+where
+    F: FnOnce(context::Context, Req) -> Fut,
+    Fut: Future<Output = Result<Resp, ServerError>>,
+{
+    ServeFn {
+        f,
+        data: PhantomData,
+    }
+}
+
+impl<Req, Resp, Fut, F> Serve for ServeFn<Req, Resp, F>
+where
+    Req: RequestName,
+    F: FnOnce(context::Context, Req) -> Fut,
+    Fut: Future<Output = Result<Resp, ServerError>>,
+{
+    type Req = Req;
+    type Resp = Resp;
+
+    async fn serve(self, ctx: context::Context, req: Req) -> Result<Resp, ServerError> {
+        (self.f)(ctx, req).await
+    }
+}
+
+/// BaseChannel is the standard implementation of a [`Channel`].
+///
+/// BaseChannel manages a [`Transport`](Transport) of client [`messages`](ClientMessage) and
+/// implements a [`Stream`] of [requests](TrackedRequest). See the [`Channel`] documentation for
+/// how to use channels.
+///
+/// Besides requests, the other type of client message handled by `BaseChannel` is [cancellation
+/// messages](ClientMessage::Cancel). `BaseChannel` does not allow direct access to cancellation
+/// messages. Instead, it internally handles them by cancelling corresponding requests (removing
+/// the corresponding in-flight requests and aborting their handlers).
+#[pin_project]
+pub struct BaseChannel<Req, Resp, T> {
+    config: Config,
+    /// Writes responses to the wire and reads requests off the wire.
+    #[pin]
+    transport: Fuse<T>,
+    /// In-flight requests that were dropped by the server before completion.
+    #[pin]
+    canceled_requests: CanceledRequests,
+    /// Notifies `canceled_requests` when a request is canceled.
+    request_cancellation: RequestCancellation,
+    /// Holds data necessary to clean up in-flight requests.
+    in_flight_requests: InFlightRequests,
+    /// Types the request and response.
+    ghost: PhantomData<(fn() -> Req, fn(Resp))>,
+}
+
+impl<Req, Resp, T> BaseChannel<Req, Resp, T>
+where
+    T: Transport<Response<Resp>, ClientMessage<Req>>,
+{
+    /// Creates a new channel backed by `transport` and configured with `config`.
+    pub fn new(config: Config, transport: T) -> Self {
+        let (request_cancellation, canceled_requests) = cancellations();
+        BaseChannel {
+            config,
+            transport: transport.fuse(),
+            canceled_requests,
+            request_cancellation,
+            in_flight_requests: InFlightRequests::default(),
+            ghost: PhantomData,
+        }
+    }
+
+    /// Creates a new channel backed by `transport` and configured with the defaults.
+    pub fn with_defaults(transport: T) -> Self {
+        Self::new(Config::default(), transport)
+    }
+
+    /// Returns the inner transport over which messages are sent and received.
+    pub fn get_ref(&self) -> &T {
+        self.transport.get_ref()
+    }
+
+    /// Returns the inner transport over which messages are sent and received.
+    pub fn get_pin_ref(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().transport.get_pin_mut()
+    }
+
+    fn in_flight_requests_mut<'a>(self: &'a mut Pin<&mut Self>) -> &'a mut InFlightRequests {
+        self.as_mut().project().in_flight_requests
+    }
+
+    fn canceled_requests_pin_mut<'a>(
+        self: &'a mut Pin<&mut Self>,
+    ) -> Pin<&'a mut CanceledRequests> {
+        self.as_mut().project().canceled_requests
+    }
+
+    fn transport_pin_mut<'a>(self: &'a mut Pin<&mut Self>) -> Pin<&'a mut Fuse<T>> {
+        self.as_mut().project().transport
+    }
+
+    fn start_request(
+        mut self: Pin<&mut Self>,
+        mut request: Request<Req>,
+    ) -> Result<TrackedRequest<Req>, AlreadyExistsError> {
+        let span = info_span!(
+            "RPC",
+            rpc.trace_id = %request.context.trace_id(),
+            rpc.deadline = %humantime::format_rfc3339(SystemTime::now() + request.context.deadline.time_until()),
+            otel.kind = "server",
+            otel.name = tracing::field::Empty,
+        );
+        span.set_context(&request.context);
+        request.context.trace_context = trace::Context::try_from(&span).unwrap_or_else(|_| {
+            tracing::trace!(
+                "OpenTelemetry subscriber not installed; making unsampled \
+                            child context."
+            );
+            request.context.trace_context.new_child()
+        });
+        let entered = span.enter();
+        tracing::info!("ReceiveRequest");
+        let start = self.in_flight_requests_mut().start_request(
+            request.id,
+            request.context.deadline,
+            span.clone(),
+        );
+        match start {
+            Ok(abort_registration) => {
+                drop(entered);
+                Ok(TrackedRequest {
+                    abort_registration,
+                    span,
+                    response_guard: ResponseGuard {
+                        request_id: request.id,
+                        request_cancellation: self.request_cancellation.clone(),
+                        cancel: false,
+                    },
+                    request,
+                })
+            }
+            Err(AlreadyExistsError) => {
+                tracing::trace!("DuplicateRequest");
+                Err(AlreadyExistsError)
+            }
+        }
+    }
+}
+
+impl<Req, Resp, T> fmt::Debug for BaseChannel<Req, Resp, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BaseChannel")
+    }
+}
+
+/// A request tracked by a [`Channel`].
+#[derive(Debug)]
+pub struct TrackedRequest<Req> {
+    /// The request sent by the client.
+    pub request: Request<Req>,
+    /// A registration to abort a future when the [`Channel`] that produced this request stops
+    /// tracking it.
+    pub abort_registration: AbortRegistration,
+    /// A span representing the server processing of this request.
+    pub span: Span,
+    /// An inert response guard. Becomes active in an InFlightRequest.
+    pub response_guard: ResponseGuard,
+}
+
+/// The server end of an open connection with a client, receiving requests from, and sending
+/// responses to, the client. `Channel` is a [`Transport`] with request lifecycle management.
+///
+/// The ways to use a Channel, in order of simplest to most complex, is:
+/// 1. [`Channel::execute`] - Requires the `tokio1` feature. This method is best for those who
+///    do not have specific scheduling needs and whose services are `Send + 'static`.
+/// 2. [`Channel::requests`] - This method is best for those who need direct access to individual
+///    requests, or are not using `tokio`, or want control over [futures](Future) scheduling.
+///    [`Requests`] is a stream of [`InFlightRequests`](InFlightRequest), each which has an
+///    [`execute`](InFlightRequest::execute) method. If using `execute`, request processing will
+///    automatically cease when either the request deadline is reached or when a corresponding
+///    cancellation message is received by the Channel.
+/// 3. [`Stream::next`](futures::stream::StreamExt::next) /
+///    [`Sink::send`](futures::sink::SinkExt::send) - A user is free to manually read requests
+///    from, and send responses into, a Channel in lieu of the previous methods. Channels stream
+///    [`TrackedRequests`](TrackedRequest), which, in addition to the request itself, contains the
+///    server [`Span`], request lifetime [`AbortRegistration`], and an inert [`ResponseGuard`].
+///    Wrapping response logic in an [`Abortable`] future using the abort registration will ensure
+///    that the response does not execute longer than the request deadline. The `Channel` itself
+///    will clean up request state once either the deadline expires, or the response guard is
+///    dropped, or a response is sent.
+///
+/// Channels must be implemented using the decorator pattern: the only way to create a
+/// `TrackedRequest` is to get one from another `Channel`. Ultimately, all `TrackedRequests` are
+/// created by [`BaseChannel`].
+pub trait Channel
+where
+    Self: Transport<Response<<Self as Channel>::Resp>, TrackedRequest<<Self as Channel>::Req>>,
+{
+    /// Type of request item.
+    type Req;
+
+    /// Type of response sink item.
+    type Resp;
+
+    /// The wrapped transport.
+    type Transport;
+
+    /// Configuration of the channel.
+    fn config(&self) -> &Config;
+
+    /// Returns the number of in-flight requests over this channel.
+    fn in_flight_requests(&self) -> usize;
+
+    /// Returns the transport underlying the channel.
+    fn transport(&self) -> &Self::Transport;
+
+    /// Caps the number of concurrent requests to `limit`. An error will be returned for requests
+    /// over the concurrency limit.
+    ///
+    /// Note that this is a very
+    /// simplistic throttling heuristic. It is easy to set a number that is too low for the
+    /// resources available to the server. For production use cases, a more advanced throttler is
+    /// likely needed.
+    fn max_concurrent_requests(
+        self,
+        limit: usize,
+    ) -> limits::requests_per_channel::MaxRequests<Self>
+    where
+        Self: Sized,
+    {
+        limits::requests_per_channel::MaxRequests::new(self, limit)
+    }
+
+    /// Returns a stream of requests that automatically handle request cancellation and response
+    /// routing.
+    ///
+    /// This is a terminal operation. After calling `requests`, the channel cannot be retrieved,
+    /// and the only way to complete requests is via [`Requests::execute`] or
+    /// [`InFlightRequest::execute`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tarpc::{
+    ///     context,
+    ///     client::{self, NewClient},
+    ///     server::{self, BaseChannel, Channel, serve},
+    ///     transport,
+    /// };
+    /// use futures::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = transport::channel::unbounded();
+    ///     let server = BaseChannel::new(server::Config::default(), rx);
+    ///     let NewClient { client, dispatch } = client::new(client::Config::default(), tx);
+    ///     tokio::spawn(dispatch);
+    ///
+    ///     let mut requests = server.requests();
+    ///     tokio::spawn(async move {
+    ///         while let Some(Ok(request)) = requests.next().await {
+    ///             tokio::spawn(request.execute(serve(|_, i| async move { Ok(i + 1) })));
+    ///         }
+    ///     });
+    ///     assert_eq!(client.call(context::current(), 1).await.unwrap(), 2);
+    /// }
+    /// ```
+    fn requests(self) -> Requests<Self>
+    where
+        Self: Sized,
+    {
+        let (responses_tx, responses) = mpsc::channel(self.config().pending_response_buffer);
+
+        Requests {
+            channel: self,
+            pending_responses: responses,
+            responses_tx,
+        }
+    }
+
+    /// Returns a stream of request execution futures. Each future represents an in-flight request
+    /// being responded to by the server. The futures must be awaited or spawned to complete their
+    /// requests.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tarpc::{context, client, server::{self, BaseChannel, Channel, serve}, transport};
+    /// use futures::prelude::*;
+    /// use tracing_subscriber::prelude::*;
+    ///
+    /// # #[cfg(not(feature = "tokio1"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "tokio1")]
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = transport::channel::unbounded();
+    ///     let client = client::new(client::Config::default(), tx).spawn();
+    ///     let channel = BaseChannel::with_defaults(rx);
+    ///     tokio::spawn(
+    ///         channel.execute(serve(|_, i: i32| async move { Ok(i + 1) }))
+    ///            .for_each(|response| async move {
+    ///                tokio::spawn(response);
+    ///            }));
+    ///     assert_eq!(
+    ///         client.call(context::current(), 1).await.unwrap(),
+    ///         2);
+    /// }
+    /// ```
+    fn execute<S>(self, serve: S) -> impl Stream<Item = impl Future<Output = ()>>
+    where
+        Self: Sized,
+        Self::Req: RequestName,
+        S: Serve<Req = Self::Req, Resp = Self::Resp> + Clone,
+    {
+        self.requests().execute(serve)
+    }
+}
+
+impl<Req, Resp, T> Stream for BaseChannel<Req, Resp, T>
+where
+    T: Transport<Response<Resp>, ClientMessage<Req>>,
+{
+    type Item = Result<TrackedRequest<Req>, ChannelError<T::Error>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        #[derive(Clone, Copy, Debug)]
+        enum ReceiverStatus {
+            Ready,
+            Pending,
+            Closed,
+        }
+
+        impl ReceiverStatus {
+            fn combine(self, other: Self) -> Self {
+                use ReceiverStatus::*;
+                match (self, other) {
+                    (Ready, _) | (_, Ready) => Ready,
+                    (Closed, Closed) => Closed,
+                    (Pending, Closed) | (Closed, Pending) | (Pending, Pending) => Pending,
+                }
+            }
+        }
+
+        use ReceiverStatus::*;
+
+        loop {
+            let cancellation_status = match self.canceled_requests_pin_mut().poll_recv(cx) {
+                Poll::Ready(Some(request_id)) => {
+                    if let Some(span) = self.in_flight_requests_mut().remove_request(request_id) {
+                        let _entered = span.enter();
+                        tracing::info!("ResponseCancelled");
+                    }
+                    Ready
+                }
+                // Pending cancellations don't block Channel closure, because all they do is ensure
+                // the Channel's internal state is cleaned up. But Channel closure also cleans up
+                // the Channel state, so there's no reason to wait on a cancellation before
+                // closing.
+                //
+                // Ready(None) can't happen, since `self` holds a Cancellation.
+                Poll::Pending | Poll::Ready(None) => Closed,
+            };
+
+            let expiration_status = match self.in_flight_requests_mut().poll_expired(cx) {
+                // No need to send a response, since the client wouldn't be waiting for one
+                // anymore.
+                Poll::Ready(Some(_)) => Ready,
+                Poll::Ready(None) => Closed,
+                Poll::Pending => Pending,
+            };
+
+            let request_status = match self
+                .transport_pin_mut()
+                .poll_next(cx)
+                .map_err(|e| ChannelError::Read(Arc::new(e)))?
+            {
+                Poll::Ready(Some(message)) => match message {
+                    ClientMessage::Request(request) => {
+                        match self.as_mut().start_request(request) {
+                            Ok(request) => return Poll::Ready(Some(Ok(request))),
+                            Err(AlreadyExistsError) => {
+                                // Instead of closing the channel if a duplicate request is sent,
+                                // just ignore it, since it's already being processed. Note that we
+                                // cannot return Poll::Pending here, since nothing has scheduled a
+                                // wakeup yet.
+                                continue;
+                            }
+                        }
+                    }
+                    ClientMessage::Cancel {
+                        trace_context,
+                        request_id,
+                    } => {
+                        if !self.in_flight_requests_mut().cancel_request(request_id) {
+                            tracing::trace!(
+                                rpc.trace_id = %trace_context.trace_id,
+                                "Received cancellation, but response handler is already complete.",
+                            );
+                        }
+                        Ready
+                    }
+                },
+                Poll::Ready(None) => Closed,
+                Poll::Pending => Pending,
+            };
+
+            let status = cancellation_status
+                .combine(expiration_status)
+                .combine(request_status);
+
+            tracing::trace!(
+                "Cancellations: {cancellation_status:?}, \
+                Expired requests: {expiration_status:?}, \
+                Inbound: {request_status:?}, \
+                Overall: {status:?}",
+            );
+            match status {
+                Ready => continue,
+                Closed => return Poll::Ready(None),
+                Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl<Req, Resp, T> Sink<Response<Resp>> for BaseChannel<Req, Resp, T>
+where
+    T: Transport<Response<Resp>, ClientMessage<Req>>,
+    T::Error: Error,
+{
+    type Error = ChannelError<T::Error>;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .transport
+            .poll_ready(cx)
+            .map_err(|e| ChannelError::Ready(Arc::new(e)))
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, response: Response<Resp>) -> Result<(), Self::Error> {
+        if let Some(span) = self
+            .in_flight_requests_mut()
+            .remove_request(response.request_id)
+        {
+            let _entered = span.enter();
+            tracing::info!("SendResponse");
+            self.project()
+                .transport
+                .start_send(response)
+                .map_err(|e| ChannelError::Write(Arc::new(e)))
+        } else {
+            // If the request isn't tracked anymore, there's no need to send the response.
+            Ok(())
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        tracing::trace!("poll_flush");
+        self.project()
+            .transport
+            .poll_flush(cx)
+            .map_err(|e| ChannelError::Flush(Arc::new(e)))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .transport
+            .poll_close(cx)
+            .map_err(|e| ChannelError::Close(Arc::new(e)))
+    }
+}
+
+impl<Req, Resp, T> AsRef<T> for BaseChannel<Req, Resp, T> {
+    fn as_ref(&self) -> &T {
+        self.transport.get_ref()
+    }
+}
+
+impl<Req, Resp, T> Channel for BaseChannel<Req, Resp, T>
+where
+    T: Transport<Response<Resp>, ClientMessage<Req>>,
+{
+    type Req = Req;
+    type Resp = Resp;
+    type Transport = T;
+
+    fn config(&self) -> &Config {
+        &self.config
+    }
+
+    fn in_flight_requests(&self) -> usize {
+        self.in_flight_requests.len()
+    }
+
+    fn transport(&self) -> &Self::Transport {
+        self.get_ref()
+    }
+}
+
+/// A stream of requests coming over a channel. `Requests` also drives the sending of responses, so
+/// it must be continually polled to ensure progress.
+#[pin_project]
+pub struct Requests<C>
+where
+    C: Channel,
+{
+    #[pin]
+    channel: C,
+    /// Responses waiting to be written to the wire.
+    pending_responses: mpsc::Receiver<Response<C::Resp>>,
+    /// Handed out to request handlers to fan in responses.
+    responses_tx: mpsc::Sender<Response<C::Resp>>,
+}
+
+impl<C> Requests<C>
+where
+    C: Channel,
+{
+    /// Returns a reference to the inner channel over which messages are sent and received.
+    pub fn channel(&self) -> &C {
+        &self.channel
+    }
+
+    /// Returns the inner channel over which messages are sent and received.
+    pub fn channel_pin_mut<'a>(self: &'a mut Pin<&mut Self>) -> Pin<&'a mut C> {
+        self.as_mut().project().channel
+    }
+
+    /// Returns the inner channel over which messages are sent and received.
+    pub fn pending_responses_mut<'a>(
+        self: &'a mut Pin<&mut Self>,
+    ) -> &'a mut mpsc::Receiver<Response<C::Resp>> {
+        self.as_mut().project().pending_responses
+    }
+
+    fn pump_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<InFlightRequest<C::Req, C::Resp>, C::Error>>> {
+        self.channel_pin_mut().poll_next(cx).map_ok(
+            |TrackedRequest {
+                 request,
+                 abort_registration,
+                 span,
+                 mut response_guard,
+             }| {
+                // The response guard becomes active once in an InFlightRequest.
+                response_guard.cancel = true;
+                {
+                    let _entered = span.enter();
+                    tracing::info!("BeginRequest");
+                }
+                InFlightRequest {
+                    request,
+                    abort_registration,
+                    span,
+                    response_guard,
+                    response_tx: self.responses_tx.clone(),
+                }
+            },
+        )
+    }
+
+    fn pump_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        read_half_closed: bool,
+    ) -> Poll<Option<Result<(), C::Error>>> {
+        match self.as_mut().poll_next_response(cx)? {
+            Poll::Ready(Some(response)) => {
+                // A Ready result from poll_next_response means the Channel is ready to be written
+                // to. Therefore, we can call start_send without worry of a full buffer.
+                self.channel_pin_mut().start_send(response)?;
+                Poll::Ready(Some(Ok(())))
+            }
+            Poll::Ready(None) => {
+                // Shutdown can't be done before we finish pumping out remaining responses.
+                ready!(self.channel_pin_mut().poll_flush(cx)?);
+                Poll::Ready(None)
+            }
+            Poll::Pending => {
+                // No more requests to process, so flush any requests buffered in the transport.
+                ready!(self.channel_pin_mut().poll_flush(cx)?);
+
+                // Being here means there are no staged requests and all written responses are
+                // fully flushed. So, if the read half is closed and there are no in-flight
+                // requests, then we can close the write half.
+                if read_half_closed && self.channel.in_flight_requests() == 0 {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
+    }
+
+    /// Yields a response ready to be written to the Channel sink.
+    ///
+    /// Note that a response will only be yielded if the Channel is *ready* to be written to (i.e.
+    /// start_send would succeed).
+    fn poll_next_response(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Response<C::Resp>, C::Error>>> {
+        ready!(self.ensure_writeable(cx)?);
+
+        match ready!(self.pending_responses_mut().poll_recv(cx)) {
+            Some(response) => Poll::Ready(Some(Ok(response))),
+            None => {
+                // This branch likely won't happen, since the Requests stream is holding a Sender.
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    /// Returns Ready if writing a message to the Channel would not fail due to a full buffer. If
+    /// the Channel is not ready to be written to, flushes it until it is ready.
+    fn ensure_writeable<'a>(
+        self: &'a mut Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<(), C::Error>>> {
+        while self.channel_pin_mut().poll_ready(cx)?.is_pending() {
+            ready!(self.channel_pin_mut().poll_flush(cx)?);
+        }
+        Poll::Ready(Some(Ok(())))
+    }
+
+    /// Returns a stream of request execution futures. Each future represents an in-flight request
+    /// being responded to by the server. The futures must be awaited or spawned to complete their
+    /// requests.
+    ///
+    /// If the channel encounters an error, the stream is terminated and the error is logged.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tarpc::{context, client, server::{self, BaseChannel, Channel, serve}, transport};
+    /// use futures::prelude::*;
+    ///
+    /// # #[cfg(not(feature = "tokio1"))]
+    /// # fn main() {}
+    /// # #[cfg(feature = "tokio1")]
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = transport::channel::unbounded();
+    ///     let requests = BaseChannel::new(server::Config::default(), rx).requests();
+    ///     let client = client::new(client::Config::default(), tx).spawn();
+    ///     tokio::spawn(
+    ///         requests.execute(serve(|_, i| async move { Ok(i + 1) }))
+    ///            .for_each(|response| async move {
+    ///                tokio::spawn(response);
+    ///            }));
+    ///     assert_eq!(client.call(context::current(), 1).await.unwrap(), 2);
+    /// }
+    /// ```
+    pub fn execute<S>(self, serve: S) -> impl Stream<Item = impl Future<Output = ()>>
+    where
+        C::Req: RequestName,
+        S: Serve<Req = C::Req, Resp = C::Resp> + Clone,
+    {
+        self.take_while(|result| {
+            if let Err(e) = result {
+                tracing::warn!("Requests stream errored out: {}", e);
+            }
+            futures::future::ready(result.is_ok())
+        })
+        .filter_map(|result| async move { result.ok() })
+        .map(move |request| {
+            let serve = serve.clone();
+            request.execute(serve)
+        })
+    }
+}
+
+impl<C> fmt::Debug for Requests<C>
+where
+    C: Channel,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "Requests")
+    }
+}
+
+/// A fail-safe to ensure requests are properly canceled if request processing is aborted before
+/// completing.
+#[derive(Debug)]
+pub struct ResponseGuard {
+    request_cancellation: RequestCancellation,
+    request_id: u64,
+    cancel: bool,
+}
+
+impl Drop for ResponseGuard {
+    fn drop(&mut self) {
+        if self.cancel {
+            self.request_cancellation.cancel(self.request_id);
+        }
+    }
+}
+
+/// A request produced by [Channel::requests].
+///
+/// If dropped without calling [`execute`](InFlightRequest::execute), a cancellation message will
+/// be sent to the Channel to clean up associated request state.
+#[derive(Debug)]
+pub struct InFlightRequest<Req, Res> {
+    request: Request<Req>,
+    abort_registration: AbortRegistration,
+    response_guard: ResponseGuard,
+    span: Span,
+    response_tx: mpsc::Sender<Response<Res>>,
+}
+
+impl<Req, Res> InFlightRequest<Req, Res> {
+    /// Returns a reference to the request.
+    pub fn get(&self) -> &Request<Req> {
+        &self.request
+    }
+
+    /// Returns a [future](Future) that executes the request using the given [service
+    /// function](Serve). The service function's output is automatically sent back to the [Channel]
+    /// that yielded this request. The request will be executed in the scope of this request's
+    /// context.
+    ///
+    /// The returned future will stop executing when the first of the following conditions is met:
+    ///
+    /// 1. The channel that yielded this request receives a [cancellation
+    ///    message](ClientMessage::Cancel) for this request.
+    /// 2. The request [deadline](crate::context::Context::deadline) is reached.
+    /// 3. The service function completes.
+    ///
+    /// If the returned Future is dropped before completion, a cancellation message will be sent to
+    /// the Channel to clean up associated request state.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tarpc::{
+    ///     context,
+    ///     client::{self, NewClient},
+    ///     server::{self, BaseChannel, Channel, serve},
+    ///     transport,
+    /// };
+    /// use futures::prelude::*;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = transport::channel::unbounded();
+    ///     let server = BaseChannel::new(server::Config::default(), rx);
+    ///     let NewClient { client, dispatch } = client::new(client::Config::default(), tx);
+    ///     tokio::spawn(dispatch);
+    ///
+    ///     tokio::spawn(async move {
+    ///         let mut requests = server.requests();
+    ///         while let Some(Ok(in_flight_request)) = requests.next().await {
+    ///             in_flight_request.execute(serve(|_, i| async move { Ok(i + 1) })).await;
+    ///         }
+    ///
+    ///     });
+    ///     assert_eq!(client.call(context::current(), 1).await.unwrap(), 2);
+    /// }
+    /// ```
+    ///
+    pub async fn execute<S>(self, serve: S)
+    where
+        Req: RequestName,
+        S: Serve<Req = Req, Resp = Res>,
+    {
+        let Self {
+            response_tx,
+            mut response_guard,
+            abort_registration,
+            span,
+            request:
+                Request {
+                    context,
+                    message,
+                    id: request_id,
+                },
+        } = self;
+        span.record("otel.name", message.name());
+        let _ = Abortable::new(
+            async move {
+                let message = serve.serve(context, message).await;
+                tracing::info!("CompleteRequest");
+                let response = Response {
+                    request_id,
+                    message,
+                };
+                let _ = response_tx.send(response).await;
+                tracing::info!("BufferResponse");
+            },
+            abort_registration,
+        )
+        .instrument(span)
+        .await;
+        // Request processing has completed, meaning either the channel canceled the request or
+        // a request was sent back to the channel. Either way, the channel will clean up the
+        // request data, so the request does not need to be canceled.
+        response_guard.cancel = false;
+    }
+}
+
+fn print_err(e: &(dyn Error + 'static)) -> String {
+    anyhow::Chain::new(e)
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join(": ")
+}
+
+impl<C> Stream for Requests<C>
+where
+    C: Channel,
+{
+    type Item = Result<InFlightRequest<C::Req, C::Resp>, C::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            let read = self.as_mut().pump_read(cx).map_err(|e| {
+                tracing::trace!("read: {}", print_err(&e));
+                e
+            })?;
+            let read_closed = matches!(read, Poll::Ready(None));
+            let write = self.as_mut().pump_write(cx, read_closed).map_err(|e| {
+                tracing::trace!("write: {}", print_err(&e));
+                e
+            })?;
+            match (read, write) {
+                (Poll::Ready(None), Poll::Ready(None)) => {
+                    tracing::trace!("read: Poll::Ready(None), write: Poll::Ready(None)");
+                    return Poll::Ready(None);
+                }
+                (Poll::Ready(Some(request_handler)), _) => {
+                    tracing::trace!("read: Poll::Ready(Some), write: _");
+                    return Poll::Ready(Some(Ok(request_handler)));
+                }
+                (_, Poll::Ready(Some(()))) => {
+                    tracing::trace!("read: _, write: Poll::Ready(Some)");
+                }
+                (read @ Poll::Pending, write) | (read, write @ Poll::Pending) => {
+                    tracing::trace!(
+                        "read pending: {}, write pending: {}",
+                        read.is_pending(),
+                        write.is_pending()
+                    );
+                    return Poll::Pending;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        in_flight_requests::AlreadyExistsError,
+        request_hook::{AfterRequest, BeforeRequest, RequestHook},
+        serve, BaseChannel, Channel, Config, Requests, Serve,
+    };
+    use crate::{
+        context, trace,
+        transport::channel::{self, UnboundedChannel},
+        ClientMessage, Request, Response, ServerError,
+    };
+    use assert_matches::assert_matches;
+    use futures::{
+        future::{pending, AbortRegistration, Abortable, Aborted},
+        prelude::*,
+        Future,
+    };
+    use futures_test::task::noop_context;
+    use std::{
+        io,
+        pin::Pin,
+        task::Poll,
+        time::{Duration, Instant},
+    };
+
+    fn test_channel<Req, Resp>() -> (
+        Pin<Box<BaseChannel<Req, Resp, UnboundedChannel<ClientMessage<Req>, Response<Resp>>>>>,
+        UnboundedChannel<Response<Resp>, ClientMessage<Req>>,
+    ) {
+        let (tx, rx) = crate::transport::channel::unbounded();
+        (Box::pin(BaseChannel::new(Config::default(), rx)), tx)
+    }
+
+    fn test_requests<Req, Resp>() -> (
+        Pin<
+            Box<
+                Requests<
+                    BaseChannel<Req, Resp, UnboundedChannel<ClientMessage<Req>, Response<Resp>>>,
+                >,
+            >,
+        >,
+        UnboundedChannel<Response<Resp>, ClientMessage<Req>>,
+    ) {
+        let (tx, rx) = crate::transport::channel::unbounded();
+        (
+            Box::pin(BaseChannel::new(Config::default(), rx).requests()),
+            tx,
+        )
+    }
+
+    fn test_bounded_requests<Req, Resp>(
+        capacity: usize,
+    ) -> (
+        Pin<
+            Box<
+                Requests<
+                    BaseChannel<Req, Resp, channel::Channel<ClientMessage<Req>, Response<Resp>>>,
+                >,
+            >,
+        >,
+        channel::Channel<Response<Resp>, ClientMessage<Req>>,
+    ) {
+        let (tx, rx) = crate::transport::channel::bounded(capacity);
+        // Add 1 because capacity 0 is not supported (but is supported by transport::channel::bounded).
+        let config = Config {
+            pending_response_buffer: capacity + 1,
+        };
+        (Box::pin(BaseChannel::new(config, rx).requests()), tx)
+    }
+
+    fn fake_request<Req>(req: Req) -> ClientMessage<Req> {
+        ClientMessage::Request(Request {
+            context: context::current(),
+            id: 0,
+            message: req,
+        })
+    }
+
+    fn test_abortable(
+        abort_registration: AbortRegistration,
+    ) -> impl Future<Output = Result<(), Aborted>> {
+        Abortable::new(pending(), abort_registration)
+    }
+
+    #[tokio::test]
+    async fn test_serve() {
+        let serve = serve(|_, i| async move { Ok(i) });
+        assert_matches!(serve.serve(context::current(), 7).await, Ok(7));
+    }
+
+    #[tokio::test]
+    async fn serve_before_mutates_context() -> anyhow::Result<()> {
+        struct SetDeadline(Instant);
+        impl<Req> BeforeRequest<Req> for SetDeadline {
+            async fn before(
+                &mut self,
+                ctx: &mut context::Context,
+                _: &Req,
+            ) -> Result<(), ServerError> {
+                ctx.deadline = self.0;
+                Ok(())
+            }
+        }
+
+        let some_time = Instant::now() + Duration::from_secs(37);
+        let some_other_time = Instant::now() + Duration::from_secs(83);
+
+        let serve = serve(move |ctx: context::Context, i| async move {
+            assert_eq!(ctx.deadline, some_time);
+            Ok(i)
+        });
+        let deadline_hook = serve.before(SetDeadline(some_time));
+        let mut ctx = context::current();
+        ctx.deadline = some_other_time;
+        deadline_hook.serve(ctx, 7).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn serve_before_and_after() -> anyhow::Result<()> {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        struct PrintLatency {
+            start: Instant,
+        }
+        impl PrintLatency {
+            fn new() -> Self {
+                Self {
+                    start: Instant::now(),
+                }
+            }
+        }
+        impl<Req> BeforeRequest<Req> for PrintLatency {
+            async fn before(
+                &mut self,
+                _: &mut context::Context,
+                _: &Req,
+            ) -> Result<(), ServerError> {
+                self.start = Instant::now();
+                Ok(())
+            }
+        }
+        impl<Resp> AfterRequest<Resp> for PrintLatency {
+            async fn after(&mut self, _: &mut context::Context, _: &mut Result<Resp, ServerError>) {
+                tracing::info!("Elapsed: {:?}", self.start.elapsed());
+            }
+        }
+
+        let serve = serve(move |_: context::Context, i| async move { Ok(i) });
+        serve
+            .before_and_after(PrintLatency::new())
+            .serve(context::current(), 7)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn serve_before_error_aborts_request() -> anyhow::Result<()> {
+        let serve = serve(|_, _| async { panic!("Shouldn't get here") });
+        let deadline_hook = serve.before(|_: &mut context::Context, _: &i32| async {
+            Err(ServerError::new(io::ErrorKind::Other, "oops".into()))
+        });
+        let resp: Result<i32, _> = deadline_hook.serve(context::current(), 7).await;
+        assert_matches!(resp, Err(_));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn base_channel_start_send_duplicate_request_returns_error() {
+        let (mut channel, _tx) = test_channel::<(), ()>();
+
+        channel
+            .as_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        assert_matches!(
+            channel.as_mut().start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: ()
+            }),
+            Err(AlreadyExistsError)
+        );
+    }
+
+    #[tokio::test]
+    async fn base_channel_poll_next_aborts_multiple_requests() {
+        let (mut channel, _tx) = test_channel::<(), ()>();
+
+        tokio::time::pause();
+        let req0 = channel
+            .as_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        let req1 = channel
+            .as_mut()
+            .start_request(Request {
+                id: 1,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        tokio::time::advance(std::time::Duration::from_secs(1000)).await;
+
+        assert_matches!(
+            channel.as_mut().poll_next(&mut noop_context()),
+            Poll::Pending
+        );
+        assert_matches!(test_abortable(req0.abort_registration).await, Err(Aborted));
+        assert_matches!(test_abortable(req1.abort_registration).await, Err(Aborted));
+    }
+
+    #[tokio::test]
+    async fn base_channel_poll_next_aborts_canceled_request() {
+        let (mut channel, mut tx) = test_channel::<(), ()>();
+
+        tokio::time::pause();
+        let req = channel
+            .as_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+
+        tx.send(ClientMessage::Cancel {
+            trace_context: trace::Context::default(),
+            request_id: 0,
+        })
+        .await
+        .unwrap();
+
+        assert_matches!(
+            channel.as_mut().poll_next(&mut noop_context()),
+            Poll::Pending
+        );
+
+        assert_matches!(test_abortable(req.abort_registration).await, Err(Aborted));
+    }
+
+    #[tokio::test]
+    async fn base_channel_with_closed_transport_and_in_flight_request_returns_pending() {
+        let (mut channel, tx) = test_channel::<(), ()>();
+
+        tokio::time::pause();
+        let _abort_registration = channel
+            .as_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+
+        drop(tx);
+        assert_matches!(
+            channel.as_mut().poll_next(&mut noop_context()),
+            Poll::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn base_channel_with_closed_transport_and_no_in_flight_requests_returns_closed() {
+        let (mut channel, tx) = test_channel::<(), ()>();
+        drop(tx);
+        assert_matches!(
+            channel.as_mut().poll_next(&mut noop_context()),
+            Poll::Ready(None)
+        );
+    }
+
+    #[tokio::test]
+    async fn base_channel_poll_next_yields_request() {
+        let (mut channel, mut tx) = test_channel::<(), ()>();
+        tx.send(fake_request(())).await.unwrap();
+
+        assert_matches!(
+            channel.as_mut().poll_next(&mut noop_context()),
+            Poll::Ready(Some(Ok(_)))
+        );
+    }
+
+    #[tokio::test]
+    async fn base_channel_poll_next_aborts_request_and_yields_request() {
+        let (mut channel, mut tx) = test_channel::<(), ()>();
+
+        tokio::time::pause();
+        let req = channel
+            .as_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        tokio::time::advance(std::time::Duration::from_secs(1000)).await;
+
+        tx.send(fake_request(())).await.unwrap();
+
+        assert_matches!(
+            channel.as_mut().poll_next(&mut noop_context()),
+            Poll::Ready(Some(Ok(_)))
+        );
+        assert_matches!(test_abortable(req.abort_registration).await, Err(Aborted));
+    }
+
+    #[tokio::test]
+    async fn base_channel_start_send_removes_in_flight_request() {
+        let (mut channel, _tx) = test_channel::<(), ()>();
+
+        channel
+            .as_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        assert_eq!(channel.in_flight_requests(), 1);
+        channel
+            .as_mut()
+            .start_send(Response {
+                request_id: 0,
+                message: Ok(()),
+            })
+            .unwrap();
+        assert_eq!(channel.in_flight_requests(), 0);
+    }
+
+    #[tokio::test]
+    async fn in_flight_request_drop_cancels_request() {
+        let (mut requests, mut tx) = test_requests::<(), ()>();
+        tx.send(fake_request(())).await.unwrap();
+
+        let request = match requests.as_mut().poll_next(&mut noop_context()) {
+            Poll::Ready(Some(Ok(request))) => request,
+            result => panic!("Unexpected result: {result:?}"),
+        };
+        drop(request);
+
+        let poll = requests
+            .as_mut()
+            .channel_pin_mut()
+            .poll_next(&mut noop_context());
+        assert!(poll.is_pending());
+        let in_flight_requests = requests.channel().in_flight_requests();
+        assert_eq!(in_flight_requests, 0);
+    }
+
+    #[tokio::test]
+    async fn in_flight_requests_successful_execute_doesnt_cancel_request() {
+        let (mut requests, mut tx) = test_requests::<(), ()>();
+        tx.send(fake_request(())).await.unwrap();
+
+        let request = match requests.as_mut().poll_next(&mut noop_context()) {
+            Poll::Ready(Some(Ok(request))) => request,
+            result => panic!("Unexpected result: {result:?}"),
+        };
+        request.execute(serve(|_, _| async { Ok(()) })).await;
+        assert!(requests
+            .as_mut()
+            .channel_pin_mut()
+            .canceled_requests
+            .poll_recv(&mut noop_context())
+            .is_pending());
+    }
+
+    #[tokio::test]
+    async fn requests_poll_next_response_returns_pending_when_buffer_full() {
+        let (mut requests, _tx) = test_bounded_requests::<(), ()>(0);
+
+        // Response written to the transport.
+        requests
+            .as_mut()
+            .channel_pin_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        requests
+            .as_mut()
+            .channel_pin_mut()
+            .start_send(Response {
+                request_id: 0,
+                message: Ok(()),
+            })
+            .unwrap();
+
+        // Response waiting to be written.
+        requests
+            .as_mut()
+            .project()
+            .responses_tx
+            .send(Response {
+                request_id: 1,
+                message: Ok(()),
+            })
+            .await
+            .unwrap();
+
+        requests
+            .as_mut()
+            .channel_pin_mut()
+            .start_request(Request {
+                id: 1,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+
+        assert_matches!(
+            requests.as_mut().poll_next_response(&mut noop_context()),
+            Poll::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn requests_pump_write_returns_pending_when_buffer_full() {
+        let (mut requests, _tx) = test_bounded_requests::<(), ()>(0);
+
+        // Response written to the transport.
+        requests
+            .as_mut()
+            .channel_pin_mut()
+            .start_request(Request {
+                id: 0,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        requests
+            .as_mut()
+            .channel_pin_mut()
+            .start_send(Response {
+                request_id: 0,
+                message: Ok(()),
+            })
+            .unwrap();
+
+        // Response waiting to be written.
+        requests
+            .as_mut()
+            .channel_pin_mut()
+            .start_request(Request {
+                id: 1,
+                context: context::current(),
+                message: (),
+            })
+            .unwrap();
+        requests
+            .as_mut()
+            .project()
+            .responses_tx
+            .send(Response {
+                request_id: 1,
+                message: Ok(()),
+            })
+            .await
+            .unwrap();
+
+        assert_matches!(
+            requests.as_mut().pump_write(&mut noop_context(), true),
+            Poll::Pending
+        );
+        // Assert that the pending response was not polled while the channel was blocked.
+        assert_matches!(
+            requests.as_mut().pending_responses_mut().recv().await,
+            Some(_)
+        );
+    }
+
+    #[tokio::test]
+    async fn requests_pump_read() {
+        let (mut requests, mut tx) = test_requests::<(), ()>();
+
+        // Response written to the transport.
+        tx.send(fake_request(())).await.unwrap();
+
+        assert_matches!(
+            requests.as_mut().pump_read(&mut noop_context()),
+            Poll::Ready(Some(Ok(_)))
+        );
+        assert_eq!(requests.channel.in_flight_requests(), 1);
+    }
+}

--- a/third_party/tarpc/src/server/in_flight_requests.rs
+++ b/third_party/tarpc/src/server/in_flight_requests.rs
@@ -1,0 +1,221 @@
+use crate::util::{Compact, TimeUntil};
+use fnv::FnvHashMap;
+use futures::future::{AbortHandle, AbortRegistration};
+use std::{
+    collections::hash_map,
+    task::{Context, Poll},
+    time::Instant,
+};
+use tokio_util::time::delay_queue::{self, DelayQueue};
+use tracing::Span;
+
+/// A data structure that tracks in-flight requests. It aborts requests,
+/// either on demand or when a request deadline expires.
+#[derive(Debug, Default)]
+pub struct InFlightRequests {
+    request_data: FnvHashMap<u64, RequestData>,
+    deadlines: DelayQueue<u64>,
+}
+
+/// Data needed to clean up a single in-flight request.
+#[derive(Debug)]
+struct RequestData {
+    /// Aborts the response handler for the associated request.
+    abort_handle: AbortHandle,
+    /// The key to remove the timer for the request's deadline.
+    deadline_key: delay_queue::Key,
+    /// The client span.
+    span: Span,
+}
+
+/// An error returned when a request attempted to start with the same ID as a request already
+/// in flight.
+#[derive(Debug)]
+pub struct AlreadyExistsError;
+
+impl InFlightRequests {
+    /// Returns the number of in-flight requests.
+    pub fn len(&self) -> usize {
+        self.request_data.len()
+    }
+
+    /// Starts a request, unless a request with the same ID is already in flight.
+    pub fn start_request(
+        &mut self,
+        request_id: u64,
+        deadline: Instant,
+        span: Span,
+    ) -> Result<AbortRegistration, AlreadyExistsError> {
+        match self.request_data.entry(request_id) {
+            hash_map::Entry::Vacant(vacant) => {
+                let timeout = deadline.time_until();
+                let (abort_handle, abort_registration) = AbortHandle::new_pair();
+                let deadline_key = self.deadlines.insert(request_id, timeout);
+                vacant.insert(RequestData {
+                    abort_handle,
+                    deadline_key,
+                    span,
+                });
+                Ok(abort_registration)
+            }
+            hash_map::Entry::Occupied(_) => Err(AlreadyExistsError),
+        }
+    }
+
+    /// Cancels an in-flight request. Returns true iff the request was found.
+    pub fn cancel_request(&mut self, request_id: u64) -> bool {
+        if let Some(RequestData {
+            span,
+            abort_handle,
+            deadline_key,
+        }) = self.request_data.remove(&request_id)
+        {
+            let _entered = span.enter();
+            self.request_data.compact(0.1);
+            abort_handle.abort();
+            self.deadlines.remove(&deadline_key);
+            tracing::info!("ReceiveCancel");
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes a request without aborting. Returns true iff the request was found.
+    /// This method should be used when a response is being sent.
+    pub fn remove_request(&mut self, request_id: u64) -> Option<Span> {
+        if let Some(request_data) = self.request_data.remove(&request_id) {
+            self.request_data.compact(0.1);
+            self.deadlines.remove(&request_data.deadline_key);
+            Some(request_data.span)
+        } else {
+            None
+        }
+    }
+
+    /// Yields a request that has expired, aborting any ongoing processing of that request.
+    pub fn poll_expired(&mut self, cx: &mut Context) -> Poll<Option<u64>> {
+        if self.deadlines.is_empty() {
+            // TODO(https://github.com/tokio-rs/tokio/issues/4161)
+            // This is a workaround for DelayQueue not always treating this case correctly.
+            return Poll::Ready(None);
+        }
+        self.deadlines.poll_expired(cx).map(|expired| {
+            let expired = expired?;
+            if let Some(RequestData {
+                abort_handle, span, ..
+            }) = self.request_data.remove(expired.get_ref())
+            {
+                let _entered = span.enter();
+                self.request_data.compact(0.1);
+                abort_handle.abort();
+                tracing::error!("DeadlineExceeded");
+            }
+            Some(expired.into_inner())
+        })
+    }
+}
+
+/// When InFlightRequests is dropped, any outstanding requests are aborted.
+impl Drop for InFlightRequests {
+    fn drop(&mut self) {
+        self.request_data
+            .values()
+            .for_each(|request_data| request_data.abort_handle.abort())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use assert_matches::assert_matches;
+    use futures::{
+        future::{pending, Abortable},
+        FutureExt,
+    };
+    use futures_test::task::noop_context;
+
+    #[tokio::test]
+    async fn start_request_increases_len() {
+        let mut in_flight_requests = InFlightRequests::default();
+        assert_eq!(in_flight_requests.len(), 0);
+        in_flight_requests
+            .start_request(0, Instant::now(), Span::current())
+            .unwrap();
+        assert_eq!(in_flight_requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn polling_expired_aborts() {
+        let mut in_flight_requests = InFlightRequests::default();
+        let abort_registration = in_flight_requests
+            .start_request(0, Instant::now(), Span::current())
+            .unwrap();
+        let mut abortable_future = Box::new(Abortable::new(pending::<()>(), abort_registration));
+
+        tokio::time::pause();
+        tokio::time::advance(std::time::Duration::from_secs(1000)).await;
+
+        assert_matches!(
+            in_flight_requests.poll_expired(&mut noop_context()),
+            Poll::Ready(Some(_))
+        );
+        assert_matches!(
+            abortable_future.poll_unpin(&mut noop_context()),
+            Poll::Ready(Err(_))
+        );
+        assert_eq!(in_flight_requests.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_request_aborts() {
+        let mut in_flight_requests = InFlightRequests::default();
+        let abort_registration = in_flight_requests
+            .start_request(0, Instant::now(), Span::current())
+            .unwrap();
+        let mut abortable_future = Box::new(Abortable::new(pending::<()>(), abort_registration));
+
+        assert!(in_flight_requests.cancel_request(0));
+        assert_matches!(
+            abortable_future.poll_unpin(&mut noop_context()),
+            Poll::Ready(Err(_))
+        );
+        assert_eq!(in_flight_requests.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn remove_request_doesnt_abort() {
+        let mut in_flight_requests = InFlightRequests::default();
+        assert!(in_flight_requests.deadlines.is_empty());
+
+        let abort_registration = in_flight_requests
+            .start_request(
+                0,
+                Instant::now() + std::time::Duration::from_secs(10),
+                Span::current(),
+            )
+            .unwrap();
+        let mut abortable_future = Box::new(Abortable::new(pending::<()>(), abort_registration));
+
+        // Precondition: Pending expiration
+        assert_matches!(
+            in_flight_requests.poll_expired(&mut noop_context()),
+            Poll::Pending
+        );
+        assert!(!in_flight_requests.deadlines.is_empty());
+
+        assert_matches!(in_flight_requests.remove_request(0), Some(_));
+        // Postcondition: No pending expirations
+        assert!(in_flight_requests.deadlines.is_empty());
+        assert_matches!(
+            in_flight_requests.poll_expired(&mut noop_context()),
+            Poll::Ready(None)
+        );
+        assert_matches!(
+            abortable_future.poll_unpin(&mut noop_context()),
+            Poll::Pending
+        );
+        assert_eq!(in_flight_requests.len(), 0);
+    }
+}

--- a/third_party/tarpc/src/server/incoming.rs
+++ b/third_party/tarpc/src/server/incoming.rs
@@ -1,0 +1,93 @@
+use super::{
+    limits::{channels_per_key::MaxChannelsPerKey, requests_per_channel::MaxRequestsPerChannel},
+    Channel, RequestName, Serve,
+};
+use futures::prelude::*;
+use std::{fmt, hash::Hash};
+
+/// An extension trait for [streams](futures::prelude::Stream) of [`Channels`](Channel).
+pub trait Incoming<C>
+where
+    Self: Sized + Stream<Item = C>,
+    C: Channel,
+{
+    /// Enforces channel per-key limits.
+    fn max_channels_per_key<K, KF>(self, n: u32, keymaker: KF) -> MaxChannelsPerKey<Self, K, KF>
+    where
+        K: fmt::Display + Eq + Hash + Clone + Unpin,
+        KF: Fn(&C) -> K,
+    {
+        MaxChannelsPerKey::new(self, n, keymaker)
+    }
+
+    /// Caps the number of concurrent requests per channel.
+    fn max_concurrent_requests_per_channel(self, n: usize) -> MaxRequestsPerChannel<Self> {
+        MaxRequestsPerChannel::new(self, n)
+    }
+
+    /// Returns a stream of channels in execution. Each channel in execution is a stream of
+    /// futures, where each future is an in-flight request being rsponded to.
+    fn execute<S>(
+        self,
+        serve: S,
+    ) -> impl Stream<Item = impl Stream<Item = impl Future<Output = ()>>>
+    where
+        C::Req: RequestName,
+        S: Serve<Req = C::Req, Resp = C::Resp> + Clone,
+    {
+        self.map(move |channel| channel.execute(serve.clone()))
+    }
+}
+
+#[cfg(feature = "tokio1")]
+/// Spawns all channels-in-execution, delegating to the tokio runtime to manage their completion.
+/// Each channel is spawned, and each request from each channel is spawned.
+/// Note that this function is generic over any stream-of-streams-of-futures, but it is intended
+/// for spawning streams of channels.
+///
+/// # Example
+/// ```rust
+/// use tarpc::{
+///     context,
+///     client::{self, NewClient},
+///     server::{self, BaseChannel, Channel, incoming::{Incoming, spawn_incoming}, serve},
+///     transport,
+/// };
+/// use futures::prelude::*;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let (tx, rx) = transport::channel::unbounded();
+///     let NewClient { client, dispatch } = client::new(client::Config::default(), tx);
+///     tokio::spawn(dispatch);
+///
+///     let incoming = stream::once(async move {
+///         BaseChannel::new(server::Config::default(), rx)
+///     }).execute(serve(|_, i| async move { Ok(i + 1) }));
+///     tokio::spawn(spawn_incoming(incoming));
+///     assert_eq!(client.call(context::current(), 1).await.unwrap(), 2);
+/// }
+/// ```
+pub async fn spawn_incoming(
+    incoming: impl Stream<
+        Item = impl Stream<Item = impl Future<Output = ()> + Send + 'static> + Send + 'static,
+    >,
+) {
+    use futures::pin_mut;
+    pin_mut!(incoming);
+    while let Some(channel) = incoming.next().await {
+        tokio::spawn(async move {
+            pin_mut!(channel);
+            while let Some(request) = channel.next().await {
+                tokio::spawn(request);
+            }
+        });
+    }
+}
+
+impl<S, C> Incoming<C> for S
+where
+    S: Sized + Stream<Item = C>,
+    C: Channel,
+{
+}

--- a/third_party/tarpc/src/server/limits.rs
+++ b/third_party/tarpc/src/server/limits.rs
@@ -1,0 +1,5 @@
+/// Provides functionality to limit the number of active channels.
+pub mod channels_per_key;
+
+/// Provides a [channel](crate::server::Channel) that limits the number of in-flight requests.
+pub mod requests_per_channel;

--- a/third_party/tarpc/src/server/limits/channels_per_key.rs
+++ b/third_party/tarpc/src/server/limits/channels_per_key.rs
@@ -1,0 +1,480 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use crate::{
+    server::{self, Channel},
+    util::Compact,
+};
+use fnv::FnvHashMap;
+use futures::{prelude::*, ready, stream::Fuse, task::*};
+use pin_project::pin_project;
+use std::sync::{Arc, Weak};
+use std::{
+    collections::hash_map::Entry, convert::TryFrom, fmt, hash::Hash, marker::Unpin, pin::Pin,
+};
+use tokio::sync::mpsc;
+use tracing::{debug, info, trace};
+
+/// An [`Incoming`](crate::server::incoming::Incoming) stream that drops new channels based on
+/// per-key limits.
+///
+/// The decision to drop a Channel is made once at the time the Channel materializes. Once a
+/// Channel is yielded, it will not be prematurely dropped.
+#[pin_project]
+#[derive(Debug)]
+pub struct MaxChannelsPerKey<S, K, F>
+where
+    K: Eq + Hash,
+{
+    #[pin]
+    listener: Fuse<S>,
+    channels_per_key: u32,
+    dropped_keys: mpsc::UnboundedReceiver<K>,
+    dropped_keys_tx: mpsc::UnboundedSender<K>,
+    key_counts: FnvHashMap<K, Weak<Tracker<K>>>,
+    keymaker: F,
+}
+
+/// A channel that is tracked by [`MaxChannelsPerKey`].
+#[pin_project]
+#[derive(Debug)]
+pub struct TrackedChannel<C, K> {
+    #[pin]
+    inner: C,
+    tracker: Arc<Tracker<K>>,
+}
+
+#[derive(Debug)]
+struct Tracker<K> {
+    key: Option<K>,
+    dropped_keys: mpsc::UnboundedSender<K>,
+}
+
+impl<K> Drop for Tracker<K> {
+    fn drop(&mut self) {
+        // Don't care if the listener is dropped.
+        let _ = self.dropped_keys.send(self.key.take().unwrap());
+    }
+}
+
+impl<C, K> Stream for TrackedChannel<C, K>
+where
+    C: Stream,
+{
+    type Item = <C as Stream>::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        self.inner_pin_mut().poll_next(cx)
+    }
+}
+
+impl<C, I, K> Sink<I> for TrackedChannel<C, K>
+where
+    C: Sink<I>,
+{
+    type Error = C::Error;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.inner_pin_mut().poll_ready(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: I) -> Result<(), Self::Error> {
+        self.inner_pin_mut().start_send(item)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.inner_pin_mut().poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.inner_pin_mut().poll_close(cx)
+    }
+}
+
+impl<C, K> AsRef<C> for TrackedChannel<C, K> {
+    fn as_ref(&self) -> &C {
+        &self.inner
+    }
+}
+
+impl<C, K> Channel for TrackedChannel<C, K>
+where
+    C: Channel,
+{
+    type Req = C::Req;
+    type Resp = C::Resp;
+    type Transport = C::Transport;
+
+    fn config(&self) -> &server::Config {
+        self.inner.config()
+    }
+
+    fn in_flight_requests(&self) -> usize {
+        self.inner.in_flight_requests()
+    }
+
+    fn transport(&self) -> &Self::Transport {
+        self.inner.transport()
+    }
+}
+
+impl<C, K> TrackedChannel<C, K> {
+    /// Returns the inner channel.
+    pub fn get_ref(&self) -> &C {
+        &self.inner
+    }
+
+    /// Returns the pinned inner channel.
+    fn inner_pin_mut<'a>(self: &'a mut Pin<&mut Self>) -> Pin<&'a mut C> {
+        self.as_mut().project().inner
+    }
+}
+
+impl<S, K, F> MaxChannelsPerKey<S, K, F>
+where
+    K: Eq + Hash,
+    S: Stream,
+    F: Fn(&S::Item) -> K,
+{
+    /// Sheds new channels to stay under configured limits.
+    pub(crate) fn new(listener: S, channels_per_key: u32, keymaker: F) -> Self {
+        let (dropped_keys_tx, dropped_keys) = mpsc::unbounded_channel();
+        MaxChannelsPerKey {
+            listener: listener.fuse(),
+            channels_per_key,
+            dropped_keys,
+            dropped_keys_tx,
+            key_counts: FnvHashMap::default(),
+            keymaker,
+        }
+    }
+}
+
+impl<S, K, F> MaxChannelsPerKey<S, K, F>
+where
+    S: Stream,
+    K: fmt::Display + Eq + Hash + Clone + Unpin,
+    F: Fn(&S::Item) -> K,
+{
+    fn listener_pin_mut<'a>(self: &'a mut Pin<&mut Self>) -> Pin<&'a mut Fuse<S>> {
+        self.as_mut().project().listener
+    }
+
+    fn handle_new_channel(
+        mut self: Pin<&mut Self>,
+        stream: S::Item,
+    ) -> Result<TrackedChannel<S::Item, K>, K> {
+        let key = (self.as_mut().keymaker)(&stream);
+        let tracker = self.as_mut().increment_channels_for_key(key.clone())?;
+
+        trace!(
+            channel_filter_key = %key,
+            open_channels = Arc::strong_count(&tracker),
+            max_open_channels = self.channels_per_key,
+            "Opening channel");
+
+        Ok(TrackedChannel {
+            tracker,
+            inner: stream,
+        })
+    }
+
+    fn increment_channels_for_key(self: Pin<&mut Self>, key: K) -> Result<Arc<Tracker<K>>, K> {
+        let self_ = self.project();
+        let dropped_keys = self_.dropped_keys_tx;
+        match self_.key_counts.entry(key.clone()) {
+            Entry::Vacant(vacant) => {
+                let tracker = Arc::new(Tracker {
+                    key: Some(key),
+                    dropped_keys: dropped_keys.clone(),
+                });
+
+                vacant.insert(Arc::downgrade(&tracker));
+                Ok(tracker)
+            }
+            Entry::Occupied(mut o) => {
+                let count = o.get().strong_count();
+                if count >= usize::try_from(*self_.channels_per_key).unwrap() {
+                    info!(
+                        channel_filter_key = %key,
+                        open_channels = count,
+                        max_open_channels = *self_.channels_per_key,
+                        "At open channel limit");
+                    Err(key)
+                } else {
+                    Ok(o.get().upgrade().unwrap_or_else(|| {
+                        let tracker = Arc::new(Tracker {
+                            key: Some(key),
+                            dropped_keys: dropped_keys.clone(),
+                        });
+
+                        *o.get_mut() = Arc::downgrade(&tracker);
+                        tracker
+                    }))
+                }
+            }
+        }
+    }
+
+    fn poll_listener(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<TrackedChannel<S::Item, K>, K>>> {
+        match ready!(self.listener_pin_mut().poll_next_unpin(cx)) {
+            Some(codec) => Poll::Ready(Some(self.handle_new_channel(codec))),
+            None => Poll::Ready(None),
+        }
+    }
+
+    fn poll_closed_channels(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let self_ = self.project();
+        match ready!(self_.dropped_keys.poll_recv(cx)) {
+            Some(key) => {
+                debug!(
+                    channel_filter_key = %key,
+                    "All channels dropped");
+                self_.key_counts.remove(&key);
+                self_.key_counts.compact(0.1);
+                Poll::Ready(())
+            }
+            None => unreachable!("Holding a copy of closed_channels and didn't close it."),
+        }
+    }
+}
+
+impl<S, K, F> Stream for MaxChannelsPerKey<S, K, F>
+where
+    S: Stream,
+    K: fmt::Display + Eq + Hash + Clone + Unpin,
+    F: Fn(&S::Item) -> K,
+{
+    type Item = TrackedChannel<S::Item, K>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<TrackedChannel<S::Item, K>>> {
+        loop {
+            match (
+                self.as_mut().poll_listener(cx),
+                self.as_mut().poll_closed_channels(cx),
+            ) {
+                (Poll::Ready(Some(Ok(channel))), _) => {
+                    return Poll::Ready(Some(channel));
+                }
+                (Poll::Ready(Some(Err(_))), _) => {
+                    continue;
+                }
+                (_, Poll::Ready(())) => continue,
+                (Poll::Pending, Poll::Pending) => return Poll::Pending,
+                (Poll::Ready(None), Poll::Pending) => {
+                    trace!("Shutting down listener.");
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+}
+#[cfg(test)]
+fn ctx() -> Context<'static> {
+    use futures::task::*;
+
+    Context::from_waker(noop_waker_ref())
+}
+
+#[test]
+fn tracker_drop() {
+    use assert_matches::assert_matches;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    Tracker {
+        key: Some(1),
+        dropped_keys: tx,
+    };
+    assert_matches!(rx.poll_recv(&mut ctx()), Poll::Ready(Some(1)));
+}
+
+#[test]
+fn tracked_channel_stream() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    let (chan_tx, chan) = futures::channel::mpsc::unbounded();
+    let (dropped_keys, _) = mpsc::unbounded_channel();
+    let channel = TrackedChannel {
+        inner: chan,
+        tracker: Arc::new(Tracker {
+            key: Some(1),
+            dropped_keys,
+        }),
+    };
+
+    chan_tx.unbounded_send("test").unwrap();
+    pin_mut!(channel);
+    assert_matches!(channel.poll_next(&mut ctx()), Poll::Ready(Some("test")));
+}
+
+#[test]
+fn tracked_channel_sink() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    let (chan, mut chan_rx) = futures::channel::mpsc::unbounded();
+    let (dropped_keys, _) = mpsc::unbounded_channel();
+    let channel = TrackedChannel {
+        inner: chan,
+        tracker: Arc::new(Tracker {
+            key: Some(1),
+            dropped_keys,
+        }),
+    };
+
+    pin_mut!(channel);
+    assert_matches!(channel.as_mut().poll_ready(&mut ctx()), Poll::Ready(Ok(())));
+    assert_matches!(channel.as_mut().start_send("test"), Ok(()));
+    assert_matches!(channel.as_mut().poll_flush(&mut ctx()), Poll::Ready(Ok(())));
+    assert_matches!(chan_rx.try_next(), Ok(Some("test")));
+}
+
+#[test]
+fn channel_filter_increment_channels_for_key() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    struct TestChannel {
+        key: &'static str,
+    }
+    let (_, listener) = futures::channel::mpsc::unbounded();
+    let filter = MaxChannelsPerKey::new(listener, 2, |chan: &TestChannel| chan.key);
+    pin_mut!(filter);
+    let tracker1 = filter.as_mut().increment_channels_for_key("key").unwrap();
+    assert_eq!(Arc::strong_count(&tracker1), 1);
+    let tracker2 = filter.as_mut().increment_channels_for_key("key").unwrap();
+    assert_eq!(Arc::strong_count(&tracker1), 2);
+    assert_matches!(filter.increment_channels_for_key("key"), Err("key"));
+    drop(tracker2);
+    assert_eq!(Arc::strong_count(&tracker1), 1);
+}
+
+#[test]
+fn channel_filter_handle_new_channel() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    #[derive(Debug)]
+    struct TestChannel {
+        key: &'static str,
+    }
+    let (_, listener) = futures::channel::mpsc::unbounded();
+    let filter = MaxChannelsPerKey::new(listener, 2, |chan: &TestChannel| chan.key);
+    pin_mut!(filter);
+    let channel1 = filter
+        .as_mut()
+        .handle_new_channel(TestChannel { key: "key" })
+        .unwrap();
+    assert_eq!(Arc::strong_count(&channel1.tracker), 1);
+
+    let channel2 = filter
+        .as_mut()
+        .handle_new_channel(TestChannel { key: "key" })
+        .unwrap();
+    assert_eq!(Arc::strong_count(&channel1.tracker), 2);
+
+    assert_matches!(
+        filter.handle_new_channel(TestChannel { key: "key" }),
+        Err("key")
+    );
+    drop(channel2);
+    assert_eq!(Arc::strong_count(&channel1.tracker), 1);
+}
+
+#[test]
+fn channel_filter_poll_listener() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    #[derive(Debug)]
+    struct TestChannel {
+        key: &'static str,
+    }
+    let (new_channels, listener) = futures::channel::mpsc::unbounded();
+    let filter = MaxChannelsPerKey::new(listener, 2, |chan: &TestChannel| chan.key);
+    pin_mut!(filter);
+
+    new_channels
+        .unbounded_send(TestChannel { key: "key" })
+        .unwrap();
+    let channel1 =
+        assert_matches!(filter.as_mut().poll_listener(&mut ctx()), Poll::Ready(Some(Ok(c))) => c);
+    assert_eq!(Arc::strong_count(&channel1.tracker), 1);
+
+    new_channels
+        .unbounded_send(TestChannel { key: "key" })
+        .unwrap();
+    let _channel2 =
+        assert_matches!(filter.as_mut().poll_listener(&mut ctx()), Poll::Ready(Some(Ok(c))) => c);
+    assert_eq!(Arc::strong_count(&channel1.tracker), 2);
+
+    new_channels
+        .unbounded_send(TestChannel { key: "key" })
+        .unwrap();
+    let key =
+        assert_matches!(filter.as_mut().poll_listener(&mut ctx()), Poll::Ready(Some(Err(k))) => k);
+    assert_eq!(key, "key");
+    assert_eq!(Arc::strong_count(&channel1.tracker), 2);
+}
+
+#[test]
+fn channel_filter_poll_closed_channels() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    #[derive(Debug)]
+    struct TestChannel {
+        key: &'static str,
+    }
+    let (new_channels, listener) = futures::channel::mpsc::unbounded();
+    let filter = MaxChannelsPerKey::new(listener, 2, |chan: &TestChannel| chan.key);
+    pin_mut!(filter);
+
+    new_channels
+        .unbounded_send(TestChannel { key: "key" })
+        .unwrap();
+    let channel =
+        assert_matches!(filter.as_mut().poll_listener(&mut ctx()), Poll::Ready(Some(Ok(c))) => c);
+    assert_eq!(filter.key_counts.len(), 1);
+
+    drop(channel);
+    assert_matches!(
+        filter.as_mut().poll_closed_channels(&mut ctx()),
+        Poll::Ready(())
+    );
+    assert!(filter.key_counts.is_empty());
+}
+
+#[test]
+fn channel_filter_stream() {
+    use assert_matches::assert_matches;
+    use pin_utils::pin_mut;
+
+    #[derive(Debug)]
+    struct TestChannel {
+        key: &'static str,
+    }
+    let (new_channels, listener) = futures::channel::mpsc::unbounded();
+    let filter = MaxChannelsPerKey::new(listener, 2, |chan: &TestChannel| chan.key);
+    pin_mut!(filter);
+
+    new_channels
+        .unbounded_send(TestChannel { key: "key" })
+        .unwrap();
+    let channel = assert_matches!(filter.as_mut().poll_next(&mut ctx()), Poll::Ready(Some(c)) => c);
+    assert_eq!(filter.key_counts.len(), 1);
+
+    drop(channel);
+    assert_matches!(filter.as_mut().poll_next(&mut ctx()), Poll::Pending);
+    assert!(filter.key_counts.is_empty());
+}

--- a/third_party/tarpc/src/server/limits/requests_per_channel.rs
+++ b/third_party/tarpc/src/server/limits/requests_per_channel.rs
@@ -1,0 +1,341 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use crate::{
+    server::{Channel, Config},
+    Response, ServerError,
+};
+use futures::{prelude::*, ready, task::*};
+use pin_project::pin_project;
+use std::{io, pin::Pin};
+
+/// A [`Channel`] that limits the number of concurrent requests by throttling.
+///
+/// Note that this is a very basic throttling heuristic. It is easy to set a number that is too low
+/// for the resources available to the server. For production use cases, a more advanced throttler
+/// is likely needed.
+#[pin_project]
+#[derive(Debug)]
+pub struct MaxRequests<C> {
+    max_in_flight_requests: usize,
+    #[pin]
+    inner: C,
+}
+
+impl<C> MaxRequests<C> {
+    /// Returns the inner channel.
+    pub fn get_ref(&self) -> &C {
+        &self.inner
+    }
+}
+
+impl<C> MaxRequests<C>
+where
+    C: Channel,
+{
+    /// Returns a new `MaxRequests` that wraps the given channel and limits concurrent requests to
+    /// `max_in_flight_requests`.
+    pub fn new(inner: C, max_in_flight_requests: usize) -> Self {
+        MaxRequests {
+            max_in_flight_requests,
+            inner,
+        }
+    }
+}
+
+impl<C> Stream for MaxRequests<C>
+where
+    C: Channel,
+{
+    type Item = <C as Stream>::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        while self.as_mut().in_flight_requests() >= *self.as_mut().project().max_in_flight_requests
+        {
+            ready!(self.as_mut().project().inner.poll_ready(cx)?);
+
+            match ready!(self.as_mut().project().inner.poll_next(cx)?) {
+                Some(r) => {
+                    let _entered = r.span.enter();
+                    tracing::info!(
+                        in_flight_requests = self.as_mut().in_flight_requests(),
+                        "ThrottleRequest",
+                    );
+
+                    self.as_mut().start_send(Response {
+                        request_id: r.request.id,
+                        message: Err(ServerError {
+                            kind: io::ErrorKind::WouldBlock,
+                            detail: "server throttled the request.".into(),
+                        }),
+                    })?;
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+        self.project().inner.poll_next(cx)
+    }
+}
+
+impl<C> Sink<Response<<C as Channel>::Resp>> for MaxRequests<C>
+where
+    C: Channel,
+{
+    type Error = C::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_ready(cx)
+    }
+
+    fn start_send(
+        self: Pin<&mut Self>,
+        item: Response<<C as Channel>::Resp>,
+    ) -> Result<(), Self::Error> {
+        self.project().inner.start_send(item)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+impl<C> AsRef<C> for MaxRequests<C> {
+    fn as_ref(&self) -> &C {
+        &self.inner
+    }
+}
+
+impl<C> Channel for MaxRequests<C>
+where
+    C: Channel,
+{
+    type Req = <C as Channel>::Req;
+    type Resp = <C as Channel>::Resp;
+    type Transport = <C as Channel>::Transport;
+
+    fn in_flight_requests(&self) -> usize {
+        self.inner.in_flight_requests()
+    }
+
+    fn config(&self) -> &Config {
+        self.inner.config()
+    }
+
+    fn transport(&self) -> &Self::Transport {
+        self.inner.transport()
+    }
+}
+
+/// An [`Incoming`](crate::server::incoming::Incoming) stream of channels that enforce limits on
+/// the number of in-flight requests.
+#[pin_project]
+#[derive(Debug)]
+pub struct MaxRequestsPerChannel<S> {
+    #[pin]
+    inner: S,
+    max_in_flight_requests: usize,
+}
+
+impl<S> MaxRequestsPerChannel<S>
+where
+    S: Stream,
+    <S as Stream>::Item: Channel,
+{
+    pub(crate) fn new(inner: S, max_in_flight_requests: usize) -> Self {
+        Self {
+            inner,
+            max_in_flight_requests,
+        }
+    }
+}
+
+impl<S> Stream for MaxRequestsPerChannel<S>
+where
+    S: Stream,
+    <S as Stream>::Item: Channel,
+{
+    type Item = MaxRequests<<S as Stream>::Item>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        match ready!(self.as_mut().project().inner.poll_next(cx)) {
+            Some(channel) => Poll::Ready(Some(MaxRequests::new(
+                channel,
+                *self.project().max_in_flight_requests,
+            ))),
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::server::{
+        testing::{self, FakeChannel, PollExt},
+        TrackedRequest,
+    };
+    use pin_utils::pin_mut;
+    use std::{
+        marker::PhantomData,
+        time::{Duration, Instant},
+    };
+    use tracing::Span;
+
+    #[tokio::test]
+    async fn throttler_in_flight_requests() {
+        let throttler = MaxRequests {
+            max_in_flight_requests: 0,
+            inner: FakeChannel::default::<isize, isize>(),
+        };
+
+        pin_mut!(throttler);
+        for i in 0..5 {
+            throttler
+                .inner
+                .in_flight_requests
+                .start_request(i, Instant::now() + Duration::from_secs(1), Span::current())
+                .unwrap();
+        }
+        assert_eq!(throttler.as_mut().in_flight_requests(), 5);
+    }
+
+    #[test]
+    fn throttler_poll_next_done() {
+        let throttler = MaxRequests {
+            max_in_flight_requests: 0,
+            inner: FakeChannel::default::<isize, isize>(),
+        };
+
+        pin_mut!(throttler);
+        assert!(throttler.as_mut().poll_next(&mut testing::cx()).is_done());
+    }
+
+    #[test]
+    fn throttler_poll_next_some() -> io::Result<()> {
+        let throttler = MaxRequests {
+            max_in_flight_requests: 1,
+            inner: FakeChannel::default::<isize, isize>(),
+        };
+
+        pin_mut!(throttler);
+        throttler.inner.push_req(0, 1);
+        assert!(throttler.as_mut().poll_ready(&mut testing::cx()).is_ready());
+        assert_eq!(
+            throttler
+                .as_mut()
+                .poll_next(&mut testing::cx())?
+                .map(|r| r.map(|r| (r.request.id, r.request.message))),
+            Poll::Ready(Some((0, 1)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn throttler_poll_next_throttled() {
+        let throttler = MaxRequests {
+            max_in_flight_requests: 0,
+            inner: FakeChannel::default::<isize, isize>(),
+        };
+
+        pin_mut!(throttler);
+        throttler.inner.push_req(1, 1);
+        assert!(throttler.as_mut().poll_next(&mut testing::cx()).is_done());
+        assert_eq!(throttler.inner.sink.len(), 1);
+        let resp = throttler.inner.sink.front().unwrap();
+        assert_eq!(resp.request_id, 1);
+        assert!(resp.message.is_err());
+    }
+
+    #[test]
+    fn throttler_poll_next_throttled_sink_not_ready() {
+        let throttler = MaxRequests {
+            max_in_flight_requests: 0,
+            inner: PendingSink::default::<isize, isize>(),
+        };
+        pin_mut!(throttler);
+        assert!(throttler.poll_next(&mut testing::cx()).is_pending());
+
+        struct PendingSink<In, Out> {
+            ghost: PhantomData<fn(Out) -> In>,
+        }
+        impl PendingSink<(), ()> {
+            pub fn default<Req, Resp>(
+            ) -> PendingSink<io::Result<TrackedRequest<Req>>, Response<Resp>> {
+                PendingSink { ghost: PhantomData }
+            }
+        }
+        impl<In, Out> Stream for PendingSink<In, Out> {
+            type Item = In;
+            fn poll_next(self: Pin<&mut Self>, _: &mut Context) -> Poll<Option<Self::Item>> {
+                unimplemented!()
+            }
+        }
+        impl<In, Out> Sink<Out> for PendingSink<In, Out> {
+            type Error = io::Error;
+            fn poll_ready(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
+                Poll::Pending
+            }
+            fn start_send(self: Pin<&mut Self>, _: Out) -> Result<(), Self::Error> {
+                Err(io::Error::from(io::ErrorKind::WouldBlock))
+            }
+            fn poll_flush(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
+                Poll::Pending
+            }
+            fn poll_close(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
+                Poll::Pending
+            }
+        }
+        impl<Req, Resp> Channel for PendingSink<io::Result<TrackedRequest<Req>>, Response<Resp>> {
+            type Req = Req;
+            type Resp = Resp;
+            type Transport = ();
+            fn config(&self) -> &Config {
+                unimplemented!()
+            }
+            fn in_flight_requests(&self) -> usize {
+                0
+            }
+            fn transport(&self) -> &() {
+                &()
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn throttler_start_send() {
+        let throttler = MaxRequests {
+            max_in_flight_requests: 0,
+            inner: FakeChannel::default::<isize, isize>(),
+        };
+
+        pin_mut!(throttler);
+        throttler
+            .inner
+            .in_flight_requests
+            .start_request(0, Instant::now() + Duration::from_secs(1), Span::current())
+            .unwrap();
+        throttler
+            .as_mut()
+            .start_send(Response {
+                request_id: 0,
+                message: Ok(1),
+            })
+            .unwrap();
+        assert_eq!(throttler.inner.in_flight_requests.len(), 0);
+        assert_eq!(
+            throttler.inner.sink.front(),
+            Some(&Response {
+                request_id: 0,
+                message: Ok(1),
+            })
+        );
+    }
+}

--- a/third_party/tarpc/src/server/request_hook.rs
+++ b/third_party/tarpc/src/server/request_hook.rs
@@ -1,0 +1,169 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Hooks for horizontal functionality that can run either before or after a request is executed.
+
+use crate::server::Serve;
+
+/// A request hook that runs before a request is executed.
+mod before;
+
+/// A request hook that runs after a request is completed.
+mod after;
+
+/// A request hook that runs both before a request is executed and after it is completed.
+mod before_and_after;
+
+pub use {
+    after::{AfterRequest, ServeThenHook},
+    before::{
+        before, BeforeRequest, BeforeRequestCons, BeforeRequestList, BeforeRequestNil,
+        HookThenServe,
+    },
+    before_and_after::HookThenServeThenHook,
+};
+
+/// Hooks that run before and/or after serving a request.
+pub trait RequestHook: Serve {
+    /// Runs a hook before execution of the request.
+    ///
+    /// If the hook returns an error, the request will not be executed and the error will be
+    /// returned instead.
+    ///
+    /// The hook can also modify the request context. This could be used, for example, to enforce a
+    /// maximum deadline on all requests.
+    ///
+    /// Any type that implements [`BeforeRequest`] can be used as the hook. Types that implement
+    /// `FnMut(&mut Context, &RequestType) -> impl Future<Output = Result<(), ServerError>>` can
+    /// also be used.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use futures::{executor::block_on, future};
+    /// use tarpc::{context, ServerError, server::{Serve, request_hook::RequestHook, serve}};
+    /// use std::io;
+    ///
+    /// let serve = serve(|_ctx, i| async move { Ok(i + 1) })
+    ///     .before(|_ctx: &mut context::Context, req: &i32| {
+    ///         future::ready(
+    ///             if *req == 1 {
+    ///                 Err(ServerError::new(
+    ///                     io::ErrorKind::Other,
+    ///                     format!("I don't like {req}")))
+    ///             } else {
+    ///                 Ok(())
+    ///             })
+    ///     });
+    /// let response = serve.serve(context::current(), 1);
+    /// assert!(block_on(response).is_err());
+    /// ```
+    fn before<Hook>(self, hook: Hook) -> HookThenServe<Self, Hook>
+    where
+        Hook: BeforeRequest<Self::Req>,
+        Self: Sized,
+    {
+        HookThenServe::new(self, hook)
+    }
+
+    /// Runs a hook after completion of a request.
+    ///
+    /// The hook can modify the request context and the response.
+    ///
+    /// Any type that implements [`AfterRequest`] can be used as the hook. Types that implement
+    /// `FnMut(&mut Context, &mut Result<ResponseType, ServerError>) -> impl Future<Output = ()>`
+    /// can also be used.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use futures::{executor::block_on, future};
+    /// use tarpc::{context, ServerError, server::{Serve, request_hook::RequestHook, serve}};
+    /// use std::io;
+    ///
+    /// let serve = serve(
+    ///     |_ctx, i| async move {
+    ///         if i == 1 {
+    ///             Err(ServerError::new(
+    ///                 io::ErrorKind::Other,
+    ///                 format!("{i} is the loneliest number")))
+    ///         } else {
+    ///             Ok(i + 1)
+    ///         }
+    ///     })
+    ///     .after(|_ctx: &mut context::Context, resp: &mut Result<i32, ServerError>| {
+    ///         if let Err(e) = resp {
+    ///             eprintln!("server error: {e:?}");
+    ///         }
+    ///         future::ready(())
+    ///     });
+    ///
+    /// let response = serve.serve(context::current(), 1);
+    /// assert!(block_on(response).is_err());
+    /// ```
+    fn after<Hook>(self, hook: Hook) -> ServeThenHook<Self, Hook>
+    where
+        Hook: AfterRequest<Self::Resp>,
+        Self: Sized,
+    {
+        ServeThenHook::new(self, hook)
+    }
+
+    /// Runs a hook before and after execution of the request.
+    ///
+    /// If the hook returns an error, the request will not be executed and the error will be
+    /// returned instead.
+    ///
+    /// The hook can also modify the request context and the response. This could be used, for
+    /// example, to enforce a maximum deadline on all requests.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use futures::{executor::block_on, future};
+    /// use tarpc::{
+    ///     context, ServerError,
+    ///     server::{Serve, serve, request_hook::{BeforeRequest, AfterRequest, RequestHook}}
+    /// };
+    /// use std::{io, time::Instant};
+    ///
+    /// struct PrintLatency(Instant);
+    ///
+    /// impl<Req> BeforeRequest<Req> for PrintLatency {
+    ///     async fn before(&mut self, _: &mut context::Context, _: &Req) -> Result<(), ServerError> {
+    ///         self.0 = Instant::now();
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// impl<Resp> AfterRequest<Resp> for PrintLatency {
+    ///     async fn after(
+    ///         &mut self,
+    ///         _: &mut context::Context,
+    ///         _: &mut Result<Resp, ServerError>,
+    ///     ) {
+    ///         tracing::info!("Elapsed: {:?}", self.0.elapsed());
+    ///     }
+    /// }
+    ///
+    /// let serve = serve(|_ctx, i| async move {
+    ///         Ok(i + 1)
+    ///     }).before_and_after(PrintLatency(Instant::now()));
+    /// let response = serve.serve(context::current(), 1);
+    /// assert!(block_on(response).is_ok());
+    /// ```
+    fn before_and_after<Hook>(
+        self,
+        hook: Hook,
+    ) -> HookThenServeThenHook<Self::Req, Self::Resp, Self, Hook>
+    where
+        Hook: BeforeRequest<Self::Req> + AfterRequest<Self::Resp>,
+        Self: Sized,
+    {
+        HookThenServeThenHook::new(self, hook)
+    }
+}
+impl<S: Serve> RequestHook for S {}

--- a/third_party/tarpc/src/server/request_hook/after.rs
+++ b/third_party/tarpc/src/server/request_hook/after.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a hook that runs after request execution.
+
+use crate::{context, server::Serve, ServerError};
+use futures::prelude::*;
+
+/// A hook that runs after request execution.
+#[allow(async_fn_in_trait)]
+pub trait AfterRequest<Resp> {
+    /// The function that is called after request execution.
+    ///
+    /// The hook can modify the request context and the response.
+    async fn after(&mut self, ctx: &mut context::Context, resp: &mut Result<Resp, ServerError>);
+}
+
+impl<F, Fut, Resp> AfterRequest<Resp> for F
+where
+    F: FnMut(&mut context::Context, &mut Result<Resp, ServerError>) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    async fn after(&mut self, ctx: &mut context::Context, resp: &mut Result<Resp, ServerError>) {
+        self(ctx, resp).await
+    }
+}
+
+/// A Service function that runs a hook after request execution.
+pub struct ServeThenHook<Serv, Hook> {
+    serve: Serv,
+    hook: Hook,
+}
+
+impl<Serv, Hook> ServeThenHook<Serv, Hook> {
+    pub(crate) fn new(serve: Serv, hook: Hook) -> Self {
+        Self { serve, hook }
+    }
+}
+
+impl<Serv: Clone, Hook: Clone> Clone for ServeThenHook<Serv, Hook> {
+    fn clone(&self) -> Self {
+        Self {
+            serve: self.serve.clone(),
+            hook: self.hook.clone(),
+        }
+    }
+}
+
+impl<Serv, Hook> Serve for ServeThenHook<Serv, Hook>
+where
+    Serv: Serve,
+    Hook: AfterRequest<Serv::Resp>,
+{
+    type Req = Serv::Req;
+    type Resp = Serv::Resp;
+
+    async fn serve(
+        self,
+        mut ctx: context::Context,
+        req: Serv::Req,
+    ) -> Result<Serv::Resp, ServerError> {
+        let ServeThenHook {
+            serve, mut hook, ..
+        } = self;
+        let mut resp = serve.serve(ctx, req).await;
+        hook.after(&mut ctx, &mut resp).await;
+        resp
+    }
+}

--- a/third_party/tarpc/src/server/request_hook/before.rs
+++ b/third_party/tarpc/src/server/request_hook/before.rs
@@ -1,0 +1,216 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a hook that runs before request execution.
+
+use crate::{context, server::Serve, ServerError};
+use futures::prelude::*;
+
+/// A hook that runs before request execution.
+#[allow(async_fn_in_trait)]
+pub trait BeforeRequest<Req> {
+    /// The function that is called before request execution.
+    ///
+    /// If this function returns an error, the request will not be executed and the error will be
+    /// returned instead.
+    ///
+    /// This function can also modify the request context. This could be used, for example, to
+    /// enforce a maximum deadline on all requests.
+    async fn before(&mut self, ctx: &mut context::Context, req: &Req) -> Result<(), ServerError>;
+}
+
+/// A list of hooks that run in order before request execution.
+pub trait BeforeRequestList<Req>: BeforeRequest<Req> {
+    /// The hook returned by `BeforeRequestList::then`.
+    type Then<Next>: BeforeRequest<Req>
+    where
+        Next: BeforeRequest<Req>;
+
+    /// Returns a hook that, when run, runs two hooks, first `self` and then `next`.
+    fn then<Next: BeforeRequest<Req>>(self, next: Next) -> Self::Then<Next>;
+
+    /// Same as `then`, but helps the compiler with type inference when Next is a closure.
+    fn then_fn<
+        Next: FnMut(&mut context::Context, &Req) -> Fut,
+        Fut: Future<Output = Result<(), ServerError>>,
+    >(
+        self,
+        next: Next,
+    ) -> Self::Then<Next>
+    where
+        Self: Sized,
+    {
+        self.then(next)
+    }
+
+    /// The service fn returned by `BeforeRequestList::serving`.
+    type Serve<S: Serve<Req = Req>>: Serve<Req = Req>;
+
+    /// Runs the list of request hooks before execution of the given serve fn.
+    /// This is equivalent to `serve.before(before_request_chain)` but may be syntactically nicer.
+    fn serving<S: Serve<Req = Req>>(self, serve: S) -> Self::Serve<S>;
+}
+
+impl<F, Fut, Req> BeforeRequest<Req> for F
+where
+    F: FnMut(&mut context::Context, &Req) -> Fut,
+    Fut: Future<Output = Result<(), ServerError>>,
+{
+    async fn before(&mut self, ctx: &mut context::Context, req: &Req) -> Result<(), ServerError> {
+        self(ctx, req).await
+    }
+}
+
+/// A Service function that runs a hook before request execution.
+#[derive(Clone)]
+pub struct HookThenServe<Serv, Hook> {
+    serve: Serv,
+    hook: Hook,
+}
+
+impl<Serv, Hook> HookThenServe<Serv, Hook> {
+    pub(crate) fn new(serve: Serv, hook: Hook) -> Self {
+        Self { serve, hook }
+    }
+}
+
+impl<Serv, Hook> Serve for HookThenServe<Serv, Hook>
+where
+    Serv: Serve,
+    Hook: BeforeRequest<Serv::Req>,
+{
+    type Req = Serv::Req;
+    type Resp = Serv::Resp;
+
+    async fn serve(
+        self,
+        mut ctx: context::Context,
+        req: Self::Req,
+    ) -> Result<Serv::Resp, ServerError> {
+        let HookThenServe {
+            serve, mut hook, ..
+        } = self;
+        hook.before(&mut ctx, &req).await?;
+        serve.serve(ctx, req).await
+    }
+}
+
+/// Returns a request hook builder that runs a series of hooks before request execution.
+///
+/// Example
+///
+/// ```rust
+/// use futures::{executor::block_on, future};
+/// use tarpc::{context, ServerError, server::{Serve, serve, request_hook::{self,
+///             BeforeRequest, BeforeRequestList}}};
+/// use std::{cell::Cell, io};
+///
+/// let i = Cell::new(0);
+/// let serve = request_hook::before()
+///     .then_fn(|_, _| async {
+///         assert!(i.get() == 0);
+///         i.set(1);
+///         Ok(())
+///     })
+///     .then_fn(|_, _| async {
+///         assert!(i.get() == 1);
+///         i.set(2);
+///         Ok(())
+///     })
+///     .serving(serve(|_ctx, i| async move { Ok(i + 1) }));
+/// let response = serve.clone().serve(context::current(), 1);
+/// assert!(block_on(response).is_ok());
+/// assert!(i.get() == 2);
+/// ```
+pub fn before() -> BeforeRequestNil {
+    BeforeRequestNil
+}
+
+/// A list of hooks that run in order before a request is executed.
+#[derive(Clone, Copy)]
+pub struct BeforeRequestCons<First, Rest>(First, Rest);
+
+/// A noop hook that runs before a request is executed.
+#[derive(Clone, Copy)]
+pub struct BeforeRequestNil;
+
+impl<Req, First: BeforeRequest<Req>, Rest: BeforeRequest<Req>> BeforeRequest<Req>
+    for BeforeRequestCons<First, Rest>
+{
+    async fn before(&mut self, ctx: &mut context::Context, req: &Req) -> Result<(), ServerError> {
+        let BeforeRequestCons(first, rest) = self;
+        first.before(ctx, req).await?;
+        rest.before(ctx, req).await?;
+        Ok(())
+    }
+}
+
+impl<Req> BeforeRequest<Req> for BeforeRequestNil {
+    async fn before(&mut self, _: &mut context::Context, _: &Req) -> Result<(), ServerError> {
+        Ok(())
+    }
+}
+
+impl<Req, First: BeforeRequest<Req>, Rest: BeforeRequestList<Req>> BeforeRequestList<Req>
+    for BeforeRequestCons<First, Rest>
+{
+    type Then<Next>
+        = BeforeRequestCons<First, Rest::Then<Next>>
+    where
+        Next: BeforeRequest<Req>;
+
+    fn then<Next: BeforeRequest<Req>>(self, next: Next) -> Self::Then<Next> {
+        let BeforeRequestCons(first, rest) = self;
+        BeforeRequestCons(first, rest.then(next))
+    }
+
+    type Serve<S: Serve<Req = Req>> = HookThenServe<S, Self>;
+
+    fn serving<S: Serve<Req = Req>>(self, serve: S) -> Self::Serve<S> {
+        HookThenServe::new(serve, self)
+    }
+}
+
+impl<Req> BeforeRequestList<Req> for BeforeRequestNil {
+    type Then<Next>
+        = BeforeRequestCons<Next, BeforeRequestNil>
+    where
+        Next: BeforeRequest<Req>;
+
+    fn then<Next: BeforeRequest<Req>>(self, next: Next) -> Self::Then<Next> {
+        BeforeRequestCons(next, BeforeRequestNil)
+    }
+
+    type Serve<S: Serve<Req = Req>> = S;
+
+    fn serving<S: Serve<Req = Req>>(self, serve: S) -> S {
+        serve
+    }
+}
+
+#[test]
+fn before_request_list() {
+    use crate::server::serve;
+    use futures::executor::block_on;
+    use std::cell::Cell;
+
+    let i = Cell::new(0);
+    let serve = before()
+        .then_fn(|_, _| async {
+            assert!(i.get() == 0);
+            i.set(1);
+            Ok(())
+        })
+        .then_fn(|_, _| async {
+            assert!(i.get() == 1);
+            i.set(2);
+            Ok(())
+        })
+        .serving(serve(|_ctx, i| async move { Ok(i + 1) }));
+    let response = serve.clone().serve(context::current(), 1);
+    assert!(block_on(response).is_ok());
+    assert!(i.get() == 2);
+}

--- a/third_party/tarpc/src/server/request_hook/before_and_after.rs
+++ b/third_party/tarpc/src/server/request_hook/before_and_after.rs
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a hook that runs both before and after request execution.
+
+use super::{after::AfterRequest, before::BeforeRequest};
+use crate::{context, server::Serve, RequestName, ServerError};
+use std::marker::PhantomData;
+
+/// A Service function that runs a hook both before and after request execution.
+pub struct HookThenServeThenHook<Req, Resp, Serv, Hook> {
+    serve: Serv,
+    hook: Hook,
+    fns: PhantomData<(fn(Req), fn(Resp))>,
+}
+
+impl<Req, Resp, Serv, Hook> HookThenServeThenHook<Req, Resp, Serv, Hook> {
+    pub(crate) fn new(serve: Serv, hook: Hook) -> Self {
+        Self {
+            serve,
+            hook,
+            fns: PhantomData,
+        }
+    }
+}
+
+impl<Req, Resp, Serv: Clone, Hook: Clone> Clone for HookThenServeThenHook<Req, Resp, Serv, Hook> {
+    fn clone(&self) -> Self {
+        Self {
+            serve: self.serve.clone(),
+            hook: self.hook.clone(),
+            fns: PhantomData,
+        }
+    }
+}
+
+impl<Req, Resp, Serv, Hook> Serve for HookThenServeThenHook<Req, Resp, Serv, Hook>
+where
+    Req: RequestName,
+    Serv: Serve<Req = Req, Resp = Resp>,
+    Hook: BeforeRequest<Req> + AfterRequest<Resp>,
+{
+    type Req = Req;
+    type Resp = Resp;
+
+    async fn serve(self, mut ctx: context::Context, req: Req) -> Result<Serv::Resp, ServerError> {
+        let HookThenServeThenHook {
+            serve, mut hook, ..
+        } = self;
+        hook.before(&mut ctx, &req).await?;
+        let mut resp = serve.serve(ctx, req).await;
+        hook.after(&mut ctx, &mut resp).await;
+        resp
+    }
+}

--- a/third_party/tarpc/src/server/testing.rs
+++ b/third_party/tarpc/src/server/testing.rs
@@ -1,0 +1,139 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use crate::{
+    cancellations::{cancellations, CanceledRequests, RequestCancellation},
+    context,
+    server::{Channel, Config, ResponseGuard, TrackedRequest},
+    Request, Response,
+};
+use futures::{task::*, Sink, Stream};
+use pin_project::pin_project;
+use std::{collections::VecDeque, io, pin::Pin, time::Instant};
+use tracing::Span;
+
+#[pin_project]
+pub(crate) struct FakeChannel<In, Out> {
+    #[pin]
+    pub stream: VecDeque<In>,
+    #[pin]
+    pub sink: VecDeque<Out>,
+    pub config: Config,
+    pub in_flight_requests: super::in_flight_requests::InFlightRequests,
+    pub request_cancellation: RequestCancellation,
+    pub canceled_requests: CanceledRequests,
+}
+
+impl<In, Out> Stream for FakeChannel<In, Out>
+where
+    In: Unpin,
+{
+    type Item = In;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.project().stream.pop_front())
+    }
+}
+
+impl<In, Resp> Sink<Response<Resp>> for FakeChannel<In, Response<Resp>> {
+    type Error = io::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().sink.poll_ready(cx).map_err(|e| match e {})
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, response: Response<Resp>) -> Result<(), Self::Error> {
+        self.as_mut()
+            .project()
+            .in_flight_requests
+            .remove_request(response.request_id);
+        self.project()
+            .sink
+            .start_send(response)
+            .map_err(|e| match e {})
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().sink.poll_flush(cx).map_err(|e| match e {})
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.project().sink.poll_close(cx).map_err(|e| match e {})
+    }
+}
+
+impl<Req, Resp> Channel for FakeChannel<io::Result<TrackedRequest<Req>>, Response<Resp>>
+where
+    Req: Unpin,
+{
+    type Req = Req;
+    type Resp = Resp;
+    type Transport = ();
+
+    fn config(&self) -> &Config {
+        &self.config
+    }
+
+    fn in_flight_requests(&self) -> usize {
+        self.in_flight_requests.len()
+    }
+
+    fn transport(&self) -> &() {
+        &()
+    }
+}
+
+impl<Req, Resp> FakeChannel<io::Result<TrackedRequest<Req>>, Response<Resp>> {
+    pub fn push_req(&mut self, id: u64, message: Req) {
+        let (_, abort_registration) = futures::future::AbortHandle::new_pair();
+        let (request_cancellation, _) = cancellations();
+        self.stream.push_back(Ok(TrackedRequest {
+            request: Request {
+                context: context::Context {
+                    deadline: Instant::now(),
+                    trace_context: Default::default(),
+                },
+                id,
+                message,
+            },
+            abort_registration,
+            span: Span::none(),
+            response_guard: ResponseGuard {
+                request_cancellation,
+                request_id: id,
+                cancel: false,
+            },
+        }));
+    }
+}
+
+impl FakeChannel<(), ()> {
+    pub fn default<Req, Resp>() -> FakeChannel<io::Result<TrackedRequest<Req>>, Response<Resp>> {
+        let (request_cancellation, canceled_requests) = cancellations();
+        FakeChannel {
+            stream: Default::default(),
+            sink: Default::default(),
+            config: Default::default(),
+            in_flight_requests: Default::default(),
+            request_cancellation,
+            canceled_requests,
+        }
+    }
+}
+
+pub trait PollExt {
+    fn is_done(&self) -> bool;
+}
+
+impl<T> PollExt for Poll<Option<T>> {
+    fn is_done(&self) -> bool {
+        matches!(self, Poll::Ready(None))
+    }
+}
+
+pub fn cx() -> Context<'static> {
+    Context::from_waker(noop_waker_ref())
+}

--- a/third_party/tarpc/src/trace.rs
+++ b/third_party/tarpc/src/trace.rs
@@ -1,0 +1,261 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#![deny(missing_docs, missing_debug_implementations)]
+
+//! Provides building blocks for tracing distributed programs.
+//!
+//! A trace is logically a tree of causally-related events called spans. Traces are tracked via a
+//! [context](Context) that identifies the current trace, span, and parent of the current span.  In
+//! distributed systems, a context can be sent from client to server to connect events occurring on
+//! either side.
+//!
+//! This crate's design is based on [opencensus
+//! tracing](https://opencensus.io/core-concepts/tracing/).
+
+use opentelemetry::trace::TraceContextExt;
+use rand::Rng;
+use std::{
+    convert::TryFrom,
+    fmt::{self, Formatter},
+    num::{NonZeroU128, NonZeroU64},
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// A context for tracing the execution of processes, distributed or otherwise.
+///
+/// Consists of a span identifying an event, an optional parent span identifying a causal event
+/// that triggered the current span, and a trace with which all related spans are associated.
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct Context {
+    /// An identifier of the trace associated with the current context. A trace ID is typically
+    /// created at a root span and passed along through all causal events.
+    pub trace_id: TraceId,
+    /// An identifier of the current span. In typical RPC usage, a span is created by a client
+    /// before making an RPC, and the span ID is sent to the server. The server is free to create
+    /// its own spans, for which it sets the client's span as the parent span.
+    pub span_id: SpanId,
+    /// Indicates whether a sampler has already decided whether or not to sample the trace
+    /// associated with the Context. If `sampling_decision` is None, then a decision has not yet
+    /// been made. Downstream samplers do not need to abide by "no sample" decisions--for example,
+    /// an upstream client may choose to never sample, which may not make sense for the client's
+    /// dependencies. On the other hand, if an upstream process has chosen to sample this trace,
+    /// then the downstream samplers are expected to respect that decision and also sample the
+    /// trace. Otherwise, the full trace would not be able to be reconstructed.
+    pub sampling_decision: SamplingDecision,
+}
+
+/// A 128-bit UUID identifying a trace. All spans caused by the same originating span share the
+/// same trace ID.
+#[derive(Default, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct TraceId(#[cfg_attr(feature = "serde1", serde(with = "u128_serde"))] u128);
+
+/// A 64-bit identifier of a span within a trace. The identifier is unique within the span's trace.
+#[derive(Default, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+pub struct SpanId(u64);
+
+/// Indicates whether a sampler has decided whether or not to sample the trace associated with the
+/// Context. Downstream samplers do not need to abide by "no sample" decisions--for example, an
+/// upstream client may choose to never sample, which may not make sense for the client's
+/// dependencies. On the other hand, if an upstream process has chosen to sample this trace, then
+/// the downstream samplers are expected to respect that decision and also sample the trace.
+/// Otherwise, the full trace would not be able to be reconstructed reliably.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[repr(u8)]
+pub enum SamplingDecision {
+    /// The associated span was sampled by its creating process. Child spans must also be sampled.
+    Sampled,
+    /// The associated span was not sampled by its creating process.
+    Unsampled,
+}
+
+impl Context {
+    /// Constructs a new context with the trace ID and sampling decision inherited from the parent.
+    pub(crate) fn new_child(&self) -> Self {
+        Self {
+            trace_id: self.trace_id,
+            span_id: SpanId::random(&mut rand::thread_rng()),
+            sampling_decision: self.sampling_decision,
+        }
+    }
+}
+
+impl TraceId {
+    /// Returns a random trace ID that can be assumed to be globally unique if `rng` generates
+    /// actually-random numbers.
+    pub fn random<R: Rng>(rng: &mut R) -> Self {
+        TraceId(rng.gen::<NonZeroU128>().get())
+    }
+
+    /// Returns true iff the trace ID is 0.
+    pub fn is_none(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl SpanId {
+    /// Returns a random span ID that can be assumed to be unique within a single trace.
+    pub fn random<R: Rng>(rng: &mut R) -> Self {
+        SpanId(rng.gen::<NonZeroU64>().get())
+    }
+
+    /// Returns true iff the span ID is 0.
+    pub fn is_none(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl From<TraceId> for u128 {
+    fn from(trace_id: TraceId) -> Self {
+        trace_id.0
+    }
+}
+
+impl From<u128> for TraceId {
+    fn from(trace_id: u128) -> Self {
+        Self(trace_id)
+    }
+}
+
+impl From<SpanId> for u64 {
+    fn from(span_id: SpanId) -> Self {
+        span_id.0
+    }
+}
+
+impl From<u64> for SpanId {
+    fn from(span_id: u64) -> Self {
+        Self(span_id)
+    }
+}
+
+impl From<opentelemetry::trace::TraceId> for TraceId {
+    fn from(trace_id: opentelemetry::trace::TraceId) -> Self {
+        Self::from(u128::from_be_bytes(trace_id.to_bytes()))
+    }
+}
+
+impl From<TraceId> for opentelemetry::trace::TraceId {
+    fn from(trace_id: TraceId) -> Self {
+        Self::from_bytes(u128::from(trace_id).to_be_bytes())
+    }
+}
+
+impl From<opentelemetry::trace::SpanId> for SpanId {
+    fn from(span_id: opentelemetry::trace::SpanId) -> Self {
+        Self::from(u64::from_be_bytes(span_id.to_bytes()))
+    }
+}
+
+impl From<SpanId> for opentelemetry::trace::SpanId {
+    fn from(span_id: SpanId) -> Self {
+        Self::from_bytes(u64::from(span_id).to_be_bytes())
+    }
+}
+
+impl TryFrom<&tracing::Span> for Context {
+    type Error = NoActiveSpan;
+
+    fn try_from(span: &tracing::Span) -> Result<Self, NoActiveSpan> {
+        let context = span.context();
+        if context.has_active_span() {
+            Ok(Self::from(context.span()))
+        } else {
+            Err(NoActiveSpan)
+        }
+    }
+}
+
+impl From<opentelemetry::trace::SpanRef<'_>> for Context {
+    fn from(span: opentelemetry::trace::SpanRef<'_>) -> Self {
+        let otel_ctx = span.span_context();
+        Self {
+            trace_id: TraceId::from(otel_ctx.trace_id()),
+            span_id: SpanId::from(otel_ctx.span_id()),
+            sampling_decision: SamplingDecision::from(otel_ctx),
+        }
+    }
+}
+
+impl From<SamplingDecision> for opentelemetry::trace::TraceFlags {
+    fn from(decision: SamplingDecision) -> Self {
+        match decision {
+            SamplingDecision::Sampled => opentelemetry::trace::TraceFlags::SAMPLED,
+            SamplingDecision::Unsampled => opentelemetry::trace::TraceFlags::default(),
+        }
+    }
+}
+
+impl From<&opentelemetry::trace::SpanContext> for SamplingDecision {
+    fn from(context: &opentelemetry::trace::SpanContext) -> Self {
+        if context.is_sampled() {
+            SamplingDecision::Sampled
+        } else {
+            SamplingDecision::Unsampled
+        }
+    }
+}
+
+impl Default for SamplingDecision {
+    fn default() -> Self {
+        Self::Unsampled
+    }
+}
+
+/// Returned when a [`Context`] cannot be constructed from a [`Span`](tracing::Span).
+#[derive(Debug)]
+pub struct NoActiveSpan;
+
+impl fmt::Display for TraceId {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{:02x}", self.0)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for TraceId {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{:02x}", self.0)?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for SpanId {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{:02x}", self.0)?;
+        Ok(())
+    }
+}
+
+impl fmt::Debug for SpanId {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{:02x}", self.0)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "serde1")]
+mod u128_serde {
+    pub fn serialize<S>(u: &u128, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(&u.to_le_bytes(), serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(u128::from_le_bytes(serde::Deserialize::deserialize(
+            deserializer,
+        )?))
+    }
+}

--- a/third_party/tarpc/src/transport.rs
+++ b/third_party/tarpc/src/transport.rs
@@ -1,0 +1,40 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Provides a [`Transport`](sealed::Transport) trait as well as implementations.
+//!
+//! The rpc crate is transport- and protocol-agnostic. Any transport that impls [`Transport`](sealed::Transport)
+//! can be plugged in, using whatever protocol it wants.
+
+pub mod channel;
+
+pub(crate) mod sealed {
+    use futures::prelude::*;
+    use std::error::Error;
+
+    /// A bidirectional stream ([`Sink`] + [`Stream`]) of messages.
+    pub trait Transport<SinkItem, Item>
+    where
+        Self: Stream<Item = Result<Item, <Self as Sink<SinkItem>>::Error>>,
+        Self: Sink<SinkItem, Error = <Self as Transport<SinkItem, Item>>::TransportError>,
+        <Self as Sink<SinkItem>>::Error: Error,
+    {
+        /// Associated type where clauses are not elaborated; this associated type allows users
+        /// bounding types by Transport to avoid having to explicitly add `T::Error: Error` to their
+        /// bounds.
+        type TransportError: Error + Send + Sync + 'static;
+    }
+
+    impl<T, SinkItem, Item, E> Transport<SinkItem, Item> for T
+    where
+        T: ?Sized,
+        T: Stream<Item = Result<Item, E>>,
+        T: Sink<SinkItem, Error = E>,
+        T::Error: Error + Send + Sync + 'static,
+    {
+        type TransportError = E;
+    }
+}

--- a/third_party/tarpc/src/transport/channel.rs
+++ b/third_party/tarpc/src/transport/channel.rs
@@ -1,0 +1,219 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Transports backed by in-memory channels.
+
+use futures::{task::*, Sink, Stream};
+use pin_project::pin_project;
+use std::{error::Error, pin::Pin};
+use tokio::sync::mpsc;
+
+/// Errors that occur in the sending or receiving of messages over a channel.
+#[derive(thiserror::Error, Debug)]
+pub enum ChannelError {
+    /// An error occurred readying to send into the channel.
+    #[error("an error occurred readying to send into the channel")]
+    Ready(#[source] Box<dyn Error + Send + Sync + 'static>),
+    /// An error occurred sending into the channel.
+    #[error("an error occurred sending into the channel")]
+    Send(#[source] Box<dyn Error + Send + Sync + 'static>),
+    /// An error occurred receiving from the channel.
+    #[error("an error occurred receiving from the channel")]
+    Receive(#[source] Box<dyn Error + Send + Sync + 'static>),
+}
+
+/// Returns two unbounded channel peers. Each [`Stream`] yields items sent through the other's
+/// [`Sink`].
+pub fn unbounded<SinkItem, Item>() -> (
+    UnboundedChannel<SinkItem, Item>,
+    UnboundedChannel<Item, SinkItem>,
+) {
+    let (tx1, rx2) = mpsc::unbounded_channel();
+    let (tx2, rx1) = mpsc::unbounded_channel();
+    (
+        UnboundedChannel { tx: tx1, rx: rx1 },
+        UnboundedChannel { tx: tx2, rx: rx2 },
+    )
+}
+
+/// A bi-directional channel backed by an [`UnboundedSender`](mpsc::UnboundedSender)
+/// and [`UnboundedReceiver`](mpsc::UnboundedReceiver).
+#[derive(Debug)]
+pub struct UnboundedChannel<Item, SinkItem> {
+    rx: mpsc::UnboundedReceiver<Item>,
+    tx: mpsc::UnboundedSender<SinkItem>,
+}
+
+impl<Item, SinkItem> Stream for UnboundedChannel<Item, SinkItem> {
+    type Item = Result<Item, ChannelError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Item, ChannelError>>> {
+        self.rx
+            .poll_recv(cx)
+            .map(|option| option.map(Ok))
+            .map_err(ChannelError::Receive)
+    }
+}
+
+const CLOSED_MESSAGE: &str = "the channel is closed and cannot accept new items for sending";
+
+impl<Item, SinkItem> Sink<SinkItem> for UnboundedChannel<Item, SinkItem> {
+    type Error = ChannelError;
+
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(if self.tx.is_closed() {
+            Err(ChannelError::Ready(CLOSED_MESSAGE.into()))
+        } else {
+            Ok(())
+        })
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: SinkItem) -> Result<(), Self::Error> {
+        self.tx
+            .send(item)
+            .map_err(|_| ChannelError::Send(CLOSED_MESSAGE.into()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // UnboundedSender requires no flushing.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // UnboundedSender can't initiate closure.
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Returns two channel peers with buffer equal to `capacity`. Each [`Stream`] yields items sent
+/// through the other's [`Sink`].
+pub fn bounded<SinkItem, Item>(
+    capacity: usize,
+) -> (Channel<SinkItem, Item>, Channel<Item, SinkItem>) {
+    let (tx1, rx2) = futures::channel::mpsc::channel(capacity);
+    let (tx2, rx1) = futures::channel::mpsc::channel(capacity);
+    (Channel { tx: tx1, rx: rx1 }, Channel { tx: tx2, rx: rx2 })
+}
+
+/// A bi-directional channel backed by a [`Sender`](futures::channel::mpsc::Sender)
+/// and [`Receiver`](futures::channel::mpsc::Receiver).
+#[pin_project]
+#[derive(Debug)]
+pub struct Channel<Item, SinkItem> {
+    #[pin]
+    rx: futures::channel::mpsc::Receiver<Item>,
+    #[pin]
+    tx: futures::channel::mpsc::Sender<SinkItem>,
+}
+
+impl<Item, SinkItem> Stream for Channel<Item, SinkItem> {
+    type Item = Result<Item, ChannelError>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Item, ChannelError>>> {
+        self.project()
+            .rx
+            .poll_next(cx)
+            .map(|option| option.map(Ok))
+            .map_err(ChannelError::Receive)
+    }
+}
+
+impl<Item, SinkItem> Sink<SinkItem> for Channel<Item, SinkItem> {
+    type Error = ChannelError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .tx
+            .poll_ready(cx)
+            .map_err(|e| ChannelError::Ready(Box::new(e)))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: SinkItem) -> Result<(), Self::Error> {
+        self.project()
+            .tx
+            .start_send(item)
+            .map_err(|e| ChannelError::Send(Box::new(e)))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .tx
+            .poll_flush(cx)
+            .map_err(|e| ChannelError::Send(Box::new(e)))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .tx
+            .poll_close(cx)
+            .map_err(|e| ChannelError::Send(Box::new(e)))
+    }
+}
+
+#[cfg(all(test, feature = "tokio1"))]
+mod tests {
+    use crate::{
+        client::{self, RpcError},
+        context,
+        server::{incoming::Incoming, serve, BaseChannel},
+        transport::{
+            self,
+            channel::{Channel, UnboundedChannel},
+        },
+        ServerError,
+    };
+    use assert_matches::assert_matches;
+    use futures::{prelude::*, stream};
+    use std::io;
+    use tracing::trace;
+
+    #[test]
+    fn ensure_is_transport() {
+        fn is_transport<SinkItem, Item, T: crate::Transport<SinkItem, Item>>() {}
+        is_transport::<(), (), UnboundedChannel<(), ()>>();
+        is_transport::<(), (), Channel<(), ()>>();
+    }
+
+    #[tokio::test]
+    async fn integration() -> anyhow::Result<()> {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let (client_channel, server_channel) = transport::channel::unbounded();
+        tokio::spawn(
+            stream::once(future::ready(server_channel))
+                .map(BaseChannel::with_defaults)
+                .execute(serve(|_ctx, request: String| async move {
+                    request.parse::<u64>().map_err(|_| {
+                        ServerError::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("{request:?} is not an int"),
+                        )
+                    })
+                }))
+                .for_each(|channel| async move {
+                    tokio::spawn(channel.for_each(|response| response));
+                }),
+        );
+
+        let client = client::new(client::Config::default(), client_channel).spawn();
+
+        let response1 = client.call(context::current(), "123".into()).await;
+        let response2 = client.call(context::current(), "abc".into()).await;
+
+        trace!("response1: {:?}, response2: {:?}", response1, response2);
+
+        assert_matches!(response1, Ok(123));
+        assert_matches!(response2, Err(RpcError::Server(e)) if e.kind == io::ErrorKind::InvalidInput);
+
+        Ok(())
+    }
+}

--- a/third_party/tarpc/src/util.rs
+++ b/third_party/tarpc/src/util.rs
@@ -1,0 +1,71 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, Hash},
+    time::{Duration, Instant},
+};
+
+#[cfg(feature = "serde1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde1")))]
+pub mod serde;
+
+/// Extension trait for [Instants](Instant) in the future, i.e. deadlines.
+pub trait TimeUntil {
+    /// How much time from now until this time is reached.
+    fn time_until(&self) -> Duration;
+}
+
+impl TimeUntil for Instant {
+    fn time_until(&self) -> Duration {
+        self.duration_since(Instant::now())
+    }
+}
+
+/// Collection compaction; configurable `shrink_to_fit`.
+pub trait Compact {
+    /// Compacts space if the ratio of length : capacity is less than `usage_ratio_threshold`.
+    fn compact(&mut self, usage_ratio_threshold: f64);
+}
+
+impl<K, V, H> Compact for HashMap<K, V, H>
+where
+    K: Eq + Hash,
+    H: BuildHasher,
+{
+    fn compact(&mut self, usage_ratio_threshold: f64) {
+        let usage_ratio_threshold = usage_ratio_threshold.clamp(f64::MIN_POSITIVE, 1.);
+        let cap = f64::max(1000., self.len() as f64 / usage_ratio_threshold);
+        self.shrink_to(cap as usize);
+    }
+}
+
+#[test]
+fn test_compact() {
+    let mut map = HashMap::with_capacity(2048);
+    assert_eq!(map.capacity(), 3584);
+
+    // Make usage ratio 25%
+    for i in 0..896 {
+        map.insert(format!("k{i}"), "v");
+    }
+
+    map.compact(-1.0);
+    assert_eq!(map.capacity(), 3584);
+
+    map.compact(0.25);
+    assert_eq!(map.capacity(), 3584);
+
+    map.compact(0.50);
+    assert_eq!(map.capacity(), 1792);
+
+    map.compact(1.0);
+    assert_eq!(map.capacity(), 1792);
+
+    map.compact(2.0);
+    assert_eq!(map.capacity(), 1792);
+}

--- a/third_party/tarpc/src/util/serde.rs
+++ b/third_party/tarpc/src/util/serde.rs
@@ -1,0 +1,73 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::io;
+
+/// Serializes [`io::ErrorKind`] as a `u32`.
+#[allow(clippy::trivially_copy_pass_by_ref)] // Exact fn signature required by serde derive
+pub fn serialize_io_error_kind_as_u32<S>(
+    kind: &io::ErrorKind,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    use std::io::ErrorKind::*;
+    match *kind {
+        NotFound => 0,
+        PermissionDenied => 1,
+        ConnectionRefused => 2,
+        ConnectionReset => 3,
+        ConnectionAborted => 4,
+        NotConnected => 5,
+        AddrInUse => 6,
+        AddrNotAvailable => 7,
+        BrokenPipe => 8,
+        AlreadyExists => 9,
+        WouldBlock => 10,
+        InvalidInput => 11,
+        InvalidData => 12,
+        TimedOut => 13,
+        WriteZero => 14,
+        Interrupted => 15,
+        Other => 16,
+        UnexpectedEof => 17,
+        _ => 16,
+    }
+    .serialize(serializer)
+}
+
+/// Deserializes [`io::ErrorKind`] from a `u32`.
+pub fn deserialize_io_error_kind_from_u32<'de, D>(
+    deserializer: D,
+) -> Result<io::ErrorKind, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use std::io::ErrorKind::*;
+    Ok(match u32::deserialize(deserializer)? {
+        0 => NotFound,
+        1 => PermissionDenied,
+        2 => ConnectionRefused,
+        3 => ConnectionReset,
+        4 => ConnectionAborted,
+        5 => NotConnected,
+        6 => AddrInUse,
+        7 => AddrNotAvailable,
+        8 => BrokenPipe,
+        9 => AlreadyExists,
+        10 => WouldBlock,
+        11 => InvalidInput,
+        12 => InvalidData,
+        13 => TimedOut,
+        14 => WriteZero,
+        15 => Interrupted,
+        16 => Other,
+        17 => UnexpectedEof,
+        _ => Other,
+    })
+}


### PR DESCRIPTION
## Summary

Dependabot security update for `opentelemetry_sdk` failed with `security_update_not_possible` ([run](https://github.com/AprilNEA/OpenLogi/actions/runs/30712026356/job/91401036679), [alert](https://github.com/AprilNEA/OpenLogi/security/dependabot/2)):

- Vulnerable: `opentelemetry_sdk <= 0.32.0` ([GHSA-w9wp-h8wv-79jx](https://github.com/advisories/GHSA-w9wp-h8wv-79jx) / CVE-2026-48504)
- Fixed: `0.32.1`
- Resolvable with current graph: only `0.30.0`

### Why Dependabot cannot update it

OpenLogi does not depend on `opentelemetry_sdk` directly. The chain is:

```
tarpc 0.37 (crates.io)
  └─ tracing-opentelemetry ^0.31
       └─ opentelemetry_sdk ^0.30   (normal dependency)
```

`tarpc` 0.37 also hard-pins `opentelemetry ^0.30`. The patched SDK is on the **0.32** line, which is semver-incompatible with those pins, so cargo (and Dependabot) cannot resolve a safe version without changing `tarpc` itself.

Upstream status:

- crates.io `tarpc` is still **0.37.0** / otel **0.30**
- `google/tarpc` `main` only moved to otel **0.31** (still vulnerable range)
- Open Dependabot PRs on tarpc for 0.32 have not landed; otel is also not optional ([google/tarpc#564](https://github.com/google/tarpc/issues/564))

OpenLogi never installs a baggage propagator and only uses tarpc over a local socket, so the practical exploit path is weak — but the advisory still shows as an open Dependabot alert until the package leaves the graph.

## Changes

- Vendor a minimal `tarpc` 0.37.0 tree under `third_party/tarpc` and `[patch.crates-io]` it in.
- Bump that tree to `opentelemetry` / `opentelemetry-semantic-conventions` **0.32** and `tracing-opentelemetry` **0.33**.
- `tracing-opentelemetry` 0.33 keeps `opentelemetry_sdk` as a **dev-dependency only**, so it disappears from our runtime/lockfile graph entirely (not merely upgraded).
- One-line source delta vs crates.io 0.37.0: ignore the `Result` from `set_parent` (return type changed in toe 0.32+).
- Document the pin and removal criteria in `third_party/tarpc/README.md`.

No OpenLogi IPC/API code changes. Remove the vendor when a crates.io `tarpc` release depends on `tracing-opentelemetry >= 0.32.1` (or otherwise no longer pulls a vulnerable SDK).

## Testing

```sh
cargo check -p openlogi-agent-core -p openlogi-agent -p openlogi-cli
RUSTFLAGS="-D warnings" cargo clippy -p openlogi-agent-core -p openlogi-agent -p openlogi-cli --all-targets -- -D warnings
cargo tree -p openlogi-agent-core -i opentelemetry_sdk   # → no matching packages
```

- Confirmed `opentelemetry_sdk` is absent from `Cargo.lock`
- Confirmed gpui git pin unchanged (`1a246efd…`)
- Not runtime-tested on hardware (dependency-only change)