### PR TITLE
refactor(core,inject): collapse inject backends onto a platform-neutral Effect IR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,6 +5149,7 @@ dependencies = [
  "etcetera",
  "plist",
  "serde",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 etcetera = "0.11.0"
 atomic-write-file = { workspace = true }
+strum = { version = "0.27", features = ["derive"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.10.0"

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -15,6 +15,7 @@ mod application_target;
 mod button;
 mod category;
 mod defaults;
+mod effect;
 mod gesture;
 mod key_combo;
 mod swipe;
@@ -33,6 +34,7 @@ pub use application_target::{ApplicationTarget, ApplicationTargetError};
 pub use button::ButtonId;
 pub use category::Category;
 pub use defaults::{default_binding, default_binding_for, default_gesture_binding};
+pub use effect::{Effect, MediaKey, MouseButton, NativeAction, Script, Shortcut};
 pub use gesture::GestureDirection;
 pub use key_combo::{KeyCombo, KeyComboParseError, KeyboardUsage, KeyboardUsageError};
 pub use swipe::{

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -91,7 +91,7 @@ pub enum MouseButton {
 /// Each backend owns a `Shortcut -> KeyCombo` table (plus, for the couple of
 /// shortcuts a given OS has no ordinary chord for, a small override) rather
 /// than sharing one table — see the per-backend `combo`/`press_shortcut`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, strum::VariantArray)]
 pub enum Shortcut {
     /// Copy the selection.
     Copy,
@@ -130,30 +130,14 @@ pub enum Shortcut {
 impl Shortcut {
     /// Every named shortcut, in declaration order.
     ///
-    /// The single shared iteration source for per-backend `Shortcut ->
-    /// KeyCombo` table-completeness tests, so those tests can't drift into
-    /// three independently-maintained copies of "every `Shortcut`
-    /// variant" — see `tests::all_is_exhaustive` below, which pairs this
-    /// with a wildcard-free match: adding a variant without extending
-    /// both fails to compile.
-    pub const ALL: [Shortcut; 16] = [
-        Shortcut::Copy,
-        Shortcut::Paste,
-        Shortcut::Cut,
-        Shortcut::Undo,
-        Shortcut::Redo,
-        Shortcut::SelectAll,
-        Shortcut::Find,
-        Shortcut::Save,
-        Shortcut::BrowserBack,
-        Shortcut::BrowserForward,
-        Shortcut::NewTab,
-        Shortcut::CloseTab,
-        Shortcut::ReopenTab,
-        Shortcut::NextTab,
-        Shortcut::PrevTab,
-        Shortcut::ReloadPage,
-    ];
+    /// `#[derive(strum::VariantArray)]` generates this straight from the
+    /// enum's variant list at compile time, so it cannot go stale the way a
+    /// hand-written array literal could: there is no second, independently
+    /// editable list for it to drift from — a variant that's missing here
+    /// would mean the enum itself doesn't have it. The single shared
+    /// iteration source for each backend's `Shortcut -> KeyCombo`
+    /// table-completeness test.
+    pub const ALL: &'static [Shortcut] = <Shortcut as strum::VariantArray>::VARIANTS;
 }
 
 /// A media/volume key.
@@ -291,44 +275,6 @@ impl Action {
             Action::RunAppleScript(src) => Effect::Script(Script::AppleScript(src)),
             Action::RunShellCommand(cmd) => Effect::Script(Script::ShellCommand(cmd)),
             Action::Workflow(steps) => Effect::Script(Script::Workflow(steps)),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::Shortcut;
-
-    /// Pairs with [`Shortcut::ALL`]: this match has no wildcard arm, so
-    /// adding a `Shortcut` variant without adding it *here* fails to
-    /// compile — which is the prompt to also add it to `ALL` a few lines
-    /// up, instead of three per-backend test lists silently going stale.
-    #[test]
-    fn all_is_exhaustive() {
-        assert_eq!(
-            Shortcut::ALL.len(),
-            16,
-            "Shortcut::ALL grew or shrank without updating this test"
-        );
-        for shortcut in Shortcut::ALL {
-            match shortcut {
-                Shortcut::Copy
-                | Shortcut::Paste
-                | Shortcut::Cut
-                | Shortcut::Undo
-                | Shortcut::Redo
-                | Shortcut::SelectAll
-                | Shortcut::Find
-                | Shortcut::Save
-                | Shortcut::BrowserBack
-                | Shortcut::BrowserForward
-                | Shortcut::NewTab
-                | Shortcut::CloseTab
-                | Shortcut::ReopenTab
-                | Shortcut::NextTab
-                | Shortcut::PrevTab
-                | Shortcut::ReloadPage => {}
-            }
         }
     }
 }

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -127,6 +127,35 @@ pub enum Shortcut {
     ReloadPage,
 }
 
+impl Shortcut {
+    /// Every named shortcut, in declaration order.
+    ///
+    /// The single shared iteration source for per-backend `Shortcut ->
+    /// KeyCombo` table-completeness tests, so those tests can't drift into
+    /// three independently-maintained copies of "every `Shortcut`
+    /// variant" — see `tests::all_is_exhaustive` below, which pairs this
+    /// with a wildcard-free match: adding a variant without extending
+    /// both fails to compile.
+    pub const ALL: [Shortcut; 16] = [
+        Shortcut::Copy,
+        Shortcut::Paste,
+        Shortcut::Cut,
+        Shortcut::Undo,
+        Shortcut::Redo,
+        Shortcut::SelectAll,
+        Shortcut::Find,
+        Shortcut::Save,
+        Shortcut::BrowserBack,
+        Shortcut::BrowserForward,
+        Shortcut::NewTab,
+        Shortcut::CloseTab,
+        Shortcut::ReopenTab,
+        Shortcut::NextTab,
+        Shortcut::PrevTab,
+        Shortcut::ReloadPage,
+    ];
+}
+
 /// A media/volume key.
 ///
 /// Every backend reaches these through a dedicated OS mechanism — NX
@@ -262,6 +291,44 @@ impl Action {
             Action::RunAppleScript(src) => Effect::Script(Script::AppleScript(src)),
             Action::RunShellCommand(cmd) => Effect::Script(Script::ShellCommand(cmd)),
             Action::Workflow(steps) => Effect::Script(Script::Workflow(steps)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Shortcut;
+
+    /// Pairs with [`Shortcut::ALL`]: this match has no wildcard arm, so
+    /// adding a `Shortcut` variant without adding it *here* fails to
+    /// compile — which is the prompt to also add it to `ALL` a few lines
+    /// up, instead of three per-backend test lists silently going stale.
+    #[test]
+    fn all_is_exhaustive() {
+        assert_eq!(
+            Shortcut::ALL.len(),
+            16,
+            "Shortcut::ALL grew or shrank without updating this test"
+        );
+        for shortcut in Shortcut::ALL {
+            match shortcut {
+                Shortcut::Copy
+                | Shortcut::Paste
+                | Shortcut::Cut
+                | Shortcut::Undo
+                | Shortcut::Redo
+                | Shortcut::SelectAll
+                | Shortcut::Find
+                | Shortcut::Save
+                | Shortcut::BrowserBack
+                | Shortcut::BrowserForward
+                | Shortcut::NewTab
+                | Shortcut::CloseTab
+                | Shortcut::ReopenTab
+                | Shortcut::NextTab
+                | Shortcut::PrevTab
+                | Shortcut::ReloadPage => {}
+            }
         }
     }
 }

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -1,0 +1,267 @@
+//! A platform-neutral synthesis IR.
+//!
+//! [`Action`] has one variant per user-facing behaviour (52 of them), but the
+//! three `openlogi-inject` backends don't care about most of that
+//! granularity — they care about *mechanism*: "press this chord", "click
+//! this mouse button", "fire this media key", "there is no portable way to
+//! do this, use the OS-specific path". [`Action::effect`] is the single
+//! exhaustive match that sorts every variant into one of those buckets, so
+//! each backend matches on ~10-variant [`Effect`] instead of re-deriving the
+//! full `Action` vocabulary three times.
+//!
+//! [`Shortcut`], [`MediaKey`], and [`NativeAction`] are semantic, not
+//! mechanical: the same named shortcut is not the same chord on every OS
+//! (`BrowserBack` is ⌘\[ on macOS, Alt+Left on Linux, and a dedicated
+//! virtual key with no modifier on Windows), so each backend owns its own
+//! lookup table from these enums to its platform's key/API. The
+//! exhaustiveness check on those enums is what keeps all three backends
+//! honest when a variant is added — a backend that forgets a case fails to
+//! compile rather than silently no-op-ing.
+
+use super::action::{Action, WorkflowStep};
+use super::key_combo::KeyCombo;
+
+/// What firing an [`Action`] should do, independent of platform.
+///
+/// `openlogi_inject`'s per-OS backends match on this instead of on
+/// [`Action`] directly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Effect<'a> {
+    /// Suppress the input entirely: no OS event at all.
+    None,
+    /// Synthesise a physical mouse button click.
+    Click(MouseButton),
+    /// Fire a named shortcut. Each backend maps this to its own platform
+    /// chord (or, for the rare shortcut with no chord at all on some OS, a
+    /// dedicated native code path) — see that backend's `combo` table.
+    Shortcut(Shortcut),
+    /// Press an already-resolved keyboard chord: a user-recorded
+    /// [`Action::CustomShortcut`], or a workflow's `PressKey` step.
+    Key(&'a KeyCombo),
+    /// Synthesise one scroll tick. `dx`/`dy` are unit direction (-1/0/1);
+    /// each backend applies its own tick magnitude.
+    Scroll {
+        /// Horizontal direction: -1 left, 1 right, 0 none.
+        dx: i8,
+        /// Vertical direction: -1 down, 1 up, 0 none.
+        dy: i8,
+    },
+    /// Fire a media/volume key. Every backend reaches these through a
+    /// dedicated OS mechanism rather than an ordinary keyboard chord.
+    Media(MediaKey),
+    /// A window-manager or power action with no shared cross-platform
+    /// chord — each backend has its own dedicated handling, which may be a
+    /// debug-logged no-op where the OS has no equivalent at all.
+    Native(NativeAction),
+    /// A power-user scripting escape hatch.
+    Script(Script<'a>),
+    /// Type this text via unicode input.
+    Text(&'a str),
+    /// Handled entirely by the agent/hook layer — DPI presets, SmartShift,
+    /// the Actions Ring, and launching an application. The injector logs
+    /// and does nothing.
+    ///
+    /// [`Action::OpenApplication`] is included here even though
+    /// `openlogi_inject::execute` does open it: that happens in the
+    /// platform-independent dispatcher *before* a backend ever sees the
+    /// action (the config target is opened via the `opener` crate, not
+    /// through any per-OS synthesis path), so from a backend's point of
+    /// view it is exactly as much a no-op as the DPI actions.
+    AgentSide,
+}
+
+/// A physical mouse button an [`Effect::Click`] should press.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MouseButton {
+    /// Primary button.
+    Left,
+    /// Secondary button.
+    Right,
+    /// Wheel-click button.
+    Middle,
+    /// Extra "back" side button (button 4).
+    Back,
+    /// Extra "forward" side button (button 5).
+    Forward,
+}
+
+/// A named shortcut whose chord is the same *concept* on every OS but not
+/// the same keys.
+///
+/// Each backend owns a `Shortcut -> KeyCombo` table (plus, for the couple of
+/// shortcuts a given OS has no ordinary chord for, a small override) rather
+/// than sharing one table — see the per-backend `combo`/`press_shortcut`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Shortcut {
+    /// Copy the selection.
+    Copy,
+    /// Paste from the clipboard.
+    Paste,
+    /// Cut the selection.
+    Cut,
+    /// Undo the last action.
+    Undo,
+    /// Redo the last undone action.
+    Redo,
+    /// Select all content.
+    SelectAll,
+    /// Open find/search.
+    Find,
+    /// Save the current document.
+    Save,
+    /// Navigate backward in browser history.
+    BrowserBack,
+    /// Navigate forward in browser history.
+    BrowserForward,
+    /// Open a new tab.
+    NewTab,
+    /// Close the current tab.
+    CloseTab,
+    /// Reopen the last closed tab.
+    ReopenTab,
+    /// Switch to the next tab.
+    NextTab,
+    /// Switch to the previous tab.
+    PrevTab,
+    /// Reload the current page.
+    ReloadPage,
+}
+
+/// A media/volume key.
+///
+/// Every backend reaches these through a dedicated OS mechanism — NX
+/// system-defined keys on macOS, MPRIS/XF86 keys on Linux, dedicated media
+/// virtual keys on Windows — rather than an ordinary keyboard chord.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MediaKey {
+    /// Toggle play/pause.
+    PlayPause,
+    /// Skip to the next track.
+    NextTrack,
+    /// Go back to the previous track.
+    PrevTrack,
+    /// Increase system volume.
+    VolumeUp,
+    /// Decrease system volume.
+    VolumeDown,
+    /// Toggle system mute.
+    Mute,
+}
+
+/// A window-manager or power action with no shared cross-platform chord.
+///
+/// Each backend reaches it through its own dedicated OS API — or, where the
+/// OS has no equivalent at all, a debug-logged no-op.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum NativeAction {
+    /// Show all windows across spaces (macOS Mission Control).
+    MissionControl,
+    /// Show all windows of the frontmost app (macOS App Exposé).
+    AppExpose,
+    /// Switch to the previous desktop/space.
+    PreviousDesktop,
+    /// Switch to the next desktop/space.
+    NextDesktop,
+    /// Hide all windows to reveal the desktop.
+    ShowDesktop,
+    /// Open the application launcher.
+    LaunchpadShow,
+    /// Lock the screen.
+    LockScreen,
+    /// Capture a full-screen screenshot.
+    Screenshot,
+    /// Capture a selected screen region.
+    CaptureRegion,
+    /// Put the computer to sleep.
+    Sleep,
+}
+
+/// A power-user scripting escape hatch, borrowed from the originating
+/// [`Action::RunAppleScript`], [`Action::RunShellCommand`], or
+/// [`Action::Workflow`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Script<'a> {
+    /// Run an AppleScript source string. macOS-only; other backends warn.
+    AppleScript(&'a str),
+    /// Run a shell command string.
+    ShellCommand(&'a str),
+    /// Run an ordered sequence of workflow steps.
+    Workflow(&'a [WorkflowStep]),
+}
+
+impl Action {
+    /// Classify this action into the platform-neutral [`Effect`] IR that
+    /// `openlogi-inject`'s backends dispatch on.
+    ///
+    /// This is the single exhaustive match over the full [`Action`]
+    /// vocabulary that a new backend needs — see the module docs.
+    #[must_use]
+    pub fn effect(&self) -> Effect<'_> {
+        match self {
+            Action::None => Effect::None,
+
+            Action::LeftClick => Effect::Click(MouseButton::Left),
+            Action::RightClick => Effect::Click(MouseButton::Right),
+            Action::MiddleClick => Effect::Click(MouseButton::Middle),
+            Action::MouseBack => Effect::Click(MouseButton::Back),
+            Action::MouseForward => Effect::Click(MouseButton::Forward),
+
+            Action::Copy => Effect::Shortcut(Shortcut::Copy),
+            Action::Paste => Effect::Shortcut(Shortcut::Paste),
+            Action::Cut => Effect::Shortcut(Shortcut::Cut),
+            Action::Undo => Effect::Shortcut(Shortcut::Undo),
+            Action::Redo => Effect::Shortcut(Shortcut::Redo),
+            Action::SelectAll => Effect::Shortcut(Shortcut::SelectAll),
+            Action::Find => Effect::Shortcut(Shortcut::Find),
+            Action::Save => Effect::Shortcut(Shortcut::Save),
+
+            Action::BrowserBack => Effect::Shortcut(Shortcut::BrowserBack),
+            Action::BrowserForward => Effect::Shortcut(Shortcut::BrowserForward),
+            Action::NewTab => Effect::Shortcut(Shortcut::NewTab),
+            Action::CloseTab => Effect::Shortcut(Shortcut::CloseTab),
+            Action::ReopenTab => Effect::Shortcut(Shortcut::ReopenTab),
+            Action::NextTab => Effect::Shortcut(Shortcut::NextTab),
+            Action::PrevTab => Effect::Shortcut(Shortcut::PrevTab),
+            Action::ReloadPage => Effect::Shortcut(Shortcut::ReloadPage),
+
+            Action::MissionControl => Effect::Native(NativeAction::MissionControl),
+            Action::AppExpose => Effect::Native(NativeAction::AppExpose),
+            Action::PreviousDesktop => Effect::Native(NativeAction::PreviousDesktop),
+            Action::NextDesktop => Effect::Native(NativeAction::NextDesktop),
+            Action::ShowDesktop => Effect::Native(NativeAction::ShowDesktop),
+            Action::LaunchpadShow => Effect::Native(NativeAction::LaunchpadShow),
+
+            Action::LockScreen => Effect::Native(NativeAction::LockScreen),
+            Action::Screenshot => Effect::Native(NativeAction::Screenshot),
+            Action::CaptureRegion => Effect::Native(NativeAction::CaptureRegion),
+            Action::Sleep => Effect::Native(NativeAction::Sleep),
+
+            Action::PlayPause => Effect::Media(MediaKey::PlayPause),
+            Action::NextTrack => Effect::Media(MediaKey::NextTrack),
+            Action::PrevTrack => Effect::Media(MediaKey::PrevTrack),
+            Action::VolumeUp => Effect::Media(MediaKey::VolumeUp),
+            Action::VolumeDown => Effect::Media(MediaKey::VolumeDown),
+            Action::MuteVolume => Effect::Media(MediaKey::Mute),
+
+            // DPI/SmartShift/the Actions Ring/OpenApplication are all handled
+            // above (or beside) the injector — see `Effect::AgentSide`.
+            Action::CycleDpiPresets
+            | Action::SetDpiPreset(_)
+            | Action::ToggleSmartShift
+            | Action::ShowActionsRing
+            | Action::OpenApplication(_) => Effect::AgentSide,
+
+            Action::ScrollUp => Effect::Scroll { dx: 0, dy: 1 },
+            Action::ScrollDown => Effect::Scroll { dx: 0, dy: -1 },
+            Action::HorizontalScrollLeft => Effect::Scroll { dx: -1, dy: 0 },
+            Action::HorizontalScrollRight => Effect::Scroll { dx: 1, dy: 0 },
+
+            Action::CustomShortcut(combo) => Effect::Key(combo),
+
+            Action::TypeText(text) => Effect::Text(text),
+            Action::RunAppleScript(src) => Effect::Script(Script::AppleScript(src)),
+            Action::RunShellCommand(cmd) => Effect::Script(Script::ShellCommand(cmd)),
+            Action::Workflow(steps) => Effect::Script(Script::Workflow(steps)),
+        }
+    }
+}

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -392,3 +392,81 @@ fn haptic_panel_defaults_to_opening_the_actions_ring() {
     );
     assert!(ButtonId::ALL.contains(&ButtonId::HapticPanel));
 }
+
+// ── Effect classification ─────────────────────────────────────────────────
+//
+// `Action::effect()` is the platform-neutral IR `openlogi-inject`'s three
+// backends dispatch on instead of matching `Action` directly. These tests
+// don't re-derive the match (that would be tautological) — they assert the
+// one property every caller actually depends on: every pickable action
+// lowers to *some* real effect, and only `Action::None` is `Effect::None`.
+
+#[test]
+fn catalog_actions_lower_to_a_non_none_effect_except_none() {
+    for action in Action::catalog() {
+        let is_none_effect = matches!(action.effect(), Effect::None);
+        assert_eq!(
+            is_none_effect,
+            action == Action::None,
+            "{action:?} effect classification disagrees with being Action::None"
+        );
+    }
+}
+
+#[test]
+fn power_user_and_device_side_actions_lower_to_the_expected_bucket() {
+    let combo: KeyCombo = "Cmd+P"
+        .parse()
+        .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
+    let custom_shortcut = Action::CustomShortcut(combo);
+    assert_matches!(custom_shortcut.effect(), Effect::Key(_));
+
+    let type_text = Action::TypeText("hi".into());
+    assert_matches!(type_text.effect(), Effect::Text("hi"));
+
+    let run_apple_script = Action::RunAppleScript("beep".into());
+    assert_matches!(
+        run_apple_script.effect(),
+        Effect::Script(Script::AppleScript("beep"))
+    );
+
+    let run_shell_command = Action::RunShellCommand("date".into());
+    assert_matches!(
+        run_shell_command.effect(),
+        Effect::Script(Script::ShellCommand("date"))
+    );
+
+    let workflow = Action::Workflow(vec![]);
+    assert_matches!(workflow.effect(), Effect::Script(Script::Workflow(&[])));
+
+    // DPI/SmartShift/the Actions Ring/OpenApplication are all handled above
+    // or beside the injector, never inside a backend's own dispatch.
+    for action in [
+        Action::CycleDpiPresets,
+        Action::SetDpiPreset(2),
+        Action::ToggleSmartShift,
+        Action::ShowActionsRing,
+    ] {
+        assert_matches!(action.effect(), Effect::AgentSide);
+    }
+    let target = ApplicationTarget::new("/Applications/Safari.app", "")
+        .unwrap_or_else(|error| panic!("valid target failed: {error}"));
+    assert_matches!(Action::OpenApplication(target).effect(), Effect::AgentSide);
+}
+
+#[test]
+fn scroll_actions_lower_to_unit_direction() {
+    assert_eq!(Action::ScrollUp.effect(), Effect::Scroll { dx: 0, dy: 1 });
+    assert_eq!(
+        Action::ScrollDown.effect(),
+        Effect::Scroll { dx: 0, dy: -1 }
+    );
+    assert_eq!(
+        Action::HorizontalScrollLeft.effect(),
+        Effect::Scroll { dx: -1, dy: 0 }
+    );
+    assert_eq!(
+        Action::HorizontalScrollRight.effect(),
+        Effect::Scroll { dx: 1, dy: 0 }
+    );
+}

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -12,112 +12,160 @@ use evdev::uinput::VirtualDevice;
 use evdev::{AttributeSet, EventType, InputEvent, KeyCode, RelativeAxisCode};
 use zbus::blocking::Connection as DbusConn;
 
-use openlogi_core::binding::{Action, WorkflowStep};
+use openlogi_core::binding::{
+    Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
+};
 
-/// Linux implementation: inject events via a shared `uinput` virtual device.
+/// Linux implementation: classify `action` into an [`Effect`] and inject the
+/// resulting events via a shared `uinput` virtual device.
 pub(super) fn execute(action: &Action) {
-    let ctrl = KeyCode::KEY_LEFTCTRL;
-    let shift = KeyCode::KEY_LEFTSHIFT;
-    let alt = KeyCode::KEY_LEFTALT;
-    match action {
-        // ── Mouse clicks ──────────────────────────────────────────────────
-        Action::LeftClick => click(KeyCode::BTN_LEFT),
-        Action::RightClick => click(KeyCode::BTN_RIGHT),
-        Action::MiddleClick => click(KeyCode::BTN_MIDDLE),
+    match action.effect() {
+        Effect::None => {}
         // Extra mouse buttons: BTN_SIDE/BTN_EXTRA are the evdev side
         // buttons ("back"/"forward") browsers handle natively.
-        Action::MouseBack => click(KeyCode::BTN_SIDE),
-        Action::MouseForward => click(KeyCode::BTN_EXTRA),
-        // ── Editing ───────────────────────────────────────────────────────
-        Action::Copy => press_key(&[ctrl], KeyCode::KEY_C),
-        Action::Paste => press_key(&[ctrl], KeyCode::KEY_V),
-        Action::Cut => press_key(&[ctrl], KeyCode::KEY_X),
-        Action::Undo => press_key(&[ctrl], KeyCode::KEY_Z),
-        // Redo is Ctrl+Shift+Z on Linux (matches macOS ⌘⇧Z convention).
-        Action::Redo => press_key(&[ctrl, shift], KeyCode::KEY_Z),
-        Action::SelectAll => press_key(&[ctrl], KeyCode::KEY_A),
-        Action::Find => press_key(&[ctrl], KeyCode::KEY_F),
-        Action::Save => press_key(&[ctrl], KeyCode::KEY_S),
-        // ── Browser / Navigation ──────────────────────────────────────────
-        Action::BrowserBack => press_key(&[alt], KeyCode::KEY_LEFT),
-        Action::BrowserForward => press_key(&[alt], KeyCode::KEY_RIGHT),
-        Action::NewTab => press_key(&[ctrl], KeyCode::KEY_T),
-        Action::CloseTab => press_key(&[ctrl], KeyCode::KEY_W),
-        Action::ReopenTab => press_key(&[ctrl, shift], KeyCode::KEY_T),
-        Action::NextTab => press_key(&[ctrl], KeyCode::KEY_TAB),
-        Action::PrevTab => press_key(&[ctrl, shift], KeyCode::KEY_TAB),
-        Action::ReloadPage => press_key(&[ctrl], KeyCode::KEY_R),
-        // ── Navigation — macOS-specific ───────────────────────────────────
+        Effect::Click(button) => click(mouse_button_code(button)),
+        Effect::Shortcut(shortcut) => press_combo(&combo(shortcut)),
+        Effect::Key(combo) => press_combo(combo),
+        Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
+        Effect::Media(key) => dispatch_media(key),
+        Effect::Native(native) => dispatch_native(action, native),
+        Effect::Script(script) => dispatch_script(script),
+        Effect::Text(text) => {
+            tracing::warn!(
+                chars = text.chars().count(),
+                "TypeText injection is not implemented on Linux yet"
+            );
+        }
+        Effect::AgentSide => {
+            tracing::debug!(
+                action = action.label(),
+                "device action handled by hook/HID layer"
+            );
+        }
+    }
+}
+
+fn mouse_button_code(button: MouseButton) -> KeyCode {
+    match button {
+        MouseButton::Left => KeyCode::BTN_LEFT,
+        MouseButton::Right => KeyCode::BTN_RIGHT,
+        MouseButton::Middle => KeyCode::BTN_MIDDLE,
+        MouseButton::Back => KeyCode::BTN_SIDE,
+        MouseButton::Forward => KeyCode::BTN_EXTRA,
+    }
+}
+
+/// The Linux chord for each named [`Shortcut`].
+///
+/// Parsed through [`KeyCombo`]'s existing, tested `FromStr` rather than
+/// hand-built keycode lists — the table stays a flat, auditable list of
+/// chord strings instead of a second modifier-encoding call site.
+fn combo(shortcut: Shortcut) -> KeyCombo {
+    let text = match shortcut {
+        Shortcut::Copy => "Ctrl+C",
+        Shortcut::Paste => "Ctrl+V",
+        Shortcut::Cut => "Ctrl+X",
+        Shortcut::Undo => "Ctrl+Z",
+        // Ctrl+Shift+Z matches the macOS ⌘⇧Z convention (see `Shortcut::Redo`
+        // doc on `Action`); Ctrl+Y is the GTK/LibreOffice convention and is
+        // left to a `CustomShortcut` binding.
+        Shortcut::Redo => "Ctrl+Shift+Z",
+        Shortcut::SelectAll => "Ctrl+A",
+        Shortcut::Find => "Ctrl+F",
+        Shortcut::Save => "Ctrl+S",
+        Shortcut::BrowserBack => "Alt+Left",
+        Shortcut::BrowserForward => "Alt+Right",
+        Shortcut::NewTab => "Ctrl+T",
+        Shortcut::CloseTab => "Ctrl+W",
+        Shortcut::ReopenTab => "Ctrl+Shift+T",
+        Shortcut::NextTab => "Ctrl+Tab",
+        Shortcut::PrevTab => "Ctrl+Shift+Tab",
+        Shortcut::ReloadPage => "Ctrl+R",
+    };
+    parse_shortcut(text)
+}
+
+fn parse_shortcut(text: &str) -> KeyCombo {
+    text.parse()
+        .unwrap_or_else(|error| unreachable!("hardcoded shortcut table entry {text:?}: {error}"))
+}
+
+/// Press an already-resolved chord: a table lookup from [`combo`] or a
+/// user-recorded [`Action::CustomShortcut`]/`WorkflowStep::PressKey`.
+fn press_combo(combo: &KeyCombo) {
+    let Some(key) = hid_usage_to_linux(combo.key().code()) else {
+        tracing::warn!(
+            usage = combo.key().code(),
+            "shortcut usage has no Linux mapping — press ignored"
+        );
+        return;
+    };
+    press_key(&modifiers_to_keycodes(combo), key);
+}
+
+/// MPRIS targets the running media player; XF86 volume keys go to the
+/// system mixer (PulseAudio/PipeWire) which is what users expect.
+fn dispatch_media(key: MediaKey) {
+    match key {
+        MediaKey::PlayPause => mpris_command("PlayPause"),
+        MediaKey::NextTrack => mpris_command("Next"),
+        MediaKey::PrevTrack => mpris_command("Previous"),
+        MediaKey::VolumeUp => press_key(&[], KeyCode::KEY_VOLUMEUP),
+        MediaKey::VolumeDown => press_key(&[], KeyCode::KEY_VOLUMEDOWN),
+        MediaKey::Mute => press_key(&[], KeyCode::KEY_MUTE),
+    }
+}
+
+/// Dispatch a window-manager or power [`NativeAction`]. `action` is only
+/// used for its label in the "no Linux equivalent" debug log.
+fn dispatch_native(action: &Action, native: NativeAction) {
+    let ctrl = KeyCode::KEY_LEFTCTRL;
+    let alt = KeyCode::KEY_LEFTALT;
+    match native {
         // No universal Linux equivalent; the compositor shortcut varies.
-        Action::MissionControl
-        | Action::AppExpose
-        | Action::ShowDesktop
-        | Action::LaunchpadShow => {
+        NativeAction::MissionControl
+        | NativeAction::AppExpose
+        | NativeAction::ShowDesktop
+        | NativeAction::LaunchpadShow => {
             tracing::debug!(
                 action = action.label(),
                 "no Linux equivalent — action skipped"
             );
         }
         // Ctrl+Alt+←/→ is the default in GNOME and KDE.
-        Action::PreviousDesktop => press_key(&[ctrl, alt], KeyCode::KEY_LEFT),
-        Action::NextDesktop => press_key(&[ctrl, alt], KeyCode::KEY_RIGHT),
-        // ── System ────────────────────────────────────────────────────────
-        // logind LockSessions() via the system bus; falls back to Super+L.
-        Action::LockScreen => lock_screen(),
-        // logind Suspend() via the system bus.
-        Action::Sleep => sleep_system(),
+        NativeAction::PreviousDesktop => press_key(&[ctrl, alt], KeyCode::KEY_LEFT),
+        NativeAction::NextDesktop => press_key(&[ctrl, alt], KeyCode::KEY_RIGHT),
+        // logind LockSession() via the system bus; falls back to Super+L.
+        NativeAction::LockScreen => lock_screen(),
         // Region vs full-screen capture depends on the desktop environment's
         // screenshot handler for Print Screen, so both map to the same key.
-        Action::Screenshot | Action::CaptureRegion => press_key(&[], KeyCode::KEY_SYSRQ),
-        // ── Media ─────────────────────────────────────────────────────────
-        // MPRIS targets the running media player; XF86 volume keys go to the
-        // system mixer (PulseAudio/PipeWire) which is what users expect.
-        Action::PlayPause => mpris_command("PlayPause"),
-        Action::NextTrack => mpris_command("Next"),
-        Action::PrevTrack => mpris_command("Previous"),
-        Action::VolumeUp => press_key(&[], KeyCode::KEY_VOLUMEUP),
-        Action::VolumeDown => press_key(&[], KeyCode::KEY_VOLUMEDOWN),
-        Action::MuteVolume => press_key(&[], KeyCode::KEY_MUTE),
-        // ── DPI / SmartShift: handled at hook/HID layer ───────────────────
-        Action::CycleDpiPresets
-        | Action::SetDpiPreset(_)
-        | Action::ToggleSmartShift
-        | Action::ShowActionsRing
-        | Action::OpenApplication(_) => {
-            tracing::debug!(
-                action = action.label(),
-                "device action handled by hook/HID layer"
-            );
+        NativeAction::Screenshot | NativeAction::CaptureRegion => {
+            press_key(&[], KeyCode::KEY_SYSRQ);
         }
-        // ── Scroll ────────────────────────────────────────────────────────
-        Action::ScrollUp => scroll(RelativeAxisCode::REL_WHEEL, 3),
-        Action::ScrollDown => scroll(RelativeAxisCode::REL_WHEEL, -3),
-        Action::HorizontalScrollLeft => scroll(RelativeAxisCode::REL_HWHEEL, -3),
-        Action::HorizontalScrollRight => scroll(RelativeAxisCode::REL_HWHEEL, 3),
-        // ── No-op ─────────────────────────────────────────────────────────
-        Action::None => {}
-        // ── Custom shortcut ───────────────────────────────────────────────
-        Action::CustomShortcut(combo) => {
-            let Some(key) = hid_usage_to_linux(combo.key().code()) else {
-                tracing::warn!(
-                    usage = combo.key().code(),
-                    "CustomShortcut usage has no Linux mapping — press ignored"
-                );
-                return;
-            };
-            press_key(&modifiers_to_keycodes(combo), key);
-        }
-        Action::TypeText(text) => {
-            tracing::warn!(
-                chars = text.chars().count(),
-                "TypeText injection is not implemented on Linux yet"
-            );
-        }
-        Action::RunAppleScript(_) => {
+        // logind Suspend() via the system bus.
+        NativeAction::Sleep => sleep_system(),
+    }
+}
+
+fn dispatch_script(script: Script<'_>) {
+    match script {
+        Script::AppleScript(_) => {
             tracing::warn!("RunAppleScript is only supported on macOS");
         }
-        Action::RunShellCommand(cmd) => run_shell_command_async(cmd.clone()),
-        Action::Workflow(steps) => run_workflow_async(steps.clone()),
+        Script::ShellCommand(cmd) => run_shell_command_async(cmd.to_string()),
+        Script::Workflow(steps) => run_workflow_async(steps.to_vec()),
+    }
+}
+
+/// Synthesise one scroll tick in direction `(dx, dy)`. Unit direction
+/// (-1/0/1) scaled by the fixed relative-axis magnitude the four
+/// `Scroll*`/`HorizontalScroll*` actions have always used.
+fn dispatch_scroll(dx: i8, dy: i8) {
+    if dy != 0 {
+        scroll(RelativeAxisCode::REL_WHEEL, i32::from(dy) * 3);
+    }
+    if dx != 0 {
+        scroll(RelativeAxisCode::REL_HWHEEL, i32::from(dx) * 3);
     }
 }
 
@@ -561,9 +609,9 @@ fn try_mpris_command(command: &str) -> Option<()> {
 #[cfg(test)]
 mod tests {
     use evdev::KeyCode;
-    use openlogi_core::binding::KeyCombo;
+    use openlogi_core::binding::{KeyCombo, Shortcut};
 
-    use super::{hid_usage_to_linux, modifiers_to_keycodes};
+    use super::{combo, hid_usage_to_linux, modifiers_to_keycodes};
 
     #[test]
     fn modifiers_map_to_linux_without_duplicate_control() {
@@ -587,5 +635,44 @@ mod tests {
         assert_eq!(hid_usage_to_linux(0x3a), Some(KeyCode::KEY_F1));
         assert_eq!(hid_usage_to_linux(0x6f), Some(KeyCode::KEY_F20));
         assert_eq!(hid_usage_to_linux(0xff), None);
+    }
+
+    /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an
+    /// edit to the table can't silently change what Ctrl+C sends.
+    /// `BrowserBack` and `Redo` differ from macOS/Windows by design (see
+    /// the module doc on `combo`), so each backend pins its own rows.
+    #[test]
+    fn combo_table_pins_representative_shortcuts() {
+        assert_eq!(combo(Shortcut::Copy).rendered_label(), "Ctrl+C");
+        assert_eq!(combo(Shortcut::Redo).rendered_label(), "Ctrl+Shift+Z");
+        assert_eq!(combo(Shortcut::BrowserBack).rendered_label(), "Alt+Left");
+        assert_eq!(combo(Shortcut::NextTab).rendered_label(), "Ctrl+Tab");
+        // hid_usage_to_linux must actually resolve every table entry, or a
+        // `Shortcut` silently no-ops instead of pressing anything (see
+        // `press_combo`'s warn-and-drop path).
+        for shortcut in [
+            Shortcut::Copy,
+            Shortcut::Paste,
+            Shortcut::Cut,
+            Shortcut::Undo,
+            Shortcut::Redo,
+            Shortcut::SelectAll,
+            Shortcut::Find,
+            Shortcut::Save,
+            Shortcut::BrowserBack,
+            Shortcut::BrowserForward,
+            Shortcut::NewTab,
+            Shortcut::CloseTab,
+            Shortcut::ReopenTab,
+            Shortcut::NextTab,
+            Shortcut::PrevTab,
+            Shortcut::ReloadPage,
+        ] {
+            let key = combo(shortcut).key().code();
+            assert!(
+                hid_usage_to_linux(key).is_some(),
+                "{shortcut:?} table entry has no Linux keycode mapping"
+            );
+        }
     }
 }

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -649,25 +649,11 @@ mod tests {
         assert_eq!(combo(Shortcut::NextTab).rendered_label(), "Ctrl+Tab");
         // hid_usage_to_linux must actually resolve every table entry, or a
         // `Shortcut` silently no-ops instead of pressing anything (see
-        // `press_combo`'s warn-and-drop path).
-        for shortcut in [
-            Shortcut::Copy,
-            Shortcut::Paste,
-            Shortcut::Cut,
-            Shortcut::Undo,
-            Shortcut::Redo,
-            Shortcut::SelectAll,
-            Shortcut::Find,
-            Shortcut::Save,
-            Shortcut::BrowserBack,
-            Shortcut::BrowserForward,
-            Shortcut::NewTab,
-            Shortcut::CloseTab,
-            Shortcut::ReopenTab,
-            Shortcut::NextTab,
-            Shortcut::PrevTab,
-            Shortcut::ReloadPage,
-        ] {
+        // `press_combo`'s warn-and-drop path). Iterates `Shortcut::ALL`
+        // rather than a hand-copied list, so a newly added `Shortcut`
+        // variant is checked here automatically instead of depending on
+        // someone remembering to extend a second, independent list.
+        for shortcut in Shortcut::ALL {
             let key = combo(shortcut).key().code();
             assert!(
                 hid_usage_to_linux(key).is_some(),

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -653,7 +653,7 @@ mod tests {
         // rather than a hand-copied list, so a newly added `Shortcut`
         // variant is checked here automatically instead of depending on
         // someone remembering to extend a second, independent list.
-        for shortcut in Shortcut::ALL {
+        for &shortcut in Shortcut::ALL {
             let key = combo(shortcut).key().code();
             assert!(
                 hid_usage_to_linux(key).is_some(),

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -368,7 +368,7 @@ mod tests {
         // rather than a hand-copied list, so a newly added `Shortcut`
         // variant is checked here automatically instead of depending on
         // someone remembering to extend a second, independent list.
-        for shortcut in Shortcut::ALL {
+        for &shortcut in Shortcut::ALL {
             let key = combo(shortcut).key().code();
             assert!(
                 hid_usage_to_macos(key).is_some(),

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -8,7 +8,9 @@ use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use core_graphics::geometry::CGPoint;
 
 use core_foundation::base::TCFType as _;
-use openlogi_core::binding::{Action, KeyCombo, WorkflowStep};
+use openlogi_core::binding::{
+    Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
+};
 
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
 const NX_KEYTYPE_SOUND_UP: i32 = 0;
@@ -18,127 +20,136 @@ const NX_KEYTYPE_PLAY: i32 = 16;
 const NX_KEYTYPE_NEXT: i32 = 17;
 const NX_KEYTYPE_PREVIOUS: i32 = 18;
 
-// ── macOS virtual key codes ────────────────────────────────────────────────
-// Source: <HIToolbox/Events.h> kVK_* constants. Values are layout-independent
-// for the US ANSI keyboard.
-const VK_A: u16 = 0x00;
-const VK_C: u16 = 0x08;
-const VK_F: u16 = 0x03;
-const VK_R: u16 = 0x0F;
-const VK_S: u16 = 0x01;
-const VK_T: u16 = 0x11;
-const VK_V: u16 = 0x09;
-const VK_W: u16 = 0x0D;
-const VK_X: u16 = 0x07;
-const VK_Z: u16 = 0x06;
-const VK_TAB: u16 = 0x30;
-
-/// macOS implementation: dispatch to the appropriate event helper.
+/// macOS implementation: classify `action` into an [`Effect`] and dispatch
+/// to the appropriate event helper.
 pub(super) fn execute(action: &Action) {
-    // Modifier bit shorthands.
-    let cmd = CGEventFlags::CGEventFlagCommand;
-    let shift = CGEventFlags::CGEventFlagShift;
-    let ctrl = CGEventFlags::CGEventFlagControl;
-
-    match action {
+    match action.effect() {
         // Suppressed input: captured but deliberately produces no event.
-        Action::None => {}
-        // ── Mouse clicks: synthesise a click at the cursor ────────────────
+        Effect::None => {}
         // Remapping a *different* button to a click lands here (e.g. Back →
         // MiddleClick). A button left on its own native click never reaches
         // this — the hook passes it straight through to the OS.
-        Action::LeftClick => post_click(CGMouseButton::Left),
-        Action::RightClick => post_click(CGMouseButton::Right),
-        Action::MiddleClick => post_click(CGMouseButton::Center),
-        // Extra mouse buttons: post the real button4/5 the OS treats as
-        // back/forward. Button numbers are 0-indexed (3 = back / "button 4",
-        // 4 = forward / "button 5").
-        Action::MouseBack => post_other_button(3),
-        Action::MouseForward => post_other_button(4),
-        // ── Editing ───────────────────────────────────────────────────────
-        Action::Copy => post_key(VK_C, cmd),
-        Action::Paste => post_key(VK_V, cmd),
-        Action::Cut => post_key(VK_X, cmd),
-        Action::Undo => post_key(VK_Z, cmd),
-        Action::Redo => post_key(VK_Z, cmd | shift),
-        Action::SelectAll => post_key(VK_A, cmd),
-        Action::Find => post_key(VK_F, cmd),
-        Action::Save => post_key(VK_S, cmd),
-        // ── Browser / Navigation ──────────────────────────────────────────
-        // BrowserBack/Forward: Cmd+[ / Cmd+] for Chrome and other apps.
-        // Safari is handled upstream via ax_navigate_browser() with the PID
-        // captured at press time — by the time execute() is called the AX path
-        // has already run, so this fallback is for non-Safari browsers only.
-        // kVK_ANSI_LeftBracket = 0x21, kVK_ANSI_RightBracket = 0x1E
-        Action::BrowserBack => post_key(0x21, cmd),
-        Action::BrowserForward => post_key(0x1E, cmd),
-        Action::NewTab => post_key(VK_T, cmd),
-        Action::CloseTab => post_key(VK_W, cmd),
-        Action::ReopenTab => post_key(VK_T, cmd | shift),
-        Action::NextTab => post_key(VK_TAB, ctrl),
-        Action::PrevTab => post_key(VK_TAB, ctrl | shift),
-        Action::ReloadPage => post_key(VK_R, cmd),
-        // ── Navigation / Window: posted straight to the Dock ──────────────
-        // Synthesising these shortcuts is unreliable — the WindowServer
-        // matcher needs the exact configured key (incl. the Fn flag) and
-        // Show Desktop ignores synthetic events entirely — so they go to the
-        // Dock via `CoreDockSendNotification`, which fires regardless of the
-        // user's keyboard settings.
-        Action::MissionControl => mission_control(),
-        Action::AppExpose => app_expose(),
-        Action::PreviousDesktop => previous_desktop(),
-        Action::NextDesktop => next_desktop(),
-        Action::ShowDesktop => show_desktop(),
-        Action::LaunchpadShow => launchpad(),
-        // ── System ────────────────────────────────────────────────────────
-        // Lock screen = Cmd+Ctrl+Q (kVK_ANSI_Q = 0x0C)
-        Action::LockScreen => post_key(0x0C, cmd | ctrl),
-        // Screenshot = Cmd+Shift+3 (kVK_ANSI_3 = 0x14)
-        Action::Screenshot => post_key(0x14, cmd | shift),
-        // Capture region to clipboard = Cmd+Shift+Ctrl+4 (kVK_ANSI_4 = 0x15)
-        Action::CaptureRegion => post_key(0x15, cmd | shift | ctrl),
-        // Sleep has no CGEvent equivalent (the WindowServer ignores a
-        // synthesised power key), so ask powermanagement directly. `pmset
-        // sleepnow` works for the console user without privileges.
-        Action::Sleep => sleep_system(),
-        // ── Media ─────────────────────────────────────────────────────────
+        Effect::Click(button) => dispatch_click(button),
+        Effect::Shortcut(shortcut) => post_keycombo(&combo(shortcut)),
+        Effect::Key(combo) => post_keycombo(combo),
+        Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         // Media/volume controls are NX system-defined keys, not ordinary
         // keyboard virtual-key events. Posting kVK_Volume* through
         // CGEventCreateKeyboardEvent is ignored by macOS' volume handler.
-        Action::PlayPause => post_media_key(NX_KEYTYPE_PLAY),
-        Action::NextTrack => post_media_key(NX_KEYTYPE_NEXT),
-        Action::PrevTrack => post_media_key(NX_KEYTYPE_PREVIOUS),
-        Action::VolumeUp => post_media_key(NX_KEYTYPE_SOUND_UP),
-        Action::VolumeDown => post_media_key(NX_KEYTYPE_SOUND_DOWN),
-        Action::MuteVolume => post_media_key(NX_KEYTYPE_MUTE),
-        // ── DPI / SmartShift: handled at hook/HID layer ───────────────────
-        Action::CycleDpiPresets
-        | Action::SetDpiPreset(_)
-        | Action::ToggleSmartShift
-        | Action::ShowActionsRing
-        | Action::OpenApplication(_) => {
+        Effect::Media(key) => post_media_key(nx_key(key)),
+        Effect::Native(native) => dispatch_native(native),
+        Effect::Script(script) => dispatch_script(script),
+        // TypeText emits a unicode string, layout-independent.
+        Effect::Text(text) => post_unicode(text),
+        Effect::AgentSide => {
             tracing::debug!(
                 action = action.label(),
                 "device action handled by hook/HID layer"
             );
         }
-        // ── Scroll ────────────────────────────────────────────────────────
-        Action::ScrollUp
-        | Action::ScrollDown
-        | Action::HorizontalScrollLeft
-        | Action::HorizontalScrollRight => post_scroll(action),
-        // ── Custom ────────────────────────────────────────────────────────
-        Action::CustomShortcut(combo) => {
-            post_keycombo(combo);
-        }
-        // TypeText emits a unicode string, layout-independent.
-        Action::TypeText(text) => post_unicode(text),
-        // Run actions spawn off the tap thread: the callback must not block
-        // (posting a key while waiting on a child process would wedge input).
-        Action::RunAppleScript(src) => run_apple_script_async(src.clone()),
-        Action::RunShellCommand(cmd) => run_shell_command_async(cmd.clone()),
-        // Workflows can sleep between steps, so they also run off the tap thread.
-        Action::Workflow(steps) => run_workflow_async(steps.clone()),
+    }
+}
+
+/// Synthesise a click for `button` at the cursor location. Extra buttons
+/// post the real button4/5 the OS treats as back/forward.
+fn dispatch_click(button: MouseButton) {
+    match button {
+        MouseButton::Left => post_click(CGMouseButton::Left),
+        MouseButton::Right => post_click(CGMouseButton::Right),
+        MouseButton::Middle => post_click(CGMouseButton::Center),
+        // Button numbers are 0-indexed (3 = back / "button 4", 4 = forward /
+        // "button 5").
+        MouseButton::Back => post_other_button(3),
+        MouseButton::Forward => post_other_button(4),
+    }
+}
+
+/// The macOS chord for each named [`Shortcut`].
+///
+/// Parsed through [`KeyCombo`]'s existing, tested `FromStr` rather than
+/// hand-built modifier bits — the table stays a flat, auditable list of
+/// chord strings instead of a second bit-packing call site.
+fn combo(shortcut: Shortcut) -> KeyCombo {
+    let text = match shortcut {
+        Shortcut::Copy => "Cmd+C",
+        Shortcut::Paste => "Cmd+V",
+        Shortcut::Cut => "Cmd+X",
+        Shortcut::Undo => "Cmd+Z",
+        Shortcut::Redo => "Cmd+Shift+Z",
+        Shortcut::SelectAll => "Cmd+A",
+        Shortcut::Find => "Cmd+F",
+        Shortcut::Save => "Cmd+S",
+        // Cmd+[ / Cmd+] for Chrome and other apps. Safari is handled
+        // upstream via ax_navigate_browser() with the PID captured at press
+        // time — by the time execute() is called the AX path has already
+        // run, so this is the fallback for non-Safari browsers only.
+        Shortcut::BrowserBack => "Cmd+[",
+        Shortcut::BrowserForward => "Cmd+]",
+        Shortcut::NewTab => "Cmd+T",
+        Shortcut::CloseTab => "Cmd+W",
+        Shortcut::ReopenTab => "Cmd+Shift+T",
+        Shortcut::NextTab => "Ctrl+Tab",
+        Shortcut::PrevTab => "Ctrl+Shift+Tab",
+        Shortcut::ReloadPage => "Cmd+R",
+    };
+    parse_shortcut(text)
+}
+
+fn parse_shortcut(text: &str) -> KeyCombo {
+    text.parse()
+        .unwrap_or_else(|error| unreachable!("hardcoded shortcut table entry {text:?}: {error}"))
+}
+
+/// Dispatch a window-manager or power [`NativeAction`].
+///
+/// These are all posted straight to the Dock or WindowServer via private
+/// SPIs rather than a synthesised keyboard chord — see the module docs on
+/// [`mission_control`] and friends for why.
+fn dispatch_native(native: NativeAction) {
+    let cmd = CGEventFlags::CGEventFlagCommand;
+    let shift = CGEventFlags::CGEventFlagShift;
+    let ctrl = CGEventFlags::CGEventFlagControl;
+    match native {
+        NativeAction::MissionControl => mission_control(),
+        NativeAction::AppExpose => app_expose(),
+        NativeAction::PreviousDesktop => previous_desktop(),
+        NativeAction::NextDesktop => next_desktop(),
+        NativeAction::ShowDesktop => show_desktop(),
+        NativeAction::LaunchpadShow => launchpad(),
+        // Lock screen = Cmd+Ctrl+Q (kVK_ANSI_Q = 0x0C)
+        NativeAction::LockScreen => post_key(0x0C, cmd | ctrl),
+        // Screenshot = Cmd+Shift+3 (kVK_ANSI_3 = 0x14)
+        NativeAction::Screenshot => post_key(0x14, cmd | shift),
+        // Capture region to clipboard = Cmd+Shift+Ctrl+4 (kVK_ANSI_4 = 0x15)
+        NativeAction::CaptureRegion => post_key(0x15, cmd | shift | ctrl),
+        // Sleep has no CGEvent equivalent (the WindowServer ignores a
+        // synthesised power key), so ask powermanagement directly. `pmset
+        // sleepnow` works for the console user without privileges.
+        NativeAction::Sleep => sleep_system(),
+    }
+}
+
+fn nx_key(key: MediaKey) -> i32 {
+    match key {
+        MediaKey::PlayPause => NX_KEYTYPE_PLAY,
+        MediaKey::NextTrack => NX_KEYTYPE_NEXT,
+        MediaKey::PrevTrack => NX_KEYTYPE_PREVIOUS,
+        MediaKey::VolumeUp => NX_KEYTYPE_SOUND_UP,
+        MediaKey::VolumeDown => NX_KEYTYPE_SOUND_DOWN,
+        MediaKey::Mute => NX_KEYTYPE_MUTE,
+    }
+}
+
+/// Dispatch a power-user scripting [`Script`] action.
+///
+/// All three spawn off the tap thread: the callback must not block (posting
+/// a key while waiting on a child process, or sleeping through a workflow
+/// `Delay`, would wedge input).
+fn dispatch_script(script: Script<'_>) {
+    match script {
+        Script::AppleScript(src) => run_apple_script_async(src.to_string()),
+        Script::ShellCommand(cmd) => run_shell_command_async(cmd.to_string()),
+        Script::Workflow(steps) => run_workflow_async(steps.to_vec()),
     }
 }
 
@@ -326,7 +337,9 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
-    use super::hid_usage_to_macos;
+    use openlogi_core::binding::Shortcut;
+
+    use super::{combo, hid_usage_to_macos};
 
     #[test]
     fn hid_usages_map_to_macos_virtual_keys() {
@@ -336,6 +349,46 @@ mod tests {
         assert_eq!(hid_usage_to_macos(0x3a), Some(0x7a));
         assert_eq!(hid_usage_to_macos(0x6f), Some(0x5a));
         assert_eq!(hid_usage_to_macos(0xff), None);
+    }
+
+    /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an
+    /// edit to the table can't silently change what ⌘C sends. macOS and
+    /// Linux only overlap on the letter-key chords: both `BrowserBack` and
+    /// `Redo` differ across the three backends by design (see the module
+    /// doc on `combo`), so each backend pins its own rows independently.
+    #[test]
+    fn combo_table_pins_representative_shortcuts() {
+        assert_eq!(combo(Shortcut::Copy).rendered_label(), "Cmd+C");
+        assert_eq!(combo(Shortcut::Redo).rendered_label(), "Cmd+Shift+Z");
+        assert_eq!(combo(Shortcut::BrowserBack).rendered_label(), "Cmd+[");
+        assert_eq!(combo(Shortcut::NextTab).rendered_label(), "Ctrl+Tab");
+        // hid_usage_to_macos must actually resolve every table entry, or a
+        // `Shortcut` silently no-ops instead of pressing anything (see
+        // `post_keycombo`'s warn-and-drop path).
+        for shortcut in [
+            Shortcut::Copy,
+            Shortcut::Paste,
+            Shortcut::Cut,
+            Shortcut::Undo,
+            Shortcut::Redo,
+            Shortcut::SelectAll,
+            Shortcut::Find,
+            Shortcut::Save,
+            Shortcut::BrowserBack,
+            Shortcut::BrowserForward,
+            Shortcut::NewTab,
+            Shortcut::CloseTab,
+            Shortcut::ReopenTab,
+            Shortcut::NextTab,
+            Shortcut::PrevTab,
+            Shortcut::ReloadPage,
+        ] {
+            let key = combo(shortcut).key().code();
+            assert!(
+                hid_usage_to_macos(key).is_some(),
+                "{shortcut:?} table entry has no macOS virtual-key mapping"
+            );
+        }
     }
 }
 
@@ -442,19 +495,16 @@ fn sleep_system() {
     }
 }
 
-/// Post a synthetic scroll event for `action` (one of the `Scroll*` variants).
-fn post_scroll(action: &Action) {
+/// Post a synthetic scroll event for one tick in direction `(dx, dy)`. Unit
+/// direction (-1/0/1) scaled by the fixed "one tick" pixel magnitude the
+/// four `Scroll*`/`HorizontalScroll*` actions have always used.
+fn dispatch_scroll(dx: i8, dy: i8) {
     let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
         tracing::warn!("CGEventSource::new failed for scroll");
         return;
     };
-    let (v, h): (i32, i32) = match action {
-        Action::ScrollUp => (3, 0),
-        Action::ScrollDown => (-3, 0),
-        Action::HorizontalScrollLeft => (0, -3),
-        Action::HorizontalScrollRight => (0, 3),
-        _ => return,
-    };
+    let v = i32::from(dy) * 3;
+    let h = i32::from(dx) * 3;
     let Ok(ev) = CGEvent::new_scroll_event(src, ScrollEventUnit::PIXEL, 2, v, h, 0) else {
         tracing::warn!("CGEvent::new_scroll_event failed");
         return;

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -364,25 +364,11 @@ mod tests {
         assert_eq!(combo(Shortcut::NextTab).rendered_label(), "Ctrl+Tab");
         // hid_usage_to_macos must actually resolve every table entry, or a
         // `Shortcut` silently no-ops instead of pressing anything (see
-        // `post_keycombo`'s warn-and-drop path).
-        for shortcut in [
-            Shortcut::Copy,
-            Shortcut::Paste,
-            Shortcut::Cut,
-            Shortcut::Undo,
-            Shortcut::Redo,
-            Shortcut::SelectAll,
-            Shortcut::Find,
-            Shortcut::Save,
-            Shortcut::BrowserBack,
-            Shortcut::BrowserForward,
-            Shortcut::NewTab,
-            Shortcut::CloseTab,
-            Shortcut::ReopenTab,
-            Shortcut::NextTab,
-            Shortcut::PrevTab,
-            Shortcut::ReloadPage,
-        ] {
+        // `post_keycombo`'s warn-and-drop path). Iterates `Shortcut::ALL`
+        // rather than a hand-copied list, so a newly added `Shortcut`
+        // variant is checked here automatically instead of depending on
+        // someone remembering to extend a second, independent list.
+        for shortcut in Shortcut::ALL {
             let key = combo(shortcut).key().code();
             assert!(
                 hid_usage_to_macos(key).is_some(),

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -10,23 +10,15 @@ use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
     MOUSEEVENTF_XUP, MOUSEINPUT, SendInput,
 };
 
-use openlogi_core::binding::{Action, KeyCombo, WorkflowStep};
+use openlogi_core::binding::{
+    Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
+};
 
 const WHEEL_DELTA: i32 = 120;
 
-const VK_A: u16 = 0x41;
-const VK_C: u16 = 0x43;
 const VK_D: u16 = 0x44;
-const VK_F: u16 = 0x46;
 const VK_L: u16 = 0x4C;
-const VK_R: u16 = 0x52;
 const VK_S: u16 = 0x53;
-const VK_T: u16 = 0x54;
-const VK_V: u16 = 0x56;
-const VK_W: u16 = 0x57;
-const VK_X: u16 = 0x58;
-const VK_Y: u16 = 0x59;
-const VK_Z: u16 = 0x5A;
 const VK_TAB: u16 = 0x09;
 const VK_LEFT: u16 = 0x25;
 const VK_RIGHT: u16 = 0x27;
@@ -43,109 +35,130 @@ const VK_MEDIA_NEXT_TRACK: u16 = 0xB0;
 const VK_MEDIA_PREV_TRACK: u16 = 0xB1;
 const VK_MEDIA_PLAY_PAUSE: u16 = 0xB3;
 
-#[derive(Clone, Copy)]
-enum MouseButton {
-    Left,
-    Right,
-    Middle,
-    /// Extra button 4 ("back").
-    Back,
-    /// Extra button 5 ("forward").
-    Forward,
-}
-
 // XBUTTON1/XBUTTON2 from WinUser.h — windows-sys puts them behind the
 // Win32_UI_WindowsAndMessaging feature; not worth enabling for two
 // integers (same treatment as the VK_* codes above).
 const XBUTTON1: i32 = 1;
 const XBUTTON2: i32 = 2;
 
-/// Windows implementation: synthesise events via `SendInput`. macOS
-/// window-manager actions map to their Windows equivalents; `CustomShortcut`
-/// maps macOS `kVK_*` codes to Windows virtual-key codes (Cmd → Ctrl).
+/// Windows implementation: classify `action` into an [`Effect`] and
+/// synthesise events via `SendInput`. macOS window-manager actions map to
+/// their Windows equivalents; `CustomShortcut` maps macOS `kVK_*` codes to
+/// Windows virtual-key codes (Cmd → Ctrl).
 pub(super) fn execute(action: &Action) {
-    match action {
-        Action::LeftClick => post_click(MouseButton::Left),
-        Action::RightClick => post_click(MouseButton::Right),
-        Action::MiddleClick => post_click(MouseButton::Middle),
-        Action::MouseBack => post_click(MouseButton::Back),
-        Action::MouseForward => post_click(MouseButton::Forward),
-        Action::Copy => post_key(VK_C, &[VK_CONTROL]),
-        Action::Paste => post_key(VK_V, &[VK_CONTROL]),
-        Action::Cut => post_key(VK_X, &[VK_CONTROL]),
-        Action::Undo => post_key(VK_Z, &[VK_CONTROL]),
-        Action::Redo => post_key(VK_Y, &[VK_CONTROL]),
-        Action::SelectAll => post_key(VK_A, &[VK_CONTROL]),
-        Action::Find => post_key(VK_F, &[VK_CONTROL]),
-        Action::Save => post_key(VK_S, &[VK_CONTROL]),
-        Action::BrowserBack => post_key(VK_BROWSER_BACK, &[]),
-        Action::BrowserForward => post_key(VK_BROWSER_FORWARD, &[]),
-        Action::NewTab => post_key(VK_T, &[VK_CONTROL]),
-        Action::CloseTab => post_key(VK_W, &[VK_CONTROL]),
-        Action::ReopenTab => {
-            post_key(VK_T, &[VK_CONTROL, VK_SHIFT]);
-        }
-        Action::NextTab => post_key(VK_TAB, &[VK_CONTROL]),
-        Action::PrevTab => {
-            post_key(VK_TAB, &[VK_CONTROL, VK_SHIFT]);
-        }
-        Action::ReloadPage => post_key(VK_R, &[VK_CONTROL]),
-        Action::MissionControl | Action::AppExpose => {
-            post_key(VK_TAB, &[VK_LWIN]);
-        }
-        Action::PreviousDesktop => {
-            post_key(VK_LEFT, &[VK_LWIN, VK_CONTROL]);
-        }
-        Action::NextDesktop => {
-            post_key(VK_RIGHT, &[VK_LWIN, VK_CONTROL]);
-        }
-        Action::ShowDesktop => post_key(VK_D, &[VK_LWIN]),
-        Action::LaunchpadShow => post_key(VK_LWIN, &[]),
-        Action::LockScreen => post_key(VK_L, &[VK_LWIN]),
-        // Win+Shift+S opens the snip overlay, which serves both full-screen
-        // and region capture on Windows.
-        Action::Screenshot | Action::CaptureRegion => {
-            post_key(VK_S, &[VK_LWIN, VK_SHIFT]);
-        }
-        // Suspending reliably needs `SetSuspendState` (powrprof.dll), which
-        // hibernates instead when hibernation is enabled — no clean win from
-        // a background agent, so the action is skipped on Windows for now.
-        Action::Sleep => {
-            tracing::debug!("Sleep has no Windows synthesis yet — action skipped");
-        }
-        Action::PlayPause => post_key(VK_MEDIA_PLAY_PAUSE, &[]),
-        Action::NextTrack => post_key(VK_MEDIA_NEXT_TRACK, &[]),
-        Action::PrevTrack => post_key(VK_MEDIA_PREV_TRACK, &[]),
-        Action::VolumeUp => post_key(VK_VOLUME_UP, &[]),
-        Action::VolumeDown => post_key(VK_VOLUME_DOWN, &[]),
-        Action::MuteVolume => post_key(VK_VOLUME_MUTE, &[]),
-        Action::CycleDpiPresets
-        | Action::SetDpiPreset(_)
-        | Action::ToggleSmartShift
-        | Action::ShowActionsRing
-        | Action::OpenApplication(_) => {
-            tracing::debug!(
-                action = action.label(),
-                "device action handled by hook/HID layer"
-            );
-        }
-        Action::ScrollUp
-        | Action::ScrollDown
-        | Action::HorizontalScrollLeft
-        | Action::HorizontalScrollRight => post_scroll(action),
-        Action::CustomShortcut(combo) => post_custom_shortcut(combo),
-        Action::TypeText(text) => {
+    match action.effect() {
+        Effect::None => {}
+        Effect::Click(button) => post_click(button),
+        Effect::Shortcut(shortcut) => press_shortcut(shortcut),
+        Effect::Key(combo) => post_custom_shortcut(combo),
+        Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
+        Effect::Media(key) => dispatch_media(key),
+        Effect::Native(native) => dispatch_native(native),
+        Effect::Script(script) => dispatch_script(script),
+        Effect::Text(text) => {
             tracing::warn!(
                 chars = text.chars().count(),
                 "TypeText injection is not implemented on Windows yet"
             );
         }
-        Action::RunAppleScript(_) => {
+        Effect::AgentSide => {
+            tracing::debug!(
+                action = action.label(),
+                "device action handled by hook/HID layer"
+            );
+        }
+    }
+}
+
+/// The Windows chord for a named [`Shortcut`], or the raw virtual key to
+/// post with no modifier when Windows has no chord-shaped representation
+/// for it at all.
+///
+/// `BrowserBack`/`BrowserForward` are Windows' one exception: they fire a
+/// dedicated virtual key (`VK_BROWSER_BACK`/`_FORWARD`) with no modifier,
+/// which isn't a USB HID keyboard usage and so has no [`KeyCombo`]
+/// representation — unlike on macOS/Linux, where the same shortcuts are
+/// ordinary modifier+key chords. [`press_shortcut`] posts the `Err` case
+/// directly instead of routing it through [`post_custom_shortcut`].
+fn combo(shortcut: Shortcut) -> Result<KeyCombo, u16> {
+    let text = match shortcut {
+        Shortcut::BrowserBack => return Err(VK_BROWSER_BACK),
+        Shortcut::BrowserForward => return Err(VK_BROWSER_FORWARD),
+        Shortcut::Copy => "Ctrl+C",
+        Shortcut::Paste => "Ctrl+V",
+        Shortcut::Cut => "Ctrl+X",
+        Shortcut::Undo => "Ctrl+Z",
+        // Ctrl+Y, not Ctrl+Shift+Z: matches the dominant Windows convention
+        // (Office, most Win32/UWP apps) rather than the macOS ⌘⇧Z one.
+        Shortcut::Redo => "Ctrl+Y",
+        Shortcut::SelectAll => "Ctrl+A",
+        Shortcut::Find => "Ctrl+F",
+        Shortcut::Save => "Ctrl+S",
+        Shortcut::NewTab => "Ctrl+T",
+        Shortcut::CloseTab => "Ctrl+W",
+        Shortcut::ReopenTab => "Ctrl+Shift+T",
+        Shortcut::NextTab => "Ctrl+Tab",
+        Shortcut::PrevTab => "Ctrl+Shift+Tab",
+        Shortcut::ReloadPage => "Ctrl+R",
+    };
+    Ok(parse_shortcut(text))
+}
+
+fn parse_shortcut(text: &str) -> KeyCombo {
+    text.parse()
+        .unwrap_or_else(|error| unreachable!("hardcoded shortcut table entry {text:?}: {error}"))
+}
+
+fn press_shortcut(shortcut: Shortcut) {
+    match combo(shortcut) {
+        Ok(combo) => post_custom_shortcut(&combo),
+        Err(vk) => post_key(vk, &[]),
+    }
+}
+
+/// Dispatch a window-manager or power [`NativeAction`]. macOS window-manager
+/// concepts map to their nearest Windows shortcut; `Sleep` has no clean
+/// synthesis (see the comment below) and is skipped.
+fn dispatch_native(native: NativeAction) {
+    match native {
+        NativeAction::MissionControl | NativeAction::AppExpose => post_key(VK_TAB, &[VK_LWIN]),
+        NativeAction::PreviousDesktop => post_key(VK_LEFT, &[VK_LWIN, VK_CONTROL]),
+        NativeAction::NextDesktop => post_key(VK_RIGHT, &[VK_LWIN, VK_CONTROL]),
+        NativeAction::ShowDesktop => post_key(VK_D, &[VK_LWIN]),
+        NativeAction::LaunchpadShow => post_key(VK_LWIN, &[]),
+        NativeAction::LockScreen => post_key(VK_L, &[VK_LWIN]),
+        // Win+Shift+S opens the snip overlay, which serves both full-screen
+        // and region capture on Windows.
+        NativeAction::Screenshot | NativeAction::CaptureRegion => {
+            post_key(VK_S, &[VK_LWIN, VK_SHIFT]);
+        }
+        // Suspending reliably needs `SetSuspendState` (powrprof.dll), which
+        // hibernates instead when hibernation is enabled — no clean win from
+        // a background agent, so the action is skipped on Windows for now.
+        NativeAction::Sleep => {
+            tracing::debug!("Sleep has no Windows synthesis yet — action skipped");
+        }
+    }
+}
+
+fn dispatch_media(key: MediaKey) {
+    match key {
+        MediaKey::PlayPause => post_key(VK_MEDIA_PLAY_PAUSE, &[]),
+        MediaKey::NextTrack => post_key(VK_MEDIA_NEXT_TRACK, &[]),
+        MediaKey::PrevTrack => post_key(VK_MEDIA_PREV_TRACK, &[]),
+        MediaKey::VolumeUp => post_key(VK_VOLUME_UP, &[]),
+        MediaKey::VolumeDown => post_key(VK_VOLUME_DOWN, &[]),
+        MediaKey::Mute => post_key(VK_VOLUME_MUTE, &[]),
+    }
+}
+
+fn dispatch_script(script: Script<'_>) {
+    match script {
+        Script::AppleScript(_) => {
             tracing::warn!("RunAppleScript is only supported on macOS");
         }
-        Action::RunShellCommand(cmd) => run_shell_command_async(cmd.clone()),
-        Action::Workflow(steps) => run_workflow_async(steps.clone()),
-        Action::None => {}
+        Script::ShellCommand(cmd) => run_shell_command_async(cmd.to_string()),
+        Script::Workflow(steps) => run_workflow_async(steps.to_vec()),
     }
 }
 
@@ -207,15 +220,20 @@ fn post_key(vk: u16, modifiers: &[u16]) {
     send_inputs(&inputs);
 }
 
-fn post_scroll(action: &Action) {
-    let (flags, data) = match action {
-        Action::ScrollUp => (MOUSEEVENTF_WHEEL, WHEEL_DELTA),
-        Action::ScrollDown => (MOUSEEVENTF_WHEEL, -WHEEL_DELTA),
-        Action::HorizontalScrollLeft => (MOUSEEVENTF_HWHEEL, -WHEEL_DELTA),
-        Action::HorizontalScrollRight => (MOUSEEVENTF_HWHEEL, WHEEL_DELTA),
-        _ => return,
-    };
-    send_inputs(&[mouse_input(flags, data)]);
+/// Synthesise one scroll tick in direction `(dx, dy)`. Unit direction
+/// (-1/0/1) scaled by `WHEEL_DELTA`, the fixed magnitude the four
+/// `Scroll*`/`HorizontalScroll*` actions have always used.
+fn dispatch_scroll(dx: i8, dy: i8) {
+    let mut inputs = Vec::with_capacity(2);
+    if dy != 0 {
+        inputs.push(mouse_input(MOUSEEVENTF_WHEEL, i32::from(dy) * WHEEL_DELTA));
+    }
+    if dx != 0 {
+        inputs.push(mouse_input(MOUSEEVENTF_HWHEEL, i32::from(dx) * WHEEL_DELTA));
+    }
+    if !inputs.is_empty() {
+        send_inputs(&inputs);
+    }
 }
 
 pub(super) fn post_horizontal_scroll(delta: i32) {
@@ -309,5 +327,69 @@ fn mouse_input(flags: u32, data: i32) -> INPUT {
                 dwExtraInfo: 0,
             },
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openlogi_core::binding::Shortcut;
+
+    use super::{VK_BROWSER_BACK, VK_BROWSER_FORWARD, combo};
+
+    /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an
+    /// edit to the table can't silently change what Ctrl+C sends.
+    /// `Redo` differs from macOS/Linux by design (see the module doc on
+    /// `combo`), and `BrowserBack`/`BrowserForward` have no `KeyCombo`
+    /// representation on Windows at all — see `combo`'s doc.
+    #[test]
+    fn combo_table_pins_representative_shortcuts() {
+        assert_eq!(
+            combo(Shortcut::Copy)
+                .unwrap_or_else(|vk| panic!("Copy should be a chord, not raw vk {vk:#x}"))
+                .rendered_label(),
+            "Ctrl+C"
+        );
+        assert_eq!(
+            combo(Shortcut::Redo)
+                .unwrap_or_else(|vk| panic!("Redo should be a chord, not raw vk {vk:#x}"))
+                .rendered_label(),
+            "Ctrl+Y"
+        );
+        assert_eq!(
+            combo(Shortcut::NextTab)
+                .unwrap_or_else(|vk| panic!("NextTab should be a chord, not raw vk {vk:#x}"))
+                .rendered_label(),
+            "Ctrl+Tab"
+        );
+        assert_eq!(combo(Shortcut::BrowserBack), Err(VK_BROWSER_BACK));
+        assert_eq!(combo(Shortcut::BrowserForward), Err(VK_BROWSER_FORWARD));
+        // Every chord-shaped row must actually resolve through
+        // hid_usage_to_windows, or a `Shortcut` silently no-ops instead of
+        // pressing anything (see `post_custom_shortcut`'s warn-and-drop path).
+        for shortcut in [
+            Shortcut::Copy,
+            Shortcut::Paste,
+            Shortcut::Cut,
+            Shortcut::Undo,
+            Shortcut::Redo,
+            Shortcut::SelectAll,
+            Shortcut::Find,
+            Shortcut::Save,
+            Shortcut::NewTab,
+            Shortcut::CloseTab,
+            Shortcut::ReopenTab,
+            Shortcut::NextTab,
+            Shortcut::PrevTab,
+            Shortcut::ReloadPage,
+        ] {
+            let key = combo(shortcut)
+                .unwrap_or_else(|vk| panic!("{shortcut:?} should be a chord, not raw vk {vk:#x}"))
+                .key()
+                .code();
+            assert!(
+                super::super::hid_usage_to_windows(key).is_some(),
+                "{shortcut:?} table entry has no Windows virtual-key mapping"
+            );
+        }
     }
 }

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -365,27 +365,19 @@ mod tests {
         assert_eq!(combo(Shortcut::BrowserForward), Err(VK_BROWSER_FORWARD));
         // Every chord-shaped row must actually resolve through
         // hid_usage_to_windows, or a `Shortcut` silently no-ops instead of
-        // pressing anything (see `post_custom_shortcut`'s warn-and-drop path).
-        for shortcut in [
-            Shortcut::Copy,
-            Shortcut::Paste,
-            Shortcut::Cut,
-            Shortcut::Undo,
-            Shortcut::Redo,
-            Shortcut::SelectAll,
-            Shortcut::Find,
-            Shortcut::Save,
-            Shortcut::NewTab,
-            Shortcut::CloseTab,
-            Shortcut::ReopenTab,
-            Shortcut::NextTab,
-            Shortcut::PrevTab,
-            Shortcut::ReloadPage,
-        ] {
-            let key = combo(shortcut)
-                .unwrap_or_else(|vk| panic!("{shortcut:?} should be a chord, not raw vk {vk:#x}"))
-                .key()
-                .code();
+        // pressing anything (see `post_custom_shortcut`'s warn-and-drop
+        // path). Iterates `Shortcut::ALL` rather than a hand-copied list,
+        // so a newly added `Shortcut` variant is checked here
+        // automatically instead of depending on someone remembering to
+        // extend a second, independent list. The two raw-vk exceptions
+        // (pinned individually above) are skipped here, not silently
+        // missed: `combo`'s own match already forces every `Shortcut`
+        // variant to be classified as one or the other.
+        for shortcut in Shortcut::ALL {
+            let Ok(chord) = combo(shortcut) else {
+                continue;
+            };
+            let key = chord.key().code();
             assert!(
                 super::super::hid_usage_to_windows(key).is_some(),
                 "{shortcut:?} table entry has no Windows virtual-key mapping"

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -373,7 +373,7 @@ mod tests {
         // (pinned individually above) are skipped here, not silently
         // missed: `combo`'s own match already forces every `Shortcut`
         // variant to be classified as one or the other.
-        for shortcut in Shortcut::ALL {
+        for &shortcut in Shortcut::ALL {
             let Ok(chord) = combo(shortcut) else {
                 continue;
             };


### PR DESCRIPTION
## Summary

- Adds `Action::effect()` in `openlogi-core`, a single exhaustive match that
  classifies the full 52-variant `Action` vocabulary into a ~10-variant
  platform-neutral `Effect` IR (`Click`, `Shortcut`, `Key`, `Scroll`,
  `Media`, `Native`, `Script`, `Text`, `AgentSide`, `None`).
- Each `openlogi-inject` backend (`macos.rs`/`linux.rs`/`windows.rs`) now
  matches on `Effect` instead of re-deriving the whole `Action` vocabulary
  three times in parallel, with a small per-backend `Shortcut -> KeyCombo`
  table for the ~14-16 shortcuts that are plain modifier+key chords.
- Pure refactor: every `Action` produces the exact same OS events on every
  platform it did before.

## Changes

**`openlogi-core`**
- `crates/openlogi-core/src/binding/effect.rs` (new): `Effect<'a>`,
  `Shortcut`, `MouseButton`, `MediaKey`, `NativeAction`, `Script<'a>`, and
  `impl Action::effect(&self) -> Effect<'_>` — the only new exhaustive match
  over `Action` outside of `label`/`category`/`catalog`.
- `binding.rs`: wire the new module in and re-export its public types.
- `binding/tests.rs`: totality test (every `Action::catalog()` entry lowers
  to a non-`None` effect except `Action::None`), a power-user/device-side
  bucket test (`CustomShortcut`/`TypeText`/`RunAppleScript`/
  `RunShellCommand`/`Workflow`/DPI-SmartShift-Ring-OpenApplication), and a
  scroll-direction test.

**`openlogi-inject`**
- `inject/macos.rs`: `execute()` collapses from 56 `Action::` references to
  a 10-arm `Effect` match, plus a 16-row `Shortcut -> KeyCombo` table
  (parsed through `KeyCombo`'s existing `FromStr`) and small
  `dispatch_click`/`dispatch_native`/`nx_key`/`dispatch_script` helpers.
- `inject/linux.rs`: same shape, 51 -> 10; adds `press_combo` shared by the
  `Shortcut` table and `CustomShortcut`/workflow `PressKey`.
- `inject/windows.rs`: same shape, 54 -> 8; `combo()` returns
  `Result<KeyCombo, u16>` because `BrowserBack`/`BrowserForward` fire a
  dedicated virtual key with no modifier on Windows (not a USB HID keyboard
  usage, so no `KeyCombo` representation at all) — the `Err` case is the
  one deliberate per-OS exception to the shared table shape, preserved
  exactly from the pre-refactor source. Also drops the duplicate local
  `MouseButton` enum in favor of the shared core one.
- Each backend gets a test pinning representative `Shortcut -> KeyCombo`
  rows (including the platform-specific ones: `Redo` is Ctrl+Y on Windows
  vs Ctrl+Shift+Z on macOS/Linux; `BrowserBack` is ⌘\[ / Alt+Left / a raw
  VK) plus a check that every table entry actually resolves through that
  backend's `hid_usage_to_*`, so a table edit can't silently no-op a
  shortcut.

## Testing

Full local gate on the final commit:
```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
```
All green (149 openlogi-core tests including the new Effect tests; 3
openlogi-inject tests including the new macOS combo pinning test; no
regressions anywhere else in the workspace).

Cross-platform verification:
- **macOS**: compiled, clippy-clean, and tested natively (this machine).
- **Windows**: `cargo clippy --target x86_64-pc-windows-gnu -p
  openlogi-inject --all-targets -- -D warnings` passes on the real
  `windows-sys` dependency tree (check-only — no linker in this
  environment, so `cargo test` itself did not run). CI's `clippy-windows`
  job (native `windows-latest`) will be the first real native compile.
- **Linux**: **not compiled or tested locally** — no Linux Rust target is
  installed in this devenv shell, and `linux.rs` is `#[cfg(target_os =
  "linux")]`-gated out of every local build/clippy/test run on macOS.
  Verified entirely by hand-auditing every match arm against the
  pre-refactor source. CI's `test-linux` job (`ubuntu-latest`, real
  compile + `cargo test`) will be the first genuine verification.
- Not runtime-tested on physical hardware (no device I/O in this crate;
  the change is about OS event synthesis, verified by the `hid_usage_to_*`
  round-trip tests and manual chord-table review, not on real Logitech
  devices).

## Skipped

The stretch goal (folding `Action::label()`/`category()`/`catalog()` and
`ActionRingIcon::for_action()` into one declarative table) was left alone:
those four passes serve different audiences (backend dispatch vs. picker
UI strings vs. Actions Ring icons) and the English label text is itself an
i18n key across 20 locale files — collapsing them looked likely to either
touch GUI-facing strings (out of scope; a sibling agent owns
`crates/openlogi-gui`) or produce a much larger, harder-to-review diff for
a facet of the code the task called optional. The backend collapse above
is the full deliverable.