### PR TITLE
feat: support the MX Master 4 Haptic Sense Panel

### DIFF
--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -54,13 +54,12 @@ pub fn gesture_bindings_for(
     config: &Config,
     config_key: Option<&str>,
 ) -> BTreeMap<GestureDirection, Action> {
-    // The dedicated HID++ gesture button (CID 0x00c3) only gestures while it is the device's gesture
-    // owner. When the user moves the role to an OS-hook button (Middle/Back/
-    // Forward) or turns gestures off, return an empty map so the gesture watcher
-    // dispatches nothing — otherwise the always-seeded defaults would keep the
-    // HID++ gesture button firing regardless of the selection.
+    // A HID++ gesture source (the dedicated button or the MX Master 4 haptic
+    // panel) only gestures while it owns the device's gesture role. When the
+    // user moves the role to an OS-hook button or turns gestures off, return an
+    // empty map so the capture watcher dispatches nothing.
     let owner = config_key.and_then(|key| config.gesture_owner(key));
-    if owner != Some(ButtonId::GestureButton) {
+    if !owner.is_some_and(ButtonId::is_hidpp_gesture_source) {
         return BTreeMap::new();
     }
     let stored = config_key
@@ -239,6 +238,25 @@ mod tests {
         assert!(
             gesture_bindings_for(&cfg, Some("2b042")).is_empty(),
             "HID++ gesture button must dispatch nothing once another button owns gestures"
+        );
+    }
+
+    #[test]
+    fn haptic_panel_owner_uses_its_own_gesture_map() {
+        let mut cfg = Config::default();
+        cfg.set_gesture_owner("2b042", ButtonId::HapticPanel);
+        cfg.set_gesture_direction(
+            "2b042",
+            ButtonId::HapticPanel,
+            GestureDirection::Click,
+            Action::Copy,
+        );
+
+        let bindings = gesture_bindings_for(&cfg, Some("2b042"));
+        assert_eq!(bindings.get(&GestureDirection::Click), Some(&Action::Copy));
+        assert!(
+            oshook_gestures_for(&cfg, Some("2b042"), None).is_empty(),
+            "the haptic panel is captured over HID++, never the OS hook"
         );
     }
 }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -25,7 +25,7 @@ use crate::device_order::DeviceStableId;
 use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::ipc::InventoryHealth;
 use crate::receiver_access::ReceiverAccess;
-use crate::watchers::gesture::GestureBindings;
+use crate::watchers::gesture::{GestureBindings, HidppGestureOwner};
 
 /// The minimal per-device facts the agent needs: the config key (binding /
 /// preset lookup), the HID++ route (DPI/SmartShift writes + capture target), and
@@ -55,6 +55,7 @@ pub struct SharedRuntime {
     /// gesture watcher for the thumb-wheel/DPI-button single actions.
     pub hook_maps: SharedHookMaps,
     pub gesture_bindings: GestureBindings,
+    pub hidpp_gesture_owner: HidppGestureOwner,
     pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
     pub thumbwheel_sensitivity: Arc<AtomicI32>,
     pub capture_channel: CaptureChannel,
@@ -106,6 +107,7 @@ impl Orchestrator {
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
+            hidpp_gesture_owner: Arc::new(RwLock::new(None)),
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(AtomicI32::new(
                 config.app_settings.thumbwheel_sensitivity,
@@ -168,6 +170,12 @@ impl Orchestrator {
             &self.shared.gesture_bindings,
             gesture_bindings_for(&self.config, key),
             "gesture_bindings",
+        );
+        write_value(
+            &self.shared.hidpp_gesture_owner,
+            key.and_then(|k| self.config.gesture_owner(k))
+                .filter(|owner| owner.is_hidpp_gesture_source()),
+            "hidpp_gesture_owner",
         );
         write_value(
             &self.shared.dpi_cycle,

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -38,9 +38,15 @@ use crate::receiver_access::ReceiverAccess;
 /// direction). The watcher reads it to map a captured swipe to a bound action.
 pub type GestureBindings = Arc<RwLock<BTreeMap<GestureDirection, Action>>>;
 
+/// The active device's HID++ gesture owner. `None` means gestures are off or
+/// owned by an OS-hook button.
+pub type HidppGestureOwner = Arc<RwLock<Option<ButtonId>>>;
+
 /// Shared thumb-wheel sensitivity, mirrored from `AppState`. Read on every wheel
 /// event; written only by `AppState::set_thumbwheel_sensitivity`.
 pub type ThumbwheelSensitivity = Arc<AtomicI32>;
+
+type CaptureTarget = (DeviceRoute, bool, Option<u16>, Vec<(u16, ButtonId)>);
 
 /// How often to re-read the active device target + thumb-wheel arming so a
 /// carousel switch or a binding/sensitivity edit re-points / re-arms capture.
@@ -77,6 +83,7 @@ fn action_threshold(sensitivity: i32) -> i32 {
 pub fn spawn(
     hook_maps: SharedHookMaps,
     gesture_bindings: GestureBindings,
+    hidpp_gesture_owner: HidppGestureOwner,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture_channel: CaptureChannel,
     thumbwheel_sensitivity: ThumbwheelSensitivity,
@@ -96,6 +103,7 @@ pub fn spawn(
         runtime.block_on(manage(
             hook_maps,
             gesture_bindings,
+            hidpp_gesture_owner,
             dpi_cycle,
             capture_channel,
             thumbwheel_sensitivity,
@@ -129,6 +137,22 @@ fn thumbwheel_armed(hook_maps: &SharedHookMaps, sensitivity: i32) -> bool {
     })
 }
 
+fn plain_hidpp_buttons(
+    hook_maps: &SharedHookMaps,
+    gesture_source: Option<u16>,
+) -> Vec<(u16, ButtonId)> {
+    let panel = openlogi_hid::reprog_controls::HAPTIC_PANEL_CID;
+    if gesture_source == Some(panel) {
+        return Vec::new();
+    }
+    hook_maps
+        .read()
+        .ok()
+        .and_then(|maps| maps.bindings.get(&ButtonId::HapticPanel).cloned())
+        .filter(|action| *action != default_binding(ButtonId::HapticPanel))
+        .map_or_else(Vec::new, |_| vec![(panel, ButtonId::HapticPanel)])
+}
+
 /// Whether a finished capture session should make the manager re-arm.
 ///
 /// `done_epoch` identifies the session that signalled completion; `live_epoch`
@@ -147,14 +171,15 @@ fn should_rearm(done_epoch: u64, live_epoch: u64, has_target: bool) -> bool {
 async fn manage(
     hook_maps: SharedHookMaps,
     gesture_bindings: GestureBindings,
+    hidpp_gesture_owner: HidppGestureOwner,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture_channel: CaptureChannel,
     thumbwheel_sensitivity: ThumbwheelSensitivity,
     receiver_access: ReceiverAccess,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
-    // (route, capture_thumbwheel, divert_gesture_button)
-    let mut current: Option<(DeviceRoute, bool, bool)> = None;
+    // (route, capture_thumbwheel, gesture-source CID, plain HID++ buttons)
+    let mut current: Option<CaptureTarget> = None;
     let mut stop: Option<oneshot::Sender<()>> = None;
     let mut ticker = tokio::time::interval(TARGET_POLL);
     let mut accumulators = WheelAccumulators::default();
@@ -191,17 +216,17 @@ async fn manage(
                 } else {
                     let target = dpi_cycle.read().ok().and_then(|guard| guard.target.clone());
                     let sensitivity = thumbwheel_sensitivity.load(Ordering::Relaxed);
-                    // Divert the dedicated HID++ gesture button only while it owns the gesture role. The
-                    // shared gesture map is non-empty exactly then (gesture_bindings_for
-                    // gates on the owner), so it doubles as that signal — no need to
-                    // thread the full config in. Re-evaluated each tick, so a
-                    // ReloadConfig owner change restarts the session accordingly.
-                    let divert_gesture = gesture_bindings.read().is_ok_and(|g| !g.is_empty());
+                    let gesture_source = hidpp_gesture_owner
+                        .read()
+                        .ok()
+                        .and_then(|owner| owner.and_then(gesture_source_cid));
+                    let plain_buttons = plain_hidpp_buttons(&hook_maps, gesture_source);
                     target.map(|t| {
                         (
                             t,
                             thumbwheel_armed(&hook_maps, sensitivity),
-                            divert_gesture,
+                            gesture_source,
+                            plain_buttons,
                         )
                     })
                 };
@@ -218,12 +243,17 @@ async fn manage(
                     current = None;
                     continue;
                 }
-                if let Some((route, capture_thumbwheel, divert_gesture_button)) = want {
+                if let Some((route, capture_thumbwheel, gesture_source_cid, plain_buttons)) = want {
                     let Some(receiver_lease) = receiver_access.try_acquire_for_capture() else {
                         current = None;
                         continue;
                     };
-                    current = Some((route.clone(), capture_thumbwheel, divert_gesture_button));
+                    current = Some((
+                        route.clone(),
+                        capture_thumbwheel,
+                        gesture_source_cid,
+                        plain_buttons.clone(),
+                    ));
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let sink = tx.clone();
                     let slot = Arc::clone(&capture_channel);
@@ -235,7 +265,8 @@ async fn manage(
                         if let Err(e) = run_capture_session(
                             route,
                             capture_thumbwheel,
-                            divert_gesture_button,
+                            gesture_source_cid,
+                            plain_buttons,
                             sink,
                             stop_rx,
                             slot,
@@ -271,6 +302,14 @@ async fn manage(
                 }
             }
         }
+    }
+}
+
+fn gesture_source_cid(button: ButtonId) -> Option<u16> {
+    match button {
+        ButtonId::GestureButton => Some(openlogi_hid::reprog_controls::GESTURE_BUTTON_CID),
+        ButtonId::HapticPanel => Some(openlogi_hid::reprog_controls::HAPTIC_PANEL_CID),
+        _ => None,
     }
 }
 
@@ -597,5 +636,41 @@ mod tests {
         // The session was stopped on purpose (pairing took the receiver, or no
         // device is targeted): no target means there is nothing to re-arm.
         assert!(!should_rearm(7, 7, false));
+    }
+
+    #[test]
+    fn maps_each_hidpp_gesture_owner_to_its_physical_cid() {
+        assert_eq!(
+            gesture_source_cid(ButtonId::GestureButton),
+            Some(openlogi_hid::reprog_controls::GESTURE_BUTTON_CID)
+        );
+        assert_eq!(
+            gesture_source_cid(ButtonId::HapticPanel),
+            Some(openlogi_hid::reprog_controls::HAPTIC_PANEL_CID)
+        );
+        assert_eq!(gesture_source_cid(ButtonId::Back), None);
+    }
+
+    #[test]
+    fn plain_haptic_panel_is_armed_only_for_a_non_default_single_binding() {
+        let maps = Arc::new(RwLock::new(crate::hook_runtime::HookMaps::default()));
+        assert!(plain_hidpp_buttons(&maps, None).is_empty());
+
+        maps.write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .bindings
+            .insert(ButtonId::HapticPanel, Action::Copy);
+        assert_eq!(
+            plain_hidpp_buttons(&maps, None),
+            vec![(
+                openlogi_hid::reprog_controls::HAPTIC_PANEL_CID,
+                ButtonId::HapticPanel
+            )]
+        );
+        assert!(
+            plain_hidpp_buttons(&maps, Some(openlogi_hid::reprog_controls::HAPTIC_PANEL_CID))
+                .is_empty(),
+            "the gesture divert owns the panel while it is the gesture source"
+        );
     }
 }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -165,6 +165,7 @@ async fn run(config: Config) {
     watchers::gesture::spawn(
         shared.hook_maps.clone(),
         shared.gesture_bindings.clone(),
+        shared.hidpp_gesture_owner.clone(),
         shared.dpi_cycle.clone(),
         shared.capture_channel.clone(),
         shared.thumbwheel_sensitivity.clone(),

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -267,6 +267,7 @@ mod tests {
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
+            hidpp_gesture_owner: Arc::new(RwLock::new(None)),
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(0.into()),
             capture_channel: Arc::new(RwLock::new(None)),

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -51,13 +51,20 @@ pub enum ButtonId {
     /// The HID++ gesture button on MX-line devices. The press itself
     /// fires the bound action; swipe directions are P1.5 territory.
     GestureButton,
+    /// The MX Master 4 Haptic Sense Panel — the touch-sensitive thumb rest
+    /// (Logi metadata slot `ASSIGNMENT_NAME_SHOW_RADIAL_MENU`, HID++ CID
+    /// `0x01a0`). A separate physical control from [`ButtonId::GestureButton`];
+    /// captured over HID++ like it, and eligible as the gesture owner.
+    /// Declared last: the TOML config and any serialized form encode the
+    /// variant identifier / index, so new buttons are append-only.
+    HapticPanel,
 }
 
 impl ButtonId {
     /// Every rebindable button in declaration (physical front-to-side) order —
     /// the iteration source for default-binding seeding and the popover
     /// trigger list.
-    pub const ALL: [ButtonId; 10] = [
+    pub const ALL: [ButtonId; 11] = [
         ButtonId::LeftClick,
         ButtonId::RightClick,
         ButtonId::MiddleClick,
@@ -68,6 +75,7 @@ impl ButtonId {
         ButtonId::ThumbwheelScrollUp,
         ButtonId::ThumbwheelScrollDown,
         ButtonId::GestureButton,
+        ButtonId::HapticPanel,
     ];
 
     /// Whether this button is one the OS hook (macOS `CGEventTap` / Linux evdev)
@@ -85,6 +93,16 @@ impl ButtonId {
         )
     }
 
+    /// Whether this button is a HID++ gesture source — a control that is
+    /// captured over HID++ raw-XY diversion (never the OS hook) and can
+    /// therefore own the gesture role with swipe directions: the dedicated
+    /// gesture button, or the MX Master 4 haptic panel. The capture layer maps
+    /// each to its control ID.
+    #[must_use]
+    pub fn is_hidpp_gesture_source(self) -> bool {
+        matches!(self, ButtonId::GestureButton | ButtonId::HapticPanel)
+    }
+
     /// Human-readable label for popovers and tooltips.
     #[must_use]
     pub fn label(self) -> &'static str {
@@ -99,6 +117,7 @@ impl ButtonId {
             ButtonId::ThumbwheelScrollUp => "Thumb Wheel Up",
             ButtonId::ThumbwheelScrollDown => "Thumb Wheel Down",
             ButtonId::GestureButton => "Gesture Button",
+            ButtonId::HapticPanel => "Haptic Panel",
         }
     }
 }
@@ -758,6 +777,11 @@ pub fn default_binding(button: ButtonId) -> Action {
         ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollRight,
         ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollLeft,
         ButtonId::GestureButton => Action::MissionControl,
+        // The panel's firmware behavior (haptics, Options+ Actions Ring) has no
+        // OpenLogi equivalent yet, so an unbound panel stays native: `None`
+        // means "binding at its default" and the capture layer never diverts a
+        // button whose binding sits at the default.
+        ButtonId::HapticPanel => Action::None,
     }
 }
 

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -226,10 +226,13 @@ impl Config {
     /// per-direction adapter.
     #[must_use]
     pub fn gesture_bindings_for(&self, device_key: &str) -> BTreeMap<GestureDirection, Action> {
+        let Some(owner) = self.gesture_owner(device_key) else {
+            return BTreeMap::new();
+        };
         match self
             .devices
             .get(device_key)
-            .and_then(|d| d.bindings.get(&ButtonId::GestureButton))
+            .and_then(|d| d.bindings.get(&owner))
         {
             Some(Binding::Gesture(map)) => map.clone(),
             _ => BTreeMap::new(),

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI-skift"
 "Thumb Wheel": "Tommelfingerhjul"
 "Gesture Button": "Bevægelsesknap"
+"Haptic Panel": "Haptisk panel"
 "Up": "Op"
 "Down": "Ned"
 "Left": "Venstre"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI-Umschaltung"
 "Thumb Wheel": "Daumenrad"
 "Gesture Button": "Gestentaste"
+"Haptic Panel": "Haptik-Panel"
 "Up": "Oben"
 "Down": "Unten"
 "Left": "Links"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Εναλλαγή DPI"
 "Thumb Wheel": "Πλαϊνός τροχός"
 "Gesture Button": "Κουμπί χειρονομιών"
+"Haptic Panel": "Απτικό πάνελ"
 "Up": "Πάνω"
 "Down": "Κάτω"
 "Left": "Αριστερά"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI Toggle"
 "Thumb Wheel": "Thumb Wheel"
 "Gesture Button": "Gesture Button"
+"Haptic Panel": "Haptic Panel"
 "Up": "Up"
 "Down": "Down"
 "Left": "Left"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Cambiar DPI"
 "Thumb Wheel": "Rueda lateral"
 "Gesture Button": "Botón de gestos"
+"Haptic Panel": "Panel háptico"
 "Up": "Arriba"
 "Down": "Abajo"
 "Left": "Izquierda"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI-vaihto"
 "Thumb Wheel": "Peukalorulla"
 "Gesture Button": "Eletoiminto"
+"Haptic Panel": "Haptinen paneeli"
 "Up": "Ylös"
 "Down": "Alas"
 "Left": "Vasen"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Bascule DPI"
 "Thumb Wheel": "Molette latérale"
 "Gesture Button": "Bouton de gestes"
+"Haptic Panel": "Panneau haptique"
 "Up": "Haut"
 "Down": "Bas"
 "Left": "Gauche"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Cambia DPI"
 "Thumb Wheel": "Volante da pollice"
 "Gesture Button": "Pulsante gesture"
+"Haptic Panel": "Pannello aptico"
 "Up": "Su"
 "Down": "Giù"
 "Left": "Sinistra"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI 切り替え"
 "Thumb Wheel": "サムホイール"
 "Gesture Button": "ジェスチャーボタン"
+"Haptic Panel": "ハプティックパネル"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI 전환"
 "Thumb Wheel": "썸휠"
 "Gesture Button": "제스처 버튼"
+"Haptic Panel": "햅틱 패널"
 "Up": "위"
 "Down": "아래"
 "Left": "왼쪽"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI-veksling"
 "Thumb Wheel": "Tommelhjul"
 "Gesture Button": "Bevegelsesknapp"
+"Haptic Panel": "Haptisk panel"
 "Up": "Opp"
 "Down": "Ned"
 "Left": "Venstre"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI wisselen"
 "Thumb Wheel": "Duimwiel"
 "Gesture Button": "Gebarenknop"
+"Haptic Panel": "Haptisch paneel"
 "Up": "Omhoog"
 "Down": "Omlaag"
 "Left": "Links"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Przełącznik DPI"
 "Thumb Wheel": "Rolka kciukowa"
 "Gesture Button": "Przycisk gestów"
+"Haptic Panel": "Panel haptyczny"
 "Up": "W górę"
 "Down": "W dół"
 "Left": "W lewo"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Alternar DPI"
 "Thumb Wheel": "Roda do Polegar"
 "Gesture Button": "Botão de Gesto"
+"Haptic Panel": "Painel Háptico"
 "Up": "Cima"
 "Down": "Baixo"
 "Left": "Esquerda"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Alternar DPI"
 "Thumb Wheel": "Roda de polegar"
 "Gesture Button": "Botão de gesto"
+"Haptic Panel": "Painel háptico"
 "Up": "Cima"
 "Down": "Baixo"
 "Left": "Esquerda"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "Переключение DPI"
 "Thumb Wheel": "Колесо под большой палец"
 "Gesture Button": "Кнопка жестов"
+"Haptic Panel": "Тактильная панель"
 "Up": "Вверх"
 "Down": "Вниз"
 "Left": "Влево"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "DPI-växling"
 "Thumb Wheel": "Tumhjul"
 "Gesture Button": "Gestknapp"
+"Haptic Panel": "Haptisk panel"
 "Up": "Upp"
 "Down": "Ned"
 "Left": "Vänster"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "灵敏度切换"
 "Thumb Wheel": "拇指滚轮"
 "Gesture Button": "手势按钮"
+"Haptic Panel": "触感面板"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "靈敏度切換"
 "Thumb Wheel": "拇指滾輪"
 "Gesture Button": "手勢按鈕"
+"Haptic Panel": "觸感面板"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -157,6 +157,7 @@ _version: 1
 "DPI Toggle": "靈敏度切換"
 "Thumb Wheel": "拇指滾輪"
 "Gesture Button": "手勢按鈕"
+"Haptic Panel": "觸感面板"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/src/mouse_model/geometry.rs
+++ b/crates/openlogi-gui/src/mouse_model/geometry.rs
@@ -217,6 +217,10 @@ fn map_slot_name(name: &str) -> Option<ButtonId> {
         "SLOT_NAME_MODESHIFT_BUTTON" => Some(ButtonId::DpiToggle),
         "SLOT_NAME_THUMBWHEEL" => Some(ButtonId::Thumbwheel),
         "SLOT_NAME_GESTURE_BUTTON" => Some(ButtonId::GestureButton),
+        // The MX Master 4 Haptic Sense Panel. Logi names the slot after its
+        // Options+ default assignment (the radial Actions Ring menu), but the
+        // marker is the panel itself.
+        "ASSIGNMENT_NAME_SHOW_RADIAL_MENU" => Some(ButtonId::HapticPanel),
         _ => None,
     }
 }

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -278,10 +278,12 @@ fn scaled_model(
 }
 
 /// The gesture-capable buttons present on this device, in a stable display
-/// order: the HID++ gesture button first, then the OS-hook Middle/Back/Forward.
+/// order: the HID++ sources (gesture button, haptic panel) first, then the
+/// OS-hook Middle/Back/Forward.
 fn gesture_capable_buttons(labels: &[Label]) -> Vec<ButtonId> {
-    const ORDER: [ButtonId; 4] = [
+    const ORDER: [ButtonId; 5] = [
         ButtonId::GestureButton,
+        ButtonId::HapticPanel,
         ButtonId::MiddleClick,
         ButtonId::Back,
         ButtonId::Forward,

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -1359,8 +1359,10 @@ impl AppState {
             return BTreeMap::new();
         };
         match self.config.gesture_owner(key) {
-            // The HID++ gesture button seeds every direction from the defaults.
-            Some(ButtonId::GestureButton) => gesture_bindings_for(&self.config, Some(key)),
+            // HID++ gesture sources seed every direction from the defaults.
+            Some(owner) if owner.is_hidpp_gesture_source() => {
+                gesture_bindings_for(&self.config, Some(key))
+            }
             // A promoted OS-hook button is shown from its raw stored map (which
             // `set_gesture_owner` seeds with full defaults), so the menu matches
             // exactly what `oshook_gestures_for` dispatches — no seeding here.

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -1,6 +1,7 @@
-//! Live control capture for one device: divert the MX dedicated gesture button, the
-//! DPI/ModeShift button, and the thumb wheel over HID++ and turn their events
-//! into [`CapturedInput`] the GUI can dispatch.
+//! Live control capture for one device: divert one MX gesture source (the
+//! dedicated gesture button or MX Master 4 haptic panel), the DPI/ModeShift
+//! button, and the thumb wheel over HID++ and turn their events into
+//! [`CapturedInput`] the GUI can dispatch.
 //!
 //! [`run_capture_session`] holds a single HID++ channel open for one device,
 //! enables diversion on whichever of those controls it exposes, registers one
@@ -71,23 +72,25 @@ pub enum GestureError {
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
-    /// Mid-swipe state for the diverted dedicated gesture button (raw-XY).
+    /// Mid-swipe state for the diverted HID++ gesture source (raw-XY).
     swipe: SwipeAccumulator,
+    /// Whether to discard the next raw-XY report. The haptic panel's first
+    /// report after contact is an absolute-position jump, not a delta.
+    skip_first_raw_xy: bool,
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
+    /// Plain-diverted HID++ buttons held in the previous report.
+    plain_down: Vec<u16>,
 }
 
-/// Capture the gesture button, DPI/ModeShift button, and (when
+/// Capture the selected gesture source, DPI/ModeShift button, and (when
 /// `capture_thumbwheel`) the thumb wheel on `route` until `shutdown` resolves,
 /// forwarding each event to `sink`.
 ///
-/// The dedicated gesture button (raw-XY) is diverted only when `divert_gesture_button` —
-/// i.e. it is the device's gesture owner. When the user moves the gesture role
-/// to an OS-hook button or turns gestures off, the HID++ gesture control is
-/// left undiverted so it keeps its native behavior instead of being
-/// captured-and-swallowed. The DPI/ModeShift capture and the channel-reuse slot
-/// are independent of this.
+/// `gesture_source_cid` is the physical HID++ control that owns the gesture
+/// role. `None` leaves both HID++ gesture sources native, as required when an
+/// OS-hook button owns gestures or gestures are disabled.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
 /// device exposes, and listens. Returns once `shutdown` fires (or its sender is
@@ -96,7 +99,8 @@ struct CaptureAccum {
 pub async fn run_capture_session(
     route: DeviceRoute,
     capture_thumbwheel: bool,
-    divert_gesture_button: bool,
+    gesture_source_cid: Option<u16>,
+    plain_buttons: Vec<(u16, ButtonId)>,
     sink: mpsc::UnboundedSender<CapturedInput>,
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
@@ -109,7 +113,8 @@ pub async fn run_capture_session(
         &chan,
         device_index,
         capture_thumbwheel,
-        divert_gesture_button,
+        gesture_source_cid,
+        &plain_buttons,
     )
     .await?;
 
@@ -121,8 +126,10 @@ pub async fn run_capture_session(
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
+    let gesture_cid = armed.gesture_cid;
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
     let dpi_set = armed.dpi_cids.clone();
+    let button_set = armed.button_cids.clone();
     let listener = chan.add_msg_listener_guarded({
         let accum = Arc::clone(&accum);
         let sink = sink.clone();
@@ -137,7 +144,7 @@ pub async fn run_capture_session(
                 // Recover the guard even if a prior holder panicked — the
                 // critical section is panic-free, so the data is consistent.
                 let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(&mut acc, event, &dpi_set, &sink);
+                handle_reprog(&mut acc, event, gesture_cid, &dpi_set, &button_set, &sink);
                 return;
             }
             if let Some(idx) = thumb_index
@@ -155,8 +162,9 @@ pub async fn run_capture_session(
 
     info!(
         index = device_index,
-        gesture = armed.gesture_diverted,
+        gesture = armed.gesture_cid.is_some(),
         dpi_buttons = armed.dpi_cids.len(),
+        buttons = armed.button_cids.len(),
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
@@ -176,10 +184,12 @@ pub async fn run_capture_session(
 struct ArmedControls {
     /// `0x1b04` accessor + feature index, present when the device exposes it.
     reprog: Option<(ReprogControlsV4, u8)>,
-    /// Whether the gesture button is diverted with raw-XY reporting.
-    gesture_diverted: bool,
+    /// Gesture-source CID diverted with raw-XY reporting.
+    gesture_cid: Option<u16>,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
+    /// Other controls diverted as plain button presses.
+    button_cids: Vec<(u16, ButtonId)>,
     /// `0x2150` accessor + feature index, present when the thumb wheel is
     /// diverted.
     thumb: Option<(Thumbwheel, u8)>,
@@ -189,14 +199,17 @@ impl ArmedControls {
     /// Restore every diverted control. Failures are logged, not propagated.
     async fn disarm(&self) {
         if let Some((rc, _)) = self.reprog.as_ref() {
-            if self.gesture_diverted {
-                let r = rc
-                    .set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, false, false)
-                    .await;
-                restore(r, "gesture button");
+            if let Some(cid) = self.gesture_cid {
+                restore(
+                    rc.set_cid_reporting(cid, false, false).await,
+                    "gesture source",
+                );
             }
             for &cid in &self.dpi_cids {
                 restore(rc.set_cid_reporting(cid, false, false).await, "DPI button");
+            }
+            for &(cid, _) in &self.button_cids {
+                restore(rc.set_cid_reporting(cid, false, false).await, "button");
             }
         }
         if let Some((tw, _)) = self.thumb.as_ref() {
@@ -214,15 +227,17 @@ async fn arm_controls(
     chan: &Arc<HidppChannel>,
     slot: u8,
     capture_thumbwheel: bool,
-    divert_gesture_button: bool,
+    gesture_source_cid: Option<u16>,
+    plain_buttons: &[(u16, ButtonId)],
 ) -> Result<ArmedControls, GestureError> {
     let device = Device::new(Arc::clone(chan), slot)
         .await
         .map_err(|_| GestureError::DeviceUnreachable(slot))?;
 
     let mut reprog: Option<(ReprogControlsV4, u8)> = None;
-    let mut gesture_diverted = false;
+    let mut gesture_cid = None;
     let mut dpi_cids: Vec<u16> = Vec::new();
+    let mut button_cids = Vec::new();
     if let Some(info) = device
         .root()
         .get_feature(reprog_controls::FEATURE_ID)
@@ -232,17 +247,15 @@ async fn arm_controls(
         let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
         let controls = enumerate_controls(&rc).await?;
 
-        // Only divert the gesture button when it owns the gesture role; otherwise
-        // leave it native (a non-owner HID++ control must not be captured-and-dropped).
-        if divert_gesture_button
-            && controls
-                .iter()
-                .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
+        // Divert only the selected gesture owner. The other HID++ gesture
+        // source stays native rather than being captured and swallowed.
+        if let Some(cid) = gesture_source_cid
+            && controls.iter().any(|c| c.cid == cid && c.supports_raw_xy())
         {
-            rc.set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, true, true)
+            rc.set_cid_reporting(cid, true, true)
                 .await
                 .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-            gesture_diverted = true;
+            gesture_cid = Some(cid);
         }
         for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
@@ -250,6 +263,17 @@ async fn arm_controls(
                     .await
                     .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
                 dpi_cids.push(cid);
+            }
+        }
+        for &(cid, button) in plain_buttons {
+            if gesture_cid == Some(cid) {
+                continue;
+            }
+            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+                rc.set_cid_reporting(cid, true, false)
+                    .await
+                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                button_cids.push((cid, button));
             }
         }
         reprog = Some((rc, info.index));
@@ -287,13 +311,14 @@ async fn arm_controls(
         thumb = Some((tw, info.index));
     }
 
-    if !gesture_diverted && dpi_cids.is_empty() && thumb.is_none() {
+    if gesture_cid.is_none() && dpi_cids.is_empty() && button_cids.is_empty() && thumb.is_none() {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(ArmedControls {
         reprog,
-        gesture_diverted,
+        gesture_cid,
         dpi_cids,
+        button_cids,
         thumb,
     })
 }
@@ -332,14 +357,17 @@ async fn enumerate_controls(
 fn handle_reprog(
     acc: &mut CaptureAccum,
     event: RawControlEvent,
+    gesture_cid: Option<u16>,
     dpi_cids: &[u16],
+    button_cids: &[(u16, ButtonId)],
     sink: &mpsc::UnboundedSender<CapturedInput>,
 ) {
     match event {
         RawControlEvent::DivertedButtons(cids) => {
-            let gesture_held = cids.contains(&reprog_controls::GESTURE_BUTTON_CID);
+            let gesture_held = gesture_cid.is_some_and(|cid| cids.contains(&cid));
             if gesture_held && !acc.swipe.is_holding() {
                 acc.swipe.begin();
+                acc.skip_first_raw_xy = gesture_cid == Some(reprog_controls::HAPTIC_PANEL_CID);
             } else if !gesture_held && acc.swipe.is_holding() {
                 // A press that never committed a direction is a plain click.
                 if acc.swipe.end() {
@@ -353,8 +381,23 @@ fn handle_reprog(
                 let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::DpiToggle));
             }
             acc.dpi_down = dpi_down;
+
+            let mut next_plain_down = Vec::new();
+            for &(cid, button) in button_cids {
+                if cids.contains(&cid) {
+                    next_plain_down.push(cid);
+                    if !acc.plain_down.contains(&cid) {
+                        let _ = sink.send(CapturedInput::ButtonPressed(button));
+                    }
+                }
+            }
+            acc.plain_down = next_plain_down;
         }
         RawControlEvent::RawXy { dx, dy } => {
+            if acc.skip_first_raw_xy {
+                acc.skip_first_raw_xy = false;
+                return;
+            }
             // Commit the instant a clean direction emerges (mid-swipe, once per
             // hold); the accumulator gates on hold duration internally and drops
             // travel that arrives outside a hold.

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -13,14 +13,30 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &[], &tx);
     handle_reprog(
         &mut acc,
-        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        press(),
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
         &[],
         &tx,
     );
-    handle_reprog(&mut acc, release(), &[], &tx);
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
+        &[],
+        &tx,
+    );
+    handle_reprog(
+        &mut acc,
+        release(),
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
+        &[],
+        &tx,
+    );
 
     assert_eq!(
         rx.try_recv(),
@@ -37,12 +53,21 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &[], &tx);
+    handle_reprog(
+        &mut acc,
+        press(),
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
+        &[],
+        &tx,
+    );
     // Pretend the button has been held well past the swipe gate.
     acc.swipe.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
         &[],
         &tx,
     );
@@ -52,7 +77,14 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
         Ok(CapturedInput::Gesture(GestureDirection::Right))
     );
 
-    handle_reprog(&mut acc, release(), &[], &tx);
+    handle_reprog(
+        &mut acc,
+        release(),
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
+        &[],
+        &tx,
+    );
     assert!(
         rx.try_recv().is_err(),
         "a committed swipe must not also click on release"
@@ -66,8 +98,8 @@ fn a_held_dpi_button_presses_once_on_the_rising_edge() {
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
 
-    handle_reprog(&mut acc, down, &[dpi], &tx);
-    handle_reprog(&mut acc, down, &[dpi], &tx);
+    handle_reprog(&mut acc, down, None, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, None, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -87,9 +119,9 @@ fn a_dpi_button_re_presses_after_a_release() {
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
     let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
 
-    handle_reprog(&mut acc, down, &[dpi], &tx);
-    handle_reprog(&mut acc, up, &[dpi], &tx);
-    handle_reprog(&mut acc, down, &[dpi], &tx);
+    handle_reprog(&mut acc, down, None, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, up, None, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, None, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -99,6 +131,86 @@ fn a_dpi_button_re_presses_after_a_release() {
         rx.try_recv(),
         Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle)),
         "a release re-arms the rising edge"
+    );
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn haptic_panel_discards_its_contact_jump_then_commits_swipe() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let panel = reprog_controls::HAPTIC_PANEL_CID;
+    let down = RawControlEvent::DivertedButtons([panel, 0, 0, 0]);
+
+    handle_reprog(&mut acc, down, Some(panel), &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 2_000, dy: 0 },
+        Some(panel),
+        &[],
+        &[],
+        &tx,
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "the first panel report is an absolute contact position, not a swipe"
+    );
+
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        Some(panel),
+        &[],
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(GestureDirection::Right))
+    );
+}
+
+#[test]
+fn non_owner_hidpp_source_is_ignored() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let panel = reprog_controls::HAPTIC_PANEL_CID;
+    let panel_down = RawControlEvent::DivertedButtons([panel, 0, 0, 0]);
+
+    handle_reprog(
+        &mut acc,
+        panel_down,
+        Some(reprog_controls::GESTURE_BUTTON_CID),
+        &[],
+        &[],
+        &tx,
+    );
+    handle_reprog(&mut acc, release(), None, &[], &[], &tx);
+
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn plain_haptic_panel_binding_fires_once_per_press() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let panel = reprog_controls::HAPTIC_PANEL_CID;
+    let buttons = [(panel, ButtonId::HapticPanel)];
+    let down = RawControlEvent::DivertedButtons([panel, 0, 0, 0]);
+
+    handle_reprog(&mut acc, down, None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, down, None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, down, None, &[], &buttons, &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::HapticPanel))
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::HapticPanel))
     );
     assert!(rx.try_recv().is_err());
 }

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -43,6 +43,12 @@ pub const FEATURE_ID: u16 = 0x1b04;
 /// bindable/capturable input.
 pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 
+/// Control ID of the MX Master 4 Haptic Sense Panel. It is a separate
+/// raw-XY-capable control from [`GESTURE_BUTTON_CID`]. Its first raw-XY report
+/// after contact is an absolute-position jump and must not enter the swipe
+/// accumulator.
+pub const HAPTIC_PANEL_CID: u16 = 0x01a0;
+
 /// Control IDs of the "DPI / ModeShift" button family. Whichever a device
 /// exposes (and can divert) is captured and mapped to
 /// [`ButtonId::DpiToggle`](openlogi_core::binding::ButtonId::DpiToggle): the MX


### PR DESCRIPTION
## Summary

Add focused MX Master 4 Haptic Sense Panel input support without coupling it to the larger Action Ring UI work.

The panel is now exposed as a bindable control and can be used either as a plain button or as the active HID++ gesture source for Click/Up/Down/Left/Right bindings. Older MX devices keep using the existing dedicated gesture-button CID.

Fixes #313.

## Changes

- add `ButtonId::HapticPanel` and surface it in the device controls UI
- map the MX Master 4 panel to HID++ CID `0x01a0`
- select the physical raw-XY gesture source from the configured gesture owner
- discard the panel's first absolute-position raw-XY report after contact
- support a non-gesture single binding with rising-edge press detection
- leave non-owned HID++ gesture controls in their native mode and restore diverted controls on teardown
- add the Haptic Panel label to all 20 locale files

This PR intentionally does not implement Action Ring UI or haptic-feedback output; those remain separate concerns tracked by #15 and #92.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p openlogi-core -p openlogi-hid --lib --offline -- -D warnings`
- `cargo clippy -p openlogi-agent-core --all-targets --offline -- -D warnings`
- `cargo test -p openlogi-core -p openlogi-hid --offline` (187 tests)
- `cargo test -p openlogi-agent-core --offline` (56 tests)
- `cargo check -p openlogi-agent --locked`

Hardware runtime validation and the full GUI build were not available locally because this macOS environment has Command Line Tools but not the full Xcode/Metal toolchain. The PR is therefore opened as a draft for CI and MX Master 4 hardware validation.

## Attribution

The core button model, UI metadata, and locale work preserve Hiroaki Tagawa's original commit authorship. The capture implementation is adapted from the same MX Master 4 investigation and credits that work as a co-authored commit.
