### PR TITLE
feat(gui): clarify pairing failures and offline editing

### DIFF
--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Konfigurationsmappe"
 "Connected": "Tilsluttet"
 "Offline": "Offline"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batteri"
 "Charging": "Oplader"
 "Full": "Fuldt"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Konfigurationsordner"
 "Connected": "Verbunden"
 "Offline": "Offline"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Akku"
 "Charging": "Wird geladen"
 "Full": "Voll"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Φάκελος διαμόρφωσης"
 "Connected": "Συνδεδεμένη"
 "Offline": "Εκτός σύνδεσης"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Μπαταρία"
 "Charging": "Φόρτιση"
 "Full": "Πλήρης"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Config folder"
 "Connected": "Connected"
 "Offline": "Offline"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Battery"
 "Charging": "Charging"
 "Full": "Full"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Carpeta de configuración"
 "Connected": "Conectado"
 "Offline": "Sin conexión"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batería"
 "Charging": "Cargando"
 "Full": "Completa"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Määrityskansio"
 "Connected": "Yhdistetty"
 "Offline": "Ei yhteyttä"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Akku"
 "Charging": "Latautuu"
 "Full": "Täynnä"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Dossier de configuration"
 "Connected": "Connecté"
 "Offline": "Hors ligne"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batterie"
 "Charging": "En charge"
 "Full": "Pleine"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Cartella configurazione"
 "Connected": "Connesso"
 "Offline": "Offline"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batteria"
 "Charging": "In carica"
 "Full": "Carica completa"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "設定フォルダー"
 "Connected": "接続済み"
 "Offline": "オフライン"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "バッテリー"
 "Charging": "充電中"
 "Full": "フル充電"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "설정 폴더"
 "Connected": "연결됨"
 "Offline": "오프라인"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "배터리"
 "Charging": "충전 중"
 "Full": "완충"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Konfigurasjonsmappe"
 "Connected": "Tilkoblet"
 "Offline": "Frakoblet"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batteri"
 "Charging": "Lader"
 "Full": "Fullt"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Configuratiemap"
 "Connected": "Verbonden"
 "Offline": "Offline"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batterij"
 "Charging": "Opladen"
 "Full": "Vol"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Folder konfiguracji"
 "Connected": "Połączono"
 "Offline": "Offline"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Bateria"
 "Charging": "Ładowanie"
 "Full": "Pełna"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Pasta de configuração"
 "Connected": "Conectado"
 "Offline": "Off-line"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Bateria"
 "Charging": "Carregando"
 "Full": "Cheia"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Pasta de configuração"
 "Connected": "Ligado"
 "Offline": "Desligado"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Bateria"
 "Charging": "A carregar"
 "Full": "Completa"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Папка конфигурации"
 "Connected": "Подключено"
 "Offline": "Не в сети"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Батарея"
 "Charging": "Заряжается"
 "Full": "Полный заряд"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "Konfigurationsmapp"
 "Connected": "Ansluten"
 "Offline": "Frånkopplad"
+"Device offline — changes will apply when it reconnects.": "Device offline — changes will apply when it reconnects."
 "Battery": "Batteri"
 "Charging": "Laddar"
 "Full": "Fulladdat"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "配置文件夹"
 "Connected": "已连接"
 "Offline": "离线"
+"Device offline — changes will apply when it reconnects.": "设备离线 —— 重新连接后将应用更改。"
 "Battery": "电量"
 "Charging": "充电中"
 "Full": "已充满"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "設定資料夾"
 "Connected": "已連線"
 "Offline": "離線"
+"Device offline — changes will apply when it reconnects.": "裝置離線 —— 重新連線後將套用變更。"
 "Battery": "電量"
 "Charging": "充電中"
 "Full": "已充滿"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -28,6 +28,7 @@ _version: 1
 "Config folder": "設定資料夾"
 "Connected": "已連線"
 "Offline": "離線"
+"Device offline — changes will apply when it reconnects.": "裝置離線 —— 重新連線後將套用變更。"
 "Battery": "電量"
 "Charging": "充電中"
 "Full": "已充滿"

--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -95,12 +95,41 @@ pub(super) fn detail_content(
     pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
-    match active {
+    let online = cx
+        .try_global::<AppState>()
+        .and_then(AppState::current_record)
+        .is_some_and(|record| record.online);
+    let content = match active {
         DetailTab::Buttons => buttons_tab(mouse_model).into_any_element(),
         DetailTab::Pointer => pointer_tab(dpi_panel, smartshift_panel, pal, cx).into_any_element(),
         DetailTab::Lighting => lighting_tab(lighting_panel, pal).into_any_element(),
         DetailTab::Device => device_tab(pal, cx).into_any_element(),
-    }
+    };
+    v_flex()
+        .flex_1()
+        .min_h_0()
+        .w_full()
+        .when(!online, |this| {
+            this.child(
+                h_flex()
+                    .flex_shrink_0()
+                    .w_full()
+                    .items_center()
+                    .gap_2()
+                    .border_b_1()
+                    .border_color(pal.border)
+                    .bg(pal.surface)
+                    .px_5()
+                    .py_2()
+                    .text_caption()
+                    .text_color(pal.text_muted)
+                    .child(Icon::new(IconName::Info).size_4())
+                    .child(tr!(
+                        "Device offline — changes will apply when it reconnects."
+                    )),
+            )
+        })
+        .child(content)
 }
 
 /// The device's sections as a compact, centred segmented control for the

--- a/crates/openlogi-gui/src/windows/add_device.rs
+++ b/crates/openlogi-gui/src/windows/add_device.rs
@@ -48,8 +48,8 @@ pub enum PairingUi {
     Passkey(PasskeyMethod),
     /// A device paired into `slot`.
     Paired { slot: u8 },
-    /// The session ended without pairing; carries localized display copy.
-    Failed(String),
+    /// The session ended without pairing.
+    Failed(PairingFailure),
 }
 
 impl Global for PairingUi {}
@@ -93,21 +93,22 @@ pub fn apply_update(cx: &mut App, update: PairingUpdate) {
         }
         PairingUpdate::Passkey(method) => PairingUi::Passkey(method),
         PairingUpdate::Paired { slot } => PairingUi::Paired { slot },
-        PairingUpdate::Failed(failure) => PairingUi::Failed(pairing_failure_text(failure)),
+        PairingUpdate::Failed(failure) => PairingUi::Failed(failure),
     };
     cx.set_global(next);
 }
 
-fn pairing_failure_text(failure: PairingFailure) -> String {
+fn pairing_failure_text(failure: &PairingFailure) -> String {
     match failure {
         PairingFailure::Hid { message } => {
-            tr!("HID transport error: %{message}", message => message).to_string()
+            tr!("HID transport error: %{message}", message => message.clone()).to_string()
         }
         PairingFailure::ReceiverNotFound => {
             tr!("No supported pairing-capable receiver was found.").to_string()
         }
         PairingFailure::Register { message } => {
-            tr!("Receiver register access failed: %{message}", message => message).to_string()
+            tr!("Receiver register access failed: %{message}", message => message.clone())
+                .to_string()
         }
         PairingFailure::Timeout => tr!("Pairing timed out.").to_string(),
         PairingFailure::Device { code } => tr!(
@@ -271,7 +272,7 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
                         .on_click(|_, _, cx| cx.set_global(PairingUi::Idle)),
                 );
         }
-        PairingUi::Failed(detail) => {
+        PairingUi::Failed(failure) => {
             col = col
                 .child(
                     div()
@@ -279,7 +280,20 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
                         .font_weight(FontWeight::MEDIUM)
                         .child(tr!("Pairing failed")),
                 )
-                .child(hint(SharedString::from(detail.clone()), pal))
+                .child(hint(pairing_failure_text(failure), pal))
+                .when(
+                    matches!(failure, PairingFailure::ReceiverNotFound),
+                    |this| {
+                        this.child(hint(
+                            tr!(
+                                "Plug in or pair a supported Logitech device — it'll show up here \
+                                 automatically. For direct Bluetooth connections, pair in your \
+                                 computer's bluetooth settings."
+                            ),
+                            pal,
+                        ))
+                    },
+                )
                 .child(
                     action_button("ad-retry", tr!("Try again"), true)
                         .on_click(|_, _, cx| start_search(cx)),


### PR DESCRIPTION
## Summary

Clarifies what happens when a known device is offline and gives users a concrete recovery path when receiver pairing cannot start.

## Changes

- **gui:** show a compact offline banner across every device-detail tab explaining that edits apply after reconnection.
- **gui:** preserve the typed pairing failure in view state so receiver-not-found can render targeted recovery guidance.
- **gui:** point users to a connected Bolt or Unifying receiver, or to the computer's Bluetooth settings for direct Bluetooth pairing.
- **i18n:** add the offline edit-sync message to every locale, with localized Chinese variants.

## Testing

- `direnv exec . cargo test -p openlogi-gui i18n` — 4 passed
- `devenv tasks run openlogi:check`
- Runtime-checked the offline MX Vertical detail page and receiver-not-found Add Device state in Simplified Chinese.
- Not runtime-tested on hardware.

Stacked on #500.

## Screenshots

<img width="1081" height="768" alt="openlogi-offline-guidance" src="https://github.com/user-attachments/assets/6f28add8-971c-4080-b8c0-aaed46c1edca" />
<img width="520" height="492" alt="openlogi-pairing-guidance" src="https://github.com/user-attachments/assets/78caae6a-b0d0-4f5d-b2cb-5536b2ab07e9" />
