### PR TITLE
build(nix): build dependencies once with crane, and stop gating source-only PRs on it

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,17 +1,25 @@
 name: Nix CI
 
 # Build the Nix package (flake `.#openlogi`) so it can't silently rot — the
-# failure mode that killed the previous flake (#262). With the importCargoLock
-# approach the only thing that can go stale is a git-pin hash in
-# nix/package.nix `outputHashes`, and that only when a git pin (gpui,
-# gpui-component, ...) is bumped in Cargo.lock. This workflow makes that
-# failure happen in the PR that bumps the pin — the error message prints the
-# correct hash to paste — instead of silently on master afterwards. The path
-# filter only skips files that cannot feed the Linux build (docs, other
-# platforms' packaging, unrelated workflows); everything the build consumes —
-# lockfile, manifests, build scripts, toolchain, Rust source, and the
-# Nix/packaging files themselves — triggers it, so no change can bypass this
-# job and rot master.
+# failure mode that killed the previous flake (#262).
+#
+# On master this watches everything the Linux build consumes, so nothing can
+# rot it unnoticed. On PRs it watches a much narrower set, because the two
+# cases are not equally likely and the job is not cheap:
+#
+# - What a PR realistically breaks is the packaging *inputs* — the flake, the
+#   package expression, the lockfile and manifests (a new `-sys` dependency
+#   needs a new `buildInput`), the toolchain, the packaged unit/desktop/udev
+#   files. Those gate the job here, so the break still lands in the PR that
+#   causes it.
+# - What only master needs to catch is the rarer kind: source that compiles
+#   under the dev toolchain but not in the Nix sandbox, with no manifest
+#   change to announce it. Running every source PR through a full Linux build
+#   to catch that costs far more than fixing it on master does.
+#
+# The `outputHashes` staleness this job was originally built around no longer
+# exists: crane fetches git dependencies by the revision Cargo.lock already
+# pins (see nix/package.nix), so there is no hash left to go stale.
 on:
   push:
     branches: [master]
@@ -33,16 +41,11 @@ on:
     paths:
       - "Cargo.lock"
       - "**/Cargo.toml"
-      - "**/build.rs"
       - "rust-toolchain.toml"
-      - "src/**"
-      - "crates/**"
-      - "third_party/**"
       - "flake.nix"
       - "flake.lock"
       - "nix/**"
       - "packaging/linux/**"
-      - "design/icon/openlogi.png"
       - ".github/workflows/nix.yml"
 
 jobs:

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785542685,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,18 @@
   description = "OpenLogi — local-first companion for Logitech HID++ peripherals";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.crane.url = "github:ipetkov/crane";
 
   # The dev shell lives in devenv.nix (devenv.yaml); this flake only exposes
   # the buildable Linux package so `nix build` / `nix run` are first-class.
   # See nix/package.nix for why this vendoring approach avoids the cargoHash
   # churn that led to the previous flake's removal (#262).
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      crane,
+    }:
     let
       systems = [
         "x86_64-linux"
@@ -17,9 +22,18 @@
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
-      packages = forAllSystems (system: {
-        openlogi = nixpkgs.legacyPackages.${system}.callPackage ./nix/package.nix { src = self; };
-        default = self.packages.${system}.openlogi;
-      });
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          openlogi = pkgs.callPackage ./nix/package.nix {
+            src = self;
+            craneLib = crane.mkLib pkgs;
+          };
+          default = self.packages.${system}.openlogi;
+        }
+      );
     };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,30 +3,26 @@
 # Build via the flake:
 #   nix build .#openlogi
 #
-# ## Why this doesn't suffer the #262 cargoHash churn
+# ## Why crane, and why there are no hashes here
 #
-# The previous flake (removed in #262) used fetchCargoVendor, whose single
-# cargoHash covers one FOD containing every dependency plus a copy of
-# Cargo.lock. Because the lock embeds the local openlogi* crate versions,
-# every release bump invalidated the hash even when no dependency changed.
+# The flake removed in #262 used fetchCargoVendor: one `cargoHash` covering
+# every dependency *plus* a copy of Cargo.lock, so every release bump
+# invalidated it. Its replacement (#491) used rustPlatform's `cargoLock`, which
+# fixed that but still needed one manual hash per git repository and — being a
+# single derivation — recompiled the whole dependency tree, gpui included, on
+# every source change. That is the ~22 min every PR was paying.
 #
-# This package uses rustPlatform's `cargoLock` (importCargoLock) instead:
-# - crates.io dependencies are fetched individually using the checksums
-#   already recorded in Cargo.lock — no manual hashes, ever.
-# - git dependencies need one manual hash per repository (not per crate,
-#   not per release): importCargoLock resolves `outputHashes` keys to git
-#   commit SHAs, so the hashes below stay valid until a git pin actually
-#   moves. A version bump of OpenLogi itself changes nothing here.
-#
-# The only recurring maintenance is: when a git pin (gpui, gpui-component,
-# ...) is bumped, update the corresponding entry below — the failing build
-# prints the correct hash to paste. The nix.yml workflow makes that failure
-# happen in the PR that bumps the pin, not silently on master afterwards.
+# crane addresses both:
+# - Dependencies build in their own derivation, so a source-only change reuses
+#   them and only the workspace's own crates recompile.
+# - Git dependencies are fetched with `builtins.fetchGit`, which is addressed
+#   by the revision Cargo.lock already pins. There are no `outputHashes` to
+#   maintain, and none to go stale when a pin moves.
 {
   lib,
-  rustPlatform,
-  fetchgit,
+  craneLib,
   src,
+  rustPlatform,
   pkg-config,
   makeWrapper,
   fontconfig,
@@ -52,122 +48,124 @@ let
   ];
 
   # gpui-component checkout for the GUI build script. The upstream themes live
-  # at the repository root next to (not inside) the gpui-component crate, so
-  # the per-crate vendor tree importCargoLock produces doesn't contain them.
-  # build.rs provides OPENLOGI_THEMES_DIR as an explicit override — point it
-  # at a separate checkout. The rev must match Cargo.lock (a mismatch fails
-  # the build with a hash error, so it cannot drift silently); the hash is
-  # shared with outputHashes below.
-  gpuiComponentRev = "031555662e99a1b5a549990b47f246d475b8288a";
-  gpuiComponentHash = "sha256-yOXdgxQgfvGN2/+OdDnl1pYti0DoGFvS3Tyqvj3Bkng=";
-  gpuiComponentSrc = fetchgit {
+  # at the repository root next to (not inside) the gpui-component crate, and
+  # vendoring extracts crates rather than repositories — so they are absent
+  # from the vendor tree. build.rs takes OPENLOGI_THEMES_DIR as an explicit
+  # override; point it at a separate checkout. The rev must match Cargo.lock,
+  # or the GUI builds against themes it was not locked to.
+  gpuiComponentSrc = builtins.fetchGit {
     url = "https://github.com/longbridge/gpui-component";
-    rev = gpuiComponentRev;
-    hash = gpuiComponentHash;
-  };
-in
-rustPlatform.buildRustPackage {
-  pname = "openlogi";
-  inherit version src;
-
-  cargoLock = {
-    lockFile = "${src}/Cargo.lock";
-    # One hash per git repository, keyed by any crate from that repo.
-    # Obtain new values from the error message of a failing build, or with
-    # `nix-prefetch-git <url> --rev <rev>`.
-    outputHashes = {
-      "gpui-0.2.2" = "sha256-Av+unZNI39dEb+zwSIU+SkEjqagHWrc7W8KehEgQ4H8=";
-      "gpui-component-0.5.2" = gpuiComponentHash;
-      "gpui-updater-0.0.6" = "sha256-v8rn8tEkKBi8T2LtBV92uB+XtEeuBwj0qxGcDqEIwIw=";
-      "proptest-1.10.0" = "sha256-p5NTcHhruI8QQvANACg8AMRVNmuvGxs2NLit+/8PaWo=";
-      "zed-font-kit-0.14.1-zed" = "sha256-KXygi0olNQi5yM8eaJVykNDtbPMDjT+cWPBF8UrtXR4=";
-      "zed-reqwest-0.12.15-zed" = "sha256-p4SiUrOrbTlk/3bBrzN/mq/t+1Gzy2ot4nso6w6S+F8=";
-      "zed-scap-0.0.8-zed" = "sha256-BihiQHlal/eRsktyf0GI3aSWsUCW7WcICMsC2Xvb7kw=";
-      "zed-xim-0.4.0-zed" = "sha256-pRT4Sz1JU9ros47/7pmIW9kosWOGMOItcnNd+VrvnpE=";
-    };
+    rev = "031555662e99a1b5a549990b47f246d475b8288a";
+    allRefs = true;
   };
 
-  postPatch = ''
+  cargoVendorDir = craneLib.vendorCargoDeps {
+    inherit src;
+
     # gpui-component's IconName proc-macro reads `../assets/assets/icons`
-    # relative to its own crate, assuming the upstream repo's workspace
-    # layout. The vendor tree lays crates out flat, so recreate the sibling
-    # directory as a link to the gpui-component-assets crate. Fail loudly if
+    # relative to its own crate — the upstream repo's layout, where the assets
+    # live beside it rather than inside it. Vendoring extracts that repo's
+    # crates as siblings, so the directory the macro walks up to is missing;
+    # recreate it as a link to the assets crate. This has to happen inside the
+    # checkout rather than over the finished vendor tree, because the tree's
+    # generated config.toml points cargo at these store paths by absolute
+    # path — a patched copy of it would simply never be read. Fail loudly if
     # the glob doesn't resolve to exactly one directory.
-    assets=("$cargoDepsCopy"/gpui-component-assets-*)
-    if [ ''${#assets[@]} -ne 1 ] || [ ! -d "''${assets[0]}" ]; then
-      echo "could not uniquely locate the vendored gpui-component-assets: ''${assets[*]}" >&2
-      exit 1
-    fi
-    ln -sfn "''${assets[0]}" "$cargoDepsCopy/assets"
+    overrideVendorGitCheckout =
+      packages: drv:
+      if lib.any (p: p.name == "gpui-component") packages then
+        drv.overrideAttrs (old: {
+          postInstall = (old.postInstall or "") + ''
+            assets=("$out"/gpui-component-assets-*)
+            if [ ''${#assets[@]} -ne 1 ] || [ ! -d "''${assets[0]}" ]; then
+              echo "could not uniquely locate the vendored gpui-component-assets: ''${assets[*]}" >&2
+              exit 1
+            fi
+            ln -sfn "''${assets[0]}" "$out/assets"
+          '';
+        })
+      else
+        drv;
+  };
+
+  commonArgs = {
+    inherit src version cargoVendorDir;
+    pname = "openlogi";
+    strictDeps = true;
 
     # The workspace cargo config is dev-shell tooling: a macOS-scoped linker
     # and runner (inert on Linux), a default DEVELOPER_DIR, cargo aliases.
     # Nothing the sandboxed build needs — drop it so the build stays hermetic
     # rather than tracking whatever dev ergonomics land there next.
-    rm -f .cargo/config.toml
-  '';
+    postPatch = ''
+      rm -f .cargo/config.toml
+    '';
 
-  env.OPENLOGI_THEMES_DIR = "${gpuiComponentSrc}/themes";
+    env.OPENLOGI_THEMES_DIR = "${gpuiComponentSrc}/themes";
 
-  nativeBuildInputs = [
-    pkg-config
-    makeWrapper
-    rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
-  ];
-
-  # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls;
-  # evdev/hidraw are opened directly (pure Rust); vulkan is dlopened, so it
-  # belongs in runtimeLibs above, not here.
-  buildInputs = [
-    fontconfig # GPUI text rendering (yeslogic-fontconfig-sys)
-    freetype # font-kit (freetype-sys)
-    libxkbcommon # GPUI keyboard handling
-    wayland # wayland-sys
-    libxcb # xcb / x11rb — the hook and GPUI's X11 backend
-  ];
-
-  # The three shipped binaries; xtask (macOS bundling/DMG) is not used on
-  # Linux.
-  cargoBuildFlags = [
-    "--package=openlogi"
-    "--package=openlogi-agent"
-    "--package=openlogi-gui"
-  ];
-
-  # Some tests require real Logitech hardware, D-Bus, or uinput — none of
-  # which exist in the sandbox. The Rust CI workflow runs the test suite.
-  doCheck = false;
-
-  postInstall = ''
-    install -Dm644 packaging/linux/desktop/openlogi.desktop \
-      "$out/share/applications/openlogi.desktop"
-    install -Dm644 design/icon/openlogi.png \
-      "$out/share/icons/hicolor/512x512/apps/openlogi.png"
-    install -Dm644 packaging/linux/udev/70-openlogi.rules \
-      "$out/lib/udev/rules.d/70-openlogi.rules"
-    install -Dm644 packaging/linux/systemd/openlogi-agent.service \
-      "$out/lib/systemd/user/openlogi-agent.service"
-  '';
-
-  postFixup = ''
-    wrapProgram "$out/bin/openlogi-gui" \
-      --prefix LD_LIBRARY_PATH : "${runtimeLibs}"
-
-    # The packaged unit hardcodes /usr/bin; point it at this output.
-    substituteInPlace "$out/lib/systemd/user/openlogi-agent.service" \
-      --replace-fail /usr/bin/openlogi-agent "$out/bin/openlogi-agent"
-  '';
-
-  meta = {
-    description = "Local-first companion for Logitech HID++ peripherals";
-    homepage = "https://github.com/AprilNEA/OpenLogi";
-    license = with lib.licenses; [
-      mit
-      asl20
+    nativeBuildInputs = [
+      pkg-config
+      makeWrapper
+      rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
     ];
-    mainProgram = "openlogi";
-    # Darwin support (the .app bundle, see nixpkgs' `openlogi`) could be
-    # revived here later; this package is authored and tested on Linux.
-    platforms = lib.platforms.linux;
+
+    # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls;
+    # evdev/hidraw are opened directly (pure Rust); vulkan is dlopened, so it
+    # belongs in runtimeLibs above, not here.
+    buildInputs = [
+      fontconfig # GPUI text rendering (yeslogic-fontconfig-sys)
+      freetype # font-kit (freetype-sys)
+      libxkbcommon # GPUI keyboard handling
+      wayland # wayland-sys
+      libxcb # xcb / x11rb — the hook and GPUI's X11 backend
+    ];
+
+    # The three shipped binaries; xtask (macOS bundling/DMG) is not used on
+    # Linux.
+    cargoExtraArgs = "--package=openlogi --package=openlogi-agent --package=openlogi-gui";
+
+    # Some tests require real Logitech hardware, D-Bus, or uinput — none of
+    # which exist in the sandbox. The Rust CI workflow runs the test suite.
+    doCheck = false;
   };
-}
+in
+craneLib.buildPackage (
+  commonArgs
+  // {
+    # The dependency-only build that every later source change reuses.
+    cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+    postInstall = ''
+      install -Dm644 packaging/linux/desktop/openlogi.desktop \
+        "$out/share/applications/openlogi.desktop"
+      install -Dm644 design/icon/openlogi.png \
+        "$out/share/icons/hicolor/512x512/apps/openlogi.png"
+      install -Dm644 packaging/linux/udev/70-openlogi.rules \
+        "$out/lib/udev/rules.d/70-openlogi.rules"
+      install -Dm644 packaging/linux/systemd/openlogi-agent.service \
+        "$out/lib/systemd/user/openlogi-agent.service"
+    '';
+
+    postFixup = ''
+      wrapProgram "$out/bin/openlogi-gui" \
+        --prefix LD_LIBRARY_PATH : "${runtimeLibs}"
+
+      # The packaged unit hardcodes /usr/bin; point it at this output.
+      substituteInPlace "$out/lib/systemd/user/openlogi-agent.service" \
+        --replace-fail /usr/bin/openlogi-agent "$out/bin/openlogi-agent"
+    '';
+
+    meta = {
+      description = "Local-first companion for Logitech HID++ peripherals";
+      homepage = "https://github.com/AprilNEA/OpenLogi";
+      license = with lib.licenses; [
+        mit
+        asl20
+      ];
+      mainProgram = "openlogi";
+      # Darwin support (the .app bundle, see nixpkgs' `openlogi`) could be
+      # revived here later; this package is authored and tested on Linux.
+      platforms = lib.platforms.linux;
+    };
+  }
+)


### PR DESCRIPTION
## Summary

Answers @davidbudnick's question on #598. The Nix job isn't degraded — it was never cheap, and it ran on every PR.

**Why it costs 22 minutes.** `rustPlatform.buildRustPackage` is a *single* derivation, so every source change recompiles the entire dependency tree, gpui included. magic-nix-cache (#580) can't help: it restores store paths, and the package's input hash changes with the source. crane splits dependencies into their own derivation, so a source-only change reuses them and only the workspace's crates rebuild.

**Why it ran on every PR.** To make a stale `outputHashes` entry fail in the PR that bumped the git pin, with the error printing the hash to paste. crane fetches git dependencies with `builtins.fetchGit`, addressed by the revision `Cargo.lock` already pins — so that table is gone, and with it the failure the per-PR trigger was guarding against.

So: dependencies build once, and PRs only pay for the build when they touch something that can actually break the packaging.

## Changes

- `flake.nix`: crane input; `craneLib` passed to the package.
- `nix/package.nix`: `buildDepsOnly` + `buildPackage` over one `commonArgs`; `outputHashes` deleted; themes checkout via `builtins.fetchGit`.
- The gpui-component icon hack moves into crane's `overrideVendorGitCheckout`. It has to patch the git checkout, not the finished vendor tree: that tree's generated `config.toml` points cargo at store paths by **absolute path**, so a patched copy would never be read. (I had it the wrong way first; the local vendor build is what caught it.)
- `nix.yml`: PRs trigger on the packaging inputs — flake, package expression, lockfile and manifests (a new `-sys` dependency needs a new `buildInput`), toolchain, packaged unit/desktop/udev files. Master keeps watching everything, which is where the rarer "compiles in the dev toolchain but not in the sandbox" failure gets caught.

## Testing

No local Linux build — this machine is aarch64-darwin with no Linux builder, so **CI is the first real compile**. What could be checked locally was:

- `nix eval .#packages.{x86_64,aarch64}-linux.openlogi.drvPath` — the flake instantiates in pure eval, which is what proves the git dependencies resolve with no `outputHashes` at all.
- Built the vendor derivation and inspected it: crane groups crates per source (`<sha>/<crate>`), the gpui-component source holds `gpui-component`, `-assets` and `-macros` as siblings, and the `assets` link lands in the checkout.
- Read the icon macro to confirm the link is where it will be looked for: `Path::join` then `read_dir`, no normalisation, so `..` is resolved by the kernel through the symlinked crate directory.

The first run on master will still be slow: the dependency derivation has to be built once before anything can reuse it. The saving shows up after that.