### PR TITLE
fix(gui): open the Actions Ring on the display containing the cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,6 +5153,7 @@ dependencies = [
  "anyhow",
  "backon",
  "block2 0.6.2",
+ "core-graphics 0.25.0",
  "disclaim",
  "embed-resource",
  "fluent-langneg",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -63,6 +63,10 @@ embed-resource = "3.0.9"
 # Menu-bar (NSStatusItem) FFI — GPUI has no status-bar API. objc2 gives typed,
 # `Retained<T>`-owned AppKit bindings so the status-item code can't leak (#99).
 [target.'cfg(target_os = "macos")'.dependencies]
+# CGGetActiveDisplayList/CGDisplayBounds for the overlay: locating the cursor's
+# display needs global display bounds, which GPUI's display API doesn't expose
+# (its bounds are display-relative). C FFI, so core-graphics per platform/AGENTS.md.
+core-graphics = { workspace = true }
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSAppearance", "NSWindow", "NSEvent", "block2"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSProcessInfo"] }

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -408,21 +408,50 @@ fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
 )]
 fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
     let cursor = openlogi_hook::cursor_position();
-    let cursor_point = cursor.map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)));
-    let display = cursor_point
-        .and_then(|cursor| {
-            cx.displays()
-                .into_iter()
-                .find(|display| display.bounds().contains(&cursor))
-        })
-        .or_else(|| cx.primary_display());
-    let center = cursor_point
-        .or_else(|| display.as_ref().map(|display| display.bounds().center()))
-        .unwrap_or_default();
     let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
+    // GPUI window bounds are display-relative (`display.bounds()` zeroes every
+    // origin) while the hook reports the cursor in global coordinates, so the
+    // cursor's display must be resolved natively and the cursor translated into
+    // that display's space. Feeding the global point straight into the clamp
+    // pins a ring triggered on a secondary display to the primary one's edge.
+    let native_display = cursor
+        .as_ref()
+        .and_then(|cursor| overlay_platform::display_containing(cursor.x, cursor.y));
+    let (display_id, center, display_bounds) =
+        if let (Some(cursor), Some(display)) = (&cursor, native_display) {
+            (
+                Some(gpui::DisplayId::from(display.id)),
+                point(
+                    px((cursor.x - display.origin.0) as f32),
+                    px((cursor.y - display.origin.1) as f32),
+                ),
+                Some(Bounds::new(
+                    Point::default(),
+                    Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
+                )),
+            )
+        } else {
+            // No cursor or no native lookup (non-macOS): GPUI's own display
+            // list, centering on the display when the cursor is unknown.
+            let cursor_point = cursor
+                .as_ref()
+                .map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)));
+            let display = cursor_point
+                .and_then(|cursor| {
+                    cx.displays()
+                        .into_iter()
+                        .find(|display| display.bounds().contains(&cursor))
+                })
+                .or_else(|| cx.primary_display());
+            let center = cursor_point
+                .or_else(|| display.as_ref().map(|display| display.bounds().center()))
+                .unwrap_or_default();
+            let bounds = display.as_ref().map(|display| display.bounds());
+            (display.map(|display| display.id()), center, bounds)
+        };
     let desired_origin = point(center.x - size.width / 2.0, center.y - size.height / 2.0);
-    let origin = display.as_ref().map_or(desired_origin, |display| {
-        clamp_window_origin(desired_origin, size, display.bounds())
+    let origin = display_bounds.map_or(desired_origin, |display_bounds| {
+        clamp_window_origin(desired_origin, size, display_bounds)
     });
     let bounds = Bounds::new(origin, size);
     WindowOptions {
@@ -434,7 +463,7 @@ fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
         is_movable: false,
         is_resizable: false,
         is_minimizable: false,
-        display_id: display.map(|display| display.id()),
+        display_id,
         window_background: WindowBackgroundAppearance::Transparent,
         app_id: Some("openlogi-action-ring".to_string()),
         ..WindowOptions::default()

--- a/crates/openlogi-gui/src/platform/overlay.rs
+++ b/crates/openlogi-gui/src/platform/overlay.rs
@@ -85,3 +85,59 @@ pub struct ClickAwayMonitor(());
 pub fn watch_clicks_outside(_on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
     None
 }
+
+/// One display's global geometry, in the same top-left-origin global point
+/// space that `openlogi_hook::cursor_position()` reports.
+pub struct CursorDisplay {
+    /// Native display id; on macOS the `CGDirectDisplayID`, numerically equal
+    /// to GPUI's `DisplayId` for the same display.
+    pub id: u64,
+    /// Global origin (top-left corner) of the display, in points.
+    pub origin: (f64, f64),
+    /// Display size in points.
+    pub size: (f64, f64),
+}
+
+/// Find the display whose global bounds contain the point `(x, y)`.
+///
+/// GPUI's `PlatformDisplay::bounds()` zeroes every display's origin (window
+/// bounds are display-relative), so mapping a global cursor position to its
+/// display has to go through CoreGraphics.
+#[cfg(target_os = "macos")]
+#[expect(
+    unsafe_code,
+    reason = "CGGetActiveDisplayList/CGDisplayBounds are plain C FFI; GPUI exposes no global display bounds"
+)]
+pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
+    use core_graphics::display::{CGDisplayBounds, CGGetActiveDisplayList};
+
+    const MAX_DISPLAYS: u32 = 32;
+    let mut ids = [0u32; MAX_DISPLAYS as usize];
+    let mut count = 0u32;
+    // SAFETY: the list write is bounded by the capacity we pass; `count`
+    // reports how many entries were actually filled.
+    let result = unsafe { CGGetActiveDisplayList(MAX_DISPLAYS, ids.as_mut_ptr(), &raw mut count) };
+    if result != 0 {
+        return None;
+    }
+    ids.iter().take(count as usize).find_map(|&id| {
+        // SAFETY: side-effect-free C getter on an id from the active list.
+        let bounds = unsafe { CGDisplayBounds(id) };
+        let contains = x >= bounds.origin.x
+            && x < bounds.origin.x + bounds.size.width
+            && y >= bounds.origin.y
+            && y < bounds.origin.y + bounds.size.height;
+        contains.then(|| CursorDisplay {
+            id: u64::from(id),
+            origin: (bounds.origin.x, bounds.origin.y),
+            size: (bounds.size.width, bounds.size.height),
+        })
+    })
+}
+
+/// Away from macOS the GPUI display list already carries global origins, so
+/// there is nothing to resolve natively.
+#[cfg(not(target_os = "macos"))]
+pub fn display_containing(_x: f64, _y: f64) -> Option<CursorDisplay> {
+    None
+}


### PR DESCRIPTION
On a multi-monitor Mac, triggering the Actions Ring with the cursor on a secondary display renders the ring on the **primary** display, pinned to the edge nearest the cursor.

## Root cause

A coordinate-space mismatch in the overlay:

- `openlogi_hook::cursor_position()` reports the cursor in **global** CoreGraphics coordinates (top-left of the primary display, y-down).
- GPUI's `PlatformDisplay::bounds()` (current pinned zed rev) returns a **zeroed origin** for every display — window bounds are display-relative, with the screen chosen by `WindowOptions::display_id`.

So `cx.displays().find(|d| d.bounds().contains(&cursor))` can never match a cursor whose global coordinates fall outside the primary display's size: the code falls back to `primary_display()` and then clamps the global cursor point into a zero-origin bounds — producing exactly "ring on the primary display's near edge".

## Fix

Resolve the cursor's display natively via `CGGetActiveDisplayList`/`CGDisplayBounds` (whose global bounds share the cursor's coordinate space), translate the cursor into that display's local space, clamp inside it, and pass the matching `display_id` (on macOS the `CGDirectDisplayID` is numerically identical to GPUI's `DisplayId`). Non-macOS keeps the previous GPUI-only path, and it remains the fallback when the native lookup returns nothing.

Verified on a 3× Studio Display setup: the ring now opens cursor-centered on all three displays.

Unrelated but observed while here: each ring open can log `ERROR gpui::window: RefCell already borrowed` — AppKit fires a synchronous window callback while the overlay is still inside its own `cx.update` (remove-windows → `open_window` → `configure_windows`), and gpui drops the re-entrant callback with that message. It persists after this fix (positioning is unaffected); can file separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)