### PR TITLE
fix(hid,gui): stop the device list flapping on transient probe failures

### DIFF
--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -505,11 +505,12 @@ impl AppState {
     /// Pair each transient direct record in the snapshot with the device it
     /// physically is. A transient key (`…:unit:00000000`) is a half-read probe
     /// of some existing device, not a new one (#482): when exactly one known
-    /// card shares its `direct:<vid>:<pid>` wire identity, the transient record
-    /// is folded into that card instead of surfacing beside it (or evicting
-    /// it). A transient record whose wire identity is already live and online
-    /// is dropped as probe noise, and an ambiguous one (two known same-model
-    /// cards) is left alone.
+    /// card sharing its `direct:<vid>:<pid>` wire identity is not live online —
+    /// so the half-read probe can only be that device — the transient record is
+    /// folded into that card instead of surfacing beside it (or evicting it).
+    /// With no such card the transient is dropped as probe noise when its wire
+    /// product is already live online, and an ambiguous one (two known
+    /// same-model cards absent) is left alone.
     fn adopt_transient_records(
         &self,
         by_key: &mut BTreeMap<String, DeviceRecord>,
@@ -527,26 +528,30 @@ impl AppState {
             let same_wire = |key: &str, record: &DeviceRecord| {
                 record.is_persistent() && direct_key_prefix(key) == Some(prefix)
             };
-            if by_key
-                .iter()
-                .any(|(k, record)| same_wire(k, record) && record.online)
-            {
-                by_key.remove(&key);
-                continue;
-            }
+            // A live online sibling is accounted for and never a candidate,
+            // but it must not discard the transient — the half-read probe may
+            // be the *other* same-model device.
             let mut candidates: Vec<String> = by_key
                 .iter()
-                .filter(|(k, record)| same_wire(k, record))
+                .filter(|(k, record)| same_wire(k, record) && !record.online)
                 .map(|(k, _)| k.clone())
                 .collect();
             for previous in &self.device_list {
                 if same_wire(&previous.config_key, previous)
+                    && !by_key.contains_key(&previous.config_key)
                     && !candidates.contains(&previous.config_key)
                 {
                     candidates.push(previous.config_key.clone());
                 }
             }
             let [known_key] = candidates.as_slice() else {
+                if candidates.is_empty()
+                    && by_key
+                        .iter()
+                        .any(|(k, record)| same_wire(k, record) && record.online)
+                {
+                    by_key.remove(&key);
+                }
                 continue;
             };
             // Last tick's record carries the freshest identity; the offline
@@ -1547,6 +1552,45 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].config_key, "direct:046d:b023:unit:a393cae0");
         assert!(merged[0].online);
+    }
+
+    #[test]
+    fn transient_probe_adopts_the_absent_sibling_of_a_live_twin() {
+        // Two same-model devices; one probes complete, the other half-reads.
+        // The live twin must not get the transient discarded as its own noise:
+        // the half-read probe can only be the sibling, which keeps its card
+        // online and routed.
+        let cache = AssetResolver::new();
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut state = AppState::with_runtime(
+            Config::default(),
+            &[
+                direct_inventory([1, 1, 1, 1]),
+                direct_inventory([2, 2, 2, 2]),
+            ],
+            &cache,
+            commands,
+        );
+
+        let snapshot = build_device_list(
+            &[direct_inventory([1, 1, 1, 1]), direct_inventory([0; 4])],
+            &cache,
+            &state.config,
+        );
+        let merged = state.merge_inventory_snapshot(snapshot);
+
+        assert_eq!(merged.len(), 2, "no third card for the half-read probe");
+        let Some(sibling) = merged
+            .iter()
+            .find(|r| r.config_key == "direct:046d:b023:unit:02020202")
+        else {
+            panic!("the sibling card must survive under its physical key");
+        };
+        assert!(
+            sibling.online,
+            "the half-read probe keeps the sibling online"
+        );
+        assert!(sibling.route.is_some(), "the live route stays usable");
     }
 
     #[test]

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -32,7 +32,10 @@ use load::LazyDeviceData;
 
 use crate::asset::AssetResolver;
 use crate::data::mouse_buttons::{Action, Binding, ButtonId, GestureDirection};
-use crate::state::devices::{build_device_list, pick_initial_device, sort_device_list};
+use crate::state::devices::{
+    adopt_transient_record, build_device_list, direct_key_prefix, pick_initial_device,
+    sort_device_list,
+};
 use openlogi_agent_core::bindings::{bindings_for, gesture_bindings_for};
 use openlogi_agent_core::device_order::PhysicalDeviceKey;
 
@@ -444,10 +447,17 @@ impl AppState {
             .into_iter()
             .map(|record| (record.config_key.clone(), record))
             .collect::<BTreeMap<_, _>>();
+        let mut adopted = self.adopt_transient_records(&mut by_key);
         let mut merged = Vec::with_capacity(by_key.len().max(self.device_list.len()));
 
         for previous in &self.device_list {
             if let Some(record) = by_key.remove(&previous.config_key) {
+                self.inventory_misses.remove(&previous.config_key);
+                merged.push(record);
+                continue;
+            }
+
+            if let Some(record) = adopted.remove(&previous.config_key) {
                 self.inventory_misses.remove(&previous.config_key);
                 merged.push(record);
                 continue;
@@ -480,6 +490,9 @@ impl AppState {
             self.inventory_misses.remove(&key);
             merged.push(record);
         }
+        // Adopted records whose known card was never in the previous list
+        // (identity known only from config) still belong in the carousel.
+        merged.extend(adopted.into_values());
         self.inventory_misses
             .retain(|key, _| merged.iter().any(|record| record.config_key == *key));
         // `merged` is `previous-order + newly-appeared`, so re-apply the
@@ -487,6 +500,73 @@ impl AppState {
         // the carousel permanently.
         sort_device_list(&mut merged);
         merged
+    }
+
+    /// Pair each transient direct record in the snapshot with the device it
+    /// physically is. A transient key (`…:unit:00000000`) is a half-read probe
+    /// of some existing device, not a new one (#482): when exactly one known
+    /// card shares its `direct:<vid>:<pid>` wire identity, the transient record
+    /// is folded into that card instead of surfacing beside it (or evicting
+    /// it). A transient record whose wire identity is already live and online
+    /// is dropped as probe noise, and an ambiguous one (two known same-model
+    /// cards) is left alone.
+    fn adopt_transient_records(
+        &self,
+        by_key: &mut BTreeMap<String, DeviceRecord>,
+    ) -> BTreeMap<String, DeviceRecord> {
+        let transient_keys: Vec<String> = by_key
+            .values()
+            .filter(|record| !record.is_persistent())
+            .map(|record| record.config_key.clone())
+            .collect();
+        let mut adopted = BTreeMap::new();
+        for key in transient_keys {
+            let Some(prefix) = direct_key_prefix(&key) else {
+                continue;
+            };
+            let same_wire = |key: &str, record: &DeviceRecord| {
+                record.is_persistent() && direct_key_prefix(key) == Some(prefix)
+            };
+            if by_key
+                .iter()
+                .any(|(k, record)| same_wire(k, record) && record.online)
+            {
+                by_key.remove(&key);
+                continue;
+            }
+            let mut candidates: Vec<String> = by_key
+                .iter()
+                .filter(|(k, record)| same_wire(k, record))
+                .map(|(k, _)| k.clone())
+                .collect();
+            for previous in &self.device_list {
+                if same_wire(&previous.config_key, previous)
+                    && !candidates.contains(&previous.config_key)
+                {
+                    candidates.push(previous.config_key.clone());
+                }
+            }
+            let [known_key] = candidates.as_slice() else {
+                continue;
+            };
+            // Last tick's record carries the freshest identity; the offline
+            // placeholder built from config is the fallback.
+            let known = self
+                .device_list
+                .iter()
+                .find(|record| record.config_key == *known_key)
+                .cloned()
+                .or_else(|| by_key.get(known_key).cloned());
+            let Some(known) = known else {
+                continue;
+            };
+            let known_key = known_key.clone();
+            by_key.remove(&known_key);
+            if let Some(live) = by_key.remove(&key) {
+                adopted.insert(known_key, adopt_transient_record(&known, live));
+            }
+        }
+        adopted
     }
 
     /// Switch the carousel to `idx`. Out-of-range indices are silently
@@ -1412,6 +1492,89 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].config_key, "direct:046d:b023:unit:a393cae0");
         assert!(merged[0].is_persistent());
+    }
+
+    #[test]
+    fn transient_probe_folds_into_its_known_card() {
+        // #482: a half-read probe (all-zero unit id) of the only known device
+        // with that vid/pid must not evict the known card or appear beside it —
+        // the card keeps its identity and takes the live volatile state.
+        let cache = AssetResolver::new();
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut state = AppState::with_runtime(
+            Config::default(),
+            &[direct_inventory([0xa3, 0x93, 0xca, 0xe0])],
+            &cache,
+            commands,
+        );
+        let stable_key = "direct:046d:b023:unit:a393cae0";
+        assert_eq!(state.device_list[0].config_key, stable_key);
+
+        let transient_list = build_device_list(&[direct_inventory([0; 4])], &cache, &state.config);
+        let merged = state.merge_inventory_snapshot(transient_list);
+
+        assert_eq!(merged.len(), 1, "no second card for the half-read probe");
+        assert_eq!(merged[0].config_key, stable_key);
+        assert!(merged[0].is_persistent());
+        assert!(merged[0].online, "the live probe supplies volatile state");
+        assert!(merged[0].route.is_some(), "the live route is kept usable");
+    }
+
+    #[test]
+    fn transient_record_beside_its_live_device_is_dropped() {
+        // Both a full and a half-read probe of the same wire product in one
+        // snapshot: the transient record is probe noise, not a second device.
+        let cache = AssetResolver::new();
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut state = AppState::with_runtime(
+            Config::default(),
+            &[direct_inventory([0xa3, 0x93, 0xca, 0xe0])],
+            &cache,
+            commands,
+        );
+
+        let both = build_device_list(
+            &[
+                direct_inventory([0xa3, 0x93, 0xca, 0xe0]),
+                direct_inventory([0; 4]),
+            ],
+            &cache,
+            &state.config,
+        );
+        assert_eq!(both.len(), 2);
+        let merged = state.merge_inventory_snapshot(both);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].config_key, "direct:046d:b023:unit:a393cae0");
+        assert!(merged[0].online);
+    }
+
+    #[test]
+    fn ambiguous_transient_probe_is_not_adopted() {
+        // Two same-model devices are known; a half-read probe could be either,
+        // so neither card may steal it.
+        let cache = AssetResolver::new();
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut state = AppState::with_runtime(
+            Config::default(),
+            &[
+                direct_inventory([1, 1, 1, 1]),
+                direct_inventory([2, 2, 2, 2]),
+            ],
+            &cache,
+            commands,
+        );
+        assert_eq!(state.device_list.len(), 2);
+
+        let transient_list = build_device_list(&[direct_inventory([0; 4])], &cache, &state.config);
+        let merged = state.merge_inventory_snapshot(transient_list);
+
+        assert_eq!(merged.len(), 3, "both known cards survive on grace");
+        assert_eq!(
+            merged.iter().filter(|r| !r.is_persistent()).count(),
+            1,
+            "the transient card stays its own record"
+        );
     }
 
     #[test]

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -312,6 +312,42 @@ fn model_info_from_legacy_model_key(key: &str) -> Option<DeviceModelInfo> {
     })
 }
 
+/// The `direct:<vid>:<pid>` prefix of a direct config key, or `None` for any
+/// other key shape. Two keys sharing a prefix name the same wire product.
+pub(super) fn direct_key_prefix(key: &str) -> Option<&str> {
+    let rest = key.strip_prefix("direct:")?;
+    let (vid, rest) = rest.split_once(':')?;
+    let (pid, identity) = rest.split_once(':')?;
+    (!vid.is_empty() && !pid.is_empty() && !identity.is_empty())
+        .then(|| &key[..key.len() - identity.len() - 1])
+}
+
+/// Fold a transient live record into the known card it physically is: the card
+/// keeps its persisted identity while the live record supplies volatile state.
+pub(super) fn adopt_transient_record(known: &DeviceRecord, live: DeviceRecord) -> DeviceRecord {
+    DeviceRecord {
+        config_key: known.config_key.clone(),
+        persistent: true,
+        model_key: known.model_key.clone(),
+        display_name: known.display_name.clone(),
+        asset: known.asset.clone().or(live.asset),
+        model_info: known.model_info.clone().or(live.model_info),
+        codename: known.codename.clone().or(live.codename),
+        serial_number: known.serial_number.clone(),
+        unit_id: known.unit_id,
+        route: live.route,
+        kind: if known.kind == DeviceKind::Unknown {
+            live.kind
+        } else {
+            known.kind
+        },
+        capabilities: live.capabilities.or(known.capabilities),
+        slot: live.slot,
+        online: live.online,
+        battery: live.battery.or_else(|| known.battery.clone()),
+    }
+}
+
 /// Order the carousel by physical route. HID enumeration order can change as
 /// different mice wake, sleep, or are selected; sorting by the stable route
 /// (not whichever HID node was reported first) keeps the header stable.
@@ -441,7 +477,7 @@ mod tests {
 
     use super::{
         Capabilities, DeviceIdentity, DeviceKind, DeviceModelInfo, DeviceRecord, DeviceTransports,
-        append_offline_known, build_device_list, effective_kind, offline_record,
+        append_offline_known, build_device_list, direct_key_prefix, effective_kind, offline_record,
         pick_initial_device,
     };
 
@@ -734,6 +770,32 @@ mod tests {
             &HashSet::new(),
         );
         assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn direct_key_prefix_names_the_wire_product() {
+        assert_eq!(
+            direct_key_prefix("direct:046d:c09d:unit:46002e00"),
+            Some("direct:046d:c09d")
+        );
+        assert_eq!(
+            direct_key_prefix("direct:046d:c09d:serial:abc123"),
+            Some("direct:046d:c09d")
+        );
+        assert_eq!(
+            direct_key_prefix("direct:046d:c09d:unit:00000000"),
+            Some("direct:046d:c09d"),
+            "transient keys share the prefix of their physical siblings"
+        );
+    }
+
+    #[test]
+    fn non_direct_keys_have_no_wire_prefix() {
+        assert_eq!(direct_key_prefix("receiver:da2699e1:slot:1"), None);
+        assert_eq!(direct_key_prefix("unknown:slot:0:unit:00000000"), None);
+        assert_eq!(direct_key_prefix("2b034"), None);
+        assert_eq!(direct_key_prefix("direct:046d:c09d:"), None);
+        assert_eq!(direct_key_prefix("direct:046d"), None);
     }
 
     #[test]

--- a/crates/openlogi-hid/src/inventory/cache.rs
+++ b/crates/openlogi-hid/src/inventory/cache.rs
@@ -86,10 +86,20 @@ pub(super) async fn probe_or_reuse(
     tick: u64,
 ) -> (ProbedFeatures, CacheOutcome) {
     if online && cached.is_none_or(|c| is_stale(c, tick)) {
-        let (fresh, battery_index) = probe_features(channel, index).await;
+        let (mut fresh, battery_index) = probe_features(channel, index).await;
         // `capabilities` is `Some` exactly when the feature-table walk succeeded;
         // only then is the probe worth caching.
         if fresh.capabilities.is_some() {
+            if let Some(c) = cached {
+                backfill_identity(&mut fresh, &c.probe);
+            }
+            // A first-sight probe whose identity reads failed is served but not
+            // memoized: caching it would pin a wrong (all-zero unit or
+            // serial-less) config key for `REFRESH_TICKS` (#482). The next tick
+            // re-probes instead.
+            if fresh.identity_incomplete && cached.is_none() {
+                return (fresh, seen(id));
+            }
             return match id {
                 Some(key) => {
                     let value = Cached {
@@ -128,5 +138,31 @@ pub(super) async fn probe_or_reuse(
             (c.probe.clone(), seen(id))
         }
         None => (ProbedFeatures::default(), seen(id)),
+    }
+}
+
+/// Carry immutable identity data the fresh probe failed to read forward from
+/// the cached probe, so a transient `DeviceInformation` failure can't flip the
+/// device's config key (#482). A probe whose identity reads all succeeded is
+/// returned untouched.
+pub(super) fn backfill_identity(fresh: &mut ProbedFeatures, cached: &ProbedFeatures) {
+    if fresh.kind.is_none() {
+        fresh.kind = cached.kind;
+    }
+    if !fresh.identity_incomplete {
+        return;
+    }
+    match (fresh.model_info.as_mut(), cached.model_info.as_ref()) {
+        (None, Some(previous)) => {
+            fresh.model_info = Some(previous.clone());
+            fresh.identity_incomplete = false;
+        }
+        (Some(now), Some(previous))
+            if now.serial_number.is_none() && previous.serial_number.is_some() =>
+        {
+            now.serial_number.clone_from(&previous.serial_number);
+            fresh.identity_incomplete = false;
+        }
+        _ => {}
     }
 }

--- a/crates/openlogi-hid/src/inventory/features.rs
+++ b/crates/openlogi-hid/src/inventory/features.rs
@@ -28,6 +28,9 @@ pub(super) struct ProbedFeatures {
     pub(super) kind: Option<DeviceKind>,
     /// Configuration capabilities derived from the device's feature table.
     pub(super) capabilities: Option<Capabilities>,
+    /// A `DeviceInformation` read *failed* (vs. the feature being absent), so
+    /// the identity fields above may be missing data the device does have.
+    pub(super) identity_incomplete: bool,
 }
 
 /// Read just the battery by addressing the `UnifiedBattery` feature at its
@@ -114,6 +117,7 @@ pub(super) async fn probe_features(
         None => None,
     };
 
+    let mut identity_incomplete = false;
     let model_info = match device.get_feature::<DeviceInformationFeature>() {
         Some(feature) => match feature.get_device_info().await {
             Ok(info) => {
@@ -122,6 +126,7 @@ pub(super) async fn probe_features(
                         Ok(serial) => normalize_serial_number(&serial),
                         Err(e) => {
                             debug!(slot, error = ?e, "DeviceInformation serial read failed");
+                            identity_incomplete = true;
                             None
                         }
                     }
@@ -144,6 +149,7 @@ pub(super) async fn probe_features(
             }
             Err(e) => {
                 debug!(slot, error = ?e, "DeviceInformation read failed");
+                identity_incomplete = true;
                 None
             }
         },
@@ -171,6 +177,7 @@ pub(super) async fn probe_features(
             model_info,
             kind,
             capabilities,
+            identity_incomplete,
         },
         battery_index,
     )

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -1,8 +1,12 @@
 use std::collections::HashSet;
 
-use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
+use openlogi_core::device::{
+    DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+};
 
-use super::cache::{CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, is_stale};
+use super::cache::{
+    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
+};
 use super::probe::{NodeProbe, assemble_bolt_probe, parse_codename_unifying};
 use super::{Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop};
 use crate::inventory::features::ProbedFeatures;
@@ -255,6 +259,95 @@ fn bolt_probe_is_incomplete_when_the_count_register_is_unanswered() {
         "no count register means we couldn't fully check"
     );
     assert!(!probe.healthy);
+}
+
+fn model(unit_id: [u8; 4], serial: Option<&str>) -> DeviceModelInfo {
+    DeviceModelInfo {
+        entity_count: 1,
+        serial_number: serial.map(str::to_string),
+        unit_id,
+        transports: DeviceTransports::default(),
+        model_ids: [0xc09d, 0, 0],
+        extended_model_id: 1,
+    }
+}
+
+fn probed(model_info: Option<DeviceModelInfo>, identity_incomplete: bool) -> ProbedFeatures {
+    ProbedFeatures {
+        model_info,
+        identity_incomplete,
+        kind: Some(DeviceKind::Mouse),
+        ..ProbedFeatures::default()
+    }
+}
+
+#[test]
+fn failed_device_info_read_backfills_from_cache() {
+    let mut fresh = probed(None, true);
+    let cached = probed(Some(model([0x46, 0, 0x2e, 0], None)), false);
+
+    backfill_identity(&mut fresh, &cached);
+
+    assert_eq!(fresh.model_info, cached.model_info);
+    assert!(
+        !fresh.identity_incomplete,
+        "a backfilled identity is complete and may be cached"
+    );
+}
+
+#[test]
+fn failed_serial_read_backfills_only_the_serial() {
+    let mut fresh = probed(Some(model([1, 2, 3, 4], None)), true);
+    let cached = probed(Some(model([9, 9, 9, 9], Some("abc123"))), false);
+
+    backfill_identity(&mut fresh, &cached);
+
+    let Some(info) = fresh.model_info else {
+        panic!("model info kept");
+    };
+    assert_eq!(info.serial_number.as_deref(), Some("abc123"));
+    assert_eq!(info.unit_id, [1, 2, 3, 4], "fresh unit id wins");
+    assert!(!fresh.identity_incomplete);
+}
+
+#[test]
+fn complete_probe_is_never_overwritten_by_cache() {
+    let mut fresh = probed(Some(model([1, 2, 3, 4], None)), false);
+    let cached = probed(Some(model([9, 9, 9, 9], Some("stale"))), false);
+
+    backfill_identity(&mut fresh, &cached);
+
+    let Some(info) = fresh.model_info else {
+        panic!("model info kept");
+    };
+    assert_eq!(info.unit_id, [1, 2, 3, 4]);
+    assert!(
+        info.serial_number.is_none(),
+        "no serial was read, none faked"
+    );
+}
+
+#[test]
+fn incomplete_probe_without_cached_identity_stays_incomplete() {
+    let mut fresh = probed(None, true);
+    let cached = probed(None, false);
+
+    backfill_identity(&mut fresh, &cached);
+
+    assert!(
+        fresh.identity_incomplete,
+        "nothing to backfill from — the caller must not memoize this probe"
+    );
+}
+
+#[test]
+fn failed_kind_read_is_carried_forward() {
+    let mut fresh = ProbedFeatures::default();
+    let cached = probed(None, false);
+
+    backfill_identity(&mut fresh, &cached);
+
+    assert_eq!(fresh.kind, Some(DeviceKind::Mouse));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Stops the device list flapping reported in #482: cards for direct (USB/Bluetooth) devices appearing and disappearing, momentarily duplicating, and kicking the GUI back to the device-list page.

The trigger was HID++ response cross-talk between concurrent channels on the same HID node, whose root cause (a shared software id) was fixed by #489. This PR removes the remaining amplifiers, so that any transient `DeviceInformation` (0x0003) read failure — sleep, host switch, USB hiccup — can no longer flip a device's config key:

- A probe whose feature walk succeeded but whose `get_device_info()`/`get_serial_number()` read failed used to be **cached for ~30 s** (the cache only checked `capabilities`), pinning a wrong `unit:00000000` / serial-less identity — the flip seen in #482 and the duplicate cards in #387. The same "misclassified after one dropped response" failure shape is what #468 reports on the Bluetooth path.
- When the wrong key did surface, the GUI treated it as "known device gone + new device appeared": the known card was evicted (zero grace since #451), a transient card appeared beside or instead of it, and the selection reset popped the route back to the device list page.

Now the enumerator backfills the immutable identity fields from the cached probe (and refuses to memoize a half-read identity on first sight), and the GUI folds a transient `direct:<vid>:<pid>:unit:00000000` record into the one known card with the same wire identity instead of surfacing it as its own device.

## Changes

- `openlogi-hid`: `ProbedFeatures` now records when a `DeviceInformation` read *failed* (vs. the feature being absent). `probe_or_reuse` backfills `model_info` / serial / kind from the cached probe on such failures, and no longer caches a first-sight probe with a half-read identity, so the config key never silently degrades to `unit:00000000` or flips between `serial:` and `unit:` forms.
- `openlogi-gui`: `merge_inventory_snapshot` pairs each transient direct record with the known card sharing its `direct:<vid>:<pid>` wire identity — folding it in (keeping the persisted identity, taking the live route/online/battery state) when the match is unambiguous, dropping it as noise when the same wire product is already live, and leaving it alone when two same-model cards make the match ambiguous.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (new coverage: identity backfill edge cases in `openlogi-hid`, and adopt/suppress/ambiguous merge paths in `openlogi-gui`)
- Not runtime-tested on hardware. To verify on a setup like the reporter's (wired G102 + Unifying receiver): page the device carousel and switch settings tabs repeatedly; the wired mouse's card should stay put, never duplicate, and the GUI should not jump back to the device list. `OPENLOGI_LOG=openlogi_hid=debug` should show no `DeviceInformation read failed` tick producing a `unit:00000000` key change.

Related: #468 (same misclassification signature on Bluetooth), #387 / #451 (duplicate-card symptom of the same identity flip), #489 (root-cause fix for the response cross-talk that triggers the failed reads).

Fixes #482
