### PR TITLE
feat(macos): add software scroll inversion fallback

### DIFF
--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -275,6 +275,7 @@ thread_local! {
 /// granted or on an unsupported platform — the app continues without crashing.
 pub fn start(
     hooks: SharedHookMaps,
+    scroll_inversions: SharedScrollInversions,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture: CaptureChannel,
     monitor: SharedEventMonitor,
@@ -392,7 +393,12 @@ pub fn start(
                 HOLD.with_borrow_mut(HoldState::cancel);
                 EventDisposition::PassThrough
             }
-            MouseEvent::Scroll { .. } => EventDisposition::PassThrough,
+            MouseEvent::Scroll {
+                delta_y,
+                from_trackpad,
+                device,
+                ..
+            } => scroll_disposition(delta_y, from_trackpad, device.as_ref(), &scroll_inversions),
         }
     });
 
@@ -495,15 +501,15 @@ mod tests {
     use openlogi_core::binding::GESTURE_SWIPE_THRESHOLD;
     use openlogi_hook::EventDevice;
 
-    fn accepts_existing_start_signature(
-        _start: fn(
-            SharedHookMaps,
-            Arc<RwLock<DpiCycleState>>,
-            CaptureChannel,
-            SharedEventMonitor,
-        ) -> Option<Hook>,
-    ) {
-    }
+    type StartFn = fn(
+        SharedHookMaps,
+        SharedScrollInversions,
+        Arc<RwLock<DpiCycleState>>,
+        CaptureChannel,
+        SharedEventMonitor,
+    ) -> Option<Hook>;
+
+    fn accepts_existing_start_signature(_start: StartFn) {}
 
     // The mid-swipe gate itself is unit-tested on `SwipeAccumulator` in
     // `openlogi-core`; these cover only what `HoldState` adds on top — tagging a
@@ -540,7 +546,7 @@ mod tests {
     }
 
     #[test]
-    fn start_keeps_the_existing_four_argument_contract() {
+    fn start_accepts_scroll_inversions() {
         accepts_existing_start_signature(start);
     }
 

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -13,7 +13,7 @@ use openlogi_core::binding::{
     Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
 };
 use openlogi_hid::CaptureChannel;
-use openlogi_hook::{EventDisposition, Hook, MouseEvent};
+use openlogi_hook::{EventDevice, EventDisposition, Hook, MouseEvent};
 use tracing::{info, warn};
 
 use crate::DpiCycleState;
@@ -38,6 +38,181 @@ pub struct HookMaps {
 /// Shared, atomically-published [`HookMaps`], threaded between the config owner
 /// (orchestrator), the OS-hook callback, and the gesture watcher.
 pub type SharedHookMaps = Arc<RwLock<HookMaps>>;
+
+/// Device identity fields used to match a physical scroll source to its
+/// software inversion setting.
+#[derive(Default)]
+pub struct ScrollDeviceKey {
+    /// USB/Bluetooth/HID vendor id, when known.
+    pub vendor_id: Option<u32>,
+    /// USB/Bluetooth/HID product id, when known.
+    pub product_id: Option<u32>,
+    /// Human-readable HID product name, when known.
+    pub product_name: Option<String>,
+}
+
+/// Per-device software scroll inversion settings.
+///
+/// Product ids are matched exactly before normalized product names. Conflicting
+/// settings for the same identity are retained as ambiguous and never match.
+#[derive(Default)]
+pub struct ScrollInversions {
+    by_product_id: BTreeMap<(u32, u32), Option<bool>>,
+    by_product_name: BTreeMap<(Option<u32>, String), Option<bool>>,
+}
+
+impl ScrollInversions {
+    /// Build the lookup from the product identities known to the orchestrator.
+    #[must_use]
+    pub fn new(entries: impl IntoIterator<Item = (ScrollDeviceKey, bool)>) -> Self {
+        let mut by_product_id = BTreeMap::new();
+        let mut by_product_name = BTreeMap::new();
+        for (key, invert) in entries {
+            if let (Some(vendor_id), Some(product_id)) = (key.vendor_id, key.product_id) {
+                merge_inversion(&mut by_product_id, (vendor_id, product_id), invert);
+            }
+            if let Some(product_name) = key
+                .product_name
+                .and_then(|name| normalize_product_name(&name))
+            {
+                merge_inversion(&mut by_product_name, (key.vendor_id, product_name), invert);
+            }
+        }
+        Self {
+            by_product_id,
+            by_product_name,
+        }
+    }
+
+    /// Resolve the inversion setting for an event source, or `None` when the
+    /// source is unknown or its matching identities are ambiguous.
+    #[must_use]
+    pub fn inversion_for(&self, device: Option<&EventDevice>) -> Option<bool> {
+        let device = device?;
+        if let (Some(vendor_id), Some(product_id)) = (device.vendor_id, device.product_id)
+            && let Some(invert) = self.by_product_id.get(&(vendor_id, product_id))
+        {
+            return *invert;
+        }
+
+        let product_name = device
+            .product_name
+            .as_deref()
+            .and_then(normalize_product_name)?;
+        match consistent_inversion(
+            self.by_product_name
+                .iter()
+                .filter(|((known_vendor, known_name), _)| {
+                    vendors_compatible(*known_vendor, device.vendor_id)
+                        && known_name == &product_name
+                })
+                .map(|(_, invert)| invert),
+        ) {
+            InversionConsensus::NoCandidates => {}
+            InversionConsensus::Ambiguous => return None,
+            InversionConsensus::Matched(invert) => return Some(invert),
+        }
+
+        match consistent_inversion(
+            self.by_product_name
+                .iter()
+                .filter(|((known_vendor, known_name), _)| {
+                    vendors_compatible(*known_vendor, device.vendor_id)
+                        && product_names_match(known_name, &product_name)
+                })
+                .map(|(_, invert)| invert),
+        ) {
+            InversionConsensus::Matched(invert) => Some(invert),
+            InversionConsensus::NoCandidates | InversionConsensus::Ambiguous => None,
+        }
+    }
+}
+
+fn merge_inversion<K: Ord>(map: &mut BTreeMap<K, Option<bool>>, key: K, invert: bool) {
+    map.entry(key)
+        .and_modify(|existing| {
+            if *existing != Some(invert) {
+                *existing = None;
+            }
+        })
+        .or_insert(Some(invert));
+}
+
+fn normalize_product_name(name: &str) -> Option<String> {
+    let normalized = name.trim().to_lowercase();
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn product_names_match(known: &str, event: &str) -> bool {
+    known.chars().count() >= 4
+        && event.chars().count() >= 4
+        && (known.contains(event) || event.contains(known))
+}
+
+fn vendors_compatible(known: Option<u32>, event: Option<u32>) -> bool {
+    !matches!((known, event), (Some(known), Some(event)) if known != event)
+}
+
+enum InversionConsensus {
+    NoCandidates,
+    Ambiguous,
+    Matched(bool),
+}
+
+fn consistent_inversion<'a>(
+    candidates: impl IntoIterator<Item = &'a Option<bool>>,
+) -> InversionConsensus {
+    let mut matched = None;
+    for invert in candidates {
+        let Some(invert) = *invert else {
+            return InversionConsensus::Ambiguous;
+        };
+        if matched.is_some_and(|existing| existing != invert) {
+            return InversionConsensus::Ambiguous;
+        }
+        matched = Some(invert);
+    }
+    matched.map_or(
+        InversionConsensus::NoCandidates,
+        InversionConsensus::Matched,
+    )
+}
+
+/// Decide whether a vertical wheel event should be inverted on this platform.
+///
+/// Unknown or ambiguous devices, disabled settings, trackpad events, and zero
+/// vertical deltas always pass through unchanged.
+#[must_use]
+pub fn scroll_disposition(
+    delta_y: f32,
+    from_trackpad: bool,
+    device: Option<&EventDevice>,
+    scroll_inversions: &SharedScrollInversions,
+) -> EventDisposition {
+    let should_invert = scroll_inversions
+        .read()
+        .ok()
+        .and_then(|inversions| inversions.inversion_for(device))
+        .unwrap_or(false);
+    if should_invert && !from_trackpad && delta_y != 0.0 {
+        inverted_scroll_disposition()
+    } else {
+        EventDisposition::PassThrough
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn inverted_scroll_disposition() -> EventDisposition {
+    EventDisposition::InvertScroll
+}
+
+#[cfg(not(target_os = "macos"))]
+fn inverted_scroll_disposition() -> EventDisposition {
+    EventDisposition::PassThrough
+}
+
+/// Shared, atomically published per-device scroll inversion settings.
+pub type SharedScrollInversions = Arc<RwLock<ScrollInversions>>;
 
 /// Tracks which OS-hook button (Middle/Back/Forward) is mid-hold and defers the
 /// swipe detection itself to a shared [`SwipeAccumulator`], which commits a swipe
@@ -318,6 +493,17 @@ pub fn dispatch_action(
 mod tests {
     use super::*;
     use openlogi_core::binding::GESTURE_SWIPE_THRESHOLD;
+    use openlogi_hook::EventDevice;
+
+    fn accepts_existing_start_signature(
+        _start: fn(
+            SharedHookMaps,
+            Arc<RwLock<DpiCycleState>>,
+            CaptureChannel,
+            SharedEventMonitor,
+        ) -> Option<Hook>,
+    ) {
+    }
 
     // The mid-swipe gate itself is unit-tested on `SwipeAccumulator` in
     // `openlogi-core`; these cover only what `HoldState` adds on top — tagging a
@@ -351,6 +537,357 @@ mod tests {
         assert_eq!(hold.end(ButtonId::Forward), None);
         // ...and ending the held button with no swipe is a plain click.
         assert_eq!(hold.end(ButtonId::Back), Some(true));
+    }
+
+    #[test]
+    fn start_keeps_the_existing_four_argument_contract() {
+        accepts_existing_start_signature(start);
+    }
+
+    #[test]
+    fn scroll_inversions_prefer_exact_product_id_over_name() {
+        let inversions = ScrollInversions::new([
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb037),
+                    product_name: Some("MX Anywhere 3S".to_string()),
+                },
+                true,
+            ),
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb042),
+                    product_name: Some("MX Master 4".to_string()),
+                },
+                false,
+            ),
+        ]);
+        let event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb037),
+            product_name: Some("MX Master 4".to_string()),
+        };
+
+        assert_eq!(inversions.inversion_for(Some(&event)), Some(true));
+    }
+
+    #[test]
+    fn scroll_inversions_scope_product_ids_to_vendor() {
+        let inversions = ScrollInversions::new([(
+            ScrollDeviceKey {
+                vendor_id: Some(0x046d),
+                product_id: Some(0xb037),
+                product_name: None,
+            },
+            true,
+        )]);
+
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x1234),
+                product_id: Some(0xb037),
+                product_name: None,
+            })),
+            None,
+            "the same product id from another vendor must not match"
+        );
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: None,
+                product_id: Some(0xb037),
+                product_name: None,
+            })),
+            None,
+            "a missing event vendor must not guess a product-id match"
+        );
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: Some(0xb037),
+                product_name: None,
+            })),
+            Some(true),
+            "the exact Logitech vendor/product pair still matches"
+        );
+
+        let missing_known_vendor = ScrollInversions::new([(
+            ScrollDeviceKey {
+                vendor_id: None,
+                product_id: Some(0xb037),
+                product_name: None,
+            },
+            true,
+        )]);
+        assert_eq!(
+            missing_known_vendor.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: Some(0xb037),
+                product_name: None,
+            })),
+            None,
+            "a missing known vendor must not create a product-id match"
+        );
+    }
+
+    #[test]
+    fn scroll_inversions_scope_product_names_to_vendor() {
+        let inversions = ScrollInversions::new([(
+            ScrollDeviceKey {
+                vendor_id: Some(0x046d),
+                product_id: None,
+                product_name: Some("M650".to_string()),
+            },
+            true,
+        )]);
+
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x1234),
+                product_id: None,
+                product_name: Some("M650".to_string()),
+            })),
+            None,
+            "the same product name from another known vendor must not match"
+        );
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: None,
+                product_name: Some("Logitech Signature M650 L".to_string()),
+            })),
+            Some(true),
+            "the Logitech name containment fallback still matches"
+        );
+
+        let missing_known_vendor = ScrollInversions::new([(
+            ScrollDeviceKey {
+                vendor_id: None,
+                product_id: None,
+                product_name: Some("M650".to_string()),
+            },
+            true,
+        )]);
+        assert_eq!(
+            missing_known_vendor.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: None,
+                product_name: Some("Logitech Signature M650 L".to_string()),
+            })),
+            Some(true),
+            "a sole unknown-vendor name may be used as a fallback"
+        );
+    }
+
+    #[test]
+    fn scroll_inversions_fall_back_to_normalized_product_name() {
+        let inversions = ScrollInversions::new([
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: None,
+                    product_name: Some("  MX Anywhere 3S  ".to_string()),
+                },
+                true,
+            ),
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: None,
+                    product_name: Some("M650".to_string()),
+                },
+                false,
+            ),
+        ]);
+
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: None,
+                product_name: Some("mx anywhere 3s".to_string()),
+            })),
+            Some(true),
+            "trimmed lowercase exact names match"
+        );
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: None,
+                product_name: Some("Logitech Signature M650 L".to_string()),
+            })),
+            Some(false),
+            "names of at least four characters may match by containment"
+        );
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: None,
+                product_name: Some("650".to_string()),
+            })),
+            None,
+            "short names must not match by containment"
+        );
+    }
+
+    #[test]
+    fn scroll_inversions_drop_conflicting_identities() {
+        let key = || ScrollDeviceKey {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xc548),
+            product_name: Some("USB Receiver".to_string()),
+        };
+        let inversions = ScrollInversions::new([(key(), true), (key(), false)]);
+
+        assert_eq!(
+            inversions.inversion_for(Some(&EventDevice {
+                vendor_id: Some(0x046d),
+                product_id: Some(0xc548),
+                product_name: Some("USB Receiver".to_string()),
+            })),
+            None
+        );
+    }
+
+    #[test]
+    fn scroll_inversions_drop_conflicting_normalized_names_without_product_id() {
+        let key = || ScrollDeviceKey {
+            vendor_id: None,
+            product_id: None,
+            product_name: Some("  USB Receiver  ".to_string()),
+        };
+        let inversions = Arc::new(RwLock::new(ScrollInversions::new([
+            (key(), true),
+            (key(), false),
+        ])));
+        let event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: None,
+            product_name: Some("usb receiver".to_string()),
+        };
+
+        assert_eq!(
+            inversions
+                .read()
+                .ok()
+                .and_then(|settings| settings.inversion_for(Some(&event))),
+            None
+        );
+        assert_eq!(
+            scroll_disposition(1.0, false, Some(&event), &inversions),
+            EventDisposition::PassThrough
+        );
+    }
+
+    #[test]
+    fn scroll_inversions_reject_conflicting_containment_candidates() {
+        let inversions = Arc::new(RwLock::new(ScrollInversions::new([
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: None,
+                    product_name: Some("M650".to_string()),
+                },
+                true,
+            ),
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: None,
+                    product_name: Some("Signature M650".to_string()),
+                },
+                false,
+            ),
+        ])));
+        let event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: None,
+            product_name: Some("Logitech Signature M650 L".to_string()),
+        };
+
+        assert_eq!(
+            inversions
+                .read()
+                .ok()
+                .and_then(|settings| settings.inversion_for(Some(&event))),
+            None
+        );
+        assert_eq!(
+            scroll_disposition(1.0, false, Some(&event), &inversions),
+            EventDisposition::PassThrough
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn scroll_disposition_inverts_an_enabled_known_mouse_wheel() {
+        let inversions = Arc::new(RwLock::new(ScrollInversions::new([(
+            ScrollDeviceKey {
+                vendor_id: Some(0x046d),
+                product_id: Some(0xb037),
+                product_name: None,
+            },
+            true,
+        )])));
+        let event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb037),
+            product_name: None,
+        };
+
+        assert_eq!(
+            scroll_disposition(1.0, false, Some(&event), &inversions),
+            EventDisposition::InvertScroll
+        );
+    }
+
+    #[test]
+    fn scroll_disposition_passes_disabled_trackpad_unknown_and_zero_delta() {
+        let inversions = Arc::new(RwLock::new(ScrollInversions::new([
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb037),
+                    product_name: None,
+                },
+                true,
+            ),
+            (
+                ScrollDeviceKey {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb042),
+                    product_name: None,
+                },
+                false,
+            ),
+        ])));
+        let enabled = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb037),
+            product_name: None,
+        };
+        let disabled = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb042),
+            product_name: None,
+        };
+
+        assert_eq!(
+            scroll_disposition(1.0, false, Some(&disabled), &inversions),
+            EventDisposition::PassThrough
+        );
+        assert_eq!(
+            scroll_disposition(1.0, true, Some(&enabled), &inversions),
+            EventDisposition::PassThrough
+        );
+        assert_eq!(
+            scroll_disposition(1.0, false, None, &inversions),
+            EventDisposition::PassThrough
+        );
+        assert_eq!(
+            scroll_disposition(0.0, false, Some(&enabled), &inversions),
+            EventDisposition::PassThrough
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -53,8 +53,10 @@ pub struct ScrollDeviceKey {
 
 /// Per-device software scroll inversion settings.
 ///
-/// Product ids are matched exactly before normalized product names. Conflicting
-/// settings for the same identity are retained as ambiguous and never match.
+/// A reported product id is authoritative and must match exactly; normalized
+/// product names are considered only when the event has no product id.
+/// Conflicting settings for the same identity are retained as ambiguous and
+/// never match.
 #[derive(Default)]
 pub struct ScrollInversions {
     by_product_id: BTreeMap<(u32, u32), Option<bool>>,
@@ -89,10 +91,13 @@ impl ScrollInversions {
     #[must_use]
     pub fn inversion_for(&self, device: Option<&EventDevice>) -> Option<bool> {
         let device = device?;
-        if let (Some(vendor_id), Some(product_id)) = (device.vendor_id, device.product_id)
-            && let Some(invert) = self.by_product_id.get(&(vendor_id, product_id))
-        {
-            return *invert;
+        if let Some(product_id) = device.product_id {
+            let vendor_id = device.vendor_id?;
+            return self
+                .by_product_id
+                .get(&(vendor_id, product_id))
+                .copied()
+                .flatten();
         }
 
         let product_name = device
@@ -189,12 +194,15 @@ pub fn scroll_disposition(
     device: Option<&EventDevice>,
     scroll_inversions: &SharedScrollInversions,
 ) -> EventDisposition {
+    if from_trackpad || delta_y == 0.0 {
+        return EventDisposition::PassThrough;
+    }
     let should_invert = scroll_inversions
         .read()
         .ok()
         .and_then(|inversions| inversions.inversion_for(device))
         .unwrap_or(false);
-    if should_invert && !from_trackpad && delta_y != 0.0 {
+    if should_invert {
         inverted_scroll_disposition()
     } else {
         EventDisposition::PassThrough
@@ -501,16 +509,6 @@ mod tests {
     use openlogi_core::binding::GESTURE_SWIPE_THRESHOLD;
     use openlogi_hook::EventDevice;
 
-    type StartFn = fn(
-        SharedHookMaps,
-        SharedScrollInversions,
-        Arc<RwLock<DpiCycleState>>,
-        CaptureChannel,
-        SharedEventMonitor,
-    ) -> Option<Hook>;
-
-    fn accepts_existing_start_signature(_start: StartFn) {}
-
     // The mid-swipe gate itself is unit-tested on `SwipeAccumulator` in
     // `openlogi-core`; these cover only what `HoldState` adds on top — tagging a
     // commit with the held button, and matching the button on release.
@@ -546,11 +544,6 @@ mod tests {
     }
 
     #[test]
-    fn start_accepts_scroll_inversions() {
-        accepts_existing_start_signature(start);
-    }
-
-    #[test]
     fn scroll_inversions_prefer_exact_product_id_over_name() {
         let inversions = ScrollInversions::new([
             (
@@ -577,6 +570,36 @@ mod tests {
         };
 
         assert_eq!(inversions.inversion_for(Some(&event)), Some(true));
+    }
+
+    #[test]
+    fn scroll_inversions_do_not_fall_back_to_name_after_product_id_miss() {
+        let inversions = Arc::new(RwLock::new(ScrollInversions::new([(
+            ScrollDeviceKey {
+                vendor_id: Some(0x046d),
+                product_id: Some(0xb037),
+                product_name: Some("M650".to_string()),
+            },
+            true,
+        )])));
+        let event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb042),
+            product_name: Some("M650".to_string()),
+        };
+
+        assert_eq!(
+            inversions
+                .read()
+                .ok()
+                .and_then(|settings| settings.inversion_for(Some(&event))),
+            None,
+            "a reported product id makes name fallback unsafe"
+        );
+        assert_eq!(
+            scroll_disposition(1.0, false, Some(&event), &inversions),
+            EventDisposition::PassThrough
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -22,7 +22,9 @@ use tracing::warn;
 use crate::DpiCycleState;
 use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
 use crate::device_order::DeviceStableId;
-use crate::hook_runtime::{HookMaps, SharedHookMaps};
+use crate::hook_runtime::{
+    HookMaps, ScrollDeviceKey, ScrollInversions, SharedHookMaps, SharedScrollInversions,
+};
 use crate::ipc::InventoryHealth;
 use crate::receiver_access::ReceiverAccess;
 use crate::watchers::gesture::GestureBindings;
@@ -38,6 +40,12 @@ struct AgentDevice {
     slot: u8,
     serial: Option<String>,
     unit_id: [u8; 4],
+    model_ids: [u16; 3],
+    product_name: Option<String>,
+    receiver_vendor_id: u16,
+    receiver_product_id: u16,
+    receiver_name: String,
+    receiver_identity_safe: bool,
     capabilities: Option<Capabilities>,
     /// Live link state from the inventory snapshot. An offline→online
     /// transition is a reconnect — the device may have power-cycled, so its
@@ -54,6 +62,10 @@ pub struct SharedRuntime {
     /// rebuild publishes both atomically (see [`HookMaps`]). Also read by the
     /// gesture watcher for the thumb-wheel/DPI-button single actions.
     pub hook_maps: SharedHookMaps,
+    /// Software scroll inversion settings for pointer devices whose firmware
+    /// cannot invert natively. The OS hook matches these against event-source
+    /// identities; native-capable devices are omitted to prevent double inversion.
+    pub scroll_inversions: SharedScrollInversions,
     pub gesture_bindings: GestureBindings,
     pub dpi_cycle: Arc<RwLock<DpiCycleState>>,
     pub thumbwheel_sensitivity: Arc<AtomicI32>,
@@ -105,6 +117,7 @@ impl Orchestrator {
     pub fn new(config: Config) -> Self {
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
+            scroll_inversions: Arc::new(RwLock::new(ScrollInversions::default())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(AtomicI32::new(
@@ -170,6 +183,11 @@ impl Orchestrator {
             "gesture_bindings",
         );
         write_value(
+            &self.shared.scroll_inversions,
+            self.scroll_inversions_for_devices(),
+            "scroll_inversions",
+        );
+        write_value(
             &self.shared.dpi_cycle,
             DpiCycleState {
                 presets: key.map(|k| self.config.dpi_presets(k)).unwrap_or_default(),
@@ -183,6 +201,37 @@ impl Orchestrator {
             self.config.app_settings.thumbwheel_sensitivity,
             Ordering::Relaxed,
         );
+    }
+
+    fn scroll_inversions_for_devices(&self) -> ScrollInversions {
+        let entries = self.devices.iter().flat_map(|dev| {
+            let software_inversion = dev
+                .capabilities
+                .is_some_and(|capabilities| capabilities.pointer && !capabilities.scroll_inversion);
+            let invert = software_inversion.then(|| self.config.invert_scroll(&dev.config_key));
+
+            let device_keys = dev
+                .model_ids
+                .into_iter()
+                .filter(|product_id| *product_id != 0)
+                .map(|product_id| ScrollDeviceKey {
+                    vendor_id: Some(u32::from(dev.receiver_vendor_id)),
+                    product_id: Some(u32::from(product_id)),
+                    product_name: dev.product_name.clone(),
+                });
+            let receiver_key = dev
+                .receiver_identity_safe
+                .then(|| ScrollDeviceKey {
+                    vendor_id: Some(u32::from(dev.receiver_vendor_id)),
+                    product_id: Some(u32::from(dev.receiver_product_id)),
+                    product_name: Some(dev.receiver_name.clone()),
+                })
+                .into_iter();
+            device_keys
+                .chain(receiver_key)
+                .filter_map(move |key| invert.map(|invert| (key, invert)))
+        });
+        ScrollInversions::new(entries)
     }
 
     /// Apply a fresh inventory snapshot. Always refreshes the snapshot the IPC
@@ -216,6 +265,12 @@ impl Orchestrator {
             || devices.iter().zip(&self.devices).any(|(a, b)| {
                 a.config_key != b.config_key
                     || a.route != b.route
+                    || a.model_ids != b.model_ids
+                    || a.product_name != b.product_name
+                    || a.receiver_vendor_id != b.receiver_vendor_id
+                    || a.receiver_product_id != b.receiver_product_id
+                    || a.receiver_name != b.receiver_name
+                    || a.receiver_identity_safe != b.receiver_identity_safe
                     || a.capabilities != b.capabilities
             });
         if !changed {
@@ -388,6 +443,20 @@ fn configured_wheel_mode(
 fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
     let mut devices = Vec::new();
     for inv in inventories {
+        // An OS event attributed only to a shared receiver cannot identify
+        // which paired mouse produced it. Publish that identity only when the
+        // receiver has exactly one possible pointer source. Unknown capability
+        // records count conservatively: an offline mouse must not make another
+        // slot's software setting bleed onto it when it wakes.
+        let receiver_pointer_count = inv
+            .paired
+            .iter()
+            .filter(|paired| {
+                paired
+                    .capabilities
+                    .is_none_or(|capabilities| capabilities.pointer)
+            })
+            .count();
         for paired in &inv.paired {
             let Some(model) = paired.model_info.as_ref() else {
                 continue;
@@ -402,6 +471,11 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
             let Some(config_key) = stable_id.physical_key() else {
                 continue;
             };
+            let receiver_identity_safe = matches!(route.as_ref(), Some(DeviceRoute::Direct { .. }))
+                || (matches!(
+                    route.as_ref(),
+                    Some(DeviceRoute::Bolt { .. } | DeviceRoute::Unifying { .. })
+                ) && receiver_pointer_count == 1);
             devices.push(AgentDevice {
                 config_key: config_key.into_string(),
                 model_key: model.config_key(),
@@ -409,6 +483,12 @@ fn build_devices(inventories: &[DeviceInventory]) -> Vec<AgentDevice> {
                 slot: paired.slot,
                 serial: model.serial_number.clone(),
                 unit_id: model.unit_id,
+                model_ids: model.model_ids,
+                product_name: paired.codename.clone(),
+                receiver_vendor_id: inv.receiver.vendor_id,
+                receiver_product_id: inv.receiver.product_id,
+                receiver_name: inv.receiver.name.clone(),
+                receiver_identity_safe,
                 capabilities: paired.capabilities,
                 online: paired.online,
             });
@@ -528,6 +608,7 @@ mod tests {
         ReceiverInfo,
     };
     use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
+    use openlogi_hook::{EventDevice, EventDisposition};
 
     fn dev(key: &str, slot: u8, online: bool) -> AgentDevice {
         AgentDevice {
@@ -540,6 +621,12 @@ mod tests {
             slot,
             serial: None,
             unit_id: [0; 4],
+            model_ids: [0; 3],
+            product_name: None,
+            receiver_vendor_id: 0x046d,
+            receiver_product_id: 0xc548,
+            receiver_name: "Logi Bolt Receiver".to_string(),
+            receiver_identity_safe: false,
             capabilities: None,
             online,
         }
@@ -580,6 +667,247 @@ mod tests {
         let devices = build_devices(&[direct_inventory(Some("ABC123"), [0; 4])]);
         assert_eq!(devices.len(), 1);
         assert_eq!(devices[0].config_key, "direct:046d:b023:serial:abc123");
+    }
+
+    fn software_scroll_capabilities() -> Capabilities {
+        Capabilities {
+            pointer: true,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        }
+    }
+
+    fn shared_receiver_inventory(second_capabilities: Option<Capabilities>) -> DeviceInventory {
+        let mut inventory = direct_inventory(Some("software"), [1, 2, 3, 4]);
+        inventory.receiver = ReceiverInfo {
+            name: "Logi Bolt Receiver".to_string(),
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+            unique_id: Some("RX".to_string()),
+        };
+        inventory.paired[0].slot = 1;
+        inventory.paired[0].codename = Some("Signature M650".to_string());
+        inventory.paired[0].capabilities = Some(software_scroll_capabilities());
+        let Some(software_model) = inventory.paired[0].model_info.as_mut() else {
+            panic!("shared receiver fixture must include model info");
+        };
+        software_model.model_ids = [0xb02a, 0, 0];
+
+        let mut second = inventory.paired[0].clone();
+        second.slot = 2;
+        second.codename = Some("Second Pointer".to_string());
+        second.capabilities = second_capabilities;
+        let Some(second_model) = second.model_info.as_mut() else {
+            panic!("shared receiver fixture must include model info");
+        };
+        second_model.model_ids = [0xb034, 0, 0];
+        inventory.paired.push(second);
+        inventory
+    }
+
+    fn scroll_inversion_for(orch: &Orchestrator, event: &EventDevice) -> Option<bool> {
+        orch.shared()
+            .scroll_inversions
+            .read()
+            .ok()
+            .and_then(|inversions| inversions.inversion_for(Some(event)))
+    }
+
+    #[test]
+    fn direct_m650_uses_software_inversion_even_with_a_direct_route() {
+        let mut inventory = direct_inventory(Some("M650-1"), [1, 2, 3, 4]);
+        inventory.receiver.name = "Logitech Signature M650 L".to_string();
+        inventory.receiver.product_id = 0xb02a;
+        inventory.paired[0].codename = Some("M650".to_string());
+        let Some(model_info) = inventory.paired[0].model_info.as_mut() else {
+            panic!("direct inventory fixture must include model info");
+        };
+        model_info.model_ids = [0xb02a, 0, 0];
+        inventory.paired[0].capabilities = Some(software_scroll_capabilities());
+
+        let mut config = Config::default();
+        config.set_invert_scroll("direct:046d:b02a:serial:m650-1", true);
+        let mut orch = Orchestrator::new(config);
+        orch.refresh_inventory(&[inventory]);
+
+        assert_eq!(
+            scroll_inversion_for(
+                &orch,
+                &EventDevice {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb02a),
+                    product_name: Some("Logitech Signature M650 L".to_string()),
+                },
+            ),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn shared_receiver_identity_is_excluded_for_mixed_software_and_native_pointers() {
+        let inventory = shared_receiver_inventory(Some(Capabilities {
+            pointer: true,
+            scroll_inversion: true,
+            ..Capabilities::default()
+        }));
+
+        let mut config = Config::default();
+        config.set_invert_scroll("receiver:rx:slot:1", true);
+        let mut orch = Orchestrator::new(config);
+        orch.refresh_inventory(&[inventory]);
+        let receiver_event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xc548),
+            product_name: Some("Logi Bolt Receiver".to_string()),
+        };
+        let model_event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb02a),
+            product_name: Some("Signature M650".to_string()),
+        };
+
+        assert_eq!(scroll_inversion_for(&orch, &receiver_event), None);
+        assert_eq!(
+            crate::hook_runtime::scroll_disposition(
+                1.0,
+                false,
+                Some(&receiver_event),
+                &orch.shared().scroll_inversions,
+            ),
+            EventDisposition::PassThrough
+        );
+        assert_eq!(scroll_inversion_for(&orch, &model_event), Some(true));
+    }
+
+    #[test]
+    fn unknown_shared_receiver_occupant_conservatively_excludes_receiver_identity() {
+        let inventory = shared_receiver_inventory(None);
+        let mut config = Config::default();
+        config.set_invert_scroll("receiver:rx:slot:1", true);
+        let mut orch = Orchestrator::new(config);
+        orch.refresh_inventory(&[inventory]);
+
+        assert_eq!(
+            scroll_inversion_for(
+                &orch,
+                &EventDevice {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xc548),
+                    product_name: Some("Logi Bolt Receiver".to_string()),
+                },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn native_scroll_inversion_devices_are_excluded_from_software_map() {
+        let mut inventory = direct_inventory(Some("native"), [1, 2, 3, 4]);
+        inventory.paired[0].capabilities = Some(Capabilities {
+            pointer: true,
+            scroll_inversion: true,
+            ..Capabilities::default()
+        });
+        let mut config = Config::default();
+        config.set_invert_scroll("direct:046d:b023:serial:native", true);
+        let mut orch = Orchestrator::new(config);
+        orch.refresh_inventory(&[inventory]);
+
+        assert_eq!(
+            scroll_inversion_for(
+                &orch,
+                &EventDevice {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb023),
+                    product_name: Some("MX Master 3S".to_string()),
+                },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn non_pointer_devices_are_excluded_from_software_scroll_map() {
+        let mut inventory = direct_inventory(Some("keyboard"), [1, 2, 3, 4]);
+        inventory.paired[0].capabilities = Some(Capabilities {
+            pointer: false,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        });
+        let mut config = Config::default();
+        config.set_invert_scroll("direct:046d:b023:serial:keyboard", true);
+        let mut orch = Orchestrator::new(config);
+        orch.refresh_inventory(&[inventory]);
+
+        assert_eq!(
+            scroll_inversion_for(
+                &orch,
+                &EventDevice {
+                    vendor_id: Some(0x046d),
+                    product_id: Some(0xb023),
+                    product_name: Some("MX Master 3S".to_string()),
+                },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn config_reload_republishes_software_scroll_inversion() {
+        let mut inventory = direct_inventory(Some("reload"), [1, 2, 3, 4]);
+        inventory.paired[0].capabilities = Some(software_scroll_capabilities());
+        let key = "direct:046d:b023:serial:reload";
+        let event = EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xb023),
+            product_name: Some("MX Master 3S".to_string()),
+        };
+        let mut orch = Orchestrator::new(Config::default());
+        orch.refresh_inventory(&[inventory]);
+        assert_eq!(scroll_inversion_for(&orch, &event), Some(false));
+
+        let mut config = Config::default();
+        config.set_invert_scroll(key, true);
+        orch.reload_config(config);
+        assert_eq!(scroll_inversion_for(&orch, &event), Some(true));
+    }
+
+    #[test]
+    fn identity_and_capability_changes_republish_software_scroll_map() {
+        let mut inventory = direct_inventory(Some("changing"), [1, 2, 3, 4]);
+        inventory.receiver.name = "Old Mouse".to_string();
+        inventory.paired[0].codename = Some("Old Mouse".to_string());
+        inventory.paired[0].capabilities = Some(software_scroll_capabilities());
+        let mut config = Config::default();
+        config.set_invert_scroll("direct:046d:b023:serial:changing", true);
+        let mut orch = Orchestrator::new(config);
+        orch.refresh_inventory(&[inventory.clone()]);
+        let named_event = |name: &str| EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: None,
+            product_name: Some(name.to_string()),
+        };
+        assert_eq!(
+            scroll_inversion_for(&orch, &named_event("Old Mouse")),
+            Some(true)
+        );
+
+        inventory.receiver.name = "New Mouse".to_string();
+        inventory.paired[0].codename = Some("New Mouse".to_string());
+        orch.refresh_inventory(&[inventory.clone()]);
+        assert_eq!(scroll_inversion_for(&orch, &named_event("Old Mouse")), None);
+        assert_eq!(
+            scroll_inversion_for(&orch, &named_event("New Mouse")),
+            Some(true)
+        );
+
+        inventory.paired[0].capabilities = Some(Capabilities {
+            pointer: true,
+            scroll_inversion: true,
+            ..Capabilities::default()
+        });
+        orch.refresh_inventory(&[inventory]);
+        assert_eq!(scroll_inversion_for(&orch, &named_event("New Mouse")), None);
     }
 
     #[test]

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -231,6 +231,7 @@ async fn run(config: Config) {
                         info!("accessibility granted — installing OS mouse hook");
                         hook = hook_runtime::start(
                             shared.hook_maps.clone(),
+                            shared.scroll_inversions.clone(),
                             shared.dpi_cycle.clone(),
                             shared.capture_channel.clone(),
                             Arc::clone(&event_monitor),

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -260,12 +260,13 @@ mod tests {
     use std::sync::RwLock;
 
     use openlogi_agent_core::DpiCycleState;
-    use openlogi_agent_core::hook_runtime::HookMaps;
+    use openlogi_agent_core::hook_runtime::{HookMaps, ScrollInversions};
     use openlogi_agent_core::receiver_access::ReceiverAccess;
 
     fn shared_runtime() -> SharedRuntime {
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
+            scroll_inversions: Arc::new(RwLock::new(ScrollInversions::default())),
             gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycleState::default())),
             thumbwheel_sensitivity: Arc::new(0.into()),

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Rulning"
 "Invert scroll direction": "Vend rulleretning om"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Vend musens rullehjul om. Din pegeplade beholder systemets rulleretning."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Vend musens rullehjul om i macOS. Din pegeplade beholder systemets rulleretning."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Hjulopløsning"
 "Device default": "Enhedsstandard"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Scrollen"
 "Invert scroll direction": "Scrollrichtung umkehren"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Kehrt das Scrollrad dieser Maus um. Dein Trackpad behält die Scrollrichtung des Systems."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Kehrt das Scrollrad dieser Maus unter macOS um. Dein Trackpad behält die Scrollrichtung des Systems."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Mausradauflösung"
 "Device default": "Gerätestandard"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Κύλιση"
 "Invert scroll direction": "Αντιστροφή κατεύθυνσης κύλισης"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Αντιστρέφει τον τροχό κύλισης αυτού του ποντικιού. Το trackpad διατηρεί την κατεύθυνση κύλισης του συστήματος."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Αντιστρέφει τον τροχό κύλισης αυτού του ποντικιού στο macOS. Το trackpad διατηρεί την κατεύθυνση κύλισης του συστήματος."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Ανάλυση τροχού"
 "Device default": "Προεπιλογή συσκευής"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Scrolling"
 "Invert scroll direction": "Invert scroll direction"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Wheel resolution"
 "Device default": "Device default"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Desplazamiento"
 "Invert scroll direction": "Invertir dirección de desplazamiento"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Invierte la rueda de desplazamiento de este ratón. Tu trackpad conserva la dirección de desplazamiento del sistema."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Invierte la rueda de desplazamiento de este ratón en macOS. Tu trackpad conserva la dirección de desplazamiento del sistema."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Resolución de la rueda"
 "Device default": "Predeterminado del dispositivo"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Vieritys"
 "Invert scroll direction": "Käännä vierityssuunta"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Kääntää tämän hiiren vierityspyörän. Ohjauslevy säilyttää järjestelmän vierityssuunnan."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Kääntää tämän hiiren vierityspyörän macOS:ssä. Ohjauslevy säilyttää järjestelmän vierityssuunnan."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Vierityspyörän tarkkuus"
 "Device default": "Laitteen oletus"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Défilement"
 "Invert scroll direction": "Inverser le sens de défilement"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverse la molette de cette souris. Votre trackpad conserve le sens de défilement du système."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Inverse la molette de cette souris sous macOS. Votre trackpad conserve le sens de défilement du système."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Résolution de la molette"
 "Device default": "Réglage par défaut de l’appareil"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Scorrimento"
 "Invert scroll direction": "Inverti direzione di scorrimento"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverte la rotellina di questo mouse. Il trackpad mantiene la direzione di scorrimento del sistema."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Inverte la rotellina di questo mouse su macOS. Il trackpad mantiene la direzione di scorrimento del sistema."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Risoluzione rotellina"
 "Device default": "Predefinita del dispositivo"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "スクロール"
 "Invert scroll direction": "スクロール方向を反転"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "このマウスのスクロールホイールを反転します。トラックパッドはシステムのスクロール方向を維持します。"
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "macOSでこのマウスのスクロールホイールを反転します。トラックパッドはシステムのスクロール方向を維持します。"
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "ホイール解像度"
 "Device default": "デバイスのデフォルト"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "스크롤"
 "Invert scroll direction": "스크롤 방향 반전"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "이 마우스의 스크롤 휠을 반전합니다. 트랙패드는 시스템 스크롤 방향을 유지합니다."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "macOS에서 이 마우스의 스크롤 휠을 반전합니다. 트랙패드는 시스템 스크롤 방향을 유지합니다."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "휠 해상도"
 "Device default": "기기 기본값"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Rulling"
 "Invert scroll direction": "Inverter rulleretning"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverterer rullehjulet på denne musen. Styreplaten beholder systemets rulleretning."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Inverterer rullehjulet på denne musen i macOS. Styreplaten beholder systemets rulleretning."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Hjuloppløsning"
 "Device default": "Enhetsstandard"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Scrollen"
 "Invert scroll direction": "Scrollrichting omkeren"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Keert het scrollwiel van deze muis om. Je trackpad behoudt de scrollrichting van het systeem."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Keert in macOS het scrollwiel van deze muis om. Je trackpad behoudt de scrollrichting van het systeem."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Wielresolutie"
 "Device default": "Apparaatstandaard"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Przewijanie"
 "Invert scroll direction": "Odwróć kierunek przewijania"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Odwraca kółko przewijania tej myszy. Gładzik zachowuje systemowy kierunek przewijania."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Odwraca kółko przewijania tej myszy w systemie macOS. Gładzik zachowuje systemowy kierunek przewijania."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Rozdzielczość kółka"
 "Device default": "Domyślne urządzenia"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Rolagem"
 "Invert scroll direction": "Inverter direção de rolagem"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverte a roda de rolagem deste mouse. Seu trackpad mantém a direção de rolagem do sistema."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Inverte a roda de rolagem deste mouse no macOS. Seu trackpad mantém a direção de rolagem do sistema."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Resolução da roda"
 "Device default": "Padrão do dispositivo"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Deslocação"
 "Invert scroll direction": "Inverter direção de deslocação"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverte a roda de deslocação deste rato. O seu trackpad mantém a direção de deslocação do sistema."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Inverte a roda de deslocação deste rato no macOS. O seu trackpad mantém a direção de deslocação do sistema."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Resolução da roda"
 "Device default": "Predefinição do dispositivo"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Прокрутка"
 "Invert scroll direction": "Инвертировать направление прокрутки"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Инвертирует колёсико прокрутки этой мыши. Трекпад сохраняет системное направление прокрутки."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Инвертирует колёсико прокрутки этой мыши в macOS. Трекпад сохраняет системное направление прокрутки."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Разрешение колеса"
 "Device default": "По умолчанию устройства"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "Rullning"
 "Invert scroll direction": "Invertera rullningsriktning"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "Inverterar mushjulet på den här musen. Din styrplatta behåller systemets rullningsriktning."
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "Inverterar mushjulet på den här musen i macOS. Din styrplatta behåller systemets rullningsriktning."
 "This device does not report native HID++ scroll inversion support.": "This device does not report native HID++ scroll inversion support."
 "Wheel resolution": "Hjulupplösning"
 "Device default": "Enhetsstandard"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "滚动"
 "Invert scroll direction": "反转滚动方向"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "反转这只鼠标的滚轮方向。触控板仍保持系统的滚动方向。"
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "在 macOS 中反转这只鼠标的滚轮方向。触控板仍保持系统的滚动方向。"
 "This device does not report native HID++ scroll inversion support.": "此设备未报告原生 HID++ 滚动反转支持。"
 "Wheel resolution": "滚轮分辨率"
 "Device default": "设备默认值"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "捲動"
 "Invert scroll direction": "反轉捲動方向"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "反轉此滑鼠的滾輪方向。觸控板會維持系統的捲動方向。"
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "在 macOS 中反轉此滑鼠的滾輪方向。觸控板會維持系統的捲動方向。"
 "This device does not report native HID++ scroll inversion support.": "此裝置未回報原生 HID++ 捲動方向反轉支援。"
 "Wheel resolution": "滾輪解析度"
 "Device default": "裝置預設值"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -271,6 +271,7 @@ _version: 1
 "Scrolling": "捲動"
 "Invert scroll direction": "反轉捲動方向"
 "Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.": "反轉此滑鼠的滾輪方向。觸控板會維持系統的捲動方向。"
+"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction.": "在 macOS 中反轉此滑鼠的滾輪方向。觸控板會維持系統的捲動方向。"
 "This device does not report native HID++ scroll inversion support.": "此裝置未回報原生 HID++ 捲動方向反轉支援。"
 "Wheel resolution": "滾輪解析度"
 "Device default": "裝置預設值"

--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -229,18 +229,23 @@ fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
 /// Pure config — no hardware read — so it is a plain settings block rather than
 /// an `Entity` panel like DPI / SmartShift.
 fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
-    let (inverted, inversion_supported, resolution, hires_supported) = cx
+    let (inverted, native_inversion, inversion_supported, resolution, hires_supported) = cx
         .try_global::<AppState>()
-        .map_or((false, false, None, false), |state| {
+        .map_or((false, false, false, None, false), |state| {
             (
                 state.current_invert_scroll(),
+                state.current_native_scroll_inversion_supported(),
                 state.current_scroll_inversion_supported(),
                 state.current_scroll_resolution(),
                 state.current_hires_wheel_supported(),
             )
         });
-    let inversion_description = if inversion_supported {
+    let inversion_description = if native_inversion {
         tr!("Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.")
+    } else if inversion_supported {
+        tr!(
+            "Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction."
+        )
     } else {
         tr!("This device does not report native HID++ scroll inversion support.")
     };

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -153,6 +153,9 @@ pub struct AppState {
     /// rebuild, and "apply now" device changes (DPI / SmartShift / lighting)
     /// go out as their own commands. The GUI never opens a device itself.
     ipc_commands: mpsc::UnboundedSender<crate::ipc_client::Command>,
+    /// Isolated persistence target for tests that exercise commit + reload.
+    #[cfg(test)]
+    test_config_path: Option<std::path::PathBuf>,
     /// Raw inventory from the last *completed* enumeration, kept for the
     /// diagnostics report (receivers + transports). The poll path only stores
     /// [`InventoryHealth::Ready`](openlogi_agent_core::ipc::InventoryHealth)
@@ -209,6 +212,8 @@ impl AppState {
             device_list,
             config,
             ipc_commands,
+            #[cfg(test)]
+            test_config_path: None,
             last_inventory: Vec::new(),
             #[cfg(all(target_os = "macos", debug_assertions))]
             monitor_events: std::collections::VecDeque::new(),
@@ -237,7 +242,14 @@ impl AppState {
     /// next reconnect or wake. Skipping the reload keeps the agent on whatever
     /// it already runs; the GUI keeps the new value in memory either way.
     fn persist_and_reload(&self, what: &str) {
-        if let Err(e) = self.config.save_atomic() {
+        #[cfg(test)]
+        let save = self.test_config_path.as_ref().map_or_else(
+            || self.config.save_atomic(),
+            |path| self.config.save_to_path(path),
+        );
+        #[cfg(not(test))]
+        let save = self.config.save_atomic();
+        if let Err(e) = save {
             warn!(error = %e, what, "could not persist to config.toml — agent reload skipped");
             return;
         }
@@ -962,18 +974,31 @@ impl AppState {
 
     /// Whether the active device reports native HID++ wheel inversion support.
     #[must_use]
-    pub fn current_scroll_inversion_supported(&self) -> bool {
+    pub fn current_native_scroll_inversion_supported(&self) -> bool {
         self.current_record()
             .and_then(|record| record.capabilities)
             .is_some_and(|capabilities| capabilities.scroll_inversion)
     }
 
+    /// Whether the active device can invert its scroll wheel, either through
+    /// native HID++ support or the macOS host-side fallback.
+    #[must_use]
+    pub fn current_scroll_inversion_supported(&self) -> bool {
+        self.current_record().is_some_and(|record| {
+            scroll_inversion_supported(
+                record.capabilities,
+                record.is_persistent(),
+                cfg!(target_os = "macos"),
+            )
+        })
+    }
+
     /// Set the active device's scroll-wheel inversion, persist it, and reload
-    /// the agent so it writes the device's native HID++ wheel inversion. No-op
-    /// when no device is selected or the active device does not report support.
+    /// the agent so it applies either native HID++ inversion or the macOS
+    /// host-side fallback. No-op when no supported persistent device is selected.
     pub fn commit_invert_scroll(&mut self, invert: bool) {
         if !self.current_scroll_inversion_supported() {
-            debug!("active device does not support native scroll inversion");
+            debug!("active device does not support scroll inversion");
             return;
         }
         let Some(key) = self
@@ -1531,6 +1556,17 @@ fn smartshift_read_is_current(
     }
 }
 
+fn scroll_inversion_supported(
+    capabilities: Option<openlogi_core::device::Capabilities>,
+    persistent: bool,
+    macos_fallback: bool,
+) -> bool {
+    persistent
+        && capabilities.is_some_and(|capabilities| {
+            capabilities.scroll_inversion || (macos_fallback && capabilities.pointer)
+        })
+}
+
 fn set_scroll_resolution_if_supported(
     config: &mut Config,
     key: &str,
@@ -1559,11 +1595,23 @@ mod tests {
     use openlogi_hid::{SmartShiftMode, SmartShiftStatus};
 
     use super::{
-        AppState, Load, SmartShiftWriteStatus, build_device_list,
+        AppState, Load, SmartShiftWriteStatus, build_device_list, scroll_inversion_supported,
         set_scroll_resolution_if_supported, smartshift_read_is_current, smartshift_write_outcome,
     };
 
     fn direct_inventory(unit_id: [u8; 4]) -> DeviceInventory {
+        direct_inventory_with(
+            unit_id,
+            DeviceKind::Mouse,
+            Capabilities::presumed_from_kind(DeviceKind::Mouse),
+        )
+    }
+
+    fn direct_inventory_with(
+        unit_id: [u8; 4],
+        kind: DeviceKind,
+        capabilities: Capabilities,
+    ) -> DeviceInventory {
         DeviceInventory {
             receiver: ReceiverInfo {
                 name: "MX Master 3S".to_string(),
@@ -1575,7 +1623,7 @@ mod tests {
                 slot: openlogi_hid::DIRECT_DEVICE_INDEX,
                 codename: Some("MX Master 3S".to_string()),
                 wpid: None,
-                kind: DeviceKind::Mouse,
+                kind,
                 online: true,
                 battery: None,
                 model_info: Some(DeviceModelInfo {
@@ -1586,9 +1634,153 @@ mod tests {
                     model_ids: [0xb034, 0, 0],
                     extended_model_id: 2,
                 }),
-                capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+                capabilities: Some(capabilities),
             }],
         }
+    }
+
+    #[test]
+    fn native_scroll_inversion_remains_supported() {
+        let capabilities = Capabilities {
+            pointer: true,
+            scroll_inversion: true,
+            ..Capabilities::default()
+        };
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let state = AppState::with_runtime(
+            Config::default(),
+            &[direct_inventory_with(
+                [0xa3, 0x93, 0xca, 0xe0],
+                DeviceKind::Mouse,
+                capabilities,
+            )],
+            &AssetResolver::new(),
+            commands,
+        );
+
+        assert!(state.current_native_scroll_inversion_supported());
+        assert!(state.current_scroll_inversion_supported());
+    }
+
+    #[test]
+    fn software_scroll_inversion_is_macos_only() {
+        let capabilities = Some(Capabilities {
+            pointer: true,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        });
+
+        assert!(scroll_inversion_supported(capabilities, true, true));
+        assert!(!scroll_inversion_supported(capabilities, true, false));
+        assert!(!scroll_inversion_supported(capabilities, false, true));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn persistent_pointer_supports_macos_scroll_inversion_fallback() {
+        let capabilities = Capabilities {
+            pointer: true,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        };
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let state = AppState::with_runtime(
+            Config::default(),
+            &[direct_inventory_with(
+                [0x65, 0x00, 0x00, 0x01],
+                DeviceKind::Mouse,
+                capabilities,
+            )],
+            &AssetResolver::new(),
+            commands,
+        );
+
+        assert!(!state.current_native_scroll_inversion_supported());
+        assert!(state.current_scroll_inversion_supported());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn m650_fallback_commit_persists_and_reloads() {
+        let capabilities = Capabilities {
+            pointer: true,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        };
+        let mut inventory =
+            direct_inventory_with([0x65, 0x00, 0x00, 0x01], DeviceKind::Mouse, capabilities);
+        inventory.receiver.name = "M650".to_string();
+        inventory.paired[0].codename = Some("M650".to_string());
+        let (commands, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut state = AppState::with_runtime(
+            Config::default(),
+            &[inventory],
+            &AssetResolver::new(),
+            commands,
+        );
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.toml");
+        state.test_config_path = Some(config_path.clone());
+        let key = state
+            .current_record()
+            .expect("M650 record")
+            .config_key
+            .clone();
+
+        state.commit_invert_scroll(true);
+
+        assert!(state.current_invert_scroll());
+        let saved = Config::load_from_path(&config_path).expect("saved config");
+        assert!(saved.invert_scroll(&key));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(crate::ipc_client::Command::ReloadConfig)
+        ));
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn non_pointer_does_not_support_scroll_inversion_fallback() {
+        let capabilities = Capabilities {
+            pointer: false,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        };
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let state = AppState::with_runtime(
+            Config::default(),
+            &[direct_inventory_with(
+                [0x65, 0x00, 0x00, 0x01],
+                DeviceKind::Keyboard,
+                capabilities,
+            )],
+            &AssetResolver::new(),
+            commands,
+        );
+
+        assert!(!state.current_scroll_inversion_supported());
+    }
+
+    #[test]
+    fn transient_pointer_does_not_support_scroll_inversion_fallback() {
+        let capabilities = Capabilities {
+            pointer: true,
+            scroll_inversion: false,
+            ..Capabilities::default()
+        };
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        let state = AppState::with_runtime(
+            Config::default(),
+            &[direct_inventory_with(
+                [0; 4],
+                DeviceKind::Mouse,
+                capabilities,
+            )],
+            &AssetResolver::new(),
+            commands,
+        );
+
+        assert!(!state.current_scroll_inversion_supported());
     }
 
     #[test]

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -99,6 +99,13 @@ pub enum EventDisposition {
     PassThrough,
     /// Drop the event; the target application never sees it.
     Suppress,
+    /// Replace a macOS scroll event with one whose vertical axis is inverted.
+    ///
+    /// The original event is preserved if the synthetic replacement cannot be
+    /// created. Available only on macOS because other hooks handle scroll
+    /// replacement through their platform-native paths.
+    #[cfg(target_os = "macos")]
+    InvertScroll,
 }
 
 /// Where in the event stream a tap is inserted (macOS `CGEventTapLocation`).

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -417,6 +417,177 @@ fn usable_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
     event.get_integer_value_field(axis.line) as f64
 }
 
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGEventCreateCopy(event: *const std::ffi::c_void) -> *mut std::ffi::c_void;
+}
+
+fn inverted_scroll_event(event: &CGEvent) -> Result<CGEvent, ()> {
+    // SAFETY: `event.as_ptr()` is a live CGEventRef. A non-null return is a
+    // distinct +1 retained copy which `CGEvent::from_ptr` takes ownership of.
+    let copy = unsafe { CGEventCreateCopy(event.as_ptr().cast()) };
+    if copy.is_null() {
+        return Err(());
+    }
+    // SAFETY: `copy` is a non-null, +1 retained CGEventRef returned above.
+    let replacement = unsafe { CGEvent::from_ptr(copy.cast()) };
+    replacement.set_integer_value_field(
+        VERTICAL.line,
+        event
+            .get_integer_value_field(VERTICAL.line)
+            .saturating_neg(),
+    );
+    replacement.set_double_value_field(
+        VERTICAL.fixed,
+        -event.get_double_value_field(VERTICAL.fixed),
+    );
+    replacement.set_double_value_field(
+        VERTICAL.point,
+        -event.get_double_value_field(VERTICAL.point),
+    );
+    replacement.set_integer_value_field(
+        EventField::EVENT_SOURCE_USER_DATA,
+        openlogi_inject::SYNTHETIC_EVENT_USER_DATA,
+    );
+    Ok(replacement)
+}
+
+fn callback_result(disposition: EventDisposition, event: &CGEvent) -> CallbackResult {
+    match disposition {
+        EventDisposition::PassThrough => CallbackResult::Keep,
+        EventDisposition::Suppress => CallbackResult::Drop,
+        EventDisposition::InvertScroll => {
+            if let Ok(replacement) = inverted_scroll_event(event) {
+                CallbackResult::Replace(replacement)
+            } else {
+                warn!("failed to copy scroll event for inversion; preserving original event");
+                CallbackResult::Keep
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod scroll_tests {
+    use core_graphics::event::{CGEvent, CallbackResult, ScrollEventUnit};
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+    use foreign_types_shared::ForeignType as _;
+
+    use super::{
+        HORIZONTAL, MOMENTUM_PHASE, SCROLL_COUNT, SCROLL_PHASE, VERTICAL, callback_result,
+        inverted_scroll_event, translate,
+    };
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    unsafe extern "C" {
+        fn CGEventGetTimestamp(event: *const std::ffi::c_void) -> u64;
+        fn CGEventSetTimestamp(event: *mut std::ffi::c_void, timestamp: u64);
+    }
+
+    fn scroll_event(unit: u32, vertical: i32, horizontal: i32) -> CGEvent {
+        let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState)
+            .unwrap_or_else(|()| panic!("test event source should be available"));
+        CGEvent::new_scroll_event(source, unit, 2, vertical, horizontal, 0)
+            .unwrap_or_else(|()| panic!("test scroll event should be available"))
+    }
+
+    #[test]
+    fn inverted_scroll_event_is_marked_and_does_not_reenter_translation() {
+        let event = scroll_event(ScrollEventUnit::LINE, 7, -3);
+
+        let inverted = inverted_scroll_event(&event)
+            .unwrap_or_else(|()| panic!("replacement should be created"));
+
+        assert_eq!(
+            inverted
+                .get_integer_value_field(core_graphics::event::EventField::EVENT_SOURCE_USER_DATA),
+            openlogi_inject::SYNTHETIC_EVENT_USER_DATA
+        );
+        assert!(translate(core_graphics::event::CGEventType::ScrollWheel, &inverted).is_none());
+    }
+
+    #[test]
+    fn inverted_scroll_event_preserves_fractional_axes_and_metadata() {
+        let event = scroll_event(ScrollEventUnit::PIXEL, 12, -7);
+        event.set_integer_value_field(VERTICAL.line, 3);
+        event.set_double_value_field(VERTICAL.fixed, 1.25);
+        event.set_double_value_field(VERTICAL.point, 12.5);
+        event.set_integer_value_field(HORIZONTAL.line, -2);
+        event.set_double_value_field(HORIZONTAL.fixed, -0.75);
+        event.set_double_value_field(HORIZONTAL.point, -7.5);
+        event.set_integer_value_field(SCROLL_PHASE, 2);
+        event.set_integer_value_field(MOMENTUM_PHASE, 3);
+        event.set_integer_value_field(SCROLL_COUNT, 4);
+        // SAFETY: `event.as_ptr()` is a live CGEvent for the duration of this call.
+        unsafe { CGEventSetTimestamp(event.as_ptr().cast(), 0x1234_5678_9ABC_DEF0) };
+        let vertical_line = event.get_integer_value_field(VERTICAL.line);
+        let vertical_fixed = event.get_double_value_field(VERTICAL.fixed);
+        let vertical_point = event.get_double_value_field(VERTICAL.point);
+        let horizontal_line = event.get_integer_value_field(HORIZONTAL.line);
+        let horizontal_fixed = event.get_double_value_field(HORIZONTAL.fixed);
+        let horizontal_point = event.get_double_value_field(HORIZONTAL.point);
+
+        let inverted = inverted_scroll_event(&event)
+            .unwrap_or_else(|()| panic!("replacement should be copied"));
+
+        assert_ne!(inverted.as_ptr(), event.as_ptr());
+        assert_eq!(
+            inverted.get_integer_value_field(VERTICAL.line),
+            vertical_line.saturating_neg()
+        );
+        assert!(
+            (inverted.get_double_value_field(VERTICAL.fixed) + vertical_fixed).abs() < f64::EPSILON
+        );
+        assert!(
+            (inverted.get_double_value_field(VERTICAL.point) + vertical_point).abs() < f64::EPSILON
+        );
+        assert_eq!(
+            inverted.get_integer_value_field(HORIZONTAL.line),
+            horizontal_line
+        );
+        assert!(
+            (inverted.get_double_value_field(HORIZONTAL.fixed) - horizontal_fixed).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (inverted.get_double_value_field(HORIZONTAL.point) - horizontal_point).abs()
+                < f64::EPSILON
+        );
+        assert_eq!(inverted.get_integer_value_field(SCROLL_PHASE), 2);
+        assert_eq!(inverted.get_integer_value_field(MOMENTUM_PHASE), 3);
+        assert_eq!(inverted.get_integer_value_field(SCROLL_COUNT), 4);
+        // SAFETY: both pointers are live CGEvents for the duration of these calls.
+        assert_eq!(
+            unsafe { CGEventGetTimestamp(inverted.as_ptr().cast()) },
+            unsafe { CGEventGetTimestamp(event.as_ptr().cast()) }
+        );
+        assert_eq!(event.get_integer_value_field(VERTICAL.line), vertical_line);
+        assert!(
+            (event.get_double_value_field(VERTICAL.fixed) - vertical_fixed).abs() < f64::EPSILON
+        );
+        assert!(
+            (event.get_double_value_field(VERTICAL.point) - vertical_point).abs() < f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn invert_disposition_returns_replacement_event() {
+        let event = scroll_event(ScrollEventUnit::PIXEL, 5, -2);
+
+        let result = callback_result(crate::EventDisposition::InvertScroll, &event);
+
+        let CallbackResult::Replace(replacement) = result else {
+            panic!("invert disposition should replace the captured event");
+        };
+        assert!((replacement.get_double_value_field(VERTICAL.point) + 5.0).abs() < f64::EPSILON);
+        assert_eq!(
+            replacement
+                .get_integer_value_field(core_graphics::event::EventField::EVENT_SOURCE_USER_DATA),
+            openlogi_inject::SYNTHETIC_EVENT_USER_DATA
+        );
+    }
+}
+
 /// Create the event tap and run loop on a dedicated thread.
 pub(crate) fn start(
     cb: impl Fn(MouseEvent) -> EventDisposition + Send + Sync + 'static,
@@ -494,10 +665,7 @@ fn thread_main(
             let Some(mouse_event) = translate(etype, event) else {
                 return CallbackResult::Keep;
             };
-            match cb(mouse_event) {
-                EventDisposition::PassThrough => CallbackResult::Keep,
-                EventDisposition::Suppress => CallbackResult::Drop,
-            }
+            callback_result(cb(mouse_event), event)
         },
     );
 

--- a/docs/superpowers/plans/2026-08-06-macos-scroll-inversion-fallback.md
+++ b/docs/superpowers/plans/2026-08-06-macos-scroll-inversion-fallback.md
@@ -1,0 +1,232 @@
+# macOS Scroll Inversion Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a persistent Logitech mouse such as Signature M650 use per-device scroll-direction inversion on macOS when it lacks native HID++ `0x2121` inversion support, without changing trackpad scrolling or double-inverting native-capable mice.
+
+**Architecture:** Keep `Capabilities::scroll_inversion` as the native hardware capability. The agent publishes a separate in-process map of non-native pointer identities and configured inversion values; the macOS event tap resolves each physical scroll event and replaces only a matched vertical mouse-wheel event with a marked synthetic event. The GUI enables this fallback for persistent pointer devices on macOS; config and IPC formats remain unchanged.
+
+**Tech Stack:** Rust workspace, `core-graphics` CGEventTap, IOKit sender identity, GPUI, TOML config, Cargo test/clippy/rustfmt.
+
+---
+
+### Task 1: macOS hook inversion disposition and safe event replacement
+
+**Files:**
+- Modify: `crates/openlogi-hook/src/lib.rs`
+- Modify: `crates/openlogi-hook/src/macos.rs`
+
+- [ ] **Step 1: Write failing conversion tests**
+
+Add macOS unit tests beside `usable_scroll_delta` which create line- and pixel-unit `CGEvent::new_scroll_event` values. Assert a new helper negates the vertical delta, preserves the horizontal delta, and selects pixel units when either captured axis uses point/fixed-point data.
+
+```rust
+#[test]
+fn synthetic_scroll_values_invert_vertical_and_preserve_horizontal() {
+    let event = CGEvent::new_scroll_event(None, ScrollEventUnit::Line, 2, 7, -3).unwrap();
+    let values = synthetic_scroll_values(&event);
+    assert_eq!(values.vertical, -7);
+    assert_eq!(values.horizontal, -3);
+    assert_eq!(values.unit, ScrollEventUnit::Line);
+}
+```
+
+- [ ] **Step 2: Verify the test fails**
+
+Run `cargo test -p openlogi-hook synthetic_scroll_values_invert_vertical_and_preserve_horizontal`.
+
+Expected: compilation fails because `synthetic_scroll_values` does not exist.
+
+- [ ] **Step 3: Implement the minimal replacement path**
+
+Add a macOS-only `EventDisposition::InvertScroll`. Make an independent `CGEventCreateCopy`, negate its vertical line/fixed/point fields, preserve horizontal and all metadata, set `openlogi_inject::SYNTHETIC_EVENT_USER_DATA`, and return it through `CallbackResult::Replace`. Return `Keep` if copying fails. Do not restructure the tap thread or run loop.
+
+```rust
+match cb(mouse_event) {
+    EventDisposition::PassThrough => CallbackResult::Keep,
+    EventDisposition::Suppress => CallbackResult::Drop,
+    EventDisposition::InvertScroll => inverted_scroll_event(event)
+        .map_or(CallbackResult::Keep, CallbackResult::Replace),
+}
+```
+
+- [ ] **Step 4: Verify and format**
+
+Run `cargo test -p openlogi-hook` and `cargo fmt --all -- --check`.
+
+Expected: all hook tests pass and formatting is clean.
+
+- [ ] **Step 5: Commit**
+
+Run `git add crates/openlogi-hook/src/lib.rs crates/openlogi-hook/src/macos.rs` and `git commit -m "feat(hook): add macos scroll inversion disposition"`.
+
+### Task 2: Per-device software decisions in the agent runtime
+
+**Files:**
+- Modify: `crates/openlogi-agent-core/src/hook_runtime.rs`
+
+- [ ] **Step 1: Write failing identity and decision tests**
+
+Add tests for product-ID preference, normalized/contained product-name fallback, conflicting identity removal, and disposition gating. The disposition test must prove a matched enabled M650 mouse yields `InvertScroll`, while trackpad, unknown source, zero vertical delta, and disabled match pass through.
+
+```rust
+#[test]
+fn scroll_disposition_only_inverts_matched_mouse_wheels() {
+    let inversions = Arc::new(RwLock::new(ScrollInversions::new([(
+        ScrollDeviceKey { vendor_id: Some(0x046d), product_id: Some(0xb02a), product_name: Some("Logi M650".into()) },
+        true,
+    )])));
+    let mouse = EventDevice { vendor_id: Some(0x046d), product_id: Some(0xb02a), product_name: Some("Logi M650".into()) };
+    assert_eq!(scroll_disposition(1.0, false, Some(&mouse), &inversions), EventDisposition::InvertScroll);
+    assert_eq!(scroll_disposition(1.0, true, Some(&mouse), &inversions), EventDisposition::PassThrough);
+    assert_eq!(scroll_disposition(1.0, false, None, &inversions), EventDisposition::PassThrough);
+}
+```
+
+- [ ] **Step 2: Verify the test fails**
+
+Run `cargo test -p openlogi-agent-core scroll_disposition_only_inverts_matched_mouse_wheels`.
+
+Expected: compilation fails because the software inversion types and helper do not exist.
+
+- [ ] **Step 3: Implement the shared identity map**
+
+Implement `ScrollDeviceKey`, `ScrollInversions`, and `SharedScrollInversions` with vendor-aware `BTreeMap`s. Treat a reported product ID as authoritative and require an exact vendor/product pair; only events without a product ID may compare lowercase trimmed names with a minimum four-character containment match. Discard an identity if two device entries assign conflicting values. Return `InvertScroll` only for an enabled, non-trackpad, non-zero vertical event matched to the map.
+
+- [ ] **Step 4: Verify and format**
+
+Run `cargo test -p openlogi-agent-core hook_runtime` and `cargo fmt --all -- --check`.
+
+Expected: all focused tests pass and formatting is clean.
+
+- [ ] **Step 5: Commit**
+
+Run `git add crates/openlogi-agent-core/src/hook_runtime.rs` and `git commit -m "feat(agent): decide software scroll inversion per device"`.
+
+### Task 3: Publish only non-native pointer devices
+
+**Files:**
+- Modify: `crates/openlogi-agent-core/src/orchestrator.rs`
+- Modify: `crates/openlogi-agent/src/main.rs`
+
+- [ ] **Step 1: Write failing orchestrator tests**
+
+Extend the inventory fixture so tests can set model IDs, product names, pointer capability, and native inversion capability. Assert a persistent M650-like device with `pointer = true`, `scroll_inversion = false`, and saved `invert_scroll = true` appears in `shared.scroll_inversions`; assert native-capable and non-pointer devices do not.
+
+```rust
+let source = EventDevice {
+    vendor_id: Some(0x046d),
+    product_id: Some(0xb02a),
+    product_name: Some("Logi M650".into()),
+    ..EventDevice::default()
+};
+assert!(orchestrator.shared().scroll_inversions.read().unwrap()
+    .inversion_for(Some(&source)).is_some_and(|(_, value)| value));
+```
+
+- [ ] **Step 2: Verify the test fails**
+
+Run `cargo test -p openlogi-agent-core rebuild_publishes_only_non_native_pointer_scroll_fallbacks`.
+
+Expected: compilation fails because `SharedRuntime` has no fallback map and `AgentDevice` retains no event-source identity.
+
+- [ ] **Step 3: Wire inventory identity into rebuilds**
+
+Retain nonzero `model.model_ids`, `paired.codename`, and receiver identity in `AgentDevice`. Add `scroll_inversions` to `SharedRuntime`, initialize it, and rebuild from devices satisfying `capabilities.is_some_and(|caps| caps.pointer && !caps.scroll_inversion)`. Publish vendor-aware device identity for every eligible device. Publish a Bolt/Unifying receiver identity only when the inventory has exactly one possible pointer; keep direct-device identity available. Include identity/capability/safety changes in rebuild detection. Pass `shared.scroll_inversions` into `hook_runtime::start` in `openlogi-agent/src/main.rs`.
+
+- [ ] **Step 4: Verify and format**
+
+Run `cargo test -p openlogi-agent-core orchestrator`, `cargo check -p openlogi-agent`, and `cargo fmt --all -- --check`.
+
+Expected: focused tests pass, the agent compiles, and formatting is clean.
+
+- [ ] **Step 5: Commit**
+
+Run `git add crates/openlogi-agent-core/src/orchestrator.rs crates/openlogi-agent/src/main.rs` and `git commit -m "feat(agent): publish macos scroll fallback devices"`.
+
+### Task 4: Enable and explain the fallback in the GUI
+
+**Files:**
+- Modify: `crates/openlogi-gui/src/state.rs`
+- Modify: `crates/openlogi-gui/src/app/detail.rs`
+- Modify: every `crates/openlogi-gui/locales/*.yml`
+
+- [ ] **Step 1: Write failing AppState support tests**
+
+Add tests proving that on macOS a persistent pointer without native inversion supports the toggle, a native-capable persistent device supports it, and a non-pointer or transient device does not. Keep a separate accessor reporting native support for the explanatory text.
+
+```rust
+assert!(state.current_scroll_inversion_supported());
+assert!(!state.current_native_scroll_inversion_supported());
+state.commit_invert_scroll(true);
+assert!(state.current_invert_scroll());
+```
+
+- [ ] **Step 2: Verify the test fails**
+
+Run `cargo test -p openlogi-gui scroll_inversion_supports_persistent_macos_pointer_fallback`.
+
+Expected: the support assertion fails because the current gate accepts only native HID++ capability.
+
+- [ ] **Step 3: Implement the platform-aware gate and descriptions**
+
+Make `current_scroll_inversion_supported` accept native capability everywhere and, under `cfg!(target_os = "macos")`, a persistent pointer device. Add `current_native_scroll_inversion_supported`. Update `commit_invert_scroll` wording for either path. In the scrolling card, use the native description for native devices, a new source key `"Reverse this mouse's scroll wheel in macOS. Your trackpad keeps the system scroll direction."` for fallback, and the existing unavailable description otherwise. Add the same key to all locale files so parity tests remain valid; untranslated locales may temporarily use the English source string.
+
+- [ ] **Step 4: Verify and format**
+
+Run `cargo test -p openlogi-gui scroll_inversion`, `cargo test -p openlogi-gui locale_files_have_the_same_keys`, and `cargo fmt --all -- --check`.
+
+Expected: focused GUI tests and locale parity pass. If GPUI fails because `xcrun` cannot find `metal`, preserve the exact environment failure and validate non-GPUI crates separately.
+
+- [ ] **Step 5: Commit**
+
+Run `git add crates/openlogi-gui/src/state.rs crates/openlogi-gui/src/app/detail.rs crates/openlogi-gui/locales` and `git commit -m "feat(gui): expose macos scroll inversion fallback"`.
+
+### Task 5: Verification, documentation, and publication
+
+**Files:**
+- Verify: all modified files
+- Include: `docs/superpowers/specs/2026-08-06-macos-scroll-inversion-fallback-design.md`
+- Include: `docs/superpowers/plans/2026-08-06-macos-scroll-inversion-fallback.md`
+
+- [ ] **Step 1: Run focused verification**
+
+Run `cargo test -p openlogi-hook`, `cargo test -p openlogi-agent-core`, `cargo check -p openlogi-agent`, and `cargo fmt --all -- --check` with the task-local Rust toolchain and Command Line Tools SDK.
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Run the workspace gate**
+
+Run `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`.
+
+Expected: pass with full Xcode/Metal. If GPUI again reports that `xcrun` cannot find `metal`, record this environment limitation and do not claim the GUI workspace gate passed.
+
+- [ ] **Step 3: Review scope and invariants**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat upstream/master...HEAD
+git diff upstream/master...HEAD -- crates/openlogi-hook crates/openlogi-agent-core crates/openlogi-agent crates/openlogi-gui docs/superpowers
+```
+
+Confirm native devices are excluded, unknown/trackpad events pass through, the original is dropped only after synthetic creation succeeds, no IPC/config schema changed, and no unrelated files are included.
+
+- [ ] **Step 4: Commit documentation**
+
+Run `git add docs/superpowers/specs/2026-08-06-macos-scroll-inversion-fallback-design.md docs/superpowers/plans/2026-08-06-macos-scroll-inversion-fallback.md` and `git commit -m "docs(scroll): document macos inversion fallback"`.
+
+- [ ] **Step 5: Push without force**
+
+Run `git push -u origin feat/macos-scroll-inversion-fallback`.
+
+Expected: the branch is created on `zinego/OpenLogi`. Never use a force-push option.
+
+- [ ] **Step 6: Perform real-M650 acceptance separately**
+
+Install/run the patched build with Accessibility and Input Monitoring permissions. Verify the M650 toggle is available; Off and On produce opposite vertical scrolling; trackpad direction is unchanged; horizontal scrolling is unchanged; and side-button mappings still work. Report this as hardware validation only after observing it.
+
+- [ ] **Step 7: Draft the PR and wait for approval**
+
+Prepare an English title/body explaining the M650 reproduction, native-capability semantics, fallback identity matching, automated checks, and Metal/hardware validation status. Show it to the user and wait for explicit approval before `gh pr create`.

--- a/docs/superpowers/specs/2026-08-06-macos-scroll-inversion-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-06-macos-scroll-inversion-fallback-design.md
@@ -1,0 +1,55 @@
+# macOS Software Scroll Inversion Fallback
+
+## Scope
+
+OpenLogi will support per-device scroll inversion on macOS when a Logitech mouse does not report the native HID++ `0x2121 HiResWheel` inversion capability. Devices that report native inversion will keep the existing firmware-backed path. Linux and Windows behavior will not change.
+
+The motivating device is a Signature M650 L connected directly over Bluetooth LE on macOS 26.5.1. OpenLogi 0.6.23 identifies it as `direct:046d:b02a:serial:2401lz05xrb8` and persists `pointer = true`, `scroll_inversion = false`, and `hires_wheel = false`. The installed CLI could not produce a raw feature table because macOS Input Monitoring permission belongs to the background agent rather than the standalone CLI, but both the GUI and persisted inventory agree that the device does not expose native inversion. The design therefore does not fabricate a `0x2121` capability or send unsupported HID++ writes.
+
+## Capability Semantics
+
+`Capabilities::scroll_inversion` will continue to mean that the device reports native HID++ wheel inversion. It will not be widened to mean that OpenLogi can provide a host-side fallback. This preserves the feature-table contract and keeps the native hardware writer correctly gated.
+
+The GUI will compute whether inversion is available from the platform and the selected device. On macOS, a persistent pointer device may use the toggle whether or not native inversion is present. On other platforms, availability remains equal to `Capabilities::scroll_inversion`. The UI description will distinguish native inversion from the macOS software fallback so users understand that the fallback requires the Accessibility-backed input hook.
+
+## Configuration and Agent Data Flow
+
+The existing per-device `invert_scroll` field remains the only persisted setting. The GUI will continue to save the config and call the existing append-only `reload_config` RPC. No IPC type, method, protocol version, or config schema change is needed.
+
+When configuration or inventory changes, the agent will keep applying native wheel modes only to devices whose `Capabilities::scroll_inversion` value is true. Independently, macOS agent state will publish a software inversion lookup for configured pointer devices whose native inversion capability is false. A device with native support must never enter the software lookup because applying both paths would restore the original direction.
+
+The software lookup will use the physical identity available from the inventory and config. Vendor-and-product ID is the preferred exact match. A normalized product name, still constrained by vendor when both sides report one, is a fallback for event sources that do not expose a product ID. If two configured devices produce the same lookup identity with conflicting inversion values, that identity will be discarded rather than tied to the currently selected GUI device. A Bolt or Unifying receiver identity is published only when its inventory contains exactly one possible pointer; mixed native/software devices and incomplete capability probes therefore cannot leak one mouse's software setting to another mouse behind the shared receiver.
+
+## macOS Event Handling
+
+The current macOS hook already resolves an `IOHIDEvent` sender to an `EventDevice`, distinguishes trackpads from Logitech free-spin wheels, and reads point, fixed-point, and line scroll fields. The fallback will reuse this source attribution instead of phase-only detection, because a free-spin mouse wheel may carry phase fields that resemble a trackpad.
+
+For each physical scroll event, the agent policy will first look up the source device. A trackpad event, an unknown source, an ambiguous identity, a device without inversion enabled, or a native-inversion device will pass through unchanged. A matched software-fallback mouse with `invert_scroll = true` will request a macOS-only inversion disposition.
+
+The macOS hook will make an independent `CGEventCreateCopy` of the captured event, reverse all three vertical delta fields (line, fixed-point, and point), and preserve the horizontal fields plus phase, momentum, count, timestamp, and fractional precision. The copy will carry OpenLogi's existing synthetic-event marker and will be returned directly through `CallbackResult::Replace`, avoiding a second HID-tap pass. If copying fails, the original event will pass through so scrolling is not lost.
+
+The Accessibility revocation and bounded run-loop state machine in `openlogi-hook/src/macos.rs` will remain structurally unchanged. The work will add the transform at the existing event-disposition boundary rather than restructure tap lifecycle code.
+
+## User Interface
+
+The Pointer tab will enable “Invert scroll direction” for the M650 and other persistent pointer devices on macOS. A native-capable device will retain the existing native description. A fallback device will explain that OpenLogi reverses the mouse wheel in software on macOS and leaves trackpad scrolling unchanged. Wheel resolution controls remain disabled when `hires_wheel` is false; software inversion does not imply resolution support.
+
+## Failure Behavior
+
+The fallback is deliberately fail-open. Missing identity, ambiguous matches, poisoned shared state, synthetic event allocation failure, or absent Accessibility permission leaves the original scroll event unchanged. These conditions may disable inversion, but they must not disable ordinary scrolling or affect a trackpad.
+
+Native HID++ write errors remain on the existing logging and retry path. Software fallback does not mask or replace native support, and it does not address the separate native-inversion sleep/wake persistence report in issue #516.
+
+## Automated Verification
+
+Implementation will begin with failing tests. Agent-core tests will show that a macOS M650-like pointer device with `scroll_inversion = false` enters the software lookup while a native-capable device does not. Lookup tests will cover product-ID precedence, normalized-name fallback, unknown sources, and conflicting identities. Policy tests will cover enabled mouse events, disabled mouse events, trackpads, and zero vertical deltas.
+
+Hook tests will cover synthetic-loop rejection, an independent replacement object, all three vertical delta encodings, fractional precision, and preservation of horizontal and scroll metadata. Agent tests will also cover vendor isolation and shared-receiver ambiguity. GUI state tests will show that macOS pointer devices can persist inversion without native capability, while non-macOS gating remains unchanged through cfg-specific helpers. Existing native wheel-mode tests must continue proving that unsupported devices receive no HID++ inversion write.
+
+The local completion gate is `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`. macOS success does not prove Linux or Windows cfg-gated code; their behavior is intentionally unchanged and CI remains the authoritative cross-platform check.
+
+## Hardware Acceptance
+
+Automated tests can prove policy, matching, transformation, and regression behavior, but they cannot prove CoreGraphics attribution for this physical M650. Hardware acceptance will use a locally built OpenLogi app with the existing persistent macOS permissions. The M650 toggle must become available, enabling it must reverse vertical wheel scrolling, disabling it must restore the original direction, horizontal behavior must remain unchanged, and trackpad scrolling must remain unchanged. The test will also confirm that side-button mappings still work and that the event tap remains responsive after repeated toggles.
+
+Any hardware observation will be reported separately from automated verification. No GitHub issue, pull request, comment, or other public artifact will be created without a separate English draft and explicit approval.


### PR DESCRIPTION
## Summary

Add a per-device macOS software fallback for scroll inversion when a persistent pointer device, such as the Signature M650, does not expose native HID++ `0x2121` inversion support.

The native capability remains authoritative. Devices that support native inversion continue using HID++, while unsupported devices can invert vertical wheel events through the existing macOS event tap without changing trackpad scrolling.

## Changes

- **hook**
  - Add a macOS scroll inversion disposition.
  - Replace captured scroll events with copied events whose vertical line, fixed, and point deltas are inverted.
  - Preserve horizontal deltas and event metadata.
  - Mark replacements as synthetic to prevent event-tap re-entry.

- **agent**
  - Publish software inversion settings only for persistent pointer devices without native inversion support.
  - Match event sources conservatively by vendor/product ID, with normalized product-name fallback when no product ID is available.
  - Reject ambiguous identities and unsafe shared-receiver attribution.
  - Republish the lookup after inventory, capability, or configuration changes.

- **gui**
  - Enable scroll inversion for persistent macOS pointer devices that lack native HID++ inversion.
  - Keep the native-support status separate from software fallback availability.
  - Explain that the fallback affects the mouse wheel while leaving trackpad direction unchanged.
  - Add the new explanatory string to all locale files.

- **docs**
  - Document the fallback design, failure behavior, automated coverage, and hardware acceptance criteria.

## Testing

Passed locally:

- `cargo fmt --all -- --check`
- `cargo clippy -p openlogi-hook -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- `cargo test -p openlogi-hook -p openlogi-agent-core -p openlogi-agent`
  - 89 unit, wire-format, and documentation tests passed.

Attempted locally but blocked by the host toolchain:

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Both full-workspace commands reached `gpui_macos` and then stopped because this Mac has Command Line Tools but not Xcode's optional `metal` compiler. CI remains the authoritative full-workspace and cross-platform check.

Hardware validation:

- Signature M650 L connected directly over Bluetooth on macOS.
- Enabling the fallback was observed to reverse the physical mouse wheel direction.
- Complete acceptance for trackpad isolation, horizontal scrolling, side-button behavior, repeated toggles, and the final GUI availability state has not yet been recorded.

Screenshot: pending final GUI capture.

Fixes: N/A — no matching issue is currently filed.
