### PR TITLE
feat(agent): add a hardware-free mock agent for GUI development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,11 @@ New GUI strings: insert the same key in the **same position** in every
   into `target/dev/OpenLogi.app`. `cargo build` does NOT refresh that bundle,
   and a second instance exits on the singleton lock: quit the old instance and
   re-`run` before judging a UI change "not applied".
+- No hardware attached? `cargo run -p openlogi-agent --bin openlogi-agent-mock`
+  serves a scripted inventory (both route kinds, every capability-gated panel, a
+  pairing flow) over the IPC socket, so the GUI runs unmodified. It defaults to
+  the `openlogi-dev` profile — same socket the dev bundle uses, production app
+  untouched. Details in `docs/DEVELOPMENT.md`.
 
 ## Rust standards
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,4 +120,3 @@ strip = "symbols"
 # SDK). See third_party/tarpc/README.md.
 [patch.crates-io]
 tarpc = { path = "third_party/tarpc" }
-

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -14,6 +14,13 @@ publish = false
 name = "openlogi-agent"
 path = "src/main.rs"
 
+# Hardware-free mock agent for GUI development: serves a scripted inventory over
+# the real IPC socket. Dev-only — xtask bundles `openlogi-agent` by exact path,
+# so this binary never ships.
+[[bin]]
+name = "openlogi-agent-mock"
+path = "src/bin/mock_agent.rs"
+
 [dependencies]
 openlogi-agent-core = { path = "../openlogi-agent-core" }
 openlogi-core = { path = "../openlogi-core" }

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -781,6 +781,12 @@ impl Agent for MockAgent {
         let state = Arc::clone(&self.state);
         tokio::spawn(async move {
             tokio::time::sleep(PASSKEY_DELAY).await;
+            // A cancel in the meantime ends the flow: a plain cancel leaves the
+            // GUI polling this very channel, so sending the prompt anyway would
+            // show it a passkey *after* `Failed(Cancelled)`.
+            if state.lock().await.pairing_session(id).is_none() {
+                return;
+            }
             let _ = tx.send(PairingUpdate::Passkey(PasskeyMethod::Keyboard(
                 "482913".to_string(),
             )));

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -222,6 +222,11 @@ impl DeviceSettings {
 
 /// An in-flight scripted pairing session.
 struct PairingSession {
+    /// Identifies this session to the tasks it spawned. Their sleeps outlive a
+    /// cancel, so every one of them must prove it is still the live session
+    /// before touching state — otherwise a session started right after a cancel
+    /// inherits the previous one's discovery or gets consumed by it.
+    id: u64,
     updates: UnboundedSender<PairingUpdate>,
     /// The candidate surfaced by discovery, once `DISCOVERY_DELAY` elapsed;
     /// `pair_device` only accepts its address.
@@ -241,6 +246,8 @@ struct State {
     /// unique here because the script has a single receiver.
     settings: HashMap<u8, DeviceSettings>,
     pairing: Option<PairingSession>,
+    /// Id handed to the next pairing session; only ever increases.
+    next_pairing_id: u64,
     started: Instant,
 }
 
@@ -287,8 +294,35 @@ impl State {
             next_slot: KEYBOARD_SLOT + 1,
             settings,
             pairing: None,
+            next_pairing_id: 0,
             started: Instant::now(),
         })
+    }
+
+    /// Register a new pairing session and return its id.
+    fn begin_pairing(&mut self, updates: UnboundedSender<PairingUpdate>) -> u64 {
+        let id = self.next_pairing_id;
+        self.next_pairing_id += 1;
+        self.pairing = Some(PairingSession {
+            id,
+            updates,
+            discovered: None,
+        });
+        id
+    }
+
+    /// The live session, but only if it is still the one `id` started.
+    fn pairing_session(&mut self, id: u64) -> Option<&mut PairingSession> {
+        self.pairing.as_mut().filter(|session| session.id == id)
+    }
+
+    /// End the live session, but only if it is still the one `id` started.
+    fn end_pairing(&mut self, id: u64) -> Option<PairingSession> {
+        if self.pairing.as_ref().is_some_and(|s| s.id == id) {
+            self.pairing.take()
+        } else {
+            None
+        }
     }
 
     /// Whether a host camera is "in use" right now — flipped on a timer so the
@@ -698,16 +732,13 @@ impl Agent for MockAgent {
         _selector: ReceiverSelector,
     ) -> Result<(), PairingCommandError> {
         let (tx, rx) = mpsc::unbounded_channel();
-        {
+        let id = {
             let mut state = self.state.lock().await;
             if state.pairing.is_some() {
                 return Err(PairingCommandError::AlreadyActive);
             }
-            state.pairing = Some(PairingSession {
-                updates: tx.clone(),
-                discovered: None,
-            });
-        }
+            state.begin_pairing(tx.clone())
+        };
         *self.pairing_rx.lock().await = Some(rx);
         let _ = tx.send(PairingUpdate::Searching);
 
@@ -715,7 +746,9 @@ impl Agent for MockAgent {
         tokio::spawn(async move {
             tokio::time::sleep(DISCOVERY_DELAY).await;
             let mut state = state.lock().await;
-            if let Some(session) = state.pairing.as_mut() {
+            // Only *this* session's discovery: a cancel and restart inside the
+            // delay must not hand the replacement a device it never searched for.
+            if let Some(session) = state.pairing_session(id) {
                 let found = FoundDevice {
                     address: CANDIDATE_ADDRESS,
                     name: "ERGO K860".to_string(),
@@ -730,7 +763,7 @@ impl Agent for MockAgent {
     }
 
     async fn pair_device(self, _: Context, address: [u8; 6]) -> Result<(), PairingCommandError> {
-        let (tx, name) = {
+        let (id, tx, name) = {
             let state = self.state.lock().await;
             let Some(session) = state.pairing.as_ref() else {
                 return Err(PairingCommandError::NoActiveSession);
@@ -742,7 +775,7 @@ impl Agent for MockAgent {
             else {
                 return Err(PairingCommandError::UnknownDevice);
             };
-            (session.updates.clone(), found.name.clone())
+            (session.id, session.updates.clone(), found.name.clone())
         };
 
         let state = Arc::clone(&self.state);
@@ -753,8 +786,10 @@ impl Agent for MockAgent {
             )));
             tokio::time::sleep(PASSKEY_TYPING_DELAY).await;
             let mut state = state.lock().await;
-            // Session gone = cancelled while the "user" was typing.
-            if state.pairing.take().is_none() {
+            // No session of ours left = cancelled while the "user" was typing.
+            // Ending it by id also means a session started in the meantime is
+            // neither consumed here nor completed with our (dropped) channel.
+            if state.end_pairing(id).is_none() {
                 return;
             }
             let slot = state.pair_scripted(&name);
@@ -764,13 +799,13 @@ impl Agent for MockAgent {
     }
 
     async fn cancel_pairing(self, _: Context) -> Result<(), PairingCommandError> {
-        let mut state = self.state.lock().await;
-        let Some(session) = state.pairing.take() else {
-            return Err(PairingCommandError::NoActiveSession);
-        };
-        let _ = session
-            .updates
-            .send(PairingUpdate::Failed(PairingFailure::Cancelled));
+        // Cancelling with nothing active is `Ok` in the real agent, so it is
+        // `Ok` here — the GUI must not see a different contract from the mock.
+        if let Some(session) = self.state.lock().await.pairing.take() {
+            let _ = session
+                .updates
+                .send(PairingUpdate::Failed(PairingFailure::Cancelled));
+        }
         Ok(())
     }
 

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -73,6 +73,10 @@ const PASSKEY_DELAY: Duration = Duration::from_millis(800);
 const PASSKEY_TYPING_DELAY: Duration = Duration::from_secs(3);
 /// How long `next_pairing` holds an empty long-poll before answering `None`.
 const PAIRING_HOLD: Duration = Duration::from_secs(2);
+/// How often that hold checks for an event. Short enough that a scripted step
+/// reaches the GUI promptly; see [`MockAgent::next_pairing`] for why the hold
+/// polls instead of awaiting the receiver.
+const PAIRING_POLL_TICK: Duration = Duration::from_millis(100);
 
 fn main() -> ExitCode {
     tracing_subscriber::fmt()
@@ -189,7 +193,12 @@ struct PairingSession {
 /// Everything the RPCs read or mutate. Guarded by one async mutex; locks stay
 /// short and never span an await.
 struct State {
-    inventory: Vec<DeviceInventory>,
+    /// Devices added by a scripted pairing session, appended to the Bolt
+    /// receiver's paired list. The scripted devices themselves are rebuilt per
+    /// poll, so this holds only what pairing added.
+    paired_extra: Vec<PairedDevice>,
+    /// Slot the next scripted pairing assigns.
+    next_slot: u8,
     /// Keyed by HID++ device index (Bolt slot / [`DIRECT_DEVICE_INDEX`]),
     /// unique here because the script has a single receiver.
     settings: HashMap<u8, DeviceSettings>,
@@ -236,26 +245,21 @@ impl State {
             },
         );
         Ok(Self {
-            inventory: vec![bolt_inventory(), direct_inventory()],
+            paired_extra: Vec::new(),
+            next_slot: KEYBOARD_SLOT + 1,
             settings,
             pairing: None,
             started: Instant::now(),
         })
     }
 
-    /// The inventory as polled: the template with the online mouse's battery
-    /// re-derived from elapsed time, so successive snapshots visibly differ
-    /// and the GUI's poll → repaint loop can be watched working.
+    /// The inventory as polled. Rebuilt per call so the online mouse's battery
+    /// is re-derived from elapsed time: successive snapshots visibly differ and
+    /// the GUI's poll → repaint loop can be watched working.
     fn render_inventory(&self) -> Vec<DeviceInventory> {
-        let mut inventory = self.inventory.clone();
-        if let Some(mouse) = inventory
-            .iter_mut()
-            .find(|group| group.receiver.unique_id.as_deref() == Some(RECEIVER_UID))
-            .and_then(|group| group.paired.iter_mut().find(|d| d.slot == MOUSE_SLOT))
-        {
-            mouse.battery = Some(draining_battery(self.started.elapsed()));
-        }
-        inventory
+        let mut bolt = bolt_inventory(draining_battery(self.started.elapsed()));
+        bolt.paired.extend_from_slice(&self.paired_extra);
+        vec![bolt, direct_inventory()]
     }
 
     fn settings_for(&self, route: &DeviceRoute) -> Result<&DeviceSettings, WriteError> {
@@ -273,21 +277,9 @@ impl State {
     /// Append the scripted pairing candidate to the Bolt receiver's inventory
     /// and return its assigned slot.
     fn pair_scripted(&mut self, name: &str) -> u8 {
-        let Some(group) = self
-            .inventory
-            .iter_mut()
-            .find(|group| group.receiver.unique_id.as_deref() == Some(RECEIVER_UID))
-        else {
-            return 0;
-        };
-        let slot = group
-            .paired
-            .iter()
-            .map(|d| d.slot)
-            .max()
-            .unwrap_or(0)
-            .saturating_add(1);
-        group.paired.push(PairedDevice {
+        let slot = self.next_slot;
+        self.next_slot = self.next_slot.saturating_add(1);
+        self.paired_extra.push(PairedDevice {
             slot,
             codename: Some(name.to_string()),
             wpid: Some(0x408a),
@@ -334,7 +326,9 @@ fn draining_battery(elapsed: Duration) -> BatteryInfo {
     }
 }
 
-fn bolt_inventory() -> DeviceInventory {
+/// The scripted Bolt receiver and its devices. `mouse_battery` is passed in
+/// because it is the one field that moves between polls.
+fn bolt_inventory(mouse_battery: BatteryInfo) -> DeviceInventory {
     DeviceInventory {
         receiver: ReceiverInfo {
             name: "Logi Bolt Receiver".to_string(),
@@ -349,8 +343,7 @@ fn bolt_inventory() -> DeviceInventory {
                 wpid: Some(0xb034),
                 kind: DeviceKind::Mouse,
                 online: true,
-                // Placeholder; render_inventory() re-derives it per poll.
-                battery: None,
+                battery: Some(mouse_battery),
                 model_info: Some(DeviceModelInfo {
                     entity_count: 3,
                     serial_number: Some("2140LZ00MOCK".to_string()),
@@ -692,19 +685,24 @@ impl Agent for MockAgent {
     }
 
     async fn next_pairing(self, _: Context) -> Option<PairingUpdate> {
-        let mut guard = self.pairing_rx.lock().await;
-        if let Some(rx) = guard.as_mut() {
-            match tokio::time::timeout(PAIRING_HOLD, rx.recv()).await {
-                Ok(Some(update)) => return Some(update),
-                // Channel closed and drained — the session is over; drop the
-                // receiver so later polls take the slow path instead of
-                // spinning on an instant `None`.
-                Ok(None) => *guard = None,
-                Err(_elapsed) => return None,
+        // Polled rather than awaiting the receiver directly: the lock is then
+        // never held across an await, so a `start_pairing` arriving mid-hold
+        // isn't stuck behind this poll. A drained-but-open channel and a
+        // finished session look the same here — both simply wait out the hold,
+        // which is what keeps the GUI's poll loop from spinning.
+        let started = Instant::now();
+        while started.elapsed() < PAIRING_HOLD {
+            if let Some(update) = self
+                .pairing_rx
+                .lock()
+                .await
+                .as_mut()
+                .and_then(|rx| rx.try_recv().ok())
+            {
+                return Some(update);
             }
+            tokio::time::sleep(PAIRING_POLL_TICK).await;
         }
-        drop(guard);
-        tokio::time::sleep(PAIRING_HOLD).await;
         None
     }
 

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -1,0 +1,721 @@
+//! Hardware-free mock agent for GUI development.
+//!
+//! Serves the same tarpc [`Agent`] service as the real agent — on the real IPC
+//! socket — from a scripted in-memory inventory: no HID I/O, no input hook, no
+//! Accessibility. The GUI needs zero changes; it connects, handshakes the real
+//! [`PROTOCOL_VERSION`], and renders whatever this binary scripts.
+//!
+//! ```sh
+//! pkill -x openlogi-agent            # stop the real agent if one is running
+//! cargo run -p openlogi-agent --bin openlogi-agent-mock
+//! cargo run -p openlogi-gui          # in a second terminal
+//! ```
+//!
+//! The mock holds the agent's `agent.lock`, so real agents spawned meanwhile
+//! (by the GUI's auto-spawn or launchd) exit as duplicates; conversely the mock
+//! refuses to start while a real agent is running. Scripted behavior:
+//!
+//! - A Bolt receiver with an online mouse (DPI + SmartShift + battery that
+//!   drains ~1%/minute), an offline mouse, and a lighting-capable keyboard,
+//!   plus one directly-attached mouse — covering every panel and both route
+//!   kinds without hardware.
+//! - DPI / SmartShift writes persist in memory and read back, so sliders and
+//!   toggles behave like a live device.
+//! - `start_pairing` runs a scripted Bolt flow: discovery → passkey → paired,
+//!   and the paired keyboard joins the inventory.
+
+use std::collections::HashMap;
+use std::process::ExitCode;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::StreamExt as _;
+use interprocess::local_socket::traits::tokio::Listener as _;
+use openlogi_agent_core::ipc::{
+    Agent, AgentSnapshot, AgentStatus, FoundDevice, InventoryHealth, MonitorEvent,
+    PROTOCOL_VERSION, PairingCommandError, PairingFailure, PairingUpdate,
+};
+use openlogi_agent_core::transport;
+use openlogi_core::config::{Config, Lighting};
+use openlogi_core::device::{
+    BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
+    DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+};
+use openlogi_core::single_instance::{self, InstanceError};
+use openlogi_hid::{
+    DIRECT_DEVICE_INDEX, DeviceRoute, DpiCapabilities, DpiInfo, PasskeyMethod, ReceiverSelector,
+    SmartShiftMode, SmartShiftStatus, WriteError,
+};
+use tarpc::context::Context;
+use tarpc::server::{BaseChannel, Channel as _};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+const LOGITECH_VID: u16 = 0x046d;
+/// Unique ID of the scripted Bolt receiver; Bolt routes are matched against it.
+const RECEIVER_UID: &str = "MOCK-BOLT-01";
+const MOUSE_SLOT: u8 = 1;
+const OFFLINE_SLOT: u8 = 2;
+const KEYBOARD_SLOT: u8 = 3;
+/// Product ID of the scripted directly-attached mouse; `DeviceRoute::Direct`
+/// is matched against it.
+const DIRECT_PID: u16 = 0xb020;
+
+/// BTLE address of the scripted pairing candidate.
+const CANDIDATE_ADDRESS: [u8; 6] = [0xe0, 0x15, 0x27, 0x42, 0x91, 0x3a];
+/// How long "discovery" runs before the candidate appears.
+const DISCOVERY_DELAY: Duration = Duration::from_millis(1500);
+/// Pause between accepting `pair_device` and asking for the passkey.
+const PASSKEY_DELAY: Duration = Duration::from_millis(800);
+/// How long the "user" takes to type the passkey before pairing completes.
+const PASSKEY_TYPING_DELAY: Duration = Duration::from_secs(3);
+/// How long `next_pairing` holds an empty long-poll before answering `None`.
+const PAIRING_HOLD: Duration = Duration::from_secs(2);
+
+fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            EnvFilter::try_from_env("OPENLOGI_LOG").unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    // Impersonate the agent role fully: holding `agent.lock` makes every real
+    // agent spawned meanwhile (GUI auto-spawn, launchd KeepAlive) exit as a
+    // duplicate — its takeover handshake sees us answer the current
+    // PROTOCOL_VERSION and stands down.
+    let _guard = match single_instance::acquire("agent.lock") {
+        Ok(guard) => guard,
+        Err(InstanceError::AlreadyRunning { path }) => {
+            warn!(
+                path = %path.display(),
+                "an openlogi-agent is already running — quit it first (pkill -x openlogi-agent)"
+            );
+            return ExitCode::FAILURE;
+        }
+        Err(e) => {
+            warn!(error = %e, "single-instance check failed");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let state = match State::new() {
+        Ok(state) => state,
+        Err(e) => {
+            warn!(error = %e, "could not build the scripted inventory");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            warn!(error = %e, "tokio runtime init failed");
+            return ExitCode::FAILURE;
+        }
+    };
+    match runtime.block_on(serve(MockAgent::new(state))) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            warn!(error = %e, "could not bind the IPC socket");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Accept loop — the mock's copy of `server::run` (kept verbatim rather than
+/// making the production loop generic over its service impl for a dev tool).
+async fn serve(server: MockAgent) -> std::io::Result<()> {
+    let listener = transport::bind()?;
+    info!("mock agent listening on the real IPC socket");
+    loop {
+        let stream = match listener.accept().await {
+            Ok(stream) => stream,
+            Err(e) => {
+                warn!(error = %e, "IPC accept failed");
+                continue;
+            }
+        };
+        let server = server.clone();
+        let channel = BaseChannel::with_defaults(transport::wrap(stream));
+        tokio::spawn(
+            channel
+                .execute(server.serve())
+                .for_each(|response| async move {
+                    tokio::spawn(response);
+                }),
+        );
+    }
+}
+
+/// Mutable DPI state for one scripted device.
+struct DpiState {
+    current: u16,
+    capabilities: DpiCapabilities,
+}
+
+/// What one scripted device answers to the settings RPCs. `None` / `false`
+/// answer [`WriteError::FeatureUnsupported`], exercising the GUI's permanent-
+/// error path (it must stop re-probing).
+struct DeviceSettings {
+    dpi: Option<DpiState>,
+    smartshift: Option<SmartShiftStatus>,
+    lighting: bool,
+}
+
+impl DeviceSettings {
+    fn unsupported() -> Self {
+        Self {
+            dpi: None,
+            smartshift: None,
+            lighting: false,
+        }
+    }
+}
+
+/// An in-flight scripted pairing session.
+struct PairingSession {
+    updates: UnboundedSender<PairingUpdate>,
+    /// The candidate surfaced by discovery, once `DISCOVERY_DELAY` elapsed;
+    /// `pair_device` only accepts its address.
+    discovered: Option<FoundDevice>,
+}
+
+/// Everything the RPCs read or mutate. Guarded by one async mutex; locks stay
+/// short and never span an await.
+struct State {
+    inventory: Vec<DeviceInventory>,
+    /// Keyed by HID++ device index (Bolt slot / [`DIRECT_DEVICE_INDEX`]),
+    /// unique here because the script has a single receiver.
+    settings: HashMap<u8, DeviceSettings>,
+    pairing: Option<PairingSession>,
+    started: Instant,
+}
+
+impl State {
+    fn new() -> Result<Self, WriteError> {
+        let mut settings = HashMap::new();
+        settings.insert(
+            MOUSE_SLOT,
+            DeviceSettings {
+                dpi: Some(DpiState {
+                    current: 1600,
+                    capabilities: DpiCapabilities::new((200u16..=8000).step_by(50).collect())?,
+                }),
+                smartshift: Some(SmartShiftStatus {
+                    mode: SmartShiftMode::Ratchet,
+                    auto_disengage: 16,
+                    tunable_torque: 50,
+                }),
+                lighting: false,
+            },
+        );
+        settings.insert(OFFLINE_SLOT, DeviceSettings::unsupported());
+        settings.insert(
+            KEYBOARD_SLOT,
+            DeviceSettings {
+                dpi: None,
+                smartshift: None,
+                lighting: true,
+            },
+        );
+        settings.insert(
+            DIRECT_DEVICE_INDEX,
+            DeviceSettings {
+                dpi: Some(DpiState {
+                    current: 1000,
+                    capabilities: DpiCapabilities::new((400u16..=4000).step_by(100).collect())?,
+                }),
+                smartshift: None,
+                lighting: false,
+            },
+        );
+        Ok(Self {
+            inventory: vec![bolt_inventory(), direct_inventory()],
+            settings,
+            pairing: None,
+            started: Instant::now(),
+        })
+    }
+
+    /// The inventory as polled: the template with the online mouse's battery
+    /// re-derived from elapsed time, so successive snapshots visibly differ
+    /// and the GUI's poll → repaint loop can be watched working.
+    fn render_inventory(&self) -> Vec<DeviceInventory> {
+        let mut inventory = self.inventory.clone();
+        if let Some(mouse) = inventory
+            .iter_mut()
+            .find(|group| group.receiver.unique_id.as_deref() == Some(RECEIVER_UID))
+            .and_then(|group| group.paired.iter_mut().find(|d| d.slot == MOUSE_SLOT))
+        {
+            mouse.battery = Some(draining_battery(self.started.elapsed()));
+        }
+        inventory
+    }
+
+    fn settings_for(&self, route: &DeviceRoute) -> Result<&DeviceSettings, WriteError> {
+        settings_key(route)
+            .and_then(|key| self.settings.get(&key))
+            .ok_or(WriteError::DeviceNotFound)
+    }
+
+    fn settings_for_mut(&mut self, route: &DeviceRoute) -> Result<&mut DeviceSettings, WriteError> {
+        settings_key(route)
+            .and_then(|key| self.settings.get_mut(&key))
+            .ok_or(WriteError::DeviceNotFound)
+    }
+
+    /// Append the scripted pairing candidate to the Bolt receiver's inventory
+    /// and return its assigned slot.
+    fn pair_scripted(&mut self, name: &str) -> u8 {
+        let Some(group) = self
+            .inventory
+            .iter_mut()
+            .find(|group| group.receiver.unique_id.as_deref() == Some(RECEIVER_UID))
+        else {
+            return 0;
+        };
+        let slot = group
+            .paired
+            .iter()
+            .map(|d| d.slot)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
+        group.paired.push(PairedDevice {
+            slot,
+            codename: Some(name.to_string()),
+            wpid: Some(0x408a),
+            kind: DeviceKind::Keyboard,
+            online: true,
+            battery: Some(BatteryInfo {
+                percentage: 90,
+                level: BatteryLevel::Full,
+                status: BatteryStatus::Discharging,
+            }),
+            model_info: None,
+            capabilities: Some(Capabilities::default()),
+        });
+        self.settings.insert(slot, DeviceSettings::unsupported());
+        slot
+    }
+}
+
+/// Resolve a wire route to the scripted settings key. `None` = no such device.
+fn settings_key(route: &DeviceRoute) -> Option<u8> {
+    match route {
+        DeviceRoute::Bolt { receiver_uid, slot } if receiver_uid == RECEIVER_UID => Some(*slot),
+        DeviceRoute::Direct {
+            vendor_id: LOGITECH_VID,
+            product_id: DIRECT_PID,
+        } => Some(DIRECT_DEVICE_INDEX),
+        _ => None,
+    }
+}
+
+/// Sawtooth battery for the online mouse: 80% draining ~1%/minute down to
+/// 20%, then back to 80%, with the coarse level tracking the percentage.
+fn draining_battery(elapsed: Duration) -> BatteryInfo {
+    let drained = u8::try_from(elapsed.as_secs() / 60 % 61).unwrap_or(0);
+    let percentage = 80 - drained;
+    BatteryInfo {
+        percentage,
+        level: match percentage {
+            0..=10 => BatteryLevel::Critical,
+            11..=25 => BatteryLevel::Low,
+            _ => BatteryLevel::Good,
+        },
+        status: BatteryStatus::Discharging,
+    }
+}
+
+fn bolt_inventory() -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "Logi Bolt Receiver".to_string(),
+            vendor_id: LOGITECH_VID,
+            product_id: 0xc548,
+            unique_id: Some(RECEIVER_UID.to_string()),
+        },
+        paired: vec![
+            PairedDevice {
+                slot: MOUSE_SLOT,
+                codename: Some("MX Master 3S".to_string()),
+                wpid: Some(0xb034),
+                kind: DeviceKind::Mouse,
+                online: true,
+                // Placeholder; render_inventory() re-derives it per poll.
+                battery: None,
+                model_info: Some(DeviceModelInfo {
+                    entity_count: 3,
+                    serial_number: Some("2140LZ00MOCK".to_string()),
+                    unit_id: [0x01, 0x02, 0x03, 0x04],
+                    transports: DeviceTransports {
+                        usb: false,
+                        equad: true,
+                        btle: true,
+                        bluetooth: false,
+                    },
+                    model_ids: [0xb034, 0x4082, 0],
+                    extended_model_id: 0x0b,
+                }),
+                capabilities: Some(Capabilities {
+                    buttons: true,
+                    pointer: true,
+                    lighting: false,
+                    scroll_inversion: true,
+                    hires_wheel: true,
+                }),
+            },
+            PairedDevice {
+                slot: OFFLINE_SLOT,
+                codename: Some("MX Anywhere 3".to_string()),
+                wpid: Some(0x4090),
+                kind: DeviceKind::Mouse,
+                online: false,
+                battery: None,
+                model_info: None,
+                capabilities: None,
+            },
+            // Lighting is scripted `true` (unlike a real MX Keys) so the
+            // Lighting panel is reachable without G-series hardware.
+            PairedDevice {
+                slot: KEYBOARD_SLOT,
+                codename: Some("MX Keys".to_string()),
+                wpid: Some(0x408a),
+                kind: DeviceKind::Keyboard,
+                online: true,
+                battery: Some(BatteryInfo {
+                    percentage: 100,
+                    level: BatteryLevel::Full,
+                    status: BatteryStatus::Full,
+                }),
+                model_info: Some(DeviceModelInfo {
+                    entity_count: 2,
+                    serial_number: None,
+                    unit_id: [0x05, 0x06, 0x07, 0x08],
+                    transports: DeviceTransports {
+                        usb: false,
+                        equad: true,
+                        btle: true,
+                        bluetooth: false,
+                    },
+                    model_ids: [0x408a, 0xb35b, 0],
+                    extended_model_id: 0,
+                }),
+                capabilities: Some(Capabilities {
+                    buttons: false,
+                    pointer: false,
+                    lighting: true,
+                    scroll_inversion: false,
+                    hires_wheel: false,
+                }),
+            },
+        ],
+    }
+}
+
+/// A directly-attached (Bluetooth) mouse: its synthetic receiver entry mirrors
+/// the device itself, and its route is [`DeviceRoute::Direct`].
+fn direct_inventory() -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "MX Vertical".to_string(),
+            vendor_id: LOGITECH_VID,
+            product_id: DIRECT_PID,
+            unique_id: None,
+        },
+        paired: vec![PairedDevice {
+            slot: DIRECT_DEVICE_INDEX,
+            codename: Some("MX Vertical".to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: Some(BatteryInfo {
+                percentage: 55,
+                level: BatteryLevel::Good,
+                status: BatteryStatus::Discharging,
+            }),
+            model_info: Some(DeviceModelInfo {
+                entity_count: 2,
+                serial_number: None,
+                unit_id: [0x09, 0x0a, 0x0b, 0x0c],
+                transports: DeviceTransports {
+                    usb: true,
+                    equad: false,
+                    btle: true,
+                    bluetooth: false,
+                },
+                model_ids: [DIRECT_PID, 0, 0],
+                extended_model_id: 0,
+            }),
+            capabilities: Some(Capabilities {
+                buttons: true,
+                pointer: true,
+                lighting: false,
+                scroll_inversion: false,
+                hires_wheel: false,
+            }),
+        }],
+    }
+}
+
+/// `launch_at_login` mirrors the config file so the Settings toggle round-trips
+/// (the GUI saves config.toml, calls `reload_config`, then expects the next
+/// snapshot to agree). Everything else is scripted green.
+fn agent_status() -> AgentStatus {
+    let launch_at_login =
+        Config::load_or_default().is_ok_and(|config| config.app_settings.launch_at_login);
+    AgentStatus {
+        accessibility_granted: true,
+        hook_installed: true,
+        launch_at_login,
+        inventory: InventoryHealth::Ready,
+        protocol_version: PROTOCOL_VERSION,
+        // The "-mock" marker shows up anywhere the GUI displays the agent
+        // version, so a mock session can't be mistaken for a live one.
+        agent_version: concat!(env!("CARGO_PKG_VERSION"), "-mock").to_string(),
+    }
+}
+
+/// The scripted [`Agent`] implementation, cloned per connection.
+#[derive(Clone)]
+struct MockAgent {
+    state: Arc<Mutex<State>>,
+    /// Long-poll side of the pairing channel, outside [`MockAgent::state`] so a
+    /// held `next_pairing` can't block `snapshot`.
+    pairing_rx: Arc<Mutex<Option<UnboundedReceiver<PairingUpdate>>>>,
+}
+
+impl MockAgent {
+    fn new(state: State) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(state)),
+            pairing_rx: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+// Pairing updates are sent with `let _ =`: a send only fails when the GUI's
+// long-poll receiver is gone (Add Device window closed / GUI died), and
+// dropping the event is exactly right then.
+impl Agent for MockAgent {
+    async fn protocol_version(self, _: Context) -> u32 {
+        PROTOCOL_VERSION
+    }
+
+    async fn status(self, _: Context) -> AgentStatus {
+        agent_status()
+    }
+
+    async fn inventory(self, _: Context) -> Vec<DeviceInventory> {
+        self.state.lock().await.render_inventory()
+    }
+
+    async fn reload_config(self, _: Context) {
+        info!("reload_config (no-op in the mock)");
+    }
+
+    async fn set_dpi(self, _: Context, route: DeviceRoute, dpi: u32) -> Result<(), WriteError> {
+        let mut state = self.state.lock().await;
+        let settings = state.settings_for_mut(&route)?;
+        let dpi_state = settings
+            .dpi
+            .as_mut()
+            .ok_or(WriteError::FeatureUnsupported {
+                feature_hex: 0x2201,
+            })?;
+        dpi_state.current = dpi_state.capabilities.nearest(dpi);
+        info!(%route, dpi = dpi_state.current, "set_dpi");
+        Ok(())
+    }
+
+    async fn set_lighting(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        lighting: Lighting,
+    ) -> Result<(), WriteError> {
+        let state = self.state.lock().await;
+        if !state.settings_for(&route)?.lighting {
+            return Err(WriteError::FeatureUnsupported {
+                feature_hex: 0x8070,
+            });
+        }
+        info!(%route, ?lighting, "set_lighting");
+        Ok(())
+    }
+
+    async fn set_smartshift(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        mode: SmartShiftMode,
+        auto_disengage: u8,
+        tunable_torque: u8,
+    ) -> Result<(), WriteError> {
+        let mut state = self.state.lock().await;
+        let settings = state.settings_for_mut(&route)?;
+        let smartshift = settings
+            .smartshift
+            .as_mut()
+            .ok_or(WriteError::FeatureUnsupported {
+                feature_hex: 0x2110,
+            })?;
+        *smartshift = SmartShiftStatus {
+            mode,
+            auto_disengage,
+            tunable_torque,
+        };
+        info!(%route, ?mode, auto_disengage, tunable_torque, "set_smartshift");
+        Ok(())
+    }
+
+    async fn read_dpi(self, _: Context, route: DeviceRoute) -> Result<DpiInfo, WriteError> {
+        let state = self.state.lock().await;
+        state
+            .settings_for(&route)?
+            .dpi
+            .as_ref()
+            .map(|dpi| DpiInfo {
+                current: dpi.current,
+                capabilities: dpi.capabilities.clone(),
+            })
+            .ok_or(WriteError::FeatureUnsupported {
+                feature_hex: 0x2201,
+            })
+    }
+
+    async fn read_smartshift(
+        self,
+        _: Context,
+        route: DeviceRoute,
+    ) -> Result<SmartShiftStatus, WriteError> {
+        let state = self.state.lock().await;
+        state
+            .settings_for(&route)?
+            .smartshift
+            .ok_or(WriteError::FeatureUnsupported {
+                feature_hex: 0x2110,
+            })
+    }
+
+    async fn request_accessibility_prompt(self, _: Context) {
+        info!("request_accessibility_prompt (no-op in the mock)");
+    }
+
+    async fn start_pairing(
+        self,
+        _: Context,
+        _selector: ReceiverSelector,
+    ) -> Result<(), PairingCommandError> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        {
+            let mut state = self.state.lock().await;
+            if state.pairing.is_some() {
+                return Err(PairingCommandError::AlreadyActive);
+            }
+            state.pairing = Some(PairingSession {
+                updates: tx.clone(),
+                discovered: None,
+            });
+        }
+        *self.pairing_rx.lock().await = Some(rx);
+        let _ = tx.send(PairingUpdate::Searching);
+
+        let state = Arc::clone(&self.state);
+        tokio::spawn(async move {
+            tokio::time::sleep(DISCOVERY_DELAY).await;
+            let mut state = state.lock().await;
+            if let Some(session) = state.pairing.as_mut() {
+                let found = FoundDevice {
+                    address: CANDIDATE_ADDRESS,
+                    name: "ERGO K860".to_string(),
+                };
+                let _ = session
+                    .updates
+                    .send(PairingUpdate::DeviceFound(found.clone()));
+                session.discovered = Some(found);
+            }
+        });
+        Ok(())
+    }
+
+    async fn pair_device(self, _: Context, address: [u8; 6]) -> Result<(), PairingCommandError> {
+        let (tx, name) = {
+            let state = self.state.lock().await;
+            let Some(session) = state.pairing.as_ref() else {
+                return Err(PairingCommandError::NoActiveSession);
+            };
+            let Some(found) = session
+                .discovered
+                .as_ref()
+                .filter(|found| found.address == address)
+            else {
+                return Err(PairingCommandError::UnknownDevice);
+            };
+            (session.updates.clone(), found.name.clone())
+        };
+
+        let state = Arc::clone(&self.state);
+        tokio::spawn(async move {
+            tokio::time::sleep(PASSKEY_DELAY).await;
+            let _ = tx.send(PairingUpdate::Passkey(PasskeyMethod::Keyboard(
+                "482913".to_string(),
+            )));
+            tokio::time::sleep(PASSKEY_TYPING_DELAY).await;
+            let mut state = state.lock().await;
+            // Session gone = cancelled while the "user" was typing.
+            if state.pairing.take().is_none() {
+                return;
+            }
+            let slot = state.pair_scripted(&name);
+            let _ = tx.send(PairingUpdate::Paired { slot });
+        });
+        Ok(())
+    }
+
+    async fn cancel_pairing(self, _: Context) -> Result<(), PairingCommandError> {
+        let mut state = self.state.lock().await;
+        let Some(session) = state.pairing.take() else {
+            return Err(PairingCommandError::NoActiveSession);
+        };
+        let _ = session
+            .updates
+            .send(PairingUpdate::Failed(PairingFailure::Cancelled));
+        Ok(())
+    }
+
+    async fn next_pairing(self, _: Context) -> Option<PairingUpdate> {
+        let mut guard = self.pairing_rx.lock().await;
+        if let Some(rx) = guard.as_mut() {
+            match tokio::time::timeout(PAIRING_HOLD, rx.recv()).await {
+                Ok(Some(update)) => return Some(update),
+                // Channel closed and drained — the session is over; drop the
+                // receiver so later polls take the slow path instead of
+                // spinning on an instant `None`.
+                Ok(None) => *guard = None,
+                Err(_elapsed) => return None,
+            }
+        }
+        drop(guard);
+        tokio::time::sleep(PAIRING_HOLD).await;
+        None
+    }
+
+    async fn snapshot(self, _: Context) -> AgentSnapshot {
+        AgentSnapshot {
+            status: agent_status(),
+            inventory: self.state.lock().await.render_inventory(),
+        }
+    }
+
+    async fn poll_event_monitor(self, _: Context) -> Vec<MonitorEvent> {
+        Vec::new()
+    }
+}

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -1,24 +1,30 @@
 //! Hardware-free mock agent for GUI development.
 //!
-//! Serves the same tarpc [`Agent`] service as the real agent — on the real IPC
-//! socket — from a scripted in-memory inventory: no HID I/O, no input hook, no
-//! Accessibility. The GUI needs zero changes; it connects, handshakes the real
-//! [`PROTOCOL_VERSION`], and renders whatever this binary scripts.
+//! Serves the same tarpc [`Agent`] service as the real agent, from a scripted
+//! in-memory inventory: no HID I/O, no input hook, no Accessibility. The GUI
+//! needs zero changes; it connects, handshakes the real [`PROTOCOL_VERSION`],
+//! and renders whatever this binary scripts.
 //!
 //! ```sh
-//! pkill -x openlogi-agent            # stop the real agent if one is running
 //! cargo run -p openlogi-agent --bin openlogi-agent-mock
-//! cargo run -p openlogi-gui          # in a second terminal
+//! OPENLOGI_DEV_AGENT=0 cargo run -p openlogi-gui   # in a second terminal
 //! ```
 //!
-//! The mock holds the agent's `agent.lock`, so real agents spawned meanwhile
-//! (by the GUI's auto-spawn or launchd) exit as duplicates; conversely the mock
-//! refuses to start while a real agent is running. Scripted behavior:
+//! It defaults to the `openlogi-dev` profile — the one the dev app bundle
+//! already uses — so it meets the dev GUI on the dev socket and the installed
+//! production app is left alone. `OPENLOGI_PROFILE=prod` serves the production
+//! socket instead, where the shared `agent.lock` keeps the mock and a real
+//! agent from running at the same time in either direction.
+//!
+//! Scripted behavior:
 //!
 //! - A Bolt receiver with an online mouse (DPI + SmartShift + battery that
 //!   drains ~1%/minute), an offline mouse, and a lighting-capable keyboard,
 //!   plus one directly-attached mouse — covering every panel and both route
 //!   kinds without hardware.
+//! - A standalone Litra light whose power / brightness / temperature writes
+//!   persist, and a `camera_active` flag that flips every 30s so the
+//!   camera-linked light rendering has something to follow.
 //! - DPI / SmartShift writes persist in memory and read back, so sliders and
 //!   toggles behave like a live device.
 //! - `start_pairing` runs a scripted Bolt flow: discovery → passkey → paired,
@@ -39,12 +45,13 @@ use openlogi_agent_core::transport;
 use openlogi_core::config::{Config, Lighting};
 use openlogi_core::device::{
     BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
-    DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+    DeviceModelInfo, DeviceTransports, LightCapabilities, LightValueRange, LightValueUnit,
+    PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
 use openlogi_core::single_instance::{self, InstanceError};
 use openlogi_hid::{
-    DIRECT_DEVICE_INDEX, DeviceRoute, DpiCapabilities, DpiInfo, PasskeyMethod, ReceiverSelector,
-    SmartShiftMode, SmartShiftStatus, WriteError,
+    DIRECT_DEVICE_INDEX, DeviceRoute, DpiCapabilities, DpiInfo, LightCommand, PasskeyMethod,
+    ReceiverSelector, SmartShiftMode, SmartShiftStatus, WriteError,
 };
 use tarpc::context::Context;
 use tarpc::server::{BaseChannel, Channel as _};
@@ -62,6 +69,10 @@ const KEYBOARD_SLOT: u8 = 3;
 /// Product ID of the scripted directly-attached mouse; `DeviceRoute::Direct`
 /// is matched against it.
 const DIRECT_PID: u16 = 0xb020;
+/// Product ID of the scripted standalone Litra light (Litra Glow).
+const LITRA_PID: u16 = 0xc900;
+/// How often the scripted `camera_active` flag flips.
+const CAMERA_TOGGLE_PERIOD: Duration = Duration::from_secs(30);
 
 /// BTLE address of the scripted pairing candidate.
 const CANDIDATE_ADDRESS: [u8; 6] = [0xe0, 0x15, 0x27, 0x42, 0x91, 0x3a];
@@ -79,6 +90,7 @@ const PAIRING_HOLD: Duration = Duration::from_secs(2);
 const PAIRING_POLL_TICK: Duration = Duration::from_millis(100);
 
 fn main() -> ExitCode {
+    default_to_dev_profile();
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(
@@ -132,11 +144,37 @@ fn main() -> ExitCode {
     }
 }
 
+/// Claim the `openlogi-dev` profile unless the caller picked one.
+///
+/// A bare `cargo run` binary has no `.dev` bundle to be recognized by, so
+/// without this the mock would resolve the *production* socket, lock and config
+/// while the dev GUI (which does run from a `.dev` bundle) waits on the dev
+/// socket — the two would never meet, and the mock would sit on the installed
+/// app's paths instead.
+fn default_to_dev_profile() {
+    if std::env::var_os("OPENLOGI_PROFILE").is_some() {
+        return;
+    }
+    // SAFETY: `set_var` is unsound only against concurrent env access. This is
+    // the first statement of `main`: no runtime, no tracing subscriber, no
+    // other thread exists yet, and nothing has read the environment.
+    #[expect(
+        unsafe_code,
+        reason = "the profile must be chosen before openlogi_core::paths caches it, and only a process-wide env var selects it"
+    )]
+    unsafe {
+        std::env::set_var("OPENLOGI_PROFILE", "dev");
+    }
+}
+
 /// Accept loop — the mock's copy of `server::run` (kept verbatim rather than
 /// making the production loop generic over its service impl for a dev tool).
 async fn serve(server: MockAgent) -> std::io::Result<()> {
     let listener = transport::bind()?;
-    info!("mock agent listening on the real IPC socket");
+    info!(
+        profile = std::env::var("OPENLOGI_PROFILE").unwrap_or_default(),
+        "mock agent listening"
+    );
     loop {
         let stream = match listener.accept().await {
             Ok(stream) => stream,
@@ -253,6 +291,12 @@ impl State {
         })
     }
 
+    /// Whether a host camera is "in use" right now — flipped on a timer so the
+    /// camera-linked light rendering has a changing input to follow.
+    fn camera_active(&self) -> bool {
+        self.started.elapsed().as_secs() / CAMERA_TOGGLE_PERIOD.as_secs() % 2 == 1
+    }
+
     /// The inventory as polled. Rebuilt per call so the online mouse's battery
     /// is re-derived from elapsed time: successive snapshots visibly differ and
     /// the GUI's poll → repaint loop can be watched working.
@@ -295,6 +339,49 @@ impl State {
         });
         self.settings.insert(slot, DeviceSettings::unsupported());
         slot
+    }
+}
+
+/// The scripted standalone Litra light. The wire form carries the light's
+/// *capabilities*, not its current values — the panel reads those from config —
+/// so this is constant, and writes are answered by [`MockAgent::set_light`].
+fn standalone_light() -> StandaloneDevice {
+    StandaloneDevice {
+        address: RawDeviceAddress {
+            vendor_id: LOGITECH_VID,
+            product_id: LITRA_PID,
+            usage_page: 0xff43,
+            usage_id: 0x0202,
+            identity: "MOCK-LITRA-01".to_string(),
+        },
+        display_name: "Litra Glow".to_string(),
+        manufacturer: Some("Logitech".to_string()),
+        serial_number: Some("MOCKLITRA1".to_string()),
+        unit_id: [0x0d, 0x0e, 0x0f, 0x10],
+        kind: DeviceKind::Unknown,
+        online: true,
+        capabilities: None,
+        light_capabilities: Some(LightCapabilities {
+            power: true,
+            brightness: LightValueRange::new(0, 100, 1, LightValueUnit::Percent).ok(),
+            temperature: LightValueRange::new(2700, 6500, 100, LightValueUnit::Kelvin).ok(),
+            color: false,
+            zones: false,
+        }),
+        driver_id: "litra".to_string(),
+        // Must stay `Some` until #571 is fixed: `registry_model_id` is
+        // `skip_serializing_if`, which truncates the bincode stream when it is
+        // `None` and makes the whole snapshot undecodable. `8c900` is also the
+        // real registry id for a Litra Glow, so the asset lookup resolves.
+        registry_model_id: Some("8c900".to_string()),
+    }
+}
+
+/// The route the GUI addresses the scripted light by.
+fn light_route() -> DeviceRoute {
+    DeviceRoute::Direct {
+        vendor_id: LOGITECH_VID,
+        product_id: LITRA_PID,
     }
 }
 
@@ -363,6 +450,7 @@ fn bolt_inventory(mouse_battery: BatteryInfo) -> DeviceInventory {
                     lighting: false,
                     scroll_inversion: true,
                     hires_wheel: true,
+                    thumbwheel: true,
                 }),
             },
             PairedDevice {
@@ -407,6 +495,7 @@ fn bolt_inventory(mouse_battery: BatteryInfo) -> DeviceInventory {
                     lighting: true,
                     scroll_inversion: false,
                     hires_wheel: false,
+                    thumbwheel: false,
                 }),
             },
         ],
@@ -453,6 +542,7 @@ fn direct_inventory() -> DeviceInventory {
                 lighting: false,
                 scroll_inversion: false,
                 hires_wheel: false,
+                thumbwheel: false,
             }),
         }],
     }
@@ -707,13 +797,42 @@ impl Agent for MockAgent {
     }
 
     async fn snapshot(self, _: Context) -> AgentSnapshot {
+        let state = self.state.lock().await;
         AgentSnapshot {
             status: agent_status(),
-            inventory: self.state.lock().await.render_inventory(),
+            inventory: state.render_inventory(),
+            standalone: vec![standalone_light()],
+            camera_active: state.camera_active(),
         }
     }
 
     async fn poll_event_monitor(self, _: Context) -> Vec<MonitorEvent> {
         Vec::new()
+    }
+
+    async fn set_light(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        command: LightCommand,
+    ) -> Result<(), WriteError> {
+        if route != light_route() {
+            return Err(WriteError::DeviceNotFound);
+        }
+        info!(%route, ?command, "set_light");
+        Ok(())
+    }
+
+    async fn set_light_manual_power(
+        self,
+        _: Context,
+        route: DeviceRoute,
+        enabled: bool,
+    ) -> Result<(), WriteError> {
+        if route != light_route() {
+            return Err(WriteError::DeviceNotFound);
+        }
+        info!(%route, enabled, "set_light_manual_power");
+        Ok(())
     }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,6 +85,31 @@ To install the CLI binary on `PATH`:
 cargo install --path .
 ```
 
+## Developing the GUI without hardware
+
+`openlogi-agent-mock` serves the real agent IPC contract from a scripted
+in-memory inventory, so the desktop app can be developed with no Logitech
+device (or receiver) attached:
+
+```sh
+cargo run -p openlogi-agent --bin openlogi-agent-mock  # then, in another terminal:
+cargo run -p openlogi-gui
+```
+
+The mock defaults itself to the `openlogi-dev` profile (as if `OPENLOGI_PROFILE=dev`
+were set), which is the profile the dev app bundle already uses — so it meets the
+dev GUI on the dev socket and the installed production app keeps running
+untouched. The GUI needs no flag or rebuild. Pass `OPENLOGI_PROFILE=prod` to
+serve the production socket instead; the mock then contends for the production
+agent's single-instance lock and refuses to start while it is running.
+
+The script covers an online mouse (DPI and SmartShift writes persist and read
+back, battery drains so poll-driven repaints are visible), an offline mouse, a
+lighting-capable keyboard, a directly-attached device, and a full Bolt pairing
+flow (discovery → passkey → paired). Its agent version carries a `-mock` suffix,
+so a mock session is identifiable in the UI. It is a dev tool only and is never
+bundled.
+
 ## Project layout
 
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -92,16 +92,20 @@ in-memory inventory, so the desktop app can be developed with no Logitech
 device (or receiver) attached:
 
 ```sh
-cargo run -p openlogi-agent --bin openlogi-agent-mock  # then, in another terminal:
-cargo run -p openlogi-gui
+cargo run -p openlogi-agent --bin openlogi-agent-mock   # then, in another terminal:
+OPENLOGI_DEV_AGENT=0 cargo run -p openlogi-gui
 ```
 
 The mock defaults itself to the `openlogi-dev` profile (as if `OPENLOGI_PROFILE=dev`
 were set), which is the profile the dev app bundle already uses — so it meets the
 dev GUI on the dev socket and the installed production app keeps running
-untouched. The GUI needs no flag or rebuild. Pass `OPENLOGI_PROFILE=prod` to
-serve the production socket instead; the mock then contends for the production
-agent's single-instance lock and refuses to start while it is running.
+untouched. `OPENLOGI_DEV_AGENT=0` keeps the runner from building and embedding
+the real agent for the GUI to auto-spawn; add `OPENLOGI_ALLOW_EXTERNAL_AGENT=1`
+if your installed production agent is running, since the runner's guard against
+it predates the profile split and cannot know the dev GUI is on a separate
+socket. Pass `OPENLOGI_PROFILE=prod` to serve the production socket instead; the
+mock then contends for the production agent's single-instance lock and refuses
+to start while it is running.
 
 The script covers an online mouse (DPI and SmartShift writes persist and read
 back, battery drains so poll-driven repaints are visible), an offline mouse, a

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,8 +98,11 @@ OPENLOGI_DEV_AGENT=0 cargo run -p openlogi-gui
 
 The mock defaults itself to the `openlogi-dev` profile (as if `OPENLOGI_PROFILE=dev`
 were set), which is the profile the dev app bundle already uses — so it meets the
-dev GUI on the dev socket and the installed production app keeps running
-untouched. `OPENLOGI_DEV_AGENT=0` keeps the runner from building and embedding
+dev GUI on the dev socket, and an installed *release* build, which is on the
+production profile, keeps running untouched. (A locally built bundle installed
+into `/Applications` carries `.dev` identifiers and therefore shares the dev
+profile: it and the mock contend for the same lock, and whichever starts second
+exits.) `OPENLOGI_DEV_AGENT=0` keeps the runner from building and embedding
 the real agent for the GUI to auto-spawn; add `OPENLOGI_ALLOW_EXTERNAL_AGENT=1`
 if your installed production agent is running, since the runner's guard against
 it predates the profile split and cannot know the dev GUI is on a separate

--- a/third_party/tarpc/Cargo.toml
+++ b/third_party/tarpc/Cargo.toml
@@ -58,4 +58,3 @@ tracing = { version = "0.1", default-features = false, features = [
 tracing-opentelemetry = { version = "0.33", default-features = false }
 opentelemetry = { version = "0.32", default-features = false }
 opentelemetry-semantic-conventions = "0.32"
-


### PR DESCRIPTION
## Summary

Adds `openlogi-agent-mock`, a dev-only binary that serves the real `Agent` tarpc
contract from a scripted in-memory inventory. The GUI runs unmodified against it —
no device, no receiver, no Accessibility grant — which unblocks UI work on machines
with no hardware attached and makes states that are awkward to reproduce on real
devices (offline device, unsupported feature, a full pairing flow, a standalone
light) reachable on demand.

It defaults itself to the `openlogi-dev` profile — the one the dev app bundle
already uses — so it meets the dev GUI on the dev socket and the installed
production app keeps running untouched.

The mock is a separate binary rather than a flag on the real agent: no production
code path changes, and `xtask` bundles `openlogi-agent` by exact path, so it can
never ship.

## Changes

- **`openlogi-agent`**: new `openlogi-agent-mock` bin (`src/bin/mock_agent.rs`).
  - Scripts a Bolt receiver with an online mouse (buttons, pointer, hi-res wheel,
    thumbwheel), an offline mouse (no capabilities — exercises the
    `presumed_from_kind` fallback) and a lighting-capable keyboard, plus a
    directly-attached mouse and a standalone Litra Glow: both `DeviceRoute` kinds,
    every capability-gated panel, and the standalone-light surface.
  - DPI and SmartShift writes persist in memory and read back; devices without a
    feature answer `FeatureUnsupported` and unknown routes `DeviceNotFound`, so the
    GUI's permanent-vs-transient error handling is exercised.
  - The online mouse's battery drains ~1%/minute and `camera_active` flips every
    30s, making poll-driven repaints and camera-linked light rendering observable.
  - `start_pairing` runs a scripted Bolt session (Searching → DeviceFound →
    Passkey → Paired) and the paired device joins the inventory.
  - Holds that profile's `agent.lock` and answers the current `PROTOCOL_VERSION`,
    so a real agent spawned meanwhile exits as a duplicate and a release agent's
    takeover handshake stands down. `agent_version` carries a `-mock` suffix so a
    mock session is identifiable in the UI.
- **docs**: run recipe and the two runner flags it needs in `docs/DEVELOPMENT.md`;
  pointer in `AGENTS.md`'s build/run section.
- **style**: strips a trailing blank line from `Cargo.toml` and
  `third_party/tarpc/Cargo.toml` — the `end-of-file-fixer` hook rewrites both on
  every push, so pushes are blocked until they are committed. Unrelated to the
  mock; happy to split it out.

No changes to the IPC contract — `PROTOCOL_VERSION` is untouched.

## Testing

- `devenv tasks run openlogi:check` (fmt + clippy `-D warnings` + workspace tests)
  — passes.
- Ran the dev GUI against the mock end to end. It connects on the dev socket,
  decodes snapshots, and resolves a real asset depot for every scripted device
  (`mx_master_3s`, `mx_keys`, `mx_vertical`, `litra_glow`). The installed
  production agent kept running throughout, untouched.
- Drove every RPC over the socket with a throwaway tarpc client (not committed):
  handshake at v13, snapshot, `set_dpi(3000)` → `read_dpi` reads back 3000,
  `read_smartshift`, `FeatureUnsupported` on the keyboard, `DeviceNotFound` on an
  unknown route, `set_light` / `set_light_manual_power` accepted for the light and
  rejected for a wrong route, and the pairing flow through `Paired { slot: 4 }`
  with the device appearing in the next snapshot.
- Not hardware-verified, and deliberately so — this changes no device code path.
  Device-card visuals were not screenshotted (this dev host has no screen-recording
  permission); the panels are driven by the scripted `Capabilities` verified above.

## Note

Building this surfaced #571: `StandaloneDevice::registry_model_id` is
`skip_serializing_if`, which truncates the bincode stream when it is `None` and
makes the entire snapshot undecodable by the GUI. The mock therefore always sends
a `Some(...)`. Not fixed here — it needs a `PROTOCOL_VERSION` bump and golden
regeneration of its own.
