### PR TITLE
fix(agent): reuse inventory channels for input capture

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, RwLock};
 
 use openlogi_core::config::{Config, ScrollResolution};
 use openlogi_core::device::{Capabilities, DeviceInventory};
-use openlogi_hid::{CaptureChannel, DeviceRoute};
+use openlogi_hid::{CaptureChannel, ChannelRegistry, DeviceRoute};
 use tracing::warn;
 
 use crate::DpiCycleState;
@@ -58,6 +58,8 @@ pub struct SharedRuntime {
     pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
     pub thumbwheel_sensitivity: Arc<AtomicI32>,
     pub capture_channel: CaptureChannel,
+    /// Exact-route channels owned and published by the inventory enumerator.
+    pub channel_registry: ChannelRegistry,
     /// Exclusive receiver access shared by HID++ capture and pairing. Capture
     /// and pairing must never open the same receiver HID node concurrently.
     pub receiver_access: ReceiverAccess,
@@ -111,6 +113,7 @@ impl Orchestrator {
                 config.app_settings.thumbwheel_sensitivity,
             )),
             capture_channel: Arc::new(RwLock::new(None)),
+            channel_registry: ChannelRegistry::default(),
             receiver_access: ReceiverAccess::default(),
         };
         let orch = Self {

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -27,8 +27,8 @@ use std::time::{Duration, Instant};
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 use openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY;
 use openlogi_hid::{
-    CaptureChannel, CaptureStop, CapturedInput, ChannelRegistry, DeviceRoute, run_capture_session,
-    run_capture_session_with_registry,
+    CaptureChannel, CaptureStop, CapturedInput, ChannelRegistry, DeviceRoute,
+    run_capture_session_with_registry, run_capture_session_with_stop_reason,
 };
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
@@ -251,7 +251,7 @@ fn spawn_capture_session(launch: CaptureLaunch) -> oneshot::Sender<CaptureStop> 
                 )
                 .await
             } else {
-                run_capture_session(
+                run_capture_session_with_stop_reason(
                     launch.route,
                     launch.capture_thumbwheel,
                     launch.divert_gesture_button,

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -26,13 +26,16 @@ use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 use openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY;
-use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
+use openlogi_hid::{
+    CaptureChannel, CaptureStop, CapturedInput, ChannelRegistry, DeviceRoute, run_capture_session,
+    run_capture_session_with_registry,
+};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
 use crate::DpiCycleState;
 use crate::hook_runtime::{self, SharedHookMaps};
-use crate::receiver_access::ReceiverAccess;
+use crate::receiver_access::{CaptureReceiverLease, ReceiverAccess};
 
 /// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
 /// direction). The watcher reads it to map a captured swipe to a bound action.
@@ -82,6 +85,47 @@ pub fn spawn(
     thumbwheel_sensitivity: ThumbwheelSensitivity,
     receiver_access: ReceiverAccess,
 ) {
+    spawn_inner(
+        hook_maps,
+        gesture_bindings,
+        dpi_cycle,
+        capture_channel,
+        thumbwheel_sensitivity,
+        receiver_access,
+        None,
+    );
+}
+
+/// Spawn capture in Agent mode, reusing only inventory-published channels.
+pub fn spawn_with_registry(
+    hook_maps: SharedHookMaps,
+    gesture_bindings: GestureBindings,
+    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    capture_channel: CaptureChannel,
+    thumbwheel_sensitivity: ThumbwheelSensitivity,
+    receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
+) {
+    spawn_inner(
+        hook_maps,
+        gesture_bindings,
+        dpi_cycle,
+        capture_channel,
+        thumbwheel_sensitivity,
+        receiver_access,
+        Some(registry),
+    );
+}
+
+fn spawn_inner(
+    hook_maps: SharedHookMaps,
+    gesture_bindings: GestureBindings,
+    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    capture_channel: CaptureChannel,
+    thumbwheel_sensitivity: ThumbwheelSensitivity,
+    receiver_access: ReceiverAccess,
+    registry: Option<ChannelRegistry>,
+) {
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -100,6 +144,7 @@ pub fn spawn(
             capture_channel,
             thumbwheel_sensitivity,
             receiver_access,
+            registry,
         ));
     });
 }
@@ -141,6 +186,94 @@ fn should_rearm(done_epoch: u64, live_epoch: u64, has_target: bool) -> bool {
     done_epoch == live_epoch && has_target
 }
 
+fn stop_reason<T: PartialEq>(
+    want: Option<&T>,
+    current: Option<&T>,
+    connection_is_current: bool,
+) -> Option<CaptureStop> {
+    current?;
+    if want == current {
+        (!connection_is_current).then_some(CaptureStop::Revoked)
+    } else {
+        Some(CaptureStop::Graceful)
+    }
+}
+
+fn acknowledge_stopping(stopping_epoch: &mut Option<u64>, done_epoch: u64) -> bool {
+    if *stopping_epoch == Some(done_epoch) {
+        *stopping_epoch = None;
+        true
+    } else {
+        false
+    }
+}
+
+fn capture_connection_is_current(
+    registry: Option<&ChannelRegistry>,
+    capture_channel: &CaptureChannel,
+) -> bool {
+    let Some(registry) = registry else {
+        return true;
+    };
+    capture_channel
+        .read()
+        .ok()
+        .and_then(|slot| slot.clone())
+        .is_some_and(|shared| registry.is_current(&shared))
+}
+
+struct CaptureLaunch {
+    route: DeviceRoute,
+    capture_thumbwheel: bool,
+    divert_gesture_button: bool,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    channel_slot: CaptureChannel,
+    receiver_lease: CaptureReceiverLease,
+    registry: Option<ChannelRegistry>,
+    done: mpsc::UnboundedSender<u64>,
+    epoch: u64,
+}
+
+fn spawn_capture_session(launch: CaptureLaunch) -> oneshot::Sender<CaptureStop> {
+    let (stop_tx, stop_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let result = {
+            let receiver_lease = launch.receiver_lease;
+            let result = if let Some(registry) = launch.registry.as_ref() {
+                run_capture_session_with_registry(
+                    launch.route,
+                    launch.capture_thumbwheel,
+                    launch.divert_gesture_button,
+                    launch.sink,
+                    stop_rx,
+                    launch.channel_slot,
+                    registry,
+                )
+                .await
+            } else {
+                run_capture_session(
+                    launch.route,
+                    launch.capture_thumbwheel,
+                    launch.divert_gesture_button,
+                    launch.sink,
+                    stop_rx,
+                    launch.channel_slot,
+                )
+                .await
+            };
+            drop(receiver_lease);
+            result
+        };
+        if let Err(error) = result {
+            debug!(%error, "capture session ended");
+        }
+        // Completion is sent only after the capture future released its channel
+        // and the receiver lease above, so the manager can safely replace it.
+        let _ = launch.done.send(launch.epoch);
+    });
+    stop_tx
+}
+
 /// Keep one capture session alive for the active device, restarting it when the
 /// device or the thumb-wheel arming changes, and dispatch incoming inputs. Runs
 /// for the lifetime of the process.
@@ -151,11 +284,13 @@ async fn manage(
     capture_channel: CaptureChannel,
     thumbwheel_sensitivity: ThumbwheelSensitivity,
     receiver_access: ReceiverAccess,
+    registry: Option<ChannelRegistry>,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedInput>();
     // (route, capture_thumbwheel, divert_gesture_button)
     let mut current: Option<(DeviceRoute, bool, bool)> = None;
-    let mut stop: Option<oneshot::Sender<()>> = None;
+    let mut stop: Option<oneshot::Sender<CaptureStop>> = None;
+    let mut stopping_epoch: Option<u64> = None;
     let mut ticker = tokio::time::interval(TARGET_POLL);
     let mut accumulators = WheelAccumulators::default();
     // Capture sessions run as detached tasks, so an unexpected exit (a transient
@@ -205,17 +340,22 @@ async fn manage(
                         )
                     })
                 };
-                if want == current {
+                if stopping_epoch.is_some() {
                     continue;
                 }
-                // Target or thumb-wheel arming changed (or first tick): stop the
-                // old session and start one for the new state. Sending on the
-                // oneshot lets the old session restore the diverted controls.
-                if let Some(stop) = stop.take() {
-                    let _ = stop.send(());
-                }
-                if current.is_some() {
+                let connection_is_current =
+                    capture_connection_is_current(registry.as_ref(), &capture_channel);
+                if let Some(reason) =
+                    stop_reason(want.as_ref(), current.as_ref(), connection_is_current)
+                {
+                    if let Some(stop) = stop.take() {
+                        let _ = stop.send(reason);
+                    }
+                    stopping_epoch = Some(epoch);
                     current = None;
+                    continue;
+                }
+                if want == current {
                     continue;
                 }
                 if let Some((route, capture_thumbwheel, divert_gesture_button)) = want {
@@ -224,36 +364,30 @@ async fn manage(
                         continue;
                     };
                     current = Some((route.clone(), capture_thumbwheel, divert_gesture_button));
-                    let (stop_tx, stop_rx) = oneshot::channel();
-                    let sink = tx.clone();
-                    let slot = Arc::clone(&capture_channel);
                     epoch = epoch.wrapping_add(1);
-                    let session_epoch = epoch;
-                    let done = done_tx.clone();
-                    tokio::spawn(async move {
-                        let _receiver_lease = receiver_lease;
-                        if let Err(e) = run_capture_session(
-                            route,
-                            capture_thumbwheel,
-                            divert_gesture_button,
-                            sink,
-                            stop_rx,
-                            slot,
-                        )
-                        .await
-                        {
-                            debug!(error = %e, "capture session ended");
-                        }
-                        // Report completion so the manager can re-arm if this exit
-                        // was unexpected rather than a deliberate stop.
-                        let _ = done.send(session_epoch);
-                    });
-                    stop = Some(stop_tx);
+                    stop = Some(spawn_capture_session(CaptureLaunch {
+                        route,
+                        capture_thumbwheel,
+                        divert_gesture_button,
+                        sink: tx.clone(),
+                        channel_slot: Arc::clone(&capture_channel),
+                        receiver_lease,
+                        registry: registry.clone(),
+                        done: done_tx.clone(),
+                        epoch,
+                    }));
                 } else {
                     current = None;
                 }
             }
             Some(done_epoch) = done_rx.recv() => {
+                if acknowledge_stopping(&mut stopping_epoch, done_epoch) {
+                    // The stopped task has cleared its slot, dropped the
+                    // listener/channel and released any receiver lease. A later
+                    // poll may now arm the desired replacement.
+                    stop = None;
+                    continue;
+                }
                 // A capture session ended on its own. Re-arm only when it is the
                 // session we currently believe is live for an active target;
                 // clearing `current` lets the next tick start a fresh session.
@@ -445,6 +579,9 @@ fn advance(
 
 #[cfg(test)]
 mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::PoisonError;
+
     use super::*;
 
     #[test]
@@ -597,5 +734,59 @@ mod tests {
         // The session was stopped on purpose (pairing took the receiver, or no
         // device is targeted): no target means there is nothing to re-arm.
         assert!(!should_rearm(7, 7, false));
+    }
+
+    #[test]
+    fn unchanged_target_keeps_the_current_connection() {
+        assert_eq!(
+            stop_reason(Some(&"device-a"), Some(&"device-a"), true),
+            None
+        );
+    }
+
+    #[test]
+    fn revoked_connection_stops_without_disarming_it() {
+        assert_eq!(
+            stop_reason(Some(&"device-a"), Some(&"device-a"), false),
+            Some(CaptureStop::Revoked)
+        );
+    }
+
+    #[test]
+    fn target_change_stops_gracefully_while_connection_is_current() {
+        assert_eq!(
+            stop_reason(Some(&"device-b"), Some(&"device-a"), true),
+            Some(CaptureStop::Graceful)
+        );
+        assert_eq!(
+            stop_reason::<&str>(None, Some(&"device-a"), true),
+            Some(CaptureStop::Graceful)
+        );
+    }
+
+    #[test]
+    fn replacement_waits_for_the_stopped_epochs_acknowledgement() {
+        let mut stopping_epoch = Some(7);
+
+        assert!(!acknowledge_stopping(&mut stopping_epoch, 6));
+        assert_eq!(stopping_epoch, Some(7));
+
+        assert!(acknowledge_stopping(&mut stopping_epoch, 7));
+        assert_eq!(stopping_epoch, None);
+    }
+
+    #[test]
+    fn poisoned_capture_slot_fails_the_current_connection_check_closed() {
+        let capture: CaptureChannel = Arc::new(RwLock::new(None));
+        let poison = Arc::clone(&capture);
+        let _ = catch_unwind(AssertUnwindSafe(move || {
+            let _guard = poison.write().unwrap_or_else(PoisonError::into_inner);
+            panic!("poison capture slot");
+        }));
+
+        assert!(!capture_connection_is_current(
+            Some(&ChannelRegistry::default()),
+            &capture
+        ));
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, SystemTime};
 
 use futures_lite::StreamExt as _;
 use openlogi_core::device::DeviceInventory;
+use openlogi_hid::ChannelRegistry;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -110,7 +111,25 @@ impl WatchState {
 /// the loop exits cleanly. The watcher dying instead (a panic inside the HID
 /// backend) closes the channel — the agent select loop maps that closure to
 /// `Unavailable` too.
+#[must_use]
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
+    spawn_inner(period, None)
+}
+
+/// Spawn the persistent watcher and publish its inventory-owned HID++ channels
+/// into `registry` for Agent capture and hardware operations.
+#[must_use]
+pub fn spawn_with_registry(
+    period: Duration,
+    registry: ChannelRegistry,
+) -> mpsc::UnboundedReceiver<InventoryEvent> {
+    spawn_inner(period, Some(registry))
+}
+
+fn spawn_inner(
+    period: Duration,
+    registry: Option<ChannelRegistry>,
+) -> mpsc::UnboundedReceiver<InventoryEvent> {
     let (tx, rx) = mpsc::unbounded_channel();
     let worker_tx = tx.clone();
     let spawn_result = thread::Builder::new()
@@ -129,7 +148,10 @@ pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<InventoryEvent> {
             // A persistent enumerator so its per-device probe cache survives
             // across ticks — a known device's immutable data (model, features)
             // is reused instead of being re-handshaked every poll.
-            let mut enumerator = openlogi_hid::Enumerator::default();
+            let mut enumerator = registry.map_or_else(
+                openlogi_hid::Enumerator::default,
+                openlogi_hid::Enumerator::with_registry,
+            );
             let mut state = WatchState::default();
             let mut last_tick = SystemTime::now();
             // `block_on` installs runtime context so a backend that registers an

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -162,16 +162,20 @@ async fn run(config: Config) {
     // wheel) needs no Accessibility permission — start it up front. It reads the
     // shared maps and dispatches bound actions itself; the two pairing flags let
     // it release its capture session while a pairing session owns the receiver.
-    watchers::gesture::spawn(
+    watchers::gesture::spawn_with_registry(
         shared.hook_maps.clone(),
         shared.gesture_bindings.clone(),
         shared.dpi_cycle.clone(),
         shared.capture_channel.clone(),
         shared.thumbwheel_sensitivity.clone(),
         shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
     );
 
-    let mut inventory_rx = watchers::inventory::spawn(Duration::from_secs(2));
+    let mut inventory_rx = watchers::inventory::spawn_with_registry(
+        Duration::from_secs(2),
+        shared.channel_registry.clone(),
+    );
     let mut app_rx = watchers::foreground_app::spawn(Duration::from_secs(1));
     let mut accessibility_rx = watchers::accessibility::spawn(Duration::from_millis(1200));
 

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -270,6 +270,7 @@ mod tests {
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(0.into()),
             capture_channel: Arc::new(RwLock::new(None)),
+            channel_registry: openlogi_hid::ChannelRegistry::default(),
             receiver_access: ReceiverAccess::default(),
         }
     }

--- a/crates/openlogi-hid/src/channel_registry.rs
+++ b/crates/openlogi-hid/src/channel_registry.rs
@@ -209,6 +209,7 @@ impl ChannelRegistry {
 mod tests {
     use std::collections::HashSet;
     use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::Arc;
 
     use crate::DeviceRoute;
 
@@ -280,6 +281,22 @@ mod tests {
         assert!(
             !registry.any_current(|candidate, channel| { candidate == &route && *channel == "b" })
         );
+    }
+
+    #[test]
+    fn same_route_with_a_different_arc_is_not_current() {
+        let route = direct(0xb35b);
+        let published = Arc::new(());
+        let stale = Arc::new(());
+        let registry = Registry::<u8, Arc<()>>::default();
+        registry.replace_node(1, [route.clone()], Arc::clone(&published));
+
+        assert!(registry.any_current(|candidate, channel| {
+            candidate == &route && Arc::ptr_eq(channel, &published)
+        }));
+        assert!(!registry.any_current(|candidate, channel| {
+            candidate == &route && Arc::ptr_eq(channel, &stale)
+        }));
     }
 
     #[test]

--- a/crates/openlogi-hid/src/channel_registry.rs
+++ b/crates/openlogi-hid/src/channel_registry.rs
@@ -1,0 +1,346 @@
+//! Registry of HID++ channels owned by the persistent inventory enumerator.
+
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::sync::{Arc, PoisonError, RwLock};
+
+use async_hid::DeviceId;
+use hidpp::channel::HidppChannel;
+
+use crate::{DeviceRoute, SharedChannel};
+
+struct Publication<Node, Channel> {
+    node: Node,
+    sequence: u64,
+    routes: Vec<DeviceRoute>,
+    channel: Channel,
+}
+
+struct NodeRegistry<Node, Channel> {
+    publications: Vec<Publication<Node, Channel>>,
+    next_sequence: u64,
+}
+
+impl<Node, Channel> Default for NodeRegistry<Node, Channel> {
+    fn default() -> Self {
+        Self {
+            publications: Vec::new(),
+            next_sequence: 0,
+        }
+    }
+}
+
+impl<Node: Eq, Channel> NodeRegistry<Node, Channel> {
+    fn replace_node(
+        &mut self,
+        node: Node,
+        routes: impl IntoIterator<Item = DeviceRoute>,
+        channel: Channel,
+    ) {
+        let routes = routes.into_iter().collect();
+        if let Some(publication) = self
+            .publications
+            .iter_mut()
+            .find(|publication| publication.node == node)
+        {
+            publication.routes = routes;
+            publication.channel = channel;
+            return;
+        }
+
+        let sequence = self.next_sequence;
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.publications.push(Publication {
+            node,
+            sequence,
+            routes,
+            channel,
+        });
+    }
+
+    fn remove_node(&mut self, node: &Node) {
+        self.publications
+            .retain(|publication| publication.node != *node);
+    }
+
+    fn lookup(&self, route: &DeviceRoute) -> Option<&Channel> {
+        self.publications
+            .iter()
+            .filter(|publication| publication.routes.contains(route))
+            .min_by_key(|publication| publication.sequence)
+            .map(|publication| &publication.channel)
+    }
+
+    fn any_current(&self, mut predicate: impl FnMut(&DeviceRoute, &Channel) -> bool) -> bool {
+        self.publications.iter().any(|publication| {
+            publication.routes.iter().any(|route| {
+                predicate(route, &publication.channel)
+                    && self
+                        .lookup(route)
+                        .is_some_and(|winner| std::ptr::eq(winner, &raw const publication.channel))
+            })
+        })
+    }
+}
+
+impl<Node: Eq + Hash, Channel> NodeRegistry<Node, Channel> {
+    fn retain_nodes(&mut self, nodes: &HashSet<Node>) {
+        self.publications
+            .retain(|publication| nodes.contains(&publication.node));
+    }
+}
+
+struct Registry<Node, Channel> {
+    state: Arc<RwLock<NodeRegistry<Node, Channel>>>,
+}
+
+impl<Node, Channel> Clone for Registry<Node, Channel> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+        }
+    }
+}
+
+impl<Node, Channel> Default for Registry<Node, Channel> {
+    fn default() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(NodeRegistry::default())),
+        }
+    }
+}
+
+impl<Node: Eq, Channel> Registry<Node, Channel> {
+    fn replace_node(
+        &self,
+        node: Node,
+        routes: impl IntoIterator<Item = DeviceRoute>,
+        channel: Channel,
+    ) {
+        self.state
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .replace_node(node, routes, channel);
+    }
+
+    fn remove_node(&self, node: &Node) {
+        self.state
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove_node(node);
+    }
+}
+
+impl<Node: Eq + Hash, Channel> Registry<Node, Channel> {
+    fn retain_nodes(&self, nodes: &HashSet<Node>) {
+        self.state
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .retain_nodes(nodes);
+    }
+}
+
+impl<Node: Eq, Channel: Clone> Registry<Node, Channel> {
+    fn lookup(&self, route: &DeviceRoute) -> Option<Channel> {
+        self.state.read().ok()?.lookup(route).cloned()
+    }
+}
+
+impl<Node: Eq, Channel> Registry<Node, Channel> {
+    fn any_current(&self, predicate: impl FnMut(&DeviceRoute, &Channel) -> bool) -> bool {
+        self.state
+            .read()
+            .ok()
+            .is_some_and(|state| state.any_current(predicate))
+    }
+}
+
+/// Channels already opened and owned by the persistent inventory enumerator.
+///
+/// Publications are keyed by OS HID node internally and selected by exact
+/// [`DeviceRoute`]. When identical direct devices publish the same route, the
+/// oldest live node wins until it is removed.
+#[derive(Clone, Default)]
+pub struct ChannelRegistry {
+    inner: Registry<DeviceId, Arc<HidppChannel>>,
+}
+
+impl ChannelRegistry {
+    /// Replace every route published by `node`, preserving that node's original
+    /// collision priority when it was already present.
+    pub(crate) fn replace_node(
+        &self,
+        node: DeviceId,
+        routes: impl IntoIterator<Item = DeviceRoute>,
+        channel: Arc<HidppChannel>,
+    ) {
+        self.inner.replace_node(node, routes, channel);
+    }
+
+    /// Remove every route and channel reference owned by `node`.
+    pub(crate) fn remove_node(&self, node: &DeviceId) {
+        self.inner.remove_node(node);
+    }
+
+    /// Remove publications for nodes absent from the current OS enumeration.
+    pub(crate) fn retain_nodes(&self, nodes: &HashSet<DeviceId>) {
+        self.inner.retain_nodes(nodes);
+    }
+
+    /// Clone the current exact-route winner.
+    #[must_use]
+    pub fn lookup(&self, route: &DeviceRoute) -> Option<SharedChannel> {
+        self.inner
+            .lookup(route)
+            .map(|channel| SharedChannel::new(channel, route.clone()))
+    }
+
+    /// Whether `shared` is still the winning publication for its exact route
+    /// and points to the same underlying connection.
+    #[must_use]
+    pub fn is_current(&self, shared: &SharedChannel) -> bool {
+        self.inner.any_current(|route, channel| {
+            shared.matches(route) && Arc::ptr_eq(channel, shared.channel())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use crate::DeviceRoute;
+
+    use super::{PoisonError, Registry};
+
+    impl<Node, Channel> Registry<Node, Channel> {
+        fn poison_for_test(&self) {
+            let _ = catch_unwind(AssertUnwindSafe(|| {
+                let _guard = self.state.write().unwrap_or_else(PoisonError::into_inner);
+                panic!("poison registry for test");
+            }));
+        }
+    }
+
+    impl<Node: Eq, Channel: Clone> Registry<Node, Channel> {
+        fn publisher_lookup_for_test(&self, route: &DeviceRoute) -> Option<Channel> {
+            self.state
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .lookup(route)
+                .cloned()
+        }
+    }
+
+    fn direct(product_id: u16) -> DeviceRoute {
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id,
+        }
+    }
+
+    fn bolt(uid: &str, slot: u8) -> DeviceRoute {
+        DeviceRoute::Bolt {
+            receiver_uid: uid.into(),
+            slot,
+        }
+    }
+
+    #[test]
+    fn lookup_rejects_every_non_exact_route_field() {
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [bolt("AABB", 2)], "channel-a");
+
+        assert_eq!(registry.lookup(&bolt("AABB", 2)), Some("channel-a"));
+        assert_eq!(registry.lookup(&bolt("AABB", 3)), None);
+        assert_eq!(registry.lookup(&bolt("CCDD", 2)), None);
+        assert_eq!(registry.lookup(&direct(0xb35b)), None);
+    }
+
+    #[test]
+    fn one_node_can_publish_multiple_receiver_slots() {
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [bolt("AABB", 1), bolt("AABB", 4)], "receiver-channel");
+
+        assert_eq!(registry.lookup(&bolt("AABB", 1)), Some("receiver-channel"));
+        assert_eq!(registry.lookup(&bolt("AABB", 4)), Some("receiver-channel"));
+    }
+
+    #[test]
+    fn current_check_uses_only_the_exact_winning_publication() {
+        let route = direct(0xb35b);
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [route.clone()], "a");
+        registry.replace_node(2, [route.clone()], "b");
+
+        assert!(
+            registry.any_current(|candidate, channel| { candidate == &route && *channel == "a" })
+        );
+        assert!(
+            !registry.any_current(|candidate, channel| { candidate == &route && *channel == "b" })
+        );
+    }
+
+    #[test]
+    fn replacing_winner_preserves_priority_then_removal_promotes_next_owner() {
+        let route = direct(0xb35b);
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [route.clone()], "a-v1");
+        registry.replace_node(2, [route.clone()], "b");
+
+        assert_eq!(registry.lookup(&route), Some("a-v1"));
+
+        registry.replace_node(1, [route.clone()], "a-v2");
+        assert_eq!(registry.lookup(&route), Some("a-v2"));
+
+        registry.remove_node(&1);
+        assert_eq!(registry.lookup(&route), Some("b"));
+    }
+
+    #[test]
+    fn replacing_one_node_is_atomic_and_does_not_touch_another() {
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [bolt("A", 1), bolt("A", 2)], "a");
+        registry.replace_node(2, [bolt("B", 1)], "b");
+
+        registry.replace_node(1, [bolt("A", 3)], "a-new");
+
+        assert_eq!(registry.lookup(&bolt("A", 1)), None);
+        assert_eq!(registry.lookup(&bolt("A", 2)), None);
+        assert_eq!(registry.lookup(&bolt("A", 3)), Some("a-new"));
+        assert_eq!(registry.lookup(&bolt("B", 1)), Some("b"));
+    }
+
+    #[test]
+    fn retaining_nodes_removes_only_absent_owners() {
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [direct(0xb35b)], "a");
+        registry.replace_node(2, [direct(0xb36b)], "b");
+
+        registry.retain_nodes(&HashSet::from([2]));
+
+        assert_eq!(registry.lookup(&direct(0xb35b)), None);
+        assert_eq!(registry.lookup(&direct(0xb36b)), Some("b"));
+    }
+
+    #[test]
+    fn poisoned_read_fails_closed_but_publishers_can_clean_up() {
+        let registry = Registry::<u8, &'static str>::default();
+        registry.replace_node(1, [direct(0xb35b)], "a");
+        registry.poison_for_test();
+
+        assert_eq!(registry.lookup(&direct(0xb35b)), None);
+        assert!(!registry.any_current(|_, _| true));
+
+        registry.remove_node(&1);
+        registry.replace_node(2, [direct(0xb36b)], "b");
+        registry.retain_nodes(&HashSet::from([2]));
+
+        assert_eq!(registry.publisher_lookup_for_test(&direct(0xb35b)), None);
+        assert_eq!(
+            registry.publisher_lookup_for_test(&direct(0xb36b)),
+            Some("b")
+        );
+    }
+}

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -4,7 +4,9 @@
 //!
 //! [`run_capture_session`] holds a single HID++ channel open for one device,
 //! enables diversion on whichever of those controls it exposes, registers one
-//! message listener, and restores every control's default mapping on shutdown.
+//! message listener, and restores every control's default mapping on graceful
+//! shutdown. Registry revocation instead releases the stale channel without
+//! sending cleanup traffic through it.
 //! Using one channel matters: a second channel to the same device would split
 //! its input-report stream, so all captured controls share this session.
 //!
@@ -25,6 +27,7 @@ use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
+use crate::channel_registry::ChannelRegistry;
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::route::{DeviceRoute, open_route_channel};
 use crate::thumbwheel::{self, Thumbwheel};
@@ -34,6 +37,17 @@ use crate::write::SharedChannel;
 /// SmartShift writes can reuse it instead of opening a fresh one. `None`
 /// whenever no session is connected.
 pub type CaptureChannel = Arc<RwLock<Option<SharedChannel>>>;
+
+/// Why an active capture session is stopping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaptureStop {
+    /// The target/configuration changed while the channel is still current, so
+    /// diverted controls must be restored before the session exits.
+    Graceful,
+    /// Inventory revoked or replaced the underlying connection. Clear local
+    /// ownership without sending restoration requests through the stale channel.
+    Revoked,
+}
 
 /// One input captured from the active device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -90,34 +104,92 @@ struct CaptureAccum {
 /// are independent of this.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
-/// device exposes, and listens. Returns once `shutdown` fires (or its sender is
-/// dropped), after restoring every diverted control. Setup errors are returned;
-/// failures to restore on the way out are logged, not propagated.
+/// device exposes, and listens. A [`CaptureStop::Graceful`] shutdown restores
+/// every diverted control; [`CaptureStop::Revoked`] clears local ownership
+/// without writing through the stale connection. Dropping the shutdown sender
+/// is treated as graceful. Setup errors are returned; failures to restore on
+/// the way out are logged, not propagated.
 pub async fn run_capture_session(
     route: DeviceRoute,
     capture_thumbwheel: bool,
     divert_gesture_button: bool,
     sink: mpsc::UnboundedSender<CapturedInput>,
-    shutdown: oneshot::Receiver<()>,
+    shutdown: oneshot::Receiver<CaptureStop>,
     channel_slot: CaptureChannel,
 ) -> Result<(), GestureError> {
     let chan = open_route_channel(&route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
+    let shared = SharedChannel::new(chan, route.clone());
+    run_capture_session_on(
+        route,
+        shared,
+        capture_thumbwheel,
+        divert_gesture_button,
+        sink,
+        shutdown,
+        channel_slot,
+    )
+    .await
+}
+
+/// Run capture on the exact channel currently published by `registry`.
+///
+/// A registry miss returns [`GestureError::DeviceNotFound`] without falling
+/// back to route enumeration/opening; the Agent watcher retries after a later
+/// inventory publication.
+pub async fn run_capture_session_with_registry(
+    route: DeviceRoute,
+    capture_thumbwheel: bool,
+    divert_gesture_button: bool,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<CaptureStop>,
+    channel_slot: CaptureChannel,
+    registry: &ChannelRegistry,
+) -> Result<(), GestureError> {
+    let shared = registry
+        .lookup(&route)
+        .ok_or(GestureError::DeviceNotFound)?;
+    run_capture_session_on(
+        route,
+        shared,
+        capture_thumbwheel,
+        divert_gesture_button,
+        sink,
+        shutdown,
+        channel_slot,
+    )
+    .await
+}
+
+async fn run_capture_session_on(
+    route: DeviceRoute,
+    shared: SharedChannel,
+    capture_thumbwheel: bool,
+    divert_gesture_button: bool,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<CaptureStop>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let chan = Arc::clone(shared.channel());
     let device_index = route.device_index();
+    // Publish before the first setup await so the watcher can validate exact
+    // channel identity on its next poll, even while arming is still in flight.
+    replace_capture_slot(&channel_slot, Some(shared));
     let armed = arm_controls(
         &chan,
         device_index,
         capture_thumbwheel,
         divert_gesture_button,
     )
-    .await?;
-
-    // Publish this device's open channel so DPI/SmartShift writes reuse it
-    // instead of opening their own. Cleared on the way out.
-    if let Ok(mut slot) = channel_slot.write() {
-        *slot = Some(SharedChannel::new(Arc::clone(&chan), route.clone()));
-    }
+    .await;
+    let armed = match armed {
+        Ok(armed) => armed,
+        Err(error) => {
+            replace_capture_slot(&channel_slot, None);
+            return Err(error);
+        }
+    };
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
@@ -160,15 +232,38 @@ pub async fn run_capture_session(
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
-    let _ = shutdown.await;
+    let stop = shutdown.await.unwrap_or(CaptureStop::Graceful);
 
-    drop(listener);
-    if let Ok(mut slot) = channel_slot.write() {
-        *slot = None;
-    }
-    armed.disarm().await;
+    teardown_capture(
+        || replace_capture_slot(&channel_slot, None),
+        listener,
+        stop,
+        || armed.disarm(),
+    )
+    .await;
     debug!(index = device_index, "control capture stopped");
     Ok(())
+}
+
+fn replace_capture_slot(slot: &CaptureChannel, value: Option<SharedChannel>) {
+    *slot.write().unwrap_or_else(PoisonError::into_inner) = value;
+}
+
+async fn teardown_capture<Listener, Clear, Disarm, DisarmFuture>(
+    clear: Clear,
+    listener: Listener,
+    stop: CaptureStop,
+    disarm: Disarm,
+) where
+    Clear: FnOnce(),
+    Disarm: FnOnce() -> DisarmFuture,
+    DisarmFuture: std::future::Future<Output = ()>,
+{
+    clear();
+    drop(listener);
+    if stop == CaptureStop::Graceful {
+        disarm().await;
+    }
 }
 
 /// The set of controls a session has diverted, kept so they can be handed back

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -104,12 +104,40 @@ struct CaptureAccum {
 /// are independent of this.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
-/// device exposes, and listens. A [`CaptureStop::Graceful`] shutdown restores
-/// every diverted control; [`CaptureStop::Revoked`] clears local ownership
-/// without writing through the stale connection. Dropping the shutdown sender
-/// is treated as graceful. Setup errors are returned; failures to restore on
-/// the way out are logged, not propagated.
+/// device exposes, and listens. Returns once `shutdown` fires (or its sender is
+/// dropped), after restoring every diverted control. Setup errors are returned;
+/// failures to restore on the way out are logged, not propagated.
 pub async fn run_capture_session(
+    route: DeviceRoute,
+    capture_thumbwheel: bool,
+    divert_gesture_button: bool,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let chan = open_route_channel(&route)
+        .await?
+        .ok_or(GestureError::DeviceNotFound)?;
+    let shared = SharedChannel::new(chan, route.clone());
+    run_capture_session_on(
+        route,
+        shared,
+        capture_thumbwheel,
+        divert_gesture_button,
+        sink,
+        graceful_shutdown(shutdown),
+        channel_slot,
+    )
+    .await
+}
+
+/// Run standalone capture with an explicit graceful-or-revoked stop reason.
+///
+/// This is the reason-aware counterpart to [`run_capture_session`]. A
+/// [`CaptureStop::Graceful`] shutdown restores diverted controls;
+/// [`CaptureStop::Revoked`] releases local ownership without writing through
+/// the stale connection. Dropping the shutdown sender is treated as graceful.
+pub async fn run_capture_session_with_stop_reason(
     route: DeviceRoute,
     capture_thumbwheel: bool,
     divert_gesture_button: bool,
@@ -127,7 +155,7 @@ pub async fn run_capture_session(
         capture_thumbwheel,
         divert_gesture_button,
         sink,
-        shutdown,
+        explicit_shutdown(shutdown),
         channel_slot,
     )
     .await
@@ -156,21 +184,33 @@ pub async fn run_capture_session_with_registry(
         capture_thumbwheel,
         divert_gesture_button,
         sink,
-        shutdown,
+        explicit_shutdown(shutdown),
         channel_slot,
     )
     .await
 }
 
-async fn run_capture_session_on(
+async fn graceful_shutdown(shutdown: oneshot::Receiver<()>) -> CaptureStop {
+    let _ = shutdown.await;
+    CaptureStop::Graceful
+}
+
+async fn explicit_shutdown(shutdown: oneshot::Receiver<CaptureStop>) -> CaptureStop {
+    shutdown.await.unwrap_or(CaptureStop::Graceful)
+}
+
+async fn run_capture_session_on<Shutdown>(
     route: DeviceRoute,
     shared: SharedChannel,
     capture_thumbwheel: bool,
     divert_gesture_button: bool,
     sink: mpsc::UnboundedSender<CapturedInput>,
-    shutdown: oneshot::Receiver<CaptureStop>,
+    shutdown: Shutdown,
     channel_slot: CaptureChannel,
-) -> Result<(), GestureError> {
+) -> Result<(), GestureError>
+where
+    Shutdown: std::future::Future<Output = CaptureStop>,
+{
     let chan = Arc::clone(shared.channel());
     let device_index = route.device_index();
     // Publish before the first setup await so the watcher can validate exact
@@ -232,7 +272,7 @@ async fn run_capture_session_on(
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
-    let stop = shutdown.await.unwrap_or(CaptureStop::Graceful);
+    let stop = shutdown.await;
 
     teardown_capture(
         || replace_capture_slot(&channel_slot, None),

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -1,5 +1,97 @@
 use super::*;
 
+use std::cell::RefCell;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::rc::Rc;
+
+struct DropRecorder(Rc<RefCell<Vec<&'static str>>>);
+
+impl Drop for DropRecorder {
+    fn drop(&mut self) {
+        self.0.borrow_mut().push("listener");
+    }
+}
+
+#[tokio::test]
+async fn graceful_teardown_clears_then_drops_listener_then_disarms() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    teardown_capture(
+        {
+            let events = Rc::clone(&events);
+            move || events.borrow_mut().push("clear")
+        },
+        DropRecorder(Rc::clone(&events)),
+        CaptureStop::Graceful,
+        {
+            let events = Rc::clone(&events);
+            move || async move { events.borrow_mut().push("disarm") }
+        },
+    )
+    .await;
+
+    assert_eq!(*events.borrow(), ["clear", "listener", "disarm"]);
+}
+
+#[tokio::test]
+async fn revoked_teardown_clears_then_drops_listener_without_disarm() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    teardown_capture(
+        {
+            let events = Rc::clone(&events);
+            move || events.borrow_mut().push("clear")
+        },
+        DropRecorder(Rc::clone(&events)),
+        CaptureStop::Revoked,
+        {
+            let events = Rc::clone(&events);
+            move || async move { events.borrow_mut().push("disarm") }
+        },
+    )
+    .await;
+
+    assert_eq!(*events.borrow(), ["clear", "listener"]);
+}
+
+#[test]
+fn capture_slot_cleanup_recovers_a_poisoned_writer() {
+    let slot: CaptureChannel = Arc::new(RwLock::new(None));
+    let poison = Arc::clone(&slot);
+    let _ = catch_unwind(AssertUnwindSafe(move || {
+        let _guard = poison.write().unwrap_or_else(PoisonError::into_inner);
+        panic!("poison capture slot");
+    }));
+
+    replace_capture_slot(&slot, None);
+
+    assert!(
+        slot.read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn registry_miss_does_not_fall_back_to_opening_the_route() {
+    let route = DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xb35b,
+    };
+    let registry = ChannelRegistry::default();
+    let (sink, _events) = mpsc::unbounded_channel();
+    let (_stop, shutdown) = oneshot::channel();
+    let slot: CaptureChannel = Arc::new(RwLock::new(None));
+
+    let result =
+        run_capture_session_with_registry(route, false, false, sink, shutdown, slot, &registry)
+            .await;
+
+    let Err(error) = result else {
+        panic!("an empty Agent registry must fail before any route open");
+    };
+
+    assert!(matches!(error, GestureError::DeviceNotFound));
+}
+
 fn press() -> RawControlEvent {
     RawControlEvent::DivertedButtons([reprog_controls::GESTURE_BUTTON_CID, 0, 0, 0])
 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    hash::Hash,
     sync::Arc,
     time::Duration,
 };
@@ -13,7 +14,9 @@ use thiserror::Error;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
+use crate::channel_registry::ChannelRegistry;
 use crate::node_ledger::NodeLedger;
+use crate::route::DeviceRoute;
 use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
 
 mod cache;
@@ -100,11 +103,14 @@ pub struct Enumerator {
     /// each open also leaks an `io_service_t` in async-hid's macOS backend — so a
     /// steadily-connected node is opened once here and reused until it
     /// disconnects.
-    channels: HashMap<async_hid::DeviceId, CachedChannel>,
+    channels: ChannelCache<async_hid::DeviceId, CachedChannel>,
     /// Per-node last-good inventory + consecutive-failure counts: replays a
     /// node's snapshot through transient probe failures and decides when its
     /// cached channel must be dropped and reopened (see [`crate::node_ledger`]).
     ledger: NodeLedger<async_hid::DeviceId>,
+    /// Optional publication sink used by the persistent Agent watcher. One-shot
+    /// callers keep this `None` and retain the route-opening library behavior.
+    registry: Option<ChannelRegistry>,
     tick: u64,
 }
 
@@ -115,6 +121,102 @@ pub struct Enumerator {
 struct CachedChannel {
     info: async_hid::DeviceInfo,
     channel: Arc<HidppChannel>,
+}
+
+struct PreparedNodes {
+    active: Vec<(async_hid::DeviceInfo, Arc<HidppChannel>)>,
+    open_failures: Vec<async_hid::DeviceId>,
+    retiring: Vec<async_hid::DeviceId>,
+}
+
+/// Disjoint active and retiring channels, generic so ownership transitions can
+/// be tested without constructing a platform HID node.
+struct ChannelCache<Node, Channel> {
+    active: HashMap<Node, Channel>,
+    retiring: HashMap<Node, Channel>,
+}
+
+impl<Node, Channel> Default for ChannelCache<Node, Channel> {
+    fn default() -> Self {
+        Self {
+            active: HashMap::new(),
+            retiring: HashMap::new(),
+        }
+    }
+}
+
+impl<Node: Eq + Hash + Clone, Channel> ChannelCache<Node, Channel> {
+    fn get(&self, node: &Node) -> Option<&Channel> {
+        self.active.get(node)
+    }
+
+    fn insert(&mut self, node: Node, channel: Channel) {
+        debug_assert!(!self.retiring.contains_key(&node));
+        self.active.insert(node, channel);
+    }
+
+    fn retire_node(&mut self, node: &Node) -> Option<()> {
+        let channel = self.active.remove(node)?;
+        self.retiring.insert(node.clone(), channel);
+        Some(())
+    }
+
+    /// Whether this node may be opened during the current tick. A quiescent
+    /// retirement is dropped here, but opening remains deferred to a later tick.
+    fn prepare_open(&mut self, node: &Node, is_quiescent: impl FnOnce(&Channel) -> bool) -> bool {
+        let Some(channel) = self.retiring.get(node) else {
+            return true;
+        };
+        if is_quiescent(channel) {
+            self.retiring.remove(node);
+        }
+        false
+    }
+
+    fn retire_absent(&mut self, seen: &HashSet<Node>) {
+        let absent = self
+            .active
+            .keys()
+            .filter(|node| !seen.contains(*node))
+            .cloned()
+            .collect::<Vec<_>>();
+        for node in absent {
+            let _ = self.retire_node(&node);
+        }
+    }
+
+    fn reap_absent(&mut self, seen: &HashSet<Node>, is_quiescent: impl Fn(&Channel) -> bool) {
+        self.retiring
+            .retain(|node, channel| seen.contains(node) || !is_quiescent(channel));
+    }
+
+    #[cfg(test)]
+    fn is_retiring(&self, node: &Node) -> bool {
+        self.retiring.contains_key(node)
+    }
+}
+
+fn routes_for_inventories(inventories: &[DeviceInventory]) -> Vec<DeviceRoute> {
+    inventories
+        .iter()
+        .flat_map(|inventory| {
+            inventory
+                .paired
+                .iter()
+                .filter_map(|paired| DeviceRoute::device_route_for(inventory, paired.slot))
+        })
+        .collect()
+}
+
+fn settle_unhealthy_node<Node: Eq + Hash + Clone>(
+    ledger: &mut NodeLedger<Node>,
+    node: &Node,
+    all_complete: &mut bool,
+    all_healthy: &mut bool,
+) -> Option<DeviceInventory> {
+    *all_complete = false;
+    *all_healthy = false;
+    ledger.settle(node, false, None).inventory
 }
 
 /// Enumerate all Logitech HID++ receivers visible to the current process and
@@ -204,6 +306,70 @@ const ONESHOT_ATTEMPTS: u8 = 4;
 const ONESHOT_RETRY_DELAY: Duration = Duration::from_millis(300);
 
 impl Enumerator {
+    /// Build a persistent enumerator that publishes its already-open channels
+    /// into `registry` after each settled inventory tick.
+    #[must_use]
+    pub fn with_registry(registry: ChannelRegistry) -> Self {
+        Self {
+            registry: Some(registry),
+            ..Self::default()
+        }
+    }
+
+    async fn prepare_nodes(&mut self, candidates: Vec<async_hid::Device>) -> PreparedNodes {
+        let mut active = Vec::new();
+        let mut seen_nodes = HashSet::new();
+        let mut open_failures = Vec::new();
+        let mut retiring = Vec::new();
+        for dev in candidates {
+            let node = dev.id.clone();
+            seen_nodes.insert(node.clone());
+            if !self
+                .channels
+                .prepare_open(&node, |cached| Arc::strong_count(&cached.channel) == 1)
+            {
+                retiring.push(node);
+                continue;
+            }
+            if let Some(open) = self.channels.get(&node) {
+                active.push((open.info.clone(), Arc::clone(&open.channel)));
+                continue;
+            }
+            match open_hidpp_channel(dev).await {
+                Ok(Some((info, channel))) => {
+                    self.channels.insert(
+                        node,
+                        CachedChannel {
+                            info: info.clone(),
+                            channel: Arc::clone(&channel),
+                        },
+                    );
+                    active.push((info, channel));
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(error = ?e, "failed to open HID++ channel — retrying next tick");
+                    open_failures.push(node);
+                }
+            }
+        }
+
+        if let Some(registry) = &self.registry {
+            registry.retain_nodes(&seen_nodes);
+        }
+        self.channels.retire_absent(&seen_nodes);
+        self.channels.reap_absent(&seen_nodes, |cached| {
+            Arc::strong_count(&cached.channel) == 1
+        });
+        self.ledger.retain_nodes(&seen_nodes);
+
+        PreparedNodes {
+            active,
+            open_failures,
+            retiring,
+        }
+    }
+
     /// One enumeration pass, reusing the cache from prior passes. Probes every
     /// HID candidate concurrently (so one asleep node that burns the whole
     /// `PROBE_BUDGET` can't stall the others), reusing each device's cached
@@ -236,48 +402,13 @@ impl Enumerator {
         let candidates = enumerate_hidpp_devices().await?;
         debug!(count = candidates.len(), "HID++ candidate interfaces");
 
-        // Reuse an open channel per node, opening one only for a node seen for
-        // the first time. Sequential because opening mutates the channel cache,
-        // but in steady state every node is already cached so this is just
-        // lookups — an actual open happens only when a new device appears.
-        let mut active: Vec<(async_hid::DeviceInfo, Arc<HidppChannel>)> = Vec::new();
-        let mut seen_nodes: HashSet<async_hid::DeviceId> = HashSet::new();
-        let mut open_failures: Vec<async_hid::DeviceId> = Vec::new();
-        for dev in candidates {
-            let node = dev.id.clone();
-            seen_nodes.insert(node.clone());
-            if let Some(open) = self.channels.get(&node) {
-                active.push((open.info.clone(), Arc::clone(&open.channel)));
-                continue;
-            }
-            match open_hidpp_channel(dev).await {
-                Ok(Some((info, channel))) => {
-                    self.channels.insert(
-                        node,
-                        CachedChannel {
-                            info: info.clone(),
-                            channel: Arc::clone(&channel),
-                        },
-                    );
-                    active.push((info, channel));
-                }
-                Ok(None) => {} // speaks HID but not HID++ — not one of ours
-                // The node is listed but unreachable right now — settled as a
-                // failed probe below, so its last inventory is replayed.
-                Err(e) => {
-                    warn!(error = ?e, "failed to open HID++ channel — retrying next tick");
-                    open_failures.push(node);
-                }
-            }
-        }
-        // Drop channels for nodes that vanished this tick. A node missing from
-        // the enumeration is a real disconnect (the IOHIDManager device set is
-        // authoritative, unlike a HID++ probe timeout), so close the device and
-        // join its read thread now instead of leaving a dead channel behind; a
-        // reconnect re-opens under a fresh node id. The ledger forgets vanished
-        // nodes for the same reason — a true disconnect must not be replayed.
-        self.channels.retain(|node, _| seen_nodes.contains(node));
-        self.ledger.retain_nodes(&seen_nodes);
+        // Reuse an open channel per node, opening only when no active or
+        // retiring connection owns that OS node.
+        let PreparedNodes {
+            active,
+            open_failures,
+            retiring: retiring_nodes,
+        } = self.prepare_nodes(candidates).await;
 
         // Probe each open channel concurrently, sharing `&cache` read-only;
         // updates are collected and applied afterwards (no `RefCell`).
@@ -287,8 +418,12 @@ impl Enumerator {
                 .into_iter()
                 .map(|(info, channel)| async move {
                     let node = info.id.clone();
-                    let probe = timeout(PROBE_BUDGET, probe_one(info, channel, cache, tick)).await;
-                    (node, probe)
+                    let probe = timeout(
+                        PROBE_BUDGET,
+                        probe_one(info, Arc::clone(&channel), cache, tick),
+                    )
+                    .await;
+                    (node, channel, probe)
                 })
                 .collect::<Vec<_>>()
                 .join()
@@ -303,7 +438,7 @@ impl Enumerator {
         // governed by `probe.healthy`.
         let mut all_complete = true;
         let mut all_healthy = true;
-        for (node, result) in results {
+        for (node, channel, result) in results {
             let probe = if let Ok(probe) = result {
                 probe
             } else {
@@ -318,18 +453,47 @@ impl Enumerator {
             all_healthy &= probe.healthy;
             outcomes.extend(probe.outcomes);
             let settled = self.ledger.settle(&node, probe.healthy, probe.inventory);
-            if settled.evict_channel && self.channels.remove(&node).is_some() {
-                warn!("node probe keeps failing — dropping its channel to reopen next tick");
+            if settled.evict_channel {
+                if let Some(registry) = &self.registry {
+                    registry.remove_node(&node);
+                }
+                if self.channels.retire_node(&node).is_some() {
+                    warn!("node probe keeps failing — retiring its channel before reopen");
+                }
+            } else if let Some(registry) = &self.registry {
+                let routes = settled
+                    .inventory
+                    .as_ref()
+                    .map_or_else(Vec::new, |inventory| {
+                        routes_for_inventories(std::slice::from_ref(inventory))
+                    });
+                if routes.is_empty() {
+                    registry.remove_node(&node);
+                } else {
+                    registry.replace_node(node.clone(), routes, channel);
+                }
             }
             inventories.extend(settled.inventory);
+        }
+        // A listed node whose old connection is still retiring is an unhealthy
+        // probe, not a disconnect: preserve the ledger's normal replay grace.
+        for node in retiring_nodes {
+            inventories.extend(settle_unhealthy_node(
+                &mut self.ledger,
+                &node,
+                &mut all_complete,
+                &mut all_healthy,
+            ));
         }
         // Nodes that wouldn't open this tick still replay their last snapshot
         // (they have no cached channel to evict).
         for node in open_failures {
-            all_complete = false;
-            all_healthy = false;
-            let settled = self.ledger.settle(&node, false, None);
-            inventories.extend(settled.inventory);
+            inventories.extend(settle_unhealthy_node(
+                &mut self.ledger,
+                &node,
+                &mut all_complete,
+                &mut all_healthy,
+            ));
         }
 
         // Apply fresh probes and record which devices were seen this tick.

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use openlogi_core::device::{
     DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
@@ -8,8 +9,12 @@ use super::cache::{
     CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
 };
 use super::probe::{NodeProbe, assemble_bolt_probe, parse_codename_unifying};
-use super::{Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop};
+use super::{
+    ChannelCache, Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop, routes_for_inventories,
+    settle_unhealthy_node,
+};
 use crate::inventory::features::ProbedFeatures;
+use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
 
 fn cache_entry(probed_tick: u64) -> Cached {
     Cached {
@@ -102,6 +107,138 @@ fn inventory(slots: &[u8]) -> Vec<DeviceInventory> {
             })
             .collect(),
     }]
+}
+
+#[test]
+fn settled_inventories_publish_exact_receiver_routes() {
+    assert_eq!(
+        routes_for_inventories(&inventory(&[1, 4])),
+        vec![
+            DeviceRoute::Unifying {
+                receiver_uid: "receiver-1".into(),
+                slot: 1,
+            },
+            DeviceRoute::Unifying {
+                receiver_uid: "receiver-1".into(),
+                slot: 4,
+            },
+        ]
+    );
+
+    assert_eq!(
+        routes_for_inventories(&inventory(&[4])),
+        vec![DeviceRoute::Unifying {
+            receiver_uid: "receiver-1".into(),
+            slot: 4,
+        }],
+        "a vanished slot must not survive the next atomic node replacement"
+    );
+}
+
+#[test]
+fn settled_direct_inventory_publishes_one_direct_route() {
+    let direct = vec![DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "MX Keys".into(),
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+            unique_id: None,
+        },
+        paired: vec![PairedDevice {
+            slot: DIRECT_DEVICE_INDEX,
+            codename: Some("MX Keys".into()),
+            wpid: Some(0xb35b),
+            kind: DeviceKind::Keyboard,
+            online: true,
+            battery: None,
+            model_info: None,
+            capabilities: None,
+        }],
+    }];
+
+    assert_eq!(
+        routes_for_inventories(&direct),
+        vec![DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        }]
+    );
+}
+
+#[test]
+fn channel_cache_retires_and_defers_reopen_until_a_later_tick() {
+    let mut cache = ChannelCache::<u8, Arc<()>>::default();
+    let channel = Arc::new(());
+    cache.insert(1, Arc::clone(&channel));
+
+    assert!(cache.retire_node(&1).is_some());
+    assert!(cache.get(&1).is_none());
+    assert!(!cache.prepare_open(&1, |channel| Arc::strong_count(channel) == 1));
+
+    drop(channel);
+    assert!(cache.is_retiring(&1));
+    assert!(
+        !cache.prepare_open(&1, |channel| Arc::strong_count(channel) == 1),
+        "the tick that drops retirement still skips opening"
+    );
+    assert!(!cache.is_retiring(&1));
+    assert!(
+        cache.prepare_open(&1, |channel| Arc::strong_count(channel) == 1),
+        "only a later tick may reopen"
+    );
+}
+
+#[test]
+fn absent_channels_retire_and_quiescent_absent_retirement_is_reaped() {
+    let mut cache = ChannelCache::<u8, Arc<()>>::default();
+    cache.insert(1, Arc::new(()));
+    cache.insert(2, Arc::new(()));
+
+    cache.retire_absent(&HashSet::from([2]));
+    assert!(cache.is_retiring(&1));
+    assert!(cache.get(&2).is_some());
+
+    cache.reap_absent(&HashSet::from([2]), |channel| {
+        Arc::strong_count(channel) == 1
+    });
+    assert!(!cache.is_retiring(&1));
+}
+
+#[test]
+fn retiring_node_replays_ledger_and_marks_tick_unhealthy() {
+    let mut ledger = crate::node_ledger::NodeLedger::<u8>::default();
+    let expected = inventory(&[1]);
+    let settled = ledger.settle(&1, true, Some(expected[0].clone()));
+    assert_eq!(settled.inventory, Some(expected[0].clone()));
+
+    let mut complete = true;
+    let mut healthy = true;
+    let replay = settle_unhealthy_node(&mut ledger, &1, &mut complete, &mut healthy);
+
+    assert_eq!(replay, Some(expected[0].clone()));
+    assert!(!complete);
+    assert!(!healthy);
+}
+
+#[test]
+fn retiring_node_inventory_expires_after_the_existing_ledger_grace() {
+    let mut ledger = crate::node_ledger::NodeLedger::<u8>::default();
+    let expected = inventory(&[1]);
+    ledger.settle(&1, true, Some(expected[0].clone()));
+
+    let mut complete = true;
+    let mut healthy = true;
+    for _ in 0..3 {
+        assert_eq!(
+            settle_unhealthy_node(&mut ledger, &1, &mut complete, &mut healthy),
+            Some(expected[0].clone())
+        );
+    }
+    assert_eq!(
+        settle_unhealthy_node(&mut ledger, &1, &mut complete, &mut healthy),
+        None,
+        "retirement must not extend stale inventory beyond ledger policy"
+    );
 }
 
 #[test]

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -31,7 +31,10 @@ pub mod thumbwheel;
 pub mod write;
 
 pub use channel_registry::ChannelRegistry;
-pub use gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
+pub use gesture::{
+    CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
+    run_capture_session_with_registry,
+};
 pub use hires_wheel::{
     ScrollReportingTarget, ScrollResolution, ScrollWheelMode, get_scroll_wheel_mode,
     get_scroll_wheel_mode_on, set_scroll_inversion, set_scroll_inversion_on, set_scroll_resolution,

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -33,7 +33,7 @@ pub mod write;
 pub use channel_registry::ChannelRegistry;
 pub use gesture::{
     CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
-    run_capture_session_with_registry,
+    run_capture_session_with_registry, run_capture_session_with_stop_reason,
 };
 pub use hires_wheel::{
     ScrollReportingTarget, ScrollResolution, ScrollWheelMode, get_scroll_wheel_mode,

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(rustdoc::bare_urls)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+mod channel_registry;
 mod mappings;
 mod node_ledger;
 mod route;
@@ -29,6 +30,7 @@ pub mod smartshift;
 pub mod thumbwheel;
 pub mod write;
 
+pub use channel_registry::ChannelRegistry;
 pub use gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
 pub use hires_wheel::{
     ScrollReportingTarget, ScrollResolution, ScrollWheelMode, get_scroll_wheel_mode,


### PR DESCRIPTION
## Summary

Make Agent input capture reuse the HID++ channel already owned by persistent
inventory instead of opening a competing handle for the same OS node.

This is an infrastructure-only change. It does not change the IPC or config
schema and does not add GUI behavior.

## Changes

- **hid**: add a node-owned `ChannelRegistry` that publishes exact direct,
  Bolt, and Unifying routes from settled inventory, with stable collision
  handling and quiescent retirement before a node is reopened.
- **hid**: run capture on the registry-selected channel in Agent mode, fail
  closed on a registry miss, and preserve route-opening behavior for standalone
  callers.
- **agent-core**: distinguish graceful capture shutdown from connection
  revocation, and wait for the old capture epoch to release its listener and
  channel before starting a replacement.
- **agent**: keep one registry in `SharedRuntime` and pass it to both the
  persistent inventory and gesture watchers.
- **tests**: cover exact-route lookup, competing-node promotion, poisoned-lock
  recovery, publication and retirement, registry misses, stale connection
  revocation, teardown ordering, replacement acknowledgement, and standalone
  compatibility.

## Testing

```text
cargo test -p openlogi-hid gesture -- --nocapture
cargo test -p openlogi-agent-core watchers -- --nocapture
cargo test -p openlogi-agent pairing -- --nocapture
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS=-Dwarnings cargo doc -p openlogi-hid --no-deps --document-private-items
git diff --check upstream/master...HEAD
```

The same registry/capture implementation was runtime-tested on macOS with an
MX Keys connected over Bluetooth-direct while validating the full feature
stack: inventory remained visible and the keyboard remained usable. This
reduced branch was not rerun independently on hardware after extraction.

Receiver hardware was not runtime-tested for this PR.

Part of #521