### PR TITLE
fix(ci): merge Crowdin downloads into locale catalogs

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -2,6 +2,8 @@
 paths:
   - "crates/openlogi-gui/locales/**"
   - "crates/openlogi-gui/src/i18n.rs"
+  - "scripts/i18n/**"
+  - ".github/workflows/crowdin.yml"
 ---
 
 # i18n (rust-i18n + Crowdin)
@@ -22,8 +24,10 @@ paths:
   include list in the parity test in sync.
 - Check with `cargo test -p openlogi-gui i18n`. CI's Linux tests exclude the GUI,
   so this runs on macOS CI and locally (needs the Xcode/Metal env from devenv).
-- Crowdin workflow (root `crowdin.yml` + `.github/workflows/crowdin.yml`):
-  uploads **`en.yml` sources** and **per-language translations from git**, then
-  downloads Crowdin’s export with **`skip_untranslated_strings`** so English
-  fill-in never lands in git. Bot PRs only bring real translator progress via
-  `crowdin/i18n`.
+- Crowdin workflow (`crowdin.yml` + `.github/workflows/crowdin.yml`):
+  1. Snapshot complete `locales/*.yml`
+  2. Upload `en.yml` sources + per-language translations from git
+  3. Download with `skip_untranslated_strings` (sparse export is OK)
+  4. **Merge** via `scripts/i18n/merge_crowdin_download.py` — only apply values
+     that differ from English; never delete keys; never keep English fill-in
+  5. Open `crowdin/i18n` only when a real value improved

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -12,6 +12,7 @@ on:
       - crates/openlogi-gui/locales/en.yml
       - crowdin.yml
       - .github/workflows/crowdin.yml
+      - scripts/i18n/**
       - .github/actions/github-app-token-from-1password/**
 
 permissions:
@@ -29,8 +30,8 @@ jobs:
 
     steps:
       # persist-credentials must stay false: checkout's default GITHUB_TOKEN
-      # http.extraheader would win over the app token when crowdin/github-action
-      # pushes crowdin/i18n (403 as github-actions[bot] despite env GITHUB_TOKEN).
+      # http.extraheader would win over the app token when we push crowdin/i18n
+      # (403 as github-actions[bot] despite env GITHUB_TOKEN).
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -60,12 +61,20 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PROJECT_ID
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.OP_CROWDIN_SECRET_ITEM }}/CROWDIN_PERSONAL_TOKEN
 
-      # en.yml = English source of truth. Non-English catalogs in git are seeded
-      # into Crowdin (per language) so the download does not wipe real
-      # translations with English fill-in. Crowdin is where people improve
-      # translations; the bot PR brings their work back into the repo.
-      # skip_untranslated_strings: never commit English source fill-in for
-      # keys nobody has translated yet (runtime already falls back to en).
+      - name: Self-test locale merge script
+        run: python3 scripts/i18n/merge_crowdin_download.py --self-test
+
+      # Complete catalogs in git are the merge base. Crowdin download overwrites
+      # the working tree; without a snapshot we cannot restore keys the export
+      # omitted (skip_untranslated) or un-clobber English fill-in.
+      - name: Snapshot locale catalogs
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/openlogi-locales-before
+          cp crates/openlogi-gui/locales/*.yml /tmp/openlogi-locales-before/
+
+      # Upload sources + seed per-language translations, then download only
+      # (no push/PR — we merge first so sparse/English exports never land).
       - name: Synchronize with Crowdin
         uses: crowdin/github-action@c7af9bc98b01694653031fef2a0dc6c7888ce9bc # v2.17.0
         with:
@@ -77,22 +86,57 @@ jobs:
           upload_translations: true
           import_eq_suggestions: false
           download_translations: true
+          # Sparse export is fine: merge restores omitted keys from the snapshot.
           skip_untranslated_strings: true
-          localization_branch_name: crowdin/i18n
-          commit_message: "chore(i18n): sync Crowdin translations"
-          create_pull_request: true
-          pull_request_title: "chore(i18n): sync Crowdin translations"
-          pull_request_body: |
-            Automated per-language translation sync from Crowdin.
-
-            - `en.yml` is the English source of truth (new UI strings go there first).
-            - Feature PRs also add the same keys to every `locales/*.yml` (parity test).
-            - Existing non-English catalogs are uploaded to Crowdin first so real translations are not replaced with English fill-in.
-            - Download uses `skip_untranslated_strings` — only real translations land here, never English stubs.
-            - This PR is Crowdin → git for translated locales only (`export_languages` in `crowdin.yml`).
-          github_user_name: Crowdin Bot
-          github_user_email: support+bot@crowdin.com
+          push_translations: false
+          create_pull_request: false
         env:
           GITHUB_TOKEN: ${{ steps.github_app.outputs.token }}
           CROWDIN_PROJECT_ID: ${{ steps.crowdin_config.outputs.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ steps.crowdin_config.outputs.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Merge Crowdin export into complete catalogs
+        run: |
+          set -euo pipefail
+          python3 scripts/i18n/merge_crowdin_download.py \
+            --before /tmp/openlogi-locales-before \
+            --locales crates/openlogi-gui/locales \
+            --en crates/openlogi-gui/locales/en.yml
+
+      - name: Push translation branch and open PR
+        env:
+          GH_TOKEN: ${{ steps.github_app.outputs.token }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- crates/openlogi-gui/locales/; then
+            echo "No real Crowdin translation updates"
+            exit 0
+          fi
+
+          git config user.name "Crowdin Bot"
+          git config user.email "support+bot@crowdin.com"
+          git checkout -B crowdin/i18n
+          git add crates/openlogi-gui/locales/
+          git commit -m "chore(i18n): sync Crowdin translations"
+          git push -f origin crowdin/i18n
+
+          if gh pr view crowdin/i18n --json number --jq .number >/dev/null 2>&1; then
+            echo "Translation PR already open for crowdin/i18n"
+          else
+            body="$(cat <<'EOF'
+          Automated per-language translation sync from Crowdin.
+
+          - `en.yml` is the English source of truth; feature PRs keep key parity across all `locales/*.yml`.
+          - Existing non-English catalogs are uploaded first so Crowdin is seeded with real work.
+          - Download is merged into complete catalogs: only values that differ from English are applied.
+          - Untranslated keys are never replaced with English fill-in and never deleted (#549 / #552).
+          EOF
+          )"
+            # Strip the common indent from the workflow heredoc.
+            body="$(printf '%s\n' "$body" | sed 's/^          //')"
+            gh pr create \
+              --base master \
+              --head crowdin/i18n \
+              --title "chore(i18n): sync Crowdin translations" \
+              --body "$body"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,8 +247,10 @@ including what was NOT verified.
 - Add or change UI strings in **every** `crates/openlogi-gui/locales/*.yml` in
   the same PR. `en.yml` is the English source of truth (the English text IS the
   key); other files must not lag — the parity test fails the build.
-- Crowdin improves non-English **values** over time. The sync job downloads with
-  `skip_untranslated_strings` so English stubs never open a bot PR.
+- Crowdin improves non-English **values** over time. The sync job **merges**
+  downloads into complete catalogs (`scripts/i18n/merge_crowdin_download.py`):
+  only real translations apply; English fill-in and sparse exports never wipe
+  keys or open noise PRs.
 - Details: [`.claude/rules/i18n.md`](.claude/rules/i18n.md).
 
 ## Subsystem rules — read before touching

--- a/devenv.nix
+++ b/devenv.nix
@@ -112,11 +112,19 @@ in
       '';
     };
     "openlogi:i18n-download" = {
-      description = "Download per-language translations from Crowdin and run i18n tests.";
+      description = "Download Crowdin translations, merge into complete catalogs, run i18n tests.";
       exec = ''
         set -e
         ${requireXcodeMetal}
+        python3 scripts/i18n/merge_crowdin_download.py --self-test
+        before="$(mktemp -d)"
+        cp crates/openlogi-gui/locales/*.yml "$before/"
         crowdin download --skip-untranslated-strings
+        python3 scripts/i18n/merge_crowdin_download.py \
+          --before "$before" \
+          --locales crates/openlogi-gui/locales \
+          --en crates/openlogi-gui/locales/en.yml
+        rm -rf "$before"
         cargo test -p openlogi-gui i18n
       '';
     };

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -199,9 +199,9 @@ cargo run -p xtask -- release latest-json \
 
 `.github/workflows/crowdin.yml` syncs GUI locales with
 [Crowdin](https://crowdin.com/project/openlogi) and opens a `crowdin/i18n` PR
-when downloads change something — nightly, and on master pushes that touch
-English sources (`en.yml`), `crowdin.yml`, the Crowdin workflow, or the shared
-GitHub App token action.
+when a **real** translation value improved — nightly, and on master pushes that
+touch English sources (`en.yml`), `crowdin.yml`, the Crowdin workflow, the merge
+script under `scripts/i18n/`, or the shared GitHub App token action.
 
 **How it helps translation**
 
@@ -210,23 +210,27 @@ GitHub App token action.
 | `en.yml` (git) | English source of truth — English text is the key |
 | All `locales/*.yml` in git | Same keys as `en.yml` (parity test); seed Crowdin per language |
 | Crowdin project | Where people improve non-English **values** |
-| Bot PR (`crowdin/i18n`) | Brings real Crowdin translations back into the repo |
+| Merge script | Applies only values ≠ English; restores keys sparse exports omit |
+| Bot PR (`crowdin/i18n`) | Only when a non-English value actually changed |
 
 Feature PRs add new keys to **every** locale file in the same change. Crowdin
-does not invent translations; it only stores and syncs them. The download uses
-`skip_untranslated_strings` so untranslated keys are **omitted** (never English
-fill-in). Runtime still falls back to English for a missing key, but catalogs
-must stay in key parity so that never happens for shipped strings.
+does not invent translations; it only stores and syncs them. A raw Crowdin
+download is unsafe: untranslated strings come back as English (#549), and
+`skip_untranslated_strings` overwrites catalogs with sparse files that delete
+keys (#552). The workflow always **snapshots → download → merge** via
+`scripts/i18n/merge_crowdin_download.py` so catalogs stay complete and only real
+translations land in git.
 
 Each run:
 
-1. Uploads `en.yml` **sources**.
-2. Uploads **per-language translations** already in git (`import_eq_suggestions`
+1. Snapshots every `locales/*.yml`.
+2. Uploads `en.yml` **sources**.
+3. Uploads **per-language translations** already in git (`import_eq_suggestions`
    off so `value == English` is not stored as a finished translation).
-3. Downloads Crowdin’s export for configured languages with
-   **`skip_untranslated_strings`** (`export_languages` / `languages_mapping` in
-   `crowdin.yml`).
-4. Opens/updates `crowdin/i18n` when the catalogs differ.
+4. Downloads Crowdin’s export (`skip_untranslated_strings`; sparse is fine).
+5. Merges the export into the snapshot (English fill-in ignored; omitted keys
+   kept; headers / `_version` preserved).
+6. Opens/updates `crowdin/i18n` only when the working tree still differs.
 
 Like the release workflow, the job reads its credentials from one 1Password
 item referenced by the GitHub secret `OP_CROWDIN_SECRET_ITEM`. The item must
@@ -255,5 +259,6 @@ Local helpers (with Crowdin credentials configured):
 
 ```sh
 devenv tasks run openlogi:i18n-upload    # en.yml sources + per-language translations
-devenv tasks run openlogi:i18n-download  # download (skip untranslated) + i18n tests
+devenv tasks run openlogi:i18n-download  # download + merge + i18n tests
+python3 scripts/i18n/merge_crowdin_download.py --self-test
 ```

--- a/scripts/i18n/merge_crowdin_download.py
+++ b/scripts/i18n/merge_crowdin_download.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Merge a Crowdin locale download into complete git catalogs.
+
+Crowdin download overwrites each non-English `locales/*.yml` file. Two failure
+modes that raw download creates:
+
+1. Untranslated strings exported as English source (`"Key": "Key"`) — #549.
+2. `skip_untranslated_strings` exports a sparse file and deletes every other
+   key (including headers) — #552.
+
+This script treats the pre-download git catalogs as the complete base and only
+accepts Crowdin values that differ from the English source in `en.yml`. Keys
+Crowdin omitted stay as they were. Result always has every `en.yml` key (parity)
+and keeps the pre-download header / `_version` lines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ENTRY_RE = re.compile(r'^"((?:\\.|[^"\\])*)":\s*"((?:\\.|[^"\\])*)"\s*$')
+
+DEFAULT_HEADER = (
+    "# OpenLogi GUI translations. Managed by Crowdin; "
+    "edit source text there when possible.\n"
+    "_version: 1\n"
+)
+
+
+def unescape(value: str) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(value):
+        if value[i] == "\\" and i + 1 < len(value):
+            out.append(value[i + 1])
+            i += 2
+            continue
+        out.append(value[i])
+        i += 1
+    return "".join(out)
+
+
+def escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def parse_entries(text: str) -> dict[str, str]:
+    entries: dict[str, str] = {}
+    for line in text.splitlines():
+        match = ENTRY_RE.match(line)
+        if match is None:
+            continue
+        entries[unescape(match.group(1))] = unescape(match.group(2))
+    return entries
+
+
+def parse_entries_path(path: Path) -> dict[str, str]:
+    return parse_entries(path.read_text(encoding="utf-8"))
+
+
+def header_lines(text: str) -> list[str]:
+    """Non-entry lines before the first translation entry."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        if ENTRY_RE.match(line):
+            break
+        lines.append(line)
+    return lines
+
+
+def en_key_order(en_text: str) -> list[str]:
+    order: list[str] = []
+    for line in en_text.splitlines():
+        match = ENTRY_RE.match(line)
+        if match is None:
+            continue
+        order.append(unescape(match.group(1)))
+    return order
+
+
+def merge_catalog(
+    en_entries: dict[str, str],
+    en_order: list[str],
+    before_text: str,
+    after_text: str,
+) -> str:
+    before_entries = parse_entries(before_text)
+    after_entries = parse_entries(after_text)
+    header = header_lines(before_text)
+    if not any(line.strip() for line in header):
+        header = DEFAULT_HEADER.rstrip("\n").split("\n")
+
+    merged: dict[str, str] = {}
+    for key in en_order:
+        source = en_entries[key]
+        previous = before_entries.get(key, source)
+        crowdin = after_entries.get(key)
+        if crowdin is not None and crowdin != source:
+            merged[key] = crowdin
+        else:
+            merged[key] = previous
+
+    out_lines = list(header)
+    while out_lines and out_lines[-1] == "":
+        out_lines.pop()
+    for key in en_order:
+        out_lines.append(f'"{escape(key)}": "{escape(merged[key])}"')
+    return "\n".join(out_lines) + "\n"
+
+
+def merge_locales(before_dir: Path, locales_dir: Path, en_path: Path) -> int:
+    en_text = en_path.read_text(encoding="utf-8")
+    en_entries = parse_entries(en_text)
+    en_order = en_key_order(en_text)
+    if not en_order:
+        raise SystemExit(f"{en_path} has no translation entries")
+
+    changed_files = 0
+    for after_path in sorted(locales_dir.glob("*.yml")):
+        if after_path.name == "en.yml":
+            continue
+        before_path = before_dir / after_path.name
+        if not before_path.is_file():
+            print(f"skip {after_path.name}: no pre-download snapshot", file=sys.stderr)
+            continue
+        before_text = before_path.read_text(encoding="utf-8")
+        after_text = after_path.read_text(encoding="utf-8")
+        merged = merge_catalog(en_entries, en_order, before_text, after_text)
+        if merged == after_text:
+            continue
+
+        before_entries = parse_entries(before_text)
+        after_entries = parse_entries(after_text)
+        improvements = 0
+        for key, source in en_entries.items():
+            crowdin = after_entries.get(key)
+            previous = before_entries.get(key, source)
+            if crowdin is not None and crowdin != source and crowdin != previous:
+                improvements += 1
+
+        after_path.write_text(merged, encoding="utf-8")
+        changed_files += 1
+        if improvements:
+            print(
+                f"{after_path.name}: applied {improvements} Crowdin "
+                f"improvement(s); kept {len(en_order)} keys for parity"
+            )
+        else:
+            print(
+                f"{after_path.name}: restored complete catalog "
+                f"({len(en_order)} keys; no Crowdin improvements)"
+            )
+    return changed_files
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--before",
+        type=Path,
+        help="Directory of locale YAML files snapshotted before Crowdin download",
+    )
+    parser.add_argument(
+        "--locales",
+        type=Path,
+        help="Locale directory Crowdin just wrote into",
+    )
+    parser.add_argument(
+        "--en",
+        type=Path,
+        help="Path to en.yml (English source of truth)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run built-in regression checks and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(MergeTests)
+        result = unittest.TextTestRunner(verbosity=2).run(suite)
+        return 0 if result.wasSuccessful() else 1
+
+    if args.before is None or args.locales is None or args.en is None:
+        parser.error("--before, --locales, and --en are required unless --self-test")
+
+    changed = merge_locales(args.before, args.locales, args.en)
+    print(f"updated {changed} locale file(s)")
+    return 0
+
+
+class MergeTests(unittest.TestCase):
+    def test_sparse_download_keeps_parity_and_accepts_real_updates(self) -> None:
+        """#552: skip_untranslated export must not delete keys or headers."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            before = root / "before"
+            after = root / "after"
+            before.mkdir()
+            after.mkdir()
+            en = root / "en.yml"
+            en.write_text(
+                "\n".join(
+                    [
+                        "_version: 1",
+                        '"Camera": "Camera"',
+                        '"Sleep": "Sleep"',
+                        '"DPI": "DPI"',
+                        '"Back / Forward": "Back / Forward"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (before / "de.yml").write_text(
+                "\n".join(
+                    [
+                        "# OpenLogi GUI translations.",
+                        "_version: 1",
+                        '"Camera": "Kamera"',
+                        '"Sleep": "Ruhezustand"',
+                        '"DPI": "DPI"',
+                        '"Back / Forward": "Zurück / Vor"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            # Sparse Crowdin export: only one improved string, no header.
+            (after / "de.yml").write_text(
+                '"Sleep": "Schlafen"\n',
+                encoding="utf-8",
+            )
+
+            changed = merge_locales(before, after, en)
+            text = (after / "de.yml").read_text(encoding="utf-8")
+            self.assertEqual(changed, 1)
+            self.assertIn("# OpenLogi GUI translations.", text)
+            self.assertIn("_version: 1", text)
+            self.assertIn('"Camera": "Kamera"', text)
+            self.assertIn('"Sleep": "Schlafen"', text)
+            self.assertIn('"DPI": "DPI"', text)
+            self.assertIn('"Back / Forward": "Zurück / Vor"', text)
+            self.assertEqual(len(parse_entries(text)), 4)
+
+    def test_english_fill_in_does_not_clobber_real_translations(self) -> None:
+        """#549 / older clobber: English export values must not wipe git."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            before = root / "before"
+            after = root / "after"
+            before.mkdir()
+            after.mkdir()
+            en = root / "en.yml"
+            en.write_text(
+                "\n".join(
+                    [
+                        '"Camera": "Camera"',
+                        '"Sleep": "Sleep"',
+                        '"New feature": "New feature"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (before / "de.yml").write_text(
+                "\n".join(
+                    [
+                        "_version: 1",
+                        '"Camera": "Kamera"',
+                        '"Sleep": "Ruhezustand"',
+                        '"New feature": "New feature"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (after / "de.yml").write_text(
+                "\n".join(
+                    [
+                        "_version: 1",
+                        '"Camera": "Camera"',
+                        '"Sleep": "Schlafen"',
+                        '"New feature": "Neue Funktion"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            merge_locales(before, after, en)
+            text = (after / "de.yml").read_text(encoding="utf-8")
+            self.assertIn('"Camera": "Kamera"', text)
+            self.assertIn('"Sleep": "Schlafen"', text)
+            self.assertIn('"New feature": "Neue Funktion"', text)
+
+    def test_english_only_export_restores_git_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            before = root / "before"
+            after = root / "after"
+            before.mkdir()
+            after.mkdir()
+            en = root / "en.yml"
+            en.write_text(
+                "\n".join(['"Camera": "Camera"', '"Sleep": "Sleep"', ""]),
+                encoding="utf-8",
+            )
+            (before / "de.yml").write_text(
+                "\n".join(
+                    [
+                        "_version: 1",
+                        '"Camera": "Kamera"',
+                        '"Sleep": "Ruhezustand"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            (after / "de.yml").write_text(
+                "\n".join(
+                    [
+                        "_version: 1",
+                        '"Camera": "Camera"',
+                        '"Sleep": "Sleep"',
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            merge_locales(before, after, en)
+            text = (after / "de.yml").read_text(encoding="utf-8")
+            self.assertIn('"Camera": "Kamera"', text)
+            self.assertIn('"Sleep": "Ruhezustand"', text)
+            self.assertNotIn('"Camera": "Camera"', text)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

#552 was the flip side of #551: `skip_untranslated_strings` made Crowdin export **sparse** locale files, and the action **overwrote** complete catalogs — deleting ~1.3k English-stub keys (and headers). Zero real translations improved.

Raw Crowdin download is unsafe either way:

| Mode | Failure |
|------|---------|
| Full export | English fill-in for untranslated keys (#549) |
| `skip_untranslated_strings` | Sparse files delete every other key (#552) |

**Fix:** snapshot → download → **merge**. Only apply values that differ from English; always keep complete catalogs and headers.

Closes the class of bugs behind #549 / #552 (close #552; do not merge it).

## Changes

- **`scripts/i18n/merge_crowdin_download.py`** — merge Crowdin export into pre-download catalogs; `--self-test` covers sparse + English-clobber cases
- **`.github/workflows/crowdin.yml`** — no direct push from `crowdin/github-action`; merge first; open `crowdin/i18n` only when a real value changed
- **`devenv.nix`** — local `i18n-download` uses the same snapshot/merge path
- **docs** — `AGENTS.md`, `.claude/rules/i18n.md`, `docs/DEVELOPMENT.md`

## Testing

- `python3 scripts/i18n/merge_crowdin_download.py --self-test` — 3 passed
- Simulated #552 sparse export against all 19 locale files — full 364-key parity restored for every language
- Not live Crowdin-tested from this branch (needs secrets). After merge: close any open English-stub/sparse bot PR, re-run **Crowdin** once; expect no PR (or only real value improvements)

Not runtime-tested on hardware.