### PR TITLE
fix(gui): redraw the Actions Ring on hover changes

### DIFF
--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -127,14 +127,16 @@ impl RingView {
                         .size(px(22.0))
                         .text_color(hsla(0.0, 0.0, 0.98, 1.0)),
                 )
-                .on_hover(cx.listener(move |this, hovered, _, _| {
+                .on_hover(cx.listener(move |this, hovered, _, cx| {
                     if *hovered && this.hovered != Some(slot) {
                         this.hovered = Some(slot);
                         let _ = this
                             .commands
                             .send(OverlayCommand::Hover { session_id, slot });
+                        cx.notify();
                     } else if !*hovered && this.hovered == Some(slot) {
                         this.hovered = None;
+                        cx.notify();
                     }
                 }))
                 .on_click(move |_, window, cx| {


### PR DESCRIPTION
The slot `on_hover` listener updates `RingView::hovered` (and reports the hover over IPC, so device haptics play) but never calls `cx.notify()` — gpui never re-renders, so the hovered slot's highlight and the hover label under the ring center never appear. The haptic buzzing while nothing changes visually makes the bug easy to reproduce on any ring.

Fix: notify on both the enter and leave transitions.

Verified on real hardware (MX Master 4, Bolt, macOS 15.7.9): highlight + label now track the pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)