### PR TITLE
chore(lints): adopt the shared clippy lint set, and fix what it surfaced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,12 @@ a `reason`. What that changes day to day:
 - Every `unsafe` block needs a `// SAFETY:` comment saying why it is sound.
 - `assert!(r.is_ok())` / `assert!(r.is_err())` are rejected — unwrap the `Result` (in a
   test module that already allows it) or give the assertion a message.
+- A test module that wants `expect`/`unwrap` says so:
+  `#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]` on the
+  module (or on its `mod tests;` declaration). Never route around the lint with
+  `unwrap_or_else(|e| panic!("…: {e}"))` — that is the same panic with the check switched
+  off. The one honest use of that form is a *dynamic* panic message, where `expect` would
+  need a `format!` that allocates on the happy path (`expect_fun_call`).
 - A test module gated on more than `test` needs stacked attributes (`#[cfg(test)]` then
   `#[cfg(unix)]`), not `#[cfg(all(test, unix))]`, which clippy reads as a test outside a
   test module. Integration tests under `tests/` carry a file-level

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,11 +138,30 @@ New GUI strings: insert the same key in the **same position** in every
 
 ## Rust standards
 
-Edition 2024, MSRV 1.96. Workspace lints (root `Cargo.toml`): `unsafe_code = "deny"`
-(opt out per item with `#[expect(unsafe_code, reason = "…")]` plus a `// SAFETY:`
-comment), `clippy::pedantic` at warn, `unwrap_used`/`expect_used` at warn.
-`openlogi-hidpp` deliberately does not inherit workspace lints (vendored code). Any
-lint suppression carries a `reason`.
+Edition 2024, MSRV 1.96. There is exactly **one** lint table, in the root `Cargo.toml`,
+and every crate inherits it with `[lints] workspace = true` — never a private copy, or
+the next lint added to the workspace silently skips that crate. A crate needing a
+different level opts out **in source** (the `openlogi-hook` platform modules carry
+`#![allow(unsafe_code, reason = "…")]`), because Cargo rejects mixing `workspace = true`
+with local overrides. `openlogi-hidpp` deliberately stays out of the table (vendored).
+
+The table: `unsafe_code = "deny"` (opt out per item with `#[expect(unsafe_code,
+reason = "…")]` plus a `// SAFETY:` comment), `clippy::pedantic` at warn,
+`unwrap_used`/`expect_used` at warn, plus the shared lint set —
+`assertions_on_result_states`, `cast_possible_truncation`, `cast_possible_wrap`,
+`cast_sign_loss`, `error_impl_error`, `exit`, `or_fun_call`, `ptr_as_ptr`,
+`tests_outside_test_module`, `undocumented_unsafe_blocks`. Any lint suppression carries
+a `reason`. What that changes day to day:
+
+- Every `unsafe` block needs a `// SAFETY:` comment saying why it is sound.
+- `assert!(r.is_ok())` / `assert!(r.is_err())` are rejected — unwrap the `Result` (in a
+  test module that already allows it) or give the assertion a message.
+- A test module gated on more than `test` needs stacked attributes (`#[cfg(test)]` then
+  `#[cfg(unix)]`), not `#[cfg(all(test, unix))]`, which clippy reads as a test outside a
+  test module. Integration tests under `tests/` carry a file-level
+  `#![expect(clippy::tests_outside_test_module, reason = "…")]`.
+- `std::process::exit` needs `#[expect(clippy::exit, reason = "…")]` naming why that call
+  site cannot hand an `ExitCode` back to `main` instead.
 
 Encode invariants in the type system instead of checking them at runtime:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,6 +5117,8 @@ version = "0.6.27"
 dependencies = [
  "block2 0.6.2",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "serde",
  "tracing",
  "v4l",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,20 @@ unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "allow"
 doc_markdown = "allow"
+# Shared lint set, kept in sync with
+# https://gist.github.com/AprilNEA/cdf81f76840fcb883a32503ee7caa539.
+# `cast_*` and `ptr_as_ptr` are pedantic members already; they are listed
+# explicitly so the set stands on its own if the pedantic group ever moves.
+assertions_on_result_states = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_sign_loss = "warn"
+error_impl_error = "warn"
+exit = "warn"
+or_fun_call = "warn"
+ptr_as_ptr = "warn"
+tests_outside_test_module = "warn"
+undocumented_unsafe_blocks = "warn"
 
 [profile.release]
 lto = "fat"

--- a/crates/openlogi-agent-core/src/action_ring.rs
+++ b/crates/openlogi-agent-core/src/action_ring.rs
@@ -289,6 +289,7 @@ impl ActionRingManager {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
     use openlogi_core::binding::ActionRingConfig;
@@ -339,10 +340,7 @@ mod tests {
 
         // Second press: dismissed via an empty invocation on the same poll.
         assert!(manager.dismiss_active());
-        let dismissal = manager
-            .next_invocation()
-            .await
-            .unwrap_or_else(|| panic!("dismissal queued"));
+        let dismissal = manager.next_invocation().await.expect("dismissal queued");
         assert!(dismissal.slots.is_empty());
         assert_ne!(dismissal.session_id, opened.session_id);
 
@@ -376,7 +374,7 @@ mod tests {
         let invocation = manager.begin(spec());
         let activation = manager
             .activate(invocation.session_id, ActionRingSlot::Top)
-            .unwrap_or_else(|error| panic!("{error:?}"));
+            .expect("a live session must activate its top slot");
         assert_eq!(activation.device_key, "mouse-a");
         assert_eq!(activation.action, Action::Cut);
         assert!(matches!(
@@ -417,12 +415,9 @@ mod tests {
             manager.activate(first.session_id, ActionRingSlot::Top),
             Err(ActionRingCommandError::SessionNotFound)
         ));
-        let reactivated = manager.activate(second.session_id, ActionRingSlot::Top);
-        assert!(
-            reactivated.is_ok(),
-            "the replacement session must still be activatable: {:?}",
-            reactivated.as_ref().err()
-        );
+        manager
+            .activate(second.session_id, ActionRingSlot::Top)
+            .expect("the replacement session must still be activatable");
     }
 
     /// The two clocks start at different moments — the session when `begin`
@@ -442,13 +437,10 @@ mod tests {
         let manager = ActionRingManager::default();
         let invocation = manager.begin(spec());
         let mut state = manager.state();
-        let session = state
-            .active
-            .as_mut()
-            .unwrap_or_else(|| panic!("begin creates a session"));
+        let session = state.active.as_mut().expect("begin creates a session");
         session.opened_at = Instant::now()
             .checked_sub(SESSION_LIFETIME + Duration::from_secs(1))
-            .unwrap_or_else(|| panic!("test instant has sufficient history"));
+            .expect("test instant has sufficient history");
         drop(state);
 
         assert!(matches!(

--- a/crates/openlogi-agent-core/src/action_ring.rs
+++ b/crates/openlogi-agent-core/src/action_ring.rs
@@ -417,10 +417,11 @@ mod tests {
             manager.activate(first.session_id, ActionRingSlot::Top),
             Err(ActionRingCommandError::SessionNotFound)
         ));
+        let reactivated = manager.activate(second.session_id, ActionRingSlot::Top);
         assert!(
-            manager
-                .activate(second.session_id, ActionRingSlot::Top)
-                .is_ok()
+            reactivated.is_ok(),
+            "the replacement session must still be activatable: {:?}",
+            reactivated.as_ref().err()
         );
     }
 

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -211,6 +211,11 @@ mod tests {
         tokio::task::yield_now().await;
         assert!(!waiting.is_finished());
         drop(transition);
-        assert!(waiting.await.is_ok());
+        let acquired = waiting.await;
+        assert!(
+            acquired.is_ok(),
+            "bounded io must acquire its lease once the host transition releases: {:?}",
+            acquired.as_ref().err()
+        );
     }
 }

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -123,6 +123,7 @@ impl Drop for ExclusiveRequest {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
@@ -148,12 +149,12 @@ mod tests {
     async fn pooled_sessions_share_access_before_pairing() {
         let access = ReceiverAccess::default();
 
-        let first = access.try_acquire_for_session().unwrap_or_else(|| {
-            panic!("fresh receiver access should grant first session lease");
-        });
-        let second = access.try_acquire_for_session().unwrap_or_else(|| {
-            panic!("pooled sessions should share receiver access");
-        });
+        let first = access
+            .try_acquire_for_session()
+            .expect("fresh receiver access should grant first session lease");
+        let second = access
+            .try_acquire_for_session()
+            .expect("pooled sessions should share receiver access");
 
         drop((first, second));
     }
@@ -161,9 +162,9 @@ mod tests {
     #[tokio::test]
     async fn cancelled_pairing_wait_withdraws_request() {
         let access = ReceiverAccess::default();
-        let capture = access.try_acquire_for_session().unwrap_or_else(|| {
-            panic!("fresh receiver access should grant capture lease");
-        });
+        let capture = access
+            .try_acquire_for_session()
+            .expect("fresh receiver access should grant capture lease");
 
         let waiting = tokio::spawn({
             let access = access.clone();
@@ -211,11 +212,8 @@ mod tests {
         tokio::task::yield_now().await;
         assert!(!waiting.is_finished());
         drop(transition);
-        let acquired = waiting.await;
-        assert!(
-            acquired.is_ok(),
-            "bounded io must acquire its lease once the host transition releases: {:?}",
-            acquired.as_ref().err()
-        );
+        waiting
+            .await
+            .expect("bounded io must acquire its lease once the host transition releases");
     }
 }

--- a/crates/openlogi-agent-core/tests/wire_format.rs
+++ b/crates/openlogi-agent-core/tests/wire_format.rs
@@ -18,6 +18,10 @@
 //! golden with the actual hex from the assertion message.
 
 #![allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+#![expect(
+    clippy::tests_outside_test_module,
+    reason = "an integration test file is already its own test-only crate"
+)]
 
 use std::collections::BTreeMap;
 use std::fmt::Write;

--- a/crates/openlogi-agent/build.rs
+++ b/crates/openlogi-agent/build.rs
@@ -7,10 +7,10 @@
 //! exact version already in Cargo.lock as gpui's own build-dependency, so it
 //! adds an edge, not a crate, and cannot move the pinned gpui rev.
 
-// A build script fails by panicking, so `expect` (with a message that surfaces
-// in the build log) is the idiomatic error path here — exempt it from the
-// workspace's strict runtime lints.
-#![allow(clippy::expect_used)]
+#![allow(
+    clippy::expect_used,
+    reason = "a build script fails by panicking, so expect — whose message surfaces in the build log — is the idiomatic error path"
+)]
 
 use std::path::PathBuf;
 use std::{env, fs};

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -157,13 +157,13 @@ fn default_to_dev_profile() {
     if std::env::var_os("OPENLOGI_PROFILE").is_some() {
         return;
     }
-    // SAFETY: `set_var` is unsound only against concurrent env access. This is
-    // the first statement of `main`: no runtime, no tracing subscriber, no
-    // other thread exists yet, and nothing has read the environment.
     #[expect(
         unsafe_code,
         reason = "the profile must be chosen before openlogi_core::paths caches it, and only a process-wide env var selects it"
     )]
+    // SAFETY: `set_var` is unsound only against concurrent env access. This is
+    // the first statement of `main`: no runtime, no tracing subscriber, no
+    // other thread exists yet, and nothing has read the environment.
     unsafe {
         std::env::set_var("OPENLOGI_PROFILE", "dev");
     }

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -309,7 +309,8 @@ fn run_systemctl(args: &[&str]) {
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(test)]
+#[cfg(target_os = "macos")]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
@@ -356,7 +357,8 @@ mod tests {
     }
 }
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
+#[cfg(target_os = "linux")]
 mod linux_tests {
     use super::*;
 

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -321,7 +321,11 @@ mod tests {
         let result = manager.cancel();
 
         assert_eq!(result, Ok(()));
-        assert!(ctrl_rx.try_recv().is_err());
+        let sent = ctrl_rx.try_recv();
+        assert!(
+            sent.is_err(),
+            "cancel without an active session must not reach the watcher, got {sent:?}"
+        );
     }
 
     #[tokio::test]
@@ -391,6 +395,10 @@ mod tests {
             panic!("test device cache lock should not be poisoned");
         };
         assert_eq!(devices.len(), 1);
-        assert!(ctrl_rx.try_recv().is_err());
+        let sent = ctrl_rx.try_recv();
+        assert!(
+            sent.is_err(),
+            "an overlapping start must not reach the watcher, got {sent:?}"
+        );
     }
 }

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -133,6 +133,10 @@ fn restart(path: &Path) {
         "executable changed on disk — relaunching as the new macOS agent"
     );
     match schedule_macos_relaunch(path) {
+        #[expect(
+            clippy::exit,
+            reason = "the successor is already scheduled and waits on this process releasing the singleton lock and IPC socket; this watcher thread cannot return a status to `main`, which is parked in the AppKit run loop"
+        )]
         Ok(()) => std::process::exit(0),
         Err(e) => {
             warn!(error = %e, "could not schedule updated agent relaunch — keeping the current image and retrying");
@@ -177,6 +181,10 @@ fn restart(path: &Path) {
         path = %path.display(),
         "executable changed on disk — exiting so the new binary can start"
     );
+    #[expect(
+        clippy::exit,
+        reason = "windows has no `exec`, and this watcher thread cannot return a status to `main`, which is blocked on the agent core; releasing the singleton lock by exiting is what lets the replaced binary start"
+    )]
     std::process::exit(0);
 }
 

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -96,19 +96,7 @@ define_class!(
 
         #[unsafe(method(quitOpenLogi:))]
         fn quit_openlogi(&self, _sender: Option<&AnyObject>) {
-            // Tell a *running* GUI to quit too, but don't let `open` cold-launch
-            // one just to immediately quit it (it would flash a window — and on
-            // first run the update-consent prompt — before exiting). The gate
-            // keeps the target warm in the common case, so the blocking
-            // `.output()` (which guarantees Apple-Event delivery) returns at
-            // once; a GUI that races to exit after the check was quitting anyway.
-            if gui_is_running() {
-                let _ = std::process::Command::new("open")
-                    .arg(DeeplinkCommand::Quit.to_url())
-                    .output();
-            }
-            info!("menu-bar Quit — exiting agent");
-            std::process::exit(0);
+            quit_agent();
         }
     }
 );
@@ -133,6 +121,30 @@ fn open_url(url: &str) {
 /// macOS launches the GUI (cold start) or hands the URL to the running app.
 fn open_command(command: DeeplinkCommand) {
     open_url(&command.to_url());
+}
+
+/// Menu-bar Quit: take a running GUI with us, then end the process.
+///
+/// Kept out of `define_class!` so the lint set actually sees the exit — clippy
+/// does not look inside macro expansions.
+fn quit_agent() -> ! {
+    // Tell a *running* GUI to quit too, but don't let `open` cold-launch one
+    // just to immediately quit it (it would flash a window — and on first run
+    // the update-consent prompt — before exiting). The gate keeps the target
+    // warm in the common case, so the blocking `.output()` (which guarantees
+    // Apple-Event delivery) returns at once; a GUI that races to exit after the
+    // check was quitting anyway.
+    if gui_is_running() {
+        let _ = std::process::Command::new("open")
+            .arg(DeeplinkCommand::Quit.to_url())
+            .output();
+    }
+    info!("menu-bar Quit — exiting agent");
+    #[expect(
+        clippy::exit,
+        reason = "reached from an AppKit menu action on the main thread: the run loop owns `main`'s stack frame, so no status can travel back to it"
+    )]
+    std::process::exit(0)
 }
 
 /// Whether an OpenLogi GUI process is currently running (prod or dev bundle).
@@ -162,6 +174,10 @@ fn gui_is_running() -> bool {
 pub fn run_app_loop(show_in_menu_bar: bool, resume_pending: Arc<AtomicBool>) -> ! {
     let Some(mtm) = MainThreadMarker::new() else {
         warn!("agent AppKit loop not started off the main thread — exiting");
+        #[expect(
+            clippy::exit,
+            reason = "this branch means `run_app_loop` was called off the process main thread, where AppKit cannot run at all; the function is `-> !` and `main` returns `()`, so a failure status has nowhere to propagate"
+        )]
         std::process::exit(1);
     };
     let app = NSApplication::sharedApplication(mtm);
@@ -174,6 +190,10 @@ pub fn run_app_loop(show_in_menu_bar: bool, resume_pending: Arc<AtomicBool>) -> 
     info!(show_in_menu_bar, "agent AppKit loop started");
 
     app.run();
+    #[expect(
+        clippy::exit,
+        reason = "AppKit only returns from `run()` once the loop is torn down, and the agent core is still running on another thread; this function is `-> !` with no return path, so the process ends here"
+    )]
     std::process::exit(0);
 }
 

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -418,6 +418,10 @@ fn quit(hwnd: HWND) {
         Shell_NotifyIconW(NIM_DELETE, &raw const nid);
     }
     info!("tray Quit — exiting agent");
+    #[expect(
+        clippy::exit,
+        reason = "reached from the window procedure on the tray thread: the status cannot travel back through an `extern \"system\"` callback, and ending the message pump would only end this thread while `main` keeps running the agent core"
+    )]
     std::process::exit(0);
 }
 

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -149,6 +149,10 @@ unsafe extern "system" fn wnd_proc(
         WM_TRAY => {
             match lparam as u32 {
                 WM_LBUTTONUP => open_or_focus_gui(),
+                // SAFETY: win32 dispatches this callback on the tray thread —
+                // the one that created `hwnd` and pumps its messages — so the
+                // handle is live for the whole call, and `TrackPopupMenu` gets
+                // the owning thread it requires.
                 WM_RBUTTONUP | WM_CONTEXTMENU => unsafe { show_menu(hwnd) },
                 _ => {}
             }
@@ -156,9 +160,16 @@ unsafe extern "system" fn wnd_proc(
         }
         m if m != 0 && m == TASKBAR_CREATED.load(Ordering::Relaxed) => {
             // Explorer restarted; every tray icon was dropped. Re-add ours.
+            // SAFETY: `hwnd` is our own window, still live while its window
+            // procedure runs, and this is the thread that created it — the
+            // same conditions under which `run_tray_loop` first added the icon.
             unsafe { add_tray_icon(hwnd) };
             0
         }
+        // SAFETY: handing the system back the message it just delivered,
+        // unchanged: `hwnd` is live for the duration of the callback and
+        // `wparam`/`lparam` are the payload win32 paired with `msg`, which is
+        // exactly what the default handler expects.
         _ => unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) },
     }
 }

--- a/crates/openlogi-camera/Cargo.toml
+++ b/crates/openlogi-camera/Cargo.toml
@@ -19,9 +19,30 @@ tracing = { workspace = true }
 # permissions, the hook's NSWorkspace read): leak-proof `Retained<T>` ownership,
 # `define_class!` for the frame delegate (matching the agent tray target), and
 # `block2` for the `requestAccess…` completion block.
+#
+# The UVC control path is IOKit rather than AVFoundation, and gets the same
+# treatment from the objc2 bindings: `CFRetained` for CoreFoundation values,
+# `IOServiceGetMatchingServices` taking the matching dictionary *by value*
+# (it consumes a reference), and the real `IOUSBDeviceInterface182` vtable —
+# so nothing here declares its own `extern "C"` block.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
 block2 = "0.6"
+objc2-core-foundation = { workspace = true, features = [
+    "std",
+    "CFDictionary",
+    "CFNumber",
+    "CFString",
+    "CFUUID",
+] }
+objc2-io-kit = { workspace = true, features = [
+    "std",
+    "libc",
+    "usb",
+    "AppleUSBDefinitions",
+    "IOUSBLib",
+    "USB",
+] }
 
 # DirectShow enumeration + IAMVideoProcAmp / IAMCameraControl UVC controls.
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/openlogi-camera/Cargo.toml
+++ b/crates/openlogi-camera/Cargo.toml
@@ -44,15 +44,7 @@ v4l = "0.14"
 zune-jpeg = "0.5"
 zune-core = "0.5"
 
-# Mirrors [workspace.lints]. unsafe_code stays denied; the AVFoundation modules
-# opt in locally with #[expect(unsafe_code)]. (The `unexpected_cfgs` allow the
-# old objc 0.2 macros needed is gone — objc2 doesn't emit `cfg(cargo-clippy)`.)
-[lints.rust]
-unsafe_code = "deny"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
-missing_errors_doc = "allow"
-doc_markdown = "allow"
+# unsafe_code stays denied (from [workspace.lints]); the AVFoundation modules opt
+# in locally with #[expect(unsafe_code)].
+[lints]
+workspace = true

--- a/crates/openlogi-camera/src/capture_windows.rs
+++ b/crates/openlogi-camera/src/capture_windows.rs
@@ -349,10 +349,12 @@ unsafe fn activate_source(unique_id: &str) -> Result<IMFMediaSource, CaptureErro
     // the thread. `MFEnumDeviceSources` fills `devices` with one CoTaskMem
     // allocation holding exactly `count` nullable interface pointers —
     // `Option<IMFActivate>` is a pointer-sized niche over that — so the slice
-    // spans only memory MF allocated, and it is freed once, after the loop and
-    // after the chosen activate has been retained out of it by `clone`.
-    // `GetAllocatedString` hands back a CoTaskMem PWSTR that is copied into
-    // `link_str` before being freed, so nothing outlives its allocation.
+    // spans only memory MF allocated, and the null case is ruled out before it
+    // is built. Every element is moved out with `take`, which is what carries
+    // MF's reference into Rust's ownership, and the array itself is freed once,
+    // after the borrow ends. `GetAllocatedString` hands back a CoTaskMem PWSTR
+    // that is copied into `link_str` before being freed, so nothing outlives
+    // its allocation.
     unsafe {
         let mut enum_attrs = None;
         MFCreateAttributes(&raw mut enum_attrs, 1).map_err(setup_err)?;
@@ -366,9 +368,21 @@ unsafe fn activate_source(unique_id: &str) -> Result<IMFMediaSource, CaptureErro
 
         let (mut devices, mut count) = (std::ptr::null_mut::<Option<IMFActivate>>(), 0u32);
         MFEnumDeviceSources(&enum_attrs, &raw mut devices, &raw mut count).map_err(setup_err)?;
-        let list = std::slice::from_raw_parts(devices, count as usize);
+        if devices.is_null() {
+            return Err(CaptureError::NotFound);
+        }
+        let list = std::slice::from_raw_parts_mut(devices, count as usize);
         let mut chosen = None;
-        for activate in list.iter().flatten() {
+        for slot in &mut *list {
+            // MF hands the caller one reference per device and freeing the
+            // array releases none of them, so every activate is moved out —
+            // the ones that are not chosen are released when they drop below.
+            let Some(activate) = slot.take() else {
+                continue;
+            };
+            if chosen.is_some() {
+                continue;
+            }
             let (mut link, mut len) = (windows::core::PWSTR::null(), 0u32);
             if activate
                 .GetAllocatedString(
@@ -383,8 +397,7 @@ unsafe fn activate_source(unique_id: &str) -> Result<IMFMediaSource, CaptureErro
             let link_str = link.to_string().unwrap_or_default();
             CoTaskMemFree(Some(link.as_ptr().cast()));
             if device_instance(&link_str).eq_ignore_ascii_case(device_instance(unique_id)) {
-                chosen = Some(activate.clone());
-                break;
+                chosen = Some(activate);
             }
         }
         let result = match chosen {

--- a/crates/openlogi-camera/src/capture_windows.rs
+++ b/crates/openlogi-camera/src/capture_windows.rs
@@ -34,13 +34,14 @@ use windows::Win32::Media::MediaFoundation::{
     MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID,
     MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK, MF_MT_DEFAULT_STRIDE,
     MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING,
-    MF_SOURCE_READER_FIRST_VIDEO_STREAM, MF_VERSION, MFCreateAttributes, MFCreateMediaType,
-    MFCreateSourceReaderFromMediaSource, MFEnumDeviceSources, MFMediaType_Video, MFSTARTUP_LITE,
-    MFStartup, MFVideoFormat_NV12, MFVideoFormat_RGB24, MFVideoFormat_RGB32, MFVideoFormat_YUY2,
+    MF_SOURCE_READER_FIRST_VIDEO_STREAM, MFCreateAttributes, MFCreateMediaType,
+    MFCreateSourceReaderFromMediaSource, MFEnumDeviceSources, MFMediaType_Video,
+    MFVideoFormat_NV12, MFVideoFormat_RGB24, MFVideoFormat_RGB32, MFVideoFormat_YUY2,
 };
-use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoTaskMemFree};
+use windows::Win32::System::Com::CoTaskMemFree;
 
 pub use crate::capture_types::{CaptureError, Frame};
+use crate::com_windows::{ComApartment, MediaFoundation};
 
 /// The preview's target frame width: matches the macOS backend's 720p preset —
 /// Retina-sharp in the 480pt preview box without 1080p copy/upload cost. The
@@ -177,29 +178,46 @@ pub fn request_camera_access() {}
 
 /// The reader thread: builds the Media Foundation graph, reports the outcome
 /// through `setup`, then pulls and decodes samples until told to stop.
+///
+/// This is an ordinary application thread pulling samples synchronously, not
+/// one of Media Foundation's work queues — the one thread kind on which the
+/// platform calls, and so the guards below, would be illegal.
 fn reader_thread(unique_id: &str, shared: &Shared, setup: &mpsc::Sender<Result<(), CaptureError>>) {
-    // SAFETY: COM + MF init on this thread; every interface is released by the
-    // `windows` wrappers when the thread's locals drop.
-    let reader = unsafe {
-        let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
-        if let Err(e) = MFStartup(MF_VERSION, MFSTARTUP_LITE) {
-            let _ = setup.send(Err(CaptureError::Setup(e.to_string())));
+    // Declared before anything COM so it drops last: every Media Foundation
+    // interface built below is a COM object, and releasing one after its
+    // apartment closed is exactly the bug these guards exist to prevent.
+    let com = ComApartment::enter();
+    let media_foundation = match com.start_media_foundation() {
+        Ok(started) => started,
+        Err(e) => {
+            let _ = setup.send(Err(setup_err(e)));
             return;
         }
-        match open_reader(unique_id) {
-            Ok(opened) => opened,
-            Err(e) => {
-                let _ = setup.send(Err(e));
-                return;
-            }
-        }
     };
-    let (reader, stride_hint) = reader;
-    let _ = setup.send(Ok(()));
 
+    // The whole object graph lives in this `match`, so the reader — and with it
+    // the media source and every media type — has released by the time the
+    // platform guard drops at the end of the function.
+    match open_reader(&media_foundation, unique_id) {
+        Ok((reader, stride_hint)) => {
+            let _ = setup.send(Ok(()));
+            pump_frames(&reader, shared, stride_hint);
+        }
+        Err(e) => {
+            let _ = setup.send(Err(e));
+        }
+    }
+    drop(media_foundation);
+}
+
+/// Pull and decode samples into `shared` until the stream is told to stop or
+/// the reader errors out.
+fn pump_frames(reader: &IMFSourceReader, shared: &Shared, stride_hint: StrideHint) {
     while !shared.stop.load(Ordering::Relaxed) {
-        // SAFETY: synchronous ReadSample with documented out-params; the
-        // sample and its buffer are released when the wrappers drop.
+        // SAFETY: synchronous ReadSample with documented out-params, on the
+        // thread that owns the reader and while the platform guard keeps Media
+        // Foundation started; the sample and its buffer are released when the
+        // wrappers drop.
         unsafe {
             let (mut flags, mut sample) = (0u32, None);
             if reader
@@ -244,10 +262,13 @@ struct StrideHint {
 /// Build the source reader for `unique_id`: activate the matching device,
 /// pick the native format closest to [`TARGET_WIDTH`], and negotiate RGB32
 /// output (Media Foundation inserts the decoder/converter).
-unsafe fn open_reader(unique_id: &str) -> Result<(IMFSourceReader, StrideHint), CaptureError> {
-    // SAFETY: only `reader_thread` calls this, after `CoInitializeEx` and
-    // `MFStartup` on that same thread and while MF stays started for the
-    // reader's lifetime — the precondition every call below needs.
+fn open_reader(
+    platform: &MediaFoundation<'_>,
+    unique_id: &str,
+) -> Result<(IMFSourceReader, StrideHint), CaptureError> {
+    // SAFETY: the `platform` borrow is the precondition every call below needs
+    // — Media Foundation started, inside an apartment — and the caller holds
+    // both guards for longer than the returned reader.
     // `MFCreateAttributes` writes its +1 `IMFAttributes` into the local
     // `Option`, which is checked before use; that attribute set, the reader, the
     // media types the enumeration keeps and the output type are all refcounted
@@ -255,7 +276,7 @@ unsafe fn open_reader(unique_id: &str) -> Result<(IMFSourceReader, StrideHint), 
     // against a live interface, and the reader is handed back to the very thread
     // that will pull samples from it.
     unsafe {
-        let source = activate_source(unique_id)?;
+        let source = activate_source(platform, unique_id)?;
 
         let mut reader_attrs = None;
         MFCreateAttributes(&raw mut reader_attrs, 1).map_err(setup_err)?;
@@ -343,10 +364,13 @@ unsafe fn open_reader(unique_id: &str) -> Result<(IMFSourceReader, StrideHint), 
 /// device path). The two APIs register the camera under different
 /// interface-class GUIDs, so they are matched on the shared device-instance
 /// portion (see [`device_instance`]).
-unsafe fn activate_source(unique_id: &str) -> Result<IMFMediaSource, CaptureError> {
-    // SAFETY: reached only from `open_reader` on the reader thread, i.e. after
-    // `CoInitializeEx` and `MFStartup`, which is what these MF calls require of
-    // the thread. `MFEnumDeviceSources` fills `devices` with one CoTaskMem
+fn activate_source(
+    _platform: &MediaFoundation<'_>,
+    unique_id: &str,
+) -> Result<IMFMediaSource, CaptureError> {
+    // SAFETY: the `_platform` borrow proves Media Foundation is started inside
+    // an apartment on this thread, which is what these MF calls require of it.
+    // `MFEnumDeviceSources` fills `devices` with one CoTaskMem
     // allocation holding exactly `count` nullable interface pointers —
     // `Option<IMFActivate>` is a pointer-sized niche over that — so the slice
     // spans only memory MF allocated, and the null case is ruled out before it

--- a/crates/openlogi-camera/src/capture_windows.rs
+++ b/crates/openlogi-camera/src/capture_windows.rs
@@ -245,6 +245,15 @@ struct StrideHint {
 /// pick the native format closest to [`TARGET_WIDTH`], and negotiate RGB32
 /// output (Media Foundation inserts the decoder/converter).
 unsafe fn open_reader(unique_id: &str) -> Result<(IMFSourceReader, StrideHint), CaptureError> {
+    // SAFETY: only `reader_thread` calls this, after `CoInitializeEx` and
+    // `MFStartup` on that same thread and while MF stays started for the
+    // reader's lifetime — the precondition every call below needs.
+    // `MFCreateAttributes` writes its +1 `IMFAttributes` into the local
+    // `Option`, which is checked before use; that attribute set, the reader, the
+    // media types the enumeration keeps and the output type are all refcounted
+    // wrappers released when they drop. Each method call runs on this thread
+    // against a live interface, and the reader is handed back to the very thread
+    // that will pull samples from it.
     unsafe {
         let source = activate_source(unique_id)?;
 
@@ -335,6 +344,15 @@ unsafe fn open_reader(unique_id: &str) -> Result<(IMFSourceReader, StrideHint), 
 /// interface-class GUIDs, so they are matched on the shared device-instance
 /// portion (see [`device_instance`]).
 unsafe fn activate_source(unique_id: &str) -> Result<IMFMediaSource, CaptureError> {
+    // SAFETY: reached only from `open_reader` on the reader thread, i.e. after
+    // `CoInitializeEx` and `MFStartup`, which is what these MF calls require of
+    // the thread. `MFEnumDeviceSources` fills `devices` with one CoTaskMem
+    // allocation holding exactly `count` nullable interface pointers —
+    // `Option<IMFActivate>` is a pointer-sized niche over that — so the slice
+    // spans only memory MF allocated, and it is freed once, after the loop and
+    // after the chosen activate has been retained out of it by `clone`.
+    // `GetAllocatedString` hands back a CoTaskMem PWSTR that is copied into
+    // `link_str` before being freed, so nothing outlives its allocation.
     unsafe {
         let mut enum_attrs = None;
         MFCreateAttributes(&raw mut enum_attrs, 1).map_err(setup_err)?;

--- a/crates/openlogi-camera/src/com_windows.rs
+++ b/crates/openlogi-camera/src/com_windows.rs
@@ -1,0 +1,128 @@
+//! COM apartment and Media Foundation platform lifetimes, as guards.
+//!
+//! Both Windows backends have to initialize COM — DirectShow enumeration for
+//! controls, Media Foundation for capture — and both used to do it and never
+//! tear it down, so every enumeration and every preview session left a count
+//! behind on a thread that then exited. Initialization is paired here instead,
+//! by types whose drop is the teardown.
+//!
+//! The two halves count differently, which is why they are two guards:
+//!
+//! - COM is per **thread**. Every successful `CoInitializeEx` — including one
+//!   that returns `S_FALSE` because the thread was already initialized — owes a
+//!   `CoUninitialize` on that same thread, and a *failed* one owes nothing.
+//! - Media Foundation is not documented as per-thread at all: `MFShutdown` is
+//!   specified only as "call this function once for every call to `MFStartup`",
+//!   with no statement that one thread's shutdown leaves another thread's
+//!   platform running. So the platform is refcounted *here* — started for the
+//!   first live guard, shut down when the last one goes — and no capture
+//!   session can pull Media Foundation out from under another.
+
+#![expect(
+    unsafe_code,
+    reason = "COM apartment and Media Foundation platform initialization"
+)]
+
+use std::marker::PhantomData;
+use std::sync::{Mutex, PoisonError};
+
+use windows::Win32::Media::MediaFoundation::{MF_VERSION, MFSTARTUP_LITE, MFShutdown, MFStartup};
+use windows::Win32::System::Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize};
+
+/// A COM apartment entered on the current thread, left on drop.
+///
+/// Every COM interface pointer obtained under a guard must be released **before**
+/// the guard drops. Rust drops locals in reverse declaration order, so the guard
+/// is declared first in its scope; anything that outlives it borrows it, which
+/// turns that ordering into a compile error rather than a convention.
+pub(crate) struct ComApartment {
+    /// Whether *this* guard's call incremented the thread's initialization
+    /// count. `RPC_E_CHANGED_MODE` means the thread already sits in an
+    /// incompatible apartment: both backends work under either model, so the
+    /// existing one is borrowed — but never torn down, since nothing was added
+    /// to its count.
+    owned: bool,
+    /// `CoUninitialize` has to run on the thread that initialized, so the guard
+    /// cannot travel to another one.
+    _not_send: PhantomData<*const ()>,
+}
+
+impl ComApartment {
+    /// Enter the multithreaded apartment on this thread.
+    pub(crate) fn enter() -> Self {
+        // SAFETY: no reserved parameter, and a single concurrency flag. The
+        // returned HRESULT is a success code for both `S_OK` and `S_FALSE`,
+        // which are exactly the two outcomes that owe a `CoUninitialize`.
+        let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+        Self {
+            owned: hr.is_ok(),
+            _not_send: PhantomData,
+        }
+    }
+
+    /// Start the Media Foundation platform for as long as the returned guard
+    /// lives — and no longer than this apartment, which the borrow enforces:
+    /// Media Foundation's objects are COM, so the apartment has to outlive the
+    /// platform, and dropping them the other way round will not compile.
+    ///
+    /// # Errors
+    /// Whatever `MFStartup` reports, when this is the guard that starts the
+    /// platform.
+    pub(crate) fn start_media_foundation(&self) -> windows::core::Result<MediaFoundation<'_>> {
+        let mut live = live_guards();
+        if *live == 0 {
+            // SAFETY: called on an application thread that has just entered an
+            // apartment — never from a Media Foundation work queue, the one
+            // thread kind the platform calls forbid. `MFSTARTUP_LITE` skips the
+            // sockets library, which no local capture path needs.
+            unsafe { MFStartup(MF_VERSION, MFSTARTUP_LITE) }?;
+        }
+        *live += 1;
+        Ok(MediaFoundation { _com: self })
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
+        // SAFETY: balances, exactly once and on the initializing thread, the
+        // successful `CoInitializeEx` in `enter`. Every interface created under
+        // this guard has already been released — callers hold it in the
+        // outermost binding of their scope, and anything that outlives it
+        // borrows it.
+        unsafe { CoUninitialize() };
+    }
+}
+
+/// The Media Foundation platform, started for as long as this guard lives.
+///
+/// `!Send` follows from the borrowed [`ComApartment`], which is itself pinned to
+/// its thread.
+pub(crate) struct MediaFoundation<'a> {
+    _com: &'a ComApartment,
+}
+
+impl Drop for MediaFoundation<'_> {
+    fn drop(&mut self) {
+        let mut live = live_guards();
+        *live -= 1;
+        if *live != 0 {
+            return;
+        }
+        // SAFETY: this is the last live guard, so the shutdown balances the one
+        // `MFStartup` above, and every Media Foundation interface any of them
+        // created has been released first — each capture session owns its whole
+        // object graph in a scope that closes before its guard drops.
+        let _ = unsafe { MFShutdown() };
+    }
+}
+
+/// How many [`MediaFoundation`] guards are alive process-wide.
+fn live_guards() -> std::sync::MutexGuard<'static, usize> {
+    static LIVE: Mutex<usize> = Mutex::new(0);
+    // Poisoning is impossible — no holder panics — but recover rather than
+    // unwrap, so a panic elsewhere could not strand the platform.
+    LIVE.lock().unwrap_or_else(PoisonError::into_inner)
+}

--- a/crates/openlogi-camera/src/lib.rs
+++ b/crates/openlogi-camera/src/lib.rs
@@ -32,6 +32,9 @@ pub use capture::{
 };
 
 #[cfg(target_os = "windows")]
+mod com_windows;
+
+#[cfg(target_os = "windows")]
 mod capture_windows;
 #[cfg(target_os = "windows")]
 pub use capture_windows::{

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -527,6 +527,21 @@ fn video_control_topology(device: &SeizedDevice) -> Option<VcTopology> {
         .find_map(scan_descriptors)
 }
 
+/// The VideoControl interface the descriptor walk is currently inside, and the
+/// entities seen in it so far.
+///
+/// A class-specific descriptor belongs to the interface it follows, so this is
+/// dropped on leaving the block: VideoStreaming reuses descriptor type `0x24`
+/// with its own subtype numbering, in which `0x05` is a frame descriptor rather
+/// than a Processing Unit and `0x02` an output header rather than an input
+/// terminal. Tracking the block — instead of a bare "have we seen a
+/// VideoControl interface" flag — is what keeps a frame index from being read
+/// as a Processing-Unit id on a camera whose VideoControl block has none.
+struct VcBlock {
+    interface: u8,
+    camera_terminal: Option<u8>,
+}
+
 /// Walk a configuration-descriptor blob, collecting the first VideoControl
 /// interface's Processing-Unit and camera-terminal entity ids.
 ///
@@ -535,8 +550,7 @@ fn video_control_topology(device: &SeizedDevice) -> Option<VcTopology> {
 /// misreading the bytes after it.
 fn scan_descriptors(blob: &[u8]) -> Option<VcTopology> {
     let mut rest = blob;
-    let mut vc_interface: Option<u8> = None;
-    let mut camera_terminal: Option<u8> = None;
+    let mut block: Option<VcBlock> = None;
     while rest.len() >= 2 {
         let len = usize::from(rest[0]);
         let dtype = rest[1];
@@ -549,15 +563,19 @@ fn scan_descriptors(blob: &[u8]) -> Option<VcTopology> {
         if dtype == DESC_INTERFACE {
             // bInterfaceNumber, bInterfaceClass and bInterfaceSubClass sit at
             // offsets 2, 5 and 6 of an interface descriptor.
-            if let (Some(&number), Some(&class), Some(&subclass)) =
-                (descriptor.get(2), descriptor.get(5), descriptor.get(6))
-                && class == CC_VIDEO
-                && subclass == SC_VIDEOCONTROL
-            {
-                vc_interface = Some(number);
-            }
+            block = match (descriptor.get(2), descriptor.get(5), descriptor.get(6)) {
+                (Some(&interface), Some(&class), Some(&subclass))
+                    if class == CC_VIDEO && subclass == SC_VIDEOCONTROL =>
+                {
+                    Some(VcBlock {
+                        interface,
+                        camera_terminal: None,
+                    })
+                }
+                _ => None,
+            };
         } else if dtype == DESC_CS_INTERFACE
-            && let Some(vc) = vc_interface
+            && let Some(block) = block.as_mut()
             && let (Some(&subtype), Some(&entity)) = (descriptor.get(2), descriptor.get(3))
         {
             // bUnitID / bTerminalID sit at offset 3 in both descriptors; an
@@ -565,14 +583,14 @@ fn scan_descriptors(blob: &[u8]) -> Option<VcTopology> {
             // sensor — skip composite/other input terminals.
             if subtype == VC_INPUT_TERMINAL && descriptor.len() >= 8 {
                 let terminal_type = u16::from(descriptor[4]) | (u16::from(descriptor[5]) << 8);
-                if terminal_type == ITT_CAMERA && camera_terminal.is_none() {
-                    camera_terminal = Some(entity);
+                if terminal_type == ITT_CAMERA && block.camera_terminal.is_none() {
+                    block.camera_terminal = Some(entity);
                 }
             } else if subtype == VC_PROCESSING_UNIT {
                 return Some(VcTopology {
-                    vc_interface: vc,
+                    vc_interface: block.interface,
                     processing_unit: entity,
-                    camera_terminal,
+                    camera_terminal: block.camera_terminal,
                 });
             }
         }
@@ -676,6 +694,32 @@ mod tests {
         let blob: Vec<u8> = [
             interface(0, 0x01, 0x01), // audio
             processing_unit(9),
+        ]
+        .concat();
+        assert_eq!(scan_descriptors(&blob), None);
+    }
+
+    /// …and neither do the ones *after* it. VideoStreaming reuses descriptor
+    /// type 0x24 with its own subtype numbering, where 0x05 is
+    /// VS_FRAME_UNCOMPRESSED rather than VC_PROCESSING_UNIT. A camera whose
+    /// VideoControl block has no Processing Unit must report none, not the
+    /// first frame descriptor's bFrameIndex — which would send every image
+    /// control to whatever entity happens to share that id.
+    #[test]
+    fn a_videostreaming_frame_descriptor_is_not_a_processing_unit() {
+        // A real VS_FRAME_UNCOMPRESSED: 30 bytes, descriptor type 0x24 like a
+        // VideoControl unit, subtype 0x05, and bFrameIndex sitting exactly
+        // where a unit keeps its bUnitID.
+        let mut vs_frame = vec![0u8; 30];
+        vs_frame[0] = 30;
+        vs_frame[1] = 0x24;
+        vs_frame[2] = 0x05;
+        vs_frame[3] = 1;
+        let blob: Vec<u8> = [
+            interface(0, 0x0E, 0x01), // VideoControl — no processing unit
+            input_terminal(1, ITT_CAMERA),
+            interface(1, 0x0E, 0x02), // VideoStreaming
+            vs_frame,
         ]
         .concat();
         assert_eq!(scan_descriptors(&blob), None);

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -324,6 +324,14 @@ unsafe fn registry_location_and_serial(
     service: IoService,
     serial_key: *const c_void,
 ) -> Option<(u32, String)> {
+    // SAFETY: `service` is a live io_service_t the enumeration loop holds for
+    // the whole call (it releases it only after this returns), so both registry
+    // reads address a valid IOKit object, and `serial_key` is the caller's
+    // CFString, only borrowed here. `IORegistryEntryCreateCFProperty` follows
+    // the Create rule: each +1 CFTypeRef it returns is handed straight to
+    // `cf_number_u32` / `cf_string_value`, which release it on every path, and
+    // the `locationID` key created for the fallback is released before it
+    // returns.
     unsafe {
         // Prefer the USB device interface for location (matches control open);
         // fall back to the registry number property when the plug-in is busy.
@@ -351,6 +359,18 @@ unsafe fn registry_location_and_serial(
 
 /// Location id via a transient `IOUSBDeviceInterface` (no open/seize).
 unsafe fn device_location_id(service: IoService) -> Option<u32> {
+    // SAFETY: `service` is a live io_service_t held by the caller for the whole
+    // call. The two +1 CFUUIDs are released once
+    // `IOCreatePlugInInterfaceForService` — which only borrows them — has
+    // returned, and `plugin` is used only after its status/null check.
+    // `query_interface` follows the IOKit plug-in ABI: the interface pointer
+    // itself is the `this` argument, and `PlugInInterface` mirrors
+    // IOCFPlugInInterface's IUnknown head. The device interface it yields
+    // carries its own reference, and this path never opens the device, so the
+    // stop-then-release `IODestroyPlugInInterface` performs leaves `dev` valid;
+    // it is the `kIOUSBDeviceInterfaceID182` vtable `UsbDeviceInterface`
+    // describes, `get_location_id` writes only the local `location`, and the
+    // paired `release` balances the `query_interface` retain before returning.
     unsafe {
         let user_client = make_uuid(&KIO_USB_DEVICE_USER_CLIENT_TYPE_ID);
         let plugin_type = make_uuid(&KIO_CF_PLUGIN_INTERFACE_ID);
@@ -398,6 +418,15 @@ unsafe fn cf_string_value(cf: *const c_void) -> Option<String> {
     if cf.is_null() {
         return None;
     }
+    // SAFETY: `cf` is non-null (checked above) and a +1 CFTypeRef its callers
+    // hand over from a Create/Copy call; nothing reads it after the `CFRelease`
+    // that balances it, and the only returns that skip that release are the
+    // capacity checks, which need a string a quarter of the address space long
+    // — no CFString reaches them. The type check gates the CFString calls, so
+    // `CFStringGetLength`/`CFStringGetCString` only ever see a CFStringRef, and
+    // the buffer passed to the conversion is `cap` bytes long with `cap` given
+    // as its size — enough for UTF-8's worst case plus the NUL, and bounded by
+    // CFString either way.
     unsafe {
         if CFGetTypeID(cf) != CFStringGetTypeID() {
             CFRelease(cf);
@@ -426,6 +455,10 @@ unsafe fn cf_number_u32(cf: *const c_void) -> Option<u32> {
     if cf.is_null() {
         return None;
     }
+    // SAFETY: `cf` is non-null (checked above) and a +1 CFTypeRef we own, so the
+    // one `CFRelease` on each path balances it. The type check ahead of
+    // `CFNumberGetValue` means it sees a CFNumberRef, and the destination is a
+    // local `u32` — exactly the size and alignment `kCFNumberSInt32Type` writes.
     unsafe {
         if CFGetTypeID(cf) != CFNumberGetTypeID() {
             CFRelease(cf);
@@ -799,6 +832,20 @@ impl UsbDevice {
         want_vid: u16,
         _want_location: Option<u32>,
     ) -> Option<Opened> {
+        // SAFETY: `service` is a live io_service_t `open_for` holds across this
+        // call. The two +1 CFUUIDs are released once
+        // `IOCreatePlugInInterfaceForService` — which only borrows them — has
+        // returned, and `plugin`/`dev_ptr` are used only after their
+        // status/null checks. `query_interface` gets the plug-in pointer itself
+        // as the `this` argument, per the IOKit plug-in ABI, and asks for
+        // `kIOUSBDeviceInterfaceID182`, the vtable `UsbDeviceInterface`
+        // describes; the interface it yields holds its own reference, and the
+        // seize below has not run yet, so the stop-then-release
+        // `IODestroyPlugInInterface` performs leaves `dev` valid.
+        // `get_device_vendor` and `get_location_id` write only the locals passed
+        // to them, every return taken after `dev` exists releases it (closing it
+        // first once the seize succeeded), and on the success path that teardown
+        // becomes `UsbDevice`'s `Drop`.
         unsafe {
             let user_client = make_uuid(&KIO_USB_DEVICE_USER_CLIENT_TYPE_ID);
             let plugin_type = make_uuid(&KIO_CF_PLUGIN_INTERFACE_ID);
@@ -878,6 +925,15 @@ struct VcTopology {
 /// Parse the configuration descriptor for the VideoControl interface number,
 /// the Processing-Unit id, and the camera (input) terminal id.
 unsafe fn video_control_topology(dev: *mut *mut UsbDeviceInterface) -> Option<VcTopology> {
+    // SAFETY: `dev` is the interface `try_open` opened and still owns for the
+    // whole call, so its vtable entries are live and
+    // `get_number_of_configurations` writes only the local. On success
+    // `get_configuration_descriptor_ptr` hands back the interface's cached
+    // configuration-descriptor blob, which stays valid while `dev` is open and
+    // is at least the nine-byte header the USB spec mandates — so reading
+    // wTotalLength at offsets 2 and 3 is in bounds. IOUSBLib sized that blob
+    // from the very wTotalLength read here, which is the bound
+    // `scan_descriptors` then stays inside.
     unsafe {
         let mut num_configs: u8 = 0;
         ((**dev).get_number_of_configurations)(dev.cast::<c_void>(), &raw mut num_configs);
@@ -902,6 +958,13 @@ unsafe fn video_control_topology(dev: *mut *mut UsbDeviceInterface) -> Option<Vc
 /// Walk a configuration descriptor blob, collecting the first VideoControl
 /// interface's Processing-Unit and camera-terminal entity ids.
 unsafe fn scan_descriptors(base: *const u8, total: usize) -> Option<VcTopology> {
+    // SAFETY: the caller passes a configuration-descriptor blob together with
+    // its own wTotalLength, so `base` is readable for `total` bytes and outlives
+    // the walk. Every read stays in that window: a descriptor is only entered
+    // when `off + 2 <= total` and `off + len <= total`, and each field is read
+    // after checking that the descriptor's own `bLength` covers it — 9 bytes for
+    // an interface descriptor's number/class/subclass, 4 for a class-specific
+    // subtype and entity id, 8 for an input terminal's wTerminalType.
     unsafe {
         let mut off = 0usize;
         let mut vc_interface: Option<u8> = None;
@@ -944,6 +1007,11 @@ unsafe fn scan_descriptors(base: *const u8, total: usize) -> Option<VcTopology> 
 }
 
 unsafe fn make_uuid(bytes: &[u8; 16]) -> CfUuidRef {
+    // SAFETY: `CfUuidBytes` is `#[repr(C)]` around `[u8; 16]`, so it matches
+    // CFUUIDBytes' sixteen `UInt8` fields in size, alignment and by-value ABI,
+    // and it is passed as a copy — nothing of the caller's is borrowed past the
+    // call. The null allocator selects the default one, and the +1 CFUUIDRef
+    // returned is released by every caller.
     unsafe { CFUUIDCreateFromUUIDBytes(ptr::null(), CfUuidBytes { bytes: *bytes }) }
 }
 

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -12,11 +12,10 @@
 //! attached), open it via the IOKit `IOUSBDeviceInterface` plug-in, parse the
 //! configuration descriptor for the VideoControl interface number and the
 //! Processing-Unit id, then issue UVC `GET_*`/`SET_CUR` requests.
+//!
+//! The IOKit handles themselves live in [`iokit`], which owns every `unsafe`
+//! block in this backend and hands the descriptor up as a plain `&[u8]`.
 
-#![expect(
-    unsafe_code,
-    reason = "IOKit USB (IOUSBDeviceInterface) control-transfer FFI for UVC Processing-Unit controls"
-)]
 #![allow(
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
@@ -24,9 +23,15 @@
     reason = "UVC payloads are bounded 16-bit values copied verbatim"
 )]
 
-use std::ffi::{CString, c_void};
-use std::ptr;
-use std::ptr::NonNull;
+mod iokit;
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use objc2_core_foundation::{CFNumber, CFString};
+use objc2_io_kit::IOUSBDevRequest;
+
+use iokit::{IoObject, SeizedDevice, UsbInterface};
 
 /// Which UVC entity a control request addresses: the Camera Terminal (lens:
 /// zoom/focus/exposure) or the Processing Unit (image: brightness/…).
@@ -123,8 +128,6 @@ const AE_MANUAL: u8 = 0x01;
 /// Auto modes to try when enabling auto-exposure, most- to least-automatic
 /// (full auto, aperture priority, shutter priority) — cameras support subsets.
 const AE_AUTO_MODES: [u8; 3] = [0x02, 0x08, 0x04];
-
-const KIO_RETURN_SUCCESS: i32 = 0;
 
 /// Hold the process-wide seize/enumeration lock — see [`crate::USB_QUIESCE`].
 fn quiesce() -> std::sync::MutexGuard<'static, ()> {
@@ -281,351 +284,48 @@ pub(crate) fn location_hint(unique_id: &str) -> Option<u32> {
 ///
 /// Read from the IORegistry only — no device open — so enumeration can prefer
 /// the port-stable serial for config keys without racing a control seize.
-pub(crate) fn usb_serials_by_location() -> std::collections::HashMap<u32, String> {
-    use std::collections::HashMap;
-
-    let mut out = HashMap::new();
-    let Ok(class) = CString::new("IOUSBDevice") else {
-        return out;
-    };
-    // SAFETY: matching dict is consumed by GetMatchingServices; each service
-    // is released after we read its registry properties.
-    unsafe {
-        let matching = IOServiceMatching(class.as_ptr());
-        if matching.is_null() {
-            return out;
-        }
-        let mut iter: IoIterator = 0;
-        if IOServiceGetMatchingServices(kIOMainPortDefault, matching, &raw mut iter)
-            != KIO_RETURN_SUCCESS
-        {
-            return out;
-        }
-        let Some(key) = cf_string("USB Serial Number") else {
-            IOObjectRelease(iter);
-            return out;
-        };
-        loop {
-            let service = IOIteratorNext(iter);
-            if service == 0 {
-                break;
-            }
-            if let Some((location, serial)) = registry_location_and_serial(service, key) {
-                out.entry(location).or_insert(serial);
-            }
-            IOObjectRelease(service);
-        }
-        CFRelease(key.as_ptr());
-        IOObjectRelease(iter);
-    }
-    out
+pub(crate) fn usb_serials_by_location() -> HashMap<u32, String> {
+    let serial_key = CFString::from_static_str("USB Serial Number");
+    let location_key = CFString::from_static_str("locationID");
+    iokit::usb_devices()
+        .into_iter()
+        .flatten()
+        .filter_map(|service| registry_location_and_serial(&service, &serial_key, &location_key))
+        .fold(HashMap::new(), |mut serials, (location, serial)| {
+            serials.entry(location).or_insert(serial);
+            serials
+        })
 }
 
 /// Location id + USB serial from an `IOUSBDevice` service, without opening it.
-unsafe fn registry_location_and_serial(
-    service: IoService,
-    serial_key: NonNull<c_void>,
+fn registry_location_and_serial(
+    service: &IoObject,
+    serial_key: &CFString,
+    location_key: &CFString,
 ) -> Option<(u32, String)> {
-    // SAFETY: `service` is a live io_service_t the enumeration loop holds for
-    // the whole call (it releases it only after this returns), so both registry
-    // reads address a valid IOKit object, and `serial_key` is a CFString the
-    // caller created and still owns, only borrowed here. Both property reads
-    // pass a key that exists — IOKit dereferences one without a null check —
-    // which the caller guarantees by construction, `NonNull` being what makes a
-    // failed creation impossible to pass, and the `?` on the `locationID` key
-    // repeating that here. `IORegistryEntryCreateCFProperty` follows the Create
-    // rule: each +1 CFTypeRef it returns is handed straight to `cf_number_u32` /
-    // `cf_string_value`, which release it on every path, and the `locationID`
-    // key created for the fallback is released before it returns.
-    unsafe {
-        // Prefer the USB device interface for location (matches control open);
-        // fall back to the registry number property when the plug-in is busy.
-        let location = device_location_id(service).or_else(|| {
-            let key = cf_string("locationID")?;
-            let loc = cf_number_u32(IORegistryEntryCreateCFProperty(
-                service,
-                key.as_ptr(),
-                ptr::null(),
-                0,
-            ));
-            CFRelease(key.as_ptr());
-            loc
+    // Prefer the USB device interface for the location (it is what the control
+    // path matches on); fall back to the registry number when the plug-in is
+    // busy.
+    let location = UsbInterface::open(service)
+        .and_then(|interface| interface.location_id())
+        .or_else(|| {
+            iokit::registry_property(service, location_key)?
+                .downcast::<CFNumber>()
+                .ok()?
+                .as_i32()
+                .map(i32::cast_unsigned)
         })?;
-        let serial_ref =
-            IORegistryEntryCreateCFProperty(service, serial_key.as_ptr(), ptr::null(), 0);
-        let serial = cf_string_value(serial_ref)?;
-        if serial.is_empty() {
-            return None;
-        }
-        Some((location, serial))
-    }
+    let serial = iokit::registry_property(service, serial_key)?
+        .downcast::<CFString>()
+        .ok()?
+        .to_string();
+    (!serial.is_empty()).then_some((location, serial))
 }
 
-/// Location id via a transient `IOUSBDeviceInterface` (no open/seize).
-unsafe fn device_location_id(service: IoService) -> Option<u32> {
-    // SAFETY: `service` is a live io_service_t held by the caller for the whole
-    // call. The two +1 CFUUIDs are released once
-    // `IOCreatePlugInInterfaceForService` — which only borrows them — has
-    // returned, and `plugin` is used only after its status/null check.
-    // `query_interface` follows the IOKit plug-in ABI: the interface pointer
-    // itself is the `this` argument, and `PlugInInterface` mirrors
-    // IOCFPlugInInterface's IUnknown head. The device interface it yields
-    // carries its own reference, and this path never opens the device, so the
-    // stop-then-release `IODestroyPlugInInterface` performs leaves `dev` valid;
-    // it is the `kIOUSBDeviceInterfaceID182` vtable `UsbDeviceInterface`
-    // describes, `get_location_id` writes only the local `location`, and the
-    // paired `release` balances the `query_interface` retain before returning.
-    unsafe {
-        let user_client = make_uuid(&KIO_USB_DEVICE_USER_CLIENT_TYPE_ID);
-        let plugin_type = make_uuid(&KIO_CF_PLUGIN_INTERFACE_ID);
-        let mut plugin: *mut *mut PlugInInterface = ptr::null_mut();
-        let mut score: i32 = 0;
-        let rc = IOCreatePlugInInterfaceForService(
-            service,
-            user_client,
-            plugin_type,
-            &raw mut plugin,
-            &raw mut score,
-        );
-        CFRelease(user_client);
-        CFRelease(plugin_type);
-        if rc != KIO_RETURN_SUCCESS || plugin.is_null() {
-            return None;
-        }
-        let dev_uuid_ref = make_uuid(&KIO_USB_DEVICE_INTERFACE_ID);
-        let dev_uuid = CFUUIDGetUUIDBytes(dev_uuid_ref);
-        CFRelease(dev_uuid_ref);
-        let mut dev_ptr: *mut c_void = ptr::null_mut();
-        let qrc = ((**plugin).query_interface)(plugin.cast::<c_void>(), dev_uuid, &raw mut dev_ptr);
-        IODestroyPlugInInterface(plugin);
-        if qrc != 0 || dev_ptr.is_null() {
-            return None;
-        }
-        let dev = dev_ptr.cast::<*mut UsbDeviceInterface>();
-        let mut location: u32 = 0;
-        let ok = ((**dev).get_location_id)(dev.cast::<c_void>(), &raw mut location)
-            == KIO_RETURN_SUCCESS;
-        ((**dev).release)(dev.cast::<c_void>());
-        ok.then_some(location)
-    }
-}
-
-/// A freshly created CFString the caller owns, or `None` if `s` holds an
-/// interior NUL or CoreFoundation could not create the string. Returning
-/// `NonNull` makes a failed creation impossible to hand to an IOKit call that
-/// would dereference the key.
-fn cf_string(s: &str) -> Option<NonNull<c_void>> {
-    let c = CString::new(s).ok()?;
-    // SAFETY: UTF-8 C string; returned CFString is owned by the caller.
-    let cf =
-        unsafe { CFStringCreateWithCString(ptr::null(), c.as_ptr(), K_CF_STRING_ENCODING_UTF8) }
-            .cast_mut();
-    NonNull::new(cf)
-}
-
-unsafe fn cf_string_value(cf: *const c_void) -> Option<String> {
-    if cf.is_null() {
-        return None;
-    }
-    // SAFETY: `cf` is non-null (checked above) and a +1 CFTypeRef its callers
-    // hand over from a Create/Copy call. `decode_cf_string` only borrows it, and
-    // the `CFRelease` below balances that +1 exactly once on every path out —
-    // including the capacity checks, which bail with `?` from the borrow rather
-    // than from here.
-    unsafe {
-        let value = decode_cf_string(cf);
-        CFRelease(cf);
-        value
-    }
-}
-
-/// Decode a **borrowed** `CFStringRef` as UTF-8. Ownership stays with the
-/// caller, which releases `cf` whichever way this returns.
-unsafe fn decode_cf_string(cf: *const c_void) -> Option<String> {
-    // SAFETY: the caller's +1 CFTypeRef is live for the whole call. The type
-    // check gates the CFString calls, so `CFStringGetLength`/`CFStringGetCString`
-    // only ever see a CFStringRef, and the buffer passed to the conversion is
-    // `cap` bytes long with `cap` given as its size — enough for UTF-8's worst
-    // case plus the NUL, and bounded by CFString either way.
-    unsafe {
-        if CFGetTypeID(cf) != CFStringGetTypeID() {
-            return None;
-        }
-        let len = CFStringGetLength(cf);
-        // UTF-8 worst case 4 bytes/char + NUL.
-        let cap = usize::try_from(len).ok()?.checked_mul(4)?.checked_add(1)?;
-        let mut buf = vec![0u8; cap];
-        if CFStringGetCString(
-            cf,
-            buf.as_mut_ptr().cast(),
-            isize::try_from(cap).ok()?,
-            K_CF_STRING_ENCODING_UTF8,
-        ) == 0
-        {
-            return None;
-        }
-        let nul = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
-        String::from_utf8(buf[..nul].to_vec()).ok()
-    }
-}
-
-unsafe fn cf_number_u32(cf: *const c_void) -> Option<u32> {
-    if cf.is_null() {
-        return None;
-    }
-    // SAFETY: `cf` is non-null (checked above) and a +1 CFTypeRef we own, so the
-    // one `CFRelease` on each path balances it. The type check ahead of
-    // `CFNumberGetValue` means it sees a CFNumberRef, and the destination is a
-    // local `u32` — exactly the size and alignment `kCFNumberSInt32Type` writes.
-    unsafe {
-        if CFGetTypeID(cf) != CFNumberGetTypeID() {
-            CFRelease(cf);
-            return None;
-        }
-        let mut value: u32 = 0;
-        let ok = CFNumberGetValue(cf, K_CF_NUMBER_SINT32_TYPE, (&raw mut value).cast()) != 0;
-        CFRelease(cf);
-        ok.then_some(value)
-    }
-}
-
-// ── IOKit / CoreFoundation FFI ───────────────────────────────────────────────
-type IoReturn = i32;
-type IoService = u32;
-type IoIterator = u32;
-type CfUuidRef = *const c_void;
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct CfUuidBytes {
-    bytes: [u8; 16],
-}
-
-#[repr(C)]
-struct IoUsbDevRequest {
-    bm_request_type: u8,
-    b_request: u8,
-    w_value: u16,
-    w_index: u16,
-    w_length: u16,
-    p_data: *mut c_void,
-    w_len_done: u32,
-}
-
-// IOCFPlugInInterface — we only need the IUnknown head (QueryInterface/Release).
-#[repr(C)]
-struct PlugInInterface {
-    _reserved: *mut c_void,
-    query_interface: extern "C" fn(*mut c_void, CfUuidBytes, *mut *mut c_void) -> i32,
-    add_ref: extern "C" fn(*mut c_void) -> u32,
-    release: extern "C" fn(*mut c_void) -> u32,
-}
-
-// IOUSBDeviceInterface vtable (IOUSBLib.h). Slots we don't call are typed as
-// opaque pointers so the offsets of the ones we *do* call stay correct.
-#[repr(C)]
-struct UsbDeviceInterface {
-    _reserved: *mut c_void,
-    query_interface: extern "C" fn(*mut c_void, CfUuidBytes, *mut *mut c_void) -> i32,
-    add_ref: extern "C" fn(*mut c_void) -> u32,
-    release: extern "C" fn(*mut c_void) -> u32,
-    create_device_async_event_source: *const c_void,
-    get_device_async_event_source: *const c_void,
-    create_device_async_port: *const c_void,
-    get_device_async_port: *const c_void,
-    usb_device_open: extern "C" fn(*mut c_void) -> IoReturn,
-    usb_device_close: extern "C" fn(*mut c_void) -> IoReturn,
-    get_device_class: *const c_void,
-    get_device_sub_class: *const c_void,
-    get_device_protocol: *const c_void,
-    get_device_vendor: extern "C" fn(*mut c_void, *mut u16) -> IoReturn,
-    get_device_product: extern "C" fn(*mut c_void, *mut u16) -> IoReturn,
-    get_device_release_number: *const c_void,
-    get_device_address: *const c_void,
-    get_device_bus_power_available: *const c_void,
-    get_device_speed: *const c_void,
-    get_number_of_configurations: extern "C" fn(*mut c_void, *mut u8) -> IoReturn,
-    get_location_id: extern "C" fn(*mut c_void, *mut u32) -> IoReturn,
-    get_configuration_descriptor_ptr: extern "C" fn(*mut c_void, u8, *mut *const u8) -> IoReturn,
-    get_configuration: *const c_void,
-    set_configuration: *const c_void,
-    get_bus_frame_number: *const c_void,
-    reset_device: *const c_void,
-    device_request: extern "C" fn(*mut c_void, *mut IoUsbDevRequest) -> IoReturn,
-    device_request_async: *const c_void,
-    create_interface_iterator: *const c_void,
-    // IOUSBDeviceInterface182 adds OpenSeize: open even while the kernel video
-    // driver holds the device for streaming, so controls work during a preview.
-    usb_device_open_seize: extern "C" fn(*mut c_void) -> IoReturn,
-    // remaining methods unused
-}
-
-#[link(name = "IOKit", kind = "framework")]
-unsafe extern "C" {
-    static kIOMainPortDefault: u32;
-    fn IOServiceMatching(name: *const i8) -> *mut c_void;
-    fn IOServiceGetMatchingServices(
-        main_port: u32,
-        matching: *mut c_void,
-        existing: *mut IoIterator,
-    ) -> IoReturn;
-    fn IOIteratorNext(iterator: IoIterator) -> IoService;
-    fn IOObjectRelease(object: u32) -> IoReturn;
-    fn IOCreatePlugInInterfaceForService(
-        service: IoService,
-        plugin_type: CfUuidRef,
-        interface_type: CfUuidRef,
-        plug_in: *mut *mut *mut PlugInInterface,
-        score: *mut i32,
-    ) -> IoReturn;
-    fn IODestroyPlugInInterface(interface: *mut *mut PlugInInterface) -> IoReturn;
-    fn IORegistryEntryCreateCFProperty(
-        entry: IoService,
-        key: *const c_void,
-        allocator: *const c_void,
-        options: u32,
-    ) -> *const c_void;
-}
-
-#[link(name = "CoreFoundation", kind = "framework")]
-unsafe extern "C" {
-    fn CFUUIDCreateFromUUIDBytes(allocator: *const c_void, bytes: CfUuidBytes) -> CfUuidRef;
-    fn CFUUIDGetUUIDBytes(uuid: CfUuidRef) -> CfUuidBytes;
-    fn CFRelease(cf: *const c_void);
-    fn CFStringCreateWithCString(
-        allocator: *const c_void,
-        c_str: *const i8,
-        encoding: u32,
-    ) -> *const c_void;
-    fn CFStringGetTypeID() -> usize;
-    fn CFNumberGetTypeID() -> usize;
-    fn CFGetTypeID(cf: *const c_void) -> usize;
-    fn CFStringGetLength(s: *const c_void) -> isize;
-    fn CFStringGetCString(s: *const c_void, buf: *mut i8, buffer_size: isize, encoding: u32) -> u8;
-    fn CFNumberGetValue(number: *const c_void, the_type: i32, value_ptr: *mut c_void) -> u8;
-}
-
-/// `kCFStringEncodingUTF8`.
-const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
-/// `kCFNumberSInt32Type` — locationID is a 32-bit number in the registry.
-const K_CF_NUMBER_SINT32_TYPE: i32 = 3;
-
-// IOUSBLib UUIDs, as raw bytes (UUID order).
-const KIO_USB_DEVICE_USER_CLIENT_TYPE_ID: [u8; 16] = [
-    0x9d, 0xc7, 0xb7, 0x80, 0x9e, 0xc0, 0x11, 0xd4, 0xa5, 0x4f, 0x00, 0x0a, 0x27, 0x05, 0x28, 0x61,
-];
-const KIO_CF_PLUGIN_INTERFACE_ID: [u8; 16] = [
-    0xc2, 0x44, 0xe8, 0x58, 0x10, 0x9c, 0x11, 0xd4, 0x91, 0xd4, 0x00, 0x50, 0xe4, 0xc6, 0x42, 0x6f,
-];
-// kIOUSBDeviceInterfaceID182 — the first version exposing USBDeviceOpenSeize.
-const KIO_USB_DEVICE_INTERFACE_ID: [u8; 16] = [
-    0x15, 0x2f, 0xc4, 0x96, 0x48, 0x91, 0x11, 0xd5, 0x9d, 0x52, 0x00, 0x0a, 0x27, 0x80, 0x1e, 0x86,
-];
-
-/// An opened IOKit USB device interface, with its UVC topology resolved. Closes
-/// and releases on drop.
+/// An opened IOKit USB device with its UVC topology resolved. The seize is
+/// released when [`iokit::SeizedDevice`] drops.
 struct UsbDevice {
-    dev: *mut *mut UsbDeviceInterface,
+    device: SeizedDevice,
     vc_interface: u8,
     /// Processing-Unit id (image controls).
     unit_id: u8,
@@ -644,77 +344,62 @@ impl UsbDevice {
         // pick the one whose location matches), but parse it as a fallback.
         let want_location = location_hint(unique_id);
 
-        // SAFETY: standard IOKit device enumeration; each retained object is
-        // released, and the matching dictionary is consumed by the call.
-        unsafe {
-            let class = CString::new("IOUSBDevice").map_err(|e| ControlError::Io(e.to_string()))?;
-            let matching = IOServiceMatching(class.as_ptr());
-            if matching.is_null() {
-                return Err(ControlError::Io("IOServiceMatching".into()));
+        let services = iokit::usb_devices().map_err(|call| ControlError::Io(call.to_string()))?;
+        let mut chosen: Option<Opened> = None;
+        // Count Logitech cameras reached on the location-less path. With a
+        // parseable location only an exact match opens; without a hint (an
+        // unparseable unique id) the first Logitech camera is a best effort
+        // that is only safe when it's the *only* one — see the fail-closed
+        // check after the loop.
+        let mut vendor_candidates = 0usize;
+        for service in services {
+            let Some(found) = Self::try_open(&service, want_vid) else {
+                continue;
+            };
+            if want_location.is_some_and(|want| found.matched_location == Some(want)) {
+                chosen = Some(found);
+                break;
             }
-            let mut iter: IoIterator = 0;
-            if IOServiceGetMatchingServices(kIOMainPortDefault, matching, &raw mut iter)
-                != KIO_RETURN_SUCCESS
-            {
-                return Err(ControlError::Io("IOServiceGetMatchingServices".into()));
-            }
-
-            let mut chosen: Option<Opened> = None;
-            // Count Logitech cameras reached on the location-less path. With a
-            // parseable location only an exact match opens; without a hint (an
-            // unparseable unique id) the first Logitech camera is a best effort
-            // that is only safe when it's the *only* one — see the fail-closed
-            // check after the loop.
-            let mut vendor_candidates = 0usize;
-            loop {
-                let service = IOIteratorNext(iter);
-                if service == 0 {
-                    break;
-                }
-                match Self::try_open(service, want_vid, want_location) {
-                    Some(found) => {
-                        let exact =
-                            want_location.is_some_and(|l| found.matched_location == Some(l));
-                        IOObjectRelease(service);
-                        if exact {
-                            if let Some(prev) = chosen.take() {
-                                prev.into_device().close();
-                            }
-                            chosen = Some(found);
-                            break;
-                        } else if want_location.is_none() {
-                            vendor_candidates += 1;
-                            if chosen.is_none() {
-                                chosen = Some(found);
-                            } else {
-                                found.into_device().close();
-                            }
-                        } else {
-                            found.into_device().close();
-                        }
-                    }
-                    None => {
-                        IOObjectRelease(service);
-                    }
+            if want_location.is_none() {
+                vendor_candidates += 1;
+                if chosen.is_none() {
+                    chosen = Some(found);
                 }
             }
-            IOObjectRelease(iter);
-
-            // A location-less match is only unambiguous with exactly one
-            // Logitech camera attached; with two (and a unique id we couldn't
-            // parse into a USB location) we can't tell them apart, so refuse
-            // rather than write the wrong camera's registers.
-            if want_location.is_none() && vendor_candidates > 1 {
-                if let Some(dev) = chosen.take() {
-                    dev.into_device().close();
-                }
-                return Err(ControlError::Ambiguous);
-            }
-
-            chosen
-                .map(Opened::into_device)
-                .ok_or(ControlError::NotFound)
         }
+
+        // A location-less match is only unambiguous with exactly one Logitech
+        // camera attached; with two (and a unique id we couldn't parse into a
+        // USB location) we can't tell them apart, so refuse rather than write
+        // the wrong camera's registers.
+        if want_location.is_none() && vendor_candidates > 1 {
+            return Err(ControlError::Ambiguous);
+        }
+
+        chosen
+            .map(Opened::into_device)
+            .ok_or(ControlError::NotFound)
+    }
+
+    /// Try to build an [`Opened`] from a USB service: query the device
+    /// interface, match the vendor id, seize it, and resolve its UVC topology.
+    fn try_open(service: &IoObject, want_vid: u16) -> Option<Opened> {
+        let interface = UsbInterface::open(service)?;
+        if interface.vendor_id()? != want_vid {
+            return None;
+        }
+        let matched_location = interface.location_id();
+        let device = interface.seize()?;
+        let topology = video_control_topology(&device)?;
+        Some(Opened {
+            device: Self {
+                device,
+                vc_interface: topology.vc_interface,
+                unit_id: topology.processing_unit,
+                terminal_id: topology.camera_terminal,
+            },
+            matched_location,
+        })
     }
 
     /// The entity id addressed for `unit`, or `Unsupported` when the camera's
@@ -795,36 +480,19 @@ impl UsbDevice {
         entity: u8,
         data: &mut [u8],
     ) -> Result<(), ControlError> {
-        let mut req = IoUsbDevRequest {
-            bm_request_type: request_type,
-            b_request: request,
-            w_value: selector << 8,
-            w_index: (u16::from(entity) << 8) | u16::from(self.vc_interface),
-            w_length: data.len() as u16,
-            p_data: data.as_mut_ptr().cast::<c_void>(),
-            w_len_done: 0,
+        let mut req = IOUSBDevRequest {
+            bmRequestType: request_type,
+            bRequest: request,
+            wValue: selector << 8,
+            wIndex: (u16::from(entity) << 8) | u16::from(self.vc_interface),
+            wLength: data.len() as u16,
+            pData: data.as_mut_ptr().cast::<c_void>(),
+            wLenDone: 0,
         };
-        // SAFETY: `self.dev` is a live IOUSBDeviceInterface**; DeviceRequest reads
-        // `req` and writes into the `data` buffer it points at.
-        let rc = unsafe { ((**self.dev).device_request)(self.dev.cast::<c_void>(), &raw mut req) };
-        if rc != KIO_RETURN_SUCCESS {
-            return Err(ControlError::Unsupported);
-        }
-        Ok(())
-    }
-
-    fn close(self) {
-        // Drop handles the teardown.
-        drop(self);
-    }
-}
-
-impl Drop for UsbDevice {
-    fn drop(&mut self) {
-        // SAFETY: `self.dev` is a live interface we opened; close then release it.
-        unsafe {
-            let _ = ((**self.dev).usb_device_close)(self.dev.cast::<c_void>());
-            ((**self.dev).release)(self.dev.cast::<c_void>());
+        if self.device.control_request(&mut req) {
+            Ok(())
+        } else {
+            Err(ControlError::Unsupported)
         }
     }
 }
@@ -842,200 +510,79 @@ impl Opened {
     }
 }
 
-impl UsbDevice {
-    /// Try to build an [`Opened`] from an `io_service_t`: query the device
-    /// interface, match the vendor id, open it, and resolve its UVC topology.
-    unsafe fn try_open(
-        service: IoService,
-        want_vid: u16,
-        _want_location: Option<u32>,
-    ) -> Option<Opened> {
-        // SAFETY: `service` is a live io_service_t `open_for` holds across this
-        // call. The two +1 CFUUIDs are released once
-        // `IOCreatePlugInInterfaceForService` — which only borrows them — has
-        // returned, and `plugin`/`dev_ptr` are used only after their
-        // status/null checks. `query_interface` gets the plug-in pointer itself
-        // as the `this` argument, per the IOKit plug-in ABI, and asks for
-        // `kIOUSBDeviceInterfaceID182`, the vtable `UsbDeviceInterface`
-        // describes; the interface it yields holds its own reference, and the
-        // seize below has not run yet, so the stop-then-release
-        // `IODestroyPlugInInterface` performs leaves `dev` valid.
-        // `get_device_vendor` and `get_location_id` write only the locals passed
-        // to them, every return taken after `dev` exists releases it (closing it
-        // first once the seize succeeded), and on the success path that teardown
-        // becomes `UsbDevice`'s `Drop`.
-        unsafe {
-            let user_client = make_uuid(&KIO_USB_DEVICE_USER_CLIENT_TYPE_ID);
-            let plugin_type = make_uuid(&KIO_CF_PLUGIN_INTERFACE_ID);
-            let mut plugin: *mut *mut PlugInInterface = ptr::null_mut();
-            let mut score: i32 = 0;
-            let rc = IOCreatePlugInInterfaceForService(
-                service,
-                user_client,
-                plugin_type,
-                &raw mut plugin,
-                &raw mut score,
-            );
-            CFRelease(user_client);
-            CFRelease(plugin_type);
-            if rc != KIO_RETURN_SUCCESS || plugin.is_null() {
-                return None;
-            }
-
-            let dev_uuid_ref = make_uuid(&KIO_USB_DEVICE_INTERFACE_ID);
-            let dev_uuid = CFUUIDGetUUIDBytes(dev_uuid_ref);
-            CFRelease(dev_uuid_ref);
-            let mut dev_ptr: *mut c_void = ptr::null_mut();
-            let qrc =
-                ((**plugin).query_interface)(plugin.cast::<c_void>(), dev_uuid, &raw mut dev_ptr);
-            IODestroyPlugInInterface(plugin);
-            if qrc != 0 || dev_ptr.is_null() {
-                return None;
-            }
-            let dev = dev_ptr.cast::<*mut UsbDeviceInterface>();
-
-            let mut vid: u16 = 0;
-            ((**dev).get_device_vendor)(dev.cast::<c_void>(), &raw mut vid);
-            if vid != want_vid {
-                ((**dev).release)(dev.cast::<c_void>());
-                return None;
-            }
-
-            let mut location: u32 = 0;
-            let loc_ok = ((**dev).get_location_id)(dev.cast::<c_void>(), &raw mut location)
-                == KIO_RETURN_SUCCESS;
-
-            // Seize (not plain open) so a control transfer succeeds even while
-            // the camera is streaming in this or another app. Callers batch their
-            // reads/writes into one open to keep this churn low.
-            if ((**dev).usb_device_open_seize)(dev.cast::<c_void>()) != KIO_RETURN_SUCCESS {
-                ((**dev).release)(dev.cast::<c_void>());
-                return None;
-            }
-
-            let Some(topology) = video_control_topology(dev) else {
-                let _ = ((**dev).usb_device_close)(dev.cast::<c_void>());
-                ((**dev).release)(dev.cast::<c_void>());
-                return None;
-            };
-
-            Some(Opened {
-                device: UsbDevice {
-                    dev,
-                    vc_interface: topology.vc_interface,
-                    unit_id: topology.processing_unit,
-                    terminal_id: topology.camera_terminal,
-                },
-                matched_location: loc_ok.then_some(location),
-            })
-        }
-    }
-}
-
 /// The VideoControl entities a control request can address, parsed from the
 /// configuration descriptor.
+#[derive(Debug, PartialEq, Eq)]
 struct VcTopology {
     vc_interface: u8,
     processing_unit: u8,
     camera_terminal: Option<u8>,
 }
 
-/// Parse the configuration descriptor for the VideoControl interface number,
-/// the Processing-Unit id, and the camera (input) terminal id.
-unsafe fn video_control_topology(dev: *mut *mut UsbDeviceInterface) -> Option<VcTopology> {
-    // SAFETY: `dev` is the interface `try_open` opened and still owns for the
-    // whole call, so its vtable entries are live and
-    // `get_number_of_configurations` writes only the local. On success
-    // `get_configuration_descriptor_ptr` hands back the interface's cached
-    // configuration-descriptor blob, which stays valid while `dev` is open and
-    // is at least the nine-byte header the USB spec mandates — so reading
-    // wTotalLength at offsets 2 and 3 is in bounds. IOUSBLib sized that blob
-    // from the very wTotalLength read here, which is the bound
-    // `scan_descriptors` then stays inside.
-    unsafe {
-        let mut num_configs: u8 = 0;
-        ((**dev).get_number_of_configurations)(dev.cast::<c_void>(), &raw mut num_configs);
-        for cfg in 0..num_configs {
-            let mut desc: *const u8 = ptr::null();
-            if ((**dev).get_configuration_descriptor_ptr)(dev.cast::<c_void>(), cfg, &raw mut desc)
-                != KIO_RETURN_SUCCESS
-                || desc.is_null()
-            {
-                continue;
-            }
-            // wTotalLength at offset 2..4 (little-endian).
-            let total = u16::from(*desc.add(2)) | (u16::from(*desc.add(3)) << 8);
-            if let Some(found) = scan_descriptors(desc, total as usize) {
-                return Some(found);
-            }
-        }
-        None
-    }
+/// Parse the device's configuration descriptors for the VideoControl interface
+/// number, the Processing-Unit id, and the camera (input) terminal id.
+fn video_control_topology(device: &SeizedDevice) -> Option<VcTopology> {
+    (0..device.configuration_count()?)
+        .filter_map(|index| device.configuration_descriptor(index))
+        .find_map(scan_descriptors)
 }
 
-/// Walk a configuration descriptor blob, collecting the first VideoControl
+/// Walk a configuration-descriptor blob, collecting the first VideoControl
 /// interface's Processing-Unit and camera-terminal entity ids.
-unsafe fn scan_descriptors(base: *const u8, total: usize) -> Option<VcTopology> {
-    // SAFETY: the caller passes a configuration-descriptor blob together with
-    // its own wTotalLength, so `base` is readable for `total` bytes and outlives
-    // the walk. Every read stays in that window: a descriptor is only entered
-    // when `off + 2 <= total` and `off + len <= total`, and each field is read
-    // after checking that the descriptor's own `bLength` covers it — 9 bytes for
-    // an interface descriptor's number/class/subclass, 4 for a class-specific
-    // subtype and entity id, 8 for an input terminal's wTerminalType.
-    unsafe {
-        let mut off = 0usize;
-        let mut vc_interface: Option<u8> = None;
-        let mut camera_terminal: Option<u8> = None;
-        while off + 2 <= total {
-            let len = *base.add(off) as usize;
-            if len < 2 || off + len > total {
-                break;
-            }
-            let dtype = *base.add(off + 1);
-            if dtype == DESC_INTERFACE && len >= 9 {
-                let class = *base.add(off + 5);
-                let sub = *base.add(off + 6);
-                vc_interface = (class == CC_VIDEO && sub == SC_VIDEOCONTROL)
-                    .then(|| *base.add(off + 2))
-                    .or(vc_interface);
-            } else if dtype == DESC_CS_INTERFACE && len >= 4 && vc_interface.is_some() {
-                let subtype = *base.add(off + 2);
-                // bUnitID / bTerminalID sit at offset 3 in both descriptors;
-                // an input terminal's wTerminalType (offset 4..6) must be the
-                // camera sensor — skip composite/other input terminals.
-                if subtype == VC_INPUT_TERMINAL && len >= 8 {
-                    let ttype =
-                        u16::from(*base.add(off + 4)) | (u16::from(*base.add(off + 5)) << 8);
-                    if ttype == ITT_CAMERA && camera_terminal.is_none() {
-                        camera_terminal = Some(*base.add(off + 3));
-                    }
-                } else if subtype == VC_PROCESSING_UNIT {
-                    return vc_interface.map(|vc| VcTopology {
-                        vc_interface: vc,
-                        processing_unit: *base.add(off + 3),
-                        camera_terminal,
-                    });
-                }
-            }
-            off += len;
+///
+/// The walk stops at the first descriptor whose `bLength` is nonsense or would
+/// run past the blob, so a malformed descriptor truncates the scan rather than
+/// misreading the bytes after it.
+fn scan_descriptors(blob: &[u8]) -> Option<VcTopology> {
+    let mut rest = blob;
+    let mut vc_interface: Option<u8> = None;
+    let mut camera_terminal: Option<u8> = None;
+    while rest.len() >= 2 {
+        let len = usize::from(rest[0]);
+        let dtype = rest[1];
+        if len < 2 || len > rest.len() {
+            break;
         }
-        None
-    }
-}
+        let (descriptor, tail) = rest.split_at(len);
+        rest = tail;
 
-unsafe fn make_uuid(bytes: &[u8; 16]) -> CfUuidRef {
-    // SAFETY: `CfUuidBytes` is `#[repr(C)]` around `[u8; 16]`, so it matches
-    // CFUUIDBytes' sixteen `UInt8` fields in size, alignment and by-value ABI,
-    // and it is passed as a copy — nothing of the caller's is borrowed past the
-    // call. The null allocator selects the default one, and the +1 CFUUIDRef
-    // returned is released by every caller.
-    unsafe { CFUUIDCreateFromUUIDBytes(ptr::null(), CfUuidBytes { bytes: *bytes }) }
+        if dtype == DESC_INTERFACE {
+            // bInterfaceNumber, bInterfaceClass and bInterfaceSubClass sit at
+            // offsets 2, 5 and 6 of an interface descriptor.
+            if let (Some(&number), Some(&class), Some(&subclass)) =
+                (descriptor.get(2), descriptor.get(5), descriptor.get(6))
+                && class == CC_VIDEO
+                && subclass == SC_VIDEOCONTROL
+            {
+                vc_interface = Some(number);
+            }
+        } else if dtype == DESC_CS_INTERFACE
+            && let Some(vc) = vc_interface
+            && let (Some(&subtype), Some(&entity)) = (descriptor.get(2), descriptor.get(3))
+        {
+            // bUnitID / bTerminalID sit at offset 3 in both descriptors; an
+            // input terminal's wTerminalType (offsets 4..6) must be the camera
+            // sensor — skip composite/other input terminals.
+            if subtype == VC_INPUT_TERMINAL && descriptor.len() >= 8 {
+                let terminal_type = u16::from(descriptor[4]) | (u16::from(descriptor[5]) << 8);
+                if terminal_type == ITT_CAMERA && camera_terminal.is_none() {
+                    camera_terminal = Some(entity);
+                }
+            } else if subtype == VC_PROCESSING_UNIT {
+                return Some(VcTopology {
+                    vc_interface: vc,
+                    processing_unit: entity,
+                    camera_terminal,
+                });
+            }
+        }
+    }
+    None
 }
 
 #[cfg(test)]
 mod tests {
-    use super::location_hint;
+    use super::{ITT_CAMERA, VcTopology, location_hint, scan_descriptors};
 
     /// AVFoundation prints the location id unpadded: a StreamCam on bus
     /// 0x01123000 yields a 15-digit id whose leading run is only 7 digits.
@@ -1057,5 +604,91 @@ mod tests {
         assert_eq!(location_hint("0x46d0893"), None);
         assert_eq!(location_hint("46d0893"), None);
         assert_eq!(location_hint(""), None);
+    }
+
+    /// A 9-byte interface descriptor with the given number/class/subclass.
+    fn interface(number: u8, class: u8, subclass: u8) -> Vec<u8> {
+        vec![9, 0x04, number, 0, 0, class, subclass, 0, 0]
+    }
+
+    /// An 8-byte VC_INPUT_TERMINAL descriptor for `entity`.
+    fn input_terminal(entity: u8, terminal_type: u16) -> Vec<u8> {
+        vec![
+            8,
+            0x24,
+            0x02,
+            entity,
+            terminal_type as u8,
+            (terminal_type >> 8) as u8,
+            0,
+            0,
+        ]
+    }
+
+    /// A minimal VC_PROCESSING_UNIT descriptor for `entity`.
+    fn processing_unit(entity: u8) -> Vec<u8> {
+        vec![4, 0x24, 0x05, entity]
+    }
+
+    #[test]
+    fn finds_the_processing_unit_behind_a_videocontrol_interface() {
+        let blob: Vec<u8> = [
+            vec![9, 0x02, 0, 0, 0, 0, 0, 0, 0], // configuration header
+            interface(3, 0x0E, 0x01),           // VideoControl
+            input_terminal(1, ITT_CAMERA),
+            processing_unit(2),
+        ]
+        .concat();
+        assert_eq!(
+            scan_descriptors(&blob),
+            Some(VcTopology {
+                vc_interface: 3,
+                processing_unit: 2,
+                camera_terminal: Some(1),
+            })
+        );
+    }
+
+    /// Composite/other input terminals are not the camera sensor, so lens
+    /// controls must report unsupported rather than address the wrong entity.
+    #[test]
+    fn a_non_camera_input_terminal_leaves_lens_controls_unsupported() {
+        let blob: Vec<u8> = [
+            interface(0, 0x0E, 0x01),
+            input_terminal(1, 0x0401), // ITT_MEDIA_TRANSPORT_INPUT
+            processing_unit(5),
+        ]
+        .concat();
+        assert_eq!(
+            scan_descriptors(&blob),
+            Some(VcTopology {
+                vc_interface: 0,
+                processing_unit: 5,
+                camera_terminal: None,
+            })
+        );
+    }
+
+    /// Class-specific descriptors before any VideoControl interface belong to
+    /// some other function and must not be read as UVC entities.
+    #[test]
+    fn class_descriptors_outside_a_videocontrol_interface_are_ignored() {
+        let blob: Vec<u8> = [
+            interface(0, 0x01, 0x01), // audio
+            processing_unit(9),
+        ]
+        .concat();
+        assert_eq!(scan_descriptors(&blob), None);
+    }
+
+    /// A descriptor whose bLength overruns the blob truncates the walk instead
+    /// of reading past it — and a zero length must not loop forever.
+    #[test]
+    fn malformed_lengths_stop_the_walk() {
+        let overrun: Vec<u8> = [interface(0, 0x0E, 0x01), vec![64, 0x24, 0x05, 7]].concat();
+        assert_eq!(scan_descriptors(&overrun), None);
+
+        let zero_length: Vec<u8> = [interface(0, 0x0E, 0x01), vec![0, 0x24]].concat();
+        assert_eq!(scan_descriptors(&zero_length), None);
     }
 }

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -26,6 +26,7 @@
 
 use std::ffi::{CString, c_void};
 use std::ptr;
+use std::ptr::NonNull;
 
 /// Which UVC entity a control request addresses: the Camera Terminal (lens:
 /// zoom/focus/exposure) or the Processing Unit (image: brightness/…).
@@ -300,7 +301,10 @@ pub(crate) fn usb_serials_by_location() -> std::collections::HashMap<u32, String
         {
             return out;
         }
-        let key = cf_string("USB Serial Number");
+        let Some(key) = cf_string("USB Serial Number") else {
+            IOObjectRelease(iter);
+            return out;
+        };
         loop {
             let service = IOIteratorNext(iter);
             if service == 0 {
@@ -311,9 +315,7 @@ pub(crate) fn usb_serials_by_location() -> std::collections::HashMap<u32, String
             }
             IOObjectRelease(service);
         }
-        if !key.is_null() {
-            CFRelease(key);
-        }
+        CFRelease(key.as_ptr());
         IOObjectRelease(iter);
     }
     out
@@ -322,33 +324,35 @@ pub(crate) fn usb_serials_by_location() -> std::collections::HashMap<u32, String
 /// Location id + USB serial from an `IOUSBDevice` service, without opening it.
 unsafe fn registry_location_and_serial(
     service: IoService,
-    serial_key: *const c_void,
+    serial_key: NonNull<c_void>,
 ) -> Option<(u32, String)> {
     // SAFETY: `service` is a live io_service_t the enumeration loop holds for
     // the whole call (it releases it only after this returns), so both registry
-    // reads address a valid IOKit object, and `serial_key` is the caller's
-    // CFString, only borrowed here. `IORegistryEntryCreateCFProperty` follows
-    // the Create rule: each +1 CFTypeRef it returns is handed straight to
-    // `cf_number_u32` / `cf_string_value`, which release it on every path, and
-    // the `locationID` key created for the fallback is released before it
-    // returns.
+    // reads address a valid IOKit object, and `serial_key` is a CFString the
+    // caller created and still owns, only borrowed here. Both property reads
+    // pass a key that exists — IOKit dereferences one without a null check —
+    // which the caller guarantees by construction, `NonNull` being what makes a
+    // failed creation impossible to pass, and the `?` on the `locationID` key
+    // repeating that here. `IORegistryEntryCreateCFProperty` follows the Create
+    // rule: each +1 CFTypeRef it returns is handed straight to `cf_number_u32` /
+    // `cf_string_value`, which release it on every path, and the `locationID`
+    // key created for the fallback is released before it returns.
     unsafe {
         // Prefer the USB device interface for location (matches control open);
         // fall back to the registry number property when the plug-in is busy.
         let location = device_location_id(service).or_else(|| {
-            let key = cf_string("locationID");
+            let key = cf_string("locationID")?;
             let loc = cf_number_u32(IORegistryEntryCreateCFProperty(
                 service,
-                key,
+                key.as_ptr(),
                 ptr::null(),
                 0,
             ));
-            if !key.is_null() {
-                CFRelease(key);
-            }
+            CFRelease(key.as_ptr());
             loc
         })?;
-        let serial_ref = IORegistryEntryCreateCFProperty(service, serial_key, ptr::null(), 0);
+        let serial_ref =
+            IORegistryEntryCreateCFProperty(service, serial_key.as_ptr(), ptr::null(), 0);
         let serial = cf_string_value(serial_ref)?;
         if serial.is_empty() {
             return None;
@@ -406,12 +410,17 @@ unsafe fn device_location_id(service: IoService) -> Option<u32> {
     }
 }
 
-fn cf_string(s: &str) -> *const c_void {
-    let Ok(c) = CString::new(s) else {
-        return ptr::null();
-    };
+/// A freshly created CFString the caller owns, or `None` if `s` holds an
+/// interior NUL or CoreFoundation could not create the string. Returning
+/// `NonNull` makes a failed creation impossible to hand to an IOKit call that
+/// would dereference the key.
+fn cf_string(s: &str) -> Option<NonNull<c_void>> {
+    let c = CString::new(s).ok()?;
     // SAFETY: UTF-8 C string; returned CFString is owned by the caller.
-    unsafe { CFStringCreateWithCString(ptr::null(), c.as_ptr(), K_CF_STRING_ENCODING_UTF8) }
+    let cf =
+        unsafe { CFStringCreateWithCString(ptr::null(), c.as_ptr(), K_CF_STRING_ENCODING_UTF8) }
+            .cast_mut();
+    NonNull::new(cf)
 }
 
 unsafe fn cf_string_value(cf: *const c_void) -> Option<String> {
@@ -419,31 +428,40 @@ unsafe fn cf_string_value(cf: *const c_void) -> Option<String> {
         return None;
     }
     // SAFETY: `cf` is non-null (checked above) and a +1 CFTypeRef its callers
-    // hand over from a Create/Copy call; nothing reads it after the `CFRelease`
-    // that balances it, and the only returns that skip that release are the
-    // capacity checks, which need a string a quarter of the address space long
-    // — no CFString reaches them. The type check gates the CFString calls, so
-    // `CFStringGetLength`/`CFStringGetCString` only ever see a CFStringRef, and
-    // the buffer passed to the conversion is `cap` bytes long with `cap` given
-    // as its size — enough for UTF-8's worst case plus the NUL, and bounded by
-    // CFString either way.
+    // hand over from a Create/Copy call. `decode_cf_string` only borrows it, and
+    // the `CFRelease` below balances that +1 exactly once on every path out —
+    // including the capacity checks, which bail with `?` from the borrow rather
+    // than from here.
+    unsafe {
+        let value = decode_cf_string(cf);
+        CFRelease(cf);
+        value
+    }
+}
+
+/// Decode a **borrowed** `CFStringRef` as UTF-8. Ownership stays with the
+/// caller, which releases `cf` whichever way this returns.
+unsafe fn decode_cf_string(cf: *const c_void) -> Option<String> {
+    // SAFETY: the caller's +1 CFTypeRef is live for the whole call. The type
+    // check gates the CFString calls, so `CFStringGetLength`/`CFStringGetCString`
+    // only ever see a CFStringRef, and the buffer passed to the conversion is
+    // `cap` bytes long with `cap` given as its size — enough for UTF-8's worst
+    // case plus the NUL, and bounded by CFString either way.
     unsafe {
         if CFGetTypeID(cf) != CFStringGetTypeID() {
-            CFRelease(cf);
             return None;
         }
         let len = CFStringGetLength(cf);
         // UTF-8 worst case 4 bytes/char + NUL.
         let cap = usize::try_from(len).ok()?.checked_mul(4)?.checked_add(1)?;
         let mut buf = vec![0u8; cap];
-        let ok = CFStringGetCString(
+        if CFStringGetCString(
             cf,
             buf.as_mut_ptr().cast(),
             isize::try_from(cap).ok()?,
             K_CF_STRING_ENCODING_UTF8,
-        ) != 0;
-        CFRelease(cf);
-        if !ok {
+        ) == 0
+        {
             return None;
         }
         let nul = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());

--- a/crates/openlogi-camera/src/uvc/iokit.rs
+++ b/crates/openlogi-camera/src/uvc/iokit.rs
@@ -1,0 +1,312 @@
+//! The IOKit half of the macOS UVC backend: USB device discovery, registry
+//! reads, and the `IOUSBDeviceInterface` plug-in.
+//!
+//! Every handle IOKit hands out is `+1` and has to be released exactly once, on
+//! every path out — which is what each wrapper here exists to make automatic.
+//! [`IoObject`] releases an `io_object_t`, [`UsbInterface`] releases a plug-in
+//! interface, [`SeizedDevice`] closes the seize it opened, and CoreFoundation
+//! values arrive as `CFRetained`, whose drop *is* the release. So there is no
+//! hand-balanced teardown left to get wrong, and every `unsafe` block in the
+//! macOS backend lives in this file.
+//!
+//! The configuration descriptor leaves here as a plain `&[u8]` borrowed from
+//! the open device, so the descriptor parser above is ordinary safe code.
+
+#![expect(
+    unsafe_code,
+    reason = "IOKit USB plug-in (IOUSBDeviceInterface182) FFI for UVC control transfers"
+)]
+
+use std::ffi::c_void;
+use std::num::NonZeroU32;
+use std::ptr;
+use std::ptr::NonNull;
+
+use objc2_core_foundation::{CFDictionary, CFRetained, CFString, CFType, CFUUID};
+use objc2_io_kit::{
+    IOCFPlugInInterface, IOCreatePlugInInterfaceForService, IODestroyPlugInInterface,
+    IOIteratorNext, IOObjectRelease, IORegistryEntryCreateCFProperty, IOServiceGetMatchingServices,
+    IOServiceMatching, IOUSBConfigurationDescriptor, IOUSBConfigurationDescriptorPtr,
+    IOUSBDevRequest, IOUSBDeviceInterface182, io_iterator_t, io_object_t, kIOMainPortDefault,
+};
+
+/// `kIOReturnSuccess`, which shares its value with `KERN_SUCCESS` and `S_OK`.
+const SUCCESS: i32 = 0;
+
+/// A reference to an IOKit object this process owns, released on drop.
+///
+/// IOKit spells "no object" as `0`, so [`NonZeroU32`] turns that sentinel into
+/// `None` rather than a handle that would later be released as if it were real.
+pub(super) struct IoObject(NonZeroU32);
+
+impl IoObject {
+    /// Adopt a reference IOKit created for us, or `None` for its null object.
+    fn adopt(raw: io_object_t) -> Option<Self> {
+        NonZeroU32::new(raw).map(Self)
+    }
+
+    fn raw(&self) -> io_object_t {
+        self.0.get()
+    }
+}
+
+impl Drop for IoObject {
+    fn drop(&mut self) {
+        let _ = IOObjectRelease(self.0.get());
+    }
+}
+
+/// The services an IOKit iterator yields. Each one arrives as its own
+/// [`IoObject`], and the iterator handle is released when this is dropped.
+///
+/// A matching lookup that succeeds with nothing to report hands back IOKit's
+/// null iterator, which is held here as `None` and simply yields no services.
+pub(super) struct IoServices(Option<IoObject>);
+
+impl Iterator for IoServices {
+    type Item = IoObject;
+
+    fn next(&mut self) -> Option<IoObject> {
+        IoObject::adopt(IOIteratorNext(self.0.as_ref()?.raw()))
+    }
+}
+
+/// Every `IOUSBDevice` currently attached.
+///
+/// # Errors
+/// The name of the IOKit call that failed, for a caller that reports it — an
+/// empty iterator means "no such device", which is not the same thing.
+pub(super) fn usb_devices() -> Result<IoServices, &'static str> {
+    // SAFETY: a NUL-terminated literal names the class, and the `+1` dictionary
+    // the call creates is adopted by `CFRetained`.
+    let matching =
+        unsafe { IOServiceMatching(c"IOUSBDevice".as_ptr()) }.ok_or("IOServiceMatching")?;
+    // The lookup consumes one reference to the dictionary — which this binding
+    // spells by taking it *by value* — so handing it over is its last use.
+    let matching = CFRetained::<CFDictionary>::from(&*matching);
+    let mut iterator: io_iterator_t = 0;
+    // SAFETY: `kIOMainPortDefault` is IOKit's own static, and `iterator` is a
+    // live local the call fills in on success.
+    let rc = unsafe {
+        IOServiceGetMatchingServices(kIOMainPortDefault, Some(matching), &raw mut iterator)
+    };
+    if rc != SUCCESS {
+        return Err("IOServiceGetMatchingServices");
+    }
+    Ok(IoServices(IoObject::adopt(iterator)))
+}
+
+/// One property of a registry entry, as the CoreFoundation type IOKit stored
+/// it under. Callers narrow it with `CFRetained::downcast`.
+pub(super) fn registry_property(entry: &IoObject, key: &CFString) -> Option<CFRetained<CFType>> {
+    // SAFETY: `entry` holds a live reference for the whole call, and `key` is a
+    // live CFString — the key IOKit dereferences with no null check of its own.
+    // The `+1` container it creates is adopted by `CFRetained`.
+    unsafe { IORegistryEntryCreateCFProperty(entry.raw(), Some(key), None, 0) }
+}
+
+// IOUSBLib's plug-in UUIDs, as the `CFUUIDGetConstantUUIDWithBytes` macros in
+// IOUSBLib.h and IOCFPlugIn.h spell them.
+/// `kIOUSBDeviceUserClientTypeID`.
+const USB_DEVICE_USER_CLIENT_TYPE_ID: [u8; 16] = [
+    0x9d, 0xc7, 0xb7, 0x80, 0x9e, 0xc0, 0x11, 0xd4, 0xa5, 0x4f, 0x00, 0x0a, 0x27, 0x05, 0x28, 0x61,
+];
+/// `kIOCFPlugInInterfaceID`.
+const CF_PLUGIN_INTERFACE_ID: [u8; 16] = [
+    0xc2, 0x44, 0xe8, 0x58, 0x10, 0x9c, 0x11, 0xd4, 0x91, 0xd4, 0x00, 0x50, 0xe4, 0xc6, 0x42, 0x6f,
+];
+/// `kIOUSBDeviceInterfaceID182` — the first revision exposing
+/// `USBDeviceOpenSeize`, and the vtable [`IOUSBDeviceInterface182`] describes.
+const USB_DEVICE_INTERFACE_ID_182: [u8; 16] = [
+    0x15, 0x2f, 0xc4, 0x96, 0x48, 0x91, 0x11, 0xd5, 0x9d, 0x52, 0x00, 0x0a, 0x27, 0x80, 0x1e, 0x86,
+];
+
+/// The constant CFUUID for `b`, which CoreFoundation spells one byte per
+/// argument.
+fn uuid(b: [u8; 16]) -> Option<CFRetained<CFUUID>> {
+    CFUUID::constant_uuid_with_bytes(
+        None, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12],
+        b[13], b[14], b[15],
+    )
+}
+
+/// A retained `IOUSBDeviceInterface182`, released on drop.
+///
+/// The device is not open yet: this is the interface IOKit's USB plug-in hands
+/// back, and it answers the read-only queries (vendor id, location id) on its
+/// own. Opening it for control transfers is [`UsbInterface::seize`].
+pub(super) struct UsbInterface(NonNull<*mut IOUSBDeviceInterface182>);
+
+impl UsbInterface {
+    /// Ask IOKit's USB plug-in for `service`'s device interface.
+    pub(super) fn open(service: &IoObject) -> Option<Self> {
+        let user_client = uuid(USB_DEVICE_USER_CLIENT_TYPE_ID)?;
+        let plugin_type = uuid(CF_PLUGIN_INTERFACE_ID)?;
+        let device_type = uuid(USB_DEVICE_INTERFACE_ID_182)?;
+        let mut plugin: *mut *mut IOCFPlugInInterface = ptr::null_mut();
+        let mut score = 0i32;
+
+        // SAFETY: `service` is live for the whole call, the two UUIDs are only
+        // borrowed by it, and `plugin`/`score` are live locals it writes.
+        let rc = unsafe {
+            IOCreatePlugInInterfaceForService(
+                service.raw(),
+                Some(&user_client),
+                Some(&plugin_type),
+                &raw mut plugin,
+                &raw mut score,
+            )
+        };
+        if rc != SUCCESS {
+            return None;
+        }
+        let plugin = NonNull::new(plugin)?;
+
+        // SAFETY: the plug-in's IUnknown head is live until
+        // `IODestroyPlugInInterface` stops and releases it, which happens on
+        // every path below — including a missing `QueryInterface` slot. Per the
+        // IOKit plug-in ABI the interface pointer itself is the `this`
+        // argument, and `device` is a live local the query writes. The
+        // interface it yields for `kIOUSBDeviceInterfaceID182` carries its own
+        // reference, so it stays valid once the plug-in is gone.
+        let device = unsafe {
+            let mut device: *mut c_void = ptr::null_mut();
+            let queried = (**plugin.as_ptr()).QueryInterface.is_some_and(|query| {
+                query(
+                    plugin.as_ptr().cast(),
+                    device_type.uuid_bytes(),
+                    &raw mut device,
+                ) == SUCCESS
+            });
+            let _ = IODestroyPlugInInterface(plugin.as_ptr());
+            if !queried {
+                return None;
+            }
+            device
+        };
+        NonNull::new(device.cast::<*mut IOUSBDeviceInterface182>()).map(Self)
+    }
+
+    /// The vtable IOKit installed for this interface.
+    fn vtable(&self) -> &IOUSBDeviceInterface182 {
+        // SAFETY: `self.0` is the interface pointer IOKit returned — valid
+        // until `Release`, which only `Drop` calls — and a COM-style interface
+        // pointer points at its own vtable.
+        unsafe { &**self.0.as_ptr() }
+    }
+
+    /// The `this` argument every vtable entry takes: per the IOKit plug-in ABI
+    /// that is the interface pointer itself, not the vtable it points at.
+    fn this(&self) -> *mut c_void {
+        self.0.as_ptr().cast()
+    }
+
+    /// The device's USB vendor id, without opening it.
+    pub(super) fn vendor_id(&self) -> Option<u16> {
+        let get = self.vtable().GetDeviceVendor?;
+        let mut vendor = 0u16;
+        // SAFETY: `get` is this interface's own vtable entry, called with the
+        // interface as `this`, and it writes only the local `vendor`.
+        (unsafe { get(self.this(), &raw mut vendor) } == SUCCESS).then_some(vendor)
+    }
+
+    /// The device's USB location id, without opening it.
+    pub(super) fn location_id(&self) -> Option<u32> {
+        let get = self.vtable().GetLocationID?;
+        let mut location = 0u32;
+        // SAFETY: as [`Self::vendor_id`]; writes only the local `location`.
+        (unsafe { get(self.this(), &raw mut location) } == SUCCESS).then_some(location)
+    }
+
+    /// Open the device for control transfers.
+    ///
+    /// Seize rather than a plain open, so a transfer lands even while the
+    /// kernel video driver holds the camera for streaming — in this app or
+    /// another one.
+    pub(super) fn seize(self) -> Option<SeizedDevice> {
+        let open = self.vtable().USBDeviceOpenSeize?;
+        // SAFETY: as [`Self::vendor_id`]; takes no out-parameter.
+        if unsafe { open(self.this()) } != SUCCESS {
+            return None;
+        }
+        Some(SeizedDevice(self))
+    }
+}
+
+impl Drop for UsbInterface {
+    fn drop(&mut self) {
+        let Some(release) = self.vtable().Release else {
+            return;
+        };
+        // SAFETY: this balances the one reference `QueryInterface` handed over
+        // in `open`, and `Drop` runs exactly once.
+        unsafe { release(self.this()) };
+    }
+}
+
+/// A [`UsbInterface`] opened with `USBDeviceOpenSeize`. Closes on drop, after
+/// which the interface it wraps releases itself.
+pub(super) struct SeizedDevice(UsbInterface);
+
+impl SeizedDevice {
+    /// Send a request on the device's default control pipe, reporting whether
+    /// the device answered it (a camera NAKs controls it does not implement).
+    ///
+    /// The pipe is not owned by the streaming driver, so this works while the
+    /// camera is live.
+    #[must_use]
+    pub(super) fn control_request(&self, request: &mut IOUSBDevRequest) -> bool {
+        let Some(device_request) = self.0.vtable().DeviceRequest else {
+            return false;
+        };
+        // SAFETY: the device is open for exclusive access, which is what
+        // `DeviceRequest` requires. It reads `request` and writes through the
+        // `pData` pointer inside it, which the caller owns for the whole call.
+        unsafe { device_request(self.0.this(), &raw mut *request) == SUCCESS }
+    }
+
+    /// How many configurations the device's descriptor advertises.
+    pub(super) fn configuration_count(&self) -> Option<u8> {
+        let get = self.0.vtable().GetNumberOfConfigurations?;
+        let mut count = 0u8;
+        // SAFETY: an open device's vtable entry, writing only the local.
+        (unsafe { get(self.0.this(), &raw mut count) } == SUCCESS).then_some(count)
+    }
+
+    /// Configuration descriptor `index` as the blob IOKit cached for the
+    /// device, bounded by the `wTotalLength` in its own header.
+    ///
+    /// Borrowed from the open device, so it cannot outlive the seize.
+    pub(super) fn configuration_descriptor(&self, index: u8) -> Option<&[u8]> {
+        let get = self.0.vtable().GetConfigurationDescriptorPtr?;
+        let mut header: IOUSBConfigurationDescriptorPtr = ptr::null_mut();
+        // SAFETY: an open device's vtable entry, writing only the local
+        // `header`. On success it hands back IOUSBLib's cached copy of the
+        // configuration descriptor, which stays put for as long as the device
+        // is open — hence the borrow of `self`. IOUSBLib sizes that copy from
+        // the `wTotalLength` read here, so the blob is exactly that many bytes;
+        // the USB spec's nine-byte configuration header is the lower bound
+        // checked before the slice is built, and `wTotalLength` is read by
+        // value because the descriptor is `#[repr(packed)]`.
+        unsafe {
+            if get(self.0.this(), index, &raw mut header) != SUCCESS {
+                return None;
+            }
+            let header = NonNull::new(header)?;
+            let total = usize::from((*header.as_ptr()).wTotalLength);
+            (total >= size_of::<IOUSBConfigurationDescriptor>())
+                .then(|| std::slice::from_raw_parts(header.as_ptr().cast::<u8>(), total))
+        }
+    }
+}
+
+impl Drop for SeizedDevice {
+    fn drop(&mut self) {
+        let Some(close) = self.0.vtable().USBDeviceClose else {
+            return;
+        };
+        // SAFETY: this balances the `USBDeviceOpenSeize` that built `self`, and
+        // `Drop` runs exactly once — before the inner interface releases.
+        unsafe { close(self.0.this()) };
+    }
+}

--- a/crates/openlogi-camera/src/uvc_linux.rs
+++ b/crates/openlogi-camera/src/uvc_linux.rs
@@ -391,10 +391,12 @@ fn write_value(device: &Device, id: u32, value: i64) -> Result<(), ControlError>
 /// Standard UVC controls fit comfortably; saturating keeps a driver reporting
 /// an absurd bound from wrapping into a negative slider bound.
 fn clamp_i32(value: i64) -> i32 {
-    i32::try_from(value).unwrap_or(if value.is_negative() {
-        i32::MIN
-    } else {
-        i32::MAX
+    i32::try_from(value).unwrap_or_else(|_| {
+        if value.is_negative() {
+            i32::MIN
+        } else {
+            i32::MAX
+        }
     })
 }
 

--- a/crates/openlogi-camera/src/uvc_windows.rs
+++ b/crates/openlogi-camera/src/uvc_windows.rs
@@ -19,16 +19,16 @@
     reason = "DirectShow COM (device enumeration + IAMVideoProcAmp / IAMCameraControl)"
 )]
 
+use std::marker::PhantomData;
+
 use windows::Win32::Media::DirectShow::{IAMCameraControl, IAMVideoProcAmp, IBaseFilter};
 use windows::Win32::System::Com::StructuredStorage::IPropertyBag;
-use windows::Win32::System::Com::{
-    CLSCTX_INPROC_SERVER, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, IEnumMoniker,
-    IMoniker,
-};
+use windows::Win32::System::Com::{CLSCTX_INPROC_SERVER, CoCreateInstance, IEnumMoniker, IMoniker};
 use windows::Win32::System::Variant::{VARIANT, VT_BSTR};
 use windows::core::{GUID, Interface, w};
 
 use crate::Camera;
+use crate::com_windows::ComApartment;
 use crate::controls::{
     AutoState, AutoToggle, CameraControl, CameraState, ControlError, ControlRange,
 };
@@ -91,7 +91,8 @@ impl AutoToggle {
 /// vendor/product ids parsed out of the device path. Non-USB sources (virtual
 /// cameras) carry no `vid_`/`pid_` markers and are dropped.
 pub fn enumerate() -> Vec<Camera> {
-    monikers()
+    let com = ComApartment::enter();
+    monikers(&com)
         .map(|monikers| {
             monikers
                 .into_iter()
@@ -110,7 +111,8 @@ pub fn control_range(
     unique_id: &str,
     control: CameraControl,
 ) -> Result<ControlRange, ControlError> {
-    let dev = Device::open(unique_id)?;
+    let com = ComApartment::enter();
+    let dev = Device::open(&com, unique_id)?;
     dev.range(control.prop()).map(|(range, _)| range)
 }
 
@@ -128,7 +130,8 @@ pub fn control_ranges(unique_id: &str) -> Result<Vec<(CameraControl, ControlRang
 /// # Errors
 /// [`ControlError::NotFound`] when no camera matches `unique_id`.
 pub fn read_camera_state(unique_id: &str) -> Result<CameraState, ControlError> {
-    let dev = Device::open(unique_id)?;
+    let com = ComApartment::enter();
+    let dev = Device::open(&com, unique_id)?;
     let mut state = CameraState::default();
     for control in CameraControl::ALL {
         if let Ok((range, _)) = dev.range(control.prop()) {
@@ -164,7 +167,8 @@ pub fn set_control(
     control: CameraControl,
     value: i32,
 ) -> Result<(), ControlError> {
-    let dev = Device::open(unique_id)?;
+    let com = ComApartment::enter();
+    let dev = Device::open(&com, unique_id)?;
     dev.set(control.prop(), value, FLAG_MANUAL)
 }
 
@@ -173,7 +177,8 @@ pub fn set_control(
 /// # Errors
 /// As [`control_range`].
 pub fn set_auto(unique_id: &str, toggle: AutoToggle, on: bool) -> Result<(), ControlError> {
-    let dev = Device::open(unique_id)?;
+    let com = ComApartment::enter();
+    let dev = Device::open(&com, unique_id)?;
     dev.set_auto(toggle.prop(), on)
 }
 
@@ -189,7 +194,8 @@ pub fn apply_settings(
     autos: &[(AutoToggle, bool)],
     values: &[(CameraControl, i32)],
 ) -> Result<(), ControlError> {
-    let dev = Device::open(unique_id)?;
+    let com = ComApartment::enter();
+    let dev = Device::open(&com, unique_id)?;
     let mut first_err = None;
     for (toggle, on) in autos {
         if let Err(e) = dev.set_auto(toggle.prop(), *on) {
@@ -206,16 +212,22 @@ pub fn apply_settings(
 
 /// A camera's bound capture filter, with the two control interfaces it may
 /// implement (a camera without lens motors typically lacks `IAMCameraControl`).
-struct Device {
+///
+/// Borrowing the apartment it was bound in is what keeps the interfaces from
+/// outliving it: callers enter the apartment first, so this drops first, and
+/// any ordering that would release a filter after `CoUninitialize` does not
+/// compile.
+struct Device<'a> {
     proc_amp: Option<IAMVideoProcAmp>,
     camera_control: Option<IAMCameraControl>,
+    _com: PhantomData<&'a ComApartment>,
 }
 
-impl Device {
+impl<'a> Device<'a> {
     /// Bind the capture filter whose device path equals `unique_id`. Exact
     /// match only — guessing another camera could adjust the wrong hardware.
-    fn open(unique_id: &str) -> Result<Self, ControlError> {
-        let monikers = monikers().map_err(|e| ControlError::Io(e.to_string()))?;
+    fn open(com: &'a ComApartment, unique_id: &str) -> Result<Self, ControlError> {
+        let monikers = monikers(com).map_err(|e| ControlError::Io(e.to_string()))?;
         for moniker in monikers {
             if read_property(&moniker, w!("DevicePath")).as_deref() != Some(unique_id) {
                 continue;
@@ -227,6 +239,7 @@ impl Device {
             return Ok(Self {
                 proc_amp: filter.cast().ok(),
                 camera_control: filter.cast().ok(),
+                _com: PhantomData,
             });
         }
         Err(ControlError::NotFound)
@@ -333,12 +346,16 @@ impl Device {
 
 /// Every video-input moniker DirectShow reports (empty when the category has
 /// no devices, which the enumerator signals with `S_FALSE`).
-fn monikers() -> windows::core::Result<Vec<IMoniker>> {
-    // SAFETY: standard COM setup + documented enumerator calls. Double
-    // initialization (or an existing STA on this thread) is harmless here —
-    // the enumerator works under either apartment model.
+///
+/// The monikers are COM objects belonging to the caller's apartment, so the
+/// guard is a parameter rather than something entered here: it proves one is
+/// live for the call, and leaves the caller — which drops the returned vector
+/// well before its own guard — owning the ordering.
+fn monikers(_com: &ComApartment) -> windows::core::Result<Vec<IMoniker>> {
+    // SAFETY: documented enumerator calls, made under the caller's apartment.
+    // The enumerator works under either apartment model, so it does not matter
+    // whether that guard entered the MTA or joined an existing STA.
     unsafe {
-        let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
         let dev_enum: windows::Win32::Media::DirectShow::ICreateDevEnum =
             CoCreateInstance(&CLSID_SYSTEM_DEVICE_ENUM, None, CLSCTX_INPROC_SERVER)?;
         let mut enum_moniker: Option<IEnumMoniker> = None;

--- a/crates/openlogi-cli/src/cmd/light.rs
+++ b/crates/openlogi-cli/src/cmd/light.rs
@@ -233,14 +233,15 @@ mod tests {
     #[test]
     fn selection_requires_disambiguation_and_supports_name_queries() {
         let devices = vec![device("Litra Glow"), device("Litra Beam")];
-        assert!(select(&devices, None).is_err());
+        select(&devices, None).expect_err("two lights and no --device must be ambiguous");
         assert_eq!(
             select(&devices, Some("beam"))
                 .expect("matching device")
                 .display_name,
             "Litra Beam"
         );
-        assert!(select(&devices, Some("litra")).is_err());
+        select(&devices, Some("litra"))
+            .expect_err("a --device query matching both lights must be ambiguous");
         assert_eq!(
             select(&devices[..1], None)
                 .expect("single device")

--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use anyhow::{Context, Result};
 use clap::Args;
 use openlogi_camera::Camera;
@@ -6,7 +8,16 @@ use openlogi_core::device::{BatteryInfo, DeviceInventory, DeviceModelInfo, Paire
 #[derive(Debug, Args)]
 pub struct ListArgs {}
 
-pub async fn run(_args: ListArgs) -> Result<()> {
+/// Exit status for "the scan succeeded, but nothing is connected" — distinct
+/// from the failure status a real enumeration error produces.
+const NOTHING_FOUND: u8 = 2;
+
+/// Print every connected receiver, paired device and Logitech webcam.
+///
+/// Returns the `NOTHING_FOUND` status when neither a HID++ device nor a webcam
+/// is present, so scripts can tell "no hardware" apart from a failed
+/// enumeration.
+pub async fn run(_args: ListArgs) -> Result<ExitCode> {
     let inventories = openlogi_hid::enumerate()
         .await
         .context("failed to enumerate HID++ devices")?;
@@ -25,7 +36,7 @@ pub async fn run(_args: ListArgs) -> Result<()> {
             "  - hidpp 0.2 only recognises Logi Bolt receivers (PID 0xC548); other \
              receivers (Unifying) aren't surfaced yet."
         );
-        std::process::exit(2);
+        return Ok(ExitCode::from(NOTHING_FOUND));
     }
 
     for (i, inv) in inventories.iter().enumerate() {
@@ -42,7 +53,7 @@ pub async fn run(_args: ListArgs) -> Result<()> {
         print_cameras(&cameras);
     }
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 fn print_cameras(cameras: &[Camera]) {

--- a/crates/openlogi-cli/src/cmd/mod.rs
+++ b/crates/openlogi-cli/src/cmd/mod.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use anyhow::Result;
 use clap::Subcommand;
 
@@ -31,18 +33,23 @@ pub enum Command {
 }
 
 impl Command {
-    pub async fn run(self) -> Result<()> {
+    /// Dispatch the parsed subcommand and report the process exit status.
+    ///
+    /// Only `list` reports a status of its own (nothing connected); every
+    /// other subcommand either succeeds or fails outright.
+    pub async fn run(self) -> Result<ExitCode> {
         match self {
-            Self::List(args) => list::run(args).await,
-            Self::Backlight(args) => backlight::run(args).await,
+            Self::List(args) => return list::run(args).await,
+            Self::Backlight(args) => backlight::run(args).await?,
             // Camera capture is blocking AVFoundation — no need for the async runtime.
-            Self::Snapshot(args) => snapshot::run(args),
+            Self::Snapshot(args) => snapshot::run(args)?,
             // UVC control transfers are blocking IOKit — no async runtime needed.
-            Self::Camera(args) => camera::run(args),
+            Self::Camera(args) => camera::run(args)?,
             // `assets sync` is blocking HTTP — no need for the async runtime.
-            Self::Assets(cmd) => cmd.run(),
-            Self::Diag(cmd) => cmd.run().await,
-            Self::Light(cmd) => cmd.run().await,
+            Self::Assets(cmd) => cmd.run()?,
+            Self::Diag(cmd) => cmd.run().await?,
+            Self::Light(cmd) => cmd.run().await?,
         }
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/crates/openlogi-cli/src/lib.rs
+++ b/crates/openlogi-cli/src/lib.rs
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn backlight_rejects_an_unknown_action() {
         let result = Cli::try_parse_from(["openlogi", "backlight", "dim"]);
-        assert!(result.is_err());
+        result.expect_err("an unknown backlight action must be rejected");
     }
 
     #[test]
@@ -109,7 +109,7 @@ mod tests {
             "--sensitivity",
             "10",
         ]);
-        assert!(result.is_err());
+        result.expect_err("--leave-flipped and --sensitivity must conflict");
     }
 
     #[test]
@@ -117,7 +117,7 @@ mod tests {
         // `--sensitivity` is a `NonZeroU8`; 0 must fail to parse rather than
         // silently becoming "no change" downstream.
         let result = Cli::try_parse_from(["openlogi", "diag", "smartshift", "--sensitivity", "0"]);
-        assert!(result.is_err());
+        result.expect_err("a zero --sensitivity must fail to parse");
     }
 
     #[test]
@@ -163,7 +163,7 @@ mod tests {
         let result = Cli::try_parse_from([
             "openlogi", "diag", "lighting", "ff0000", "--method", "bogus",
         ]);
-        assert!(result.is_err());
+        result.expect_err("an unknown lighting method must be rejected");
     }
 
     #[test]

--- a/crates/openlogi-cli/src/lib.rs
+++ b/crates/openlogi-cli/src/lib.rs
@@ -1,6 +1,8 @@
 //! OpenLogi CLI implementation. The `openlogi` binary is a thin wrapper that
 //! calls [`run`]; the command tree and argument parsing live here.
 
+use std::process::ExitCode;
+
 use anyhow::Result;
 use clap::Parser;
 use tracing_subscriber::{EnvFilter, fmt};
@@ -21,7 +23,10 @@ struct Cli {
 }
 
 /// Initialise logging, parse arguments, and dispatch the chosen subcommand.
-pub async fn run() -> Result<()> {
+///
+/// Returns the exit status the process should terminate with — `list` uses a
+/// distinct one to report that no hardware is connected.
+pub async fn run() -> Result<ExitCode> {
     fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -437,8 +437,19 @@ Bottom = { action = { CustomShortcut = "Cmd+Shift+P" } }
 
     #[test]
     fn recursive_action_fails_deserialization() {
-        let parsed = toml::from_str::<RingAction>("\"ShowActionsRing\"");
-        assert!(parsed.is_err());
+        // A bare `"ShowActionsRing"` is not a TOML document, so the slot has to
+        // be deserialized the way config.toml stores it — otherwise the parse
+        // fails on syntax and never reaches the recursion guard.
+        let error = match toml::from_str::<ActionRingEntry>("action = \"ShowActionsRing\"") {
+            Ok(entry) => panic!("a ring slot must not recursively open the ring, got {entry:?}"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains(&RingActionError::RecursiveTrigger.to_string()),
+            "expected the recursion guard to reject the slot, got: {error}"
+        );
     }
 
     #[test]

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -312,6 +312,7 @@ const fn default_true() -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
@@ -345,9 +346,9 @@ mod tests {
             action: RingAction,
         }
 
-        let action = RingAction::new(Action::Copy).unwrap_or_else(|error| panic!("{error}"));
-        let encoded = toml::to_string(&Wrapper { action })
-            .unwrap_or_else(|error| panic!("could not serialize ring action: {error}"));
+        let action = RingAction::new(Action::Copy).expect("copy must be a valid ring action");
+        let encoded =
+            toml::to_string(&Wrapper { action }).expect("could not serialize ring action");
         assert_eq!(encoded, "action = \"Copy\"\n");
     }
 
@@ -359,22 +360,21 @@ mod tests {
             Top = { action = "Copy", label = "Copy Invoice" }
             "#,
         )
-        .unwrap_or_else(|error| panic!("could not deserialize labelled layout: {error}"));
+        .expect("could not deserialize labelled layout");
         assert_eq!(
             layout.slots[&ActionRingSlot::Top].custom_label(),
             Some("Copy Invoice")
         );
 
-        let encoded = toml::to_string(&layout)
-            .unwrap_or_else(|error| panic!("could not serialize labelled layout: {error}"));
+        let encoded = toml::to_string(&layout).expect("could not serialize labelled layout");
         let decoded = toml::from_str::<ActionRingLayout>(&encoded)
-            .unwrap_or_else(|error| panic!("could not deserialize labelled layout: {error}"));
+            .expect("could not deserialize labelled layout");
         assert_eq!(decoded, layout);
 
         // Like icons, a label sticks to its slot when the action is replaced.
         layout.set_action(
             ActionRingSlot::Top,
-            Some(RingAction::new(Action::Paste).unwrap_or_else(|error| panic!("{error}"))),
+            Some(RingAction::new(Action::Paste).expect("paste must be a valid ring action")),
         );
         assert_eq!(
             layout.slots[&ActionRingSlot::Top].custom_label(),
@@ -385,8 +385,7 @@ mod tests {
     #[test]
     fn unlabelled_entries_serialize_without_a_label_key() {
         let layout = ActionRingLayout::default();
-        let encoded = toml::to_string(&layout)
-            .unwrap_or_else(|error| panic!("could not serialize ring layout: {error}"));
+        let encoded = toml::to_string(&layout).expect("could not serialize ring layout");
         assert!(!encoded.contains("label"));
     }
 
@@ -402,10 +401,9 @@ mod tests {
     fn custom_icons_roundtrip_without_changing_slot_actions() {
         let mut layout = ActionRingLayout::default();
         layout.set_icon(ActionRingSlot::Top, Some(ActionRingIcon::Keyboard));
-        let encoded = toml::to_string(&layout)
-            .unwrap_or_else(|error| panic!("could not serialize ring layout: {error}"));
+        let encoded = toml::to_string(&layout).expect("could not serialize ring layout");
         let decoded = toml::from_str::<ActionRingLayout>(&encoded)
-            .unwrap_or_else(|error| panic!("could not deserialize ring layout: {error}"));
+            .expect("could not deserialize ring layout");
         assert_eq!(decoded, layout);
         assert_eq!(decoded.slots[&ActionRingSlot::Top].action(), &Action::Cut);
         assert_eq!(
@@ -423,7 +421,7 @@ Top = { action = "Copy", icon = "Keyboard" }
 Bottom = { action = { CustomShortcut = "Cmd+Shift+P" } }
 "#,
         )
-        .unwrap_or_else(|error| panic!("documented ring layout failed: {error}"));
+        .expect("documented ring layout failed");
         assert_eq!(layout.slots[&ActionRingSlot::Top].action(), &Action::Copy);
         assert_eq!(
             layout.slots[&ActionRingSlot::Top].custom_icon(),
@@ -459,7 +457,7 @@ Bottom = { action = { CustomShortcut = "Cmd+Shift+P" } }
             slots: BTreeMap::from([(
                 ActionRingSlot::Top,
                 ActionRingEntry::new(
-                    RingAction::new(Action::NewTab).unwrap_or_else(|error| panic!("{error}")),
+                    RingAction::new(Action::NewTab).expect("new tab must be a valid ring action"),
                 ),
             )]),
         };

--- a/crates/openlogi-core/src/binding/application_target.rs
+++ b/crates/openlogi-core/src/binding/application_target.rs
@@ -82,13 +82,14 @@ impl From<ApplicationTarget> for ApplicationTargetWire {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
     #[test]
     fn validates_and_derives_display_name() {
-        let target = ApplicationTarget::new("/Applications/Safari.app", "")
-            .unwrap_or_else(|error| panic!("valid target failed: {error}"));
+        let target =
+            ApplicationTarget::new("/Applications/Safari.app", "").expect("valid target failed");
         assert_eq!(target.path(), "/Applications/Safari.app");
         assert_eq!(target.display_name(), "Safari");
         assert_eq!(
@@ -99,10 +100,9 @@ mod tests {
 
     #[test]
     fn roundtrips_as_a_human_readable_target_table() {
-        let target = ApplicationTarget::new("https://example.test", "Example")
-            .unwrap_or_else(|error| panic!("valid target failed: {error}"));
-        let encoded = toml::to_string(&target)
-            .unwrap_or_else(|error| panic!("target serialization failed: {error}"));
+        let target =
+            ApplicationTarget::new("https://example.test", "Example").expect("valid target failed");
+        let encoded = toml::to_string(&target).expect("target serialization failed");
         assert!(encoded.contains("path = \"https://example.test\""));
         assert_eq!(toml::from_str::<ApplicationTarget>(&encoded), Ok(target));
     }

--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -381,7 +381,18 @@ mod tests {
 
     #[test]
     fn rejects_unknown_serialized_usage_and_modifier_bits() {
-        assert!(toml::from_str::<KeyboardUsage>("255").is_err());
+        // A bare `255` is not a TOML document, so the usage has to arrive in a
+        // wire field — otherwise the parse fails on syntax and never reaches
+        // the `try_from = "u8"` guard.
+        let Err(error) = toml::from_str::<KeyComboWire>("modifiers = 0\nkey = 255") else {
+            panic!("usage 255 is not a supported HID keyboard usage and must be rejected")
+        };
+        assert!(
+            error
+                .to_string()
+                .contains(&KeyboardUsageError(255).to_string()),
+            "expected the usage guard to reject 255, got: {error}"
+        );
         assert_eq!(
             KeyCombo::try_from(KeyComboWire {
                 modifiers: 128,

--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -332,6 +332,7 @@ fn parse_key(token: &str) -> Result<KeyboardUsage, KeyComboParseError> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
@@ -339,7 +340,7 @@ mod tests {
     fn parses_modifiers_letters_and_navigation_keys() {
         let combo = "Cmd+Shift+P"
             .parse::<KeyCombo>()
-            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+            .expect("valid shortcut failed");
         assert!(combo.has_command());
         assert!(combo.has_shift());
         assert_eq!(combo.key().code(), 0x13);
@@ -347,7 +348,7 @@ mod tests {
 
         let combo = "Ctrl+Alt+Left"
             .parse::<KeyCombo>()
-            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+            .expect("valid shortcut failed");
         assert!(combo.has_control());
         assert!(combo.has_option());
         assert_eq!(combo.key().code(), 0x50);
@@ -356,9 +357,7 @@ mod tests {
 
     #[test]
     fn a_uses_its_platform_neutral_hid_usage() {
-        let combo = "Cmd+A"
-            .parse::<KeyCombo>()
-            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+        let combo = "Cmd+A".parse::<KeyCombo>().expect("valid shortcut failed");
         assert_eq!(combo.key().code(), 0x04);
         assert_eq!(combo.rendered_label(), "Cmd+A");
     }
@@ -411,10 +410,9 @@ mod tests {
 
         let combo = "Cmd+Shift+P"
             .parse::<KeyCombo>()
-            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+            .expect("valid shortcut failed");
         let wrapper = Wrapper { shortcut: combo };
-        let encoded = toml::to_string(&wrapper)
-            .unwrap_or_else(|error| panic!("shortcut serialization failed: {error}"));
+        let encoded = toml::to_string(&wrapper).expect("shortcut serialization failed");
         assert_eq!(encoded, "shortcut = \"Cmd+Shift+P\"\n");
         assert_eq!(toml::from_str::<Wrapper>(&encoded), Ok(wrapper));
     }

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -91,11 +91,7 @@ fn workflow_label_category_and_catalog_exclusion() {
     let wf = Action::Workflow(vec![
         WorkflowStep::TypeText("bite me".into()),
         WorkflowStep::Delay { millis: 5000 },
-        WorkflowStep::PressKey(
-            "Enter"
-                .parse()
-                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
-        ),
+        WorkflowStep::PressKey("Enter".parse().expect("valid shortcut failed")),
     ]);
     assert_eq!(wf.label(), "Workflow (3 steps)");
     assert_eq!(wf.category(), Category::Editing);
@@ -112,11 +108,7 @@ fn workflow_roundtrips_toml() {
     let wf = Action::Workflow(vec![
         WorkflowStep::TypeText("bite me".into()),
         WorkflowStep::Delay { millis: 5000 },
-        WorkflowStep::PressKey(
-            "Shift+Enter"
-                .parse()
-                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
-        ),
+        WorkflowStep::PressKey("Shift+Enter".parse().expect("valid shortcut failed")),
         WorkflowStep::RunShellCommand("echo done".into()),
     ]);
     let toml = toml::to_string(&wf).expect("serialize");
@@ -151,9 +143,7 @@ fn binding_single_roundtrips_including_payload_variants() {
     bindings.insert(
         ButtonId::Forward,
         Binding::Single(Action::CustomShortcut(
-            "Cmd+P"
-                .parse()
-                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+            "Cmd+P".parse().expect("valid shortcut failed"),
         )),
     );
     let back = binding_roundtrip(bindings);
@@ -258,27 +248,19 @@ fn all_catalog_variants_roundtrip_toml() {
 
 #[test]
 fn custom_shortcut_roundtrips_toml() {
-    let action = Action::CustomShortcut(
-        "Cmd+Shift+P"
-            .parse()
-            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
-    );
+    let action = Action::CustomShortcut("Cmd+Shift+P".parse().expect("valid shortcut failed"));
     assert_eq!(roundtrip(&action), action);
 }
 
 #[test]
 fn key_combo_rendered_label_is_canonical() {
-    let combo: KeyCombo = "Cmd+Shift+P"
-        .parse()
-        .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+    let combo: KeyCombo = "Cmd+Shift+P".parse().expect("valid shortcut failed");
     assert_eq!(combo.rendered_label(), "Cmd+Shift+P");
 }
 
 #[test]
 fn key_combo_rendered_label_falls_back_to_modifiers_plus_key() {
-    let combo: KeyCombo = "Cmd+Shift+P"
-        .parse()
-        .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+    let combo: KeyCombo = "Cmd+Shift+P".parse().expect("valid shortcut failed");
     assert_eq!(combo.rendered_label(), "Cmd+Shift+P");
 }
 

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -433,9 +433,7 @@ fn bindings_roundtrip_per_device() {
         "2b042",
         ButtonId::DpiToggle,
         Binding::Single(Action::CustomShortcut(
-            "Cmd+P"
-                .parse()
-                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+            "Cmd+P".parse().expect("valid shortcut failed"),
         )),
     );
     cfg.set_binding("4082d", ButtonId::Back, Binding::Single(Action::Paste));
@@ -448,9 +446,7 @@ fn bindings_roundtrip_per_device() {
     assert_eq!(
         a.get(&ButtonId::DpiToggle),
         Some(&Binding::Single(Action::CustomShortcut(
-            "Cmd+P"
-                .parse()
-                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"))
+            "Cmd+P".parse().expect("valid shortcut failed")
         )))
     );
 

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -101,9 +101,14 @@ fn key_trigger_parses_and_displays_extended_function_keys() {
 
 #[test]
 fn key_trigger_rejects_unknown() {
-    assert!("f99".parse::<KeyTrigger>().is_err());
-    assert!("shift+".parse::<KeyTrigger>().is_err());
-    assert!("".parse::<KeyTrigger>().is_err());
+    "f99"
+        .parse::<KeyTrigger>()
+        .expect_err("f99 is not a known key name");
+    "shift+"
+        .parse::<KeyTrigger>()
+        .expect_err("a modifier with no key must be rejected");
+    "".parse::<KeyTrigger>()
+        .expect_err("an empty trigger must be rejected");
 }
 
 #[test]

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -598,10 +598,14 @@ mod tests {
 
     #[test]
     fn light_ranges_reject_invalid_grids_and_units() {
-        assert!(LightValueRange::new(10, 1, 1, LightValueUnit::Lumens).is_err());
-        assert!(LightValueRange::new(0, 10, 0, LightValueUnit::Lumens).is_err());
-        assert!(LightValueRange::new(0, 10, 3, LightValueUnit::Lumens).is_err());
-        assert!(LightValueRange::new(0, 101, 1, LightValueUnit::Percent).is_err());
+        LightValueRange::new(10, 1, 1, LightValueUnit::Lumens)
+            .expect_err("a minimum above the maximum must be rejected");
+        LightValueRange::new(0, 10, 0, LightValueUnit::Lumens)
+            .expect_err("a zero step must be rejected");
+        LightValueRange::new(0, 10, 3, LightValueUnit::Lumens)
+            .expect_err("a step that does not divide the span must be rejected");
+        LightValueRange::new(0, 101, 1, LightValueUnit::Percent)
+            .expect_err("a percent range above 100 must be rejected");
     }
 
     #[test]
@@ -619,6 +623,6 @@ mod tests {
         let result = toml::from_str::<LightValueRange>(
             "min = 2700\nmax = 6500\nstep = 0\nunit = 'kelvin'\n",
         );
-        assert!(result.is_err());
+        result.expect_err("a zero step must not survive deserialization");
     }
 }

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -157,7 +157,8 @@ pub fn agent_socket_path() -> Result<PathBuf, PathsError> {
     Ok(runtime_dir()?.join("agent.sock"))
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
+#[cfg(unix)]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -76,18 +76,11 @@ objc2-io-kit = { workspace = true, features = ["std", "hidsystem"] }
 # NSEvent global-monitor handlers are ObjC blocks (overlay click-away dismissal).
 block2 = { workspace = true }
 
-# unsafe_code stays denied; the status-item/tray modules opt in locally with
-# #[expect(unsafe_code)] for the few objc2 calls (init-with-action, set-target,
-# super-init) that remain unsafe.
-[lints.rust]
-unsafe_code = "deny"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
-missing_errors_doc = "allow"
-doc_markdown = "allow"
+# unsafe_code stays denied (from [workspace.lints]); the status-item/tray modules
+# opt in locally with #[expect(unsafe_code)] for the few objc2 calls
+# (init-with-action, set-target, super-init) that remain unsafe.
+[lints]
+workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/openlogi-gui/build.rs
+++ b/crates/openlogi-gui/build.rs
@@ -19,10 +19,10 @@
 //! the exact version already in the lock as gpui's own build-dependency, which
 //! adds an edge, not a crate.
 
-// A build script fails by panicking, so `expect` (with a message that surfaces
-// in the build log) is the idiomatic error path here — exempt it from the
-// workspace's strict runtime lints.
-#![allow(clippy::expect_used)]
+#![allow(
+    clippy::expect_used,
+    reason = "a build script fails by panicking, so expect — whose message surfaces in the build log — is the idiomatic error path"
+)]
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};

--- a/crates/openlogi-gui/src/app/detail.rs
+++ b/crates/openlogi-gui/src/app/detail.rs
@@ -495,13 +495,15 @@ fn light_tab(
     pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
-    let (asset, online, enabled, settings) = cx.try_global::<AppState>().map_or(
-        (
-            None,
-            false,
-            false,
-            openlogi_core::config::LightSettings::default(),
-        ),
+    let (asset, online, enabled, settings) = cx.try_global::<AppState>().map_or_else(
+        || {
+            (
+                None,
+                false,
+                false,
+                openlogi_core::config::LightSettings::default(),
+            )
+        },
         |state| {
             let record = state.current_record();
             (
@@ -602,23 +604,25 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
                 .map(|r| state.device_enabled(&r.config_key))
         })
         .unwrap_or(true);
-    let (binding_count, gesture_count, preset_count, app_profile) = cx
-        .try_global::<AppState>()
-        .map_or((0, 0, 0, tr!("Default profile").to_string()), |state| {
-            (
-                state.button_bindings.len(),
-                state
-                    .gesture_bindings
-                    .values()
-                    .map(std::collections::BTreeMap::len)
-                    .sum::<usize>(),
-                state.dpi_presets().len(),
-                state
-                    .current_app_bundle
-                    .clone()
-                    .unwrap_or_else(|| tr!("Default profile").to_string()),
-            )
-        });
+    let (binding_count, gesture_count, preset_count, app_profile) =
+        cx.try_global::<AppState>().map_or_else(
+            || (0, 0, 0, tr!("Default profile").to_string()),
+            |state| {
+                (
+                    state.button_bindings.len(),
+                    state
+                        .gesture_bindings
+                        .values()
+                        .map(std::collections::BTreeMap::len)
+                        .sum::<usize>(),
+                    state.dpi_presets().len(),
+                    state
+                        .current_app_bundle
+                        .clone()
+                        .unwrap_or_else(|| tr!("Default profile").to_string()),
+                )
+            },
+        );
 
     let content = v_flex()
         .gap_3()

--- a/crates/openlogi-gui/src/components/light_panel.rs
+++ b/crates/openlogi-gui/src/components/light_panel.rs
@@ -83,7 +83,7 @@ impl LightPanel {
         if let Some(range) = brightness_range {
             let value = range
                 .native_for_percent(settings.brightness_percent)
-                .unwrap_or(range.min());
+                .unwrap_or_else(|| range.min());
             let slider = cx.new(|_| {
                 SliderState::new()
                     .max(f32::from(range.max()))
@@ -170,7 +170,7 @@ impl Render for LightPanel {
             if let (Some(range), Some(slider)) = (self.brightness_range, &self.brightness) {
                 let value = range
                     .native_for_percent(settings.brightness_percent)
-                    .unwrap_or(range.min());
+                    .unwrap_or_else(|| range.min());
                 slider.update(cx, |slider, cx| {
                     slider.set_value(f32::from(value), window, cx);
                 });
@@ -210,7 +210,7 @@ impl Render for LightPanel {
         if let (Some(range), Some(slider)) = (self.brightness_range, &self.brightness) {
             let value = range
                 .native_for_percent(settings.brightness_percent)
-                .unwrap_or(range.min());
+                .unwrap_or_else(|| range.min());
             panel = panel.child(control_well(
                 tr!("BRIGHTNESS"),
                 format_light_value(value, range.unit()),

--- a/crates/openlogi-gui/src/ipc_client.rs
+++ b/crates/openlogi-gui/src/ipc_client.rs
@@ -394,39 +394,6 @@ fn helper_bundle(path: &std::path::Path) -> Option<&std::path::Path> {
     (bundle.extension()? == "app").then_some(bundle)
 }
 
-#[cfg(all(test, target_os = "macos"))]
-mod tests {
-    use std::path::Path;
-
-    use super::helper_bundle;
-
-    #[test]
-    fn helper_bundle_resolves_only_the_packaged_layout() {
-        let packaged = Path::new(
-            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
-        );
-        assert_eq!(
-            helper_bundle(packaged),
-            Some(Path::new(
-                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app"
-            ))
-        );
-        let dev = Path::new(
-            "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
-        );
-        assert_eq!(
-            helper_bundle(dev),
-            Some(Path::new(
-                "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app"
-            ))
-        );
-        assert_eq!(
-            helper_bundle(Path::new("target/debug/openlogi-agent")),
-            None
-        );
-    }
-}
-
 /// Resolve the agent executable relative to the running GUI: a sibling in the
 /// cargo target dir (dev, and the flat Windows install layout), else the
 /// embedded `OpenLogiAgent.app` login-item helper (packaged macOS build).
@@ -723,5 +690,39 @@ fn reply_disconnected(
         }
         Command::CancelPairing => {}
         _ => {}
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_os = "macos")]
+mod tests {
+    use std::path::Path;
+
+    use super::helper_bundle;
+
+    #[test]
+    fn helper_bundle_resolves_only_the_packaged_layout() {
+        let packaged = Path::new(
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
+        );
+        assert_eq!(
+            helper_bundle(packaged),
+            Some(Path::new(
+                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app"
+            ))
+        );
+        let dev = Path::new(
+            "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
+        );
+        assert_eq!(
+            helper_bundle(dev),
+            Some(Path::new(
+                "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app"
+            ))
+        );
+        assert_eq!(
+            helper_bundle(Path::new("target/debug/openlogi-agent")),
+            None
+        );
     }
 }

--- a/crates/openlogi-gui/src/platform/os.rs
+++ b/crates/openlogi-gui/src/platform/os.rs
@@ -47,9 +47,15 @@ pub fn set_app_appearance(appearance: Appearance) {
     };
     let named = match appearance {
         Appearance::System => None,
-        // SAFETY: the `NSAppearanceName` constants are static framework globals,
-        // valid for the whole process; `appearanceNamed` copies what it needs.
+        // SAFETY: `NSAppearanceNameAqua` is an AppKit `extern static` typed
+        // `&'static NSAppearanceName`; its non-lazy binding is resolved when the
+        // framework loads, before `main`, and AppKit never reassigns it — so
+        // this is a shared read of a live `&'static` of the declared type.
         Appearance::Light => NSAppearance::appearanceNamed(unsafe { NSAppearanceNameAqua }),
+        // SAFETY: `NSAppearanceNameDarkAqua` is an AppKit `extern static` typed
+        // `&'static NSAppearanceName`; its non-lazy binding is resolved when the
+        // framework loads, before `main`, and AppKit never reassigns it — so
+        // this is a shared read of a live `&'static` of the declared type.
         Appearance::Dark => NSAppearance::appearanceNamed(unsafe { NSAppearanceNameDarkAqua }),
     };
     NSApplication::sharedApplication(mtm).setAppearance(named.as_deref());

--- a/crates/openlogi-gui/src/platform/permissions.rs
+++ b/crates/openlogi-gui/src/platform/permissions.rs
@@ -308,7 +308,8 @@ pub(crate) mod linux {
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
+#[cfg(target_os = "linux")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -512,7 +512,7 @@ pub(super) fn adopt_transient_record(known: &DeviceRecord, live: DeviceRecord) -
             .registry_model_id
             .or_else(|| known.registry_model_id.clone()),
         route: live.route,
-        capture_id: live.capture_id.or(known.capture_id.clone()),
+        capture_id: live.capture_id.or_else(|| known.capture_id.clone()),
         kind: if known.kind == DeviceKind::Unknown {
             live.kind
         } else {

--- a/crates/openlogi-gui/src/theme.rs
+++ b/crates/openlogi-gui/src/theme.rs
@@ -218,17 +218,18 @@ pub fn register_builtin_themes(cx: &mut App) {
 /// appearance is read directly and it repaints; pass `None` from a settings
 /// edit (no window in hand) — every open window is refreshed instead.
 pub fn apply_from_settings(window: Option<&mut Window>, cx: &mut App) {
-    let (appearance, light_name, dark_name, radius) =
-        cx.try_global::<AppState>()
-            .map_or((Appearance::default(), None, None, None), |state| {
-                let s = state.app_settings();
-                (
-                    s.appearance,
-                    s.theme_light.clone(),
-                    s.theme_dark.clone(),
-                    s.ui_radius,
-                )
-            });
+    let (appearance, light_name, dark_name, radius) = cx.try_global::<AppState>().map_or_else(
+        || (Appearance::default(), None, None, None),
+        |state| {
+            let s = state.app_settings();
+            (
+                s.appearance,
+                s.theme_light.clone(),
+                s.theme_dark.clone(),
+                s.ui_radius,
+            )
+        },
+    );
 
     // Sync the native window chrome (titlebar) to the pref first, so the
     // `System` branch below reads the *real* OS appearance rather than a stale

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -521,5 +521,8 @@ fn a_dpi_button_re_presses_after_a_release() {
         Ok(CapturedInput::ButtonPressed(ButtonId::DpiToggle, None)),
         "a release re-arms the rising edge"
     );
-    assert!(rx.try_recv().is_err());
+    assert!(
+        rx.try_recv().is_err(),
+        "press → release → press emits exactly two presses"
+    );
 }

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -542,7 +542,10 @@ mod tests {
 
     #[test]
     fn host_outside_device_range_is_rejected() {
-        assert!(host_change_required(0, 2, 2).is_err());
+        assert!(
+            host_change_required(0, 2, 2).is_err(),
+            "host 2 is outside a device that reports 2 hosts and must be rejected"
+        );
     }
 
     #[test]

--- a/crates/openlogi-hid/src/pairing/tests.rs
+++ b/crates/openlogi-hid/src/pairing/tests.rs
@@ -45,7 +45,8 @@ async fn malformed_passkey_after_pair_cancels_bolt_pairing() {
                 kind: BoltDeviceKind::Keyboard,
                 name: "Test Keyboard".into(),
             }))
-            .is_ok()
+            .is_ok(),
+        "the pair command must reach the session's command receiver"
     );
 
     let exchange = async {
@@ -60,7 +61,10 @@ async fn malformed_passkey_after_pair_cancels_bolt_pairing() {
         data[0] = RECEIVER_INDEX;
         data[1] = notification::id::PASSKEY_REQUEST;
         data[3..9].copy_from_slice(b"12x456");
-        assert!(notification_tx.send(HidppMessage::Long(data)).is_ok());
+        assert!(
+            notification_tx.send(HidppMessage::Long(data)).is_ok(),
+            "the malformed passkey notification must reach the running session"
+        );
 
         let Some(cancel) = written_reports.recv().await else {
             panic!("mock channel closed before cancel command");

--- a/crates/openlogi-hid/src/standalone.rs
+++ b/crates/openlogi-hid/src/standalone.rs
@@ -139,6 +139,10 @@ mod tests {
     #[test]
     fn distinct_serials_can_share_the_same_hid_tuple() {
         let devices = vec![raw("serial:one"), raw("serial:two")];
-        assert!(validate_no_ambiguous_nodes(&devices).is_ok());
+        let validation = validate_no_ambiguous_nodes(&devices);
+        assert!(
+            validation.is_ok(),
+            "serial-backed nodes stay distinguishable: {validation:?}"
+        );
     }
 }

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -111,4 +111,5 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests;

--- a/crates/openlogi-hid/src/write/litra.rs
+++ b/crates/openlogi-hid/src/write/litra.rs
@@ -336,8 +336,12 @@ mod tests {
 
     #[test]
     fn glow_temperature_accepts_only_aligned_inclusive_boundaries() {
-        assert!(encode_command(LitraModel::Glow, LightCommand::TemperatureKelvin(2700)).is_ok());
-        assert!(encode_command(LitraModel::Glow, LightCommand::TemperatureKelvin(6500)).is_ok());
+        let minimum = encode_command(LitraModel::Glow, LightCommand::TemperatureKelvin(2700))
+            .expect("2700 K is the inclusive lower bound");
+        let maximum = encode_command(LitraModel::Glow, LightCommand::TemperatureKelvin(6500))
+            .expect("6500 K is the inclusive upper bound");
+        assert_eq!(&minimum[3..6], &[COMMAND_TEMPERATURE, 0x0a, 0x8c]);
+        assert_eq!(&maximum[3..6], &[COMMAND_TEMPERATURE, 0x19, 0x64]);
         for invalid in [2600, 2750, 6600] {
             assert_matches!(
                 encode_command(LitraModel::Glow, LightCommand::TemperatureKelvin(invalid)),

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -213,7 +213,7 @@ fn per_key_lighting_builds_only_very_long_frames_then_one_long_commit() {
     let reports = per_key_reports(0x03, 0x27, 0x11, 0x22, 0x33);
     let (commit, frames) = reports
         .split_last()
-        .unwrap_or_else(|| panic!("per-key lighting must emit a commit"));
+        .expect("per-key lighting must emit a commit");
 
     assert_eq!(frames.len(), 17);
     assert!(frames.iter().all(|report| report.len() == 64));
@@ -246,7 +246,7 @@ async fn shared_read_and_lighting_apis_use_the_supplied_channel() -> Result<(), 
     let channel = Arc::new(
         HidppChannel::from_raw_channel(raw)
             .await
-            .unwrap_or_else(|error| panic!("scripted HID++ channel must open: {error:?}")),
+            .expect("scripted HID++ channel must open"),
     );
     let shared = SharedChannel::new(
         channel,

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -52,12 +52,7 @@ windows-sys = { workspace = true, features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
-[lints.rust]
-unsafe_code = "allow"
-
-[lints.clippy]
-pedantic = { level = "warn", priority = -1 }
-unwrap_used = "warn"
-expect_used = "warn"
-missing_errors_doc = "allow"
-doc_markdown = "allow"
+# unsafe_code is denied workspace-wide; the three platform modules are wall-to-wall
+# OS FFI, so each opts out at its own module root instead of the whole crate.
+[lints]
+workspace = true

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -18,6 +18,10 @@
 //! group) and write access to `/dev/uinput` (the `input` or `uinput` group, or
 //! a `udev` rule granting access). Without those, `start()` returns
 //! [`crate::HookError::Linux`].
+#![allow(
+    unsafe_code,
+    reason = "the wake pipe and the Wayland toplevel listener call libc directly"
+)]
 
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -258,6 +258,9 @@ fn poll_fd(fd: libc::c_int, deadline: Instant) -> bool {
         if timeout_ms == 0 {
             return false;
         }
+        // SAFETY: `pfd` is a live, correctly aligned single `pollfd` we own for
+        // the whole call and the length argument matches that one element;
+        // `poll` only writes `revents` back into it.
         let r = unsafe { libc::poll(&raw mut pfd, 1, timeout_ms) };
         if r > 0 {
             return true;
@@ -266,6 +269,9 @@ fn poll_fd(fd: libc::c_int, deadline: Instant) -> bool {
             return false;
         }
         // r < 0 — check errno
+        // SAFETY: `__errno_location` always returns a valid, aligned pointer to
+        // this thread's own errno slot, live for the thread's lifetime, and it
+        // is read here on the same thread that made the failing `poll` call.
         let e = unsafe { *libc::__errno_location() };
         if e != libc::EINTR {
             return false;

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -643,6 +643,10 @@ fn spawn_callback_watchdog(
                 );
                 // Hard exit: disable_tap alone cannot unblock an in-flight
                 // callback, and a live active HID tap freezes all pointer I/O.
+                #[expect(
+                    clippy::exit,
+                    reason = "this watchdog thread has no caller to return to and the stuck callback owns the active HID tap, which serialises every pointer event machine-wide; only process death makes macOS tear the tap down"
+                )]
                 std::process::exit(FREEZE_HAZARD_EXIT_CODE);
             }
         })
@@ -708,6 +712,10 @@ fn spawn_lifecycle_watchdog(
                             "HID CGEventTap lifecycle did not make progress before deadline — \
                              exiting agent to restore system input"
                         );
+                        #[expect(
+                            clippy::exit,
+                            reason = "the tap thread is wedged (TCC revocation can stall it inside CoreGraphics), so no unwinding path can reach it from this watchdog thread; a live HID tap left behind freezes all input until the process dies"
+                        )]
                         std::process::exit(FREEZE_HAZARD_EXIT_CODE);
                     }
                 }

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -1,4 +1,8 @@
 //! macOS `CGEventTap` implementation of the OS-level mouse hook.
+#![allow(
+    unsafe_code,
+    reason = "the event tap is built on Core Graphics / Core Foundation C APIs"
+)]
 
 mod watchdog;
 

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -1014,6 +1014,7 @@ pub(crate) fn stop(inner: HookInner) {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 
@@ -1022,8 +1023,8 @@ mod tests {
     #[test]
     fn tap_callback_suppresses_normally_and_passes_through_panics() {
         let source = CGEventSource::new(CGEventSourceStateID::Private)
-            .unwrap_or_else(|()| panic!("CGEventSourceCreate failed"));
-        let event = CGEvent::new(source).unwrap_or_else(|()| panic!("CGEventCreate failed"));
+            .expect("CGEventSourceCreate must succeed");
+        let event = CGEvent::new(source).expect("CGEventCreate must succeed");
 
         assert!(matches!(
             run_tap_callback(

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -176,14 +176,16 @@ fn sender_device_info(sender_id: u64) -> SenderDeviceInfo {
                         .map(|p| unsafe { CFString::wrap_under_create_rule(p.cast()) }.to_string())
                 };
                 let num_prop = |k| {
-                    // SAFETY: a numeric property is a +1 CFNumber; wrap takes ownership.
                     service_property(service, k)
                         .and_then(|p| {
+                            // SAFETY: `service_property` only yields a non-null, +1 CF
+                            // value, and every key passed below is published by IOKit as
+                            // a CFNumber, so the cast keeps the type; the create rule
+                            // hands that retain to the wrapper, which releases it on drop.
                             unsafe { CFNumber::wrap_under_create_rule(p.cast()) }.to_i64()
                         })
                         .and_then(|n| u32::try_from(n).ok())
                 };
-                // SAFETY: a String property is a +1 CFString; wrap takes ownership.
                 let product_name = string_prop("Product");
                 let info = SenderDeviceInfo {
                     is_trackpad: product_name
@@ -935,6 +937,10 @@ pub(crate) fn list_event_taps() -> Vec<EventTapInfo> {
     // pattern is a valid instance (`enabled = false`, all numeric fields 0).
     // `CGGetEventTapList` overwrites each slot it fills.
     let mut taps: Vec<CGEventTapInformation> = vec![unsafe { std::mem::zeroed() }; count as usize];
+    // SAFETY: `taps` holds exactly `count` initialised, correctly aligned slots
+    // and stays alive for the call, and that same `count` is the maximum passed
+    // in, so the C side cannot write past the allocation; the out-parameter
+    // points at a live local it may only overwrite.
     let err = unsafe { CGGetEventTapList(count, taps.as_mut_ptr(), &raw mut count) };
     if err != 0 {
         return Vec::new();

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -1,6 +1,10 @@
 //! Windows `WH_MOUSE_LL` + `WH_KEYBOARD_LL` implementation of the OS-level
 //! input hook.
 #![allow(
+    unsafe_code,
+    reason = "the low-level input hook is built on the Win32 C API"
+)]
+#![allow(
     clippy::borrow_as_ptr,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -559,6 +559,7 @@ fn try_mpris_command(command: &str) -> Option<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use evdev::KeyCode;
     use openlogi_core::binding::KeyCombo;
@@ -569,7 +570,7 @@ mod tests {
     fn modifiers_map_to_linux_without_duplicate_control() {
         let combo = "Cmd+Ctrl+Shift+Alt+A"
             .parse::<KeyCombo>()
-            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+            .expect("a valid shortcut must parse");
         assert_eq!(
             modifiers_to_keycodes(&combo),
             vec![

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -156,7 +156,8 @@ fn post_click(button: CGMouseButton) {
     };
     // A fresh event reports the current pointer location; mouse events need
     // an explicit position or they land at (0, 0).
-    let location = CGEvent::new(src.clone()).map_or(CGPoint::new(0., 0.), |e| e.location());
+    let location =
+        CGEvent::new(src.clone()).map_or_else(|()| CGPoint::new(0., 0.), |e| e.location());
     let (down, up) = match button {
         CGMouseButton::Left => (CGEventType::LeftMouseDown, CGEventType::LeftMouseUp),
         CGMouseButton::Right => (CGEventType::RightMouseDown, CGEventType::RightMouseUp),
@@ -185,7 +186,8 @@ fn post_other_button(button_number: i64) {
         tracing::warn!("CGEventSource::new failed for extra mouse button");
         return;
     };
-    let location = CGEvent::new(src.clone()).map_or(CGPoint::new(0., 0.), |e| e.location());
+    let location =
+        CGEvent::new(src.clone()).map_or_else(|()| CGPoint::new(0., 0.), |e| e.location());
     for (kind, phase) in [
         (CGEventType::OtherMouseDown, "down"),
         (CGEventType::OtherMouseUp, "up"),

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,6 +4,35 @@ Durable "why we did it this way" records that are not obvious from the code.
 Add a dated entry when a non-obvious architectural or dependency decision is
 made or revisited.
 
+## 2026-08: Shared clippy lint set
+
+The workspace adopted the shared ten-lint set (`assertions_on_result_states`,
+`cast_possible_truncation`, `cast_possible_wrap`, `cast_sign_loss`,
+`error_impl_error`, `exit`, `or_fun_call`, `ptr_as_ptr`,
+`tests_outside_test_module`, `undocumented_unsafe_blocks`) on top of the
+existing `pedantic` + `unwrap_used`/`expect_used` table.
+
+- One table, inherited everywhere. `openlogi-gui`, `openlogi-camera` and
+  `openlogi-hook` carried hand-copied duplicates of `[workspace.lints]`, so any
+  lint added to the workspace would have silently skipped them — three of the
+  crates holding most of the FFI. Cargo rejects `[lints] workspace = true`
+  alongside local overrides, so `openlogi-hook` moved its `unsafe_code` opt-out
+  into its three platform modules. `openlogi-hidpp` stays out on purpose
+  (vendored).
+- `tests_outside_test_module` only recognises a literal `#[cfg(test)]`. Compound
+  gates are written as stacked attributes (`#[cfg(test)]` then `#[cfg(unix)]`);
+  an integration test under `tests/` carries a file-level `#![expect(…)]`
+  because that file is already a test-only crate. Splitting the attribute also
+  wakes `items_after_test_module`, so such a module belongs last in its file.
+- `exit` gets a real `ExitCode` wherever the call site can return — `openlogi
+  list` hands status 2 back to `main` — and a reasoned `#[expect]` where it
+  cannot (the AppKit run loop, the watchdog threads, the update handover).
+  Clippy does not look inside `define_class!`, so the menu-bar Quit body moved
+  out of the macro rather than escape the lint by accident.
+- Not adopted: the policy's `unexpected_cfgs` / `check-cfg = ['cfg(kani)']`
+  entry. Nothing here uses Kani, and `unexpected_cfgs` already warns by default,
+  so it would be dead configuration.
+
 ## 2026-08: Standalone raw-light boundary
 
 Standalone lights such as Litra stay outside the HID++ receiver/paired-device

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
+use std::process::ExitCode;
+
 use anyhow::Result;
 
+// `Result<ExitCode, anyhow::Error>` is itself a `Termination`: the status
+// travels back from the subcommand, and an error still prints the anyhow
+// chain before exiting with a failure status.
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<()> {
+async fn main() -> Result<ExitCode> {
     openlogi_cli::run().await
 }


### PR DESCRIPTION
## Summary

Adopts the shared clippy lint set (https://gist.github.com/AprilNEA/cdf81f76840fcb883a32503ee7caa539)
across the whole workspace and fixes every violation it surfaces. The policy is
applied as real code changes, not suppressions: every remaining `allow`/`expect`
in the diff carries a `reason` explaining why that call site cannot do better.

The first thing the audit found was that the lint table did not actually reach
the whole workspace. `openlogi-gui`, `openlogi-camera` and `openlogi-hook` each
carried a hand-copied `[lints]` table instead of `workspace = true`, so they were
silently exempt from anything added centrally — and between them they hold most
of the workspace's FFI. That is fixed first, in its own commit, because every
later commit depends on the lints reaching those crates.

Turning the lints on there surfaced three real defects in the camera backends,
which are fixed at the root rather than suppressed:

- **Media Foundation leaked every `IMFActivate`** `MFEnumDeviceSources` returns.
  Freeing the array releases none of them, and the chosen one was additionally
  `clone`d. Reachable on every Windows preview.
- **`CoInitializeEx`/`MFStartup` were never balanced.** Every camera enumeration
  and every preview session left a COM initialization count behind on a thread
  that then exited, pinning that thread's apartment, its RPC connections and the
  in-process servers loaded on its behalf.
- **The UVC descriptor walk read entities from the wrong interface.** It armed on
  the first VideoControl interface and never disarmed, so a VideoStreaming frame
  descriptor (which shares descriptor type `0x24`, with `0x05` meaning
  `VS_FRAME_UNCOMPRESSED` rather than `VC_PROCESSING_UNIT`) was accepted as the
  Processing Unit and its `bFrameIndex` became the entity id.

The macOS UVC backend is rewritten onto the objc2 bindings in the process. It
declared its own `extern "C"` blocks for CoreFoundation, IOKit and the IOUSBLib
plug-in — including a hand-written `IOUSBDeviceInterface182` vtable — and
balanced every release by hand on each return path. `objc2-io-kit` binds all of
it, so the declarations are gone and the ownership rules are expressed in types.

## Changes

### Lint policy

- **root `Cargo.toml`** — the ten lints from the gist added to
  `[workspace.lints.clippy]`, with a comment pointing at the source and noting
  that the `cast_*`/`ptr_as_ptr` members are listed explicitly even though
  `pedantic` already implies them.
- **`openlogi-gui`, `openlogi-camera`, `openlogi-hook`** — hand-copied lint
  tables replaced with `[lints] workspace = true`. Cargo rejects mixing that with
  a local override, so `openlogi-hook`'s per-platform `unsafe_code` exemption
  moves into the source as a module-level `#![allow(unsafe_code, reason = "…")]`.
- **`AGENTS.md`, `docs/DECISIONS.md`** — the rule and its rationale written down:
  one lint table, what each lint changes day to day, and the house idiom for test
  modules that want `expect`/`unwrap`.

### Violations fixed as code

- **`openlogi-cli`, root `src/main.rs`** — `ExitCode` is threaded back to `main`
  instead of calling `std::process::exit`, so `list`'s "nothing found" status is
  now a return value. The one `exit` that survives is the agent's menu-bar Quit,
  where an AppKit menu action owns `main`'s stack frame and no status can travel
  back to it; it carries an `#[expect(clippy::exit, reason = "…")]` saying so.
- **`openlogi-core`, `openlogi-hid`, `openlogi-agent-core`, `openlogi-gui`** —
  39 `unwrap_or_else(|e| panic!("…"))` sites normalised. That form is an
  `expect` with the lint switched off by construction; test modules now say
  `#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]`
  and use `expect` outright. The one legitimate use of the closure form is a
  *dynamic* panic message in `openlogi-gui/build.rs`, where `expect` would need a
  `format!` that `clippy::expect_fun_call` rejects.
- **`assertions_on_result_states`** — `assert!(r.is_ok())` replaced by unwrapping
  the `Result` and asserting on the value, so a failure prints the error.
- **`tests_outside_test_module`** — test modules gated on more than `test` split
  into stacked `#[cfg(test)]` + `#[cfg(unix)]` attributes. That wakes
  `items_after_test_module`, so `openlogi-gui/src/ipc_client.rs`'s test module
  also moves to the end of the file; integration tests under `tests/` take a
  file-level `#![expect(clippy::tests_outside_test_module, reason = "…")]`.
- **`or_fun_call`** — `openlogi-gui` fallbacks built lazily.
- **`undocumented_unsafe_blocks`** — every `unsafe` block in the workspace gained
  a `// SAFETY:` comment stating why it is sound, across `openlogi-hook`,
  `openlogi-inject`, `openlogi-agent` and `openlogi-camera`.

### `openlogi-camera`

- **`capture_windows.rs`** — `activate_source` moves every `IMFActivate` out of
  the enumeration array with `Option::take`, so the ones that are not chosen are
  released when they drop. Previously all of them leaked.
- **`com_windows.rs`** (new) — `CoInitializeEx`/`MFStartup` become RAII guards.
  The two count differently, so they are two types. COM is per thread:
  `ComApartment` records whether *its* call incremented the count (`hr.is_ok()`,
  since `S_OK` and `S_FALSE` both owe a `CoUninitialize` while
  `RPC_E_CHANGED_MODE` owes nothing and means an incompatible apartment already
  exists to borrow), and is `!Send` because the balancing call must run on the
  initializing thread. Media Foundation is documented only as "call `MFShutdown`
  once for every call to `MFStartup`", with nothing said about one thread's
  shutdown leaving another thread's platform up — so the platform is refcounted
  here instead, started for the first live guard and shut down when the last one
  goes. A second capture session cannot pull it out from under the first.
- Ordering is compiler-checked rather than commented, since releasing a COM
  interface after its apartment closes is the failure this exists to prevent and
  Rust drops locals in reverse declaration order. `MediaFoundation<'a>` borrows
  the apartment and `Device<'a>` borrows it through `PhantomData`; inverting
  either ordering is rejected (`E0505` and `E0716`). `open_reader` and
  `activate_source` stop being `unsafe fn` as a result — their precondition was
  "Media Foundation is started inside an apartment on this thread", which the
  `&MediaFoundation<'_>` they now take proves outright.
- **`uvc.rs` + `uvc/iokit.rs`** (new) — the hand-rolled `extern "C"` blocks are
  replaced by `objc2-core-foundation` / `objc2-io-kit`. `CFRetained`'s drop *is*
  the release; `IOServiceGetMatchingServices` takes the matching dictionary **by
  value**, which is how the binding spells "consumes a reference"; and the vtable
  slots arrive as `Option<fn>` rather than the non-nullable function pointers the
  hand-rolled version declared, where a null slot would have been UB. Everything
  owning a raw handle moved to `uvc/iokit.rs`: `IoObject` releases an
  `io_object_t` (`NonZeroU32`, so IOKit's null object cannot be released as
  though it were real), `IoServices` releases the iterator, `UsbInterface`
  releases the plug-in interface, `SeizedDevice` closes the seize it opened.
  `try_open` and `device_location_id` had six hand-balanced teardown paths
  between them; they now have none.
- That leaves `uvc.rs` with no `unsafe` at all, because the configuration
  descriptor comes back as a `&[u8]` borrowed from the open device instead of a
  raw pointer plus a length. `scan_descriptors` is therefore ordinary safe code
  and gets unit tests it could not have had before.
- **`uvc.rs`** — the descriptor walk now tracks the VideoControl block it is
  inside rather than a "have we seen one" flag, so entities can only be collected
  while inside the interface that owns them. This closes both the
  `VS_FRAME_UNCOMPRESSED`/`VC_PROCESSING_UNIT` `0x05` collision and the
  `VS_OUTPUT_HEADER`/`VC_INPUT_TERMINAL` `0x02` one, and stops a camera terminal
  carrying across an interface boundary.
- **`uvc.rs`** — `cf_string` returns `Option<NonNull>` so a failed CFString
  creation cannot reach an IOKit call that dereferences the key without a null
  check. Structural hardening, not a live bug fix: `CFStringCreateWithCString`
  only returns null on allocation failure for the ASCII literals used here. (A
  NULL key really does `SIGSEGV` in `IORegistryEntrySearchCFProperty` — verified
  with a C probe — the path just is not reachable.) This is superseded by the
  objc2 migration two commits later, which removes the question entirely.

## Testing

```
cargo fmt --all -- --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings         # clean
cargo test --workspace                                        # 25 targets, 0 failed
cargo clippy -p openlogi-camera --target x86_64-pc-windows-gnu \
  --all-targets -- -D warnings                                # clean
```

Every commit was additionally checked out and linted on its own, on both the
host target and `x86_64-pc-windows-gnu`, so the history stays bisectable.

The workspace-wide Windows cross-lint cannot run on this machine — `ring`'s C
build fails under the cross toolchain — so the Windows check is per-crate.
Linux has no toolchain here either; its cfg-gated changes are hand-audited
against master and otherwise rely on CI.

**Hardware verification:**

- **macOS, verified on real hardware.** The rewritten IOKit path enumerates 6 USB
  devices and reads 5 serials, with the Studio Display's location id matching
  what `system_profiler` reports. Resident memory is flat across 2500
  enumerations, which is the check that matters for a change whose whole point is
  release balance.
- **macOS UVC control transfers: not runtime-tested.** No Logitech camera
  attached, so `USBDeviceOpenSeize` and the `GET_*`/`SET_CUR` path are covered
  only by the descriptor-parser unit tests and by compile-time review.
- **Windows: not runtime-tested at all.** No Windows machine. The COM/Media
  Foundation changes are cross-lint-only, with the ordering guarantees confirmed
  by deliberately inverting each guard ordering and checking the compiler
  rejects it.
- **Linux: unaffected by the camera work**, and otherwise only touched by lint
  fixes.

Two behaviours are deliberately left alone, with the reasoning recorded rather
than acted on: `IMFMediaSource::Shutdown` is not called by hand, because with
`MFCreateSourceReaderFromMediaSource` the reader owns that unless
`MF_SOURCE_READER_DISCONNECT_MEDIASOURCE_ON_SHUTDOWN` is set and doing both is
undocumented; and `pump_frames` still does not inspect `ReadSample`'s flags,
which is pre-existing behaviour this PR does not change.
