### PR TITLE
feat(agent): pressing the ring trigger again dismisses the Actions Ring

### DIFF
--- a/crates/openlogi-agent-core/src/action_ring.rs
+++ b/crates/openlogi-agent-core/src/action_ring.rs
@@ -138,6 +138,42 @@ impl ActionRingManager {
         invocation
     }
 
+    /// Dismiss the showing session, if any, and return whether one was
+    /// dismissed. Queues an **empty invocation** (zero slots) — the overlay
+    /// treats that as "close the ring without opening a new one", which keeps
+    /// the dismissal inside the existing `next_action_ring` wire format. Lets
+    /// a second press of the ring trigger toggle the ring closed.
+    ///
+    /// The empty placeholder session is not "showing" (it has no actions), so
+    /// a trigger press racing the overlay's close acknowledgement re-opens the
+    /// ring instead of dismissing nothing.
+    pub fn dismiss_active(&self) -> bool {
+        let mut state = self.state();
+        state.expire();
+        match state.active.take() {
+            Some(session) if !session.actions.is_empty() => {
+                let session_id = self.next_session.fetch_add(1, Ordering::Relaxed);
+                state.active = Some(Session {
+                    invocation: ActionRingInvocation {
+                        session_id,
+                        slots: BTreeMap::new(),
+                        language: None,
+                    },
+                    pending: true,
+                    device_key: session.device_key,
+                    haptic_route: session.haptic_route,
+                    actions: BTreeMap::new(),
+                    hovered: None,
+                    opened_at: Instant::now(),
+                });
+                drop(state);
+                self.changed.notify_one();
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Wait for the next invocation, returning `None` when the hold window
     /// elapses so the overlay can check its agent connection and poll again.
     pub async fn next_invocation(&self) -> Option<ActionRingInvocation> {
@@ -272,6 +308,32 @@ mod tests {
             }
         );
         assert_eq!(invocation.language.as_deref(), Some("fr"));
+    }
+
+    #[tokio::test]
+    async fn second_trigger_press_dismisses_and_third_reopens() {
+        let manager = ActionRingManager::default();
+
+        // Nothing showing yet: the first press must open, not dismiss.
+        assert!(!manager.dismiss_active());
+        let opened = manager.begin(spec());
+        assert_eq!(manager.next_invocation().await, Some(opened.clone()));
+
+        // Second press: dismissed via an empty invocation on the same poll.
+        assert!(manager.dismiss_active());
+        let dismissal = manager.next_invocation().await.expect("dismissal queued");
+        assert!(dismissal.slots.is_empty());
+        assert_ne!(dismissal.session_id, opened.session_id);
+
+        // The placeholder is not "showing": a third press opens again.
+        assert!(!manager.dismiss_active());
+        let reopened = manager.begin(spec());
+        assert!(!reopened.slots.is_empty());
+
+        // The overlay's Cancel for the dismissal id must not kill the new
+        // session.
+        manager.cancel(dismissal.session_id);
+        assert!(manager.dismiss_active());
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/action_ring.rs
+++ b/crates/openlogi-agent-core/src/action_ring.rs
@@ -321,7 +321,10 @@ mod tests {
 
         // Second press: dismissed via an empty invocation on the same poll.
         assert!(manager.dismiss_active());
-        let dismissal = manager.next_invocation().await.expect("dismissal queued");
+        let dismissal = manager
+            .next_invocation()
+            .await
+            .unwrap_or_else(|| panic!("dismissal queued"));
         assert!(dismissal.slots.is_empty());
         assert_ne!(dismissal.session_id, opened.session_id);
 

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -172,6 +172,10 @@ async fn begin_action_ring(
     action_ring: &ActionRingManager,
     device_key: Option<&str>,
 ) {
+    // A second trigger press while the ring is showing closes it.
+    if action_ring.dismiss_active() {
+        return;
+    }
     if let Some(session) = orchestrator.lock().await.action_ring_session(device_key) {
         action_ring.begin(session);
     }

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -249,6 +249,20 @@ fn main() -> Result<()> {
         overlay_platform::configure_application();
         cx.spawn(async move |cx| {
             while let Some(invocation) = invocations.recv().await {
+                // An empty invocation is the agent's dismissal signal (second
+                // trigger press): close any showing ring, open nothing, and
+                // acknowledge so the agent can clear the placeholder session.
+                if invocation.slots.is_empty() {
+                    cx.update(|cx| {
+                        for handle in cx.windows() {
+                            let _ = handle.update(cx, |_, window, _| window.remove_window());
+                        }
+                    });
+                    let _ = commands.send(OverlayCommand::Cancel {
+                        session_id: invocation.session_id,
+                    });
+                    continue;
+                }
                 rust_i18n::set_locale(locale::resolve(invocation.language.as_deref()));
                 cx.update(|cx| {
                     for handle in cx.windows() {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -184,7 +184,8 @@ temperature_kelvin = 4600
 
 Action names are the catalog's variant names (`LeftClick`, `MouseBack`,
 `Copy`, `PlayPause`, `CycleDpiPresets`, …). `ShowActionsRing` opens the ring;
-a detected Haptic Sense Panel uses it by default. Ring slots reject
+a detected Haptic Sense Panel uses it by default, and pressing the trigger
+again while the ring is showing dismisses it. Ring slots reject
 `ShowActionsRing` itself to prevent recursive sessions. `OpenApplication`
 accepts an application, folder, filesystem path, or URL. A leading `~` is
 expanded when the action runs; for example:


### PR DESCRIPTION
## Problem

Logi Options+ closes the Actions Ring on a second press of the trigger that opened it. OpenLogi leaves the ring up until a slot activation, the center ×, or the 15 s display timeout — so the natural "never mind" gesture (tap the Haptic Sense Panel again) does nothing. (Complements #591, which adds click-away dismissal; together they give full Logi dismissal parity.)

## Fix

Track the live overlay session in `ActionRingManager`. When the ring trigger fires while a session is active, `dismiss_active()` queues an **empty invocation** (zero slots) on the existing long-poll instead of opening a new session. The overlay treats an empty invocation as "close whatever is showing" and acknowledges with a cancel, so the placeholder session is reaped even if the overlay missed the original one. No IPC or protocol change — it reuses the `next_action_ring` long-poll and the existing cancel path.

Also documents the behavior in CONFIGURATION.md's `ShowActionsRing` paragraph.

## Testing

- Unit tests in `action_ring.rs` cover: second trigger dismisses; dismissal doesn't kill a subsequently opened session; cancel for the dismissal id is a no-op on the new session.
- `cargo fmt` / `clippy` / tests clean (the only clippy/CI errors on this branch are master's pre-existing mock-agent breakage — see #587).
- Live-tested on macOS 15.7.9 (MX Master 4, Bolt): running as part of my daily-driver build all day — open ring, second panel press closes it; slots/×/timeout/click-away unchanged.

CI note: expect the inherited mock-agent failures until #587 lands (PR CI builds the branch merged with master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)