### PR TITLE
ci(release): keep release job on a branch

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -239,7 +239,12 @@ jobs:
             exit 1
           fi
           echo "Checking out version-bump commit ${bump_sha} for ${tag}"
-          git checkout --force "${bump_sha}"
+          # Stay on a real branch with @{upstream} set. A bare SHA checkout
+          # detaches HEAD and release-plz aborts with "cannot determine current
+          # branch". Pin master to the bump commit only for this job's workspace
+          # (does not push, does not bump versions).
+          git switch --force -C master "${bump_sha}"
+          git branch --set-upstream-to=origin/master master
           echo "skip=false" >> "$GITHUB_ENV"
           echo "release_sha=${bump_sha}" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

`release-plz release` for v0.6.24 failed because the pin step did `git checkout <sha>`, leaving a detached HEAD. release-plz then dies with `cannot determine current branch` (`@{upstream}`).

This only keeps that pin on a real `master` branch with upstream set. No version bump, no changelog, no tag creation in this PR.

## Changes

- `release-plz.yml`: `git switch -C master <bump_sha>` + set upstream instead of bare SHA checkout

## Testing

- Not runtime-tested (workflow-only). After merge, re-run the release via `workflow_dispatch` on master so the fixed YAML is used (re-running the failed job on `f92b03d` still has the broken checkout).
- Expected: `v0.6.24` tag cut from the existing `chore: release v0.6.24` commit; no new version.

## Recovery (post-merge)

1. Merge this PR.
2. Actions → Release PR → Run workflow (`workflow_dispatch`).
3. Confirm `v0.6.24` appears; do not hand-create the tag.