### PR TITLE
feat(windows): enable in-app MSI updates via gpui-updater v0.0.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,13 +292,12 @@ jobs:
           release_prefix="s3://${R2_BUCKET}/releases/${GITHUB_REF_NAME}"
           channel_manifest="s3://${R2_BUCKET}/channels/stable/latest.json"
 
-          # latest.json now carries the Windows msi/zip entries (notify-only:
-          # a Windows check resolves and routes to the GitHub Release for the
-          # download — the client's install flow stays off, INSTALL_SUPPORTED
-          # is false). Their asset + signature URLs point into this prefix, so
-          # the zip/msi and their minisigs must ship here too or the manifest
-          # would reference 404s. *.exe stays excluded defensively — no bare
-          # exe ships anymore.
+          # latest.json carries the Windows msi/zip entries; the client
+          # downloads the msi and installs it via gpui-updater's staged
+          # msiexec flow. Their asset + signature URLs point into this
+          # prefix, so the zip/msi and their minisigs must ship here too or
+          # the manifest would reference 404s. *.exe stays excluded
+          # defensively — no bare exe ships anymore.
           aws s3 cp dist/ "$release_prefix/" \
             --recursive \
             --exclude latest.json \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,8 +2780,8 @@ dependencies = [
 
 [[package]]
 name = "gpui-updater"
-version = "0.0.5"
-source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.5#dd592ac89c45a061ddc3a40160eecf1dfe7302fe"
+version = "0.0.6"
+source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.6#e8a85768793ac3238b0c1bc1f32d6a1544667ec3"
 dependencies = [
  "gpui",
  "minisign-verify",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["png"] }
 rust-i18n = "4"
 sys-locale = "0.3.2"
-gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.5", features = ["gpui"] }
+gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.6", features = ["gpui"] }
 # Spawn the agent under its own macOS TCC identity (see ipc_client::spawn_agent).
 # Cross-platform: a no-op pass-through to std::process::Command off macOS.
 disclaim = "0.1"

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Behold OpenLogis ikon i menulinjen. Når den er slået fra, forbliver det i Dock'en."
 "Show in the notification area": "Vis i meddelelsesområdet"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Behold OpenLogis ikon i proceslinjens meddelelsesområde. Træder i kraft, næste gang baggrundsagenten starter."
-"Download from GitHub": "Download fra GitHub"
 "Assets": "Ressourcer"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "OpenLogi-Symbol in der Menüleiste behalten. Wenn deaktiviert, bleibt es stattdessen im Dock."
 "Show in the notification area": "Im Infobereich anzeigen"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "OpenLogi-Symbol im Infobereich der Taskleiste anzeigen. Wird beim nächsten Start des Hintergrund-Agenten wirksam."
-"Download from GitHub": "Von GitHub herunterladen"
 "Assets": "Ressourcen"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Διατήρηση του εικονιδίου του OpenLogi στη γραμμή μενού. Όταν είναι ανενεργό, παραμένει στο Dock."
 "Show in the notification area": "Εμφάνιση στην περιοχή ειδοποιήσεων"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Διατηρεί το εικονίδιο του OpenLogi στην περιοχή ειδοποιήσεων της γραμμής εργασιών. Ισχύει από την επόμενη εκκίνηση της υπηρεσίας παρασκηνίου."
-"Download from GitHub": "Λήψη από το GitHub"
 "Assets": "Πόροι"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead."
 "Show in the notification area": "Show in the notification area"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts."
-"Download from GitHub": "Download from GitHub"
 "Assets": "Assets"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Mantén el icono de OpenLogi en la barra de menús. Si se desactiva, permanece en el Dock."
 "Show in the notification area": "Mostrar en el área de notificación"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantiene el icono de OpenLogi en el área de notificación de la barra de tareas. Surte efecto la próxima vez que se inicie el agente en segundo plano."
-"Download from GitHub": "Descargar desde GitHub"
 "Assets": "Recursos"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Pidä OpenLogin kuvake valikkorivillä. Kun pois päältä, se pysyy Dockissa."
 "Show in the notification area": "Näytä ilmoitusalueella"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Pitää OpenLogin kuvakkeen tehtäväpalkin ilmoitusalueella. Tulee voimaan, kun taustaprosessi käynnistyy seuraavan kerran."
-"Download from GitHub": "Lataa GitHubista"
 "Assets": "Resurssit"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Conserver l'icône d'OpenLogi dans la barre des menus. Si désactivé, elle reste dans le Dock."
 "Show in the notification area": "Afficher dans la zone de notification"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Garde l'icône d'OpenLogi dans la zone de notification de la barre des tâches. Prend effet au prochain démarrage de l'agent en arrière-plan."
-"Download from GitHub": "Télécharger depuis GitHub"
 "Assets": "Ressources"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Mantieni l'icona di OpenLogi nella barra dei menu. Quando è disattivata, rimarrà invece nel Dock."
 "Show in the notification area": "Mostra nell'area di notifica"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantiene l'icona di OpenLogi nell'area di notifica della barra delle applicazioni. Ha effetto al prossimo avvio dell'agente in background."
-"Download from GitHub": "Scarica da GitHub"
 "Assets": "Risorse"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "OpenLogi のアイコンをメニューバーに表示します。オフにすると Dock に残ります。"
 "Show in the notification area": "通知領域に表示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "タスクバーの通知領域に OpenLogi のアイコンを表示します。バックグラウンドエージェントの次回起動時に反映されます。"
-"Download from GitHub": "GitHub からダウンロード"
 "Assets": "アセット"
 "Asset source": "アセットソース"
 "Automatic (recommended)": "自動（推奨）"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "OpenLogi 아이콘을 메뉴 막대에 유지합니다. 끄면 대신 Dock에 남습니다."
 "Show in the notification area": "알림 영역에 표시"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "작업 표시줄 알림 영역에 OpenLogi 아이콘을 유지합니다. 백그라운드 에이전트가 다음에 시작될 때 적용됩니다."
-"Download from GitHub": "GitHub에서 다운로드"
 "Assets": "리소스"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Behold OpenLogi-ikonet i menylinjen. Når av forblir det i Dock-en i stedet."
 "Show in the notification area": "Vis i varslingsområdet"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Beholder OpenLogi-ikonet i varslingsområdet på oppgavelinjen. Trer i kraft neste gang bakgrunnsagenten starter."
-"Download from GitHub": "Last ned fra GitHub"
 "Assets": "Ressurser"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Houd het OpenLogi-pictogram in de menubalk. Indien uit, blijft het in het Dock."
 "Show in the notification area": "Weergeven in het systeemvak"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Houdt het OpenLogi-pictogram in het systeemvak van de taakbalk. Wordt van kracht wanneer de achtergrondagent opnieuw start."
-"Download from GitHub": "Downloaden van GitHub"
 "Assets": "Bronnen"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Zachowaj ikonę OpenLogi na pasku menu. Po wyłączeniu pozostanie w Docku."
 "Show in the notification area": "Pokaż w obszarze powiadomień"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Utrzymuje ikonę OpenLogi w obszarze powiadomień paska zadań. Zacznie obowiązywać przy następnym uruchomieniu agenta w tle."
-"Download from GitHub": "Pobierz z GitHuba"
 "Assets": "Zasoby"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Manter o ícone do OpenLogi na barra de menus. Quando desativado, permanece no Dock."
 "Show in the notification area": "Mostrar na área de notificação"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantém o ícone do OpenLogi na área de notificação da barra de tarefas. Entra em vigor na próxima vez que o agente em segundo plano iniciar."
-"Download from GitHub": "Baixar do GitHub"
 "Assets": "Recursos"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Manter o ícone do OpenLogi na barra de menus. Quando desativado, permanece no Dock."
 "Show in the notification area": "Mostrar na área de notificação"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantém o ícone do OpenLogi na área de notificação da barra de tarefas. Produz efeito no próximo arranque do agente em segundo plano."
-"Download from GitHub": "Transferir do GitHub"
 "Assets": "Recursos"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Оставлять значок OpenLogi в строке меню. Если выключено, приложение остаётся в Dock."
 "Show in the notification area": "Показывать в области уведомлений"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Значок OpenLogi останется в области уведомлений панели задач. Вступает в силу при следующем запуске фонового агента."
-"Download from GitHub": "Скачать с GitHub"
 "Assets": "Ресурсы"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Behåll OpenLogis ikon i menyraden. När av stannar den i Dock i stället."
 "Show in the notification area": "Visa i meddelandefältet"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Behåller OpenLogis ikon i aktivitetsfältets meddelandefält. Träder i kraft nästa gång bakgrundsagenten startar."
-"Download from GitHub": "Ladda ner från GitHub"
 "Assets": "Resurser"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "在菜单栏保留 OpenLogi 图标；关闭后改为停留在程序坞中。"
 "Show in the notification area": "在通知区域显示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "在任务栏通知区域保留 OpenLogi 图标。将在后台代理下次启动时生效。"
-"Download from GitHub": "从 GitHub 下载"
 "Assets": "资源"
 "Asset source": "资源来源"
 "Automatic (recommended)": "自动选择（推荐）"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。"
 "Show in the notification area": "在通知區域顯示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "在工作列通知區域保留 OpenLogi 圖示。將於背景代理程式下次啟動時生效。"
-"Download from GitHub": "從 GitHub 下載"
 "Assets": "資源"
 "Asset source": "資源來源"
 "Automatic (recommended)": "自動選擇（建議）"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -108,7 +108,6 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。"
 "Show in the notification area": "在通知區域顯示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "在工作列通知區域保留 OpenLogi 圖示。將於背景代理程式下次啟動時生效。"
-"Download from GitHub": "從 GitHub 下載"
 "Assets": "資源"
 "Asset source": "資源來源"
 "Automatic (recommended)": "自動選擇（建議）"

--- a/crates/openlogi-gui/src/platform/updater.rs
+++ b/crates/openlogi-gui/src/platform/updater.rs
@@ -77,15 +77,6 @@ fn minisign_public_key() -> Option<&'static str> {
         .filter(|key| !key.is_empty())
 }
 
-/// Whether this platform's install flow is wired end to end. gpui-updater's
-/// Windows strategy is rename-in-place for a bare `.exe`; handing it the MSI
-/// the manifest serves would clobber `OpenLogi.exe` with installer bytes.
-/// Until an msiexec flow lands upstream, Windows checks are notify-only: a
-/// check still resolves and surfaces "update available", but nothing
-/// downloads or installs — the Updates page routes the user to the release
-/// instead.
-pub const INSTALL_SUPPORTED: bool = !cfg!(target_os = "windows");
-
 fn release_arch() -> &'static str {
     match std::env::consts::ARCH {
         "aarch64" => "arm64",
@@ -97,9 +88,7 @@ fn release_format() -> &'static str {
     match std::env::consts::OS {
         "macos" => "dmg",
         // Matches the `format` field `xtask release latest-json` emits for the
-        // per-arch MSIs. No bare exe ships anymore, so "exe" could never
-        // match; with [`INSTALL_SUPPORTED`] false the format only has to let a
-        // *check* resolve.
+        // per-arch MSIs, which gpui-updater applies via its staged msiexec flow.
         "windows" => "msi",
         _ => "tar.gz",
     }
@@ -116,10 +105,9 @@ pub fn install(cx: &mut App, settings: &AppSettings) {
     // later manual check — is honoured. Installed unconditionally; it's inert
     // until both the flag is on and a check resolves to `Available`.
     let auto_install = cx.observe(&updater, |updater, cx| {
-        let opted_in = INSTALL_SUPPORTED
-            && cx
-                .try_global::<AppState>()
-                .is_some_and(|s| s.app_settings().auto_install_updates);
+        let opted_in = cx
+            .try_global::<AppState>()
+            .is_some_and(|s| s.app_settings().auto_install_updates);
         if opted_in && matches!(updater.read(cx).status(), UpdateStatus::Available(_)) {
             updater.update(cx, Updater::download_and_install);
         }

--- a/crates/openlogi-gui/src/windows/settings/updates.rs
+++ b/crates/openlogi-gui/src/windows/settings/updates.rs
@@ -16,31 +16,28 @@ pub(super) fn updates_page(updater: Entity<Updater>, pal: Palette) -> SettingPag
         update_hero(&updater, pal, cx)
     }));
 
-    let toggles = SettingGroup::new().item(
-        SettingItem::new(
-            tr!("Check for updates"),
-            SettingField::switch(
-                |cx| {
-                    cx.try_global::<AppState>()
-                        .is_some_and(|s| s.app_settings().check_for_updates)
-                },
-                |enabled, cx| {
-                    cx.update_global::<AppState, _>(move |s, _| {
-                        s.set_check_for_updates(enabled);
-                    });
-                    cx.refresh_windows();
-                },
-            ),
+    let toggles = SettingGroup::new()
+        .item(
+            SettingItem::new(
+                tr!("Check for updates"),
+                SettingField::switch(
+                    |cx| {
+                        cx.try_global::<AppState>()
+                            .is_some_and(|s| s.app_settings().check_for_updates)
+                    },
+                    |enabled, cx| {
+                        cx.update_global::<AppState, _>(move |s, _| {
+                            s.set_check_for_updates(enabled);
+                        });
+                        cx.refresh_windows();
+                    },
+                ),
+            )
+            .description(tr!(
+                "Check once per launch for a new version (query only — no automatic download)."
+            )),
         )
-        .description(tr!(
-            "Check once per launch for a new version (query only — no automatic download)."
-        )),
-    );
-    // Offering the auto-install switch on a platform whose install flow isn't
-    // wired (Windows, today) would be a control that silently does nothing —
-    // hide it instead; checks there are notify-only.
-    let toggles = if crate::platform::updater::INSTALL_SUPPORTED {
-        toggles.item(
+        .item(
             SettingItem::new(
                 tr!("Automatically download and install"),
                 SettingField::switch(
@@ -59,10 +56,7 @@ pub(super) fn updates_page(updater: Entity<Updater>, pal: Palette) -> SettingPag
             .description(tr!(
                 "Download updates in the background and apply them the next time OpenLogi restarts."
             )),
-        )
-    } else {
-        toggles
-    };
+        );
 
     let source = SettingGroup::new().item(SettingItem::render(move |_, _, _| update_source(pal)));
 
@@ -115,15 +109,6 @@ fn update_hero(updater: &Entity<Updater>, pal: Palette, cx: &mut App) -> AnyElem
     let action = {
         let u = updater.clone();
         match &status {
-            // No wired install flow (Windows): a found update routes to the
-            // GitHub release for a manual download instead of feeding
-            // gpui-updater an artifact its installer can't apply.
-            UpdateStatus::Available(_) if !crate::platform::updater::INSTALL_SUPPORTED => {
-                Button::new("update-download")
-                    .outline()
-                    .label(tr!("Download from GitHub"))
-                    .on_click(|_, _, cx| cx.open_url(RELEASES_URL))
-            }
             UpdateStatus::Available(_) => Button::new("update-install")
                 .outline()
                 .label(tr!("Download & Install"))

--- a/xtask/src/commands/release/latest_json.rs
+++ b/xtask/src/commands/release/latest_json.rs
@@ -31,9 +31,8 @@ pub(crate) struct Args {
     /// Also emit the per-arch Windows `.msi`/`.zip` entries. Off by default so
     /// the manifest can never reference objects the release workflow's R2
     /// upload step doesn't ship. The release workflow passes it and ships the
-    /// zip/msi to the `releases/` prefix; the entries are notify-only (the
-    /// Windows client resolves a check but installs from the GitHub Release —
-    /// `INSTALL_SUPPORTED` is false).
+    /// zip/msi to the `releases/` prefix; the Windows client downloads the
+    /// `.msi` and installs it via gpui-updater's staged msiexec flow.
     #[arg(long)]
     include_windows: bool,
 }


### PR DESCRIPTION
## Summary

Bumps gpui-updater to [v0.0.6](https://github.com/AprilNEA/gpui-updater/releases/tag/v0.0.6), which brings the staged msiexec install flow for `.msi` artifacts (AprilNEA/gpui-updater#6) and retries for transient download failures (AprilNEA/gpui-updater#5). With an MSI install flow finally upstream, Windows update checks are no longer notify-only: the `INSTALL_SUPPORTED` gate and its fallback paths are removed, so Windows gets the same **Download & Install** button and **Automatically download and install** toggle as macOS and Linux. A found update downloads the per-arch MSI from the update manifest, verifies it (SHA-256 + minisign, `Verification::Strict`), stages an apply script, and applies it via `msiexec /passive /norestart` after the app exits through "Restart to Update".

## Changes

- **gui**: pin `gpui-updater` at `tag = "v0.0.6"`; `Cargo.lock` updated surgically so the `zed`/`gpui` and `gpui-component` pins are untouched (a plain `cargo update -p gpui-updater` would have moved the zed rev).
- **gui**: remove `platform::updater::INSTALL_SUPPORTED` and both notify-only branches — the "Download from GitHub" action on the Updates page and the hidden auto-install toggle; the auto-install observer no longer gates on platform. The `release_format()` comment now reflects that the MSI entries are installable.
- **i18n**: drop the now-unused `"Download from GitHub"` key from `en.yml` and all 19 translations (ordered-parity test passes).
- **xtask**: update the `--include-windows` doc on `release latest-json` — the emitted MSI entries are consumed by the client's install flow, not notify-only.
- **ci**: same doc fix in the R2 upload step comment in `release.yml`.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — all suites green, including `i18n::tests::locale_files_have_the_same_keys`
- gpui-updater v0.0.6 was released from a green tree (fmt + clippy `-D warnings` + 31 tests + doctests)
- **Not runtime-tested on hardware/Windows.** To verify end to end on a Windows machine: run a build whose embedded version is older than the published manifest, Settings → Updates → Download & Install, then "Restart to Update" — the app should exit, msiexec should run passively, and the app should relaunch on the new version. The macOS/Linux flows are unchanged by the gate removal.

No UI change on macOS/Linux; on Windows the Updates page gains the auto-install toggle and the install action replaces the "Download from GitHub" button (no screenshot — not built on Windows here).
