### PR TITLE
ci(nix): run the Linux build weekly, and revert crane

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,25 +1,17 @@
 name: Nix CI
 
 # Build the Nix package (flake `.#openlogi`) so it can't silently rot — the
-# failure mode that killed the previous flake (#262).
-#
-# On master this watches everything the Linux build consumes, so nothing can
-# rot it unnoticed. On PRs it watches a much narrower set, because the two
-# cases are not equally likely and the job is not cheap:
-#
-# - What a PR realistically breaks is the packaging *inputs* — the flake, the
-#   package expression, the lockfile and manifests (a new `-sys` dependency
-#   needs a new `buildInput`), the toolchain, the packaged unit/desktop/udev
-#   files. Those gate the job here, so the break still lands in the PR that
-#   causes it.
-# - What only master needs to catch is the rarer kind: source that compiles
-#   under the dev toolchain but not in the Nix sandbox, with no manifest
-#   change to announce it. Running every source PR through a full Linux build
-#   to catch that costs far more than fixing it on master does.
-#
-# The `outputHashes` staleness this job was originally built around no longer
-# exists: crane fetches git dependencies by the revision Cargo.lock already
-# pins (see nix/package.nix), so there is no hash left to go stale.
+# failure mode that killed the previous flake (#262). With the importCargoLock
+# approach the only thing that can go stale is a git-pin hash in
+# nix/package.nix `outputHashes`, and that only when a git pin (gpui,
+# gpui-component, ...) is bumped in Cargo.lock. This workflow makes that
+# failure happen in the PR that bumps the pin — the error message prints the
+# correct hash to paste — instead of silently on master afterwards. The path
+# filter only skips files that cannot feed the Linux build (docs, other
+# platforms' packaging, unrelated workflows); everything the build consumes —
+# lockfile, manifests, build scripts, toolchain, Rust source, and the
+# Nix/packaging files themselves — triggers it, so no change can bypass this
+# job and rot master.
 on:
   push:
     branches: [master]
@@ -41,11 +33,16 @@ on:
     paths:
       - "Cargo.lock"
       - "**/Cargo.toml"
+      - "**/build.rs"
       - "rust-toolchain.toml"
+      - "src/**"
+      - "crates/**"
+      - "third_party/**"
       - "flake.nix"
       - "flake.lock"
       - "nix/**"
       - "packaging/linux/**"
+      - "design/icon/openlogi.png"
       - ".github/workflows/nix.yml"
 
 jobs:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,48 +1,32 @@
 name: Nix CI
 
 # Build the Nix package (flake `.#openlogi`) so it can't silently rot — the
-# failure mode that killed the previous flake (#262). With the importCargoLock
-# approach the only thing that can go stale is a git-pin hash in
-# nix/package.nix `outputHashes`, and that only when a git pin (gpui,
-# gpui-component, ...) is bumped in Cargo.lock. This workflow makes that
-# failure happen in the PR that bumps the pin — the error message prints the
-# correct hash to paste — instead of silently on master afterwards. The path
-# filter only skips files that cannot feed the Linux build (docs, other
-# platforms' packaging, unrelated workflows); everything the build consumes —
-# lockfile, manifests, build scripts, toolchain, Rust source, and the
-# Nix/packaging files themselves — triggers it, so no change can bypass this
-# job and rot master.
+# failure mode that killed the previous flake (#262).
+#
+# It runs weekly rather than per change, because the cost and the risk are
+# wildly mismatched. A full Linux build of this workspace takes ~20 minutes
+# and is by far the most expensive job in CI, while in 60 runs this one has
+# never failed — and the flake is not an install path anyone is pointed at:
+# the README ships `.deb` / `.rpm` / `.pkg.tar.zst` for Linux. What can rot it
+# is nixpkgs-unstable drifting, a new `-sys` dependency needing a buildInput,
+# or a bumped git pin invalidating an `outputHashes` entry. None of those are
+# urgent enough to make every contributor wait for them; noticing within a
+# week is fine, and the failing build prints the hash to paste.
+#
+# Editing the flake or the package expression *is* the moment a break is
+# likely and the feedback is worth having immediately, so those paths still
+# trigger it on their own PR. `workflow_dispatch` covers "I want to check
+# this now" — e.g. after bumping a git pin in Cargo.lock.
 on:
-  push:
-    branches: [master]
-    paths:
-      - "Cargo.lock"
-      - "**/Cargo.toml"
-      - "**/build.rs"
-      - "rust-toolchain.toml"
-      - "src/**"
-      - "crates/**"
-      - "third_party/**"
-      - "flake.nix"
-      - "flake.lock"
-      - "nix/**"
-      - "packaging/linux/**"
-      - "design/icon/openlogi.png"
-      - ".github/workflows/nix.yml"
+  schedule:
+    # Mondays, 04:17 UTC. Off-peak, and far from the release cadence.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
   pull_request:
     paths:
-      - "Cargo.lock"
-      - "**/Cargo.toml"
-      - "**/build.rs"
-      - "rust-toolchain.toml"
-      - "src/**"
-      - "crates/**"
-      - "third_party/**"
       - "flake.nix"
       - "flake.lock"
       - "nix/**"
-      - "packaging/linux/**"
-      - "design/icon/openlogi.png"
       - ".github/workflows/nix.yml"
 
 jobs:

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1785782307,
-        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785542685,
@@ -33,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,18 +2,13 @@
   description = "OpenLogi — local-first companion for Logitech HID++ peripherals";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.crane.url = "github:ipetkov/crane";
 
   # The dev shell lives in devenv.nix (devenv.yaml); this flake only exposes
   # the buildable Linux package so `nix build` / `nix run` are first-class.
   # See nix/package.nix for why this vendoring approach avoids the cargoHash
   # churn that led to the previous flake's removal (#262).
   outputs =
-    {
-      self,
-      nixpkgs,
-      crane,
-    }:
+    { self, nixpkgs }:
     let
       systems = [
         "x86_64-linux"
@@ -22,18 +17,9 @@
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
-      packages = forAllSystems (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        {
-          openlogi = pkgs.callPackage ./nix/package.nix {
-            src = self;
-            craneLib = crane.mkLib pkgs;
-          };
-          default = self.packages.${system}.openlogi;
-        }
-      );
+      packages = forAllSystems (system: {
+        openlogi = nixpkgs.legacyPackages.${system}.callPackage ./nix/package.nix { src = self; };
+        default = self.packages.${system}.openlogi;
+      });
     };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,26 +3,30 @@
 # Build via the flake:
 #   nix build .#openlogi
 #
-# ## Why crane, and why there are no hashes here
+# ## Why this doesn't suffer the #262 cargoHash churn
 #
-# The flake removed in #262 used fetchCargoVendor: one `cargoHash` covering
-# every dependency *plus* a copy of Cargo.lock, so every release bump
-# invalidated it. Its replacement (#491) used rustPlatform's `cargoLock`, which
-# fixed that but still needed one manual hash per git repository and — being a
-# single derivation — recompiled the whole dependency tree, gpui included, on
-# every source change. That is the ~22 min every PR was paying.
+# The previous flake (removed in #262) used fetchCargoVendor, whose single
+# cargoHash covers one FOD containing every dependency plus a copy of
+# Cargo.lock. Because the lock embeds the local openlogi* crate versions,
+# every release bump invalidated the hash even when no dependency changed.
 #
-# crane addresses both:
-# - Dependencies build in their own derivation, so a source-only change reuses
-#   them and only the workspace's own crates recompile.
-# - Git dependencies are fetched with `builtins.fetchGit`, which is addressed
-#   by the revision Cargo.lock already pins. There are no `outputHashes` to
-#   maintain, and none to go stale when a pin moves.
+# This package uses rustPlatform's `cargoLock` (importCargoLock) instead:
+# - crates.io dependencies are fetched individually using the checksums
+#   already recorded in Cargo.lock — no manual hashes, ever.
+# - git dependencies need one manual hash per repository (not per crate,
+#   not per release): importCargoLock resolves `outputHashes` keys to git
+#   commit SHAs, so the hashes below stay valid until a git pin actually
+#   moves. A version bump of OpenLogi itself changes nothing here.
+#
+# The only recurring maintenance is: when a git pin (gpui, gpui-component,
+# ...) is bumped, update the corresponding entry below — the failing build
+# prints the correct hash to paste. The nix.yml workflow makes that failure
+# happen in the PR that bumps the pin, not silently on master afterwards.
 {
   lib,
-  craneLib,
-  src,
   rustPlatform,
+  fetchgit,
+  src,
   pkg-config,
   makeWrapper,
   fontconfig,
@@ -48,124 +52,122 @@ let
   ];
 
   # gpui-component checkout for the GUI build script. The upstream themes live
-  # at the repository root next to (not inside) the gpui-component crate, and
-  # vendoring extracts crates rather than repositories — so they are absent
-  # from the vendor tree. build.rs takes OPENLOGI_THEMES_DIR as an explicit
-  # override; point it at a separate checkout. The rev must match Cargo.lock,
-  # or the GUI builds against themes it was not locked to.
-  gpuiComponentSrc = builtins.fetchGit {
+  # at the repository root next to (not inside) the gpui-component crate, so
+  # the per-crate vendor tree importCargoLock produces doesn't contain them.
+  # build.rs provides OPENLOGI_THEMES_DIR as an explicit override — point it
+  # at a separate checkout. The rev must match Cargo.lock (a mismatch fails
+  # the build with a hash error, so it cannot drift silently); the hash is
+  # shared with outputHashes below.
+  gpuiComponentRev = "031555662e99a1b5a549990b47f246d475b8288a";
+  gpuiComponentHash = "sha256-yOXdgxQgfvGN2/+OdDnl1pYti0DoGFvS3Tyqvj3Bkng=";
+  gpuiComponentSrc = fetchgit {
     url = "https://github.com/longbridge/gpui-component";
-    rev = "031555662e99a1b5a549990b47f246d475b8288a";
-    allRefs = true;
+    rev = gpuiComponentRev;
+    hash = gpuiComponentHash;
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "openlogi";
+  inherit version src;
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    # One hash per git repository, keyed by any crate from that repo.
+    # Obtain new values from the error message of a failing build, or with
+    # `nix-prefetch-git <url> --rev <rev>`.
+    outputHashes = {
+      "gpui-0.2.2" = "sha256-Av+unZNI39dEb+zwSIU+SkEjqagHWrc7W8KehEgQ4H8=";
+      "gpui-component-0.5.2" = gpuiComponentHash;
+      "gpui-updater-0.0.6" = "sha256-v8rn8tEkKBi8T2LtBV92uB+XtEeuBwj0qxGcDqEIwIw=";
+      "proptest-1.10.0" = "sha256-p5NTcHhruI8QQvANACg8AMRVNmuvGxs2NLit+/8PaWo=";
+      "zed-font-kit-0.14.1-zed" = "sha256-KXygi0olNQi5yM8eaJVykNDtbPMDjT+cWPBF8UrtXR4=";
+      "zed-reqwest-0.12.15-zed" = "sha256-p4SiUrOrbTlk/3bBrzN/mq/t+1Gzy2ot4nso6w6S+F8=";
+      "zed-scap-0.0.8-zed" = "sha256-BihiQHlal/eRsktyf0GI3aSWsUCW7WcICMsC2Xvb7kw=";
+      "zed-xim-0.4.0-zed" = "sha256-pRT4Sz1JU9ros47/7pmIW9kosWOGMOItcnNd+VrvnpE=";
+    };
   };
 
-  cargoVendorDir = craneLib.vendorCargoDeps {
-    inherit src;
-
+  postPatch = ''
     # gpui-component's IconName proc-macro reads `../assets/assets/icons`
-    # relative to its own crate — the upstream repo's layout, where the assets
-    # live beside it rather than inside it. Vendoring extracts that repo's
-    # crates as siblings, so the directory the macro walks up to is missing;
-    # recreate it as a link to the assets crate. This has to happen inside the
-    # checkout rather than over the finished vendor tree, because the tree's
-    # generated config.toml points cargo at these store paths by absolute
-    # path — a patched copy of it would simply never be read. Fail loudly if
+    # relative to its own crate, assuming the upstream repo's workspace
+    # layout. The vendor tree lays crates out flat, so recreate the sibling
+    # directory as a link to the gpui-component-assets crate. Fail loudly if
     # the glob doesn't resolve to exactly one directory.
-    overrideVendorGitCheckout =
-      packages: drv:
-      if lib.any (p: p.name == "gpui-component") packages then
-        drv.overrideAttrs (old: {
-          postInstall = (old.postInstall or "") + ''
-            assets=("$out"/gpui-component-assets-*)
-            if [ ''${#assets[@]} -ne 1 ] || [ ! -d "''${assets[0]}" ]; then
-              echo "could not uniquely locate the vendored gpui-component-assets: ''${assets[*]}" >&2
-              exit 1
-            fi
-            ln -sfn "''${assets[0]}" "$out/assets"
-          '';
-        })
-      else
-        drv;
-  };
-
-  commonArgs = {
-    inherit src version cargoVendorDir;
-    pname = "openlogi";
-    strictDeps = true;
+    assets=("$cargoDepsCopy"/gpui-component-assets-*)
+    if [ ''${#assets[@]} -ne 1 ] || [ ! -d "''${assets[0]}" ]; then
+      echo "could not uniquely locate the vendored gpui-component-assets: ''${assets[*]}" >&2
+      exit 1
+    fi
+    ln -sfn "''${assets[0]}" "$cargoDepsCopy/assets"
 
     # The workspace cargo config is dev-shell tooling: a macOS-scoped linker
     # and runner (inert on Linux), a default DEVELOPER_DIR, cargo aliases.
     # Nothing the sandboxed build needs — drop it so the build stays hermetic
     # rather than tracking whatever dev ergonomics land there next.
-    postPatch = ''
-      rm -f .cargo/config.toml
-    '';
+    rm -f .cargo/config.toml
+  '';
 
-    env.OPENLOGI_THEMES_DIR = "${gpuiComponentSrc}/themes";
+  env.OPENLOGI_THEMES_DIR = "${gpuiComponentSrc}/themes";
 
-    nativeBuildInputs = [
-      pkg-config
-      makeWrapper
-      rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
+  ];
+
+  # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls;
+  # evdev/hidraw are opened directly (pure Rust); vulkan is dlopened, so it
+  # belongs in runtimeLibs above, not here.
+  buildInputs = [
+    fontconfig # GPUI text rendering (yeslogic-fontconfig-sys)
+    freetype # font-kit (freetype-sys)
+    libxkbcommon # GPUI keyboard handling
+    wayland # wayland-sys
+    libxcb # xcb / x11rb — the hook and GPUI's X11 backend
+  ];
+
+  # The three shipped binaries; xtask (macOS bundling/DMG) is not used on
+  # Linux.
+  cargoBuildFlags = [
+    "--package=openlogi"
+    "--package=openlogi-agent"
+    "--package=openlogi-gui"
+  ];
+
+  # Some tests require real Logitech hardware, D-Bus, or uinput — none of
+  # which exist in the sandbox. The Rust CI workflow runs the test suite.
+  doCheck = false;
+
+  postInstall = ''
+    install -Dm644 packaging/linux/desktop/openlogi.desktop \
+      "$out/share/applications/openlogi.desktop"
+    install -Dm644 design/icon/openlogi.png \
+      "$out/share/icons/hicolor/512x512/apps/openlogi.png"
+    install -Dm644 packaging/linux/udev/70-openlogi.rules \
+      "$out/lib/udev/rules.d/70-openlogi.rules"
+    install -Dm644 packaging/linux/systemd/openlogi-agent.service \
+      "$out/lib/systemd/user/openlogi-agent.service"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/openlogi-gui" \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}"
+
+    # The packaged unit hardcodes /usr/bin; point it at this output.
+    substituteInPlace "$out/lib/systemd/user/openlogi-agent.service" \
+      --replace-fail /usr/bin/openlogi-agent "$out/bin/openlogi-agent"
+  '';
+
+  meta = {
+    description = "Local-first companion for Logitech HID++ peripherals";
+    homepage = "https://github.com/AprilNEA/OpenLogi";
+    license = with lib.licenses; [
+      mit
+      asl20
     ];
-
-    # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls;
-    # evdev/hidraw are opened directly (pure Rust); vulkan is dlopened, so it
-    # belongs in runtimeLibs above, not here.
-    buildInputs = [
-      fontconfig # GPUI text rendering (yeslogic-fontconfig-sys)
-      freetype # font-kit (freetype-sys)
-      libxkbcommon # GPUI keyboard handling
-      wayland # wayland-sys
-      libxcb # xcb / x11rb — the hook and GPUI's X11 backend
-    ];
-
-    # The three shipped binaries; xtask (macOS bundling/DMG) is not used on
-    # Linux.
-    cargoExtraArgs = "--package=openlogi --package=openlogi-agent --package=openlogi-gui";
-
-    # Some tests require real Logitech hardware, D-Bus, or uinput — none of
-    # which exist in the sandbox. The Rust CI workflow runs the test suite.
-    doCheck = false;
+    mainProgram = "openlogi";
+    # Darwin support (the .app bundle, see nixpkgs' `openlogi`) could be
+    # revived here later; this package is authored and tested on Linux.
+    platforms = lib.platforms.linux;
   };
-in
-craneLib.buildPackage (
-  commonArgs
-  // {
-    # The dependency-only build that every later source change reuses.
-    cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-    postInstall = ''
-      install -Dm644 packaging/linux/desktop/openlogi.desktop \
-        "$out/share/applications/openlogi.desktop"
-      install -Dm644 design/icon/openlogi.png \
-        "$out/share/icons/hicolor/512x512/apps/openlogi.png"
-      install -Dm644 packaging/linux/udev/70-openlogi.rules \
-        "$out/lib/udev/rules.d/70-openlogi.rules"
-      install -Dm644 packaging/linux/systemd/openlogi-agent.service \
-        "$out/lib/systemd/user/openlogi-agent.service"
-    '';
-
-    postFixup = ''
-      wrapProgram "$out/bin/openlogi-gui" \
-        --prefix LD_LIBRARY_PATH : "${runtimeLibs}"
-
-      # The packaged unit hardcodes /usr/bin; point it at this output.
-      substituteInPlace "$out/lib/systemd/user/openlogi-agent.service" \
-        --replace-fail /usr/bin/openlogi-agent "$out/bin/openlogi-agent"
-    '';
-
-    meta = {
-      description = "Local-first companion for Logitech HID++ peripherals";
-      homepage = "https://github.com/AprilNEA/OpenLogi";
-      license = with lib.licenses; [
-        mit
-        asl20
-      ];
-      mainProgram = "openlogi";
-      # Darwin support (the .app bundle, see nixpkgs' `openlogi`) could be
-      # revived here later; this package is authored and tested on Linux.
-      platforms = lib.platforms.linux;
-    };
-  }
-)
+}


### PR DESCRIPTION
## Summary

Follows #600 and the question under #598. Having measured it, the per-change Nix build isn't worth what it costs, and the crane migration was optimising for a cadence we shouldn't have.

**Why weekly.** It is the most expensive job in CI — a full Linux build of the workspace, 20+ minutes — and in **60 runs it has never failed once**. It also guards an install path nobody is pointed at: the README ships `.deb` / `.rpm` / `.pkg.tar.zst` for Linux, and the flake appears only in developer-facing docs. What can genuinely rot it — nixpkgs-unstable drifting, a new `-sys` dependency needing a `buildInput`, a bumped git pin invalidating an `outputHashes` entry — is real but rare, and none of it is urgent enough to make every contributor wait. Noticing within a week is fine, and the failing build prints the hash to paste.

Editing the flake or the package expression *is* the moment a break is likely, so those paths still trigger it on their own PR, and `workflow_dispatch` covers "check this now" after bumping a pin.

**Why crane goes back.** Its entire benefit is a warm dependency derivation. At a weekly cadence the GitHub Actions cache is evicted between runs, so every run is cold — and cold is where crane loses:

| | duration |
|---|---|
| `buildRustPackage` (baseline) | 21–23 min |
| crane, cold run ① | 32 min |
| crane, cold run ② | 47 min |

It compiles the dependencies and then the package instead of both at once, so it pays twice for what a single derivation does once. That leaves an extra flake input and a vendor-checkout hook buying a speedup nothing will collect. The `outputHashes` table returns with it — one hash per git repository, updated when a pin moves, which is the cheaper trade at this cadence.

Note the warm number was never measured: both crane runs were cold, the second having started while the first was still uploading its cache. If the flake ever becomes a first-class install path, crane is worth revisiting — with the cache question settled first, since the dependency closure is large and the GHA cache caps at 10 GB per repository.

## Testing

`nix eval .#packages.x86_64-linux.openlogi.drvPath` after the revert — the restored expression still instantiates. The build itself is the same one that has been green for weeks; this PR touches its schedule, not its content.

This PR changes `nix/**`, so it triggers the job under the new rules and is verified by it.