### PR TITLE
refactor(macos): read TCC permissions through typed objc2 bindings

### DIFF
--- a/.claude/rules/hook.md
+++ b/.claude/rules/hook.md
@@ -8,8 +8,10 @@ paths:
 - macOS: the CGEventTap freeze-hazard state machine is load-bearing. The tap must
   self-disable when Accessibility is revoked, on its own thread, with the bounded
   run-loop slice — a stopped watcher after grant once froze all input on the machine.
-  Don't restructure it casually, and don't migrate the tap to `objc2-core-graphics`
-  (the `NSWorkspace` read is the only part that moved to `objc2`).
+  Don't restructure it casually, and don't migrate the tap to `objc2-core-graphics`.
+  The `NSWorkspace` read and the Accessibility-trust check/prompt are the parts that
+  did move to the objc2 framework crates — see `platform/AGENTS.md` for the rule that
+  every TCC call uses a typed binding rather than a hand-written `extern` block.
 - The tap callback must never block and never panic: use `try_read`/`try_lock` only,
   queue bound actions off-thread, wrap the user callback in `catch_unwind`, and keep
   the stuck-callback watchdog that force-exits the agent if the budget is exceeded.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4723,6 +4723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-application-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69282c2b5bc58fba07cb9de2113619532eb551e98efe3d8d695509ef45fbd53b"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5167,6 +5177,7 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
+ "objc2-io-kit",
  "opener",
  "openlogi-agent-core",
  "openlogi-assets",
@@ -5242,6 +5253,8 @@ dependencies = [
  "libc",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-application-services",
+ "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "openlogi-core",
  "openlogi-inject",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,18 @@ core-foundation = { version = "0.10", default-features = false, features = ["lin
 opener = "0.8.5"
 shellexpand = "3.1.2"
 evdev = "0.13"
-# macOS ObjC FFI (see platform/CLAUDE.md): objc2 gives leak-proof Retained<T>
-# bindings. Feature lists are selected per crate; the version stays unified so
-# a resolve can't move gpui's Cargo.lock pin out from under the GUI.
+# macOS ObjC / C FFI (see platform/CLAUDE.md): objc2 gives leak-proof Retained<T>
+# bindings, and the framework crates give typed bindings for the C APIs (privacy
+# permissions included) instead of hand-written `#[link] extern "C"` blocks.
+# Feature lists are selected per crate — these crates are huge, so every entry is
+# `default-features = false`. The version stays unified so a resolve can't move
+# gpui's Cargo.lock pin out from under the GUI.
 objc2 = "0.6.4"
 objc2-app-kit = "0.3.2"
 objc2-foundation = "0.3.2"
+objc2-core-foundation = { version = "0.3.2", default-features = false }
+objc2-application-services = { version = "0.3.2", default-features = false }
+objc2-io-kit = { version = "0.3.2", default-features = false }
 # The block ABI crate objc2's generated bindings use for handler arguments;
 # same unified-version rationale as the objc2 crates above.
 block2 = "0.6.2"

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -70,6 +70,9 @@ core-graphics = { workspace = true }
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSAppearance", "NSWindow", "NSEvent", "block2"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSProcessInfo"] }
+# Input-Monitoring status (`IOHIDCheckAccess`) with typed request/access enums —
+# see platform/permissions.rs.
+objc2-io-kit = { workspace = true, features = ["std", "hidsystem"] }
 # NSEvent global-monitor handlers are ObjC blocks (overlay click-away dismissal).
 block2 = { workspace = true }
 

--- a/crates/openlogi-gui/src/platform/AGENTS.md
+++ b/crates/openlogi-gui/src/platform/AGENTS.md
@@ -7,8 +7,11 @@ FFI is exactly these files — keep them in sync:
 
 - `status_item.rs` — safe `objc2` wrappers over `NSStatusItem` / `NSMenu` / `NSMenuItem`.
 - `tray.rs` — the OpenLogi menu-bar semantics + the `OpenLogiMenuTarget` (`define_class!`).
-- `permissions.rs` — `CBCentralManager.authorization` (`objc2` class lookup) + `IOHIDCheckAccess` (C FFI).
-- `crates/openlogi-hook/src/macos.rs` — CGEventTap (on `core-graphics`, see below) + the `NSWorkspace` frontmost-app read (`objc2`).
+- `permissions.rs` — `CBCentralManager.authorization` (`objc2` class lookup) + `IOHIDCheckAccess`
+  (`objc2-io-kit`).
+- `crates/openlogi-hook/src/macos.rs` — CGEventTap (on `core-graphics`, see below), the
+  `NSWorkspace` frontmost-app read (`objc2`), and the Accessibility-trust check/prompt
+  (`objc2-application-services` + `objc2-core-foundation`).
 
 Spawning the agent under its own macOS TCC identity (so its Accessibility /
 Input-Monitoring grants aren't attributed to the GUI, issue #214) lives in the
@@ -49,6 +52,50 @@ That is *why* this code can't reproduce issue #99 (a `+1` `NSString` leaked on e
   `NSThread.isMainThread` + `dispatch2` runtime-check idiom here — we use the compile-time
   `MainThreadMarker` guarantee.
 
+## Privacy permissions (TCC): typed framework crates, never a hand-rolled `extern`
+
+There is no general TCC API, and no crate that wraps one: Apple ships no public way to
+enumerate or request TCC state generically, and `TCC.db` is SIP-protected (reading it needs
+Full Disk Access). Every permission is its own framework call, so "the TCC layer" is just
+this table:
+
+| Permission | Crate | Symbol |
+|---|---|---|
+| Accessibility | `objc2-application-services` (`HIServices` + `AXUIElement`) | `AXIsProcessTrusted` / `AXIsProcessTrustedWithOptions` |
+| Input Monitoring / Post Event | `objc2-io-kit` (`hidsystem`) | `IOHIDCheckAccess` / `IOHIDRequestAccess` |
+| Bluetooth | `objc2` class lookup (see below) | `+[CBManager authorization]` |
+| Camera / microphone | `openlogi-camera` (`capture.rs`) | `+[AVCaptureDevice authorizationStatusForMediaType:]` |
+| Screen Recording (unused) | `objc2-core-graphics` | `CGPreflightScreenCaptureAccess` |
+| Full Disk Access (unused) | — | no API; only a probe of a protected path |
+
+Rules:
+
+- **Never re-declare these in a `#[link(name = "…", kind = "framework")] extern "C"` block**
+  and never hardcode their discriminants. The generated bindings are typed
+  (`IOHIDRequestType::ListenEvent`, `IOHIDAccessType::Granted`), which is the workspace rule
+  about wire values in another guise — a bare `IOHIDCheckAccess(1) == 0` says nothing.
+  `IOHIDCheckAccess` is a *safe* fn in `objc2-io-kit`; the AX pair is `unsafe` only because
+  the options dictionary is untyped.
+- Add these crates with `cargo add … --no-default-features --features <modules>` (they are
+  huge and gated per C header), then declare the version once in the workspace table with
+  `default-features = false` and pick features per crate. **Umbrella-feature trap:** a leaf
+  feature is not enough — `AXUIElement` also needs `HIServices`, or the symbols silently
+  don't exist.
+- **Checking never prompts; prompting belongs to whoever owns the resource.** The agent
+  raises the Accessibility prompt (it owns the tap) and opens HID; the GUI only reads status
+  and deep-links to System Settings (`open_pane`). Don't call `IOHIDRequestAccess` or the
+  `kAXTrustedCheckOptionPrompt` variant from the GUI — the grant would land on the wrong
+  code-signing identity (issue #214, see `disclaim`).
+- `CBCentralManager.authorization` deliberately stays an `AnyClass::get` + `msg_send!` lookup
+  rather than `objc2-core-bluetooth`: a missing class must degrade to `Unknown`, not panic.
+- Deliberate raw-FFI exceptions, all of them symbols with no bindings to migrate to:
+  `CGEventCopyIOHIDEvent` / `IOHIDEventGetSenderID` (undocumented, in the hook) and
+  `responsibility_spawnattrs_setdisclaim` (private SPI, in the `disclaim` crate).
+- Not migrated yet, don't copy the pattern: `openlogi-inject`'s `ax_nav` block (raw
+  `AXUIElement` navigation + manual `CFRetain`/`CFRelease`) and `openlogi-camera`'s
+  `AVAuthorizationStatus` integers — both have typed homes (`objc2-application-services`,
+  `objc2-av-foundation`) whenever someone touches them next.
+
 ## The `unsafe` that remains (and the `# SAFETY` rule)
 
 `objc2` marks only a few calls `unsafe`; each `unsafe` block does one operation with a
@@ -58,7 +105,9 @@ That is *why* this code can't reproduce issue #99 (a `+1` `NSString` leaked on e
   *weak* reference, so the tray retains `MenuTarget` for the app's lifetime).
 - `msg_send![super(this), init]` in `MenuTarget::new`.
 - `NSString::to_str(pool)` in the hook (borrow tied to the pool).
-- the hook's accessibility C FFI + the `CBCentralManager` class-method send.
+- the hook's `AXIsProcessTrusted[WithOptions]` calls and the two extern statics they need
+  (`kAXTrustedCheckOptionPrompt`, `kCFBooleanTrue`), plus the `CBCentralManager`
+  class-method send. `IOHIDCheckAccess` needs none — `objc2-io-kit` exposes it as safe.
 
 `status_item.rs`/`tray.rs` opt into `#[expect(unsafe_code)]` locally; `unsafe_code` stays
 `deny` for the gui crate otherwise.
@@ -86,6 +135,12 @@ pool belongs. (`openlogi-core`'s `post_media_key` follows the same pattern for m
 crates, then **verify the `zed`/`gpui-component` git pins in `Cargo.lock` didn't move** (the
 gpui pin is held only by the lock; a resolve can bump it — restore with `cargo update -p gpui
 --precise <commit>`).
+
+Every objc2 framework crate is declared once in the workspace table (`objc2-app-kit`,
+`objc2-foundation`, `objc2-core-foundation`, `objc2-application-services`, `objc2-io-kit`)
+with `default-features = false`, and each member picks only the feature modules it uses. A
+new one belongs in that table too, not inline in a member manifest — the unified version is
+what keeps a resolve from dragging the gpui pin along.
 
 ## Build & verify
 

--- a/crates/openlogi-gui/src/platform/permissions.rs
+++ b/crates/openlogi-gui/src/platform/permissions.rs
@@ -175,21 +175,14 @@ pub fn request_camera_access(_cx: &mut gpui::App) {}
 mod macos {
     #![expect(
         unsafe_code,
-        reason = "IOKit (IOHIDCheckAccess) + CoreBluetooth privacy-permission FFI"
+        reason = "CoreBluetooth force-link + `+[CBManager authorization]` class-method send"
     )]
 
     use objc2::msg_send;
     use objc2::runtime::AnyClass;
+    use objc2_io_kit::{IOHIDAccessType, IOHIDCheckAccess, IOHIDRequestType};
 
     use super::PermissionStatus;
-
-    // Query the current HID access without prompting. `IOHIDRequestType`:
-    // PostEvent = 0, ListenEvent = 1. Returned `IOHIDAccessType`: Granted = 0,
-    // Denied = 1, Unknown = 2.
-    #[link(name = "IOKit", kind = "framework")]
-    unsafe extern "C" {
-        fn IOHIDCheckAccess(request_type: u32) -> u32;
-    }
 
     // Force-link CoreBluetooth so the `CBCentralManager` class is normally
     // registered for the `Class::get` lookup in `bluetooth()` (which degrades
@@ -197,14 +190,13 @@ mod macos {
     #[link(name = "CoreBluetooth", kind = "framework")]
     unsafe extern "C" {}
 
-    const REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
-
     pub(super) fn input_monitoring() -> PermissionStatus {
-        // SAFETY: `IOHIDCheckAccess` is a side-effect-free query taking a valid
-        // `IOHIDRequestType` discriminant.
-        match unsafe { IOHIDCheckAccess(REQUEST_TYPE_LISTEN_EVENT) } {
-            0 => PermissionStatus::Granted,
-            1 => PermissionStatus::Denied,
+        // `IOHIDCheckAccess` queries the current HID access without prompting;
+        // `IOHIDRequestAccess` is the prompting variant we deliberately don't
+        // call here (the agent owns HID I/O, so it must raise the prompt).
+        match IOHIDCheckAccess(IOHIDRequestType::ListenEvent) {
+            IOHIDAccessType::Granted => PermissionStatus::Granted,
+            IOHIDAccessType::Denied => PermissionStatus::Denied,
             _ => PermissionStatus::Unknown,
         }
     }

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -36,6 +36,11 @@ foreign-types-shared = "0.3"
 objc2 = { workspace = true }
 objc2-foundation = { workspace = true, features = ["NSString"] }
 objc2-app-kit = { workspace = true, features = ["NSWorkspace", "NSRunningApplication"] }
+# Accessibility-trust query + prompt (`AXIsProcessTrusted[WithOptions]`) and the
+# `kAXTrustedCheckOptionPrompt` dictionary it takes — typed, so no hand-written
+# ApplicationServices `extern` block.
+objc2-application-services = { workspace = true, features = ["std", "HIServices", "AXUIElement"] }
+objc2-core-foundation = { workspace = true, features = ["std", "CFDictionary", "CFNumber"] }
 
 # WH_MOUSE_LL low-level mouse hook + foreground-process path (GetForegroundWindow
 # / QueryFullProcessImageNameW).

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -22,6 +22,7 @@ use core_graphics::event::{
 };
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use foreign_types_shared::ForeignType as _;
+use objc2_application_services::{AXIsProcessTrusted, AXIsProcessTrustedWithOptions};
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -51,16 +52,6 @@ pub(crate) struct HookInner {
 // documentation states that CFRunLoop objects can be passed between
 // threads; only CFRunLoopRun must be called on the owning thread.
 unsafe impl Send for HookInner {}
-
-// Raw FFI for `AXIsProcessTrustedWithOptions` from the Accessibility
-// framework. Passing `NULL` queries trust state without prompting; passing
-// a dictionary with `kAXTrustedCheckOptionPrompt = true` raises the system
-// permission dialog and registers the process in the Accessibility list.
-#[link(name = "ApplicationServices", kind = "framework")]
-unsafe extern "C" {
-    fn AXIsProcessTrustedWithOptions(options: *const std::ffi::c_void) -> bool;
-    static kAXTrustedCheckOptionPrompt: core_foundation::string::CFStringRef;
-}
 
 /// Opaque `IOHIDEventRef` — the HID event backing a `CGEvent`.
 type IOHIDEventRef = *mut std::ffi::c_void;
@@ -210,29 +201,30 @@ fn sender_device_info(sender_id: u64) -> SenderDeviceInfo {
 
 /// Check whether this process has been granted Accessibility access.
 pub(crate) fn has_accessibility() -> bool {
-    // SAFETY: NULL is documented as a valid argument; it queries the current
-    // trust state without raising a permission dialog.
-    unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) }
+    // SAFETY: takes no arguments and only reads the current trust state — the
+    // non-prompting counterpart of `AXIsProcessTrustedWithOptions`.
+    unsafe { AXIsProcessTrusted() }
 }
 
 /// Raise the Accessibility prompt + register the process. See
 /// [`super::Hook::prompt_accessibility`].
+///
+/// The `kAXTrustedCheckOptionPrompt = true` option is what makes macOS surface
+/// the dialog and list the process in System Settings; without it this is just
+/// [`has_accessibility`].
 pub(crate) fn prompt_accessibility() {
-    use core_foundation::base::TCFType as _;
-    use core_foundation::boolean::CFBoolean;
-    use core_foundation::dictionary::CFDictionary;
-    use core_foundation::string::CFString;
+    use objc2_application_services::kAXTrustedCheckOptionPrompt;
+    use objc2_core_foundation::{CFDictionary, kCFBooleanTrue};
 
-    // SAFETY: `kAXTrustedCheckOptionPrompt` is a framework-provided
-    // `CFStringRef` constant; wrapping under the get rule borrows it
-    // without taking ownership.
-    let key = unsafe { CFString::wrap_under_get_rule(kAXTrustedCheckOptionPrompt) };
-    let options =
-        CFDictionary::from_CFType_pairs(&[(key.as_CFType(), CFBoolean::true_value().as_CFType())]);
-    // SAFETY: `options` is a valid `CFDictionaryRef` for the lifetime of
-    // the call; the function reads it and (if untrusted) shows the dialog.
-    // The returned trust state is observed separately via the watcher.
-    let _trusted = unsafe { AXIsProcessTrustedWithOptions(options.as_concrete_TypeRef().cast()) };
+    // SAFETY: both are framework-provided constants, live for the process
+    // lifetime; reading them copies a `&'static` reference.
+    let (key, value) = unsafe { (kAXTrustedCheckOptionPrompt, kCFBooleanTrue) };
+    let Some(value) = value else { return };
+    let options = CFDictionary::from_slices(&[key], &[value]);
+    // SAFETY: the dictionary holds exactly the documented key/value types
+    // (`kAXTrustedCheckOptionPrompt` → `CFBoolean`). The returned trust state is
+    // observed separately via the watcher, so it is deliberately dropped here.
+    let _trusted = unsafe { AXIsProcessTrustedWithOptions(Some(options.as_opaque())) };
 }
 
 /// Read the frontmost application's bundle identifier via `NSWorkspace`.


### PR DESCRIPTION
## Summary

Both macOS privacy-permission checks were hand-written FFI: the GUI declared
`IOHIDCheckAccess` in a `#[link(name = "IOKit")] extern "C"` block and compared raw
`0`/`1`/`2`, and the hook declared `AXIsProcessTrustedWithOptions` plus the
`kAXTrustedCheckOptionPrompt` `CFStringRef` static, passing the options dictionary as a
cast `*const c_void`. Both APIs already have generated bindings in the objc2 framework
crates, which type exactly the values we were open-coding.

There is no general TCC API — Apple exposes no way to enumerate or request TCC state
generically, and `TCC.db` is SIP-protected — so "the TCC layer" is per-permission calls.
That is now written down as a rule instead of being rediscovered per site.

## Changes

**`openlogi-gui`**
- `platform/permissions.rs`: `IOHIDCheckAccess(IOHIDRequestType::ListenEvent)` matched
  against `IOHIDAccessType::Granted` / `Denied` via `objc2-io-kit`. It is a safe fn there,
  so the module's `#[expect(unsafe_code)]` now covers only the CoreBluetooth force-link and
  the `+[CBManager authorization]` send.
- `platform/AGENTS.md`: new "Privacy permissions (TCC)" section — permission → crate/symbol
  table, the ban on re-declaring these symbols or hardcoding their discriminants, the
  workspace-table + `--no-default-features` convention, the umbrella-feature trap
  (`AXUIElement` resolves to nothing without `HIServices`), and "checking never prompts;
  prompting belongs to the process that owns the resource" (#214). Also names what stays raw
  on purpose (undocumented symbols with no bindings) and what is merely un-migrated, so
  neither reads as precedent.

**`openlogi-hook`**
- `macos.rs`: `AXIsProcessTrusted()` for the check and
  `AXIsProcessTrustedWithOptions(Some(options.as_opaque()))` for the prompt, with the options
  dictionary built by `CFDictionary::from_slices` — no `extern` block, no pointer casts.

**Workspace**
- `objc2-core-foundation`, `objc2-application-services`, `objc2-io-kit` declared once in the
  workspace table with `default-features = false`; members pick feature modules. The
  `zed`/`gpui-component` git pins in `Cargo.lock` are unchanged.
- `.claude/rules/hook.md`: the "only `NSWorkspace` moved to objc2" note was stale.

## Testing

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace                      # 863 passed, 0 failed
cargo run -p openlogi-hook --example accessibility_watch
```

The example exercises the migrated Accessibility path in a real process and reports
`currently granted: true`, matching the pre-migration behaviour for a trusted parent.

Not runtime-tested on hardware, and two paths are not runtime-verified: the Settings
window's Input Monitoring row (the typed constants map 1:1 onto the previous `0`/`1`/`2`
per the generated bindings, but the pane was not opened in a running app) and the
`kAXTrustedCheckOptionPrompt` dialog, which needs an untrusted process plus user
interaction.
