### PR TITLE
fix(config): harden schema and persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5154,6 +5154,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
 ]

--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ Things OpenLogi does that Options+ won't:
 - **Run on Linux.** Options+ ships for macOS and Windows only. OpenLogi treats
   Linux as a first-class platform: evdev/uinput hook, udev rules, a systemd
   user unit, and `.deb` / `.rpm` / `.pkg.tar.zst` packages.
-- **Move the Gesture Button.** Pick which physical button owns the gesture
-  role — the dedicated Gesture Button, middle, back, or forward — with per-direction swipe
-  bindings, or turn gestures off entirely. Options+ pins the gesture role to
-  the dedicated Gesture Button.
+- **Put gestures on any button.** The dedicated Gesture Button, middle, back,
+  and forward buttons can each have their own per-direction swipe bindings.
+  Options+ pins gestures to the dedicated Gesture Button.
 - **Keep config in plain text.** Everything is one TOML file you can read,
   diff, version-control, and copy between machines.
 - **Script it.** A real CLI: device inventory, asset prefetch, and on-device

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -103,7 +103,7 @@ pub type SharedHookMaps = Arc<RwLock<HookMaps>>;
 /// mouse bindings these are not per-app-profile (M1 scope — per the spec's
 /// non-goals), so a single map suffices. Keyed by the config `KeyTrigger`
 /// (keycode + modifiers).
-pub type SharedKeyboardBindings = Arc<RwLock<std::collections::HashMap<KeyTrigger, Action>>>;
+pub type SharedKeyboardBindings = Arc<RwLock<BTreeMap<KeyTrigger, Action>>>;
 
 /// Convert the hook-layer modifier state into the config-layer type (the two
 /// live in different crates — core is leaf-level and duplicates the four

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -51,9 +51,9 @@ use openlogi_hid::{
 };
 use openlogi_ipc::transport;
 use openlogi_ipc::{
-    ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus, FoundDevice,
-    InventoryHealth, MonitorEvent, PROTOCOL_VERSION, PairingCommandError, PairingFailure,
-    PairingUpdate,
+    ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus,
+    ConfigReloadError, FoundDevice, InventoryHealth, MonitorEvent, PROTOCOL_VERSION,
+    PairingCommandError, PairingFailure, PairingUpdate,
 };
 use tarpc::context::Context;
 use tarpc::server::{BaseChannel, Channel as _};
@@ -642,8 +642,9 @@ impl Agent for MockAgent {
         self.state.lock().await.render_inventory()
     }
 
-    async fn reload_config(self, _: Context) {
+    async fn reload_config(self, _: Context) -> Result<(), ConfigReloadError> {
         info!("reload_config (no-op in the mock)");
+        Ok(())
     }
 
     // The mock has no Actions Ring hardware: long-polls idle until the

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -267,7 +267,7 @@ mod tests {
     fn shared_runtime() -> SharedRuntime {
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
-            keyboard_bindings: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            keyboard_bindings: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -24,8 +24,8 @@ use openlogi_hid::{
 };
 use openlogi_ipc::transport;
 use openlogi_ipc::{
-    ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus, MonitorEvent,
-    PROTOCOL_VERSION, PairingCommandError, PairingUpdate,
+    ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus,
+    ConfigReloadError, MonitorEvent, PROTOCOL_VERSION, PairingCommandError, PairingUpdate,
 };
 
 use crate::pairing::PairingManager;
@@ -100,7 +100,7 @@ impl Agent for AgentServer {
         self.orchestrator.lock().await.inventory()
     }
 
-    async fn reload_config(self, _: Context) {
+    async fn reload_config(self, _: Context) -> Result<(), ConfigReloadError> {
         match Config::load_or_default() {
             Ok(config) => {
                 let launch_at_login = config.app_settings.launch_at_login;
@@ -108,8 +108,14 @@ impl Agent for AgentServer {
                 // The GUI's launch-at-login toggle reaches us through this
                 // reload, so re-reconcile the autostart from the new config.
                 crate::launch_agent::reconcile(launch_at_login);
+                Ok(())
             }
-            Err(e) => warn!(error = %e, "reload_config: parse failed; keeping current config"),
+            Err(error) => {
+                warn!(error = %error, "reload_config: parse failed; keeping current config");
+                Err(ConfigReloadError {
+                    message: error.to_string(),
+                })
+            }
         }
     }
 

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -19,6 +19,7 @@ etcetera = "0.11.0"
 atomic-write-file = { workspace = true }
 num_enum = { workspace = true }
 strum = { version = "0.27", features = ["derive"] }
+toml_edit = "0.22"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.10.0"

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -142,6 +142,7 @@ impl<'de> Deserialize<'de> for RingAction {
 /// Keeping the action and optional presentation icon in one value makes an
 /// orphan icon impossible: clearing a slot removes the complete entry.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActionRingEntry {
     action: RingAction,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -203,6 +204,7 @@ impl ActionRingEntry {
 
 /// The actions displayed at the eight fixed ring positions.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActionRingLayout {
     /// Populated ring positions. An absent key is an intentionally empty slot.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -263,6 +265,7 @@ impl Default for ActionRingLayout {
 
 /// Per-device Actions Ring settings and application-specific layouts.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActionRingConfig {
     /// Whether `ShowActionsRing` opens this device's ring.
     #[serde(default = "default_true")]

--- a/crates/openlogi-core/src/binding/application_target.rs
+++ b/crates/openlogi-core/src/binding/application_target.rs
@@ -58,6 +58,7 @@ impl ApplicationTarget {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ApplicationTargetWire {
     path: String,
     #[serde(default)]

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -247,6 +247,98 @@ fn all_catalog_variants_roundtrip_toml() {
 }
 
 #[test]
+fn persisted_action_variant_names_are_stable() {
+    let mut actions = Action::catalog();
+    actions.extend([
+        Action::SetDpiPreset(0),
+        Action::CustomShortcut(
+            "F1".parse()
+                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+        ),
+        Action::TypeText(String::new()),
+        Action::RunAppleScript(String::new()),
+        Action::RunShellCommand(String::new()),
+        Action::Workflow(Vec::new()),
+        Action::ShowActionsRing,
+        Action::OpenApplication(
+            ApplicationTarget::new("/Applications/OpenLogi.app", "OpenLogi")
+                .unwrap_or_else(|error| panic!("valid target failed: {error}")),
+        ),
+    ]);
+    let mut actual: Vec<String> = actions
+        .into_iter()
+        .map(
+            |action| match toml::Value::try_from(action).expect("serialize action") {
+                toml::Value::String(name) => name,
+                toml::Value::Table(table) if table.len() == 1 => table
+                    .into_iter()
+                    .next()
+                    .map(|(key, _)| key)
+                    .expect("one variant key"),
+                value => panic!("unexpected action shape: {value:?}"),
+            },
+        )
+        .collect();
+    actual.sort();
+    let mut expected = [
+        "AppExpose",
+        "BrowserBack",
+        "BrowserForward",
+        "CaptureRegion",
+        "CloseTab",
+        "Copy",
+        "CustomShortcut",
+        "Cut",
+        "CycleDpiPresets",
+        "Find",
+        "HorizontalScrollLeft",
+        "HorizontalScrollRight",
+        "LaunchpadShow",
+        "LeftClick",
+        "LockScreen",
+        "MiddleClick",
+        "MissionControl",
+        "MouseBack",
+        "MouseForward",
+        "MuteVolume",
+        "NewTab",
+        "NextDesktop",
+        "NextTab",
+        "NextTrack",
+        "None",
+        "OpenApplication",
+        "Paste",
+        "PlayPause",
+        "PrevTab",
+        "PrevTrack",
+        "PreviousDesktop",
+        "Redo",
+        "ReloadPage",
+        "ReopenTab",
+        "RightClick",
+        "RunAppleScript",
+        "RunShellCommand",
+        "Save",
+        "Screenshot",
+        "ScrollDown",
+        "ScrollUp",
+        "SelectAll",
+        "SetDpiPreset",
+        "ShowActionsRing",
+        "ShowDesktop",
+        "Sleep",
+        "ToggleSmartShift",
+        "TypeText",
+        "Undo",
+        "VolumeDown",
+        "VolumeUp",
+        "Workflow",
+    ];
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn custom_shortcut_roundtrips_toml() {
     let action = Action::CustomShortcut("Cmd+Shift+P".parse().expect("valid shortcut failed"));
     assert_eq!(roundtrip(&action), action);

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -6,19 +6,12 @@
 //! as `"receiver:abc123:slot:2"`. Schema migrations branch on
 //! [`Config::schema_version`].
 
-use std::{
-    collections::{BTreeMap, HashSet},
-    ffi::OsString,
-    fs, io,
-    path::{Path, PathBuf},
-    sync::{Mutex, OnceLock, PoisonError},
-};
+use std::{collections::BTreeMap, path::Path};
 
-use atomic_write_file::AtomicWriteFile;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 mod device;
+mod file;
 mod key_trigger;
 mod settings;
 
@@ -26,24 +19,26 @@ mod settings;
 mod tests;
 
 pub use device::{DeviceConfig, DeviceIdentity};
+pub use file::{ConfigError, ConfigFile};
+#[cfg(test)]
+use file::{backup_existing_config, config_backup_path};
 pub use key_trigger::{KeyModifiers, KeyTrigger, KeyboardConfig, ParseTriggerError};
 pub use settings::LightSettings;
 pub use settings::{
     AppSettings, Appearance, AssetSourcePreference, CameraControls, DEFAULT_THUMBWHEEL_SENSITIVITY,
-    GestureOwner, Lighting, MAX_THUMBWHEEL_SENSITIVITY, MIN_THUMBWHEEL_SENSITIVITY,
+    Lighting, MAX_THUMBWHEEL_SENSITIVITY, MIN_THUMBWHEEL_SENSITIVITY,
     SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, SMARTSHIFT_MIN_AUTO_DISENGAGE, ScrollResolution, SmartShift,
-    WheelMode,
+    WheelMode, clamp_thumbwheel_sensitivity,
 };
 
 use crate::binding::{
     Action, ActionRingConfig, ActionRingIcon, ActionRingSlot, Binding, ButtonId, GestureDirection,
     RingAction, default_binding, default_binding_for, default_gesture_binding,
 };
-use crate::paths::{self, PathsError};
-
-/// The schema version the current build produces. Bumped on breaking layout
-/// changes; readers branch on the parsed value before consuming the rest of
-/// the file.
+use settings::GestureOwner;
+/// The schema version the current build produces. Bumped whenever the
+/// persisted shape or enum vocabulary changes; readers inspect this value
+/// before consuming the rest of the file.
 ///
 /// v4 removes the one-gesture-button-per-device owner lock: gesture mode is a
 /// per-button fact read from the binding shape, so `gesture_owner` no longer
@@ -60,19 +55,18 @@ use crate::paths::{self, PathsError};
 /// v2 merged the per-device `button_bindings` + `gesture_bindings` maps into a
 /// single `bindings: BTreeMap<ButtonId, Binding>`. A v1 file still loads (the
 /// `RawDeviceConfig` shim folds the legacy fields) and self-heals to v2 on the
-/// next save; [`Config::load_from_path`] rejects only versions *newer* than this
-/// so a forward file fails loudly instead of silently losing bindings.
+/// next save; [`Config::load_from_path`] accepts supported versions `1` through
+/// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
+/// silently losing bindings.
 pub const SCHEMA_VERSION: u32 = 4;
-
-const CONFIG_BACKUP_GENERATIONS: usize = 5;
-static BACKED_UP_CONFIGS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// Schema version the file was written with. Compared against
-    /// [`SCHEMA_VERSION`] on load: older layouts migrate, newer ones are
-    /// rejected loudly rather than silently losing settings.
+    /// [`SCHEMA_VERSION`] on load: supported older layouts migrate, while zero
+    /// and newer layouts are rejected rather than silently losing settings.
     pub schema_version: u32,
     /// Non-device-scoped preferences (autostart, tray, language, …).
     #[serde(default, skip_serializing_if = "AppSettings::is_default")]
@@ -112,111 +106,7 @@ impl Default for Config {
     }
 }
 
-/// Failure loading or persisting `config.toml`. The file-scoped variants
-/// carry the offending path so callers can surface an actionable message.
-#[derive(Debug, Error)]
-pub enum ConfigError {
-    /// The platform config directory could not be resolved (no home
-    /// directory for the current user).
-    #[error("could not resolve config path")]
-    Path(#[from] PathsError),
-    /// Reading the config file from disk failed.
-    #[error("could not read config at {path}")]
-    Read {
-        /// The config file the read targeted.
-        path: PathBuf,
-        /// The underlying I/O error.
-        #[source]
-        source: io::Error,
-    },
-    /// The file was read but is not valid TOML for this schema.
-    #[error("could not parse config at {path}")]
-    Parse {
-        /// The config file that failed to parse.
-        path: PathBuf,
-        /// The underlying TOML deserialization error.
-        #[source]
-        source: toml::de::Error,
-    },
-    /// Writing the updated config back to disk failed.
-    #[error("could not write config at {path}")]
-    Write {
-        /// The config file the write targeted.
-        path: PathBuf,
-        /// The underlying I/O error.
-        #[source]
-        source: io::Error,
-    },
-    /// The in-memory config could not be serialized to TOML — a bug in the
-    /// config types rather than user error, since [`Config`] always
-    /// serializes cleanly.
-    #[error("could not serialize config")]
-    Serialize(#[from] toml::ser::Error),
-    /// The file declares a `schema_version` newer than this build
-    /// understands; failing loudly avoids silently dropping settings a newer
-    /// build wrote.
-    #[error("config at {path} has unsupported schema_version {found}")]
-    UnsupportedSchemaVersion {
-        /// The config file carrying the unsupported version.
-        path: PathBuf,
-        /// The `schema_version` the file declared.
-        found: u32,
-    },
-}
-
-#[allow(
-    clippy::result_large_err,
-    reason = "Config I/O keeps rich parse/write context and is not a hot path"
-)]
 impl Config {
-    /// Loads the config from the default user path, returning
-    /// [`Config::default`] if the file does not exist yet.
-    pub fn load_or_default() -> Result<Self, ConfigError> {
-        Self::load_from_path(&paths::config_path()?)
-    }
-
-    /// Same as [`Self::load_or_default`] but reads from `path`. Used by tests
-    /// to avoid touching the real user config.
-    pub fn load_from_path(path: &Path) -> Result<Self, ConfigError> {
-        match fs::read_to_string(path) {
-            Ok(text) => {
-                let mut config: Self =
-                    toml::from_str(&text).map_err(|source| ConfigError::Parse {
-                        path: path.to_path_buf(),
-                        source,
-                    })?;
-                // Accept any version up to the current one: older files migrate
-                // through the per-device [`RawDeviceConfig`] shim and self-heal on
-                // the next save. Only a *newer* file is rejected — loudly, so a
-                // downgraded binary refuses to load (and silently wipe) a config
-                // it can't represent.
-                if config.schema_version > SCHEMA_VERSION {
-                    return Err(ConfigError::UnsupportedSchemaVersion {
-                        path: path.to_path_buf(),
-                        found: config.schema_version,
-                    });
-                }
-                // An owner-locked file (v3 and older) rewrites its gesture
-                // shapes to shape-driven form. Version-gated: on a v4 file
-                // several gesture-shaped buttons are a deliberate state that
-                // must round-trip untouched.
-                if config.schema_version <= 3 {
-                    config.migrate_owner_locked_gestures();
-                }
-                // Stamp the in-memory doc to the current version so a re-save
-                // writes the migrated shape (the device shim already folded
-                // the legacy fields during deserialize).
-                config.schema_version = SCHEMA_VERSION;
-                Ok(config)
-            }
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
-            Err(source) => Err(ConfigError::Read {
-                path: path.to_path_buf(),
-                source,
-            }),
-        }
-    }
-
     /// A config that never touches the on-disk file: [`Self::save_atomic`] is
     /// a no-op. For tests that drive the state layer's persistence paths —
     /// with a default config those would overwrite the developer's real
@@ -227,35 +117,6 @@ impl Config {
             ephemeral: true,
             ..Self::default()
         }
-    }
-
-    /// Writes the config atomically to the default user path: serialize to a
-    /// sibling temp file, then rename over the target. On Unix the temp file
-    /// is created with mode 0600. No-op for an [`Self::ephemeral`] config.
-    pub fn save_atomic(&self) -> Result<(), ConfigError> {
-        if self.ephemeral {
-            return Ok(());
-        }
-        self.save_to_path(&paths::config_path()?)
-    }
-
-    /// Same as [`Self::save_atomic`] but writes to `path`. Used by tests.
-    pub fn save_to_path(&self, path: &Path) -> Result<(), ConfigError> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
-                path: path.to_path_buf(),
-                source,
-            })?;
-        }
-        let body = toml::to_string_pretty(self)?;
-        backup_config_once(path).map_err(|source| ConfigError::Write {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        write_atomic(path, body.as_bytes()).map_err(|source| ConfigError::Write {
-            path: path.to_path_buf(),
-            source,
-        })
     }
 
     /// Returns the bindings stored for `device_key`, or an empty map if the
@@ -297,7 +158,7 @@ impl Config {
 
     /// The global keyboard F-key bindings (read accessor).
     #[must_use]
-    pub fn keyboard_bindings(&self) -> &std::collections::HashMap<KeyTrigger, Action> {
+    pub fn keyboard_bindings(&self) -> &BTreeMap<KeyTrigger, Action> {
         &self.keyboard.bindings
     }
 
@@ -693,7 +554,7 @@ impl Config {
         self.devices
             .entry(device_key.to_string())
             .or_default()
-            .identity = Some(identity);
+            .identity = Some(identity.without_unit_identifiers());
     }
 
     /// Whether `device_key` has a non-empty per-app binding overlay for the
@@ -916,7 +777,7 @@ impl Config {
         self.devices
             .entry(device_key.to_string())
             .or_default()
-            .thumbwheel_sensitivity = sensitivity;
+            .thumbwheel_sensitivity = sensitivity.map(clamp_thumbwheel_sensitivity);
     }
 }
 
@@ -941,63 +802,4 @@ fn app_overlay<'a, T>(overlays: &'a BTreeMap<String, T>, app: &str) -> Option<&'
 
         overlays.get(&format!("exe:{}", executable_name.to_ascii_lowercase()))
     })
-}
-
-fn backup_config_once(path: &Path) -> io::Result<()> {
-    let backed_up = BACKED_UP_CONFIGS.get_or_init(|| Mutex::new(HashSet::new()));
-    let mut backed_up = backed_up.lock().unwrap_or_else(PoisonError::into_inner);
-    if backed_up.contains(path) {
-        return Ok(());
-    }
-    match fs::metadata(path) {
-        Ok(_) => backup_existing_config(path)?,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error),
-    }
-    backed_up.insert(path.to_path_buf());
-    Ok(())
-}
-
-fn backup_existing_config(path: &Path) -> io::Result<()> {
-    for generation in (1..CONFIG_BACKUP_GENERATIONS).rev() {
-        let source = config_backup_path(path, generation)?;
-        match fs::read(&source) {
-            Ok(bytes) => write_atomic(&config_backup_path(path, generation + 1)?, &bytes)?,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
-        }
-    }
-    write_atomic(&config_backup_path(path, 1)?, &fs::read(path)?)
-}
-
-fn config_backup_path(path: &Path, generation: usize) -> io::Result<PathBuf> {
-    let Some(file_name) = path.file_name() else {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "config path has no file name",
-        ));
-    };
-    let mut backup_name = OsString::from(file_name);
-    backup_name.push(format!(".backup.{generation}"));
-    Ok(path.with_file_name(backup_name))
-}
-
-/// Write `bytes` to `path` atomically via a randomized temp file + rename,
-/// with the directory fsync the old hand-rolled writer lacked.
-fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    #[cfg_attr(
-        not(unix),
-        expect(unused_mut, reason = "only the unix path mutates the options")
-    )]
-    let mut options = AtomicWriteFile::options();
-    #[cfg(unix)]
-    {
-        use atomic_write_file::unix::OpenOptionsExt as _;
-        use std::os::unix::fs::OpenOptionsExt as _;
-        // Force 0600 on every save, matching the previous writer.
-        options.preserve_mode(false).mode(0o600);
-    }
-    let mut file = options.open(path)?;
-    io::Write::write_all(&mut file, bytes)?;
-    file.commit()
 }

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::settings::{
     CameraControls, GestureOwner, LightSettings, Lighting, ScrollResolution, SmartShift,
-    deserialize_gesture_owner,
+    deserialize_gesture_owner, deserialize_optional_thumbwheel_sensitivity,
 };
 use crate::binding::{Action, ActionRingConfig, Binding, ButtonId, GestureDirection};
 use crate::device::{Capabilities, DeviceKind, DeviceModelInfo, LightCapabilities};
@@ -26,6 +26,7 @@ use crate::device::{Capabilities, DeviceKind, DeviceModelInfo, LightCapabilities
 /// vanishing from the device list (and losing its Pointer/Buttons panels)
 /// until a cold probe happens to win its race — see issue #159.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeviceIdentity {
     /// The name shown in the carousel, as resolved from the asset registry the
     /// last time the device was online.
@@ -58,13 +59,25 @@ pub struct DeviceIdentity {
     pub registry_model_id: Option<String>,
 }
 
+impl DeviceIdentity {
+    /// Remove per-unit identifiers before this model snapshot is persisted.
+    #[must_use]
+    pub fn without_unit_identifiers(mut self) -> Self {
+        if let Some(model) = &mut self.model_info {
+            model.serial_number = None;
+            model.unit_id = [0; 4];
+        }
+        self
+    }
+}
+
 /// Settings scoped to a single physical device.
 ///
 /// Deserialization goes through `RawDeviceConfig` (`#[serde(from)]`) so
 /// pre-v2 files — which split bindings across `button_bindings` +
 /// `gesture_bindings` — fold into the unified [`Self::bindings`] map. Only
-/// `bindings` is ever serialized, so a migrated file self-heals to the v2 shape
-/// on its next save.
+/// `bindings` is ever serialized, so a migrated file is rewritten to the v2
+/// shape on its next save.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(from = "RawDeviceConfig")]
 pub struct DeviceConfig {
@@ -81,7 +94,7 @@ pub struct DeviceConfig {
     /// (gesture mode is per-button; see
     /// [`Config::set_gesture_mode`](crate::config::Config::set_gesture_mode)).
     #[serde(skip_serializing)]
-    pub gesture_owner: Option<GestureOwner>,
+    pub(super) gesture_owner: Option<GestureOwner>,
     /// Last-known identity (name / kind / capabilities), captured while the
     /// device was online. Lets the UI render this device — with the right
     /// config panels — on a cold start before any probe, or while it sleeps.
@@ -115,13 +128,21 @@ pub struct DeviceConfig {
     /// [`Action::CycleDpiPresets`] and indexed by
     /// [`Action::SetDpiPreset`]. Empty means "no presets configured" —
     /// the cycle action becomes a no-op until the user adds at least one.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_dpi_presets",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub dpi_presets: Vec<u32>,
     /// The sensor DPI the user committed for this device. Persisted because
     /// the value lives in device RAM and resets on a power cycle (#189); the
     /// agent re-applies it when the device reconnects. `None` until the user
     /// first changes DPI.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_dpi",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub dpi: Option<u32>,
     /// Per-device RGB lighting (static color + brightness + on/off). `None`
     /// until the user changes it, so it stays out of `config.toml` otherwise.
@@ -149,7 +170,11 @@ pub struct DeviceConfig {
     /// Per-device thumb-wheel sensitivity override. `None` falls back to the
     /// app-wide
     /// [`AppSettings::thumbwheel_sensitivity`](crate::config::AppSettings::thumbwheel_sensitivity).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_thumbwheel_sensitivity",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub thumbwheel_sensitivity: Option<i32>,
     /// Invert this device's scroll-wheel direction relative to the OS setting
     /// (issue #126): on, a wheel tick scrolls the opposite way, so a user who
@@ -230,17 +255,45 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
+fn deserialize_dpi_presets<'de, D>(deserializer: D) -> Result<Vec<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let values = Vec::<u32>::deserialize(deserializer)?;
+    if let Some(value) = values.iter().find(|value| u16::try_from(**value).is_err()) {
+        return Err(serde::de::Error::custom(format_args!(
+            "DPI must fit the HID++ 16-bit range, got {value}"
+        )));
+    }
+    Ok(values)
+}
+
+fn deserialize_optional_dpi<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<u32>::deserialize(deserializer)?;
+    if let Some(value) = value
+        && u16::try_from(value).is_err()
+    {
+        return Err(serde::de::Error::custom(format_args!(
+            "DPI must fit the HID++ 16-bit range, got {value}"
+        )));
+    }
+    Ok(value)
+}
+
 /// Deserialize-only shim that folds the pre-v2 `button_bindings` +
 /// `gesture_bindings` fields into [`DeviceConfig::bindings`]. Never serialized
 /// (only [`DeviceConfig`] is), so reading a legacy file and saving rewrites it
 /// in the v2 shape.
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawDeviceConfig {
     /// Explicit gesture owner (v2.1+). Absent on older configs → `None` → the
-    /// owner is inferred in
-    /// [`Config::gesture_owner`](crate::config::Config::gesture_owner). A
-    /// present-but-invalid value is tolerated as `None` (infer), not a parse
-    /// error — see [`deserialize_gesture_owner`].
+    /// owner is inferred during the version-gated migration. A
+    /// present-but-invalid legacy value is tolerated as `None` for compatibility
+    /// with v3-and-older behavior; current schemas reject the field first.
     #[serde(default, deserialize_with = "deserialize_gesture_owner")]
     gesture_owner: Option<GestureOwner>,
     #[serde(default)]
@@ -261,9 +314,9 @@ struct RawDeviceConfig {
     per_app_bindings: BTreeMap<String, BTreeMap<ButtonId, Action>>,
     #[serde(default)]
     action_ring: ActionRingConfig,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_dpi_presets")]
     dpi_presets: Vec<u32>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_dpi")]
     dpi: Option<u32>,
     #[serde(default)]
     lighting: Option<Lighting>,
@@ -277,7 +330,10 @@ struct RawDeviceConfig {
     camera_profiles: BTreeMap<String, CameraControls>,
     #[serde(default)]
     camera_profile: Option<String>,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_thumbwheel_sensitivity"
+    )]
     thumbwheel_sensitivity: Option<i32>,
     #[serde(default)]
     invert_scroll: bool,
@@ -325,7 +381,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
         DeviceConfig {
             enabled: raw.enabled,
             gesture_owner: raw.gesture_owner,
-            identity: raw.identity,
+            identity: raw.identity.map(DeviceIdentity::without_unit_identifiers),
             bindings,
             disabled_gestures: raw.disabled_gestures,
             per_app_bindings: raw.per_app_bindings,

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -1,0 +1,372 @@
+//! Version-aware configuration loading and conflict-safe persistence.
+
+use std::{
+    collections::HashSet,
+    ffi::OsString,
+    fs, io,
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock, PoisonError},
+};
+
+use atomic_write_file::AtomicWriteFile;
+use serde::Deserialize;
+use thiserror::Error;
+use toml_edit::{DocumentMut, Item, Table};
+
+use super::{Config, SCHEMA_VERSION};
+use crate::paths::{self, PathsError};
+
+const CONFIG_BACKUP_GENERATIONS: usize = 5;
+static BACKED_UP_CONFIGS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
+/// Failure loading or persisting `config.toml`.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// The platform config directory could not be resolved.
+    #[error("could not resolve config path: {0}")]
+    Path(#[from] PathsError),
+    /// Reading the config file from disk failed.
+    #[error("could not read config at {path}: {source}")]
+    Read {
+        /// The config file the read targeted.
+        path: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+    /// The file is not valid TOML for its declared schema.
+    #[error("could not parse config at {path}: {source}")]
+    Parse {
+        /// The config file that failed to parse.
+        path: PathBuf,
+        /// The underlying TOML deserialization error, including line/column.
+        #[source]
+        source: Box<toml::de::Error>,
+    },
+    /// A field from an older schema was used with a version where it is invalid.
+    #[error("config at {path} uses obsolete field {field} with schema_version {version}")]
+    ObsoleteField {
+        /// The config file containing the field.
+        path: PathBuf,
+        /// Dotted path to the obsolete field.
+        field: String,
+        /// Schema version declared by the file.
+        version: u32,
+    },
+    /// The file changed after it was loaded, so overwriting it would lose edits.
+    #[error("config at {path} changed on disk; restart OpenLogi to reload it")]
+    Conflict {
+        /// The concurrently modified config file.
+        path: PathBuf,
+    },
+    /// Writing the updated config back to disk failed.
+    #[error("could not write config at {path}: {source}")]
+    Write {
+        /// The config file the write targeted.
+        path: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+    /// The in-memory config could not be serialized to TOML.
+    #[error("could not serialize config: {0}")]
+    Serialize(#[from] toml::ser::Error),
+    /// A generated or previously parsed TOML document could not be edited.
+    #[error("could not preserve config formatting at {path}: {source}")]
+    Edit {
+        /// The config file whose document was being updated.
+        path: PathBuf,
+        /// The TOML editing parser error.
+        #[source]
+        source: Box<toml_edit::TomlError>,
+    },
+    /// The file declares a schema outside the supported version range.
+    #[error("config at {path} has unsupported schema_version {found}")]
+    UnsupportedSchemaVersion {
+        /// The config file carrying the unsupported version.
+        path: PathBuf,
+        /// The schema version the file declared.
+        found: u32,
+    },
+}
+
+/// A loaded config file plus the exact source revision it came from.
+///
+/// Saving compares that source with the current file before writing, so an
+/// editor or another process cannot be overwritten by a stale GUI snapshot.
+/// Existing comments and formatting are retained for keys that still exist.
+#[derive(Debug, Clone)]
+pub struct ConfigFile {
+    path: PathBuf,
+    source: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ConfigHeader {
+    schema_version: u32,
+}
+
+impl ConfigFile {
+    /// Load the default user config, returning a writable default when the
+    /// file does not exist yet.
+    pub fn load_or_default() -> Result<(Config, Self), ConfigError> {
+        Self::load_from_path(&paths::config_path()?)
+    }
+
+    /// Load `path`, retaining its source revision for conflict-safe saves.
+    pub fn load_from_path(path: &Path) -> Result<(Config, Self), ConfigError> {
+        match fs::read_to_string(path) {
+            Ok(source) => {
+                let config = parse_config(path, &source)?;
+                Ok((
+                    config,
+                    Self {
+                        path: path.to_path_buf(),
+                        source: Some(source),
+                    },
+                ))
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok((
+                Config::default(),
+                Self {
+                    path: path.to_path_buf(),
+                    source: None,
+                },
+            )),
+            Err(source) => Err(ConfigError::Read {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
+    }
+
+    /// Save `config` only if the file still matches the loaded revision.
+    pub fn save(&mut self, config: &Config) -> Result<(), ConfigError> {
+        let current = match fs::read_to_string(&self.path) {
+            Ok(source) => Some(source),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(source) => {
+                return Err(ConfigError::Read {
+                    path: self.path.clone(),
+                    source,
+                });
+            }
+        };
+        if current != self.source {
+            return Err(ConfigError::Conflict {
+                path: self.path.clone(),
+            });
+        }
+
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
+                path: self.path.clone(),
+                source,
+            })?;
+        }
+        let body = render_config(config, self.source.as_deref(), &self.path)?;
+        backup_config_once(&self.path).map_err(|source| ConfigError::Write {
+            path: self.path.clone(),
+            source,
+        })?;
+        write_atomic(&self.path, body.as_bytes()).map_err(|source| ConfigError::Write {
+            path: self.path.clone(),
+            source,
+        })?;
+        self.source = Some(body);
+        Ok(())
+    }
+}
+
+impl Config {
+    /// Loads the config from the default user path, returning a default when
+    /// the file does not exist yet.
+    pub fn load_or_default() -> Result<Self, ConfigError> {
+        ConfigFile::load_or_default().map(|(config, _)| config)
+    }
+
+    /// Load from `path` without retaining a writable source revision.
+    pub fn load_from_path(path: &Path) -> Result<Self, ConfigError> {
+        ConfigFile::load_from_path(path).map(|(config, _)| config)
+    }
+
+    /// Atomically save to the default path. Long-lived writers should retain
+    /// and use [`ConfigFile`] so concurrent edits can be detected.
+    pub fn save_atomic(&self) -> Result<(), ConfigError> {
+        if self.ephemeral {
+            return Ok(());
+        }
+        self.save_to_path(&paths::config_path()?)
+    }
+
+    /// Atomically save to `path`, preserving comments in its current content.
+    /// Used by tests and one-shot tools; long-lived writers should use
+    /// [`ConfigFile::save`].
+    pub fn save_to_path(&self, path: &Path) -> Result<(), ConfigError> {
+        let (_, mut file) = ConfigFile::load_from_path(path)?;
+        file.save(self)
+    }
+}
+
+fn parse_config(path: &Path, source: &str) -> Result<Config, ConfigError> {
+    let header: ConfigHeader = toml::from_str(source).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })?;
+    if header.schema_version == 0 || header.schema_version > SCHEMA_VERSION {
+        return Err(ConfigError::UnsupportedSchemaVersion {
+            path: path.to_path_buf(),
+            found: header.schema_version,
+        });
+    }
+    reject_obsolete_fields(path, source, header.schema_version)?;
+    let mut config: Config = toml::from_str(source).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })?;
+    if header.schema_version <= 3 {
+        config.migrate_owner_locked_gestures();
+    }
+    config.schema_version = SCHEMA_VERSION;
+    Ok(config)
+}
+
+fn reject_obsolete_fields(path: &Path, source: &str, version: u32) -> Result<(), ConfigError> {
+    let value: toml::Value = toml::from_str(source).map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })?;
+    let Some(devices) = value.get("devices").and_then(toml::Value::as_table) else {
+        return Ok(());
+    };
+    for (device_key, value) in devices {
+        let Some(device) = value.as_table() else {
+            continue;
+        };
+        for (field, last_version) in [
+            ("button_bindings", 1),
+            ("gesture_bindings", 1),
+            ("gesture_owner", 3),
+        ] {
+            if version > last_version && device.contains_key(field) {
+                return Err(ConfigError::ObsoleteField {
+                    path: path.to_path_buf(),
+                    field: format!("devices.{device_key}.{field}"),
+                    version,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_config(
+    config: &Config,
+    original: Option<&str>,
+    path: &Path,
+) -> Result<String, ConfigError> {
+    let generated = toml::to_string_pretty(config)?;
+    let Some(original) = original else {
+        return Ok(generated);
+    };
+    let mut document = original
+        .parse::<DocumentMut>()
+        .map_err(|source| ConfigError::Edit {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?;
+    let generated = generated
+        .parse::<DocumentMut>()
+        .map_err(|source| ConfigError::Edit {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?;
+    reconcile_table(document.as_table_mut(), generated.as_table());
+    Ok(document.to_string())
+}
+
+fn reconcile_table(current: &mut Table, generated: &Table) {
+    let stale: Vec<String> = current
+        .iter()
+        .filter(|(key, _)| generated.get(key).is_none())
+        .map(|(key, _)| key.to_string())
+        .collect();
+    for key in stale {
+        current.remove(&key);
+    }
+    for (key, generated_item) in generated {
+        if let Some(current_item) = current.get_mut(key) {
+            reconcile_item(current_item, generated_item);
+        } else {
+            current.insert(key, generated_item.clone());
+        }
+    }
+}
+
+fn reconcile_item(current: &mut Item, generated: &Item) {
+    if let (Some(current), Some(generated)) = (current.as_table_mut(), generated.as_table()) {
+        reconcile_table(current, generated);
+        return;
+    }
+    let decor = current.as_value().map(|value| value.decor().clone());
+    *current = generated.clone();
+    if let (Some(decor), Some(value)) = (decor, current.as_value_mut()) {
+        *value.decor_mut() = decor;
+    }
+}
+
+fn backup_config_once(path: &Path) -> io::Result<()> {
+    let backed_up = BACKED_UP_CONFIGS.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut backed_up = backed_up.lock().unwrap_or_else(PoisonError::into_inner);
+    if backed_up.contains(path) {
+        return Ok(());
+    }
+    match fs::metadata(path) {
+        Ok(_) => backup_existing_config(path)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    backed_up.insert(path.to_path_buf());
+    Ok(())
+}
+
+pub(super) fn backup_existing_config(path: &Path) -> io::Result<()> {
+    for generation in (1..CONFIG_BACKUP_GENERATIONS).rev() {
+        let source = config_backup_path(path, generation)?;
+        match fs::read(&source) {
+            Ok(bytes) => write_atomic(&config_backup_path(path, generation + 1)?, &bytes)?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    write_atomic(&config_backup_path(path, 1)?, &fs::read(path)?)
+}
+
+pub(super) fn config_backup_path(path: &Path, generation: usize) -> io::Result<PathBuf> {
+    let Some(file_name) = path.file_name() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "config path has no file name",
+        ));
+    };
+    let mut backup_name = OsString::from(file_name);
+    backup_name.push(format!(".backup.{generation}"));
+    Ok(path.with_file_name(backup_name))
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    #[cfg_attr(
+        not(unix),
+        expect(unused_mut, reason = "only the unix path mutates the options")
+    )]
+    let mut options = AtomicWriteFile::options();
+    #[cfg(unix)]
+    {
+        use atomic_write_file::unix::OpenOptionsExt as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.preserve_mode(false).mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    io::Write::write_all(&mut file, bytes)?;
+    file.commit()
+}

--- a/crates/openlogi-core/src/config/key_trigger.rs
+++ b/crates/openlogi-core/src/config/key_trigger.rs
@@ -1,5 +1,7 @@
 //! Keyboard key triggers and the global keyboard-bindings section.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::binding::Action;
@@ -173,8 +175,9 @@ impl std::str::FromStr for KeyTrigger {
 
 /// The top-level `[keyboard]` table. Bindings are keyed by [`KeyTrigger`].
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KeyboardConfig {
     /// Function-key trigger → action map for the remapper.
-    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
-    pub bindings: std::collections::HashMap<KeyTrigger, Action>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub bindings: BTreeMap<KeyTrigger, Action>,
 }

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -1,7 +1,6 @@
 //! App-wide and per-device *value* settings: [`AppSettings`], [`Appearance`],
 //! [`Lighting`], [`ScrollResolution`], [`WheelMode`] / [`SmartShift`], and
-//! [`GestureOwner`], plus
-//! their serde `default_*` / `deserialize_*` helpers.
+//! the legacy [`GestureOwner`], plus their serde helpers.
 
 use std::collections::BTreeMap;
 
@@ -51,6 +50,7 @@ pub enum AssetSourcePreference {
 /// All fields are `#[serde(default)]` so adding a new one is backward
 /// compatible — old config files just keep the default for the new field.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[allow(
     clippy::struct_excessive_bools,
     reason = "independent on/off user preferences, not a state machine"
@@ -131,7 +131,10 @@ pub struct AppSettings {
     /// custom wheel action needs to fire. [`DEFAULT_THUMBWHEEL_SENSITIVITY`]
     /// (the out-of-the-box value) means 1× scroll speed; the wheel is only
     /// diverted from native scrolling once this leaves the default.
-    #[serde(default = "default_thumbwheel_sensitivity")]
+    #[serde(
+        default = "default_thumbwheel_sensitivity",
+        deserialize_with = "deserialize_thumbwheel_sensitivity"
+    )]
     pub thumbwheel_sensitivity: i32,
     /// Light/dark appearance preference. Defaults to following the OS.
     #[serde(default)]
@@ -159,6 +162,12 @@ pub const DEFAULT_THUMBWHEEL_SENSITIVITY: i32 = 14;
 pub const MIN_THUMBWHEEL_SENSITIVITY: i32 = 1;
 /// Highest selectable [`AppSettings::thumbwheel_sensitivity`].
 pub const MAX_THUMBWHEEL_SENSITIVITY: i32 = 100;
+
+/// Clamp a UI-provided thumb-wheel sensitivity to the persisted range.
+#[must_use]
+pub fn clamp_thumbwheel_sensitivity(value: i32) -> i32 {
+    value.clamp(MIN_THUMBWHEEL_SENSITIVITY, MAX_THUMBWHEEL_SENSITIVITY)
+}
 
 impl AppSettings {
     /// `skip_serializing_if` helper: true when nothing diverges from the
@@ -204,6 +213,40 @@ const fn default_thumbwheel_sensitivity() -> i32 {
     DEFAULT_THUMBWHEEL_SENSITIVITY
 }
 
+pub(super) fn deserialize_thumbwheel_sensitivity<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = i32::deserialize(deserializer)?;
+    if (MIN_THUMBWHEEL_SENSITIVITY..=MAX_THUMBWHEEL_SENSITIVITY).contains(&value) {
+        Ok(value)
+    } else {
+        Err(serde::de::Error::custom(format_args!(
+            "thumbwheel sensitivity must be between {MIN_THUMBWHEEL_SENSITIVITY} and {MAX_THUMBWHEEL_SENSITIVITY}, got {value}"
+        )))
+    }
+}
+
+pub(super) fn deserialize_optional_thumbwheel_sensitivity<'de, D>(
+    deserializer: D,
+) -> Result<Option<i32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<i32>::deserialize(deserializer)?;
+    value
+        .map(|value| {
+            if (MIN_THUMBWHEEL_SENSITIVITY..=MAX_THUMBWHEEL_SENSITIVITY).contains(&value) {
+                Ok(value)
+            } else {
+                Err(serde::de::Error::custom(format_args!(
+                    "thumbwheel sensitivity must be between {MIN_THUMBWHEEL_SENSITIVITY} and {MAX_THUMBWHEEL_SENSITIVITY}, got {value}"
+                )))
+            }
+        })
+        .transpose()
+}
+
 /// Per-device RGB lighting: a single static color, brightness, and on/off.
 /// Deliberately basic — per-key effects are a later addition.
 ///
@@ -211,21 +254,20 @@ const fn default_thumbwheel_sensitivity() -> i32 {
 /// changes require a `PROTOCOL_VERSION` bump (guarded by
 /// `openlogi-ipc/tests/wire_format.rs`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Lighting {
     /// Master on/off for the device's lighting. The color and brightness
     /// persist while disabled, so re-enabling restores the previous look.
     #[serde(default = "default_lighting_enabled")]
     pub enabled: bool,
     /// Static color as 6 hex digits `"RRGGBB"` (no leading `#`). A value
-    /// that does not parse falls back to white on load — the same per-field
-    /// tolerance as `brightness`, because failing the whole load would
-    /// discard the user's entire config (see the `load_or_default` callers).
+    /// that does not parse is rejected with its TOML location.
     #[serde(
         default = "default_lighting_color",
         deserialize_with = "deserialize_lighting_color"
     )]
     pub color: Rgb,
-    /// Brightness percent, clamped to 0–100 on load.
+    /// Brightness percent (`0`–`100`).
     #[serde(
         default = "default_lighting_brightness",
         deserialize_with = "deserialize_brightness"
@@ -239,6 +281,7 @@ pub struct Lighting {
 /// works for lumen-based, percentage-based, and stepped light protocols. The
 /// selected driver maps it to its native range when applying the setting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LightSettings {
     /// Whether the light should be on.
     #[serde(default = "default_true")]
@@ -285,7 +328,7 @@ impl LightSettings {
         Self {
             enabled,
             auto_camera: false,
-            brightness_percent,
+            brightness_percent: brightness_percent.min(100),
             temperature_kelvin,
             color: None,
         }
@@ -322,29 +365,33 @@ fn default_lighting_brightness() -> u8 {
     100
 }
 
-/// Clamp a deserialized brightness into the UI's `0..=100` range, so a
-/// hand-edited `config.toml` can't feed out-of-range values into the scaling
-/// math (which assumes `brightness <= 100`).
+/// Reject brightness outside the UI and hardware contract.
 fn deserialize_brightness<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    Ok(u8::deserialize(deserializer)?.min(100))
+    let value = u8::deserialize(deserializer)?;
+    if value <= 100 {
+        Ok(value)
+    } else {
+        Err(serde::de::Error::custom(format_args!(
+            "brightness must be between 0 and 100, got {value}"
+        )))
+    }
 }
 
-/// Accept the optional `#` prefix supported by older releases, then fall back
-/// to white when the configured color does not parse, mirroring the `brightness`
-/// clamp above instead of failing the whole config load.
+/// Accept the optional `#` prefix supported by older releases, then parse the
+/// validated RGB value.
 fn deserialize_lighting_color<'de, D>(deserializer: D) -> Result<Rgb, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let color = String::deserialize(deserializer)?;
-    Ok(color
+    color
         .strip_prefix('#')
         .unwrap_or(color.as_str())
         .parse()
-        .unwrap_or(Rgb::WHITE))
+        .map_err(serde::de::Error::custom)
 }
 
 /// Per-webcam UVC controls, keyed by control name (`brightness`, `focus`,
@@ -381,38 +428,29 @@ pub enum WheelMode {
 }
 
 /// SmartShift auto-disengage out-of-box default (`16` ≈ 4 turn/s, per the
-/// x2110 / x2111 spec). The sensitivity slider's default and the heal target
-/// for a corrupt persisted threshold.
+/// x2110 / x2111 spec). The sensitivity slider's default.
 pub const SMARTSHIFT_AUTO_DISENGAGE_DEFAULT: u8 = 16;
 
 /// Smallest auto-disengage threshold OpenLogi will store or apply (`8` ≈
 /// 2 turn/s). Below this the ratchet releases into free-spin at everyday scroll
 /// speeds, leaving the wheel "stuck" spinning (#317); `0` is also the firmware
 /// "do not change" sentinel that must never be stored as a real value. A
-/// persisted threshold below this floor is a corrupt artifact and is healed to
-/// [`SMARTSHIFT_AUTO_DISENGAGE_DEFAULT`] on load.
+/// persisted threshold below this floor is rejected on load.
 pub const SMARTSHIFT_MIN_AUTO_DISENGAGE: u8 = 8;
 
-/// Heal a persisted auto-disengage threshold on load: anything below
-/// [`SMARTSHIFT_MIN_AUTO_DISENGAGE`] (including the `0` sentinel) becomes the
-/// default. `0xFF` (permanent ratchet) and every real threshold at or above the
-/// floor pass through unchanged.
+/// Reject a persisted auto-disengage threshold below the supported floor.
 fn deserialize_auto_disengage<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let value = u8::deserialize(deserializer)?;
-    Ok(if value < SMARTSHIFT_MIN_AUTO_DISENGAGE {
-        tracing::warn!(
-            value,
-            min = SMARTSHIFT_MIN_AUTO_DISENGAGE,
-            default = SMARTSHIFT_AUTO_DISENGAGE_DEFAULT,
-            "healed persisted SmartShift auto-disengage threshold below supported floor"
-        );
-        SMARTSHIFT_AUTO_DISENGAGE_DEFAULT
+    if value >= SMARTSHIFT_MIN_AUTO_DISENGAGE {
+        Ok(value)
     } else {
-        value
-    })
+        Err(serde::de::Error::custom(format_args!(
+            "SmartShift auto_disengage must be between {SMARTSHIFT_MIN_AUTO_DISENGAGE} and 255, got {value}"
+        )))
+    }
 }
 
 /// Per-device SmartShift wheel configuration, persisted so the agent can
@@ -424,16 +462,17 @@ where
 /// `config.toml` on reload), so it is free to evolve without a
 /// `PROTOCOL_VERSION` bump.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SmartShift {
     /// The persisted wheel mode, re-applied to device RAM on reconnect.
     pub mode: WheelMode,
     /// SmartShift auto-disengage threshold (`0x08`–`0xFE`, in 0.25 turn/s
     /// steps), or `0xFF` for a permanently engaged ratchet. A persisted value
-    /// below [`SMARTSHIFT_MIN_AUTO_DISENGAGE`] is healed to the default on load.
+    /// below [`SMARTSHIFT_MIN_AUTO_DISENGAGE`] is rejected on load.
     #[serde(deserialize_with = "deserialize_auto_disengage")]
     pub auto_disengage: u8,
-    /// Tunable-torque force percentage (`1`–`100`), `0` when the device
-    /// doesn't support tunable torque.
+    /// Firmware tunable-torque level (`1`–`255`), `0` when the device does not
+    /// expose tunable torque. HID++ defines the full non-zero byte range.
     pub tunable_torque: u8,
 }
 
@@ -443,20 +482,17 @@ pub struct SmartShift {
 /// binding shapes, which are the whole truth from then on. Read as a bare TOML
 /// scalar (`"Off"` or a [`ButtonId`] name).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum GestureOwner {
+pub(super) enum GestureOwner {
     /// Gestures were explicitly turned off for this device.
     Off,
     /// The named button owned the gesture role.
     Button(ButtonId),
 }
 
-/// Lenient field deserializer for `RawDeviceConfig::gesture_owner`
-/// (`crate::config::device`). An unrecognized or miscased value (`"back"`, a
-/// typo, a future-version button name) is treated as absent — i.e. "infer the
-/// owner" — rather than failing the whole-document parse and reverting *every*
-/// device's settings to defaults. Mirrors [`deserialize_brightness`], which
-/// clamps a bad value instead of erroring; a hand-editable config should
-/// degrade one field, not the document.
+/// Lenient legacy deserializer for v3-and-older `gesture_owner`. Those releases
+/// already treated an unknown value as absent and inferred the owner; preserving
+/// that behavior keeps migration compatible. Current schemas reject the field
+/// before device deserialization.
 pub(super) fn deserialize_gesture_owner<'de, D>(
     deserializer: D,
 ) -> Result<Option<GestureOwner>, D::Error>
@@ -482,28 +518,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn low_auto_disengage_heals_to_default_on_load() {
-        // A pre-#317 config could persist a runaway-low threshold (or the `0`
-        // sentinel); loading it must heal to the default so reapply doesn't
-        // re-program free-spin-on-any-scroll into the device — while a real
-        // threshold and the `0xFF` permanent-ratchet value pass through.
-        let heal = |v: u8| {
-            let body = format!("mode = \"ratchet\"\nauto_disengage = {v}\ntunable_torque = 50\n");
+    fn smartshift_rejects_values_outside_the_persisted_contract() {
+        let parse = |auto_disengage: u8, tunable_torque: u8| {
+            let body = format!(
+                "mode = \"ratchet\"\nauto_disengage = {auto_disengage}\ntunable_torque = {tunable_torque}\n"
+            );
             toml::from_str::<SmartShift>(&body)
-                .expect("parse")
-                .auto_disengage
         };
-        assert_eq!(heal(0), SMARTSHIFT_AUTO_DISENGAGE_DEFAULT);
-        assert_eq!(heal(1), SMARTSHIFT_AUTO_DISENGAGE_DEFAULT);
-        assert_eq!(
-            heal(SMARTSHIFT_MIN_AUTO_DISENGAGE - 1),
-            SMARTSHIFT_AUTO_DISENGAGE_DEFAULT
-        );
-        assert_eq!(
-            heal(SMARTSHIFT_MIN_AUTO_DISENGAGE),
-            SMARTSHIFT_MIN_AUTO_DISENGAGE
-        );
-        assert_eq!(heal(16), 16);
-        assert_eq!(heal(0xff), 0xff);
+        parse(SMARTSHIFT_MIN_AUTO_DISENGAGE - 1, 50)
+            .expect_err("auto_disengage below the persisted minimum must be rejected");
+        parse(SMARTSHIFT_MIN_AUTO_DISENGAGE, 50).expect("the minimum itself is in contract");
+        parse(0xff, 0xff).expect("the top of both ranges is in contract");
     }
 }

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 
-use std::assert_matches;
+use std::{assert_matches, fs};
 
 use super::*;
 use crate::binding::{default_binding, default_gesture_binding};
@@ -12,6 +12,13 @@ fn write_and_read(config: &Config) -> Config {
     let path = dir.path().join("config.toml");
     config.save_to_path(&path).expect("save");
     Config::load_from_path(&path).expect("load")
+}
+
+#[test]
+fn canonical_configuration_example_parses() {
+    let body = include_str!("../../../../docs/config.example.toml");
+    let config: Config = toml::from_str(body).expect("documented config must parse");
+    assert_eq!(config.schema_version, SCHEMA_VERSION);
 }
 
 #[test]
@@ -229,8 +236,8 @@ fn standalone_light_settings_roundtrip_per_device() {
 }
 
 #[test]
-fn standalone_light_brightness_is_clamped_on_load() {
-    let cfg: Config = toml::from_str(
+fn standalone_light_brightness_outside_percentage_range_is_rejected() {
+    let error = toml::from_str::<Config>(
         r"
             schema_version = 3
             [devices.glow.light]
@@ -238,11 +245,8 @@ fn standalone_light_brightness_is_clamped_on_load() {
             brightness_percent = 255
         ",
     )
-    .expect("light config loads");
-    assert_eq!(
-        cfg.light("glow").map(|light| light.brightness_percent),
-        Some(100)
-    );
+    .expect_err("out-of-range brightness must fail");
+    assert!(error.to_string().contains("between 0 and 100"));
 }
 
 #[test]
@@ -269,8 +273,8 @@ fn standalone_light_camera_automation_roundtrips() {
 }
 
 #[test]
-fn unparseable_lighting_color_falls_back_to_white() {
-    let cfg: Config = toml::from_str(
+fn unparseable_lighting_color_is_rejected() {
+    let error = toml::from_str::<Config>(
         r#"
             schema_version = 3
             [devices.g513.lighting]
@@ -279,11 +283,8 @@ fn unparseable_lighting_color_falls_back_to_white() {
             brightness = 50
         "#,
     )
-    .expect("config with a bad color still loads");
-    assert_eq!(
-        cfg.lighting("g513").map(|l| l.color),
-        Some(crate::color::Rgb::WHITE)
-    );
+    .expect_err("invalid RGB must fail");
+    assert!(error.to_string().contains("invalid RGB color"));
 }
 
 #[test]
@@ -553,6 +554,39 @@ fn device_identity_roundtrips_and_is_iterable() {
         parsed.known_identities().collect::<Vec<_>>(),
         vec![("2b034", &mouse)]
     );
+}
+
+#[test]
+fn persisted_identity_strips_per_unit_identifiers() {
+    use crate::device::{Capabilities, DeviceKind, DeviceModelInfo, DeviceTransports};
+
+    let mut config = Config::default();
+    config.set_device_identity(
+        "receiver:test:slot:1",
+        DeviceIdentity {
+            display_name: "Mouse".into(),
+            model_info: Some(DeviceModelInfo {
+                entity_count: 1,
+                serial_number: Some("private-serial".into()),
+                unit_id: [1, 2, 3, 4],
+                transports: DeviceTransports::default(),
+                model_ids: [0xb034, 0, 0],
+                extended_model_id: 2,
+            }),
+            codename: None,
+            kind: DeviceKind::Mouse,
+            capabilities: Capabilities::default(),
+            light_capabilities: None,
+            driver_id: None,
+            registry_model_id: None,
+        },
+    );
+    let model = config
+        .device_identity("receiver:test:slot:1")
+        .and_then(|identity| identity.model_info.as_ref())
+        .expect("model info");
+    assert_eq!(model.serial_number, None);
+    assert_eq!(model.unit_id, [0; 4]);
 }
 
 #[test]
@@ -927,6 +961,111 @@ fn rejects_newer_schema_version_but_accepts_v1() {
         Config::load_from_path(&path).is_ok(),
         "v1 should still load"
     );
+}
+
+#[test]
+fn future_version_is_rejected_before_incompatible_fields_are_parsed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        "schema_version = 99\n[app_settings]\nthumbwheel_sensitivity = \"future\"\n",
+    )
+    .expect("write");
+    assert_matches!(
+        Config::load_from_path(&path).expect_err("future schema must fail by version"),
+        ConfigError::UnsupportedSchemaVersion { found: 99, .. }
+    );
+}
+
+#[test]
+fn schema_version_zero_is_rejected() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("config.toml");
+    fs::write(&path, "schema_version = 0\n").expect("write config");
+
+    assert!(matches!(
+        Config::load_from_path(&path),
+        Err(ConfigError::UnsupportedSchemaVersion { found: 0, .. })
+    ));
+}
+
+#[test]
+fn current_schema_rejects_unknown_and_obsolete_fields() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivty = 14\n",
+    )
+    .expect("write typo");
+    assert_matches!(
+        Config::load_from_path(&path).expect_err("typo must fail"),
+        ConfigError::Parse { .. }
+    );
+
+    fs::write(
+        &path,
+        r#"schema_version = 4
+[devices.mouse.identity]
+display_name = "Mouse"
+kind = "mouse"
+capabilities = { buttons = true, pointer = true, lighting = false, scroll_inversion = false, typo = true }
+"#,
+    )
+    .expect("write nested typo");
+    assert_matches!(
+        Config::load_from_path(&path).expect_err("nested typo must fail"),
+        ConfigError::Parse { .. }
+    );
+
+    fs::write(
+        &path,
+        "schema_version = 4\n[devices.mouse]\ngesture_owner = \"Off\"\n",
+    )
+    .expect("write obsolete field");
+    assert_matches!(
+        Config::load_from_path(&path).expect_err("v4 legacy field must fail"),
+        ConfigError::ObsoleteField { .. }
+    );
+}
+
+#[test]
+fn persisted_numeric_contracts_reject_unsafe_values() {
+    for body in [
+        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivity = 0\n",
+        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivity = 101\n",
+        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivity = -2147483648\n",
+        "schema_version = 4\n[devices.mouse]\nthumbwheel_sensitivity = -1\n",
+        "schema_version = 4\n[devices.mouse]\ndpi = 65536\n",
+        "schema_version = 4\n[devices.mouse]\ndpi_presets = [800, 70000]\n",
+    ] {
+        assert!(toml::from_str::<Config>(body).is_err(), "accepted: {body}");
+    }
+}
+
+#[test]
+fn tracked_save_preserves_comments_and_rejects_concurrent_edits() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        "# keep this comment\nschema_version = 4\nselected_device = \"one\" # and this one\n",
+    )
+    .expect("write");
+    let (mut config, mut file) = ConfigFile::load_from_path(&path).expect("load tracked");
+    config.set_selected_device(Some("two".into()));
+    file.save(&config).expect("save tracked");
+    let saved = fs::read_to_string(&path).expect("read saved");
+    assert!(saved.contains("# keep this comment"));
+    assert!(saved.contains("# and this one"));
+    assert!(saved.contains("selected_device = \"two\""));
+
+    let external = format!("{saved}# external editor\n");
+    fs::write(&path, &external).expect("external edit");
+    config.set_selected_device(Some("three".into()));
+    assert_matches!(file.save(&config), Err(ConfigError::Conflict { .. }));
+    assert_eq!(fs::read_to_string(path).expect("read conflict"), external);
 }
 
 #[test]

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -94,6 +94,7 @@ impl DeviceKind {
 /// (issue #127): kind is an identity guess, capability is what the firmware
 /// actually announced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[allow(
     clippy::struct_excessive_bools,
     reason = "capabilities is a serialized feature-bit DTO; independent booleans keep the IPC/config shape explicit"
@@ -254,6 +255,7 @@ pub struct ReceiverInfo {
 /// of an extended-model byte and one of these PIDs, so callers usually want
 /// to format `extended_model_id` + `model_ids[N]` to match.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeviceModelInfo {
     /// Number of firmware entities (main firmware, bootloader, …) the
     /// device reports.
@@ -298,6 +300,7 @@ impl DeviceModelInfo {
     reason = "bitfield mirroring HID++ DeviceInformation; transports are independent flags"
 )]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeviceTransports {
     /// Wired USB.
     pub usb: bool,

--- a/crates/openlogi-core/src/device/light.rs
+++ b/crates/openlogi-core/src/device/light.rs
@@ -171,6 +171,7 @@ pub enum LightValueRangeError {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawLightValueRange {
     min: u16,
     max: u16,
@@ -193,6 +194,7 @@ impl<'de> Deserialize<'de> for LightValueRange {
 /// Optional ranges are the source of truth for UI controls. A driver must not
 /// advertise a control merely because the product is classified as a light.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[allow(
     clippy::struct_excessive_bools,
     reason = "independent optional light controls are a serialized capability DTO"

--- a/crates/openlogi-gui/src/app.rs
+++ b/crates/openlogi-gui/src/app.rs
@@ -429,6 +429,17 @@ impl Render for AppView {
             });
         let root = Self::with_back_navigation(root, cx);
 
+        if let Some(issue) = cx
+            .try_global::<AppState>()
+            .and_then(AppState::config_issue)
+            .map(gpui::SharedString::from)
+        {
+            window.set_window_title("OpenLogi");
+            return root
+                .child(status::config_issue_body(issue, pal))
+                .into_any_element();
+        }
+
         // The agent is the source of truth for both the permission state and
         // the device list; `AgentLink` is everything the GUI knows about it.
         // Until the first snapshot lands, hold a neutral connecting frame:

--- a/crates/openlogi-gui/src/app/status.rs
+++ b/crates/openlogi-gui/src/app/status.rs
@@ -11,6 +11,7 @@ use gpui_component::{
     v_flex,
 };
 
+use crate::app_menu::OpenConfigFolder;
 use crate::theme::{self, FOOTER_H, Palette, Typography as _};
 
 /// Centered spinner over a muted one-line caption — the quiet "still working"
@@ -99,6 +100,28 @@ pub(super) fn outdated_gui_body(pal: Palette) -> AnyElement {
             .on_click(|_, _, cx| cx.restart()),
     )
     .into_any_element()
+}
+
+/// Fail-closed frame for config load/save/conflict/reload failures.
+pub(super) fn config_issue_body(message: SharedString, pal: Palette) -> AnyElement {
+    notice_body(tr!("Configuration"), message, pal)
+        .size_full()
+        .child(
+            h_flex()
+                .gap_2()
+                .child(
+                    Button::new("open-config-folder")
+                        .label(tr!("Open Configuration Folder"))
+                        .on_click(|_, _, cx| cx.dispatch_action(&OpenConfigFolder)),
+                )
+                .child(
+                    Button::new("restart-after-config-error")
+                        .primary()
+                        .label(tr!("Relaunch OpenLogi"))
+                        .on_click(|_, _, cx| cx.restart()),
+                ),
+        )
+        .into_any_element()
 }
 
 /// Footer status bar: passive state only. Left — the Accessibility-permission

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -38,7 +38,7 @@ use crate::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 /// `0x01`–`0xFE` (0.25 turn/s steps); the slider exposes the usable band
 /// [`SMARTSHIFT_MIN_AUTO_DISENGAGE`]–`50` (≈2–12.5 turn/s, default ~16).
 /// Thresholds below the floor free-spin on everyday scrolling (#317), so the
-/// floor and default are shared with the `openlogi-core` config heal. A device
+/// floor and default are shared with the `openlogi-core` config contract. A device
 /// reporting a value outside the band is normalised for display by
 /// [`clamp_threshold`]; it is only rewritten once the user drags the slider.
 const THRESHOLD_MIN: u8 = SMARTSHIFT_MIN_AUTO_DISENGAGE;
@@ -585,7 +585,7 @@ fn raw_to_threshold(raw: f32) -> u8 {
 /// "do not change"/unset sentinel — releases the wheel into free-spin on the
 /// gentlest scroll (#317), so it must never seed the slider or the
 /// permanent-ratchet restore at that runaway value. Such values are normalised
-/// to the default (matching the `openlogi-core` config heal); values above the
+/// to the default (the config parser rejects such persisted values); values above the
 /// band clamp down to [`THRESHOLD_MAX`]. (`0xFF` permanent ratchet never reaches
 /// here — the caller handles it before clamping.)
 fn clamp_threshold(value: u8) -> u8 {

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -26,8 +26,8 @@ use openlogi_core::hid::{
     WriteError,
 };
 use openlogi_ipc::{
-    AgentClient, AgentStatus, InventoryHealth, PROTOCOL_VERSION, PairingCommandError,
-    PairingFailure, PairingUpdate,
+    AgentClient, AgentStatus, ConfigReloadError, InventoryHealth, PROTOCOL_VERSION,
+    PairingCommandError, PairingFailure, PairingUpdate,
 };
 use tarpc::client;
 use tarpc::context;
@@ -78,6 +78,8 @@ pub enum GuiUpdate {
         /// Agent acceptance or typed device failure.
         result: Result<(), WriteError>,
     },
+    /// Whether the agent adopted the config currently on disk.
+    ConfigReloadResult(Result<(), ConfigReloadError>),
 }
 
 /// A poll snapshot pushed to the GPUI loop on every successful poll round.
@@ -569,7 +571,10 @@ async fn handle(
         Command::ReadSmartShift(route, reply) => {
             let _ = reply.send(rpc_result(client.read_smartshift(ctx, route).await)?);
         }
-        Command::ReloadConfig => client.reload_config(ctx).await.map_err(|_| ())?,
+        Command::ReloadConfig => {
+            let result = client.reload_config(ctx).await.map_err(|_| ())?;
+            let _ = update_tx.send(GuiUpdate::ConfigReloadResult(result));
+        }
         Command::RequestAccessibilityPrompt => client
             .request_accessibility_prompt(ctx)
             .await

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -572,8 +572,24 @@ async fn handle(
             let _ = reply.send(rpc_result(client.read_smartshift(ctx, route).await)?);
         }
         Command::ReloadConfig => {
-            let result = client.reload_config(ctx).await.map_err(|_| ())?;
-            let _ = update_tx.send(GuiUpdate::ConfigReloadResult(result));
+            // A transport failure is not the agent rejecting the config, but it
+            // is still a reload that did not happen — and the file on disk has
+            // already changed. Staying silent here would leave the window
+            // showing the new settings while the agent keeps running the old
+            // ones, which is exactly the divergence this fails closed on.
+            match client.reload_config(ctx).await {
+                Ok(result) => {
+                    let _ = update_tx.send(GuiUpdate::ConfigReloadResult(result));
+                }
+                Err(error) => {
+                    let _ = update_tx.send(GuiUpdate::ConfigReloadResult(Err(ConfigReloadError {
+                        message: format!(
+                            "saved, but the agent could not be reached to apply it: {error}"
+                        ),
+                    })));
+                    return Err(());
+                }
+            }
         }
         Command::RequestAccessibilityPrompt => client
             .request_accessibility_prompt(ctx)
@@ -694,17 +710,44 @@ fn reply_disconnected(
             let _ = pairing_tx.send(PairingUpdate::Failed(PairingFailure::AgentRestarted));
         }
         Command::CancelPairing => {}
+        // Unlike the device commands above, a missed reload is not something a
+        // later poll repairs on its own: the config file has already changed,
+        // so the agent stays on the old one until another reload succeeds. Say
+        // so rather than let the window imply the change took effect.
+        Command::ReloadConfig => {
+            let _ = update_tx.send(GuiUpdate::ConfigReloadResult(Err(ConfigReloadError {
+                message: "saved, but the agent is not running, so it has not been applied yet"
+                    .to_string(),
+            })));
+        }
         _ => {}
     }
 }
 
 #[cfg(test)]
-#[cfg(target_os = "macos")]
 mod tests {
+    #[cfg(target_os = "macos")]
     use std::path::Path;
 
-    use super::helper_bundle;
+    use super::*;
 
+    #[test]
+    fn a_reload_that_never_reached_the_agent_is_reported() {
+        // The config file is already written by the time the reload is
+        // dispatched, so dropping this result silently would leave the window
+        // showing settings the agent is not running.
+        let (update_tx, mut update_rx) = mpsc::unbounded_channel();
+        let (pairing_tx, _pairing_rx) = mpsc::unbounded_channel();
+
+        reply_disconnected(&update_tx, &pairing_tx, Command::ReloadConfig);
+
+        let Ok(GuiUpdate::ConfigReloadResult(Err(error))) = update_rx.try_recv() else {
+            panic!("a reload that never reached the agent must be reported as failed");
+        };
+        assert!(!error.message.is_empty(), "the notice needs a reason");
+    }
+
+    #[cfg(target_os = "macos")]
     #[test]
     fn helper_bundle_resolves_only_the_packaged_layout() {
         let packaged = Path::new(

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -63,7 +63,7 @@ use gpui::{
 };
 use gpui_component::{ActiveTheme, Root};
 use openlogi_core::brand::{APP_ID, DeeplinkCommand};
-use openlogi_core::config::Config;
+use openlogi_core::config::{Config, ConfigFile};
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
@@ -145,10 +145,16 @@ fn main() -> Result<()> {
     let inventories: Vec<DeviceInventory> = Vec::new();
     let standalone = Vec::new();
 
-    let initial_config = Config::load_or_default().unwrap_or_else(|e| {
-        warn!(error = %e, "could not load config.toml; using defaults");
-        Config::default()
-    });
+    let (initial_config, config_persistence) = match ConfigFile::load_or_default() {
+        Ok((config, file)) => (config, ConfigPersistence::UserFile(file)),
+        Err(error) => {
+            warn!(error = %error, "could not load config.toml; disabling config writes");
+            (
+                Config::ephemeral(),
+                ConfigPersistence::ReadOnly(error.to_string()),
+            )
+        }
+    };
 
     // Resolve the UI locale before any menu or window is built so the first
     // frame already renders in the right language.
@@ -245,7 +251,7 @@ fn main() -> Result<()> {
                         &standalone,
                         &cache,
                         &latest_cams,
-                        ConfigPersistence::UserFile,
+                        config_persistence,
                         ipc_commands,
                     ));
                 }
@@ -446,6 +452,14 @@ fn main() -> Result<()> {
                         }) => {
                             let changed = cx.update_global::<AppState, _>(|state, _| {
                                 state.apply_light_command_result(key, request_id, command, result)
+                            });
+                            if changed {
+                                cx.update(gpui::App::refresh_windows);
+                            }
+                        }
+                        Some(ipc_client::GuiUpdate::ConfigReloadResult(result)) => {
+                            let changed = cx.update_global::<AppState, _>(|state, _| {
+                                state.apply_config_reload_result(result)
                             });
                             if changed {
                                 cx.update(gpui::App::refresh_windows);

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -12,7 +12,7 @@
 use std::collections::BTreeMap;
 
 use gpui::Global;
-use openlogi_core::config::{Config, KeyTrigger};
+use openlogi_core::config::{Config, ConfigFile, KeyTrigger};
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use openlogi_core::hid::SmartShiftStatus;
 use tokio::sync::mpsc;
@@ -101,12 +101,30 @@ pub enum AgentLink {
 /// Runtime state uses [`Self::UserFile`]. Tests opt into
 /// [`Self::MemoryOnly`] so realistic device fixtures can never modify the
 /// developer's actual `config.toml`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum ConfigPersistence {
-    /// Persist to OpenLogi's default per-user configuration file.
-    UserFile,
+    /// Persist through the tracked user file, preserving comments and refusing
+    /// to overwrite edits made after startup.
+    UserFile(ConfigFile),
+    /// A load error made the config unsafe to write for this process lifetime.
+    ReadOnly(String),
     /// Keep changes in the in-memory [`Config`] only.
+    #[cfg_attr(not(test), allow(dead_code, reason = "test-only persistence boundary"))]
     MemoryOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ConfigIssue {
+    Persistence(String),
+    Reload(String),
+}
+
+impl ConfigIssue {
+    fn message(&self) -> &str {
+        match self {
+            Self::Persistence(message) | Self::Reload(message) => message,
+        }
+    }
 }
 
 /// Inventory snapshots can briefly miss a real device while another HID++
@@ -176,6 +194,9 @@ pub struct AppState {
     /// [`Self::set_current_device`] so restarts preserve user bindings and
     /// the last-selected device.
     config: Config,
+    /// Last config revision that reached disk. Restored when a save fails so
+    /// the UI cannot continue presenting an unsaved value as committed.
+    persisted_config: Config,
     /// Sender to the IPC client thread. The agent owns the hook + all device
     /// I/O, so binding / setting writes persist to `config.toml` and then send
     /// [`Command::ReloadConfig`](crate::ipc_client::Command) for the agent to
@@ -184,6 +205,8 @@ pub struct AppState {
     ipc_commands: mpsc::UnboundedSender<crate::ipc_client::Command>,
     /// Explicit persistence boundary; tests use an in-memory-only state.
     config_persistence: ConfigPersistence,
+    /// User-visible load, save, conflict, or agent-reload failure.
+    config_issue: Option<ConfigIssue>,
     /// Raw inventory from the last *completed* enumeration, kept for the
     /// diagnostics report (receivers + transports). The poll path only stores
     /// [`InventoryHealth::Ready`](openlogi_ipc::InventoryHealth)
@@ -219,6 +242,11 @@ impl AppState {
         config_persistence: ConfigPersistence,
         ipc_commands: mpsc::UnboundedSender<crate::ipc_client::Command>,
     ) -> Self {
+        let persisted_config = config.clone();
+        let config_issue = match &config_persistence {
+            ConfigPersistence::ReadOnly(error) => Some(ConfigIssue::Persistence(error.clone())),
+            ConfigPersistence::UserFile(_) | ConfigPersistence::MemoryOnly => None,
+        };
         let device_list = build_device_list(inventories, standalone, cache, &config, cameras);
         // Record any device probed at launch so it survives the next cold start.
         let identities_changed = inventory::persist_identities(&mut config, &device_list);
@@ -243,8 +271,10 @@ impl AppState {
             next_smartshift_write_id: 0,
             device_list,
             config,
+            persisted_config,
             ipc_commands,
             config_persistence,
+            config_issue,
             last_inventory: Vec::new(),
             #[cfg(all(target_os = "macos", debug_assertions))]
             monitor_events: std::collections::VecDeque::new(),
@@ -265,6 +295,11 @@ impl AppState {
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        if state.config_issue.is_none()
+            && matches!(&state.config_persistence, ConfigPersistence::UserFile(_))
+        {
+            state.send_ipc(crate::ipc_client::Command::ReloadConfig);
+        }
         state
     }
     /// Send a device command to the agent over IPC, logging a dropped channel
@@ -282,21 +317,72 @@ impl AppState {
     /// The order matters: on a failed write the on-disk file still holds the
     /// *previous* config, so a reload would hand the agent stale values and
     /// (for volatile settings) silently re-apply the old DPI/SmartShift on the
-    /// next reconnect or wake. Skipping the reload keeps the agent on whatever
-    /// it already runs; the GUI keeps the new value in memory either way.
-    fn persist_and_reload(&self, what: &str) {
+    /// next reconnect or wake. A failed write restores the last persisted
+    /// config and surfaces the persistence error in the GUI.
+    fn persist_and_reload(&mut self, what: &str) -> bool {
         if self.persist_config(what) {
             self.send_ipc(crate::ipc_client::Command::ReloadConfig);
+            true
+        } else {
+            false
         }
     }
-    fn persist_config(&self, what: &str) -> bool {
-        if self.config_persistence == ConfigPersistence::MemoryOnly {
-            return true;
-        }
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, what, "could not persist to config.toml");
+    fn persist_config(&mut self, what: &str) -> bool {
+        let result = match &mut self.config_persistence {
+            ConfigPersistence::UserFile(file) => file.save(&self.config),
+            ConfigPersistence::ReadOnly(_) => {
+                self.restore_persisted_config();
+                return false;
+            }
+            ConfigPersistence::MemoryOnly => Ok(()),
+        };
+        if let Err(error) = result {
+            warn!(error = %error, what, "could not persist to config.toml");
+            self.config_issue = Some(ConfigIssue::Persistence(error.to_string()));
+            self.restore_persisted_config();
             return false;
         }
+        self.persisted_config.clone_from(&self.config);
+        if matches!(&self.config_issue, Some(ConfigIssue::Persistence(_))) {
+            self.config_issue = None;
+        }
+        true
+    }
+
+    fn restore_persisted_config(&mut self) {
+        self.config.clone_from(&self.persisted_config);
+        self.button_bindings = self.bindings_for_current();
+        self.gesture_bindings = self.current_gesture_maps();
+        self.keyboard_bindings = self.config.keyboard.bindings.clone();
+        if let Some(dpi) = self
+            .current_record()
+            .and_then(DeviceRecord::persistent_config_key)
+            .and_then(|key| self.config.dpi(key))
+        {
+            self.dpi = dpi;
+        }
+    }
+
+    /// Current config failure, shown as a fail-closed whole-window notice.
+    #[must_use]
+    pub fn config_issue(&self) -> Option<&str> {
+        self.config_issue.as_ref().map(ConfigIssue::message)
+    }
+
+    /// Record whether the agent adopted the last saved config.
+    pub fn apply_config_reload_result(
+        &mut self,
+        result: Result<(), openlogi_ipc::ConfigReloadError>,
+    ) -> bool {
+        let next = match result {
+            Err(error) => Some(ConfigIssue::Reload(error.message)),
+            Ok(()) if matches!(&self.config_issue, Some(ConfigIssue::Reload(_))) => None,
+            Ok(()) => return false,
+        };
+        if self.config_issue == next {
+            return false;
+        }
+        self.config_issue = next;
         true
     }
     /// A clone of the IPC command sender, so views (the DPI / SmartShift panels)

--- a/crates/openlogi-gui/src/state/bindings.rs
+++ b/crates/openlogi-gui/src/state/bindings.rs
@@ -41,9 +41,8 @@ impl AppState {
     /// Update a single binding in memory, on disk, and in the shared hook
     /// map for the currently selected device.
     ///
-    /// Disk failures and poisoned hook locks are logged at `warn` instead
-    /// of bubbling up: the UI thread shouldn't crash because the user's
-    /// home volume is full or because the hook thread panicked.
+    /// Disk failures restore the persisted projection and surface a config
+    /// error instead of crashing the UI thread.
     pub fn commit_binding(&mut self, button: ButtonId, action: Action) {
         self.button_bindings.insert(button, action.clone());
 

--- a/crates/openlogi-gui/src/state/camera.rs
+++ b/crates/openlogi-gui/src/state/camera.rs
@@ -1,7 +1,5 @@
 //! Webcam control state and camera profiles.
 
-use tracing::warn;
-
 use openlogi_camera::CameraControl;
 
 use super::AppState;
@@ -58,9 +56,7 @@ impl AppState {
         let mut controls = self.config.camera_controls(config_key).unwrap_or_default();
         controls.0.insert(name.to_string(), value);
         self.config.set_camera_controls(config_key, controls);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist camera controls");
-        }
+        self.persist_config("camera controls");
     }
     /// Lift settings from the legacy port-bound `camera-<unique_id>` key onto
     /// the stable serial/model key when the latter has none. Inventory identity
@@ -86,9 +82,7 @@ impl AppState {
                 .set_camera_active_profile(config_key, Some(active));
         }
         self.config.devices.remove(&port_key);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist camera key migration");
-        }
+        self.persist_config("camera key migration");
     }
     fn camera_key_has_settings(&self, key: &str) -> bool {
         self.config.camera_controls(key).is_some()
@@ -111,16 +105,12 @@ impl AppState {
         snap: openlogi_core::config::CameraControls,
     ) {
         self.config.save_camera_profile(config_key, name, snap);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist camera profile");
-        }
+        self.persist_config("camera profile");
     }
     /// Delete a custom camera profile and persist the removal.
     pub fn delete_camera_profile(&mut self, config_key: &str, name: &str) {
         self.config.delete_camera_profile(config_key, name);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist camera profile removal");
-        }
+        self.persist_config("camera profile removal");
     }
     /// The camera profile last applied for `config_key`, if any.
     #[must_use]
@@ -130,8 +120,6 @@ impl AppState {
     /// Record (and persist) which camera profile `config_key` last applied.
     pub fn set_camera_active_profile(&mut self, config_key: &str, name: Option<String>) {
         self.config.set_camera_active_profile(config_key, name);
-        if let Err(e) = self.config.save_atomic() {
-            warn!(error = %e, "could not persist camera profile selection");
-        }
+        self.persist_config("camera profile selection");
     }
 }

--- a/crates/openlogi-gui/src/state/dpi.rs
+++ b/crates/openlogi-gui/src/state/dpi.rs
@@ -116,17 +116,19 @@ impl AppState {
         };
         let persistent_key = record.persistent_config_key().map(str::to_string);
         let route = record.route.clone();
-        if let Some(route) = route {
-            self.send_ipc(crate::ipc_client::Command::SetDpi(route, dpi));
-        }
         if let Some(persistent_key) = persistent_key {
             self.config.set_dpi(&persistent_key, dpi);
-            self.persist_and_reload("DPI");
+            if !self.persist_and_reload("DPI") {
+                return;
+            }
         } else {
             debug!(
                 key = record.config_key.as_str(),
                 "transient device DPI applied without persistence"
             );
+        }
+        if let Some(route) = route {
+            self.send_ipc(crate::ipc_client::Command::SetDpi(route, dpi));
         }
     }
 }

--- a/crates/openlogi-gui/src/state/inventory.rs
+++ b/crates/openlogi-gui/src/state/inventory.rs
@@ -349,15 +349,12 @@ pub(super) fn persist_identities(config: &mut Config, list: &[DeviceRecord]) -> 
             kind: record.kind,
             capabilities,
             light_capabilities: record.light_capabilities,
-            model_info: record.model_info.clone().map(|mut model| {
-                model.serial_number = None;
-                model.unit_id = [0; 4];
-                model
-            }),
+            model_info: record.model_info.clone(),
             codename: record.codename.clone(),
             driver_id: record.driver_id.clone(),
             registry_model_id: record.registry_model_id.clone(),
-        };
+        }
+        .without_unit_identifiers();
         if config.device_identity(config_key) != Some(&identity) {
             config.set_device_identity(config_key, identity);
             changed = true;

--- a/crates/openlogi-gui/src/state/lighting.rs
+++ b/crates/openlogi-gui/src/state/lighting.rs
@@ -40,20 +40,19 @@ impl AppState {
         };
         let key = record.persistent_config_key().map(str::to_string);
         let target = record.route.clone();
-        if let Some(route) = target {
-            self.send_ipc(crate::ipc_client::Command::SetLighting(
-                route,
-                lighting.clone(),
-            ));
-        }
-        let Some(key) = key else {
+        if let Some(key) = key {
+            self.config.set_lighting(&key, lighting.clone());
+            // Keep the agent's config copy fresh: it re-applies the saved colour
+            // when the keyboard reconnects, and without the reload it would
+            // replay whatever was saved the last time something *else* reloaded.
+            if !self.persist_and_reload("lighting") {
+                return;
+            }
+        } else {
             debug!("transient device lighting applied without persistence");
-            return;
-        };
-        self.config.set_lighting(&key, lighting);
-        // Keep the agent's config copy fresh: it re-applies the saved colour
-        // when the keyboard reconnects, and without the reload it would
-        // replay whatever was saved the last time something *else* reloaded.
-        self.persist_and_reload("lighting");
+        }
+        if let Some(route) = target {
+            self.send_ipc(crate::ipc_client::Command::SetLighting(route, lighting));
+        }
     }
 }

--- a/crates/openlogi-gui/src/state/settings.rs
+++ b/crates/openlogi-gui/src/state/settings.rs
@@ -2,7 +2,9 @@
 
 use super::AppState;
 use gpui::App;
-use openlogi_core::config::{AppSettings, Appearance, AssetSourcePreference};
+use openlogi_core::config::{
+    AppSettings, Appearance, AssetSourcePreference, clamp_thumbwheel_sensitivity,
+};
 
 impl AppState {
     /// App-wide settings backing the Settings window (launch-at-login,
@@ -14,8 +16,8 @@ impl AppState {
     }
     /// Toggle launch-at-login, persist to `config.toml`, and reconcile the
     /// macOS `LaunchAgent` plist so the change takes effect without a
-    /// restart. No-op when the value is unchanged. Disk failures are logged,
-    /// not propagated — the Settings UI shouldn't crash on a full volume.
+    /// restart. No-op when the value is unchanged. Disk failures restore the
+    /// persisted value and surface a configuration error without crashing.
     pub fn set_launch_at_login(&mut self, enabled: bool) {
         if self.config.app_settings.launch_at_login == enabled {
             return;
@@ -128,10 +130,7 @@ impl AppState {
     /// default forever. The agent picks the change up through the reloaded
     /// capture plans. No-op when the stored override would not change.
     pub fn set_device_thumbwheel_sensitivity(&mut self, key: &str, sensitivity: i32) {
-        let sensitivity = sensitivity.clamp(
-            openlogi_core::config::MIN_THUMBWHEEL_SENSITIVITY,
-            openlogi_core::config::MAX_THUMBWHEEL_SENSITIVITY,
-        );
+        let sensitivity = clamp_thumbwheel_sensitivity(sensitivity);
         let override_value =
             (sensitivity != self.config.app_settings.thumbwheel_sensitivity).then_some(sensitivity);
         let stored = self
@@ -150,12 +149,9 @@ impl AppState {
     /// Set the app-wide default thumb-wheel sensitivity (clamped to the valid
     /// range) and persist it — devices without a per-device override follow it
     /// through the reloaded capture plans. No-op when unchanged. Disk failures
-    /// are logged, not propagated.
+    /// restore the persisted value and surface a configuration error.
     pub fn set_thumbwheel_sensitivity(&mut self, sensitivity: i32) {
-        let sensitivity = sensitivity.clamp(
-            openlogi_core::config::MIN_THUMBWHEEL_SENSITIVITY,
-            openlogi_core::config::MAX_THUMBWHEEL_SENSITIVITY,
-        );
+        let sensitivity = clamp_thumbwheel_sensitivity(sensitivity);
         if self.config.app_settings.thumbwheel_sensitivity == sensitivity {
             return;
         }

--- a/crates/openlogi-gui/src/state/smartshift.rs
+++ b/crates/openlogi-gui/src/state/smartshift.rs
@@ -114,14 +114,6 @@ impl AppState {
         let persistent_key = record.persistent_config_key().map(str::to_string);
         let route = record.route.clone();
         let can_confirm = route.is_some();
-        if let Some(route) = route {
-            self.send_ipc(crate::ipc_client::Command::SetSmartShift(
-                route,
-                mode,
-                auto_disengage,
-                tunable_torque,
-            ));
-        }
         if let Some(persistent_key) = persistent_key {
             self.config.set_smartshift(
                 &persistent_key,
@@ -131,7 +123,17 @@ impl AppState {
                     tunable_torque,
                 },
             );
-            self.persist_and_reload("SmartShift");
+            if !self.persist_and_reload("SmartShift") {
+                return;
+            }
+        }
+        if let Some(route) = route {
+            self.send_ipc(crate::ipc_client::Command::SetSmartShift(
+                route,
+                mode,
+                auto_disengage,
+                tunable_torque,
+            ));
         }
         // Reflect the write immediately so the panel doesn't flicker back to
         // the previous value before a re-read lands, but queue a confirming

--- a/crates/openlogi-gui/src/state/tests.rs
+++ b/crates/openlogi-gui/src/state/tests.rs
@@ -25,6 +25,53 @@ use super::scroll::set_scroll_resolution_if_supported;
 use super::smartshift::{smartshift_read_is_current, smartshift_write_outcome};
 use super::{AppState, ConfigPersistence, LightCommandStatus, Load, SmartShiftWriteStatus};
 
+#[test]
+fn read_only_config_rolls_back_mutations_and_does_not_reload_agent() {
+    let cache = AssetResolver::new();
+    let (commands, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::ReadOnly("invalid config".into()),
+        commands,
+    );
+
+    state.set_thumbwheel_sensitivity(50);
+
+    assert_eq!(
+        state.app_settings().thumbwheel_sensitivity,
+        openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY
+    );
+    assert_eq!(state.config_issue(), Some("invalid config"));
+    assert!(receiver.try_recv().is_err());
+}
+
+#[test]
+fn agent_reload_error_stays_visible_until_a_successful_confirmation() {
+    let cache = AssetResolver::new();
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+    assert!(
+        state.apply_config_reload_result(Err(openlogi_ipc::ConfigReloadError {
+            message: "agent rejected config".into(),
+        }))
+    );
+    assert_eq!(state.config_issue(), Some("agent rejected config"));
+    assert!(state.apply_config_reload_result(Ok(())));
+    assert_eq!(state.config_issue(), None);
+}
+
 fn direct_inventory(unit_id: [u8; 4]) -> DeviceInventory {
     DeviceInventory {
         receiver: ReceiverInfo {

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -38,7 +38,15 @@ use serde::{Deserialize, Serialize};
 /// v15: custom Actions Ring presentation icons and locale appended.
 /// v16: `ActionRingPresentation::literal` inserted (custom labels render
 ///      verbatim instead of passing through localization).
-pub const PROTOCOL_VERSION: u32 = 16;
+/// v17: `reload_config` returns a typed parse/validation result.
+pub const PROTOCOL_VERSION: u32 = 17;
+
+/// Why the agent refused to adopt the config currently on disk.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigReloadError {
+    /// Actionable config error including path and TOML location when known.
+    pub message: String,
+}
 
 /// Where the agent's device enumeration stands. The distinction matters
 /// because an empty inventory list is ambiguous on its own: the GUI must keep
@@ -281,7 +289,7 @@ pub trait Agent {
     async fn inventory() -> Vec<DeviceInventory>;
     /// Re-read `config.toml` and rebuild the live binding/DPI maps. Called by
     /// the GUI after it saves a config change.
-    async fn reload_config();
+    async fn reload_config() -> Result<(), ConfigReloadError>;
     /// Apply a DPI value to `route` now (slider preview / commit).
     async fn set_dpi(route: DeviceRoute, dpi: u32) -> Result<(), WriteError>;
     /// Apply a lighting config to `route` now.

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -40,8 +40,8 @@ use openlogi_core::hid::{
 };
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, ActionRingPresentation, AgentRequest,
-    AgentSnapshot, AgentStatus, FoundDevice, InventoryHealth, MonitorEvent, PROTOCOL_VERSION,
-    PairingCommandError, PairingFailure, PairingUpdate,
+    AgentSnapshot, AgentStatus, ConfigReloadError, FoundDevice, InventoryHealth, MonitorEvent,
+    PROTOCOL_VERSION, PairingCommandError, PairingFailure, PairingUpdate,
 };
 
 /// Serialize exactly as the transport does (`tokio_serde::formats::Bincode`
@@ -69,7 +69,17 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 16);
+    assert_eq!(PROTOCOL_VERSION, 17);
+}
+
+#[test]
+fn config_reload_result() {
+    let error = ConfigReloadError {
+        message: "bad".into(),
+    };
+    assert_wire(&error, "03626164");
+    assert_wire(&Ok::<(), ConfigReloadError>(()), "00");
+    assert_wire(&Err::<(), ConfigReloadError>(error), "0103626164");
 }
 
 /// tarpc encodes the request enum's variant index, so trait *method order* is

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,206 +1,85 @@
 # Configuration
 
-How OpenLogi stores its settings. For install and usage, see the
-[README](../README.md).
+OpenLogi stores settings as plain TOML. The GUI and agent read the same file:
 
-Config is a TOML file, read on startup and written atomically on change. Before
-the first save in each app process, OpenLogi preserves the previous file as
-`config.toml.backup.1` and rotates up to `config.toml.backup.5`.
-
-- macOS & Linux: `$XDG_CONFIG_HOME/openlogi/config.toml` (default `~/.config/openlogi/config.toml`)
+- macOS and Linux: `$XDG_CONFIG_HOME/openlogi/config.toml` (normally
+  `~/.config/openlogi/config.toml`)
 - Windows: `%USERPROFILE%\.config\openlogi\config.toml`
 
-Most settings below are managed by the GUI (Settings window, action picker,
-DPI / SmartShift / lighting panels), but the file stays hand-editable;
-per-application overlays and custom shortcuts are currently authored there.
-OpenLogi reloads it on startup. Older schemas are migrated on load, including
-`schema_version = 1` files that split button and gesture bindings.
+The complete, tested example is [config.example.toml](config.example.toml).
+Copy only the sections you need and replace its example physical device keys
+with keys already written by OpenLogi for your devices.
 
-Per-device settings are keyed by physical identity, such as
-`receiver:aabbccdd:slot:1` for a receiver-connected device. This keeps two
-mice of the same model independent:
+## Editing and recovery
 
-- `bindings` — one entry per rebindable button: either a single action, or a
-  per-direction table for the gesture button.
-- `per_app_bindings` — overlays keyed by application id (bundle id such as
-  `com.microsoft.VSCode` on macOS, `WM_CLASS` on Linux/X11, or a lower-cased
-  executable path on Windows) that take precedence while that app is
-  frontmost. Windows also accepts `exe:<filename>.exe`, for example
-  `exe:sharex.exe`, as a stable fallback for Store and self-updating apps. An
-  exact path entry wins when both forms exist.
-- `action_ring` — the enabled state, haptic-feedback preference, default
-  eight-slot layout, and complete per-application layouts.
-- `dpi_presets` — the ordered list cycled by the `CycleDpiPresets` action.
-- `smartshift` — wheel mode, sensitivity, and permanent-ratchet state.
-- `invert_scroll` — reverse this device's native vertical wheel direction
-  without changing the system trackpad direction.
-- `lighting` — static RGB colour, brightness (0–100), and on/off for wired
-  RGB keyboards.
-- `light` — standalone-light power, normalized brightness, and temperature.
-  Set `auto_camera = true` on macOS to turn the light on while any camera is in
-  use and off when camera use stops; the manual power preference and the other
-  light settings remain independent.
-- `gesture_owner` — which button owns the gesture role, when chosen
-  explicitly (otherwise inferred).
-- `host_switch_targets` — on a compatible keyboard, physical config keys of
-  mice that should follow its Easy-Switch channel. Both devices must already
-  be paired on corresponding channels. The keyboard's host controls and every
-  target must expose the HID++ features needed for host switching. Configure
-  the link on every computer from which the keyboard may initiate a switch.
-- `fn_lock` — keyboards only: `true` makes the F-row send F1–F12 without
-  holding Fn, `false` keeps the printed media/shortcut functions. Absent
-  means the keyboard's own state is left alone. Re-applied on reconnect.
+The GUI writes atomically and keeps `config.toml.backup.1` through
+`config.toml.backup.5`. Existing comments and formatting are retained when the
+GUI updates known fields.
 
-The app-wide `[app_settings]` block holds `launch_at_login`,
-`check_for_updates`, and `auto_install_updates` (all off by default);
-`show_in_menu_bar` (macOS menu bar / Windows tray, ignored on Linux; on by
-default); `capture_mouse_events` (on by default; set to `false` to keep the
-agent from installing the OS-level mouse hook at all — button remapping stops
-working, but no input device is grabbed or intercepted; DPI, SmartShift, and
-the other HID++-side features keep working; takes effect on agent restart);
-`auto_download_assets` (on by default); `language` (absent = follow the system
-locale); `thumbwheel_sensitivity` (default `14`); and the `appearance` (default
-`"system"`), `theme_light`, `theme_dark`, and `ui_radius` presentation
-settings. The theme and radius overrides are absent by default.
+The schema is strict: misspelled, obsolete, and out-of-range fields stop the
+config from loading instead of silently selecting a default or disappearing on
+the next save. The GUI then opens in read-only mode and shows the exact TOML
+error. Fix the file and relaunch OpenLogi.
 
-```toml
-schema_version = 3
-selected_device = "receiver:aabbccdd:slot:1"
+If the file changes in an editor while the GUI is open, the next GUI save is
+refused rather than overwriting the external edit. Relaunch to load that
+revision. Opening the GUI also tells the resident agent to reload the current
+file, so hand edits and runtime behavior converge immediately.
 
-[app_settings]
-launch_at_login = true
-check_for_updates = false
-auto_install_updates = false
-show_in_menu_bar = true
-auto_download_assets = true
-language = "en"
-thumbwheel_sensitivity = 14
-appearance = "system"
-# Optional presentation overrides (omit to use the theme defaults):
-# theme_light = "OpenLogi Light"
-# theme_dark = "OpenLogi Dark"
-# ui_radius = 6
+Schema versions newer than the running build are rejected before their fields
+are parsed. v1 binding maps and the v2–v3 gesture-owner layout migrate on load.
+The v3 physical-device-key transition cannot safely assign older model-scoped
+device settings when two identical devices exist, so v2 model-key entries must
+be copied manually to the generated physical keys.
 
-[devices.2b042]
-dpi_presets = [800, 1600, 3200]
+## Shape
 
-# Put this on the keyboard's physical device entry. Values are the physical
-# keys of the mice that should follow it; use the exact keys already present
-# under [devices] in your generated config.
-[devices."receiver:aabbccdd:slot:1"]
-host_switch_targets = ["receiver:aabbccdd:slot:2"]
+`schema_version` is required and currently `4`. `selected_device` is an
+optional physical device key.
 
-[devices."receiver:aabbccdd:slot:1".action_ring]
-enabled = true
-haptics = true
+`[app_settings]` contains application-wide preferences:
 
-# Each populated slot owns its action, an optional presentation icon, and an
-# optional hover label. Omit `icon` to use the action's normal icon; omit
-# `label` to use the action's generic name (useful for `RunShellCommand`
-# slots, which otherwise all read "Run Command"); omit the slot to leave it
-# empty. Custom labels always render exactly as written — they are never
-# passed through localization, even when they match a built-in action name.
-[devices."receiver:aabbccdd:slot:1".action_ring.default.slots]
-Top = { action = "Copy", icon = "Keyboard" }
-TopRight = { action = "Paste", label = "Paste It" }
-Right = { action = "BrowserForward" }
-BottomRight = { action = "NextTab" }
-Bottom = { action = "ShowDesktop", icon = "Applications" }
-BottomLeft = { action = "PrevTab" }
-Left = { action = "BrowserBack" }
-TopLeft = { action = "Cut" }
+- startup, update, menu-bar / tray, input-capture, and asset-download toggles
+- `asset_source`: `automatic`, `openlogi`, `cloudflare`, or `fastly`
+- `language`, `appearance`, optional theme names, and optional UI radius
+- `thumbwheel_sensitivity`, from `1` through `100` (`14` is 1×)
 
-# A per-app ring is a complete layout, not a sparse overlay.
-[devices."receiver:aabbccdd:slot:1".action_ring.per_app."com.microsoft.VSCode".slots]
-Top = { action = "Copy" }
-TopRight = { action = "Paste" }
-Right = { action = "Redo" }
-BottomRight = { action = "NextTab" }
-Bottom = { action = "ShowDesktop" }
-BottomLeft = { action = "PrevTab" }
-Left = { action = "Undo" }
-TopLeft = { action = "Cut" }
+`[devices."<physical-key>"]` contains per-device state. Receiver keys look like
+`receiver:<receiver-id>:slot:<number>`; direct, raw-HID, and camera devices use
+other generated keys. Do not substitute a model id such as `2b042`.
 
-[devices.2b042.bindings]
-Back = "BrowserBack"
-Forward = "BrowserForward"
+Common device fields are:
 
-# Gesture button: one action per swipe direction; Click = plain press.
-[devices.2b042.bindings.GestureButton]
-Click = "MissionControl"
-Up = "MissionControl"
-Down = "AppExpose"
-Left = "PreviousDesktop"
-Right = "NextDesktop"
+- `enabled`, `dpi`, `dpi_presets`, thumb-wheel sensitivity, scroll inversion,
+  and scroll resolution
+- `bindings`: a button maps either to one action or to a gesture-direction map
+- `per_app_bindings`: sparse action overlays keyed by macOS bundle id, Linux
+  application id, exact lower-cased Windows executable path, or
+  `exe:<filename>.exe`
+- `action_ring`: default and complete per-application eight-slot layouts
+- `lighting`, `smartshift`, standalone `light`, and camera controls / profiles
+- `host_switch_targets` and `fn_lock` for compatible keyboards
+- `identity` and `disabled_gestures`, which are application-managed metadata
 
-# Per-app overlay: Back becomes Undo only while VS Code is frontmost.
-[devices.2b042.per_app_bindings."com.microsoft.VSCode"]
-Back = "Undo"
+`[keyboard.bindings]` contains global key triggers such as `f1` or
+`shift+command+f5`. Supported trigger modifiers are `shift`, `control`,
+`option`, and `command`; aliases such as `ctrl`, `alt`, and `cmd` are accepted.
 
-# Stable Windows executable-name selector (exact paths still take precedence).
-[devices.2b042.per_app_bindings."exe:sharex.exe"]
-MiddleClick = { CustomShortcut = { modifiers = 0, key_code = 122, display = "F1" } }
+## Actions
 
-# Actions Ring slots couple an executable action with an optional custom icon.
-[devices.2b042.action_ring]
-enabled = true
-haptics = true
-
-[devices.2b042.action_ring.default.slots]
-Top = { action = "Copy", icon = "Keyboard" }
-Right = { action = { OpenApplication = { path = "/Applications/Safari.app", display_name = "Safari" } }, icon = "Applications" }
-Bottom = { action = "ShowDesktop" }
-
-[devices.2b042.lighting]
-enabled = true
-color = "ff0000"
-brightness = 80
-
-# Keyboard F-row keys (Signature-series layout): a bound key is diverted
-# over HID++ and dispatches its action; an unbound key keeps its native
-# firmware function. Key names: KeySearch, KeyDictation, KeyEmoji,
-# KeyScreenCapture, KeyMicMute, KeyPlayPause, KeyMute, KeyVolumeDown,
-# KeyVolumeUp.
-[devices.2b372]
-fn_lock = false
-
-[devices.2b372.bindings]
-KeySearch = "MissionControl"
-KeyScreenCapture = "Sleep"
-
-# Standalone light (for example, a Litra Glow). The GUI writes this block under
-# the serial-backed physical key; `openlogi light list` shows its HID tuple and
-# identity when diagnosing discovery.
-# A serial-bearing Litra key looks like:
-# [devices."raw:046d:c900:ff43:0202:serial:YOUR-SERIAL".light]
-# If the HID backend exposes only a transient OS-node identity, OpenLogi does
-# not persist that key; reconnect persistence then requires a device serial.
-[devices."<raw-device-key>".light]
-enabled = true
-auto_camera = true
-brightness_percent = 65
-temperature_kelvin = 4600
-```
-
-Action names are the catalog's variant names (`LeftClick`, `MouseBack`,
-`Copy`, `PlayPause`, `CycleDpiPresets`, …). `ShowActionsRing` opens the ring;
-a detected Haptic Sense Panel uses it by default, and pressing the trigger
-again while the ring is showing dismisses it. Ring slots reject
-`ShowActionsRing` itself to prevent recursive sessions. `OpenApplication`
-accepts an application, folder, filesystem path, or URL. A leading `~` is
-expanded when the action runs; for example:
+Action names are the serialized Rust variant names, including `Copy`,
+`BrowserBack`, `PlayPause`, `CycleDpiPresets`, and `ShowActionsRing`.
+Payload actions use a one-key inline table:
 
 ```toml
-Top = { action = { OpenApplication = { path = "/Applications/Safari.app", display_name = "Safari" } } }
-Bottom = { action = { OpenApplication = { path = "~/Downloads", display_name = "Downloads" } } }
+Back = { CustomShortcut = "Cmd+Shift+P" }
+MiddleClick = { OpenApplication = { path = "~/Downloads", display_name = "Downloads" } }
 ```
 
-`CustomShortcut` stores a platform-neutral textual chord, for example:
+An Actions Ring entry wraps the action and may add an icon or literal label:
 
 ```toml
-Top = { action = { CustomShortcut = "Cmd+Shift+P" } }
+Top = { action = { CustomShortcut = "Cmd+Shift+P" }, icon = "Keyboard", label = "Command Palette" }
 ```
 
-The GUI accepts chords such as `Cmd+Shift+P`, `Ctrl+Alt+Left`, or `F5`. It also
-lets each ring slot keep its action-derived icon or choose a custom icon from
-the built-in gallery.
+`ShowActionsRing` is rejected inside a ring slot to prevent recursive rings.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,0 +1,72 @@
+# OpenLogi configuration example. Copy only the sections you need.
+schema_version = 4
+selected_device = "receiver:aabbccdd:slot:1"
+
+[app_settings]
+launch_at_login = true
+check_for_updates = false
+auto_install_updates = false
+show_in_menu_bar = true
+capture_mouse_events = true
+auto_download_assets = true
+asset_source = "automatic"
+language = "en"
+thumbwheel_sensitivity = 14
+appearance = "system"
+
+[devices."receiver:aabbccdd:slot:1"]
+dpi = 1600
+dpi_presets = [800, 1600, 3200]
+thumbwheel_sensitivity = 20
+invert_scroll = false
+scroll_resolution = "high"
+
+[devices."receiver:aabbccdd:slot:1".bindings]
+Back = "BrowserBack"
+Forward = "BrowserForward"
+
+[devices."receiver:aabbccdd:slot:1".bindings.GestureButton]
+Click = "MissionControl"
+Up = "MissionControl"
+Down = "AppExpose"
+Left = "PreviousDesktop"
+Right = "NextDesktop"
+
+[devices."receiver:aabbccdd:slot:1".per_app_bindings."com.microsoft.VSCode"]
+Back = "Undo"
+
+[devices."receiver:aabbccdd:slot:1".per_app_bindings."exe:sharex.exe"]
+MiddleClick = { CustomShortcut = "F1" }
+
+[devices."receiver:aabbccdd:slot:1".action_ring]
+enabled = true
+haptics = true
+
+[devices."receiver:aabbccdd:slot:1".action_ring.default.slots]
+Top = { action = "Copy", icon = "Keyboard" }
+Right = { action = { OpenApplication = { path = "/Applications/Safari.app", display_name = "Safari" } }, icon = "Applications" }
+Bottom = { action = "ShowDesktop", label = "Desktop" }
+
+[devices."receiver:aabbccdd:slot:1".lighting]
+enabled = true
+color = "ff0000"
+brightness = 80
+
+[devices."receiver:aabbccdd:slot:1".smartshift]
+mode = "ratchet"
+auto_disengage = 16
+tunable_torque = 50
+
+# Put host-switch links on the keyboard's physical entry.
+[devices."receiver:aabbccdd:slot:2"]
+host_switch_targets = ["receiver:aabbccdd:slot:1"]
+fn_lock = false
+
+[devices."receiver:aabbccdd:slot:2".bindings]
+KeySearch = "MissionControl"
+KeyScreenCapture = "Sleep"
+
+# Global function-key remapping, independent of a device.
+[keyboard.bindings]
+f1 = "MissionControl"
+"shift+command+f5" = "ShowDesktop"


### PR DESCRIPTION
## Summary

Harden configuration loading and persistence so malformed, future, or concurrently edited TOML cannot be silently replaced with defaults.

## Changes

- **core:** parse the schema header before the body, reject unknown/obsolete/out-of-range fields, retain v1-v4 migrations, make keyboard serialization deterministic, and preserve comments with conflict-safe tracked saves
- **agent / IPC:** return typed config reload failures, retain the last valid runtime config on failure, and bump the wire protocol to v17 with updated goldens
- **GUI:** fail closed on load/save/reload errors, roll back unsaved state, reload the resident agent at startup, and route all config writes through one persistence boundary
- **docs:** add a tested canonical schema v4 example and update configuration, migration, editing, and recovery guidance

## Testing

- `devenv shell -- cargo fmt --all -- --check`
- `devenv shell -- cargo clippy --workspace --all-targets -- -D warnings`
- `devenv shell -- cargo test --workspace`
- `devenv tasks run openlogi:check-windows`
- Not runtime-tested on hardware.
