### PR TITLE
feat(gui): polish device and pointer visuals

### DIFF
--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -6,7 +6,7 @@ use gpui::{
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    IconName,
+    Icon, IconName,
     description_list::{DescriptionItem, DescriptionList},
     h_flex,
     scroll::ScrollableElement as _,
@@ -66,6 +66,8 @@ pub(super) fn detail_header(
         .child(
             div()
                 .min_w_0()
+                .max_w(px(220.))
+                .truncate()
                 .text_heading()
                 .child(name),
         )
@@ -167,13 +169,13 @@ fn pointer_tab(
                 .flex_wrap()
                 .child(pointer_grid_card(panel_card_fill(
                     tr!("Pointer tuning"),
-                    IconName::Settings,
+                    Icon::empty().path("action-icons/gauge.svg"),
                     pal,
                     dpi_panel.clone().into_any_element(),
                 )))
                 .child(pointer_grid_card(panel_card_fill(
                     tr!("SmartShift"),
-                    IconName::Settings,
+                    Icon::empty().path("action-icons/refresh-cw.svg"),
                     pal,
                     smartshift_panel.clone().into_any_element(),
                 )))
@@ -263,7 +265,7 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
         .child(wheel_resolution_control(resolution, hires_supported, pal));
     panel_card(
         tr!("Scrolling"),
-        IconName::Settings,
+        Icon::empty().path("action-icons/mouse.svg"),
         pal,
         v_flex()
             .gap_4()
@@ -403,7 +405,7 @@ fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>, pal: Palette) -> i
         .p(px(SCREEN_PAD))
         .child(div().w_full().max_w(px(560.)).child(panel_card(
             tr!("Lighting"),
-            IconName::Palette,
+            Icon::new(IconName::Palette),
             pal,
             lighting_panel.clone().into_any_element(),
         )))
@@ -458,7 +460,12 @@ fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElem
             },
         );
 
-    panel_card(tr!("Device details"), IconName::Info, pal, content)
+    panel_card(
+        tr!("Device details"),
+        Icon::new(IconName::Info),
+        pal,
+        content,
+    )
 }
 
 fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
@@ -517,7 +524,12 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
         )
         .into_any_element();
 
-    panel_card(tr!("Configuration"), IconName::Folder, pal, content)
+    panel_card(
+        tr!("Configuration"),
+        Icon::new(IconName::Folder),
+        pal,
+        content,
+    )
 }
 
 fn device_summary(name: &str, kind: DeviceKind, online: bool, pal: Palette) -> impl IntoElement {

--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -57,7 +57,7 @@ const GALLERY_GAP: f32 = 24.;
 /// floats the device photo on the window background above its name and battery;
 /// the row centres while the cards fit the viewport and scrolls once they don't.
 /// Clicking a card opens its detail screen and makes it the active device (whose
-/// bindings the hook uses); the active card wears a faint accent ring.
+/// bindings the hook uses); the active card wears an accent ring and tint.
 pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
     let (len, active_idx) = cx.try_global::<AppState>().map_or((0, 0), |s| {
         let len = s.device_list.len();
@@ -169,13 +169,11 @@ pub(crate) fn glow_canvas(geom: Arc<GlowGeometry>, color: Hsla) -> impl IntoElem
 
 /// A device card in the Home gallery: the device photo floating on the window
 /// background above the name, connectivity dot, kind/slot, and battery. Fixed
-/// width so cards stay equal in the scrollable row. No card shows a border at
-/// rest — the accent ring appears only on hover (wired by the gallery). The
-/// `active` device (whose bindings and DPI are live) keeps a persistent but
-/// borderless marker: a faint accent fill, which reads whether or not the
-/// carousel centres it. The 1px border is always reserved in a transparent
-/// colour so the hover ring never nudges the layout. Returns a bare [`Div`] so
-/// the gallery can wire the hover and click handlers.
+/// width so cards stay equal in the scrollable row. The `active` device (whose
+/// bindings and DPI are live) keeps a persistent accent ring and faint fill;
+/// inactive cards gain the same ring on hover. The 1px border is always reserved
+/// so the hover ring never nudges the layout. Returns a bare [`Div`] so the
+/// gallery can wire the hover and click handlers.
 fn device_card(
     record: &DeviceRecord,
     active: bool,
@@ -190,7 +188,11 @@ fn device_card(
         .p_3()
         .rounded(pal.card_radius)
         .border_1()
-        .border_color(gpui::transparent_black())
+        .border_color(if active {
+            theme::accent()
+        } else {
+            gpui::transparent_black()
+        })
         .selected_fill(active)
         .child(
             div()
@@ -200,6 +202,7 @@ fn device_card(
                 .flex()
                 .items_center()
                 .justify_center()
+                .opacity(if record.online { 1. } else { 0.55 })
                 .when_some(glow, |this, (geom, color)| {
                     this.child(glow_canvas(geom, color))
                 })

--- a/crates/openlogi-gui/src/app/widgets.rs
+++ b/crates/openlogi-gui/src/app/widgets.rs
@@ -62,7 +62,7 @@ pub(super) fn main_window_title(show_device: bool, cx: &Context<AppView>) -> Sha
 
 pub(super) fn panel_card(
     title: SharedString,
-    icon: IconName,
+    icon: Icon,
     pal: Palette,
     content: AnyElement,
 ) -> impl IntoElement {
@@ -71,7 +71,7 @@ pub(super) fn panel_card(
 
 pub(super) fn panel_card_fill(
     title: SharedString,
-    icon: IconName,
+    icon: Icon,
     pal: Palette,
     content: AnyElement,
 ) -> impl IntoElement {
@@ -80,7 +80,7 @@ pub(super) fn panel_card_fill(
 
 fn panel_card_inner(
     title: SharedString,
-    icon: IconName,
+    icon: Icon,
     pal: Palette,
     content: AnyElement,
     fill_height: bool,
@@ -104,7 +104,7 @@ fn panel_card_inner(
                             .items_center()
                             .gap_2()
                             .text_color(pal.text_primary)
-                            .child(Icon::new(icon).size_4().text_color(pal.text_muted))
+                            .child(icon.size_4().text_color(pal.text_muted))
                             .child(div().text_subheading().child(title)),
                     )
                 })

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -10,7 +10,9 @@ use gpui::{
     Subscription, Window, div, px, rgb,
 };
 use gpui_component::{
-    Icon, IconName, h_flex,
+    Icon, IconName, Sizable as _,
+    button::{Button, ButtonVariants as _},
+    h_flex,
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
 };
@@ -369,8 +371,12 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
         .child(
             div()
                 .id(("dpi-preset-apply", idx))
+                .h_full()
+                .flex()
+                .items_center()
                 .text_body()
                 .text_color(pal.text_primary)
+                .cursor_pointer()
                 .child(format!("{value}"))
                 .on_click(move |_event, _window, cx| {
                     // Only apply once the supported DPI list is known, so the
@@ -387,11 +393,10 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
                 }),
         )
         .child(
-            div()
-                .id(("dpi-preset-remove", idx))
-                .text_caption()
-                .text_color(pal.text_muted)
-                .child(Icon::new(IconName::Close).size_3())
+            Button::new(("dpi-preset-remove", idx))
+                .xsmall()
+                .ghost()
+                .icon(IconName::Close)
                 .on_click(move |_event, _window, cx| {
                     let mut next = presets_for_remove.clone();
                     if idx < next.len() {


### PR DESCRIPTION
## Summary

Polish device selection and pointer settings so active, offline, and interactive states read more clearly without changing device behavior.

## Changes

- **GUI**
  - give the active device card a persistent accent ring and tint
  - dim the complete device render, including cached lighting, while offline
  - truncate long device names before they crowd the detail tabs
  - use distinct gauge, SmartShift, and mouse icons for the pointer cards
  - replace the DPI preset remove hit target with the standard button component

## Testing

- `devenv tasks run openlogi:check`
- `cargo test -p openlogi-gui` — 52 passed
- visually checked Home, Buttons, and Pointer screens with four discovered devices in the dev app
- device setting writes were not runtime-tested on hardware

Fixes: N/A (no linked issue)