### PR TITLE
fix(hid): detect and recover dead-delivery HID channels

### DIFF
--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -31,6 +31,15 @@ use crate::route::{DeviceRoute, open_route_channel};
 use crate::thumbwheel::{self, Thumbwheel};
 use crate::write::SharedChannel;
 
+/// How often the capture session pings its device to prove the channel still
+/// delivers input reports. Cheap: one HID++ round-trip per interval.
+const LIVENESS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Consecutive all-silent pings after which the capture channel is declared
+/// dead. Two, so one ping lost to transient receiver congestion (which does
+/// happen under pointer load) doesn't churn the session.
+const LIVENESS_PING_STRIKES: u8 = 2;
+
 /// Shared slot holding the active capture session's open channel, so DPI /
 /// SmartShift writes can reuse it instead of opening a fresh one. `None`
 /// whenever no session is connected.
@@ -225,7 +234,49 @@ pub async fn run_capture_session(
         thumbwheel = armed.thumb.is_some(),
         "control capture active"
     );
-    let _ = shutdown.await;
+
+    // Liveness watchdog: this session's channel is the sole delivery path for
+    // every diverted control, and a channel whose input-report delivery dies
+    // (observed on macOS with concurrent opens of one node: writes accepted,
+    // replies and events silently routed elsewhere) turns every captured
+    // button to dead air with nothing to notice. Ping the device through this
+    // channel; consecutive all-silent pings mean the channel — not the device
+    // — is gone (a sleeping/unreachable device still gets us an error *reply*,
+    // which proves delivery and resets the count). Exiting lets the manager
+    // re-arm on a fresh channel.
+    let root =
+        <hidpp::feature::root::RootFeature as hidpp::feature::CreatableFeature>::new(
+            Arc::clone(&chan),
+            device_index,
+            0,
+        );
+    let mut shutdown = std::pin::pin!(shutdown);
+    let mut silent_pings = 0u8;
+    let channel_dead = loop {
+        tokio::select! {
+            _ = &mut shutdown => break false,
+            () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
+                match root.ping(0x5a).await {
+                    Err(v20::Hidpp20Error::Channel(
+                        hidpp::channel::ChannelError::Timeout
+                        | hidpp::channel::ChannelError::NoResponse,
+                    )) => {
+                        silent_pings = silent_pings.saturating_add(1);
+                        if silent_pings >= LIVENESS_PING_STRIKES {
+                            warn!(
+                                index = device_index,
+                                "capture channel stopped delivering — restarting session on a fresh channel"
+                            );
+                            break true;
+                        }
+                    }
+                    // Any reply — pong, feature error, unreachable-device
+                    // error — proves the channel still delivers.
+                    _ => silent_pings = 0,
+                }
+            }
+        }
+    };
 
     drop(listener);
     // The slot is one last-writer-wins cell shared by every session, so a
@@ -240,7 +291,14 @@ pub async fn run_capture_session(
     {
         *slot = None;
     }
-    armed.disarm().await;
+    if channel_dead {
+        // Disarm writes would each burn a timeout on a channel that no longer
+        // answers, and the replacement session re-arms the same diverts
+        // anyway; leave the device state for it.
+        debug!(index = device_index, "skipping disarm on a dead channel");
+    } else {
+        armed.disarm().await;
+    }
     debug!(index = device_index, "control capture stopped");
     Ok(())
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -244,12 +244,11 @@ pub async fn run_capture_session(
     // — is gone (a sleeping/unreachable device still gets us an error *reply*,
     // which proves delivery and resets the count). Exiting lets the manager
     // re-arm on a fresh channel.
-    let root =
-        <hidpp::feature::root::RootFeature as hidpp::feature::CreatableFeature>::new(
-            Arc::clone(&chan),
-            device_index,
-            0,
-        );
+    let root = <hidpp::feature::root::RootFeature as hidpp::feature::CreatableFeature>::new(
+        Arc::clone(&chan),
+        device_index,
+        0,
+    );
     let mut shutdown = std::pin::pin!(shutdown);
     let mut silent_pings = 0u8;
     let channel_dead = loop {

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -17,7 +17,7 @@ use tracing::{debug, warn};
 
 use crate::channel_registry::ChannelRegistry;
 use crate::node_ledger::NodeLedger;
-use crate::route::DeviceRoute;
+use crate::route::{DeviceRoute, is_receiver_pid};
 use crate::transport::{enumerate_hidpp_devices, open_hidpp_channel};
 
 mod cache;
@@ -56,6 +56,26 @@ const MAX_BOLT_SLOTS: u8 = 6;
 /// re-asks for per entry. At 6 s one lost report consumed the whole budget and
 /// the walk was abandoned mid-table, surfacing as a mouse that never appeared.
 const PROBE_BUDGET: Duration = Duration::from_secs(25);
+
+/// Probe budget for receiver nodes (Bolt/Unifying/Lightspeed dongles).
+///
+/// The 25 s [`PROBE_BUDGET`] is sized for Bluetooth-direct feature walks that
+/// receivers never perform. Keeping the receiver budget tighter matters
+/// because a full-budget timeout is also the detection path for a channel
+/// whose input-report delivery died (observed on macOS with concurrent opens
+/// of the same node: requests keep being written and answered, but the
+/// replies are delivered only to the other open handle). Until the channel is
+/// replaced every write on it stalls — DPI, SmartShift, ring haptics — so
+/// this budget bounds that outage.
+///
+/// It must still fit a receiver probe's real worst case, which is NOT the
+/// millisecond register reads but a paired device's full HID++ 2.0 feature
+/// walk: 1.5 s arrival drain + the sequential pairing-register pass + one
+/// slot's [`BOLT_SLOT_PROBE`] (10 s). 6 s proved too tight — a legitimate
+/// deep walk tripped the dead-delivery eviction, the surfaced-empty inventory
+/// tore down capture plans, and a pinned stale channel Arc then deadlocked
+/// recovery (dead buttons until restart). 13 s clears the honest worst case.
+const RECEIVER_PROBE_BUDGET: Duration = Duration::from_secs(13);
 
 /// Per-slot budget for the HID++ 2.0 feature walk on a Unifying paired device.
 ///
@@ -528,12 +548,23 @@ impl Enumerator {
                 .into_iter()
                 .map(|(info, channel)| async move {
                     let node = info.id.clone();
+                    // Receivers answer register reads over local USB in
+                    // milliseconds; only direct (esp. Bluetooth) devices need
+                    // the long feature-walk budget. A tight receiver budget
+                    // bounds the outage when its channel's input-report
+                    // delivery dies (writes accepted, replies never seen —
+                    // observed on macOS with concurrent opens of one node).
+                    let budget = if is_receiver_pid(info.product_id) {
+                        RECEIVER_PROBE_BUDGET
+                    } else {
+                        PROBE_BUDGET
+                    };
                     let probe = timeout(
-                        PROBE_BUDGET,
+                        budget,
                         probe_one(info, Arc::clone(&channel), cache, tick),
                     )
                     .await;
-                    (node, channel, probe)
+                    (node, channel, probe, budget)
                 })
                 .collect::<Vec<_>>()
                 .join()
@@ -548,22 +579,27 @@ impl Enumerator {
         // governed by `probe.healthy`.
         let mut all_complete = true;
         let mut all_healthy = true;
-        for (node, channel, result) in results {
+        for (node, channel, result, budget) in results {
+            let mut budget_timeout = false;
             let probe = if let Ok(probe) = result {
                 probe
             } else {
                 // The probe burned the whole budget — an asleep direct device,
-                // or a channel whose read loop parked on a dead handle (see
-                // `AsyncHidChannel::read_report`). Either way: "couldn't
+                // or a channel whose input-report delivery died (writes
+                // accepted, replies never seen). Either way: "couldn't
                 // check", not "nothing there".
-                warn!(budget = ?PROBE_BUDGET, "device probe timed out — treating as a failed probe");
+                warn!(?budget, "device probe timed out — treating as a failed probe");
+                budget_timeout = true;
                 NodeProbe::failed()
             };
             all_complete &= probe.complete;
             all_healthy &= probe.healthy;
             outcomes.extend(probe.outcomes);
             let settled = self.ledger.settle(&node, probe.healthy, probe.inventory);
-            if settled.evict_channel {
+            // A full-budget timeout is the dead-delivery signature — such a
+            // channel never recovers on its own, so don't wait for the
+            // ledger's consecutive-failure threshold to replace it.
+            if settled.evict_channel || budget_timeout {
                 if let Some(registry) = &self.registry {
                     registry.remove_node(&node);
                 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -554,17 +554,15 @@ impl Enumerator {
                     // bounds the outage when its channel's input-report
                     // delivery dies (writes accepted, replies never seen —
                     // observed on macOS with concurrent opens of one node).
-                    let budget = if is_receiver_pid(info.product_id) {
+                    let receiver = is_receiver_pid(info.product_id);
+                    let budget = if receiver {
                         RECEIVER_PROBE_BUDGET
                     } else {
                         PROBE_BUDGET
                     };
-                    let probe = timeout(
-                        budget,
-                        probe_one(info, Arc::clone(&channel), cache, tick),
-                    )
-                    .await;
-                    (node, channel, probe, budget)
+                    let probe =
+                        timeout(budget, probe_one(info, Arc::clone(&channel), cache, tick)).await;
+                    (node, channel, probe, budget, receiver)
                 })
                 .collect::<Vec<_>>()
                 .join()
@@ -579,7 +577,7 @@ impl Enumerator {
         // governed by `probe.healthy`.
         let mut all_complete = true;
         let mut all_healthy = true;
-        for (node, channel, result, budget) in results {
+        for (node, channel, result, budget, receiver) in results {
             let mut budget_timeout = false;
             let probe = if let Ok(probe) = result {
                 probe
@@ -588,7 +586,10 @@ impl Enumerator {
                 // or a channel whose input-report delivery died (writes
                 // accepted, replies never seen). Either way: "couldn't
                 // check", not "nothing there".
-                warn!(?budget, "device probe timed out — treating as a failed probe");
+                warn!(
+                    ?budget,
+                    "device probe timed out — treating as a failed probe"
+                );
                 budget_timeout = true;
                 NodeProbe::failed()
             };
@@ -596,10 +597,13 @@ impl Enumerator {
             all_healthy &= probe.healthy;
             outcomes.extend(probe.outcomes);
             let settled = self.ledger.settle(&node, probe.healthy, probe.inventory);
-            // A full-budget timeout is the dead-delivery signature — such a
-            // channel never recovers on its own, so don't wait for the
-            // ledger's consecutive-failure threshold to replace it.
-            if settled.evict_channel || budget_timeout {
+            // A full-budget timeout on a receiver is the dead-delivery
+            // signature — such a channel never recovers on its own, so don't
+            // wait for the ledger's consecutive-failure threshold to replace
+            // it. A direct (especially Bluetooth) device that burns its budget
+            // may simply be asleep: keep the ledger's replay grace and
+            // two-strike policy for those.
+            if settled.evict_channel || (budget_timeout && receiver) {
                 if let Some(registry) = &self.registry {
                     registry.remove_node(&node);
                 }

--- a/crates/openlogi-hid/src/route.rs
+++ b/crates/openlogi-hid/src/route.rs
@@ -109,6 +109,13 @@ pub fn speaks_unifying_protocol(product_id: u16) -> bool {
     UNIFYING_PIDS.contains(&product_id) || LIGHTSPEED_PIDS.contains(&product_id)
 }
 
+/// Whether `product_id` is a known Logitech receiver dongle of any family
+/// (Bolt, Unifying, or Lightspeed).
+#[must_use]
+pub fn is_receiver_pid(product_id: u16) -> bool {
+    BOLT_PIDS.contains(&product_id) || speaks_unifying_protocol(product_id)
+}
+
 /// Human-readable name for a receiver identified by `product_id`, used to label
 /// it in the inventory. Lightspeed receivers share the Unifying protocol path
 /// but are surfaced under their own name.

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -376,17 +376,26 @@ impl HidppChannel {
                             res = raw_channel.read_report(&mut buf).fuse() => res
                         };
 
-                        let Ok(len) = res else {
-                            continue;
+                        let len = match res {
+                            Ok(len) => len,
+                            Err(error) => {
+                                // A silently erroring handle is indistinguishable
+                                // from a deaf one without this line.
+                                trace!(?error, "read_report error");
+                                continue;
+                            }
                         };
 
                         let Some(msg) = HidppMessage::read_raw(&buf[..len]) else {
+                            trace!(len, "report not HID++ — dropped");
                             continue;
                         };
 
                         let mut matched = false;
+                        let pending_count;
                         {
                             let mut msgs = pending_messages.lock().unwrap();
+                            pending_count = msgs.len();
                             if let Some(pos) =
                                 msgs.iter().position(|elem| (elem.response_predicate)(&msg))
                             {
@@ -395,6 +404,14 @@ impl HidppChannel {
                                 matched = true;
                             }
                         }
+
+                        trace!(
+                            len,
+                            matched,
+                            pending_count,
+                            payload = format!("{:02x?}", &buf[..len.min(16)]),
+                            "raw report received"
+                        );
 
                         let listeners: Vec<_> = message_listeners
                             .lock()


### PR DESCRIPTION
First of the mitigation PRs offered in #586 (root-cause analysis there: on macOS, with more than one open handle to the same HID node, the OS periodically stops delivering input reports to one handle; writes are still accepted and answered, but replies land only on the sibling handle. Nothing errors, and the handle never heals — only close+reopen fixes it).

Three parts:

1. **Read-loop tracing** (`openlogi-hidpp`): raw report arrival + match state + read errors at `trace` level — this is what made the mechanism visible. The loop previously also swallowed read errors silently (`let Ok(len) = res else { continue }`).

2. **Receiver probe budget + immediate retire** (`openlogi-hid/src/inventory.rs`): receiver nodes get their own 13 s budget (the 25 s `PROBE_BUDGET` is sized for Bluetooth-direct feature walks; a receiver probe's honest worst case is the 1.5 s arrival drain + the pairing-register pass + one slot's 10 s `BOLT_SLOT_PROBE` walk — an earlier 6 s attempt tripped on legitimate deep walks). A full-budget timeout is the dead-delivery signature, so it retires the channel **immediately** instead of waiting for the ledger's second 25 s strike. Cuts the write/haptic outage from ~55–80 s to ~15 s, self-healing.

3. **Capture-session liveness watchdog** (`openlogi-hid/src/gesture.rs`): the session pings its device (root feature 0x0000) every 20 s over its own channel; two consecutive *all-silent* pings exit the session so the manager re-arms on a fresh channel. Error replies count as alive — an asleep/unreachable device still proves delivery — so idle devices don't false-trip. Previously a dead capture channel meant every diverted control (remapped buttons, the MX Master 4 haptic-panel trigger) went silently dead **forever**, with nothing to notice. Disarm is skipped on a dead channel so teardown doesn't burn timeouts.

Soaked all day on the affected machine (Mac Studio, Sequoia 15.7.9, Bolt + MX Master 4, 3 displays): deaf windows keep occurring (~1–2/min at worst), every one self-heals; buttons recover in ≤ ~45 s when the capture channel is the victim.

Note: dead-buttons recovery has one more failure mode whose guard lives with the haptic feature cache — that's in the companion PR, since the cache it guards is introduced there. As argued in #586, the real fix is a single shared channel per HID node; these changes bound the damage until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)