### PR TITLE
feat(hid): persist the immutable probe cache across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5174,6 +5174,7 @@ dependencies = [
  "openlogi-core",
  "openlogi-hidpp",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5166,6 +5166,7 @@ name = "openlogi-hid"
 version = "0.6.26"
 dependencies = [
  "async-hid",
+ "atomic-write-file",
  "futures-concurrency",
  "futures-lite",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5174,6 +5174,7 @@ dependencies = [
  "openlogi-core",
  "openlogi-hidpp",
  "serde",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ serde_json = "1"
 toml = "0.8"
 ureq = { version = "3", default-features = false, features = ["rustls", "json"] }
 sha2 = "0.10"
+atomic-write-file = "0.3.0"
 backon = { version = "1.6", default-features = false, features = ["std", "std-blocking-sleep"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -251,10 +251,14 @@ fn spawn_inner(
             // A persistent enumerator so its per-device probe cache survives
             // across ticks — a known device's immutable data (model, features)
             // is reused instead of being re-handshaked every poll.
-            let mut enumerator = registry.map_or_else(
-                openlogi_hid::Enumerator::default,
-                openlogi_hid::Enumerator::with_registry,
-            );
+            // Warm-start from the persisted probe cache too, so devices keep
+            // their identity across agent restarts without a fresh interview.
+            let mut enumerator = registry
+                .map_or_else(
+                    openlogi_hid::Enumerator::default,
+                    openlogi_hid::Enumerator::with_registry,
+                )
+                .persisted();
             let mut state = WatchState::default();
             let mut last_tick = SystemTime::now();
             // `block_on` installs runtime context so a backend that registers an

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -16,7 +16,7 @@ toml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 etcetera = "0.11.0"
-atomic-write-file = "0.3.0"
+atomic-write-file = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.10.0"

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 num_enum = { workspace = true }
 futures-concurrency = "7"
+serde_json.workspace = true
 
 # Native Win32 HID report writes (windows_hid.rs) — a fallback for async-hid's
 # write path on Windows, plus the composite short/long endpoint handling in

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -45,3 +45,6 @@ objc2-app-kit = { version = "0.3.2", features = ["NSWorkspace", "NSRunningApplic
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 num_enum = { workspace = true }
 futures-concurrency = "7"
 serde_json.workspace = true
+atomic-write-file = "0.3.0"
 
 # Native Win32 HID report writes (windows_hid.rs) — a fallback for async-hid's
 # write path on Windows, plus the composite short/long endpoint handling in

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -23,7 +23,7 @@ tracing = { workspace = true }
 num_enum = { workspace = true }
 futures-concurrency = "7"
 serde_json.workspace = true
-atomic-write-file = "0.3.0"
+atomic-write-file = { workspace = true }
 
 # Native Win32 HID report writes (windows_hid.rs) — a fallback for async-hid's
 # write path on Windows, plus the composite short/long endpoint handling in

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -621,11 +621,14 @@ impl Enumerator {
             match outcome {
                 CacheOutcome::Fresh(key, cached) => {
                     seen_keys.insert(key.clone());
+                    // A completed full probe of a persistable device is worth
+                    // writing through; battery `Update`s are not (they would
+                    // rewrite the file every tick for a value that is re-read
+                    // live anyway), and neither are keys `persist::save`
+                    // filters out — dirtying on those would rewrite an
+                    // unchanged file on every refresh of a direct-only system.
+                    self.cache_dirty |= persist::is_persistable(&key);
                     self.cache.insert(key, cached);
-                    // A completed full probe is worth writing through; battery
-                    // `Update`s are not (they would rewrite the file every
-                    // tick for a value that is re-read live anyway).
-                    self.cache_dirty = true;
                 }
                 CacheOutcome::Update(key, cached) => {
                     seen_keys.insert(key.clone());
@@ -658,7 +661,7 @@ impl Enumerator {
             if *misses > CACHE_MISS_GRACE {
                 self.cache.remove(&key);
                 self.misses.remove(&key);
-                self.cache_dirty = true;
+                self.cache_dirty |= persist::is_persistable(&key);
             }
         }
     }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
+    path::PathBuf,
     sync::Arc,
     time::Duration,
 };
@@ -121,6 +122,12 @@ pub struct Enumerator {
     /// callers keep this `None` and retain the route-opening library behavior.
     registry: Option<ChannelRegistry>,
     tick: u64,
+    /// Where the immutable probe cache is persisted across restarts, `None`
+    /// for a memory-only enumerator (one-shot CLI calls, tests).
+    persist_path: Option<PathBuf>,
+    /// Whether the persistable cache content changed since the last save —
+    /// fresh full probes and evictions, not per-tick battery refreshes.
+    cache_dirty: bool,
 }
 
 /// An open channel to a receiver / direct-device HID node, held across
@@ -370,6 +377,34 @@ impl Enumerator {
         }
     }
 
+    /// Warm-start this enumerator's immutable probe cache from (and write it
+    /// back to) the on-disk cache under the app data dir, so a device fully
+    /// probed once keeps its identity across restarts. Falls back to
+    /// memory-only when no data dir is resolvable.
+    ///
+    /// A modifier rather than a constructor: persistence is orthogonal to the
+    /// channel registry, so the agent's enumerator carries both.
+    #[must_use]
+    pub fn persisted(mut self) -> Self {
+        self.persist_path = match openlogi_core::paths::data_dir() {
+            Ok(dir) => Some(dir.join("probe-cache.json")),
+            Err(e) => {
+                warn!(error = %e, "no data dir — probe cache is memory-only");
+                None
+            }
+        };
+        let cache = self
+            .persist_path
+            .as_deref()
+            .map(persist::load)
+            .unwrap_or_default();
+        if !cache.is_empty() {
+            debug!(entries = cache.len(), "probe cache warm-started from disk");
+        }
+        self.cache.extend(cache);
+        self
+    }
+
     async fn prepare_nodes(&mut self, candidates: Vec<async_hid::Device>) -> PreparedNodes {
         let mut active = Vec::new();
         let mut seen_nodes = HashSet::new();
@@ -427,6 +462,22 @@ impl Enumerator {
             active,
             open_failures,
             retiring,
+        }
+    }
+
+    /// Write the cache through to disk when its persistable content changed
+    /// this tick. Best-effort: a failed write is logged and retried on the
+    /// next dirty tick.
+    fn flush_cache(&mut self) {
+        if !self.cache_dirty {
+            return;
+        }
+        let Some(path) = self.persist_path.as_deref() else {
+            return;
+        };
+        match persist::save(path, &self.cache) {
+            Ok(()) => self.cache_dirty = false,
+            Err(e) => warn!(error = %e, ?path, "failed to persist probe cache"),
         }
     }
 
@@ -556,11 +607,27 @@ impl Enumerator {
             ));
         }
 
-        // Apply fresh probes and record which devices were seen this tick.
+        let seen_keys = self.apply_outcomes(outcomes);
+        self.evict_unseen(&seen_keys);
+        self.flush_cache();
+        Ok((inventories, all_complete, all_healthy))
+    }
+
+    /// Fold this tick's probe outcomes into the cache, returning the keys seen
+    /// so [`Self::evict_unseen`] can age out the rest.
+    fn apply_outcomes(&mut self, outcomes: Vec<CacheOutcome>) -> HashSet<CacheKey> {
         let mut seen_keys = HashSet::new();
         for outcome in outcomes {
             match outcome {
-                CacheOutcome::Fresh(key, cached) | CacheOutcome::Update(key, cached) => {
+                CacheOutcome::Fresh(key, cached) => {
+                    seen_keys.insert(key.clone());
+                    self.cache.insert(key, cached);
+                    // A completed full probe is worth writing through; battery
+                    // `Update`s are not (they would rewrite the file every
+                    // tick for a value that is re-read live anyway).
+                    self.cache_dirty = true;
+                }
+                CacheOutcome::Update(key, cached) => {
                     seen_keys.insert(key.clone());
                     self.cache.insert(key, cached);
                 }
@@ -570,8 +637,7 @@ impl Enumerator {
                 CacheOutcome::Unkeyed => {}
             }
         }
-        self.evict_unseen(&seen_keys);
-        Ok((inventories, all_complete, all_healthy))
+        seen_keys
     }
 
     /// Drop cache entries for devices not seen this tick, after a short grace so
@@ -592,6 +658,7 @@ impl Enumerator {
             if *misses > CACHE_MISS_GRACE {
                 self.cache.remove(&key);
                 self.misses.remove(&key);
+                self.cache_dirty = true;
             }
         }
     }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -21,6 +21,7 @@ use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
 
 mod cache;
 mod features;
+mod persist;
 mod probe;
 
 use cache::{CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached};
@@ -597,4 +598,5 @@ impl Enumerator {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests;

--- a/crates/openlogi-hid/src/inventory/features.rs
+++ b/crates/openlogi-hid/src/inventory/features.rs
@@ -14,6 +14,7 @@ use hidpp::{
 use openlogi_core::device::{
     BatteryInfo, BatteryLevel, Capabilities, DeviceKind, DeviceModelInfo, DeviceTransports,
 };
+use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::mappings::{
@@ -24,7 +25,7 @@ use crate::mappings::{
 
 /// Everything a single device probe yields. Any field is `None` when the
 /// device doesn't expose that feature or the read failed.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Serialize, Deserialize)]
 pub(super) struct ProbedFeatures {
     pub(super) battery: Option<BatteryInfo>,
     pub(super) model_info: Option<DeviceModelInfo>,
@@ -45,7 +46,7 @@ pub(super) struct ProbedFeatures {
 /// — the same enhanced-then-legacy split SmartShift has with `0x2111`/`0x2110`.
 /// G-series wireless gaming devices (G915, G903 LS) expose neither and report
 /// battery only as a voltage via `0x1001`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) enum BatteryProbe {
     Unified(u8),
     Legacy(u8),

--- a/crates/openlogi-hid/src/inventory/persist.rs
+++ b/crates/openlogi-hid/src/inventory/persist.rs
@@ -1,0 +1,35 @@
+//! Disk persistence for the immutable probe cache.
+//!
+//! A device's expensive probe result (model info, capabilities, feature
+//! indexes) is immutable, so it only ever needs to be read once per device —
+//! but the in-memory cache dies with the process, forcing every agent restart
+//! to re-interview every device. Persisting the cache means a device that was
+//! fully probed once keeps its identity across restarts, even on transports
+//! where a fresh walk is slow or failing (see `BOLT_SLOT_PROBE`).
+//!
+//! Only receiver-paired identities are persisted: a [`CacheKey::Direct`] is an
+//! OS-runtime node id with no cross-boot stability. Loaded entries get
+//! `probed_tick = 0`, so the regular [`super::cache::REFRESH_TICKS`]
+//! self-healing pass re-walks them on schedule; until (and unless) that walk
+//! succeeds, the persisted data serves exactly like an in-memory cache hit.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use super::cache::{CacheKey, Cached};
+
+/// Write the persistable subset of `cache` to `path` (atomically via a
+/// sibling temp file). Errors are the caller's to log — persistence is
+/// best-effort and must never fail enumeration.
+pub(super) fn save(path: &Path, cache: &HashMap<CacheKey, Cached>) -> std::io::Result<()> {
+    let _ = (path, cache);
+    Ok(())
+}
+
+/// Load a previously saved cache. Any failure — missing file, unreadable
+/// JSON, unknown schema version — yields an empty cache: the data is a
+/// warm-start optimization, never a correctness requirement.
+pub(super) fn load(path: &Path) -> HashMap<CacheKey, Cached> {
+    let _ = path;
+    HashMap::new()
+}

--- a/crates/openlogi-hid/src/inventory/persist.rs
+++ b/crates/openlogi-hid/src/inventory/persist.rs
@@ -7,8 +7,12 @@
 //! fully probed once keeps its identity across restarts, even on transports
 //! where a fresh walk is slow or failing (see `BOLT_SLOT_PROBE`).
 //!
-//! Only receiver-paired identities are persisted: a [`CacheKey::Direct`] is an
-//! OS-runtime node id with no cross-boot stability. Loaded entries get
+//! Only Bolt identities are persisted, because only they are keyed on the
+//! device's *own* identity (the pairing-register unit id), which no re-pairing
+//! can silently reassign. A [`CacheKey::UnifyingSlot`] is `receiver + slot`: a
+//! different device paired into that slot while the agent is down would
+//! inherit the previous occupant's probe on warm start. A [`CacheKey::Direct`]
+//! is an OS-runtime node id with no cross-boot stability. Loaded entries get
 //! `probed_tick = 0`, so the regular [`super::cache::REFRESH_TICKS`]
 //! self-healing pass re-walks them on schedule; until (and unless) that walk
 //! succeeds, the persisted data serves exactly like an in-memory cache hit.
@@ -24,7 +28,8 @@ use super::features::{BatteryProbe, ProbedFeatures};
 
 /// Bumped when the on-disk shape changes; a mismatched file is discarded
 /// (the cache is a warm-start optimization, not data anyone must keep).
-const SCHEMA_VERSION: u32 = 1;
+/// v2 dropped the `UnifyingSlot` key (slot-keyed, so not re-pair-safe).
+const SCHEMA_VERSION: u32 = 2;
 
 #[derive(Serialize, Deserialize)]
 struct PersistedCache {
@@ -39,30 +44,22 @@ struct PersistedEntry {
     battery: Option<BatteryProbe>,
 }
 
-/// The persistable subset of [`CacheKey`] — everything except `Direct`.
-#[derive(Serialize, Deserialize)]
+/// The persistable subset of [`CacheKey`] — Bolt only (see the module docs).
+#[derive(Clone, Copy, Serialize, Deserialize)]
 enum PersistedKey {
     Bolt { unit_id: [u8; 4] },
-    UnifyingSlot { receiver_uid: String, slot: u8 },
 }
 
 fn persistable(key: &CacheKey) -> Option<PersistedKey> {
     match key {
         CacheKey::Bolt { unit_id } => Some(PersistedKey::Bolt { unit_id: *unit_id }),
-        CacheKey::UnifyingSlot { receiver_uid, slot } => Some(PersistedKey::UnifyingSlot {
-            receiver_uid: receiver_uid.clone(),
-            slot: *slot,
-        }),
-        CacheKey::Direct(_) => None,
+        CacheKey::UnifyingSlot { .. } | CacheKey::Direct(_) => None,
     }
 }
 
 fn runtime_key(key: PersistedKey) -> CacheKey {
     match key {
         PersistedKey::Bolt { unit_id } => CacheKey::Bolt { unit_id },
-        PersistedKey::UnifyingSlot { receiver_uid, slot } => {
-            CacheKey::UnifyingSlot { receiver_uid, slot }
-        }
     }
 }
 

--- a/crates/openlogi-hid/src/inventory/persist.rs
+++ b/crates/openlogi-hid/src/inventory/persist.rs
@@ -57,6 +57,13 @@ fn persistable(key: &CacheKey) -> Option<PersistedKey> {
     }
 }
 
+/// Whether a cache change under `key` affects the persisted file at all —
+/// gates `cache_dirty` so churn on never-persisted keys (e.g. a direct-only
+/// system's full refresh) doesn't rewrite an unchanged file every pass.
+pub(super) fn is_persistable(key: &CacheKey) -> bool {
+    persistable(key).is_some()
+}
+
 fn runtime_key(key: PersistedKey) -> CacheKey {
     match key {
         PersistedKey::Bolt { unit_id } => CacheKey::Bolt { unit_id },

--- a/crates/openlogi-hid/src/inventory/persist.rs
+++ b/crates/openlogi-hid/src/inventory/persist.rs
@@ -14,22 +14,118 @@
 //! succeeds, the persisted data serves exactly like an in-memory cache hit.
 
 use std::collections::HashMap;
+use std::io;
 use std::path::Path;
 
-use super::cache::{CacheKey, Cached};
+use serde::{Deserialize, Serialize};
 
-/// Write the persistable subset of `cache` to `path` (atomically via a
-/// sibling temp file). Errors are the caller's to log — persistence is
-/// best-effort and must never fail enumeration.
-pub(super) fn save(path: &Path, cache: &HashMap<CacheKey, Cached>) -> std::io::Result<()> {
-    let _ = (path, cache);
-    Ok(())
+use super::cache::{CacheKey, Cached};
+use super::features::{BatteryProbe, ProbedFeatures};
+
+/// Bumped when the on-disk shape changes; a mismatched file is discarded
+/// (the cache is a warm-start optimization, not data anyone must keep).
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+struct PersistedCache {
+    version: u32,
+    entries: Vec<PersistedEntry>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PersistedEntry {
+    key: PersistedKey,
+    probe: ProbedFeatures,
+    battery: Option<BatteryProbe>,
+}
+
+/// The persistable subset of [`CacheKey`] — everything except `Direct`.
+#[derive(Serialize, Deserialize)]
+enum PersistedKey {
+    Bolt { unit_id: [u8; 4] },
+    UnifyingSlot { receiver_uid: String, slot: u8 },
+}
+
+fn persistable(key: &CacheKey) -> Option<PersistedKey> {
+    match key {
+        CacheKey::Bolt { unit_id } => Some(PersistedKey::Bolt { unit_id: *unit_id }),
+        CacheKey::UnifyingSlot { receiver_uid, slot } => Some(PersistedKey::UnifyingSlot {
+            receiver_uid: receiver_uid.clone(),
+            slot: *slot,
+        }),
+        CacheKey::Direct(_) => None,
+    }
+}
+
+fn runtime_key(key: PersistedKey) -> CacheKey {
+    match key {
+        PersistedKey::Bolt { unit_id } => CacheKey::Bolt { unit_id },
+        PersistedKey::UnifyingSlot { receiver_uid, slot } => {
+            CacheKey::UnifyingSlot { receiver_uid, slot }
+        }
+    }
+}
+
+/// Write the persistable subset of `cache` to `path`, atomically via a sibling
+/// temp file so a crash mid-write can't leave a torn file. Errors are the
+/// caller's to log — persistence is best-effort and must never fail
+/// enumeration.
+pub(super) fn save(path: &Path, cache: &HashMap<CacheKey, Cached>) -> io::Result<()> {
+    let entries: Vec<PersistedEntry> = cache
+        .iter()
+        .filter_map(|(key, cached)| {
+            persistable(key).map(|key| PersistedEntry {
+                key,
+                probe: cached.probe.clone(),
+                battery: cached.battery,
+            })
+        })
+        .collect();
+    let file = PersistedCache {
+        version: SCHEMA_VERSION,
+        entries,
+    };
+    let json = serde_json::to_vec(&file).map_err(io::Error::other)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)
 }
 
 /// Load a previously saved cache. Any failure — missing file, unreadable
 /// JSON, unknown schema version — yields an empty cache: the data is a
 /// warm-start optimization, never a correctness requirement.
 pub(super) fn load(path: &Path) -> HashMap<CacheKey, Cached> {
-    let _ = path;
-    HashMap::new()
+    let Ok(bytes) = std::fs::read(path) else {
+        return HashMap::new();
+    };
+    let Ok(file) = serde_json::from_slice::<PersistedCache>(&bytes) else {
+        tracing::warn!(?path, "probe cache unreadable — starting cold");
+        return HashMap::new();
+    };
+    if file.version != SCHEMA_VERSION {
+        tracing::debug!(
+            version = file.version,
+            "probe cache from another schema — starting cold"
+        );
+        return HashMap::new();
+    }
+    file.entries
+        .into_iter()
+        .map(|entry| {
+            (
+                runtime_key(entry.key),
+                Cached {
+                    probe: entry.probe,
+                    battery: entry.battery,
+                    // Restart the refresh clock: the entry serves immediately
+                    // as a cache hit, and the periodic self-healing re-walk
+                    // decides when it is due for a fresh read.
+                    probed_tick: 0,
+                },
+            )
+        })
+        .collect()
 }

--- a/crates/openlogi-hid/src/inventory/persist.rs
+++ b/crates/openlogi-hid/src/inventory/persist.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 
+use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
 
 use super::cache::{CacheKey, Cached};
@@ -70,10 +71,11 @@ fn runtime_key(key: PersistedKey) -> CacheKey {
     }
 }
 
-/// Write the persistable subset of `cache` to `path`, atomically via a sibling
-/// temp file so a crash mid-write can't leave a torn file. Errors are the
-/// caller's to log — persistence is best-effort and must never fail
-/// enumeration.
+/// Write the persistable subset of `cache` to `path`, atomically via
+/// [`AtomicWriteFile`] so a crash mid-write can't leave a torn file (and the
+/// replace works on Windows, where a plain rename onto an existing file
+/// fails). Errors are the caller's to log — persistence is best-effort and
+/// must never fail enumeration.
 pub(super) fn save(path: &Path, cache: &HashMap<CacheKey, Cached>) -> io::Result<()> {
     let entries: Vec<PersistedEntry> = cache
         .iter()
@@ -101,9 +103,9 @@ pub(super) fn save(path: &Path, cache: &HashMap<CacheKey, Cached>) -> io::Result
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, json)?;
-    std::fs::rename(&tmp, path)
+    let mut out = AtomicWriteFile::open(path)?;
+    io::Write::write_all(&mut out, &json)?;
+    out.commit()
 }
 
 /// Load a previously saved cache. Any failure — missing file, unreadable

--- a/crates/openlogi-hid/src/inventory/persist.rs
+++ b/crates/openlogi-hid/src/inventory/persist.rs
@@ -71,10 +71,18 @@ pub(super) fn save(path: &Path, cache: &HashMap<CacheKey, Cached>) -> io::Result
     let entries: Vec<PersistedEntry> = cache
         .iter()
         .filter_map(|(key, cached)| {
-            persistable(key).map(|key| PersistedEntry {
-                key,
-                probe: cached.probe.clone(),
-                battery: cached.battery,
+            persistable(key).map(|key| {
+                // The battery *reading* is volatile and re-read live on every
+                // cache hit — persisting it would resurrect a stale value
+                // after a restart. The battery *feature index*
+                // (`PersistedEntry::battery`) is immutable and kept.
+                let mut probe = cached.probe.clone();
+                probe.battery = None;
+                PersistedEntry {
+                    key,
+                    probe,
+                    battery: cached.battery,
+                }
             })
         })
         .collect();

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -8,6 +8,7 @@ use openlogi_core::device::{
 use super::cache::{
     CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
 };
+use super::persist;
 use super::probe::{
     NodeProbe, assemble_bolt_probe, parse_codename_unifying, preferred_direct_codename,
 };
@@ -15,7 +16,7 @@ use super::{
     ChannelCache, Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop, retained_nodes,
     routes_for_inventories, settle_unhealthy_node,
 };
-use crate::inventory::features::ProbedFeatures;
+use crate::inventory::features::{BatteryProbe, ProbedFeatures};
 use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
 
 fn cache_entry(probed_tick: u64) -> Cached {
@@ -531,4 +532,73 @@ fn live_cached_channel_survives_a_transient_enumeration_gap() {
     assert!(retained.contains(&2));
     assert!(!retained.contains(&3));
     assert_eq!(retained, std::collections::HashSet::from([1, 2]));
+}
+
+#[test]
+#[ignore = "RED: probe-cache persistence not implemented yet"]
+fn probe_cache_roundtrips_through_disk() {
+    // A device fully probed once must keep its identity across restarts: the
+    // persisted cache is what spares a fresh process the expensive (and on
+    // degraded transports, failing) re-interview.
+    use openlogi_core::device::{DeviceModelInfo, DeviceTransports};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("probe-cache.json");
+
+    let model = DeviceModelInfo {
+        entity_count: 1,
+        serial_number: Some("TESTSERIAL01".into()),
+        unit_id: [0xaa, 0xbb, 0xcc, 0xdd],
+        transports: DeviceTransports::default(),
+        model_ids: [0xb042, 0, 0],
+        extended_model_id: 0,
+    };
+    let probe = ProbedFeatures {
+        model_info: Some(model.clone()),
+        ..Default::default()
+    };
+    let mut cache = std::collections::HashMap::new();
+    cache.insert(
+        CacheKey::Bolt {
+            unit_id: [0xaa, 0xbb, 0xcc, 0xdd],
+        },
+        Cached {
+            probe,
+            battery: Some(BatteryProbe::Unified(9)),
+            probed_tick: 7,
+        },
+    );
+    cache.insert(
+        CacheKey::UnifyingSlot {
+            receiver_uid: "DA2699E1".into(),
+            slot: 2,
+        },
+        Cached {
+            probe: ProbedFeatures::default(),
+            battery: None,
+            probed_tick: 3,
+        },
+    );
+
+    persist::save(&path, &cache).expect("save");
+    let loaded = persist::load(&path);
+
+    let bolt = loaded
+        .get(&CacheKey::Bolt {
+            unit_id: [0xaa, 0xbb, 0xcc, 0xdd],
+        })
+        .expect("bolt entry survives a save/load cycle");
+    assert_eq!(bolt.probe.model_info.as_ref(), Some(&model));
+    assert_eq!(bolt.battery, Some(BatteryProbe::Unified(9)));
+    assert_eq!(
+        bolt.probed_tick, 0,
+        "loaded entries restart the refresh clock"
+    );
+    assert!(
+        loaded.contains_key(&CacheKey::UnifyingSlot {
+            receiver_uid: "DA2699E1".into(),
+            slot: 2,
+        }),
+        "unifying entries persist too"
+    );
 }

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -594,11 +594,12 @@ fn probe_cache_roundtrips_through_disk() {
         "loaded entries restart the refresh clock"
     );
     assert!(
-        loaded.contains_key(&CacheKey::UnifyingSlot {
+        !loaded.contains_key(&CacheKey::UnifyingSlot {
             receiver_uid: "DA2699E1".into(),
             slot: 2,
         }),
-        "unifying entries persist too"
+        "unifying entries are slot-keyed, so a re-pair while the agent is \
+         down could hand them to a different device — never persisted"
     );
 }
 

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -539,7 +539,9 @@ fn probe_cache_roundtrips_through_disk() {
     // A device fully probed once must keep its identity across restarts: the
     // persisted cache is what spares a fresh process the expensive (and on
     // degraded transports, failing) re-interview.
-    use openlogi_core::device::{DeviceModelInfo, DeviceTransports};
+    use openlogi_core::device::{
+        BatteryInfo, BatteryLevel, BatteryStatus, DeviceModelInfo, DeviceTransports,
+    };
 
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("probe-cache.json");
@@ -554,6 +556,13 @@ fn probe_cache_roundtrips_through_disk() {
     };
     let probe = ProbedFeatures {
         model_info: Some(model.clone()),
+        // A live reading at save time: volatile, so it must NOT survive the
+        // round trip (the feature index in `battery` below does).
+        battery: Some(BatteryInfo {
+            percentage: 55,
+            level: BatteryLevel::Good,
+            status: BatteryStatus::Discharging,
+        }),
         ..Default::default()
     };
     let mut cache = std::collections::HashMap::new();
@@ -589,6 +598,10 @@ fn probe_cache_roundtrips_through_disk() {
         .expect("bolt entry survives a save/load cycle");
     assert_eq!(bolt.probe.model_info.as_ref(), Some(&model));
     assert_eq!(bolt.battery, Some(BatteryProbe::Unified(9)));
+    assert!(
+        bolt.probe.battery.is_none(),
+        "the volatile battery reading must not be resurrected across restarts"
+    );
     assert_eq!(
         bolt.probed_tick, 0,
         "loaded entries restart the refresh clock"

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -535,7 +535,6 @@ fn live_cached_channel_survives_a_transient_enumeration_gap() {
 }
 
 #[test]
-#[ignore = "RED: probe-cache persistence not implemented yet"]
 fn probe_cache_roundtrips_through_disk() {
     // A device fully probed once must keep its identity across restarts: the
     // persisted cache is what spares a fresh process the expensive (and on
@@ -601,4 +600,21 @@ fn probe_cache_roundtrips_through_disk() {
         }),
         "unifying entries persist too"
     );
+}
+
+#[test]
+fn probe_cache_load_tolerates_missing_or_garbage_files() {
+    // The persisted cache is a warm-start optimization: a missing file, torn
+    // write, or foreign schema must yield an empty cache, never an error.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir.path().join("nope.json");
+    assert!(persist::load(&missing).is_empty());
+
+    let garbage = dir.path().join("garbage.json");
+    std::fs::write(&garbage, b"not json at all").expect("write");
+    assert!(persist::load(&garbage).is_empty());
+
+    let wrong_version = dir.path().join("future.json");
+    std::fs::write(&wrong_version, br#"{"version":999,"entries":[]}"#).expect("write");
+    assert!(persist::load(&wrong_version).is_empty());
 }

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -37,6 +37,41 @@ fn direct_codename_prefers_hidpp_marketing_name_over_generic_os_name() {
 }
 
 #[test]
+fn cache_dirty_tracks_only_persistable_keys() {
+    // A system whose devices never persist (direct-only, or Unifying) must not
+    // rewrite probe-cache.json on every refresh pass: the file's content
+    // wouldn't change.
+    let mut e = Enumerator::default();
+    let unifying = CacheKey::UnifyingSlot {
+        receiver_uid: "DA2699E1".into(),
+        slot: 1,
+    };
+    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry(0))]);
+    assert!(
+        !e.cache_dirty,
+        "non-persistable fresh probe dirtied the cache"
+    );
+
+    // Its eviction is equally invisible to the persisted file.
+    let nobody = HashSet::new();
+    for _ in 0..=CACHE_MISS_GRACE {
+        e.evict_unseen(&nobody);
+    }
+    assert!(!e.cache.contains_key(&unifying), "entry should be evicted");
+    assert!(!e.cache_dirty, "non-persistable eviction dirtied the cache");
+
+    // A Bolt probe is what the file stores — that one dirties it.
+    let bolt = CacheKey::Bolt {
+        unit_id: [1, 2, 3, 4],
+    };
+    e.apply_outcomes(vec![CacheOutcome::Fresh(bolt, cache_entry(0))]);
+    assert!(
+        e.cache_dirty,
+        "persistable fresh probe must dirty the cache"
+    );
+}
+
+#[test]
 fn cache_entry_survives_grace_then_evicts() {
     let mut e = Enumerator::default();
     let key = CacheKey::Bolt {


### PR DESCRIPTION

## Summary

The probe cache dies with the agent process, so every restart re-interviews every device: wasted HID++ round-trips on healthy transports, and a permanently blank identity on degraded ones (a device that answered its feature walk once may not answer it again behind a lossy path). This persists the immutable slice of the probe cache to `<data_dir>/probe-cache.json` and warm-starts it on agent startup, so a restart resumes with everything the agent already learned.

Only receiver-paired keys are persisted (they are stable across sessions), the file is schema-versioned, and writes are atomic (temp file + rename). `Enumerator::persisted()` is a composable modifier, so the agent's enumerator carries both persistence and the channel registry.

Related: #278 (the ledger-replay / probe-cache grace interaction on Bolt partial-walk recovery — a persistent cache changes that calculus for the better, though this PR does not claim to close it).

## Changes

- `hid`: new `inventory/persist.rs` — schema-versioned, atomically written probe-cache store; `Enumerator::persisted()` modifier; warm-start load in the enumerator (`inventory.rs`, `inventory/features.rs`).
- `hid`: `tempfile` added as a dev-dependency for the persistence tests (already in the workspace lockfile; the `gpui`/`gpui-component` pins are untouched).
- `agent-core`: the agent's inventory watcher composes `persisted()` with `with_registry` (`watchers/inventory.rs`).

## Testing

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — green on this branch; new unit tests cover the disk round-trip (`probe_cache_roundtrips_through_disk`) and tolerance of missing/garbage cache files (`probe_cache_load_tolerates_missing_or_garbage_files`). Schema-version mismatch falls back to an empty cache in `load()`.
- Not runtime-tested on hardware: the concrete check is to start the agent, let it enumerate a Bolt receiver, restart the agent, and confirm devices surface with full model info before the first probe tick completes.
