### PR TITLE
fix(linux): grant uaccess on Logitech input event nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ sudo pacman -U openlogi-*.pkg.tar.zst
 Packages are published for both `x86_64`/`amd64` and `arm64`/`aarch64`.
 
 The package installs udev rules that grant your user access to
-`/dev/hidraw*` and `/dev/uinput` without `sudo`. After installation,
+`/dev/hidraw*`, `/dev/uinput` and your Logitech mouse's `/dev/input/event*`
+node without `sudo`. After installation,
 enable the background agent for your user:
 
 ```sh

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -41,7 +41,7 @@ OpenLogi needs:
 - **Write access to `/dev/uinput`** — to create the virtual input device for
   button remapping.
 - **Read/write access to `/dev/hidraw*`** — to send HID++ commands to the Bolt
-  receiver.
+  receiver, or to the device itself when it is paired over Bluetooth.
 - **Read access to the mouse's `/dev/input/event*` node** — the hook grabs the
   pointer there to capture button presses. Bluetooth mice need the bundled rule
   for this: their event node hangs off `/devices/virtual/misc/uhid`, which has

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -42,6 +42,10 @@ OpenLogi needs:
   button remapping.
 - **Read/write access to `/dev/hidraw*`** — to send HID++ commands to the Bolt
   receiver.
+- **Read access to the mouse's `/dev/input/event*` node** — the hook grabs the
+  pointer there to capture button presses. Bluetooth mice need the bundled rule
+  for this: their event node hangs off `/devices/virtual/misc/uhid`, which has
+  no seat, so `logind` never grants the ACL on its own.
 
 Install the bundled udev rules to grant access to the active-seat user without
 requiring `sudo` or group membership (requires `systemd-logind`):
@@ -61,6 +65,11 @@ openlogi-agent --check-uinput 2>/dev/null || \
 
 # Check a hidraw node
 ls -la /dev/hidraw*
+
+# Check the mouse's event node — look for a "+" (ACL) in the mode, or your
+# user in the ACL itself. Without it the agent logs
+# "could not install OS mouse hook".
+getfacl /dev/input/event*
 ```
 
 The GUI Settings → Permissions page shows a live `Granted` / `Not granted`

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -83,6 +83,7 @@ if command -v udevadm > /dev/null 2>&1; then
     echo "Reloading udev rules …"
     sudo udevadm control --reload-rules
     sudo udevadm trigger --subsystem-match=hidraw
+    sudo udevadm trigger --subsystem-match=input
     sudo udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
 fi
 

--- a/packaging/linux/nfpm-scripts/postinstall.sh
+++ b/packaging/linux/nfpm-scripts/postinstall.sh
@@ -3,10 +3,13 @@ set -eu
 
 # Reload udev rules and wait for the new uaccess tags to be applied.
 # udevadm trigger is asynchronous — settle ensures the tags are in place
-# before the script exits so the agent can open /dev/hidraw* immediately.
+# before the script exits so the agent can open /dev/hidraw* and the mouse's
+# /dev/input/event* node immediately, even for a device connected before the
+# install.
 if command -v udevadm > /dev/null 2>&1; then
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=hidraw
+    udevadm trigger --subsystem-match=input
     udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
     udevadm settle 2>/dev/null || true
 fi

--- a/packaging/linux/udev/70-openlogi.rules
+++ b/packaging/linux/udev/70-openlogi.rules
@@ -1,8 +1,8 @@
 # OpenLogi udev rules
 #
-# Grants the active-seat user read/write access to Logitech HID devices and the
-# uinput kernel module — no group membership required on systems running
-# systemd-logind (uaccess tag).
+# Grants the active-seat user read/write access to Logitech HID devices, their
+# input event nodes, and the uinput kernel module — no group membership required
+# on systems running systemd-logind (uaccess tag).
 #
 # Install:
 #   sudo cp 70-openlogi.rules /etc/udev/rules.d/
@@ -25,3 +25,12 @@ SUBSYSTEM=="hidraw", KERNELS=="*:046D:*", TAG+="uaccess"
 # OPTIONS+="static_node=uinput" creates the node at boot even before any device
 # is plugged in, so the agent can open it without a trigger.
 KERNEL=="uinput", TAG+="uaccess", OPTIONS+="static_node=uinput"
+
+# Logitech input event nodes (evdev interface) — the read side of the hook.
+# hidraw alone is not enough: the hook enumerates /dev/input/event* to grab the
+# pointer. USB devices already get uaccess from logind's seat rules, but a
+# Bluetooth mouse hangs off /devices/virtual/misc/uhid, which belongs to no
+# seat, so those rules never tag it and its event node stays root:input 0660.
+# Same two matchers as the hidraw block, for the same transport reasons.
+SUBSYSTEM=="input", ATTRS{idVendor}=="046d", TAG+="uaccess"
+SUBSYSTEM=="input", KERNELS=="*:046D:*", TAG+="uaccess"

--- a/packaging/linux/udev/70-openlogi.rules
+++ b/packaging/linux/udev/70-openlogi.rules
@@ -26,11 +26,15 @@ SUBSYSTEM=="hidraw", KERNELS=="*:046D:*", TAG+="uaccess"
 # is plugged in, so the agent can open it without a trigger.
 KERNEL=="uinput", TAG+="uaccess", OPTIONS+="static_node=uinput"
 
-# Logitech input event nodes (evdev interface) — the read side of the hook.
+# Logitech pointer event nodes (evdev interface) — the read side of the hook.
 # hidraw alone is not enough: the hook enumerates /dev/input/event* to grab the
 # pointer. USB devices already get uaccess from logind's seat rules, but a
 # Bluetooth mouse hangs off /devices/virtual/misc/uhid, which belongs to no
 # seat, so those rules never tag it and its event node stays root:input 0660.
-# Same two matchers as the hidraw block, for the same transport reasons.
-SUBSYSTEM=="input", ATTRS{idVendor}=="046d", TAG+="uaccess"
-SUBSYSTEM=="input", KERNELS=="*:046D:*", TAG+="uaccess"
+#
+# Scoped to event nodes the kernel classifies as a mouse (ID_INPUT_MOUSE, set by
+# the input_id builtin in 60-input-id.rules, which runs before this file): a
+# Logitech keyboard's keystrokes must never become readable session-wide. The
+# two matchers cover the same two transports as the hidraw block above.
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", ATTRS{idVendor}=="046d", TAG+="uaccess"
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", KERNELS=="*:046D:*", TAG+="uaccess"


### PR DESCRIPTION
## Summary

The evdev hook reads `/dev/input/event*` to grab the pointer, but the bundled
udev rules only cover `hidraw` and `uinput`. On a Bluetooth-direct mouse nothing
grants access to that third node, so the hook never starts and no remapping
works.

USB devices are unaffected: logind's seat rules tag them with `uaccess` on their
own. A Bluetooth mouse hangs off `/devices/virtual/misc/uhid`, which belongs to
no seat, so those rules skip it and the node stays `root:input 0660`.

This is the same transport asymmetry as Finding 1 of #148, one layer up. #149
fixed it for `hidraw`; `input` was left out, and #119 validated the hook with
`sudo`, which hid the gap.

## Changes

- `packaging/linux/udev/70-openlogi.rules`: add the two matchers already used
  for the `hidraw` block to `SUBSYSTEM=="input"`, so the grant stays scoped to
  vendor 046d instead of requiring `input` group membership.
- `docs/INSTALL-linux.md`: list the event node as a third permission OpenLogi
  needs, and add a `getfacl` check next to the existing `hidraw` one.
- `README.md`: mention the event node in the sentence describing what the
  package grants.

No Rust code touched.

## Testing

Verified on real hardware: MX Master 3S over Bluetooth (no receiver), Fedora 44,
kernel 7.1.7-200.fc44 x86_64, GNOME Shell 50.4 on Wayland, systemd 259,
OpenLogi 0.6.23.

Rule syntax:

```console
$ udevadm verify packaging/linux/udev/70-openlogi.rules
1 udev rules files have been checked.
  Success: 1
  Fail:    0
```

Before, with only the `hidraw` and `uinput` rules installed:

```console
$ getfacl -p /dev/input/event21 | grep -E '^user:'
user::rw-
$ journalctl --user -u openlogi-agent | grep hook
WARN could not install OS mouse hook — events will not be captured
     error=no mouse device found under /dev/input
```

After adding the matchers:

```console
$ sudo udevadm control --reload-rules
$ sudo udevadm trigger --action=add --subsystem-match=input
$ getfacl -p /dev/input/event21 | grep -E '^user:'
user::rw-
user:xabier:rw-
$ systemctl --user restart openlogi-agent
$ journalctl --user -u openlogi-agent | grep hook
INFO OS mouse hook installed
```

Button remapping then works end to end. Sniffing the injector node while
pressing a remapped gesture shows the synthesized chord arriving with correct
press/release ordering:

```
KEY_LEFTCTRL DOWN / KEY_LEFTALT DOWN / KEY_LEFT DOWN
KEY_LEFT up / KEY_LEFTALT up / KEY_LEFTCTRL up
```

No re-login and no `input` group membership were needed, and `udevadm trigger`
re-applied the ACL without power-cycling the mouse.

Not verified: Bolt/Unifying receivers and wired USB (no receiver on hand — those
paths already worked and the added rules are additive), other distributions,
and X11 sessions. `cargo fmt` / `clippy` / `test` were not run: the change is
packaging and docs only, no Rust.

Fixes #529
