### PR TITLE
fix(hook): release macOS tap after accessibility revocation

### DIFF
--- a/.claude/rules/hook.md
+++ b/.claude/rules/hook.md
@@ -16,6 +16,11 @@ paths:
   An active HID-level tap serialises every pointer event; a hang freezes clicks
   machine-wide. Only suppress events from remappable Logitech sources
   (`source_is_remappable`) — never the built-in trackpad.
+- A macOS tap stop request is not proof of teardown. Keep the independent lifecycle
+  watchdog armed until the tap thread reports the tap destroyed (and, for an explicit
+  stop, the thread exited). The watchdog must not call the Accessibility trust API —
+  that query can stall during TCC revocation; monitor tap-thread progress instead, and
+  force-exit the agent if revocation or shutdown stalls so macOS releases the HID tap.
 - The off-main `frontmost_bundle_id` read keeps its explicit `autoreleasepool` — the
   watcher thread has no run loop; that is the only place in this crate a pool belongs.
 - This crate ships non-macOS implementations (evdev/uinput, WH_MOUSE_LL) that a

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -1,12 +1,14 @@
 //! macOS `CGEventTap` implementation of the OS-level mouse hook.
 
+mod watchdog;
+
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use core_foundation::base::{CFTypeRef, TCFType as _};
 use core_foundation::number::CFNumber;
@@ -25,17 +27,23 @@ use crate::{
     ButtonId, EventDevice, EventDisposition, EventTapInfo, HookError, HookEvent, KeyEvent,
     KeyModifiers, MouseEvent, TapLocation,
 };
+use watchdog::{
+    LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, TapPhase,
+    WatchdogSignals, stuck_callback,
+};
 
 /// Everything `Hook` needs to control the background thread.
 pub(crate) struct HookInner {
     thread: thread::JoinHandle<()>,
+    lifecycle_watchdog: thread::JoinHandle<()>,
     run_loop: CFRunLoop,
-    /// Termination flag, re-checked at the top of every run-loop slice.
+    /// Lifecycle signals re-checked at the top of every run-loop slice.
     /// `run_loop.stop()` only interrupts the loop while it is *inside* a
     /// `run_in_mode` slice; a stop landing in the gap between slices is
-    /// dropped, so this flag — not the CF stop alone — is the reliable
-    /// shutdown signal that guarantees the thread can never hang forever.
-    stop: Arc<AtomicBool>,
+    /// dropped, so the stop latch — not the CF stop alone — is the reliable
+    /// shutdown signal. The independent lifecycle watchdog keeps observing
+    /// that latch until the tap thread proves the tap is gone.
+    signals: Arc<WatchdogSignals>,
 }
 
 // SAFETY: CFRunLoop is a Core Foundation ref-counted object. The CF
@@ -481,38 +489,55 @@ pub(crate) fn start(
     // clone rather than by move — avoids a second Box allocation.
     let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
 
-    let stop = Arc::new(AtomicBool::new(false));
+    let signals = Arc::new(WatchdogSignals::default());
+    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
     let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
 
     let thread = {
-        let stop = Arc::clone(&stop);
-        thread::Builder::new()
+        let thread_signals = Arc::clone(&signals);
+        match thread::Builder::new()
             .name("openlogi-hook".into())
-            .spawn(move || thread_main(cb, rl_tx, stop))
-            .map_err(|e| HookError::MacOsTap(e.to_string()))?
+            .spawn(move || thread_main(cb, rl_tx, thread_signals))
+        {
+            Ok(thread) => thread,
+            Err(error) => {
+                signals.set_phase(TapPhase::ThreadExited);
+                lifecycle_watchdog.thread().unpark();
+                let _ = lifecycle_watchdog.join();
+                return Err(HookError::MacOsTap(error.to_string()));
+            }
+        }
     };
 
     // Block until the background thread confirms the run loop is live, or
     // reports failure by dropping its sender.
-    let run_loop = rl_rx.recv().map_err(|_| {
-        HookError::MacOsTap(
+    let Ok(run_loop) = rl_rx.recv() else {
+        let error = HookError::MacOsTap(
             "background thread exited before the run loop started; \
              CGEventTapCreate likely returned null"
                 .into(),
-        )
-    })?;
+        );
+        if let Err(panic) = thread.join() {
+            error!(?panic, "hook thread panicked during startup");
+        }
+        lifecycle_watchdog.thread().unpark();
+        if let Err(panic) = lifecycle_watchdog.join() {
+            error!(?panic, "hook lifecycle watchdog panicked during startup");
+        }
+        return Err(error);
+    };
 
     Ok(HookInner {
         thread,
+        lifecycle_watchdog,
         run_loop,
-        stop,
+        signals,
     })
 }
 
-/// How long the tap callback may run before the watchdog treats the agent as
-/// wedging system input and force-exits. An active HID-level tap serialises
-/// every pointer event through this callback; a hang freezes clicks machine-wide.
-const CALLBACK_STUCK_BUDGET: Duration = Duration::from_millis(200);
+const CALLBACK_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const LIFECYCLE_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const FREEZE_HAZARD_EXIT_CODE: i32 = 78;
 
 /// Event types the HID tap observes. Pointer *Dragged variants are required
 /// because a held button makes the OS emit those instead of `MouseMoved`.
@@ -570,16 +595,19 @@ fn run_tap_callback(
 /// Sibling watchdog: if the callback is still entered past the budget, abort
 /// the agent so macOS tears the tap down and system input recovers.
 fn spawn_callback_watchdog(
-    stop: Arc<AtomicBool>,
+    signals: Arc<WatchdogSignals>,
     in_callback: Arc<AtomicBool>,
     entered_at_ms: Arc<AtomicU64>,
-) {
-    let budget_ms = u64::try_from(CALLBACK_STUCK_BUDGET.as_millis()).unwrap_or(200);
-    let _ = thread::Builder::new()
+) -> std::io::Result<()> {
+    thread::Builder::new()
         .name("openlogi-hook-watchdog".into())
         .spawn(move || {
-            while !stop.load(Ordering::Relaxed) {
-                thread::sleep(Duration::from_millis(20));
+            loop {
+                let phase = signals.phase();
+                if matches!(phase, TapPhase::TapStopped | TapPhase::ThreadExited) {
+                    return;
+                }
+                thread::sleep(CALLBACK_WATCHDOG_POLL_INTERVAL);
                 if !in_callback.load(Ordering::Acquire) {
                     continue;
                 }
@@ -587,27 +615,92 @@ fn spawn_callback_watchdog(
                 if entered == 0 {
                     continue;
                 }
-                let elapsed = unix_now_ms().saturating_sub(entered);
-                if elapsed < budget_ms {
+                let Some(elapsed) = stuck_callback(signals.now_millis(), entered) else {
                     continue;
-                }
-                // Re-sample: a fresh entry may have rewritten the stamp between
-                // the first loads and the budget check.
+                };
+                // Re-sample: a fresh high-frequency event may have rewritten
+                // the stamp between the first loads and the budget check.
                 if !in_callback.load(Ordering::Acquire)
                     || entered_at_ms.load(Ordering::Acquire) != entered
                 {
                     continue;
                 }
+                if signals.phase() != TapPhase::Armed {
+                    continue;
+                }
                 error!(
-                    stuck_ms = elapsed,
+                    stuck_ms = duration_millis(elapsed),
                     "OS mouse-hook callback stuck past budget — exiting agent to \
                      restore system input (HID CGEventTap freeze hazard)"
                 );
                 // Hard exit: disable_tap alone cannot unblock an in-flight
                 // callback, and a live active HID tap freezes all pointer I/O.
-                std::process::exit(78);
+                std::process::exit(FREEZE_HAZARD_EXIT_CODE);
             }
-        });
+        })
+        .map(|_| ())
+}
+
+/// Independent lifecycle watchdog for paths that never enter the Rust tap
+/// callback (for example, TCC revocation wedging `CFRunLoopRunInMode` or the
+/// Accessibility query itself).
+///
+/// This thread is started before the tap thread, uses only atomics and a
+/// monotonic clock, and remains armed after a stop request. It deliberately
+/// does not call `has_accessibility()`: that query can itself stop returning
+/// after TCC revocation. It disarms only after the tap thread reports that the
+/// tap was synchronously disabled and destroyed, or (for explicit shutdown)
+/// after that thread has exited.
+fn spawn_lifecycle_watchdog(
+    signals: Arc<WatchdogSignals>,
+) -> Result<thread::JoinHandle<()>, HookError> {
+    thread::Builder::new()
+        .name("openlogi-hook-lifecycle-watchdog".into())
+        .spawn(move || {
+            let mut watchdog = LifecycleWatchdog::default();
+            loop {
+                let observation = LifecycleObservation {
+                    phase: signals.phase(),
+                    stop_requested: signals.stop_requested(),
+                    tap_progress_at: signals.tap_progress_at(),
+                };
+                match watchdog.evaluate(signals.now(), observation) {
+                    LifecycleDecision::Continue => {
+                        thread::park_timeout(LIFECYCLE_WATCHDOG_POLL_INTERVAL);
+                    }
+                    LifecycleDecision::Complete => return,
+                    LifecycleDecision::Exit { reason, elapsed } => {
+                        // The tap thread may have completed immediately after
+                        // the decision. Only a still-hazardous phase may exit.
+                        let phase = signals.phase();
+                        let still_hazardous = match reason {
+                            LifecycleExitReason::TapThreadStalled => phase == TapPhase::Armed,
+                            LifecycleExitReason::StopTimedOut => phase != TapPhase::ThreadExited,
+                        };
+                        if !still_hazardous {
+                            continue;
+                        }
+                        let reason = match reason {
+                            LifecycleExitReason::TapThreadStalled => {
+                                "HID tap thread stopped making progress while tap remained active"
+                            }
+                            LifecycleExitReason::StopTimedOut => {
+                                "hook stop requested but tap thread did not exit"
+                            }
+                        };
+                        error!(
+                            reason,
+                            elapsed_ms = duration_millis(elapsed),
+                            ?phase,
+                            "HID CGEventTap shutdown was not confirmed before deadline — \
+                             exiting agent to restore system input"
+                        );
+                        std::process::exit(FREEZE_HAZARD_EXIT_CODE);
+                    }
+                }
+            }
+        })
+        .map_err(|error| HookError::MacOsTap(format!("could not spawn tap watchdog: {error}")))
 }
 
 /// Body of the background hook thread.
@@ -618,16 +711,17 @@ fn spawn_callback_watchdog(
 fn thread_main(
     cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync>,
     rl_tx: mpsc::Sender<CFRunLoop>,
-    stop: Arc<AtomicBool>,
+    signals: Arc<WatchdogSignals>,
 ) {
-    // Watchdog state: the run-loop thread can't observe a stuck callback (it
-    // *is* the callback), so a sibling thread samples these atomics and kills
-    // the process if the budget is exceeded — process death is the only reliable
-    // way to release a wedged HID-level tap and restore system input.
+    // Declared first so it drops last, after the tap, callback, source, and run
+    // loop locals have unwound. The lifecycle watchdog treats this notification
+    // as proof that an explicit stop has completed, not merely been requested.
+    let _thread_exit = signals.thread_exit_guard();
     let in_callback = Arc::new(AtomicBool::new(false));
     let entered_at_ms = Arc::new(AtomicU64::new(0));
 
     let tap_result = {
+        let callback_signals = Arc::clone(&signals);
         let in_callback = Arc::clone(&in_callback);
         let entered_at_ms = Arc::clone(&entered_at_ms);
         CGEventTap::new(
@@ -636,10 +730,7 @@ fn thread_main(
             CGEventTapOptions::Default,
             hooked_event_types(),
             move |_proxy: CGEventTapProxy, etype: CGEventType, event: &CGEvent| {
-                // Publish the enter timestamp *before* the in-callback flag so
-                // the watchdog never pairs a fresh entry with a stale stamp
-                // (which would false-positive process::exit after a quiet gap).
-                entered_at_ms.store(unix_now_ms(), Ordering::Relaxed);
+                entered_at_ms.store(callback_signals.now_millis(), Ordering::Relaxed);
                 in_callback.store(true, Ordering::Release);
                 let disposition = run_tap_callback(cb.as_ref(), etype, event);
                 in_callback.store(false, Ordering::Release);
@@ -667,16 +758,26 @@ fn thread_main(
     unsafe {
         run_loop.add_source(&loop_source, kCFRunLoopCommonModes);
     }
-    tap.enable();
-    spawn_callback_watchdog(
-        Arc::clone(&stop),
+    if let Err(error) = spawn_callback_watchdog(
+        Arc::clone(&signals),
         Arc::clone(&in_callback),
         Arc::clone(&entered_at_ms),
-    );
+    ) {
+        error!(%error, "could not spawn callback watchdog — refusing to arm HID tap");
+        return;
+    }
+    tap.enable();
+    signals.mark_tap_progress();
+    signals.set_phase(TapPhase::Armed);
 
-    if rl_tx.send(run_loop).is_err() {
+    if rl_tx.send(run_loop.clone()).is_err() {
         debug!("hook parent dropped before run loop was ready; stopping");
         disable_tap(&tap);
+        // SAFETY: framework-provided static CFStringRef, 'static.
+        run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
+        drop(loop_source);
+        drop(tap);
+        signals.set_phase(TapPhase::TapStopped);
         return;
     }
 
@@ -688,17 +789,18 @@ fn thread_main(
     // down right here, on the tap's own thread, so input is restored even
     // when the UI thread is already stuck.
     //
-    // `stop()` requests shutdown two ways: it sets `stop` and calls
+    // `stop()` requests shutdown two ways: it sets the stop latch and calls
     // `run_loop.stop()`. The CF stop returns `Stopped` and breaks promptly
     // while a slice is running, but is a no-op if it lands in the gap
-    // between slices (CFRunLoopStop only acts on a running loop). The `stop`
-    // flag, checked at the top of every slice, is the reliable signal: in
+    // between slices (CFRunLoopStop only acts on a running loop). The latch,
+    // checked at the top of every slice, is the reliable signal: in
     // that race the thread notices one 500 ms slice later instead of joining
     // forever.
     loop {
-        if stop.load(Ordering::Relaxed) {
+        if signals.stop_requested() {
             break;
         }
+        signals.mark_tap_progress();
         match CFRunLoop::run_in_mode(
             // SAFETY: framework-provided static CFStringRef, 'static.
             unsafe { kCFRunLoopDefaultMode },
@@ -708,6 +810,7 @@ fn thread_main(
             CFRunLoopRunResult::Stopped | CFRunLoopRunResult::Finished => break,
             CFRunLoopRunResult::TimedOut | CFRunLoopRunResult::HandledSource => {}
         }
+        signals.mark_tap_progress();
         if !has_accessibility() {
             warn!(
                 "Accessibility revoked while the event tap was live — \
@@ -726,13 +829,15 @@ fn thread_main(
     // so input recovers immediately rather than whenever CF happens to
     // release the port.
     disable_tap(&tap);
+    // SAFETY: framework-provided static CFStringRef, 'static.
+    run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
+    drop(loop_source);
+    drop(tap);
+    signals.set_phase(TapPhase::TapStopped);
 }
 
-/// Milliseconds since the Unix epoch for the stuck-callback watchdog.
-fn unix_now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Disable an active event tap now. core-graphics only exposes the enable
@@ -858,13 +963,48 @@ fn process_name(pid: i32) -> Option<String> {
 
 /// Signal the run loop to stop and join the background thread.
 pub(crate) fn stop(inner: HookInner) {
-    // Set the flag *before* waking the loop: if `run_loop.stop()` lands in
-    // the gap between slices and is dropped, the thread still observes the
-    // flag at the next slice top. Relaxed suffices — the flag carries no
-    // other data, and `thread.join()` below is the final synchronisation.
-    inner.stop.store(true, Ordering::Relaxed);
+    // Latch stop before waking either thread. The lifecycle watchdog stays
+    // armed across the blocking join and accepts only `ThreadExited` as proof
+    // that explicit shutdown completed.
+    inner.signals.request_stop();
+    inner.lifecycle_watchdog.thread().unpark();
     inner.run_loop.stop();
     if let Err(e) = inner.thread.join() {
         error!("hook thread panicked on shutdown: {e:?}");
+    }
+    inner.lifecycle_watchdog.thread().unpark();
+    if let Err(e) = inner.lifecycle_watchdog.join() {
+        error!("hook lifecycle watchdog panicked on shutdown: {e:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+
+    use super::*;
+
+    #[test]
+    fn tap_callback_suppresses_normally_and_passes_through_panics() {
+        let source = CGEventSource::new(CGEventSourceStateID::Private)
+            .unwrap_or_else(|()| panic!("CGEventSourceCreate failed"));
+        let event = CGEvent::new(source).unwrap_or_else(|()| panic!("CGEventCreate failed"));
+
+        assert!(matches!(
+            run_tap_callback(
+                &|_| EventDisposition::Suppress,
+                CGEventType::MouseMoved,
+                &event
+            ),
+            CallbackResult::Drop
+        ));
+        assert!(matches!(
+            run_tap_callback(
+                &|_| panic!("test callback panic"),
+                CGEventType::MouseMoved,
+                &event
+            ),
+            CallbackResult::Keep
+        ));
     }
 }

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -674,7 +674,9 @@ fn spawn_lifecycle_watchdog(
                         // the decision. Only a still-hazardous phase may exit.
                         let phase = signals.phase();
                         let still_hazardous = match reason {
-                            LifecycleExitReason::TapThreadStalled => phase == TapPhase::Armed,
+                            LifecycleExitReason::TapThreadStalled => {
+                                matches!(phase, TapPhase::Arming | TapPhase::Armed)
+                            }
                             LifecycleExitReason::StopTimedOut => phase != TapPhase::ThreadExited,
                         };
                         if !still_hazardous {
@@ -766,6 +768,10 @@ fn thread_main(
         error!(%error, "could not spawn callback watchdog — refusing to arm HID tap");
         return;
     }
+    // Publish the hazardous activation interval before entering CoreGraphics:
+    // TCC revocation can stop this call from returning.
+    signals.mark_tap_progress();
+    signals.set_phase(TapPhase::Arming);
     tap.enable();
     signals.mark_tap_progress();
     signals.set_phase(TapPhase::Armed);

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -683,6 +683,9 @@ fn spawn_lifecycle_watchdog(
                             continue;
                         }
                         let reason = match reason {
+                            LifecycleExitReason::TapThreadStalled if phase == TapPhase::Arming => {
+                                "HID tap creation or activation stopped making progress"
+                            }
                             LifecycleExitReason::TapThreadStalled => {
                                 "HID tap thread stopped making progress while tap remained active"
                             }
@@ -694,7 +697,7 @@ fn spawn_lifecycle_watchdog(
                             reason,
                             elapsed_ms = duration_millis(elapsed),
                             ?phase,
-                            "HID CGEventTap shutdown was not confirmed before deadline — \
+                            "HID CGEventTap lifecycle did not make progress before deadline — \
                              exiting agent to restore system input"
                         );
                         std::process::exit(FREEZE_HAZARD_EXIT_CODE);
@@ -719,6 +722,12 @@ fn thread_main(
     // loop locals have unwound. The lifecycle watchdog treats this notification
     // as proof that an explicit stop has completed, not merely been requested.
     let _thread_exit = signals.thread_exit_guard();
+
+    // A successful CGEventTapCreate may install the HID tap before returning,
+    // so lifecycle monitoring must be armed before entering CoreGraphics.
+    signals.mark_tap_progress();
+    signals.set_phase(TapPhase::Arming);
+
     let in_callback = Arc::new(AtomicBool::new(false));
     let entered_at_ms = Arc::new(AtomicU64::new(0));
 
@@ -747,11 +756,13 @@ fn thread_main(
         // which we surface as MacOsTap.
         return;
     };
+    signals.mark_tap_progress();
 
     let Ok(loop_source) = tap.mach_port().create_runloop_source(0) else {
         error!("CFRunLoopSourceCreate failed for event tap");
         return;
     };
+    signals.mark_tap_progress();
 
     let run_loop = CFRunLoop::get_current();
 
@@ -760,6 +771,7 @@ fn thread_main(
     unsafe {
         run_loop.add_source(&loop_source, kCFRunLoopCommonModes);
     }
+    signals.mark_tap_progress();
     if let Err(error) = spawn_callback_watchdog(
         Arc::clone(&signals),
         Arc::clone(&in_callback),
@@ -768,10 +780,7 @@ fn thread_main(
         error!(%error, "could not spawn callback watchdog — refusing to arm HID tap");
         return;
     }
-    // Publish the hazardous activation interval before entering CoreGraphics:
-    // TCC revocation can stop this call from returning.
     signals.mark_tap_progress();
-    signals.set_phase(TapPhase::Arming);
     tap.enable();
     signals.mark_tap_progress();
     signals.set_phase(TapPhase::Armed);

--- a/crates/openlogi-hook/src/macos/watchdog.rs
+++ b/crates/openlogi-hook/src/macos/watchdog.rs
@@ -11,6 +11,7 @@ pub(super) const TAP_SHUTDOWN_BUDGET: Duration = Duration::from_millis(1_500);
 #[repr(u8)]
 pub(super) enum TapPhase {
     Starting,
+    Arming,
     Armed,
     TapStopped,
     ThreadExited,
@@ -55,9 +56,10 @@ impl WatchdogSignals {
     pub fn phase(&self) -> TapPhase {
         match self.phase.load(Ordering::Acquire) {
             0 => TapPhase::Starting,
-            1 => TapPhase::Armed,
-            2 => TapPhase::TapStopped,
-            3 => TapPhase::ThreadExited,
+            1 => TapPhase::Arming,
+            2 => TapPhase::Armed,
+            3 => TapPhase::TapStopped,
+            4 => TapPhase::ThreadExited,
             _ => unreachable!("invalid tap lifecycle phase"),
         }
     }
@@ -137,7 +139,7 @@ impl LifecycleWatchdog {
         match observation.phase {
             TapPhase::Starting => return LifecycleDecision::Continue,
             TapPhase::ThreadExited => return LifecycleDecision::Complete,
-            TapPhase::Armed | TapPhase::TapStopped => {}
+            TapPhase::Arming | TapPhase::Armed | TapPhase::TapStopped => {}
         }
 
         if observation.stop_requested {
@@ -149,7 +151,7 @@ impl LifecycleWatchdog {
 
         let timeout = if let Some(stopped) = self.stop_at {
             Some((LifecycleExitReason::StopTimedOut, stopped))
-        } else if observation.phase == TapPhase::Armed {
+        } else if matches!(observation.phase, TapPhase::Arming | TapPhase::Armed) {
             Some((
                 LifecycleExitReason::TapThreadStalled,
                 observation.tap_progress_at,
@@ -229,6 +231,28 @@ mod tests {
                 observation(TapPhase::TapStopped, false, Duration::ZERO)
             ),
             LifecycleDecision::Complete
+        );
+    }
+
+    #[test]
+    fn tap_activation_stall_exits_at_budget() {
+        let mut watchdog = LifecycleWatchdog::default();
+        assert_eq!(
+            watchdog.evaluate(
+                Duration::from_nanos(1_499_999_999),
+                observation(TapPhase::Arming, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                TAP_SHUTDOWN_BUDGET,
+                observation(TapPhase::Arming, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Exit {
+                reason: LifecycleExitReason::TapThreadStalled,
+                elapsed: TAP_SHUTDOWN_BUDGET,
+            }
         );
     }
 

--- a/crates/openlogi-hook/src/macos/watchdog.rs
+++ b/crates/openlogi-hook/src/macos/watchdog.rs
@@ -1,0 +1,309 @@
+//! Testable state and timing for the macOS HID tap safety watchdogs.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+pub(super) const CALLBACK_STUCK_BUDGET: Duration = Duration::from_millis(200);
+pub(super) const TAP_SHUTDOWN_BUDGET: Duration = Duration::from_millis(1_500);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub(super) enum TapPhase {
+    Starting,
+    Armed,
+    TapStopped,
+    ThreadExited,
+}
+
+/// Atomics shared by the tap, stopper, and watchdog threads.
+///
+/// A stop request is a separate latch from `phase`: it must never imply that
+/// the active HID tap has actually been detached.
+#[derive(Debug)]
+pub(super) struct WatchdogSignals {
+    // `Instant` uses CLOCK_UPTIME_RAW on macOS: monotonic, and paused while
+    // the system sleeps so resume cannot consume either watchdog budget.
+    origin: Instant,
+    phase: AtomicU8,
+    stop_requested: AtomicBool,
+    tap_progress_at_ms: AtomicU64,
+}
+
+impl Default for WatchdogSignals {
+    fn default() -> Self {
+        Self {
+            origin: Instant::now(),
+            phase: AtomicU8::new(TapPhase::Starting as u8),
+            stop_requested: AtomicBool::new(false),
+            tap_progress_at_ms: AtomicU64::new(0),
+        }
+    }
+}
+
+impl WatchdogSignals {
+    pub fn now(&self) -> Duration {
+        self.origin.elapsed()
+    }
+
+    pub fn now_millis(&self) -> u64 {
+        u64::try_from(self.now().as_millis())
+            .unwrap_or(u64::MAX - 1)
+            .saturating_add(1)
+    }
+
+    pub fn phase(&self) -> TapPhase {
+        match self.phase.load(Ordering::Acquire) {
+            0 => TapPhase::Starting,
+            1 => TapPhase::Armed,
+            2 => TapPhase::TapStopped,
+            3 => TapPhase::ThreadExited,
+            _ => unreachable!("invalid tap lifecycle phase"),
+        }
+    }
+
+    pub fn set_phase(&self, phase: TapPhase) {
+        self.phase.store(phase as u8, Ordering::Release);
+    }
+
+    pub fn request_stop(&self) {
+        self.stop_requested.store(true, Ordering::Release);
+    }
+
+    pub fn stop_requested(&self) -> bool {
+        self.stop_requested.load(Ordering::Acquire)
+    }
+
+    pub fn mark_tap_progress(&self) {
+        self.tap_progress_at_ms
+            .store(self.now_millis(), Ordering::Release);
+    }
+
+    pub fn tap_progress_at(&self) -> Duration {
+        Duration::from_millis(
+            self.tap_progress_at_ms
+                .load(Ordering::Acquire)
+                .saturating_sub(1),
+        )
+    }
+
+    pub fn thread_exit_guard(self: &Arc<Self>) -> TapThreadExitGuard {
+        TapThreadExitGuard(Arc::clone(self))
+    }
+}
+
+pub(super) struct TapThreadExitGuard(Arc<WatchdogSignals>);
+
+impl Drop for TapThreadExitGuard {
+    fn drop(&mut self) {
+        self.0.set_phase(TapPhase::ThreadExited);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct LifecycleObservation {
+    pub phase: TapPhase,
+    pub stop_requested: bool,
+    pub tap_progress_at: Duration,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum LifecycleExitReason {
+    TapThreadStalled,
+    StopTimedOut,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum LifecycleDecision {
+    Continue,
+    Complete,
+    Exit {
+        reason: LifecycleExitReason,
+        elapsed: Duration,
+    },
+}
+
+#[derive(Debug, Default)]
+pub(super) struct LifecycleWatchdog {
+    stop_at: Option<Duration>,
+}
+
+impl LifecycleWatchdog {
+    pub fn evaluate(
+        &mut self,
+        now: Duration,
+        observation: LifecycleObservation,
+    ) -> LifecycleDecision {
+        match observation.phase {
+            TapPhase::Starting => return LifecycleDecision::Continue,
+            TapPhase::ThreadExited => return LifecycleDecision::Complete,
+            TapPhase::Armed | TapPhase::TapStopped => {}
+        }
+
+        if observation.stop_requested {
+            self.stop_at.get_or_insert(now);
+        }
+        if observation.phase == TapPhase::TapStopped && !observation.stop_requested {
+            return LifecycleDecision::Complete;
+        }
+
+        let timeout = if let Some(stopped) = self.stop_at {
+            Some((LifecycleExitReason::StopTimedOut, stopped))
+        } else if observation.phase == TapPhase::Armed {
+            Some((
+                LifecycleExitReason::TapThreadStalled,
+                observation.tap_progress_at,
+            ))
+        } else {
+            None
+        };
+        let Some((reason, started)) = timeout else {
+            return LifecycleDecision::Continue;
+        };
+        let elapsed = now.saturating_sub(started);
+        if elapsed >= TAP_SHUTDOWN_BUDGET {
+            LifecycleDecision::Exit { reason, elapsed }
+        } else {
+            LifecycleDecision::Continue
+        }
+    }
+}
+
+pub(super) fn stuck_callback(now_ms: u64, entered_at_ms: u64) -> Option<Duration> {
+    let elapsed = Duration::from_millis(now_ms.saturating_sub(entered_at_ms));
+    (elapsed >= CALLBACK_STUCK_BUDGET).then_some(elapsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observation(
+        phase: TapPhase,
+        stop_requested: bool,
+        tap_progress_at: Duration,
+    ) -> LifecycleObservation {
+        LifecycleObservation {
+            phase,
+            stop_requested,
+            tap_progress_at,
+        }
+    }
+
+    #[test]
+    fn armed_tap_stall_exits_at_budget_unless_tap_stops() {
+        let mut watchdog = LifecycleWatchdog::default();
+        assert_eq!(
+            watchdog.evaluate(
+                Duration::ZERO,
+                observation(TapPhase::Armed, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                Duration::from_nanos(1_499_999_999),
+                observation(TapPhase::Armed, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                TAP_SHUTDOWN_BUDGET,
+                observation(TapPhase::Armed, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Exit {
+                reason: LifecycleExitReason::TapThreadStalled,
+                elapsed: TAP_SHUTDOWN_BUDGET,
+            }
+        );
+
+        let mut completed = LifecycleWatchdog::default();
+        let _ = completed.evaluate(
+            Duration::ZERO,
+            observation(TapPhase::Armed, false, Duration::ZERO),
+        );
+        assert_eq!(
+            completed.evaluate(
+                Duration::from_millis(500),
+                observation(TapPhase::TapStopped, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Complete
+        );
+    }
+
+    #[test]
+    fn stop_requires_thread_exit_even_after_tap_stops() {
+        let mut watchdog = LifecycleWatchdog::default();
+        let _ = watchdog.evaluate(
+            Duration::ZERO,
+            observation(TapPhase::Armed, true, Duration::ZERO),
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                Duration::from_millis(500),
+                observation(TapPhase::TapStopped, true, Duration::ZERO)
+            ),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                TAP_SHUTDOWN_BUDGET,
+                observation(TapPhase::TapStopped, true, Duration::ZERO)
+            ),
+            LifecycleDecision::Exit {
+                reason: LifecycleExitReason::StopTimedOut,
+                elapsed: TAP_SHUTDOWN_BUDGET,
+            }
+        );
+
+        let mut completed = LifecycleWatchdog::default();
+        let _ = completed.evaluate(
+            Duration::ZERO,
+            observation(TapPhase::Armed, true, Duration::ZERO),
+        );
+        assert_eq!(
+            completed.evaluate(
+                Duration::from_millis(500),
+                observation(TapPhase::ThreadExited, true, Duration::ZERO)
+            ),
+            LifecycleDecision::Complete
+        );
+    }
+
+    #[test]
+    fn starting_and_healthy_states_never_time_out() {
+        let mut watchdog = LifecycleWatchdog::default();
+        let starting = observation(TapPhase::Starting, false, Duration::ZERO);
+        assert_eq!(
+            watchdog.evaluate(Duration::ZERO, starting),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(TAP_SHUTDOWN_BUDGET * 2, starting),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                TAP_SHUTDOWN_BUDGET * 3,
+                observation(TapPhase::Armed, false, Duration::from_secs(4))
+            ),
+            LifecycleDecision::Continue
+        );
+        assert_eq!(
+            watchdog.evaluate(
+                TAP_SHUTDOWN_BUDGET * 4,
+                observation(TapPhase::ThreadExited, false, Duration::ZERO)
+            ),
+            LifecycleDecision::Complete
+        );
+    }
+
+    #[test]
+    fn callback_timeout_keeps_the_200ms_boundary() {
+        assert_eq!(stuck_callback(200, 1), None);
+        assert_eq!(stuck_callback(201, 1), Some(CALLBACK_STUCK_BUDGET));
+        // A fresh high-frequency event must not inherit an older entry time.
+        assert_eq!(stuck_callback(10_000, 9_801), None);
+    }
+}

--- a/crates/openlogi-hook/src/macos/watchdog.rs
+++ b/crates/openlogi-hook/src/macos/watchdog.rs
@@ -10,7 +10,9 @@ pub(super) const TAP_SHUTDOWN_BUDGET: Duration = Duration::from_millis(1_500);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub(super) enum TapPhase {
+    /// The tap thread has not begun CoreGraphics tap creation, so no tap can exist.
     Starting,
+    /// The tap thread is creating or activating a tap that may already exist.
     Arming,
     Armed,
     TapStopped,
@@ -235,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn tap_activation_stall_exits_at_budget() {
+    fn tap_creation_or_activation_stall_exits_at_budget() {
         let mut watchdog = LifecycleWatchdog::default();
         assert_eq!(
             watchdog.evaluate(


### PR DESCRIPTION
## Summary

On the official v0.6.26 arm64 build, removing OpenLogi's Accessibility permission in System Settings while the Agent held an active HID CGEventTap caused mouse clicks, normal trackpad input, and keyboard input to stop responding. `CGGetEventTapList` still showed an active and enabled tap owned by `openlogi-agent`; terminating the Agent removed the tap and restored input immediately.

The existing watchdog only detects a Rust callback that remains entered for more than 200 ms. It cannot detect a stall before the callback or inside the tap run loop, and a stop request could disable that watchdog before the tap thread had actually finished.

This adds an independent lifecycle watchdog that remains armed until the tap is destroyed. If tap-thread progress stops or shutdown cannot be confirmed within 1.5 seconds, the Agent exits with a non-zero status so macOS releases the tap.

## Changes

- Keep the existing 500 ms run-loop slices and 200 ms callback watchdog.
- Add a lifecycle watchdog based on monotonic tap-thread progress.
- Keep lifecycle monitoring armed after a stop request until the tap is synchronously disabled, detached, and destroyed.
- Require the tap thread to exit before considering an explicit stop complete.
- Force-exit the Agent if an active tap stalls or shutdown exceeds the 1.5-second budget.
- Keep callback panics fail-open by passing the event through.
- Separate lifecycle and timeout decisions from real sleeps and `process::exit` so race and boundary cases can be unit-tested.
- Document the macOS HID tap teardown invariant in the hook rules.

## Testing

The following commands pass locally on macOS through devenv:

- `direnv exec . cargo test -p openlogi-hook`
- `devenv tasks run openlogi:check`
- `devenv tasks run openlogi:check-windows`

Hardware verification used a development-signed Agent with an external recovery path that did not depend on CGEventTap input. With an active HID tap installed, I removed the Agent's Accessibility permission in System Settings. The active tap disappeared within approximately 350 ms of the TCC change, and normal synchronous teardown did not terminate the Agent.

I did not deliberately wedge the callback or tap run loop on the hardware system. The forced-exit fallback, stop/teardown races, normal shutdown, and the 200 ms callback boundary are covered by deterministic unit tests that do not call `process::exit` or depend on real-time sleeps.
