### PR TITLE
fix(agent): reapply volatile settings after macOS resume

### DIFF
--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -39,8 +39,8 @@ embed-resource = "3.0.9"
 # the GUI's so the resolve doesn't move the gpui Cargo.lock pin.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication"] }
-objc2-foundation = { workspace = true, features = ["NSString", "NSData", "NSArray"] }
+objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication", "NSWorkspace"] }
+objc2-foundation = { workspace = true, features = ["NSString", "NSData", "NSArray", "NSNotification"] }
 plist = "1.10.0"
 
 # Autostart via the HKCU Run key (launch_agent.rs); winreg also answers the

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -101,14 +101,16 @@ fn main() {
         // Read the menu-bar preference before `config` moves into the core
         // thread; the main thread hosts the tray.
         let show_in_menu_bar = config.app_settings.show_in_menu_bar;
+        let resume_pending = Arc::new(AtomicBool::new(false));
+        let core_resume_pending = Arc::clone(&resume_pending);
         if let Err(e) = std::thread::Builder::new()
             .name("openlogi-agent-core".into())
-            .spawn(move || runtime.block_on(run(config)))
+            .spawn(move || runtime.block_on(run(config, core_resume_pending)))
         {
             warn!(error = %e, "could not spawn the agent core thread; exiting");
             return;
         }
-        tray::run_app_loop(show_in_menu_bar);
+        tray::run_app_loop(show_in_menu_bar, resume_pending);
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -146,7 +148,7 @@ fn spawn_hidpp_watchers(shared: &SharedRuntime) {
     );
 }
 
-async fn run(config: Config) {
+async fn run(config: Config, #[cfg(target_os = "macos")] resume_pending: Arc<AtomicBool>) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
     // LaunchAgent, before `config` moves into the orchestrator.
     launch_agent::reconcile(config.app_settings.launch_at_login);
@@ -221,10 +223,17 @@ async fn run(config: Config) {
         tokio::select! {
             event = inventory_rx.recv(), if inventory_open => match event {
                 Some(watchers::inventory::InventoryEvent::Snapshot { inventories, standalone }) => {
-                    orchestrator
-                        .lock()
-                        .await
-                        .refresh_inventory(&inventories, &standalone);
+                    let mut orchestrator = orchestrator.lock().await;
+                    // The portable watcher catches long sleeps from a polling
+                    // gap. Native macOS notifications also cover short sleeps,
+                    // display wakes, and returning user sessions; consume the
+                    // coalesced signal at the exact point that can replay it.
+                    #[cfg(target_os = "macos")]
+                    if resume_pending.swap(false, Ordering::Relaxed) {
+                        info!("macOS resume notification — replaying volatile settings");
+                        orchestrator.reapply_volatile_on_next_refresh();
+                    }
+                    orchestrator.refresh_inventory(&inventories, &standalone);
                 }
                 Some(watchers::inventory::InventoryEvent::Unavailable) => {
                     orchestrator.lock().await.mark_inventory_unavailable();

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -1,4 +1,4 @@
-//! The agent's menu-bar status item.
+//! The agent's macOS AppKit loop, menu-bar item, and resume notifications.
 //!
 //! The always-on agent hosts the menu bar (the GUI is on-demand). The item
 //! carries GUI-directed actions ("Show Main Window", Settings, About, Check for
@@ -15,18 +15,55 @@
 
 #![expect(
     unsafe_code,
-    reason = "objc2 calls: super-init, init-with-action/set-target — localized here and in status_item"
+    reason = "objc2 calls: super-init, action targets, and selector-based workspace notifications"
 )]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
-use objc2::{MainThreadMarker, MainThreadOnly, define_class, msg_send, sel};
-use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSImage, NSRunningApplication};
-use objc2_foundation::NSString;
+use objc2::{
+    AnyThread, DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send, sel,
+};
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSImage, NSRunningApplication, NSWorkspace,
+    NSWorkspaceDidWakeNotification, NSWorkspaceScreensDidWakeNotification,
+    NSWorkspaceSessionDidBecomeActiveNotification,
+};
+use objc2_foundation::{NSNotification, NSNotificationName, NSString};
 use openlogi_core::brand::DeeplinkCommand;
 use tracing::{info, warn};
 
 use crate::status_item;
+
+struct ResumeTargetIvars {
+    pending: Arc<AtomicBool>,
+}
+
+define_class!(
+    // SAFETY: NSObject has no subclassing requirements, and `ResumeTarget`
+    // does not implement `Drop`.
+    #[unsafe(super(NSObject))]
+    #[ivars = ResumeTargetIvars]
+    #[name = "OpenLogiAgentWorkspaceResumeTarget"]
+    struct ResumeTarget;
+
+    impl ResumeTarget {
+        #[unsafe(method(workspaceDidResume:))]
+        fn workspace_did_resume(&self, _notification: &NSNotification) {
+            self.ivars().pending.store(true, Ordering::Relaxed);
+        }
+    }
+);
+
+impl ResumeTarget {
+    fn new(pending: Arc<AtomicBool>) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(ResumeTargetIvars { pending });
+        // SAFETY: `init` initializes our freshly allocated NSObject subclass.
+        unsafe { msg_send![super(this), init] }
+    }
+}
 
 define_class!(
     // SAFETY: NSObject has no subclassing requirements, and `MenuTarget` does
@@ -121,7 +158,8 @@ fn gui_is_running() -> bool {
 /// tokio core still does all the work). The toggle takes effect on the agent's
 /// next launch — a no-restart live toggle would need a main-thread hop from the
 /// IPC reload path (deferred; it can't be verified headlessly).
-pub fn run_app_loop(show_in_menu_bar: bool) -> ! {
+/// `resume_pending` forwards coalesced workspace resume notifications to that core.
+pub fn run_app_loop(show_in_menu_bar: bool, resume_pending: Arc<AtomicBool>) -> ! {
     let Some(mtm) = MainThreadMarker::new() else {
         warn!("agent AppKit loop not started off the main thread — exiting");
         std::process::exit(1);
@@ -132,10 +170,43 @@ pub fn run_app_loop(show_in_menu_bar: bool) -> ! {
     // Bind the status item (+ its target/menu) so they outlive `run()` — the
     // menu items only weakly reference the target. `None` when hidden.
     let _tray = show_in_menu_bar.then(|| install_status_item(mtm));
+    let _resume_target = install_resume_observer(resume_pending);
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
     std::process::exit(0);
+}
+
+/// Observe native resume transitions that the inventory polling-gap heuristic
+/// cannot see. The returned target must live for the AppKit loop's lifetime.
+fn install_resume_observer(pending: Arc<AtomicBool>) -> Retained<ResumeTarget> {
+    let target = ResumeTarget::new(pending);
+    let workspace = NSWorkspace::sharedWorkspace();
+    let center = workspace.notificationCenter();
+    for name in resume_notification_names() {
+        // SAFETY: `ResumeTarget` implements `workspaceDidResume:` with the
+        // exact one-NSNotification argument signature, and the caller retains
+        // the target for the AppKit loop's lifetime.
+        unsafe {
+            center.addObserver_selector_name_object(
+                &target,
+                sel!(workspaceDidResume:),
+                Some(name),
+                Some(&workspace),
+            );
+        }
+    }
+    target
+}
+
+fn resume_notification_names() -> [&'static NSNotificationName; 3] {
+    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+    let system_wake = unsafe { NSWorkspaceDidWakeNotification };
+    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+    let screen_wake = unsafe { NSWorkspaceScreensDidWakeNotification };
+    // SAFETY: AppKit exports each name as an immutable process-lifetime constant.
+    let session_active = unsafe { NSWorkspaceSessionDidBecomeActiveNotification };
+    [system_wake, screen_wake, session_active]
 }
 
 /// Build and install the menu-bar status item, returning the objects that must
@@ -192,4 +263,33 @@ fn install_status_item(
 
     info!("menu-bar item installed");
     (status_item, target, menu)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_notifications_are_forwarded_and_coalesced() {
+        let pending = Arc::new(AtomicBool::new(false));
+        let target = install_resume_observer(Arc::clone(&pending));
+        let workspace = NSWorkspace::sharedWorkspace();
+        let center = workspace.notificationCenter();
+
+        for name in resume_notification_names() {
+            // SAFETY: `workspace` is live, matches the registration filter,
+            // and notification delivery completes synchronously.
+            unsafe { center.postNotificationName_object(name, Some(&workspace)) };
+            assert!(pending.swap(false, Ordering::Relaxed));
+        }
+        for name in resume_notification_names() {
+            // SAFETY: Same live object and synchronous delivery as above.
+            unsafe { center.postNotificationName_object(name, Some(&workspace)) };
+        }
+        assert!(pending.swap(false, Ordering::Relaxed));
+        assert!(!pending.swap(false, Ordering::Relaxed));
+
+        // SAFETY: This is the same live target registered with `center` above.
+        unsafe { center.removeObserver(&target) };
+    }
 }


### PR DESCRIPTION
## Summary

- Observe native macOS workspace notifications for system wake, display wake, and returning user sessions.
- Coalesce overlapping notifications into one pending volatile-settings replay.
- Consume that replay at the existing inventory snapshot boundary and reuse `Orchestrator::reapply_volatile_on_next_refresh()`.

## Why

The portable inventory watcher infers a wake only from a polling gap longer than one minute. Short system sleeps, display wakes, and session reactivation can therefore leave firmware-native reverse scroll and SmartShift settings reset even though the device remains online.

The AppKit callback only sets an atomic flag; it performs no HID I/O. The next inventory snapshot runs the existing replay path for online devices, so this adds no timer or second settings implementation.

Addresses #405.

This does not re-arm programmable-control capture. #348 and #450 cover that separate capture/diversion recovery path.

## Testing

- Packaged-agent hardware smoke test on macOS arm64: reverse scroll remained active after a 30-minute sleep. The existing long-gap heuristic also covers that duration; the short-wake notification path is covered by the regression test below.
- `cargo fmt --all -- --check`
- `cargo clippy -p openlogi-agent --all-targets --locked -- -D warnings`
- `cargo test -p openlogi-agent --all-targets --locked` (11 passed, including all three workspace notifications and burst coalescing)
- `cargo clippy --workspace --all-targets --exclude openlogi-gui --locked -- -D warnings`
- `cargo test --workspace --exclude openlogi-gui --locked` (471 passed, 1 ignored)
- `cargo check -p openlogi-agent --all-targets --locked --target x86_64-unknown-linux-gnu`
- `cargo check -p openlogi-agent --all-targets --locked --target x86_64-pc-windows-msvc`

Full local workspace Clippy reached `gpui_macos` but could not compile its Metal shader because the local Xcode beta installation reports a missing Metal Toolchain. GitHub CI is left to provide the complete GUI-inclusive macOS gate.
