### PR TITLE
fix(i18n): complete Crowdin synchronization

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -13,8 +13,7 @@ on:
       - .github/workflows/crowdin.yml
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: crowdin-${{ github.ref }}
@@ -29,6 +28,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Mint GitHub App token
+        id: github_app
+        uses: ./.github/actions/github-app-token-from-1password
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
 
       - name: Load Crowdin credentials from 1Password
         id: crowdin_config
@@ -58,6 +64,6 @@ jobs:
           github_user_name: Crowdin Bot
           github_user_email: support+bot@crowdin.com
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.github_app.outputs.token }}
           CROWDIN_PROJECT_ID: ${{ steps.crowdin_config.outputs.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ steps.crowdin_config.outputs.CROWDIN_PERSONAL_TOKEN }}

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI da translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Ingen enhed tilsluttet"
 "Devices": "Enheder"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI de translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Kein Gerät verbunden"
 "Devices": "Geräte"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI el translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Καμία συσκευή δεν είναι συνδεδεμένη"
 "Devices": "Συσκευές"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI en translations. Managed by Crowdin; edit source text there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "No devices connected"
 "Devices": "Devices"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI es translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Ningún dispositivo conectado"
 "Devices": "Dispositivos"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI fi translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Ei yhdistettyä laitetta"
 "Devices": "Laitteet"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI fr translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Aucun appareil connecté"
 "Devices": "Appareils"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI it translations. Managed by Crowdin; edit translations there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Nessun dispositivo connesso"
 "Devices": "Dispositivi"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI ja translations. Managed by Crowdin; edit translations there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "デバイスが接続されていません"
 "Devices": "デバイス"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI ko translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "연결된 기기가 없습니다"
 "Devices": "기기"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI nb translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Ingen enhet tilkoblet"
 "Devices": "Enheter"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI nl translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Geen apparaat verbonden"
 "Devices": "Apparaten"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI pl translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Brak podłączonego urządzenia"
 "Devices": "Urządzenia"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI pt-BR translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Nenhum dispositivo conectado"
 "Devices": "Dispositivos"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI pt-PT translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Nenhum dispositivo ligado"
 "Devices": "Dispositivos"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI ru translations. Managed by Crowdin; edit translations there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Устройство не подключено"
 "Devices": "Устройства"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI sv translations.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "Ingen enhet ansluten"
 "Devices": "Enheter"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI zh-CN translations. Managed by Crowdin; edit translations there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "未连接设备"
 "Devices": "设备"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI zh-HK translations. Managed by Crowdin; edit translations there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "未連接裝置"
 "Devices": "裝置"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -1,4 +1,4 @@
-# OpenLogi GUI zh-TW translations. Managed by Crowdin; edit translations there when possible.
+# OpenLogi GUI translations. Managed by Crowdin; edit source text there when possible.
 _version: 1
 "No devices connected": "沒有已連線的裝置"
 "Devices": "裝置"

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -11,7 +11,7 @@ export_languages:
   - fr
   - it
   - nl
-  - no
+  - "no"
   - pl
   - pt-PT
   - pt-BR
@@ -38,7 +38,7 @@ files:
         fr: "fr"
         it: "it"
         nl: "nl"
-        no: "nb"
+        "no": "nb"
         pl: "pl"
         pt-PT: "pt-PT"
         pt-BR: "pt-BR"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -212,4 +212,7 @@ OpenLogi project:
 - Translations — Read and Write.
 
 Missing or invalid credentials fail the workflow. Translation PRs run the
-normal CI checks, including the locale key-parity test.
+normal CI checks, including the locale key-parity test. The workflow uses the
+existing `OP_GITHUB_APP_ITEM` to mint a short-lived token for pushing its
+translation branch and opening the PR; the default `GITHUB_TOKEN` remains
+read-only.


### PR DESCRIPTION
## Summary

Fix the two runtime failures exposed by the first Crowdin synchronization after #505 and keep generated translation diffs stable.

## Changes

- quote Crowdin's `no` language ID so YAML does not parse it as a Boolean
- mint the existing GitHub App token for translation branch and pull request writes while keeping the default `GITHUB_TOKEN` read-only
- make locale headers language-neutral so Crowdin exports do not create comment-only churn
- document the GitHub App token flow

## Testing

- `devenv tasks run openlogi:check`
- `actionlint .github/workflows/crowdin.yml`
- [Crowdin workflow run 30821898549](https://github.com/AprilNEA/OpenLogi/actions/runs/30821898549) — source upload and all 19 translation downloads succeeded with no generated changes
- Hardware: not runtime-tested; not applicable

Follow-up to #505.
