### PR TITLE
ci(i18n): harden Crowdin translation sync

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -29,16 +29,19 @@ jobs:
     steps:
       # Secrets are not readable in a job-level `if`, so a gate step skips the
       # sync (with a visible warning) instead of failing every scheduled run
-      # while the Crowdin 1Password item is not configured.
+      # while the Crowdin credentials are not configured. A malformed reference
+      # or missing item field still fails loudly in the load step below — once
+      # the secrets are set, a broken reference is an error, not a skip.
       - name: Check for the Crowdin 1Password item
         id: config
         env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           OP_CROWDIN_SECRET_ITEM: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}
         run: |
-          if [[ -n "$OP_CROWDIN_SECRET_ITEM" ]]; then
+          if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" && -n "$OP_CROWDIN_SECRET_ITEM" ]]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::OP_CROWDIN_SECRET_ITEM is not set; skipping the Crowdin sync."
+            echo "::warning::OP_SERVICE_ACCOUNT_TOKEN and/or OP_CROWDIN_SECRET_ITEM is not set; skipping the Crowdin sync."
             echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -49,7 +52,7 @@ jobs:
       - name: Load Crowdin credentials from 1Password
         if: steps.config.outputs.configured == 'true'
         id: crowdin_config
-        uses: 1password/load-secrets-action@v4
+        uses: 1password/load-secrets-action@eb2efd0703da22a93c467f2d1ffbb6826c11e19c # v4.1.1
         with:
           export-env: false
         env:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -27,10 +27,38 @@ jobs:
     if: github.repository == 'AprilNEA/OpenLogi'
 
     steps:
+      # Secrets are not readable in a job-level `if`, so a gate step skips the
+      # sync (with a visible warning) instead of failing every scheduled run
+      # while the Crowdin 1Password item is not configured.
+      - name: Check for the Crowdin 1Password item
+        id: config
+        env:
+          OP_CROWDIN_SECRET_ITEM: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}
+        run: |
+          if [[ -n "$OP_CROWDIN_SECRET_ITEM" ]]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::OP_CROWDIN_SECRET_ITEM is not set; skipping the Crowdin sync."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
-        uses: actions/checkout@v4
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/checkout@v6
+
+      - name: Load Crowdin credentials from 1Password
+        if: steps.config.outputs.configured == 'true'
+        id: crowdin_config
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PROJECT_ID
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PERSONAL_TOKEN
 
       - name: Synchronize with Crowdin
+        if: steps.config.outputs.configured == 'true'
         uses: crowdin/github-action@v2
         with:
           config: crowdin.yml
@@ -49,5 +77,5 @@ jobs:
           github_user_email: support+bot@crowdin.com
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ steps.crowdin_config.outputs.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ steps.crowdin_config.outputs.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -27,30 +27,10 @@ jobs:
     if: github.repository == 'AprilNEA/OpenLogi'
 
     steps:
-      # Secrets are not readable in a job-level `if`, so a gate step skips the
-      # sync (with a visible warning) instead of failing every scheduled run
-      # while the Crowdin credentials are not configured. A malformed reference
-      # or missing item field still fails loudly in the load step below — once
-      # the secrets are set, a broken reference is an error, not a skip.
-      - name: Check for the Crowdin 1Password item
-        id: config
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          OP_CROWDIN_SECRET_ITEM: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}
-        run: |
-          if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" && -n "$OP_CROWDIN_SECRET_ITEM" ]]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::OP_SERVICE_ACCOUNT_TOKEN and/or OP_CROWDIN_SECRET_ITEM is not set; skipping the Crowdin sync."
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout
-        if: steps.config.outputs.configured == 'true'
         uses: actions/checkout@v6
 
       - name: Load Crowdin credentials from 1Password
-        if: steps.config.outputs.configured == 'true'
         id: crowdin_config
         uses: 1password/load-secrets-action@eb2efd0703da22a93c467f2d1ffbb6826c11e19c # v4.1.1
         with:
@@ -61,15 +41,14 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PERSONAL_TOKEN
 
       - name: Synchronize with Crowdin
-        if: steps.config.outputs.configured == 'true'
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
         with:
           config: crowdin.yml
           upload_sources: true
           upload_translations: false
           download_translations: true
           localization_branch_name: crowdin/i18n
-          commit_message: "chore(i18n): sync Crowdin translations [skip ci]"
+          commit_message: "chore(i18n): sync Crowdin translations"
           create_pull_request: true
           pull_request_title: "chore(i18n): sync Crowdin translations"
           pull_request_body: |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Things OpenLogi does that Options+ won't:
 | Middle / mode-shift / thumbwheel button capture | ✅ middle on all platforms; mode-shift / thumbwheel device dependent |
 | Windows (agent, GUI, event hook, installer) | ✅ Windows 11 hardware validated; newer port with ongoing compatibility polish |
 
+Help improve the interface translations on [Crowdin](https://crowdin.com/project/openlogi).
+
 ¹ Media key actions use D-Bus MPRIS on Linux; a handful of macOS-specific actions have no universal Linux equivalent and are no-ops. Windows maps platform actions to native equivalents where available.
 
 ## Install

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -95,8 +95,3 @@ osx_minimum_system_version = "13.0"
 osx_url_schemes = ["openlogi"]
 icon = ["icon/AppIcon.icns"]
 resources = ["assets/**/*"]
-
-[package.metadata.i18n]
-available-locales = ["en", "ja", "ru", "zh-CN", "zh-HK", "zh-TW", "it"]
-default-locale = "en"
-load-path = "locales"

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,15 +4,50 @@ base_path: "."
 
 preserve_hierarchy: true
 
+export_languages:
+  - da
+  - de
+  - es-ES
+  - fr
+  - it
+  - nl
+  - no
+  - pl
+  - pt-PT
+  - pt-BR
+  - fi
+  - sv-SE
+  - el
+  - ru
+  - ja
+  - zh-CN
+  - zh-HK
+  - zh-TW
+  - ko
+
 files:
   - source: "/crates/openlogi-gui/locales/en.yml"
     translation: "/crates/openlogi-gui/locales/%locale%.yml"
     type: "yaml"
+    update_option: "update_as_unapproved"
     languages_mapping:
       locale:
+        da: "da"
+        de: "de"
+        es-ES: "es"
+        fr: "fr"
+        it: "it"
+        nl: "nl"
+        no: "nb"
+        pl: "pl"
+        pt-PT: "pt-PT"
+        pt-BR: "pt-BR"
+        fi: "fi"
+        sv-SE: "sv"
+        el: "el"
         ja: "ja"
         ru: "ru"
         zh-CN: "zh-CN"
         zh-HK: "zh-HK"
         zh-TW: "zh-TW"
-        it: "it"
+        ko: "ko"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -187,3 +187,17 @@ cargo run -p xtask -- release latest-json \
   --base-url https://updates.openlogi.org \
   --output dist/latest.json
 ```
+
+## Crowdin translation sync
+
+`.github/workflows/crowdin.yml` uploads `crates/openlogi-gui/locales/en.yml` to
+Crowdin and opens a `crowdin/i18n` PR with fresh translations — nightly, and on
+master pushes touching the source strings. Like the release workflow, it reads
+its credentials from one 1Password item referenced by the GitHub secret
+`OP_CROWDIN_SECRET_ITEM`. The item must contain:
+
+- `CROWDIN_PROJECT_ID` — the numeric Crowdin project id.
+- `CROWDIN_PERSONAL_TOKEN` — a Crowdin API token with access to the project.
+
+While `OP_CROWDIN_SECRET_ITEM` is unset, the workflow skips the sync with a
+warning instead of failing.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -191,13 +191,25 @@ cargo run -p xtask -- release latest-json \
 ## Crowdin translation sync
 
 `.github/workflows/crowdin.yml` uploads `crates/openlogi-gui/locales/en.yml` to
-Crowdin and opens a `crowdin/i18n` PR with fresh translations — nightly, and on
-master pushes touching the source strings. Like the release workflow, it reads
-its credentials from one 1Password item referenced by the GitHub secret
-`OP_CROWDIN_SECRET_ITEM`. The item must contain:
+[Crowdin](https://crowdin.com/project/openlogi) and opens a `crowdin/i18n` PR
+with fresh translations — nightly, and on master pushes touching the source
+strings. `crowdin.yml` limits exports to the locales shipped by the app and
+maps Crowdin language identifiers to their repository filenames.
+
+Like the release workflow, the job reads its credentials from one 1Password
+item referenced by the GitHub secret `OP_CROWDIN_SECRET_ITEM`. The item must
+contain:
 
 - `CROWDIN_PROJECT_ID` — the numeric Crowdin project id.
 - `CROWDIN_PERSONAL_TOKEN` — a Crowdin API token with access to the project.
 
-While `OP_CROWDIN_SECRET_ITEM` is unset, the workflow skips the sync with a
-warning instead of failing.
+Grant the token only these scopes and restrict its granular access to the
+OpenLogi project:
+
+- Projects (List, Get, Create, Edit) — Read.
+- Translation Status — Read Only.
+- Source files & strings — Read and Write.
+- Translations — Read and Write.
+
+Missing or invalid credentials fail the workflow. Translation PRs run the
+normal CI checks, including the locale key-parity test.


### PR DESCRIPTION
## Summary

Make the Crowdin sync operational, deterministic, and safe for the repository’s locale set. Credentials are loaded from a dedicated 1Password item, and missing or invalid configuration now fails instead of producing a misleading green skip.

## Changes

- **ci**: load Crowdin credentials through `OP_CROWDIN_SECRET_ITEM`, pin external actions, run normal CI on generated translation PRs, and fail on missing credentials.
- **i18n**: export only the 19 locales shipped by OpenLogi, map Crowdin language IDs to repository filenames, preserve translations when source strings change, and remove stale duplicate locale metadata.
- **docs**: link the public Crowdin project and document the 1Password fields, least-privilege token scopes, and failure behavior.
- **Crowdin**: align the project languages and current 320-key English source with the repository, import all existing locale files, and add a concise style guide and glossary.

## Testing

- `devenv tasks run openlogi:check`
- `actionlint .github/workflows/crowdin.yml`
- YAML parse and `git diff --check`
- All 19 Crowdin locales match their repository files across all 320 source keys
- End-to-end workflow dispatch pending merge
- Hardware: not runtime-tested; not applicable to this CI-only change