### PR TITLE
ci(nix): cache store paths with magic-nix-cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,7 +49,18 @@ jobs:
   build:
     name: nix build (Linux)
     runs-on: ubuntu-latest
+    # GHA cache upload for store paths (magic-nix-cache). Read is enough for
+    # restoring; write is needed when the job is allowed to populate the cache
+    # (push to master / same-repo PR). Fork PRs still restore but cannot write.
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+        with:
+          # Prefer GitHub Actions cache only — no FlakeHub account required.
+          use-gha-cache: enabled
+          use-flakehub: disabled
       - run: nix build .#openlogi -L


### PR DESCRIPTION
## Summary

Wire Determinate's Magic Nix Cache into the Nix CI job so store paths from `nix build .#openlogi` are saved to (and restored from) GitHub Actions cache.

Today every PR does a cold ~20 minute release build of CLI + agent + GUI. System libs already come from `cache.nixos.org`, but OpenLogi and its cargo graph recompile from scratch on a fresh runner. This reuses previously built store paths across runs without an external binary cache (Cachix / FlakeHub).

## Changes

- After `nix-installer-action`, run `magic-nix-cache-action@v14` with GHA cache explicitly enabled and FlakeHub disabled (no extra account).
- Grant `actions: write` so same-repo / master jobs can populate the cache; fork PRs still restore what they can.

## Expected impact

- Cold master run: still ~20 min, but populates the cache.
- Follow-up PRs with unchanged deps: should skip most of the dependency rebuild and only recompile what changed (often a few minutes instead of ~20).
- Lockfile / git-pin bumps still force a long rebuild for what moved.

## Testing

- Local: workflow YAML only; no product code.
- CI of this PR exercises the new step end-to-end (first run still cold; subsequent runs on the branch should start hitting the cache).