### PR TITLE
ci: speed up pipelines with shared rust-cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          # Release profile (fat LTO) — never share with CI debug keys.
+          shared-key: macos-stable-release
+          # Packaging never runs on master push; allow same-repo PRs/dispatch/release
+          # to refresh the shared release cache (few keys, not per-job thrash).
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Verify runner architecture
         run: test "$(uname -m)" = "${{ matrix.arch }}"
@@ -147,10 +154,19 @@ jobs:
           OPENLOGI_UPDATE_BASE_URL: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_BASE_URL
           OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY: ${{ secrets.OP_R2_SECRET_ITEM }}/OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY
 
+      - name: Cache Homebrew downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            ~/Library/Caches/Homebrew/downloads
+          key: brew-macos-${{ runner.arch }}-librsvg-create-dmg-v1
+          restore-keys: |
+            brew-macos-${{ runner.arch }}-
+
       - name: Install packaging tools
         run: |
-          brew install librsvg
-          brew install create-dmg
+          brew install librsvg create-dmg
 
       - name: Validate release secrets
         if: ${{ inputs.sign }}
@@ -325,9 +341,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # No rust-cache here: this workflow runs only on tag refs, whose saved
-      # caches no future tag can restore (and no default-branch job produces a
-      # matching key), so the save was pure overhead churning the cache quota.
+      # Release builds need their own cache (crt-static RUSTFLAGS + --release).
+      # Shared per matrix.arch so labeled PR packaging and dispatch runs warm
+      # each other; tag-only saves were pure quota churn under the old per-ref
+      # keys, but a shared-key entry is restorable across PR/dispatch/release.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: windows-stable-release-${{ matrix.arch }}
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       # Azure signing config lives in 1Password, matching the macOS job's secret flow.
       # load-secrets-action is a node action, so it runs on Windows runners too. The
@@ -676,6 +698,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: linux-stable-release
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       # The nfpm `arch` and the runner's native arch must agree — the packages
       # are built natively, not cross-compiled, so a mismatched runner would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
-      - run: cargo deny check
+      - run: cargo deny check --all-features
 
   clippy-windows:
     name: clippy (windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,22 @@ on:
     branches: [main, master]
   pull_request:
 
+# Cancel superseded runs on the same ref (rapid PR pushes / force-pushes).
+# Always cancel here: CI never signs or publishes artifacts.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-D warnings"
 
+# rust-cache policy (see PR description for measured rationale):
+# - prefix-key v1-rust: bust the thrashing v0-rust multi-GB entries (~21 GB).
+# - shared-key groups jobs that share OS + rustc channel + debug profile.
+# - save-if master/main only: PRs restore base-branch caches without writing
+#   new multi-GB keys that evict Windows/MSRV under the 10 GB soft limit.
 jobs:
   fmt:
     name: rustfmt
@@ -30,6 +41,10 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: linux-stable-debug
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -53,6 +68,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          # Host OS splits Linux vs macOS; rustc 1.96 is already in the key.
+          shared-key: msrv-debug
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - if: runner.os == 'Linux'
         run: |
           sudo apt-get update
@@ -63,38 +83,36 @@ jobs:
             libssl-dev libzstd-dev pkg-config
       - run: cargo check --workspace --all-targets
 
-  check-linux:
-    name: cargo check (linux)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libudev-dev \
-            gcc g++ clang libfontconfig-dev libwayland-dev \
-            libxkbcommon-x11-dev libx11-xcb-dev \
-            libssl-dev libzstd-dev pkg-config
-      - run: cargo check --workspace --all-targets
+  # Stable Linux typecheck is covered by `clippy` above (clippy subsumes
+  # `cargo check` for the same --workspace --all-targets set — same rationale
+  # as clippy-windows). MSRV stays on the `msrv` matrix (1.96).
 
   docs-hid:
     name: rustdoc (hid crates)
     runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          # Share debug deps with clippy/test-linux; RUSTDOCFLAGS is step-scoped
+          # below so it does not fork the rust-cache env hash.
+          shared-key: linux-stable-debug
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: |
           sudo apt-get update
           sudo apt-get install -y \
             libudev-dev \
             pkg-config
-      - run: cargo doc -p openlogi-hid --no-deps --document-private-items
-      - run: cargo doc -p openlogi-hidpp --no-deps --document-private-items
+      - name: cargo doc (openlogi-hid)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc -p openlogi-hid --no-deps --document-private-items
+      - name: cargo doc (openlogi-hidpp)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc -p openlogi-hidpp --no-deps --document-private-items
 
   # openlogi-core / openlogi-hid / openlogi-assets / openlogi / openlogi-hook
   # all compile on Linux today (the hook crate has stubs for non-macOS targets).
@@ -108,6 +126,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: linux-stable-debug
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -132,6 +154,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          # Host triple already splits arm64 vs x86_64 in the final cache key.
+          shared-key: macos-stable-debug
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - name: Verify runner architecture
         run: test "$(uname -m)" = "${{ matrix.arch }}"
       - run: cargo test --workspace --all-targets
@@ -141,9 +168,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      # Prebuilt binary install is faster than cargo-deny-action's bootstrap path
+      # (~100s observed); advisory DB is still fetched by `cargo deny check`.
+      - uses: taiki-e/install-action@v2
         with:
-          command: check
+          tool: cargo-deny
+      - run: cargo deny check
 
   clippy-windows:
     name: clippy (windows)
@@ -154,6 +184,10 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: windows-stable-debug
+          save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       # Whole workspace, matching the Linux jobs — GPUI's DirectX backend
       # covers the GUI on Windows. clippy subsumes `cargo check` and
       # additionally lints the Windows-only code paths (the WH_MOUSE_LL hook,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
-      - run: cargo deny check --all-features
+      # Global flags before subcommand (matches cargo-deny-action defaults).
+      - run: cargo deny --all-features check
 
   clippy-windows:
     name: clippy (windows)

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -29,6 +29,11 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: linux-stable-debug
+          # CI master is the canonical writer; release-plz only restores.
+          save-if: false
       - name: Install Linux build deps
         run: |
           sudo apt-get update
@@ -140,6 +145,11 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: linux-stable-debug
+          # CI master is the canonical writer; release-plz only restores.
+          save-if: false
       - name: Install Linux build deps
         run: |
           sudo apt-get update

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Match CI so shared-key linux-stable-debug restore hits the env hash.
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   # Opens/updates a release PR that bumps the shared workspace version and writes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust
+          shared-key: linux-stable-debug
+          # Tag publish is not a useful cache writer; restore CI deps only.
+          save-if: false
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # Match CI's RUSTFLAGS so the rust-cache env hash hits linux-stable-debug.
+      - name: Align rust-cache env with CI
+        run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
+
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust


### PR DESCRIPTION
## Summary

Cut CI wall time and machine-minutes by fixing rust-cache thrash (~21 GB / 22 entries, intermittent Windows/MSRV misses), cancelling superseded CI runs, dropping a redundant Linux compile job, and enabling Windows release caching for labeled PR packaging.

Measured baseline (live runs + local sim): quiet thrashy PRs ~8–10 min wall (Windows clippy cold ~5–6 min); push storms worse due to no CI concurrency cancel. Expected after warm master caches: ~4–6 min wall on thrashy days, ~30–50% fewer machine-minutes; quiet already-warm PRs gain little wall time.

## Changes

### `ci.yml`
- **Concurrency** with `cancel-in-progress: true` (CI never signs/publishes).
- **`prefix-key: v1-rust`** to age out thrashing `v0-rust` multi-GB entries.
- **`shared-key` groups**: `linux-stable-debug` (clippy / test-linux / docs-hid), `msrv-debug`, `macos-stable-debug`, `windows-stable-debug`.
- **`save-if` master/main only** — PRs restore base-branch caches without writing new keys under the 10 GB soft limit.
- **Drop `check-linux`** — stable `cargo clippy --workspace --all-targets` already subsumes `cargo check` (same rationale as `clippy-windows`). MSRV remains via the 1.96 matrix.
- **docs-hid**: move `RUSTDOCFLAGS` to step env so it can share the Linux debug cache key.
- **cargo-deny**: switch to `taiki-e/install-action` + `cargo deny check` (faster than full action bootstrap).

### `build.yml`
- Shared **release** cache keys for macOS / Linux packaging (`macos-stable-release`, `linux-stable-release`).
- **Add Windows rust-cache** (`windows-stable-release-${{ matrix.arch }}`) — the old “tag-only, no cache” comment was outdated; this workflow also runs on `needs: build` PRs and dispatch.
- Cache Homebrew downloads; single `brew install librsvg create-dmg`.
- Preserve existing `should-build` / `needs: build` label gate.

### `release-plz.yml` / `release.yml`
- Restore CI `linux-stable-debug` deps with **`save-if: false`** (CI master is the canonical writer).

### Explicit non-goals
- No sccache in CI (local sim: miss path slower; without a remote backend GHA runners are ephemeral).
- No apt package image rewrite (secondary ~15–30s vs multi-minute compiles).
- No product / IPC / protocol changes.

## Testing

- `python3 -c "import yaml; …"` — all four workflows parse.
- Local multi-agent simulation: clippy subsumes check; sccache not worth CI without remote store.
- Live cache inventory prior to change: ~21 GB / 22 entries under `v0-rust`.
- Not runtime-tested on GitHub Actions yet — first CI run after merge will populate `v1-rust` keys on master; PR runs restore once master has saved.

## Expected impact

| Scenario | Before (approx) | After (approx) |
|---|---|---|
| Quiet PR, Windows cache miss | 8–10 min wall | 4–6 min wall |
| Rapid force-pushes | 10–15+ min + N full matrices | 1 live matrix, rest cancelled |
| Machine-min / green PR | high (thrash + cancel waste) | ~30–50% lower steady-state |
| Cache keys | ~22 fragmented multi-GB | ~8–12 shared groups |