### PR TITLE
refactor: per-button gesture mode, replacing the one-owner lock

### DIFF
--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -78,21 +78,24 @@ pub fn gesture_bindings_for(
     bindings
 }
 
-/// Per-direction maps for the OS-hook gesture buttons (Middle/Back/Forward in
-/// gesture mode) on `config_key`, with `app_bundle`'s per-app overlay applied,
-/// for the OS hook to resolve a hold+swipe.
+/// Per-direction maps for every OS-hook button (Middle/Back/Forward) in
+/// gesture mode on `config_key`, with `app_bundle`'s per-app overlay applied,
+/// for the OS hook to resolve a hold+swipe. Gesture mode is per-button (see
+/// [`Config::is_gesture_mode`]), so any number of entries may be live at once —
+/// concurrency between them is the hook's first-hold-wins policy, not a config
+/// concern.
 ///
 /// Unlike [`gesture_bindings_for`] (the dedicated HID++ gesture button, which
 /// seeds every direction from [`default_gesture_binding`] at projection time),
-/// this returns the owner's raw stored map. In practice that map is already
-/// fully populated — [`Config::set_gesture_owner`] seeds all five directions via
-/// [`Binding::fill_gesture_defaults`] when a button is promoted — so only a
-/// hand-edited sparse map leaves a direction unbound, in which case that swipe
-/// simply does nothing. The dedicated gesture button is intentionally excluded:
-/// it never reaches the OS hook (it's captured over HID++), so it has no entry
-/// here.
+/// this returns each button's raw stored map. In practice those maps are
+/// already fully populated — [`Config::set_gesture_mode`] seeds all five
+/// directions via [`Binding::fill_gesture_defaults`] when a button is
+/// promoted — so only a hand-edited sparse map leaves a direction unbound, in
+/// which case that swipe simply does nothing. The dedicated gesture button is
+/// intentionally excluded: it never reaches the OS hook (it's captured over
+/// HID++), so it has no entry here.
 ///
-/// A per-app override of the owner button turns it into a [`Binding::Single`]
+/// A per-app override of a gesture button turns it into a [`Binding::Single`]
 /// for that app, so it stops being a gesture button there and falls through to
 /// the single-action path (which applies the override) — mirroring how a single
 /// binding is overridden per app.
@@ -105,23 +108,17 @@ pub fn oshook_gestures_for(
     let Some(key) = config_key else {
         return BTreeMap::new();
     };
-    // Only an OS-hook button (Middle/Back/Forward) as the device's gesture owner
-    // feeds the OS hook: the dedicated HID++ gesture button is captured over HID++, and a non-owner
-    // button is dispatched as its single click action. Returning *only* the owner
-    // keeps the runtime in lockstep with `gesture_owner` and the GUI, so a stray
-    // second gesture map (e.g. a hand-edited config) can't make two buttons fire.
-    let Some(owner) = config
-        .gesture_owner(key)
-        .filter(|id| id.is_os_hook_button())
-    else {
-        return BTreeMap::new();
-    };
-    // Read the per-app *effective* map: a per-app override replaces the owner with
-    // a `Single`, dropping it from the gesture set for that app.
-    match config.effective_bindings(key, app_bundle).remove(&owner) {
-        Some(Binding::Gesture(map)) => BTreeMap::from([(owner, map)]),
-        _ => BTreeMap::new(),
-    }
+    // Read the per-app *effective* map: a per-app override replaces a gesture
+    // button with a `Single`, dropping it from the gesture set for that app.
+    config
+        .effective_bindings(key, app_bundle)
+        .into_iter()
+        .filter(|(id, _)| id.is_os_hook_button())
+        .filter_map(|(id, binding)| match binding {
+            Binding::Gesture(map) => Some((id, map)),
+            Binding::Single(_) => None,
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -194,7 +191,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: multi-button gesture dispatch not implemented yet"]
     fn oshook_gestures_includes_every_gesture_mode_button() {
         // The owner lock is gone: every OS-hook button in gesture mode
         // dispatches, each through its own direction map.

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 
 use openlogi_core::binding::{
-    Action, Binding, ButtonId, GestureDirection, default_binding, default_gesture_binding,
+    Action, Binding, ButtonId, GestureDirection, default_binding, default_binding_for,
 };
 use openlogi_core::config::Config;
 
@@ -50,9 +50,9 @@ pub fn bindings_for(
 /// Per-direction maps for every HID++ gesture source (the dedicated gesture
 /// button, the MX Master 4 haptic panel) in gesture mode on `config_key`,
 /// keyed by the button its captured swipes dispatch as. Each map is seeded
-/// from [`default_gesture_binding`] with the stored directions overlaid, so
-/// the watcher always dispatches the full five-direction set the GUI shows.
-/// Empty when no HID++ source gestures (or `config_key` is `None`).
+/// via [`Binding::fill_gesture_defaults`] — the one canonical seeding rule —
+/// so the watcher always dispatches the full five-direction set the GUI
+/// shows. Empty when no HID++ source gestures (or `config_key` is `None`).
 #[must_use]
 pub fn hidpp_gesture_maps_for(
     config: &Config,
@@ -66,19 +66,18 @@ pub fn hidpp_gesture_maps_for(
         .iter()
         .copied()
         .filter(|button| button.is_hidpp_gesture_source())
-        .filter(|button| config.is_gesture_mode(key, *button))
-        .map(|button| {
-            let mut map: BTreeMap<GestureDirection, Action> = GestureDirection::ALL
-                .iter()
-                .copied()
-                .map(|d| (d, default_gesture_binding(d)))
-                .collect();
-            if let Some(Binding::Gesture(dirs)) = stored.get(&button) {
-                for (dir, action) in dirs {
-                    map.insert(*dir, action.clone());
-                }
+        .filter_map(|button| {
+            // The stored shape (or the button's canonical default) IS gesture
+            // mode — a Single-shaped source simply drops out.
+            let mut binding = stored
+                .get(&button)
+                .cloned()
+                .unwrap_or_else(|| default_binding_for(button));
+            binding.fill_gesture_defaults();
+            match binding {
+                Binding::Gesture(map) => Some((button, map)),
+                Binding::Single(_) => None,
             }
-            (button, map)
         })
         .collect()
 }
@@ -90,9 +89,9 @@ pub fn hidpp_gesture_maps_for(
 /// concurrency between them is the hook's first-hold-wins policy, not a config
 /// concern.
 ///
-/// Unlike [`hidpp_gesture_maps_for`] (whose maps seed every direction from
-/// [`default_gesture_binding`] at projection time),
-/// this returns each button's raw stored map. In practice those maps are
+/// Unlike [`hidpp_gesture_maps_for`] (whose maps seed every direction at
+/// projection time), this returns each button's raw stored map. In practice
+/// those maps are
 /// already fully populated — [`Config::set_gesture_mode`] seeds all five
 /// directions via [`Binding::fill_gesture_defaults`] when a button is
 /// promoted — so only a hand-edited sparse map leaves a direction unbound, in
@@ -129,6 +128,8 @@ pub fn oshook_gestures_for(
 #[cfg(test)]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
+    use openlogi_core::binding::default_gesture_binding;
+
     use super::*;
 
     #[test]

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -92,16 +92,26 @@ pub fn hidpp_gesture_maps_for(
     let Some(key) = config_key else {
         return BTreeMap::new();
     };
-    let mut maps = BTreeMap::new();
-    let seeded = gesture_bindings_for(config, Some(key));
-    if let Some(owner) = config
-        .gesture_owner(key)
-        .filter(|id| id.is_hidpp_gesture_source())
-        && !seeded.is_empty()
-    {
-        maps.insert(owner, seeded);
-    }
-    maps
+    let stored = config.bindings_for(key);
+    ButtonId::ALL
+        .iter()
+        .copied()
+        .filter(|button| button.is_hidpp_gesture_source())
+        .filter(|button| config.is_gesture_mode(key, *button))
+        .map(|button| {
+            let mut map: BTreeMap<GestureDirection, Action> = GestureDirection::ALL
+                .iter()
+                .copied()
+                .map(|d| (d, default_gesture_binding(d)))
+                .collect();
+            if let Some(Binding::Gesture(dirs)) = stored.get(&button) {
+                for (dir, action) in dirs {
+                    map.insert(*dir, action.clone());
+                }
+            }
+            (button, map)
+        })
+        .collect()
 }
 
 /// Per-direction maps for every OS-hook button (Middle/Back/Forward) in
@@ -234,7 +244,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: multi-source HID++ gesture maps not implemented yet"]
     fn hidpp_gesture_maps_includes_every_gesture_mode_source() {
         // Both HID++ sources in gesture mode dispatch simultaneously, each
         // through its own seeded direction map.

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -78,6 +78,32 @@ pub fn gesture_bindings_for(
     bindings
 }
 
+/// Per-direction maps for every HID++ gesture source (the dedicated gesture
+/// button, the MX Master 4 haptic panel) in gesture mode on `config_key`,
+/// keyed by the button its captured swipes dispatch as. Each map is seeded
+/// from [`default_gesture_binding`] with the stored directions overlaid, so
+/// the watcher always dispatches the full five-direction set the GUI shows.
+/// Empty when no HID++ source gestures (or `config_key` is `None`).
+#[must_use]
+pub fn hidpp_gesture_maps_for(
+    config: &Config,
+    config_key: Option<&str>,
+) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
+    let Some(key) = config_key else {
+        return BTreeMap::new();
+    };
+    let mut maps = BTreeMap::new();
+    let seeded = gesture_bindings_for(config, Some(key));
+    if let Some(owner) = config
+        .gesture_owner(key)
+        .filter(|id| id.is_hidpp_gesture_source())
+        && !seeded.is_empty()
+    {
+        maps.insert(owner, seeded);
+    }
+    maps
+}
+
 /// Per-direction maps for every OS-hook button (Middle/Back/Forward) in
 /// gesture mode on `config_key`, with `app_bundle`'s per-app overlay applied,
 /// for the OS hook to resolve a hold+swipe. Gesture mode is per-button (see
@@ -122,6 +148,7 @@ pub fn oshook_gestures_for(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
@@ -204,6 +231,32 @@ mod tests {
             oshook.contains_key(&ButtonId::MiddleClick),
             "got: {oshook:?}"
         );
+    }
+
+    #[test]
+    #[ignore = "RED: multi-source HID++ gesture maps not implemented yet"]
+    fn hidpp_gesture_maps_includes_every_gesture_mode_source() {
+        // Both HID++ sources in gesture mode dispatch simultaneously, each
+        // through its own seeded direction map.
+        let mut cfg = Config::default();
+        cfg.set_gesture_mode("2b042", ButtonId::HapticPanel, true);
+
+        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"));
+        // The dedicated button gestures by default...
+        let dedicated = maps
+            .get(&ButtonId::GestureButton)
+            .expect("the dedicated button's default gesture mode must survive");
+        assert_eq!(
+            dedicated.get(&GestureDirection::Up),
+            Some(&default_gesture_binding(GestureDirection::Up))
+        );
+        // ...and the panel's promotion adds a second, fully-seeded map.
+        let panel = maps
+            .get(&ButtonId::HapticPanel)
+            .expect("a gesture-mode panel must dispatch");
+        for dir in GestureDirection::ALL {
+            assert!(panel.contains_key(&dir), "unseeded panel arm {dir:?}");
+        }
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -194,6 +194,23 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "RED: multi-button gesture dispatch not implemented yet"]
+    fn oshook_gestures_includes_every_gesture_mode_button() {
+        // The owner lock is gone: every OS-hook button in gesture mode
+        // dispatches, each through its own direction map.
+        let mut cfg = Config::default();
+        cfg.set_gesture_mode("2b042", ButtonId::Back, true);
+        cfg.set_gesture_mode("2b042", ButtonId::MiddleClick, true);
+
+        let oshook = oshook_gestures_for(&cfg, Some("2b042"), None);
+        assert!(oshook.contains_key(&ButtonId::Back), "got: {oshook:?}");
+        assert!(
+            oshook.contains_key(&ButtonId::MiddleClick),
+            "got: {oshook:?}"
+        );
+    }
+
+    #[test]
     fn per_app_override_drops_the_owner_from_the_oshook_gesture_set() {
         // Back is the gesture owner globally...
         let mut cfg = Config::default();

--- a/crates/openlogi-agent-core/src/bindings.rs
+++ b/crates/openlogi-agent-core/src/bindings.rs
@@ -16,9 +16,9 @@ use openlogi_core::config::Config;
 /// [`default_binding`].
 ///
 /// This is the map the OS hook and the HID++ button-press path consume, so a
-/// `Binding::Gesture` is projected to its `click_action()` — the gesture
+/// `Binding::Gesture` is projected to its `click_action()` — a gesture-mode
 /// button's per-direction swipes are dispatched via the separate
-/// [`gesture_bindings_for`] map, not here.
+/// [`hidpp_gesture_maps_for`] / [`oshook_gestures_for`] maps, not here.
 #[must_use]
 pub fn bindings_for(
     config: &Config,
@@ -43,37 +43,6 @@ pub fn bindings_for(
             continue;
         }
         bindings.insert(k, binding.click_action());
-    }
-    bindings
-}
-
-/// Effective gesture bindings for the device `config_key`. Unset directions
-/// fall back to [`default_gesture_binding`].
-#[must_use]
-pub fn gesture_bindings_for(
-    config: &Config,
-    config_key: Option<&str>,
-) -> BTreeMap<GestureDirection, Action> {
-    // A HID++ gesture source (the dedicated gesture button, or the MX Master 4
-    // haptic panel) only gestures while it is the device's gesture owner. When
-    // the user moves the role to an OS-hook button (Middle/Back/Forward) or
-    // turns gestures off, return an empty map so the gesture watcher
-    // dispatches nothing — otherwise the always-seeded defaults would keep the
-    // HID++ gesture control firing regardless of the selection.
-    let owner = config_key.and_then(|key| config.gesture_owner(key));
-    if !owner.is_some_and(ButtonId::is_hidpp_gesture_source) {
-        return BTreeMap::new();
-    }
-    let stored = config_key
-        .map(|key| config.gesture_bindings_for(key))
-        .unwrap_or_default();
-    let mut bindings: BTreeMap<GestureDirection, Action> = GestureDirection::ALL
-        .iter()
-        .copied()
-        .map(|d| (d, default_gesture_binding(d)))
-        .collect();
-    for (k, v) in stored {
-        bindings.insert(k, v);
     }
     bindings
 }
@@ -121,8 +90,8 @@ pub fn hidpp_gesture_maps_for(
 /// concurrency between them is the hook's first-hold-wins policy, not a config
 /// concern.
 ///
-/// Unlike [`gesture_bindings_for`] (the dedicated HID++ gesture button, which
-/// seeds every direction from [`default_gesture_binding`] at projection time),
+/// Unlike [`hidpp_gesture_maps_for`] (whose maps seed every direction from
+/// [`default_gesture_binding`] at projection time),
 /// this returns each button's raw stored map. In practice those maps are
 /// already fully populated — [`Config::set_gesture_mode`] seeds all five
 /// directions via [`Binding::fill_gesture_defaults`] when a button is
@@ -272,7 +241,7 @@ mod tests {
     fn per_app_override_drops_the_owner_from_the_oshook_gesture_set() {
         // Back is the gesture owner globally...
         let mut cfg = Config::default();
-        cfg.set_gesture_owner("2b042", ButtonId::Back);
+        cfg.set_gesture_mode("2b042", ButtonId::Back, true);
         assert!(
             oshook_gestures_for(&cfg, Some("2b042"), None).contains_key(&ButtonId::Back),
             "Back gestures globally"
@@ -299,22 +268,25 @@ mod tests {
     }
 
     #[test]
-    fn gesture_bindings_silent_when_hidpp_button_is_not_the_owner() {
+    fn hidpp_maps_silent_for_a_demoted_dedicated_button() {
+        // Default device: the dedicated HID++ gesture button gestures, with its
+        // defaults seeded.
         let mut cfg = Config::default();
-        // Default device: the dedicated HID++ gesture button owns gestures, so its defaults are seeded.
-        let defaults = gesture_bindings_for(&cfg, Some("2b042"));
+        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"));
         assert_eq!(
-            defaults.get(&GestureDirection::Up),
+            maps.get(&ButtonId::GestureButton)
+                .and_then(|m| m.get(&GestureDirection::Up)),
             Some(&default_gesture_binding(GestureDirection::Up)),
-            "the default gesture owner is the dedicated HID++ gesture button"
+            "the dedicated button gestures by default, seeded"
         );
 
-        // Move the gesture role to an OS-hook button: the HID++ gesture button goes silent,
-        // so the watcher dispatches nothing for 0x00c3.
-        cfg.set_gesture_owner("2b042", ButtonId::Back);
+        // Demoting it silences the watcher for 0x00c3 — and promoting an
+        // OS-hook button never resurrects it.
+        cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
+        cfg.set_gesture_mode("2b042", ButtonId::Back, true);
         assert!(
-            gesture_bindings_for(&cfg, Some("2b042")).is_empty(),
-            "HID++ gesture button must dispatch nothing once another button owns gestures"
+            hidpp_gesture_maps_for(&cfg, Some("2b042")).is_empty(),
+            "a demoted dedicated button must dispatch nothing over HID++"
         );
     }
 }

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -28,13 +28,14 @@ pub struct DeviceCapturePlan {
     pub route: DeviceRoute,
     /// Per-button single actions for this device (per-app effective).
     pub bindings: BTreeMap<ButtonId, Action>,
-    /// Per-direction map when a HID++ gesture source (the dedicated gesture
-    /// button or the MX Master 4 haptic panel) owns the gesture role on this
-    /// device; empty otherwise.
-    pub gesture_bindings: BTreeMap<GestureDirection, Action>,
-    /// The gesture owner's source CID to divert with raw-XY, `None` when no
-    /// HID++ control owns the gesture role.
-    pub gesture_source_cid: Option<u16>,
+    /// Per-direction map for each HID++ gesture source (the dedicated gesture
+    /// button, the MX Master 4 haptic panel) in gesture mode on this device,
+    /// keyed by the button its captured swipes dispatch as; empty when none
+    /// gestures.
+    pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
+    /// The gesture sources' CIDs to divert with raw-XY — one per
+    /// `gesture_bindings` entry the source table knows.
+    pub gesture_source_cids: Vec<u16>,
     /// Standard buttons whose binding leaves the default — divert over
     /// `0x1b04`. A button at its default keeps its native HID behavior, so no
     /// re-synthesis is ever needed.
@@ -63,28 +64,32 @@ pub fn plan_for_device(
     rearm_generation: u64,
 ) -> DeviceCapturePlan {
     let bindings = bindings_for(config, Some(config_key), app);
-    let gesture_bindings = gesture_bindings_for(config, Some(config_key));
-    // A button acting as the OS-hook gesture owner must stay native: the hook
-    // needs to see its press to run hold+swipe detection, and diverting it
-    // would starve the hook of events.
+    // A gesture-mode OS-hook button must stay native: the hook needs to see
+    // its press to run hold+swipe detection, and diverting it would starve the
+    // hook of events.
     let oshook = oshook_gestures_for(config, Some(config_key), app);
+    // The transition shim still resolves a single gesture button; the plan
+    // shape already carries one direction map per source.
+    let owner = config.gesture_owner(config_key);
+    let hidpp_gestures = gesture_bindings_for(config, Some(config_key));
+    let gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> = owner
+        .filter(|o| o.is_hidpp_gesture_source())
+        .filter(|_| !hidpp_gestures.is_empty())
+        .map(|o| BTreeMap::from([(o, hidpp_gestures)]))
+        .unwrap_or_default();
+    let gesture_source_cids: Vec<u16> = GESTURE_SOURCE_BUTTONS
+        .into_iter()
+        .filter(|(_, button)| gesture_bindings.contains_key(button))
+        .map(|(cid, _)| cid)
+        .collect();
     // The HID++ gesture sources never reach the OS hook, so a non-default
     // single binding on one is deliverable only via a plain HID++ divert — but
-    // only while it does NOT own the gesture role (the raw-XY gesture divert
-    // owns the owner's CID, and `gesture_source_cid` is how the watcher arms
-    // that divert).
-    let owner = config.gesture_owner(config_key);
-    let gesture_source_cid = owner
-        .filter(|o| o.is_hidpp_gesture_source())
-        .and_then(|o| {
-            GESTURE_SOURCE_BUTTONS
-                .into_iter()
-                .find(|&(_, button)| button == o)
-        })
-        .map(|(cid, _)| cid);
+    // only while the source is NOT in gesture mode (the raw-XY gesture divert
+    // owns a gesturing source's CID, and `gesture_source_cids` is how the
+    // watcher arms those diverts).
     let plain_sources = GESTURE_SOURCE_BUTTONS
         .into_iter()
-        .filter(|&(_, button)| owner != Some(button));
+        .filter(|(_, button)| !gesture_bindings.contains_key(button));
     let divert_buttons: Vec<(u16, ButtonId)> = DIVERTABLE_STANDARD_BUTTONS
         .into_iter()
         .chain(plain_sources)
@@ -118,7 +123,7 @@ pub fn plan_for_device(
         route,
         bindings,
         gesture_bindings,
-        gesture_source_cid,
+        gesture_source_cids,
         divert_buttons,
         thumbwheel_bindings_nondefault,
         thumbwheel_sensitivity: config.thumbwheel_sensitivity(config_key),

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -33,9 +33,6 @@ pub struct DeviceCapturePlan {
     /// keyed by the button its captured swipes dispatch as; empty when none
     /// gestures.
     pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
-    /// The gesture sources' CIDs to divert with raw-XY — one per
-    /// `gesture_bindings` entry the source table knows.
-    pub gesture_source_cids: Vec<u16>,
     /// Standard buttons whose binding leaves the default — divert over
     /// `0x1b04`. A button at its default keeps its native HID behavior, so no
     /// re-synthesis is ever needed.
@@ -69,18 +66,13 @@ pub fn plan_for_device(
     // hook of events.
     let oshook = oshook_gestures_for(config, Some(config_key), app);
     // One direction map per HID++ source in gesture mode — several may
-    // gesture at once, each armed with its own raw-XY divert.
+    // gesture at once, each armed with its own raw-XY divert (the watcher
+    // derives the CIDs to divert from this map's keys).
     let gesture_bindings = hidpp_gesture_maps_for(config, Some(config_key));
-    let gesture_source_cids: Vec<u16> = GESTURE_SOURCE_BUTTONS
-        .into_iter()
-        .filter(|(_, button)| gesture_bindings.contains_key(button))
-        .map(|(cid, _)| cid)
-        .collect();
     // The HID++ gesture sources never reach the OS hook, so a non-default
     // single binding on one is deliverable only via a plain HID++ divert — but
     // only while the source is NOT in gesture mode (the raw-XY gesture divert
-    // owns a gesturing source's CID, and `gesture_source_cids` is how the
-    // watcher arms those diverts).
+    // owns a gesturing source's CID).
     let plain_sources = GESTURE_SOURCE_BUTTONS
         .into_iter()
         .filter(|(_, button)| !gesture_bindings.contains_key(button));
@@ -117,7 +109,6 @@ pub fn plan_for_device(
         route,
         bindings,
         gesture_bindings,
-        gesture_source_cids,
         divert_buttons,
         thumbwheel_bindings_nondefault,
         thumbwheel_sensitivity: config.thumbwheel_sensitivity(config_key),
@@ -154,12 +145,6 @@ mod tests {
                 && plan.gesture_bindings.contains_key(&ButtonId::HapticPanel),
             "both sources need their own dispatch map, got: {:?}",
             plan.gesture_bindings.keys().collect::<Vec<_>>()
-        );
-        assert!(
-            plan.gesture_source_cids.contains(&GESTURE_BUTTON_CID)
-                && plan.gesture_source_cids.contains(&HAPTIC_PANEL_CID),
-            "both source CIDs must be raw-XY diverted, got: {:?}",
-            plan.gesture_source_cids
         );
         assert!(
             !plan

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -16,7 +16,7 @@ use openlogi_core::config::Config;
 use openlogi_hid::DeviceRoute;
 use openlogi_hid::gesture::{DIVERTABLE_STANDARD_BUTTONS, GESTURE_SOURCE_BUTTONS};
 
-use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
+use crate::bindings::{bindings_for, hidpp_gesture_maps_for, oshook_gestures_for};
 
 /// Everything the capture watcher needs to run one device's session and
 /// dispatch its events.
@@ -68,15 +68,9 @@ pub fn plan_for_device(
     // its press to run hold+swipe detection, and diverting it would starve the
     // hook of events.
     let oshook = oshook_gestures_for(config, Some(config_key), app);
-    // The transition shim still resolves a single gesture button; the plan
-    // shape already carries one direction map per source.
-    let owner = config.gesture_owner(config_key);
-    let hidpp_gestures = gesture_bindings_for(config, Some(config_key));
-    let gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> = owner
-        .filter(|o| o.is_hidpp_gesture_source())
-        .filter(|_| !hidpp_gestures.is_empty())
-        .map(|o| BTreeMap::from([(o, hidpp_gestures)]))
-        .unwrap_or_default();
+    // One direction map per HID++ source in gesture mode — several may
+    // gesture at once, each armed with its own raw-XY divert.
+    let gesture_bindings = hidpp_gesture_maps_for(config, Some(config_key));
     let gesture_source_cids: Vec<u16> = GESTURE_SOURCE_BUTTONS
         .into_iter()
         .filter(|(_, button)| gesture_bindings.contains_key(button))
@@ -146,7 +140,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: multi-source HID++ gesture plans not implemented yet"]
     fn both_hidpp_sources_gesture_when_both_are_in_gesture_mode() {
         // On MX Master 4 the dedicated button and the haptic panel can gesture
         // at the same time: the plan arms a raw-XY divert for each and keeps

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -171,30 +171,30 @@ mod tests {
     }
 
     #[test]
-    fn haptic_panel_can_own_the_gesture_role() {
-        // The MX Master 4 haptic panel is a HID++ gesture source: selecting it
-        // as the gesture owner must arm the raw-XY gesture divert, exactly
-        // like the dedicated gesture button.
+    fn haptic_panel_gestures_when_promoted() {
+        // The MX Master 4 haptic panel is a HID++ gesture source: promoting it
+        // into gesture mode must arm the raw-XY gesture divert, exactly like
+        // the dedicated gesture button.
         let mut cfg = Config::default();
-        cfg.set_gesture_owner("2b042", ButtonId::HapticPanel);
+        cfg.set_gesture_mode("2b042", ButtonId::HapticPanel, true);
 
         let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
         assert!(
-            !plan.gesture_bindings.is_empty(),
-            "a panel gesture owner must arm the HID++ gesture divert"
+            plan.gesture_bindings.contains_key(&ButtonId::HapticPanel),
+            "a gesture-mode panel must arm the HID++ gesture divert"
         );
         assert!(
             !plan
                 .divert_buttons
                 .iter()
                 .any(|&(cid, _)| cid == HAPTIC_PANEL_CID),
-            "the gesture owner is delivered via raw-XY divert, never a plain one"
+            "a gesture-mode source is delivered via raw-XY divert, never a plain one"
         );
     }
 
     #[test]
-    fn single_bound_haptic_panel_is_plain_diverted_when_not_the_owner() {
-        // While the dedicated button owns gestures (the default), a single
+    fn single_bound_haptic_panel_is_plain_diverted_when_not_in_gesture_mode() {
+        // While only the dedicated button gestures (the default), a single
         // action bound to the panel is deliverable only via a plain HID++
         // divert dispatching ButtonId::HapticPanel.
         let mut cfg = Config::default();
@@ -251,7 +251,6 @@ mod tests {
         // so with gestures off a non-default single binding on it is only
         // deliverable via a plain HID++ divert.
         let mut cfg = Config::default();
-        cfg.disable_gestures("2b042");
         cfg.set_binding(
             "2b042",
             ButtonId::GestureButton,
@@ -271,13 +270,13 @@ mod tests {
     }
 
     #[test]
-    fn gesture_owner_button_is_never_plain_diverted() {
-        // When the gesture button owns the gesture role, the raw-XY gesture
+    fn gesture_mode_button_is_never_plain_diverted() {
+        // While the gesture button is in gesture mode, the raw-XY gesture
         // divert owns CID 0x00c3 — a plain divert on top would strip raw-XY.
         // (Its default Click projects to a non-default single action, so only
-        // the owner rule keeps it out of the plain list.)
+        // the gesture-mode rule keeps it out of the plain list.)
         let mut cfg = Config::default();
-        cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
+        cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
 
         let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
         assert!(
@@ -298,7 +297,7 @@ mod tests {
         // With gestures off and no explicit binding, the gesture button keeps
         // its native HID behavior — same contract as the standard buttons.
         let mut cfg = Config::default();
-        cfg.disable_gestures("2b042");
+        cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
 
         let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
         assert!(

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -146,6 +146,38 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "RED: multi-source HID++ gesture plans not implemented yet"]
+    fn both_hidpp_sources_gesture_when_both_are_in_gesture_mode() {
+        // On MX Master 4 the dedicated button and the haptic panel can gesture
+        // at the same time: the plan arms a raw-XY divert for each and keeps
+        // both out of the plain-divert list.
+        let mut cfg = Config::default();
+        cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
+        cfg.set_gesture_mode("2b042", ButtonId::HapticPanel, true);
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            plan.gesture_bindings.contains_key(&ButtonId::GestureButton)
+                && plan.gesture_bindings.contains_key(&ButtonId::HapticPanel),
+            "both sources need their own dispatch map, got: {:?}",
+            plan.gesture_bindings.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            plan.gesture_source_cids.contains(&GESTURE_BUTTON_CID)
+                && plan.gesture_source_cids.contains(&HAPTIC_PANEL_CID),
+            "both source CIDs must be raw-XY diverted, got: {:?}",
+            plan.gesture_source_cids
+        );
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(cid, _)| cid == GESTURE_BUTTON_CID || cid == HAPTIC_PANEL_CID),
+            "a raw-XY-diverted source must never also be plain-diverted"
+        );
+    }
+
+    #[test]
     fn haptic_panel_can_own_the_gesture_role() {
         // The MX Master 4 haptic panel is a HID++ gesture source: selecting it
         // as the gesture owner must arm the raw-XY gesture divert, exactly

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -129,10 +129,15 @@ struct HoldState {
 }
 
 impl HoldState {
-    /// Begin a hold for `button`.
-    fn begin(&mut self, button: ButtonId) {
+    /// Begin a hold for `button`, unless another button's hold is already in
+    /// progress — with several gesture buttons the first hold wins, so a second
+    /// press can't hijack the accumulated motion mid-swipe. Returns whether the
+    /// hold started (the caller lets a refused press fall through to the
+    /// single-action path, where it means its plain click).
+    fn begin(&mut self, button: ButtonId) -> bool {
         self.button = Some(button);
         self.swipe.begin();
+        true
     }
 
     /// Feed a pointer-move delta into the active hold, tagging a committed swipe
@@ -238,8 +243,10 @@ fn handle_button(
     // event while a config rebuild holds the write lock. Fail open if unavailable.
     if pressed {
         let is_gesture = hooks.try_read().is_ok_and(|m| m.gestures.contains_key(&id));
-        if is_gesture {
-            HOLD.with_borrow_mut(|h| h.begin(id));
+        // A refused begin — a second gesture button pressed mid-hold — falls
+        // through to the single-action path: the first hold wins and this press
+        // still means its plain click.
+        if is_gesture && HOLD.with_borrow_mut(|h| h.begin(id)) {
             return EventDisposition::Suppress;
         }
     } else {
@@ -625,6 +632,31 @@ mod tests {
             "commits at most once per hold"
         );
         // A release after a committed swipe is NOT a click.
+        assert_eq!(hold.end(ButtonId::Back), Some(false));
+    }
+
+    #[test]
+    #[ignore = "RED: first-wins concurrent-hold policy not implemented yet"]
+    fn begin_is_first_wins_while_a_hold_is_active() {
+        // Two gesture buttons pressed together: the first hold keeps the
+        // accumulator; the second press is refused (its caller falls through to
+        // the single-action path) and its release is a stray, not a click.
+        let mut hold = HoldState::default();
+        assert!(hold.begin(ButtonId::Back));
+        hold.swipe.backdate_hold_for_test();
+        assert!(
+            !hold.begin(ButtonId::Forward),
+            "a second press must not hijack the active hold"
+        );
+
+        // The accumulated motion still belongs to the first button...
+        assert_eq!(
+            hold.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
+            Some((ButtonId::Back, GestureDirection::Right))
+        );
+        // ...the refused button's release is a stray...
+        assert_eq!(hold.end(ButtonId::Forward), None);
+        // ...and the first hold ends normally (swipe fired, so not a click).
         assert_eq!(hold.end(ButtonId::Back), Some(false));
     }
 

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -122,23 +122,40 @@ fn convert_modifiers(m: openlogi_hook::KeyModifiers) -> KeyModifiers {
 /// *mid-motion* like the HID++ gesture-button path in `openlogi-hid`. This wrapper
 /// adds only the button identity the accumulator doesn't track; a press that
 /// never commits a direction is a plain click, fired on release.
+/// A gesture hold this old is presumed stale — real hold+swipe interactions
+/// finish in well under a second, and only a lost button-up (with no OS
+/// interrupt to trigger [`HoldState::cancel`]) leaves one lingering.
+const STALE_HOLD: Duration = Duration::from_secs(10);
+
 #[derive(Default)]
 struct HoldState {
-    button: Option<ButtonId>,
+    /// The held button and when its hold began. The timestamp exists solely
+    /// for stale-hold recovery in [`Self::begin`].
+    button: Option<(ButtonId, Instant)>,
     swipe: SwipeAccumulator,
 }
 
 impl HoldState {
-    /// Begin a hold for `button`, unless another button's hold is already in
+    /// Begin a hold for `button`, unless another button's live hold is in
     /// progress — with several gesture buttons the first hold wins, so a second
     /// press can't hijack the accumulated motion mid-swipe. Returns whether the
     /// hold started (the caller lets a refused press fall through to the
     /// single-action path, where it means its plain click).
+    ///
+    /// Two presses recover a hold whose button-up was lost (nothing else ever
+    /// clears it when the OS drops a release without an interrupt): a re-press
+    /// of the held button itself — a button cannot be pressed while down, so
+    /// this is proof the release was lost — and any press once the hold has
+    /// aged past [`STALE_HOLD`], without which every other gesture button
+    /// would stay refused indefinitely.
     fn begin(&mut self, button: ButtonId) -> bool {
-        if self.button.is_some() {
+        if let Some((held, since)) = self.button
+            && held != button
+            && since.elapsed() < STALE_HOLD
+        {
             return false;
         }
-        self.button = Some(button);
+        self.button = Some((button, Instant::now()));
         self.swipe.begin();
         true
     }
@@ -147,7 +164,7 @@ impl HoldState {
     /// with the held button. Returns `Some((button, direction))` exactly once per
     /// hold, or `None` while still too short, already fired, or not holding.
     fn accumulate(&mut self, dx: i32, dy: i32) -> Option<(ButtonId, GestureDirection)> {
-        let button = self.button?;
+        let (button, _) = self.button?;
         self.swipe.accumulate(dx, dy).map(|dir| (button, dir))
     }
 
@@ -156,7 +173,7 @@ impl HoldState {
     /// `Some(false)` when a swipe already fired, and `None` for a stray release
     /// of a button we weren't holding.
     fn end(&mut self, button: ButtonId) -> Option<bool> {
-        if self.button == Some(button) {
+        if self.button.is_some_and(|(held, _)| held == button) {
             self.button = None;
             Some(self.swipe.end())
         } else {
@@ -175,7 +192,13 @@ impl HoldState {
     /// Age the current hold past the staleness horizon, so tests can exercise
     /// the lost-button-up recovery without sleeping.
     #[cfg(test)]
-    fn backdate_for_test(&mut self) {}
+    fn backdate_for_test(&mut self) {
+        if let Some((_, since)) = &mut self.button
+            && let Some(aged) = Instant::now().checked_sub(STALE_HOLD)
+        {
+            *since = aged;
+        }
+    }
 }
 
 thread_local! {
@@ -644,7 +667,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: stale-hold recovery not implemented yet"]
     fn a_same_button_re_press_restarts_the_stale_hold() {
         // A press for the very button we think is held can only mean its
         // release was lost (a button cannot be pressed while down): the hold
@@ -663,7 +685,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: stale-hold recovery not implemented yet"]
     fn an_aged_hold_yields_to_a_new_buttons_press() {
         // No release ever clears a hold whose button-up was lost (and no OS
         // interrupt fired), so a different gesture button's press takes over

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -171,6 +171,11 @@ impl HoldState {
         self.button = None;
         self.swipe.end();
     }
+
+    /// Age the current hold past the staleness horizon, so tests can exercise
+    /// the lost-button-up recovery without sleeping.
+    #[cfg(test)]
+    fn backdate_for_test(&mut self) {}
 }
 
 thread_local! {
@@ -636,6 +641,46 @@ mod tests {
         );
         // A release after a committed swipe is NOT a click.
         assert_eq!(hold.end(ButtonId::Back), Some(false));
+    }
+
+    #[test]
+    #[ignore = "RED: stale-hold recovery not implemented yet"]
+    fn a_same_button_re_press_restarts_the_stale_hold() {
+        // A press for the very button we think is held can only mean its
+        // release was lost (a button cannot be pressed while down): the hold
+        // restarts instead of wedging on the stale state.
+        let mut hold = HoldState::default();
+        assert!(hold.begin(ButtonId::Back));
+        assert!(
+            hold.begin(ButtonId::Back),
+            "a same-button re-press is proof of a lost release"
+        );
+        hold.swipe.backdate_hold_for_test();
+        assert_eq!(
+            hold.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
+            Some((ButtonId::Back, GestureDirection::Right))
+        );
+    }
+
+    #[test]
+    #[ignore = "RED: stale-hold recovery not implemented yet"]
+    fn an_aged_hold_yields_to_a_new_buttons_press() {
+        // No release ever clears a hold whose button-up was lost (and no OS
+        // interrupt fired), so a different gesture button's press takes over
+        // once the hold is old enough to be presumed stale — otherwise every
+        // gesture button stays wedged until the stale one is pressed again.
+        let mut hold = HoldState::default();
+        assert!(hold.begin(ButtonId::Back));
+        hold.backdate_for_test();
+        assert!(
+            hold.begin(ButtonId::Forward),
+            "an aged hold must yield to a new press"
+        );
+        hold.swipe.backdate_hold_for_test();
+        assert_eq!(
+            hold.accumulate(GESTURE_SWIPE_THRESHOLD + 10, 0),
+            Some((ButtonId::Forward, GestureDirection::Right))
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -135,6 +135,9 @@ impl HoldState {
     /// hold started (the caller lets a refused press fall through to the
     /// single-action path, where it means its plain click).
     fn begin(&mut self, button: ButtonId) -> bool {
+        if self.button.is_some() {
+            return false;
+        }
         self.button = Some(button);
         self.swipe.begin();
         true
@@ -636,7 +639,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "RED: first-wins concurrent-hold policy not implemented yet"]
     fn begin_is_first_wins_while_a_hold_is_active() {
         // Two gesture buttons pressed together: the first hold keeps the
         // accumulator; the second press is refused (its caller falls through to

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -26,13 +26,12 @@ use openlogi_hid::{
 use tracing::{debug, info, warn};
 
 use crate::action_ring::ActionRingSessionSpec;
-use crate::bindings::{bindings_for, gesture_bindings_for, oshook_gestures_for};
+use crate::bindings::{bindings_for, oshook_gestures_for};
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans, plan_for_device};
 use crate::device_order::DeviceStableId;
 use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::ipc::InventoryHealth;
 use crate::receiver_access::ReceiverAccess;
-use crate::watchers::gesture::GestureBindings;
 use crate::watchers::host_switch::{HostSwitchLink, HostSwitchLinks};
 use crate::watchers::keyboard::{KeyboardSpec, SharedKeyboardSpec};
 use crate::{DpiCycleState, DpiCycles};
@@ -72,7 +71,6 @@ pub struct SharedRuntime {
     /// Function-key remapper bindings (keycode+modifiers → action). Not
     /// per-app-profile in M1 (spec non-goal), so a single shared map.
     pub keyboard_bindings: crate::hook_runtime::SharedKeyboardBindings,
-    pub gesture_bindings: GestureBindings,
     pub dpi_cycle: Arc<RwLock<DpiCycles>>,
     /// One capture plan per online device — what to divert and how to
     /// dispatch, keyed by the device the events arrive on. Carries each
@@ -152,7 +150,6 @@ impl Orchestrator {
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
-            gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
@@ -259,11 +256,6 @@ impl Orchestrator {
             &self.shared.hook_maps,
             self.hook_maps_for(key, self.current_app.as_deref()),
             "hook_maps",
-        );
-        write_value(
-            &self.shared.gesture_bindings,
-            gesture_bindings_for(&self.config, key),
-            "gesture_bindings",
         );
         self.publish_device_runtime();
     }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -20,7 +20,7 @@
 //! way regardless.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -106,7 +106,7 @@ fn thumbwheel_armed(plan: &DeviceCapturePlan) -> bool {
 fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
     CaptureSpec {
         capture_thumbwheel: thumbwheel_armed(plan),
-        divert_gesture_source: plan.gesture_source_cid,
+        divert_gesture_sources: plan.gesture_source_cids.clone(),
         divert_buttons: plan.divert_buttons.clone(),
     }
 }
@@ -393,12 +393,16 @@ fn dispatch(
         return;
     };
     match input {
-        CapturedInput::Gesture(direction) => {
-            if let Some(action) = plan.gesture_bindings.get(&direction) {
-                debug!(key, ?direction, action = %action.label(), "gesture → action");
+        CapturedInput::Gesture(button, direction) => {
+            if let Some(action) = plan
+                .gesture_bindings
+                .get(&button)
+                .and_then(|map| map.get(&direction))
+            {
+                debug!(key, %button, ?direction, action = %action.label(), "gesture → action");
                 dispatcher.dispatch(action, Some(key));
             } else {
-                debug!(key, ?direction, "gesture with no binding — ignored");
+                debug!(key, %button, ?direction, "gesture with no binding — ignored");
             }
         }
         CapturedInput::ButtonPressed(button, _) => {

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -26,7 +26,7 @@ use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{Action, ButtonId, default_binding};
 use openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY;
-use openlogi_hid::gesture::CaptureSpec;
+use openlogi_hid::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
 use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
@@ -106,7 +106,13 @@ fn thumbwheel_armed(plan: &DeviceCapturePlan) -> bool {
 fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
     CaptureSpec {
         capture_thumbwheel: thumbwheel_armed(plan),
-        divert_gesture_sources: plan.gesture_source_cids.clone(),
+        // Derived from the dispatch maps, so the armed diverts and the maps
+        // resolving their events can never drift apart.
+        divert_gesture_sources: GESTURE_SOURCE_BUTTONS
+            .into_iter()
+            .filter(|(_, button)| plan.gesture_bindings.contains_key(button))
+            .map(|(cid, _)| cid)
+            .collect(),
         divert_buttons: plan.divert_buttons.clone(),
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -19,12 +19,12 @@
 //! the events arrive over HID++, and the bound action is synthesised the same
 //! way regardless.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
+use openlogi_core::binding::{Action, ButtonId, default_binding};
 use openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY;
 use openlogi_hid::gesture::CaptureSpec;
 use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
@@ -34,10 +34,6 @@ use tracing::{debug, warn};
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
 use crate::hook_runtime::ActionDispatcher;
 use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
-
-/// Shared gesture-direction binding map, mirrored from `AppState` (keyed by
-/// direction). The watcher reads it to map a captured swipe to a bound action.
-pub type GestureBindings = Arc<RwLock<BTreeMap<GestureDirection, Action>>>;
 
 /// How often to re-read the active device target + thumb-wheel arming so a
 /// carousel switch or a binding/sensitivity edit re-points / re-arms capture.

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -258,7 +258,6 @@ async fn translate(
 mod tests {
     use super::*;
 
-    use std::collections::BTreeMap;
     use std::sync::RwLock;
 
     use openlogi_agent_core::DpiCycles;
@@ -269,7 +268,6 @@ mod tests {
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(std::collections::HashMap::new())),
-            gesture_bindings: Arc::new(RwLock::new(BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),

--- a/crates/openlogi-core/src/binding/value.rs
+++ b/crates/openlogi-core/src/binding/value.rs
@@ -90,6 +90,21 @@ impl Binding {
         }
     }
 
+    /// Demote a [`Gesture`](Binding::Gesture) binding in place to a
+    /// [`Single`](Binding::Single) of its [`Click`](GestureDirection::Click)
+    /// entry, falling back to `fallback` when the map has no explicit `Click` —
+    /// the inverse of [`Self::upgrade_to_gesture`]. A no-op on a
+    /// [`Single`](Binding::Single).
+    pub fn demote_to_single(&mut self, fallback: Action) {
+        if let Binding::Gesture(map) = self {
+            let click = map
+                .get(&GestureDirection::Click)
+                .cloned()
+                .unwrap_or(fallback);
+            *self = Binding::Single(click);
+        }
+    }
+
     /// Fill any unbound directions of a [`Gesture`](Binding::Gesture) binding
     /// with their canonical [`default_gesture_binding`], so a button promoted to
     /// the gesture role always exposes the full five-direction set — rather than

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -450,7 +450,13 @@ impl Config {
     /// [`Binding::Gesture`] IS gesture mode — so this resolves the old owner
     /// and rewrites the shapes to dispatch exactly what the old config did:
     ///
-    /// - the owner keeps its gesture map;
+    /// - the owner keeps its gesture map. A HID++ owner whose stored binding
+    ///   is absent or `Single`-shaped gets the seeded default direction map
+    ///   materialized: the v3 runtime seeded at projection time and dispatched
+    ///   that map regardless of the stored shape, so leaving the shape
+    ///   non-gesture would silently lose gestures in the rewritten file. (An
+    ///   OS-hook owner is different — the v3 hook only dispatched a stored
+    ///   gesture map, so a `Single` owner stays single.)
     /// - every other gesture-shaped binding demotes to a [`Binding::Single`] of
     ///   its `Click` — the only part of a dormant map the old runtime
     ///   dispatched;
@@ -470,6 +476,34 @@ impl Config {
             for (id, binding) in &mut device.bindings {
                 if Some(*id) != owner {
                     binding.demote_to_single(default_binding(*id));
+                }
+            }
+            if let Some(owner) = owner
+                && owner.is_hidpp_gesture_source()
+            {
+                let seeded = || {
+                    Binding::Gesture(
+                        GestureDirection::ALL
+                            .iter()
+                            .copied()
+                            .map(|d| (d, crate::binding::default_gesture_binding(d)))
+                            .collect(),
+                    )
+                };
+                match device.bindings.get_mut(&owner) {
+                    // A stored non-gesture shape is replaced by the map v3
+                    // actually dispatched.
+                    Some(binding) if !binding.is_gesture() => *binding = seeded(),
+                    Some(_) => {}
+                    // An absent owner only needs materializing when its
+                    // canonical default is not gesture-shaped (the haptic
+                    // panel); an absent dedicated button already means
+                    // default gesture mode.
+                    None => {
+                        if !default_binding_for(owner).is_gesture() {
+                            device.bindings.insert(owner, seeded());
+                        }
+                    }
                 }
             }
             if owner != Some(ButtonId::GestureButton) {

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -37,13 +37,21 @@ pub use settings::{
 
 use crate::binding::{
     Action, ActionRingConfig, ActionRingIcon, ActionRingSlot, Binding, ButtonId, GestureDirection,
-    RingAction, default_binding_for,
+    RingAction, default_binding, default_binding_for,
 };
 use crate::paths::{self, PathsError};
 
 /// The schema version the current build produces. Bumped on breaking layout
 /// changes; readers branch on the parsed value before consuming the rest of
 /// the file.
+///
+/// v4 removes the one-gesture-button-per-device owner lock: gesture mode is a
+/// per-button fact read from the binding shape, so `gesture_owner` no longer
+/// serializes. Loading a v3-or-older file resolves the old owner and rewrites
+/// the shapes to dispatch identically
+/// (see `Config::migrate_owner_locked_gestures`); the version gate is what
+/// keeps that pass off v4 files, where several gesture-shaped buttons are a
+/// deliberate state, not a dormant leftover.
 ///
 /// v3 changes the device map from model keys to physical-device keys. No v2
 /// device entries are migrated because model-scoped settings cannot be assigned
@@ -54,7 +62,7 @@ use crate::paths::{self, PathsError};
 /// `RawDeviceConfig` shim folds the legacy fields) and self-heals to v2 on the
 /// next save; [`Config::load_from_path`] rejects only versions *newer* than this
 /// so a forward file fails loudly instead of silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 3;
+pub const SCHEMA_VERSION: u32 = 4;
 
 const CONFIG_BACKUP_GENERATIONS: usize = 5;
 static BACKED_UP_CONFIGS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
@@ -188,8 +196,15 @@ impl Config {
                         found: config.schema_version,
                     });
                 }
+                // An owner-locked file (v3 and older) rewrites its gesture
+                // shapes to shape-driven form. Version-gated: on a v4 file
+                // several gesture-shaped buttons are a deliberate state that
+                // must round-trip untouched.
+                if config.schema_version <= 3 {
+                    config.migrate_owner_locked_gestures();
+                }
                 // Stamp the in-memory doc to the current version so a re-save
-                // writes the migrated v2 shape (the device shim already folded
+                // writes the migrated shape (the device shim already folded
                 // the legacy fields during deserialize).
                 config.schema_version = SCHEMA_VERSION;
                 Ok(config)
@@ -335,7 +350,7 @@ impl Config {
     /// in place (its action kept as the [`GestureDirection::Click`]). Returns the
     /// entry so the caller can finish it — seed every direction
     /// ([`Binding::fill_gesture_defaults`]) or set just one. Shared by
-    /// [`Self::set_gesture_owner`] and [`Self::set_gesture_direction`] so the two
+    /// [`Self::set_gesture_mode`] and [`Self::set_gesture_direction`] so the two
     /// promote a button into gesture mode identically.
     fn ensure_gesture_binding(&mut self, device_key: &str, button: ButtonId) -> &mut Binding {
         let entry = self
@@ -345,35 +360,25 @@ impl Config {
             .bindings
             .entry(button)
             .or_insert_with(|| default_binding_for(button));
+        // An explicit `Single` at the button's canonical single default carries
+        // no user customization — it is the "pinned off" marker
+        // [`Self::set_gesture_mode`] stamps on a gesture-shaped-by-default
+        // button. Re-promoting it restores the canonical default shape (the
+        // full default direction map for the dedicated gesture button) rather
+        // than freezing the pin action as a Click choice the user never made.
+        // For single-shaped-by-default buttons this replaces the value with
+        // itself, so the rule is uniform.
+        if *entry == Binding::Single(default_binding(button)) {
+            *entry = default_binding_for(button);
+        }
         entry.upgrade_to_gesture();
         entry
     }
 
-    /// The button that owns `device_key`'s single gesture role, or `None` when
-    /// gestures are turned off.
-    ///
-    /// Resolved from the explicit [`DeviceConfig::gesture_owner`] when present;
-    /// otherwise inferred (see `Self::infer_gesture_owner`) for configs
-    /// predating the field and freshly-migrated pre-v2 files. The dedicated
-    /// HID++ gesture button ([`ButtonId::GestureButton`]) owns the role by
-    /// default. At most one button gestures per device.
-    #[must_use]
-    pub fn gesture_owner(&self, device_key: &str) -> Option<ButtonId> {
-        let Some(device) = self.devices.get(device_key) else {
-            // No config yet → the dedicated HID++ gesture button is the default gesture owner.
-            return Some(ButtonId::GestureButton);
-        };
-        match device.gesture_owner {
-            Some(GestureOwner::Off) => None,
-            Some(GestureOwner::Button(id)) => Some(id),
-            None => Self::infer_gesture_owner(&device.bindings),
-        }
-    }
-
-    /// Infer the gesture owner for a config predating the explicit
-    /// [`DeviceConfig::gesture_owner`] field, from the shape of `bindings` — the
-    /// pre-field behavior, so old/migrated configs keep working until the first
-    /// explicit owner change stamps the field.
+    /// The single button the pre-v4 owner-locked runtime would have dispatched
+    /// gestures from, inferred from the binding shapes — the owner-lock-era
+    /// resolution rule, retained for [`Self::migrate_owner_locked_gestures`]
+    /// and the transition shims. `None` means gestures were off.
     fn infer_gesture_owner(bindings: &BTreeMap<ButtonId, Binding>) -> Option<ButtonId> {
         // An OS-hook button left in gesture mode took the role over.
         if let Some((id, _)) = bindings
@@ -393,35 +398,46 @@ impl Config {
         Some(ButtonId::GestureButton)
     }
 
-    /// Make `button` the device's sole gesture button.
+    /// One gesture-mode button of `device_key`, `None` when nothing gestures.
     ///
-    /// Records `button` as the explicit [`gesture_owner`](Self::gesture_owner), so
-    /// the one-gesture-button-per-device lock is a data-model fact rather than a
-    /// destructive demotion of the others — every other gesture-capable button
-    /// keeps its own gesture map intact, ready to restore if re-chosen, and is
-    /// simply not dispatched while it isn't the owner. `button` is given a full
-    /// [`Binding::Gesture`] map: a prior [`Binding::Single`] is kept as the
-    /// [`GestureDirection::Click`] action, any existing swipe arms are preserved,
-    /// and unbound directions are seeded from
-    /// [`default_gesture_binding`](crate::binding::default_gesture_binding) so every
-    /// gesture button exposes the same full five-direction set.
-    pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) {
-        self.devices
-            .entry(device_key.to_string())
-            .or_default()
-            .gesture_owner = Some(GestureOwner::Button(button));
-        self.ensure_gesture_binding(device_key, button)
-            .fill_gesture_defaults();
+    /// Transition shim over the shape-driven model for callers still built
+    /// around the retired one-owner lock: when several buttons gesture at once
+    /// (representable since v4) it reports just one, by the owner-lock-era
+    /// preference order. New code reads [`Self::gesture_mode_buttons`].
+    #[must_use]
+    pub fn gesture_owner(&self, device_key: &str) -> Option<ButtonId> {
+        self.devices.get(device_key).map_or(
+            // No config yet → the dedicated HID++ gesture button gestures by default.
+            Some(ButtonId::GestureButton),
+            |device| Self::infer_gesture_owner(&device.bindings),
+        )
     }
 
-    /// Turn gestures off for `device_key`, recording the explicit "off" choice.
-    /// Every button keeps its gesture map intact (nothing is destroyed), so
-    /// re-selecting a gesture owner later restores its directions exactly.
+    /// Make `button` the device's sole gesture button.
+    ///
+    /// Transition shim over the shape-driven model preserving the retired
+    /// selector's exclusive semantics: promotes `button` (see
+    /// [`Self::set_gesture_mode`]) and demotes every other gesture-mode button
+    /// to a [`Binding::Single`] of its `Click`. New code sets each button's
+    /// mode independently with [`Self::set_gesture_mode`].
+    pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) {
+        for other in self.gesture_mode_buttons(device_key) {
+            if other != button {
+                self.set_gesture_mode(device_key, other, false);
+            }
+        }
+        self.set_gesture_mode(device_key, button, true);
+    }
+
+    /// Turn every gesture-mode button of `device_key` off.
+    ///
+    /// Transition shim over the shape-driven model: demotes each one via
+    /// [`Self::set_gesture_mode`], which pins the gesture-shaped-by-default
+    /// dedicated button with an explicit `Single`.
     pub fn disable_gestures(&mut self, device_key: &str) {
-        self.devices
-            .entry(device_key.to_string())
-            .or_default()
-            .gesture_owner = Some(GestureOwner::Off);
+        for button in self.gesture_mode_buttons(device_key) {
+            self.set_gesture_mode(device_key, button, false);
+        }
     }
 
     /// Whether `button` on `device_key` is in gesture mode — a per-button fact
@@ -435,8 +451,13 @@ impl Config {
     /// one-gesture-button-per-device owner lock — see [`Self::set_gesture_mode`].
     #[must_use]
     pub fn is_gesture_mode(&self, device_key: &str, button: ButtonId) -> bool {
-        let _ = (device_key, button);
-        false
+        self.devices
+            .get(device_key)
+            .and_then(|d| d.bindings.get(&button))
+            .map_or_else(
+                || default_binding_for(button).is_gesture(),
+                Binding::is_gesture,
+            )
     }
 
     /// Every button of `device_key` currently in gesture mode, in [`ButtonId`]
@@ -445,8 +466,11 @@ impl Config {
     /// simply never captures it).
     #[must_use]
     pub fn gesture_mode_buttons(&self, device_key: &str) -> Vec<ButtonId> {
-        let _ = device_key;
-        Vec::new()
+        ButtonId::ALL
+            .iter()
+            .copied()
+            .filter(|b| self.is_gesture_mode(device_key, *b))
+            .collect()
     }
 
     /// Turn gesture mode on or off for one button, independently of every
@@ -459,9 +483,67 @@ impl Config {
     /// Off: demote to a [`Binding::Single`] of the map's `Click` action,
     /// falling back to the button's canonical
     /// [`default_binding`](crate::binding::default_binding) when the map has no
-    /// explicit `Click` — a demoted button always keeps a meaningful press.
+    /// explicit `Click` — a demoted button always keeps a meaningful press. A
+    /// button gesturing only by default (no stored binding) is pinned off with
+    /// an explicit `Single` at its canonical default, which the capture layer
+    /// leaves native.
     pub fn set_gesture_mode(&mut self, device_key: &str, button: ButtonId, enabled: bool) {
-        let _ = (device_key, button, enabled);
+        if enabled {
+            self.ensure_gesture_binding(device_key, button)
+                .fill_gesture_defaults();
+        } else if let Some(binding) = self
+            .devices
+            .get_mut(device_key)
+            .and_then(|d| d.bindings.get_mut(&button))
+        {
+            binding.demote_to_single(default_binding(button));
+        } else if default_binding_for(button).is_gesture() {
+            self.devices
+                .entry(device_key.to_string())
+                .or_default()
+                .bindings
+                .insert(button, Binding::Single(default_binding(button)));
+        }
+    }
+
+    /// One-time load migration for owner-locked files (`schema_version <= 3`).
+    ///
+    /// Under the owner lock at most one button dispatched gestures; every other
+    /// gesture-capable button could keep a dormant direction map awaiting
+    /// re-selection, with [`DeviceConfig::gesture_owner`] recording the choice
+    /// (absent = infer). The shape-driven model has no dormant state — a stored
+    /// [`Binding::Gesture`] IS gesture mode — so this resolves the old owner
+    /// and rewrites the shapes to dispatch exactly what the old config did:
+    ///
+    /// - the owner keeps its gesture map;
+    /// - every other gesture-shaped binding demotes to a [`Binding::Single`] of
+    ///   its `Click` — the only part of a dormant map the old runtime
+    ///   dispatched;
+    /// - a non-owner dedicated gesture button with no stored binding is pinned
+    ///   with an explicit `Single` at its canonical default (absence would
+    ///   re-enter gesture mode under the gesture-shaped default), which the
+    ///   capture layer leaves native;
+    /// - the consumed `gesture_owner` never serializes again — the shape is
+    ///   the whole truth from here on.
+    fn migrate_owner_locked_gestures(&mut self) {
+        for device in self.devices.values_mut() {
+            let owner = match device.gesture_owner.take() {
+                Some(GestureOwner::Off) => None,
+                Some(GestureOwner::Button(id)) => Some(id),
+                None => Self::infer_gesture_owner(&device.bindings),
+            };
+            for (id, binding) in &mut device.bindings {
+                if Some(*id) != owner {
+                    binding.demote_to_single(default_binding(*id));
+                }
+            }
+            if owner != Some(ButtonId::GestureButton) {
+                device
+                    .bindings
+                    .entry(ButtonId::GestureButton)
+                    .or_insert_with(|| Binding::Single(default_binding(ButtonId::GestureButton)));
+            }
+        }
     }
 
     /// Resolve the effective binding map for `device_key`, overlaying the

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -424,6 +424,46 @@ impl Config {
             .gesture_owner = Some(GestureOwner::Off);
     }
 
+    /// Whether `button` on `device_key` is in gesture mode — a per-button fact
+    /// read straight from the binding shape: a stored [`Binding::Gesture`], or
+    /// no stored binding on a button whose canonical default
+    /// ([`default_binding_for`]) is gesture-shaped (the dedicated HID++ gesture
+    /// button starts in gesture mode).
+    ///
+    /// Gesture mode is not exclusive: any number of buttons may gesture at
+    /// once, each with its own direction map. This replaces the former
+    /// one-gesture-button-per-device owner lock — see [`Self::set_gesture_mode`].
+    #[must_use]
+    pub fn is_gesture_mode(&self, device_key: &str, button: ButtonId) -> bool {
+        let _ = (device_key, button);
+        false
+    }
+
+    /// Every button of `device_key` currently in gesture mode, in [`ButtonId`]
+    /// declaration order. Purely config-derived: callers cross it with the
+    /// device's actual controls (a model without the dedicated gesture button
+    /// simply never captures it).
+    #[must_use]
+    pub fn gesture_mode_buttons(&self, device_key: &str) -> Vec<ButtonId> {
+        let _ = device_key;
+        Vec::new()
+    }
+
+    /// Turn gesture mode on or off for one button, independently of every
+    /// other button.
+    ///
+    /// On: promote the stored binding in place ([`Binding::upgrade_to_gesture`]
+    /// keeps a prior single action as the [`GestureDirection::Click`] entry)
+    /// and seed unbound directions from
+    /// [`default_gesture_binding`](crate::binding::default_gesture_binding).
+    /// Off: demote to a [`Binding::Single`] of the map's `Click` action,
+    /// falling back to the button's canonical
+    /// [`default_binding`](crate::binding::default_binding) when the map has no
+    /// explicit `Click` — a demoted button always keeps a meaningful press.
+    pub fn set_gesture_mode(&mut self, device_key: &str, button: ButtonId, enabled: bool) {
+        let _ = (device_key, button, enabled);
+    }
+
     /// Resolve the effective binding map for `device_key`, overlaying the
     /// per-app entry for `bundle_id` (if any) on top of the global per-device
     /// `bindings`. A per-app override replaces the whole button with a

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -37,7 +37,7 @@ pub use settings::{
 
 use crate::binding::{
     Action, ActionRingConfig, ActionRingIcon, ActionRingSlot, Binding, ButtonId, GestureDirection,
-    RingAction, default_binding, default_binding_for,
+    RingAction, default_binding, default_binding_for, default_gesture_binding,
 };
 use crate::paths::{self, PathsError};
 
@@ -337,17 +337,6 @@ impl Config {
             .bindings
             .entry(button)
             .or_insert_with(|| default_binding_for(button));
-        // An explicit `Single` at the button's canonical single default carries
-        // no user customization — it is the "pinned off" marker
-        // [`Self::set_gesture_mode`] stamps on a gesture-shaped-by-default
-        // button. Re-promoting it restores the canonical default shape (the
-        // full default direction map for the dedicated gesture button) rather
-        // than freezing the pin action as a Click choice the user never made.
-        // For single-shaped-by-default buttons this replaces the value with
-        // itself, so the rule is uniform.
-        if *entry == Binding::Single(default_binding(button)) {
-            *entry = default_binding_for(button);
-        }
         entry.upgrade_to_gesture();
         entry
     }
@@ -411,33 +400,54 @@ impl Config {
     /// Turn gesture mode on or off for one button, independently of every
     /// other button.
     ///
-    /// On: promote the stored binding in place ([`Binding::upgrade_to_gesture`]
-    /// keeps a prior single action as the [`GestureDirection::Click`] entry)
-    /// and seed unbound directions from
-    /// [`default_gesture_binding`](crate::binding::default_gesture_binding).
-    /// Off: demote to a [`Binding::Single`] of the map's `Click` action,
-    /// falling back to the button's canonical
-    /// [`default_binding`](crate::binding::default_binding) when the map has no
-    /// explicit `Click` — a demoted button always keeps a meaningful press. A
-    /// button gesturing only by default (no stored binding) is pinned off with
-    /// an explicit `Single` at its canonical default, which the capture layer
-    /// leaves native.
+    /// On: restore the button's stashed map when one exists (see
+    /// [`DeviceConfig::disabled_gestures`]) — an off/on round trip hands back
+    /// the user's customized arms exactly. Otherwise promote the stored
+    /// binding in place ([`Binding::upgrade_to_gesture`] keeps a prior single
+    /// action as the [`GestureDirection::Click`] entry) and seed unbound
+    /// directions from [`default_gesture_binding`].
+    ///
+    /// Off: stash the live map, then demote to a [`Binding::Single`] of the
+    /// map's `Click` action, falling back to the button's canonical
+    /// [`default_binding`] when the map has no explicit `Click` — a demoted
+    /// button always keeps a meaningful press. A button gesturing only by
+    /// default (no stored binding) stashes its seeded default map and is
+    /// pinned off with an explicit `Single` at its canonical default, which
+    /// the capture layer leaves native.
     pub fn set_gesture_mode(&mut self, device_key: &str, button: ButtonId, enabled: bool) {
         if enabled {
-            self.ensure_gesture_binding(device_key, button)
-                .fill_gesture_defaults();
-        } else if let Some(binding) = self
-            .devices
-            .get_mut(device_key)
-            .and_then(|d| d.bindings.get_mut(&button))
-        {
-            binding.demote_to_single(default_binding(button));
-        } else if default_binding_for(button).is_gesture() {
-            self.devices
-                .entry(device_key.to_string())
-                .or_default()
-                .bindings
-                .insert(button, Binding::Single(default_binding(button)));
+            let device = self.devices.entry(device_key.to_string()).or_default();
+            if let Some(map) = device.disabled_gestures.remove(&button) {
+                device.bindings.insert(button, Binding::Gesture(map));
+            } else {
+                self.ensure_gesture_binding(device_key, button)
+                    .fill_gesture_defaults();
+            }
+            return;
+        }
+        let device = self.devices.entry(device_key.to_string()).or_default();
+        match device.bindings.get_mut(&button) {
+            Some(binding) => {
+                if let Binding::Gesture(map) = binding {
+                    device.disabled_gestures.insert(button, map.clone());
+                }
+                binding.demote_to_single(default_binding(button));
+            }
+            None => {
+                if default_binding_for(button).is_gesture() {
+                    device.disabled_gestures.insert(
+                        button,
+                        GestureDirection::ALL
+                            .iter()
+                            .copied()
+                            .map(|d| (d, default_gesture_binding(d)))
+                            .collect(),
+                    );
+                    device
+                        .bindings
+                        .insert(button, Binding::Single(default_binding(button)));
+                }
+            }
         }
     }
 
@@ -457,8 +467,10 @@ impl Config {
     ///   non-gesture would silently lose gestures in the rewritten file. (An
     ///   OS-hook owner is different — the v3 hook only dispatched a stored
     ///   gesture map, so a `Single` owner stays single.)
-    /// - every other gesture-shaped binding demotes to a [`Binding::Single`] of
-    ///   its `Click` — the only part of a dormant map the old runtime
+    /// - every other gesture-shaped binding is stashed into
+    ///   [`DeviceConfig::disabled_gestures`] — keeping the owner-lock model's
+    ///   restore-on-reselection promise — and demotes to a [`Binding::Single`]
+    ///   of its `Click`, the only part of a dormant map the old runtime
     ///   dispatched;
     /// - a non-owner dedicated gesture button with no stored binding is pinned
     ///   with an explicit `Single` at its canonical default (absence would
@@ -475,6 +487,9 @@ impl Config {
             };
             for (id, binding) in &mut device.bindings {
                 if Some(*id) != owner {
+                    if let Binding::Gesture(map) = binding {
+                        device.disabled_gestures.insert(*id, map.clone());
+                    }
                     binding.demote_to_single(default_binding(*id));
                 }
             }
@@ -486,7 +501,7 @@ impl Config {
                         GestureDirection::ALL
                             .iter()
                             .copied()
-                            .map(|d| (d, crate::binding::default_gesture_binding(d)))
+                            .map(|d| (d, default_gesture_binding(d)))
                             .collect(),
                     )
                 };

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -301,29 +301,6 @@ impl Config {
         &self.keyboard.bindings
     }
 
-    /// Returns the gesture sub-bindings for `device_key`'s gesture button, or an
-    /// empty map if it isn't in gesture mode. Derived from the unified
-    /// [`DeviceConfig::bindings`]; kept as a convenience for the agent-side
-    /// per-direction adapter.
-    #[must_use]
-    pub fn gesture_bindings_for(&self, device_key: &str) -> BTreeMap<GestureDirection, Action> {
-        // Read the *owner's* stored map: the gesture role can sit on the
-        // dedicated gesture button or the MX Master 4 haptic panel (or an
-        // OS-hook button — callers gate on the owner kind), and each button
-        // keeps its own per-direction map.
-        let Some(owner) = self.gesture_owner(device_key) else {
-            return BTreeMap::new();
-        };
-        match self
-            .devices
-            .get(device_key)
-            .and_then(|d| d.bindings.get(&owner))
-        {
-            Some(Binding::Gesture(map)) => map.clone(),
-            _ => BTreeMap::new(),
-        }
-    }
-
     /// Records `action` for one `direction` of `button`'s gesture binding,
     /// creating the device entry if needed.
     ///
@@ -377,8 +354,8 @@ impl Config {
 
     /// The single button the pre-v4 owner-locked runtime would have dispatched
     /// gestures from, inferred from the binding shapes — the owner-lock-era
-    /// resolution rule, retained for [`Self::migrate_owner_locked_gestures`]
-    /// and the transition shims. `None` means gestures were off.
+    /// resolution rule, retained solely for
+    /// [`Self::migrate_owner_locked_gestures`]. `None` means gestures were off.
     fn infer_gesture_owner(bindings: &BTreeMap<ButtonId, Binding>) -> Option<ButtonId> {
         // An OS-hook button left in gesture mode took the role over.
         if let Some((id, _)) = bindings
@@ -396,48 +373,6 @@ impl Config {
         }
         // Default: the dedicated HID++ gesture button owns the gesture role.
         Some(ButtonId::GestureButton)
-    }
-
-    /// One gesture-mode button of `device_key`, `None` when nothing gestures.
-    ///
-    /// Transition shim over the shape-driven model for callers still built
-    /// around the retired one-owner lock: when several buttons gesture at once
-    /// (representable since v4) it reports just one, by the owner-lock-era
-    /// preference order. New code reads [`Self::gesture_mode_buttons`].
-    #[must_use]
-    pub fn gesture_owner(&self, device_key: &str) -> Option<ButtonId> {
-        self.devices.get(device_key).map_or(
-            // No config yet → the dedicated HID++ gesture button gestures by default.
-            Some(ButtonId::GestureButton),
-            |device| Self::infer_gesture_owner(&device.bindings),
-        )
-    }
-
-    /// Make `button` the device's sole gesture button.
-    ///
-    /// Transition shim over the shape-driven model preserving the retired
-    /// selector's exclusive semantics: promotes `button` (see
-    /// [`Self::set_gesture_mode`]) and demotes every other gesture-mode button
-    /// to a [`Binding::Single`] of its `Click`. New code sets each button's
-    /// mode independently with [`Self::set_gesture_mode`].
-    pub fn set_gesture_owner(&mut self, device_key: &str, button: ButtonId) {
-        for other in self.gesture_mode_buttons(device_key) {
-            if other != button {
-                self.set_gesture_mode(device_key, other, false);
-            }
-        }
-        self.set_gesture_mode(device_key, button, true);
-    }
-
-    /// Turn every gesture-mode button of `device_key` off.
-    ///
-    /// Transition shim over the shape-driven model: demotes each one via
-    /// [`Self::set_gesture_mode`], which pins the gesture-shaped-by-default
-    /// dedicated button with an explicit `Single`.
-    pub fn disable_gestures(&mut self, device_key: &str) {
-        for button in self.gesture_mode_buttons(device_key) {
-            self.set_gesture_mode(device_key, button, false);
-        }
     }
 
     /// Whether `button` on `device_key` is in gesture mode — a per-button fact

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -88,11 +88,18 @@ pub struct DeviceConfig {
     /// `None` for configs written before this field existed or by hand.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<DeviceIdentity>,
-    /// Every rebindable button's binding: a single [`Action`], or — for the
-    /// gesture button (and, later, any raw-XY-capable button) — a
-    /// [`Binding::Gesture`] per-direction map.
+    /// Every rebindable button's binding: a single [`Action`], or — for a
+    /// button in gesture mode — a [`Binding::Gesture`] per-direction map.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub bindings: BTreeMap<ButtonId, Binding>,
+    /// Direction maps of buttons whose gesture mode is currently OFF, keyed by
+    /// button — pure UX memory so re-enabling restores the user's customized
+    /// arms exactly
+    /// (see [`Config::set_gesture_mode`](crate::config::Config::set_gesture_mode)).
+    /// Never dispatched: the runtime reads only `bindings`, where a demoted
+    /// button is a [`Binding::Single`] of its former `Click`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub disabled_gestures: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
     /// Per-application binding overlays (P1.4). Keyed by bundle identifier
     /// (e.g. `"com.microsoft.VSCode"` on macOS). When the foreground app's
     /// id matches a key here, those bindings take precedence; anything not
@@ -179,6 +186,7 @@ impl Default for DeviceConfig {
             gesture_owner: None,
             identity: None,
             bindings: BTreeMap::new(),
+            disabled_gestures: BTreeMap::new(),
             per_app_bindings: BTreeMap::new(),
             action_ring: ActionRingConfig::default(),
             dpi_presets: Vec::new(),
@@ -240,6 +248,9 @@ struct RawDeviceConfig {
     /// v2 shape — present on already-migrated files; wins on any key collision.
     #[serde(default)]
     bindings: BTreeMap<ButtonId, Binding>,
+    /// v4 stash of turned-off gesture maps (see [`DeviceConfig::disabled_gestures`]).
+    #[serde(default)]
+    disabled_gestures: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
     /// Legacy v1 per-button single bindings.
     #[serde(default)]
     button_bindings: BTreeMap<ButtonId, Action>,
@@ -316,6 +327,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
             gesture_owner: raw.gesture_owner,
             identity: raw.identity,
             bindings,
+            disabled_gestures: raw.disabled_gestures,
             per_app_bindings: raw.per_app_bindings,
             action_ring: raw.action_ring,
             dpi_presets: raw.dpi_presets,

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -74,12 +74,13 @@ pub struct DeviceConfig {
     /// is only serialized when disabled.
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
-    /// Which button owns the device's single gesture role, once the user has
-    /// chosen explicitly. Absent means "infer" (the dedicated HID++ gesture
-    /// button owns gestures if present) — see
-    /// [`Config::gesture_owner`](crate::config::Config::gesture_owner). Listed
-    /// first so it serializes as a scalar ahead of the `bindings` sub-table.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Legacy owner-lock carrier, deserialize-only: the v3-and-older
+    /// `gesture_owner` field, held here just long enough for the version-gated
+    /// load migration (`Config::migrate_owner_locked_gestures`) to consume it.
+    /// Never serialized — since v4 the binding shape is the whole truth
+    /// (gesture mode is per-button; see
+    /// [`Config::set_gesture_mode`](crate::config::Config::set_gesture_mode)).
+    #[serde(skip_serializing)]
     pub gesture_owner: Option<GestureOwner>,
     /// Last-known identity (name / kind / capabilities), captured while the
     /// device was online. Lets the UI render this device — with the right

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -437,31 +437,17 @@ pub struct SmartShift {
     pub tunable_torque: u8,
 }
 
-/// Which control owns a device's single gesture role.
-///
-/// Stored explicitly — rather than inferred from which button happens to carry a
-/// [`Binding::Gesture`](crate::binding::Binding::Gesture) — so switching the
-/// gesture button never has to collapse a button's gesture map to encode the
-/// choice: every gesture-capable button keeps its full direction map, and only
-/// the owner is dispatched. Serialized as a bare string (`"Off"` or a
-/// [`ButtonId`] name) so it stays a TOML scalar.
+/// The v3-and-older owner-lock choice: which control owned a device's single
+/// gesture role. Deserialize-only since v4 — the load migration
+/// (`Config::migrate_owner_locked_gestures`) consumes it and rewrites the
+/// binding shapes, which are the whole truth from then on. Read as a bare TOML
+/// scalar (`"Off"` or a [`ButtonId`] name).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GestureOwner {
-    /// Gestures are explicitly turned off for this device.
+    /// Gestures were explicitly turned off for this device.
     Off,
-    /// The named button owns the gesture role.
+    /// The named button owned the gesture role.
     Button(ButtonId),
-}
-
-impl Serialize for GestureOwner {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            // "Off" can't collide with a ButtonId variant name (all CamelCase
-            // control names), so the string space is unambiguous.
-            GestureOwner::Off => serializer.serialize_str("Off"),
-            GestureOwner::Button(id) => id.serialize(serializer),
-        }
-    }
 }
 
 /// Lenient field deserializer for `RawDeviceConfig::gesture_owner`

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1276,6 +1276,119 @@ GestureButton = \"CycleDpiPresets\"
 }
 
 #[test]
+#[ignore = "RED: disabled-gesture stash not implemented yet"]
+fn off_then_on_restores_customized_swipe_arms() {
+    // Turning gesture mode off must not destroy the user's four customized
+    // swipe arms: re-enabling restores the map exactly as it was — the
+    // guarantee the owner-lock model gave via dormant maps.
+    let mut cfg = Config::default();
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
+    cfg.set_gesture_direction(
+        "2b042",
+        ButtonId::GestureButton,
+        GestureDirection::Up,
+        Action::Copy,
+    );
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
+    match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+        Some(Binding::Gesture(map)) => {
+            assert_eq!(
+                map.get(&GestureDirection::Up),
+                Some(&Action::Copy),
+                "the customized arm survives an off/on round trip"
+            );
+        }
+        other => panic!("expected the restored gesture map, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "RED: disabled-gesture stash not implemented yet"]
+fn re_promoting_a_genuine_single_keeps_it_as_click() {
+    // A user's deliberate Single that happens to equal the button's
+    // canonical default must not be mistaken for the pinned-off marker:
+    // promoting keeps their action as the Click arm instead of resetting
+    // the whole binding to the canonical default map.
+    let mut cfg = Config::default();
+    cfg.set_binding(
+        "2b042",
+        ButtonId::GestureButton,
+        Binding::Single(default_binding(ButtonId::GestureButton)),
+    );
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
+    match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+        Some(Binding::Gesture(map)) => {
+            assert_eq!(
+                map.get(&GestureDirection::Click),
+                Some(&default_binding(ButtonId::GestureButton)),
+                "the user's explicit action stays as Click"
+            );
+        }
+        other => panic!("expected a gesture binding, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "RED: disabled-gesture stash not implemented yet"]
+fn disabled_gesture_maps_survive_a_save_load_cycle() {
+    let mut cfg = Config::default();
+    cfg.set_gesture_direction(
+        "2b042",
+        ButtonId::GestureButton,
+        GestureDirection::Down,
+        Action::Paste,
+    );
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
+
+    let mut restored = write_and_read(&cfg);
+    restored.set_gesture_mode("2b042", ButtonId::GestureButton, true);
+    match restored.bindings_for("2b042").get(&ButtonId::GestureButton) {
+        Some(Binding::Gesture(map)) => {
+            assert_eq!(map.get(&GestureDirection::Down), Some(&Action::Paste));
+        }
+        other => panic!("expected the persisted stash restored, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "RED: disabled-gesture stash not implemented yet"]
+fn migration_stashes_dormant_maps_for_re_enabling() {
+    // The owner-lock model preserved every dormant non-owner map for
+    // restore-on-reselection. The migration keeps that promise: the demoted
+    // map is stashed, and turning the button back on restores it.
+    let toml = "\
+schema_version = 3
+
+[devices.2b042]
+gesture_owner = \"MiddleClick\"
+
+[devices.2b042.bindings]
+GestureButton = { Up = \"Copy\", Click = \"Paste\" }
+MiddleClick = { Up = \"MissionControl\", Click = \"MiddleClick\" }
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, toml).expect("write");
+
+    let mut cfg = Config::load_from_path(&path).expect("load");
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
+    match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+        Some(Binding::Gesture(map)) => {
+            assert_eq!(
+                map.get(&GestureDirection::Up),
+                Some(&Action::Copy),
+                "the dormant map's arms come back on re-enable"
+            );
+        }
+        other => panic!("expected the stashed dormant map restored, got {other:?}"),
+    }
+}
+#[test]
 fn migration_infers_the_owner_for_pre_field_configs() {
     // Pre-owner-field file: a gesture-shaped OS-hook button was the owner by
     // inference, silencing the dedicated button. The load preserves exactly

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1213,7 +1213,6 @@ gesture_owner = \"Off\"
 }
 
 #[test]
-#[ignore = "RED: owner-map materialization not implemented yet"]
 fn migration_materializes_a_hidpp_owners_missing_map() {
     // A v3 HID++ owner dispatched the seeded default direction map
     // regardless of its stored shape (the runtime seeded at projection
@@ -1244,7 +1243,6 @@ gesture_owner = \"HapticPanel\"
 }
 
 #[test]
-#[ignore = "RED: owner-map materialization not implemented yet"]
 fn migration_replaces_a_hidpp_owners_single_with_the_default_map() {
     // A hand-edited v3 file: the owner field says GestureButton but its
     // stored binding is a Single. The v3 runtime still dispatched the full

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1167,3 +1167,175 @@ Back = \"Copy\"
     // ...and the bad owner degraded to inference (HID++ button default here).
     assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
 }
+
+// ── Shape-driven gesture mode (the owner lock removed) ──
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn gesture_mode_is_per_button_and_not_exclusive() {
+    // The owner lock is gone: promoting a second button must not demote the
+    // dedicated gesture button's default gesture mode.
+    let mut cfg = Config::default();
+    cfg.set_gesture_mode("2b042", ButtonId::MiddleClick, true);
+
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::MiddleClick));
+    let buttons = cfg.gesture_mode_buttons("2b042");
+    assert!(
+        buttons.contains(&ButtonId::GestureButton),
+        "got: {buttons:?}"
+    );
+    assert!(buttons.contains(&ButtonId::MiddleClick), "got: {buttons:?}");
+}
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn set_gesture_mode_on_keeps_click_and_seeds_directions() {
+    // Promoting a single-bound button keeps its action as the Click entry
+    // and seeds every swipe arm, so the button exposes the full five-way set.
+    let mut cfg = Config::default();
+    cfg.set_binding("2b042", ButtonId::Back, Binding::Single(Action::Copy));
+    cfg.set_gesture_mode("2b042", ButtonId::Back, true);
+
+    let bindings = cfg.bindings_for("2b042");
+    let Some(Binding::Gesture(map)) = bindings.get(&ButtonId::Back) else {
+        panic!(
+            "expected a gesture binding, got {:?}",
+            bindings.get(&ButtonId::Back)
+        );
+    };
+    assert_eq!(map.get(&GestureDirection::Click), Some(&Action::Copy));
+    for dir in [
+        GestureDirection::Up,
+        GestureDirection::Down,
+        GestureDirection::Left,
+        GestureDirection::Right,
+    ] {
+        assert_eq!(
+            map.get(&dir),
+            Some(&default_gesture_binding(dir)),
+            "unseeded arm {dir:?}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn set_gesture_mode_off_demotes_to_the_click_action() {
+    let mut cfg = Config::default();
+    cfg.set_gesture_direction(
+        "2b042",
+        ButtonId::GestureButton,
+        GestureDirection::Click,
+        Action::Paste,
+    );
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
+
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    assert_eq!(
+        cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
+        Some(&Binding::Single(Action::Paste))
+    );
+}
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn set_gesture_mode_off_without_click_falls_back_to_the_default() {
+    // A sparse hand-edited map with no Click must not demote to a dead
+    // Single(None) — the button falls back to its canonical single default.
+    let mut cfg = Config::default();
+    let mut map = BTreeMap::new();
+    map.insert(GestureDirection::Up, Action::Copy);
+    cfg.set_binding("2b042", ButtonId::Back, Binding::Gesture(map));
+    cfg.set_gesture_mode("2b042", ButtonId::Back, false);
+
+    assert_eq!(
+        cfg.bindings_for("2b042").get(&ButtonId::Back),
+        Some(&Binding::Single(Action::BrowserBack))
+    );
+}
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn migration_demotes_the_dormant_non_owner_gesture_maps() {
+    // An owner-locked config: Middle owns gestures; the dedicated button
+    // keeps a dormant map from an earlier reign. Shape-driven load keeps the
+    // owner gesturing and flattens the dormant map to its Click, so a stored
+    // map's presence always MEANS gesture mode.
+    let toml = "\
+schema_version = 3
+
+[devices.2b042]
+gesture_owner = \"MiddleClick\"
+
+[devices.2b042.bindings]
+GestureButton = { Up = \"Copy\", Click = \"Paste\" }
+MiddleClick = { Up = \"MissionControl\", Click = \"MiddleClick\" }
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, toml).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load");
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::MiddleClick));
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    assert_eq!(
+        cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
+        Some(&Binding::Single(Action::Paste)),
+        "the dormant map demotes to its Click choice"
+    );
+    // The legacy field is gone on save — the binding shape is the whole truth.
+    let body = toml::to_string_pretty(&cfg).expect("serialize");
+    assert!(!body.contains("gesture_owner"), "got: {body}");
+}
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn migration_off_pins_the_dedicated_button_out_of_gesture_mode() {
+    // gesture_owner = "Off" with no stored bindings: absence would re-enter
+    // default gesture mode under shape rules, so the load pins the dedicated
+    // button with an explicit Single at its canonical default (which the
+    // capture layer treats as native/undiverted).
+    let toml = "\
+schema_version = 3
+
+[devices.2b042]
+gesture_owner = \"Off\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, toml).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load");
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    assert!(cfg.gesture_mode_buttons("2b042").is_empty());
+    assert_eq!(
+        cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
+        Some(&Binding::Single(default_binding(ButtonId::GestureButton)))
+    );
+}
+
+#[test]
+#[ignore = "RED: shape-driven gesture mode not implemented yet"]
+fn migration_infers_the_owner_for_pre_field_configs() {
+    // Pre-owner-field file: a gesture-shaped OS-hook button was the owner by
+    // inference, silencing the dedicated button. The load preserves exactly
+    // that: Back keeps gesturing, the dedicated button is pinned off.
+    let toml = "\
+schema_version = 2
+
+[devices.2b042.bindings]
+Back = { Up = \"Copy\" }
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, toml).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load");
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::Back));
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    assert_eq!(
+        cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
+        Some(&Binding::Single(default_binding(ButtonId::GestureButton)))
+    );
+}

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1276,7 +1276,6 @@ GestureButton = \"CycleDpiPresets\"
 }
 
 #[test]
-#[ignore = "RED: disabled-gesture stash not implemented yet"]
 fn off_then_on_restores_customized_swipe_arms() {
     // Turning gesture mode off must not destroy the user's four customized
     // swipe arms: re-enabling restores the map exactly as it was — the
@@ -1306,7 +1305,6 @@ fn off_then_on_restores_customized_swipe_arms() {
 }
 
 #[test]
-#[ignore = "RED: disabled-gesture stash not implemented yet"]
 fn re_promoting_a_genuine_single_keeps_it_as_click() {
     // A user's deliberate Single that happens to equal the button's
     // canonical default must not be mistaken for the pinned-off marker:
@@ -1332,7 +1330,6 @@ fn re_promoting_a_genuine_single_keeps_it_as_click() {
 }
 
 #[test]
-#[ignore = "RED: disabled-gesture stash not implemented yet"]
 fn disabled_gesture_maps_survive_a_save_load_cycle() {
     let mut cfg = Config::default();
     cfg.set_gesture_direction(
@@ -1354,7 +1351,6 @@ fn disabled_gesture_maps_survive_a_save_load_cycle() {
 }
 
 #[test]
-#[ignore = "RED: disabled-gesture stash not implemented yet"]
 fn migration_stashes_dormant_maps_for_re_enabling() {
     // The owner-lock model preserved every dormant non-owner map for
     // restore-on-reselection. The migration keeps that promise: the demoted

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -473,7 +473,7 @@ fn human_readable_toml_layout() {
     // The key only contains [A-Za-z0-9_], so TOML emits it as a bare-word
     // table key (no surrounding quotes). The test asserts the observable
     // structure rather than locking in a specific quoting.
-    assert!(body.contains("schema_version = 3"), "got: {body}");
+    assert!(body.contains("schema_version = 4"), "got: {body}");
     assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
     // A `Single` binding serializes byte-identically to the pre-v2 bare
     // `Action`, so the leaf line is unchanged.
@@ -840,7 +840,7 @@ Click = \"Paste\"
     // Saving self-heals to the current shape: stamped version + merged table,
     // legacy field names gone.
     let body = toml::to_string_pretty(&cfg).expect("serialize");
-    assert!(body.contains("schema_version = 3"), "got: {body}");
+    assert!(body.contains("schema_version = 4"), "got: {body}");
     assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
     assert!(!body.contains("button_bindings"), "got: {body}");
     assert!(!body.contains("gesture_bindings"), "got: {body}");
@@ -1010,9 +1010,12 @@ fn gesture_owner_defaults_to_hidpp_button_yields_to_oshook_and_can_be_off() {
 }
 
 #[test]
-fn set_gesture_owner_records_owner_without_destroying_other_maps() {
+fn set_gesture_owner_shim_switches_by_demoting_the_previous_button() {
+    // The transition shim keeps the retired selector's exclusive semantics
+    // on top of the shape-driven model: switching demotes the previous
+    // gesture button to a Single of its Click (no dormant maps — a stored
+    // gesture map always MEANS gesture mode).
     let mut cfg = Config::default();
-    // Customize the dedicated HID++ gesture button's Up swipe; it is the (inferred) owner.
     cfg.set_gesture_direction(
         "2b042",
         ButtonId::GestureButton,
@@ -1021,8 +1024,6 @@ fn set_gesture_owner_records_owner_without_destroying_other_maps() {
     );
     assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
 
-    // Promote Back: the owner becomes Back explicitly; the HID++ gesture button keeps
-    // its full gesture map (no destructive demotion).
     cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
     cfg.set_gesture_owner("2b042", ButtonId::Back);
     assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::Back));
@@ -1044,24 +1045,15 @@ fn set_gesture_owner_records_owner_without_destroying_other_maps() {
         }
         other => panic!("expected Back to be a gesture binding, got {other:?}"),
     }
-    // The HID++ gesture button's customized map survived the switch intact.
-    match bindings.get(&ButtonId::GestureButton) {
-        Some(Binding::Gesture(map)) => {
-            assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
-        }
-        other => panic!("expected the HID++ gesture button map preserved, got {other:?}"),
-    }
-
-    // Switching back restores the user's customization, not defaults
-    // (regression guard: owner-switch used to discard the swipe arms).
-    cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
-    match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
-        Some(Binding::Gesture(map)) => {
-            assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
-        }
-        other => panic!("expected preserved gesture map, got {other:?}"),
-    }
+    // The dedicated button demoted to its Click choice (seeded AppExpose).
+    assert_eq!(
+        bindings.get(&ButtonId::GestureButton),
+        Some(&Binding::Single(default_gesture_binding(
+            GestureDirection::Click
+        ))),
+        "the previous gesture button demotes to its Click"
+    );
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
 }
 
 #[test]
@@ -1102,7 +1094,10 @@ fn set_gesture_owner_seeds_a_fresh_button_with_full_directions() {
 }
 
 #[test]
-fn disable_gestures_turns_off_without_destroying_maps() {
+fn disable_gestures_shim_demotes_every_gesture_button() {
+    // The transition shim's "off" flattens each gesture-mode button to a
+    // Single of its Click — the shape IS the state, so nothing dormant
+    // survives to resurrect unexpectedly.
     let mut cfg = Config::default();
     cfg.set_gesture_direction(
         "2b042",
@@ -1111,32 +1106,37 @@ fn disable_gestures_turns_off_without_destroying_maps() {
         Action::Copy,
     );
     cfg.disable_gestures("2b042");
-    // Off, but the HID++ gesture button's customized map is preserved (re-enabling
-    // restores it rather than resurrecting a wiped default).
+
     assert_eq!(cfg.gesture_owner("2b042"), None);
-    match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
-        Some(Binding::Gesture(map)) => {
-            assert_eq!(map.get(&GestureDirection::Up), Some(&Action::Copy));
-        }
-        other => panic!("expected the gesture map preserved while off, got {other:?}"),
-    }
+    assert!(cfg.gesture_mode_buttons("2b042").is_empty());
+    assert_eq!(
+        cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
+        Some(&Binding::Single(default_gesture_binding(
+            GestureDirection::Click
+        ))),
+        "off keeps the map's Click as the button's press"
+    );
 }
 
 #[test]
-fn gesture_owner_field_roundtrips_as_a_scalar() {
+fn gesture_state_roundtrips_through_shapes_without_the_owner_field() {
+    // Since v4 the binding shape is the whole persisted truth: gesture
+    // state survives a save/load cycle with no `gesture_owner` scalar in
+    // the document.
     let mut cfg = Config::default();
-    cfg.set_gesture_owner("2b042", ButtonId::Back); // explicit button
-    cfg.disable_gestures("4082d"); // explicit off
+    cfg.set_gesture_mode("2b042", ButtonId::Back, true);
+    cfg.disable_gestures("4082d");
 
     let parsed = write_and_read(&cfg);
-    assert_eq!(parsed.gesture_owner("2b042"), Some(ButtonId::Back));
-    assert_eq!(parsed.gesture_owner("4082d"), None);
+    assert!(parsed.is_gesture_mode("2b042", ButtonId::Back));
+    assert!(
+        parsed.is_gesture_mode("2b042", ButtonId::GestureButton),
+        "the dedicated button's default gesture mode is untouched by Back's promotion"
+    );
+    assert!(parsed.gesture_mode_buttons("4082d").is_empty());
 
-    // The custom codec keeps it a bare TOML string (a nested table would risk
-    // a value-after-table serialization error, since `bindings` is a table).
     let body = toml::to_string_pretty(&cfg).expect("serialize");
-    assert!(body.contains("gesture_owner = \"Back\""), "got: {body}");
-    assert!(body.contains("gesture_owner = \"Off\""), "got: {body}");
+    assert!(!body.contains("gesture_owner"), "got: {body}");
 }
 
 #[test]
@@ -1171,7 +1171,6 @@ Back = \"Copy\"
 // ── Shape-driven gesture mode (the owner lock removed) ──
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn gesture_mode_is_per_button_and_not_exclusive() {
     // The owner lock is gone: promoting a second button must not demote the
     // dedicated gesture button's default gesture mode.
@@ -1189,7 +1188,6 @@ fn gesture_mode_is_per_button_and_not_exclusive() {
 }
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn set_gesture_mode_on_keeps_click_and_seeds_directions() {
     // Promoting a single-bound button keeps its action as the Click entry
     // and seeds every swipe arm, so the button exposes the full five-way set.
@@ -1220,7 +1218,6 @@ fn set_gesture_mode_on_keeps_click_and_seeds_directions() {
 }
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn set_gesture_mode_off_demotes_to_the_click_action() {
     let mut cfg = Config::default();
     cfg.set_gesture_direction(
@@ -1239,7 +1236,6 @@ fn set_gesture_mode_off_demotes_to_the_click_action() {
 }
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn set_gesture_mode_off_without_click_falls_back_to_the_default() {
     // A sparse hand-edited map with no Click must not demote to a dead
     // Single(None) — the button falls back to its canonical single default.
@@ -1256,7 +1252,6 @@ fn set_gesture_mode_off_without_click_falls_back_to_the_default() {
 }
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn migration_demotes_the_dormant_non_owner_gesture_maps() {
     // An owner-locked config: Middle owns gestures; the dedicated button
     // keeps a dormant map from an earlier reign. Shape-driven load keeps the
@@ -1290,7 +1285,6 @@ MiddleClick = { Up = \"MissionControl\", Click = \"MiddleClick\" }
 }
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn migration_off_pins_the_dedicated_button_out_of_gesture_mode() {
     // gesture_owner = "Off" with no stored bindings: absence would re-enter
     // default gesture mode under shape rules, so the load pins the dedicated
@@ -1316,7 +1310,6 @@ gesture_owner = \"Off\"
 }
 
 #[test]
-#[ignore = "RED: shape-driven gesture mode not implemented yet"]
 fn migration_infers_the_owner_for_pre_field_configs() {
     // Pre-owner-field file: a gesture-shaped OS-hook button was the owner by
     // inference, silencing the dedicated button. The load preserves exactly

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -981,86 +981,10 @@ fn set_gesture_direction_on_fresh_gesture_button_seeds_click() {
 }
 
 #[test]
-fn gesture_owner_defaults_to_hidpp_button_yields_to_oshook_and_can_be_off() {
-    let mut cfg = Config::default();
-    // Default: the dedicated HID++ gesture button owns the gesture role even with no config.
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
-
-    // A dedicated HID++ gesture binding keeps it the owner.
-    cfg.set_gesture_direction(
-        "2b042",
-        ButtonId::GestureButton,
-        GestureDirection::Up,
-        Action::MissionControl,
-    );
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
-
-    // An explicit OS-hook gesture button takes the role over.
-    cfg.set_binding(
-        "2b042",
-        ButtonId::Forward,
-        Binding::Gesture(BTreeMap::from([(GestureDirection::Up, Action::Copy)])),
-    );
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::Forward));
-
-    // Turning gestures off explicitly yields `None` (not the HID++ button default).
-    let mut off = Config::default();
-    off.disable_gestures("2b042");
-    assert_eq!(off.gesture_owner("2b042"), None);
-}
-
-#[test]
-fn set_gesture_owner_shim_switches_by_demoting_the_previous_button() {
-    // The transition shim keeps the retired selector's exclusive semantics
-    // on top of the shape-driven model: switching demotes the previous
-    // gesture button to a Single of its Click (no dormant maps — a stored
-    // gesture map always MEANS gesture mode).
-    let mut cfg = Config::default();
-    cfg.set_gesture_direction(
-        "2b042",
-        ButtonId::GestureButton,
-        GestureDirection::Up,
-        Action::Copy,
-    );
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
-
-    cfg.set_binding("2b042", ButtonId::Back, Action::BrowserBack.into());
-    cfg.set_gesture_owner("2b042", ButtonId::Back);
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::Back));
-
-    let bindings = cfg.bindings_for("2b042");
-    // Back is a full five-direction gesture button: its prior single action
-    // stays as Click, and the swipe arms are seeded from defaults.
-    match bindings.get(&ButtonId::Back) {
-        Some(Binding::Gesture(map)) => {
-            assert_eq!(
-                map.get(&GestureDirection::Click),
-                Some(&Action::BrowserBack)
-            );
-            assert_eq!(
-                map.get(&GestureDirection::Up),
-                Some(&default_gesture_binding(GestureDirection::Up)),
-                "a promoted button gets full default arms"
-            );
-        }
-        other => panic!("expected Back to be a gesture binding, got {other:?}"),
-    }
-    // The dedicated button demoted to its Click choice (seeded AppExpose).
-    assert_eq!(
-        bindings.get(&ButtonId::GestureButton),
-        Some(&Binding::Single(default_gesture_binding(
-            GestureDirection::Click
-        ))),
-        "the previous gesture button demotes to its Click"
-    );
-    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
-}
-
-#[test]
-fn set_gesture_owner_seeds_a_fresh_button_with_full_directions() {
+fn set_gesture_mode_seeds_a_fresh_button_with_full_directions() {
     let mut cfg = Config::default();
     // The dedicated HID++ gesture button gets the full default direction map.
-    cfg.set_gesture_owner("2b042", ButtonId::GestureButton);
+    cfg.set_gesture_mode("2b042", ButtonId::GestureButton, true);
     match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
         Some(Binding::Gesture(map)) => {
             for dir in GestureDirection::ALL {
@@ -1073,7 +997,7 @@ fn set_gesture_owner_seeds_a_fresh_button_with_full_directions() {
     // A fresh OS-hook button also gets all five directions, not just a Click:
     // its native action stays as Click, and the swipe arms are defaults — so
     // the GUI's shown defaults are exactly what the runtime dispatches.
-    cfg.set_gesture_owner("2b042", ButtonId::Forward);
+    cfg.set_gesture_mode("2b042", ButtonId::Forward, true);
     match cfg.bindings_for("2b042").get(&ButtonId::Forward) {
         Some(Binding::Gesture(map)) => {
             assert_eq!(
@@ -1091,31 +1015,9 @@ fn set_gesture_owner_seeds_a_fresh_button_with_full_directions() {
         }
         other => panic!("expected full gesture map for Forward, got {other:?}"),
     }
-}
-
-#[test]
-fn disable_gestures_shim_demotes_every_gesture_button() {
-    // The transition shim's "off" flattens each gesture-mode button to a
-    // Single of its Click — the shape IS the state, so nothing dormant
-    // survives to resurrect unexpectedly.
-    let mut cfg = Config::default();
-    cfg.set_gesture_direction(
-        "2b042",
-        ButtonId::GestureButton,
-        GestureDirection::Up,
-        Action::Copy,
-    );
-    cfg.disable_gestures("2b042");
-
-    assert_eq!(cfg.gesture_owner("2b042"), None);
-    assert!(cfg.gesture_mode_buttons("2b042").is_empty());
-    assert_eq!(
-        cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
-        Some(&Binding::Single(default_gesture_binding(
-            GestureDirection::Click
-        ))),
-        "off keeps the map's Click as the button's press"
-    );
+    // Both promotions coexist — no exclusivity.
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::Forward));
 }
 
 #[test]
@@ -1125,7 +1027,7 @@ fn gesture_state_roundtrips_through_shapes_without_the_owner_field() {
     // the document.
     let mut cfg = Config::default();
     cfg.set_gesture_mode("2b042", ButtonId::Back, true);
-    cfg.disable_gestures("4082d");
+    cfg.set_gesture_mode("4082d", ButtonId::GestureButton, false);
 
     let parsed = write_and_read(&cfg);
     assert!(parsed.is_gesture_mode("2b042", ButtonId::Back));
@@ -1164,8 +1066,9 @@ Back = \"Copy\"
         cfg.bindings_for("2b042").get(&ButtonId::Back),
         Some(&Binding::Single(Action::Copy))
     );
-    // ...and the bad owner degraded to inference (HID++ button default here).
-    assert_eq!(cfg.gesture_owner("2b042"), Some(ButtonId::GestureButton));
+    // ...and the bad owner degraded to inference (HID++ button default here),
+    // so the dedicated button keeps its default gesture mode.
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
 }
 
 // ── Shape-driven gesture mode (the owner lock removed) ──

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1213,6 +1213,71 @@ gesture_owner = \"Off\"
 }
 
 #[test]
+#[ignore = "RED: owner-map materialization not implemented yet"]
+fn migration_materializes_a_hidpp_owners_missing_map() {
+    // A v3 HID++ owner dispatched the seeded default direction map
+    // regardless of its stored shape (the runtime seeded at projection
+    // time), so an owner with no stored map must not lose gestures when
+    // the file is rewritten to v4.
+    let toml = "\
+schema_version = 3
+
+[devices.2b042]
+gesture_owner = \"HapticPanel\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, toml).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load");
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::HapticPanel));
+    match cfg.bindings_for("2b042").get(&ButtonId::HapticPanel) {
+        Some(Binding::Gesture(map)) => {
+            for dir in GestureDirection::ALL {
+                assert_eq!(map.get(&dir), Some(&default_gesture_binding(dir)));
+            }
+        }
+        other => panic!("expected the owner's materialized default map, got {other:?}"),
+    }
+    // The non-owner dedicated button is still pinned off.
+    assert!(!cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+}
+
+#[test]
+#[ignore = "RED: owner-map materialization not implemented yet"]
+fn migration_replaces_a_hidpp_owners_single_with_the_default_map() {
+    // A hand-edited v3 file: the owner field says GestureButton but its
+    // stored binding is a Single. The v3 runtime still dispatched the full
+    // default direction map (seeded at projection), so the load must
+    // materialize that map rather than keep the never-dispatched Single.
+    let toml = "\
+schema_version = 3
+
+[devices.2b042]
+gesture_owner = \"GestureButton\"
+
+[devices.2b042.bindings]
+GestureButton = \"CycleDpiPresets\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, toml).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load");
+    assert!(cfg.is_gesture_mode("2b042", ButtonId::GestureButton));
+    match cfg.bindings_for("2b042").get(&ButtonId::GestureButton) {
+        Some(Binding::Gesture(map)) => {
+            assert_eq!(
+                map.get(&GestureDirection::Click),
+                Some(&default_gesture_binding(GestureDirection::Click)),
+                "v3 dispatched the seeded default Click, not the stored Single"
+            );
+        }
+        other => panic!("expected the owner's materialized default map, got {other:?}"),
+    }
+}
+
+#[test]
 fn migration_infers_the_owner_for_pre_field_configs() {
     // Pre-owner-field file: a gesture-shaped OS-hook button was the owner by
     // inference, silencing the dedicated button. The load preserves exactly

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Vandret rulning"
 "Custom": "Brugerdefineret"
 "Gesture Button": "Bevægelsesknap"
+"Gestures": "Bevægelser"
+"Turn off gestures": "Slå bevægelser fra"
 "Haptic Panel": "Haptisk panel"
 "Up": "Op"
 "Down": "Ned"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Horizontales Scrollen"
 "Custom": "Benutzerdefiniert"
 "Gesture Button": "Gestentaste"
+"Gestures": "Gesten"
+"Turn off gestures": "Gesten deaktivieren"
 "Haptic Panel": "Haptik-Panel"
 "Up": "Oben"
 "Down": "Unten"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Οριζόντια κύλιση"
 "Custom": "Προσαρμοσμένο"
 "Gesture Button": "Κουμπί χειρονομιών"
+"Gestures": "Χειρονομίες"
+"Turn off gestures": "Απενεργοποίηση χειρονομιών"
 "Haptic Panel": "Απτικό πάνελ"
 "Up": "Πάνω"
 "Down": "Κάτω"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Horizontal Scroll"
 "Custom": "Custom"
 "Gesture Button": "Gesture Button"
+"Gestures": "Gestures"
+"Turn off gestures": "Turn off gestures"
 "Haptic Panel": "Haptic Panel"
 "Up": "Up"
 "Down": "Down"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Desplazamiento horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botón de gestos"
+"Gestures": "Gestos"
+"Turn off gestures": "Desactivar gestos"
 "Haptic Panel": "Panel háptico"
 "Up": "Arriba"
 "Down": "Abajo"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Vaakavieritys"
 "Custom": "Mukautettu"
 "Gesture Button": "Eletoiminto"
+"Gestures": "Eleet"
+"Turn off gestures": "Poista eleet käytöstä"
 "Haptic Panel": "Haptinen paneeli"
 "Up": "Ylös"
 "Down": "Alas"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Défilement horizontal"
 "Custom": "Personnalisé"
 "Gesture Button": "Bouton de gestes"
+"Gestures": "Gestes"
+"Turn off gestures": "Désactiver les gestes"
 "Haptic Panel": "Panneau haptique"
 "Up": "Haut"
 "Down": "Bas"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Scorrimento orizzontale"
 "Custom": "Personalizzato"
 "Gesture Button": "Pulsante gesture"
+"Gestures": "Gesture"
+"Turn off gestures": "Disattiva le gesture"
 "Haptic Panel": "Pannello aptico"
 "Up": "Su"
 "Down": "Giù"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "横スクロール"
 "Custom": "カスタム"
 "Gesture Button": "ジェスチャーボタン"
+"Gestures": "ジェスチャー"
+"Turn off gestures": "ジェスチャーをオフにする"
 "Haptic Panel": "ハプティックパネル"
 "Up": "上"
 "Down": "下"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "가로 스크롤"
 "Custom": "사용자 지정"
 "Gesture Button": "제스처 버튼"
+"Gestures": "제스처"
+"Turn off gestures": "제스처 끄기"
 "Haptic Panel": "햅틱 패널"
 "Up": "위"
 "Down": "아래"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Horisontal rulling"
 "Custom": "Egendefinert"
 "Gesture Button": "Bevegelsesknapp"
+"Gestures": "Bevegelser"
+"Turn off gestures": "Slå av bevegelser"
 "Haptic Panel": "Haptisk panel"
 "Up": "Opp"
 "Down": "Ned"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Horizontaal scrollen"
 "Custom": "Aangepast"
 "Gesture Button": "Gebarenknop"
+"Gestures": "Gebaren"
+"Turn off gestures": "Gebaren uitschakelen"
 "Haptic Panel": "Haptisch paneel"
 "Up": "Omhoog"
 "Down": "Omlaag"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Przewijanie poziome"
 "Custom": "Niestandardowe"
 "Gesture Button": "Przycisk gestów"
+"Gestures": "Gesty"
+"Turn off gestures": "Wyłącz gesty"
 "Haptic Panel": "Panel haptyczny"
 "Up": "W górę"
 "Down": "W dół"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Rolagem horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de Gesto"
+"Gestures": "Gestos"
+"Turn off gestures": "Desativar gestos"
 "Haptic Panel": "Painel Háptico"
 "Up": "Cima"
 "Down": "Baixo"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Deslocamento horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de gesto"
+"Gestures": "Gestos"
+"Turn off gestures": "Desativar gestos"
 "Haptic Panel": "Painel háptico"
 "Up": "Cima"
 "Down": "Baixo"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Горизонтальная прокрутка"
 "Custom": "Свой"
 "Gesture Button": "Кнопка жестов"
+"Gestures": "Жесты"
+"Turn off gestures": "Отключить жесты"
 "Haptic Panel": "Тактильная панель"
 "Up": "Вверх"
 "Down": "Вниз"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "Horisontell rullning"
 "Custom": "Anpassad"
 "Gesture Button": "Gestknapp"
+"Gestures": "Gester"
+"Turn off gestures": "Stäng av gester"
 "Haptic Panel": "Haptisk panel"
 "Up": "Upp"
 "Down": "Ned"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "水平滚动"
 "Custom": "自定义"
 "Gesture Button": "手势按钮"
+"Gestures": "手势"
+"Turn off gestures": "关闭手势"
 "Haptic Panel": "触感面板"
 "Up": "上"
 "Down": "下"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
+"Gestures": "手勢"
+"Turn off gestures": "關閉手勢"
 "Haptic Panel": "觸感面板"
 "Up": "上"
 "Down": "下"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -169,6 +169,8 @@ _version: 1
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
+"Gestures": "手勢"
+"Turn off gestures": "關閉手勢"
 "Haptic Panel": "觸感面板"
 "Up": "上"
 "Down": "下"

--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -607,7 +607,11 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
         .map_or((0, 0, 0, tr!("Default profile").to_string()), |state| {
             (
                 state.button_bindings.len(),
-                state.gesture_bindings.len(),
+                state
+                    .gesture_bindings
+                    .values()
+                    .map(std::collections::BTreeMap::len)
+                    .sum::<usize>(),
                 state.dpi_presets().len(),
                 state
                     .current_app_bundle

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -1,17 +1,20 @@
-//! Popover content for binding mouse buttons, plus the gesture button's custom
-//! two-level menu.
+//! Popover content for binding mouse buttons, plus the per-button gesture
+//! menu.
 //!
 //! - [`action_picker`] — one button → one [`Action`], rendered as a custom flat
 //!   list inside a gpui-component [`Popover`](gpui_component::popover::Popover).
 //!   Generic over the entity that should be notified after a binding changes so
-//!   the trigger re-renders with the new label.
-//! - [`gesture_overview`] — the gesture button's custom multi-level menu: a
+//!   the trigger re-renders with the new label. Gesture-capable buttons lead
+//!   with a pinned "Gestures" entry that promotes the button into gesture mode.
+//! - [`gesture_overview`] — a gesture-mode button's custom multi-level menu: a
 //!   plus-shaped navigator card (level 1) listing all five [`GestureDirection`]s
 //!   with their bound actions, and — once a direction is activated — a separate
 //!   action-list card (level 2) that flies out beside it. The two are distinct
 //!   floating cards (own surface + height), so this reads like a cascading menu
 //!   while staying fully custom-styled. The active direction is scratch state on
-//!   the [`MouseModelView`].
+//!   the [`MouseModelView`]. A footer row demotes the button back to a single
+//!   action. Any number of buttons can be in gesture mode at once, each with
+//!   its own menu.
 //!
 //! The [`action_picker`] [`Popover`] uses the framework's styled surface; the
 //! gesture menu uses `appearance(false)` and draws its own card surfaces, since
@@ -61,20 +64,34 @@ pub fn action_picker<T: 'static>(
 
     let observer = observer.clone();
     let popover = cx.entity().downgrade();
-    let on_pick: PickFn = Rc::new(move |action, window, cx| {
-        cx.update_global::<AppState, _>(|state, _| state.commit_binding(btn, action));
-        observer.update(cx, |_, cx| cx.notify());
-        if let Some(p) = popover.upgrade() {
-            p.update(cx, |s, cx| s.dismiss(window, cx));
+    let on_pick: PickFn = Rc::new({
+        let observer = observer.clone();
+        let popover = popover.clone();
+        move |action, window, cx| {
+            cx.update_global::<AppState, _>(|state, _| state.commit_binding(btn, action));
+            observer.update(cx, |_, cx| cx.notify());
+            if let Some(p) = popover.upgrade() {
+                p.update(cx, |s, cx| s.dismiss(window, cx));
+            }
         }
     });
 
     let pal = theme::palette(cx);
     let button = rust_i18n::t!(btn.label());
+    // A control that can gesture (a HID++ gesture source, or an OS-hook button
+    // the hook can hold-and-swipe) leads with a pinned mode entry above the
+    // action list: picking it promotes THIS button into gesture mode — any
+    // number of buttons may gesture at once — and the reopened popover then
+    // shows the gesture menu.
+    let gesture_capable = btn.is_hidpp_gesture_source() || btn.is_os_hook_button();
     menu_card(pal)
         .min_w(px(POPOVER_W))
         .child(title(tr!("Bind %{name}", name => button), pal))
         .child(divider(pal))
+        .when(gesture_capable, |card| {
+            card.child(gesture_mode_row(btn, &observer, &popover, pal))
+                .child(divider(pal))
+        })
         .child(scroll_list(
             "picker-scroll",
             action_rows("action-item", current.as_ref(), &on_pick, pal),
@@ -165,11 +182,52 @@ pub(crate) fn thumbwheel_picker<T: 'static>(
         .into_any_element()
 }
 
+/// The pinned "Gestures" entry leading a gesture-capable button's picker.
+/// Clicking promotes the button into gesture mode (its single action becomes
+/// the Click arm, swipe arms seed from defaults) and dismisses the popover;
+/// reopening it lands on the gesture menu.
+fn gesture_mode_row<T: 'static>(
+    btn: ButtonId,
+    observer: &Entity<T>,
+    popover: &gpui::WeakEntity<PopoverState>,
+    pal: Palette,
+) -> AnyElement {
+    let observer = observer.clone();
+    let popover = popover.clone();
+    menu_row("gesture-mode-row", pal, false)
+        .child(
+            h_flex()
+                .items_center()
+                .gap_2()
+                .child(
+                    svg()
+                        .path(GESTURE_BUTTON_ICON)
+                        .size_4()
+                        .flex_none()
+                        .text_color(pal.text_muted),
+                )
+                .child(div().child(tr!("Gestures"))),
+        )
+        .child(
+            Icon::new(IconName::ChevronRight)
+                .size_3()
+                .text_color(pal.text_muted),
+        )
+        .on_click(move |_event, window, cx| {
+            cx.update_global::<AppState, _>(|state, _| state.commit_gesture_mode(btn, true));
+            observer.update(cx, |_, cx| cx.notify());
+            if let Some(p) = popover.upgrade() {
+                p.update(cx, |s, cx| s.dismiss(window, cx));
+            }
+        })
+        .into_any_element()
+}
+
 /// Floor width of a single direction cell in the plus navigator. Three sit side
 /// by side in the middle row, so the plus is roughly `3×` this plus gaps.
 const GESTURE_CELL_W: f32 = 104.;
 
-/// Build the gesture button's custom two-level menu: the plus navigator card
+/// Build `btn`'s custom two-level gesture menu: the plus navigator card
 /// (level 1) plus, once a direction is activated, its action-list card (level 2)
 /// flown out beside it. The two are separate floating cards — own surface and
 /// height — so it reads like a cascading menu without sharing one box. The
@@ -177,6 +235,7 @@ const GESTURE_CELL_W: f32 = 104.;
 /// a cell is clicked → only the plus shows), reset on popover close. Mutating it
 /// re-renders the view, which re-renders this open popover's content.
 pub fn gesture_overview(
+    btn: ButtonId,
     view: &Entity<MouseModelView>,
     cx: &mut Context<PopoverState>,
 ) -> AnyElement {
@@ -185,9 +244,11 @@ pub fn gesture_overview(
     h_flex()
         .items_start()
         .gap_2()
-        .child(plus_card(view, active, pal, cx))
+        .child(plus_card(btn, view, active, pal, cx))
         // The flyout card only appears once a direction is activated.
-        .when_some(active, |row, dir| row.child(flyout_card(dir, view, pal, cx)))
+        .when_some(active, |row, dir| {
+            row.child(flyout_card(btn, dir, view, pal, cx))
+        })
         .into_any_element()
 }
 
@@ -212,8 +273,10 @@ pub(crate) fn menu_card(pal: Palette) -> gpui::Div {
 /// Level 1: the plus navigator. `Up` on top, `Left`/`Click`/`Right` across the
 /// middle, `Down` on the bottom. Each cell shows its glyph + label and bound
 /// action; the `active` cell (if any) is accented. Clicking a cell activates
-/// that direction (flying out the level-2 card) without committing.
+/// that direction (flying out the level-2 card) without committing. A footer
+/// row turns gesture mode off for `btn`, demoting it back to a single action.
 fn plus_card(
+    btn: ButtonId,
     view: &Entity<MouseModelView>,
     active: Option<GestureDirection>,
     pal: Palette,
@@ -224,15 +287,23 @@ fn plus_card(
         .map(|d| {
             let action = cx
                 .try_global::<AppState>()
-                .and_then(|s| s.gesture_bindings.get(&d).cloned())
+                .and_then(|s| {
+                    s.gesture_bindings
+                        .get(&btn)
+                        .and_then(|m| m.get(&d))
+                        .cloned()
+                })
                 .unwrap_or_else(|| default_gesture_binding(d));
             (d, action)
         })
         .collect();
 
-    let cell =
-        |dir: GestureDirection| direction_cell(dir, &actions[&dir], active == Some(dir), view, pal);
+    let cell = |dir: GestureDirection| {
+        direction_cell(btn, dir, &actions[&dir], active == Some(dir), view, pal)
+    };
 
+    let view_off = view.clone();
+    let popover = cx.entity().downgrade();
     menu_card(pal)
         .gap_1p5()
         .child(
@@ -256,6 +327,34 @@ fn plus_card(
                 .justify_center()
                 .child(cell(GestureDirection::Down)),
         )
+        .child(divider(pal))
+        .child(
+            // Demote back to a single action: the Click arm becomes the
+            // button's action, and the reopened popover shows the plain picker.
+            menu_row("gesture-off-row", pal, false)
+                .child(
+                    h_flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            svg()
+                                .path("action-icons/ban.svg")
+                                .size_4()
+                                .flex_none()
+                                .text_color(pal.text_muted),
+                        )
+                        .child(div().child(tr!("Turn off gestures"))),
+                )
+                .on_click(move |_event, window, cx| {
+                    cx.update_global::<AppState, _>(|state, _| {
+                        state.commit_gesture_mode(btn, false);
+                    });
+                    view_off.update(cx, |_, vcx| vcx.notify());
+                    if let Some(p) = popover.upgrade() {
+                        p.update(cx, |s, cx| s.dismiss(window, cx));
+                    }
+                }),
+        )
         .into_any_element()
 }
 
@@ -263,6 +362,7 @@ fn plus_card(
 /// direction glyph + label above its bound-action label. The `active` cell is
 /// accented (border + faint fill); a default binding's action is muted.
 fn direction_cell(
+    btn: ButtonId,
     dir: GestureDirection,
     current: &Action,
     active: bool,
@@ -275,7 +375,7 @@ fn direction_cell(
         GestureDirection::Left => 2,
         GestureDirection::Right => 3,
         GestureDirection::Click => 4,
-    };
+    } + 5 * (btn as usize);
     let header = format!("{}  {}", dir.glyph(), tr!(dir.label()));
     let action_label = tr!(current.label());
     let accessible_label = format!("{}: {action_label}", tr!(dir.label()));
@@ -318,11 +418,12 @@ fn direction_cell(
         .into_any_element()
 }
 
-/// Level 2: the `dir` direction's action picker, flown out as its own card —
-/// the category-grouped catalog with the current binding checked. Picking
-/// commits and stays open, so the level-1 cell + checkmark update in place and
-/// the user can keep editing other directions.
+/// Level 2: the `dir` direction's action picker for `btn`, flown out as its
+/// own card — the category-grouped catalog with the current binding checked.
+/// Picking commits and stays open, so the level-1 cell + checkmark update in
+/// place and the user can keep editing other directions.
 fn flyout_card(
+    btn: ButtonId,
     dir: GestureDirection,
     view: &Entity<MouseModelView>,
     pal: Palette,
@@ -330,12 +431,17 @@ fn flyout_card(
 ) -> AnyElement {
     let current = cx
         .try_global::<AppState>()
-        .and_then(|s| s.gesture_bindings.get(&dir).cloned())
+        .and_then(|s| {
+            s.gesture_bindings
+                .get(&btn)
+                .and_then(|m| m.get(&dir))
+                .cloned()
+        })
         .unwrap_or_else(|| default_gesture_binding(dir));
 
     let view_pick = view.clone();
     let on_pick: PickFn = Rc::new(move |action, _window, cx| {
-        cx.update_global::<AppState, _>(|state, _| state.commit_gesture_binding(dir, action));
+        cx.update_global::<AppState, _>(|state, _| state.commit_gesture_binding(btn, dir, action));
         // Stay open; re-render so the level-1 cell + checkmark update.
         view_pick.update(cx, |_, vcx| vcx.notify());
     });

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -270,6 +270,21 @@ pub(crate) fn menu_card(pal: Palette) -> gpui::Div {
         .p_1p5()
 }
 
+/// The action a missing gesture-map entry actually performs at runtime, so the
+/// menu never shows a swipe or tap doing something it would not.
+///
+/// Only an OS-hook button's raw (hand-edited, sparse) map can be missing an
+/// entry — HID++ sources come fully seeded (see
+/// [`AppState::current_gesture_maps`]). A tap without a `Click` entry falls
+/// through to the button's plain click action ([`default_binding`]); an
+/// unbound swipe does nothing.
+fn sparse_gesture_fallback(btn: ButtonId, dir: GestureDirection) -> Action {
+    match dir {
+        GestureDirection::Click => default_binding(btn),
+        _ => Action::None,
+    }
+}
+
 /// Level 1: the plus navigator. `Up` on top, `Left`/`Click`/`Right` across the
 /// middle, `Down` on the bottom. Each cell shows its glyph + label and bound
 /// action; the `active` cell (if any) is accented. Clicking a cell activates
@@ -293,7 +308,7 @@ fn plus_card(
                         .and_then(|m| m.get(&d))
                         .cloned()
                 })
-                .unwrap_or_else(|| default_gesture_binding(d));
+                .unwrap_or_else(|| sparse_gesture_fallback(btn, d));
             (d, action)
         })
         .collect();
@@ -437,7 +452,7 @@ fn flyout_card(
                 .and_then(|m| m.get(&dir))
                 .cloned()
         })
-        .unwrap_or_else(|| default_gesture_binding(dir));
+        .unwrap_or_else(|| sparse_gesture_fallback(btn, dir));
 
     let view_pick = view.clone();
     let on_pick: PickFn = Rc::new(move |action, _window, cx| {

--- a/crates/openlogi-gui/src/mouse_model/view.rs
+++ b/crates/openlogi-gui/src/mouse_model/view.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use gpui::{
-    Anchor, AnyElement, App, BorrowAppContext as _, Context, ElementId, Entity, Hsla,
-    InteractiveElement, IntoElement, MouseButton, ParentElement, Render, RenderOnce, Role,
-    StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, canvas, div, hsla, img,
-    prelude::FluentBuilder as _, px, rgb, svg,
+    Anchor, AnyElement, App, Context, ElementId, Entity, Hsla, InteractiveElement, IntoElement,
+    MouseButton, ParentElement, Render, RenderOnce, Role, StatefulInteractiveElement as _, Styled,
+    Subscription, Window, canvas, div, hsla, img, prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_component::{Icon, IconName, Selectable, h_flex, popover::Popover, v_flex};
 
@@ -26,7 +25,7 @@ use crate::mouse_model::picker::{
 };
 use crate::mouse_model::thumbwheel::ThumbwheelPreset;
 use crate::state::AppState;
-use crate::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
+use crate::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
 const SIDE_W: f32 = 180.;
 const SIDE_GAP: f32 = 24.;
@@ -38,8 +37,8 @@ const CARD_EDGE_INSET: f32 = SIDE_GAP + (SIDE_W - LABEL_W);
 const HOTSPOT_DOT: f32 = 12.;
 
 /// Vertical space around the model that it can't draw into: the detail header
-/// and footer, the buttons-tab padding, and the gesture selector row above the
-/// canvas. The model scales to fit whatever viewport height remains.
+/// and footer, plus the buttons-tab padding. The model scales to fit whatever
+/// viewport height remains.
 const MODEL_VERTICAL_RESERVE: f32 = 224.;
 /// Floor for the scaled model height. Below this the evenly-slotted side labels
 /// (≈[`LABEL_H`] each) start to overlap; the window's minimum height is sized to
@@ -109,7 +108,7 @@ enum BindingPopover {
 
 impl Render for MouseModelView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let (device_key, asset, active, bindings, gesture_owner, glow, thumbwheel) = cx
+        let (device_key, asset, active, bindings, gesture_buttons, glow, thumbwheel) = cx
             .try_global::<AppState>()
             .map(|s| {
                 (
@@ -117,7 +116,7 @@ impl Render for MouseModelView {
                     s.current_record().and_then(|r| r.asset.clone()),
                     s.active_button.map(MouseControlId::from_active_button),
                     s.button_bindings.clone(),
-                    s.current_gesture_owner(),
+                    s.gesture_bindings.keys().copied().collect::<Vec<_>>(),
                     s.current_record().and_then(|r| keyboard_glow(s, r)),
                     s.current_record()
                         .and_then(|r| r.capabilities)
@@ -161,12 +160,6 @@ impl Render for MouseModelView {
 
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
-        // Resolve the gesture owner against the buttons this device actually has:
-        // a mouse with no HID++ gesture button must not surface that default owner
-        // (it has none) — the role then reads as "Off" until the user picks a
-        // present button. Display-only; the stored config still infers as usual.
-        let capable = gesture_capable_buttons(&labels_outer);
-        let gesture_owner = gesture_owner.filter(|id| capable.contains(id));
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
         let breathing_art = breathing_art(asset.as_ref(), mouse_left, mouse_w, mouse_h, pal, glow);
         let hotspots_layer = hotspots_layer(
@@ -176,7 +169,7 @@ impl Render for MouseModelView {
             mouse_h,
             hovered,
             active,
-            gesture_owner,
+            &gesture_buttons,
             self.open_binding_popover,
             &view,
         );
@@ -187,7 +180,7 @@ impl Render for MouseModelView {
             .child(breathing_art)
             .child(leader_canvas)
             .children(labels_outer.iter().enumerate().map(|(idx, label)| {
-                let binding = binding_label_for_control(label.id, &bindings, gesture_owner);
+                let binding = binding_label_for_control(label.id, &bindings, &gesture_buttons);
                 label_popover(
                     idx,
                     *label,
@@ -197,25 +190,19 @@ impl Render for MouseModelView {
                     mouse_w,
                     hovered,
                     active,
-                    gesture_owner,
+                    label
+                        .id
+                        .button()
+                        .filter(|button| gesture_buttons.contains(button)),
                     self.open_binding_popover == Some(BindingPopover::Label(label.id)),
                     &view,
                 )
             }))
             .child(hotspots_layer);
 
-        // The gesture-button selector sits above the mouse: a single-select of
-        // the device's gesture-capable buttons (the HID++ gesture button plus the
-        // OS-hook Middle/Back/Forward) makes the one-gesture-button-per-device
-        // lock visible and obvious — pick one and its card opens the gesture
-        // menu, the rest stay single-action.
-        v_flex()
-            .w(px(canvas_w))
-            .gap_4()
-            .when(!capable.is_empty(), |col| {
-                col.child(gesture_owner_selector(&capable, gesture_owner, &view, pal))
-            })
-            .child(canvas)
+        // Gesture mode is a per-button fact edited inside each button's own
+        // picker (the "Gestures" entry) — no device-level selector row.
+        v_flex().w(px(canvas_w)).gap_4().child(canvas)
     }
 }
 
@@ -260,106 +247,6 @@ fn scaled_model(
             labels,
         )
     }
-}
-
-/// The gesture-capable buttons present on this device, in a stable display
-/// order: the HID++ sources (gesture button, haptic panel) first, then the
-/// OS-hook Middle/Back/Forward.
-fn gesture_capable_buttons(labels: &[Label]) -> Vec<ButtonId> {
-    const ORDER: [ButtonId; 5] = [
-        ButtonId::GestureButton,
-        ButtonId::HapticPanel,
-        ButtonId::MiddleClick,
-        ButtonId::Back,
-        ButtonId::Forward,
-    ];
-    ORDER
-        .into_iter()
-        .filter(|id| labels.iter().any(|label| label.id.button() == Some(*id)))
-        .collect()
-}
-
-/// Short, context-appropriate name for a gesture-button choice.
-fn gesture_owner_label(btn: ButtonId) -> &'static str {
-    match btn {
-        ButtonId::GestureButton => "Gesture Button",
-        ButtonId::MiddleClick => "Middle",
-        ButtonId::Back => "Back",
-        ButtonId::Forward => "Forward",
-        other => other.label(),
-    }
-}
-
-/// The "Gesture button: ( … )" single-select row above the mouse. The single
-/// select makes the one-gesture-button-per-device lock visible; picking a button
-/// commits it as the owner (demoting any previous one).
-fn gesture_owner_selector(
-    capable: &[ButtonId],
-    owner: Option<ButtonId>,
-    view: &Entity<MouseModelView>,
-    pal: Palette,
-) -> impl IntoElement {
-    h_flex()
-        .items_center()
-        .gap_2()
-        .pl(px(SIDE_W + SIDE_GAP))
-        .child(
-            div()
-                .text_caption()
-                .text_color(pal.text_muted)
-                .child(tr!("Gesture Button")),
-        )
-        .children(
-            capable
-                .iter()
-                .map(|&btn| owner_chip(Some(btn), owner, view, pal)),
-        )
-        .child(owner_chip(None, owner, view, pal))
-}
-
-/// One selectable chip in [`gesture_owner_selector`]. Clicking commits the new
-/// gesture owner via [`AppState::commit_gesture_owner`].
-fn owner_chip(
-    btn: Option<ButtonId>,
-    owner: Option<ButtonId>,
-    view: &Entity<MouseModelView>,
-    pal: Palette,
-) -> AnyElement {
-    let selected = btn == owner;
-    let text = match btn {
-        Some(b) => tr!(gesture_owner_label(b)),
-        None => tr!("Off"),
-    };
-    let id_part = btn.map_or(0usize, |b| b as usize + 1);
-    let view = view.clone();
-    div()
-        .id(("gesture-owner", id_part))
-        .role(Role::RadioButton)
-        .aria_label(text.clone())
-        .aria_toggled(if selected {
-            Toggled::True
-        } else {
-            Toggled::False
-        })
-        .px_2()
-        .py_1()
-        .rounded(pal.control_radius)
-        .selected_border(selected, pal)
-        .selected_fill(selected)
-        .text_caption()
-        .text_color(if selected {
-            pal.text_primary
-        } else {
-            pal.text_muted
-        })
-        .when(!selected, |s| s.hover(|s| s.bg(pal.surface_hover)))
-        .cursor_pointer()
-        .child(text)
-        .on_click(move |_event, _window, cx| {
-            cx.update_global::<AppState, _>(|state, _| state.commit_gesture_owner(btn));
-            view.update(cx, |_, vcx| vcx.notify());
-        })
-        .into_any_element()
 }
 
 fn leader_canvas(
@@ -423,7 +310,7 @@ fn breathing_art(
 
 #[allow(
     clippy::too_many_arguments,
-    reason = "layout inputs + hover/active/owner state; bundling would just hide the dependency"
+    reason = "layout inputs + hover/active/gesture state; bundling would just hide the dependency"
 )]
 fn hotspots_layer(
     hotspots: &[Hotspot],
@@ -432,7 +319,7 @@ fn hotspots_layer(
     mouse_h: f32,
     hovered: Option<MouseControlId>,
     active: Option<MouseControlId>,
-    gesture_owner: Option<ButtonId>,
+    gesture_buttons: &[ButtonId],
     open_popover: Option<BindingPopover>,
     view: &Entity<MouseModelView>,
 ) -> impl IntoElement {
@@ -448,7 +335,10 @@ fn hotspots_layer(
                 *hotspot,
                 hovered,
                 active,
-                gesture_owner,
+                hotspot
+                    .id
+                    .button()
+                    .filter(|button| gesture_buttons.contains(button)),
                 open_popover == Some(BindingPopover::Hotspot(hotspot.id)),
                 view,
             )
@@ -464,6 +354,7 @@ fn hotspots_layer(
 fn gesture_overview_popover<Tr>(
     popover_id: impl Into<ElementId>,
     anchor: Anchor,
+    btn: ButtonId,
     trigger: Tr,
     binding_popover: BindingPopover,
     open: bool,
@@ -488,7 +379,7 @@ where
                 vcx.notify();
             });
         })
-        .content(move |_state, _window, cx| gesture_overview(&view, cx))
+        .content(move |_state, _window, cx| gesture_overview(btn, &view, cx))
 }
 
 /// Position the popover wrapper at the label's slot in the side gutter and
@@ -509,7 +400,9 @@ fn label_popover(
     mouse_w: f32,
     hovered: Option<MouseControlId>,
     active: Option<MouseControlId>,
-    gesture_owner: Option<ButtonId>,
+    // `Some` exactly when the control is a button in gesture mode — that button
+    // opens its gesture menu instead of the plain picker.
+    gesture_button: Option<ButtonId>,
     open: bool,
     view: &Entity<MouseModelView>,
 ) -> AnyElement {
@@ -527,14 +420,11 @@ fn label_popover(
         selected: false,
         view: view.clone(),
     };
-    let popover: AnyElement = if label
-        .id
-        .button()
-        .is_some_and(|button| gesture_owner == Some(button))
-    {
+    let popover: AnyElement = if let Some(button) = gesture_button {
         gesture_overview_popover(
             ("label-popover", idx),
             Anchor::TopLeft,
+            button,
             trigger,
             binding_popover,
             open,
@@ -715,11 +605,11 @@ impl RenderOnce for LabelTrigger {
 fn binding_label_for_control(
     control: MouseControlId,
     bindings: &std::collections::BTreeMap<ButtonId, Action>,
-    gesture_owner: Option<ButtonId>,
+    gesture_buttons: &[ButtonId],
 ) -> BindingLabel {
     if control
         .button()
-        .is_some_and(|button| gesture_owner == Some(button))
+        .is_some_and(|button| gesture_buttons.contains(&button))
     {
         return BindingLabel {
             text: tr!("5 directions"),
@@ -827,7 +717,9 @@ fn hotspot_popover(
     hotspot: Hotspot,
     hovered: Option<MouseControlId>,
     active: Option<MouseControlId>,
-    gesture_owner: Option<ButtonId>,
+    // `Some` exactly when the control is a button in gesture mode — that button
+    // opens its gesture menu instead of the plain picker.
+    gesture_button: Option<ButtonId>,
     open: bool,
     view: &Entity<MouseModelView>,
 ) -> AnyElement {
@@ -840,18 +732,14 @@ fn hotspot_popover(
         view: view.clone(),
         selected: false,
     };
-    // Open the gesture menu only for the button that currently OWNS gestures —
-    // matching the side-label path — so a promoted Middle/Back/Forward opens it
-    // here too, a demoted gesture button opens the plain picker, and (when gestures
-    // are off) no hotspot re-enters the gesture editor.
-    let popover: AnyElement = if hotspot
-        .id
-        .button()
-        .is_some_and(|button| gesture_owner == Some(button))
-    {
+    // Open the gesture menu for any button in gesture mode — matching the
+    // side-label path — so a promoted Middle/Back/Forward opens it here too and
+    // a demoted button opens the plain picker.
+    let popover: AnyElement = if let Some(button) = gesture_button {
         gesture_overview_popover(
             ("hotspot-popover", idx),
             Anchor::TopRight,
+            button,
             trigger,
             binding_popover,
             open,
@@ -966,14 +854,6 @@ impl RenderOnce for HotspotTrigger {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn gesture_owner_selector_keeps_physical_gesture_button_name() {
-        assert_eq!(
-            gesture_owner_label(ButtonId::GestureButton),
-            "Gesture Button"
-        );
-    }
 
     #[test]
     fn active_thumbwheel_directions_highlight_the_paired_control() {

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -143,14 +143,14 @@ pub struct AppState {
     /// Bindings for the *currently selected* device. Reloaded whenever the
     /// carousel selection changes.
     pub button_bindings: BTreeMap<ButtonId, Action>,
-    /// Per-direction sub-bindings for the current device's gesture owner. Edited
-    /// via the gesture picker and persisted as a [`Binding::Gesture`] entry under
-    /// the owning button — the HID++ gesture button ([`ButtonId::GestureButton`]) by default,
-    /// or a promoted Middle/Back/Forward — in the device's unified binding map
-    /// ([`DeviceConfig::bindings`]). Rebuilt by the `gesture_bindings_for_current` helper.
+    /// Per-direction sub-bindings for every gesture-mode button of the current
+    /// device, keyed by button. Edited via each button's gesture menu and
+    /// persisted as that button's [`Binding::Gesture`] entry in the device's
+    /// unified binding map ([`DeviceConfig::bindings`]). Rebuilt by
+    /// [`Self::current_gesture_maps`].
     ///
     /// [`DeviceConfig::bindings`]: openlogi_core::config::DeviceConfig::bindings
-    pub gesture_bindings: BTreeMap<GestureDirection, Action>,
+    pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
     /// Global keyboard F-key bindings (Esc + F1-F19). Device-agnostic — one
     /// map applies across all keyboards — so, unlike [`Self::button_bindings`],
     /// this is *not* reloaded on device switch. Seeded once from
@@ -272,7 +272,7 @@ impl AppState {
             state.persist_config("device identity");
         }
         state.button_bindings = state.bindings_for_current();
-        state.gesture_bindings = state.gesture_bindings_for_current();
+        state.gesture_bindings = state.current_gesture_maps();
         // Keyboard bindings are global, so they seed straight from the config
         // map — no per-device resolution like mouse bindings above.
         state.keyboard_bindings = state

--- a/crates/openlogi-gui/src/state/bindings.rs
+++ b/crates/openlogi-gui/src/state/bindings.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use openlogi_agent_core::bindings::{bindings_for, gesture_bindings_for};
+use openlogi_agent_core::bindings::{bindings_for, hidpp_gesture_maps_for};
 use openlogi_core::config::KeyTrigger;
 use tracing::debug;
 
@@ -114,47 +114,32 @@ impl AppState {
     /// the gesture watcher's projection); OS-hook buttons show their raw stored
     /// map (matching the OS hook's dispatch). Empty when no device is selected.
     #[must_use]
-    #[allow(
-        dead_code,
-        clippy::unused_self,
-        reason = "RED stub — wired into the views by the GREEN change"
-    )]
     pub fn current_gesture_maps(&self) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
-        BTreeMap::new()
-    }
-
-    pub(crate) fn gesture_bindings_for_current(&self) -> BTreeMap<GestureDirection, Action> {
         let Some(key) = self
             .current_record()
             .and_then(DeviceRecord::persistent_config_key)
         else {
             return BTreeMap::new();
         };
-        match self.config.gesture_owner(key) {
-            // The HID++ gesture button seeds every direction from the defaults.
-            Some(ButtonId::GestureButton) => gesture_bindings_for(&self.config, Some(key)),
-            // A promoted OS-hook button is shown from its raw stored map (which
-            // `set_gesture_owner` seeds with full defaults), so the menu matches
-            // exactly what `oshook_gestures_for` dispatches — no seeding here.
-            Some(owner) => match self.config.bindings_for(key).get(&owner) {
-                Some(Binding::Gesture(map)) => map.clone(),
-                _ => BTreeMap::new(),
-            },
-            None => BTreeMap::new(),
+        // HID++ sources come seeded, matching the gesture watcher's projection.
+        let mut maps = hidpp_gesture_maps_for(&self.config, Some(key));
+        // A gesture-mode OS-hook button shows its raw stored map (which
+        // `set_gesture_mode` seeds with full defaults), so the menu matches
+        // exactly what `oshook_gestures_for` dispatches — no seeding here.
+        for (id, binding) in self.config.bindings_for(key) {
+            if id.is_os_hook_button()
+                && let Binding::Gesture(map) = binding
+            {
+                maps.insert(id, map);
+            }
         }
+        maps
     }
-    /// The current device's gesture button — the [`Binding::Gesture`] owner — or
-    /// `None` when no button is in gesture mode. Drives which button's card opens
-    /// the gesture menu rather than the single-action picker.
-    #[must_use]
-    pub fn current_gesture_owner(&self) -> Option<ButtonId> {
-        let key = self.current_record()?.persistent_config_key()?;
-        self.config.gesture_owner(key)
-    }
-    /// Make `button` the current device's gesture button (or clear it with
-    /// `None`), enforcing the one-gesture-button-per-device lock. Persists, tells
-    /// the agent to rebuild, and refreshes the projected maps the UI reads.
-    pub fn commit_gesture_owner(&mut self, button: Option<ButtonId>) {
+
+    /// Turn gesture mode on or off for one button of the current device —
+    /// independently of every other button. Persists, tells the agent to
+    /// rebuild, and refreshes the projected maps the UI reads.
+    pub fn commit_gesture_mode(&mut self, button: ButtonId, enabled: bool) {
         let Some(key) = self
             .current_record()
             .and_then(DeviceRecord::persistent_config_key)
@@ -162,47 +147,53 @@ impl AppState {
         else {
             return;
         };
-        match button {
-            Some(b) => {
-                self.config.set_gesture_owner(&key, b);
-            }
-            None => {
-                self.config.disable_gestures(&key);
-            }
+        if self.config.is_gesture_mode(&key, button) == enabled {
+            return;
         }
-        // The owner change shuffles bindings between the single + gesture maps.
+        self.config.set_gesture_mode(&key, button, enabled);
+        // The mode change shuffles bindings between the single + gesture maps.
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.gesture_bindings_for_current();
-        self.persist_and_reload("gesture-button change");
+        self.gesture_bindings = self.current_gesture_maps();
+        self.persist_and_reload("gesture-mode change");
     }
-    /// Update a single gesture-button sub-binding in memory, on disk, and in the
-    /// shared gesture map the watcher thread reads.
-    pub fn commit_gesture_binding(&mut self, direction: GestureDirection, action: Action) {
+
+    /// Update one direction of `button`'s gesture binding in memory, on disk,
+    /// and (via reload) in the maps the agent dispatches from.
+    pub fn commit_gesture_binding(
+        &mut self,
+        button: ButtonId,
+        direction: GestureDirection,
+        action: Action,
+    ) {
         let Some(key) = self
             .current_record()
             .and_then(DeviceRecord::persistent_config_key)
             .map(str::to_string)
         else {
             debug!(
+                ?button,
                 ?direction,
                 "no persistent device key — gesture binding edit ignored"
             );
             return;
         };
-        // Edit whichever button owns gestures — not always the HID++ gesture button. When
-        // gestures are off, a stray edit must NOT silently re-enable them on the
-        // default owner (the gesture editor shouldn't be reachable in that state):
-        // no-op instead.
-        let Some(owner) = self.config.gesture_owner(&key) else {
+        // A stray edit on a button not in gesture mode must NOT silently
+        // promote it (the gesture editor shouldn't be reachable in that
+        // state): no-op instead.
+        if !self.config.is_gesture_mode(&key, button) {
             debug!(
+                ?button,
                 ?direction,
-                "gestures are off — ignoring gesture binding edit"
+                "button is not in gesture mode — ignoring gesture binding edit"
             );
             return;
-        };
-        self.gesture_bindings.insert(direction, action.clone());
+        }
+        self.gesture_bindings
+            .entry(button)
+            .or_default()
+            .insert(direction, action.clone());
         self.config
-            .set_gesture_direction(&key, owner, direction, action);
+            .set_gesture_direction(&key, button, direction, action);
         // The agent owns the gesture watcher; have it rebuild from config.
         self.persist_and_reload("gesture binding");
     }

--- a/crates/openlogi-gui/src/state/bindings.rs
+++ b/crates/openlogi-gui/src/state/bindings.rs
@@ -108,6 +108,21 @@ impl AppState {
             self.current_app_bundle.as_deref(),
         )
     }
+    /// Per-direction display maps for every gesture-mode button of the current
+    /// device, keyed by button — what each button's gesture menu edits and what
+    /// the runtime dispatches for it. HID++ sources come fully seeded (matching
+    /// the gesture watcher's projection); OS-hook buttons show their raw stored
+    /// map (matching the OS hook's dispatch). Empty when no device is selected.
+    #[must_use]
+    #[allow(
+        dead_code,
+        clippy::unused_self,
+        reason = "RED stub — wired into the views by the GREEN change"
+    )]
+    pub fn current_gesture_maps(&self) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
+        BTreeMap::new()
+    }
+
     pub(crate) fn gesture_bindings_for_current(&self) -> BTreeMap<GestureDirection, Action> {
         let Some(key) = self
             .current_record()

--- a/crates/openlogi-gui/src/state/bindings.rs
+++ b/crates/openlogi-gui/src/state/bindings.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use openlogi_agent_core::bindings::{bindings_for, hidpp_gesture_maps_for};
+use openlogi_agent_core::bindings::{bindings_for, hidpp_gesture_maps_for, oshook_gestures_for};
 use openlogi_core::config::KeyTrigger;
 use tracing::debug;
 
@@ -121,18 +121,12 @@ impl AppState {
         else {
             return BTreeMap::new();
         };
-        // HID++ sources come seeded, matching the gesture watcher's projection.
+        // Both halves come from the same helpers the runtime dispatches with,
+        // so the menus can never drift from what the agent actually does:
+        // HID++ sources seeded like the gesture watcher, OS-hook buttons raw
+        // like the hook (global view — no per-app overlay here).
         let mut maps = hidpp_gesture_maps_for(&self.config, Some(key));
-        // A gesture-mode OS-hook button shows its raw stored map (which
-        // `set_gesture_mode` seeds with full defaults), so the menu matches
-        // exactly what `oshook_gestures_for` dispatches — no seeding here.
-        for (id, binding) in self.config.bindings_for(key) {
-            if id.is_os_hook_button()
-                && let Binding::Gesture(map) = binding
-            {
-                maps.insert(id, map);
-            }
-        }
+        maps.extend(oshook_gestures_for(&self.config, Some(key), None));
         maps
     }
 

--- a/crates/openlogi-gui/src/state/inventory.rs
+++ b/crates/openlogi-gui/src/state/inventory.rs
@@ -143,7 +143,7 @@ impl AppState {
         // tracks the now-current device rather than the old one.
         self.dpi = self.dpi_for_current();
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.gesture_bindings_for_current();
+        self.gesture_bindings = self.current_gesture_maps();
         // Display state only — the agent runs its own inventory watcher and
         // rebuilds the live binding/DPI maps itself.
         true
@@ -312,7 +312,7 @@ impl AppState {
         // device's number until a fresh read lands.
         self.dpi = self.dpi_for_current();
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.gesture_bindings_for_current();
+        self.gesture_bindings = self.current_gesture_maps();
         let Some(key) = self
             .current_record()
             .and_then(DeviceRecord::persistent_config_key)

--- a/crates/openlogi-gui/src/state/tests.rs
+++ b/crates/openlogi-gui/src/state/tests.rs
@@ -912,3 +912,51 @@ fn enabling_camera_automation_queues_effective_camera_power() {
     assert!(!state.light().enabled);
     assert!(state.light_enabled());
 }
+
+#[test]
+#[ignore = "RED: per-button gesture maps not implemented yet"]
+fn gesture_maps_cover_every_gesture_mode_button() {
+    // With per-button gesture mode, the GUI's display maps carry one entry
+    // per gesture-mode button: the dedicated button's seeded default map
+    // plus a promoted OS-hook button's stored map — simultaneously.
+    use openlogi_core::binding::{ButtonId, GestureDirection};
+
+    let mut config = Config::default();
+    config.set_device_identity(
+        "2b042",
+        DeviceIdentity {
+            display_name: "MX Master 4".to_string(),
+            kind: DeviceKind::Mouse,
+            capabilities: Capabilities::presumed_from_kind(DeviceKind::Mouse),
+            light_capabilities: None,
+            model_info: None,
+            codename: None,
+            driver_id: None,
+            registry_model_id: None,
+        },
+    );
+    config.set_gesture_mode("2b042", ButtonId::Back, true);
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let state = AppState::with_runtime(
+        config,
+        &[],
+        &[],
+        &AssetResolver::new(),
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    let maps = state.current_gesture_maps();
+    let dedicated = maps
+        .get(&ButtonId::GestureButton)
+        .expect("the dedicated button's default gesture mode must be shown");
+    assert!(
+        dedicated.contains_key(&GestureDirection::Up),
+        "HID++ maps are shown seeded, matching watcher dispatch"
+    );
+    assert!(
+        maps.contains_key(&ButtonId::Back),
+        "a promoted OS-hook button gets its own menu simultaneously"
+    );
+}

--- a/crates/openlogi-gui/src/state/tests.rs
+++ b/crates/openlogi-gui/src/state/tests.rs
@@ -914,7 +914,6 @@ fn enabling_camera_automation_queues_effective_camera_power() {
 }
 
 #[test]
-#[ignore = "RED: per-button gesture maps not implemented yet"]
 fn gesture_maps_cover_every_gesture_mode_button() {
     // With per-button gesture mode, the GUI's display maps carry one entry
     // per gesture-mode button: the dedicated button's seeded default map

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -1,5 +1,5 @@
-//! Live control capture for one device: divert the device's gesture source
-//! (the MX dedicated gesture button, or the MX Master 4 haptic panel), the
+//! Live control capture for one device: divert the device's gesture sources
+//! (the MX dedicated gesture button and/or the MX Master 4 haptic panel), the
 //! DPI/ModeShift button, and the thumb wheel over HID++ and turn their events
 //! into [`CapturedInput`] the GUI can dispatch.
 //!
@@ -48,8 +48,10 @@ pub enum CaptureStop {
 /// One input captured from the active device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CapturedInput {
-    /// A completed gesture-button swipe.
-    Gesture(GestureDirection),
+    /// A completed swipe (or tap click) from a diverted gesture source,
+    /// tagged with the source control so dispatch resolves it against that
+    /// button's own direction map.
+    Gesture(ButtonId, GestureDirection),
     /// A diverted button was pressed — the DPI/ModeShift button
     /// ([`ButtonId::DpiToggle`]) or the thumb-wheel single tap
     /// ([`ButtonId::Thumbwheel`]).
@@ -81,8 +83,13 @@ pub enum GestureError {
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
-    /// Mid-swipe state for the diverted gesture source (raw-XY).
+    /// Mid-swipe state for the currently held gesture source (raw-XY).
     swipe: SwipeAccumulator,
+    /// The gesture source that began the current hold, with the [`ButtonId`]
+    /// its events dispatch as. Raw-XY reports carry no source attribution, so
+    /// the first held source owns the accumulated motion until it is released
+    /// (first hold wins); another source pressed mid-hold is ignored.
+    gesture_source: Option<(u16, ButtonId)>,
     /// Whether the current hold's next raw-XY sample must be dropped: the
     /// haptic panel's first sample after contact is an absolute position
     /// jump, not a delta (see [`reprog_controls::HAPTIC_PANEL_CID`]).
@@ -107,10 +114,9 @@ pub const DIVERTABLE_STANDARD_BUTTONS: [(u16, ButtonId); 3] = [
 
 /// HID++ gesture sources: the `0x1b04` control ID and the [`ButtonId`] it
 /// delivers — the dedicated gesture button on most MX mice, and the Haptic
-/// Sense Panel on MX Master 4 (two distinct physical controls). The one that
-/// owns the gesture role is diverted with raw-XY; either is plain-diverted
-/// like a standard button when its binding leaves the default without the
-/// role.
+/// Sense Panel on MX Master 4 (two distinct physical controls). Each source in
+/// gesture mode is diverted with raw-XY; one with a non-default single binding
+/// instead is plain-diverted like a standard button.
 pub const GESTURE_SOURCE_BUTTONS: [(u16, ButtonId); 2] = [
     (reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton),
     (reprog_controls::HAPTIC_PANEL_CID, ButtonId::HapticPanel),
@@ -122,26 +128,25 @@ pub struct CaptureSpec {
     /// Divert the thumb wheel over `0x2150` (rotation rebind / sensitivity /
     /// click bound).
     pub capture_thumbwheel: bool,
-    /// The gesture owner's source CID (a [`GESTURE_SOURCE_BUTTONS`] member) to
-    /// divert with raw-XY, or `None` when no HID++ control owns the gesture
-    /// role.
-    pub divert_gesture_source: Option<u16>,
+    /// Gesture-source CIDs ([`GESTURE_SOURCE_BUTTONS`] members) to divert
+    /// with raw-XY — one per source in gesture mode; empty when no HID++
+    /// control gestures.
+    pub divert_gesture_sources: Vec<u16>,
     /// Buttons to divert as plain presses (no raw-XY): the
-    /// [`DIVERTABLE_STANDARD_BUTTONS`] and non-owner [`GESTURE_SOURCE_BUTTONS`]
-    /// whose binding leaves the default.
+    /// [`DIVERTABLE_STANDARD_BUTTONS`] and non-gesturing
+    /// [`GESTURE_SOURCE_BUTTONS`] whose binding leaves the default.
     pub divert_buttons: Vec<(u16, ButtonId)>,
 }
 
 /// Capture the controls selected by `spec` on `route` until `shutdown`
 /// resolves, forwarding each event to `sink`.
 ///
-/// Only the gesture owner's source (`spec.divert_gesture_source`) is diverted
-/// with raw-XY. When the user moves the gesture role to an OS-hook button or
-/// turns gestures off, the gesture sources keep their native behavior —
-/// unless a non-default single binding puts them in `spec.divert_buttons`, in
-/// which case they are diverted as plain buttons (the OS hook never sees a
-/// gesture-source CID, so this is the binding's only delivery path). The
-/// DPI/ModeShift capture and the channel-reuse slot are independent of this.
+/// Each gesture source in `spec.divert_gesture_sources` is diverted with
+/// raw-XY. A source not in gesture mode keeps its native behavior — unless a
+/// non-default single binding puts it in `spec.divert_buttons`, in which case
+/// it is diverted as a plain button (the OS hook never sees a gesture-source
+/// CID, so this is the binding's only delivery path). The DPI/ModeShift
+/// capture and the channel-reuse slot are independent of this.
 ///
 /// Opens and holds one HID++ channel, diverts whichever of those controls the
 /// device exposes, and listens. Returns once `shutdown` fires (or its sender is
@@ -168,7 +173,7 @@ pub async fn run_capture_session(
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
-    let gesture_cid = armed.gesture_cid;
+    let gesture_cids = armed.gesture_cids.clone();
     let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
     let dpi_set = armed.dpi_cids.clone();
     let button_set = armed.button_cids.clone();
@@ -186,7 +191,7 @@ pub async fn run_capture_session(
                 // Recover the guard even if a prior holder panicked — the
                 // critical section is panic-free, so the data is consistent.
                 let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(&mut acc, event, gesture_cid, &dpi_set, &button_set, &sink);
+                handle_reprog(&mut acc, event, &gesture_cids, &dpi_set, &button_set, &sink);
                 return;
             }
             if let Some(idx) = thumb_index
@@ -204,7 +209,7 @@ pub async fn run_capture_session(
 
     info!(
         index = device_index,
-        gesture = armed.gesture_cid.is_some(),
+        gesture_sources = armed.gesture_cids.len(),
         dpi_buttons = armed.dpi_cids.len(),
         buttons = armed.button_cids.len(),
         thumbwheel = armed.thumb.is_some(),
@@ -248,7 +253,10 @@ pub async fn run_capture_session_with_stop_reason(
         capture_thumbwheel,
         // The bool-era API only ever meant the dedicated gesture button; the
         // haptic panel is reachable through [`CaptureSpec`] itself.
-        divert_gesture_source: divert_gesture_button.then_some(reprog_controls::GESTURE_BUTTON_CID),
+        divert_gesture_sources: divert_gesture_button
+            .then_some(reprog_controls::GESTURE_BUTTON_CID)
+            .into_iter()
+            .collect(),
         divert_buttons: Vec::new(),
     };
     run_capture_session(route, spec, sink, rx, channel_slot).await
@@ -281,9 +289,9 @@ pub async fn run_capture_session_with_registry(
 struct ArmedControls {
     /// `0x1b04` accessor + feature index, present when the device exposes it.
     reprog: Option<(ReprogControlsV4, u8)>,
-    /// The gesture-source CID diverted with raw-XY reporting, when the spec
-    /// selected one and the device exposes it.
-    gesture_cid: Option<u16>,
+    /// The gesture-source CIDs diverted with raw-XY reporting: the
+    /// `spec.divert_gesture_sources` members the device exposes.
+    gesture_cids: Vec<u16>,
     /// DPI/ModeShift CIDs diverted as plain buttons.
     dpi_cids: Vec<u16>,
     /// Standard-button CIDs diverted per the session's [`CaptureSpec`], with
@@ -334,7 +342,7 @@ async fn arm_controls(
         armed.disarm().await;
         return Err(error);
     }
-    if armed.gesture_cid.is_none()
+    if armed.gesture_cids.is_empty()
         && armed.dpi_cids.is_empty()
         && armed.button_cids.is_empty()
         && armed.thumb.is_none()
@@ -361,15 +369,14 @@ async fn arm_controls_into(
         let controls = enumerate_controls(&rc).await?;
         armed.reprog = Some((rc.clone(), info.index));
 
-        // Only divert the gesture owner's source; every other gesture source
-        // stays native (a non-owner HID++ control must not be
-        // captured-and-dropped).
-        if let Some(cid) = spec.divert_gesture_source
-            && controls.iter().any(|c| c.cid == cid && c.supports_raw_xy())
-        {
-            let reporting = arm_reprog_control(&rc, cid, true).await?;
-            armed.reporting.push(reporting);
-            armed.gesture_cid = Some(cid);
+        // Divert each gesture-mode source; a source not listed stays native
+        // (an idle HID++ control must not be captured-and-dropped).
+        for &cid in &spec.divert_gesture_sources {
+            if controls.iter().any(|c| c.cid == cid && c.supports_raw_xy()) {
+                let reporting = arm_reprog_control(&rc, cid, true).await?;
+                armed.reporting.push(reporting);
+                armed.gesture_cids.push(cid);
+            }
         }
         for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
@@ -379,10 +386,10 @@ async fn arm_controls_into(
             }
         }
         for &(cid, button) in &spec.divert_buttons {
-            // The plan never lists the raw-XY-diverted gesture source, but
+            // The plan never lists a raw-XY-diverted gesture source, but
             // guard anyway: a plain (divert, no raw-XY) write here would strip
             // the raw-XY reporting armed above.
-            if armed.gesture_cid == Some(cid) {
+            if armed.gesture_cids.contains(&cid) {
                 continue;
             }
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
@@ -473,6 +480,17 @@ async fn restore_reporting(rc: &ReprogControlsV4, armed: ArmedCid, what: &str) {
     restore(result, what);
 }
 
+/// The [`ButtonId`] a gesture-source CID dispatches as, per
+/// [`GESTURE_SOURCE_BUTTONS`]; `None` for a CID that is not a gesture source.
+/// A spec listing an unknown CID therefore never begins a hold — the press is
+/// dropped rather than misattributed.
+fn gesture_source_button(cid: u16) -> Option<ButtonId> {
+    GESTURE_SOURCE_BUTTONS
+        .into_iter()
+        .find(|&(c, _)| c == cid)
+        .map(|(_, button)| button)
+}
+
 /// Log (don't propagate) a failure to hand a control back to the firmware.
 pub(crate) fn restore<E: std::fmt::Display>(result: Result<(), E>, what: &str) {
     if let Err(e) = result {
@@ -507,29 +525,39 @@ pub(crate) async fn enumerate_controls(
 fn handle_reprog(
     acc: &mut CaptureAccum,
     event: RawControlEvent,
-    gesture_cid: Option<u16>,
+    gesture_cids: &[u16],
     dpi_cids: &[u16],
     button_cids: &[(u16, ButtonId)],
     sink: &mpsc::UnboundedSender<CapturedInput>,
 ) {
     match event {
         RawControlEvent::DivertedButtons(cids) => {
-            // The swipe accumulator belongs to the raw-XY gesture divert. When
-            // a gesture-source control is instead diverted as a plain button
-            // (it has a single binding but not the gesture role), its press
-            // must flow through the `button_cids` loop only — not also emit a
-            // click.
-            let owner_held = gesture_cid.is_some_and(|cid| cids.contains(&cid));
-            if owner_held {
-                if !acc.swipe.is_holding() {
-                    acc.swipe.begin();
-                    acc.skip_first_raw_xy = gesture_cid == Some(reprog_controls::HAPTIC_PANEL_CID);
+            // The swipe accumulator belongs to the raw-XY gesture diverts.
+            // When a gesture-source control is instead diverted as a plain
+            // button (a single binding, not gesture mode), its press must flow
+            // through the `button_cids` loop only — not also emit a click.
+            match acc.gesture_source {
+                None => {
+                    if let Some((cid, button)) = gesture_cids
+                        .iter()
+                        .filter(|cid| cids.contains(cid))
+                        .find_map(|&cid| gesture_source_button(cid).map(|b| (cid, b)))
+                    {
+                        acc.gesture_source = Some((cid, button));
+                        acc.swipe.begin();
+                        acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID;
+                    }
                 }
-            } else if acc.swipe.is_holding() {
-                // A press that never committed a direction is a plain click.
-                if acc.swipe.end() {
-                    debug!("gesture click");
-                    let _ = sink.send(CapturedInput::Gesture(GestureDirection::Click));
+                Some((cid, button)) => {
+                    if !cids.contains(&cid) {
+                        acc.gesture_source = None;
+                        // A press that never committed a direction is a plain click.
+                        if acc.swipe.end() {
+                            debug!(%button, "gesture click");
+                            let _ =
+                                sink.send(CapturedInput::Gesture(button, GestureDirection::Click));
+                        }
+                    }
                 }
             }
 
@@ -551,6 +579,11 @@ fn handle_reprog(
             }
         }
         RawControlEvent::RawXy { dx, dy } => {
+            // Motion is attributed to the holding source; outside a hold the
+            // report is stray and dropped.
+            let Some((_, button)) = acc.gesture_source else {
+                return;
+            };
             // The haptic panel's first sample after contact is a position
             // jump; summing it would commit a bogus direction instantly.
             if acc.skip_first_raw_xy {
@@ -561,8 +594,8 @@ fn handle_reprog(
             // hold); the accumulator gates on hold duration internally and drops
             // travel that arrives outside a hold.
             if let Some(direction) = acc.swipe.accumulate(i32::from(dx), i32::from(dy)) {
-                debug!(?direction, "gesture committed");
-                let _ = sink.send(CapturedInput::Gesture(direction));
+                debug!(?direction, %button, "gesture committed");
+                let _ = sink.send(CapturedInput::Gesture(button, direction));
             }
         }
     }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -367,6 +367,9 @@ async fn arm_controls(
     Ok(armed)
 }
 
+/// The fallible arming steps of [`arm_controls`], recording each successful
+/// divert into `armed` as it lands — so the caller can disarm exactly what was
+/// armed when a later step fails.
 async fn arm_controls_into(
     device: &Device,
     chan: &Arc<HidppChannel>,
@@ -382,6 +385,8 @@ async fn arm_controls_into(
     {
         let rc = ReprogControlsV4::new(Arc::clone(chan), slot, info.index);
         let controls = enumerate_controls(&rc).await?;
+        // Register an accessor before the first divert, so a failure on any
+        // divert (including the first) can be handed back via `disarm`.
         armed.reprog = Some((rc.clone(), info.index));
 
         // Divert each gesture-mode source; a source not listed stays native
@@ -450,7 +455,6 @@ async fn arm_controls_into(
         }
         armed.thumb = Some((tw, info.index));
     }
-
     Ok(())
 }
 

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -88,8 +88,18 @@ struct CaptureAccum {
     /// The gesture source that began the current hold, with the [`ButtonId`]
     /// its events dispatch as. Raw-XY reports carry no source attribution, so
     /// the first held source owns the accumulated motion until it is released
-    /// (first hold wins); another source pressed mid-hold is ignored.
+    /// (first hold wins). While a second source is held alongside it, motion
+    /// is dropped instead of miscommitted (see [`Self::overlap`]); when the
+    /// holder releases, a still-held source takes the hold over.
     gesture_source: Option<(u16, ButtonId)>,
+    /// Whether a second armed source is held alongside the holder. Raw-XY
+    /// reports are unattributed on the wire, so overlap motion could belong to
+    /// either control — it is dropped until the overlap ends.
+    overlap: bool,
+    /// The armed gesture sources held in the last event, for edge detection:
+    /// a source not previously held that becomes the holder is a fresh touch
+    /// (the haptic panel's first sample is then a contact jump to discard).
+    gestures_down: Vec<u16>,
     /// Whether the current hold's next raw-XY sample must be dropped: the
     /// haptic panel's first sample after contact is an absolute position
     /// jump, not a delta (see [`reprog_controls::HAPTIC_PANEL_CID`]).
@@ -325,10 +335,15 @@ impl ArmedControls {
 }
 
 /// Resolve features off the device's root and divert the controls `spec`
-/// selects: the gesture button (raw-XY), DPI/ModeShift buttons and rebindable
+/// selects: the gesture sources (raw-XY), DPI/ModeShift buttons and rebindable
 /// standard buttons over `0x1b04`, and the thumb wheel over `0x2150`. The
 /// root-feature lookup mirrors `write::open_feature`,
 /// since hidpp 0.2's registry doesn't carry the features OpenLogi reimplements.
+///
+/// A failure mid-way hands every already-diverted control back to the firmware
+/// before returning: with several controls armed one after another, aborting
+/// without disarming would leave the earlier ones diverted with no session
+/// listening — captured-and-dropped until a later respawn succeeds.
 async fn arm_controls(
     chan: &Arc<HidppChannel>,
     slot: u8,
@@ -536,30 +551,45 @@ fn handle_reprog(
             // When a gesture-source control is instead diverted as a plain
             // button (a single binding, not gesture mode), its press must flow
             // through the `button_cids` loop only — not also emit a click.
+            let held: Vec<(u16, ButtonId)> = gesture_cids
+                .iter()
+                .filter(|cid| cids.contains(cid))
+                .filter_map(|&cid| gesture_source_button(cid).map(|b| (cid, b)))
+                .collect();
             match acc.gesture_source {
-                None => {
-                    if let Some((cid, button)) = gesture_cids
-                        .iter()
-                        .filter(|cid| cids.contains(cid))
-                        .find_map(|&cid| gesture_source_button(cid).map(|b| (cid, b)))
-                    {
-                        acc.gesture_source = Some((cid, button));
-                        acc.swipe.begin();
-                        acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID;
-                    }
+                Some((cid, _)) if cids.contains(&cid) => {
+                    // The holder is still down. While a second armed source is
+                    // held alongside it, unattributed raw-XY motion is dropped
+                    // (see `CaptureAccum::overlap`).
+                    acc.overlap = held.len() > 1;
                 }
-                Some((cid, button)) => {
-                    if !cids.contains(&cid) {
+                previous => {
+                    // No holder, or the holder released: a released hold that
+                    // never committed a direction is a plain click...
+                    if let Some((_, button)) = previous {
                         acc.gesture_source = None;
-                        // A press that never committed a direction is a plain click.
+                        acc.overlap = false;
                         if acc.swipe.end() {
                             debug!(%button, "gesture click");
                             let _ =
                                 sink.send(CapturedInput::Gesture(button, GestureDirection::Click));
                         }
                     }
+                    // ...and the first still-held source begins (or takes
+                    // over) the hold. A source not down in the previous event
+                    // is a fresh touch, so the panel's contact-jump discard
+                    // applies; one that was already held has had its jump
+                    // dropped during the overlap.
+                    if let Some(&(cid, button)) = held.first() {
+                        acc.gesture_source = Some((cid, button));
+                        acc.swipe.begin();
+                        acc.overlap = held.len() > 1;
+                        acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID
+                            && !acc.gestures_down.contains(&cid);
+                    }
                 }
             }
+            acc.gestures_down = held.into_iter().map(|(cid, _)| cid).collect();
 
             let dpi_down = dpi_cids.iter().any(|cid| cids.contains(cid));
             if dpi_down && !acc.dpi_down {
@@ -584,6 +614,12 @@ fn handle_reprog(
             let Some((_, button)) = acc.gesture_source else {
                 return;
             };
+            // While two armed sources are held the report could belong to
+            // either control — drop it rather than miscommit a swipe through
+            // the holder's map.
+            if acc.overlap {
+                return;
+            }
             // The haptic panel's first sample after contact is a position
             // jump; summing it would commit a bogus direction instantly.
             if acc.skip_first_raw_xy {

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-const GESTURE: Option<u16> = Some(reprog_controls::GESTURE_BUTTON_CID);
-const PANEL: Option<u16> = Some(reprog_controls::HAPTIC_PANEL_CID);
+const GESTURE: &[u16] = &[reprog_controls::GESTURE_BUTTON_CID];
+const PANEL: &[u16] = &[reprog_controls::HAPTIC_PANEL_CID];
 
 #[test]
 fn reporting_restore_preserves_every_mutable_field() {
@@ -61,7 +61,10 @@ fn quick_tap_is_a_click_even_while_the_cursor_moves() {
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::Gesture(GestureDirection::Click))
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Click
+        ))
     );
     assert!(
         rx.try_recv().is_err(),
@@ -88,7 +91,10 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::Gesture(GestureDirection::Right))
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Right
+        ))
     );
 
     handle_reprog(&mut acc, release(), GESTURE, &[], &[], &tx);
@@ -99,10 +105,10 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
 }
 
 #[test]
-fn the_haptic_panel_gestures_when_it_owns_the_role() {
-    // On MX Master 4 the panel (CID 0x01a0) can own the gesture role: its
-    // press begins a hold, its contact jump is discarded, and the raw-XY that
-    // follows commits a swipe.
+fn the_haptic_panel_gestures_when_diverted_for_gestures() {
+    // On MX Master 4 the panel (CID 0x01a0) can gesture: its press begins a
+    // hold, its contact jump is discarded, and the raw-XY that follows
+    // commits a swipe.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
@@ -129,7 +135,10 @@ fn the_haptic_panel_gestures_when_it_owns_the_role() {
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::Gesture(GestureDirection::Up))
+        Ok(CapturedInput::Gesture(
+            ButtonId::HapticPanel,
+            GestureDirection::Up
+        ))
     );
 
     handle_reprog(&mut acc, release(), PANEL, &[], &[], &tx);
@@ -149,7 +158,10 @@ fn a_quick_panel_tap_is_a_click() {
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::Gesture(GestureDirection::Click))
+        Ok(CapturedInput::Gesture(
+            ButtonId::HapticPanel,
+            GestureDirection::Click
+        ))
     );
     assert!(
         rx.try_recv().is_err(),
@@ -192,7 +204,10 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     );
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::Gesture(GestureDirection::Right))
+        Ok(CapturedInput::Gesture(
+            ButtonId::HapticPanel,
+            GestureDirection::Right
+        ))
     );
 }
 
@@ -216,15 +231,18 @@ fn the_dedicated_buttons_first_sample_is_not_discarded() {
 
     assert_eq!(
         rx.try_recv(),
-        Ok(CapturedInput::Gesture(GestureDirection::Right)),
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Right
+        )),
         "the dedicated button's very first sample still counts"
     );
 }
 
 #[test]
-fn a_non_owner_gesture_source_does_not_gesture() {
-    // The panel owns the gesture role; a dedicated-button press must not
-    // begin a hold, emit a click, or feed the swipe accumulator — the two
+fn an_undiverted_gesture_source_does_not_gesture() {
+    // Only the panel is diverted for gestures; a dedicated-button press must
+    // not begin a hold, emit a click, or feed the swipe accumulator — the two
     // sources are distinct physical controls.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
@@ -249,16 +267,16 @@ fn a_non_owner_gesture_source_does_not_gesture() {
 
 #[test]
 fn a_plain_diverted_gesture_button_presses_without_gesturing() {
-    // A gesture button diverted as a plain button (it does NOT own the gesture
-    // role; its single binding needs delivery) must dispatch as a button press
-    // only — the swipe accumulator belongs to the raw-XY gesture divert and
-    // must not also emit a gesture click on release.
+    // A gesture button diverted as a plain button (not in gesture mode; its
+    // single binding needs delivery) must dispatch as a button press only —
+    // the swipe accumulator belongs to the raw-XY gesture diverts and must
+    // not also emit a gesture click on release.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
     let buttons = [(reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)];
 
-    handle_reprog(&mut acc, press(), None, &[], &buttons, &tx);
-    handle_reprog(&mut acc, release(), None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, press(), &[], &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), &[], &[], &buttons, &tx);
 
     assert_eq!(
         rx.try_recv(),
@@ -272,15 +290,15 @@ fn a_plain_diverted_gesture_button_presses_without_gesturing() {
 
 #[test]
 fn a_plain_diverted_haptic_panel_presses_as_its_own_button() {
-    // A single action bound to the panel (which does not own the gesture
-    // role) is delivered as ButtonId::HapticPanel — its own control, never
-    // conflated with the dedicated gesture button.
+    // A single action bound to the panel (which is not in gesture mode) is
+    // delivered as ButtonId::HapticPanel — its own control, never conflated
+    // with the dedicated gesture button.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
     let buttons = [(reprog_controls::HAPTIC_PANEL_CID, ButtonId::HapticPanel)];
 
-    handle_reprog(&mut acc, panel_press(), None, &[], &buttons, &tx);
-    handle_reprog(&mut acc, release(), None, &[], &buttons, &tx);
+    handle_reprog(&mut acc, panel_press(), &[], &[], &buttons, &tx);
+    handle_reprog(&mut acc, release(), &[], &[], &buttons, &tx);
 
     assert_eq!(
         rx.try_recv(),

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -57,7 +57,6 @@ fn release() -> RawControlEvent {
 }
 
 #[test]
-#[ignore = "RED: multi-source hold takeover not implemented yet"]
 fn a_still_held_second_source_takes_over_when_the_holder_releases() {
     // Both sources diverted: press the gesture button, add the panel, release
     // the gesture button (click — no swipe committed), and the still-held
@@ -104,7 +103,6 @@ fn a_still_held_second_source_takes_over_when_the_holder_releases() {
 }
 
 #[test]
-#[ignore = "RED: overlap suppression not implemented yet"]
 fn raw_xy_during_a_two_source_overlap_is_dropped_not_misattributed() {
     // Raw-XY reports carry no source attribution: while BOTH sources are held,
     // motion must not commit through the first holder's map (the reports could
@@ -150,7 +148,6 @@ fn raw_xy_during_a_two_source_overlap_is_dropped_not_misattributed() {
 }
 
 #[test]
-#[ignore = "RED: multi-source hold takeover not implemented yet"]
 fn a_same_report_swap_to_the_panel_still_discards_its_contact_jump() {
     // Holder release and panel press arriving in ONE report: the takeover must
     // treat the panel as freshly touched, so its first raw-XY sample (the

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -2,6 +2,10 @@ use super::*;
 
 const GESTURE: &[u16] = &[reprog_controls::GESTURE_BUTTON_CID];
 const PANEL: &[u16] = &[reprog_controls::HAPTIC_PANEL_CID];
+const BOTH: &[u16] = &[
+    reprog_controls::GESTURE_BUTTON_CID,
+    reprog_controls::HAPTIC_PANEL_CID,
+];
 
 #[test]
 fn reporting_restore_preserves_every_mutable_field() {
@@ -39,8 +43,161 @@ fn panel_press() -> RawControlEvent {
     RawControlEvent::DivertedButtons([reprog_controls::HAPTIC_PANEL_CID, 0, 0, 0])
 }
 
+fn both_press() -> RawControlEvent {
+    RawControlEvent::DivertedButtons([
+        reprog_controls::GESTURE_BUTTON_CID,
+        reprog_controls::HAPTIC_PANEL_CID,
+        0,
+        0,
+    ])
+}
+
 fn release() -> RawControlEvent {
     RawControlEvent::DivertedButtons([0, 0, 0, 0])
+}
+
+#[test]
+#[ignore = "RED: multi-source hold takeover not implemented yet"]
+fn a_still_held_second_source_takes_over_when_the_holder_releases() {
+    // Both sources diverted: press the gesture button, add the panel, release
+    // the gesture button (click — no swipe committed), and the still-held
+    // panel must become the new holder so its subsequent swipe dispatches —
+    // not be swallowed until its own release.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
+    handle_reprog(&mut acc, both_press(), BOTH, &[], &[], &tx);
+    handle_reprog(&mut acc, panel_press(), BOTH, &[], &[], &tx);
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Click
+        )),
+        "the released holder still clicks"
+    );
+
+    acc.swipe.backdate_hold_for_test();
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        BOTH,
+        &[],
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(
+            ButtonId::HapticPanel,
+            GestureDirection::Right
+        )),
+        "the taken-over hold dispatches through the panel's own map"
+    );
+
+    handle_reprog(&mut acc, release(), BOTH, &[], &[], &tx);
+    assert!(
+        rx.try_recv().is_err(),
+        "a committed takeover swipe must not also click on release"
+    );
+}
+
+#[test]
+#[ignore = "RED: overlap suppression not implemented yet"]
+fn raw_xy_during_a_two_source_overlap_is_dropped_not_misattributed() {
+    // Raw-XY reports carry no source attribution: while BOTH sources are held,
+    // motion must not commit through the first holder's map (the reports could
+    // as well be the other control's). Motion resumes once the overlap ends.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    handle_reprog(&mut acc, both_press(), BOTH, &[], &[], &tx);
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        BOTH,
+        &[],
+        &[],
+        &tx,
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "ambiguous overlap motion must not commit a swipe"
+    );
+
+    // The panel lifts; the surviving hold accumulates again.
+    handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
+    acc.swipe.backdate_hold_for_test();
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        BOTH,
+        &[],
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Right
+        )),
+        "the original hold resumes once the overlap ends"
+    );
+}
+
+#[test]
+#[ignore = "RED: multi-source hold takeover not implemented yet"]
+fn a_same_report_swap_to_the_panel_still_discards_its_contact_jump() {
+    // Holder release and panel press arriving in ONE report: the takeover must
+    // treat the panel as freshly touched, so its first raw-XY sample (the
+    // absolute contact jump) is discarded before the accumulator sees it.
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let mut acc = CaptureAccum::default();
+
+    handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
+    handle_reprog(&mut acc, panel_press(), BOTH, &[], &[], &tx);
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(
+            ButtonId::GestureButton,
+            GestureDirection::Click
+        )),
+        "the swapped-out holder still clicks"
+    );
+
+    acc.swipe.backdate_hold_for_test();
+    // The contact jump — leftward, far past every threshold — must be dropped.
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -3000, dy: 40 },
+        BOTH,
+        &[],
+        &[],
+        &tx,
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "the panel's contact jump must not commit a swipe"
+    );
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: 120, dy: 5 },
+        BOTH,
+        &[],
+        &[],
+        &tx,
+    );
+    assert_eq!(
+        rx.try_recv(),
+        Ok(CapturedInput::Gesture(
+            ButtonId::HapticPanel,
+            GestureDirection::Right
+        ))
+    );
 }
 
 #[test]


### PR DESCRIPTION
> ~~Depends on #565~~ — #565 has merged; this branch is rebased onto current master and the diff now contains only this PR's own 20 commits.

## Summary

Gesture mode is currently a device-level property: exactly one button can own it, chosen from a dedicated selector row above the mouse model. That lock has no hardware basis — an MX Master can divert its gesture button, its thumb wheel, and OS-hook side buttons at once — and it puts gestures outside the flow every other binding uses, so assigning them means leaving the button you were editing.

This makes gesture mode **shape-driven and per-button**: any button carrying a Gesture-shaped map is in gesture mode. The owner field and its transition shims are gone, with a v3 config migration materializing the old HID++ owner's seeded map, so existing configs keep working unchanged.

Runtime semantics with multiple gesture buttons:

- every gesture-mode HID++ source is armed in the capture plan, and every OS-hook gesture button dispatches — **first hold wins**, with hold takeover, overlap suppression, and arm unwind across two sources;
- a demoted button's map is stashed so re-enabling gestures restores its swipe arms;
- a hold whose button-up was lost is recovered instead of wedging the state machine.

In the GUI, the action picker leads a gesture-capable button with a pinned "Gestures" entry and a gesture-mode button's popover gains a "Turn off gestures" footer; the device-level owner selector row is removed.

Related: #256, #446 (per-button gesture asks — this PR makes them structurally possible; it does not claim to close them).

## Changes

- `core`: gesture mode becomes shape-driven per button; owner field and transition shims removed; v3 migration materializes the old owner's seeded map; demoted-button map stash.
- `agent-core`: multi-source HID++ gesture plans; multi-button OS-hook dispatch with first-hold-wins, stale-hold recovery; the unread shared gesture map dropped.
- `hid`: gesture-source identity threaded through capture; hold takeover, overlap suppression, and arm unwind for two concurrent sources.
- `gui`: per-button gesture menus in the picker, owner selector removed; per-button gesture display maps.
- i18n: "Gestures" / "Turn off gestures" keys added in the same position in every `locales/*.yml`.
- Wire format untouched: no IPC enum changes, `PROTOCOL_VERSION` stays at 13, `wire_format` goldens unchanged.

## Testing

- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` — green on this branch. The series is TDD-shaped: each behavior (shape-driven mode, multi-button dispatch, multi-source plans, per-button display maps, two-source takeover/suppression, migration, swipe-arm preservation, stale-hold recovery) has a pinned test committed ahead of its implementation.
- Not runtime-tested on hardware. The two-source paths (gesture button plus thumb wheel / haptic panel held together) still need a physical MX Master pass: arm gestures on two buttons, hold both, confirm the first hold wins and the second is suppressed, release order doesn't wedge either state machine.

