### PR TITLE
fix(xtask): stamp and verify the macOS bundle identity per channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,15 +215,24 @@ jobs:
             cargo run -p xtask -- macos package
           fi
 
+      # xtask stamps and verifies this itself; re-checking the artifact here is
+      # deliberate redundancy, because a bundle that ships with the `.dev`
+      # identity voids every user's permission grants and moves them to a
+      # different config directory (releases 0.6.24–0.6.26).
       - name: Verify production bundle identities
         run: |
           set -euo pipefail
           app="target/release/bundle/osx/OpenLogi.app"
-          helper="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
-          overlay="$app/Contents/Library/LoginItems/OpenLogiOverlay.app"
-          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")" = "org.openlogi.openlogi" ]
-          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$helper/Contents/Info.plist")" = "org.openlogi.agent" ]
-          [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$overlay/Contents/Info.plist")" = "org.openlogi.overlay" ]
+          plist() { /usr/libexec/PlistBuddy -c "Print :$2" "$1/Contents/Info.plist"; }
+          check() { # bundle expected-id expected-name
+            [ "$(plist "$1" CFBundleIdentifier)" = "$2" ]
+            [ "$(plist "$1" CFBundleName)" = "$3" ]
+            [ "$(plist "$1" CFBundleDisplayName)" = "$3" ]
+            [ -f "$1/Contents/Resources/AppIcon.icns" ]
+          }
+          check "$app" "org.openlogi.openlogi" "OpenLogi"
+          check "$app/Contents/Library/LoginItems/OpenLogiAgent.app" "org.openlogi.agent" "OpenLogi Agent"
+          check "$app/Contents/Library/LoginItems/OpenLogiOverlay.app" "org.openlogi.overlay" "OpenLogi Overlay"
 
       - name: Verify signed app bundle
         if: ${{ inputs.sign }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9659,6 +9659,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2_hasher",
+ "strum",
  "tempfile",
  "time",
  "which 8.0.4",

--- a/crates/openlogi-gui/bundle/overlay-release/Info.plist
+++ b/crates/openlogi-gui/bundle/overlay-release/Info.plist
@@ -9,6 +9,8 @@
   <string>OpenLogi Overlay</string>
   <key>CFBundleExecutable</key>
   <string>openlogi-overlay</string>
+  <key>CFBundleIconFile</key>
+  <string>AppIcon</string>
   <key>CFBundleIdentifier</key>
   <string>org.openlogi.overlay</string>
   <key>CFBundlePackageType</key>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -79,6 +79,14 @@ Packaged local dev bundles (`cargo run` and
 GUI and agent from sharing the installed production app's Accessibility grant,
 single-instance lock, config, or IPC socket.
 
+Those identifiers are a channel, not a guess from the build type:
+`macos bundle` takes `--channel dev|production` (dev by default) and verifies
+what it stamped, and `macos dmg` refuses a non-production bundle once it is
+given a signing identity. Reproduce the shipped layout locally with
+`--channel production`, but don't sign and run it — it would take over the
+installed app's grants and config, which is exactly what releases
+0.6.24–0.6.26 did in reverse.
+
 To install the CLI binary on `PATH`:
 
 ```sh

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,6 +18,7 @@ plist = "1.10.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2_hasher = { version = "0.3.2", features = ["sync"] }
+strum = { version = "0.27", features = ["derive"] }
 tempfile = "3.27.0"
 time = { version = "0.3", features = ["formatting"] }
 which = "8.0.4"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -12,22 +12,37 @@ devenv shell -- cargo run -p xtask -- <command>
 ## Commands
 
 - `macos icns` — generate `crates/openlogi-gui/icon/AppIcon.icns` from the master PNG.
-- `macos bundle` — build the release `OpenLogi.app` and embed the agent helper.
+- `macos bundle [--channel dev|production]` — build `OpenLogi.app` and embed the
+  agent and overlay helpers.
 - `macos dmg` — package an existing app bundle into the branded DMG.
 - `macos package` — build the app bundle, optionally sign it, then create the branded DMG.
 - `linux package` — build release binaries and package `.deb`, `.rpm`, and
   `.pkg.tar.zst` artifacts with nfpm.
 - `release latest-json` — generate the static updater manifest for the stable channel.
 
-For local testing, `macos bundle` stamps the built app/helper as
-`org.openlogi.openlogi.dev` / `org.openlogi.agent.dev`, then signs the final
-layout with `OPENLOGI_LOCAL_CODESIGN_IDENTITY` or the first Apple Development
-identity it finds. This keeps local Accessibility/TCC grants isolated from the
-installed production `org.openlogi.agent` grant. Set `OPENLOGI_LOCAL_CODESIGN=0`
-only when you explicitly want an unsigned local bundle. `macos package` keeps
-the production bundle IDs and signs with `OPENLOGI_SIGN_IDENTITY` / `--sign-identity`.
+### Bundle identity
+
+macOS keys TCC grants to a bundle's code identity, and OpenLogi keys its config
+profile to the identifier's suffix — so the identity decides whose permission
+grants and whose settings a build inherits. Every bundle therefore gets it
+written explicitly and read back:
+
+| channel | app | agent helper | overlay helper |
+|---|---|---|---|
+| `production` | `org.openlogi.openlogi` / OpenLogi | `org.openlogi.agent` / OpenLogi Agent | `org.openlogi.overlay` / OpenLogi Overlay |
+| `dev` | the same, suffixed `.dev` / ` Dev` | | |
+
+`macos bundle` defaults to `--channel dev`, so a local build can never claim the
+installed app's grants, and signs the result with `OPENLOGI_LOCAL_CODESIGN_IDENTITY`
+or the first Apple Development identity it finds (`OPENLOGI_LOCAL_CODESIGN=0`
+leaves it unsigned). `macos package` always builds the production channel and
+signs with `OPENLOGI_SIGN_IDENTITY` / `--sign-identity`; `macos dmg` refuses to
+package anything but a production bundle once it is given a signing identity, so
+a dev build cannot reach users. That check is what releases 0.6.24–0.6.26 lacked
+when the release workflow shipped `.dev` identifiers.
+
 The raw DMG emitted by `cargo-bundle` is deleted during `macos bundle` because it
-is created before xtask embeds and signs the helper; use `macos package` when
+is created before xtask embeds and signs the helpers; use `macos package` when
 you need a DMG.
 
 The Cargo runner in `../scripts/cargo-run-macos.sh` stays outside xtask because

--- a/xtask/src/commands/macos.rs
+++ b/xtask/src/commands/macos.rs
@@ -2,30 +2,39 @@ pub(crate) mod bundle;
 pub(crate) mod dmg;
 
 use anyhow::Result;
-use clap::Subcommand;
+use clap::{Parser, Subcommand};
+
+use bundle::identity::Channel;
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
     /// Generate the macOS app icon from the master PNG.
     Icns,
-    /// Build the release OpenLogi.app bundle.
-    Bundle,
+    /// Build the OpenLogi.app bundle.
+    Bundle(BundleArgs),
     /// Create the branded macOS DMG from an existing app bundle.
     Dmg(dmg::Args),
-    /// Build the app bundle, optionally sign it, and package the branded DMG.
+    /// Build the app bundle for distribution, optionally sign it, and package
+    /// the branded DMG.
     Package(dmg::Args),
+}
+
+#[derive(Parser)]
+pub(crate) struct BundleArgs {
+    /// Identity family to stamp into the bundle. Defaults to `dev` so a local
+    /// build can never claim the installed app's permission grants or config;
+    /// the shipped bundle comes from `macos package`.
+    #[arg(long, value_enum, default_value_t = Channel::Dev)]
+    channel: Channel,
 }
 
 pub(crate) fn run(command: Command) -> Result<()> {
     match command {
         Command::Icns => bundle::generate_icns(),
-        Command::Bundle => bundle::run(),
+        Command::Bundle(args) => bundle::run(args.channel),
         Command::Dmg(args) => dmg::run(&args),
         Command::Package(args) => {
             bundle::run_for_distribution(args.sign_identity.as_deref())?;
-            if args.sign_identity.is_none() {
-                println!("==> codesign: skipped (unsigned — set OPENLOGI_SIGN_IDENTITY to sign)");
-            }
             dmg::run(&args)
         }
     }

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -497,7 +497,23 @@ fn quoted_identity(line: &str) -> Option<String> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
+    use strum::VariantArray as _;
+
     use super::*;
+
+    /// Identity work iterates every `Component`, so a component added without a
+    /// `Helper` to embed it would only surface as a stamping failure during a
+    /// real build.
+    #[test]
+    fn every_nested_component_is_embedded_by_a_helper() {
+        for &component in Component::VARIANTS {
+            assert!(
+                component == Component::App
+                    || HELPERS.iter().any(|helper| helper.component == component),
+                "{component} has no Helper entry to embed it"
+            );
+        }
+    }
 
     fn app_with_binaries(binaries: &[&str]) -> tempfile::TempDir {
         let app = tempfile::tempdir().unwrap();

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -1,3 +1,5 @@
+pub(crate) mod identity;
+
 use std::env;
 use std::path::Path;
 
@@ -6,6 +8,7 @@ use plist::Value;
 use xshell::{Shell, cmd};
 
 use crate::support::fs::{command_exists, ensure_dir, ensure_file, repo_root};
+use identity::{Channel, Component};
 
 pub(crate) fn generate_icns() -> Result<()> {
     let root = repo_root()?;
@@ -60,15 +63,19 @@ where
     Ok(())
 }
 
-pub(crate) fn run() -> Result<()> {
-    run_with_profile(&BundleProfile::Local)
+/// Build `OpenLogi.app` wearing `channel`'s identity, signing it with whatever
+/// local identity is available (dev) or leaving it unsigned (production).
+pub(crate) fn run(channel: Channel) -> Result<()> {
+    run_with_channel(channel, None)
 }
 
+/// Build the bundle that ships: always the production identity, signed with the
+/// Developer ID identity when one is given.
 pub(crate) fn run_for_distribution(sign_identity: Option<&str>) -> Result<()> {
-    run_with_profile(&BundleProfile::Distribution { sign_identity })
+    run_with_channel(Channel::Production, sign_identity)
 }
 
-fn run_with_profile(profile: &BundleProfile<'_>) -> Result<()> {
+fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()> {
     let root = repo_root()?;
     let sh = Shell::new()?;
     let _repo = sh.push_dir(&root);
@@ -111,30 +118,27 @@ fn run_with_profile(profile: &BundleProfile<'_>) -> Result<()> {
 
     let app = root.join("target/release/bundle/osx/OpenLogi.app");
     ensure_dir(&app)?;
-    embed_agent_helper(&root, &app, &xcode_env)?;
-    embed_overlay_helper(&root, &app, &xcode_env)?;
+    embed_helpers(&root, &app, &xcode_env)?;
     embed_cli(&root, &app, &xcode_env)?;
     verify_bundle_binaries(&app)?;
     stamp_privacy_usage_descriptions(&app)?;
-    match profile {
-        BundleProfile::Local => {
-            stamp_local_bundle_identity(&app)?;
-            local_sign_app_if_available()?;
+    // Identity first, then the checks, then signing — a signature seals the
+    // `Info.plist` files, so nothing may rewrite them afterwards.
+    identity::stamp(&app, channel)?;
+    identity::verify(&app, channel)?;
+    identity::verify_icons(&app)?;
+    match (channel, sign_identity) {
+        (Channel::Production, Some(identity)) => {
+            sign_app_with_timestamp(identity, TimestampMode::Secure)?;
         }
-        BundleProfile::Distribution { sign_identity } => {
-            if let Some(identity) = sign_identity {
-                sign_app_with_timestamp(identity, TimestampMode::Secure)?;
-            }
+        (Channel::Production, None) => {
+            println!("==> codesign: skipped (unsigned — set OPENLOGI_SIGN_IDENTITY to sign)");
         }
+        (Channel::Dev, _) => local_sign_app_if_available()?,
     }
     println!();
     println!("Bundle ready: {}", app.display());
     Ok(())
-}
-
-enum BundleProfile<'a> {
-    Local,
-    Distribution { sign_identity: Option<&'a str> },
 }
 
 fn remove_cargo_bundle_dmg(root: &Path) -> Result<()> {
@@ -149,79 +153,100 @@ fn remove_cargo_bundle_dmg(root: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Build the headless agent and embed it as a nested login-item helper at
-/// `OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app`. The agent is
-/// the always-on process (hook + device I/O + menu bar); shipping it inside the
-/// GUI bundle keeps one notarized artifact, lets `open -b` foreground the GUI
-/// from the agent's menu, and gives the agent a stable signed identity so its
-/// Accessibility (TCC) grant survives app updates.
-fn embed_agent_helper(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
-    let sh = Shell::new()?;
-    let _repo = sh.push_dir(root);
-    println!("==> agent helper (build)");
-    cmd!(sh, "cargo build -p openlogi-agent --release")
-        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-        .run()?;
-    let agent_bin = root.join("target/release/openlogi-agent");
-    ensure_file(&agent_bin)?;
+/// A nested login-item helper embedded under `Contents/Library/LoginItems`.
+struct Helper {
+    /// Identity component, which also locates the helper inside the app bundle.
+    component: Component,
+    /// Cargo package and binary that build it.
+    package: &'static str,
+    /// Binary name, both in `target/release` and inside the helper bundle.
+    binary: &'static str,
+    /// Checked-in release `Info.plist`, relative to the repo root.
+    info_plist: &'static str,
+    /// What the build log calls it.
+    label: &'static str,
+}
 
-    let helper = app.join("Contents/Library/LoginItems/OpenLogiAgent.app");
-    let helper_macos = helper.join("Contents/MacOS");
-    fs_err::create_dir_all(&helper_macos)
-        .with_context(|| format!("could not create {}", helper_macos.display()))?;
-    fs_err::copy(&agent_bin, helper_macos.join("openlogi-agent"))
-        .with_context(|| "could not copy the agent binary into the helper bundle".to_string())?;
-    let info_src = root.join("crates/openlogi-gui/bundle/agent-release/Info.plist");
-    ensure_file(&info_src)?;
-    let info_dst = helper.join("Contents/Info.plist");
-    fs_err::copy(&info_src, &info_dst)
-        .with_context(|| "could not write the helper Info.plist".to_string())?;
-    // Share the GUI's app icon so the agent shows the OpenLogi mark (not a
-    // generic blank) in System Settings → Accessibility, where the grant now
-    // lives under "OpenLogi Agent". The bundle command runs icon generation
-    // first, so the icns is already on disk. Matches the Info.plist
-    // CFBundleIconFile = "AppIcon".
-    let icon_src = root.join("crates/openlogi-gui/icon/AppIcon.icns");
-    ensure_file(&icon_src)?;
-    let resources = helper.join("Contents/Resources");
-    fs_err::create_dir_all(&resources)
-        .with_context(|| format!("could not create {}", resources.display()))?;
-    fs_err::copy(&icon_src, resources.join("AppIcon.icns"))
-        .with_context(|| "could not copy the app icon into the helper bundle".to_string())?;
+/// Every helper the app bundle ships.
+const HELPERS: [Helper; 2] = [
+    Helper {
+        component: Component::Agent,
+        package: "openlogi-agent",
+        binary: "openlogi-agent",
+        info_plist: "crates/openlogi-gui/bundle/agent-release/Info.plist",
+        label: "agent helper",
+    },
+    Helper {
+        component: Component::Overlay,
+        package: "openlogi-gui",
+        binary: "openlogi-overlay",
+        info_plist: "crates/openlogi-gui/bundle/overlay-release/Info.plist",
+        label: "Actions Ring overlay helper",
+    },
+];
 
-    stamp_bundle_version(&info_dst, env!("CARGO_PKG_VERSION"))?;
-
-    println!("    embedded {}", helper.display());
+/// Build each helper and embed it as a nested login-item bundle.
+///
+/// The agent is the always-on process (hook + device I/O + menu bar); shipping
+/// it inside the GUI bundle keeps one notarized artifact, lets `open -b`
+/// foreground the GUI from the agent's menu, and gives the agent a stable
+/// signed identity so its Accessibility (TCC) grant survives app updates.
+///
+/// Every helper gets the GUI's icon, so each shows the OpenLogi mark rather than
+/// a generic blank wherever macOS lists it — System Settings' Accessibility
+/// pane, Login Items. Icon generation already ran, so the icns is on disk.
+fn embed_helpers(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
+    let icon = root.join("crates/openlogi-gui/icon/AppIcon.icns");
+    ensure_file(&icon)?;
+    for helper in &HELPERS {
+        embed_helper(root, app, xcode_env, helper, &icon)?;
+    }
     Ok(())
 }
 
-fn embed_overlay_helper(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
+fn embed_helper(
+    root: &Path,
+    app: &Path,
+    xcode_env: &[(String, String)],
+    helper: &Helper,
+    icon: &Path,
+) -> Result<()> {
     let sh = Shell::new()?;
     let _repo = sh.push_dir(root);
-    println!("==> Actions Ring overlay helper (build)");
-    cmd!(
-        sh,
-        "cargo build -p openlogi-gui --bin openlogi-overlay --release"
-    )
-    .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-    .run()?;
-    let overlay_bin = root.join("target/release/openlogi-overlay");
-    ensure_file(&overlay_bin)?;
+    let Helper {
+        package,
+        binary,
+        label,
+        ..
+    } = *helper;
+    println!("==> {label} (build)");
+    cmd!(sh, "cargo build -p {package} --bin {binary} --release")
+        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+        .run()?;
+    let built = root.join("target/release").join(binary);
+    ensure_file(&built)?;
 
-    let helper = app.join("Contents/Library/LoginItems/OpenLogiOverlay.app");
-    let helper_macos = helper.join("Contents/MacOS");
-    fs_err::create_dir_all(&helper_macos)
-        .with_context(|| format!("could not create {}", helper_macos.display()))?;
-    fs_err::copy(&overlay_bin, helper_macos.join("openlogi-overlay"))
-        .with_context(|| "could not copy the Actions Ring overlay binary".to_string())?;
-    let info_src = root.join("crates/openlogi-gui/bundle/overlay-release/Info.plist");
+    let bundle = helper.component.root(app);
+    let bundle_macos = bundle.join("Contents/MacOS");
+    fs_err::create_dir_all(&bundle_macos)
+        .with_context(|| format!("could not create {}", bundle_macos.display()))?;
+    fs_err::copy(&built, bundle_macos.join(binary))
+        .with_context(|| format!("could not copy {binary} into the helper bundle"))?;
+
+    let info_src = root.join(helper.info_plist);
     ensure_file(&info_src)?;
-    let info_dst = helper.join("Contents/Info.plist");
+    let info_dst = helper.component.info_plist(app);
     fs_err::copy(&info_src, &info_dst)
-        .with_context(|| "could not write the overlay helper Info.plist".to_string())?;
+        .with_context(|| format!("could not write the {label} Info.plist"))?;
     stamp_bundle_version(&info_dst, env!("CARGO_PKG_VERSION"))?;
 
-    println!("    embedded {}", helper.display());
+    let resources = bundle.join("Contents/Resources");
+    fs_err::create_dir_all(&resources)
+        .with_context(|| format!("could not create {}", resources.display()))?;
+    fs_err::copy(icon, helper.component.icon(app))
+        .with_context(|| format!("could not copy the app icon into the {label} bundle"))?;
+
+    println!("    embedded {}", bundle.display());
     Ok(())
 }
 
@@ -299,47 +324,14 @@ fn xcode_env() -> Result<Vec<(String, String)>> {
     ])
 }
 
-fn stamp_local_bundle_identity(app: &Path) -> Result<()> {
-    println!("==> local bundle identity");
-    let app_info = app.join("Contents/Info.plist");
-    stamp_plist_strings(
-        &app_info,
-        &[
-            ("CFBundleDisplayName", "OpenLogi Dev"),
-            ("CFBundleIdentifier", "org.openlogi.openlogi.dev"),
-            ("CFBundleName", "OpenLogi Dev"),
-        ],
-    )?;
-
-    let helper_info = app.join("Contents/Library/LoginItems/OpenLogiAgent.app/Contents/Info.plist");
-    if helper_info.exists() {
-        stamp_plist_strings(
-            &helper_info,
-            &[
-                ("CFBundleDisplayName", "OpenLogi Agent Dev"),
-                ("CFBundleIdentifier", "org.openlogi.agent.dev"),
-                ("CFBundleName", "OpenLogi Agent Dev"),
-            ],
-        )?;
-    }
-
-    let overlay_info =
-        app.join("Contents/Library/LoginItems/OpenLogiOverlay.app/Contents/Info.plist");
-    if overlay_info.exists() {
-        stamp_plist_strings(
-            &overlay_info,
-            &[
-                ("CFBundleDisplayName", "OpenLogi Overlay Dev"),
-                ("CFBundleIdentifier", "org.openlogi.overlay.dev"),
-                ("CFBundleName", "OpenLogi Overlay Dev"),
-            ],
-        )?;
-    }
-
-    println!(
-        "    stamped local IDs: org.openlogi.openlogi.dev / org.openlogi.agent.dev / org.openlogi.overlay.dev"
-    );
-    Ok(())
+/// Read one string value from an `Info.plist`; `None` when the key is absent.
+fn read_plist_string(info_plist: &Path, key: &str) -> Result<Option<String>> {
+    let plist = Value::from_file(info_plist)
+        .with_context(|| format!("could not read {}", info_plist.display()))?;
+    let dict = plist
+        .as_dictionary()
+        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
+    Ok(dict.get(key).and_then(Value::as_string).map(str::to_owned))
 }
 
 fn stamp_plist_strings(info_plist: &Path, entries: &[(&str, &str)]) -> Result<()> {
@@ -381,7 +373,7 @@ fn local_sign_app_if_available() -> Result<()> {
         "==> local codesign: skipped (no Apple Development identity found;          set OPENLOGI_LOCAL_CODESIGN_IDENTITY or OPENLOGI_SIGN_IDENTITY to sign)"
     );
     println!(
-        "    warning: unsigned/ad-hoc local bundles with production bundle IDs can          make macOS Accessibility grants appear stale or missing"
+        "    warning: an unsigned bundle is re-signed ad-hoc on every build, so its own Accessibility grant goes stale each time"
     );
     Ok(())
 }
@@ -517,14 +509,6 @@ mod tests {
         app
     }
 
-    fn write_info_plist(app: &Path, relative: &str) {
-        let path = app.join(relative);
-        fs_err::create_dir_all(path.parent().unwrap()).unwrap();
-        Value::Dictionary(plist::Dictionary::new())
-            .to_file_xml(path)
-            .unwrap();
-    }
-
     #[test]
     fn verify_bundle_binaries_accepts_a_complete_bundle() {
         let app = app_with_binaries(&REQUIRED_BUNDLE_BINARIES);
@@ -545,34 +529,63 @@ mod tests {
         );
     }
 
+    /// The checked-in helper plists are what a fresh bundle starts from, so a
+    /// rename there that never reached the identity table would ship one name in
+    /// the bundle and another in every verification.
     #[test]
-    fn local_identity_stamps_every_nested_helper() {
-        let app = tempfile::tempdir().unwrap();
-        let identities = [
-            ("Contents/Info.plist", "org.openlogi.openlogi.dev"),
-            (
-                "Contents/Library/LoginItems/OpenLogiAgent.app/Contents/Info.plist",
-                "org.openlogi.agent.dev",
-            ),
-            (
-                "Contents/Library/LoginItems/OpenLogiOverlay.app/Contents/Info.plist",
-                "org.openlogi.overlay.dev",
-            ),
-        ];
-        for (path, _) in identities {
-            write_info_plist(app.path(), path);
+    fn shipped_helper_plists_declare_their_production_identity() {
+        let root = repo_root().unwrap();
+
+        for helper in &HELPERS {
+            let plist = root.join(helper.info_plist);
+            let expected = Channel::Production.identity(helper.component);
+
+            for (key, want) in [
+                ("CFBundleIdentifier", &expected.bundle_id),
+                ("CFBundleName", &expected.name),
+                ("CFBundleDisplayName", &expected.name),
+            ] {
+                assert_eq!(
+                    read_plist_string(&plist, key).unwrap().as_ref(),
+                    Some(want),
+                    "{} declares the wrong {key}",
+                    helper.info_plist
+                );
+            }
         }
+    }
 
-        stamp_local_bundle_identity(app.path()).unwrap();
+    /// Every helper must declare the shared icon, or it shows up blank in the
+    /// System Settings panes where users grant it permissions.
+    #[test]
+    fn shipped_helper_plists_declare_the_shared_icon() {
+        let root = repo_root().unwrap();
 
-        for (path, expected) in identities {
-            let plist = Value::from_file(app.path().join(path)).unwrap();
-            let actual = plist
-                .as_dictionary()
-                .unwrap()
-                .get("CFBundleIdentifier")
-                .and_then(Value::as_string);
-            assert_eq!(actual, Some(expected));
+        for helper in &HELPERS {
+            let icon =
+                read_plist_string(&root.join(helper.info_plist), "CFBundleIconFile").unwrap();
+
+            assert_eq!(
+                icon.as_deref().map(|file| file.trim_end_matches(".icns")),
+                Some("AppIcon"),
+                "{} must declare the shared app icon",
+                helper.info_plist
+            );
+        }
+    }
+
+    /// `verify_bundle_binaries` is the list a missing helper build trips over;
+    /// a helper absent from it would embed silently broken.
+    #[test]
+    fn every_helper_binary_is_a_required_bundle_binary() {
+        for helper in &HELPERS {
+            let nested = helper.component.nested_bundle().unwrap();
+            let path = format!("{nested}/Contents/MacOS/{}", helper.binary);
+
+            assert!(
+                REQUIRED_BUNDLE_BINARIES.contains(&path.as_str()),
+                "{path} is embedded but never verified"
+            );
         }
     }
 

--- a/xtask/src/commands/macos/bundle/identity.rs
+++ b/xtask/src/commands/macos/bundle/identity.rs
@@ -12,11 +12,11 @@
 //! over every component, and [`verify`] reads it back before anything signs,
 //! packages or notarizes the result.
 
-use std::fmt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
 use clap::ValueEnum;
+use strum::{Display, VariantArray};
 
 use super::{read_plist_string, stamp_plist_strings};
 
@@ -29,7 +29,11 @@ pub(crate) const APP_BUNDLE_ID: &str = "org.openlogi.openlogi";
 const ICON_STEM: &str = "AppIcon";
 
 /// Which identity family a bundle carries.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+///
+/// `Display` renders the same spelling `--channel` accepts: clap renders the
+/// flag's default through it and parses the result back.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum, Display)]
+#[strum(serialize_all = "kebab-case")]
 pub(crate) enum Channel {
     /// What ships. Users' permission grants and config directory are keyed to it.
     Production,
@@ -39,32 +43,26 @@ pub(crate) enum Channel {
     Dev,
 }
 
-impl fmt::Display for Channel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Production => "production",
-            Self::Dev => "dev",
-        })
-    }
-}
-
 /// A bundle whose identity xtask owns: the app plus each nested login-item
 /// helper it embeds.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// `VariantArray` supplies `VARIANTS`, so every pass over the bundle covers a
+/// newly added component without anyone remembering to extend a list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Display, VariantArray)]
 pub(crate) enum Component {
     /// `OpenLogi.app` itself.
+    #[strum(serialize = "app")]
     App,
     /// The always-on agent: the process that owns the hook and holds the
     /// Accessibility grant.
+    #[strum(serialize = "agent helper")]
     Agent,
     /// The Actions Ring renderer.
+    #[strum(serialize = "overlay helper")]
     Overlay,
 }
 
 impl Component {
-    /// Every component a finished bundle contains.
-    pub(crate) const ALL: [Self; 3] = [Self::App, Self::Agent, Self::Overlay];
-
     /// Where this component lives inside the app bundle; `None` is the app itself.
     pub(super) fn nested_bundle(self) -> Option<&'static str> {
         match self {
@@ -105,16 +103,6 @@ impl Component {
     }
 }
 
-impl fmt::Display for Component {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::App => "app",
-            Self::Agent => "agent helper",
-            Self::Overlay => "overlay helper",
-        })
-    }
-}
-
 /// What one component is called on one channel.
 pub(crate) struct Identity {
     /// `CFBundleIdentifier` — what TCC and the config profile key off.
@@ -152,7 +140,7 @@ fn identity_entries(identity: &Identity) -> [(&str, &str); 3] {
 /// Runs before codesigning, which seals the `Info.plist` it stamps.
 pub(crate) fn stamp(app: &Path, channel: Channel) -> Result<()> {
     println!("==> bundle identity ({channel})");
-    for component in Component::ALL {
+    for &component in Component::VARIANTS {
         let identity = channel.identity(component);
         stamp_plist_strings(&component.info_plist(app), &identity_entries(&identity))?;
         println!(
@@ -168,7 +156,7 @@ pub(crate) fn stamp(app: &Path, channel: Channel) -> Result<()> {
 /// This is the gate a distribution artifact passes before it is signed or
 /// packaged, so a bundle built for local use can never be shipped by mistake.
 pub(crate) fn verify(app: &Path, channel: Channel) -> Result<()> {
-    for component in Component::ALL {
+    for &component in Component::VARIANTS {
         let expected = channel.identity(component);
         let plist = component.info_plist(app);
         for (key, want) in identity_entries(&expected) {
@@ -188,7 +176,7 @@ pub(crate) fn verify(app: &Path, channel: Channel) -> Result<()> {
 /// no surface that lists OpenLogi's processes — System Settings' privacy panes,
 /// Login Items — shows a blank icon for one of them.
 pub(crate) fn verify_icons(app: &Path) -> Result<()> {
-    for component in Component::ALL {
+    for &component in Component::VARIANTS {
         let icon = component.icon(app);
         if !icon.is_file() {
             bail!(
@@ -220,7 +208,7 @@ mod tests {
     /// A bundle skeleton with an empty `Info.plist` per component.
     fn bundle() -> tempfile::TempDir {
         let app = tempfile::tempdir().unwrap();
-        for component in Component::ALL {
+        for &component in Component::VARIANTS {
             let plist = component.info_plist(app.path());
             fs_err::create_dir_all(plist.parent().unwrap()).unwrap();
             plist::Value::Dictionary(plist::Dictionary::new())
@@ -246,12 +234,12 @@ mod tests {
 
     #[test]
     fn a_dev_bundle_can_never_collide_with_a_shipped_one() {
-        let shipped: Vec<Identity> = Component::ALL
-            .into_iter()
-            .map(|component| Channel::Production.identity(component))
+        let shipped: Vec<Identity> = Component::VARIANTS
+            .iter()
+            .map(|&component| Channel::Production.identity(component))
             .collect();
 
-        for component in Component::ALL {
+        for &component in Component::VARIANTS {
             let dev = Channel::Dev.identity(component);
             assert!(
                 shipped.iter().all(|other| other.bundle_id != dev.bundle_id),
@@ -268,9 +256,9 @@ mod tests {
 
     #[test]
     fn shipped_identities_are_distinct_per_component() {
-        let ids: Vec<String> = Component::ALL
-            .into_iter()
-            .map(|component| Channel::Production.identity(component).bundle_id)
+        let ids: Vec<String> = Component::VARIANTS
+            .iter()
+            .map(|&component| Channel::Production.identity(component).bundle_id)
             .collect();
         for (index, id) in ids.iter().enumerate() {
             assert!(

--- a/xtask/src/commands/macos/bundle/identity.rs
+++ b/xtask/src/commands/macos/bundle/identity.rs
@@ -230,6 +230,20 @@ mod tests {
         app
     }
 
+    /// `--channel`'s default is rendered through `Display` and then parsed back
+    /// by clap's value parser, so a name only one of the two knows would break
+    /// `macos bundle` the moment the flag is omitted.
+    #[test]
+    fn each_channel_renders_as_the_flag_value_it_parses_from() {
+        for channel in [Channel::Production, Channel::Dev] {
+            assert_eq!(
+                Channel::from_str(&channel.to_string(), false).ok(),
+                Some(channel),
+                "{channel} does not round-trip through the value parser"
+            );
+        }
+    }
+
     #[test]
     fn a_dev_bundle_can_never_collide_with_a_shipped_one() {
         let shipped: Vec<Identity> = Component::ALL

--- a/xtask/src/commands/macos/bundle/identity.rs
+++ b/xtask/src/commands/macos/bundle/identity.rs
@@ -1,0 +1,324 @@
+//! The macOS identity a bundle carries: `CFBundleIdentifier` plus the name
+//! macOS lists it under.
+//!
+//! macOS keys TCC grants (Accessibility, Input Monitoring) to a bundle's code
+//! identity, and `openlogi_core::paths` keys the config profile to that
+//! identifier's suffix. A shipped bundle wearing the dev identity therefore
+//! voids every existing permission grant *and* reads a different config
+//! directory — which is what releases 0.6.24–0.6.26 did, because the identity
+//! was a side effect of which command happened to produce the bundle.
+//!
+//! So it is never inferred: [`stamp`] writes the chosen [`Channel`]'s identity
+//! over every component, and [`verify`] reads it back before anything signs,
+//! packages or notarizes the result.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, bail};
+use clap::ValueEnum;
+
+use super::{read_plist_string, stamp_plist_strings};
+
+/// The app's production bundle identifier, also advertised by the update
+/// manifest so the running app and the manifest cannot disagree.
+pub(crate) const APP_BUNDLE_ID: &str = "org.openlogi.openlogi";
+
+/// The icon every component shares, as `CFBundleIconFile` spells it (the `.icns`
+/// extension is optional there, so it is trimmed before comparing).
+const ICON_STEM: &str = "AppIcon";
+
+/// Which identity family a bundle carries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum Channel {
+    /// What ships. Users' permission grants and config directory are keyed to it.
+    Production,
+    /// Local builds. Both the identifier and the name are suffixed, so a local
+    /// bundle can never claim a shipped grant and System Settings shows which
+    /// of the two installed copies a row belongs to.
+    Dev,
+}
+
+impl fmt::Display for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Production => "production",
+            Self::Dev => "dev",
+        })
+    }
+}
+
+/// A bundle whose identity xtask owns: the app plus each nested login-item
+/// helper it embeds.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Component {
+    /// `OpenLogi.app` itself.
+    App,
+    /// The always-on agent: the process that owns the hook and holds the
+    /// Accessibility grant.
+    Agent,
+    /// The Actions Ring renderer.
+    Overlay,
+}
+
+impl Component {
+    /// Every component a finished bundle contains.
+    pub(crate) const ALL: [Self; 3] = [Self::App, Self::Agent, Self::Overlay];
+
+    /// Where this component lives inside the app bundle; `None` is the app itself.
+    pub(super) fn nested_bundle(self) -> Option<&'static str> {
+        match self {
+            Self::App => None,
+            Self::Agent => Some("Contents/Library/LoginItems/OpenLogiAgent.app"),
+            Self::Overlay => Some("Contents/Library/LoginItems/OpenLogiOverlay.app"),
+        }
+    }
+
+    /// This component's bundle root inside `app`.
+    pub(super) fn root(self, app: &Path) -> PathBuf {
+        self.nested_bundle()
+            .map_or_else(|| app.to_path_buf(), |nested| app.join(nested))
+    }
+
+    /// This component's `Info.plist`.
+    pub(super) fn info_plist(self, app: &Path) -> PathBuf {
+        self.root(app).join("Contents/Info.plist")
+    }
+
+    /// This component's copy of the shared app icon.
+    pub(super) fn icon(self, app: &Path) -> PathBuf {
+        self.root(app)
+            .join(format!("Contents/Resources/{ICON_STEM}.icns"))
+    }
+
+    /// The shipped identity — the one macOS ties existing grants to.
+    fn production(self) -> Identity {
+        let (bundle_id, name) = match self {
+            Self::App => (APP_BUNDLE_ID, "OpenLogi"),
+            Self::Agent => ("org.openlogi.agent", "OpenLogi Agent"),
+            Self::Overlay => ("org.openlogi.overlay", "OpenLogi Overlay"),
+        };
+        Identity {
+            bundle_id: bundle_id.to_owned(),
+            name: name.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for Component {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::App => "app",
+            Self::Agent => "agent helper",
+            Self::Overlay => "overlay helper",
+        })
+    }
+}
+
+/// What one component is called on one channel.
+pub(crate) struct Identity {
+    /// `CFBundleIdentifier` — what TCC and the config profile key off.
+    pub(crate) bundle_id: String,
+    /// `CFBundleName` / `CFBundleDisplayName` — what System Settings lists.
+    pub(crate) name: String,
+}
+
+impl Channel {
+    /// This channel's identity for `component`. The dev family is the shipped
+    /// one suffixed on both halves, so the two families cannot collide.
+    pub(crate) fn identity(self, component: Component) -> Identity {
+        let production = component.production();
+        match self {
+            Self::Production => production,
+            Self::Dev => Identity {
+                bundle_id: format!("{}.dev", production.bundle_id),
+                name: format!("{} Dev", production.name),
+            },
+        }
+    }
+}
+
+/// The `Info.plist` keys that carry the identity.
+fn identity_entries(identity: &Identity) -> [(&str, &str); 3] {
+    [
+        ("CFBundleIdentifier", identity.bundle_id.as_str()),
+        ("CFBundleName", identity.name.as_str()),
+        ("CFBundleDisplayName", identity.name.as_str()),
+    ]
+}
+
+/// Write `channel`'s identity over every component of the bundle at `app`.
+///
+/// Runs before codesigning, which seals the `Info.plist` it stamps.
+pub(crate) fn stamp(app: &Path, channel: Channel) -> Result<()> {
+    println!("==> bundle identity ({channel})");
+    for component in Component::ALL {
+        let identity = channel.identity(component);
+        stamp_plist_strings(&component.info_plist(app), &identity_entries(&identity))?;
+        println!(
+            "    {component}: {} ({})",
+            identity.bundle_id, identity.name
+        );
+    }
+    Ok(())
+}
+
+/// Read every component's identity back, failing unless it is `channel`'s.
+///
+/// This is the gate a distribution artifact passes before it is signed or
+/// packaged, so a bundle built for local use can never be shipped by mistake.
+pub(crate) fn verify(app: &Path, channel: Channel) -> Result<()> {
+    for component in Component::ALL {
+        let expected = channel.identity(component);
+        let plist = component.info_plist(app);
+        for (key, want) in identity_entries(&expected) {
+            let found = read_plist_string(&plist, key)?;
+            if found.as_deref() != Some(want) {
+                bail!(
+                    "{component}: {key} is {found:?}, expected {want:?} on the {channel} channel ({})",
+                    plist.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Fail unless every component ships the shared app icon *and* declares it, so
+/// no surface that lists OpenLogi's processes — System Settings' privacy panes,
+/// Login Items — shows a blank icon for one of them.
+pub(crate) fn verify_icons(app: &Path) -> Result<()> {
+    for component in Component::ALL {
+        let icon = component.icon(app);
+        if !icon.is_file() {
+            bail!(
+                "{component}: missing the shared app icon at {}",
+                icon.display()
+            );
+        }
+        let plist = component.info_plist(app);
+        let declared = read_plist_string(&plist, "CFBundleIconFile")?;
+        if declared
+            .as_deref()
+            .map(|file| file.trim_end_matches(".icns"))
+            != Some(ICON_STEM)
+        {
+            bail!(
+                "{component}: CFBundleIconFile is {declared:?}, expected {ICON_STEM:?} ({})",
+                plist.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
+mod tests {
+    use super::*;
+
+    /// A bundle skeleton with an empty `Info.plist` per component.
+    fn bundle() -> tempfile::TempDir {
+        let app = tempfile::tempdir().unwrap();
+        for component in Component::ALL {
+            let plist = component.info_plist(app.path());
+            fs_err::create_dir_all(plist.parent().unwrap()).unwrap();
+            plist::Value::Dictionary(plist::Dictionary::new())
+                .to_file_xml(plist)
+                .unwrap();
+        }
+        app
+    }
+
+    #[test]
+    fn a_dev_bundle_can_never_collide_with_a_shipped_one() {
+        let shipped: Vec<Identity> = Component::ALL
+            .into_iter()
+            .map(|component| Channel::Production.identity(component))
+            .collect();
+
+        for component in Component::ALL {
+            let dev = Channel::Dev.identity(component);
+            assert!(
+                shipped.iter().all(|other| other.bundle_id != dev.bundle_id),
+                "dev {component} id {} collides with a shipped identity",
+                dev.bundle_id
+            );
+            assert!(
+                shipped.iter().all(|other| other.name != dev.name),
+                "dev {component} name {} collides with a shipped identity",
+                dev.name
+            );
+        }
+    }
+
+    #[test]
+    fn shipped_identities_are_distinct_per_component() {
+        let ids: Vec<String> = Component::ALL
+            .into_iter()
+            .map(|component| Channel::Production.identity(component).bundle_id)
+            .collect();
+        for (index, id) in ids.iter().enumerate() {
+            assert!(
+                !ids[index + 1..].contains(id),
+                "{id} is claimed by two components"
+            );
+        }
+    }
+
+    #[test]
+    fn stamping_a_channel_makes_it_verify() {
+        for channel in [Channel::Production, Channel::Dev] {
+            let app = bundle();
+
+            stamp(app.path(), channel).unwrap();
+
+            verify(app.path(), channel).unwrap();
+        }
+    }
+
+    #[test]
+    fn a_dev_bundle_fails_production_verification() {
+        let app = bundle();
+        stamp(app.path(), Channel::Dev).unwrap();
+
+        let error = verify(app.path(), Channel::Production)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("org.openlogi.openlogi.dev") && error.contains("production"),
+            "the error must name the dev identity it found and the channel it wanted, got: {error}"
+        );
+    }
+
+    #[test]
+    fn a_shipped_bundle_fails_dev_verification() {
+        let app = bundle();
+        stamp(app.path(), Channel::Production).unwrap();
+
+        let error = verify(app.path(), Channel::Dev).unwrap_err().to_string();
+
+        assert!(error.contains("dev"), "got: {error}");
+    }
+
+    #[test]
+    fn verify_rejects_a_bundle_with_no_identity_at_all() {
+        let app = bundle();
+
+        assert!(verify(app.path(), Channel::Production).is_err());
+    }
+
+    #[test]
+    fn missing_icons_are_reported_per_component() {
+        let app = bundle();
+        stamp(app.path(), Channel::Production).unwrap();
+
+        let error = verify_icons(app.path()).unwrap_err().to_string();
+
+        assert!(
+            error.contains("missing the shared app icon"),
+            "got: {error}"
+        );
+    }
+}

--- a/xtask/src/commands/macos/dmg.rs
+++ b/xtask/src/commands/macos/dmg.rs
@@ -4,6 +4,7 @@ use anyhow::{Context as _, Result};
 use clap::Parser;
 use xshell::{Shell, cmd};
 
+use super::bundle::identity::{self, Channel};
 use crate::support::fs::{absolutize, ensure_command, ensure_dir, repo_root};
 
 #[derive(Parser)]
@@ -33,6 +34,14 @@ pub(crate) fn run(args: &Args) -> Result<()> {
     let app = absolutize(&root, &args.app);
     let output = absolutize(&root, &args.output);
     ensure_dir(&app)?;
+    // Signing makes this DMG a distribution artifact, so the bundle inside it
+    // must wear the shipped identity no matter which command built it. A dev
+    // bundle that reached users would void their permission grants and move
+    // them to a different config directory.
+    if args.sign_identity.is_some() {
+        identity::verify(&app, Channel::Production)
+            .context("a signed DMG must contain a production-identity app bundle")?;
+    }
     ensure_command("create-dmg")?;
 
     println!("==> dmg background");

--- a/xtask/src/commands/release/latest_json.rs
+++ b/xtask/src/commands/release/latest_json.rs
@@ -7,7 +7,10 @@ use serde::Serialize;
 use sha2_hasher::Sha2Hasher;
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-const APP_ID: &str = "org.openlogi.openlogi";
+// The manifest advertises the identity the shipped bundle is stamped with, so
+// both come from one constant.
+use crate::commands::macos::bundle::identity::APP_BUNDLE_ID;
+
 const CHANNEL: &str = "stable";
 const MACOS_MINIMUM_OS_VERSION: &str = "13.0";
 /// Windows 10+. Informational — the client updater doesn't gate on it today,
@@ -91,7 +94,7 @@ pub(crate) fn run(args: &Args) -> Result<()> {
 
     let manifest = Manifest {
         schema_version: 1,
-        app_id: APP_ID,
+        app_id: APP_BUNDLE_ID,
         version,
         tag: args.tag.clone(),
         channel: CHANNEL,


### PR DESCRIPTION
## Summary

Releases **0.6.24, 0.6.25 and 0.6.26 shipped with the dev bundle identifiers** — `org.openlogi.openlogi.dev`, `org.openlogi.agent.dev` — and display names "OpenLogi Dev" / "OpenLogi Agent Dev". Verified against the published DMGs:

| release | app | agent helper |
|---|---|---|
| v0.6.23 | `org.openlogi.openlogi` | `org.openlogi.agent` |
| v0.6.24 | `org.openlogi.openlogi.dev` | `org.openlogi.agent.dev` |
| v0.6.27 | `org.openlogi.openlogi` | `org.openlogi.agent` |

macOS keys TCC grants to a bundle's code identity, and `openlogi_core::paths` keys the config profile to the identifier's suffix, so upgrading users lost every Accessibility / Input Monitoring grant (System Settings still showed the old row switched on) and were silently moved to `~/.config/openlogi-dev`.

The cause: #344 made `macos bundle` rewrite the Info.plists for local use, the release workflow called exactly that command, and nothing checked the identity before the bundle was signed and notarized. #528 pointed the workflow at `macos package`, which is why v0.6.27 is correct again — but the footgun is still loaded: any `macos bundle` + sign sequence ships dev identifiers.

This makes the identity explicit and verified instead of a side effect of which command ran.

## Changes

**`xtask`**
- New `macos/bundle/identity.rs`: a `Channel` (production / dev) × `Component` (app, agent helper, overlay helper) identity table. The dev family is the shipped one suffixed on both halves, so the two can never collide.
- `identity::stamp` writes the identifier and both name keys for every component; `identity::verify` reads them back. Both run on every build, before signing — a signature seals the `Info.plist` it stamps.
- `macos dmg` refuses to package a non-production bundle once it is given a signing identity, so a dev build cannot reach users regardless of what produced it.
- `macos bundle` takes `--channel dev|production`, still defaulting to dev so a local build cannot claim the installed app's grants.
- Helper embedding is one table-driven path. Both helpers now get the shared app icon — the overlay shipped without one and appeared blank wherever macOS lists it — and each is built by `--bin`, so a release build no longer also compiles the agent's mock binary.
- The update manifest's `app_id` now comes from the same constant the bundle is stamped with.

**`crates/openlogi-gui`**
- The overlay helper's release `Info.plist` declares `CFBundleIconFile`.

**CI**
- The artifact-level identity check also asserts the display names and the presence of each icon. It is deliberate redundancy on top of xtask's own verification.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace            # 18 xtask tests, all green
```

New regression tests, each confirmed to fail when the defect is reintroduced (checked by mutation, not just by passing):

- `a_dev_bundle_fails_production_verification` / `a_shipped_bundle_fails_dev_verification` — the exact shape of the shipped regression.
- `a_dev_bundle_can_never_collide_with_a_shipped_one` — fails if the dev family stops being suffixed.
- `shipped_helper_plists_declare_their_production_identity` — pins the checked-in helper plists to the table, so a rename cannot reach the bundle without reaching the verification.
- `shipped_helper_plists_declare_the_shared_icon` — fails when the overlay's `CFBundleIconFile` is removed.
- `every_helper_binary_is_a_required_bundle_binary`, `stamping_a_channel_makes_it_verify`, `missing_icons_are_reported_per_component`.

Not run locally: a full `macos package` (the signed DMG path) — the PR installer build is the check for that.