### PR TITLE
feat(gui): add a reversed Volume preset for the thumb wheel

### DIFF
--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Forrige / næste skrivebord"
 "Previous / Next Track": "Forrige / næste nummer"
 "Volume Down / Up": "Skru ned / op"
+"Volume Up / Down": "Skru op / ned"
 "Vertical Scroll": "Lodret rulning"
 "Horizontal Scroll": "Vandret rulning"
 "Custom": "Brugerdefineret"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Vorheriger / nächster Schreibtisch"
 "Previous / Next Track": "Vorheriger / nächster Titel"
 "Volume Down / Up": "Leiser / Lauter"
+"Volume Up / Down": "Lauter / Leiser"
 "Vertical Scroll": "Vertikales Scrollen"
 "Horizontal Scroll": "Horizontales Scrollen"
 "Custom": "Benutzerdefiniert"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Προηγούμενο / επόμενο γραφείο εργασίας"
 "Previous / Next Track": "Προηγούμενο / επόμενο κομμάτι"
 "Volume Down / Up": "Μείωση / αύξηση έντασης"
+"Volume Up / Down": "Αύξηση / μείωση έντασης"
 "Vertical Scroll": "Κατακόρυφη κύλιση"
 "Horizontal Scroll": "Οριζόντια κύλιση"
 "Custom": "Προσαρμοσμένο"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Previous / Next Desktop"
 "Previous / Next Track": "Previous / Next Track"
 "Volume Down / Up": "Volume Down / Up"
+"Volume Up / Down": "Volume Up / Down"
 "Vertical Scroll": "Vertical Scroll"
 "Horizontal Scroll": "Horizontal Scroll"
 "Custom": "Custom"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Escritorio anterior / siguiente"
 "Previous / Next Track": "Pista anterior / siguiente"
 "Volume Down / Up": "Bajar / subir volumen"
+"Volume Up / Down": "Subir / bajar volumen"
 "Vertical Scroll": "Desplazamiento vertical"
 "Horizontal Scroll": "Desplazamiento horizontal"
 "Custom": "Personalizado"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Edellinen / seuraava työpöytä"
 "Previous / Next Track": "Edellinen / seuraava kappale"
 "Volume Down / Up": "Äänenvoimakkuus alas / ylös"
+"Volume Up / Down": "Äänenvoimakkuus ylös / alas"
 "Vertical Scroll": "Pystyvieritys"
 "Horizontal Scroll": "Vaakavieritys"
 "Custom": "Mukautettu"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Bureau précédent / suivant"
 "Previous / Next Track": "Piste précédente / suivante"
 "Volume Down / Up": "Baisser / augmenter le volume"
+"Volume Up / Down": "Augmenter / baisser le volume"
 "Vertical Scroll": "Défilement vertical"
 "Horizontal Scroll": "Défilement horizontal"
 "Custom": "Personnalisé"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Scrivania precedente / successiva"
 "Previous / Next Track": "Traccia precedente / successiva"
 "Volume Down / Up": "Volume giù / su"
+"Volume Up / Down": "Volume su / giù"
 "Vertical Scroll": "Scorrimento verticale"
 "Horizontal Scroll": "Scorrimento orizzontale"
 "Custom": "Personalizzato"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "前 / 次のデスクトップ"
 "Previous / Next Track": "前 / 次の曲"
 "Volume Down / Up": "音量を下げる / 上げる"
+"Volume Up / Down": "音量を上げる / 下げる"
 "Vertical Scroll": "縦スクロール"
 "Horizontal Scroll": "横スクロール"
 "Custom": "カスタム"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "이전 / 다음 데스크탑"
 "Previous / Next Track": "이전 / 다음 트랙"
 "Volume Down / Up": "볼륨 낮추기 / 높이기"
+"Volume Up / Down": "볼륨 높이기 / 낮추기"
 "Vertical Scroll": "세로 스크롤"
 "Horizontal Scroll": "가로 스크롤"
 "Custom": "사용자 지정"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Forrige / neste skrivebord"
 "Previous / Next Track": "Forrige / neste spor"
 "Volume Down / Up": "Volum ned / opp"
+"Volume Up / Down": "Volum opp / ned"
 "Vertical Scroll": "Vertikal rulling"
 "Horizontal Scroll": "Horisontal rulling"
 "Custom": "Egendefinert"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Vorig / volgend bureaublad"
 "Previous / Next Track": "Vorig / volgend nummer"
 "Volume Down / Up": "Volume omlaag / omhoog"
+"Volume Up / Down": "Volume omhoog / omlaag"
 "Vertical Scroll": "Verticaal scrollen"
 "Horizontal Scroll": "Horizontaal scrollen"
 "Custom": "Aangepast"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Poprzedni / następny pulpit"
 "Previous / Next Track": "Poprzedni / następny utwór"
 "Volume Down / Up": "Ciszej / głośniej"
+"Volume Up / Down": "Głośniej / ciszej"
 "Vertical Scroll": "Przewijanie pionowe"
 "Horizontal Scroll": "Przewijanie poziome"
 "Custom": "Niestandardowe"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Mesa anterior / próxima"
 "Previous / Next Track": "Faixa anterior / próxima"
 "Volume Down / Up": "Diminuir / aumentar volume"
+"Volume Up / Down": "Aumentar / diminuir volume"
 "Vertical Scroll": "Rolagem vertical"
 "Horizontal Scroll": "Rolagem horizontal"
 "Custom": "Personalizado"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Secretária anterior / seguinte"
 "Previous / Next Track": "Faixa anterior / seguinte"
 "Volume Down / Up": "Diminuir / aumentar volume"
+"Volume Up / Down": "Aumentar / diminuir volume"
 "Vertical Scroll": "Deslocamento vertical"
 "Horizontal Scroll": "Deslocamento horizontal"
 "Custom": "Personalizado"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Предыдущий / следующий рабочий стол"
 "Previous / Next Track": "Предыдущий / следующий трек"
 "Volume Down / Up": "Тише / громче"
+"Volume Up / Down": "Громче / тише"
 "Vertical Scroll": "Вертикальная прокрутка"
 "Horizontal Scroll": "Горизонтальная прокрутка"
 "Custom": "Свой"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "Föregående / nästa skrivbord"
 "Previous / Next Track": "Föregående / nästa spår"
 "Volume Down / Up": "Sänk / höj volymen"
+"Volume Up / Down": "Höj / sänk volymen"
 "Vertical Scroll": "Vertikal rullning"
 "Horizontal Scroll": "Horisontell rullning"
 "Custom": "Anpassad"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "上一个 / 下一个桌面"
 "Previous / Next Track": "上一首 / 下一首"
 "Volume Down / Up": "减小 / 增大音量"
+"Volume Up / Down": "增大 / 减小音量"
 "Vertical Scroll": "垂直滚动"
 "Horizontal Scroll": "水平滚动"
 "Custom": "自定义"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "上一個 / 下一個桌面"
 "Previous / Next Track": "上一首 / 下一首"
 "Volume Down / Up": "調低 / 調高音量"
+"Volume Up / Down": "調高 / 調低音量"
 "Vertical Scroll": "垂直捲動"
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -165,6 +165,7 @@ _version: 1
 "Previous / Next Desktop": "上一個 / 下一個桌面"
 "Previous / Next Track": "上一首 / 下一首"
 "Volume Down / Up": "調低 / 調高音量"
+"Volume Up / Down": "調高 / 調低音量"
 "Vertical Scroll": "垂直捲動"
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"

--- a/crates/openlogi-gui/src/mouse_model/thumbwheel.rs
+++ b/crates/openlogi-gui/src/mouse_model/thumbwheel.rs
@@ -23,13 +23,14 @@ pub(crate) enum ThumbwheelPreset {
     Desktops,
     Tracks,
     Volume,
+    VolumeReversed,
     CycleDpi,
     VerticalScroll,
     HorizontalScroll,
 }
 
 impl ThumbwheelPreset {
-    pub(crate) const ALL: [Self; 10] = [
+    pub(crate) const ALL: [Self; 11] = [
         Self::BackForward,
         Self::UndoRedo,
         Self::BrowserHistory,
@@ -37,6 +38,7 @@ impl ThumbwheelPreset {
         Self::Desktops,
         Self::Tracks,
         Self::Volume,
+        Self::VolumeReversed,
         Self::CycleDpi,
         Self::VerticalScroll,
         Self::HorizontalScroll,
@@ -52,6 +54,7 @@ impl ThumbwheelPreset {
             Self::Desktops => (Action::PreviousDesktop, Action::NextDesktop),
             Self::Tracks => (Action::PrevTrack, Action::NextTrack),
             Self::Volume => (Action::VolumeDown, Action::VolumeUp),
+            Self::VolumeReversed => (Action::VolumeUp, Action::VolumeDown),
             Self::CycleDpi => (Action::CycleDpiPresets, Action::CycleDpiPresets),
             Self::VerticalScroll => (Action::ScrollDown, Action::ScrollUp),
             Self::HorizontalScroll => (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
@@ -79,6 +82,7 @@ impl ThumbwheelPreset {
             Self::Desktops => "Previous / Next Desktop",
             Self::Tracks => "Previous / Next Track",
             Self::Volume => "Volume Down / Up",
+            Self::VolumeReversed => "Volume Up / Down",
             Self::CycleDpi => "Cycle DPI Presets",
             Self::VerticalScroll => "Vertical Scroll",
             Self::HorizontalScroll => "Horizontal Scroll",
@@ -94,7 +98,7 @@ impl ThumbwheelPreset {
             Self::Tabs => "action-icons/chevron-right.svg",
             Self::Desktops => "action-icons/square-arrow-right.svg",
             Self::Tracks => "action-icons/skip-forward.svg",
-            Self::Volume => "action-icons/volume-2.svg",
+            Self::Volume | Self::VolumeReversed => "action-icons/volume-2.svg",
             Self::CycleDpi => "action-icons/gauge.svg",
             Self::VerticalScroll => "action-icons/chevrons-up.svg",
             Self::HorizontalScroll => "action-icons/chevrons-right.svg",
@@ -116,6 +120,7 @@ mod tests {
             (Action::PreviousDesktop, Action::NextDesktop),
             (Action::PrevTrack, Action::NextTrack),
             (Action::VolumeDown, Action::VolumeUp),
+            (Action::VolumeUp, Action::VolumeDown),
             (Action::CycleDpiPresets, Action::CycleDpiPresets),
             (Action::ScrollDown, Action::ScrollUp),
             (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),


### PR DESCRIPTION
## Summary

- The thumb wheel's two directions (roll-forward / roll-backward) are already independently bindable actions in the binding model (`ButtonId::ThumbwheelScrollUp`/`ThumbwheelScrollDown`, each with its own `Action`). But the picker (`thumbwheel_picker`) only offers 10 exact curated pairs, and there was no "reversed" Volume pair — so a user whose physical roll direction feels backwards for volume (roll up = volume down, and vice versa) had no way to swap it from the app.

## Changes

- `crates/openlogi-gui/src/mouse_model/thumbwheel.rs`: add `ThumbwheelPreset::VolumeReversed` (`Volume Up / Down`, reusing the existing `Volume` icon), alongside the existing `Volume` (`Volume Down / Up`) preset. Same pattern as every other curated pair — no changes needed in `openlogi-core`, `openlogi-hid`, or `openlogi-hidpp`.
- `crates/openlogi-gui/locales/*.yml`: added the new `"Volume Up / Down"` key to all 20 locale files, in the same position (line 168, right after `"Volume Down / Up"`). Non-English values are a best-effort translation reusing the existing localized "up"/"down" vocabulary already present in each locale's `"Volume Down / Up"` entry (word-order swap only, no new vocabulary) — real review via Crowdin as usual.

## Testing

- `cargo fmt --all -- --check` — clean.
- `openlogi-gui` itself **not built/tested** — this environment has no full Xcode install for GPUI's Metal shader compile, so `cargo check -p openlogi-gui` can't get past a dependency's build script regardless of the change. The diff is intentionally small and mirrors the existing `Volume`/other preset arms exactly (same enum-match shape, same test structure).
- Manually replicated the `i18n.rs` locale-key-parity check with a standalone script comparing key sets across all 20 `locales/*.yml` against `en.yml` — full parity confirmed (399 keys each). Could not run the actual `cargo test -p openlogi-gui i18n` for the same Xcode reason above.
- Not verified on hardware/running app (blocked on the same build issue). Would appreciate a maintainer or CI confirming the build + a quick check that "Volume Up / Down" shows up correctly in the thumb-wheel picker.