### PR TITLE
fix(hid): four defects from the Actions Ring review

### DIFF
--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -524,6 +524,12 @@ async fn arm_reprog_control(
         .get_cid_reporting(cid)
         .await
         .map_err(|error| GestureError::Hidpp(format!("{error:?}")))?;
+    if original.diverted {
+        // Left over from a session that never tore down (agent killed, or
+        // another Logitech app). Worth a line: it is the state that used to be
+        // replayed on restore, leaving the button dead.
+        debug!(cid, "control was already diverted before arming");
+    }
     let mut change = reprog_controls::CidReportingChange::temporary_diversion(true, raw_xy);
     change.remap = original.remap;
     if let Err(error) = rc.set_cid_reporting_full(cid, change).await {
@@ -534,23 +540,28 @@ async fn arm_reprog_control(
     Ok(ArmedCid { cid, original })
 }
 
-fn reporting_change(
+/// The mirror image of arming: clear the diversion this session turned on and
+/// hand the control's remap target back untouched.
+///
+/// Deliberately *not* a verbatim replay of the snapshot. A control can already
+/// be diverted when the session arms it — the agent was killed mid-session, or
+/// Logi Options+ left its own diversion behind — and replaying that snapshot
+/// hands the button back diverted with nothing listening for its HID++ events
+/// and no OS event either: dead until the device sleeps or reconnects, since
+/// diversion is volatile. Arming only ever sets `diverted` / `raw_xy` (plus
+/// re-asserting `remap`), so undoing exactly those fields is the whole job;
+/// every other bit stays `None`, i.e. unchanged.
+fn undivert_change(
     reporting: reprog_controls::CidReporting,
 ) -> reprog_controls::CidReportingChange {
-    reprog_controls::CidReportingChange {
-        diverted: Some(reporting.diverted),
-        persistently_diverted: Some(reporting.persistently_diverted),
-        force_raw_xy: Some(reporting.force_raw_xy),
-        raw_xy: Some(reporting.raw_xy),
-        remap: reporting.remap,
-        analytics_key_events: Some(reporting.analytics_key_events),
-        raw_wheel: Some(reporting.raw_wheel),
-    }
+    let mut change = reprog_controls::CidReportingChange::temporary_diversion(false, false);
+    change.remap = reporting.remap;
+    change
 }
 
 async fn restore_reporting(rc: &ReprogControlsV4, armed: ArmedCid, what: &str) {
     let result = rc
-        .set_cid_reporting_full(armed.cid, reporting_change(armed.original))
+        .set_cid_reporting_full(armed.cid, undivert_change(armed.original))
         .await
         .map(|_| ());
     restore(result, what);

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -7,32 +7,48 @@ const BOTH: &[u16] = &[
     reprog_controls::HAPTIC_PANEL_CID,
 ];
 
-#[test]
-fn reporting_restore_preserves_every_mutable_field() {
-    let remap = reprog_controls::ControlId(0x0053);
-    let original = reprog_controls::CidReporting {
+fn reporting(
+    diverted: bool,
+    remap: Option<reprog_controls::ControlId>,
+) -> reprog_controls::CidReporting {
+    reprog_controls::CidReporting {
         cid: reprog_controls::ControlId(reprog_controls::GESTURE_BUTTON_CID),
-        diverted: true,
+        diverted,
         persistently_diverted: true,
         force_raw_xy: true,
-        raw_xy: false,
-        remap: Some(remap),
+        raw_xy: true,
+        remap,
         analytics_key_events: true,
         raw_wheel: true,
-    };
+    }
+}
 
-    assert_eq!(
-        reporting_change(original),
-        reprog_controls::CidReportingChange {
-            diverted: Some(true),
-            persistently_diverted: Some(true),
-            force_raw_xy: Some(true),
-            raw_xy: Some(false),
-            remap: Some(remap),
-            analytics_key_events: Some(true),
-            raw_wheel: Some(true),
-        }
-    );
+/// A control that was *already* diverted when the session armed it — an agent
+/// killed mid-session, or another Logitech app — must not be handed that state
+/// back. Replaying it leaves the button diverted with no listener: no OS event
+/// and no HID++ consumer, dead until the device sleeps.
+#[test]
+fn restore_clears_a_diversion_it_found_already_set() {
+    let change = undivert_change(reporting(true, None));
+
+    assert_eq!(change.diverted, Some(false));
+    assert_eq!(change.raw_xy, Some(false));
+}
+
+/// Arming only ever writes `diverted` / `raw_xy` and re-asserts `remap`, so
+/// restoring must leave every other bit alone rather than writing back a
+/// snapshot that may itself be this session's leftovers.
+#[test]
+fn restore_returns_the_remap_target_and_touches_nothing_else() {
+    let remap = reprog_controls::ControlId(0x0053);
+
+    let change = undivert_change(reporting(false, Some(remap)));
+
+    assert_eq!(change.remap, Some(remap));
+    assert_eq!(change.persistently_diverted, None);
+    assert_eq!(change.force_raw_xy, None);
+    assert_eq!(change.analytics_key_events, None);
+    assert_eq!(change.raw_wheel, None);
 }
 
 fn press() -> RawControlEvent {

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -582,7 +582,6 @@ impl Enumerator {
         let mut all_complete = true;
         let mut all_healthy = true;
         for (node, channel, result, budget, receiver) in results {
-            let mut budget_timeout = false;
             let probe = if let Ok(probe) = result {
                 probe
             } else {
@@ -592,22 +591,26 @@ impl Enumerator {
                 // check", not "nothing there".
                 warn!(
                     ?budget,
-                    "device probe timed out — treating as a failed probe"
+                    receiver, "device probe timed out — treating as a failed probe"
                 );
-                budget_timeout = true;
                 NodeProbe::failed()
             };
             all_complete &= probe.complete;
             all_healthy &= probe.healthy;
             outcomes.extend(probe.outcomes);
             let settled = self.ledger.settle(&node, probe.healthy, probe.inventory);
-            // A full-budget timeout on a receiver is the dead-delivery
-            // signature — such a channel never recovers on its own, so don't
-            // wait for the ledger's consecutive-failure threshold to replace
-            // it. A direct (especially Bluetooth) device that burns its budget
-            // may simply be asleep: keep the ledger's replay grace and
-            // two-strike policy for those.
-            if settled.evict_channel || (budget_timeout && receiver) {
+            // Every node waits for the ledger's consecutive-failure threshold,
+            // receivers included. One full-budget timeout is not evidence of
+            // dead delivery: [`RECEIVER_PROBE_BUDGET`] leaves barely a second
+            // over its own documented worst case, so a legitimate deep walk
+            // plus a single lost reply (5 s `SEND_RESPONSE_TIMEOUT`) already
+            // exceeds it. Evicting on that unpublishes *every* device behind
+            // the receiver — a Bolt publishes all six slots under one node —
+            // and tears down each one's capture plan. A channel whose delivery
+            // really is dead times out again on the next tick and is replaced
+            // then, with the ledger replaying its last-good inventory
+            // meanwhile, so nothing disappears from the GUI in between.
+            if settled.evict_channel {
                 if let Some(registry) = &self.registry {
                     registry.remove_node(&node);
                 }

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -192,7 +192,13 @@ impl<Node: Eq + Hash + Clone, Channel> ChannelCache<Node, Channel> {
 
     fn retire_node(&mut self, node: &Node) -> Option<&Channel> {
         let channel = self.active.remove(node)?;
-        Some(self.retiring.entry(node.clone()).or_insert(channel))
+        // Overwrite rather than keep an older retirement. Holding a node in
+        // both maps is a bug `insert` only debug-asserts against, and the
+        // caller uses what comes back to release *this* channel's cache pin —
+        // handed the stale one, it would clear the wrong pointer and leave the
+        // real pin in place, which is what blocks a node from reopening.
+        self.retiring.insert(node.clone(), channel);
+        self.retiring.get(node)
     }
 
     /// Whether this node may be opened during the current tick. A quiescent

--- a/crates/openlogi-hid/src/inventory/cache.rs
+++ b/crates/openlogi-hid/src/inventory/cache.rs
@@ -145,6 +145,16 @@ pub(super) async fn probe_or_reuse(
             if fresh.identity_incomplete && cached.is_none() {
                 return (fresh, seen(id));
             }
+            // Same reasoning for a capability read that failed part-way: the
+            // walk understates the device, and memoizing that hides a panel in
+            // the GUI for `REFRESH_TICKS`. A previous complete walk outranks
+            // this partial one, so defer to it and re-probe next tick.
+            if fresh.capabilities_incomplete {
+                if let Some(c) = cached {
+                    keep_known_capabilities(&mut fresh, &c.probe);
+                }
+                return (fresh, seen(id));
+            }
             return match id {
                 Some(key) => {
                     let value = Cached {
@@ -185,6 +195,20 @@ pub(super) async fn probe_or_reuse(
             (c.probe.clone(), seen(id))
         }
         None => (ProbedFeatures::default(), seen(id)),
+    }
+}
+
+/// Carry a previous *complete* capability walk forward over one that a lost
+/// reply cut short.
+///
+/// A partial walk understates the device — a control-table read that failed
+/// half way reads exactly like "this device has no haptic panel" — and the GUI
+/// gates its panels on capabilities, so publishing the shrunken set makes a
+/// feature vanish. A probe whose capability reads all succeeded is returned
+/// untouched, including one that legitimately lost a capability.
+pub(super) fn keep_known_capabilities(fresh: &mut ProbedFeatures, cached: &ProbedFeatures) {
+    if fresh.capabilities_incomplete && cached.capabilities.is_some() {
+        fresh.capabilities.clone_from(&cached.capabilities);
     }
 }
 

--- a/crates/openlogi-hid/src/inventory/features.rs
+++ b/crates/openlogi-hid/src/inventory/features.rs
@@ -43,6 +43,10 @@ pub(super) struct ProbedFeatures {
     /// A `DeviceInformation` read *failed* (vs. the feature being absent), so
     /// the identity fields above may be missing data the device does have.
     pub(super) identity_incomplete: bool,
+    /// A capability read *failed* (vs. the device not having the capability),
+    /// so `capabilities` above understates what the device can do. Memoizing
+    /// that would hide a panel in the GUI for `REFRESH_TICKS`.
+    pub(super) capabilities_incomplete: bool,
 }
 
 /// Which battery feature a device exposes plus its runtime feature index. Newer
@@ -207,27 +211,11 @@ pub(super) async fn probe_features(
             return (ProbedFeatures::default(), None);
         }
     };
+    let mut capabilities_incomplete = false;
     if let Some(caps) = capabilities.as_mut() {
-        if let Some(feature) = device.get_feature::<HiResWheelFeature>() {
-            caps.scroll_inversion = feature
-                .get_wheel_capabilities()
-                .await
-                .is_ok_and(|wheel| wheel.has_invert);
-        }
-        // Older MX mice (notably MX Master 2S) expose the horizontal wheel as
-        // Gestures2 gesture id 46 instead of the newer dedicated 0x2150
-        // Thumbwheel feature. Inspect the descriptor table so a generic 0x6501
-        // touch device does not become a false-positive thumbwheel device.
-        if !caps.thumbwheel
-            && let Some(feature) = device.get_feature::<Gestures2Feature>()
-        {
-            caps.thumbwheel = feature.has_thumbwheel().await.unwrap_or(false);
-        }
-        if probe_haptic_controls
-            && let Some(feature) = device.get_feature::<ReprogControlsFeature>()
-        {
-            caps.haptic_panel = has_haptic_panel(&feature).await;
-        }
+        capabilities_incomplete = probe_extra_capabilities(&device, caps, probe_haptic_controls)
+            .await
+            .is_err();
     }
 
     let battery = match battery_probe {
@@ -287,24 +275,62 @@ pub(super) async fn probe_features(
             marketing_name,
             capabilities,
             identity_incomplete,
+            capabilities_incomplete,
         },
         battery_probe,
     )
 }
 
-async fn has_haptic_panel(feature: &ReprogControlsFeature) -> bool {
-    let Ok(count) = feature.get_count().await else {
-        return false;
-    };
-    for index in 0..count {
-        let Ok(info) = feature.get_cid_info(index).await else {
-            return false;
-        };
-        if info.cid == control_ids::HAPTIC_PANEL {
-            return info.flags.is_divertable();
+/// Fill in the capabilities the feature table alone can't answer, each of which
+/// costs its own round-trips.
+///
+/// `Err(())` means a read failed, so the set now understates the device — the
+/// caller must not let that be memoized. A capability whose read merely says
+/// "no" is not an error: only an unanswered read is.
+async fn probe_extra_capabilities(
+    device: &Device,
+    caps: &mut Capabilities,
+    probe_haptic_controls: bool,
+) -> Result<(), ()> {
+    if let Some(feature) = device.get_feature::<HiResWheelFeature>() {
+        caps.scroll_inversion = feature
+            .get_wheel_capabilities()
+            .await
+            .is_ok_and(|wheel| wheel.has_invert);
+    }
+    // Older MX mice (notably MX Master 2S) expose the horizontal wheel as
+    // Gestures2 gesture id 46 instead of the newer dedicated 0x2150
+    // Thumbwheel feature. Inspect the descriptor table so a generic 0x6501
+    // touch device does not become a false-positive thumbwheel device.
+    if !caps.thumbwheel
+        && let Some(feature) = device.get_feature::<Gestures2Feature>()
+    {
+        caps.thumbwheel = feature.has_thumbwheel().await.unwrap_or(false);
+    }
+    if probe_haptic_controls && let Some(feature) = device.get_feature::<ReprogControlsFeature>() {
+        match has_haptic_panel(&feature).await {
+            Some(found) => caps.haptic_panel = found,
+            None => return Err(()),
         }
     }
-    false
+    Ok(())
+}
+
+/// Whether the device exposes a divertable haptic panel, or `None` when a read
+/// failed part-way through the ~40-entry control walk.
+///
+/// The distinction matters because the answer is memoized for `REFRESH_TICKS`:
+/// reporting a lost reply as `false` hides the Actions Ring binding for half a
+/// minute on a device that has the panel.
+async fn has_haptic_panel(feature: &ReprogControlsFeature) -> Option<bool> {
+    let count = feature.get_count().await.ok()?;
+    for index in 0..count {
+        let info = feature.get_cid_info(index).await.ok()?;
+        if info.cid == control_ids::HAPTIC_PANEL {
+            return Some(info.flags.is_divertable());
+        }
+    }
+    Some(false)
 }
 
 #[cfg(test)]

--- a/crates/openlogi-hid/src/inventory/tests.rs
+++ b/crates/openlogi-hid/src/inventory/tests.rs
@@ -2,11 +2,13 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use openlogi_core::device::{
-    DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+    Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice,
+    ReceiverInfo,
 };
 
 use super::cache::{
     CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
+    keep_known_capabilities,
 };
 use super::persist;
 use super::probe::{
@@ -465,6 +467,48 @@ fn probed(model_info: Option<DeviceModelInfo>, identity_incomplete: bool) -> Pro
         kind: Some(DeviceKind::Mouse),
         ..ProbedFeatures::default()
     }
+}
+
+/// A control-table read that fails half way reads exactly like "no haptic
+/// panel", and the answer is memoized for `REFRESH_TICKS` — so the Actions Ring
+/// binding would vanish from the GUI for half a minute on a device that has it.
+#[test]
+fn an_incomplete_capability_walk_keeps_the_last_complete_answer() {
+    let mut fresh = probed(None, false);
+    fresh.capabilities_incomplete = true;
+    fresh.capabilities = Some(Capabilities::default());
+    let mut cached = probed(None, false);
+    cached.capabilities = Some(Capabilities {
+        haptic_panel: true,
+        ..Capabilities::default()
+    });
+
+    keep_known_capabilities(&mut fresh, &cached);
+
+    assert_eq!(
+        fresh.capabilities.map(|caps| caps.haptic_panel),
+        Some(true),
+        "the panel the last complete walk saw must survive a lost reply"
+    );
+}
+
+/// A device that genuinely lost a capability must still be able to say so.
+#[test]
+fn a_complete_capability_walk_is_left_alone() {
+    let mut fresh = probed(None, false);
+    fresh.capabilities = Some(Capabilities::default());
+    let mut cached = probed(None, false);
+    cached.capabilities = Some(Capabilities {
+        haptic_panel: true,
+        ..Capabilities::default()
+    });
+
+    keep_known_capabilities(&mut fresh, &cached);
+
+    assert_eq!(
+        fresh.capabilities.map(|caps| caps.haptic_panel),
+        Some(false)
+    );
 }
 
 #[test]

--- a/crates/openlogi-hid/src/node_ledger.rs
+++ b/crates/openlogi-hid/src/node_ledger.rs
@@ -211,6 +211,27 @@ mod tests {
         assert!(!recovered.evict_channel);
     }
 
+    /// A receiver probe that burns its whole budget arrives here as one
+    /// unhealthy tick. It must not evict on its own: the budget leaves barely a
+    /// second over its documented worst case, so one lost reply during a
+    /// legitimate deep walk lands here too — and evicting unpublishes every
+    /// device behind that receiver. The devices stay visible via the replay
+    /// while a channel that really is dead trips the threshold next tick.
+    #[test]
+    fn one_failed_probe_never_evicts_but_keeps_the_devices_visible() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("bolt")));
+
+        let first = ledger.settle(&1, false, None);
+
+        assert!(!first.evict_channel);
+        assert_eq!(receiver_name(first.inventory.as_ref()), Some("bolt"));
+        assert!(
+            ledger.settle(&1, false, None).evict_channel,
+            "a node that keeps failing is still replaced on the next tick"
+        );
+    }
+
     #[test]
     fn a_healthy_empty_result_clears_the_replay_state() {
         let mut ledger = NodeLedger::default();


### PR DESCRIPTION
## Summary

Four independent defects found in a post-hoc review of the Actions Ring change set (#589 / #566 / #419 / #528). All sit on shared device-I/O paths, so they affect every device, not just the ring.

**1. One slow receiver probe unpublishes every device behind it.** #589 evicts a receiver's channel immediately when its probe burns the full budget, bypassing the ledger's two-strike grace, on the reasoning that a full-budget timeout is the dead-delivery signature. It is not a reliable one: `RECEIVER_PROBE_BUDGET` is 13 s and its own documented worst case is already 1.5 s arrival drain + the sequential pairing-register pass + a slot's 10 s feature walk, so **a single lost reply — 5 s of `SEND_RESPONSE_TIMEOUT`, exactly what #586 reports happening under pointer traffic — pushes a healthy receiver past it**. A Bolt publishes all six slots under one node, so the eviction unpublishes every device on it and tears down each capture plan; DPI, SmartShift and haptic writes then fail with `DeviceNotFound` until the channel goes quiescent and reopens.

**2. Teardown could hand a button back diverted, i.e. dead.** `restore_reporting` replayed the pre-arm reporting snapshot verbatim. If the control was *already* diverted when the session armed — agent killed mid-session, or another Logitech app — the session restored `diverted: true`. The control then emits neither an OS event nor a HID++ event anyone listens for, and stays that way until the device sleeps or reconnects (diversion is volatile).

**3. A lost reply hid a capability for half a minute.** `has_haptic_panel` walks ~40 control entries and returned `false` the moment one read failed — indistinguishable from "no haptic panel". The walk still counted as successful, so that answer was memoized for `REFRESH_TICKS`, and the GUI (which gates panels on capabilities) offered no Actions Ring binding for a device that has one.

**4. `retire_node` could hand back the wrong channel.** It used `entry().or_insert()`, so a node held in both maps would silently drop the channel just removed from `active` and return the older retiring one — and the caller uses what comes back to release *that* channel's haptic-cache pin. Clearing the wrong pointer leaves the real pin in place, which is what stops a node from reopening.

## Changes

**`crates/openlogi-hid`**
- `inventory.rs`: receivers wait for the same consecutive-failure threshold as every other node; a genuinely dead channel still times out next tick and is replaced then, with the ledger replaying its last-good inventory in between. `retire_node` overwrites instead of keeping an older retirement.
- `gesture.rs`: teardown clears the diversion it turned on (`diverted` / `raw_xy`) and returns the remap target, leaving every other reporting bit unchanged — arming never writes them, so the field-by-field replay was unnecessary as well as unsafe. Arming logs when it finds a control already diverted.
- `inventory/features.rs`, `inventory/cache.rs`: an unanswered capability read reports itself as unknown; a probe carrying one is served but not memoized, and defers to the last complete walk. The capability round-trips move into their own function (the caller had grown past the line limit).

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

All green. New tests, each confirmed to fail when its defect is reintroduced (verified by mutation, not just by passing):

- `one_failed_probe_never_evicts_but_keeps_the_devices_visible`
- `restore_clears_a_diversion_it_found_already_set` / `restore_returns_the_remap_target_and_touches_nothing_else`
- `an_incomplete_capability_walk_keeps_the_last_complete_answer` / `a_complete_capability_walk_is_left_alone`

The replaced test `reporting_restore_preserves_every_mutable_field` asserted the verbatim replay, i.e. it pinned defect 2 as the contract. Defect 4 has no test: `insert` debug-asserts the state can't arise, so a test would have to defeat that assert to build it.

Not runtime-tested on hardware. Best judged on a Bolt under sustained pointer traffic (the #586 conditions): devices should stay listed through an occasional slow probe, and the Actions Ring binding should not disappear from the GUI. For the diversion change, `kill -9` the agent mid-session and restart it — the gesture button must work again without a device sleep.

Related to #586; the double-open of the receiver's HID node that provokes the dropped replies is untouched here.