### PR TITLE
feat(gui): back navigation via the mouse's back button and Alt+Left

### DIFF
--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -1,7 +1,8 @@
 use gpui::{
     AnyElement, App, AppContext as _, BorrowAppContext as _, Context, Entity, FocusHandle,
-    InteractiveElement, IntoElement, ParentElement, Render, StatefulInteractiveElement as _,
-    Styled, Subscription, Window, div, prelude::FluentBuilder as _, px, rgb,
+    InteractiveElement, IntoElement, MouseButton, NavigationDirection, ParentElement, Render,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, div,
+    prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::{
     Icon, IconName, TitleBar,
@@ -265,6 +266,31 @@ impl AppView {
         cx.notify();
     }
 
+    /// Attach the window-level back-navigation listeners to `root`: a mouse
+    /// configurator should honor the hardware it configures. Two routes reach
+    /// us — the native navigate button (its default binding never diverts, so
+    /// the OS still sees it), and Alt+Left, which is both what a rebound
+    /// button's BrowserBack action injects on Linux and what keyboard users
+    /// expect.
+    fn with_back_navigation(root: gpui::Div, cx: &mut Context<Self>) -> gpui::Div {
+        root.on_mouse_down(
+            MouseButton::Navigate(NavigationDirection::Back),
+            cx.listener(|this, _, _, cx| {
+                if !matches!(this.route, Route::Home) {
+                    this.go_home(cx);
+                }
+            }),
+        )
+        .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, _, cx| {
+            if event.keystroke.modifiers.alt
+                && event.keystroke.key == "left"
+                && !matches!(this.route, Route::Home)
+            {
+                this.go_home(cx);
+            }
+        }))
+    }
+
     fn accessibility_gate(pal: Palette, cx: &mut Context<Self>) -> AnyElement {
         v_flex()
             .size_full()
@@ -392,6 +418,7 @@ impl Render for AppView {
             .when(cfg!(target_os = "linux"), |this| {
                 this.child(app_title_bar(pal))
             });
+        let root = Self::with_back_navigation(root, cx);
 
         // The agent is the source of truth for both the permission state and
         // the device list; `AgentLink` is everything the GUI knows about it.

--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -75,6 +75,12 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
             .selected(active_idx)
             .uniform(px(theme::GALLERY_CARD_W))
             .gap(px(GALLERY_GAP))
+            // Arrows and dots only move the *selection*, which no longer has a
+            // visible effect here (the ring shows managed state, and capture is
+            // per-device): cards are clicked directly, and the row scrolls when
+            // it overflows.
+            .arrows(false)
+            .indicators(false)
             .accent(rgb(theme::ACCENT_BLUE).into())
             .render_item(move |idx, focused, _window, cx| {
                 let pal = theme::palette(cx);

--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -75,11 +75,11 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
             .selected(active_idx)
             .uniform(px(theme::GALLERY_CARD_W))
             .gap(px(GALLERY_GAP))
-            // Arrows and dots only move the *selection*, which no longer has a
-            // visible effect here (the ring shows managed state, and capture is
-            // per-device): cards are clicked directly, and the row scrolls when
-            // it overflows.
-            .arrows(false)
+            // The arrows stay: they are the only tab-focusable control that
+            // moves the selection (and the row scrolls to the selected card),
+            // so they are the keyboard path to off-screen devices. The dots go:
+            // they duplicate the scroll position and, as plain divs, were never
+            // keyboard-operable anyway.
             .indicators(false)
             .accent(rgb(theme::ACCENT_BLUE).into())
             .render_item(move |idx, focused, _window, cx| {


### PR DESCRIPTION

## Summary

A mouse configurator should honor the hardware it configures. This lets the device-detail screen be dismissed with the mouse's back button and with Alt+Left, and removes the Home gallery's carousel arrows/dots, which became dead controls once capture went per-device.

The back button is delivered natively while it keeps its default binding (a diverted button never reaches the OS event stream), and Alt+Left is both what a rebound button's BrowserBack action injects on Linux and what keyboard users expect. Linux has no OS-level button-8 → "back" translation (unlike Windows' `WM_APPCOMMAND`), so the app opts in itself, the same way browsers do.

The gallery arrows/dots only moved the selection, which no longer has a visible effect on the Home screen — the ring shows managed state and capture runs per device (#419) — so they read as dead buttons. Cards are clicked directly and the row scrolls when it overflows.

## Changes

- `gui`: pop the device-detail screen on mouse button 4 (back) and Alt+Left (`app.rs`).
- `gui`: drop the gallery carousel arrows and dots (`app/home.rs`).

## Testing

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — green on this branch.
- Not re-verified in the running app after the rebase onto current master. The concrete check: open a device's detail view, press the mouse's back button (button 4) or Alt+Left — the view pops back to Home; on Home the gallery shows no arrows/dots and the card row scrolls when it overflows.
