### PR TITLE
refactor(gui): use semantic pointer controls

### DIFF
--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -2,11 +2,12 @@
 //! four section bodies (Buttons, Pointer, Lighting, Device).
 
 use gpui::{
-    AnyElement, BorrowAppContext as _, Context, InteractiveElement, IntoElement, ParentElement,
-    StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
+    AnyElement, BorrowAppContext as _, Context, IntoElement, ParentElement, SharedString, Styled,
+    div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    Icon, IconName,
+    Disableable as _, Icon, IconName, Selectable as _,
+    button::{Button, ButtonGroup},
     description_list::{DescriptionItem, DescriptionList},
     h_flex,
     scroll::ScrollableElement as _,
@@ -27,7 +28,7 @@ use crate::components::lighting_panel::LightingPanel;
 use crate::components::smartshift_panel::SmartShiftPanel;
 use crate::mouse_model::view::MouseModelView;
 use crate::state::{AppState, DeviceRecord};
-use crate::theme::{HEADER_H, Palette, SCREEN_PAD, SelectableStyle as _, Typography as _};
+use crate::theme::{HEADER_H, Palette, SCREEN_PAD, Typography as _};
 
 /// Device-detail top bar, in three zones: a back affordance + device name
 /// (leading), the section tabs as a centred segmented control (middle), and the
@@ -278,78 +279,41 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
 fn wheel_resolution_control(
     selected: Option<ScrollResolution>,
     enabled: bool,
-    pal: Palette,
+    _pal: Palette,
 ) -> AnyElement {
-    h_flex()
+    let values = [
+        None,
+        Some(ScrollResolution::Low),
+        Some(ScrollResolution::High),
+    ];
+    ButtonGroup::new("wheel-resolution")
         .w_full()
-        .p_1()
-        .gap_1()
-        .rounded(pal.control_radius)
-        .border_1()
-        .border_color(pal.border)
-        .child(wheel_resolution_segment(
-            "wheel-resolution-default",
-            tr!("Device default"),
-            None,
-            selected,
-            enabled,
-            pal,
-        ))
-        .child(wheel_resolution_segment(
-            "wheel-resolution-low",
-            tr!("Standard"),
-            Some(ScrollResolution::Low),
-            selected,
-            enabled,
-            pal,
-        ))
-        .child(wheel_resolution_segment(
-            "wheel-resolution-high",
-            tr!("High resolution"),
-            Some(ScrollResolution::High),
-            selected,
-            enabled,
-            pal,
-        ))
-        .into_any_element()
-}
-
-fn wheel_resolution_segment(
-    id: &'static str,
-    label: impl IntoElement,
-    value: Option<ScrollResolution>,
-    selected: Option<ScrollResolution>,
-    enabled: bool,
-    pal: Palette,
-) -> AnyElement {
-    let active = value == selected;
-    let segment = div()
-        .id(id)
-        .flex_1()
-        .px_2()
-        .py_1()
-        .rounded(pal.control_radius)
-        .text_center()
-        .text_caption()
-        .selected_fill(active)
-        .text_color(if enabled {
-            if active {
-                pal.text_primary
-            } else {
-                pal.text_muted
-            }
-        } else {
-            pal.text_muted
-        })
-        .child(label);
-    if !enabled {
-        return segment.into_any_element();
-    }
-    segment
-        .cursor_pointer()
-        .on_click(move |_event, _window, cx| {
+        .outline()
+        .disabled(!enabled)
+        .child(
+            Button::new("wheel-resolution-default")
+                .flex_1()
+                .label(tr!("Device default"))
+                .selected(selected.is_none()),
+        )
+        .child(
+            Button::new("wheel-resolution-low")
+                .flex_1()
+                .label(tr!("Standard"))
+                .selected(selected == Some(ScrollResolution::Low)),
+        )
+        .child(
+            Button::new("wheel-resolution-high")
+                .flex_1()
+                .label(tr!("High resolution"))
+                .selected(selected == Some(ScrollResolution::High)),
+        )
+        .on_click(move |indices, _window, cx| {
+            let Some(value) = indices.first().and_then(|index| values.get(*index)) else {
+                return;
+            };
             cx.update_global::<AppState, _>(|state, _| {
-                state.commit_scroll_resolution(value);
+                state.commit_scroll_resolution(*value);
             });
             cx.refresh_windows();
         })
@@ -359,7 +323,7 @@ fn wheel_resolution_segment(
 /// On/Off pill that flips the active device's scroll-wheel inversion, mirroring
 /// the SmartShift permanent-ratchet toggle.
 fn invert_scroll_toggle(on: bool, enabled: bool, pal: Palette) -> AnyElement {
-    let label = if on { tr!("On") } else { tr!("Off") };
+    let label: SharedString = if on { tr!("On") } else { tr!("Off") };
     if !enabled {
         return div()
             .px_2()
@@ -372,17 +336,10 @@ fn invert_scroll_toggle(on: bool, enabled: bool, pal: Palette) -> AnyElement {
             .child(tr!("Unavailable"))
             .into_any_element();
     }
-    div()
-        .id("invert-scroll-toggle")
-        .px_2()
-        .py_1()
-        .rounded(pal.control_radius)
-        .selected_border(on, pal)
-        .selected_fill(on)
-        .text_caption()
-        .text_color(if on { pal.text_primary } else { pal.text_muted })
-        .cursor_pointer()
-        .child(label)
+    Button::new("invert-scroll-toggle")
+        .compact()
+        .label(label)
+        .selected(on)
         .on_click(move |_event, _window, cx| {
             cx.update_global::<AppState, _>(|state, _| {
                 state.commit_invert_scroll(!on);

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -6,11 +6,10 @@
 
 use gpui::{
     AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, InteractiveElement,
-    IntoElement, ParentElement, Render, SharedString, StatefulInteractiveElement as _, Styled,
-    Subscription, Window, div, px, rgb,
+    IntoElement, ParentElement, Render, SharedString, Styled, Subscription, Window, div, px, rgb,
 };
 use gpui_component::{
-    Icon, IconName, Sizable as _,
+    IconName, Selectable as _, Sizable as _,
     button::{Button, ButtonVariants as _},
     h_flex,
     slider::{Slider, SliderEvent, SliderState},
@@ -261,7 +260,7 @@ impl Render for DpiPanel {
                             .gap_2()
                             .flex_wrap()
                             .children(preset_chips)
-                            .child(add_preset_chip(pal)),
+                            .child(add_preset_chip()),
                     ),
             )
     }
@@ -369,15 +368,14 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
         .selected_fill(active)
         .hover(|s| s.bg(pal.surface_hover))
         .child(
-            div()
-                .id(("dpi-preset-apply", idx))
+            Button::new(("dpi-preset-apply", idx))
+                .compact()
+                .ghost()
                 .h_full()
                 .flex()
                 .items_center()
-                .text_body()
-                .text_color(pal.text_primary)
-                .cursor_pointer()
-                .child(format!("{value}"))
+                .label(format!("{value}"))
+                .selected(active)
                 .on_click(move |_event, _window, cx| {
                     // Only apply once the supported DPI list is known, so the
                     // click writes a snapped, device-valid value — and can't be
@@ -410,26 +408,13 @@ fn preset_chip(idx: usize, value: u32, active: bool, presets: &[u32], pal: Palet
 }
 
 /// "+" chip that snapshots `AppState.dpi` as a new preset.
-fn add_preset_chip(pal: Palette) -> AnyElement {
-    h_flex()
-        .id("dpi-preset-add")
+fn add_preset_chip() -> AnyElement {
+    Button::new("dpi-preset-add")
+        .compact()
+        .outline()
         .h(px(CHIP_H))
-        .px_3()
-        .items_center()
-        .rounded(pal.control_radius)
-        .border_1()
-        .border_color(pal.border)
-        .bg(pal.surface)
-        .hover(|s| s.bg(pal.surface_hover))
-        .child(
-            h_flex()
-                .gap_1()
-                .items_center()
-                .text_body()
-                .text_color(pal.text_muted)
-                .child(Icon::new(IconName::Plus).size_3())
-                .child(tr!("Add")),
-        )
+        .icon(IconName::Plus)
+        .label(tr!("Add"))
         .on_click(|_event, _window, cx| {
             // Append the current DPI to the active device's preset list.
             // Duplicates are allowed — the user might want the same value

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -13,11 +13,12 @@
 //! [`crate::components::dpi_panel`].
 
 use gpui::{
-    AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, InteractiveElement,
-    IntoElement, ParentElement, Render, SharedString, StatefulInteractiveElement as _, Styled,
-    Subscription, Window, div, px, rgb,
+    AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, IntoElement,
+    ParentElement, Render, SharedString, Styled, Subscription, Window, div, px, rgb,
 };
 use gpui_component::{
+    Disableable as _, Selectable as _,
+    button::Button,
     h_flex,
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
@@ -28,7 +29,7 @@ use openlogi_hid::{AUTO_DISENGAGE_PERMANENT, DeviceRoute, SmartShiftMode, SmartS
 use crate::components::device_read::issue_device_read;
 use crate::components::status::{retry_line, status_line};
 use crate::state::{AppState, SmartShiftLoad};
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
+use crate::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
 /// Friendly slider range for the `autoDisengage` threshold. The wire field is
 /// `0x01`–`0xFE` (0.25 turn/s steps); the slider exposes the usable band
@@ -328,25 +329,16 @@ fn mode_pill(
     target: SmartShiftMode,
     cur_auto: u8,
     torque: u8,
-    pal: Palette,
+    _pal: Palette,
 ) -> AnyElement {
     let id = match target {
         SmartShiftMode::Free => "smartshift-mode-free",
         SmartShiftMode::Ratchet => "smartshift-mode-ratchet",
     };
-    div()
-        .id(id)
-        .px_3()
-        .py_1()
-        .rounded(pal.control_radius)
-        .selected_border(selected, pal)
-        .bg(pal.surface)
-        .selected_fill(selected)
-        .text_body()
-        .text_color(pal.text_primary)
-        .cursor_pointer()
-        .hover(|s| s.bg(pal.surface_hover))
-        .child(label)
+    Button::new(id)
+        .compact()
+        .label(label)
+        .selected(selected)
         .on_click(move |_event, _window, cx| {
             cx.update_global::<AppState, _>(|state, _| {
                 state.commit_smartshift(target, cur_auto, torque);
@@ -363,32 +355,14 @@ fn permanent_toggle(
     enabled: bool,
     restore_threshold: u8,
     torque: u8,
-    pal: Palette,
+    _pal: Palette,
 ) -> AnyElement {
     let label = if on { tr!("On") } else { tr!("Off") };
-    if !enabled {
-        return div()
-            .px_2()
-            .py_1()
-            .rounded(pal.control_radius)
-            .border_1()
-            .border_color(pal.border)
-            .text_caption()
-            .text_color(pal.text_muted)
-            .child(label)
-            .into_any_element();
-    }
-    div()
-        .id("smartshift-permanent")
-        .px_2()
-        .py_1()
-        .rounded(pal.control_radius)
-        .selected_border(on, pal)
-        .selected_fill(on)
-        .text_caption()
-        .text_color(if on { pal.text_primary } else { pal.text_muted })
-        .cursor_pointer()
-        .child(label)
+    Button::new("smartshift-permanent")
+        .compact()
+        .label(label)
+        .selected(on)
+        .disabled(!enabled)
         .on_click(move |_event, _window, cx| {
             cx.update_global::<AppState, _>(|state, _| {
                 let next = if on {

--- a/crates/openlogi-gui/src/components/status.rs
+++ b/crates/openlogi-gui/src/components/status.rs
@@ -6,10 +6,8 @@
 //! rendering of those rows so they read identically across panels; only the
 //! retry action differs, injected by the caller.
 
-use gpui::{
-    AnyElement, App, ElementId, InteractiveElement, IntoElement, ParentElement, SharedString,
-    StatefulInteractiveElement as _, Styled, div, px,
-};
+use gpui::{AnyElement, App, ElementId, IntoElement, ParentElement, SharedString, Styled, div, px};
+use gpui_component::button::{Button, ButtonVariants as _};
 
 use crate::theme::{self, Palette, Typography as _};
 
@@ -36,16 +34,15 @@ pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
 pub fn retry_line(
     id: impl Into<ElementId>,
     text: impl Into<SharedString>,
-    pal: Palette,
+    _pal: Palette,
     on_retry: impl Fn(&mut App) + 'static,
 ) -> AnyElement {
-    div()
-        .id(id)
+    Button::new(id)
+        .text()
         .h(px(ROW_H))
         .text_body()
         .text_color(theme::accent())
-        .hover(|s| s.text_color(pal.text_primary))
-        .child(text.into())
+        .label(text)
         .on_click(move |_event, _window, cx| on_retry(cx))
         .into_any_element()
 }


### PR DESCRIPTION
## Summary

Make pointer settings keyboard-focusable and expose semantic control names by replacing custom click targets with gpui-component buttons.

## Changes

- use semantic buttons for DPI presets, SmartShift modes, scroll inversion, and wheel resolution
- expose shared retry actions as buttons
- remove bespoke click handling while preserving selected and disabled states

## Testing

- `cargo clippy -p openlogi-gui --all-targets -- -D warnings`
- `cargo test -p openlogi-gui` — 52 passed
- `devenv tasks run openlogi:check`
- visually checked the Pointer screen in the refreshed development app
- traversed the controls with Tab and inspected the macOS accessibility tree
- device-setting writes were not runtime-tested on hardware

Fixes: N/A (no linked issue)