### PR TITLE
fix(hid): stop intermittent SmartShift InvalidArgument

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -202,6 +202,191 @@ pub fn write_smartshift_in_background(
     });
 }
 
+/// Desired SmartShift values for a reconnect re-apply.
+#[derive(Debug, Clone, Copy)]
+pub struct SmartShiftApply {
+    /// Wheel mode to write.
+    pub mode: SmartShiftMode,
+    /// Auto-disengage threshold (`0` = preserve).
+    pub auto_disengage: u8,
+    /// Tunable torque (`0` = preserve).
+    pub tunable_torque: u8,
+}
+
+/// Re-apply every volatile mouse setting for one device on a **single**
+/// background thread, sequentially, reusing the capture channel when available.
+///
+/// Agent-start reapply used to fire DPI / SmartShift / wheel-mode each on its
+/// own thread, and each opened a fresh HID++ channel when capture was not yet
+/// ready. Concurrent opens of the same Bolt/Unifying node share the OS input
+/// stream while correlating responses only by software id — they cross-talk and
+/// produce the intermittent SmartShift `InvalidArgument` seen in #485. One
+/// sequential writer removes that self-race.
+pub fn reapply_mouse_volatile_in_background(
+    capture: Option<&CaptureChannel>,
+    target: DeviceRoute,
+    resolution: Option<ScrollResolution>,
+    inverted: Option<bool>,
+    dpi: Option<u32>,
+    smartshift: Option<SmartShiftApply>,
+) {
+    let shared = reusable_channel(capture, &target);
+    let reused = shared.is_some();
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                warn!(error = %e, "tokio runtime init failed; volatile reapply skipped");
+                return;
+            }
+        };
+        let index = target.device_index();
+        rt.block_on(async {
+            if resolution.is_some() || inverted.is_some() {
+                let result = tokio::time::timeout(WRITE_BUDGET, async {
+                    apply_wheel_mode(shared.as_ref(), &target, resolution, inverted).await
+                })
+                .await;
+                log_wheel_result(index, resolution, inverted, reused, result);
+            }
+            if let Some(dpi) = dpi {
+                match u16::try_from(dpi) {
+                    Ok(dpi_u16) => {
+                        let result = tokio::time::timeout(WRITE_BUDGET, async {
+                            match &shared {
+                                Some(shared) => openlogi_hid::set_dpi_on(shared, dpi_u16).await,
+                                None => openlogi_hid::set_dpi(&target, dpi_u16).await,
+                            }
+                        })
+                        .await;
+                        match result {
+                            Ok(Ok(())) => {
+                                debug!(index, dpi = dpi_u16, reused, "DPI written to device");
+                            }
+                            Ok(Err(e)) => warn!(error = ?e, "DPI write failed"),
+                            Err(_) => warn!(
+                                dpi = dpi_u16,
+                                "DPI write timed out (device asleep/unresponsive)"
+                            ),
+                        }
+                    }
+                    Err(_) => {
+                        warn!(dpi, "DPI exceeds the HID++ u16 wire field; write skipped");
+                    }
+                }
+            }
+            if let Some(ss) = smartshift {
+                let result = tokio::time::timeout(WRITE_BUDGET, async {
+                    match &shared {
+                        Some(shared) => {
+                            openlogi_hid::set_smartshift_on(
+                                shared,
+                                ss.mode,
+                                ss.auto_disengage,
+                                ss.tunable_torque,
+                            )
+                            .await
+                        }
+                        None => {
+                            openlogi_hid::set_smartshift(
+                                &target,
+                                ss.mode,
+                                ss.auto_disengage,
+                                ss.tunable_torque,
+                            )
+                            .await
+                        }
+                    }
+                })
+                .await;
+                match result {
+                    Ok(Ok(())) => debug!(
+                        index,
+                        mode = ?ss.mode,
+                        auto_disengage = ss.auto_disengage,
+                        tunable_torque = ss.tunable_torque,
+                        reused,
+                        "SmartShift config written"
+                    ),
+                    Ok(Err(e)) => warn!(error = ?e, "SmartShift write failed"),
+                    Err(_) => warn!(
+                        index,
+                        "SmartShift write timed out (device asleep/unresponsive)"
+                    ),
+                }
+            }
+        });
+    });
+}
+
+async fn apply_wheel_mode(
+    shared: Option<&SharedChannel>,
+    target: &DeviceRoute,
+    resolution: Option<ScrollResolution>,
+    inverted: Option<bool>,
+) -> Result<(), WriteError> {
+    match (resolution, inverted, shared) {
+        (Some(resolution), Some(inverted), Some(shared)) => {
+            openlogi_hid::set_scroll_wheel_mode_on(shared, resolution, inverted)
+                .await
+                .map(|_| ())
+        }
+        (Some(resolution), Some(inverted), None) => {
+            openlogi_hid::set_scroll_wheel_mode(target, resolution, inverted)
+                .await
+                .map(|_| ())
+        }
+        (Some(resolution), None, Some(shared)) => {
+            openlogi_hid::set_scroll_resolution_on(shared, resolution)
+                .await
+                .map(|_| ())
+        }
+        (Some(resolution), None, None) => openlogi_hid::set_scroll_resolution(target, resolution)
+            .await
+            .map(|_| ()),
+        (None, Some(inverted), Some(shared)) => {
+            openlogi_hid::set_scroll_inversion_on(shared, inverted).await
+        }
+        (None, Some(inverted), None) => openlogi_hid::set_scroll_inversion(target, inverted).await,
+        (None, None, _) => Ok(()),
+    }
+}
+
+fn log_wheel_result(
+    index: u8,
+    resolution: Option<ScrollResolution>,
+    inverted: Option<bool>,
+    reused: bool,
+    result: Result<Result<(), WriteError>, tokio::time::error::Elapsed>,
+) {
+    match result {
+        Ok(Ok(())) => debug!(
+            index,
+            ?resolution,
+            ?inverted,
+            reused,
+            "native wheel mode written"
+        ),
+        Ok(Err(WriteError::FeatureUnsupported { feature_hex })) => debug!(
+            index,
+            ?resolution,
+            ?inverted,
+            feature = format_args!("{feature_hex:#06x}"),
+            "native wheel mode unsupported"
+        ),
+        Ok(Err(e)) => warn!(error = ?e, "wheel mode write failed"),
+        Err(_) => warn!(
+            index,
+            ?resolution,
+            ?inverted,
+            "wheel mode write timed out (device asleep/unresponsive)"
+        ),
+    }
+}
+
 /// Spawn an OS thread that writes `dpi` to the device at `target` via
 /// `openlogi_hid::set_dpi`. Returns immediately; failures are logged.
 ///

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -239,39 +239,37 @@ impl Orchestrator {
     }
 
     /// Push the persisted volatile settings (lighting, sensor DPI, SmartShift,
-    /// native wheel mode) to one device, fire-and-forget on background threads.
-    /// Reuses the capture session's channel when it already points at the
-    /// device, like every other hardware write.
+    /// native wheel mode) to one device. Mouse settings run on one background
+    /// thread and one HID++ channel so concurrent multi-open of the same
+    /// receiver cannot cross-talk (#485); lighting stays a separate path
+    /// (keyboards / different feature).
     fn reapply_volatile_settings(&self, dev: &AgentDevice) {
         let Some(route) = dev.route.clone() else {
             return;
         };
         let key = &dev.config_key;
         let (resolution, inverted) = configured_wheel_mode(&self.config, dev);
-        crate::hardware::write_scroll_wheel_mode_in_background(
-            Some(&self.shared.capture_channel),
-            (resolution.is_some() || inverted.is_some()).then_some(route.clone()),
-            resolution,
-            inverted,
-        );
-        if let Some(lighting) = self.config.lighting(key).filter(|l| l.enabled) {
-            crate::hardware::set_lighting_in_background(Some(route.clone()), &lighting);
-        }
-        if let Some(dpi) = self.config.dpi(key) {
-            crate::hardware::write_dpi_in_background(
+        let dpi = self.config.dpi(key);
+        let smartshift = self
+            .config
+            .smartshift(key)
+            .map(|ss| crate::hardware::SmartShiftApply {
+                mode: ss.mode.into(),
+                auto_disengage: ss.auto_disengage,
+                tunable_torque: ss.tunable_torque,
+            });
+        if resolution.is_some() || inverted.is_some() || dpi.is_some() || smartshift.is_some() {
+            crate::hardware::reapply_mouse_volatile_in_background(
                 Some(&self.shared.capture_channel),
-                Some(route.clone()),
+                route.clone(),
+                resolution,
+                inverted,
                 dpi,
+                smartshift,
             );
         }
-        if let Some(smartshift) = self.config.smartshift(key) {
-            crate::hardware::write_smartshift_in_background(
-                Some(&self.shared.capture_channel),
-                Some(route),
-                smartshift.mode.into(),
-                smartshift.auto_disengage,
-                smartshift.tunable_torque,
-            );
+        if let Some(lighting) = self.config.lighting(key).filter(|l| l.enabled) {
+            crate::hardware::set_lighting_in_background(Some(route), &lighting);
         }
     }
 

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -10,6 +10,7 @@
 
 #[cfg(not(target_os = "windows"))]
 use std::error::Error;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, LazyLock};
 
 #[cfg(not(target_os = "windows"))]
@@ -17,11 +18,22 @@ use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceReader};
 use async_hid::{DeviceInfo, DeviceWriter, HidBackend};
 use futures_lite::StreamExt as _;
 use hidpp::channel::HidppChannel;
+use hidpp::nibble::U4;
 #[cfg(not(target_os = "windows"))]
 use hidpp::{async_trait, channel::RawHidChannel};
 #[cfg(not(target_os = "windows"))]
 use tokio::sync::Mutex;
 use tracing::debug;
+
+/// Next HID++ software id seed for a freshly opened channel (`1..=15`).
+///
+/// HID++ correlates request/response by `(device, feature, function, software_id)`.
+/// Concurrent opens of the same physical HID node (inventory + capture + one-shot
+/// writes) each get a private pending queue but share the OS input report stream,
+/// so identical software ids make responses match the wrong open. Diversifying the
+/// seed and rotating after every send (see [`configure_channel_sw_ids`]) keeps
+/// multi-open traffic distinguishable.
+static NEXT_SW_ID_SEED: AtomicU8 = AtomicU8::new(1);
 
 #[cfg(any(target_os = "windows", test))]
 mod windows;
@@ -216,6 +228,19 @@ pub(crate) async fn open_route_writer(
     Ok(None)
 }
 
+/// Stamp a channel with a unique rotating software-id sequence.
+///
+/// Software id `0` is reserved for device notifications and is never used.
+fn configure_channel_sw_ids(channel: &HidppChannel) {
+    let seed = NEXT_SW_ID_SEED
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(if current >= 15 { 1 } else { current + 1 })
+        })
+        .unwrap_or(1);
+    channel.set_sw_id(U4::from_lo(seed));
+    channel.set_rotating_sw_id(true);
+}
+
 pub(crate) async fn open_hidpp_channel(
     dev: async_hid::Device,
 ) -> Result<Option<(DeviceInfo, Arc<HidppChannel>)>, async_hid::HidError> {
@@ -230,7 +255,10 @@ pub(crate) async fn open_hidpp_channel(
     {
         let raw = WindowsHidppChannel::open(dev, info.clone()).await?;
         let channel = match HidppChannel::from_raw_channel(raw).await {
-            Ok(c) => Arc::new(c),
+            Ok(c) => {
+                configure_channel_sw_ids(&c);
+                Arc::new(c)
+            }
             Err(e) => {
                 debug!(name = %info.name, error = ?e, "not a HID++ channel");
                 return Ok(None);
@@ -247,7 +275,10 @@ pub(crate) async fn open_hidpp_channel(
         let long_only = is_long_only_collection(info.usage_page, info.usage_id);
         let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
         let channel = match HidppChannel::from_raw_channel(raw).await {
-            Ok(c) => Arc::new(c),
+            Ok(c) => {
+                configure_channel_sw_ids(&c);
+                Arc::new(c)
+            }
             Err(e) => {
                 debug!(name = %info.name, error = ?e, "not a HID++ channel");
                 return Ok(None);

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -10,7 +10,7 @@
 
 #[cfg(not(target_os = "windows"))]
 use std::error::Error;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, LazyLock};
 
 #[cfg(not(target_os = "windows"))]
@@ -25,15 +25,15 @@ use hidpp::{async_trait, channel::RawHidChannel};
 use tokio::sync::Mutex;
 use tracing::debug;
 
-/// Next HID++ software id seed for a freshly opened channel (`1..=15`).
+/// Bitmask of leased HID++ software ids (`1..=15`; bit `N` means id `N` is taken).
 ///
 /// HID++ correlates request/response by `(device, feature, function, software_id)`.
-/// Concurrent opens of the same physical HID node (inventory + capture + one-shot
-/// writes) each get a private pending queue but share the OS input report stream,
-/// so identical software ids make responses match the wrong open. Diversifying the
-/// seed and rotating after every send (see [`configure_channel_sw_ids`]) keeps
-/// multi-open traffic distinguishable.
-static NEXT_SW_ID_SEED: AtomicU8 = AtomicU8::new(1);
+/// Concurrent opens of the same physical HID node each get a private pending
+/// queue but share the OS input report stream, so a shared software id lets a
+/// response satisfy the wrong open. Each channel leases one **fixed** id for its
+/// lifetime (no rotation — offset rotating sequences still collide across
+/// channels) and frees it on drop via [`HidppChannel::set_sw_id_lease`].
+static SW_ID_LEASES: AtomicU16 = AtomicU16::new(0);
 
 #[cfg(any(target_os = "windows", test))]
 mod windows;
@@ -228,17 +228,42 @@ pub(crate) async fn open_route_writer(
     Ok(None)
 }
 
-/// Stamp a channel with a unique rotating software-id sequence.
+/// Lease one free software id in `1..=15`, or `None` if all 15 are held.
+fn try_lease_sw_id() -> Option<u8> {
+    loop {
+        let bits = SW_ID_LEASES.load(Ordering::Acquire);
+        let free = (1u8..=15).find(|&id| bits & (1u16 << id) == 0)?;
+        let next = bits | (1u16 << free);
+        if SW_ID_LEASES
+            .compare_exchange(bits, next, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return Some(free);
+        }
+    }
+}
+
+fn free_sw_id(id: u8) {
+    if (1..=15).contains(&id) {
+        SW_ID_LEASES.fetch_and(!(1u16 << id), Ordering::Release);
+    }
+}
+
+/// Give `channel` a process-unique fixed software id for its lifetime.
 ///
-/// Software id `0` is reserved for device notifications and is never used.
-fn configure_channel_sw_ids(channel: &HidppChannel) {
-    let seed = NEXT_SW_ID_SEED
-        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-            Some(if current >= 15 { 1 } else { current + 1 })
-        })
-        .unwrap_or(1);
-    channel.set_sw_id(U4::from_lo(seed));
-    channel.set_rotating_sw_id(true);
+/// Software id `0` is reserved for device notifications and is never leased.
+/// Rotation stays off: concurrent channels that share a rotating `1..=15`
+/// sequence eventually reuse the same id and cross-match again.
+fn configure_channel_sw_ids(channel: &mut HidppChannel) {
+    let Some(id) = try_lease_sw_id() else {
+        // More than 15 simultaneous opens is unexpected; keep the default id
+        // rather than colliding with a live lease deliberately.
+        debug!("all HID++ software ids are leased; channel keeps default id 1");
+        return;
+    };
+    channel.set_sw_id(U4::from_lo(id));
+    channel.set_rotating_sw_id(false);
+    channel.set_sw_id_lease(id, free_sw_id);
 }
 
 pub(crate) async fn open_hidpp_channel(
@@ -255,8 +280,8 @@ pub(crate) async fn open_hidpp_channel(
     {
         let raw = WindowsHidppChannel::open(dev, info.clone()).await?;
         let channel = match HidppChannel::from_raw_channel(raw).await {
-            Ok(c) => {
-                configure_channel_sw_ids(&c);
+            Ok(mut c) => {
+                configure_channel_sw_ids(&mut c);
                 Arc::new(c)
             }
             Err(e) => {
@@ -275,8 +300,8 @@ pub(crate) async fn open_hidpp_channel(
         let long_only = is_long_only_collection(info.usage_page, info.usage_id);
         let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
         let channel = match HidppChannel::from_raw_channel(raw).await {
-            Ok(c) => {
-                configure_channel_sw_ids(&c);
+            Ok(mut c) => {
+                configure_channel_sw_ids(&mut c);
                 Arc::new(c)
             }
             Err(e) => {
@@ -289,6 +314,33 @@ pub(crate) async fn open_hidpp_channel(
         // on reconnect) only — not every ~2s tick.
         debug!(name = %info.name, vid = format_args!("{:04x}", info.vendor_id), "opened HID++ channel");
         Ok(Some((info, channel)))
+    }
+}
+
+#[cfg(test)]
+mod sw_id_lease_tests {
+    use super::{free_sw_id, try_lease_sw_id};
+
+    #[test]
+    fn leases_are_unique_until_freed() {
+        // Leave any ids held by concurrent tests alone: lease two free slots,
+        // check they differ, free them, and confirm the first id is reusable.
+        let Some(a) = try_lease_sw_id() else {
+            return;
+        };
+        let Some(b) = try_lease_sw_id() else {
+            free_sw_id(a);
+            return;
+        };
+        assert_ne!(a, b);
+        free_sw_id(a);
+        let Some(c) = try_lease_sw_id() else {
+            free_sw_id(b);
+            return;
+        };
+        assert_eq!(c, a);
+        free_sw_id(b);
+        free_sw_id(c);
     }
 }
 

--- a/crates/openlogi-hid/src/write/smartshift.rs
+++ b/crates/openlogi-hid/src/write/smartshift.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU8;
 use std::sync::Arc;
+use std::time::Duration;
 
 use hidpp::{
     channel::HidppChannel,
@@ -15,7 +16,14 @@ use tracing::debug;
 use crate::route::DeviceRoute;
 use crate::smartshift::{SmartShiftMode, SmartShiftStatus};
 
-use super::{HidppOperation, WriteError, classify_hidpp_error, open_feature, with_route};
+use super::{
+    HidppFeatureErrorKind, HidppOperation, WriteError, classify_hidpp_error, open_feature,
+    with_route,
+};
+
+/// Brief pause before re-trying a SmartShift transaction that lost a race with
+/// concurrent HID++ traffic on another open of the same node (#485).
+const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 /// Whether a failure to open the `0x2111` Enhanced SmartShift feature should
 /// trigger the `0x2110` legacy fallback. Only a missing-`0x2111` feature
@@ -26,6 +34,31 @@ pub(super) fn is_missing_enhanced(err: &WriteError) -> bool {
         err,
         WriteError::FeatureUnsupported { feature_hex } if *feature_hex == 0x2111
     )
+}
+
+/// Errors that, on SmartShift, have been observed to clear on a second attempt
+/// with byte-identical parameters after concurrent multi-open traffic settles
+/// (#485). Permanent failures (unsupported feature, bad permanent payload) are
+/// not included.
+pub(super) fn is_transient_smartshift_error(err: &WriteError) -> bool {
+    matches!(
+        err,
+        WriteError::HidppFeature {
+            kind: HidppFeatureErrorKind::InvalidArgument
+                | HidppFeatureErrorKind::Busy
+                | HidppFeatureErrorKind::HwError,
+            ..
+        } | WriteError::UnsupportedResponse { .. }
+    )
+}
+
+/// Whether `current` already satisfies a desired SmartShift write. A zero
+/// `auto_disengage` / `tunable_torque` is the firmware "do not change" sentinel
+/// on the write path, so those fields are only compared when non-zero.
+pub(super) fn status_matches_desired(current: SmartShiftStatus, desired: SmartShiftStatus) -> bool {
+    current.mode == desired.mode
+        && (desired.auto_disengage == 0 || current.auto_disengage == desired.auto_disengage)
+        && (desired.tunable_torque == 0 || current.tunable_torque == desired.tunable_torque)
 }
 
 /// Map the fork's `0x2110` [`WheelMode`] onto OpenLogi's [`SmartShiftMode`].
@@ -62,14 +95,23 @@ enum SmartShift {
 
 impl SmartShift {
     /// Open whichever SmartShift feature the device exposes. Tries `0x2111`
-    /// first; on a missing-`0x2111` error (and only that), retries with
-    /// `0x2110`. Any other error from the first attempt propagates unchanged.
+    /// first; on a missing-`0x2111` error (and only that), re-checks once before
+    /// falling back to `0x2110`. A concurrent multi-open of the same HID node
+    /// can mis-deliver a `root.get_feature` response and make a present `0x2111`
+    /// look absent (#485) — the second probe catches that before we write the
+    /// wrong feature. Any other error from either attempt propagates unchanged.
     async fn open(device: &mut Device) -> Result<Self, WriteError> {
         match open_feature::<SmartShiftEnhancedFeature>(device).await {
             Ok(feature) => Ok(Self::Enhanced(feature)),
             Err(err) if is_missing_enhanced(&err) => {
-                let feature = open_feature::<SmartShiftFeature>(device).await?;
-                Ok(Self::Legacy(feature))
+                match open_feature::<SmartShiftEnhancedFeature>(device).await {
+                    Ok(feature) => Ok(Self::Enhanced(feature)),
+                    Err(err) if is_missing_enhanced(&err) => {
+                        let feature = open_feature::<SmartShiftFeature>(device).await?;
+                        Ok(Self::Legacy(feature))
+                    }
+                    Err(err) => Err(err),
+                }
             }
             Err(err) => Err(err),
         }
@@ -252,6 +294,9 @@ pub async fn toggle_smartshift(route: &DeviceRoute) -> Result<SmartShiftMode, Wr
 
 /// The SmartShift toggle itself, on an already-open channel at HID++ `index`.
 /// Shared by [`toggle_smartshift`] and [`toggle_smartshift_on`](super::toggle_smartshift_on).
+///
+/// Retries once on the same transient errors as [`set_smartshift_on_channel`] —
+/// a ModeShift binding can race concurrent HID++ traffic the same way (#485).
 pub(super) async fn toggle_smartshift_on_channel(
     channel: &Arc<HidppChannel>,
     index: u8,
@@ -259,7 +304,23 @@ pub(super) async fn toggle_smartshift_on_channel(
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let smartshift = SmartShift::open(&mut device).await?;
+    match toggle_once(&mut device, index).await {
+        Ok(mode) => Ok(mode),
+        Err(err) if is_transient_smartshift_error(&err) => {
+            debug!(
+                index,
+                error = ?err,
+                "SmartShift toggle hit a transient error; retrying once"
+            );
+            tokio::time::sleep(TRANSIENT_RETRY_DELAY).await;
+            toggle_once(&mut device, index).await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+async fn toggle_once(device: &mut Device, index: u8) -> Result<SmartShiftMode, WriteError> {
+    let smartshift = SmartShift::open(device).await?;
     let status = smartshift.status().await?;
     let next = status.mode.flipped();
     smartshift
@@ -298,6 +359,11 @@ pub async fn set_smartshift(
 
 /// The SmartShift write itself, on an already-open channel at HID++ `index`.
 /// Shared by [`set_smartshift`] and [`set_smartshift_on`](super::set_smartshift_on).
+///
+/// Skips the HID++ write when the device already holds the desired config, and
+/// retries once after a short delay on transient device errors — the first
+/// post-start reapply races concurrent opens of the same Bolt/Unifying node and
+/// can return `InvalidArgument` for byte-identical parameters (#485).
 pub(super) async fn set_smartshift_on_channel(
     channel: &Arc<HidppChannel>,
     index: u8,
@@ -305,23 +371,58 @@ pub(super) async fn set_smartshift_on_channel(
     auto_disengage: u8,
     tunable_torque: u8,
 ) -> Result<(), WriteError> {
+    let desired = SmartShiftStatus {
+        mode,
+        auto_disengage,
+        tunable_torque,
+    };
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
     let smartshift = SmartShift::open(&mut device).await?;
-    smartshift
-        .set_status(SmartShiftStatus {
-            mode,
+    if let Ok(current) = smartshift.status().await
+        && status_matches_desired(current, desired)
+    {
+        debug!(
+            index,
+            ?mode,
             auto_disengage,
             tunable_torque,
-        })
-        .await?;
-    debug!(
-        index,
-        ?mode,
-        auto_disengage,
-        tunable_torque,
-        "wrote SmartShift config"
-    );
-    Ok(())
+            "SmartShift already matches config; skipping write"
+        );
+        return Ok(());
+    }
+    match smartshift.set_status(desired).await {
+        Ok(()) => {
+            debug!(
+                index,
+                ?mode,
+                auto_disengage,
+                tunable_torque,
+                "wrote SmartShift config"
+            );
+            Ok(())
+        }
+        Err(err) if is_transient_smartshift_error(&err) => {
+            debug!(
+                index,
+                error = ?err,
+                "SmartShift write hit a transient error; retrying once"
+            );
+            tokio::time::sleep(TRANSIENT_RETRY_DELAY).await;
+            // Re-open: the first attempt may have bound the wrong feature index
+            // after a mis-delivered root.get_feature response.
+            let smartshift = SmartShift::open(&mut device).await?;
+            smartshift.set_status(desired).await?;
+            debug!(
+                index,
+                ?mode,
+                auto_disengage,
+                tunable_torque,
+                "wrote SmartShift config"
+            );
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
 }

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -4,9 +4,12 @@ use super::*;
 use hidpp::feature::smartshift::WheelMode;
 
 use crate::SmartShiftMode;
+use crate::SmartShiftStatus;
 use crate::write::smartshift::{
-    is_missing_enhanced, smartshift_to_wheel, wheel_mode_to_smartshift,
+    is_missing_enhanced, is_transient_smartshift_error, smartshift_to_wheel,
+    status_matches_desired, wheel_mode_to_smartshift,
 };
+use crate::write::{HidppFeatureErrorKind, HidppOperation};
 
 #[test]
 fn capabilities_sort_and_deduplicate_values() -> Result<(), WriteError> {
@@ -121,4 +124,61 @@ fn transport_errors_do_not_trigger_fallback() {
         index: 0xff,
     }));
     assert!(!is_missing_enhanced(&WriteError::Hidpp("boom".into())));
+}
+
+#[test]
+fn transient_smartshift_errors_are_retryable() {
+    assert!(is_transient_smartshift_error(&WriteError::HidppFeature {
+        operation: HidppOperation::WriteSmartShift,
+        feature_hex: 0x2111,
+        kind: HidppFeatureErrorKind::InvalidArgument,
+    }));
+    assert!(is_transient_smartshift_error(&WriteError::HidppFeature {
+        operation: HidppOperation::WriteSmartShift,
+        feature_hex: 0x2110,
+        kind: HidppFeatureErrorKind::Busy,
+    }));
+    assert!(is_transient_smartshift_error(
+        &WriteError::UnsupportedResponse {
+            operation: HidppOperation::ReadSmartShift,
+            feature_hex: 0x2110,
+        }
+    ));
+}
+
+#[test]
+fn permanent_smartshift_errors_are_not_retryable() {
+    assert!(!is_transient_smartshift_error(
+        &WriteError::FeatureUnsupported {
+            feature_hex: 0x2111,
+        }
+    ));
+    assert!(!is_transient_smartshift_error(&WriteError::HidppFeature {
+        operation: HidppOperation::WriteSmartShift,
+        feature_hex: 0x2111,
+        kind: HidppFeatureErrorKind::InvalidFunctionId,
+    }));
+}
+
+#[test]
+fn status_match_ignores_zero_preserve_fields() {
+    let current = SmartShiftStatus {
+        mode: SmartShiftMode::Ratchet,
+        auto_disengage: 10,
+        tunable_torque: 33,
+    };
+    let desired = SmartShiftStatus {
+        mode: SmartShiftMode::Ratchet,
+        auto_disengage: 10,
+        // 0 = "do not change" on the write path — already-matched for reapply.
+        tunable_torque: 0,
+    };
+    assert!(status_matches_desired(current, desired));
+    assert!(!status_matches_desired(
+        current,
+        SmartShiftStatus {
+            mode: SmartShiftMode::Free,
+            ..desired
+        }
+    ));
 }

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -285,10 +285,21 @@ pub struct HidppChannel {
     /// The handle to the read thread. Should be joined after signaling
     /// [`Self::read_thread_close`].
     read_thread_hdl: Option<JoinHandle<()>>,
+
+    /// Optional process-wide software-id lease: `(id, free)` run on drop.
+    ///
+    /// OpenLogi leases a unique HID++ software id per open so concurrent
+    /// channels on the same physical HID node never share a correlation id
+    /// (software id `0` is reserved for device notifications). Local addition.
+    sw_id_lease: Option<(u8, fn(u8))>,
 }
 
 impl Drop for HidppChannel {
     fn drop(&mut self) {
+        if let Some((id, free)) = self.sw_id_lease.take() {
+            free(id);
+        }
+
         if let Some(read_thread_close) = self.read_thread_close.take() {
             // This only fails if the receiving end, which is owned by the read thread in
             // this case, is dropped.
@@ -399,6 +410,7 @@ impl HidppChannel {
             message_listeners: message_listeners_rc,
             read_thread_close: Some(close_sender),
             read_thread_hdl: Some(read_thread_hdl),
+            sw_id_lease: None,
         })
     }
 
@@ -421,6 +433,16 @@ impl HidppChannel {
     /// reserved for device notifications.
     pub fn set_rotating_sw_id(&self, enable: bool) {
         self.rotate_software_id.store(enable, Ordering::SeqCst);
+    }
+
+    /// Lease software id `id` until this channel is dropped, then call `free(id)`.
+    ///
+    /// Replaces any previous lease. Used by OpenLogi so concurrent opens of the
+    /// same HID node hold distinct correlation ids for their full lifetime.
+    ///
+    /// OpenLogi local addition.
+    pub fn set_sw_id_lease(&mut self, id: u8, free: fn(u8)) {
+        self.sw_id_lease = Some((id, free));
     }
 
     /// Provides a software ID that can be used to send a HID++ message across


### PR DESCRIPTION
## Summary

Fixes #485.

After agent start, the first SmartShift reapply can return `InvalidArgument` for byte-identical parameters that succeed on the confirming retry (~1/3 starts on MX Master 3S over Bolt). Root cause is concurrent multi-open of the same receiver HID++ node with a shared software id: responses cross-match, so the write binds the wrong feature index (or falls back to legacy `0x2110`).

## Changes

- **hidpp**: optional software-id lease released when the channel drops
- **hid**: each open leases a unique **fixed** software id (`1..=15`) for its lifetime — no shared rotating sequence (avoids cross-channel id reuse under concurrent opens)
- **hid**: SmartShift open re-checks `0x2111` before legacy fallback; write short-circuits when already matched and retries once on transient `InvalidArgument`/`Busy`/`UnsupportedResponse`; toggle gets the same retry
- **agent-core**: reapply mouse volatile settings (wheel / DPI / SmartShift) on one background thread and one channel path instead of three parallel open-route races

## Testing

```sh
cargo test -p openlogi-hid --lib
cargo test -p openlogi-agent-core --lib
cargo clippy -p openlogi-hid -p openlogi-hidpp -p openlogi-agent-core --all-targets -- -D warnings
```

Not runtime-tested on hardware. Repro for verification:

1. MX Master 3S on Logi Bolt; stop agent; flip `mode` under the device's `[...smartshift]` table in `~/.config/openlogi/config.toml`
2. `OPENLOGI_LOG=debug` start the agent; wait ~8s; grep for SmartShift
3. Expect no first-attempt `InvalidArgument` WARN (or, if residual, an immediate in-process retry success without waiting for the next inventory tick)

Fixes #485
