### PR TITLE
feat(core): support stable Windows app selectors

### DIFF
--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -442,7 +442,7 @@ impl Config {
         };
         let mut out = device.bindings.clone();
         if let Some(bid) = bundle_id
-            && let Some(overlay) = device.per_app_bindings.get(bid)
+            && let Some(overlay) = app_overlay(&device.per_app_bindings, bid)
         {
             for (k, v) in overlay {
                 out.insert(*k, Binding::Single(v.clone()));
@@ -597,9 +597,7 @@ impl Config {
     #[must_use]
     pub fn has_app_override(&self, device_key: &str, app: &str) -> bool {
         self.devices.get(device_key).is_some_and(|d| {
-            d.per_app_bindings
-                .get(app)
-                .is_some_and(|overlay| !overlay.is_empty())
+            app_overlay(&d.per_app_bindings, app).is_some_and(|overlay| !overlay.is_empty())
         })
     }
 
@@ -814,6 +812,29 @@ impl Config {
             .or_default()
             .thumbwheel_sensitivity = sensitivity;
     }
+}
+
+/// Resolve the most specific application overlay for a foreground identifier.
+///
+/// Exact keys retain precedence. On Windows the foreground identifier is a
+/// lower-cased executable path, so `exe:<filename>` provides a stable fallback
+/// for Store and self-updating applications whose install directory changes
+/// between versions. Recognizing both path separators keeps hand-authored
+/// Windows config inspectable on every platform without changing macOS bundle
+/// identifiers or Linux application classes.
+fn app_overlay<'a, T>(overlays: &'a BTreeMap<String, T>, app: &str) -> Option<&'a T> {
+    overlays.get(app).or_else(|| {
+        let executable_name = app.rsplit(['\\', '/']).next()?;
+        if executable_name.is_empty()
+            || !Path::new(executable_name)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"))
+        {
+            return None;
+        }
+
+        overlays.get(&format!("exe:{}", executable_name.to_ascii_lowercase()))
+    })
 }
 
 fn backup_config_once(path: &Path) -> io::Result<()> {

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -630,6 +630,102 @@ fn per_app_binding_removal_prunes_empty_app() {
 }
 
 #[test]
+fn windows_exe_selector_matches_versioned_path() {
+    let mut cfg = Config::default();
+    cfg.set_binding(
+        "2b042",
+        ButtonId::Back,
+        Binding::Single(Action::BrowserBack),
+    );
+    cfg.set_per_app_binding(
+        "2b042",
+        "exe:sharex.exe",
+        ButtonId::Back,
+        Some(Action::Copy),
+    );
+    cfg.set_per_app_binding(
+        "2b042",
+        "exe:sharex.exe",
+        ButtonId::Forward,
+        Some(Action::Paste),
+    );
+
+    let store_path = r"c:\program files\windowsapps\sharex_14.0.0.0_x64__abc\sharex.exe";
+    let effective = cfg.effective_bindings("2b042", Some(store_path));
+    assert_eq!(
+        effective.get(&ButtonId::Back),
+        Some(&Binding::Single(Action::Copy))
+    );
+    assert_eq!(
+        effective.get(&ButtonId::Forward),
+        Some(&Binding::Single(Action::Paste))
+    );
+    assert!(cfg.has_app_override("2b042", store_path));
+
+    // Forward slash separators still resolve (hand-authored configs).
+    let unixish = r"c:/tools/sharex/sharex.exe";
+    assert_eq!(
+        cfg.effective_bindings("2b042", Some(unixish))
+            .get(&ButtonId::Back),
+        Some(&Binding::Single(Action::Copy))
+    );
+
+    // Extension match is case-insensitive; selector key is lower-cased.
+    let mixed = r"C:\Tools\ShareX\ShareX.EXE";
+    assert_eq!(
+        cfg.effective_bindings("2b042", Some(mixed))
+            .get(&ButtonId::Back),
+        Some(&Binding::Single(Action::Copy))
+    );
+}
+
+#[test]
+fn windows_exe_selector_exact_path_takes_precedence() {
+    let mut cfg = Config::default();
+    let exact = r"c:\program files\windowsapps\sharex_14.0.0.0_x64__abc\sharex.exe";
+    cfg.set_per_app_binding(
+        "2b042",
+        "exe:sharex.exe",
+        ButtonId::Back,
+        Some(Action::Copy),
+    );
+    cfg.set_per_app_binding("2b042", exact, ButtonId::Back, Some(Action::Undo));
+
+    assert_eq!(
+        cfg.effective_bindings("2b042", Some(exact))
+            .get(&ButtonId::Back),
+        Some(&Binding::Single(Action::Undo))
+    );
+
+    // A different install path still falls back to the stable selector.
+    let other = r"c:\program files\windowsapps\sharex_15.0.0.0_x64__abc\sharex.exe";
+    assert_eq!(
+        cfg.effective_bindings("2b042", Some(other))
+            .get(&ButtonId::Back),
+        Some(&Binding::Single(Action::Copy))
+    );
+}
+
+#[test]
+fn windows_exe_selector_ignores_non_exe_identifiers() {
+    let mut cfg = Config::default();
+    cfg.set_binding(
+        "2b042",
+        ButtonId::Back,
+        Binding::Single(Action::BrowserBack),
+    );
+    cfg.set_per_app_binding("2b042", "exe:code.exe", ButtonId::Back, Some(Action::Undo));
+
+    // macOS bundle ids must not be treated as Windows paths.
+    assert_eq!(
+        cfg.effective_bindings("2b042", Some("com.microsoft.VSCode"))
+            .get(&ButtonId::Back),
+        Some(&Binding::Single(Action::BrowserBack))
+    );
+    assert!(!cfg.has_app_override("2b042", "com.microsoft.VSCode"));
+}
+
+#[test]
 fn app_settings_default_omits_block() {
     let cfg = Config::default();
     let body = toml::to_string_pretty(&cfg).expect("serialize");

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,7 +25,9 @@ mice of the same model independent:
 - `per_app_bindings` — overlays keyed by application id (bundle id such as
   `com.microsoft.VSCode` on macOS, `WM_CLASS` on Linux/X11, or a lower-cased
   executable path on Windows) that take precedence while that app is
-  frontmost.
+  frontmost. Windows also accepts `exe:<filename>.exe`, for example
+  `exe:sharex.exe`, as a stable fallback for Store and self-updating apps. An
+  exact path entry wins when both forms exist.
 - `action_ring` — the enabled state, haptic-feedback preference, default
   eight-slot layout, and complete per-application layouts.
 - `dpi_presets` — the ordered list cycled by the `CycleDpiPresets` action.
@@ -130,6 +132,10 @@ Right = "NextDesktop"
 # Per-app overlay: Back becomes Undo only while VS Code is frontmost.
 [devices.2b042.per_app_bindings."com.microsoft.VSCode"]
 Back = "Undo"
+
+# Stable Windows executable-name selector (exact paths still take precedence).
+[devices.2b042.per_app_bindings."exe:sharex.exe"]
+MiddleClick = { CustomShortcut = { modifiers = 0, key_code = 122, display = "F1" } }
 
 # Actions Ring slots couple an executable action with an optional custom icon.
 [devices.2b042.action_ring]

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -79,6 +79,7 @@ rustPlatform.buildRustPackage {
       "gpui-0.2.2" = "sha256-Av+unZNI39dEb+zwSIU+SkEjqagHWrc7W8KehEgQ4H8=";
       "gpui-component-0.5.2" = gpuiComponentHash;
       "gpui-updater-0.0.6" = "sha256-v8rn8tEkKBi8T2LtBV92uB+XtEeuBwj0qxGcDqEIwIw=";
+      "proptest-1.10.0" = "sha256-p5NTcHhruI8QQvANACg8AMRVNmuvGxs2NLit+/8PaWo=";
       "zed-font-kit-0.14.1-zed" = "sha256-KXygi0olNQi5yM8eaJVykNDtbPMDjT+cWPBF8UrtXR4=";
       "zed-reqwest-0.12.15-zed" = "sha256-p4SiUrOrbTlk/3bBrzN/mq/t+1Gzy2ot4nso6w6S+F8=";
       "zed-scap-0.0.8-zed" = "sha256-BihiQHlal/eRsktyf0GI3aSWsUCW7WcICMsC2Xvb7kw=";


### PR DESCRIPTION
## Summary

- recognize exe:<filename>.exe as a stable Windows per-application selector fallback
- retain exact-path precedence when both selector forms exist
- document the selector for Store and self-updating applications

## Direct validation

- cargo +1.96.0 build -p openlogi-core passed
- cargo +1.96.0 fmt --check passed
- openlogi-core loaded a schema-v3 config and matched exe:sharex.exe against a synthetic future versioned WindowsApps path while preserving Back=Copy and Forward=Paste

A full workspace build was not used as evidence because this workstation lacks the C++ vcruntime headers needed by ring; the focused core target is the changed closure.