### PR TITLE
fix(macos): add camera hardened-runtime entitlement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,9 @@ jobs:
           app="target/release/bundle/osx/OpenLogi.app"
           helper="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
           cli="$app/Contents/MacOS/openlogi"
+          # Hardened-runtime camera exception for the GUI (preview) and CLI
+          # (snapshot). The agent helper never opens the camera.
+          ents="crates/openlogi-gui/bundle/OpenLogi.entitlements"
           # Inside-out signing: seal the nested agent helper with its own
           # signature first, then the outer app (which seals the signed helper).
           # --deep is deprecated and can't give the helper an independent
@@ -233,13 +236,18 @@ jobs:
           # rejects its as-built ad-hoc signature.
           if [ -f "$cli" ]; then
             codesign --force --options runtime --timestamp \
+              --entitlements "$ents" \
               --sign "$APPLE_SIGNING_IDENTITY" "$cli"
           fi
           codesign --force --options runtime --timestamp \
+            --entitlements "$ents" \
             --sign "$APPLE_SIGNING_IDENTITY" "$app"
           codesign --verify --strict --verbose=2 "$app"
           [ -d "$helper" ] && codesign --verify --strict --verbose=2 "$helper"
           [ -f "$cli" ] && codesign --verify --strict --verbose=2 "$cli"
+          # Fail the release if camera access would still be blocked at runtime.
+          codesign -d --entitlements - "$app" 2>/dev/null \
+            | grep -q 'com.apple.security.device.camera'
 
       - name: Create and sign DMG
         if: ${{ inputs.sign }}

--- a/crates/openlogi-gui/bundle/OpenLogi.entitlements
+++ b/crates/openlogi-gui/bundle/OpenLogi.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Required when codesigning with the hardened runtime: without this,
+	     AVFoundation camera capture is denied even if the user would grant
+	     TCC Camera access and Info.plist has NSCameraUsageDescription. -->
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
+</plist>

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -337,8 +337,13 @@ fn local_sign_app_if_available() -> Result<()> {
 
 fn sign_app_with_timestamp(identity: &str, timestamp: TimestampMode) -> Result<()> {
     let sh = Shell::new()?;
-    let app = repo_root()?.join("target/release/bundle/osx/OpenLogi.app");
+    let root = repo_root()?;
+    let app = root.join("target/release/bundle/osx/OpenLogi.app");
     let helper = app.join("Contents/Library/LoginItems/OpenLogiAgent.app");
+    // GUI + embedded CLI open the camera (preview / snapshot). The agent helper
+    // does not — leave it without camera so its TCC identity stays minimal.
+    let camera_ents = camera_entitlements_path(&root);
+    ensure_file(&camera_ents)?;
     println!("==> codesign ({identity})");
     // Inside-out signing: seal the nested helper with its own signature first,
     // then the outer app (which seals the already-signed helper). `--deep` is
@@ -346,16 +351,16 @@ fn sign_app_with_timestamp(identity: &str, timestamp: TimestampMode) -> Result<(
     // stable, separately-signed helper identity is exactly what lets the agent's
     // Accessibility (TCC) grant persist across updates. So sign each explicitly.
     if helper.exists() {
-        codesign_runtime(identity, &helper, timestamp)?;
+        codesign_runtime(identity, &helper, timestamp, None)?;
     }
     // The embedded CLI is a second Mach-O under Contents/MacOS; sign it with the
     // hardened runtime before the outer app so it carries a Developer ID
     // signature (its as-built ad-hoc signature would fail notarization).
     let cli = app.join("Contents/MacOS/openlogi");
     if cli.exists() {
-        codesign_runtime(identity, &cli, timestamp)?;
+        codesign_runtime(identity, &cli, timestamp, Some(&camera_ents))?;
     }
-    codesign_runtime(identity, &app, timestamp)?;
+    codesign_runtime(identity, &app, timestamp, Some(&camera_ents))?;
     cmd!(sh, "codesign --verify --strict {app}").run()?;
     if helper.exists() {
         cmd!(sh, "codesign --verify --strict {helper}").run()?;
@@ -366,18 +371,42 @@ fn sign_app_with_timestamp(identity: &str, timestamp: TimestampMode) -> Result<(
     Ok(())
 }
 
-/// Sign one bundle with the hardened runtime and the requested timestamp mode.
-fn codesign_runtime(identity: &str, target: &Path, timestamp: TimestampMode) -> Result<()> {
+/// Path to the GUI/CLI entitlements (camera hardened-runtime exception).
+fn camera_entitlements_path(root: &Path) -> std::path::PathBuf {
+    root.join("crates/openlogi-gui/bundle/OpenLogi.entitlements")
+}
+
+/// Sign one target with the hardened runtime and the requested timestamp mode.
+fn codesign_runtime(
+    identity: &str,
+    target: &Path,
+    timestamp: TimestampMode,
+    entitlements: Option<&Path>,
+) -> Result<()> {
     let sh = Shell::new()?;
-    match timestamp {
-        TimestampMode::Secure => {
+    match (timestamp, entitlements) {
+        (TimestampMode::Secure, Some(ents)) => {
+            cmd!(
+                sh,
+                "codesign --force --options runtime --timestamp --entitlements {ents} --sign {identity} {target}"
+            )
+            .run()?;
+        }
+        (TimestampMode::Secure, None) => {
             cmd!(
                 sh,
                 "codesign --force --options runtime --timestamp --sign {identity} {target}"
             )
             .run()?;
         }
-        TimestampMode::None => {
+        (TimestampMode::None, Some(ents)) => {
+            cmd!(
+                sh,
+                "codesign --force --options runtime --timestamp=none --entitlements {ents} --sign {identity} {target}"
+            )
+            .run()?;
+        }
+        (TimestampMode::None, None) => {
             cmd!(
                 sh,
                 "codesign --force --options runtime --timestamp=none --sign {identity} {target}"
@@ -435,6 +464,19 @@ mod tests {
         let app = app_with_binaries(&REQUIRED_BUNDLE_BINARIES);
 
         verify_bundle_binaries(app.path()).unwrap();
+    }
+
+    #[test]
+    fn camera_entitlements_declare_device_camera() {
+        let path = camera_entitlements_path(&repo_root().unwrap());
+        let plist = Value::from_file(&path).unwrap();
+        let dict = plist.as_dictionary().unwrap();
+        assert_eq!(
+            dict.get("com.apple.security.device.camera")
+                .and_then(Value::as_boolean),
+            Some(true),
+            "hardened-runtime camera capture needs this entitlement"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardened-runtime release and local bundles still could not use the camera after #550. That PR added `NSCameraUsageDescription` and the consent prompt, but signing always uses `--options runtime` without `com.apple.security.device.camera`, so the kernel blocks AVFoundation capture before TCC can grant it. The app never appears under System Settings → Privacy & Security → Camera (or the grant is useless).

## Changes

- **`crates/openlogi-gui/bundle/OpenLogi.entitlements`** — declares `com.apple.security.device.camera`
- **`xtask` codesign** — signs the GUI app and embedded CLI with those entitlements; agent helper stays without camera (it never opens a capture session)
- **CI release sign step** — same entitlements for app + CLI, plus a post-sign check that the camera key is present

## Testing

- `cargo fmt -p xtask -- --check` — clean
- `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- `cargo test -p xtask` — all green (includes `camera_entitlements_declare_device_camera`)
- Local re-sign of `/Applications/OpenLogi.app` with the new entitlements: `codesign -d --entitlements -` shows `com.apple.security.device.camera` on the GUI and CLI; app launches

**Hardware path to verify (StreamCam attached):**

1. Install a signed build of this branch (or re-sign a local bundle with `OpenLogi.entitlements`).
2. Open the webcam device → Camera tab → click **Click to enable camera access** / Settings → Permissions → **Grant**.
3. macOS Camera consent dialog should appear; OpenLogi should show under System Settings → Privacy & Security → Camera.
4. After grant, live preview should start.