### PR TITLE
fix(agent): request Input Monitoring access at startup on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5211,6 +5211,7 @@ dependencies = [
  "num_enum",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
+ "objc2-io-kit",
  "openlogi-core",
  "openlogi-hidpp",
  "serde",

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -187,6 +187,33 @@ async fn begin_action_ring(
     }
 }
 
+/// Fire the macOS permission prompts this process needs, at startup.
+///
+/// The agent (not the GUI) owns both the CGEventTap and every HID++ device
+/// open, so it must be the binary the user authorizes for Accessibility and
+/// Input Monitoring — a grant is scoped to the code-signing identity that
+/// asks for it. macOS only shows a dialog when the process isn't already
+/// listed, so this doesn't nag on every login. The GUI's Accessibility grant
+/// button drives the same prompt on demand over IPC
+/// (`request_accessibility_prompt`); Input Monitoring has no on-demand IPC
+/// path yet, so it is only requested here, at startup.
+fn prompt_missing_permissions(capture_mouse_events: bool) {
+    // With the hook disabled the agent needs no Accessibility at all, so the
+    // opt-out also silences that prompt.
+    if capture_mouse_events && !Hook::has_accessibility() {
+        Hook::prompt_accessibility();
+    }
+
+    // Without this, macOS never registers a decision at all:
+    // `IOHIDDeviceOpen` is silently denied, the permission never appears in
+    // System Settings for the user to grant, and no HID++ device is ever
+    // discovered. `request_access` blocks on the consent dialog, so it runs
+    // on a blocking thread rather than stalling startup.
+    if !openlogi_hid::permissions::has_access() {
+        tokio::task::spawn_blocking(openlogi_hid::permissions::request_access);
+    }
+}
+
 async fn run(config: Config, #[cfg(target_os = "macos")] resume_pending: Arc<AtomicBool>) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
     // LaunchAgent, before `config` moves into the orchestrator.
@@ -197,17 +224,7 @@ async fn run(config: Config, #[cfg(target_os = "macos")] resume_pending: Arc<Ato
     // an agent restart, which the config docs state.
     let capture_mouse_events = config.app_settings.capture_mouse_events;
 
-    // The agent owns the CGEventTap, so it must be the binary the user authorizes
-    // for Accessibility. Fire the prompt at startup when we're not yet trusted so
-    // openlogi-agent appears (named correctly) in System Settings even on a
-    // launchd start with no GUI. macOS only shows the dialog when we're not
-    // already in the list, so this doesn't nag on every login. The GUI's grant
-    // button drives the same prompt over IPC (`request_accessibility_prompt`).
-    // With the hook disabled the agent needs no Accessibility at all, so the
-    // opt-out also silences the permission prompt.
-    if capture_mouse_events && !Hook::has_accessibility() {
-        Hook::prompt_accessibility();
-    }
+    prompt_missing_permissions(capture_mouse_events);
 
     // The orchestrator is shared with the IPC server (which serves inventory /
     // reload / status) and mutated by the watcher select loop, so it lives

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -44,6 +44,7 @@ windows-sys = { workspace = true, features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", features = ["NSWorkspace", "NSRunningApplication"] }
+objc2-io-kit = { workspace = true, features = ["std", "hidsystem"] }
 
 [lints]
 workspace = true

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -30,6 +30,7 @@ pub mod hotplug;
 pub mod inventory;
 pub mod keyboard;
 pub mod pairing;
+pub mod permissions;
 pub mod reprog_controls;
 pub mod smartshift;
 pub mod thumbwheel;

--- a/crates/openlogi-hid/src/permissions.rs
+++ b/crates/openlogi-hid/src/permissions.rs
@@ -1,0 +1,57 @@
+//! macOS Input Monitoring (TCC) status for the HID++ transport.
+//!
+//! `openlogi-hid` opens Logitech HID nodes through `IOHIDManager` (via
+//! `async-hid`), which macOS gates behind the Input Monitoring privacy
+//! permission — without it, every `IOHIDDeviceOpen` is silently denied and no
+//! HID++ device ever appears, with no error surfaced beyond a debug log.
+//!
+//! Checking never prompts; [`request_access`] is the prompting call, and it
+//! must run in this process (the agent), not the GUI — a TCC grant is scoped
+//! to the code-signing identity that asks for it, and the agent (not the GUI)
+//! is the one that actually opens HID devices.
+
+use std::cfg_select;
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use objc2_io_kit::{IOHIDAccessType, IOHIDCheckAccess, IOHIDRequestAccess, IOHIDRequestType};
+
+    pub(super) fn has_access() -> bool {
+        matches!(
+            IOHIDCheckAccess(IOHIDRequestType::ListenEvent),
+            IOHIDAccessType::Granted
+        )
+    }
+
+    pub(super) fn request_access() {
+        // Unlike `AXIsProcessTrustedWithOptions`, `IOHIDRequestAccess` blocks
+        // the calling thread until the user answers the consent dialog (or
+        // returns immediately if the status is already determined) — callers
+        // must run this off the async runtime.
+        let _granted = IOHIDRequestAccess(IOHIDRequestType::ListenEvent);
+    }
+}
+
+/// Whether this process currently holds Input Monitoring access.
+///
+/// Always `true` off macOS, where HID access has no privacy gate.
+#[must_use]
+pub fn has_access() -> bool {
+    cfg_select! {
+        target_os = "macos" => { macos::has_access() }
+        _ => { true }
+    }
+}
+
+/// Raise the macOS Input Monitoring consent dialog if not yet determined, so
+/// this process (and not whichever process last called it) is the one listed
+/// under System Settings → Privacy & Security → Input Monitoring.
+///
+/// Blocks the calling thread until the user responds — run it off the async
+/// runtime (e.g. `tokio::task::spawn_blocking`). No-op off macOS.
+pub fn request_access() {
+    cfg_select! {
+        target_os = "macos" => { macos::request_access(); }
+        _ => {}
+    }
+}


### PR DESCRIPTION
## Summary

- `openlogi-agent` only ever called the passive `IOHIDCheckAccess`, never the prompting `IOHIDRequestAccess`. macOS then never registers a TCC decision at all: every `IOHIDDeviceOpen` is silently denied, Input Monitoring never appears in System Settings for the user to grant it, and no HID++ device — USB, receiver, or Bluetooth-direct — is ever discovered on a fresh install.

## Changes

- `openlogi-hid`: new `permissions` module wrapping `IOHIDCheckAccess`/`IOHIDRequestAccess` (macOS-only; no-op elsewhere).
- `openlogi-agent`: fire the Input Monitoring prompt at startup, mirroring the existing Accessibility prompt, off the async runtime (`IOHIDRequestAccess` blocks on the consent dialog).

## Testing

- `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude openlogi-gui --all-targets -- -D warnings`, `cargo test --workspace --exclude openlogi-gui` — all green.
- `openlogi-gui` not built/tested (this environment has no full Xcode install for GPUI's Metal shaders; untouched by this change).
- Verified on hardware: reproduced the bug on a real MX Master 4 over BLE-direct (macOS TCC log showed repeated `TCC deny IOHIDDeviceOpen` with the Input Monitoring pane listing "No Items"); confirmed manually granting Input Monitoring to the agent bundle fixes discovery, which is what this change now triggers automatically.

Note: the Settings window's Input Monitoring status row currently checks the GUI process's own TCC grant, not the agent's, which can show a misleading status independent of this fix. Filed as #606.