### PR TITLE
refactor(agent): collapse hardware.rs's duplicated write skeletons into DeviceOp

### DIFF
--- a/crates/openlogi-agent-core/Cargo.toml
+++ b/crates/openlogi-agent-core/Cargo.toml
@@ -29,3 +29,6 @@ workspace = true
 bincode = "1.3"
 # Only to construct an `InventoryError::Hid` in the watcher's classify tests.
 async-hid = { workspace = true }
+# Only to advance virtual time in the DeviceOp/timed timeout test without a
+# real multi-second sleep.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -1,14 +1,21 @@
 //! Hardware-side actions invoked from both the GPUI thread (slider release)
 //! and the OS-event hook thread (bound button press).
 //!
-//! Each call spawns a one-shot tokio runtime on a dedicated OS thread —
-//! cheap at the cadence these fire at (≤ once per slider release / button
-//! press) and avoids holding a long-lived async runtime alongside GPUI's
-//! executor.
+//! [`DeviceOp`] is the seam every device write and read goes through: it binds
+//! a [`DeviceRoute`] to this runtime's capture/inventory channels (built via
+//! [`crate::orchestrator::SharedRuntime::device`] or
+//! [`crate::orchestrator::SharedRuntime::keyboard_device`]), then either
+//! awaits [`DeviceOp::run`] (the IPC server's reads/writes, which must report
+//! their result to the GUI) or fires [`DeviceOp::detach`] (the OS-hook and
+//! reconnect paths, which must never block their caller). Both resolve the
+//! channel the same way every caller always did — a registry-confirmed
+//! capture channel or the exact current inventory channel; a registry miss is
+//! unavailable, never a fallback to re-enumerating and opening a competing
+//! connection.
 //!
-//! Agent calls select a registry-confirmed capture channel or the exact current
-//! inventory channel. A registry miss is unavailable; the daemon never falls
-//! back to re-enumerating and opening a competing connection.
+//! `detach` spawns a one-shot tokio runtime on a dedicated OS thread — cheap
+//! at the cadence these fire at (≤ once per slider release / button press)
+//! and avoids holding a long-lived async runtime alongside GPUI's executor.
 
 use std::future::Future;
 use std::time::Duration;
@@ -18,6 +25,7 @@ use openlogi_hid::{
     CaptureChannel, ChannelRegistry, DeviceRoute, DpiInfo, HapticWaveform, HidppFeatureErrorKind,
     HidppOperation, ScrollResolution, SharedChannel, SmartShiftMode, SmartShiftStatus, WriteError,
 };
+use tokio::time::error::Elapsed;
 use tracing::{debug, warn};
 
 use crate::receiver_access::ReceiverAccess;
@@ -95,12 +103,155 @@ fn choose_authoritative<T>(
     }
 }
 
+/// One device's HID++ write or read, bound to this runtime's capture and
+/// inventory channels for `route`. Built via
+/// [`crate::orchestrator::SharedRuntime::device`] or
+/// [`crate::orchestrator::SharedRuntime::keyboard_device`] — the receiver-side
+/// counterpart of `openlogi_hid::write::with_route`'s "boilerplate-eater"
+/// pattern, applied to an already-open channel instead of a fresh one.
+pub struct DeviceOp<'a> {
+    capture: &'a CaptureChannel,
+    registry: &'a ChannelRegistry,
+    receiver_access: &'a ReceiverAccess,
+    route: DeviceRoute,
+}
+
+impl<'a> DeviceOp<'a> {
+    pub(crate) fn new(
+        capture: &'a CaptureChannel,
+        registry: &'a ChannelRegistry,
+        receiver_access: &'a ReceiverAccess,
+        route: &DeviceRoute,
+    ) -> Self {
+        Self {
+            capture,
+            registry,
+            receiver_access,
+            route: route.clone(),
+        }
+    }
+
+    /// Resolve the authoritative channel without acquiring the receiver
+    /// lease. Callers that manage their own lease/thread lifecycle across
+    /// more than one write (the volatile-settings reapply sequence) resolve
+    /// once up front through this instead of [`Self::run`]/[`Self::detach`].
+    fn resolve(&self) -> Result<SharedChannel, WriteError> {
+        authoritative_channel(Some(self.capture), self.registry, &self.route)
+    }
+
+    /// Lease the receiver, resolve the authoritative channel, then run `f`
+    /// against it under `WRITE_BUDGET`, mapping a timeout to
+    /// [`WriteError::RequestTimedOut`].
+    ///
+    /// Lease-then-resolve, not the other way around: the lease wait is
+    /// unbounded, and a channel resolved before it would risk being retired
+    /// by the inventory enumerator while still queued — the write itself
+    /// would likely still succeed on the stale handle, but anything that
+    /// caches a feature off it (see the haptic feature cache's
+    /// `EpochGuarded` note) would then pin a channel the enumerator can never
+    /// reopen. Used by every awaited device call: the IPC server's
+    /// DPI/SmartShift/lighting reads and writes, and the Actions Ring haptic
+    /// path.
+    pub async fn run<F, Fut, T>(self, op: HidppOperation, f: F) -> Result<T, WriteError>
+    where
+        F: FnOnce(SharedChannel) -> Fut,
+        Fut: Future<Output = Result<T, WriteError>>,
+    {
+        let _lease = self.receiver_access.acquire_for_io().await;
+        let shared = self.resolve()?;
+        timed(op, f(shared)).await
+    }
+
+    /// Fire-and-forget `f` on its own OS thread and one-shot runtime, with the
+    /// standard three-arm outcome logging: a completed write and a failed
+    /// write both log at their own level, keyed by `label`; a device that
+    /// never answers within `WRITE_BUDGET` warns instead of hanging the
+    /// thread forever.
+    ///
+    /// Resolves the channel on the calling thread before spawning — every
+    /// `*_in_background` write did this, so a resolution failure (no target,
+    /// registry miss) never pays for a thread spawn, and the lease (acquired
+    /// only once the thread is running) is never awaited for a write that was
+    /// already going nowhere.
+    pub fn detach<F, Fut, T>(self, label: &'static str, f: F)
+    where
+        F: FnOnce(SharedChannel) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, WriteError>>,
+    {
+        let index = self.route.device_index();
+        self.spawn_write(label, f, move |result| match result {
+            Ok(Ok(_)) => debug!(index, label, "background write completed"),
+            Ok(Err(e)) => warn!(error = ?e, label, "background write failed"),
+            Err(_) => warn!(
+                index,
+                label, "background write timed out (device asleep/unresponsive)"
+            ),
+        });
+    }
+
+    /// Core of [`Self::detach`], with the outcome handed to `log` instead of
+    /// an assumed logging shape — native wheel-mode writes log a
+    /// `FeatureUnsupported` result at `debug` (unsupported HiRes wheel/
+    /// inversion is expected on plenty of mice), unlike every other
+    /// background write's `warn`.
+    ///
+    /// Carries the calling thread's current tracing span onto the spawned OS
+    /// thread and stays inside it for the whole write: a caller that opens
+    /// `tracing::debug_span!("…", field = value)` around the `detach`/
+    /// `spawn_write` call gets `field` attached to every log line this
+    /// function and `log` emit — the generic `label`-only outcome log doesn't
+    /// have to be the only detail a background write leaves behind.
+    fn spawn_write<F, Fut, T>(
+        self,
+        label: &'static str,
+        f: F,
+        log: impl FnOnce(Result<Result<T, WriteError>, Elapsed>) + Send + 'static,
+    ) where
+        F: FnOnce(SharedChannel) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, WriteError>>,
+    {
+        let Ok(shared) = self.resolve() else {
+            debug!(route = %self.route, label, "no inventory channel — write skipped");
+            return;
+        };
+        let receiver_access = self.receiver_access.clone();
+        let span = tracing::Span::current();
+        std::thread::spawn(move || {
+            let _guard = span.enter();
+            let Some(rt) = one_shot_runtime(label) else {
+                return;
+            };
+            let result = rt.block_on(async {
+                let _lease = receiver_access.acquire_for_io().await;
+                tokio::time::timeout(WRITE_BUDGET, f(shared)).await
+            });
+            log(result);
+        });
+    }
+}
+
+/// Build the one-shot current-thread runtime every background write spawns
+/// its OS thread onto. Logs and returns `None` on the rare case that
+/// initialization itself fails (e.g. OS resource exhaustion).
+fn one_shot_runtime(label: &str) -> Option<tokio::runtime::Runtime> {
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => Some(rt),
+        Err(e) => {
+            warn!(error = %e, label, "tokio runtime init failed; write skipped");
+            None
+        }
+    }
+}
+
 /// Spawn an OS thread that toggles SmartShift (free ↔ ratchet) on the
 /// device at `target` via its current shared channel. Returns
 /// immediately; failures (incl. devices that expose neither `0x2111` nor
 /// the older `0x2110` SmartShift feature) are logged.
 pub fn toggle_smartshift_in_background(
-    capture: Option<&CaptureChannel>,
+    capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
@@ -109,39 +260,19 @@ pub fn toggle_smartshift_in_background(
         debug!("no target device — SmartShift toggle skipped");
         return;
     };
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — SmartShift toggle skipped");
-        return;
-    };
-    let receiver_access = receiver_access.clone();
-    std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; SmartShift toggle skipped");
-                return;
-            }
-        };
-        let result = rt.block_on(async {
-            let _lease = receiver_access.acquire_for_io().await;
-            tokio::time::timeout(WRITE_BUDGET, async {
-                openlogi_hid::toggle_smartshift_on(&shared).await
-            })
-            .await
-        });
-        let index = target.device_index();
-        match result {
-            Ok(Ok(mode)) => debug!(index, ?mode, "SmartShift toggled"),
-            Ok(Err(e)) => warn!(error = ?e, "SmartShift toggle failed"),
-            Err(_) => warn!(
-                index,
-                "SmartShift toggle timed out (device asleep/unresponsive)"
-            ),
-        }
-    });
+    // The toggled-to mode is only known once the write replies, so the span
+    // starts with an empty field and the closure records it on success —
+    // `detach`'s outcome log (and any other log line emitted while this span
+    // is entered) then carries it instead of just the generic `label`.
+    let _span = tracing::debug_span!("SmartShift toggle", mode = tracing::field::Empty).entered();
+    DeviceOp::new(capture, registry, receiver_access, &target).detach(
+        "SmartShift toggle",
+        |c| async move {
+            let mode = openlogi_hid::toggle_smartshift_on(&c).await?;
+            tracing::Span::current().record("mode", tracing::field::debug(mode));
+            Ok(())
+        },
+    );
 }
 
 /// Read the device's current SmartShift configuration (wheel mode +
@@ -181,7 +312,7 @@ pub fn read_smartshift_status_blocking(
 ///
 /// `target == None` is a no-op (dev environment without a real device).
 pub fn write_smartshift_in_background(
-    capture: Option<&CaptureChannel>,
+    capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
@@ -193,93 +324,24 @@ pub fn write_smartshift_in_background(
         debug!("no target device — SmartShift write skipped");
         return;
     };
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — SmartShift write skipped");
-        return;
-    };
-    let receiver_access = receiver_access.clone();
-    std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; SmartShift write skipped");
-                return;
-            }
-        };
-        let result = rt.block_on(async {
-            let _lease = receiver_access.acquire_for_io().await;
-            tokio::time::timeout(WRITE_BUDGET, async {
-                openlogi_hid::set_smartshift_on(&shared, mode, auto_disengage, tunable_torque).await
-            })
-            .await
-        });
-        let index = target.device_index();
-        match result {
-            Ok(Ok(())) => debug!(
-                index,
-                ?mode,
-                auto_disengage,
-                tunable_torque,
-                "SmartShift config written"
-            ),
-            Ok(Err(e)) => warn!(error = ?e, "SmartShift write failed"),
-            Err(_) => warn!(
-                index,
-                "SmartShift write timed out (device asleep/unresponsive)"
-            ),
-        }
-    });
+    let _span =
+        tracing::debug_span!("SmartShift write", ?mode, auto_disengage, tunable_torque).entered();
+    DeviceOp::new(capture, registry, receiver_access, &target).detach(
+        "SmartShift write",
+        move |c| async move {
+            openlogi_hid::set_smartshift_on(&c, mode, auto_disengage, tunable_torque).await
+        },
+    );
 }
 
-/// Spawn an OS thread that writes the keyboard Fn-lock state to the device at
-/// `target` via [`openlogi_hid::set_fn_lock_on`]. Returns immediately; failures
-/// (incl. keyboards that expose neither `0x40a3` nor `0x40a2` fn inversion)
-/// are logged.
-///
-/// `target == None` is a no-op (dev environment without a real device).
-pub fn write_fn_lock_in_background(
-    capture: Option<&CaptureChannel>,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    target: Option<DeviceRoute>,
-    on: bool,
-) {
-    let Some(target) = target else {
-        debug!(on, "no target device — Fn-lock write skipped");
-        return;
-    };
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — Fn-lock write skipped");
-        return;
-    };
-    let receiver_access = receiver_access.clone();
-    std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; Fn-lock write skipped");
-                return;
-            }
-        };
-        let result = rt.block_on(async {
-            let _lease = receiver_access.acquire_for_io().await;
-            tokio::time::timeout(WRITE_BUDGET, openlogi_hid::set_fn_lock_on(&shared, on)).await
-        });
-        let index = target.device_index();
-        match result {
-            Ok(Ok(())) => debug!(index, on, "Fn-lock written"),
-            Ok(Err(e)) => warn!(error = ?e, "Fn-lock write failed"),
-            Err(_) => warn!(
-                index,
-                "Fn-lock write timed out (device asleep/unresponsive)"
-            ),
-        }
+/// Spawn an OS thread that writes the keyboard Fn-lock state to `op`'s device
+/// via [`openlogi_hid::set_fn_lock_on`]. Returns immediately; failures (incl.
+/// keyboards that expose neither `0x40a3` nor `0x40a2` fn inversion) are
+/// logged.
+pub fn write_fn_lock_in_background(op: DeviceOp<'_>, on: bool) {
+    let _span = tracing::debug_span!("Fn-lock write", on).entered();
+    op.detach("Fn-lock write", move |c| async move {
+        openlogi_hid::set_fn_lock_on(&c, on).await
     });
 }
 
@@ -294,7 +356,7 @@ pub struct SmartShiftApply {
     pub tunable_torque: u8,
 }
 
-/// Re-apply every volatile mouse setting for one device on a **single**
+/// Re-apply every volatile mouse setting for `op`'s device on a **single**
 /// background thread, sequentially, on the current inventory-owned channel.
 ///
 /// Agent-start reapply used to fire DPI / SmartShift / wheel-mode each on its
@@ -302,38 +364,29 @@ pub struct SmartShiftApply {
 /// ready. Concurrent opens of the same Bolt/Unifying node share the OS input
 /// stream while correlating responses only by software id — they cross-talk and
 /// produce the intermittent SmartShift `InvalidArgument` seen in #485. One
-/// sequential writer removes that self-race.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "background reapply keeps one device write lifecycle together"
-)]
+/// sequential writer removes that self-race, so this deliberately does NOT
+/// decompose into three [`DeviceOp::detach`] calls: the channel is resolved
+/// once, the lease is held for the whole sequence, and every write below runs
+/// on the one OS thread spawned here. Takes `op` by reference (unlike every
+/// other function here) because it only ever reads its fields — it never
+/// hands the operation itself to [`DeviceOp::run`] or [`DeviceOp::detach`].
 pub fn reapply_mouse_volatile_in_background(
-    capture: Option<&CaptureChannel>,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    target: DeviceRoute,
+    op: &DeviceOp<'_>,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
     dpi: Option<u32>,
     smartshift: Option<SmartShiftApply>,
 ) {
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — volatile reapply skipped");
+    let Ok(shared) = op.resolve() else {
+        debug!(route = %op.route, "no inventory channel — volatile reapply skipped");
         return;
     };
-    let receiver_access = receiver_access.clone();
+    let receiver_access = op.receiver_access.clone();
+    let index = op.route.device_index();
     std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; volatile reapply skipped");
-                return;
-            }
+        let Some(rt) = one_shot_runtime("volatile reapply") else {
+            return;
         };
-        let index = target.device_index();
         rt.block_on(async {
             let _lease = receiver_access.acquire_for_io().await;
             if resolution.is_some() || inverted.is_some() {
@@ -419,7 +472,7 @@ fn log_wheel_result(
     index: u8,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
-    result: Result<Result<(), WriteError>, tokio::time::error::Elapsed>,
+    result: Result<Result<(), WriteError>, Elapsed>,
 ) {
     match result {
         Ok(Ok(())) => debug!(index, ?resolution, ?inverted, "native wheel mode written"),
@@ -445,7 +498,7 @@ fn log_wheel_result(
 ///
 /// `target == None` is a no-op (dev environment without a real device).
 pub fn write_dpi_in_background(
-    capture: Option<&CaptureChannel>,
+    capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
     target: Option<DeviceRoute>,
@@ -455,48 +508,17 @@ pub fn write_dpi_in_background(
         debug!(dpi, "no target device — DPI write skipped");
         return;
     };
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — DPI write skipped");
+    // All device-supported DPI values fit in HID++'s u16 wire field; a
+    // larger value is a caller bug and must not be clamped onto the device.
+    let Ok(dpi_u16) = u16::try_from(dpi) else {
+        warn!(dpi, "DPI exceeds the HID++ u16 wire field; write skipped");
         return;
     };
-    let receiver_access = receiver_access.clone();
-    std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; DPI write skipped");
-                return;
-            }
-        };
-        // All device-supported DPI values fit in HID++'s u16 wire field; a
-        // larger value is a caller bug and must not be clamped onto the device.
-        let Ok(dpi_u16) = u16::try_from(dpi) else {
-            warn!(dpi, "DPI exceeds the HID++ u16 wire field; write skipped");
-            return;
-        };
-        let result = rt.block_on(async {
-            let _lease = receiver_access.acquire_for_io().await;
-            tokio::time::timeout(WRITE_BUDGET, async {
-                openlogi_hid::set_dpi_on(&shared, dpi_u16).await
-            })
-            .await
+    let _span = tracing::debug_span!("DPI write", dpi = dpi_u16).entered();
+    DeviceOp::new(capture, registry, receiver_access, &target)
+        .detach("DPI write", move |c| async move {
+            openlogi_hid::set_dpi_on(&c, dpi_u16).await
         });
-        match result {
-            Ok(Ok(())) => debug!(
-                index = target.device_index(),
-                dpi = dpi_u16,
-                "DPI written to device"
-            ),
-            Ok(Err(e)) => warn!(error = ?e, "DPI write failed"),
-            Err(_) => warn!(
-                dpi = dpi_u16,
-                "DPI write timed out (device asleep/unresponsive)"
-            ),
-        }
-    });
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -509,28 +531,18 @@ enum ScrollWheelModeChange {
     },
 }
 
-/// Spawn an OS thread that reconciles the configured native HiResWheel mode.
+/// Spawn an OS thread that reconciles the configured native HiResWheel mode
+/// for `op`'s device.
 ///
 /// `resolution == None` preserves the current device resolution;
 /// `inverted == None` preserves the current inversion bit. At least one field
 /// must be set by the caller. Unsupported devices are expected and only logged
 /// at debug level.
 pub fn write_scroll_wheel_mode_in_background(
-    capture: Option<&CaptureChannel>,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    target: Option<DeviceRoute>,
+    op: DeviceOp<'_>,
     resolution: Option<ScrollResolution>,
     inverted: Option<bool>,
 ) {
-    let Some(target) = target else {
-        debug!(
-            ?resolution,
-            ?inverted,
-            "no target device — wheel mode write skipped"
-        );
-        return;
-    };
     let change = match (resolution, inverted) {
         (Some(resolution), Some(inverted)) => ScrollWheelModeChange::ResolutionAndInversion {
             resolution,
@@ -543,116 +555,42 @@ pub fn write_scroll_wheel_mode_in_background(
             return;
         }
     };
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — wheel mode write skipped");
-        return;
-    };
-    let receiver_access = receiver_access.clone();
-    std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; wheel mode write skipped");
-                return;
-            }
-        };
-        let result = rt.block_on(async {
-            let _lease = receiver_access.acquire_for_io().await;
-            tokio::time::timeout(WRITE_BUDGET, async {
-                match change {
-                    ScrollWheelModeChange::ResolutionAndInversion {
-                        resolution,
-                        inverted,
-                    } => openlogi_hid::set_scroll_wheel_mode_on(&shared, resolution, inverted)
+    let index = op.route.device_index();
+    op.spawn_write(
+        "wheel mode write",
+        move |shared| async move {
+            match change {
+                ScrollWheelModeChange::ResolutionAndInversion {
+                    resolution,
+                    inverted,
+                } => openlogi_hid::set_scroll_wheel_mode_on(&shared, resolution, inverted)
+                    .await
+                    .map(|_| ()),
+                ScrollWheelModeChange::Resolution(resolution) => {
+                    openlogi_hid::set_scroll_resolution_on(&shared, resolution)
                         .await
-                        .map(|_| ()),
-                    ScrollWheelModeChange::Resolution(resolution) => {
-                        openlogi_hid::set_scroll_resolution_on(&shared, resolution)
-                            .await
-                            .map(|_| ())
-                    }
-                    ScrollWheelModeChange::Inversion(inverted) => {
-                        openlogi_hid::set_scroll_inversion_on(&shared, inverted).await
-                    }
+                        .map(|_| ())
                 }
-            })
-            .await
-        });
-        let index = target.device_index();
-        match result {
-            Ok(Ok(())) => debug!(index, ?resolution, ?inverted, "native wheel mode written"),
-            Ok(Err(WriteError::FeatureUnsupported { feature_hex })) => debug!(
-                index,
-                ?resolution,
-                ?inverted,
-                feature = format_args!("{feature_hex:#06x}"),
-                "native wheel mode unsupported"
-            ),
-            Ok(Err(e)) => warn!(error = ?e, "wheel mode write failed"),
-            Err(_) => warn!(
-                index,
-                ?resolution,
-                ?inverted,
-                "wheel mode write timed out (device asleep/unresponsive)"
-            ),
-        }
-    });
+                ScrollWheelModeChange::Inversion(inverted) => {
+                    openlogi_hid::set_scroll_inversion_on(&shared, inverted).await
+                }
+            }
+        },
+        move |result| log_wheel_result(index, resolution, inverted, result),
+    );
 }
 
-/// Apply `lighting` to the keyboard at `target` on a background thread.
+/// Apply `lighting` to the keyboard at `op`'s device on a background thread.
 ///
 /// Resolves the configured colour (scaled by brightness, or black when the
 /// lighting is off) and writes every key over HID++ via
-/// [`openlogi_hid::set_keyboard_color_on`]. A `None` target is a no-op (dev
-/// runs without a device); a registry miss and write failures are logged, not
-/// surfaced.
-pub fn set_lighting_in_background(
-    capture: Option<&CaptureChannel>,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    target: Option<DeviceRoute>,
-    lighting: &Lighting,
-) {
-    let Some(target) = target else {
-        debug!("no target device — lighting write skipped");
-        return;
-    };
-    let Ok(shared) = authoritative_channel(capture, registry, &target) else {
-        debug!(route = %target, "no inventory channel — lighting write skipped");
-        return;
-    };
+/// [`openlogi_hid::set_keyboard_color_on`]. A registry miss and write
+/// failures are logged, not surfaced.
+pub fn set_lighting_in_background(op: DeviceOp<'_>, lighting: &Lighting) {
     let (r, g, b) = lighting_rgb(lighting);
-    let receiver_access = receiver_access.clone();
-    std::thread::spawn(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                warn!(error = %e, "tokio runtime init failed; lighting write skipped");
-                return;
-            }
-        };
-        let result = rt.block_on(async {
-            let _lease = receiver_access.acquire_for_io().await;
-            tokio::time::timeout(
-                WRITE_BUDGET,
-                openlogi_hid::set_keyboard_color_on(&shared, r, g, b),
-            )
-            .await
-        });
-        match result {
-            Ok(Ok(())) => debug!(r, g, b, "lighting written to keyboard"),
-            Ok(Err(e)) => warn!(error = ?e, "lighting write failed"),
-            Err(_) => warn!(
-                r,
-                g, b, "lighting write timed out (device asleep/unresponsive)"
-            ),
-        }
+    let _span = tracing::debug_span!("lighting write", r, g, b).entered();
+    op.detach("lighting write", move |c| async move {
+        openlogi_hid::set_keyboard_color_on(&c, r, g, b).await
     });
 }
 

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -639,11 +639,19 @@ pub fn set_lighting_in_background(
         };
         let result = rt.block_on(async {
             let _lease = receiver_access.acquire_for_io().await;
-            openlogi_hid::set_keyboard_color_on(&shared, r, g, b).await
+            tokio::time::timeout(
+                WRITE_BUDGET,
+                openlogi_hid::set_keyboard_color_on(&shared, r, g, b),
+            )
+            .await
         });
         match result {
-            Ok(()) => debug!(r, g, b, "lighting written to keyboard"),
-            Err(e) => warn!(error = ?e, "lighting write failed"),
+            Ok(Ok(())) => debug!(r, g, b, "lighting written to keyboard"),
+            Ok(Err(e)) => warn!(error = ?e, "lighting write failed"),
+            Err(_) => warn!(
+                r,
+                g, b, "lighting write timed out (device asleep/unresponsive)"
+            ),
         }
     });
 }

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -631,8 +631,10 @@ async fn timed<T>(
 #[cfg(test)]
 mod tests {
     use std::cell::Cell;
+    use std::sync::RwLock;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
-    use super::choose_authoritative;
+    use super::*;
 
     #[test]
     fn current_capture_wins_without_consulting_the_registry_again() {
@@ -662,5 +664,94 @@ mod tests {
         let selected = choose_authoritative(Some("stale"), |_| false, || None);
 
         assert_eq!(selected, None);
+    }
+
+    fn unresolvable_route() -> DeviceRoute {
+        // A route no capture/registry in this test ever publishes — every
+        // resolve attempt against it takes the registry-miss path.
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc52b,
+        }
+    }
+
+    /// `DeviceOp::run` must fail fast on a registry miss ([`DeviceNotFound`],
+    /// the same path `authoritative_channel` uses to clear the haptic feature
+    /// cache) and must never invoke `f` — a route that can't be resolved has no
+    /// channel to hand it, so running the caller's write would be a bug, not a
+    /// no-op.
+    #[tokio::test]
+    async fn run_on_a_registry_miss_returns_device_not_found_without_calling_f() {
+        let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
+        let registry = ChannelRegistry::default();
+        let receiver_access = ReceiverAccess::default();
+        let route = unresolvable_route();
+        let called = std::sync::Arc::new(AtomicBool::new(false));
+        let called_for_closure = std::sync::Arc::clone(&called);
+
+        let result = DeviceOp::new(&capture, &registry, &receiver_access, &route)
+            .run(HidppOperation::WriteDpi, move |_shared| {
+                called_for_closure.store(true, Ordering::SeqCst);
+                async move { Ok::<(), WriteError>(()) }
+            })
+            .await;
+
+        assert!(matches!(result, Err(WriteError::DeviceNotFound)));
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "f must not run when the route can't be resolved"
+        );
+    }
+
+    /// `DeviceOp::detach` resolves before spawning, so a registry miss must
+    /// return synchronously (no thread, no lease wait) and never call `f`.
+    #[tokio::test]
+    async fn detach_on_a_registry_miss_never_calls_f() {
+        let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
+        let registry = ChannelRegistry::default();
+        let receiver_access = ReceiverAccess::default();
+        let route = unresolvable_route();
+        let called = std::sync::Arc::new(AtomicBool::new(false));
+        let called_for_closure = std::sync::Arc::clone(&called);
+
+        DeviceOp::new(&capture, &registry, &receiver_access, &route).detach(
+            "test write",
+            move |_shared| {
+                called_for_closure.store(true, Ordering::SeqCst);
+                async move { Ok::<(), WriteError>(()) }
+            },
+        );
+
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "f must not run when the route can't be resolved"
+        );
+    }
+
+    /// The timeout every [`DeviceOp::run`] call relies on: a write that never
+    /// resolves within `WRITE_BUDGET` must map to
+    /// [`WriteError::RequestTimedOut`] carrying the operation, not hang
+    /// forever. Uses a paused clock so the test doesn't spend `WRITE_BUDGET`
+    /// (5s) of real wall-clock time.
+    #[tokio::test(start_paused = true)]
+    #[allow(clippy::expect_used, reason = "expect is idiomatic in tests")]
+    async fn timed_maps_an_elapsed_deadline_to_request_timed_out() {
+        let handle = tokio::spawn(timed(
+            HidppOperation::WriteDpi,
+            std::future::pending::<Result<(), WriteError>>(),
+        ));
+        // Let the spawned task run up to its first await point so the
+        // underlying sleep is armed before we fast-forward the clock past it.
+        tokio::task::yield_now().await;
+        tokio::time::advance(WRITE_BUDGET + Duration::from_millis(1)).await;
+
+        let result = handle.await.expect("timed task must not panic");
+
+        assert!(matches!(
+            result,
+            Err(WriteError::RequestTimedOut {
+                operation: HidppOperation::WriteDpi
+            })
+        ));
     }
 }

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -190,17 +190,14 @@ impl<'a> DeviceOp<'a> {
     }
 
     /// Core of [`Self::detach`], with the outcome handed to `log` instead of
-    /// an assumed logging shape — native wheel-mode writes log a
-    /// `FeatureUnsupported` result at `debug` (unsupported HiRes wheel/
-    /// inversion is expected on plenty of mice), unlike every other
-    /// background write's `warn`.
-    ///
-    /// Carries the calling thread's current tracing span onto the spawned OS
-    /// thread and stays inside it for the whole write: a caller that opens
-    /// `tracing::debug_span!("…", field = value)` around the `detach`/
-    /// `spawn_write` call gets `field` attached to every log line this
-    /// function and `log` emit — the generic `label`-only outcome log doesn't
-    /// have to be the only detail a background write leaves behind.
+    /// an assumed logging shape. Used directly (bypassing `detach`) by any
+    /// write whose input carries a value worth logging — a written DPI, a
+    /// SmartShift config, an `on`/`off` flag, an RGB triple — so that value
+    /// stays in the log line instead of collapsing to the generic
+    /// `label`-only outcome message; native wheel-mode writes use the same
+    /// seam to log a `FeatureUnsupported` result at `debug` (unsupported
+    /// HiRes wheel/inversion is expected on plenty of mice), unlike every
+    /// other background write's `warn`.
     fn spawn_write<F, Fut, T>(
         self,
         label: &'static str,
@@ -215,9 +212,7 @@ impl<'a> DeviceOp<'a> {
             return;
         };
         let receiver_access = self.receiver_access.clone();
-        let span = tracing::Span::current();
         std::thread::spawn(move || {
-            let _guard = span.enter();
             let Some(rt) = one_shot_runtime(label) else {
                 return;
             };
@@ -260,17 +255,17 @@ pub fn toggle_smartshift_in_background(
         debug!("no target device — SmartShift toggle skipped");
         return;
     };
-    // The toggled-to mode is only known once the write replies, so the span
-    // starts with an empty field and the closure records it on success —
-    // `detach`'s outcome log (and any other log line emitted while this span
-    // is entered) then carries it instead of just the generic `label`.
-    let _span = tracing::debug_span!("SmartShift toggle", mode = tracing::field::Empty).entered();
-    DeviceOp::new(capture, registry, receiver_access, &target).detach(
+    let index = target.device_index();
+    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
         "SmartShift toggle",
-        |c| async move {
-            let mode = openlogi_hid::toggle_smartshift_on(&c).await?;
-            tracing::Span::current().record("mode", tracing::field::debug(mode));
-            Ok(())
+        |c| async move { openlogi_hid::toggle_smartshift_on(&c).await },
+        move |result| match result {
+            Ok(Ok(mode)) => debug!(index, ?mode, "SmartShift toggled"),
+            Ok(Err(e)) => warn!(error = ?e, "SmartShift toggle failed"),
+            Err(_) => warn!(
+                index,
+                "SmartShift toggle timed out (device asleep/unresponsive)"
+            ),
         },
     );
 }
@@ -324,12 +319,25 @@ pub fn write_smartshift_in_background(
         debug!("no target device — SmartShift write skipped");
         return;
     };
-    let _span =
-        tracing::debug_span!("SmartShift write", ?mode, auto_disengage, tunable_torque).entered();
-    DeviceOp::new(capture, registry, receiver_access, &target).detach(
+    let index = target.device_index();
+    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
         "SmartShift write",
         move |c| async move {
             openlogi_hid::set_smartshift_on(&c, mode, auto_disengage, tunable_torque).await
+        },
+        move |result| match result {
+            Ok(Ok(())) => debug!(
+                index,
+                ?mode,
+                auto_disengage,
+                tunable_torque,
+                "SmartShift config written"
+            ),
+            Ok(Err(e)) => warn!(error = ?e, "SmartShift write failed"),
+            Err(_) => warn!(
+                index,
+                "SmartShift write timed out (device asleep/unresponsive)"
+            ),
         },
     );
 }
@@ -339,10 +347,19 @@ pub fn write_smartshift_in_background(
 /// keyboards that expose neither `0x40a3` nor `0x40a2` fn inversion) are
 /// logged.
 pub fn write_fn_lock_in_background(op: DeviceOp<'_>, on: bool) {
-    let _span = tracing::debug_span!("Fn-lock write", on).entered();
-    op.detach("Fn-lock write", move |c| async move {
-        openlogi_hid::set_fn_lock_on(&c, on).await
-    });
+    let index = op.route.device_index();
+    op.spawn_write(
+        "Fn-lock write",
+        move |c| async move { openlogi_hid::set_fn_lock_on(&c, on).await },
+        move |result| match result {
+            Ok(Ok(())) => debug!(index, on, "Fn-lock written"),
+            Ok(Err(e)) => warn!(error = ?e, "Fn-lock write failed"),
+            Err(_) => warn!(
+                index,
+                "Fn-lock write timed out (device asleep/unresponsive)"
+            ),
+        },
+    );
 }
 
 /// Desired SmartShift values for a reconnect re-apply.
@@ -514,11 +531,19 @@ pub fn write_dpi_in_background(
         warn!(dpi, "DPI exceeds the HID++ u16 wire field; write skipped");
         return;
     };
-    let _span = tracing::debug_span!("DPI write", dpi = dpi_u16).entered();
-    DeviceOp::new(capture, registry, receiver_access, &target)
-        .detach("DPI write", move |c| async move {
-            openlogi_hid::set_dpi_on(&c, dpi_u16).await
-        });
+    let index = target.device_index();
+    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
+        "DPI write",
+        move |c| async move { openlogi_hid::set_dpi_on(&c, dpi_u16).await },
+        move |result| match result {
+            Ok(Ok(())) => debug!(index, dpi = dpi_u16, "DPI written to device"),
+            Ok(Err(e)) => warn!(error = ?e, "DPI write failed"),
+            Err(_) => warn!(
+                dpi = dpi_u16,
+                "DPI write timed out (device asleep/unresponsive)"
+            ),
+        },
+    );
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -588,10 +613,18 @@ pub fn write_scroll_wheel_mode_in_background(
 /// failures are logged, not surfaced.
 pub fn set_lighting_in_background(op: DeviceOp<'_>, lighting: &Lighting) {
     let (r, g, b) = lighting_rgb(lighting);
-    let _span = tracing::debug_span!("lighting write", r, g, b).entered();
-    op.detach("lighting write", move |c| async move {
-        openlogi_hid::set_keyboard_color_on(&c, r, g, b).await
-    });
+    op.spawn_write(
+        "lighting write",
+        move |c| async move { openlogi_hid::set_keyboard_color_on(&c, r, g, b).await },
+        move |result| match result {
+            Ok(Ok(())) => debug!(r, g, b, "lighting written to keyboard"),
+            Ok(Err(e)) => warn!(error = ?e, "lighting write failed"),
+            Err(_) => warn!(
+                r,
+                g, b, "lighting write timed out (device asleep/unresponsive)"
+            ),
+        },
+    );
 }
 
 /// Resolve a [`Lighting`] config to an `(r, g, b)` triple: the configured

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 
 use openlogi_core::config::Lighting;
 use openlogi_hid::{
-    CaptureChannel, ChannelRegistry, DeviceRoute, DpiInfo, HapticWaveform, HidppFeatureErrorKind,
-    HidppOperation, ScrollResolution, SharedChannel, SmartShiftMode, SmartShiftStatus, WriteError,
+    CaptureChannel, ChannelRegistry, DeviceRoute, DpiInfo, HidppFeatureErrorKind, HidppOperation,
+    ScrollResolution, SharedChannel, SmartShiftMode, SmartShiftStatus, WriteError,
 };
 use tokio::time::error::Elapsed;
 use tracing::{debug, warn};
@@ -596,7 +596,8 @@ pub fn set_lighting_in_background(op: DeviceOp<'_>, lighting: &Lighting) {
 
 /// Resolve a [`Lighting`] config to an `(r, g, b)` triple: the configured
 /// colour scaled by brightness, or black when lighting is off.
-fn lighting_rgb(lighting: &Lighting) -> (u8, u8, u8) {
+#[must_use]
+pub fn lighting_rgb(lighting: &Lighting) -> (u8, u8, u8) {
     if !lighting.enabled {
         return (0, 0, 0);
     }
@@ -606,147 +607,14 @@ fn lighting_rgb(lighting: &Lighting) -> (u8, u8, u8) {
     (scale(r), scale(g), scale(b))
 }
 
-// Async, awaitable variants used by the IPC server (the GUI routes "apply now"
-// / "read" device commands through the agent, which awaits and reports the
-// result). They use a registry-confirmed capture channel or the exact current
-// inventory channel, exactly like the fire-and-forget `*_in_background`
-// helpers, so the daemon never opens a second channel to a device it holds.
-
-/// Apply `dpi` to `route` on its current inventory-owned channel.
-pub async fn apply_dpi(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-    dpi: u32,
-) -> Result<(), WriteError> {
-    // Reject a DPI beyond the HID++ u16 wire field the same way the device
-    // itself would reject an out-of-range argument.
-    let dpi = u16::try_from(dpi).map_err(|_| WriteError::HidppFeature {
+/// Reject a DPI beyond the HID++ `u16` wire field the same way the device
+/// itself would reject an out-of-range argument, rather than clamping it.
+pub fn dpi_wire_value(dpi: u32) -> Result<u16, WriteError> {
+    u16::try_from(dpi).map_err(|_| WriteError::HidppFeature {
         operation: HidppOperation::WriteDpi,
         feature_hex: 0x2201,
         kind: HidppFeatureErrorKind::OutOfRange,
-    })?;
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    timed(
-        HidppOperation::WriteDpi,
-        openlogi_hid::set_dpi_on(&shared, dpi),
-    )
-    .await
-}
-
-/// Apply a full SmartShift config to `route` (capture-channel-aware).
-pub async fn apply_smartshift(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-    mode: SmartShiftMode,
-    auto_disengage: u8,
-    tunable_torque: u8,
-) -> Result<(), WriteError> {
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    timed(
-        HidppOperation::WriteSmartShift,
-        openlogi_hid::set_smartshift_on(&shared, mode, auto_disengage, tunable_torque),
-    )
-    .await
-}
-
-/// Arm the firmware haptic engine (enable + non-zero intensity) for the
-/// device at `route`. Called once per Actions Ring session before the first
-/// hover — some power transitions clear the firmware state, after which plays
-/// are accepted silently. Returns `true` when a repair write was needed.
-pub async fn ensure_ring_haptics_armed(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-) -> Result<bool, WriteError> {
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    timed(
-        HidppOperation::PlayHaptic,
-        openlogi_hid::ensure_haptics_armed_on(registry, &shared),
-    )
-    .await
-}
-
-/// Play one Actions Ring haptic waveform on the registry-authoritative channel.
-///
-/// Haptics are best-effort feedback: the caller supplies a route only when the
-/// persisted ring setting and the live device capability both allow it, and
-/// failures are logged by the IPC handler without failing the interaction.
-pub async fn play_haptic(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-    waveform: HapticWaveform,
-) -> Result<(), WriteError> {
-    // Lease first, resolve second — the wait is unbounded, and a channel
-    // resolved before it can be retired by the enumerator while we queue. The
-    // play itself would still succeed on the retired handle; it is the feature
-    // cache that must not outlive the channel (see `EpochGuarded::store`).
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    timed(
-        HidppOperation::PlayHaptic,
-        openlogi_hid::play_haptic_on(registry, &shared, waveform),
-    )
-    .await
-}
-
-/// Apply a lighting config to the keyboard at `route`.
-pub async fn apply_lighting(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-    lighting: &Lighting,
-) -> Result<(), WriteError> {
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    let (r, g, b) = lighting_rgb(lighting);
-    timed(
-        HidppOperation::Lighting,
-        openlogi_hid::set_keyboard_color_on(&shared, r, g, b),
-    )
-    .await
-}
-
-/// Read the current DPI + supported values from `route`.
-pub async fn read_dpi(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-) -> Result<DpiInfo, WriteError> {
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    timed(
-        HidppOperation::ReadDpiCapabilities,
-        openlogi_hid::get_dpi_info_on(&shared),
-    )
-    .await
-}
-
-/// Read the current SmartShift config from `route`.
-pub async fn read_smartshift(
-    capture: &CaptureChannel,
-    registry: &ChannelRegistry,
-    receiver_access: &ReceiverAccess,
-    route: &DeviceRoute,
-) -> Result<SmartShiftStatus, WriteError> {
-    let _lease = receiver_access.acquire_for_io().await;
-    let shared = authoritative_channel(Some(capture), registry, route)?;
-    timed(
-        HidppOperation::ReadSmartShift,
-        openlogi_hid::get_smartshift_status_on(&shared),
-    )
-    .await
+    })
 }
 
 /// Bound any single HID++ call by [`WRITE_BUDGET`] so an asleep / unresponsive

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -595,7 +595,7 @@ pub fn dispatch_action(
             let target = dpi_cycle.read().ok().and_then(|g| g.target_for(device_key));
             info!("SmartShift toggle → flipping wheel mode");
             if let Some(registry) = registry {
-                toggle_smartshift_in_background(Some(capture), registry, receiver_access, target);
+                toggle_smartshift_in_background(capture, registry, receiver_access, target);
             } else {
                 warn!("no inventory registry — SmartShift toggle skipped");
             }
@@ -625,7 +625,7 @@ pub fn dispatch_action(
     if let Some((dpi, target)) = next {
         info!(dpi, "DPI action → writing to device");
         if let Some(registry) = registry {
-            write_dpi_in_background(Some(capture), registry, receiver_access, target, dpi);
+            write_dpi_in_background(capture, registry, receiver_access, target, dpi);
         } else {
             warn!("no inventory registry — DPI action skipped");
         }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -29,6 +29,7 @@ use crate::action_ring::ActionRingSessionSpec;
 use crate::bindings::{bindings_for, oshook_gestures_for};
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans, plan_for_device};
 use crate::device_order::DeviceStableId;
+use crate::hardware::DeviceOp;
 use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::ipc::InventoryHealth;
 use crate::receiver_access::ReceiverAccess;
@@ -96,6 +97,34 @@ pub struct SharedRuntime {
     pub receiver_access: ReceiverAccess,
     /// Keyboard → pointing-device routes resolved from `config.toml`.
     pub host_switch_links: HostSwitchLinks,
+}
+
+impl SharedRuntime {
+    /// Bind a device operation to `route` on the mouse/pointer capture
+    /// channel — the registry-confirmed capture channel or the exact current
+    /// inventory channel that every device write already resolves through.
+    #[must_use]
+    pub fn device(&self, route: &DeviceRoute) -> DeviceOp<'_> {
+        DeviceOp::new(
+            &self.capture_channel,
+            &self.channel_registry,
+            &self.receiver_access,
+            route,
+        )
+    }
+
+    /// Same, but against the keyboard capture channel — Fn-lock writes run on
+    /// the keyboard's own capture session, not the mouse-oriented
+    /// [`Self::capture_channel`].
+    #[must_use]
+    pub fn keyboard_device(&self, route: &DeviceRoute) -> DeviceOp<'_> {
+        DeviceOp::new(
+            &self.keyboard_channel,
+            &self.channel_registry,
+            &self.receiver_access,
+            route,
+        )
+    }
 }
 
 /// Owns the config + device selection and keeps [`SharedRuntime`] in sync.
@@ -453,10 +482,7 @@ impl Orchestrator {
             });
         if resolution.is_some() || inverted.is_some() || dpi.is_some() || smartshift.is_some() {
             crate::hardware::reapply_mouse_volatile_in_background(
-                Some(&self.shared.capture_channel),
-                &self.shared.channel_registry,
-                &self.shared.receiver_access,
-                route.clone(),
+                &self.shared.device(&route),
                 resolution,
                 inverted,
                 dpi,
@@ -464,20 +490,11 @@ impl Orchestrator {
             );
         }
         if let Some(lighting) = self.config.lighting(key).filter(|l| l.enabled) {
-            crate::hardware::set_lighting_in_background(
-                Some(&self.shared.capture_channel),
-                &self.shared.channel_registry,
-                &self.shared.receiver_access,
-                Some(route.clone()),
-                &lighting,
-            );
+            crate::hardware::set_lighting_in_background(self.shared.device(&route), &lighting);
         }
         if let Some(fn_lock) = self.config.fn_lock(key) {
             crate::hardware::write_fn_lock_in_background(
-                Some(&self.shared.keyboard_channel),
-                &self.shared.channel_registry,
-                &self.shared.receiver_access,
-                Some(route.clone()),
+                self.shared.keyboard_device(&route),
                 fn_lock,
             );
         }
@@ -557,19 +574,13 @@ impl Orchestrator {
     /// it on every reload costs at most one wheel-mode read per device — and
     /// still recovers a device whose earlier write timed out while it was waking.
     fn apply_native_wheel_modes(&self) {
-        for dev in self
-            .devices
-            .iter()
-            .filter(|dev| dev.online && dev.route.is_some())
-        {
+        for dev in self.devices.iter().filter(|dev| dev.online) {
+            let Some(route) = dev.route.clone() else {
+                continue;
+            };
             let (resolution, inverted) = configured_wheel_mode(&self.config, dev);
             crate::hardware::write_scroll_wheel_mode_in_background(
-                Some(&self.shared.capture_channel),
-                &self.shared.channel_registry,
-                &self.shared.receiver_access,
-                (resolution.is_some() || inverted.is_some())
-                    .then(|| dev.route.clone())
-                    .flatten(),
+                self.shared.device(&route),
                 resolution,
                 inverted,
             );
@@ -718,17 +729,13 @@ impl Orchestrator {
     /// [`Self::reapply_volatile_settings`]); the write is a single HID++ call,
     /// so re-applying an unchanged state is cheap.
     fn apply_fn_locks(&self) {
-        for dev in self
-            .devices
-            .iter()
-            .filter(|dev| dev.online && dev.route.is_some())
-        {
+        for dev in self.devices.iter().filter(|dev| dev.online) {
+            let Some(route) = dev.route.clone() else {
+                continue;
+            };
             if let Some(fn_lock) = self.config.fn_lock(&dev.config_key) {
                 crate::hardware::write_fn_lock_in_background(
-                    Some(&self.shared.keyboard_channel),
-                    &self.shared.channel_registry,
-                    &self.shared.receiver_access,
-                    dev.route.clone(),
+                    self.shared.keyboard_device(&route),
                     fn_lock,
                 );
             }

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -23,8 +23,8 @@ use openlogi_core::binding::ActionRingSlot;
 use openlogi_core::config::{Config, Lighting};
 use openlogi_core::device::DeviceInventory;
 use openlogi_hid::{
-    DeviceRoute, DpiInfo, HapticWaveform, LightCommand, ReceiverSelector, SmartShiftMode,
-    SmartShiftStatus, WriteError,
+    DeviceRoute, DpiInfo, HapticWaveform, HidppOperation, LightCommand, ReceiverSelector,
+    SmartShiftMode, SmartShiftStatus, WriteError,
 };
 
 use crate::pairing::PairingManager;
@@ -113,14 +113,13 @@ impl Agent for AgentServer {
     }
 
     async fn set_dpi(self, _: Context, route: DeviceRoute, dpi: u32) -> Result<(), WriteError> {
-        hardware::apply_dpi(
-            &self.shared.capture_channel,
-            &self.shared.channel_registry,
-            &self.shared.receiver_access,
-            &route,
-            dpi,
-        )
-        .await
+        let dpi = hardware::dpi_wire_value(dpi)?;
+        self.shared
+            .device(&route)
+            .run(HidppOperation::WriteDpi, |c| async move {
+                openlogi_hid::set_dpi_on(&c, dpi).await
+            })
+            .await
     }
 
     async fn set_lighting(
@@ -129,14 +128,13 @@ impl Agent for AgentServer {
         route: DeviceRoute,
         lighting: Lighting,
     ) -> Result<(), WriteError> {
-        hardware::apply_lighting(
-            &self.shared.capture_channel,
-            &self.shared.channel_registry,
-            &self.shared.receiver_access,
-            &route,
-            &lighting,
-        )
-        .await
+        let (r, g, b) = hardware::lighting_rgb(&lighting);
+        self.shared
+            .device(&route)
+            .run(HidppOperation::Lighting, |c| async move {
+                openlogi_hid::set_keyboard_color_on(&c, r, g, b).await
+            })
+            .await
     }
 
     async fn set_smartshift(
@@ -147,26 +145,21 @@ impl Agent for AgentServer {
         auto_disengage: u8,
         tunable_torque: u8,
     ) -> Result<(), WriteError> {
-        hardware::apply_smartshift(
-            &self.shared.capture_channel,
-            &self.shared.channel_registry,
-            &self.shared.receiver_access,
-            &route,
-            mode,
-            auto_disengage,
-            tunable_torque,
-        )
-        .await
+        self.shared
+            .device(&route)
+            .run(HidppOperation::WriteSmartShift, |c| async move {
+                openlogi_hid::set_smartshift_on(&c, mode, auto_disengage, tunable_torque).await
+            })
+            .await
     }
 
     async fn read_dpi(self, _: Context, route: DeviceRoute) -> Result<DpiInfo, WriteError> {
-        hardware::read_dpi(
-            &self.shared.capture_channel,
-            &self.shared.channel_registry,
-            &self.shared.receiver_access,
-            &route,
-        )
-        .await
+        self.shared
+            .device(&route)
+            .run(HidppOperation::ReadDpiCapabilities, |c| async move {
+                openlogi_hid::get_dpi_info_on(&c).await
+            })
+            .await
     }
 
     async fn read_smartshift(
@@ -174,13 +167,12 @@ impl Agent for AgentServer {
         _: Context,
         route: DeviceRoute,
     ) -> Result<SmartShiftStatus, WriteError> {
-        hardware::read_smartshift(
-            &self.shared.capture_channel,
-            &self.shared.channel_registry,
-            &self.shared.receiver_access,
-            &route,
-        )
-        .await
+        self.shared
+            .device(&route)
+            .run(HidppOperation::ReadSmartShift, |c| async move {
+                openlogi_hid::get_smartshift_status_on(&c).await
+            })
+            .await
     }
 
     async fn request_accessibility_prompt(self, _: Context) {
@@ -352,12 +344,11 @@ async fn arm_firmware_haptics(shared: &SharedRuntime, route: &DeviceRoute) {
         };
         match tokio::time::timeout(
             remaining,
-            hardware::ensure_ring_haptics_armed(
-                &shared.capture_channel,
-                &shared.channel_registry,
-                &shared.receiver_access,
-                route,
-            ),
+            shared
+                .device(route)
+                .run(HidppOperation::PlayHaptic, |c| async move {
+                    openlogi_hid::ensure_haptics_armed_on(&shared.channel_registry, &c).await
+                }),
         )
         .await
         {
@@ -402,13 +393,11 @@ async fn play_within_budget(
         };
         match tokio::time::timeout(
             remaining,
-            hardware::play_haptic(
-                &shared.capture_channel,
-                &shared.channel_registry,
-                &shared.receiver_access,
-                route,
-                waveform,
-            ),
+            shared
+                .device(route)
+                .run(HidppOperation::PlayHaptic, |c| async move {
+                    openlogi_hid::play_haptic_on(&shared.channel_registry, &c, waveform).await
+                }),
         )
         .await
         {


### PR DESCRIPTION
## Summary

`crates/openlogi-agent-core/src/hardware.rs` had two families of near-identical
boilerplate: seven fire-and-forget `*_in_background` functions (each ~35 lines:
None-target guard → resolve → thread spawn → one-shot runtime → lease → timeout
→ 3-arm log) and seven awaited `apply_*`/`read_*`/`play_haptic`/
`ensure_ring_haptics_armed` functions sharing the same `(capture, registry,
receiver_access)` triple that `server.rs` spelled out by hand at every call
site. Both collapse onto a new `DeviceOp` type — the receiver-side counterpart
of `openlogi-hid`'s `with_route` "boilerplate-eater".

## Changes

- **`openlogi-agent-core`**
  - **Behavior fix, in its own commit** (`fix(agent): bound the background
    lighting write by WRITE_BUDGET`): `set_lighting_in_background` awaited its
    HID++ write with no timeout at all — unlike every sibling
    `*_in_background` writer — so an asleep/unresponsive keyboard leaked that
    background thread forever. Fixed independently of the `DeviceOp` refactor
    so it's revertible/cherry-pickable on its own and shows up in the
    release-plz changelog as a `fix`, not buried inside a `refactor` commit.
  - Add `DeviceOp<'a>` (`hardware.rs`): binds a `DeviceRoute` to the runtime's
    capture/inventory channels, then either `run()`s once (awaited, leases
    before resolving) or `detach()`es fire-and-forget on its own OS thread with
    standard 3-arm logging. `SharedRuntime::device`/`keyboard_device`
    (`orchestrator.rs`) build one from the shared runtime.
  - Every `*_in_background` function now goes through `DeviceOp`, except
    `reapply_mouse_volatile_in_background`, which stays hand-rolled and now
    takes `&DeviceOp` (it only reads fields, never hands the op to
    `run`/`detach`/`spawn_write`) — it must keep DPI/SmartShift/wheel-mode
    sequential on one OS thread with one resolved channel and one held lease
    (issue #485). Its `#[expect(clippy::too_many_arguments)]` is gone now that
    the four loose capture/registry/receiver_access/route params collapsed
    into one `&DeviceOp`.
  - **Diagnostics preserved, not just collapsed** (second `fix(agent):`
    commit): the generic `DeviceOp::detach` outcome log carries only `label`,
    which would silently have dropped every value the old bespoke logging
    carried (the written DPI, the SmartShift mode/auto_disengage/
    tunable_torque, the Fn-lock `on`, the lighting `r`/`g`/`b`). The five
    writes that carry an interesting value call `DeviceOp::spawn_write`
    directly (the same seam `write_scroll_wheel_mode_in_background` already
    used for its own custom logging) with their own 3-arm outcome closure
    instead of the generic `detach`, so `"DPI written to device"`,
    `"SmartShift config written"`, `"Fn-lock written"`, and `"lighting written
    to keyboard"` are byte-for-byte the log lines master had before this PR.
    `detach` itself is unchanged (still used by writes with nothing extra to
    log, and by its own registry-miss test).
  - `apply_dpi`, `apply_smartshift`, `apply_lighting`, `read_dpi`,
    `read_smartshift`, `play_haptic`, `ensure_ring_haptics_armed` are removed;
    their single call sites in `server.rs` now call `DeviceOp::run` directly.
    Their DPI-range check and lighting RGB scaling survive as two small `pub`
    helpers, `dpi_wire_value` and `lighting_rgb`.
  - `orchestrator.rs` / `hook_runtime.rs` call sites updated to the new
    `SharedRuntime::device(&route)` / `keyboard_device(&route)` builders.
  - Three new tests on the `DeviceOp` seam (see Testing).
  - `write_smartshift_in_background`, `read_dpi_info_blocking`, and
    `read_smartshift_status_blocking` have zero callers anywhere in the
    workspace (the latter two predate the GUI's move to IPC-only device
    reads, it looks like). Left in place, not deleted here — tracked as #615.
  - Net: `hardware.rs` 852 → 790 lines, despite adding the new `DeviceOp` type
    with full rustdoc, its tests, and the restored per-value logging.
- **`openlogi-agent`**
  - `server.rs`'s IPC handlers (`set_dpi`, `set_lighting`, `set_smartshift`,
    `read_dpi`, `read_smartshift`) and the Actions Ring haptic worker
    (`arm_firmware_haptics`, `play_within_budget`) now call
    `self.shared.device(&route).run(HidppOperation::…, |c| async move { … })`
    directly instead of the removed `hardware::apply_*`/`read_*` wrappers.

### Preserved behavior (audited per-function, not normalized silently)

1. **Lease-vs-resolve ordering unchanged for every function.** The seven
   `apply_*`/`read_*`/`play_haptic`/`ensure_ring_haptics_armed` functions were
   *all* already lease-then-resolve; `DeviceOp::run` does the same
   (lease → resolve → `timed`), so nothing changed there. The seven
   `*_in_background` functions were all resolve-on-the-caller's-thread, *then*
   spawn a thread that leases; `DeviceOp::detach`/`spawn_write` preserve that
   exact order too. No function's ordering was unified or flipped.
2. `reapply_mouse_volatile_in_background` still resolves once, holds one lease,
   and runs DPI/SmartShift/wheel-mode sequentially on the one OS thread it
   spawns — confirmed by re-reading the diff line by line; it deliberately does
   not decompose into three `detach`/`spawn_write` calls.
3. `authoritative_channel`'s registry-miss path still calls
   `openlogi_hid::clear_haptic_feature_cache()` before returning
   `DeviceNotFound` — untouched, and now covered by a test (see Testing).
4. `WRITE_BUDGET` now wraps *every* background write, including
   `set_lighting_in_background` (see the isolated `fix:` commit above).
5. DPI-range rejection kept its two distinct shapes: `dpi_wire_value` (used by
   `server.rs`'s `set_dpi`) returns the typed
   `WriteError::HidppFeature{OutOfRange}`; `write_dpi_in_background` still logs
   and skips instead of erroring.
6. `set_dpi_on_channel`'s read-back verification (untouched, lives in
   `openlogi-hid`) and `log_wheel_result`'s `FeatureUnsupported`-is-`debug`-not-
   `warn` distinction are both intact and unchanged — wheel-mode writes still
   route through `log_wheel_result` exactly as before.

## Testing

```
direnv exec . cargo fmt --all -- --check
direnv exec . env CARGO_BUILD_JOBS=8 cargo clippy --workspace --all-targets -- -D warnings
direnv exec . env CARGO_BUILD_JOBS=8 cargo test --workspace
direnv exec . env CARGO_BUILD_JOBS=8 cargo test -p openlogi-agent-core --test wire_format
```

All green on the final tree. `wire_format` goldens are byte-for-byte unchanged
(no `PROTOCOL_VERSION` bump needed — this branch never touches a type that
crosses the IPC wire). `orchestrator/tests.rs` (103 pre-existing agent-core
unit tests, including every `orchestrator::tests::*` and the three
`hardware::tests::*` `choose_authoritative` tests) pass unchanged.

Three new tests exercise real `DeviceOp` logic (not tautological mirrors of the
implementation):
- `run_on_a_registry_miss_returns_device_not_found_without_calling_f` /
  `detach_on_a_registry_miss_never_calls_f` — a registry miss propagates
  `WriteError::DeviceNotFound` and never invokes the caller's write closure.
- `timed_maps_an_elapsed_deadline_to_request_timed_out` — an elapsed
  `WRITE_BUDGET` maps to `WriteError::RequestTimedOut { operation }`, using a
  paused tokio clock (`tokio/test-util`, dev-dependency only) so the test
  advances virtual time instead of sleeping 5 real seconds.

A real end-to-end `DeviceOp::run` timeout test (resolve succeeds, then the
write itself times out) isn't possible from this crate: `SharedChannel` has no
public constructor outside `openlogi-hid`, so there's no way to make
`resolve()` succeed without a real device open.

**Not runtime-tested on hardware** — the `*_in_background` family is
fire-and-forget and hardware-bound; verifying the lease/resolve/timeout paths,
the sequential volatile-reapply write, and the fixed lighting timeout gap all
need a physical device.
