### PR TITLE
fix(hid): serialize Unifying receiver identity reads

### DIFF
--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -20,8 +20,8 @@ pub async fn run(_args: ListArgs) -> Result<()> {
              permission: System Settings → Privacy & Security → Input Monitoring."
         );
         println!(
-            "  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other \
-             receivers (Unifying) aren't surfaced yet."
+            "  - Logi Bolt (PID 0xC548) and Unifying receivers (PID 0xC52B / 0xC532) \
+             are supported; make sure the paired device is powered on and awake."
         );
         std::process::exit(2);
     }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -58,6 +58,13 @@ const PROBE_BUDGET: Duration = Duration::from_secs(6);
 /// just lacks capabilities / battery until the next tick.
 const UNIFYING_SLOT_PROBE: Duration = Duration::from_millis(3500);
 
+/// Total budget for receiver-backed Unifying slot-name reads.
+///
+/// These requests must be serialized because they share the receiver address
+/// and register. Names are optional, so do not let an unresponsive slot consume
+/// the six-second node budget before the per-device feature walks begin.
+const UNIFYING_IDENTITY_PROBE: Duration = Duration::from_millis(750);
+
 /// Per-slot budget for the HID++ 2.0 feature walk on a Bolt paired device.
 ///
 /// Without a per-slot cap a single online device that stops answering its

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -2,7 +2,8 @@ use std::{collections::HashMap, sync::Arc};
 
 use futures_concurrency::future::Join as _;
 use hidpp::{
-    channel::HidppChannel,
+    channel::{HidppChannel, HidppMessage},
+    protocol::v10::{self, MessageType},
     receiver::{
         self, Receiver,
         bolt::{
@@ -23,7 +24,9 @@ use crate::route::DIRECT_DEVICE_INDEX;
 
 use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
-use super::{ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_SLOT_PROBE};
+use super::{
+    ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_IDENTITY_PROBE, UNIFYING_SLOT_PROBE,
+};
 
 /// One probed node's contribution this tick: its inventory (if any), whether
 /// the node actually answered — the ledger replays the last snapshot when it
@@ -207,10 +210,29 @@ async fn probe_unifying_receiver(
     // channel correlates replies by register, not by the slot encoded in the
     // payload. Overlapping these reads can therefore cross-talk or leave one
     // request waiting until the outer PROBE_BUDGET expires.
+    let mut codenames = HashMap::with_capacity(connections.len());
+    let identity_reads = async {
+        for connection in &connections {
+            let slot = connection.index;
+            codenames.insert(slot, read_codename_unifying(&channel, slot).await);
+        }
+    };
+    if timeout(UNIFYING_IDENTITY_PROBE, identity_reads)
+        .await
+        .is_err()
+    {
+        debug!(
+            budget = ?UNIFYING_IDENTITY_PROBE,
+            completed = codenames.len(),
+            total = connections.len(),
+            "Unifying identity phase timed out; continuing without remaining names"
+        );
+    }
+
     let mut identities = Vec::with_capacity(connections.len());
     for connection in &connections {
         let slot = connection.index;
-        let codename = read_codename_unifying(&channel, slot).await;
+        let codename = codenames.remove(&slot).flatten();
         debug!(
             slot,
             online = connection.online,
@@ -642,11 +664,37 @@ async fn walk_unifying_slot(
 /// no chunk byte — wire-verified `40 0c "MX Master 2S"`. The name lives on the
 /// receiver, so it reads even while the device is offline (e.g. moved to BT).
 async fn read_codename_unifying(channel: &HidppChannel, slot: u8) -> Option<String> {
+    let sub_register = 0x40 + slot - 1;
     let response = channel
-        .read_long_register(0xFF, 0xB5, [0x40 + slot - 1, 0x00, 0x00])
+        .send_with_timeout(
+            v10::Message::Short(
+                v10::MessageHeader {
+                    device_index: 0xFF,
+                    sub_id: MessageType::GetLongRegister.into(),
+                },
+                [0xB5, sub_register, 0x00, 0x00],
+            )
+            .into(),
+            move |raw| is_unifying_codename_response(raw, sub_register),
+            UNIFYING_IDENTITY_PROBE,
+        )
         .await
         .ok()?;
-    parse_codename_unifying(&response)
+    let payload = v10::Message::from(response).extend_payload();
+    parse_codename_unifying(&payload[1..=16])
+}
+
+/// Match the echoed name sub-register as well as the RAP register header.
+/// This prevents a response arriving after a timed-out identity read from
+/// satisfying the following slot's request.
+pub(super) fn is_unifying_codename_response(raw: &HidppMessage, expected_sub_register: u8) -> bool {
+    let response = v10::Message::from(*raw);
+    let header = response.header();
+    let payload = response.extend_payload();
+    header.device_index == 0xFF
+        && header.sub_id == MessageType::GetLongRegister.into()
+        && payload[0] == 0xB5
+        && payload[1] == expected_sub_register
 }
 
 /// Parse a Unifying name-register response `[sub, len, data..]` into a string.

--- a/crates/openlogi-hid/src/inventory/probe.rs
+++ b/crates/openlogi-hid/src/inventory/probe.rs
@@ -202,11 +202,36 @@ async fn probe_unifying_receiver(
     // across probe cycles instead of jittering.
     connections.sort_by_key(|c| c.index);
 
-    // Probe all online slots concurrently so a slow HID++ 2.0 feature walk on
-    // one device doesn't push the next slot past the PROBE_BUDGET deadline.
-    // Pass the receiver UID so each slot's cache key is scoped to this specific
-    // receiver — two Unifying receivers sharing a slot number must not share a
-    // cache entry (different devices, different capabilities).
+    // Phase 1 — read each slot's name from the receiver sequentially. Like the
+    // Bolt pairing/name registers, every request addresses device 0xff and the
+    // channel correlates replies by register, not by the slot encoded in the
+    // payload. Overlapping these reads can therefore cross-talk or leave one
+    // request waiting until the outer PROBE_BUDGET expires.
+    let mut identities = Vec::with_capacity(connections.len());
+    for connection in &connections {
+        let slot = connection.index;
+        let codename = read_codename_unifying(&channel, slot).await;
+        debug!(
+            slot,
+            online = connection.online,
+            wpid = format_args!("{:04x}", connection.wpid),
+            kind = ?connection.kind,
+            codename = ?codename,
+            "unifying paired slot"
+        );
+        identities.push(UnifyingSlotIdentity {
+            slot,
+            codename,
+            wpid: connection.wpid,
+            register_kind: map_unifying_kind(connection.kind),
+        });
+    }
+
+    // Phase 2 — walk the devices concurrently. These requests address their
+    // individual slot indices, so they can be correlated safely and a slow
+    // HID++ 2.0 feature walk cannot hold every other device behind it. Pass the
+    // receiver UID so two Unifying receivers sharing a slot number cannot share
+    // a cache entry (different devices, different capabilities).
     let receiver_uid_fallback;
     let receiver_uid = if let Some(uid) = unique_id.as_deref() {
         uid
@@ -218,14 +243,14 @@ async fn probe_unifying_receiver(
         receiver_uid_fallback = format!("pid:{:04x}", info.product_id);
         &receiver_uid_fallback
     };
-    let slot_results = connections
+    let slot_results = identities
         .iter()
-        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache, tick))
+        .map(|identity| walk_unifying_slot(&channel, identity, receiver_uid, cache, tick))
         .collect::<Vec<_>>()
         .join()
         .await;
 
-    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().flatten().unzip();
+    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().unzip();
 
     if let Some(count) = pairing_count
         && paired.len() != usize::from(count)
@@ -536,7 +561,17 @@ async fn drain_device_arrival_unifying(
     Some(out)
 }
 
-/// Probe a Unifying slot from a live device-connection event.
+/// Identity read from the receiver's registers for one occupied Unifying slot.
+/// The receiver-backed name reads that create these values must be serialized;
+/// see [`probe_unifying_receiver`].
+struct UnifyingSlotIdentity {
+    slot: u8,
+    codename: Option<String>,
+    wpid: u16,
+    register_kind: DeviceKind,
+}
+
+/// Walk a Unifying slot identified from a live device-connection event.
 ///
 /// Device-arrival events carry the slot index, kind, wpid, and online status —
 /// enough to surface an entry for every currently-connected device. The
@@ -544,23 +579,14 @@ async fn drain_device_arrival_unifying(
 /// working `get_device_pairing_information` call; we derive a stable cache key
 /// from the receiver UID + slot so the feature-table walk is amortised at ~30s
 /// and two receivers sharing a slot number don't collide in the cache.
-async fn probe_unifying_slot(
+async fn walk_unifying_slot(
     channel: &Arc<HidppChannel>,
-    event: &UnifyingDeviceConnection,
+    identity: &UnifyingSlotIdentity,
     receiver_uid: &str,
     cache: &HashMap<CacheKey, Cached>,
     tick: u64,
-) -> Option<(PairedDevice, CacheOutcome)> {
-    let slot = event.index;
-    let codename = read_codename_unifying(channel, slot).await;
-    debug!(
-        slot,
-        online = event.online,
-        wpid = format_args!("{:04x}", event.wpid),
-        kind = ?event.kind,
-        codename = ?codename,
-        "unifying paired slot"
-    );
+) -> (PairedDevice, CacheOutcome) {
+    let slot = identity.slot;
 
     // Cache key: full receiver serial + slot so two Unifying receivers with
     // a device on the same slot number never share a cache entry.
@@ -569,7 +595,7 @@ async fn probe_unifying_slot(
         slot,
     };
     let cached = cache.get(&id);
-    let register_kind = map_unifying_kind(event.kind);
+    let register_kind = identity.register_kind;
 
     // `trigger_device_arrival` re-broadcasts a 0x41 for *every* paired slot,
     // online or not, and the crate's `event.online` reads the wrong notification
@@ -594,8 +620,8 @@ async fn probe_unifying_slot(
 
     let device = PairedDevice {
         slot,
-        codename,
-        wpid: Some(event.wpid),
+        codename: identity.codename.clone(),
+        wpid: Some(identity.wpid),
         kind: resolve_device_kind(probe.kind, register_kind),
         // Reachable on this receiver iff the feature walk got through this tick.
         // Caveat: a GUI cache hit can serve stale capabilities for up to
@@ -607,7 +633,7 @@ async fn probe_unifying_slot(
         model_info: probe.model_info,
         capabilities: probe.capabilities,
     };
-    Some((device, outcome))
+    (device, outcome)
 }
 
 /// Reads a Unifying paired device's name. Unifying stores names at

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -1,5 +1,9 @@
 use std::collections::HashSet;
 
+use hidpp::{
+    channel::{HidppMessage, LONG_REPORT_LENGTH},
+    protocol::v10::MessageType,
+};
 use openlogi_core::device::{
     DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
 };
@@ -7,7 +11,9 @@ use openlogi_core::device::{
 use super::cache::{
     CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
 };
-use super::probe::{NodeProbe, assemble_bolt_probe, parse_codename_unifying};
+use super::probe::{
+    NodeProbe, assemble_bolt_probe, is_unifying_codename_response, parse_codename_unifying,
+};
 use super::{Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop};
 use crate::inventory::features::ProbedFeatures;
 
@@ -372,4 +378,25 @@ fn codename_clamps_overlong_len() {
 #[test]
 fn codename_rejects_short_response() {
     assert_eq!(parse_codename_unifying(&[0x40]), None);
+}
+
+fn unifying_codename_response(sub_register: u8) -> HidppMessage {
+    let mut raw = [0u8; LONG_REPORT_LENGTH - 1];
+    raw[0] = 0xff;
+    raw[1] = MessageType::GetLongRegister.into();
+    raw[2] = 0xb5;
+    raw[3] = sub_register;
+    HidppMessage::Long(raw)
+}
+
+#[test]
+fn codename_response_matches_the_requested_slot() {
+    let response = unifying_codename_response(0x41);
+    assert!(is_unifying_codename_response(&response, 0x41));
+}
+
+#[test]
+fn late_codename_response_cannot_match_the_next_slot() {
+    let late_slot_one = unifying_codename_response(0x40);
+    assert!(!is_unifying_codename_response(&late_slot_one, 0x41));
 }


### PR DESCRIPTION
## Summary

Unifying device-name requests all address receiver index `0xff`, and replies are correlated by register rather than by the paired slot carried in the payload. Running these requests concurrently can cross-wire replies or leave a request waiting until the probe budget expires.

Read receiver-backed slot identities sequentially, then retain concurrency for the slower per-device HID++ feature walks.

## Changes

- **openlogi-hid**
  - Read Unifying slot names sequentially before starting device feature walks.
  - Keep per-device HID++ probing concurrent.
  - Preserve receiver-scoped cache keys and stable slot ordering.
- **openlogi-cli**
  - Replace the stale message saying Unifying receivers are unsupported.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p openlogi-hid -p openlogi-cli`
- `cargo clippy -p openlogi-hid -p openlogi-cli --all-targets -- -D warnings`
- 114 tests passed.
- Hardware-tested on Windows 11 with an M720 Triathlon connected through a Unifying receiver. The receiver had additional paired slots but only the M720 was powered on.