### PR TITLE
fix(gui,assets): fit the Keys tab to legacy keyboard assets (G513)

### DIFF
--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -71,11 +71,18 @@ pub struct FileEntry {
 
 /// Filename schemas Logi ships, most-preferred first. Newer depots use the
 /// `*_core` names; older ones — most keyboards, the MX Vertical, older mice —
-/// ship the bare names. A depot commits to one schema, never a mix, so
-/// resolving each slot to the first name the registry actually lists picks
-/// the right one. The manifest then maps `device_image` /
-/// `device_buttons_image` to the concrete render for colour variants.
-pub const METADATA_FILES: [&str; 2] = ["core_metadata.json", "metadata.json"];
+/// ship the bare names. Render schemas never mix within a depot, so resolving
+/// each slot to the first name the registry actually lists picks the right
+/// one. The manifest then maps `device_image` / `device_buttons_image` to the
+/// concrete render for colour variants.
+///
+/// Metadata is the one slot where legacy keyboard depots *do* ship two files:
+/// the G513 family's `metadata.json` is authored against the G512 banner
+/// renders, while `metadata_full.json` matches the `front.png` the primary
+/// model actually fetches (the manifest's `image_metadata` for `g513` names
+/// it). Preferring `metadata_full.json` keeps the key markers on the render
+/// we display.
+pub const METADATA_FILES: [&str; 3] = ["core_metadata.json", "metadata_full.json", "metadata.json"];
 pub const FRONT_RENDER_FILES: [&str; 2] = ["front_core.png", "front.png"];
 pub const BUTTONS_RENDER_FILES: [&str; 2] = ["side_core.png", "side.png"];
 

--- a/crates/openlogi-gui/src/asset.rs
+++ b/crates/openlogi-gui/src/asset.rs
@@ -320,13 +320,20 @@ impl AssetResolver {
                 png_height,
                 "asset hit"
             );
+            let kind = DeviceKind::from_registry_type(&entry.kind);
+            // Only keyboards paint the inter-key glow, and the runtime
+            // fallback decodes the full render — don't pay that for mice.
+            let glow = (kind == DeviceKind::Keyboard)
+                .then(|| self::glow::resolve_glow_geometry(&dir, &image_path))
+                .flatten()
+                .map(Arc::new);
             return Some(ResolvedAsset {
                 depot: depot.to_string(),
                 display_name: entry.display_name.clone(),
-                kind: DeviceKind::from_registry_type(&entry.kind),
+                kind,
                 image_path,
                 hero_image_path,
-                glow: self::glow::load_glow_geometry(&dir).map(Arc::new),
+                glow,
                 metadata,
                 png_width,
                 png_height,

--- a/crates/openlogi-gui/src/asset/glow.rs
+++ b/crates/openlogi-gui/src/asset/glow.rs
@@ -19,7 +19,13 @@ use serde::Deserialize;
 use tracing::warn;
 
 /// Metadata files to read the precomputed mask from, newest schema first.
-const META_FILES: [&str; 2] = ["core_metadata.json", "metadata.json"];
+const META_FILES: [&str; 3] = ["core_metadata.json", "metadata_full.json", "metadata.json"];
+
+/// Ceiling on a runtime-derived mask's width — the same ~1k scale as the
+/// pipeline-baked masks, and what keeps the flood fill cheap.
+const COMPUTED_MASK_MAX_W: u32 = 1024;
+/// Alpha below this counts as see-through when deriving holes from a render.
+const HOLE_ALPHA: u8 = 96;
 
 /// Sanity bound on a baked mask's stored dimensions. The masks are ~1k px wide;
 /// anything far larger is a corrupt or hostile `metadata.json`. The cap also
@@ -62,14 +68,109 @@ pub(crate) struct GlowGeometry {
     pub segments: Vec<GlowSeg>,
 }
 
+/// The inter-key hole geometry for a depot: the pipeline-baked mask when the
+/// metadata ships one, otherwise derived at resolve time from the render's own
+/// alpha channel — so any keyboard with a transparent render glows, not just
+/// the depots the asset pipeline has processed.
+pub(crate) fn resolve_glow_geometry(dir: &Path, image_path: &Path) -> Option<GlowGeometry> {
+    load_glow_geometry(dir).or_else(|| compute_glow_geometry(image_path))
+}
+
 /// Load and decode the precomputed glow mask from a depot directory's metadata.
-/// `None` when the depot ships no mask (the feature gate) or it's malformed.
-pub(crate) fn load_glow_geometry(dir: &Path) -> Option<GlowGeometry> {
+/// `None` when the depot ships no mask or it's malformed.
+fn load_glow_geometry(dir: &Path) -> Option<GlowGeometry> {
     let mask = META_FILES.iter().find_map(|name| {
         let text = std::fs::read_to_string(dir.join(name)).ok()?;
         serde_json::from_str::<MetaGlow>(&text).ok()?.glow
     })?;
     GlowGeometry::from_mask(&mask)
+}
+
+/// Derive the inter-key holes straight from the render's alpha channel:
+/// flood-fill the see-through field inward from the image border, and whatever
+/// see-through cells remain unreached are enclosed by the silhouette — the
+/// holes. The image is binned to ≤[`COMPUTED_MASK_MAX_W`] cells wide; a cell
+/// is see-through when *any* source pixel in its bin is, so the few-pixel
+/// slits between floating keycaps survive the binning. Border-connected
+/// transparency (including background reachable through open seams) is
+/// "outside" and never glows, which is what keeps the colour inside the
+/// silhouette.
+fn compute_glow_geometry(image_path: &Path) -> Option<GlowGeometry> {
+    let img = image::open(image_path).ok()?.into_rgba8();
+    let (src_w, src_h) = img.dimensions();
+    if src_w == 0 || src_h == 0 || src_w > MAX_MASK_DIM || src_h > MAX_MASK_DIM {
+        return None;
+    }
+    let scale = src_w.div_ceil(COMPUTED_MASK_MAX_W).max(1);
+    let (w, h) = (src_w.div_ceil(scale), src_h.div_ceil(scale));
+
+    // 0 = opaque, 1 = see-through, 2 = see-through and border-connected.
+    let mut cells = vec![0u8; (w as usize) * (h as usize)];
+    for (x, y, pixel) in img.enumerate_pixels() {
+        if pixel.0[3] < HOLE_ALPHA {
+            cells[((y / scale) * w + (x / scale)) as usize] = 1;
+        }
+    }
+
+    let mut queue: std::collections::VecDeque<(u32, u32)> = (0..w)
+        .flat_map(|x| [(x, 0), (x, h - 1)])
+        .chain((0..h).flat_map(|y| [(0, y), (w - 1, y)]))
+        .filter(|&(x, y)| cells[(y * w + x) as usize] == 1)
+        .collect();
+    for &(x, y) in &queue {
+        cells[(y * w + x) as usize] = 2;
+    }
+    while let Some((x, y)) = queue.pop_front() {
+        let neighbors = [
+            (x.wrapping_sub(1), y),
+            (x + 1, y),
+            (x, y.wrapping_sub(1)),
+            (x, y + 1),
+        ];
+        for (nx, ny) in neighbors {
+            if nx < w && ny < h && cells[(ny * w + nx) as usize] == 1 {
+                cells[(ny * w + nx) as usize] = 2;
+                queue.push_back((nx, ny));
+            }
+        }
+    }
+
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "mask coords are < 8192 px — well within f32 mantissa"
+    )]
+    let (wf, hf) = (w as f32, h as f32);
+    let mut segments = Vec::new();
+    for y in 0..h {
+        let mut x = 0;
+        while x < w {
+            if cells[(y * w + x) as usize] == 1 {
+                let start = x;
+                while x < w && cells[(y * w + x) as usize] == 1 {
+                    x += 1;
+                }
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "mask coords are < 8192 px — well within f32 mantissa"
+                )]
+                segments.push(GlowSeg {
+                    x: start as f32 / wf,
+                    y: y as f32 / hf,
+                    w: (x - start) as f32 / wf,
+                    h: 1.0 / hf,
+                });
+            } else {
+                x += 1;
+            }
+        }
+    }
+    if segments.is_empty() {
+        return None;
+    }
+    Some(GlowGeometry {
+        aspect: wf / hf,
+        segments,
+    })
 }
 
 impl GlowGeometry {
@@ -169,5 +270,69 @@ mod tests {
             runs: vec![3, 2], // sums to 5, not 16
         };
         assert!(GlowGeometry::from_mask(&mask).is_none());
+    }
+
+    /// Write an RGBA png where `1` cells are solid and the rest fully
+    /// transparent.
+    fn write_png(dir: &std::path::Path, name: &str, rows: &[&[u8]]) -> std::path::PathBuf {
+        let h = u32::try_from(rows.len()).expect("test image height fits u32");
+        let w = u32::try_from(rows[0].len()).expect("test image width fits u32");
+        let mut img = image::RgbaImage::new(w, h);
+        for (y, row) in rows.iter().enumerate() {
+            for (x, &cell) in row.iter().enumerate() {
+                let alpha = if cell == 1 { 255 } else { 0 };
+                let (x, y) = (
+                    u32::try_from(x).expect("test x fits u32"),
+                    u32::try_from(y).expect("test y fits u32"),
+                );
+                img.put_pixel(x, y, image::Rgba([40, 40, 40, alpha]));
+            }
+        }
+        let path = dir.join(name);
+        img.save(&path).expect("write png");
+        path
+    }
+
+    #[test]
+    fn computed_geometry_finds_only_enclosed_holes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A ring of opaque pixels around one transparent pixel (a hole), with
+        // border-connected transparency everywhere else.
+        let path = write_png(
+            dir.path(),
+            "ring.png",
+            &[
+                &[0, 0, 0, 0, 0],
+                &[0, 1, 1, 1, 0],
+                &[0, 1, 0, 1, 0],
+                &[0, 1, 1, 1, 0],
+                &[0, 0, 0, 0, 0],
+            ],
+        );
+        let geom = compute_glow_geometry(&path).expect("hole found");
+        assert_eq!(geom.segments.len(), 1);
+        let seg = geom.segments[0];
+        assert!((seg.x - 0.4).abs() < 1e-6, "hole at col 2 of 5");
+        assert!((seg.y - 0.4).abs() < 1e-6, "hole at row 2 of 5");
+        assert!((geom.aspect - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn computed_geometry_ignores_border_connected_transparency() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A C-shape: the notch opens to the border, so nothing is enclosed.
+        let path = write_png(
+            dir.path(),
+            "open.png",
+            &[&[1, 1, 1], &[1, 0, 0], &[1, 1, 1]],
+        );
+        assert!(compute_glow_geometry(&path).is_none());
+    }
+
+    #[test]
+    fn computed_geometry_skips_fully_opaque_renders() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = write_png(dir.path(), "solid.png", &[&[1, 1], &[1, 1]]);
+        assert!(compute_glow_geometry(&path).is_none());
     }
 }

--- a/crates/openlogi-gui/src/keyboard_model/function_row.rs
+++ b/crates/openlogi-gui/src/keyboard_model/function_row.rs
@@ -468,10 +468,14 @@ fn keyboard_pane(
             hovered,
             (img_w, img_h),
         ))
-        .children(slots.iter().cloned().map(|s| {
-            let highlighted = key_is_highlighted(s.idx, selected, hovered);
-            key_callout(s, highlighted, img_w, &view_clone, pal)
-        }))
+        .children({
+            let count = slots.len();
+            let view_for_callouts = view_clone.clone();
+            slots.iter().cloned().map(move |s| {
+                let highlighted = key_is_highlighted(s.idx, selected, hovered);
+                key_callout(s, count, highlighted, img_w, &view_for_callouts, pal)
+            })
+        })
         // Click-targets overlay, centered on each key's marker point.
         .child(
             div()
@@ -487,16 +491,17 @@ fn keyboard_pane(
         )
 }
 
-/// One callout bubble above a function key.
+/// One callout bubble in the band above the keyboard.
 fn key_callout(
     slot: KeySlot,
+    count: usize,
     highlighted: bool,
     img_w: f32,
     view: &Entity<FunctionRowView>,
     pal: &Palette,
 ) -> AnyElement {
     let idx = slot.idx;
-    let left = callout_left_px(slot.x_frac, img_w, KEY_CALLOUT_W);
+    let left = callout_left_px(idx, count, img_w, KEY_CALLOUT_W);
     let top = callout_top_px(idx);
     let view_hover = view.clone();
     let view_click = view.clone();
@@ -683,11 +688,12 @@ fn paint_keyboard_leaders(
     (img_w, img_h): (f32, f32),
     window: &mut Window,
 ) {
+    let count = guides.len();
     for (idx, x_frac, y_frac) in guides {
         let highlighted = key_is_highlighted(idx, selected, hovered);
         let key_x = x_frac * img_w;
         let key_y = CALLOUT_BAND_H + (y_frac * img_h);
-        let callout_x = callout_left_px(x_frac, img_w, KEY_CALLOUT_W) + KEY_CALLOUT_W / 2.;
+        let callout_x = callout_center_x(idx, count, img_w);
         let callout_bottom = callout_top_px(idx) + KEY_CALLOUT_H;
         let start = bounds.origin + point(px(callout_x), px(callout_bottom));
         let elbow = bounds.origin + point(px(callout_x), px(CALLOUT_BAND_H - 14.));
@@ -715,8 +721,20 @@ fn key_is_highlighted(idx: usize, selected: Option<usize>, hovered: Option<usize
     selected == Some(idx) || hovered == Some(idx)
 }
 
-fn callout_left_px(x_frac: f32, image_w: f32, callout_w: f32) -> f32 {
-    (x_frac * image_w - callout_w / 2.0).clamp(0.0, image_w - callout_w)
+/// Callout bubbles lay out *evenly* across the pane instead of over their
+/// keys: a dense F-row (a G513 packs Esc-F12 into half the render width)
+/// would otherwise stack the bubbles into an overlapping wall. The leader
+/// lines fan from each bubble down to its true key position.
+fn callout_center_x(idx: usize, count: usize, image_w: f32) -> f32 {
+    let margin = KEY_CALLOUT_W / 2.0 + 4.0;
+    if count <= 1 {
+        return image_w / 2.0;
+    }
+    margin + (idx as f32) * (image_w - 2.0 * margin) / ((count - 1) as f32)
+}
+
+fn callout_left_px(idx: usize, count: usize, image_w: f32, callout_w: f32) -> f32 {
+    (callout_center_x(idx, count, image_w) - callout_w / 2.0).clamp(0.0, image_w - callout_w)
 }
 
 fn key_target_left_px(x_frac: f32, img_w: f32, target_w: f32) -> f32 {
@@ -1262,10 +1280,30 @@ mod tests {
     }
 
     #[test]
-    fn callout_left_edge_is_clamped_to_keyboard_width() {
-        assert_eq!(callout_left_px(0.0, 700.0, 64.0), 0.0);
-        assert_eq!(callout_left_px(0.5, 700.0, 64.0), 318.0);
-        assert_eq!(callout_left_px(1.0, 700.0, 64.0), 636.0);
+    fn callouts_spread_evenly_from_margin_to_margin() {
+        let margin = KEY_CALLOUT_W / 2.0 + 4.0;
+        assert_approx_eq(callout_center_x(0, 13, 700.0), margin);
+        assert_approx_eq(callout_center_x(12, 13, 700.0), 700.0 - margin);
+        assert_approx_eq(callout_center_x(0, 1, 700.0), 350.0);
+        assert!(callout_left_px(0, 13, 700.0, KEY_CALLOUT_W) >= 0.0);
+        assert!(callout_left_px(12, 13, 700.0, KEY_CALLOUT_W) <= 700.0 - KEY_CALLOUT_W);
+    }
+
+    /// Bubbles share a stagger lane with every second key; same-lane
+    /// neighbours must never overlap for any board size the row can show.
+    #[test]
+    fn same_lane_callouts_never_overlap() {
+        for count in [13usize, 20] {
+            for idx in 0..count.saturating_sub(2) {
+                let gap = callout_center_x(idx + 2, count, KEYBOARD_W)
+                    - callout_center_x(idx, count, KEYBOARD_W);
+                assert!(
+                    gap >= KEY_CALLOUT_W,
+                    "lane neighbours {idx}/{} overlap at count {count}: gap {gap}",
+                    idx + 2
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/openlogi-gui/src/keyboard_model/function_row.rs
+++ b/crates/openlogi-gui/src/keyboard_model/function_row.rs
@@ -19,9 +19,10 @@
 )]
 
 use std::rc::Rc;
+use std::sync::Arc;
 
 use gpui::{
-    AnyElement, AppContext as _, BorrowAppContext as _, Bounds, Context, Entity, FontWeight,
+    AnyElement, AppContext as _, BorrowAppContext as _, Bounds, Context, Entity, FontWeight, Hsla,
     InteractiveElement, IntoElement, ParentElement, PathBuilder, Render,
     StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, point,
     prelude::FluentBuilder as _, px, rgb, svg,
@@ -30,11 +31,13 @@ use gpui_component::{h_flex, input::InputState, v_flex};
 use openlogi_core::binding::WorkflowStep;
 use openlogi_core::config::{KeyModifiers, KeyTrigger};
 
-use crate::asset::ResolvedAsset;
+use crate::app::{glow_canvas, keyboard_glow};
+use crate::asset::{GlowGeometry, ResolvedAsset};
 use crate::data::mouse_buttons::Action;
 use crate::keyboard_model::editors::{
     PowerUserKind, text_editor_placeholder, text_editor_seed, workflow_editor_seed,
 };
+use crate::mouse_model::geometry::asset_dimensions_for_png;
 use crate::mouse_model::picker::{
     PickFn, action_icon_path, action_rows, divider, menu_card, menu_row, scroll_list,
     section_header,
@@ -44,9 +47,11 @@ use crate::theme::{self, ACCENT_BLUE, Palette};
 use gpui::ease_in_out;
 use gpui::{Animation, AnimationExt, img};
 
-/// The programmable top-row keys visible on MX Keys-class keyboards: Esc, then
-/// F1-F19. Each entry is the display label (on the key) + the [`KeyTrigger`]
-/// keycode it binds.
+/// The full programmable top row: Esc, then F1-F19. Each entry is the display
+/// label (on the key) + the [`KeyTrigger`] keycode it binds. MX Keys-class
+/// boards expose all 20; boards with a shorter F-row (a G513 has F1-F12)
+/// surface a prefix of this list, sized by the asset's key markers — see
+/// [`key_points`].
 const FUNCTION_KEYS: [(&str, u16); 20] = [
     ("Esc", 0x35),
     ("F1", 0x7A),
@@ -74,13 +79,18 @@ const FUNCTION_KEYS: [(&str, u16); 20] = [
 const PANEL_W: f32 = 320.;
 /// Duration of the keyboard slide + panel slide animation.
 const SLIDE_MS: u64 = 180;
-/// Authored keyboard render width in the Keys inspector.
+/// Maximum keyboard render width in the Keys inspector.
 const KEYBOARD_W: f32 = 700.;
-/// Approximate keyboard render height used for hit/leader overlays.
-const KEYBOARD_IMG_H: f32 = 220.;
+/// Render size when no asset resolved: the placeholder box.
+const FALLBACK_KEYBOARD_SIZE: (f32, f32) = (KEYBOARD_W, 220.);
 /// Space above the keyboard reserved for function-key callouts.
 const CALLOUT_BAND_H: f32 = 118.;
-const KEYBOARD_TOTAL_H: f32 = CALLOUT_BAND_H + KEYBOARD_IMG_H;
+/// Vertical chrome around the keyboard pane (header, tab strip, screen
+/// padding, footer) — the viewport height minus this and the callout band is
+/// what the render may occupy before it scales down to fit.
+const KEYS_VERTICAL_RESERVE: f32 = 224.;
+/// Floor on the render height so a tiny window still shows a usable model.
+const KEYBOARD_MIN_IMG_H: f32 = 160.;
 const KEY_CALLOUT_W: f32 = 60.;
 const KEY_CALLOUT_H: f32 = 48.;
 const KEY_CALLOUT_TOP_UPPER: f32 = 4.;
@@ -89,6 +99,9 @@ const KEY_TARGET_W: f32 = 30.;
 const KEY_TARGET_H: f32 = 30.;
 const KEY_HOTSPOT_DOT: f32 = 12.;
 const FALLBACK_KEY_Y_FRAC: f32 = 0.153;
+/// Legacy pixel-marker depots (G513 family) mark F1-F12 but not Esc. Esc sits
+/// this many key pitches left of F1 on that chassis (measured on the render).
+const ESC_LEFT_OF_F1_PITCHES: f32 = 1.55;
 /// Logitech key markers are authored against a tighter internal keyboard
 /// image. The rendered `front.png` includes a little more top/left padding, so
 /// the raw marker lands high-left of the visible keycap center.
@@ -212,10 +225,18 @@ impl FunctionRowView {
     }
 }
 
+/// The app-state slice the view renders from: the device's asset, the global
+/// keyboard bindings, and the lighting glow (geometry + tinted colour).
+type StateSnapshot = (
+    Option<ResolvedAsset>,
+    Vec<(KeyTrigger, Action)>,
+    Option<(Arc<GlowGeometry>, Hsla)>,
+);
+
 impl Render for FunctionRowView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
-        let (asset, bindings): (Option<ResolvedAsset>, Vec<(KeyTrigger, Action)>) = cx
+        let (asset, bindings, glow): StateSnapshot = cx
             .try_global::<AppState>()
             .map(|s| {
                 (
@@ -224,15 +245,19 @@ impl Render for FunctionRowView {
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
+                    s.current_record().and_then(|r| keyboard_glow(s, r)),
                 )
             })
             .unwrap_or_default();
 
+        let viewport_h = f32::from(window.viewport_size().height);
+        let render_size = keyboard_render_size(asset.as_ref(), viewport_h);
         let points = key_points(asset.as_ref());
         let slots: Vec<KeySlot> = FUNCTION_KEYS
             .iter()
+            .zip(points.iter())
             .enumerate()
-            .map(|(idx, (label, keycode))| {
+            .map(|(idx, ((label, keycode), point))| {
                 let trigger = KeyTrigger {
                     keycode: *keycode,
                     modifiers: KeyModifiers::default(),
@@ -245,13 +270,21 @@ impl Render for FunctionRowView {
                     idx,
                     label,
                     trigger,
-                    x_frac: points[idx].x_frac,
-                    y_frac: points[idx].y_frac,
+                    x_frac: point.x_frac,
+                    y_frac: point.y_frac,
                     bound,
                 }
             })
             .collect();
 
+        // A stale selection can outlive a device switch to a shorter F-row;
+        // drop it instead of indexing past the new slot list.
+        if self.selected_key.is_some_and(|idx| idx >= slots.len()) {
+            self.selected_key = None;
+            self.active_editor = None;
+            self.text_state = None;
+            self.workflow_draft.clear();
+        }
         let selected = self.selected_key;
         let hovered = self.hovered_key;
         let active_editor = self.active_editor;
@@ -289,6 +322,8 @@ impl Render for FunctionRowView {
         v_flex().w_full().items_center().child(inspector_row(
             slots,
             asset,
+            glow,
+            render_size,
             selected,
             hovered,
             active_editor,
@@ -300,6 +335,19 @@ impl Render for FunctionRowView {
             cx,
         ))
     }
+}
+
+/// The keyboard render size: the actual PNG aspect at up to [`KEYBOARD_W`]
+/// wide, shrunk to fit the viewport height. Sizing off the real aspect keeps
+/// `ObjectFit::Contain` from letterboxing and keeps the marker overlays
+/// registered with the rendered keys — the G513 render (with wrist rest) is
+/// nearly twice as tall as an MX Keys render at the same width.
+fn keyboard_render_size(asset: Option<&ResolvedAsset>, viewport_h: f32) -> (f32, f32) {
+    let Some(asset) = asset.filter(|a| a.png_height > 0) else {
+        return FALLBACK_KEYBOARD_SIZE;
+    };
+    let target_h = (viewport_h - KEYS_VERTICAL_RESERVE - CALLOUT_BAND_H).max(KEYBOARD_MIN_IMG_H);
+    asset_dimensions_for_png(asset, target_h, KEYBOARD_W)
 }
 
 /// One function-row key with its resolved layout + binding.
@@ -317,6 +365,8 @@ struct KeySlot {
 fn inspector_row(
     slots: Vec<KeySlot>,
     asset: Option<ResolvedAsset>,
+    glow: Option<(Arc<GlowGeometry>, Hsla)>,
+    render_size: (f32, f32),
     selected: Option<usize>,
     hovered: Option<usize>,
     active_editor: Option<PowerUserKind>,
@@ -327,7 +377,16 @@ fn inspector_row(
     window: &mut Window,
     cx: &mut Context<FunctionRowView>,
 ) -> impl IntoElement {
-    let keyboard = keyboard_pane(slots.clone(), asset.as_ref(), selected, hovered, view, pal);
+    let keyboard = keyboard_pane(
+        slots.clone(),
+        asset.as_ref(),
+        glow,
+        render_size,
+        selected,
+        hovered,
+        view,
+        pal,
+    );
 
     // When nothing is selected, just the keyboard, full width.
     let Some(selected) = selected else {
@@ -373,6 +432,8 @@ fn inspector_row(
 fn keyboard_pane(
     slots: Vec<KeySlot>,
     asset: Option<&ResolvedAsset>,
+    glow: Option<(Arc<GlowGeometry>, Hsla)>,
+    (img_w, img_h): (f32, f32),
     selected: Option<usize>,
     hovered: Option<usize>,
     view: &Entity<FunctionRowView>,
@@ -383,19 +444,33 @@ fn keyboard_pane(
 
     div()
         .relative()
-        .w(px(KEYBOARD_W))
-        .h(px(KEYBOARD_TOTAL_H))
+        .w(px(img_w))
+        .h(px(CALLOUT_BAND_H + img_h))
         .child(
             div()
                 .absolute()
                 .top(px(CALLOUT_BAND_H))
                 .left(px(0.))
-                .child(image_or_fallback(img_path, KEYBOARD_W, pal)),
+                .w(px(img_w))
+                .h(px(img_h))
+                // The keyboard's RGB paints *behind* the render, so the opaque
+                // keys occlude it and the colour only reads through the
+                // inter-key gaps — same treatment as the home gallery and the
+                // mouse model.
+                .when_some(glow, |this, (geom, color)| {
+                    this.child(glow_canvas(geom, color))
+                })
+                .child(image_or_fallback(img_path, img_w, img_h, pal)),
         )
-        .child(keyboard_leader_canvas(slots.clone(), selected, hovered))
+        .child(keyboard_leader_canvas(
+            slots.clone(),
+            selected,
+            hovered,
+            (img_w, img_h),
+        ))
         .children(slots.iter().cloned().map(|s| {
             let highlighted = key_is_highlighted(s.idx, selected, hovered);
-            key_callout(s, highlighted, &view_clone, pal)
+            key_callout(s, highlighted, img_w, &view_clone, pal)
         }))
         // Click-targets overlay, centered on each key's marker point.
         .child(
@@ -403,11 +478,11 @@ fn keyboard_pane(
                 .absolute()
                 .top(px(CALLOUT_BAND_H))
                 .left(px(0.))
-                .w(px(KEYBOARD_W))
-                .h(px(KEYBOARD_IMG_H))
+                .w(px(img_w))
+                .h(px(img_h))
                 .children(slots.into_iter().map(|s| {
                     let highlighted = key_is_highlighted(s.idx, selected, hovered);
-                    key_click_target(s, highlighted, &view_clone, pal)
+                    key_click_target(s, highlighted, (img_w, img_h), &view_clone, pal)
                 })),
         )
 }
@@ -416,11 +491,12 @@ fn keyboard_pane(
 fn key_callout(
     slot: KeySlot,
     highlighted: bool,
+    img_w: f32,
     view: &Entity<FunctionRowView>,
     pal: &Palette,
 ) -> AnyElement {
     let idx = slot.idx;
-    let left = callout_left_px(slot.x_frac, KEYBOARD_W, KEY_CALLOUT_W);
+    let left = callout_left_px(slot.x_frac, img_w, KEY_CALLOUT_W);
     let top = callout_top_px(idx);
     let view_hover = view.clone();
     let view_click = view.clone();
@@ -514,6 +590,7 @@ fn key_callout(
 fn key_click_target(
     slot: KeySlot,
     highlighted: bool,
+    (img_w, img_h): (f32, f32),
     view: &Entity<FunctionRowView>,
     _pal: &Palette,
 ) -> AnyElement {
@@ -522,8 +599,8 @@ fn key_click_target(
     let y_frac = slot.y_frac;
     let view_hover = view.clone();
     let view_click = view.clone();
-    let left = key_target_left_px(x_frac, KEY_TARGET_W);
-    let top = key_target_top_px(y_frac, KEY_TARGET_H);
+    let left = key_target_left_px(x_frac, img_w, KEY_TARGET_W);
+    let top = key_target_top_px(y_frac, img_h, KEY_TARGET_H);
 
     div()
         .id(("key-target", idx))
@@ -581,6 +658,7 @@ fn keyboard_leader_canvas(
     slots: Vec<KeySlot>,
     selected: Option<usize>,
     hovered: Option<usize>,
+    (img_w, img_h): (f32, f32),
 ) -> impl IntoElement {
     let guides: Vec<(usize, f32, f32)> =
         slots.iter().map(|s| (s.idx, s.x_frac, s.y_frac)).collect();
@@ -588,13 +666,13 @@ fn keyboard_leader_canvas(
         move |_bounds, _, _| (guides, selected, hovered),
         move |bounds, payload, window, _app| {
             let (guides, selected, hovered) = payload;
-            paint_keyboard_leaders(bounds, guides, selected, hovered, window);
+            paint_keyboard_leaders(bounds, guides, selected, hovered, (img_w, img_h), window);
         },
     )
     .absolute()
     .inset_0()
-    .w(px(KEYBOARD_W))
-    .h(px(KEYBOARD_TOTAL_H))
+    .w(px(img_w))
+    .h(px(CALLOUT_BAND_H + img_h))
 }
 
 fn paint_keyboard_leaders(
@@ -602,13 +680,14 @@ fn paint_keyboard_leaders(
     guides: Vec<(usize, f32, f32)>,
     selected: Option<usize>,
     hovered: Option<usize>,
+    (img_w, img_h): (f32, f32),
     window: &mut Window,
 ) {
     for (idx, x_frac, y_frac) in guides {
         let highlighted = key_is_highlighted(idx, selected, hovered);
-        let key_x = x_frac * KEYBOARD_W;
-        let key_y = CALLOUT_BAND_H + (y_frac * KEYBOARD_IMG_H);
-        let callout_x = callout_left_px(x_frac, KEYBOARD_W, KEY_CALLOUT_W) + KEY_CALLOUT_W / 2.;
+        let key_x = x_frac * img_w;
+        let key_y = CALLOUT_BAND_H + (y_frac * img_h);
+        let callout_x = callout_left_px(x_frac, img_w, KEY_CALLOUT_W) + KEY_CALLOUT_W / 2.;
         let callout_bottom = callout_top_px(idx) + KEY_CALLOUT_H;
         let start = bounds.origin + point(px(callout_x), px(callout_bottom));
         let elbow = bounds.origin + point(px(callout_x), px(CALLOUT_BAND_H - 14.));
@@ -640,12 +719,12 @@ fn callout_left_px(x_frac: f32, image_w: f32, callout_w: f32) -> f32 {
     (x_frac * image_w - callout_w / 2.0).clamp(0.0, image_w - callout_w)
 }
 
-fn key_target_left_px(x_frac: f32, target_w: f32) -> f32 {
-    (x_frac * KEYBOARD_W - target_w / 2.0).clamp(0.0, KEYBOARD_W - target_w)
+fn key_target_left_px(x_frac: f32, img_w: f32, target_w: f32) -> f32 {
+    (x_frac * img_w - target_w / 2.0).clamp(0.0, img_w - target_w)
 }
 
-fn key_target_top_px(y_frac: f32, target_h: f32) -> f32 {
-    (y_frac * KEYBOARD_IMG_H - target_h / 2.0).clamp(0.0, KEYBOARD_IMG_H - target_h)
+fn key_target_top_px(y_frac: f32, img_h: f32, target_h: f32) -> f32 {
+    (y_frac * img_h - target_h / 2.0).clamp(0.0, img_h - target_h)
 }
 
 fn callout_top_px(idx: usize) -> f32 {
@@ -818,10 +897,16 @@ struct KeyPoint {
     y_frac: f32,
 }
 
-/// Resolve key marker points as fractions [0..1] of the rendered image. Prefer
-/// asset metadata's top-row markers; fall back to even spacing on the same row.
+/// Resolve key marker points as fractions [0..1] of the rendered image, along
+/// with how many top-row keys the board exposes (`points.len()` — the visible
+/// prefix of [`FUNCTION_KEYS`]). Prefer asset metadata's top-row markers —
+/// percent-based on MX Keys-class depots, pixel-based on legacy keyboard
+/// depots (G513) — and fall back to even spacing on the same row.
 fn key_points(asset: Option<&ResolvedAsset>) -> Vec<KeyPoint> {
     if let Some(a) = asset {
+        if let Some(points) = legacy_pixel_key_points(a) {
+            return points;
+        }
         let key_markers = sorted_marker_points(a, &["device_keys_image", "device_buttons_image"]);
         let easy_switch_markers = sorted_marker_points(a, &["device_easyswitch_image"]);
 
@@ -868,6 +953,79 @@ fn key_x_fractions(asset: Option<&ResolvedAsset>) -> Vec<f32> {
         .into_iter()
         .map(|point| point.x_frac)
         .collect()
+}
+
+/// Key points from a legacy pixel-marker depot (the G513 family), or `None`
+/// when the asset isn't one.
+///
+/// Legacy `metadata*.json` files mark each F-key's cap-face centre in
+/// *absolute pixels* of the authored canvas (`origin`), not percentages. The
+/// markers only apply when that canvas is the render we actually cached —
+/// the same depot also ships marker sets authored against other variants'
+/// renders (the G513's `metadata.json` belongs to the G512 banner render) —
+/// so a depot whose `origin` doesn't match the PNG is rejected rather than
+/// misplacing every callout.
+fn legacy_pixel_key_points(asset: &ResolvedAsset) -> Option<Vec<KeyPoint>> {
+    let img = asset
+        .metadata
+        .images
+        .iter()
+        .find(|img| img.key == "device_image" && !img.assignments.is_empty())?;
+    if img.origin.width != asset.png_width || img.origin.height != asset.png_height {
+        return None;
+    }
+    let (w, h) = (img.origin.width as f32, img.origin.height as f32);
+
+    let mut markers: Vec<KeyPoint> = img
+        .assignments
+        .iter()
+        .map(|asg| asg.marker)
+        // Percent-schema depots never exceed 100 on either axis; anything
+        // beyond is a pixel coordinate. Mixed files don't exist in the wild,
+        // but a percent marker slipping through would land off by 27x.
+        .filter(|m| m.x > 100. || m.y > 100.)
+        .map(|m| KeyPoint {
+            x_frac: (m.x / w).clamp(0.0, 1.0),
+            y_frac: (m.y / h).clamp(0.0, 1.0),
+        })
+        .collect();
+    if markers.len() < 2 || markers.len() > FUNCTION_KEYS.len() - 1 {
+        return None;
+    }
+    markers.sort_by(|a, b| {
+        a.x_frac
+            .partial_cmp(&b.x_frac)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // The depots mark F1..Fn but never Esc; place it left of F1 by the F-row's
+    // own key pitch so it stays registered at any render size.
+    let pitch = median_pitch(&markers)?;
+    let first = markers[0];
+    let esc = KeyPoint {
+        x_frac: (first.x_frac - ESC_LEFT_OF_F1_PITCHES * pitch).max(0.0),
+        y_frac: first.y_frac,
+    };
+
+    let mut out = Vec::with_capacity(markers.len() + 1);
+    out.push(esc);
+    out.extend(markers);
+    Some(out)
+}
+
+/// Median gap between adjacent marker x positions — the F-row's key pitch.
+/// The median rides out the wider inter-cluster gaps (F4→F5, F8→F9).
+fn median_pitch(sorted_markers: &[KeyPoint]) -> Option<f32> {
+    let mut gaps: Vec<f32> = sorted_markers
+        .windows(2)
+        .map(|pair| pair[1].x_frac - pair[0].x_frac)
+        .filter(|gap| *gap > 0.)
+        .collect();
+    if gaps.is_empty() {
+        return None;
+    }
+    gaps.sort_by(f32::total_cmp);
+    Some(gaps[gaps.len() / 2])
 }
 
 fn sorted_marker_points(asset: &ResolvedAsset, image_keys: &[&str]) -> Vec<KeyPoint> {
@@ -925,17 +1083,17 @@ fn fallback_key_points() -> Vec<KeyPoint> {
         .collect()
 }
 
-/// The keyboard image, or a labeled placeholder when no asset resolved.
+/// The keyboard image, or a labeled placeholder when no asset resolved. The
+/// element is sized to the PNG's own aspect (see [`keyboard_render_size`]), so
+/// the contain-fit paints edge to edge and the marker overlays stay registered.
 fn image_or_fallback(
     img_path: Option<std::path::PathBuf>,
     img_w: f32,
+    img_h: f32,
     pal: &Palette,
 ) -> AnyElement {
     match img_path {
-        Some(path) if path.exists() => img(path)
-            .w(px(img_w))
-            .h(px(KEYBOARD_IMG_H))
-            .into_any_element(),
+        Some(path) if path.exists() => img(path).w(px(img_w)).h(px(img_h)).into_any_element(),
         Some(_) | None => div()
             .w(px(img_w))
             .h(px(160.))
@@ -1033,7 +1191,74 @@ mod tests {
         assert_eq!(points.len(), 20);
         assert_approx_eq(points[19].x_frac, 0.967);
         assert_approx_eq(points[19].y_frac, 0.153);
-        assert_approx_eq(key_target_top_px(points[19].y_frac, 30.0), 18.66);
+        assert_approx_eq(key_target_top_px(points[19].y_frac, 220.0, 30.0), 18.66);
+    }
+
+    /// The G513 family's `metadata_full.json`: `device_image` markers in
+    /// absolute pixels of the authored canvas, which matches the cached
+    /// render. F1-F12 come from the markers; Esc is synthesized one chassis
+    /// offset left of F1.
+    #[test]
+    fn g513_pixel_markers_resolve_esc_plus_f1_to_f12() {
+        let marker_xs = [
+            285., 405., 525., 645., 840., 960., 1080., 1200., 1395., 1515., 1635., 1755.,
+        ];
+        let asset = legacy_asset(&marker_xs, 290., (2760, 1600), (2760, 1600));
+
+        let points = key_points(Some(&asset));
+
+        assert_eq!(points.len(), 13, "Esc + F1-F12, no phantom F13-F19");
+        assert_approx_eq(points[1].x_frac, 285. / 2760.);
+        assert_approx_eq(points[12].x_frac, 1755. / 2760.);
+        // Esc: 1.55 key pitches (median gap 120px) left of F1.
+        assert_approx_eq(points[0].x_frac, (285. - 1.55 * 120.) / 2760.);
+        for point in &points {
+            assert_approx_eq(point.y_frac, 290. / 1600.);
+        }
+        assert!(
+            points
+                .windows(2)
+                .all(|pair| pair[0].x_frac < pair[1].x_frac),
+            "points stay in physical left-to-right order"
+        );
+    }
+
+    /// The same depot's `metadata.json` is authored against a *different*
+    /// render (the G512 banner). Its origin doesn't match the cached PNG, so
+    /// the markers must be rejected in favour of the even-spacing fallback
+    /// rather than misplacing every callout.
+    #[test]
+    fn pixel_markers_for_a_different_render_fall_back_to_even_spacing() {
+        let marker_xs = [370., 525., 680., 835., 1090., 1250., 1400., 1555.];
+        let asset = legacy_asset(&marker_xs, 300., (3598, 1315), (2760, 1600));
+
+        let points = key_points(Some(&asset));
+
+        assert_eq!(points.len(), FUNCTION_KEYS.len());
+        assert_approx_eq(points[0].x_frac, EVEN_SPACING_START);
+        assert_approx_eq(points[19].x_frac, EVEN_SPACING_END);
+    }
+
+    #[test]
+    fn render_size_follows_the_png_aspect_up_to_the_width_cap() {
+        // MX Keys-class render (1872x728): width-bound at a roomy viewport.
+        let mx = legacy_asset(&[], 0., (1872, 728), (1872, 728));
+        let (w, h) = keyboard_render_size(Some(&mx), 900.);
+        assert_approx_eq(w, 700.);
+        assert!((h - 700. * 728. / 1872.).abs() < 0.01);
+
+        // G513 render (2760x1600) is far taller at the same width.
+        let g513 = legacy_asset(&[], 0., (2760, 1600), (2760, 1600));
+        let (w, h) = keyboard_render_size(Some(&g513), 900.);
+        assert_approx_eq(w, 700.);
+        assert!((h - 700. * 1600. / 2760.).abs() < 0.01);
+
+        // A short viewport shrinks the render instead of overflowing it.
+        let (w, h) = keyboard_render_size(Some(&g513), 500.);
+        assert_approx_eq(h, KEYBOARD_MIN_IMG_H);
+        assert!((w - KEYBOARD_MIN_IMG_H * 2760. / 1600.).abs() < 0.01);
+
+        assert_eq!(keyboard_render_size(None, 900.), FALLBACK_KEYBOARD_SIZE);
     }
 
     #[test]
@@ -1066,6 +1291,44 @@ mod tests {
             KEY_CALLOUT_W * upper_count as f32 <= KEYBOARD_W,
             "upper callout lane overlaps before spacing is considered"
         );
+    }
+
+    /// A legacy pixel-marker asset: `device_image` assignments in absolute
+    /// pixels of an `origin` canvas, over a render of `png` dimensions.
+    fn legacy_asset(
+        marker_xs: &[f32],
+        marker_y: f32,
+        origin: (u32, u32),
+        png: (u32, u32),
+    ) -> ResolvedAsset {
+        let assignments = marker_xs
+            .iter()
+            .map(|x| Assignment {
+                slot_name: String::new(),
+                marker: Point { x: *x, y: marker_y },
+                label: Direction { x: -1, y: -1 },
+            })
+            .collect();
+        ResolvedAsset {
+            depot: "g513".to_string(),
+            display_name: "G513".to_string(),
+            kind: DeviceKind::Keyboard,
+            image_path: PathBuf::from("/tmp/g513.png"),
+            hero_image_path: None,
+            glow: None,
+            metadata: Metadata {
+                images: vec![ImageEntry {
+                    key: "device_image".to_string(),
+                    origin: Origin {
+                        width: origin.0,
+                        height: origin.1,
+                    },
+                    assignments,
+                }],
+            },
+            png_width: png.0,
+            png_height: png.1,
+        }
     }
 
     fn asset_with_markers(key_markers: &[f32], easy_switch_markers: &[f32]) -> ResolvedAsset {

--- a/crates/openlogi-gui/src/mouse_model/mod.rs
+++ b/crates/openlogi-gui/src/mouse_model/mod.rs
@@ -3,7 +3,7 @@
 //!
 //! Per UI.md phases 6 (this view), 7 (leader lines), and 8 (ambient motion).
 
-mod geometry;
+pub mod geometry;
 pub mod leader_lines;
 pub mod picker;
 pub mod view;


### PR DESCRIPTION
## Summary

The v0.6.24 function-key remapper (#344) was authored against MX Keys-class assets and breaks on keyboards with legacy asset depots. On a G513 the Keys tab rendered 20 evenly-spaced callouts (phantom F13-F19 included) whose leader lines pointed into empty space, drew the render nearly twice as tall as its reserved band (clipping the wrist rest against the window edge), and showed the board unlit. Three stacked causes:

1. **Wrong metadata file.** The G513 depot's `metadata.json` is authored against the G512 banner render (origin 3598x1315); the depot manifest names `metadata_full.json` (origin 2760x1600 — exactly the shipped `front.png`) for the primary model, but sync never fetched it.
2. **Marker schema not understood.** `key_points()` only read percent-based `device_keys_image`/`device_easyswitch_image` markers; the legacy schema (absolute pixel markers under `device_image`) fell through to the even-spacing fallback, and the hard-coded Esc+F1-F19 list rendered keys the board doesn't have.
3. **Hard-coded MX Keys aspect.** The render was styled 700x220 (3.18:1) while the G513 render is 1.73:1 — and gpui's `Img` overrides the styled height with the intrinsic aspect ratio, so every overlay computed against a height the photo wasn't drawn at.

None of the changes are G513-specific: markers resolve for any depot whose authored canvas matches its cached render, the visible key row is sized by the marker count, the pane sizes from the actual PNG aspect on every board, and lighting glow now works for **any** keyboard with a transparent render — depots without a pipeline-baked hole mask get one derived at resolve time by flood-filling the render's alpha channel (border-connected transparency is background; the enclosed remainder is the inter-key holes).

## Changes

- **openlogi-assets**: `METADATA_FILES` prefers `metadata_full.json` over `metadata.json`, routing both the sync download and the resolver to the marker set authored for the render we display.
- **openlogi-gui (asset/glow)**: `resolve_glow_geometry` falls back to a runtime-computed hole mask (alpha flood fill, binned to the same ~1k scale as baked masks; a bin is see-through when any pixel is, so the few-pixel keycap slits survive). Glow resolution is gated to keyboards so mouse resolves never pay the image decode. `metadata_full.json` is also consulted for baked masks.
- **openlogi-gui (keyboard_model)**: legacy pixel markers resolve as fractions of the authored canvas, gated on that canvas matching the cached PNG (marker sets authored for other variants' renders are rejected); the visible row is the `FUNCTION_KEYS` prefix sized by marker count, with Esc synthesized one chassis offset left of F1; the pane sizes from the PNG aspect and shrinks to fit the viewport; the lighting glow paints behind the render like the home gallery and mouse model; a stale selection outliving a device switch to a shorter F-row is dropped instead of indexing out of bounds.




## Before / After

**Before — the v0.6.24 regression on a G513** (phantom F13-F19, callouts floating in space, render overflowing into the footer, board unlit):

![before: broken v0.6.24 Keys tab](https://raw.githubusercontent.com/davidbudnick/OpenLogi/assets/keys-tab-screenshots/before-g513-keys.png)

**After — this PR** (Esc-F12 only, callouts spread evenly with leaders fanning to the real keys, render fit to its pane, lighting reading through the key gaps):

![after: fixed Keys tab](https://raw.githubusercontent.com/davidbudnick/OpenLogi/assets/keys-tab-screenshots/after-g513-keys.png)

Home gallery, same G513 (runtime-derived glow, board's actual lighting colour):

![home](https://raw.githubusercontent.com/davidbudnick/OpenLogi/assets/keys-tab-screenshots/after-home-glow.png)

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- New tests: legacy pixel markers resolve Esc+F1-F12 with no phantom keys; marker sets authored for a different render fall back to even spacing; render size follows the PNG aspect up to the width cap and shrinks to fit short viewports; computed glow finds only enclosed holes, ignores border-connected transparency, and skips opaque renders.
- Runtime-tested on hardware (Windows 11, wired G513): dev GUI against the production agent — callouts land on the physical F-row, Esc+F1-F12 only, full render visible with the wrist rest, board's blue lighting reads through the key gaps on both the Keys tab and the home card. Screenshots above are from that session. MX Keys-class percent-marker path is covered by the existing tests; not runtime-tested on MX hardware.

Regression introduced by #344 in v0.6.24.

