### PR TITLE
ci(i18n): seed Crowdin per language before download

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -23,6 +23,8 @@ paths:
   include list in the subset test in sync.
 - Check with `cargo test -p openlogi-gui i18n`. CI's Linux tests exclude the GUI,
   so this runs on macOS CI and locally (needs the Xcode/Metal env from devenv).
-- Crowdin uploads **`en.yml` sources only** (root `crowdin.yml` +
-  `.github/workflows/crowdin.yml`). Do not treat git non-English files as a
-  second source of truth.
+- Crowdin workflow (root `crowdin.yml` + `.github/workflows/crowdin.yml`):
+  uploads **`en.yml` sources** and **per-language translations from git**, then
+  downloads Crowdin’s export. That seeds Crowdin so real de/ja/… strings are not
+  wiped by English fill-in, and brings translator progress back via
+  `crowdin/i18n`. Feature PRs still only need `en.yml` for new copy.

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -60,24 +60,32 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PROJECT_ID
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PERSONAL_TOKEN
 
-      # English (en.yml) is the only source of truth for strings. Crowdin holds
-      # non-English translations; untranslated keys export as English fill-in
-      # until translators finish — that is expected, not a git merge conflict.
+      # en.yml = English source of truth. Non-English catalogs in git are seeded
+      # into Crowdin (per language) so the download does not wipe real
+      # translations with English fill-in. Crowdin is where people improve
+      # translations; the bot PR brings their work back into the repo.
       - name: Synchronize with Crowdin
         uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
         with:
           config: crowdin.yml
           upload_sources: true
-          upload_translations: false
+          # Seed each language from git so Crowdin learns existing translations
+          # (de/ja/…). import_eq_suggestions false: value==English is not a
+          # translation and must not overwrite Crowdin work as "done".
+          upload_translations: true
+          import_eq_suggestions: false
           download_translations: true
           localization_branch_name: crowdin/i18n
           commit_message: "chore(i18n): sync Crowdin translations"
           create_pull_request: true
           pull_request_title: "chore(i18n): sync Crowdin translations"
           pull_request_body: |
-            Automated non-English translation sync from Crowdin.
+            Automated per-language translation sync from Crowdin.
 
-            `en.yml` in git is the source of truth for English strings. This PR only updates translated locale catalogs from Crowdin (`export_languages` in `crowdin.yml`). Untranslated keys may still match English until Crowdin is updated.
+            - `en.yml` is the English source of truth (new UI strings go there).
+            - Existing non-English catalogs are uploaded to Crowdin first so real translations are not replaced with English fill-in.
+            - This PR is Crowdin → git for translated locales only (`export_languages` in `crowdin.yml`).
+            - Truly untranslated keys may still match English until translators finish them in Crowdin.
           github_user_name: Crowdin Bot
           github_user_email: support+bot@crowdin.com
         env:

--- a/devenv.nix
+++ b/devenv.nix
@@ -88,11 +88,15 @@ in
       '';
     };
     "openlogi:i18n-upload" = {
-      description = "Upload English source strings (en.yml) to Crowdin.";
-      exec = "crowdin upload sources";
+      description = "Upload en.yml sources and per-language translations to Crowdin.";
+      exec = ''
+        set -e
+        crowdin upload sources
+        crowdin upload translations
+      '';
     };
     "openlogi:i18n-download" = {
-      description = "Download non-English translations from Crowdin and run i18n tests.";
+      description = "Download per-language translations from Crowdin and run i18n tests.";
       exec = ''
         set -e
         ${requireXcodeMetal}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -197,24 +197,34 @@ cargo run -p xtask -- release latest-json \
 
 ## Crowdin translation sync
 
-`.github/workflows/crowdin.yml` syncs **non-English** GUI locales with
+`.github/workflows/crowdin.yml` syncs GUI locales with
 [Crowdin](https://crowdin.com/project/openlogi) and opens a `crowdin/i18n` PR
 when downloads change something — nightly, and on master pushes that touch
 English sources (`en.yml`), `crowdin.yml`, the Crowdin workflow, or the shared
 GitHub App token action.
 
-**English (`en.yml`) is the only source of truth for strings.** Add or edit UI
-copy there. Crowdin is only for translating those keys into other languages;
-do not hand-maintain non-English locale files as a second source of truth.
-Untranslated keys may still match English until Crowdin is updated — that is
-expected.
+**How it helps translation**
+
+| | Role |
+|--|--|
+| `en.yml` (git) | English source of truth — add new UI strings here only |
+| Per-language `locales/*.yml` in git | Seeded into Crowdin so existing de/ja/… work is not lost |
+| Crowdin project | Where people translate and improve each language |
+| Bot PR (`crowdin/i18n`) | Brings Crowdin’s per-language progress back into the repo |
+
+Do not treat every feature PR as “edit all 19 locale files.” New copy goes in
+`en.yml`; Crowdin + this job handle the rest. Untranslated keys may still match
+English until someone translates them in Crowdin — that is incomplete work, not
+“remove language support.”
 
 Each run:
 
-1. Uploads `en.yml` **sources** to Crowdin (not locale translations from git).
-2. Downloads Crowdin's non-English export (see `export_languages` /
+1. Uploads `en.yml` **sources**.
+2. Uploads **per-language translations** already in git (`import_eq_suggestions`
+   off so `value == English` is not stored as a finished translation).
+3. Downloads Crowdin’s export for configured languages (`export_languages` /
    `languages_mapping` in `crowdin.yml`).
-3. Opens/updates `crowdin/i18n` when the translated catalogs differ.
+4. Opens/updates `crowdin/i18n` when the catalogs differ.
 
 Like the release workflow, the job reads its credentials from one 1Password
 item referenced by the GitHub secret `OP_CROWDIN_SECRET_ITEM`. The item must
@@ -246,6 +256,6 @@ string — Crowdin + this workflow own non-English updates.
 Local helpers (with Crowdin credentials configured):
 
 ```sh
-devenv tasks run openlogi:i18n-upload    # upload en.yml sources
-devenv tasks run openlogi:i18n-download  # download non-English locales + i18n tests
+devenv tasks run openlogi:i18n-upload    # en.yml sources + per-language translations
+devenv tasks run openlogi:i18n-download  # download locales + i18n tests
 ```


### PR DESCRIPTION
## Summary

Crowdin should help translate **each language**, not wipe good catalogs with English.

After #538 the job only uploaded `en.yml`, then downloaded. Crowdin had no Camera/Sleep/… strings for de/ja/…, so export filled **English** over real translations (#539). Language support was not removed — per-language text was clobbered.

## Fix

Before download, **upload per-language translations from git** into Crowdin:

1. Upload English sources (`en.yml`)
2. Upload existing `da`/`de`/`ja`/… catalogs (seed Crowdin per language)
3. Download Crowdin export
4. Open/update `crowdin/i18n` when catalogs differ

`import_eq_suggestions: false` so `value == English` is not stored as a finished translation.

Feature work still only needs `en.yml` for new UI copy. Crowdin remains where people translate; the bot brings that work back.

## Changes

- `.github/workflows/crowdin.yml` — `upload_translations: true`
- `devenv.nix` — local i18n-upload seeds sources + translations
- `docs/DEVELOPMENT.md` + `.claude/rules/i18n.md` — document the model

## Testing

- Not live Crowdin-tested from this branch (needs secrets)

After merge: close/ignore any English-clobber sync PR, re-run **Crowdin** workflow once so Crowdin learns existing Kameras/etc.

Closes the failure mode behind #539.