### PR TITLE
feat(gui): dismiss the Actions Ring on a click outside it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5152,6 +5152,7 @@ version = "0.6.26"
 dependencies = [
  "anyhow",
  "backon",
+ "block2 0.6.2",
  "disclaim",
  "embed-resource",
  "fluent-langneg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ evdev = "0.13"
 objc2 = "0.6.4"
 objc2-app-kit = "0.3.2"
 objc2-foundation = "0.3.2"
+# The block ABI crate objc2's generated bindings use for handler arguments;
+# same unified-version rationale as the objc2 crates above.
+block2 = "0.6.2"
 
 # gpui / gpui_platform track zed's default branch, matching how gpui-component
 # declares them (an explicit rev here would fork the git source and conflict).

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -64,8 +64,10 @@ embed-resource = "3.0.9"
 # `Retained<T>`-owned AppKit bindings so the status-item code can't leak (#99).
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSAppearance", "NSWindow"] }
+objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSAppearance", "NSWindow", "NSEvent", "block2"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSProcessInfo"] }
+# NSEvent global-monitor handlers are ObjC blocks (overlay click-away dismissal).
+block2 = { workspace = true }
 
 # unsafe_code stays denied; the status-item/tray modules opt in locally with
 # #[expect(unsafe_code)] for the few objc2 calls (init-with-action, set-target,

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -247,6 +247,7 @@ fn main() -> Result<()> {
     let app = gpui_platform::application().with_assets(app_assets::AppAssets);
     app.run(move |cx| {
         overlay_platform::configure_application();
+        spawn_click_away_dismissal(cx);
         cx.spawn(async move |cx| {
             while let Some(invocation) = invocations.recv().await {
                 rust_i18n::set_locale(locale::resolve(invocation.language.as_deref()));
@@ -287,6 +288,48 @@ fn main() -> Result<()> {
         .detach();
     });
     Ok(())
+}
+
+/// Dismiss a showing ring when the user clicks anywhere off it, the way a
+/// transient popup closes on click-away — without swallowing that click.
+///
+/// The ring window only covers its own 360×360 bounds, so an outside click
+/// never reaches the window's handlers. A global monitor closes the gap:
+/// macOS only delivers it events routed to *other* applications, so clicks on
+/// the ring itself can't race the slot/cancel handlers, and monitors can't
+/// consume events, so the click lands where the user aimed it. The handler
+/// only pings a channel; window teardown runs on the GPUI side, where a
+/// re-entrant AppKit callback can't find the App borrowed.
+fn spawn_click_away_dismissal(cx: &mut gpui::App) {
+    let (clicks_tx, mut clicks) = mpsc::unbounded_channel::<()>();
+    let monitor = overlay_platform::watch_clicks_outside(move || {
+        let _ = clicks_tx.send(());
+    });
+    if monitor.is_none() && cfg!(target_os = "macos") {
+        warn!(
+            "could not install the click-away monitor; the ring will not dismiss on outside clicks"
+        );
+    }
+    cx.spawn(async move |cx| {
+        // The native monitor lives (and drops) with this task.
+        let _monitor = monitor;
+        while clicks.recv().await.is_some() {
+            cx.update(|cx| {
+                for handle in cx.windows() {
+                    let Some(ring) = handle.downcast::<RingView>() else {
+                        continue;
+                    };
+                    let _ = ring.update(cx, |view, window, _| {
+                        let _ = view.commands.send(OverlayCommand::Cancel {
+                            session_id: view.invocation.session_id,
+                        });
+                        window.remove_window();
+                    });
+                }
+            });
+        }
+    })
+    .detach();
 }
 
 #[allow(

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -25,6 +25,10 @@ mod overlay_platform;
 use std::{
     future::Future,
     pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -247,11 +251,13 @@ fn main() -> Result<()> {
     let app = gpui_platform::application().with_assets(app_assets::AppAssets);
     app.run(move |cx| {
         overlay_platform::configure_application();
-        spawn_click_away_dismissal(cx);
+        let live_session = Arc::new(ClickAwaySession::new());
+        spawn_click_away_dismissal(cx, Arc::clone(&live_session));
         cx.spawn(async move |cx| {
             while let Some(invocation) = invocations.recv().await {
                 rust_i18n::set_locale(locale::resolve(invocation.language.as_deref()));
                 cx.update(|cx| {
+                    live_session.clear();
                     for handle in cx.windows() {
                         let _ = handle.update(cx, |_, window, _| window.remove_window());
                     }
@@ -267,6 +273,7 @@ fn main() -> Result<()> {
                         })
                     }) {
                         Ok(handle) => {
+                            live_session.set(session_id);
                             overlay_platform::configure_windows();
                             cx.spawn(async move |cx| {
                                 cx.background_executor().timer(DISPLAY_LIFETIME).await;
@@ -290,6 +297,40 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+/// Session the click-away monitor may dismiss; `0` means no ring is showing.
+struct ClickAwaySession(AtomicU64);
+
+impl ClickAwaySession {
+    const fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    /// Publish which ring is showing, or `0` while none is.
+    fn set(&self, session_id: u64) {
+        self.0.store(session_id, Ordering::Release);
+    }
+
+    /// Forget the showing session so later clicks cannot name it.
+    fn clear(&self) {
+        self.set(0);
+    }
+
+    /// Session id at click time, or `None` when no ring is showing.
+    #[must_use]
+    fn observe(&self) -> Option<u64> {
+        match self.0.load(Ordering::Acquire) {
+            0 => None,
+            session_id => Some(session_id),
+        }
+    }
+}
+
+/// True when the click still names the ring that is open.
+#[must_use]
+const fn click_away_targets(observed: u64, open: u64) -> bool {
+    observed != 0 && observed == open
+}
+
 /// Dismiss a showing ring when the user clicks anywhere off it, the way a
 /// transient popup closes on click-away — without swallowing that click.
 ///
@@ -298,12 +339,15 @@ fn main() -> Result<()> {
 /// macOS only delivers it events routed to *other* applications, so clicks on
 /// the ring itself can't race the slot/cancel handlers, and monitors can't
 /// consume events, so the click lands where the user aimed it. The handler
-/// only pings a channel; window teardown runs on the GPUI side, where a
-/// re-entrant AppKit callback can't find the App borrowed.
-fn spawn_click_away_dismissal(cx: &mut gpui::App) {
-    let (clicks_tx, mut clicks) = mpsc::unbounded_channel::<()>();
+/// snapshots the showing session onto a channel; teardown runs on the GPUI
+/// side, and only that session is cancelled so a queued click cannot close a
+/// ring that opened afterward.
+fn spawn_click_away_dismissal(cx: &mut gpui::App, live: Arc<ClickAwaySession>) {
+    let (clicks_tx, mut clicks) = mpsc::unbounded_channel();
     let monitor = overlay_platform::watch_clicks_outside(move || {
-        let _ = clicks_tx.send(());
+        if let Some(session_id) = live.observe() {
+            let _ = clicks_tx.send(session_id);
+        }
     });
     if monitor.is_none() && cfg!(target_os = "macos") {
         warn!(
@@ -311,25 +355,37 @@ fn spawn_click_away_dismissal(cx: &mut gpui::App) {
         );
     }
     cx.spawn(async move |cx| {
-        // The native monitor lives (and drops) with this task.
+        #[cfg(target_os = "macos")]
         let _monitor = monitor;
-        while clicks.recv().await.is_some() {
-            cx.update(|cx| {
-                for handle in cx.windows() {
-                    let Some(ring) = handle.downcast::<RingView>() else {
-                        continue;
-                    };
-                    let _ = ring.update(cx, |view, window, _| {
-                        let _ = view.commands.send(OverlayCommand::Cancel {
-                            session_id: view.invocation.session_id,
-                        });
-                        window.remove_window();
-                    });
-                }
-            });
+        #[cfg(not(target_os = "macos"))]
+        drop_unused_click_away_monitor(monitor);
+        while let Some(session_id) = clicks.recv().await {
+            cx.update(|cx| dismiss_click_away(cx, session_id));
         }
     })
     .detach();
+}
+
+/// Drop the stub monitor; non-macOS has no native owner to keep alive.
+#[cfg(not(target_os = "macos"))]
+const fn drop_unused_click_away_monitor(_monitor: Option<overlay_platform::ClickAwayMonitor>) {}
+
+/// Cancel the open ring only if it is still the session the click named.
+fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
+    for handle in cx.windows() {
+        let Some(ring) = handle.downcast::<RingView>() else {
+            continue;
+        };
+        let _ = ring.update(cx, |view, window, _| {
+            if !click_away_targets(session_id, view.invocation.session_id) {
+                return;
+            }
+            let _ = view.commands.send(OverlayCommand::Cancel {
+                session_id: view.invocation.session_id,
+            });
+            window.remove_window();
+        });
+    }
 }
 
 #[allow(
@@ -817,5 +873,34 @@ mod tests {
             clamp_window_origin(desired, Size::new(px(400.0), px(400.0)), display),
             desired
         );
+    }
+
+    #[test]
+    fn no_click_is_observed_when_no_ring_is_showing() {
+        let live = ClickAwaySession::new();
+        assert_eq!(live.observe(), None);
+        live.set(11);
+        live.clear();
+        assert_eq!(live.observe(), None);
+    }
+
+    #[test]
+    fn a_click_queued_before_a_new_ring_does_not_target_it() {
+        let live = ClickAwaySession::new();
+        live.set(11);
+        let queued = live.observe().expect("a showing ring is observable");
+        live.set(12);
+        assert!(
+            !click_away_targets(queued, live.observe().expect("replacement is showing")),
+            "a click snapshotted against the previous session must not close the new ring"
+        );
+    }
+
+    #[test]
+    fn a_click_against_the_showing_ring_targets_it() {
+        let live = ClickAwaySession::new();
+        live.set(7);
+        let queued = live.observe().expect("a showing ring is observable");
+        assert!(click_away_targets(queued, 7));
     }
 }

--- a/crates/openlogi-gui/src/platform/overlay.rs
+++ b/crates/openlogi-gui/src/platform/overlay.rs
@@ -33,3 +33,55 @@ pub fn configure_application() {}
 /// Other GPUI backends need no additional native window configuration here.
 #[cfg(not(target_os = "macos"))]
 pub fn configure_windows() {}
+
+/// Owner of the native click-away event monitor; dropping it removes the
+/// monitor. Create and drop on the main thread.
+#[cfg(target_os = "macos")]
+pub struct ClickAwayMonitor(objc2::rc::Retained<objc2::runtime::AnyObject>);
+
+#[cfg(target_os = "macos")]
+impl Drop for ClickAwayMonitor {
+    #[expect(
+        unsafe_code,
+        reason = "NSEvent::removeMonitor is plain AppKit FFI; the token is exactly what addGlobalMonitor returned"
+    )]
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is the monitor token returned by
+        // `addGlobalMonitorForEventsMatchingMask_handler`, removed only once.
+        unsafe { objc2_app_kit::NSEvent::removeMonitor(&self.0) };
+    }
+}
+
+/// Invoke `on_mouse_down` for every mouse-down that macOS delivers to *other*
+/// applications, for as long as the returned monitor is held.
+///
+/// Global `NSEvent` monitors never see events routed to this process's own
+/// windows and cannot consume the events they observe — together exactly the
+/// ring's click-away contract: clicks on the ring keep hitting the GPUI
+/// handlers they always did, while a click anywhere else can dismiss the ring
+/// without being swallowed. Must be called on the main thread (returns `None`
+/// off it); the handler runs on the main run loop.
+#[cfg(target_os = "macos")]
+pub fn watch_clicks_outside(on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSEvent, NSEventMask};
+
+    MainThreadMarker::new()?;
+    let handler: block2::RcBlock<dyn Fn(std::ptr::NonNull<NSEvent>)> =
+        block2::RcBlock::new(move |_event| on_mouse_down());
+    NSEvent::addGlobalMonitorForEventsMatchingMask_handler(
+        NSEventMask::LeftMouseDown | NSEventMask::RightMouseDown | NSEventMask::OtherMouseDown,
+        &handler,
+    )
+    .map(ClickAwayMonitor)
+}
+
+/// Away from macOS no global click monitor is available; the ring keeps its
+/// in-window dismissal paths (center ×, slot activation, timeout).
+#[cfg(not(target_os = "macos"))]
+pub struct ClickAwayMonitor(());
+
+#[cfg(not(target_os = "macos"))]
+pub fn watch_clicks_outside(_on_mouse_down: impl Fn() + 'static) -> Option<ClickAwayMonitor> {
+    None
+}


### PR DESCRIPTION
## Problem

The Actions Ring stays open when the user clicks anywhere off it. The ring window only covers its own 360×360 bounds, so an outside click never reaches the overlay's handlers at all — the only dismissal paths are a slot activation, the center ×, or the 15 s display timeout. Transient popups conventionally close on click-away (Logi Options+'s ring does).

## Fix

Install a global `NSEvent` mouse-down monitor for as long as the overlay runs (`watch_clicks_outside` in `platform/overlay.rs`). Two AppKit properties make this exactly the right contract:

- macOS delivers global-monitor events only for events routed to **other** applications, so clicks on the ring itself keep hitting the GPUI slot/cancel handlers with no race and no bounds math;
- global monitors cannot consume the events they observe, so the dismissing click still lands where the user aimed it (matching Logi Options+).

The monitor handler only pings an unbounded channel; window teardown runs on the GPUI side (`spawn_click_away_dismissal`), sending the same cancel the center button sends. No IPC or protocol change. Non-macOS keeps the existing in-window dismissal paths.

Adds `block2` (the block ABI crate objc2's generated bindings already use) plus the `NSEvent`/`block2` features of objc2-app-kit.

## Testing

- `cargo fmt` / `clippy` / workspace tests clean.
- Live-tested on macOS 15.7.9 (MX Master 4 via Bolt, 3-display setup): clicking the desktop or another app dismisses the ring and the click still lands where aimed; slot activation, center ×, and timeout behavior unchanged; clicks on the ring never trigger the monitor.

CI note: expect the inherited mock-agent failures until #587 lands — this branch is off current master, and PR CI builds the branch merged with master, which doesn't compile without that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)