### PR TITLE
fix(agent): route hardware operations through inventory channels

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -6,19 +6,17 @@
 //! press) and avoids holding a long-lived async runtime alongside GPUI's
 //! executor.
 //!
-//! When the HID++ capture session already has the target device open, these
-//! reuse that channel ([`openlogi_hid::CaptureChannel`]) instead of
-//! re-enumerating and opening a fresh one — the dominant cost of a write. The
-//! transient open is kept as a fallback for callers (e.g. the CGEventTap hook)
-//! firing while no session is connected.
+//! Agent calls select a registry-confirmed capture channel or the exact current
+//! inventory channel. A registry miss is unavailable; the daemon never falls
+//! back to re-enumerating and opening a competing connection.
 
 use std::future::Future;
 use std::time::Duration;
 
 use openlogi_core::config::Lighting;
 use openlogi_hid::{
-    CaptureChannel, DeviceRoute, DpiInfo, HidppFeatureErrorKind, HidppOperation, ScrollResolution,
-    SharedChannel, SmartShiftMode, SmartShiftStatus, WriteError,
+    CaptureChannel, ChannelRegistry, DeviceRoute, DpiInfo, HidppFeatureErrorKind, HidppOperation,
+    ScrollResolution, SharedChannel, SmartShiftMode, SmartShiftStatus, WriteError,
 };
 use tracing::{debug, warn};
 
@@ -32,7 +30,12 @@ const WRITE_BUDGET: Duration = Duration::from_secs(5);
 ///
 /// This helper is intentionally blocking so GPUI callers can run it via
 /// `cx.background_spawn` without making the UI thread own a Tokio runtime.
-pub fn read_dpi_info_blocking(target: &DeviceRoute) -> Result<DpiInfo, WriteError> {
+pub fn read_dpi_info_blocking(
+    capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
+    target: &DeviceRoute,
+) -> Result<DpiInfo, WriteError> {
+    let shared = authoritative_channel(capture, registry, target)?;
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -41,7 +44,7 @@ pub fn read_dpi_info_blocking(target: &DeviceRoute) -> Result<DpiInfo, WriteErro
         })?;
 
     rt.block_on(async {
-        tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_dpi_info(target))
+        tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_dpi_info_on(&shared))
             .await
             .map_err(|_| WriteError::RequestTimedOut {
                 operation: HidppOperation::ReadDpiCapabilities,
@@ -49,34 +52,52 @@ pub fn read_dpi_info_blocking(target: &DeviceRoute) -> Result<DpiInfo, WriteErro
     })
 }
 
-/// Clone out the capture session's channel when it reaches `route`. `None` when
-/// no capture session is connected or the open channel points at a different
-/// device.
-fn reusable_channel(
+/// Select the only Agent-authoritative channel for `route`.
+fn authoritative_channel(
     capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     route: &DeviceRoute,
-) -> Option<SharedChannel> {
-    capture?
-        .read()
-        .ok()
+) -> Result<SharedChannel, WriteError> {
+    let capture = capture
+        .and_then(|capture| capture.read().ok())
         .and_then(|slot| (*slot).clone())
-        .filter(|chan| chan.matches(route))
+        .filter(|channel| channel.matches(route));
+    choose_authoritative(
+        capture,
+        |channel| registry.is_current(channel),
+        || registry.lookup(route),
+    )
+    .ok_or(WriteError::DeviceNotFound)
+}
+
+fn choose_authoritative<T>(
+    capture: Option<T>,
+    capture_is_current: impl FnOnce(&T) -> bool,
+    registry_lookup: impl FnOnce() -> Option<T>,
+) -> Option<T> {
+    match capture {
+        Some(capture) if capture_is_current(&capture) => Some(capture),
+        _ => registry_lookup(),
+    }
 }
 
 /// Spawn an OS thread that toggles SmartShift (free ↔ ratchet) on the
-/// device at `target` via `openlogi_hid::toggle_smartshift`. Returns
+/// device at `target` via its current shared channel. Returns
 /// immediately; failures (incl. devices that expose neither `0x2111` nor
 /// the older `0x2110` SmartShift feature) are logged.
 pub fn toggle_smartshift_in_background(
     capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     target: Option<DeviceRoute>,
 ) {
     let Some(target) = target else {
         debug!("no target device — SmartShift toggle skipped");
         return;
     };
-    let shared = reusable_channel(capture, &target);
-    let reused = shared.is_some();
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — SmartShift toggle skipped");
+        return;
+    };
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -90,16 +111,13 @@ pub fn toggle_smartshift_in_background(
         };
         let result = rt.block_on(async {
             tokio::time::timeout(WRITE_BUDGET, async {
-                match &shared {
-                    Some(shared) => openlogi_hid::toggle_smartshift_on(shared).await,
-                    None => openlogi_hid::toggle_smartshift(&target).await,
-                }
+                openlogi_hid::toggle_smartshift_on(&shared).await
             })
             .await
         });
         let index = target.device_index();
         match result {
-            Ok(Ok(mode)) => debug!(index, ?mode, reused, "SmartShift toggled"),
+            Ok(Ok(mode)) => debug!(index, ?mode, "SmartShift toggled"),
             Ok(Err(e)) => warn!(error = ?e, "SmartShift toggle failed"),
             Err(_) => warn!(
                 index,
@@ -115,8 +133,11 @@ pub fn toggle_smartshift_in_background(
 /// Blocking, like [`read_dpi_info_blocking`], so the SmartShift panel can run
 /// it off a dedicated OS thread without the UI thread owning a Tokio runtime.
 pub fn read_smartshift_status_blocking(
+    capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     target: &DeviceRoute,
 ) -> Result<SmartShiftStatus, WriteError> {
+    let shared = authoritative_channel(capture, registry, target)?;
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -125,22 +146,26 @@ pub fn read_smartshift_status_blocking(
         })?;
 
     rt.block_on(async {
-        tokio::time::timeout(WRITE_BUDGET, openlogi_hid::get_smartshift_status(target))
-            .await
-            .map_err(|_| WriteError::RequestTimedOut {
-                operation: HidppOperation::ReadSmartShift,
-            })?
+        tokio::time::timeout(
+            WRITE_BUDGET,
+            openlogi_hid::get_smartshift_status_on(&shared),
+        )
+        .await
+        .map_err(|_| WriteError::RequestTimedOut {
+            operation: HidppOperation::ReadSmartShift,
+        })?
     })
 }
 
 /// Spawn an OS thread that writes a full SmartShift configuration to the device
-/// at `target` via [`openlogi_hid::set_smartshift`]. Returns immediately;
+/// at `target` via its current shared channel. Returns immediately;
 /// failures (incl. devices that expose neither `0x2111` nor the older `0x2110`
 /// SmartShift feature) are logged.
 ///
 /// `target == None` is a no-op (dev environment without a real device).
 pub fn write_smartshift_in_background(
     capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     target: Option<DeviceRoute>,
     mode: SmartShiftMode,
     auto_disengage: u8,
@@ -150,8 +175,10 @@ pub fn write_smartshift_in_background(
         debug!("no target device — SmartShift write skipped");
         return;
     };
-    let shared = reusable_channel(capture, &target);
-    let reused = shared.is_some();
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — SmartShift write skipped");
+        return;
+    };
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -165,21 +192,7 @@ pub fn write_smartshift_in_background(
         };
         let result = rt.block_on(async {
             tokio::time::timeout(WRITE_BUDGET, async {
-                match &shared {
-                    Some(shared) => {
-                        openlogi_hid::set_smartshift_on(
-                            shared,
-                            mode,
-                            auto_disengage,
-                            tunable_torque,
-                        )
-                        .await
-                    }
-                    None => {
-                        openlogi_hid::set_smartshift(&target, mode, auto_disengage, tunable_torque)
-                            .await
-                    }
-                }
+                openlogi_hid::set_smartshift_on(&shared, mode, auto_disengage, tunable_torque).await
             })
             .await
         });
@@ -190,7 +203,6 @@ pub fn write_smartshift_in_background(
                 ?mode,
                 auto_disengage,
                 tunable_torque,
-                reused,
                 "SmartShift config written"
             ),
             Ok(Err(e)) => warn!(error = ?e, "SmartShift write failed"),
@@ -214,7 +226,7 @@ pub struct SmartShiftApply {
 }
 
 /// Re-apply every volatile mouse setting for one device on a **single**
-/// background thread, sequentially, reusing the capture channel when available.
+/// background thread, sequentially, on the current inventory-owned channel.
 ///
 /// Agent-start reapply used to fire DPI / SmartShift / wheel-mode each on its
 /// own thread, and each opened a fresh HID++ channel when capture was not yet
@@ -224,14 +236,17 @@ pub struct SmartShiftApply {
 /// sequential writer removes that self-race.
 pub fn reapply_mouse_volatile_in_background(
     capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     target: DeviceRoute,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
     dpi: Option<u32>,
     smartshift: Option<SmartShiftApply>,
 ) {
-    let shared = reusable_channel(capture, &target);
-    let reused = shared.is_some();
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — volatile reapply skipped");
+        return;
+    };
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -247,24 +262,21 @@ pub fn reapply_mouse_volatile_in_background(
         rt.block_on(async {
             if resolution.is_some() || inverted.is_some() {
                 let result = tokio::time::timeout(WRITE_BUDGET, async {
-                    apply_wheel_mode(shared.as_ref(), &target, resolution, inverted).await
+                    apply_wheel_mode(&shared, resolution, inverted).await
                 })
                 .await;
-                log_wheel_result(index, resolution, inverted, reused, result);
+                log_wheel_result(index, resolution, inverted, result);
             }
             if let Some(dpi) = dpi {
                 match u16::try_from(dpi) {
                     Ok(dpi_u16) => {
                         let result = tokio::time::timeout(WRITE_BUDGET, async {
-                            match &shared {
-                                Some(shared) => openlogi_hid::set_dpi_on(shared, dpi_u16).await,
-                                None => openlogi_hid::set_dpi(&target, dpi_u16).await,
-                            }
+                            openlogi_hid::set_dpi_on(&shared, dpi_u16).await
                         })
                         .await;
                         match result {
                             Ok(Ok(())) => {
-                                debug!(index, dpi = dpi_u16, reused, "DPI written to device");
+                                debug!(index, dpi = dpi_u16, "DPI written to device");
                             }
                             Ok(Err(e)) => warn!(error = ?e, "DPI write failed"),
                             Err(_) => warn!(
@@ -280,26 +292,13 @@ pub fn reapply_mouse_volatile_in_background(
             }
             if let Some(ss) = smartshift {
                 let result = tokio::time::timeout(WRITE_BUDGET, async {
-                    match &shared {
-                        Some(shared) => {
-                            openlogi_hid::set_smartshift_on(
-                                shared,
-                                ss.mode,
-                                ss.auto_disengage,
-                                ss.tunable_torque,
-                            )
-                            .await
-                        }
-                        None => {
-                            openlogi_hid::set_smartshift(
-                                &target,
-                                ss.mode,
-                                ss.auto_disengage,
-                                ss.tunable_torque,
-                            )
-                            .await
-                        }
-                    }
+                    openlogi_hid::set_smartshift_on(
+                        &shared,
+                        ss.mode,
+                        ss.auto_disengage,
+                        ss.tunable_torque,
+                    )
+                    .await
                 })
                 .await;
                 match result {
@@ -308,7 +307,6 @@ pub fn reapply_mouse_volatile_in_background(
                         mode = ?ss.mode,
                         auto_disengage = ss.auto_disengage,
                         tunable_torque = ss.tunable_torque,
-                        reused,
                         "SmartShift config written"
                     ),
                     Ok(Err(e)) => warn!(error = ?e, "SmartShift write failed"),
@@ -323,35 +321,21 @@ pub fn reapply_mouse_volatile_in_background(
 }
 
 async fn apply_wheel_mode(
-    shared: Option<&SharedChannel>,
-    target: &DeviceRoute,
+    shared: &SharedChannel,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
 ) -> Result<(), WriteError> {
-    match (resolution, inverted, shared) {
-        (Some(resolution), Some(inverted), Some(shared)) => {
+    match (resolution, inverted) {
+        (Some(resolution), Some(inverted)) => {
             openlogi_hid::set_scroll_wheel_mode_on(shared, resolution, inverted)
                 .await
                 .map(|_| ())
         }
-        (Some(resolution), Some(inverted), None) => {
-            openlogi_hid::set_scroll_wheel_mode(target, resolution, inverted)
-                .await
-                .map(|_| ())
-        }
-        (Some(resolution), None, Some(shared)) => {
-            openlogi_hid::set_scroll_resolution_on(shared, resolution)
-                .await
-                .map(|_| ())
-        }
-        (Some(resolution), None, None) => openlogi_hid::set_scroll_resolution(target, resolution)
+        (Some(resolution), None) => openlogi_hid::set_scroll_resolution_on(shared, resolution)
             .await
             .map(|_| ()),
-        (None, Some(inverted), Some(shared)) => {
-            openlogi_hid::set_scroll_inversion_on(shared, inverted).await
-        }
-        (None, Some(inverted), None) => openlogi_hid::set_scroll_inversion(target, inverted).await,
-        (None, None, _) => Ok(()),
+        (None, Some(inverted)) => openlogi_hid::set_scroll_inversion_on(shared, inverted).await,
+        (None, None) => Ok(()),
     }
 }
 
@@ -359,17 +343,10 @@ fn log_wheel_result(
     index: u8,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
-    reused: bool,
     result: Result<Result<(), WriteError>, tokio::time::error::Elapsed>,
 ) {
     match result {
-        Ok(Ok(())) => debug!(
-            index,
-            ?resolution,
-            ?inverted,
-            reused,
-            "native wheel mode written"
-        ),
+        Ok(Ok(())) => debug!(index, ?resolution, ?inverted, "native wheel mode written"),
         Ok(Err(WriteError::FeatureUnsupported { feature_hex })) => debug!(
             index,
             ?resolution,
@@ -387,12 +364,13 @@ fn log_wheel_result(
     }
 }
 
-/// Spawn an OS thread that writes `dpi` to the device at `target` via
-/// `openlogi_hid::set_dpi`. Returns immediately; failures are logged.
+/// Spawn an OS thread that writes `dpi` to the device at `target` via its
+/// current shared channel. Returns immediately; failures are logged.
 ///
 /// `target == None` is a no-op (dev environment without a real device).
 pub fn write_dpi_in_background(
     capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     target: Option<DeviceRoute>,
     dpi: u32,
 ) {
@@ -400,8 +378,10 @@ pub fn write_dpi_in_background(
         debug!(dpi, "no target device — DPI write skipped");
         return;
     };
-    let shared = reusable_channel(capture, &target);
-    let reused = shared.is_some();
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — DPI write skipped");
+        return;
+    };
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -421,10 +401,7 @@ pub fn write_dpi_in_background(
         };
         let result = rt.block_on(async {
             tokio::time::timeout(WRITE_BUDGET, async {
-                match &shared {
-                    Some(shared) => openlogi_hid::set_dpi_on(shared, dpi_u16).await,
-                    None => openlogi_hid::set_dpi(&target, dpi_u16).await,
-                }
+                openlogi_hid::set_dpi_on(&shared, dpi_u16).await
             })
             .await
         });
@@ -432,7 +409,6 @@ pub fn write_dpi_in_background(
             Ok(Ok(())) => debug!(
                 index = target.device_index(),
                 dpi = dpi_u16,
-                reused,
                 "DPI written to device"
             ),
             Ok(Err(e)) => warn!(error = ?e, "DPI write failed"),
@@ -462,6 +438,7 @@ enum ScrollWheelModeChange {
 /// at debug level.
 pub fn write_scroll_wheel_mode_in_background(
     capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
     target: Option<DeviceRoute>,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
@@ -486,8 +463,10 @@ pub fn write_scroll_wheel_mode_in_background(
             return;
         }
     };
-    let shared = reusable_channel(capture, &target);
-    let reused = shared.is_some();
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — wheel mode write skipped");
+        return;
+    };
     std::thread::spawn(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -501,40 +480,20 @@ pub fn write_scroll_wheel_mode_in_background(
         };
         let result = rt.block_on(async {
             tokio::time::timeout(WRITE_BUDGET, async {
-                match (change, &shared) {
-                    (
-                        ScrollWheelModeChange::ResolutionAndInversion {
-                            resolution,
-                            inverted,
-                        },
-                        Some(shared),
-                    ) => openlogi_hid::set_scroll_wheel_mode_on(shared, resolution, inverted)
+                match change {
+                    ScrollWheelModeChange::ResolutionAndInversion {
+                        resolution,
+                        inverted,
+                    } => openlogi_hid::set_scroll_wheel_mode_on(&shared, resolution, inverted)
                         .await
                         .map(|_| ()),
-                    (
-                        ScrollWheelModeChange::ResolutionAndInversion {
-                            resolution,
-                            inverted,
-                        },
-                        None,
-                    ) => openlogi_hid::set_scroll_wheel_mode(&target, resolution, inverted)
-                        .await
-                        .map(|_| ()),
-                    (ScrollWheelModeChange::Resolution(resolution), Some(shared)) => {
-                        openlogi_hid::set_scroll_resolution_on(shared, resolution)
+                    ScrollWheelModeChange::Resolution(resolution) => {
+                        openlogi_hid::set_scroll_resolution_on(&shared, resolution)
                             .await
                             .map(|_| ())
                     }
-                    (ScrollWheelModeChange::Resolution(resolution), None) => {
-                        openlogi_hid::set_scroll_resolution(&target, resolution)
-                            .await
-                            .map(|_| ())
-                    }
-                    (ScrollWheelModeChange::Inversion(inverted), Some(shared)) => {
-                        openlogi_hid::set_scroll_inversion_on(shared, inverted).await
-                    }
-                    (ScrollWheelModeChange::Inversion(inverted), None) => {
-                        openlogi_hid::set_scroll_inversion(&target, inverted).await
+                    ScrollWheelModeChange::Inversion(inverted) => {
+                        openlogi_hid::set_scroll_inversion_on(&shared, inverted).await
                     }
                 }
             })
@@ -542,13 +501,7 @@ pub fn write_scroll_wheel_mode_in_background(
         });
         let index = target.device_index();
         match result {
-            Ok(Ok(())) => debug!(
-                index,
-                ?resolution,
-                ?inverted,
-                reused,
-                "native wheel mode written"
-            ),
+            Ok(Ok(())) => debug!(index, ?resolution, ?inverted, "native wheel mode written"),
             Ok(Err(WriteError::FeatureUnsupported { feature_hex })) => debug!(
                 index,
                 ?resolution,
@@ -571,11 +524,21 @@ pub fn write_scroll_wheel_mode_in_background(
 ///
 /// Resolves the configured colour (scaled by brightness, or black when the
 /// lighting is off) and writes every key over HID++ via
-/// [`openlogi_hid::set_keyboard_color`]. A `None` target is a no-op (dev runs
-/// without a device); failures are logged, not surfaced.
-pub fn set_lighting_in_background(target: Option<DeviceRoute>, lighting: &Lighting) {
+/// [`openlogi_hid::set_keyboard_color_on`]. A `None` target is a no-op (dev
+/// runs without a device); a registry miss and write failures are logged, not
+/// surfaced.
+pub fn set_lighting_in_background(
+    capture: Option<&CaptureChannel>,
+    registry: &ChannelRegistry,
+    target: Option<DeviceRoute>,
+    lighting: &Lighting,
+) {
     let Some(target) = target else {
         debug!("no target device — lighting write skipped");
+        return;
+    };
+    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
+        debug!(route = %target, "no inventory channel — lighting write skipped");
         return;
     };
     let (r, g, b) = lighting_rgb(lighting);
@@ -590,7 +553,7 @@ pub fn set_lighting_in_background(target: Option<DeviceRoute>, lighting: &Lighti
                 return;
             }
         };
-        match rt.block_on(openlogi_hid::set_keyboard_color(&target, r, g, b)) {
+        match rt.block_on(openlogi_hid::set_keyboard_color_on(&shared, r, g, b)) {
             Ok(()) => debug!(r, g, b, "lighting written to keyboard"),
             Err(e) => warn!(error = ?e, "lighting write failed"),
         }
@@ -611,13 +574,14 @@ fn lighting_rgb(lighting: &Lighting) -> (u8, u8, u8) {
 
 // Async, awaitable variants used by the IPC server (the GUI routes "apply now"
 // / "read" device commands through the agent, which awaits and reports the
-// result). Writes reuse the capture session's open channel when it targets the
-// same device, exactly like the fire-and-forget `*_in_background` helpers, so
-// the daemon never opens a second channel to a device it already holds.
+// result). They use a registry-confirmed capture channel or the exact current
+// inventory channel, exactly like the fire-and-forget `*_in_background`
+// helpers, so the daemon never opens a second channel to a device it holds.
 
-/// Apply `dpi` to `route`, reusing the capture session's channel when possible.
+/// Apply `dpi` to `route` on its current inventory-owned channel.
 pub async fn apply_dpi(
     capture: &CaptureChannel,
+    registry: &ChannelRegistry,
     route: &DeviceRoute,
     dpi: u32,
 ) -> Result<(), WriteError> {
@@ -628,60 +592,71 @@ pub async fn apply_dpi(
         feature_hex: 0x2201,
         kind: HidppFeatureErrorKind::OutOfRange,
     })?;
-    let shared = reusable_channel(Some(capture), route);
-    timed(HidppOperation::WriteDpi, async {
-        match &shared {
-            Some(shared) => openlogi_hid::set_dpi_on(shared, dpi).await,
-            None => openlogi_hid::set_dpi(route, dpi).await,
-        }
-    })
+    let shared = authoritative_channel(Some(capture), registry, route)?;
+    timed(
+        HidppOperation::WriteDpi,
+        openlogi_hid::set_dpi_on(&shared, dpi),
+    )
     .await
 }
 
 /// Apply a full SmartShift config to `route` (capture-channel-aware).
 pub async fn apply_smartshift(
     capture: &CaptureChannel,
+    registry: &ChannelRegistry,
     route: &DeviceRoute,
     mode: SmartShiftMode,
     auto_disengage: u8,
     tunable_torque: u8,
 ) -> Result<(), WriteError> {
-    let shared = reusable_channel(Some(capture), route);
-    timed(HidppOperation::WriteSmartShift, async {
-        match &shared {
-            Some(shared) => {
-                openlogi_hid::set_smartshift_on(shared, mode, auto_disengage, tunable_torque).await
-            }
-            None => openlogi_hid::set_smartshift(route, mode, auto_disengage, tunable_torque).await,
-        }
-    })
+    let shared = authoritative_channel(Some(capture), registry, route)?;
+    timed(
+        HidppOperation::WriteSmartShift,
+        openlogi_hid::set_smartshift_on(&shared, mode, auto_disengage, tunable_torque),
+    )
     .await
 }
 
 /// Apply a lighting config to the keyboard at `route`.
-pub async fn apply_lighting(route: &DeviceRoute, lighting: &Lighting) -> Result<(), WriteError> {
+pub async fn apply_lighting(
+    capture: &CaptureChannel,
+    registry: &ChannelRegistry,
+    route: &DeviceRoute,
+    lighting: &Lighting,
+) -> Result<(), WriteError> {
+    let shared = authoritative_channel(Some(capture), registry, route)?;
     let (r, g, b) = lighting_rgb(lighting);
     timed(
         HidppOperation::Lighting,
-        openlogi_hid::set_keyboard_color(route, r, g, b),
+        openlogi_hid::set_keyboard_color_on(&shared, r, g, b),
     )
     .await
 }
 
 /// Read the current DPI + supported values from `route`.
-pub async fn read_dpi(route: &DeviceRoute) -> Result<DpiInfo, WriteError> {
+pub async fn read_dpi(
+    capture: &CaptureChannel,
+    registry: &ChannelRegistry,
+    route: &DeviceRoute,
+) -> Result<DpiInfo, WriteError> {
+    let shared = authoritative_channel(Some(capture), registry, route)?;
     timed(
         HidppOperation::ReadDpiCapabilities,
-        openlogi_hid::get_dpi_info(route),
+        openlogi_hid::get_dpi_info_on(&shared),
     )
     .await
 }
 
 /// Read the current SmartShift config from `route`.
-pub async fn read_smartshift(route: &DeviceRoute) -> Result<SmartShiftStatus, WriteError> {
+pub async fn read_smartshift(
+    capture: &CaptureChannel,
+    registry: &ChannelRegistry,
+    route: &DeviceRoute,
+) -> Result<SmartShiftStatus, WriteError> {
+    let shared = authoritative_channel(Some(capture), registry, route)?;
     timed(
         HidppOperation::ReadSmartShift,
-        openlogi_hid::get_smartshift_status(route),
+        openlogi_hid::get_smartshift_status_on(&shared),
     )
     .await
 }
@@ -695,4 +670,41 @@ async fn timed<T>(
     tokio::time::timeout(WRITE_BUDGET, fut)
         .await
         .map_err(|_| WriteError::RequestTimedOut { operation })?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::choose_authoritative;
+
+    #[test]
+    fn current_capture_wins_without_consulting_the_registry_again() {
+        let looked_up = Cell::new(false);
+        let selected = choose_authoritative(
+            Some("capture"),
+            |_| true,
+            || {
+                looked_up.set(true);
+                Some("registry")
+            },
+        );
+
+        assert_eq!(selected, Some("capture"));
+        assert!(!looked_up.get());
+    }
+
+    #[test]
+    fn stale_capture_falls_through_to_the_registry_winner() {
+        let selected = choose_authoritative(Some("stale"), |_| false, || Some("registry-current"));
+
+        assert_eq!(selected, Some("registry-current"));
+    }
+
+    #[test]
+    fn registry_miss_has_no_route_open_fallback() {
+        let selected = choose_authoritative(Some("stale"), |_| false, || None);
+
+        assert_eq!(selected, None);
+    }
 }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use openlogi_core::binding::{
     Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
 };
-use openlogi_hid::CaptureChannel;
+use openlogi_hid::{CaptureChannel, ChannelRegistry};
 use openlogi_hook::{EventDisposition, Hook, MouseEvent};
 use tracing::{info, warn};
 
@@ -103,6 +103,7 @@ pub fn start(
     hooks: SharedHookMaps,
     dpi_cycle: Arc<RwLock<DpiCycleState>>,
     capture: CaptureChannel,
+    registry: ChannelRegistry,
     monitor: SharedEventMonitor,
 ) -> Option<Hook> {
     if !Hook::has_accessibility() {
@@ -158,7 +159,7 @@ pub fn start(
                                 .map(|m| resolve_gesture_click(&m.gestures, id));
                             if let Some(action) = action {
                                 info!(button = %id, action = %action.label(), "gesture click → executing bound action");
-                                dispatch_action(&action, &dpi_cycle, &capture);
+                                dispatch_action(&action, &dpi_cycle, &capture, Some(&registry));
                             }
                         }
                         return EventDisposition::Suppress;
@@ -181,7 +182,7 @@ pub fn start(
 
                 if pressed {
                     info!(button = %id, action = %action.label(), "button → executing bound action");
-                    dispatch_action(&action, &dpi_cycle, &capture);
+                    dispatch_action(&action, &dpi_cycle, &capture, Some(&registry));
                 }
                 EventDisposition::Suppress
             }
@@ -207,7 +208,7 @@ pub fn start(
                     });
                     if let Some(action) = action {
                         info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
-                        dispatch_action(&action, &dpi_cycle, &capture);
+                        dispatch_action(&action, &dpi_cycle, &capture, Some(&registry));
                     }
                 }
                 EventDisposition::PassThrough
@@ -306,11 +307,14 @@ fn browser_nav_debounce_ok(action: &Action) -> bool {
 /// `dpi_cycle` is held across a write lock long enough to advance the index
 /// and snapshot the new DPI + target; the actual HID write spawns its own
 /// thread via [`write_dpi_in_background`] to keep event callbacks non-blocking.
-/// `capture` lets those writes reuse the capture session's open channel.
+/// `registry` confirms that `capture` is still current or supplies the current
+/// inventory channel. Hardware actions are skipped when standalone callers do
+/// not provide a registry.
 pub fn dispatch_action(
     action: &Action,
     dpi_cycle: &Arc<RwLock<DpiCycleState>>,
     capture: &CaptureChannel,
+    registry: Option<&ChannelRegistry>,
 ) {
     let next = match action {
         Action::CycleDpiPresets => match dpi_cycle.write() {
@@ -330,7 +334,11 @@ pub fn dispatch_action(
         Action::ToggleSmartShift => {
             let target = dpi_cycle.read().ok().and_then(|g| g.target.clone());
             info!("SmartShift toggle → flipping wheel mode");
-            toggle_smartshift_in_background(Some(capture), target);
+            if let Some(registry) = registry {
+                toggle_smartshift_in_background(Some(capture), registry, target);
+            } else {
+                warn!("no inventory registry — SmartShift toggle skipped");
+            }
             return;
         }
         // BrowserBack/BrowserForward fall through to the keyboard shortcut
@@ -356,7 +364,11 @@ pub fn dispatch_action(
     };
     if let Some((dpi, target)) = next {
         info!(dpi, "DPI action → writing to device");
-        write_dpi_in_background(Some(capture), target, dpi);
+        if let Some(registry) = registry {
+            write_dpi_in_background(Some(capture), registry, target, dpi);
+        } else {
+            warn!("no inventory registry — DPI action skipped");
+        }
     } else if matches!(action, Action::CycleDpiPresets | Action::SetDpiPreset(_)) {
         info!(
             action = %action.label(),

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -264,6 +264,7 @@ impl Orchestrator {
         if resolution.is_some() || inverted.is_some() || dpi.is_some() || smartshift.is_some() {
             crate::hardware::reapply_mouse_volatile_in_background(
                 Some(&self.shared.capture_channel),
+                &self.shared.channel_registry,
                 route.clone(),
                 resolution,
                 inverted,
@@ -272,7 +273,12 @@ impl Orchestrator {
             );
         }
         if let Some(lighting) = self.config.lighting(key).filter(|l| l.enabled) {
-            crate::hardware::set_lighting_in_background(Some(route), &lighting);
+            crate::hardware::set_lighting_in_background(
+                Some(&self.shared.capture_channel),
+                &self.shared.channel_registry,
+                Some(route),
+                &lighting,
+            );
         }
     }
 
@@ -292,6 +298,7 @@ impl Orchestrator {
             let (resolution, inverted) = configured_wheel_mode(&self.config, dev);
             crate::hardware::write_scroll_wheel_mode_in_background(
                 Some(&self.shared.capture_channel),
+                &self.shared.channel_registry,
                 (resolution.is_some() || inverted.is_some())
                     .then(|| dev.route.clone())
                     .flatten(),

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -312,8 +312,11 @@ async fn manage(
                     &mut accumulators,
                     &hook_maps,
                     &gesture_bindings,
-                    &dpi_cycle,
-                    &capture_channel,
+                    DispatchHardware {
+                        dpi_cycle: &dpi_cycle,
+                        capture: &capture_channel,
+                        registry: registry.as_ref(),
+                    },
                     &thumbwheel_sensitivity,
                 );
             }
@@ -442,13 +445,19 @@ enum WheelOutput {
 }
 
 /// Route one captured input to its bound action (or re-synthesised scroll).
+#[derive(Clone, Copy)]
+struct DispatchHardware<'a> {
+    dpi_cycle: &'a Arc<RwLock<DpiCycleState>>,
+    capture: &'a CaptureChannel,
+    registry: Option<&'a ChannelRegistry>,
+}
+
 fn dispatch(
     input: CapturedInput,
     accumulators: &mut WheelAccumulators,
     hook_maps: &SharedHookMaps,
     gesture_bindings: &GestureBindings,
-    dpi_cycle: &Arc<RwLock<DpiCycleState>>,
-    capture: &CaptureChannel,
+    hardware: DispatchHardware<'_>,
     thumbwheel_sensitivity: &ThumbwheelSensitivity,
 ) {
     match input {
@@ -459,7 +468,12 @@ fn dispatch(
                 .and_then(|guard| guard.get(&direction).cloned());
             if let Some(action) = action {
                 debug!(?direction, action = %action.label(), "gesture → action");
-                hook_runtime::dispatch_action(&action, dpi_cycle, capture);
+                hook_runtime::dispatch_action(
+                    &action,
+                    hardware.dpi_cycle,
+                    hardware.capture,
+                    hardware.registry,
+                );
             } else {
                 debug!(?direction, "gesture with no binding — ignored");
             }
@@ -481,7 +495,12 @@ fn dispatch(
                         )
                     });
                 if !ax_handled {
-                    hook_runtime::dispatch_action(&action, dpi_cycle, capture);
+                    hook_runtime::dispatch_action(
+                        &action,
+                        hardware.dpi_cycle,
+                        hardware.capture,
+                        hardware.registry,
+                    );
                 }
             } else {
                 debug!(?button, "HID++ button with no binding — ignored");
@@ -514,7 +533,12 @@ fn dispatch(
                 }
                 WheelOutput::FireAction => {
                     debug!(?button, action = %action.label(), "thumb wheel → action");
-                    hook_runtime::dispatch_action(&action, dpi_cycle, capture);
+                    hook_runtime::dispatch_action(
+                        &action,
+                        hardware.dpi_cycle,
+                        hardware.capture,
+                        hardware.registry,
+                    );
                 }
             }
         }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -237,6 +237,7 @@ async fn run(config: Config) {
                             shared.hook_maps.clone(),
                             shared.dpi_cycle.clone(),
                             shared.capture_channel.clone(),
+                            shared.channel_registry.clone(),
                             Arc::clone(&event_monitor),
                         );
                         hook_installed.store(hook.is_some(), Ordering::Relaxed);

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -80,7 +80,13 @@ impl Agent for AgentServer {
     }
 
     async fn set_dpi(self, _: Context, route: DeviceRoute, dpi: u32) -> Result<(), WriteError> {
-        hardware::apply_dpi(&self.shared.capture_channel, &route, dpi).await
+        hardware::apply_dpi(
+            &self.shared.capture_channel,
+            &self.shared.channel_registry,
+            &route,
+            dpi,
+        )
+        .await
     }
 
     async fn set_lighting(
@@ -89,7 +95,13 @@ impl Agent for AgentServer {
         route: DeviceRoute,
         lighting: Lighting,
     ) -> Result<(), WriteError> {
-        hardware::apply_lighting(&route, &lighting).await
+        hardware::apply_lighting(
+            &self.shared.capture_channel,
+            &self.shared.channel_registry,
+            &route,
+            &lighting,
+        )
+        .await
     }
 
     async fn set_smartshift(
@@ -102,6 +114,7 @@ impl Agent for AgentServer {
     ) -> Result<(), WriteError> {
         hardware::apply_smartshift(
             &self.shared.capture_channel,
+            &self.shared.channel_registry,
             &route,
             mode,
             auto_disengage,
@@ -111,7 +124,12 @@ impl Agent for AgentServer {
     }
 
     async fn read_dpi(self, _: Context, route: DeviceRoute) -> Result<DpiInfo, WriteError> {
-        hardware::read_dpi(&route).await
+        hardware::read_dpi(
+            &self.shared.capture_channel,
+            &self.shared.channel_registry,
+            &route,
+        )
+        .await
     }
 
     async fn read_smartshift(
@@ -119,7 +137,12 @@ impl Agent for AgentServer {
         _: Context,
         route: DeviceRoute,
     ) -> Result<SmartShiftStatus, WriteError> {
-        hardware::read_smartshift(&route).await
+        hardware::read_smartshift(
+            &self.shared.capture_channel,
+            &self.shared.channel_registry,
+            &route,
+        )
+        .await
     }
 
     async fn request_accessibility_prompt(self, _: Context) {

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -51,7 +51,8 @@ pub use smartshift::{AUTO_DISENGAGE_PERMANENT, SmartShiftMode, SmartShiftStatus}
 pub use write::{
     DpiCapabilities, DpiInfo, FeatureEntry, HidppFeatureErrorKind, HidppOperation, LightingMethod,
     ReprogControlEntry, SharedChannel, WriteError, dump_features, dump_reprog_controls, get_dpi,
-    get_dpi_info, get_smartshift_status, set_dpi, set_dpi_on, set_keyboard_color,
-    set_keyboard_color_with, set_smartshift, set_smartshift_on, set_smartshift_sensitivity,
+    get_dpi_info, get_dpi_info_on, get_smartshift_status, get_smartshift_status_on, set_dpi,
+    set_dpi_on, set_keyboard_color, set_keyboard_color_on, set_keyboard_color_with,
+    set_keyboard_color_with_on, set_smartshift, set_smartshift_on, set_smartshift_sensitivity,
     toggle_smartshift, toggle_smartshift_on,
 };

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -14,8 +14,8 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, LazyLock};
 
 #[cfg(not(target_os = "windows"))]
-use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceReader};
-use async_hid::{DeviceInfo, DeviceWriter, HidBackend};
+use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceReader, DeviceWriter};
+use async_hid::{DeviceInfo, HidBackend};
 use futures_lite::StreamExt as _;
 use hidpp::channel::HidppChannel;
 use hidpp::nibble::U4;

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -110,11 +110,11 @@ fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
 /// backend is the usage async-hid intends, and keeps the device set warm between
 /// polls. `HidBackend` is `Arc`-backed, so this is shared, not copied.
 ///
-/// `enumerate` is also reached from `open_route_writer`, so the inventory
-/// watcher and a (rare) lighting write can enumerate through this one backend
-/// concurrently. That is sound: async-hid declares the backend `Send + Sync`,
-/// `enumerate` only reads a snapshot (`IOHIDManagerCopyDevices`), and sharing a
-/// single long-lived `IOHIDManager` across threads is the model hidapi uses too.
+/// Inventory and route-addressed standalone operations may enumerate through
+/// this one backend concurrently. That is sound: async-hid declares the backend
+/// `Send + Sync`, `enumerate` only reads a snapshot
+/// (`IOHIDManagerCopyDevices`), and sharing a single long-lived `IOHIDManager`
+/// across threads is the model hidapi uses too.
 static HID_BACKEND: LazyLock<HidBackend> = LazyLock::new(HidBackend::default);
 
 /// The process-wide HID backend shared by enumeration and hotplug watching.
@@ -202,30 +202,6 @@ fn is_receiver_child_sysfs_path(path: &str) -> bool {
 #[cfg(not(target_os = "linux"))]
 fn is_receiver_child_node(_id: &async_hid::DeviceId) -> bool {
     false
-}
-
-/// Open the raw HID writer for a directly-attached (USB) device, for sending
-/// reports the HID++ wrapper can't model — e.g. the 64-byte `0x12` lighting
-/// frames G-series keyboards use. Returns `None` for Bolt routes or when no
-/// matching node is connected.
-pub(crate) async fn open_route_writer(
-    route: &crate::route::DeviceRoute,
-) -> Result<Option<DeviceWriter>, async_hid::HidError> {
-    let crate::route::DeviceRoute::Direct {
-        vendor_id,
-        product_id,
-    } = route
-    else {
-        return Ok(None);
-    };
-    let candidates = enumerate_hidpp_devices().await?;
-    for dev in candidates {
-        if dev.vendor_id == *vendor_id && dev.product_id == *product_id {
-            let (_reader, writer) = dev.open().await?;
-            return Ok(Some(writer));
-        }
-    }
-    Ok(None)
 }
 
 /// Lease one free software id in `1..=15`, or `None` if all 15 are held.

--- a/crates/openlogi-hid/src/transport/windows.rs
+++ b/crates/openlogi-hid/src/transport/windows.rs
@@ -5,12 +5,11 @@ use std::{error::Error, io};
 use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceInfo, DeviceReader, DeviceWriter};
 #[cfg(target_os = "windows")]
 use futures_lite::StreamExt as _;
+use hidpp::channel::{LONG_REPORT_ID, SHORT_REPORT_ID};
 #[cfg(target_os = "windows")]
 use hidpp::{
     async_trait,
-    channel::{
-        LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel, SHORT_REPORT_ID, SHORT_REPORT_LENGTH,
-    },
+    channel::{LONG_REPORT_LENGTH, RawHidChannel, SHORT_REPORT_LENGTH},
 };
 #[cfg(target_os = "windows")]
 use tokio::sync::Mutex;
@@ -22,6 +21,22 @@ use crate::windows_hid::NativeHidWriter;
 
 #[cfg(target_os = "windows")]
 use super::HID_BACKEND;
+
+const VERY_LONG_REPORT_ID: u8 = 0x12;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReportEndpoint {
+    Short,
+    Long,
+}
+
+fn endpoint_for_report_id(report_id: u8) -> Option<ReportEndpoint> {
+    match report_id {
+        SHORT_REPORT_ID => Some(ReportEndpoint::Short),
+        LONG_REPORT_ID | VERY_LONG_REPORT_ID => Some(ReportEndpoint::Long),
+        _ => None,
+    }
+}
 
 #[cfg(target_os = "windows")]
 struct HidEndpoint {
@@ -189,9 +204,9 @@ impl RawHidChannel for WindowsHidppChannel {
     }
 
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
-        let endpoint = match src.first().copied() {
-            Some(SHORT_REPORT_ID) => self.short.as_ref(),
-            Some(LONG_REPORT_ID) => self.long.as_ref(),
+        let endpoint = match src.first().copied().and_then(endpoint_for_report_id) {
+            Some(ReportEndpoint::Short) => self.short.as_ref(),
+            Some(ReportEndpoint::Long) => self.long.as_ref(),
             _ => None,
         }
         .ok_or_else(|| {
@@ -266,4 +281,26 @@ fn copy_report(
     }
     dst[..len].copy_from_slice(&src[..len]);
     Ok(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_ids_select_their_windows_endpoint() {
+        assert_eq!(
+            endpoint_for_report_id(SHORT_REPORT_ID),
+            Some(ReportEndpoint::Short)
+        );
+        assert_eq!(
+            endpoint_for_report_id(LONG_REPORT_ID),
+            Some(ReportEndpoint::Long)
+        );
+        assert_eq!(
+            endpoint_for_report_id(VERY_LONG_REPORT_ID),
+            Some(ReportEndpoint::Long)
+        );
+        assert_eq!(endpoint_for_report_id(0x13), None);
+    }
 }

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -3,9 +3,9 @@
 //! Each entry point takes a [`DeviceRoute`] and resolves it to an open channel
 //! through `open_route_channel`, so the same call works whether the device is
 //! behind a Bolt receiver or attached directly (USB cable / Bluetooth). Each
-//! call re-enumerates and re-opens — fine at the frequency this is invoked
-//! (once per slider release) — unless a [`SharedChannel`] from the capture
-//! session is reused.
+//! route-addressed call re-enumerates and re-opens, while the corresponding
+//! `_on` entry points reuse a [`SharedChannel`] already owned by inventory or a
+//! standalone capture session.
 
 use std::sync::Arc;
 
@@ -24,7 +24,10 @@ pub use diagnostics::{FeatureEntry, ReprogControlEntry, dump_features, dump_repr
 pub use dpi::{DpiCapabilities, DpiInfo, get_dpi, get_dpi_info, set_dpi};
 pub use error::{HidppFeatureErrorKind, HidppOperation, WriteError};
 pub use lighting::{LightingMethod, set_keyboard_color, set_keyboard_color_with};
-pub use shared::{SharedChannel, set_dpi_on, set_smartshift_on, toggle_smartshift_on};
+pub use shared::{
+    SharedChannel, get_dpi_info_on, get_smartshift_status_on, set_dpi_on, set_keyboard_color_on,
+    set_keyboard_color_with_on, set_smartshift_on, toggle_smartshift_on,
+};
 pub use smartshift::{
     get_smartshift_status, set_smartshift, set_smartshift_sensitivity, toggle_smartshift,
 };

--- a/crates/openlogi-hid/src/write/dpi.rs
+++ b/crates/openlogi-hid/src/write/dpi.rs
@@ -125,16 +125,23 @@ pub struct DpiInfo {
 pub async fn get_dpi(route: &DeviceRoute) -> Result<u16, WriteError> {
     let index = route.device_index();
     with_route(route, move |channel| async move {
-        let mut device = Device::new(Arc::clone(&channel), index)
-            .await
-            .map_err(|_| WriteError::DeviceUnreachable { index })?;
-        let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
-        feature
-            .get_sensor_dpi(0)
-            .await
-            .map_err(|e| classify_hidpp_error(e, HidppOperation::ReadDpi, AdjustableDpiFeature::ID))
+        get_dpi_on_channel(&channel, index).await
     })
     .await
+}
+
+async fn get_dpi_on_channel(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    index: u8,
+) -> Result<u16, WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
+    feature
+        .get_sensor_dpi(0)
+        .await
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::ReadDpi, AdjustableDpiFeature::ID))
 }
 
 /// Classify a HID++ error from the AdjustableDpi functions. A device that
@@ -162,35 +169,42 @@ fn classify_dpi_error(error: Hidpp20Error) -> WriteError {
 pub async fn get_dpi_info(route: &DeviceRoute) -> Result<DpiInfo, WriteError> {
     let index = route.device_index();
     with_route(route, move |channel| async move {
-        let mut device = Device::new(Arc::clone(&channel), index)
-            .await
-            .map_err(|_| WriteError::DeviceUnreachable { index })?;
-        let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
-        let sensor_count = feature
-            .get_sensor_count()
-            .await
-            .map_err(classify_dpi_error)?;
-        if sensor_count == 0 {
-            // The device claims AdjustableDpi but exposes no sensor — it cannot
-            // report DPI, and that won't change on retry.
-            return Err(WriteError::FeatureUnsupported {
-                feature_hex: AdjustableDpiFeature::ID,
-            });
-        }
-        let current = feature
-            .get_sensor_dpi(0)
-            .await
-            .map_err(classify_dpi_error)?;
-        let values = feature
-            .get_sensor_dpi_list(0)
-            .await
-            .map_err(classify_dpi_error)?;
-        Ok(DpiInfo {
-            current,
-            capabilities: DpiCapabilities::new(values)?,
-        })
+        get_dpi_info_on_channel(&channel, index).await
     })
     .await
+}
+
+pub(super) async fn get_dpi_info_on_channel(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    index: u8,
+) -> Result<DpiInfo, WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
+    let sensor_count = feature
+        .get_sensor_count()
+        .await
+        .map_err(classify_dpi_error)?;
+    if sensor_count == 0 {
+        // The device claims AdjustableDpi but exposes no sensor — it cannot
+        // report DPI, and that won't change on retry.
+        return Err(WriteError::FeatureUnsupported {
+            feature_hex: AdjustableDpiFeature::ID,
+        });
+    }
+    let current = feature
+        .get_sensor_dpi(0)
+        .await
+        .map_err(classify_dpi_error)?;
+    let values = feature
+        .get_sensor_dpi_list(0)
+        .await
+        .map_err(classify_dpi_error)?;
+    Ok(DpiInfo {
+        current,
+        capabilities: DpiCapabilities::new(values)?,
+    })
 }
 
 /// Set sensor 0's DPI for the device addressed by `route`.

--- a/crates/openlogi-hid/src/write/lighting.rs
+++ b/crates/openlogi-hid/src/write/lighting.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
 use std::time::Duration;
 
-use async_hid::AsyncHidWrite;
 use hidpp::{
+    channel::{ChannelError, HidppChannel},
     device::Device,
     feature::{
         CreatableFeature,
@@ -90,15 +91,30 @@ pub async fn set_keyboard_color_with(
     g: u8,
     b: u8,
 ) -> Result<(), WriteError> {
+    let device_index = route.device_index();
+    with_route(route, move |channel| async move {
+        set_keyboard_color_with_on_channel(&channel, device_index, method, r, g, b).await
+    })
+    .await
+}
+
+pub(super) async fn set_keyboard_color_with_on_channel(
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
+    method: LightingMethod,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), WriteError> {
     match method {
-        LightingMethod::PerKey => set_color_per_key(route, r, g, b).await,
-        LightingMethod::Effects => set_color_effects(route, r, g, b).await,
-        LightingMethod::Auto => match set_color_effects(route, r, g, b).await {
+        LightingMethod::PerKey => set_color_per_key(channel, device_index, r, g, b).await,
+        LightingMethod::Effects => set_color_effects(channel, device_index, r, g, b).await,
+        LightingMethod::Auto => match set_color_effects(channel, device_index, r, g, b).await {
             Err(WriteError::FeatureUnsupported { feature_hex })
                 if feature_hex == COLOR_LED_EFFECTS_FEATURE =>
             {
                 debug!("no 0x8070 effect engine — falling back to 0x8080 per-key");
-                set_color_per_key(route, r, g, b).await
+                set_color_per_key(channel, device_index, r, g, b).await
             }
             other => other,
         },
@@ -109,24 +125,21 @@ pub async fn set_keyboard_color_with(
 /// when the device doesn't expose it; the index differs per device, so callers
 /// can't hard-code it.
 async fn resolve_feature_index(
-    route: &DeviceRoute,
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
     feature_id: u16,
 ) -> Result<Option<u8>, WriteError> {
-    let device_index = route.device_index();
-    with_route(route, move |channel| async move {
-        let device = Device::new(std::sync::Arc::clone(&channel), device_index)
-            .await
-            .map_err(|_| WriteError::DeviceUnreachable {
-                index: device_index,
-            })?;
-        let info = device
-            .root()
-            .get_feature(feature_id)
-            .await
-            .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, feature_id))?;
-        Ok(info.map(|i| i.index))
-    })
-    .await
+    let device = Device::new(Arc::clone(channel), device_index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable {
+            index: device_index,
+        })?;
+    let info = device
+        .root()
+        .get_feature(feature_id)
+        .await
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, feature_id))?;
+    Ok(info.map(|i| i.index))
 }
 
 /// Set a solid colour via `ColorLedEffects` (`0x8070`): a fixed effect per zone,
@@ -137,54 +150,56 @@ async fn resolve_feature_index(
 /// first so only existing zones are driven (a typed `set_zone_effect` awaits the
 /// device's reply, so unlike the former raw fire-and-forget path a write to a
 /// non-existent zone would surface as an error rather than a silent no-op).
-async fn set_color_effects(route: &DeviceRoute, r: u8, g: u8, b: u8) -> Result<(), WriteError> {
-    let index = route.device_index();
-    with_route(route, move |channel| async move {
-        let mut device = Device::new(std::sync::Arc::clone(&channel), index)
-            .await
-            .map_err(|_| WriteError::DeviceUnreachable { index })?;
-        let feature = open_feature::<ColorLedEffectsFeature>(&mut device).await?;
-        let zone_count = feature
-            .get_info()
-            .await
-            .map_err(classify_lighting_error)?
-            .zone_count;
+async fn set_color_effects(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<ColorLedEffectsFeature>(&mut device).await?;
+    let zone_count = feature
+        .get_info()
+        .await
+        .map_err(classify_lighting_error)?
+        .zone_count;
 
-        let mut params = [0u8; ZONE_EFFECT_PARAM_COUNT];
-        params[0] = r;
-        params[1] = g;
-        params[2] = b;
-        let zones_to_write = if zone_count == 0 {
-            debug!(
-                index,
-                "0x8070 reported zero zones; applying legacy 4-zone fallback"
-            );
-            MAX_COLOR_LED_EFFECT_ZONES
-        } else {
-            zone_count.min(MAX_COLOR_LED_EFFECT_ZONES)
-        };
-        if zone_count > MAX_COLOR_LED_EFFECT_ZONES {
-            debug!(
-                index,
-                zone_count,
-                capped_zone_count = MAX_COLOR_LED_EFFECT_ZONES,
-                "0x8070 zone count capped to legacy write limit"
-            );
-        }
-        for zone in 0..zones_to_write {
-            feature
-                .set_zone_effect(zone, EFFECT_FIXED, params, Persistence::Volatile)
-                .await
-                .map_err(classify_lighting_error)?;
-            tokio::time::sleep(FRAME_GAP).await;
-        }
+    let mut params = [0u8; ZONE_EFFECT_PARAM_COUNT];
+    params[0] = r;
+    params[1] = g;
+    params[2] = b;
+    let zones_to_write = if zone_count == 0 {
         debug!(
             index,
-            zone_count, zones_to_write, r, g, b, "set keyboard colour via typed 0x8070"
+            "0x8070 reported zero zones; applying legacy 4-zone fallback"
         );
-        Ok(())
-    })
-    .await
+        MAX_COLOR_LED_EFFECT_ZONES
+    } else {
+        zone_count.min(MAX_COLOR_LED_EFFECT_ZONES)
+    };
+    if zone_count > MAX_COLOR_LED_EFFECT_ZONES {
+        debug!(
+            index,
+            zone_count,
+            capped_zone_count = MAX_COLOR_LED_EFFECT_ZONES,
+            "0x8070 zone count capped to legacy write limit"
+        );
+    }
+    for zone in 0..zones_to_write {
+        feature
+            .set_zone_effect(zone, EFFECT_FIXED, params, Persistence::Volatile)
+            .await
+            .map_err(classify_lighting_error)?;
+        tokio::time::sleep(FRAME_GAP).await;
+    }
+    debug!(
+        index,
+        zone_count, zones_to_write, r, g, b, "set keyboard colour via typed 0x8070"
+    );
+    Ok(())
 }
 
 /// Classify a HID++ error from the `ColorLedEffects` functions.
@@ -195,17 +210,46 @@ fn classify_lighting_error(error: hidpp::protocol::v20::Hidpp20Error) -> WriteEr
 /// Set a solid colour via `PerKeyLighting` (`0x8080`): stream every key's colour
 /// in 64-byte `0x12` frames, then commit. `FeatureUnsupported` when the device
 /// exposes no `0x8080`.
-async fn set_color_per_key(route: &DeviceRoute, r: u8, g: u8, b: u8) -> Result<(), WriteError> {
-    let device_index = route.device_index();
-    let feature_index = resolve_feature_index(route, PER_KEY_LIGHTING_FEATURE)
+async fn set_color_per_key(
+    channel: &Arc<HidppChannel>,
+    device_index: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), WriteError> {
+    let feature_index = resolve_feature_index(channel, device_index, PER_KEY_LIGHTING_FEATURE)
         .await?
         .ok_or(WriteError::FeatureUnsupported {
             feature_hex: PER_KEY_LIGHTING_FEATURE,
         })?;
 
-    let Some(mut writer) = crate::transport::open_route_writer(route).await? else {
-        return Err(WriteError::DeviceNotFound);
-    };
+    for report in per_key_reports(device_index, feature_index, r, g, b) {
+        let written = channel
+            .write_raw_report(&report)
+            .await
+            .map_err(classify_raw_lighting_error)?;
+        if written != report.len() {
+            return Err(WriteError::Hidpp(format!(
+                "raw lighting report wrote {written} of {} bytes",
+                report.len()
+            )));
+        }
+    }
+    debug!(
+        device_index,
+        feature_index, r, g, b, "set keyboard colour via 0x8080"
+    );
+    Ok(())
+}
+
+pub(super) fn per_key_reports(
+    device_index: u8,
+    feature_index: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Vec<Vec<u8>> {
+    let mut reports = Vec::new();
     // Each 64-byte `0x12` "set group keys" packet carries up to 14
     // `(keyID, R, G, B)` entries; keyIDs are HID usage codes. Cover the whole
     // keyboard usage range (incl. modifiers at `0xe0..`) so every key lights,
@@ -226,23 +270,22 @@ async fn set_color_per_key(route: &DeviceRoute, r: u8, g: u8, b: u8) -> Result<(
             rep[off + 2] = g;
             rep[off + 3] = b;
         }
-        writer
-            .write_output_report(&rep)
-            .await
-            .map_err(WriteError::from)?;
+        reports.push(rep);
     }
     let mut commit = vec![0u8; 20];
     commit[0] = REPORT_LONG;
     commit[1] = device_index;
     commit[2] = feature_index;
     commit[3] = (FN_FRAME_END << 4) | SW_ID;
-    writer
-        .write_output_report(&commit)
-        .await
-        .map_err(WriteError::from)?;
-    debug!(
-        device_index,
-        feature_index, r, g, b, "set keyboard colour via 0x8080"
-    );
-    Ok(())
+    reports.push(commit);
+    reports
+}
+
+fn classify_raw_lighting_error(error: ChannelError) -> WriteError {
+    match error {
+        ChannelError::Timeout => WriteError::RequestTimedOut {
+            operation: HidppOperation::Lighting,
+        },
+        other => WriteError::Hidpp(format!("{other:?}")),
+    }
 }

--- a/crates/openlogi-hid/src/write/shared.rs
+++ b/crates/openlogi-hid/src/write/shared.rs
@@ -4,18 +4,21 @@ use hidpp::channel::HidppChannel;
 
 use crate::route::DeviceRoute;
 use crate::smartshift::SmartShiftMode;
+use crate::smartshift::SmartShiftStatus;
 
 use super::WriteError;
-use super::dpi::set_dpi_on_channel;
-use super::smartshift::{set_smartshift_on_channel, toggle_smartshift_on_channel};
+use super::dpi::{DpiInfo, get_dpi_info_on_channel, set_dpi_on_channel};
+use super::lighting::{LightingMethod, set_keyboard_color_with_on_channel};
+use super::smartshift::{
+    get_smartshift_status_on_channel, set_smartshift_on_channel, toggle_smartshift_on_channel,
+};
 
-/// An open HID++ channel to a device, shared so DPI / SmartShift writes can
-/// reuse the capture session's connection instead of re-enumerating and
-/// opening a fresh channel each time (which costs ~100ms+).
+/// An open HID++ channel to a device, shared so route-addressed reads and writes
+/// can reuse an inventory- or capture-owned connection instead of
+/// re-enumerating and opening a fresh channel each time (which costs ~100ms+).
 ///
 /// Cheap to clone (an `Arc` plus the [`DeviceRoute`] it points at). Built by
-/// the capture session via `SharedChannel::new` and stashed in a slot the
-/// GUI's write path consults.
+/// the inventory registry or a standalone capture session.
 #[derive(Clone)]
 pub struct SharedChannel {
     channel: Arc<HidppChannel>,
@@ -51,9 +54,21 @@ pub async fn set_dpi_on(shared: &SharedChannel, dpi: u16) -> Result<(), WriteErr
     set_dpi_on_channel(&shared.channel, shared.route.device_index(), dpi).await
 }
 
+/// Read current DPI and supported values on an already-open [`SharedChannel`].
+pub async fn get_dpi_info_on(shared: &SharedChannel) -> Result<DpiInfo, WriteError> {
+    get_dpi_info_on_channel(&shared.channel, shared.route.device_index()).await
+}
+
 /// Toggle SmartShift on an already-open [`SharedChannel`].
 pub async fn toggle_smartshift_on(shared: &SharedChannel) -> Result<SmartShiftMode, WriteError> {
     toggle_smartshift_on_channel(&shared.channel, shared.route.device_index()).await
+}
+
+/// Read SmartShift mode and sensitivity on an already-open [`SharedChannel`].
+pub async fn get_smartshift_status_on(
+    shared: &SharedChannel,
+) -> Result<SmartShiftStatus, WriteError> {
+    get_smartshift_status_on_channel(&shared.channel, shared.route.device_index()).await
 }
 
 /// Write a full SmartShift configuration on an already-open [`SharedChannel`]
@@ -70,6 +85,37 @@ pub async fn set_smartshift_on(
         mode,
         auto_disengage,
         tunable_torque,
+    )
+    .await
+}
+
+/// Set a solid keyboard colour on an already-open [`SharedChannel`], using
+/// [`LightingMethod::Auto`].
+pub async fn set_keyboard_color_on(
+    shared: &SharedChannel,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), WriteError> {
+    set_keyboard_color_with_on(shared, LightingMethod::Auto, r, g, b).await
+}
+
+/// Set a solid keyboard colour on an already-open [`SharedChannel`] with an
+/// explicit lighting method.
+pub async fn set_keyboard_color_with_on(
+    shared: &SharedChannel,
+    method: LightingMethod,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), WriteError> {
+    set_keyboard_color_with_on_channel(
+        &shared.channel,
+        shared.route.device_index(),
+        method,
+        r,
+        g,
+        b,
     )
     .await
 }

--- a/crates/openlogi-hid/src/write/smartshift.rs
+++ b/crates/openlogi-hid/src/write/smartshift.rs
@@ -241,13 +241,20 @@ impl SmartShift {
 pub async fn get_smartshift_status(route: &DeviceRoute) -> Result<SmartShiftStatus, WriteError> {
     let index = route.device_index();
     with_route(route, move |channel| async move {
-        let mut device = Device::new(Arc::clone(&channel), index)
-            .await
-            .map_err(|_| WriteError::DeviceUnreachable { index })?;
-        let smartshift = SmartShift::open(&mut device).await?;
-        smartshift.status().await
+        get_smartshift_status_on_channel(&channel, index).await
     })
     .await
+}
+
+pub(super) async fn get_smartshift_status_on_channel(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+) -> Result<SmartShiftStatus, WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let smartshift = SmartShift::open(&mut device).await?;
+    smartshift.status().await
 }
 
 /// Set the SmartShift auto-disengage sensitivity on `route`, preserving the

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -1,10 +1,16 @@
 use std::assert_matches;
+use std::error::Error;
+use std::io;
+use std::sync::{Arc, Mutex, PoisonError};
 
 use super::*;
+use hidpp::channel::{HidppChannel, RawHidChannel};
 use hidpp::feature::smartshift::WheelMode;
+use tokio::sync::mpsc;
 
 use crate::SmartShiftMode;
 use crate::SmartShiftStatus;
+use crate::write::lighting::per_key_reports;
 use crate::write::smartshift::{
     is_missing_enhanced, is_transient_smartshift_error, smartshift_to_wheel,
     status_matches_desired, wheel_mode_to_smartshift,
@@ -181,4 +187,220 @@ fn status_match_ignores_zero_preserve_fields() {
             ..desired
         }
     ));
+}
+
+#[test]
+fn per_key_lighting_builds_only_very_long_frames_then_one_long_commit() {
+    let reports = per_key_reports(0x03, 0x27, 0x11, 0x22, 0x33);
+    let (commit, frames) = reports
+        .split_last()
+        .unwrap_or_else(|| panic!("per-key lighting must emit a commit"));
+
+    assert_eq!(frames.len(), 17);
+    assert!(frames.iter().all(|report| report.len() == 64));
+    assert!(frames.iter().all(|report| report[0] == 0x12));
+    assert!(frames.iter().all(|report| report[1] == 0x03));
+    assert!(frames.iter().all(|report| report[2] == 0x27));
+    assert!(frames.iter().all(|report| report[3] == 0x3a));
+    assert!(frames.iter().all(|report| report[5] == 0x01));
+    assert!(frames.iter().all(|report| report[7] == 0x0e));
+
+    let entries: Vec<_> = frames
+        .iter()
+        .flat_map(|report| report[8..64].chunks_exact(4))
+        .take(0xe9)
+        .map(|entry| (entry[0], entry[1], entry[2], entry[3]))
+        .collect();
+    assert_eq!(entries.len(), 0xe9);
+    for (key, entry) in (0x00u8..=0xe8).zip(entries) {
+        assert_eq!(entry, (key, 0x11, 0x22, 0x33));
+    }
+
+    assert_eq!(commit.len(), 20);
+    assert_eq!(&commit[..4], &[0x11, 0x03, 0x27, 0x5a]);
+    assert!(commit[4..].iter().all(|byte| *byte == 0));
+}
+
+#[tokio::test]
+async fn shared_read_and_lighting_apis_use_the_supplied_channel() -> Result<(), WriteError> {
+    let (raw, handle) = ScriptedRawHidChannel::new();
+    let channel = Arc::new(
+        HidppChannel::from_raw_channel(raw)
+            .await
+            .unwrap_or_else(|error| panic!("scripted HID++ channel must open: {error:?}")),
+    );
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    let dpi = get_dpi_info_on(&shared).await?;
+    assert_eq!(dpi.current, 800);
+    assert_eq!(dpi.capabilities.values(), [400, 800, 1600]);
+
+    let smartshift = get_smartshift_status_on(&shared).await?;
+    assert_eq!(smartshift.mode, SmartShiftMode::Ratchet);
+    assert_eq!(smartshift.auto_disengage, 10);
+    assert_eq!(smartshift.tunable_torque, 33);
+
+    // The scripted device reports no 0x8070 effect engine, so Auto must fall
+    // back to 0x8080 without opening a second transport.
+    set_keyboard_color_on(&shared, 0x11, 0x22, 0x33).await?;
+
+    let written = handle.written_reports();
+    let very_long: Vec<_> = written
+        .iter()
+        .filter(|report| report.first() == Some(&0x12))
+        .collect();
+    assert_eq!(very_long.len(), 17);
+    assert!(very_long.iter().all(|report| report.len() == 64));
+    assert!(written.iter().any(|report| {
+        report.len() == 20
+            && report[0] == 0x11
+            && report[1] == 0xff
+            && report[2] == 0x07
+            && report[3] >> 4 == 0x05
+    }));
+    Ok(())
+}
+
+#[derive(Clone)]
+struct ScriptedRawHidHandle {
+    written: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl ScriptedRawHidHandle {
+    fn written_reports(&self) -> Vec<Vec<u8>> {
+        self.written
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+}
+
+struct ScriptedRawHidChannel {
+    incoming_tx: mpsc::UnboundedSender<Vec<u8>>,
+    incoming_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
+    written: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl ScriptedRawHidChannel {
+    fn new() -> (Self, ScriptedRawHidHandle) {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let written = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                incoming_tx,
+                incoming_rx: tokio::sync::Mutex::new(incoming_rx),
+                written: Arc::clone(&written),
+            },
+            ScriptedRawHidHandle { written },
+        )
+    }
+}
+
+#[hidpp::async_trait]
+impl RawHidChannel for ScriptedRawHidChannel {
+    fn vendor_id(&self) -> u16 {
+        0x046d
+    }
+
+    fn product_id(&self) -> u16 {
+        0xb35b
+    }
+
+    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        self.written
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(src.to_vec());
+        if let Some(response) = scripted_response(src) {
+            self.incoming_tx.send(response).map_err(|_| mock_error())?;
+        }
+        Ok(src.len())
+    }
+
+    async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        let Some(report) = self.incoming_rx.lock().await.recv().await else {
+            return Err(mock_error());
+        };
+        let len = report.len().min(buf.len());
+        buf[..len].copy_from_slice(&report[..len]);
+        Ok(len)
+    }
+
+    fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
+        Some((true, true))
+    }
+
+    async fn get_report_descriptor(
+        &self,
+        _buf: &mut [u8],
+    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        unreachable!("scripted channel declares HID++ support")
+    }
+}
+
+fn scripted_response(request: &[u8]) -> Option<Vec<u8>> {
+    if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
+        return None;
+    }
+    let feature_index = request[2];
+    let function = request[3] >> 4;
+    let mut payload = [0u8; 16];
+    let long = match (feature_index, function) {
+        // Root ping used by Device::new.
+        (0x00, 0x01) => {
+            payload[0] = 4;
+            false
+        }
+        // Root feature lookup.
+        (0x00, 0x00) => {
+            let feature_id = u16::from_be_bytes([request[4], request[5]]);
+            payload[0] = match feature_id {
+                0x2201 => 0x05,
+                0x2111 => 0x06,
+                0x8080 => 0x07,
+                _ => 0x00,
+            };
+            false
+        }
+        // AdjustableDpi sensor count/current/list.
+        (0x05, 0x00) => {
+            payload[0] = 1;
+            false
+        }
+        (0x05, 0x02) => {
+            payload[1..3].copy_from_slice(&800u16.to_be_bytes());
+            false
+        }
+        (0x05, 0x01) => {
+            payload[..8].copy_from_slice(&[0, 0x01, 0x90, 0x03, 0x20, 0x06, 0x40, 0]);
+            true
+        }
+        // Enhanced SmartShift status.
+        (0x06, 0x01) => {
+            payload[..3].copy_from_slice(&[u8::from(WheelMode::Ratchet), 10, 33]);
+            false
+        }
+        // Raw per-key frame commit expects no reply.
+        _ => return None,
+    };
+
+    let mut response = vec![0u8; if long { 20 } else { 7 }];
+    response[0] = if long { 0x11 } else { 0x10 };
+    response[1..4].copy_from_slice(&request[1..4]);
+    let payload_len = response.len() - 4;
+    response[4..].copy_from_slice(&payload[..payload_len]);
+    Some(response)
+}
+
+fn mock_error() -> Box<dyn Error + Send + Sync> {
+    Box::new(io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "scripted HID channel closed",
+    ))
 }

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -31,6 +31,10 @@ const MAX_REPORT_DESCRIPTOR_LENGTH: usize = 4096;
 /// As we only care about HID++ reports, this equals to [`LONG_REPORT_LENGTH`].
 const MAX_REPORT_LENGTH: usize = LONG_REPORT_LENGTH;
 
+/// Largest output report accepted by [`HidppChannel::write_raw_report`].
+/// Logitech's very-long HID++ lighting report (`0x12`) is 64 bytes.
+const MAX_RAW_REPORT_LENGTH: usize = 64;
+
 /// The default time budget for a [`HidppChannel::send`] request: the report
 /// write plus the wait for a matching response. Callers that need a different
 /// budget can use [`HidppChannel::send_with_timeout`].
@@ -619,6 +623,34 @@ impl HidppChannel {
             .map_err(ChannelError::Implementation)
     }
 
+    /// Write one raw HID report through this channel's already-owned transport.
+    ///
+    /// Reports must contain `1..=64` bytes, including their report ID. The
+    /// operation is bounded by [`SEND_RESPONSE_TIMEOUT`] and returns the exact
+    /// byte count reported by the transport. This is intended for HID++ report
+    /// widths such as the 64-byte `0x12` lighting frame that [`HidppMessage`]
+    /// cannot represent.
+    pub async fn write_raw_report(&self, report: &[u8]) -> Result<usize, ChannelError> {
+        self.write_raw_report_with_timeout(report, SEND_RESPONSE_TIMEOUT)
+            .await
+    }
+
+    async fn write_raw_report_with_timeout(
+        &self,
+        report: &[u8],
+        timeout: Duration,
+    ) -> Result<usize, ChannelError> {
+        if !(1..=MAX_RAW_REPORT_LENGTH).contains(&report.len()) {
+            return Err(ChannelError::InvalidRawReportLength(report.len()));
+        }
+
+        let mut write = std::pin::pin!(self.raw_channel.write_report(report).fuse());
+        select! {
+            result = write => result.map_err(ChannelError::Implementation),
+            _ = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
+        }
+    }
+
     /// Registers a listener that will be called for every incoming message.
     ///
     /// Returns a handle that can be used to remove the listener using a call to
@@ -687,14 +719,20 @@ pub enum ChannelError {
     #[error("the channel does not support the given HID++ message type")]
     MessageTypeNotSupported,
 
+    /// Indicates that a raw output report was empty or exceeded 64 bytes.
+    #[error("raw HID reports must contain 1..=64 bytes, got {0}")]
+    InvalidRawReportLength(usize),
+
     /// Indicates that no response was received following a request.
     #[error("the device did not respond to the request")]
     NoResponse,
 
-    /// Indicates that a request did not complete within its time budget —
-    /// typically the device is asleep, out of range or connected to another
-    /// host. See [`HidppChannel::send_with_timeout`].
-    #[error("the request timed out before the device responded")]
+    /// Indicates that a bounded channel operation did not complete — typically
+    /// because the device is asleep, out of range, connected to another host,
+    /// or its transport write is wedged. See
+    /// [`HidppChannel::send_with_timeout`] and
+    /// [`HidppChannel::write_raw_report`].
+    #[error("the HID channel operation timed out")]
     Timeout,
 }
 
@@ -716,7 +754,7 @@ mod tests {
         io,
         sync::{
             Arc, Mutex,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
         },
         time::{Duration, Instant},
     };
@@ -879,6 +917,59 @@ mod tests {
 
             assert_eq!(handle.written_reports().len(), 1);
             assert_pending_empty(&channel);
+        });
+    }
+
+    #[test]
+    fn raw_report_write_forwards_exact_bytes_and_length() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+            let report = [0x12; MAX_RAW_REPORT_LENGTH];
+
+            let written = channel.write_raw_report(&report).await.unwrap();
+
+            assert_eq!(written, report.len());
+            assert_eq!(handle.written_reports(), [report.to_vec()]);
+        });
+    }
+
+    #[test]
+    fn raw_report_write_rejects_empty_and_oversized_inputs_without_io() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+
+            let empty = channel.write_raw_report(&[]).await.unwrap_err();
+            let oversized = channel
+                .write_raw_report(&[0; MAX_RAW_REPORT_LENGTH + 1])
+                .await
+                .unwrap_err();
+
+            assert!(matches!(empty, ChannelError::InvalidRawReportLength(0)));
+            assert!(matches!(
+                oversized,
+                ChannelError::InvalidRawReportLength(65)
+            ));
+            assert!(handle.written_reports().is_empty());
+        });
+    }
+
+    #[test]
+    fn raw_report_write_times_out_when_the_transport_parks() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            handle.park_writes();
+            let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+            let started = Instant::now();
+
+            let error = channel
+                .write_raw_report_with_timeout(&[LONG_REPORT_ID], Duration::from_millis(25))
+                .await
+                .unwrap_err();
+
+            assert!(matches!(error, ChannelError::Timeout));
+            assert!(started.elapsed() < Duration::from_secs(1));
         });
     }
 
@@ -1133,6 +1224,7 @@ mod tests {
         incoming_tx: async_channel::Sender<Vec<u8>>,
         written_reports: Arc<Mutex<Vec<Vec<u8>>>>,
         responses_on_write: Arc<Mutex<VecDeque<Vec<u8>>>>,
+        park_writes: Arc<AtomicBool>,
     }
 
     impl MockRawHidHandle {
@@ -1150,6 +1242,10 @@ mod tests {
         fn written_reports(&self) -> Vec<Vec<u8>> {
             self.written_reports.lock().unwrap().clone()
         }
+
+        fn park_writes(&self) {
+            self.park_writes.store(true, Ordering::SeqCst);
+        }
     }
 
     struct MockRawHidChannel {
@@ -1157,6 +1253,7 @@ mod tests {
         incoming_rx: async_channel::Receiver<Vec<u8>>,
         written_reports: Arc<Mutex<Vec<Vec<u8>>>>,
         responses_on_write: Arc<Mutex<VecDeque<Vec<u8>>>>,
+        park_writes: Arc<AtomicBool>,
     }
 
     impl MockRawHidChannel {
@@ -1164,11 +1261,13 @@ mod tests {
             let (incoming_tx, incoming_rx) = async_channel::unbounded();
             let written_reports = Arc::new(Mutex::new(Vec::new()));
             let responses_on_write = Arc::new(Mutex::new(VecDeque::new()));
+            let park_writes = Arc::new(AtomicBool::new(false));
 
             let handle = MockRawHidHandle {
                 incoming_tx: incoming_tx.clone(),
                 written_reports: Arc::clone(&written_reports),
                 responses_on_write: Arc::clone(&responses_on_write),
+                park_writes: Arc::clone(&park_writes),
             };
 
             (
@@ -1177,6 +1276,7 @@ mod tests {
                     incoming_rx,
                     written_reports,
                     responses_on_write,
+                    park_writes,
                 },
                 handle,
             )
@@ -1195,6 +1295,9 @@ mod tests {
 
         async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Sync + Send>> {
             self.written_reports.lock().unwrap().push(src.to_vec());
+            if self.park_writes.load(Ordering::SeqCst) {
+                return std::future::pending().await;
+            }
             let response = self.responses_on_write.lock().unwrap().pop_front();
             if let Some(response) = response {
                 self.incoming_tx.send(response).await.unwrap();


### PR DESCRIPTION
## Summary

Route all Agent-side, route-addressed HID++ reads and writes through the exact inventory-owned channel introduced by #522. This avoids competing HID opens while the inventory or capture watcher already owns the device and provides the shared-channel foundation needed by the MX Keys work.

## Changes

- **openlogi-hidpp:** add bounded raw report writes for 64-byte `0x12` lighting frames and route `0x12` through the Windows long-report endpoint
- **openlogi-hid:** add existing-channel variants for DPI, SmartShift, and keyboard lighting; move per-key lighting reports onto the owned `HidppChannel`
- **openlogi-agent-core / openlogi-agent:** use a registry-confirmed capture channel or the exact current inventory channel for IPC calls, reconnect reapply, hook actions, and gesture actions
- keep the route-opening APIs available for standalone CLI/library callers; an Agent registry miss does not open a fallback channel

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hidpp -p openlogi-hid --no-deps`
- Hardware: these commits were exercised on an MX Keys over Bluetooth in the full feature branch; discovery, normal key input, and lighting on/off worked. The isolated rebased branch was not rerun on hardware.
- Windows: the `0x12` endpoint selection is unit-tested, but the change was not runtime-tested on Windows hardware.

Part of #521
