### PR TITLE
ci(i18n): fix Crowdin translation branch push

### DIFF
--- a/.github/actions/github-app-token-from-1password/action.yml
+++ b/.github/actions/github-app-token-from-1password/action.yml
@@ -41,7 +41,8 @@ runs:
 
     # The App private key is stored base64-encoded in 1Password (a raw PEM's
     # newlines get mangled to spaces on paste). Decode it here; base64 ignores
-    # whitespace, so it survives re-mangling.
+    # whitespace, so it survives re-mangling. Mask each PEM line so the runner
+    # does not echo the key when create-github-app-token logs its `with:` block.
     - name: Decode GitHub App private key
       id: app-key
       shell: bash
@@ -49,6 +50,11 @@ runs:
         APP_KEY_B64: ${{ steps.load-secrets.outputs.GITHUB_APP_PRIVATE_KEY }}
       run: |
         key="$(printf '%s' "$APP_KEY_B64" | tr -d '[:space:]' | base64 -d)"
+        while IFS= read -r line || [ -n "${line}" ]; do
+          if [ -n "${line}" ]; then
+            echo "::add-mask::${line}"
+          fi
+        done <<< "${key}"
         {
           echo 'pem<<__PEM__'
           printf '%s\n' "$key"

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -26,8 +26,13 @@ jobs:
     if: github.repository == 'AprilNEA/OpenLogi'
 
     steps:
+      # persist-credentials must stay false: checkout's default GITHUB_TOKEN
+      # http.extraheader would win over the app token when crowdin/github-action
+      # pushes crowdin/i18n (403 as github-actions[bot] despite env GITHUB_TOKEN).
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Mint GitHub App token
         id: github_app
@@ -35,6 +40,13 @@ jobs:
         with:
           op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
+
+      - name: Configure git for App token
+        env:
+          GH_TOKEN: ${{ steps.github_app.outputs.token }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Load Crowdin credentials from 1Password
         id: crowdin_config

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -11,6 +11,7 @@ on:
       - crowdin.yml
       - crates/openlogi-gui/locales/en.yml
       - .github/workflows/crowdin.yml
+      - .github/actions/github-app-token-from-1password/**
 
 permissions:
   contents: read

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -222,4 +222,6 @@ Missing or invalid credentials fail the workflow. Translation PRs run the
 normal CI checks, including the locale key-parity test. The workflow uses the
 existing `OP_GITHUB_APP_ITEM` to mint a short-lived token for pushing its
 translation branch and opening the PR; the default `GITHUB_TOKEN` remains
-read-only.
+read-only. Checkout runs with `persist-credentials: false` and the origin
+remote is rewritten to the app token so `crowdin/github-action` does not
+inherit the read-only Actions credential for git push.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -199,9 +199,12 @@ cargo run -p xtask -- release latest-json \
 
 `.github/workflows/crowdin.yml` uploads `crates/openlogi-gui/locales/en.yml` to
 [Crowdin](https://crowdin.com/project/openlogi) and opens a `crowdin/i18n` PR
-with fresh translations — nightly, and on master pushes touching the source
-strings. `crowdin.yml` limits exports to the locales shipped by the app and
-maps Crowdin language identifiers to their repository filenames.
+with fresh translations — nightly, and on master pushes that touch the English
+source strings, `crowdin.yml`, the Crowdin workflow, or the shared GitHub App
+token action the job uses. That path filter is intentional: Crowdin config and
+auth wiring changes re-run the same pipeline so the sync stays green.
+`crowdin.yml` limits exports to the locales shipped by the app and maps Crowdin
+language identifiers to their repository filenames.
 
 Like the release workflow, the job reads its credentials from one 1Password
 item referenced by the GitHub secret `OP_CROWDIN_SECRET_ITEM`. The item must


### PR DESCRIPTION
## Summary

Crowdin source upload and translation download succeed, but the job fails when pushing `crowdin/i18n` and opening the sync PR. Git was still using the default Actions credential from `actions/checkout` even though the step sets `GITHUB_TOKEN` to the GitHub App installation token.

## Changes

- **crowdin workflow:** `persist-credentials: false` on checkout, then point `origin` at the minted app token (same pattern as release-plz) so `crowdin/github-action` pushes with write access
- **path filters:** also run Crowdin on master when `.github/actions/github-app-token-from-1password/**` changes, so auth-action and workflow/config edits re-validate the same pipeline (alongside existing `crowdin.yml`, `en.yml`, and workflow paths)
- **github-app-token composite:** mask decoded private-key PEM lines before they are passed into `create-github-app-token`, so runner `with:` input logging stays clean
- **docs:** note the git credential setup and path triggers in the Crowdin section of `DEVELOPMENT.md`

## Testing

- Confirmed recent Crowdin failures stop at `PUSH TO BRANCH crowdin/i18n` with `Permission ... denied to github-actions[bot]` after Crowdin API steps succeed
- Locally verified the AprilNEA GitHub App installation token can write refs / push when used as the git credential (app permissions: `contents: write`, `pull_requests: write`)
- Not re-run against live Crowdin from this branch (needs secrets on `master` / workflow_dispatch on the upstream workflow)

After merge, the master push that lands this workflow/path change will itself trigger **Crowdin → Synchronize translations** and validate the fix end-to-end.