### PR TITLE
fix(hook): never wedge system pointer input

### DIFF
--- a/.claude/rules/hook.md
+++ b/.claude/rules/hook.md
@@ -10,6 +10,12 @@ paths:
   run-loop slice — a stopped watcher after grant once froze all input on the machine.
   Don't restructure it casually, and don't migrate the tap to `objc2-core-graphics`
   (the `NSWorkspace` read is the only part that moved to `objc2`).
+- The tap callback must never block and never panic: use `try_read`/`try_lock` only,
+  queue bound actions off-thread, wrap the user callback in `catch_unwind`, and keep
+  the stuck-callback watchdog that force-exits the agent if the budget is exceeded.
+  An active HID-level tap serialises every pointer event; a hang freezes clicks
+  machine-wide. Only suppress events from remappable Logitech sources
+  (`source_is_remappable`) — never the built-in trackpad.
 - The off-main `frontmost_bundle_id` read keeps its explicit `autoreleasepool` — the
   watcher thread has no run loop; that is the only place in this crate a pool belongs.
 - This crate ships non-macOS implementations (evdev/uinput, WH_MOUSE_LL) that a

--- a/crates/openlogi-agent-core/src/event_monitor.rs
+++ b/crates/openlogi-agent-core/src/event_monitor.rs
@@ -55,7 +55,7 @@ impl EventMonitor {
             return;
         }
         let mapped = match event {
-            MouseEvent::Button { id, pressed } => MonitorEvent::Button {
+            MouseEvent::Button { id, pressed, .. } => MonitorEvent::Button {
                 button: id.to_string(),
                 pressed: *pressed,
             },
@@ -68,7 +68,9 @@ impl EventMonitor {
             MouseEvent::CaptureInterrupted => MonitorEvent::CaptureInterrupted,
             MouseEvent::Moved { .. } => return,
         };
-        if let Ok(mut buf) = self.buf.lock() {
+        // `try_lock` only — the freeze-sensitive hook callback must never block
+        // on the monitor buffer (a contended `lock` stalls every pointer event).
+        if let Ok(mut buf) = self.buf.try_lock() {
             if buf.len() == CAPACITY {
                 buf.pop_front();
             }
@@ -137,6 +139,7 @@ mod tests {
         m.record(&MouseEvent::Button {
             id: ButtonId::Back,
             pressed: true,
+            device: None,
         });
         assert!(!m.enabled());
 
@@ -152,6 +155,7 @@ mod tests {
         m.record(&MouseEvent::Button {
             id: ButtonId::Forward,
             pressed: false,
+            device: None,
         });
         assert_eq!(
             m.poll(),

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -7,14 +7,16 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{
     Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
 };
 use openlogi_hid::{CaptureChannel, ChannelRegistry};
-use openlogi_hook::{EventDisposition, Hook, MouseEvent};
+use openlogi_hook::{EventDevice, EventDisposition, Hook, MouseEvent, source_is_remappable};
 use tracing::{info, warn};
 
 use crate::DpiCycleState;
@@ -98,6 +100,141 @@ thread_local! {
     static HOLD: RefCell<HoldState> = RefCell::new(HoldState::default());
 }
 
+/// Whether a button event's physical source may be remapped/suppressed.
+///
+/// macOS attributes every CGEvent to an IOKit sender and fails closed: only
+/// known Logitech non-trackpad devices are remappable, so the built-in
+/// trackpad can never be swallowed. Linux/Windows often lack attribution
+/// (`device: None`); those platforms already restrict which devices the hook
+/// attaches to, so unknown sources stay remappable.
+fn button_source_may_remap(device: Option<&EventDevice>) -> bool {
+    match device {
+        Some(d) => source_is_remappable(Some(d)),
+        None => {
+            // Attribution missing: safe on Linux/Windows (device selection is
+            // upstream of the callback). On macOS fail closed — an unattributed
+            // event is more likely a trackpad/system source than a Logi mouse.
+            !cfg!(target_os = "macos")
+        }
+    }
+}
+
+/// Off-thread worker for bound actions so the tap callback never injects input.
+fn spawn_action_worker(
+    dpi_cycle: Arc<RwLock<DpiCycleState>>,
+    capture: CaptureChannel,
+    registry: ChannelRegistry,
+    receiver_access: ReceiverAccess,
+) -> mpsc::SyncSender<Action> {
+    let (tx, rx) = mpsc::sync_channel::<Action>(64);
+    let _ = thread::Builder::new()
+        .name("openlogi-action".into())
+        .spawn(move || {
+            while let Ok(action) = rx.recv() {
+                dispatch_action(
+                    &action,
+                    &dpi_cycle,
+                    &capture,
+                    Some(&registry),
+                    &receiver_access,
+                );
+            }
+        });
+    tx
+}
+
+/// Queue a bound action without blocking the tap callback. Returns `false` if
+/// the queue is full (caller should fail open and pass the physical event).
+fn try_queue_action(tx: &mpsc::SyncSender<Action>, action: Action) -> bool {
+    if tx.try_send(action).is_err() {
+        warn!("action queue full — dropping bound action to keep the input hook live");
+        false
+    } else {
+        true
+    }
+}
+
+/// Remap path for Middle/Back/Forward. Must stay lock-light and non-blocking.
+fn handle_button(
+    id: ButtonId,
+    pressed: bool,
+    device: Option<&EventDevice>,
+    hooks: &SharedHookMaps,
+    action_tx: &mpsc::SyncSender<Action>,
+) -> EventDisposition {
+    // Primary L/R always pass through (suppressing them would brick the mouse).
+    if !id.is_os_hook_button() || !button_source_may_remap(device) {
+        return EventDisposition::PassThrough;
+    }
+
+    // `try_read` only: a blocking read on the tap thread freezes every pointer
+    // event while a config rebuild holds the write lock. Fail open if unavailable.
+    if pressed {
+        let is_gesture = hooks.try_read().is_ok_and(|m| m.gestures.contains_key(&id));
+        if is_gesture {
+            HOLD.with_borrow_mut(|h| h.begin(id));
+            return EventDisposition::Suppress;
+        }
+    } else {
+        // Drop the HOLD borrow before any queueing (re-entrancy freeze hazard).
+        let ended = HOLD.with_borrow_mut(|h| h.end(id));
+        if let Some(was_click) = ended {
+            if was_click {
+                let action = hooks
+                    .try_read()
+                    .ok()
+                    .map(|m| resolve_gesture_click(&m.gestures, id));
+                if let Some(action) = action {
+                    info!(button = %id, action = %action.label(), "gesture click → executing bound action");
+                    let _ = try_queue_action(action_tx, action);
+                }
+            }
+            return EventDisposition::Suppress;
+        }
+    }
+
+    let action = hooks
+        .try_read()
+        .ok()
+        .and_then(|m| m.bindings.get(&id).cloned());
+    let Some(action) = action else {
+        return EventDisposition::PassThrough;
+    };
+    if is_native_click(id, &action) {
+        return EventDisposition::PassThrough;
+    }
+    if pressed {
+        info!(button = %id, action = %action.label(), "button → executing bound action");
+        if !try_queue_action(action_tx, action) {
+            return EventDisposition::PassThrough;
+        }
+    }
+    EventDisposition::Suppress
+}
+
+/// Feed an in-progress gesture hold; always pass motion through so the cursor moves.
+fn handle_moved(
+    delta_x: i32,
+    delta_y: i32,
+    hooks: &SharedHookMaps,
+    action_tx: &mpsc::SyncSender<Action>,
+) -> EventDisposition {
+    let commit = HOLD.with_borrow_mut(|h| h.accumulate(delta_x, delta_y));
+    if let Some((button, dir)) = commit {
+        let action = hooks.try_read().ok().map(|m| {
+            m.gestures
+                .get(&button)
+                .and_then(|dirs| dirs.get(&dir).cloned())
+                .unwrap_or_else(|| resolve_gesture_click(&m.gestures, button))
+        });
+        if let Some(action) = action {
+            info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
+            let _ = try_queue_action(action_tx, action);
+        }
+    }
+    EventDisposition::PassThrough
+}
+
 /// Attempt to start the OS hook. Returns `None` if Accessibility is not
 /// granted or on an unsupported platform — the app continues without crashing.
 pub fn start(
@@ -116,126 +253,23 @@ pub fn start(
         return None;
     }
 
+    // Actions never run on the tap callback thread (HID CGEventTap freeze hazard).
+    let action_tx = spawn_action_worker(dpi_cycle, capture, registry, receiver_access);
+
     // The per-hold pointer accumulator lives in the thread-local `HOLD`; the
     // callback must never block — see the freeze-hazard note in `macos.rs`.
     let result = Hook::start(move |event| {
-        // Mirror the raw event to the GUI's live monitor first (a single relaxed
-        // atomic load while monitoring is off — see `event_monitor`), before any
-        // remapping decides its disposition.
         monitor.record(&event);
         match event {
-            MouseEvent::Button { id, pressed } => {
-                // The CGEventTap only sees standard buttons 0-4. We remap
-                // Middle/Back/Forward; the primary L/R clicks always pass through
-                // (suppressing them would brick the mouse), and the DPI / thumb /
-                // dedicated gesture button aren't visible to the tap at all — the
-                // dedicated gesture button is captured separately over HID++.
-                if !id.is_os_hook_button() {
-                    return EventDisposition::PassThrough;
-                }
-
-                // Gesture button: suppress the native click and begin a hold. The
-                // swipe commits mid-motion in the `Moved` arm; here, on release, we
-                // only fire the plain `Click` when no swipe committed. The cursor is
-                // free to drift via the pass-through `Moved` events during the hold.
-                if pressed {
-                    let is_gesture = hooks.read().is_ok_and(|m| m.gestures.contains_key(&id));
-                    if is_gesture {
-                        HOLD.with_borrow_mut(|h| h.begin(id));
-                        return EventDisposition::Suppress;
-                    }
-                } else {
-                    // Release: end the hold and release the `HOLD` borrow *before* any
-                    // dispatch — the callback must stay lock-light, since a
-                    // synthesized event could otherwise re-enter the tap and re-borrow
-                    // `HOLD` (a RefCell double-borrow panic, freeze hazard).
-                    let ended = HOLD.with_borrow_mut(|h| h.end(id));
-                    if let Some(was_click) = ended {
-                        if was_click {
-                            // No swipe committed → fire the plain click. Resolve to an
-                            // owned action (so no lock is held across dispatch), then
-                            // dispatch with the guard already dropped.
-                            let action = hooks
-                                .read()
-                                .ok()
-                                .map(|m| resolve_gesture_click(&m.gestures, id));
-                            if let Some(action) = action {
-                                info!(button = %id, action = %action.label(), "gesture click → executing bound action");
-                                dispatch_action(
-                                    &action,
-                                    &dpi_cycle,
-                                    &capture,
-                                    Some(&registry),
-                                    &receiver_access,
-                                );
-                            }
-                        }
-                        return EventDisposition::Suppress;
-                    }
-                }
-
-                // Single-action button.
-                let action = hooks.read().ok().and_then(|m| m.bindings.get(&id).cloned());
-                let Some(action) = action else {
-                    // Unbound → leave the physical button to the OS.
-                    return EventDisposition::PassThrough;
-                };
-
-                // A button left on its own native click (e.g. Middle → MiddleClick)
-                // should just do that click; suppressing and re-synthesising it
-                // would be pointless churn.
-                if is_native_click(id, &action) {
-                    return EventDisposition::PassThrough;
-                }
-
-                if pressed {
-                    info!(button = %id, action = %action.label(), "button → executing bound action");
-                    dispatch_action(
-                        &action,
-                        &dpi_cycle,
-                        &capture,
-                        Some(&registry),
-                        &receiver_access,
-                    );
-                }
-                EventDisposition::Suppress
-            }
+            MouseEvent::Button {
+                id,
+                pressed,
+                device,
+            } => handle_button(id, pressed, device.as_ref(), &hooks, &action_tx),
             MouseEvent::Moved { delta_x, delta_y } => {
-                // Feed an in-progress hold; a committed swipe fires here, mid-motion.
-                // Always pass through so the cursor keeps moving — the swipe is read,
-                // not consumed (the B2 cursor-drift tradeoff vs. a HID++ raw-XY divert
-                // that would freeze the pointer).
-                let commit = HOLD.with_borrow_mut(|h| h.accumulate(delta_x, delta_y));
-                if let Some((button, dir)) = commit {
-                    // Resolve to an owned action and drop the read guard before
-                    // dispatch (same lock-light rule as the release arm). The button
-                    // can leave the gesture set mid-hold (a per-app rebuild); the
-                    // commit has already armed `fired`, so the release won't fire a
-                    // click. Fall back to the same click action the release path uses
-                    // so the suppressed press is never swallowed into nothing —
-                    // symmetric with `resolve_gesture_click`.
-                    let action = hooks.read().ok().map(|m| {
-                        m.gestures
-                            .get(&button)
-                            .and_then(|dirs| dirs.get(&dir).cloned())
-                            .unwrap_or_else(|| resolve_gesture_click(&m.gestures, button))
-                    });
-                    if let Some(action) = action {
-                        info!(button = %button, ?dir, action = %action.label(), "gesture swipe → executing bound action");
-                        dispatch_action(
-                            &action,
-                            &dpi_cycle,
-                            &capture,
-                            Some(&registry),
-                            &receiver_access,
-                        );
-                    }
-                }
-                EventDisposition::PassThrough
+                handle_moved(delta_x, delta_y, &hooks, &action_tx)
             }
             MouseEvent::CaptureInterrupted => {
-                // The OS dropped events (tap disabled); cancel any hold so a lost
-                // button-up can't later commit a phantom swipe off ordinary motion.
                 HOLD.with_borrow_mut(HoldState::cancel);
                 EventDisposition::PassThrough
             }

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -6,7 +6,7 @@
 //! and gesture events.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::thread;
@@ -98,6 +98,10 @@ thread_local! {
     /// Thread-local rather than a shared `Mutex` keeps the hot path lock-free and
     /// free of cross-thread contention on the freeze-sensitive callback.
     static HOLD: RefCell<HoldState> = RefCell::new(HoldState::default());
+    /// Buttons whose physical press was delivered because the action queue
+    /// rejected the remap. Their matching release must also pass through so
+    /// apps never see a stuck auxiliary button (down without up).
+    static FAIL_OPEN_PRESSES: RefCell<HashSet<ButtonId>> = RefCell::new(HashSet::new());
 }
 
 /// Whether a button event's physical source may be remapped/suppressed.
@@ -205,11 +209,39 @@ fn handle_button(
     }
     if pressed {
         info!(button = %id, action = %action.label(), "button → executing bound action");
-        if !try_queue_action(action_tx, action) {
-            return EventDisposition::PassThrough;
-        }
+        let queued = try_queue_action(action_tx, action);
+        return FAIL_OPEN_PRESSES.with_borrow_mut(|s| remapped_press_disposition(id, queued, s));
     }
-    EventDisposition::Suppress
+    FAIL_OPEN_PRESSES.with_borrow_mut(|s| remapped_release_disposition(id, s))
+}
+
+/// Press of a remapped single-action button: suppress when the action was
+/// queued, otherwise pass through and mark `id` so the release pairs.
+fn remapped_press_disposition(
+    id: ButtonId,
+    queued: bool,
+    fail_open: &mut HashSet<ButtonId>,
+) -> EventDisposition {
+    if queued {
+        fail_open.remove(&id);
+        EventDisposition::Suppress
+    } else {
+        fail_open.insert(id);
+        EventDisposition::PassThrough
+    }
+}
+
+/// Release of a remapped single-action button: pass through only when the
+/// matching press was fail-opened (queue rejection), else suppress.
+fn remapped_release_disposition(
+    id: ButtonId,
+    fail_open: &mut HashSet<ButtonId>,
+) -> EventDisposition {
+    if fail_open.remove(&id) {
+        EventDisposition::PassThrough
+    } else {
+        EventDisposition::Suppress
+    }
 }
 
 /// Feed an in-progress gesture hold; always pass motion through so the cursor moves.
@@ -490,6 +522,34 @@ mod tests {
             BTreeMap::from([(GestureDirection::Click, Action::None)]),
         )]);
         assert_eq!(resolve_gesture_click(&off, ButtonId::Back), Action::None);
+    }
+
+    #[test]
+    fn fail_open_press_pairs_release() {
+        let mut fail_open = HashSet::new();
+        // Queue accepted → suppress press and release.
+        assert_eq!(
+            remapped_press_disposition(ButtonId::Back, true, &mut fail_open),
+            EventDisposition::Suppress
+        );
+        assert_eq!(
+            remapped_release_disposition(ButtonId::Back, &mut fail_open),
+            EventDisposition::Suppress
+        );
+        // Queue rejected → pass through press *and* matching release.
+        assert_eq!(
+            remapped_press_disposition(ButtonId::Forward, false, &mut fail_open),
+            EventDisposition::PassThrough
+        );
+        assert_eq!(
+            remapped_release_disposition(ButtonId::Forward, &mut fail_open),
+            EventDisposition::PassThrough
+        );
+        // A later unpaired release of that button suppresses again.
+        assert_eq!(
+            remapped_release_disposition(ButtonId::Forward, &mut fail_open),
+            EventDisposition::Suppress
+        );
     }
 
     #[test]

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -29,6 +29,9 @@ use std::cfg_select;
 
 pub use openlogi_core::binding::ButtonId;
 
+/// Logitech's USB/Bluetooth vendor id (`0x046D`).
+pub const LOGITECH_VENDOR_ID: u32 = 0x046d;
+
 /// Best-effort identity for the physical device that produced an OS event.
 ///
 /// Platform hooks fill the stable fields they can read cheaply from the native
@@ -44,6 +47,43 @@ pub struct EventDevice {
     pub product_name: Option<String>,
 }
 
+impl EventDevice {
+    /// Whether this looks like a trackpad/touchpad (must never be remapped).
+    #[must_use]
+    pub fn is_trackpad_like(&self) -> bool {
+        self.product_name.as_deref().is_some_and(|n| {
+            let n = n.to_ascii_lowercase();
+            n.contains("trackpad") || n.contains("touchpad") || n.contains("touch pad")
+        })
+    }
+
+    /// Whether this is a Logitech product OpenLogi may remap buttons for.
+    #[must_use]
+    pub fn is_logitech(&self) -> bool {
+        if self.vendor_id == Some(LOGITECH_VENDOR_ID) {
+            return true;
+        }
+        self.product_name.as_deref().is_some_and(|n| {
+            let n = n.to_ascii_lowercase();
+            n.contains("logitech") || n.starts_with("logi ")
+        })
+    }
+}
+
+/// Whether the OS hook may suppress/remap a button event from this source.
+///
+/// Fail-closed on macOS-style attribution: only a known Logitech non-trackpad
+/// source is remappable. Unknown / non-Logitech / trackpad sources always pass
+/// through so a wedged remap policy can never brick the system pointer.
+#[must_use]
+pub fn source_is_remappable(device: Option<&EventDevice>) -> bool {
+    match device {
+        Some(d) if d.is_trackpad_like() => false,
+        Some(d) => d.is_logitech(),
+        None => false,
+    }
+}
+
 /// An event captured at the OS layer.
 #[derive(Clone, Debug)]
 pub enum MouseEvent {
@@ -53,6 +93,9 @@ pub enum MouseEvent {
         id: ButtonId,
         /// `true` = button down; `false` = button up.
         pressed: bool,
+        /// Best-effort physical source. `None` when the platform cannot
+        /// attribute the event (Windows today) or it was synthetic.
+        device: Option<EventDevice>,
     },
     /// A scroll-wheel tick (or continuous momentum scroll).
     Scroll {

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -37,7 +37,7 @@ use x11rb::properties::WmClass;
 use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
 use x11rb::rust_connection::RustConnection;
 
-use crate::{ButtonId, EventDisposition, HookError, MouseEvent};
+use crate::{ButtonId, EventDisposition, HookError, LOGITECH_VENDOR_ID, MouseEvent};
 
 /// Prefix carried by every uinput device OpenLogi creates — the hook's
 /// pass-through mice ([`VIRTUAL_DEVICE_NAME`]) and openlogi-inject's
@@ -151,19 +151,21 @@ fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
 fn find_mouse_devices() -> Vec<(std::path::PathBuf, Device)> {
     evdev::enumerate()
         .filter(|(path, d)| {
+            let vendor = u32::from(d.input_id().vendor());
             let hookable = is_hookable_mouse(
                 d.name(),
                 d.supported_keys(),
                 d.supported_relative_axes(),
                 d.supported_absolute_axes(),
                 d.properties(),
+                vendor,
             );
             if !hookable
                 && d.supported_keys()
                     .is_some_and(|keys| keys.contains(KeyCode::BTN_LEFT))
             {
                 debug!(
-                    "not hooking {} ({}): has mouse buttons but is not a plain relative-pointer mouse",
+                    "not hooking {} ({}): has mouse buttons but is not a managed Logitech relative-pointer mouse",
                     path.display(),
                     d.name().unwrap_or("unnamed"),
                 );
@@ -183,16 +185,25 @@ fn find_mouse_devices() -> Vec<(std::path::PathBuf, Device)> {
 /// are excluded too: libinput derives their on-button scrolling from the
 /// `POINTING_STICK` input property, which a re-injected uinput stream loses,
 /// and built-in sticks are never OpenLogi's target hardware.
+///
+/// Only Logitech devices are grabbed: OpenLogi remaps Logitech mice, and an
+/// exclusive grab on any other vendor's pointer (or a misclassified built-in
+/// trackpad) would leave that device dead for the life of the agent (#484).
 fn is_hookable_mouse(
     name: Option<&str>,
     keys: Option<&AttributeSetRef<KeyCode>>,
     rel_axes: Option<&AttributeSetRef<RelativeAxisCode>>,
     abs_axes: Option<&AttributeSetRef<AbsoluteAxisCode>>,
     props: &AttributeSetRef<PropType>,
+    vendor_id: u32,
 ) -> bool {
     // Never hook one of our own uinput devices (an unnamed device is fine —
     // ours are always named).
     if name.is_some_and(|n| n.starts_with(OPENLOGI_DEVICE_PREFIX)) {
+        return false;
+    }
+    // OpenLogi only remaps Logitech hardware — never grab foreign vendors.
+    if vendor_id != LOGITECH_VENDOR_ID {
         return false;
     }
     // A mouse clicks and moves relatively; nothing else qualifies. This alone
@@ -298,9 +309,12 @@ fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent
     match event.destructure() {
         EventSummary::Key(_, key, value) => {
             let id = key_to_button(key)?;
+            // Device is already Logitech-only (see `is_hookable_mouse`); the
+            // agent runtime treats `device: None` as remappable on Linux.
             Some(MouseEvent::Button {
                 id,
                 pressed: value != 0,
+                device: None,
             })
         }
         EventSummary::RelativeAxis(_, axis, value) => match axis {
@@ -576,7 +590,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::LeftClick,
-                pressed: true
+                pressed: true,
+                device: None,
             })
         );
     }
@@ -588,7 +603,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::LeftClick,
-                pressed: false
+                pressed: false,
+                device: None,
             })
         );
     }
@@ -600,7 +616,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::Back,
-                pressed: true
+                pressed: true,
+                device: None,
             })
         );
     }
@@ -612,7 +629,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::Back,
-                pressed: true
+                pressed: true,
+                device: None,
             })
         );
     }
@@ -624,7 +642,8 @@ mod tests {
             translate(&event, false),
             Some(MouseEvent::Button {
                 id: ButtonId::Forward,
-                pressed: true
+                pressed: true,
+                device: None,
             })
         );
     }
@@ -748,6 +767,7 @@ mod tests {
         rel: Option<AttributeSet<RelativeAxisCode>>,
         abs: Option<AttributeSet<AbsoluteAxisCode>>,
         props: AttributeSet<PropType>,
+        vendor_id: u32,
     }
 
     impl Caps {
@@ -770,6 +790,7 @@ mod tests {
                 ),
                 abs: None,
                 props: AttributeSet::new(),
+                vendor_id: LOGITECH_VENDOR_ID,
             }
         }
 
@@ -780,6 +801,7 @@ mod tests {
                 self.rel.as_deref(),
                 self.abs.as_deref(),
                 &self.props,
+                self.vendor_id,
             )
         }
     }
@@ -797,6 +819,20 @@ mod tests {
             caps.is_hookable(),
             "a missing name must not exclude a device"
         );
+    }
+
+    #[test]
+    fn non_logitech_mouse_is_not_hookable() {
+        let mut caps = Caps::mouse();
+        caps.name = Some("Apple SPI Trackpad");
+        caps.vendor_id = 0x05ac;
+        assert!(
+            !caps.is_hookable(),
+            "foreign vendors must never be exclusively grabbed"
+        );
+        caps.name = Some("Generic USB Mouse");
+        caps.vendor_id = 0x1234;
+        assert!(!caps.is_hookable());
     }
 
     #[test]

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -2,9 +2,11 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use core_foundation::base::{CFTypeRef, TCFType as _};
 use core_foundation::number::CFNumber;
@@ -261,6 +263,11 @@ fn button_number_to_id(n: i64) -> Option<ButtonId> {
     }
 }
 
+/// Best-effort device identity for a button event's HID sender.
+fn button_source(event: &CGEvent) -> Option<crate::EventDevice> {
+    event_sender_id(event).map(|id| sender_device_info(id).event_device)
+}
+
 /// Convert a `CGEvent` to our [`MouseEvent`] vocabulary. Returns `None`
 /// for event types we don't translate (e.g. move events, unknown buttons).
 fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
@@ -288,26 +295,38 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
         CGEventType::LeftMouseDown => Some(MouseEvent::Button {
             id: ButtonId::LeftClick,
             pressed: true,
+            device: button_source(event),
         }),
         CGEventType::LeftMouseUp => Some(MouseEvent::Button {
             id: ButtonId::LeftClick,
             pressed: false,
+            device: button_source(event),
         }),
         CGEventType::RightMouseDown => Some(MouseEvent::Button {
             id: ButtonId::RightClick,
             pressed: true,
+            device: button_source(event),
         }),
         CGEventType::RightMouseUp => Some(MouseEvent::Button {
             id: ButtonId::RightClick,
             pressed: false,
+            device: button_source(event),
         }),
         CGEventType::OtherMouseDown => {
             let n = event.get_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER);
-            button_number_to_id(n).map(|id| MouseEvent::Button { id, pressed: true })
+            button_number_to_id(n).map(|id| MouseEvent::Button {
+                id,
+                pressed: true,
+                device: button_source(event),
+            })
         }
         CGEventType::OtherMouseUp => {
             let n = event.get_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER);
-            button_number_to_id(n).map(|id| MouseEvent::Button { id, pressed: false })
+            button_number_to_id(n).map(|id| MouseEvent::Button {
+                id,
+                pressed: false,
+                device: button_source(event),
+            })
         }
         CGEventType::ScrollWheel => {
             // axis 1 = vertical scroll; axis 2 = horizontal scroll. Read the
@@ -457,6 +476,91 @@ pub(crate) fn start(
     })
 }
 
+/// How long the tap callback may run before the watchdog treats the agent as
+/// wedging system input and force-exits. An active HID-level tap serialises
+/// every pointer event through this callback; a hang freezes clicks machine-wide.
+const CALLBACK_STUCK_BUDGET: Duration = Duration::from_millis(200);
+
+/// Event types the HID tap observes. Pointer *Dragged variants are required
+/// because a held button makes the OS emit those instead of `MouseMoved`.
+fn hooked_event_types() -> Vec<CGEventType> {
+    vec![
+        CGEventType::LeftMouseDown,
+        CGEventType::LeftMouseUp,
+        CGEventType::RightMouseDown,
+        CGEventType::RightMouseUp,
+        CGEventType::OtherMouseDown,
+        CGEventType::OtherMouseUp,
+        CGEventType::ScrollWheel,
+        CGEventType::MouseMoved,
+        CGEventType::LeftMouseDragged,
+        CGEventType::RightMouseDragged,
+        CGEventType::OtherMouseDragged,
+    ]
+}
+
+/// Invoke the user callback under `catch_unwind`, always failing open.
+fn run_tap_callback(
+    cb: &dyn Fn(MouseEvent) -> EventDisposition,
+    etype: CGEventType,
+    event: &CGEvent,
+) -> CallbackResult {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let Some(mouse_event) = translate(etype, event) else {
+            return CallbackResult::Keep;
+        };
+        match cb(mouse_event) {
+            EventDisposition::PassThrough => CallbackResult::Keep,
+            EventDisposition::Suppress => CallbackResult::Drop,
+        }
+    }));
+    if let Ok(disposition) = result {
+        disposition
+    } else {
+        error!(
+            "OS mouse-hook callback panicked — passing event through to \
+             avoid wedging system input"
+        );
+        CallbackResult::Keep
+    }
+}
+
+/// Sibling watchdog: if the callback is still entered past the budget, abort
+/// the agent so macOS tears the tap down and system input recovers.
+fn spawn_callback_watchdog(
+    stop: Arc<AtomicBool>,
+    in_callback: Arc<AtomicBool>,
+    entered_at_ms: Arc<AtomicU64>,
+) {
+    let budget_ms = u64::try_from(CALLBACK_STUCK_BUDGET.as_millis()).unwrap_or(200);
+    let _ = thread::Builder::new()
+        .name("openlogi-hook-watchdog".into())
+        .spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                thread::sleep(Duration::from_millis(20));
+                if !in_callback.load(Ordering::Acquire) {
+                    continue;
+                }
+                let entered = entered_at_ms.load(Ordering::Acquire);
+                if entered == 0 {
+                    continue;
+                }
+                let elapsed = unix_now_ms().saturating_sub(entered);
+                if elapsed < budget_ms {
+                    continue;
+                }
+                error!(
+                    stuck_ms = elapsed,
+                    "OS mouse-hook callback stuck past budget — exiting agent to \
+                     restore system input (HID CGEventTap freeze hazard)"
+                );
+                // Hard exit: disable_tap alone cannot unblock an in-flight
+                // callback, and a live active HID tap freezes all pointer I/O.
+                std::process::exit(78);
+            }
+        });
+}
+
 /// Body of the background hook thread.
 #[allow(
     clippy::needless_pass_by_value,
@@ -467,39 +571,30 @@ fn thread_main(
     rl_tx: mpsc::Sender<CFRunLoop>,
     stop: Arc<AtomicBool>,
 ) {
-    let event_types = vec![
-        CGEventType::LeftMouseDown,
-        CGEventType::LeftMouseUp,
-        CGEventType::RightMouseDown,
-        CGEventType::RightMouseUp,
-        CGEventType::OtherMouseDown,
-        CGEventType::OtherMouseUp,
-        CGEventType::ScrollWheel,
-        // Pointer movement, for gesture-button hold+swipe. A held button makes
-        // the OS emit *Dragged rather than MouseMoved, so all four are needed.
-        // The callback stays lock-light (see `hook_runtime`) so this high-rate
-        // stream can't stall the tap.
-        CGEventType::MouseMoved,
-        CGEventType::LeftMouseDragged,
-        CGEventType::RightMouseDragged,
-        CGEventType::OtherMouseDragged,
-    ];
+    // Watchdog state: the run-loop thread can't observe a stuck callback (it
+    // *is* the callback), so a sibling thread samples these atomics and kills
+    // the process if the budget is exceeded — process death is the only reliable
+    // way to release a wedged HID-level tap and restore system input.
+    let in_callback = Arc::new(AtomicBool::new(false));
+    let entered_at_ms = Arc::new(AtomicU64::new(0));
 
-    let tap_result = CGEventTap::new(
-        CGEventTapLocation::HID,
-        CGEventTapPlacement::HeadInsertEventTap,
-        CGEventTapOptions::Default,
-        event_types,
-        move |_proxy: CGEventTapProxy, etype: CGEventType, event: &CGEvent| {
-            let Some(mouse_event) = translate(etype, event) else {
-                return CallbackResult::Keep;
-            };
-            match cb(mouse_event) {
-                EventDisposition::PassThrough => CallbackResult::Keep,
-                EventDisposition::Suppress => CallbackResult::Drop,
-            }
-        },
-    );
+    let tap_result = {
+        let in_callback = Arc::clone(&in_callback);
+        let entered_at_ms = Arc::clone(&entered_at_ms);
+        CGEventTap::new(
+            CGEventTapLocation::HID,
+            CGEventTapPlacement::HeadInsertEventTap,
+            CGEventTapOptions::Default,
+            hooked_event_types(),
+            move |_proxy: CGEventTapProxy, etype: CGEventType, event: &CGEvent| {
+                in_callback.store(true, Ordering::Release);
+                entered_at_ms.store(unix_now_ms(), Ordering::Release);
+                let disposition = run_tap_callback(cb.as_ref(), etype, event);
+                in_callback.store(false, Ordering::Release);
+                disposition
+            },
+        )
+    };
 
     let Ok(tap) = tap_result else {
         error!("CGEventTapCreate returned null — Accessibility may have been revoked");
@@ -521,9 +616,15 @@ fn thread_main(
         run_loop.add_source(&loop_source, kCFRunLoopCommonModes);
     }
     tap.enable();
+    spawn_callback_watchdog(
+        Arc::clone(&stop),
+        Arc::clone(&in_callback),
+        Arc::clone(&entered_at_ms),
+    );
 
     if rl_tx.send(run_loop).is_err() {
         debug!("hook parent dropped before run loop was ready; stopping");
+        disable_tap(&tap);
         return;
     }
 
@@ -549,7 +650,7 @@ fn thread_main(
         match CFRunLoop::run_in_mode(
             // SAFETY: framework-provided static CFStringRef, 'static.
             unsafe { kCFRunLoopDefaultMode },
-            std::time::Duration::from_millis(500),
+            Duration::from_millis(500),
             false,
         ) {
             CFRunLoopRunResult::Stopped | CFRunLoopRunResult::Finished => break,
@@ -573,6 +674,13 @@ fn thread_main(
     // so input recovers immediately rather than whenever CF happens to
     // release the port.
     disable_tap(&tap);
+}
+
+/// Milliseconds since the Unix epoch for the stuck-callback watchdog.
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
 }
 
 /// Disable an active event tap now. core-graphics only exposes the enable

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -549,6 +549,13 @@ fn spawn_callback_watchdog(
                 if elapsed < budget_ms {
                     continue;
                 }
+                // Re-sample: a fresh entry may have rewritten the stamp between
+                // the first loads and the budget check.
+                if !in_callback.load(Ordering::Acquire)
+                    || entered_at_ms.load(Ordering::Acquire) != entered
+                {
+                    continue;
+                }
                 error!(
                     stuck_ms = elapsed,
                     "OS mouse-hook callback stuck past budget — exiting agent to \
@@ -587,8 +594,11 @@ fn thread_main(
             CGEventTapOptions::Default,
             hooked_event_types(),
             move |_proxy: CGEventTapProxy, etype: CGEventType, event: &CGEvent| {
+                // Publish the enter timestamp *before* the in-callback flag so
+                // the watchdog never pairs a fresh entry with a stale stamp
+                // (which would false-positive process::exit after a quiet gap).
+                entered_at_ms.store(unix_now_ms(), Ordering::Relaxed);
                 in_callback.store(true, Ordering::Release);
-                entered_at_ms.store(unix_now_ms(), Ordering::Release);
                 let disposition = run_tap_callback(cb.as_ref(), etype, event);
                 in_callback.store(false, Ordering::Release);
                 disposition

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -26,6 +26,7 @@ fn mouse_event_clone_and_debug() {
         MouseEvent::Button {
             id: ButtonId::Back,
             pressed: true,
+            device: None,
         },
         MouseEvent::Scroll {
             delta_x: 1.0,
@@ -51,6 +52,40 @@ fn event_disposition_equality() {
     assert_eq!(EventDisposition::PassThrough, EventDisposition::PassThrough);
     assert_eq!(EventDisposition::Suppress, EventDisposition::Suppress);
     assert_ne!(EventDisposition::PassThrough, EventDisposition::Suppress);
+}
+
+/// Remap policy is fail-closed: only known Logitech non-trackpad sources.
+#[test]
+fn source_is_remappable_policy() {
+    assert!(!source_is_remappable(None));
+
+    let trackpad = EventDevice {
+        vendor_id: Some(0),
+        product_id: None,
+        product_name: Some("Apple Internal Keyboard / Trackpad".into()),
+    };
+    assert!(!source_is_remappable(Some(&trackpad)));
+
+    let apple_mouse = EventDevice {
+        vendor_id: Some(0x05ac),
+        product_id: Some(0x030d),
+        product_name: Some("Magic Mouse".into()),
+    };
+    assert!(!source_is_remappable(Some(&apple_mouse)));
+
+    let logi = EventDevice {
+        vendor_id: Some(LOGITECH_VENDOR_ID),
+        product_id: Some(0xb034),
+        product_name: Some("MX Master 3S".into()),
+    };
+    assert!(source_is_remappable(Some(&logi)));
+
+    let logi_by_name = EventDevice {
+        vendor_id: None,
+        product_id: None,
+        product_name: Some("Logitech USB Receiver".into()),
+    };
+    assert!(source_is_remappable(Some(&logi_by_name)));
 }
 
 /// On unsupported targets (not macOS, Linux, or Windows), `Hook::start`

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -263,7 +263,14 @@ fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
             },
             _ => return None,
         };
-        return Some(MouseEvent::Button { id, pressed });
+        // Windows WH_MOUSE_LL does not expose a cheap device identity; leave
+        // `device` as None so remapping still works (see hook_runtime: non-macOS
+        // keeps remapping when attribution is absent).
+        return Some(MouseEvent::Button {
+            id,
+            pressed,
+            device: None,
+        });
     }
 
     match wparam as u32 {


### PR DESCRIPTION
## Summary

An active HID-level `CGEventTap` serialises **every** pointer event through the agent callback. If that callback blocks (contended lock, sync inject, panic) or the Linux hook exclusively grabs a built-in trackpad, the machine's trackpad/mouse can appear completely dead until the agent is killed.

This hardens the input path so OpenLogi **fails open** and cannot brick system clicks.

## Changes

- **openlogi-hook (macOS)**:
  - Wrap the tap user callback in `catch_unwind` and always pass the event through on panic
  - Add a stuck-callback watchdog (200ms budget) that force-exits the agent so macOS tears the tap down and restores input
  - Attach IOKit device identity to button events
- **openlogi-hook (policy)**:
  - `source_is_remappable` / `EventDevice::{is_logitech,is_trackpad_like}` — only known Logitech non-trackpad sources may be suppressed
  - macOS fails closed when attribution is missing (trackpad/system sources pass through)
- **openlogi-hook (Linux)**:
  - Only exclusively grab Logitech relative-pointer mice (vendor `0x046d`), so a misclassified built-in trackpad can never be seized (related: #484)
- **openlogi-agent-core**:
  - Bound actions run on a dedicated worker thread (`try_send` queue) — never inject CGEvents from the tap callback
  - Hook map reads use `try_read` (fail open on contention)
  - Event monitor uses `try_lock` so a GUI poll cannot stall the callback
- **docs**: extend `.claude/rules/hook.md` with the freeze-hazard invariants

## Testing

- `cargo fmt -p openlogi-hook -p openlogi-agent-core`
- `cargo clippy -p openlogi-hook -p openlogi-agent-core --all-targets -- -D warnings`
- `cargo test -p openlogi-hook -p openlogi-agent-core --lib`
- Not runtime-tested on hardware after this patch (reproduced the wedge by running a dev `openlogi-gui`/`openlogi-agent` and recovering by killing the agent; full regression needs a laptop trackpad + Logitech mouse with Accessibility granted)

Fixes #484 (Linux trackpad grab path)