### PR TITLE
fix: keep the ring session alive as long as the ring is clickable

### DIFF
--- a/crates/openlogi-agent-core/src/action_ring.rs
+++ b/crates/openlogi-agent-core/src/action_ring.rs
@@ -16,7 +16,25 @@ use tokio::sync::Notify;
 use crate::ipc::{ActionRingCommandError, ActionRingInvocation, ActionRingPresentation};
 
 const LONG_POLL_HOLD: Duration = Duration::from_secs(20);
-const SESSION_LIFETIME: Duration = Duration::from_secs(15);
+
+/// How long the overlay keeps the ring on screen, counted from the moment its
+/// window opens. The overlay owns the display; the constant lives here so the
+/// session that has to outlive it is derived from it rather than kept in step
+/// by hand.
+pub const DISPLAY_LIFETIME: Duration = Duration::from_secs(15);
+
+/// Slack between the window closing and the session expiring.
+///
+/// The two clocks do not start together: a session is stamped in `begin`,
+/// while the overlay's timer starts only once the long poll has delivered the
+/// invocation and the window is up. Giving them equal durations expired the
+/// session *before* the ring the user could still click disappeared, and a
+/// click landing in that tail returned `SessionNotFound` — the window closed
+/// and the action silently did not run. This covers that gap plus the click's
+/// round-trip back.
+const SESSION_GRACE: Duration = Duration::from_secs(3);
+
+const SESSION_LIFETIME: Duration = DISPLAY_LIFETIME.saturating_add(SESSION_GRACE);
 
 /// Immutable input used to open one ring session.
 pub struct ActionRingSessionSpec {
@@ -403,6 +421,18 @@ mod tests {
             manager
                 .activate(second.session_id, ActionRingSlot::Top)
                 .is_ok()
+        );
+    }
+
+    /// The two clocks start at different moments — the session when `begin`
+    /// stamps it, the window once the long poll has delivered and the overlay
+    /// is up — so equal durations expire the session while the ring is still
+    /// on screen, and the click that lands there is silently dropped.
+    #[test]
+    fn a_session_outlives_the_window_it_serves() {
+        assert!(
+            SESSION_LIFETIME > DISPLAY_LIFETIME,
+            "a click on a still-visible ring must still find its session"
         );
     }
 

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -39,6 +39,7 @@ use gpui::{
     WindowBackgroundAppearance, WindowBounds, WindowKind, WindowOptions, div, hsla, point,
     prelude::FluentBuilder as _, px, svg,
 };
+use openlogi_agent_core::action_ring::DISPLAY_LIFETIME;
 use openlogi_agent_core::ipc::{ActionRingInvocation, AgentClient, PROTOCOL_VERSION};
 use openlogi_core::binding::ActionRingSlot;
 use tarpc::{client, context};
@@ -49,7 +50,6 @@ use tracing_subscriber::EnvFilter;
 const WINDOW_SIZE: f32 = 360.0;
 const SLOT_SIZE: f32 = 54.0;
 const RADIUS: f32 = 122.0;
-const DISPLAY_LIFETIME: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OverlayCommand {
@@ -544,16 +544,25 @@ async fn poll_invocations(tx: mpsc::UnboundedSender<ActionRingInvocation>) {
     }
 }
 
+/// Fold a newly-produced command into the one still waiting to be sent.
+///
+/// A hover is dropped once its own session has already been activated or
+/// cancelled — the buzz would be for a ring that is closing. It must be the
+/// *same* session though: rings open back to back, and the view only emits a
+/// hover when the hovered slot changes, so swallowing the new ring's first
+/// hover loses it for as long as the pointer stays where it is.
 fn coalesce_command(current: OverlayCommand, next: OverlayCommand) -> OverlayCommand {
-    match next {
-        OverlayCommand::Hover { .. }
-            if matches!(
-                current,
-                OverlayCommand::Activate { .. } | OverlayCommand::Cancel { .. }
-            ) =>
-        {
-            current
-        }
+    match (next, current) {
+        (
+            OverlayCommand::Hover { session_id, .. },
+            OverlayCommand::Activate {
+                session_id: closing,
+                ..
+            }
+            | OverlayCommand::Cancel {
+                session_id: closing,
+            },
+        ) if session_id == closing => current,
         _ => next,
     }
 }
@@ -771,6 +780,25 @@ mod tests {
         assert!(matches!(
             coalesce_command(activation, hover),
             OverlayCommand::Activate { .. }
+        ));
+    }
+
+    /// Rings open back to back — dismiss one, open the next — and the view
+    /// only emits a hover when the hovered slot *changes*. Swallowing the new
+    /// ring's first hover therefore loses it entirely for as long as the
+    /// pointer stays put: no hover buzz, and the agent believing nothing is
+    /// hovered.
+    #[test]
+    fn a_new_sessions_hover_survives_the_previous_sessions_dismissal() {
+        let closing = OverlayCommand::Cancel { session_id: 1 };
+        let hover = OverlayCommand::Hover {
+            session_id: 2,
+            slot: ActionRingSlot::Top,
+        };
+
+        assert!(matches!(
+            coalesce_command(closing, hover),
+            OverlayCommand::Hover { session_id: 2, .. }
         ));
     }
 


### PR DESCRIPTION
## Summary

Findings 8 and 9 from the post-hoc review of the Actions Ring change set. Both live on the boundary between the agent's session and the overlay's window, and both silently swallow user input rather than failing visibly.

**The session expired before the window did.** `SESSION_LIFETIME` and `DISPLAY_LIFETIME` were both 15 s, but their clocks start at different moments: the session is stamped in `begin`, while the overlay's timer starts only once the long poll has delivered the invocation and the window is up. The session therefore always died first, and a click landing in that tail returned `SessionNotFound` — the ring closed and the action simply did not run.

**A new ring lost its first hover.** `coalesce_command` dropped any `Hover` while an `Activate`/`Cancel` was pending, without comparing `session_id`. Rings open back to back (dismiss one, open the next), and the view only emits a hover when the hovered slot *changes* — so the new ring's first hover was swallowed and never re-sent while the pointer stayed put. No hover feedback, and the agent left believing nothing was hovered for the rest of the dwell.

## Changes

**`crates/openlogi-agent-core`**
- `DISPLAY_LIFETIME` becomes the declared constant (the overlay owns the display), and `SESSION_LIFETIME` is derived from it plus slack for the click's round-trip. Deriving it is the point: two hand-kept constants are what drifted into being equal.

**`crates/openlogi-gui`**
- The overlay imports that lifetime instead of declaring its own.
- `coalesce_command` only suppresses a hover belonging to the *same* session as the pending terminal command.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```

All green.

- `a_new_sessions_hover_survives_the_previous_sessions_dismissal` — confirmed to fail when the session comparison is removed again.
- `a_session_outlives_the_window_it_serves` — pins the relationship the two constants must keep.

Not runtime-tested on hardware. Best judged by clicking a slot in the last second before the ring fades (the action must still run), and by dismissing a ring and immediately opening another with the pointer already over a slot (that slot must buzz).