### PR TITLE
feat: capture the MX Master 4 haptic panel as a first-class control

### DIFF
--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -54,13 +54,14 @@ pub fn gesture_bindings_for(
     config: &Config,
     config_key: Option<&str>,
 ) -> BTreeMap<GestureDirection, Action> {
-    // The dedicated HID++ gesture button (CID 0x00c3) only gestures while it is the device's gesture
-    // owner. When the user moves the role to an OS-hook button (Middle/Back/
-    // Forward) or turns gestures off, return an empty map so the gesture watcher
+    // A HID++ gesture source (the dedicated gesture button, or the MX Master 4
+    // haptic panel) only gestures while it is the device's gesture owner. When
+    // the user moves the role to an OS-hook button (Middle/Back/Forward) or
+    // turns gestures off, return an empty map so the gesture watcher
     // dispatches nothing — otherwise the always-seeded defaults would keep the
-    // HID++ gesture button firing regardless of the selection.
+    // HID++ gesture control firing regardless of the selection.
     let owner = config_key.and_then(|key| config.gesture_owner(key));
-    if owner != Some(ButtonId::GestureButton) {
+    if !owner.is_some_and(ButtonId::is_hidpp_gesture_source) {
         return BTreeMap::new();
     }
     let stored = config_key

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -65,11 +65,12 @@ pub fn plan_for_device(
     // needs to see its press to run hold+swipe detection, and diverting it
     // would starve the hook of events.
     let oshook = oshook_gestures_for(config, Some(config_key), app);
-    // The dedicated gesture button never reaches the OS hook, so a non-default
+    // The HID++ gesture control never reaches the OS hook, so a non-default
     // single binding on it is deliverable only via a plain HID++ divert — but
     // only while it does NOT own the gesture role (the raw-XY gesture divert
-    // owns CID 0x00c3 in that case, and `gesture_bindings` is how the watcher
-    // arms that divert).
+    // owns its CIDs in that case, and `gesture_bindings` is how the watcher
+    // arms that divert). `GESTURE_BUTTON_CID` is a marker here: the capture
+    // session expands it to whichever gesture-source CIDs the device exposes.
     let plain_gesture_button = gesture_bindings
         .is_empty()
         .then_some((GESTURE_BUTTON_CID, ButtonId::GestureButton));

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -14,8 +14,7 @@ use std::sync::{Arc, RwLock};
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 use openlogi_core::config::Config;
 use openlogi_hid::DeviceRoute;
-use openlogi_hid::gesture::DIVERTABLE_STANDARD_BUTTONS;
-use openlogi_hid::reprog_controls::GESTURE_BUTTON_CID;
+use openlogi_hid::gesture::{DIVERTABLE_STANDARD_BUTTONS, GESTURE_SOURCE_BUTTONS};
 
 use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
 
@@ -29,9 +28,13 @@ pub struct DeviceCapturePlan {
     pub route: DeviceRoute,
     /// Per-button single actions for this device (per-app effective).
     pub bindings: BTreeMap<ButtonId, Action>,
-    /// Per-direction map when the dedicated HID++ gesture button owns the
-    /// gesture role on this device; empty otherwise.
+    /// Per-direction map when a HID++ gesture source (the dedicated gesture
+    /// button or the MX Master 4 haptic panel) owns the gesture role on this
+    /// device; empty otherwise.
     pub gesture_bindings: BTreeMap<GestureDirection, Action>,
+    /// The gesture owner's source CID to divert with raw-XY, `None` when no
+    /// HID++ control owns the gesture role.
+    pub gesture_source_cid: Option<u16>,
     /// Standard buttons whose binding leaves the default — divert over
     /// `0x1b04`. A button at its default keeps its native HID behavior, so no
     /// re-synthesis is ever needed.
@@ -65,18 +68,26 @@ pub fn plan_for_device(
     // needs to see its press to run hold+swipe detection, and diverting it
     // would starve the hook of events.
     let oshook = oshook_gestures_for(config, Some(config_key), app);
-    // The HID++ gesture control never reaches the OS hook, so a non-default
-    // single binding on it is deliverable only via a plain HID++ divert — but
+    // The HID++ gesture sources never reach the OS hook, so a non-default
+    // single binding on one is deliverable only via a plain HID++ divert — but
     // only while it does NOT own the gesture role (the raw-XY gesture divert
-    // owns its CIDs in that case, and `gesture_bindings` is how the watcher
-    // arms that divert). `GESTURE_BUTTON_CID` is a marker here: the capture
-    // session expands it to whichever gesture-source CIDs the device exposes.
-    let plain_gesture_button = gesture_bindings
-        .is_empty()
-        .then_some((GESTURE_BUTTON_CID, ButtonId::GestureButton));
+    // owns the owner's CID, and `gesture_source_cid` is how the watcher arms
+    // that divert).
+    let owner = config.gesture_owner(config_key);
+    let gesture_source_cid = owner
+        .filter(|o| o.is_hidpp_gesture_source())
+        .and_then(|o| {
+            GESTURE_SOURCE_BUTTONS
+                .into_iter()
+                .find(|&(_, button)| button == o)
+        })
+        .map(|(cid, _)| cid);
+    let plain_sources = GESTURE_SOURCE_BUTTONS
+        .into_iter()
+        .filter(|&(_, button)| owner != Some(button));
     let divert_buttons: Vec<(u16, ButtonId)> = DIVERTABLE_STANDARD_BUTTONS
         .into_iter()
-        .chain(plain_gesture_button)
+        .chain(plain_sources)
         .filter(|(_, button)| !oshook.contains_key(button))
         .filter(|(_, button)| {
             bindings
@@ -100,6 +111,7 @@ pub fn plan_for_device(
         route,
         bindings,
         gesture_bindings,
+        gesture_source_cid,
         divert_buttons,
         thumbwheel_bindings_nondefault,
         thumbwheel_sensitivity: config.thumbwheel_sensitivity(config_key),
@@ -122,7 +134,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: the haptic panel as its own control is not implemented yet"]
     fn haptic_panel_can_own_the_gesture_role() {
         // The MX Master 4 haptic panel is a HID++ gesture source: selecting it
         // as the gesture owner must arm the raw-XY gesture divert, exactly
@@ -145,7 +156,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: the haptic panel as its own control is not implemented yet"]
     fn single_bound_haptic_panel_is_plain_diverted_when_not_the_owner() {
         // While the dedicated button owns gestures (the default), a single
         // action bound to the panel is deliverable only via a plain HID++
@@ -166,7 +176,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: the haptic panel as its own control is not implemented yet"]
     fn unbound_haptic_panel_stays_native() {
         // Default binding for the panel is Action::None — an untouched panel
         // must not be diverted, so its firmware behavior (haptics) survives.

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -110,7 +110,7 @@ pub fn plan_for_device(
 #[cfg(test)]
 mod tests {
     use openlogi_core::binding::Binding;
-    use openlogi_hid::reprog_controls::GESTURE_BUTTON_CID;
+    use openlogi_hid::reprog_controls::{GESTURE_BUTTON_CID, HAPTIC_PANEL_CID};
 
     use super::*;
 
@@ -119,6 +119,67 @@ mod tests {
             receiver_uid: "cafe".into(),
             slot: 2,
         }
+    }
+
+    #[test]
+    #[ignore = "RED: the haptic panel as its own control is not implemented yet"]
+    fn haptic_panel_can_own_the_gesture_role() {
+        // The MX Master 4 haptic panel is a HID++ gesture source: selecting it
+        // as the gesture owner must arm the raw-XY gesture divert, exactly
+        // like the dedicated gesture button.
+        let mut cfg = Config::default();
+        cfg.set_gesture_owner("2b042", ButtonId::HapticPanel);
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            !plan.gesture_bindings.is_empty(),
+            "a panel gesture owner must arm the HID++ gesture divert"
+        );
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(cid, _)| cid == HAPTIC_PANEL_CID),
+            "the gesture owner is delivered via raw-XY divert, never a plain one"
+        );
+    }
+
+    #[test]
+    #[ignore = "RED: the haptic panel as its own control is not implemented yet"]
+    fn single_bound_haptic_panel_is_plain_diverted_when_not_the_owner() {
+        // While the dedicated button owns gestures (the default), a single
+        // action bound to the panel is deliverable only via a plain HID++
+        // divert dispatching ButtonId::HapticPanel.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b042",
+            ButtonId::HapticPanel,
+            Binding::Single(Action::Copy),
+        );
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            plan.divert_buttons
+                .contains(&(HAPTIC_PANEL_CID, ButtonId::HapticPanel)),
+            "a single-bound panel must be plain-diverted, or the binding can never fire"
+        );
+    }
+
+    #[test]
+    #[ignore = "RED: the haptic panel as its own control is not implemented yet"]
+    fn unbound_haptic_panel_stays_native() {
+        // Default binding for the panel is Action::None — an untouched panel
+        // must not be diverted, so its firmware behavior (haptics) survives.
+        let cfg = Config::default();
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(cid, _)| cid == HAPTIC_PANEL_CID),
+            "an unbound panel must keep its native behavior"
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -115,7 +115,7 @@ fn thumbwheel_armed(plan: &DeviceCapturePlan) -> bool {
 fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
     CaptureSpec {
         capture_thumbwheel: thumbwheel_armed(plan),
-        divert_gesture_button: !plan.gesture_bindings.is_empty(),
+        divert_gesture_source: plan.gesture_source_cid,
         divert_buttons: plan.divert_buttons.clone(),
     }
 }

--- a/crates/openlogi-core/src/binding/button.rs
+++ b/crates/openlogi-core/src/binding/button.rs
@@ -60,13 +60,20 @@ pub enum ButtonId {
     /// Keyboard "Volume Up" control (CID `0x00e9`) — F12 on the Signature
     /// series.
     KeyVolumeUp,
+    /// The MX Master 4 Haptic Sense Panel — the touch-sensitive thumb rest
+    /// (Logi metadata slot `ASSIGNMENT_NAME_SHOW_RADIAL_MENU`, HID++ CID
+    /// `0x01a0`). A separate physical control from [`ButtonId::GestureButton`];
+    /// captured over HID++ like it, and eligible as the gesture owner.
+    /// Declared last: the TOML config and any serialized form encode the
+    /// variant identifier / index, so new buttons are append-only.
+    HapticPanel,
 }
 
 impl ButtonId {
     /// Every rebindable button in declaration (physical front-to-side) order —
     /// the iteration source for default-binding seeding and the popover
     /// trigger list.
-    pub const ALL: [ButtonId; 10] = [
+    pub const ALL: [ButtonId; 11] = [
         ButtonId::LeftClick,
         ButtonId::RightClick,
         ButtonId::MiddleClick,
@@ -77,6 +84,7 @@ impl ButtonId {
         ButtonId::ThumbwheelScrollUp,
         ButtonId::ThumbwheelScrollDown,
         ButtonId::GestureButton,
+        ButtonId::HapticPanel,
     ];
 
     /// The divertable keyboard F-row controls, in F-row order. Kept out of
@@ -110,6 +118,16 @@ impl ButtonId {
         )
     }
 
+    /// Whether this button is a HID++ gesture source — a control that is
+    /// captured over HID++ raw-XY diversion (never the OS hook) and can
+    /// therefore own the gesture role with swipe directions: the dedicated
+    /// gesture button, or the MX Master 4 haptic panel. The capture layer maps
+    /// each to its control ID.
+    #[must_use]
+    pub fn is_hidpp_gesture_source(self) -> bool {
+        matches!(self, ButtonId::GestureButton | ButtonId::HapticPanel)
+    }
+
     /// Human-readable label for popovers and tooltips.
     #[must_use]
     pub fn label(self) -> &'static str {
@@ -133,6 +151,7 @@ impl ButtonId {
             ButtonId::KeyMute => "Mute Key",
             ButtonId::KeyVolumeDown => "Volume Down Key",
             ButtonId::KeyVolumeUp => "Volume Up Key",
+            ButtonId::HapticPanel => "Haptic Panel",
         }
     }
 }

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -36,9 +36,12 @@ pub fn default_binding(button: ButtonId) -> Action {
         ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollRight,
         ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollLeft,
         ButtonId::GestureButton => Action::MissionControl,
-        // Keyboard keys stay on their native firmware function until the user
-        // explicitly binds them; an unbound key is never diverted, so a
-        // `None` default keeps the projection total without capturing anything.
+        // Keyboard keys and the MX Master 4 haptic panel stay on their native
+        // firmware function (media keys; haptics and the Options+ Actions Ring)
+        // until the user explicitly binds them — neither has an OpenLogi
+        // equivalent yet. `None` means "binding at its default", and the
+        // capture layer never diverts a control sitting at its default, so this
+        // keeps the projection total without capturing anything.
         ButtonId::KeySearch
         | ButtonId::KeyDictation
         | ButtonId::KeyEmoji
@@ -47,7 +50,8 @@ pub fn default_binding(button: ButtonId) -> Action {
         | ButtonId::KeyPlayPause
         | ButtonId::KeyMute
         | ButtonId::KeyVolumeDown
-        | ButtonId::KeyVolumeUp => Action::None,
+        | ButtonId::KeyVolumeUp
+        | ButtonId::HapticPanel => Action::None,
     }
 }
 

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -280,10 +280,17 @@ impl Config {
     /// per-direction adapter.
     #[must_use]
     pub fn gesture_bindings_for(&self, device_key: &str) -> BTreeMap<GestureDirection, Action> {
+        // Read the *owner's* stored map: the gesture role can sit on the
+        // dedicated gesture button or the MX Master 4 haptic panel (or an
+        // OS-hook button — callers gate on the owner kind), and each button
+        // keeps its own per-direction map.
+        let Some(owner) = self.gesture_owner(device_key) else {
+            return BTreeMap::new();
+        };
         match self
             .devices
             .get(device_key)
-            .and_then(|d| d.bindings.get(&ButtonId::GestureButton))
+            .and_then(|d| d.bindings.get(&owner))
         {
             Some(Binding::Gesture(map)) => map.clone(),
             _ => BTreeMap::new(),

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Vandret rulning"
 "Custom": "Brugerdefineret"
 "Gesture Button": "Bevægelsesknap"
+"Haptic Panel": "Haptisk panel"
 "Up": "Op"
 "Down": "Ned"
 "Left": "Venstre"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Horizontales Scrollen"
 "Custom": "Benutzerdefiniert"
 "Gesture Button": "Gestentaste"
+"Haptic Panel": "Haptik-Panel"
 "Up": "Oben"
 "Down": "Unten"
 "Left": "Links"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Οριζόντια κύλιση"
 "Custom": "Προσαρμοσμένο"
 "Gesture Button": "Κουμπί χειρονομιών"
+"Haptic Panel": "Απτικό πάνελ"
 "Up": "Πάνω"
 "Down": "Κάτω"
 "Left": "Αριστερά"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Horizontal Scroll"
 "Custom": "Custom"
 "Gesture Button": "Gesture Button"
+"Haptic Panel": "Haptic Panel"
 "Up": "Up"
 "Down": "Down"
 "Left": "Left"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Desplazamiento horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botón de gestos"
+"Haptic Panel": "Panel háptico"
 "Up": "Arriba"
 "Down": "Abajo"
 "Left": "Izquierda"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Vaakavieritys"
 "Custom": "Mukautettu"
 "Gesture Button": "Eletoiminto"
+"Haptic Panel": "Haptinen paneeli"
 "Up": "Ylös"
 "Down": "Alas"
 "Left": "Vasen"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Défilement horizontal"
 "Custom": "Personnalisé"
 "Gesture Button": "Bouton de gestes"
+"Haptic Panel": "Panneau haptique"
 "Up": "Haut"
 "Down": "Bas"
 "Left": "Gauche"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Scorrimento orizzontale"
 "Custom": "Personalizzato"
 "Gesture Button": "Pulsante gesture"
+"Haptic Panel": "Pannello aptico"
 "Up": "Su"
 "Down": "Giù"
 "Left": "Sinistra"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "横スクロール"
 "Custom": "カスタム"
 "Gesture Button": "ジェスチャーボタン"
+"Haptic Panel": "ハプティックパネル"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "가로 스크롤"
 "Custom": "사용자 지정"
 "Gesture Button": "제스처 버튼"
+"Haptic Panel": "햅틱 패널"
 "Up": "위"
 "Down": "아래"
 "Left": "왼쪽"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Horisontal rulling"
 "Custom": "Egendefinert"
 "Gesture Button": "Bevegelsesknapp"
+"Haptic Panel": "Haptisk panel"
 "Up": "Opp"
 "Down": "Ned"
 "Left": "Venstre"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Horizontaal scrollen"
 "Custom": "Aangepast"
 "Gesture Button": "Gebarenknop"
+"Haptic Panel": "Haptisch paneel"
 "Up": "Omhoog"
 "Down": "Omlaag"
 "Left": "Links"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Przewijanie poziome"
 "Custom": "Niestandardowe"
 "Gesture Button": "Przycisk gestów"
+"Haptic Panel": "Panel haptyczny"
 "Up": "W górę"
 "Down": "W dół"
 "Left": "W lewo"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Rolagem horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de Gesto"
+"Haptic Panel": "Painel Háptico"
 "Up": "Cima"
 "Down": "Baixo"
 "Left": "Esquerda"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Deslocamento horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de gesto"
+"Haptic Panel": "Painel háptico"
 "Up": "Cima"
 "Down": "Baixo"
 "Left": "Esquerda"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Горизонтальная прокрутка"
 "Custom": "Свой"
 "Gesture Button": "Кнопка жестов"
+"Haptic Panel": "Тактильная панель"
 "Up": "Вверх"
 "Down": "Вниз"
 "Left": "Влево"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "Horisontell rullning"
 "Custom": "Anpassad"
 "Gesture Button": "Gestknapp"
+"Haptic Panel": "Haptisk panel"
 "Up": "Upp"
 "Down": "Ned"
 "Left": "Vänster"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "水平滚动"
 "Custom": "自定义"
 "Gesture Button": "手势按钮"
+"Haptic Panel": "触感面板"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
+"Haptic Panel": "觸感面板"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -169,6 +169,7 @@ _version: 1
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
+"Haptic Panel": "觸感面板"
 "Up": "上"
 "Down": "下"
 "Left": "左"

--- a/crates/openlogi-gui/src/mouse_model/geometry.rs
+++ b/crates/openlogi-gui/src/mouse_model/geometry.rs
@@ -184,6 +184,10 @@ fn map_slot_name(name: &str) -> Option<MouseControlId> {
         "SLOT_NAME_MODESHIFT_BUTTON" => Some(MouseControlId::Button(ButtonId::DpiToggle)),
         "SLOT_NAME_THUMBWHEEL" => Some(MouseControlId::ThumbwheelRotation),
         "SLOT_NAME_GESTURE_BUTTON" => Some(MouseControlId::Button(ButtonId::GestureButton)),
+        // The MX Master 4 Haptic Sense Panel. Logi names the slot after its
+        // Options+ default assignment (the radial Actions Ring menu), but the
+        // marker is the panel itself.
+        "ASSIGNMENT_NAME_SHOW_RADIAL_MENU" => Some(MouseControlId::Button(ButtonId::HapticPanel)),
         _ => None,
     }
 }

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -263,10 +263,12 @@ fn scaled_model(
 }
 
 /// The gesture-capable buttons present on this device, in a stable display
-/// order: the HID++ gesture button first, then the OS-hook Middle/Back/Forward.
+/// order: the HID++ sources (gesture button, haptic panel) first, then the
+/// OS-hook Middle/Back/Forward.
 fn gesture_capable_buttons(labels: &[Label]) -> Vec<ButtonId> {
-    const ORDER: [ButtonId; 4] = [
+    const ORDER: [ButtonId; 5] = [
         ButtonId::GestureButton,
+        ButtonId::HapticPanel,
         ButtonId::MiddleClick,
         ButtonId::Back,
         ButtonId::Forward,

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -104,36 +104,43 @@ pub const DIVERTABLE_STANDARD_BUTTONS: [(u16, ButtonId); 3] = [
     (0x0056, ButtonId::Forward),
 ];
 
+/// HID++ gesture sources: the `0x1b04` control ID and the [`ButtonId`] it
+/// delivers — the dedicated gesture button on most MX mice, and the Haptic
+/// Sense Panel on MX Master 4 (two distinct physical controls). The one that
+/// owns the gesture role is diverted with raw-XY; either is plain-diverted
+/// like a standard button when its binding leaves the default without the
+/// role.
+pub const GESTURE_SOURCE_BUTTONS: [(u16, ButtonId); 2] = [
+    (reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton),
+    (reprog_controls::HAPTIC_PANEL_CID, ButtonId::HapticPanel),
+];
+
 /// Which of one device's controls a capture session should divert.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CaptureSpec {
     /// Divert the thumb wheel over `0x2150` (rotation rebind / sensitivity /
     /// click bound).
     pub capture_thumbwheel: bool,
-    /// Divert the device's gesture sources — the
-    /// [`reprog_controls::GESTURE_SOURCE_CIDS`] members it exposes — with
-    /// raw-XY (the HID++ gesture control owns the gesture role).
-    pub divert_gesture_button: bool,
+    /// The gesture owner's source CID (a [`GESTURE_SOURCE_BUTTONS`] member) to
+    /// divert with raw-XY, or `None` when no HID++ control owns the gesture
+    /// role.
+    pub divert_gesture_source: Option<u16>,
     /// Buttons to divert as plain presses (no raw-XY): the
-    /// [`DIVERTABLE_STANDARD_BUTTONS`] whose binding leaves the default, plus
-    /// the gesture sources (marked by `GESTURE_BUTTON_CID`) when
-    /// [`ButtonId::GestureButton`] carries a non-default single binding
-    /// without owning the gesture role.
+    /// [`DIVERTABLE_STANDARD_BUTTONS`] and non-owner [`GESTURE_SOURCE_BUTTONS`]
+    /// whose binding leaves the default.
     pub divert_buttons: Vec<(u16, ButtonId)>,
 }
 
 /// Capture the controls selected by `spec` on `route` until `shutdown`
 /// resolves, forwarding each event to `sink`.
 ///
-/// The device's gesture sources (raw-XY) are diverted only when
-/// `spec.divert_gesture_button` — i.e. the HID++ gesture control is the
-/// device's gesture owner. When the user moves the gesture role to an OS-hook
-/// button or turns gestures off, the gesture sources keep their native
-/// behavior — unless a non-default single binding puts them in
-/// `spec.divert_buttons`, in which case they are diverted as plain buttons
-/// (the OS hook never sees a gesture-source CID, so this is the binding's
-/// only delivery path). The DPI/ModeShift capture and the channel-reuse slot
-/// are independent of this.
+/// Only the gesture owner's source (`spec.divert_gesture_source`) is diverted
+/// with raw-XY. When the user moves the gesture role to an OS-hook button or
+/// turns gestures off, the gesture sources keep their native behavior —
+/// unless a non-default single binding puts them in `spec.divert_buttons`, in
+/// which case they are diverted as plain buttons (the OS hook never sees a
+/// gesture-source CID, so this is the binding's only delivery path). The
+/// DPI/ModeShift capture and the channel-reuse slot are independent of this.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
 /// device exposes, and listens. Returns once `shutdown` fires (or its sender is
@@ -160,7 +167,7 @@ pub async fn run_capture_session(
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
-    let gesture_cids = armed.gesture_cids.clone();
+    let gesture_cid = armed.gesture_cid;
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
     let dpi_set = armed.dpi_cids.clone();
     let button_set = armed.button_cids.clone();
@@ -178,7 +185,7 @@ pub async fn run_capture_session(
                 // Recover the guard even if a prior holder panicked — the
                 // critical section is panic-free, so the data is consistent.
                 let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(&mut acc, event, &gesture_cids, &dpi_set, &button_set, &sink);
+                handle_reprog(&mut acc, event, gesture_cid, &dpi_set, &button_set, &sink);
                 return;
             }
             if let Some(idx) = thumb_index
@@ -196,7 +203,7 @@ pub async fn run_capture_session(
 
     info!(
         index = device_index,
-        gesture_sources = armed.gesture_cids.len(),
+        gesture = armed.gesture_cid.is_some(),
         dpi_buttons = armed.dpi_cids.len(),
         buttons = armed.button_cids.len(),
         thumbwheel = armed.thumb.is_some(),
@@ -238,7 +245,9 @@ pub async fn run_capture_session_with_stop_reason(
     });
     let spec = CaptureSpec {
         capture_thumbwheel,
-        divert_gesture_button,
+        // The bool-era API only ever meant the dedicated gesture button; the
+        // haptic panel is reachable through [`CaptureSpec`] itself.
+        divert_gesture_source: divert_gesture_button.then_some(reprog_controls::GESTURE_BUTTON_CID),
         divert_buttons: Vec::new(),
     };
     run_capture_session(route, spec, sink, rx, channel_slot).await
@@ -270,8 +279,9 @@ pub async fn run_capture_session_with_registry(
 struct ArmedControls {
     /// `0x1b04` accessor + feature index, present when the device exposes it.
     reprog: Option<(ReprogControlsV4, u8)>,
-    /// Gesture-source CIDs diverted with raw-XY reporting.
-    gesture_cids: Vec<u16>,
+    /// The gesture-source CID diverted with raw-XY reporting, when the spec
+    /// selected one and the device exposes it.
+    gesture_cid: Option<u16>,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
     /// Standard-button CIDs diverted per the session's [`CaptureSpec`], with
@@ -286,7 +296,7 @@ impl ArmedControls {
     /// Restore every diverted control. Failures are logged, not propagated.
     async fn disarm(&self) {
         if let Some((rc, _)) = self.reprog.as_ref() {
-            for &cid in &self.gesture_cids {
+            if let Some(cid) = self.gesture_cid {
                 let r = rc.set_cid_reporting(cid, false, false).await;
                 restore(r, "gesture source");
             }
@@ -321,7 +331,7 @@ async fn arm_controls(
         .map_err(|_| GestureError::DeviceUnreachable(slot))?;
 
     let mut reprog: Option<(ReprogControlsV4, u8)> = None;
-    let mut gesture_cids: Vec<u16> = Vec::new();
+    let mut gesture_cid: Option<u16> = None;
     let mut dpi_cids: Vec<u16> = Vec::new();
     let mut button_cids: Vec<(u16, ButtonId)> = Vec::new();
     if let Some(info) = device
@@ -333,15 +343,16 @@ async fn arm_controls(
         let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
         let controls = enumerate_controls(&rc).await?;
 
-        // Only divert a gesture source when it owns the gesture role; otherwise
-        // leave it native (a non-owner HID++ control must not be captured-and-dropped).
-        if spec.divert_gesture_button {
-            for cid in gesture_source_cids(&controls) {
-                rc.set_cid_reporting(cid, true, true)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                gesture_cids.push(cid);
-            }
+        // Only divert the gesture owner's source; every other gesture source
+        // stays native (a non-owner HID++ control must not be
+        // captured-and-dropped).
+        if let Some(cid) = spec.divert_gesture_source
+            && controls.iter().any(|c| c.cid == cid && c.supports_raw_xy())
+        {
+            rc.set_cid_reporting(cid, true, true)
+                .await
+                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+            gesture_cid = Some(cid);
         }
         for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
@@ -352,28 +363,17 @@ async fn arm_controls(
             }
         }
         for &(cid, button) in &spec.divert_buttons {
-            // [`ButtonId::GestureButton`]'s physical control differs per
-            // device, so its marker CID expands to every gesture source the
-            // device exposes.
-            let targets: &[u16] = if cid == reprog_controls::GESTURE_BUTTON_CID {
-                &reprog_controls::GESTURE_SOURCE_CIDS
-            } else {
-                std::slice::from_ref(&cid)
-            };
-            for &cid in targets {
-                // The plan never lists a gesture-source CID while the raw-XY
-                // gesture divert owns it, but guard anyway: a plain (divert, no
-                // raw-XY) write here would strip the raw-XY reporting armed
-                // above.
-                if gesture_cids.contains(&cid) {
-                    continue;
-                }
-                if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-                    rc.set_cid_reporting(cid, true, false)
-                        .await
-                        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                    button_cids.push((cid, button));
-                }
+            // The plan never lists the raw-XY-diverted gesture source, but
+            // guard anyway: a plain (divert, no raw-XY) write here would strip
+            // the raw-XY reporting armed above.
+            if gesture_cid == Some(cid) {
+                continue;
+            }
+            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+                rc.set_cid_reporting(cid, true, false)
+                    .await
+                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                button_cids.push((cid, button));
             }
         }
         reprog = Some((rc, info.index));
@@ -411,26 +411,16 @@ async fn arm_controls(
         thumb = Some((tw, info.index));
     }
 
-    if gesture_cids.is_empty() && dpi_cids.is_empty() && button_cids.is_empty() && thumb.is_none() {
+    if gesture_cid.is_none() && dpi_cids.is_empty() && button_cids.is_empty() && thumb.is_none() {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(ArmedControls {
         reprog,
-        gesture_cids,
+        gesture_cid,
         dpi_cids,
         button_cids,
         thumb,
     })
-}
-
-/// The gesture-source CIDs to divert with raw-XY on this device: the members
-/// of [`reprog_controls::GESTURE_SOURCE_CIDS`] its control table exposes with
-/// raw-XY support.
-fn gesture_source_cids(controls: &[reprog_controls::CtrlIdInfo]) -> Vec<u16> {
-    reprog_controls::GESTURE_SOURCE_CIDS
-        .into_iter()
-        .filter(|&cid| controls.iter().any(|c| c.cid == cid && c.supports_raw_xy()))
-        .collect()
 }
 
 /// Log (don't propagate) a failure to hand a control back to the firmware.
@@ -467,7 +457,7 @@ pub(crate) async fn enumerate_controls(
 fn handle_reprog(
     acc: &mut CaptureAccum,
     event: RawControlEvent,
-    gesture_cids: &[u16],
+    gesture_cid: Option<u16>,
     dpi_cids: &[u16],
     button_cids: &[(u16, ButtonId)],
     sink: &mpsc::UnboundedSender<CapturedInput>,
@@ -479,11 +469,11 @@ fn handle_reprog(
             // (it has a single binding but not the gesture role), its press
             // must flow through the `button_cids` loop only — not also emit a
             // click.
-            let held_source = gesture_cids.iter().find(|cid| cids.contains(cid));
-            if let Some(&cid) = held_source {
+            let owner_held = gesture_cid.is_some_and(|cid| cids.contains(&cid));
+            if owner_held {
                 if !acc.swipe.is_holding() {
                     acc.swipe.begin();
-                    acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID;
+                    acc.skip_first_raw_xy = gesture_cid == Some(reprog_controls::HAPTIC_PANEL_CID);
                 }
             } else if acc.swipe.is_holding() {
                 // A press that never committed a direction is a plain click.

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -1,6 +1,6 @@
-//! Live control capture for one device: divert the MX dedicated gesture button, the
-//! DPI/ModeShift button, and the thumb wheel over HID++ and turn their events
-//! into [`CapturedInput`] the GUI can dispatch.
+//! Live control capture for one device: divert the device's gesture source,
+//! the DPI/ModeShift button, and the thumb wheel over HID++ and turn their
+//! events into [`CapturedInput`] the GUI can dispatch.
 //!
 //! [`run_capture_session`] holds a single HID++ channel open for one device,
 //! enables diversion on whichever of those controls it exposes, registers one
@@ -80,7 +80,7 @@ pub enum GestureError {
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
-    /// Mid-swipe state for the diverted dedicated gesture button (raw-XY).
+    /// Mid-swipe state for the diverted gesture source (raw-XY).
     swipe: SwipeAccumulator,
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
@@ -105,27 +105,30 @@ pub struct CaptureSpec {
     /// Divert the thumb wheel over `0x2150` (rotation rebind / sensitivity /
     /// click bound).
     pub capture_thumbwheel: bool,
-    /// Divert the dedicated gesture button with raw-XY (it owns the gesture
-    /// role).
+    /// Divert the device's gesture sources — the
+    /// [`reprog_controls::GESTURE_SOURCE_CIDS`] members it exposes — with
+    /// raw-XY (the HID++ gesture control owns the gesture role).
     pub divert_gesture_button: bool,
     /// Buttons to divert as plain presses (no raw-XY): the
     /// [`DIVERTABLE_STANDARD_BUTTONS`] whose binding leaves the default, plus
-    /// the dedicated gesture button when it carries a non-default single
-    /// binding without owning the gesture role.
+    /// the gesture sources (marked by `GESTURE_BUTTON_CID`) when
+    /// [`ButtonId::GestureButton`] carries a non-default single binding
+    /// without owning the gesture role.
     pub divert_buttons: Vec<(u16, ButtonId)>,
 }
 
 /// Capture the controls selected by `spec` on `route` until `shutdown`
 /// resolves, forwarding each event to `sink`.
 ///
-/// The dedicated gesture button (raw-XY) is diverted only when
-/// `spec.divert_gesture_button` — i.e. it is the device's gesture owner. When
-/// the user moves the gesture role to an OS-hook button or turns gestures off,
-/// the HID++ gesture control keeps its native behavior — unless a non-default
-/// single binding puts it in `spec.divert_buttons`, in which case it is
-/// diverted as a plain button (the OS hook never sees CID `0x00c3`, so this is
-/// the binding's only delivery path). The DPI/ModeShift capture and the
-/// channel-reuse slot are independent of this.
+/// The device's gesture sources (raw-XY) are diverted only when
+/// `spec.divert_gesture_button` — i.e. the HID++ gesture control is the
+/// device's gesture owner. When the user moves the gesture role to an OS-hook
+/// button or turns gestures off, the gesture sources keep their native
+/// behavior — unless a non-default single binding puts them in
+/// `spec.divert_buttons`, in which case they are diverted as plain buttons
+/// (the OS hook never sees a gesture-source CID, so this is the binding's
+/// only delivery path). The DPI/ModeShift capture and the channel-reuse slot
+/// are independent of this.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
 /// device exposes, and listens. Returns once `shutdown` fires (or its sender is
@@ -152,7 +155,7 @@ pub async fn run_capture_session(
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
-    let gesture_diverted = armed.gesture_diverted;
+    let gesture_cids = armed.gesture_cids.clone();
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
     let dpi_set = armed.dpi_cids.clone();
     let button_set = armed.button_cids.clone();
@@ -170,14 +173,7 @@ pub async fn run_capture_session(
                 // Recover the guard even if a prior holder panicked — the
                 // critical section is panic-free, so the data is consistent.
                 let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(
-                    &mut acc,
-                    event,
-                    gesture_diverted,
-                    &dpi_set,
-                    &button_set,
-                    &sink,
-                );
+                handle_reprog(&mut acc, event, &gesture_cids, &dpi_set, &button_set, &sink);
                 return;
             }
             if let Some(idx) = thumb_index
@@ -195,7 +191,7 @@ pub async fn run_capture_session(
 
     info!(
         index = device_index,
-        gesture = armed.gesture_diverted,
+        gesture_sources = armed.gesture_cids.len(),
         dpi_buttons = armed.dpi_cids.len(),
         buttons = armed.button_cids.len(),
         thumbwheel = armed.thumb.is_some(),
@@ -269,8 +265,8 @@ pub async fn run_capture_session_with_registry(
 struct ArmedControls {
     /// `0x1b04` accessor + feature index, present when the device exposes it.
     reprog: Option<(ReprogControlsV4, u8)>,
-    /// Whether the gesture button is diverted with raw-XY reporting.
-    gesture_diverted: bool,
+    /// Gesture-source CIDs diverted with raw-XY reporting.
+    gesture_cids: Vec<u16>,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
     /// Standard-button CIDs diverted per the session's [`CaptureSpec`], with
@@ -285,11 +281,9 @@ impl ArmedControls {
     /// Restore every diverted control. Failures are logged, not propagated.
     async fn disarm(&self) {
         if let Some((rc, _)) = self.reprog.as_ref() {
-            if self.gesture_diverted {
-                let r = rc
-                    .set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, false, false)
-                    .await;
-                restore(r, "gesture button");
+            for &cid in &self.gesture_cids {
+                let r = rc.set_cid_reporting(cid, false, false).await;
+                restore(r, "gesture source");
             }
             for &cid in &self.dpi_cids {
                 restore(rc.set_cid_reporting(cid, false, false).await, "DPI button");
@@ -322,7 +316,7 @@ async fn arm_controls(
         .map_err(|_| GestureError::DeviceUnreachable(slot))?;
 
     let mut reprog: Option<(ReprogControlsV4, u8)> = None;
-    let mut gesture_diverted = false;
+    let mut gesture_cids: Vec<u16> = Vec::new();
     let mut dpi_cids: Vec<u16> = Vec::new();
     let mut button_cids: Vec<(u16, ButtonId)> = Vec::new();
     if let Some(info) = device
@@ -334,17 +328,15 @@ async fn arm_controls(
         let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
         let controls = enumerate_controls(&rc).await?;
 
-        // Only divert the gesture button when it owns the gesture role; otherwise
+        // Only divert a gesture source when it owns the gesture role; otherwise
         // leave it native (a non-owner HID++ control must not be captured-and-dropped).
-        if spec.divert_gesture_button
-            && controls
-                .iter()
-                .any(|c| c.cid == reprog_controls::GESTURE_BUTTON_CID && c.supports_raw_xy())
-        {
-            rc.set_cid_reporting(reprog_controls::GESTURE_BUTTON_CID, true, true)
-                .await
-                .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-            gesture_diverted = true;
+        if spec.divert_gesture_button {
+            for cid in gesture_source_cids(&controls) {
+                rc.set_cid_reporting(cid, true, true)
+                    .await
+                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                gesture_cids.push(cid);
+            }
         }
         for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
@@ -355,17 +347,28 @@ async fn arm_controls(
             }
         }
         for &(cid, button) in &spec.divert_buttons {
-            // The plan never lists CID 0x00c3 while the raw-XY gesture divert
-            // owns it, but guard anyway: a plain (divert, no raw-XY) write here
-            // would strip the raw-XY reporting armed above.
-            if gesture_diverted && cid == reprog_controls::GESTURE_BUTTON_CID {
-                continue;
-            }
-            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-                rc.set_cid_reporting(cid, true, false)
-                    .await
-                    .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
-                button_cids.push((cid, button));
+            // [`ButtonId::GestureButton`]'s physical control differs per
+            // device, so its marker CID expands to every gesture source the
+            // device exposes.
+            let targets: &[u16] = if cid == reprog_controls::GESTURE_BUTTON_CID {
+                &reprog_controls::GESTURE_SOURCE_CIDS
+            } else {
+                std::slice::from_ref(&cid)
+            };
+            for &cid in targets {
+                // The plan never lists a gesture-source CID while the raw-XY
+                // gesture divert owns it, but guard anyway: a plain (divert, no
+                // raw-XY) write here would strip the raw-XY reporting armed
+                // above.
+                if gesture_cids.contains(&cid) {
+                    continue;
+                }
+                if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
+                    rc.set_cid_reporting(cid, true, false)
+                        .await
+                        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
+                    button_cids.push((cid, button));
+                }
             }
         }
         reprog = Some((rc, info.index));
@@ -403,16 +406,26 @@ async fn arm_controls(
         thumb = Some((tw, info.index));
     }
 
-    if !gesture_diverted && dpi_cids.is_empty() && button_cids.is_empty() && thumb.is_none() {
+    if gesture_cids.is_empty() && dpi_cids.is_empty() && button_cids.is_empty() && thumb.is_none() {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(ArmedControls {
         reprog,
-        gesture_diverted,
+        gesture_cids,
         dpi_cids,
         button_cids,
         thumb,
     })
+}
+
+/// The gesture-source CIDs to divert with raw-XY on this device: the members
+/// of [`reprog_controls::GESTURE_SOURCE_CIDS`] its control table exposes with
+/// raw-XY support.
+fn gesture_source_cids(controls: &[reprog_controls::CtrlIdInfo]) -> Vec<u16> {
+    reprog_controls::GESTURE_SOURCE_CIDS
+        .into_iter()
+        .filter(|&cid| controls.iter().any(|c| c.cid == cid && c.supports_raw_xy()))
+        .collect()
 }
 
 /// Log (don't propagate) a failure to hand a control back to the firmware.
@@ -449,7 +462,7 @@ pub(crate) async fn enumerate_controls(
 fn handle_reprog(
     acc: &mut CaptureAccum,
     event: RawControlEvent,
-    gesture_diverted: bool,
+    gesture_cids: &[u16],
     dpi_cids: &[u16],
     button_cids: &[(u16, ButtonId)],
     sink: &mpsc::UnboundedSender<CapturedInput>,
@@ -457,19 +470,20 @@ fn handle_reprog(
     match event {
         RawControlEvent::DivertedButtons(cids) => {
             // The swipe accumulator belongs to the raw-XY gesture divert. When
-            // the gesture button is instead diverted as a plain button (it has
-            // a single binding but not the gesture role), its press must flow
-            // through the `button_cids` loop only — not also emit a click.
-            if gesture_diverted {
-                let gesture_held = cids.contains(&reprog_controls::GESTURE_BUTTON_CID);
-                if gesture_held && !acc.swipe.is_holding() {
+            // a gesture-source control is instead diverted as a plain button
+            // (it has a single binding but not the gesture role), its press
+            // must flow through the `button_cids` loop only — not also emit a
+            // click.
+            let held_source = gesture_cids.iter().find(|cid| cids.contains(cid));
+            if held_source.is_some() {
+                if !acc.swipe.is_holding() {
                     acc.swipe.begin();
-                } else if !gesture_held && acc.swipe.is_holding() {
-                    // A press that never committed a direction is a plain click.
-                    if acc.swipe.end() {
-                        debug!("gesture click");
-                        let _ = sink.send(CapturedInput::Gesture(GestureDirection::Click));
-                    }
+                }
+            } else if acc.swipe.is_holding() {
+                // A press that never committed a direction is a plain click.
+                if acc.swipe.end() {
+                    debug!("gesture click");
+                    let _ = sink.send(CapturedInput::Gesture(GestureDirection::Click));
                 }
             }
 

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -1,6 +1,7 @@
-//! Live control capture for one device: divert the device's gesture source,
-//! the DPI/ModeShift button, and the thumb wheel over HID++ and turn their
-//! events into [`CapturedInput`] the GUI can dispatch.
+//! Live control capture for one device: divert the device's gesture source
+//! (the MX dedicated gesture button, or the MX Master 4 haptic panel), the
+//! DPI/ModeShift button, and the thumb wheel over HID++ and turn their events
+//! into [`CapturedInput`] the GUI can dispatch.
 //!
 //! [`run_capture_session`] holds a single HID++ channel open for one device,
 //! enables diversion on whichever of those controls it exposes, registers one
@@ -82,6 +83,10 @@ pub enum GestureError {
 struct CaptureAccum {
     /// Mid-swipe state for the diverted gesture source (raw-XY).
     swipe: SwipeAccumulator,
+    /// Whether the current hold's next raw-XY sample must be dropped: the
+    /// haptic panel's first sample after contact is an absolute position
+    /// jump, not a delta (see [`reprog_controls::HAPTIC_PANEL_CID`]).
+    skip_first_raw_xy: bool,
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
@@ -475,9 +480,10 @@ fn handle_reprog(
             // must flow through the `button_cids` loop only — not also emit a
             // click.
             let held_source = gesture_cids.iter().find(|cid| cids.contains(cid));
-            if held_source.is_some() {
+            if let Some(&cid) = held_source {
                 if !acc.swipe.is_holding() {
                     acc.swipe.begin();
+                    acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID;
                 }
             } else if acc.swipe.is_holding() {
                 // A press that never committed a direction is a plain click.
@@ -505,6 +511,12 @@ fn handle_reprog(
             }
         }
         RawControlEvent::RawXy { dx, dy } => {
+            // The haptic panel's first sample after contact is a position
+            // jump; summing it would commit a bogus direction instantly.
+            if acc.skip_first_raw_xy {
+                acc.skip_first_raw_xy = false;
+                return;
+            }
             // Commit the instant a clean direction emerges (mid-swipe, once per
             // hold); the accumulator gates on hold duration internally and drops
             // travel that arrives outside a hold.

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -12,17 +12,18 @@ fn release() -> RawControlEvent {
 fn quick_tap_is_a_click_even_while_the_cursor_moves() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
+    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, press(), true, &[], &[], &tx);
+    handle_reprog(&mut acc, press(), &sources, &[], &[], &tx);
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        true,
+        &sources,
         &[],
         &[],
         &tx,
     );
-    handle_reprog(&mut acc, release(), true, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), &sources, &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -38,14 +39,15 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
 fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
+    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, press(), true, &[], &[], &tx);
+    handle_reprog(&mut acc, press(), &sources, &[], &[], &tx);
     // Pretend the button has been held well past the swipe gate.
     acc.swipe.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        true,
+        &sources,
         &[],
         &[],
         &tx,
@@ -56,7 +58,7 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
         Ok(CapturedInput::Gesture(GestureDirection::Right))
     );
 
-    handle_reprog(&mut acc, release(), true, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), &sources, &[], &[], &tx);
     assert!(
         rx.try_recv().is_err(),
         "a committed swipe must not also click on release"
@@ -73,8 +75,8 @@ fn a_plain_diverted_gesture_button_presses_without_gesturing() {
     let mut acc = CaptureAccum::default();
     let buttons = [(reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)];
 
-    handle_reprog(&mut acc, press(), false, &[], &buttons, &tx);
-    handle_reprog(&mut acc, release(), false, &[], &buttons, &tx);
+    handle_reprog(&mut acc, press(), &[], &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), &[], &[], &buttons, &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -92,9 +94,10 @@ fn a_held_dpi_button_presses_once_on_the_rising_edge() {
     let mut acc = CaptureAccum::default();
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
+    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
-    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -113,10 +116,11 @@ fn a_dpi_button_re_presses_after_a_release() {
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
     let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
+    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
-    handle_reprog(&mut acc, up, true, &[dpi], &[], &tx);
-    handle_reprog(&mut acc, down, true, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, up, &sources, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -1,11 +1,7 @@
 use super::*;
 
-/// The gesture sources of a device exposing both the dedicated button and the
-/// MX Master 4 haptic panel — the widest arming `arm_controls` can produce.
-const BOTH_SOURCES: [u16; 2] = [
-    reprog_controls::GESTURE_BUTTON_CID,
-    reprog_controls::HAPTIC_PANEL_CID,
-];
+const GESTURE: Option<u16> = Some(reprog_controls::GESTURE_BUTTON_CID);
+const PANEL: Option<u16> = Some(reprog_controls::HAPTIC_PANEL_CID);
 
 fn press() -> RawControlEvent {
     RawControlEvent::DivertedButtons([reprog_controls::GESTURE_BUTTON_CID, 0, 0, 0])
@@ -23,18 +19,17 @@ fn release() -> RawControlEvent {
 fn quick_tap_is_a_click_even_while_the_cursor_moves() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
-    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, press(), &sources, &[], &[], &tx);
+    handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        &sources,
+        GESTURE,
         &[],
         &[],
         &tx,
     );
-    handle_reprog(&mut acc, release(), &sources, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), GESTURE, &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -50,15 +45,14 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
 fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
-    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, press(), &sources, &[], &[], &tx);
+    handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
     // Pretend the button has been held well past the swipe gate.
     acc.swipe.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        &sources,
+        GESTURE,
         &[],
         &[],
         &tx,
@@ -69,7 +63,7 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
         Ok(CapturedInput::Gesture(GestureDirection::Right))
     );
 
-    handle_reprog(&mut acc, release(), &sources, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), GESTURE, &[], &[], &tx);
     assert!(
         rx.try_recv().is_err(),
         "a committed swipe must not also click on release"
@@ -77,20 +71,20 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
 }
 
 #[test]
-fn the_haptic_panel_gestures_like_the_dedicated_button() {
-    // On MX Master 4 the gesture role is delivered by the haptic panel (CID
-    // 0x01a0): its press must begin a hold and its raw-XY must commit a swipe,
-    // even when the dedicated button's CID is also armed.
+fn the_haptic_panel_gestures_when_it_owns_the_role() {
+    // On MX Master 4 the panel (CID 0x01a0) can own the gesture role: its
+    // press begins a hold, its contact jump is discarded, and the raw-XY that
+    // follows commits a swipe.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, panel_press(), &BOTH_SOURCES, &[], &[], &tx);
+    handle_reprog(&mut acc, panel_press(), PANEL, &[], &[], &tx);
     acc.swipe.backdate_hold_for_test();
     // The panel's contact jump, discarded before the accumulator sees it.
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: -3000, dy: 40 },
-        &BOTH_SOURCES,
+        PANEL,
         &[],
         &[],
         &tx,
@@ -99,7 +93,7 @@ fn the_haptic_panel_gestures_like_the_dedicated_button() {
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 5, dy: -120 },
-        &BOTH_SOURCES,
+        PANEL,
         &[],
         &[],
         &tx,
@@ -110,7 +104,7 @@ fn the_haptic_panel_gestures_like_the_dedicated_button() {
         Ok(CapturedInput::Gesture(GestureDirection::Up))
     );
 
-    handle_reprog(&mut acc, release(), &BOTH_SOURCES, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), PANEL, &[], &[], &tx);
     assert!(
         rx.try_recv().is_err(),
         "a committed panel swipe must not also click on release"
@@ -122,8 +116,8 @@ fn a_quick_panel_tap_is_a_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, panel_press(), &BOTH_SOURCES, &[], &[], &tx);
-    handle_reprog(&mut acc, release(), &BOTH_SOURCES, &[], &[], &tx);
+    handle_reprog(&mut acc, panel_press(), PANEL, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), PANEL, &[], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -143,13 +137,13 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, panel_press(), &BOTH_SOURCES, &[], &[], &tx);
+    handle_reprog(&mut acc, panel_press(), PANEL, &[], &[], &tx);
     acc.swipe.backdate_hold_for_test();
     // The contact jump — leftward, far past every threshold.
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: -3000, dy: 40 },
-        &BOTH_SOURCES,
+        PANEL,
         &[],
         &[],
         &tx,
@@ -163,7 +157,7 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        &BOTH_SOURCES,
+        PANEL,
         &[],
         &[],
         &tx,
@@ -181,12 +175,12 @@ fn the_dedicated_buttons_first_sample_is_not_discarded() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
-    handle_reprog(&mut acc, press(), &BOTH_SOURCES, &[], &[], &tx);
+    handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
     acc.swipe.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
-        &BOTH_SOURCES,
+        GESTURE,
         &[],
         &[],
         &tx,
@@ -200,70 +194,28 @@ fn the_dedicated_buttons_first_sample_is_not_discarded() {
 }
 
 #[test]
-fn a_plain_diverted_haptic_panel_presses_as_the_gesture_button() {
-    // With gestures off and a single binding on [`ButtonId::GestureButton`],
-    // the MX Master 4 panel is plain-diverted and its press must deliver that
-    // binding — the panel is the gesture button on that model.
+fn a_non_owner_gesture_source_does_not_gesture() {
+    // The panel owns the gesture role; a dedicated-button press must not
+    // begin a hold, emit a click, or feed the swipe accumulator — the two
+    // sources are distinct physical controls.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
-    let buttons = [(reprog_controls::HAPTIC_PANEL_CID, ButtonId::GestureButton)];
 
-    handle_reprog(&mut acc, panel_press(), &[], &[], &buttons, &tx);
-    handle_reprog(&mut acc, release(), &[], &[], &buttons, &tx);
-
-    assert_eq!(
-        rx.try_recv(),
-        Ok(CapturedInput::ButtonPressed(ButtonId::GestureButton, None))
+    handle_reprog(&mut acc, press(), PANEL, &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        PANEL,
+        &[],
+        &[],
+        &tx,
     );
+    handle_reprog(&mut acc, release(), PANEL, &[], &[], &tx);
+
     assert!(
         rx.try_recv().is_err(),
-        "a plain-diverted panel must not also emit a gesture click"
-    );
-}
-
-#[test]
-fn gesture_source_discovery_arms_whatever_the_device_exposes() {
-    let raw_xy_flags =
-        (reprog_controls::CidFlags::RAW_XY | reprog_controls::CidFlags::DIVERTABLE).bits();
-    // MX Master 3S-style entry: the dedicated button, with raw-XY.
-    let dedicated = reprog_controls::CtrlIdInfo {
-        cid: reprog_controls::GESTURE_BUTTON_CID,
-        task_id: 0,
-        flags: raw_xy_flags,
-    };
-    // MX Master 4-style haptic panel entry.
-    let panel = reprog_controls::CtrlIdInfo {
-        cid: reprog_controls::HAPTIC_PANEL_CID,
-        task_id: 0,
-        flags: raw_xy_flags,
-    };
-    // A control without raw-XY can't decode swipes — never a gesture source.
-    let no_raw_xy = reprog_controls::CtrlIdInfo {
-        cid: reprog_controls::HAPTIC_PANEL_CID,
-        task_id: 0,
-        flags: reprog_controls::CidFlags::DIVERTABLE.bits(),
-    };
-
-    assert_eq!(
-        gesture_source_cids(&[dedicated]),
-        vec![reprog_controls::GESTURE_BUTTON_CID]
-    );
-    assert_eq!(
-        gesture_source_cids(&[panel]),
-        vec![reprog_controls::HAPTIC_PANEL_CID]
-    );
-    assert_eq!(
-        gesture_source_cids(&[dedicated, panel]),
-        vec![
-            reprog_controls::GESTURE_BUTTON_CID,
-            reprog_controls::HAPTIC_PANEL_CID
-        ],
-        "a device exposing both arms both"
-    );
-    assert_eq!(
-        gesture_source_cids(&[no_raw_xy]),
-        Vec::<u16>::new(),
-        "raw-XY support is required"
+        "a non-owner source must neither gesture nor click"
     );
 }
 
@@ -277,8 +229,8 @@ fn a_plain_diverted_gesture_button_presses_without_gesturing() {
     let mut acc = CaptureAccum::default();
     let buttons = [(reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)];
 
-    handle_reprog(&mut acc, press(), &[], &[], &buttons, &tx);
-    handle_reprog(&mut acc, release(), &[], &[], &buttons, &tx);
+    handle_reprog(&mut acc, press(), None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), None, &[], &buttons, &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -291,15 +243,36 @@ fn a_plain_diverted_gesture_button_presses_without_gesturing() {
 }
 
 #[test]
+fn a_plain_diverted_haptic_panel_presses_as_its_own_button() {
+    // A single action bound to the panel (which does not own the gesture
+    // role) is delivered as ButtonId::HapticPanel — its own control, never
+    // conflated with the dedicated gesture button.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let buttons = [(reprog_controls::HAPTIC_PANEL_CID, ButtonId::HapticPanel)];
+
+    handle_reprog(&mut acc, panel_press(), None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), None, &[], &buttons, &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::HapticPanel, None))
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "a plain-diverted panel must not also emit a gesture click"
+    );
+}
+
+#[test]
 fn a_held_dpi_button_presses_once_on_the_rising_edge() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
-    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
-    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, GESTURE, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, GESTURE, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -318,11 +291,10 @@ fn a_dpi_button_re_presses_after_a_release() {
     let dpi = reprog_controls::DPI_MODE_SHIFT_CIDS[0];
     let down = RawControlEvent::DivertedButtons([dpi, 0, 0, 0]);
     let up = RawControlEvent::DivertedButtons([0, 0, 0, 0]);
-    let sources = [reprog_controls::GESTURE_BUTTON_CID];
 
-    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
-    handle_reprog(&mut acc, up, &sources, &[dpi], &[], &tx);
-    handle_reprog(&mut acc, down, &sources, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, GESTURE, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, up, GESTURE, &[dpi], &[], &tx);
+    handle_reprog(&mut acc, down, GESTURE, &[dpi], &[], &tx);
 
     assert_eq!(
         rx.try_recv(),

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -1,7 +1,18 @@
 use super::*;
 
+/// The gesture sources of a device exposing both the dedicated button and the
+/// MX Master 4 haptic panel — the widest arming `arm_controls` can produce.
+const BOTH_SOURCES: [u16; 2] = [
+    reprog_controls::GESTURE_BUTTON_CID,
+    reprog_controls::HAPTIC_PANEL_CID,
+];
+
 fn press() -> RawControlEvent {
     RawControlEvent::DivertedButtons([reprog_controls::GESTURE_BUTTON_CID, 0, 0, 0])
+}
+
+fn panel_press() -> RawControlEvent {
+    RawControlEvent::DivertedButtons([reprog_controls::HAPTIC_PANEL_CID, 0, 0, 0])
 }
 
 fn release() -> RawControlEvent {
@@ -62,6 +73,203 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
     assert!(
         rx.try_recv().is_err(),
         "a committed swipe must not also click on release"
+    );
+}
+
+#[test]
+#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
+fn the_haptic_panel_gestures_like_the_dedicated_button() {
+    // On MX Master 4 the gesture role is delivered by the haptic panel (CID
+    // 0x01a0): its press must begin a hold and its raw-XY must commit a swipe,
+    // even when the dedicated button's CID is also armed.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, panel_press(), &BOTH_SOURCES, &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    // The panel's contact jump, discarded before the accumulator sees it.
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -3000, dy: 40 },
+        &BOTH_SOURCES,
+        &[],
+        &[],
+        &tx,
+    );
+    // The real swipe that follows.
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 5, dy: -120 },
+        &BOTH_SOURCES,
+        &[],
+        &[],
+        &tx,
+    );
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(GestureDirection::Up))
+    );
+
+    handle_reprog(&mut acc, release(), &BOTH_SOURCES, &[], &[], &tx);
+    assert!(
+        rx.try_recv().is_err(),
+        "a committed panel swipe must not also click on release"
+    );
+}
+
+#[test]
+#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
+fn a_quick_panel_tap_is_a_click() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, panel_press(), &BOTH_SOURCES, &[], &[], &tx);
+    handle_reprog(&mut acc, release(), &BOTH_SOURCES, &[], &[], &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(GestureDirection::Click))
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "a panel tap emits exactly one click"
+    );
+}
+
+#[test]
+#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
+fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
+    // Real-hardware probe finding: the panel's first raw-XY sample after
+    // contact is a large position jump (up to thousands of units), not a
+    // relative delta. Un-discarded it would instantly commit a bogus swipe.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, panel_press(), &BOTH_SOURCES, &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    // The contact jump — leftward, far past every threshold.
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -3000, dy: 40 },
+        &BOTH_SOURCES,
+        &[],
+        &[],
+        &tx,
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "the contact jump must not commit a swipe"
+    );
+    // The real swipe starts from a clean accumulator: had the jump been
+    // summed, this rightward travel could never commit Right.
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        &BOTH_SOURCES,
+        &[],
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(GestureDirection::Right))
+    );
+}
+
+#[test]
+#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
+fn the_dedicated_buttons_first_sample_is_not_discarded() {
+    // The discard is a panel quirk: the dedicated button's raw-XY stream is
+    // relative from the first sample, which must keep committing as-is.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, press(), &BOTH_SOURCES, &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        &BOTH_SOURCES,
+        &[],
+        &[],
+        &tx,
+    );
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(GestureDirection::Right)),
+        "the dedicated button's very first sample still counts"
+    );
+}
+
+#[test]
+#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
+fn a_plain_diverted_haptic_panel_presses_as_the_gesture_button() {
+    // With gestures off and a single binding on [`ButtonId::GestureButton`],
+    // the MX Master 4 panel is plain-diverted and its press must deliver that
+    // binding — the panel is the gesture button on that model.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+    let buttons = [(reprog_controls::HAPTIC_PANEL_CID, ButtonId::GestureButton)];
+
+    handle_reprog(&mut acc, panel_press(), &[], &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), &[], &[], &buttons, &tx);
+
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::ButtonPressed(ButtonId::GestureButton, None))
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "a plain-diverted panel must not also emit a gesture click"
+    );
+}
+
+#[test]
+#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
+fn gesture_source_discovery_arms_whatever_the_device_exposes() {
+    let raw_xy_flags =
+        (reprog_controls::CidFlags::RAW_XY | reprog_controls::CidFlags::DIVERTABLE).bits();
+    // MX Master 3S-style entry: the dedicated button, with raw-XY.
+    let dedicated = reprog_controls::CtrlIdInfo {
+        cid: reprog_controls::GESTURE_BUTTON_CID,
+        task_id: 0,
+        flags: raw_xy_flags,
+    };
+    // MX Master 4-style haptic panel entry.
+    let panel = reprog_controls::CtrlIdInfo {
+        cid: reprog_controls::HAPTIC_PANEL_CID,
+        task_id: 0,
+        flags: raw_xy_flags,
+    };
+    // A control without raw-XY can't decode swipes — never a gesture source.
+    let no_raw_xy = reprog_controls::CtrlIdInfo {
+        cid: reprog_controls::HAPTIC_PANEL_CID,
+        task_id: 0,
+        flags: reprog_controls::CidFlags::DIVERTABLE.bits(),
+    };
+
+    assert_eq!(
+        gesture_source_cids(&[dedicated]),
+        vec![reprog_controls::GESTURE_BUTTON_CID]
+    );
+    assert_eq!(
+        gesture_source_cids(&[panel]),
+        vec![reprog_controls::HAPTIC_PANEL_CID]
+    );
+    assert_eq!(
+        gesture_source_cids(&[dedicated, panel]),
+        vec![
+            reprog_controls::GESTURE_BUTTON_CID,
+            reprog_controls::HAPTIC_PANEL_CID
+        ],
+        "a device exposing both arms both"
+    );
+    assert_eq!(
+        gesture_source_cids(&[no_raw_xy]),
+        Vec::<u16>::new(),
+        "raw-XY support is required"
     );
 }
 

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -77,7 +77,6 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
 }
 
 #[test]
-#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
 fn the_haptic_panel_gestures_like_the_dedicated_button() {
     // On MX Master 4 the gesture role is delivered by the haptic panel (CID
     // 0x01a0): its press must begin a hold and its raw-XY must commit a swipe,
@@ -119,7 +118,6 @@ fn the_haptic_panel_gestures_like_the_dedicated_button() {
 }
 
 #[test]
-#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
 fn a_quick_panel_tap_is_a_click() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
@@ -138,7 +136,6 @@ fn a_quick_panel_tap_is_a_click() {
 }
 
 #[test]
-#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
 fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     // Real-hardware probe finding: the panel's first raw-XY sample after
     // contact is a large position jump (up to thousands of units), not a
@@ -178,7 +175,6 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
 }
 
 #[test]
-#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
 fn the_dedicated_buttons_first_sample_is_not_discarded() {
     // The discard is a panel quirk: the dedicated button's raw-XY stream is
     // relative from the first sample, which must keep committing as-is.
@@ -204,7 +200,6 @@ fn the_dedicated_buttons_first_sample_is_not_discarded() {
 }
 
 #[test]
-#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
 fn a_plain_diverted_haptic_panel_presses_as_the_gesture_button() {
     // With gestures off and a single binding on [`ButtonId::GestureButton`],
     // the MX Master 4 panel is plain-diverted and its press must deliver that
@@ -227,7 +222,6 @@ fn a_plain_diverted_haptic_panel_presses_as_the_gesture_button() {
 }
 
 #[test]
-#[ignore = "RED: MX Master 4 haptic panel capture not implemented yet"]
 fn gesture_source_discovery_arms_whatever_the_device_exposes() {
     let raw_xy_flags =
         (reprog_controls::CidFlags::RAW_XY | reprog_controls::CidFlags::DIVERTABLE).bits();

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -44,6 +44,17 @@ pub const FEATURE_ID: u16 = 0x1b04;
 /// bindable/capturable input.
 pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 
+/// Control ID of the MX Master 4 Haptic Sense Panel — the touch-sensitive
+/// thumb rest that replaces the dedicated gesture button on that model.
+///
+/// Reverse-engineered on real hardware (MX Master 4, Bolt receiver); not in
+/// the published `0x1b04` control-ID lists. Press/release arrive as
+/// `divertedButtonsEvent` with this CID, and while touched the panel streams
+/// relative raw-XY at ~125 Hz exactly like the dedicated gesture button —
+/// except that the first raw-XY sample after contact is a large position jump
+/// that must be discarded before feeding a swipe accumulator.
+pub const HAPTIC_PANEL_CID: u16 = 0x01a0;
+
 /// The controls that can act as a device's HID++ gesture source and deliver
 /// [`ButtonId::GestureButton`](openlogi_core::binding::ButtonId::GestureButton)
 /// — its swipes and click when it owns the gesture role, its plain press

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -44,6 +44,12 @@ pub const FEATURE_ID: u16 = 0x1b04;
 /// bindable/capturable input.
 pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 
+/// The controls that can act as a device's HID++ gesture source and deliver
+/// [`ButtonId::GestureButton`](openlogi_core::binding::ButtonId::GestureButton)
+/// — its swipes and click when it owns the gesture role, its plain press
+/// otherwise. Capture arms whichever members a device exposes.
+pub const GESTURE_SOURCE_CIDS: [u16; 1] = [GESTURE_BUTTON_CID];
+
 /// Control IDs of the "DPI / ModeShift" button family. Whichever a device
 /// exposes (and can divert) is captured and mapped to
 /// [`ButtonId::DpiToggle`](openlogi_core::binding::ButtonId::DpiToggle): the MX

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -38,10 +38,8 @@ pub const FEATURE_ID: u16 = 0x1b04;
 /// Control ID of the MX-line dedicated gesture button (`Mouse_Gesture_Button`,
 /// Logitech "App_Switch_Gesture").
 ///
-/// MX Master 4 also has a separate Haptic Sense Panel in the thumb area. That
-/// panel is not this CID; it must be discovered from the device's `0x1b04`
-/// control table and supported explicitly before OpenLogi treats it as a
-/// bindable/capturable input.
+/// MX Master 4 also has a separate Haptic Sense Panel in the thumb area; that
+/// panel is [`HAPTIC_PANEL_CID`], not this CID.
 pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 
 /// Control ID of the MX Master 4 Haptic Sense Panel — the touch-sensitive
@@ -58,8 +56,9 @@ pub const HAPTIC_PANEL_CID: u16 = 0x01a0;
 /// The controls that can act as a device's HID++ gesture source and deliver
 /// [`ButtonId::GestureButton`](openlogi_core::binding::ButtonId::GestureButton)
 /// — its swipes and click when it owns the gesture role, its plain press
-/// otherwise. Capture arms whichever members a device exposes.
-pub const GESTURE_SOURCE_CIDS: [u16; 1] = [GESTURE_BUTTON_CID];
+/// otherwise: the dedicated gesture button on most MX mice, the Haptic Sense
+/// Panel on MX Master 4. Capture arms whichever members a device exposes.
+pub const GESTURE_SOURCE_CIDS: [u16; 2] = [GESTURE_BUTTON_CID, HAPTIC_PANEL_CID];
 
 /// Control IDs of the "DPI / ModeShift" button family. Whichever a device
 /// exposes (and can divert) is captured and mapped to

--- a/crates/openlogi-hid/src/reprog_controls.rs
+++ b/crates/openlogi-hid/src/reprog_controls.rs
@@ -53,13 +53,6 @@ pub const GESTURE_BUTTON_CID: u16 = 0x00c3;
 /// that must be discarded before feeding a swipe accumulator.
 pub const HAPTIC_PANEL_CID: u16 = 0x01a0;
 
-/// The controls that can act as a device's HID++ gesture source and deliver
-/// [`ButtonId::GestureButton`](openlogi_core::binding::ButtonId::GestureButton)
-/// — its swipes and click when it owns the gesture role, its plain press
-/// otherwise: the dedicated gesture button on most MX mice, the Haptic Sense
-/// Panel on MX Master 4. Capture arms whichever members a device exposes.
-pub const GESTURE_SOURCE_CIDS: [u16; 2] = [GESTURE_BUTTON_CID, HAPTIC_PANEL_CID];
-
 /// Control IDs of the "DPI / ModeShift" button family. Whichever a device
 /// exposes (and can divert) is captured and mapped to
 /// [`ButtonId::DpiToggle`](openlogi_core::binding::ButtonId::DpiToggle): the MX


### PR DESCRIPTION

## Summary

The MX Master 4's Haptic Sense Panel (CID `0x01a0`) is a physical control distinct from the dedicated gesture button, but OpenLogi neither captured it nor showed it anywhere in the GUI: gestures bound to the thumb pad did nothing, and there was no place to assign it (#313).

This models the panel as `ButtonId::HapticPanel` end to end:

- capture arms the gesture owner's **own** source CID with raw-XY — dedicated button or panel — and discards the panel's contact-jump first sample;
- a single-bound non-owner source is plain-diverted and delivers its own `ButtonId`;
- the mouse model maps the `ASSIGNMENT_NAME_SHOW_RADIAL_MENU` marker to a panel hotspot, offers the panel as a gesture-owner choice, and labels it in every locale.

The first commit generalizes gesture capture from a single hardwired CID to a per-device source-CID list, which is what lets the panel participate at all.

## Changes

- `hid`: generalize gesture capture to a per-device source-CID list; capture the haptic panel as a gesture source with first-sample contact-jump suppression (`gesture.rs`, `reprog_controls.rs`).
- `core`: add `ButtonId::HapticPanel` (append-only, wire-compatible — `PROTOCOL_VERSION` untouched, `wire_format` goldens unchanged).
- `agent-core`: capture plans arm the gesture owner's own source CID; the panel is covered as its own control.
- `gui` + all locales: panel hotspot on the MX Master 4 mouse model, gesture-owner choice, and a label key added in the same position in every `locales/*.yml`.

## Testing

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — green on this branch (includes the `i18n` parity test and new gesture-capture tests for the panel source).
- Not runtime-tested on hardware yet. Concrete check on an MX Master 4: assign gestures to the thumb pad — swipes on the panel should fire them; assign a plain action to the panel while the gesture button owns gestures — the panel should deliver its own binding.

Fixes #313
