### PR TITLE
refactor(gui): fold AppState's per-device side tables and dpi/smartshift twins

### DIFF
--- a/crates/openlogi-gui/src/app/home.rs
+++ b/crates/openlogi-gui/src/app/home.rs
@@ -95,12 +95,12 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
                     .try_global::<AppState>()
                     .is_some_and(|s| s.device_enabled(&record.config_key));
                 let light_enabled = cx.try_global::<AppState>().is_some_and(|state| {
-                    record.kind == DeviceKind::Light && state.light_enabled_for(&record.config_key)
+                    record.kind == DeviceKind::Light && state.light_enabled_for(&record.device_key())
                 });
                 let light_settings = cx
                     .try_global::<AppState>()
                     .map_or_else(LightSettings::default, |state| {
-                        state.light_for(&record.config_key)
+                        state.light_for(&record.device_key())
                     });
                 let glow = cx
                     .try_global::<AppState>()

--- a/crates/openlogi-gui/src/components/device_read.rs
+++ b/crates/openlogi-gui/src/components/device_read.rs
@@ -19,9 +19,10 @@ use crate::state::{AppState, DeviceKey};
 /// `make_command` builds the read [`Command`] from the route and reply channel
 /// (e.g. [`Command::ReadDpi`]); `store` applies a delivered result (e.g.
 /// [`AppState::store_dpi_info`]); `clear` resets the loading marker when the
-/// reply is dropped (e.g. [`AppState::clear_dpi_loading`]). The caller marks the
-/// loading state first for an initial load, or skips it for a post-write confirm
-/// re-read so the optimistic value stays on screen until the real one lands.
+/// reply is dropped (e.g. `|state, key| state.reads.dpi.clear_loading(key)`).
+/// The caller marks the loading state first for an initial load, or skips it
+/// for a post-write confirm re-read so the optimistic value stays on screen
+/// until the real one lands.
 pub fn issue_device_read<P, T>(
     cx: &mut Context<P>,
     key: DeviceKey,

--- a/crates/openlogi-gui/src/components/device_read.rs
+++ b/crates/openlogi-gui/src/components/device_read.rs
@@ -11,7 +11,7 @@ use openlogi_hid::DeviceRoute;
 use tokio::sync::oneshot;
 
 use crate::ipc_client::Command;
-use crate::state::AppState;
+use crate::state::{AppState, DeviceKey};
 
 /// Issue a one-shot device read over IPC and apply its typed result to
 /// [`AppState`], off the render thread.
@@ -24,11 +24,11 @@ use crate::state::AppState;
 /// re-read so the optimistic value stays on screen until the real one lands.
 pub fn issue_device_read<P, T>(
     cx: &mut Context<P>,
-    key: String,
+    key: DeviceKey,
     route: DeviceRoute,
     make_command: impl FnOnce(DeviceRoute, oneshot::Sender<T>) -> Command,
-    store: impl FnOnce(&mut AppState, String, &DeviceRoute, T) + 'static,
-    clear: impl Fn(&mut AppState, &str) + 'static,
+    store: impl FnOnce(&mut AppState, DeviceKey, &DeviceRoute, T) + 'static,
+    clear: impl Fn(&mut AppState, &DeviceKey) + 'static,
 ) where
     P: 'static,
     T: 'static,

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 
 use crate::components::device_read::issue_device_read;
 use crate::components::status::{retry_line, status_line};
-use crate::state::{AppState, DpiStatus};
+use crate::state::{AppState, DeviceKey, DpiStatus};
 use crate::theme::{self, Palette, SelectableStyle, Typography as _};
 
 pub struct DpiPanel {
@@ -39,7 +39,7 @@ struct SliderShape {
 }
 
 struct DpiPanelSnapshot {
-    device_key: String,
+    device_key: DeviceKey,
     dpi: u32,
     presets: Vec<u32>,
     status: DpiStatus,
@@ -181,7 +181,7 @@ impl Render for DpiPanel {
 
         if let DpiStatus::Ready(info) = &snapshot.status {
             self.ensure_slider(
-                &snapshot.device_key,
+                snapshot.device_key.as_str(),
                 &info.capabilities,
                 snapshot.dpi,
                 window,
@@ -271,7 +271,7 @@ fn dpi_panel_snapshot(cx: &mut Context<DpiPanel>) -> DpiPanelSnapshot {
         .and_then(|s| {
             let record = s.current_record()?;
             Some(DpiPanelSnapshot {
-                device_key: record.config_key.clone(),
+                device_key: record.device_key(),
                 dpi: s.dpi,
                 presets: s.dpi_presets(),
                 status: s.current_dpi_status(),
@@ -279,7 +279,7 @@ fn dpi_panel_snapshot(cx: &mut Context<DpiPanel>) -> DpiPanelSnapshot {
             })
         })
         .unwrap_or_else(|| DpiPanelSnapshot {
-            device_key: String::new(),
+            device_key: DeviceKey::default(),
             dpi: crate::state::DEFAULT_DPI,
             presets: Vec::new(),
             status: DpiStatus::Unsupported(tr!("No active device").to_string()),
@@ -429,13 +429,13 @@ fn add_preset_chip() -> AnyElement {
         .into_any_element()
 }
 
-fn dpi_load_target(cx: &mut Context<DpiPanel>) -> Option<(String, DeviceRoute)> {
+fn dpi_load_target(cx: &mut Context<DpiPanel>) -> Option<(DeviceKey, DeviceRoute)> {
     cx.try_global::<AppState>().and_then(|state| {
         if !state.current_dpi_unqueried() {
             return None;
         }
         let record = state.current_record()?;
-        Some((record.config_key.clone(), record.route.clone()?))
+        Some((record.device_key(), record.route.clone()?))
     })
 }
 

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -81,7 +81,7 @@ impl DpiPanel {
             return;
         };
 
-        cx.update_global::<AppState, _>(|state, _| state.mark_dpi_loading(&key));
+        cx.update_global::<AppState, _>(|state, _| state.reads.dpi.mark_loading(&key));
         // The agent owns device I/O: request the DPI read over IPC and store the
         // typed reply off the render thread. The typed `WriteError` reaches
         // `store_dpi_info` intact, so a permanent `FeatureUnsupported` /
@@ -92,7 +92,7 @@ impl DpiPanel {
             route,
             crate::ipc_client::Command::ReadDpi,
             AppState::store_dpi_info,
-            AppState::clear_dpi_loading,
+            |state, key| state.reads.dpi.clear_loading(key),
         );
     }
 
@@ -216,6 +216,7 @@ impl Render for DpiPanel {
             &snapshot.status,
             self.slider_state.as_ref(),
             snapshot.reachable,
+            snapshot.device_key.clone(),
             pal,
         );
 
@@ -270,11 +271,12 @@ fn dpi_panel_snapshot(cx: &mut Context<DpiPanel>) -> DpiPanelSnapshot {
     cx.try_global::<AppState>()
         .and_then(|s| {
             let record = s.current_record()?;
+            let device_key = record.device_key();
             Some(DpiPanelSnapshot {
-                device_key: record.device_key(),
+                status: s.reads.dpi.status(&device_key),
+                device_key,
                 dpi: s.dpi,
                 presets: s.dpi_presets(),
-                status: s.current_dpi_status(),
                 reachable: record.route.is_some(),
             })
         })
@@ -312,6 +314,7 @@ fn slider_element(
     status: &DpiStatus,
     slider_state: Option<&Entity<SliderState>>,
     reachable: bool,
+    key: DeviceKey,
     pal: Palette,
 ) -> AnyElement {
     match (status, slider_state) {
@@ -338,8 +341,8 @@ fn slider_element(
             "dpi-retry",
             tr!("Couldn't read DPI — click to retry."),
             pal,
-            |cx| {
-                cx.update_global::<AppState, _>(|state, _| state.retry_active_dpi());
+            move |cx| {
+                cx.update_global::<AppState, _>(|state, _| state.reads.dpi.retry(&key));
                 cx.refresh_windows();
             },
         ),
@@ -431,11 +434,12 @@ fn add_preset_chip() -> AnyElement {
 
 fn dpi_load_target(cx: &mut Context<DpiPanel>) -> Option<(DeviceKey, DeviceRoute)> {
     cx.try_global::<AppState>().and_then(|state| {
-        if !state.current_dpi_unqueried() {
+        let record = state.current_record()?;
+        let key = record.device_key();
+        if !state.reads.dpi.unqueried(&key) {
             return None;
         }
-        let record = state.current_record()?;
-        Some((record.device_key(), record.route.clone()?))
+        Some((key, record.route.clone()?))
     })
 }
 

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -31,7 +31,7 @@ use openlogi_hid::{AUTO_DISENGAGE_PERMANENT, DeviceRoute, SmartShiftMode, SmartS
 
 use crate::components::device_read::issue_device_read;
 use crate::components::status::{retry_line, status_line};
-use crate::state::{AppState, SmartShiftLoad, SmartShiftWriteStatus};
+use crate::state::{AppState, DeviceKey, SmartShiftLoad, SmartShiftWriteStatus};
 use crate::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
 /// Friendly slider range for the `autoDisengage` threshold. The wire field is
@@ -186,10 +186,10 @@ impl SmartShiftPanel {
     /// so a permanent `FeatureUnsupported` reaches `store_smartshift_status`
     /// intact and the panel stops re-probing instead of retrying every reselect.
     fn issue_smartshift_read(
-        key: String,
+        key: DeviceKey,
         route: DeviceRoute,
         write_id: Option<u64>,
-        clear: impl Fn(&mut AppState, &str) + 'static,
+        clear: impl Fn(&mut AppState, &DeviceKey) + 'static,
         cx: &mut Context<Self>,
     ) {
         issue_device_read(
@@ -433,7 +433,7 @@ fn smartshift_write_feedback(
 
 fn smartshift_load_target(
     cx: &mut Context<SmartShiftPanel>,
-) -> Option<(String, DeviceRoute, Option<u64>)> {
+) -> Option<(DeviceKey, DeviceRoute, Option<u64>)> {
     cx.try_global::<AppState>().and_then(|state| {
         if !state.current_smartshift_unqueried() {
             return None;
@@ -443,7 +443,7 @@ fn smartshift_load_target(
             Some(SmartShiftWriteStatus::Applying { write_id, .. }) => Some(write_id),
             Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
         };
-        Some((record.config_key.clone(), record.route.clone()?, write_id))
+        Some((record.device_key(), record.route.clone()?, write_id))
     })
 }
 

--- a/crates/openlogi-gui/src/components/smartshift_panel.rs
+++ b/crates/openlogi-gui/src/components/smartshift_panel.rs
@@ -13,7 +13,7 @@
 //! [`crate::components::dpi_panel`].
 
 use gpui::{
-    AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, IntoElement,
+    AnyElement, App, AppContext as _, BorrowAppContext as _, Context, Entity, IntoElement,
     ParentElement, Render, SharedString, Styled, Subscription, Window, div, px, rgb,
 };
 use gpui_component::{
@@ -157,8 +157,14 @@ impl SmartShiftPanel {
         let Some((key, route, write_id)) = smartshift_load_target(cx) else {
             return;
         };
-        cx.update_global::<AppState, _>(|state, _| state.mark_smartshift_loading(&key));
-        Self::issue_smartshift_read(key, route, write_id, AppState::clear_smartshift_loading, cx);
+        cx.update_global::<AppState, _>(|state, _| state.reads.smartshift.mark_loading(&key));
+        Self::issue_smartshift_read(
+            key,
+            route,
+            write_id,
+            |state, key| state.reads.smartshift.clear_loading(key),
+            cx,
+        );
     }
 
     /// Re-read once after an optimistic write to confirm the device actually
@@ -368,9 +374,13 @@ impl Render for SmartShiftPanel {
         Self::ensure_smartshift_confirm(cx);
         let pal = theme::palette(cx);
 
-        let status = cx
+        let (key, status) = cx
             .try_global::<AppState>()
-            .map_or(SmartShiftLoad::Unknown, AppState::current_smartshift_status);
+            .and_then(|state| {
+                let key = state.current_record()?.device_key();
+                Some((Some(key.clone()), state.reads.smartshift.status(&key)))
+            })
+            .unwrap_or((None, SmartShiftLoad::Unknown));
         let write_status = cx
             .try_global::<AppState>()
             .and_then(AppState::current_smartshift_write_status);
@@ -392,10 +402,7 @@ impl Render for SmartShiftPanel {
                 "smartshift-retry",
                 tr!("Couldn't read SmartShift — click to retry."),
                 pal,
-                |cx| {
-                    cx.update_global::<AppState, _>(|state, _| state.retry_active_smartshift());
-                    cx.refresh_windows();
-                },
+                retry_smartshift_closure(key.clone()),
             ),
             SmartShiftLoad::Unsupported(_) => {
                 status_line(tr!("This device does not support SmartShift."), pal)
@@ -403,14 +410,25 @@ impl Render for SmartShiftPanel {
         };
 
         let feedback = show_write_status
-            .then(|| smartshift_write_feedback(write_status, pal))
+            .then(|| smartshift_write_feedback(write_status, key, pal))
             .flatten();
         v_flex().gap_3().w_full().child(content).children(feedback)
     }
 }
 
+/// A retry action bound to `key`, or a no-op when there is no active device.
+fn retry_smartshift_closure(key: Option<DeviceKey>) -> impl Fn(&mut App) + 'static {
+    move |cx| {
+        if let Some(key) = &key {
+            cx.update_global::<AppState, _>(|state, _| state.retry_smartshift(key));
+        }
+        cx.refresh_windows();
+    }
+}
+
 fn smartshift_write_feedback(
     status: Option<SmartShiftWriteStatus>,
+    key: Option<DeviceKey>,
     pal: Palette,
 ) -> Option<AnyElement> {
     match status {
@@ -422,10 +440,7 @@ fn smartshift_write_feedback(
             "smartshift-confirm-retry",
             tr!("Couldn't read SmartShift — click to retry."),
             pal,
-            |cx| {
-                cx.update_global::<AppState, _>(|state, _| state.retry_active_smartshift());
-                cx.refresh_windows();
-            },
+            retry_smartshift_closure(key),
         )),
         None => None,
     }
@@ -435,15 +450,16 @@ fn smartshift_load_target(
     cx: &mut Context<SmartShiftPanel>,
 ) -> Option<(DeviceKey, DeviceRoute, Option<u64>)> {
     cx.try_global::<AppState>().and_then(|state| {
-        if !state.current_smartshift_unqueried() {
+        let record = state.current_record()?;
+        let key = record.device_key();
+        if !state.reads.smartshift.unqueried(&key) {
             return None;
         }
-        let record = state.current_record()?;
         let write_id = match state.current_smartshift_write_status() {
             Some(SmartShiftWriteStatus::Applying { write_id, .. }) => Some(write_id),
             Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
         };
-        Some((record.device_key(), record.route.clone()?, write_id))
+        Some((key, record.route.clone()?, write_id))
     })
 }
 

--- a/crates/openlogi-gui/src/components/status.rs
+++ b/crates/openlogi-gui/src/components/status.rs
@@ -27,10 +27,8 @@ pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
 }
 
 /// A clickable accent line that re-arms a failed read on click. `on_retry` runs
-/// the panel's retry (e.g. [`AppState::retry_active_dpi`]) — the only recovery
+/// the panel's retry (e.g. `state.reads.dpi.retry(&key)`) — the only recovery
 /// path when the carousel holds a single device, where re-selecting is a no-op.
-///
-/// [`AppState::retry_active_dpi`]: crate::state::AppState::retry_active_dpi
 pub fn retry_line(
     id: impl Into<ElementId>,
     text: impl Into<SharedString>,

--- a/crates/openlogi-gui/src/diagnostics.rs
+++ b/crates/openlogi-gui/src/diagnostics.rs
@@ -124,7 +124,7 @@ fn collect_devices(state: &AppState) -> Vec<DeviceDiag> {
                 online: record.online,
                 battery: record.battery.clone(),
                 capabilities: record.capabilities,
-                dpi: dpi_summary(state.dpi_status_for(&record.config_key)),
+                dpi: dpi_summary(state.dpi_status_for(&record.device_key())),
                 // Diagnostics are model-level by contract. The runtime config
                 // key may contain a receiver UID or raw-device serial.
                 config_key: record.model_key.clone(),

--- a/crates/openlogi-gui/src/diagnostics.rs
+++ b/crates/openlogi-gui/src/diagnostics.rs
@@ -124,7 +124,7 @@ fn collect_devices(state: &AppState) -> Vec<DeviceDiag> {
                 online: record.online,
                 battery: record.battery.clone(),
                 capabilities: record.capabilities,
-                dpi: dpi_summary(state.dpi_status_for(&record.device_key())),
+                dpi: dpi_summary(state.reads.dpi.get(&record.device_key()).cloned()),
                 // Diagnostics are model-level by contract. The runtime config
                 // key may contain a receiver UID or raw-device serial.
                 config_key: record.model_key.clone(),

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -18,6 +18,7 @@ use openlogi_hid::{DpiInfo, SmartShiftStatus};
 use tokio::sync::mpsc;
 use tracing::warn;
 
+pub(crate) use device_key::DeviceKey;
 pub use devices::DeviceRecord;
 pub use light::LightCommandStatus;
 #[cfg(test)]
@@ -52,6 +53,7 @@ use openlogi_core::binding::{ActionRingConfig, ActionRingIcon, ActionRingSlot, R
 mod agent;
 mod bindings;
 mod camera;
+mod device_key;
 mod devices;
 mod dpi;
 mod inventory;

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeMap;
 use gpui::Global;
 use openlogi_core::config::{Config, KeyTrigger};
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
-use openlogi_hid::{DpiInfo, SmartShiftStatus};
+use openlogi_hid::SmartShiftStatus;
 use tokio::sync::mpsc;
 use tracing::warn;
 
@@ -43,7 +43,7 @@ pub enum SmartShiftWriteStatus {
 
 use device_ui::DeviceUiState;
 pub(crate) use devices::camera_model_info;
-use load::LazyDeviceData;
+use load::DeviceReads;
 
 use crate::asset::AssetResolver;
 use crate::data::mouse_buttons::{Action, ButtonId, GestureDirection};
@@ -127,7 +127,7 @@ pub struct AppState {
     /// Aggregate host-camera activity reported by the agent. Runtime only.
     camera_active: bool,
     /// Per-device UI state outside the persisted config and the lazily-loaded
-    /// DPI/SmartShift reads ([`Self::dpi_data`] / [`Self::smartshift_data`]) —
+    /// DPI/SmartShift reads ([`Self::reads`]) —
     /// manual camera-light overrides, volatile light settings, in-flight
     /// light commands, inventory-miss counters, and SmartShift write/confirm
     /// bookkeeping. One row per device instead of one map per concern; see
@@ -161,14 +161,12 @@ pub struct AppState {
     /// Sorted (`BTreeMap`) for stable render order in the function-row view.
     pub keyboard_bindings: BTreeMap<KeyTrigger, Action>,
     pub dpi: u32,
-    /// DPI capability load state keyed by [`DeviceKey`]. Loaded lazily
-    /// because HID++ reads must not block device switching or rendering.
-    dpi_data: LazyDeviceData<DpiInfo>,
-    /// SmartShift (`0x2111`) config load state keyed by [`DeviceKey`]. Loaded
-    /// lazily on the same pattern as [`Self::dpi_data`]; the device persists
-    /// the values itself, so this is a read/write cache, not a source of
-    /// truth saved to disk.
-    smartshift_data: LazyDeviceData<SmartShiftStatus>,
+    /// Lazily-loaded DPI and SmartShift read caches, keyed by [`DeviceKey`].
+    /// HID++ reads must not block device switching or rendering, so callers
+    /// reach these directly (`state.reads.dpi.retry(&key)`,
+    /// `state.reads.smartshift.status(&key)`, …) rather than through a
+    /// per-subsystem forwarding method.
+    pub(crate) reads: DeviceReads,
     /// Monotonic identity assigned to the next confirmable SmartShift write.
     next_smartshift_write_id: u64,
     /// All paired devices, in carousel order. Each entry caches the per-
@@ -241,8 +239,7 @@ impl AppState {
             gesture_bindings: BTreeMap::new(),
             keyboard_bindings: BTreeMap::new(),
             dpi: DEFAULT_DPI,
-            dpi_data: LazyDeviceData::default(),
-            smartshift_data: LazyDeviceData::default(),
+            reads: DeviceReads::default(),
             next_smartshift_write_id: 0,
             device_list,
             config,

--- a/crates/openlogi-gui/src/state.rs
+++ b/crates/openlogi-gui/src/state.rs
@@ -12,7 +12,7 @@
 use std::collections::BTreeMap;
 
 use gpui::Global;
-use openlogi_core::config::{Config, KeyTrigger, LightSettings};
+use openlogi_core::config::{Config, KeyTrigger};
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use openlogi_hid::{DpiInfo, SmartShiftStatus};
 use tokio::sync::mpsc;
@@ -41,8 +41,8 @@ pub enum SmartShiftWriteStatus {
     Failed,
 }
 
+use device_ui::DeviceUiState;
 pub(crate) use devices::camera_model_info;
-use light::PendingLightCommand;
 use load::LazyDeviceData;
 
 use crate::asset::AssetResolver;
@@ -54,6 +54,7 @@ mod agent;
 mod bindings;
 mod camera;
 mod device_key;
+mod device_ui;
 mod devices;
 mod dpi;
 mod inventory;
@@ -125,14 +126,14 @@ pub struct AppState {
     pub current_app_bundle: Option<String>,
     /// Aggregate host-camera activity reported by the agent. Runtime only.
     camera_active: bool,
-    /// Transient manual power choices for camera-linked lights. Cleared on
-    /// the next camera-state transition and never persisted as an override.
-    manual_light_overrides: BTreeMap<String, bool>,
-    /// Session-only settings for raw devices whose OS-node identity is not
-    /// stable enough to persist in `config.toml`.
-    volatile_light_settings: BTreeMap<String, LightSettings>,
-    light_commands: BTreeMap<String, PendingLightCommand>,
-    light_command_status: Option<(String, u64, LightCommandStatus)>,
+    /// Per-device UI state outside the persisted config and the lazily-loaded
+    /// DPI/SmartShift reads ([`Self::dpi_data`] / [`Self::smartshift_data`]) —
+    /// manual camera-light overrides, volatile light settings, in-flight
+    /// light commands, inventory-miss counters, and SmartShift write/confirm
+    /// bookkeeping. One row per device instead of one map per concern; see
+    /// [`DeviceUiState`].
+    device_ui: BTreeMap<DeviceKey, DeviceUiState>,
+    light_command_status: Option<(DeviceKey, u64, LightCommandStatus)>,
     next_light_request_id: u64,
     /// The hotspot the user most recently armed by clicking. Drives the
     /// "selected button" outline on the mouse model and the popover content.
@@ -160,28 +161,16 @@ pub struct AppState {
     /// Sorted (`BTreeMap`) for stable render order in the function-row view.
     pub keyboard_bindings: BTreeMap<KeyTrigger, Action>,
     pub dpi: u32,
-    /// DPI capability load state keyed by [`DeviceRecord::config_key`]. Loaded
-    /// lazily because HID++ reads must not block device switching or rendering.
+    /// DPI capability load state keyed by [`DeviceKey`]. Loaded lazily
+    /// because HID++ reads must not block device switching or rendering.
     dpi_data: LazyDeviceData<DpiInfo>,
-    /// Consecutive inventory snapshots that omitted a previously-known device,
-    /// keyed by [`DeviceRecord::config_key`]. Used to debounce transient HID++
-    /// probe misses without hiding a real disconnect forever.
-    inventory_misses: BTreeMap<String, u8>,
-    /// SmartShift (`0x2111`) config load state keyed by
-    /// [`DeviceRecord::config_key`]. Loaded lazily on the same pattern as
-    /// [`Self::dpi_data`]; the device persists the values itself, so this is a
-    /// read/write cache, not a source of truth saved to disk.
+    /// SmartShift (`0x2111`) config load state keyed by [`DeviceKey`]. Loaded
+    /// lazily on the same pattern as [`Self::dpi_data`]; the device persists
+    /// the values itself, so this is a read/write cache, not a source of
+    /// truth saved to disk.
     smartshift_data: LazyDeviceData<SmartShiftStatus>,
-    /// Devices whose SmartShift was just written optimistically and still need a
-    /// confirming re-read, keyed by [`DeviceRecord::config_key`]. A fire-and-
-    /// forget write can be rejected/timed-out by a sleeping device, so the panel
-    /// re-reads (without a Loading flicker) to replace the optimistic value with
-    /// the device's actual state. See [`Self::commit_smartshift`].
-    smartshift_pending_confirm: BTreeMap<String, u64>,
     /// Monotonic identity assigned to the next confirmable SmartShift write.
     next_smartshift_write_id: u64,
-    /// Visible outcome of the post-write SmartShift confirmation.
-    smartshift_write_status: BTreeMap<String, SmartShiftWriteStatus>,
     /// All paired devices, in carousel order. Each entry caches the per-
     /// device data the views need so a switch is a pure index update.
     pub device_list: Vec<DeviceRecord>,
@@ -240,9 +229,7 @@ impl AppState {
             current_device,
             current_app_bundle: None,
             camera_active: false,
-            manual_light_overrides: BTreeMap::new(),
-            volatile_light_settings: BTreeMap::new(),
-            light_commands: BTreeMap::new(),
+            device_ui: BTreeMap::new(),
             light_command_status: None,
             next_light_request_id: 0,
             active_button: None,
@@ -255,11 +242,8 @@ impl AppState {
             keyboard_bindings: BTreeMap::new(),
             dpi: DEFAULT_DPI,
             dpi_data: LazyDeviceData::default(),
-            inventory_misses: BTreeMap::new(),
             smartshift_data: LazyDeviceData::default(),
-            smartshift_pending_confirm: BTreeMap::new(),
             next_smartshift_write_id: 0,
-            smartshift_write_status: BTreeMap::new(),
             device_list,
             config,
             ipc_commands,

--- a/crates/openlogi-gui/src/state/device_key.rs
+++ b/crates/openlogi-gui/src/state/device_key.rs
@@ -1,0 +1,73 @@
+//! Typed key for `AppState`'s per-device UI-state side tables.
+
+use std::borrow::Borrow;
+use std::fmt;
+
+/// Identifies one device across [`AppState`](super::AppState)'s per-device UI
+/// caches: the DPI/SmartShift lazy-read state
+/// ([`DeviceReads`](super::load::DeviceReads)) and the consolidated
+/// per-device row ([`DeviceUiState`](super::device_ui::DeviceUiState)).
+///
+/// Wraps a device's config key — see
+/// [`DeviceRecord::device_key`](super::devices::DeviceRecord::device_key) —
+/// so a plain `String` computed for some unrelated purpose (a display name, a
+/// model key, a capture id) can't be passed to one of these maps by
+/// accident: every call site has to go through that one conversion point.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub(crate) struct DeviceKey(String);
+
+impl DeviceKey {
+    /// Borrow the underlying key as a string slice.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DeviceKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for DeviceKey {
+    fn from(key: &str) -> Self {
+        Self(key.to_string())
+    }
+}
+
+impl From<String> for DeviceKey {
+    fn from(key: String) -> Self {
+        Self(key)
+    }
+}
+
+/// Lets a `BTreeMap<DeviceKey, _>` be read (`get`/`remove`/`contains_key`)
+/// with a plain `&str` — most reads have a borrowed config key on hand
+/// already and have no reason to allocate a throwaway `DeviceKey` just to
+/// look something up.
+impl Borrow<str> for DeviceKey {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeviceKey;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn borrowed_str_lookup_finds_an_owned_key() {
+        let mut map = BTreeMap::new();
+        map.insert(DeviceKey::from("2b034"), 7);
+        assert_eq!(map.get("2b034"), Some(&7));
+        assert_eq!(map.get("missing"), None);
+    }
+
+    #[test]
+    fn equality_and_ordering_are_value_based() {
+        assert_eq!(DeviceKey::from("a"), DeviceKey::from("a".to_string()));
+        assert_ne!(DeviceKey::from("a"), DeviceKey::from("b"));
+        assert!(DeviceKey::from("a") < DeviceKey::from("b"));
+    }
+}

--- a/crates/openlogi-gui/src/state/device_ui.rs
+++ b/crates/openlogi-gui/src/state/device_ui.rs
@@ -1,0 +1,33 @@
+//! Consolidated per-device UI-state row.
+
+use openlogi_core::config::LightSettings;
+
+use super::SmartShiftWriteStatus;
+use super::light::PendingLightCommand;
+
+/// Everything `AppState` tracks per device outside the persisted config and
+/// the lazily-loaded DPI/SmartShift reads ([`super::load::LazyDeviceData`]).
+///
+/// Replaces six parallel `BTreeMap<String, _>` fields that all shared the
+/// same device-key domain — manual camera-light override, volatile light
+/// settings, an in-flight light command, the inventory-miss counter, a
+/// pending SmartShift write id, and the SmartShift write-confirmation status
+/// — with one row per device. A device absent from the owning map is
+/// equivalent to every field here at its default.
+#[derive(Debug, Default)]
+pub(super) struct DeviceUiState {
+    /// Transient manual power choice for a camera-linked light, overriding
+    /// the automatic camera-derived state until the next camera transition.
+    pub(super) manual_light_override: Option<bool>,
+    /// Session-only light settings for a device whose OS-node identity is
+    /// not stable enough to persist to `config.toml`.
+    pub(super) volatile_light: Option<LightSettings>,
+    /// The in-flight optimistic standalone-light write, if any.
+    pub(super) light_command: Option<PendingLightCommand>,
+    /// Consecutive inventory snapshots that omitted this device.
+    pub(super) inventory_misses: u8,
+    /// Identity of the SmartShift write awaiting a confirming re-read.
+    pub(super) smartshift_pending_confirm: Option<u64>,
+    /// Visible outcome of the post-write SmartShift confirmation.
+    pub(super) smartshift_write_status: Option<SmartShiftWriteStatus>,
+}

--- a/crates/openlogi-gui/src/state/devices.rs
+++ b/crates/openlogi-gui/src/state/devices.rs
@@ -12,6 +12,7 @@ use openlogi_core::device::{
 use openlogi_hid::DeviceRoute;
 use tracing::debug;
 
+use super::device_key::DeviceKey;
 use crate::asset::{AssetResolver, ResolvedAsset};
 
 /// One paired device with everything the UI needs to switch to it in O(1):
@@ -64,6 +65,13 @@ pub struct DeviceRecord {
 }
 
 impl DeviceRecord {
+    /// Typed key for `AppState`'s per-device UI caches (DPI/SmartShift load
+    /// state, standalone-light overrides, inventory-miss counters). Wraps
+    /// [`Self::config_key`] — see [`DeviceKey`].
+    pub(crate) fn device_key(&self) -> DeviceKey {
+        DeviceKey::from(self.config_key.as_str())
+    }
+
     /// Return the configuration key only when it identifies one physical
     /// device and is therefore safe to persist.
     pub(super) fn persistent_config_key(&self) -> Option<&str> {

--- a/crates/openlogi-gui/src/state/dpi.rs
+++ b/crates/openlogi-gui/src/state/dpi.rs
@@ -1,4 +1,5 @@
-//! DPI load state, presets, and live writes.
+//! DPI presets and live writes. Capability discovery itself lives in
+//! [`super::load::LazyDeviceData`], reached directly as `self.reads.dpi`.
 
 use openlogi_hid::{DeviceRoute, DpiCapabilities, DpiInfo, WriteError};
 use tracing::debug;
@@ -10,11 +11,6 @@ use super::load::DpiStatus;
 use super::{AppState, DEFAULT_DPI};
 
 impl AppState {
-    /// The cached DPI-discovery status for `key`, for the diagnostics report.
-    #[must_use]
-    pub fn dpi_status_for(&self, key: &DeviceKey) -> Option<DpiStatus> {
-        self.dpi_data.get(key).cloned()
-    }
     /// Replace the DPI preset list for the currently selected device. The
     /// new list is persisted to `config.toml` and pushed into the shared
     /// hook map so the next `CycleDpiPresets` press sees it. The cycle
@@ -44,51 +40,17 @@ impl AppState {
             .map(|key| self.config.dpi_presets(key))
             .unwrap_or_default()
     }
-    /// DPI capability status for the active device.
-    #[must_use]
-    pub fn current_dpi_status(&self) -> DpiStatus {
-        self.current_record().map_or(DpiStatus::Unknown, |record| {
-            self.dpi_data.status(&record.device_key())
-        })
-    }
-    /// Whether the active device still needs a DPI read (no status recorded —
-    /// i.e. `Unknown`). Cheaper than `current_dpi_status() == Unknown`: it
-    /// avoids cloning the `DpiInfo`, which matters on the per-frame render path.
-    #[must_use]
-    pub fn current_dpi_unqueried(&self) -> bool {
-        self.current_record()
-            .is_some_and(|record| self.dpi_data.unqueried(&record.device_key()))
-    }
     /// The active device's known DPI, falling back to [`DEFAULT_DPI`] until its
     /// capability read completes. Used to seed `self.dpi` on a device switch.
     #[must_use]
     pub(crate) fn dpi_for_current(&self) -> u32 {
         self.current_record()
-            .and_then(|record| self.dpi_data.get(&record.device_key()))
+            .and_then(|record| self.reads.dpi.get(&record.device_key()))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(u32::from(info.current)),
                 _ => None,
             })
             .unwrap_or(DEFAULT_DPI)
-    }
-    /// Mark DPI capability discovery as in flight for `key`.
-    pub fn mark_dpi_loading(&mut self, key: &DeviceKey) {
-        self.dpi_data.mark_loading(key);
-    }
-    /// Reset a stuck `Loading` for `key` back to `Unknown`. Called when the
-    /// discovery worker vanished without delivering a result (e.g. it panicked),
-    /// so the device isn't wedged on "Reading…" with no path to retry.
-    pub fn clear_dpi_loading(&mut self, key: &DeviceKey) {
-        self.dpi_data.clear_loading(key);
-    }
-    /// Drop the active device's recorded DPI status so the next render
-    /// re-runs discovery. Backs the "click to retry" affordance on a
-    /// [`DpiStatus::Failed`] device, which is the only recovery path when the
-    /// carousel has a single device (re-selecting it is a no-op).
-    pub fn retry_active_dpi(&mut self) {
-        if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
-            self.dpi_data.retry(&key);
-        }
     }
     /// Store a DPI capability discovery result if it still matches the known
     /// device route. This guards against async reads completing after the
@@ -111,7 +73,7 @@ impl AppState {
         // Only the active device owns the shared `self.dpi`; a result landing for
         // a background device after a carousel switch must not clobber the
         // visible value.
-        if let Some(info) = self.dpi_data.store(
+        if let Some(info) = self.reads.dpi.store(
             key,
             result,
             dpi_error_is_permanent,
@@ -127,7 +89,7 @@ impl AppState {
     #[must_use]
     pub fn active_dpi_capabilities(&self) -> Option<&DpiCapabilities> {
         self.current_record()
-            .and_then(|record| self.dpi_data.get(&record.device_key()))
+            .and_then(|record| self.reads.dpi.get(&record.device_key()))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(&info.capabilities),
                 DpiStatus::Unknown
@@ -152,7 +114,6 @@ impl AppState {
             debug!("no active device — DPI change kept in memory only");
             return;
         };
-        let key = record.config_key.clone();
         let persistent_key = record.persistent_config_key().map(str::to_string);
         let route = record.route.clone();
         if let Some(route) = route {
@@ -162,7 +123,10 @@ impl AppState {
             self.config.set_dpi(&persistent_key, dpi);
             self.persist_and_reload("DPI");
         } else {
-            debug!(key, "transient device DPI applied without persistence");
+            debug!(
+                key = record.config_key.as_str(),
+                "transient device DPI applied without persistence"
+            );
         }
     }
 }

--- a/crates/openlogi-gui/src/state/dpi.rs
+++ b/crates/openlogi-gui/src/state/dpi.rs
@@ -5,13 +5,14 @@ use tracing::debug;
 
 use crate::state::devices::DeviceRecord;
 
+use super::device_key::DeviceKey;
 use super::load::DpiStatus;
 use super::{AppState, DEFAULT_DPI};
 
 impl AppState {
     /// The cached DPI-discovery status for `key`, for the diagnostics report.
     #[must_use]
-    pub fn dpi_status_for(&self, key: &str) -> Option<DpiStatus> {
+    pub fn dpi_status_for(&self, key: &DeviceKey) -> Option<DpiStatus> {
         self.dpi_data.get(key).cloned()
     }
     /// Replace the DPI preset list for the currently selected device. The
@@ -47,7 +48,7 @@ impl AppState {
     #[must_use]
     pub fn current_dpi_status(&self) -> DpiStatus {
         self.current_record().map_or(DpiStatus::Unknown, |record| {
-            self.dpi_data.status(&record.config_key)
+            self.dpi_data.status(&record.device_key())
         })
     }
     /// Whether the active device still needs a DPI read (no status recorded —
@@ -56,14 +57,14 @@ impl AppState {
     #[must_use]
     pub fn current_dpi_unqueried(&self) -> bool {
         self.current_record()
-            .is_some_and(|record| self.dpi_data.unqueried(&record.config_key))
+            .is_some_and(|record| self.dpi_data.unqueried(&record.device_key()))
     }
     /// The active device's known DPI, falling back to [`DEFAULT_DPI`] until its
     /// capability read completes. Used to seed `self.dpi` on a device switch.
     #[must_use]
     pub(crate) fn dpi_for_current(&self) -> u32 {
         self.current_record()
-            .and_then(|record| self.dpi_data.get(&record.config_key))
+            .and_then(|record| self.dpi_data.get(&record.device_key()))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(u32::from(info.current)),
                 _ => None,
@@ -71,13 +72,13 @@ impl AppState {
             .unwrap_or(DEFAULT_DPI)
     }
     /// Mark DPI capability discovery as in flight for `key`.
-    pub fn mark_dpi_loading(&mut self, key: &str) {
+    pub fn mark_dpi_loading(&mut self, key: &DeviceKey) {
         self.dpi_data.mark_loading(key);
     }
     /// Reset a stuck `Loading` for `key` back to `Unknown`. Called when the
     /// discovery worker vanished without delivering a result (e.g. it panicked),
     /// so the device isn't wedged on "Reading…" with no path to retry.
-    pub fn clear_dpi_loading(&mut self, key: &str) {
+    pub fn clear_dpi_loading(&mut self, key: &DeviceKey) {
         self.dpi_data.clear_loading(key);
     }
     /// Drop the active device's recorded DPI status so the next render
@@ -85,7 +86,7 @@ impl AppState {
     /// [`DpiStatus::Failed`] device, which is the only recovery path when the
     /// carousel has a single device (re-selecting it is a no-op).
     pub fn retry_active_dpi(&mut self) {
-        if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
+        if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
             self.dpi_data.retry(&key);
         }
     }
@@ -94,19 +95,19 @@ impl AppState {
     /// carousel or inventory changed.
     pub fn store_dpi_info(
         &mut self,
-        key: String,
+        key: DeviceKey,
         route: &DeviceRoute,
         result: Result<DpiInfo, WriteError>,
     ) {
-        let is_active = self.current_record().map(|r| r.config_key.as_str()) == Some(key.as_str());
+        let is_active = self.current_record().is_some_and(|r| r.device_key() == key);
         let matches_route = self
             .device_list
             .iter()
-            .any(|record| record.config_key == key && record.route.as_ref() == Some(route));
+            .any(|record| record.device_key() == key && record.route.as_ref() == Some(route));
         let still_present = self
             .device_list
             .iter()
-            .any(|record| record.config_key == key);
+            .any(|record| record.device_key() == key);
         // Only the active device owns the shared `self.dpi`; a result landing for
         // a background device after a carousel switch must not clobber the
         // visible value.
@@ -126,7 +127,7 @@ impl AppState {
     #[must_use]
     pub fn active_dpi_capabilities(&self) -> Option<&DpiCapabilities> {
         self.current_record()
-            .and_then(|record| self.dpi_data.get(&record.config_key))
+            .and_then(|record| self.dpi_data.get(&record.device_key()))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(&info.capabilities),
                 DpiStatus::Unknown

--- a/crates/openlogi-gui/src/state/inventory.rs
+++ b/crates/openlogi-gui/src/state/inventory.rs
@@ -124,8 +124,8 @@ impl AppState {
 
         self.device_list = merged_list;
         for key in &rerouted {
-            self.dpi_data.remove(key);
-            self.smartshift_data.remove(key);
+            self.reads.dpi.remove(key);
+            self.reads.smartshift.remove(key);
             if let Some(entry) = self.device_ui.get_mut(key) {
                 entry.smartshift_pending_confirm = None;
                 entry.smartshift_write_status = None;
@@ -136,8 +136,8 @@ impl AppState {
                 .iter()
                 .any(|r| r.config_key.as_str() == key)
         };
-        self.dpi_data.retain_present(present);
-        self.smartshift_data.retain_present(present);
+        self.reads.dpi.retain_present(present);
+        self.reads.smartshift.retain_present(present);
         self.current_device = new_index;
         // The active device may have changed (selection fell back to index 0
         // when the previous one vanished); re-seed the displayed DPI so it
@@ -304,14 +304,11 @@ impl AppState {
         // A device left in `Failed` (transient read errors exhausted its retry
         // budget) gets one fresh attempt each time it is re-selected.
         if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
-            if matches!(self.dpi_data.get(&key), Some(Load::Failed(_))) {
-                self.dpi_data.retry(&key);
+            if matches!(self.reads.dpi.get(&key), Some(Load::Failed(_))) {
+                self.reads.dpi.retry(&key);
             }
-            if matches!(self.smartshift_data.get(&key), Some(Load::Failed(_))) {
-                self.smartshift_data.retry(&key);
-                if let Some(entry) = self.device_ui.get_mut(&key) {
-                    entry.smartshift_write_status = None;
-                }
+            if matches!(self.reads.smartshift.get(&key), Some(Load::Failed(_))) {
+                self.retry_smartshift(&key);
             }
         }
         // `self.dpi` is the active device's value; adopt the newly-selected

--- a/crates/openlogi-gui/src/state/inventory.rs
+++ b/crates/openlogi-gui/src/state/inventory.rs
@@ -12,6 +12,7 @@ use crate::state::devices::{
     DeviceRecord, adopt_transient_record, build_device_list, direct_key_prefix, sort_device_list,
 };
 
+use super::device_key::DeviceKey;
 use super::load::Load;
 use super::{AppState, INVENTORY_MISS_GRACE};
 
@@ -110,22 +111,22 @@ impl AppState {
 
         // A device that came back on a different route must re-discover DPI —
         // its cached status/attempts were keyed to the now-dead route.
-        let rerouted: Vec<String> = merged_list
+        let rerouted: Vec<DeviceKey> = merged_list
             .iter()
             .filter(|new| {
                 self.device_list
                     .iter()
                     .any(|old| old.config_key == new.config_key && old.route != new.route)
             })
-            .map(|new| new.config_key.clone())
+            .map(DeviceRecord::device_key)
             .collect();
 
         self.device_list = merged_list;
         for key in &rerouted {
             self.dpi_data.remove(key);
             self.smartshift_data.remove(key);
-            self.smartshift_pending_confirm.remove(key);
-            self.smartshift_write_status.remove(key);
+            self.smartshift_pending_confirm.remove(key.as_str());
+            self.smartshift_write_status.remove(key.as_str());
         }
         let present = |key: &str| {
             self.device_list
@@ -298,13 +299,13 @@ impl AppState {
         self.current_device = idx;
         // A device left in `Failed` (transient read errors exhausted its retry
         // budget) gets one fresh attempt each time it is re-selected.
-        if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
+        if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
             if matches!(self.dpi_data.get(&key), Some(Load::Failed(_))) {
                 self.dpi_data.retry(&key);
             }
             if matches!(self.smartshift_data.get(&key), Some(Load::Failed(_))) {
                 self.smartshift_data.retry(&key);
-                self.smartshift_write_status.remove(&key);
+                self.smartshift_write_status.remove(key.as_str());
             }
         }
         // `self.dpi` is the active device's value; adopt the newly-selected

--- a/crates/openlogi-gui/src/state/inventory.rs
+++ b/crates/openlogi-gui/src/state/inventory.rs
@@ -13,6 +13,7 @@ use crate::state::devices::{
 };
 
 use super::device_key::DeviceKey;
+use super::device_ui::DeviceUiState;
 use super::load::Load;
 use super::{AppState, INVENTORY_MISS_GRACE};
 
@@ -125,8 +126,10 @@ impl AppState {
         for key in &rerouted {
             self.dpi_data.remove(key);
             self.smartshift_data.remove(key);
-            self.smartshift_pending_confirm.remove(key.as_str());
-            self.smartshift_write_status.remove(key.as_str());
+            if let Some(entry) = self.device_ui.get_mut(key) {
+                entry.smartshift_pending_confirm = None;
+                entry.smartshift_write_status = None;
+            }
         }
         let present = |key: &str| {
             self.device_list
@@ -135,9 +138,6 @@ impl AppState {
         };
         self.dpi_data.retain_present(present);
         self.smartshift_data.retain_present(present);
-        self.smartshift_pending_confirm
-            .retain(|key, _| present(key));
-        self.smartshift_write_status.retain(|key, _| present(key));
         self.current_device = new_index;
         // The active device may have changed (selection fell back to index 0
         // when the previous one vanished); re-seed the displayed DPI so it
@@ -163,13 +163,13 @@ impl AppState {
         for previous in &self.device_list {
             let inv = previous.inventory_key();
             if let Some(record) = by_key.remove(&inv) {
-                self.inventory_misses.remove(&inv);
+                clear_inventory_misses(&mut self.device_ui, &inv);
                 merged.push(record);
                 continue;
             }
 
             if let Some(record) = adopted.remove(&inv) {
-                self.inventory_misses.remove(&inv);
+                clear_inventory_misses(&mut self.device_ui, &inv);
                 merged.push(record);
                 continue;
             }
@@ -178,23 +178,27 @@ impl AppState {
             // the next snapshot resolves a physical serial/unit key, retaining
             // this record through the normal miss grace would show both cards.
             if !previous.is_persistent() {
-                self.inventory_misses.remove(&inv);
+                clear_inventory_misses(&mut self.device_ui, &inv);
                 continue;
             }
 
             // Cameras reappear under a new capture id after a port change —
             // do not grace-keep a stale cam-live entry beside the new one.
             if previous.kind == openlogi_core::device::DeviceKind::Camera {
-                self.inventory_misses.remove(&inv);
+                clear_inventory_misses(&mut self.device_ui, &inv);
                 continue;
             }
 
-            let misses = self.inventory_misses.entry(inv.clone()).or_insert(0);
-            *misses = misses.saturating_add(1);
-            if *misses <= INVENTORY_MISS_GRACE {
+            let entry = self
+                .device_ui
+                .entry(DeviceKey::from(inv.as_str()))
+                .or_default();
+            entry.inventory_misses = entry.inventory_misses.saturating_add(1);
+            let misses = entry.inventory_misses;
+            if misses <= INVENTORY_MISS_GRACE {
                 debug!(
                     key = %inv,
-                    misses = *misses,
+                    misses,
                     "keeping device through transient inventory miss"
                 );
                 merged.push(previous.clone());
@@ -202,14 +206,14 @@ impl AppState {
         }
 
         for (key, record) in by_key {
-            self.inventory_misses.remove(&key);
+            clear_inventory_misses(&mut self.device_ui, &key);
             merged.push(record);
         }
         // Adopted records whose known card was never in the previous list
         // (identity known only from config) still belong in the carousel.
         merged.extend(adopted.into_values());
-        self.inventory_misses
-            .retain(|key, _| merged.iter().any(|record| record.inventory_key() == *key));
+        let live: HashSet<String> = merged.iter().map(DeviceRecord::inventory_key).collect();
+        self.device_ui.retain(|key, _| live.contains(key.as_str()));
         // `merged` is `previous-order + newly-appeared`, so re-apply the
         // canonical route order or a new device would be stuck at the end of
         // the carousel permanently.
@@ -305,7 +309,9 @@ impl AppState {
             }
             if matches!(self.smartshift_data.get(&key), Some(Load::Failed(_))) {
                 self.smartshift_data.retry(&key);
-                self.smartshift_write_status.remove(key.as_str());
+                if let Some(entry) = self.device_ui.get_mut(&key) {
+                    entry.smartshift_write_status = None;
+                }
             }
         }
         // `self.dpi` is the active device's value; adopt the newly-selected
@@ -361,4 +367,15 @@ pub(super) fn persist_identities(config: &mut Config, list: &[DeviceRecord]) -> 
         }
     }
     changed
+}
+
+/// Reset `key`'s consecutive-miss counter — the device was just confirmed
+/// present (live, adopted, or freshly appeared) or is a kind that never earns
+/// grace (transient, camera). Leaves the rest of the device's UI row
+/// untouched. A free function, not an `AppState` method, so callers can hold
+/// it alongside a live borrow of `self.device_list`.
+fn clear_inventory_misses(device_ui: &mut BTreeMap<DeviceKey, DeviceUiState>, key: &str) {
+    if let Some(entry) = device_ui.get_mut(key) {
+        entry.inventory_misses = 0;
+    }
 }

--- a/crates/openlogi-gui/src/state/light.rs
+++ b/crates/openlogi-gui/src/state/light.rs
@@ -7,6 +7,8 @@ use openlogi_hid::{DeviceRoute, LightCommand, WriteError};
 use tracing::debug;
 
 use super::AppState;
+use super::device_key::DeviceKey;
+use super::device_ui::DeviceUiState;
 
 const fn camera_policy_applies(light: LightSettings) -> bool {
     cfg!(target_os = "macos") && light.auto_camera
@@ -23,6 +25,7 @@ pub enum LightCommandStatus {
     Offline,
 }
 
+#[derive(Debug)]
 pub(super) struct PendingLightCommand {
     request_id: u64,
     pending: u16,
@@ -36,6 +39,7 @@ pub(super) struct PendingLightCommand {
     superseded: Vec<SupersededLightCommand>,
 }
 
+#[derive(Debug)]
 struct SupersededLightCommand {
     request_id: u64,
     pending: u16,
@@ -43,7 +47,7 @@ struct SupersededLightCommand {
     failure: Option<String>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 struct ManualOverrideRollback {
     previous: Option<bool>,
 }
@@ -53,17 +57,17 @@ impl AppState {
     #[must_use]
     pub fn light_enabled(&self) -> bool {
         self.current_record()
-            .is_some_and(|record| self.light_enabled_for(&record.config_key))
+            .is_some_and(|record| self.light_enabled_for(&record.device_key()))
     }
 
     /// Effective power state for any standalone-light key.
     #[must_use]
-    pub fn light_enabled_for(&self, key: &str) -> bool {
+    pub fn light_enabled_for(&self, key: &DeviceKey) -> bool {
         let light = self.light_for(key);
         if camera_policy_applies(light) {
-            self.manual_light_overrides
+            self.device_ui
                 .get(key)
-                .copied()
+                .and_then(|entry| entry.manual_light_override)
                 .unwrap_or(self.camera_active)
         } else {
             light.enabled
@@ -75,7 +79,9 @@ impl AppState {
     pub fn set_camera_active(&mut self, active: bool) -> bool {
         let changed = self.camera_active != active;
         if changed {
-            self.manual_light_overrides.clear();
+            for entry in self.device_ui.values_mut() {
+                entry.manual_light_override = None;
+            }
         }
         self.camera_active = active;
         changed
@@ -92,20 +98,19 @@ impl AppState {
     /// Latest light-command status for the selected device, if one exists.
     #[must_use]
     pub fn light_command_status(&self) -> Option<LightCommandStatus> {
-        let key = self.current_record()?.config_key.as_str();
+        let key = self.current_record()?.device_key();
         self.light_command_status
             .as_ref()
-            .filter(|(status_key, _, _)| status_key == key)
+            .filter(|(status_key, _, _)| *status_key == key)
             .map(|(_, _, status)| status.clone())
     }
 
-    fn begin_light_command(&mut self, key: &str, online: bool) -> u64 {
+    fn begin_light_command(&mut self, key: &DeviceKey, online: bool) -> u64 {
         self.next_light_request_id = self.next_light_request_id.wrapping_add(1);
         let request_id = self.next_light_request_id;
         if online {
-            self.light_commands.insert(
-                key.to_string(),
-                PendingLightCommand {
+            self.device_ui.entry(key.clone()).or_default().light_command =
+                Some(PendingLightCommand {
                     request_id,
                     pending: 0,
                     settings: None,
@@ -116,25 +121,27 @@ impl AppState {
                     successful_commands: Vec::new(),
                     failure: None,
                     superseded: Vec::new(),
-                },
-            );
+                });
             self.light_command_status =
-                Some((key.to_string(), request_id, LightCommandStatus::Pending));
+                Some((key.clone(), request_id, LightCommandStatus::Pending));
         } else {
             self.light_command_status =
-                Some((key.to_string(), request_id, LightCommandStatus::Offline));
+                Some((key.clone(), request_id, LightCommandStatus::Offline));
         }
         request_id
     }
 
     fn queue_light_command(
         &mut self,
-        key: &str,
+        key: &DeviceKey,
         request_id: u64,
         route: DeviceRoute,
         command: LightCommand,
     ) {
-        if let Some(pending) = self.light_commands.get_mut(key)
+        if let Some(pending) = self
+            .device_ui
+            .get_mut(key)
+            .and_then(|entry| entry.light_command.as_mut())
             && pending.request_id == request_id
         {
             pending.pending = pending.pending.saturating_add(1);
@@ -154,8 +161,12 @@ impl AppState {
         }
     }
 
-    fn supersede_light_command(&mut self, key: &str) -> Vec<SupersededLightCommand> {
-        let Some(pending) = self.light_commands.remove(key) else {
+    fn supersede_light_command(&mut self, key: &DeviceKey) -> Vec<SupersededLightCommand> {
+        let Some(pending) = self
+            .device_ui
+            .get_mut(key)
+            .and_then(|entry| entry.light_command.take())
+        else {
             return Vec::new();
         };
         let mut superseded = pending.superseded;
@@ -178,7 +189,12 @@ impl AppState {
         command: LightCommand,
         result: Result<(), WriteError>,
     ) -> bool {
-        let Some(pending) = self.light_commands.get_mut(&key) else {
+        let key = DeviceKey::from(key);
+        let Some(pending) = self
+            .device_ui
+            .get_mut(&key)
+            .and_then(|entry| entry.light_command.as_mut())
+        else {
             return false;
         };
         if pending.request_id == request_id {
@@ -211,7 +227,11 @@ impl AppState {
             return true;
         }
 
-        let Some(pending) = self.light_commands.remove(&key) else {
+        let Some(pending) = self
+            .device_ui
+            .get_mut(&key)
+            .and_then(|entry| entry.light_command.take())
+        else {
             return false;
         };
         let failure = pending.failure.clone().or_else(|| {
@@ -229,37 +249,33 @@ impl AppState {
         let manual_override_rollback = pending.manual_override_rollback;
         if let Some(error) = failure {
             if successful_commands.is_empty() {
-                if let Some(previous) = pending.previous_volatile {
-                    self.volatile_light_settings.insert(key.clone(), previous);
-                } else {
-                    self.volatile_light_settings.remove(&key);
-                }
-                restore_manual_override(
-                    &mut self.manual_light_overrides,
-                    &key,
-                    manual_override_rollback,
-                );
+                self.device_ui
+                    .entry(key.clone())
+                    .or_default()
+                    .volatile_light = pending.previous_volatile;
+                restore_manual_override(&mut self.device_ui, &key, manual_override_rollback);
             } else {
                 let mut accepted = pending.rollback_settings;
                 for &command in &successful_commands {
                     apply_light_command(&mut accepted, command);
                 }
                 if let Some(persistent_key) = pending.persistent_key {
-                    self.volatile_light_settings.remove(&key);
+                    if let Some(entry) = self.device_ui.get_mut(&key) {
+                        entry.volatile_light = None;
+                    }
                     self.config.set_light(&persistent_key, accepted);
                     self.persist_and_reload("partial light");
                 } else {
-                    self.volatile_light_settings.insert(key.clone(), accepted);
+                    self.device_ui
+                        .entry(key.clone())
+                        .or_default()
+                        .volatile_light = Some(accepted);
                 }
                 if !successful_commands
                     .iter()
                     .any(|command| matches!(command, LightCommand::Power(_)))
                 {
-                    restore_manual_override(
-                        &mut self.manual_light_overrides,
-                        &key,
-                        manual_override_rollback,
-                    );
+                    restore_manual_override(&mut self.device_ui, &key, manual_override_rollback);
                 }
             }
             self.light_command_status = Some((key, request_id, LightCommandStatus::Failed(error)));
@@ -268,7 +284,9 @@ impl AppState {
                 (pending.settings, pending.persistent_key)
             {
                 self.config.set_light(&persistent_key, settings);
-                self.volatile_light_settings.remove(&key);
+                if let Some(entry) = self.device_ui.get_mut(&key) {
+                    entry.volatile_light = None;
+                }
                 self.persist_and_reload("light");
             }
             // Successful writes are reflected by the controls themselves; do
@@ -284,18 +302,66 @@ impl AppState {
     pub fn light(&self) -> LightSettings {
         self.current_record()
             .map_or_else(LightSettings::default, |record| {
-                self.light_for(&record.config_key)
+                self.light_for(&record.device_key())
             })
     }
 
     /// The standalone-light settings for any persistent or runtime device key.
     #[must_use]
-    pub fn light_for(&self, key: &str) -> LightSettings {
-        self.volatile_light_settings
+    pub fn light_for(&self, key: &DeviceKey) -> LightSettings {
+        self.device_ui
             .get(key)
-            .copied()
-            .or_else(|| self.config.light(key))
+            .and_then(|entry| entry.volatile_light)
+            .or_else(|| self.config.light(key.as_str()))
             .unwrap_or_default()
+    }
+
+    /// The rollback point for a new optimistic light write: inherited from an
+    /// in-flight command this one supersedes (so a chain of edits always
+    /// rolls back to the last *accepted* value, never a still-pending one),
+    /// or freshly computed from `fallback` and the current volatile settings.
+    fn light_write_rollback(
+        &self,
+        key: &DeviceKey,
+        fallback: LightSettings,
+    ) -> (LightSettings, Option<LightSettings>) {
+        self.device_ui
+            .get(key)
+            .and_then(|entry| entry.light_command.as_ref())
+            .map_or_else(
+                || {
+                    (
+                        fallback,
+                        self.device_ui
+                            .get(key)
+                            .and_then(|entry| entry.volatile_light),
+                    )
+                },
+                |pending| (pending.rollback_settings, pending.previous_volatile),
+            )
+    }
+
+    /// The manual-override rollback for a `commit_light` write: inherited
+    /// from an in-flight command this one supersedes, or — only when the
+    /// camera-linked auto mode itself just flipped — the override in effect
+    /// right now.
+    fn light_mode_override_rollback(
+        &self,
+        key: &DeviceKey,
+        camera_mode_changed: bool,
+    ) -> Option<ManualOverrideRollback> {
+        self.device_ui
+            .get(key)
+            .and_then(|entry| entry.light_command.as_ref())
+            .and_then(|pending| pending.manual_override_rollback)
+            .or_else(|| {
+                camera_mode_changed.then(|| ManualOverrideRollback {
+                    previous: self
+                        .device_ui
+                        .get(key)
+                        .and_then(|entry| entry.manual_light_override),
+                })
+            })
     }
 
     /// Persist and apply standalone-light settings through the agent-owned
@@ -305,7 +371,7 @@ impl AppState {
         let Some((runtime_key, key, route, online, capabilities)) =
             self.current_record().map(|record| {
                 (
-                    record.config_key.clone(),
+                    record.device_key(),
                     record.persistent_config_key().map(str::to_string),
                     record.route.clone(),
                     record.online,
@@ -328,17 +394,10 @@ impl AppState {
         } else {
             light.enabled
         };
-        let inherited_override_rollback = self
-            .light_commands
-            .get(&runtime_key)
-            .and_then(|pending| pending.manual_override_rollback);
-        let manual_override_rollback = inherited_override_rollback.or_else(|| {
-            camera_mode_changed.then(|| ManualOverrideRollback {
-                previous: self.manual_light_overrides.get(&runtime_key).copied(),
-            })
-        });
-        if camera_mode_changed {
-            self.manual_light_overrides.remove(&runtime_key);
+        let manual_override_rollback =
+            self.light_mode_override_rollback(&runtime_key, camera_mode_changed);
+        if camera_mode_changed && let Some(entry) = self.device_ui.get_mut(&runtime_key) {
+            entry.manual_light_override = None;
         }
         let mut effective = light;
         effective.enabled = effective_enabled;
@@ -348,17 +407,11 @@ impl AppState {
         // If this request supersedes another optimistic write, both must roll
         // back to the last accepted value—not to the superseded pending value.
         let (rollback_settings, previous_volatile) =
-            self.light_commands.get(&runtime_key).map_or_else(
-                || {
-                    (
-                        previous,
-                        self.volatile_light_settings.get(&runtime_key).copied(),
-                    )
-                },
-                |pending| (pending.rollback_settings, pending.previous_volatile),
-            );
-        self.volatile_light_settings
-            .insert(runtime_key.clone(), light);
+            self.light_write_rollback(&runtime_key, previous);
+        self.device_ui
+            .entry(runtime_key.clone())
+            .or_default()
+            .volatile_light = Some(light);
         if !commands.is_empty() {
             let can_apply = online && route.is_some();
             let superseded = if can_apply {
@@ -368,7 +421,11 @@ impl AppState {
             };
             let request_id = self.begin_light_command(&runtime_key, can_apply);
             if can_apply && let Some(route) = route {
-                if let Some(pending) = self.light_commands.get_mut(&runtime_key) {
+                if let Some(pending) = self
+                    .device_ui
+                    .get_mut(&runtime_key)
+                    .and_then(|entry| entry.light_command.as_mut())
+                {
                     pending.settings = Some(light);
                     pending.persistent_key.clone_from(&key);
                     pending.rollback_settings = rollback_settings;
@@ -383,11 +440,16 @@ impl AppState {
             }
         }
         if let Some(key) = key {
-            self.volatile_light_settings.remove(&runtime_key);
+            if let Some(entry) = self.device_ui.get_mut(&runtime_key) {
+                entry.volatile_light = None;
+            }
             self.config.set_light(&key, light);
             self.persist_and_reload("light");
         } else {
-            self.volatile_light_settings.insert(runtime_key, light);
+            self.device_ui
+                .entry(runtime_key)
+                .or_default()
+                .volatile_light = Some(light);
         }
     }
 
@@ -397,7 +459,7 @@ impl AppState {
     pub fn commit_manual_light_power(&mut self, enabled: bool) {
         let Some((runtime_key, key, route, online)) = self.current_record().map(|record| {
             (
-                record.config_key.clone(),
+                record.device_key(),
                 record.persistent_config_key().map(str::to_string),
                 record.route.clone(),
                 record.online,
@@ -413,30 +475,17 @@ impl AppState {
             return;
         }
 
-        let (rollback_settings, previous_volatile) =
-            self.light_commands.get(&runtime_key).map_or_else(
-                || {
-                    (
-                        light,
-                        self.volatile_light_settings.get(&runtime_key).copied(),
-                    )
-                },
-                |pending| (pending.rollback_settings, pending.previous_volatile),
-            );
-        let manual_override_rollback = self
-            .light_commands
-            .get(&runtime_key)
-            .and_then(|pending| pending.manual_override_rollback)
-            .or_else(|| {
-                Some(ManualOverrideRollback {
-                    previous: self.manual_light_overrides.get(&runtime_key).copied(),
-                })
-            });
+        let (rollback_settings, previous_volatile) = self.light_write_rollback(&runtime_key, light);
+        // Unlike `commit_light`, a manual power toggle always changes the
+        // override, so the fallback branch always applies — pass `true` to
+        // unconditionally take it rather than gate it on a camera-mode flip.
+        let manual_override_rollback = self.light_mode_override_rollback(&runtime_key, true);
         light.enabled = enabled;
-        self.manual_light_overrides
-            .insert(runtime_key.clone(), enabled);
-        self.volatile_light_settings
-            .insert(runtime_key.clone(), light);
+        {
+            let entry = self.device_ui.entry(runtime_key.clone()).or_default();
+            entry.manual_light_override = Some(enabled);
+            entry.volatile_light = Some(light);
+        }
 
         let can_apply = online && route.is_some();
         let superseded = if can_apply {
@@ -446,7 +495,11 @@ impl AppState {
         };
         let request_id = self.begin_light_command(&runtime_key, can_apply);
         if can_apply && let Some(route) = route {
-            if let Some(pending) = self.light_commands.get_mut(&runtime_key) {
+            if let Some(pending) = self
+                .device_ui
+                .get_mut(&runtime_key)
+                .and_then(|entry| entry.light_command.as_mut())
+            {
                 pending.pending = 1;
                 pending.settings = Some(light);
                 pending.persistent_key.clone_from(&key);
@@ -458,11 +511,11 @@ impl AppState {
             if !self.send_ipc(crate::ipc_client::Command::SetLightManualPower(
                 route,
                 enabled,
-                runtime_key.clone(),
+                runtime_key.to_string(),
                 request_id,
             )) {
                 self.apply_light_command_result(
-                    runtime_key,
+                    runtime_key.to_string(),
                     request_id,
                     LightCommand::Power(enabled),
                     Err(WriteError::AgentUnavailable),
@@ -472,7 +525,9 @@ impl AppState {
         }
 
         if let Some(key) = key {
-            self.volatile_light_settings.remove(&runtime_key);
+            if let Some(entry) = self.device_ui.get_mut(&runtime_key) {
+                entry.volatile_light = None;
+            }
             self.config.set_light(&key, light);
             self.persist_and_reload("manual light power");
         }
@@ -493,15 +548,14 @@ fn apply_light_command(settings: &mut LightSettings, command: LightCommand) {
 }
 
 fn restore_manual_override(
-    overrides: &mut BTreeMap<String, bool>,
-    key: &str,
+    device_ui: &mut BTreeMap<DeviceKey, DeviceUiState>,
+    key: &DeviceKey,
     rollback: Option<ManualOverrideRollback>,
 ) {
     if let Some(rollback) = rollback {
-        if let Some(previous) = rollback.previous {
-            overrides.insert(key.to_string(), previous);
-        } else {
-            overrides.remove(key);
-        }
+        device_ui
+            .entry(key.clone())
+            .or_default()
+            .manual_light_override = rollback.previous;
     }
 }

--- a/crates/openlogi-gui/src/state/load.rs
+++ b/crates/openlogi-gui/src/state/load.rs
@@ -46,6 +46,17 @@ pub type DpiStatus = Load<DpiInfo>;
 /// GUI only ever reads and writes the device.
 pub type SmartShiftLoad = Load<SmartShiftStatus>;
 
+/// The lazily-loaded DPI and SmartShift read caches, grouped so callers reach
+/// them as `state.reads.dpi` / `state.reads.smartshift` and use
+/// [`LazyDeviceData`]'s own methods directly — instead of `AppState` growing
+/// a same-shaped forwarding method twice, once per subsystem, for every
+/// operation the generic already provides.
+#[derive(Default)]
+pub(crate) struct DeviceReads {
+    pub(crate) dpi: LazyDeviceData<DpiInfo>,
+    pub(crate) smartshift: LazyDeviceData<SmartShiftStatus>,
+}
+
 /// Per-device lazy-load cache for a background HID++ read, keyed by
 /// [`DeviceKey`]. Holds each device's [`Load`] state plus its transient-retry
 /// counter, and carries the stale-route guard + retry-budget policy once, for

--- a/crates/openlogi-gui/src/state/load.rs
+++ b/crates/openlogi-gui/src/state/load.rs
@@ -6,6 +6,8 @@ use std::collections::BTreeMap;
 use openlogi_hid::{DpiInfo, SmartShiftStatus, WriteError};
 use tracing::debug;
 
+use super::device_key::DeviceKey;
+
 /// How many times to retry a device read (DPI capability discovery or a
 /// SmartShift read) after a transient HID++ error (read timeout, busy device)
 /// before giving up. A genuine "feature not supported" reply is permanent and
@@ -45,14 +47,14 @@ pub type DpiStatus = Load<DpiInfo>;
 pub type SmartShiftLoad = Load<SmartShiftStatus>;
 
 /// Per-device lazy-load cache for a background HID++ read, keyed by
-/// [`DeviceRecord::config_key`](super::DeviceRecord::config_key). Holds each
-/// device's [`Load`] state plus its transient-retry counter, and carries the
-/// stale-route guard + retry-budget policy once, for both DPI and SmartShift.
-pub(super) struct LazyDeviceData<T> {
-    by_device: BTreeMap<String, Load<T>>,
+/// [`DeviceKey`]. Holds each device's [`Load`] state plus its transient-retry
+/// counter, and carries the stale-route guard + retry-budget policy once, for
+/// both DPI and SmartShift.
+pub(crate) struct LazyDeviceData<T> {
+    by_device: BTreeMap<DeviceKey, Load<T>>,
     /// Consecutive transient read failures per device, capped by
     /// [`LOAD_MAX_ATTEMPTS`] before the device settles on [`Load::Failed`].
-    attempts: BTreeMap<String, u8>,
+    attempts: BTreeMap<DeviceKey, u8>,
 }
 
 // Manual `Default` (not derived): a derive would demand `T: Default`, but the
@@ -68,31 +70,31 @@ impl<T> Default for LazyDeviceData<T> {
 
 impl<T: Clone> LazyDeviceData<T> {
     /// The recorded state for `key`, or [`Load::Unknown`] if never queried.
-    pub(super) fn status(&self, key: &str) -> Load<T> {
+    pub(crate) fn status(&self, key: &DeviceKey) -> Load<T> {
         self.by_device.get(key).cloned().unwrap_or(Load::Unknown)
     }
 
     /// The raw recorded entry for `key`, for callers that match on `Ready`
     /// without cloning the payload.
-    pub(super) fn get(&self, key: &str) -> Option<&Load<T>> {
+    pub(crate) fn get(&self, key: &DeviceKey) -> Option<&Load<T>> {
         self.by_device.get(key)
     }
 
     /// Whether `key` still needs a read (nothing recorded yet). Cheaper than
     /// cloning [`status`](Self::status) on the per-frame render path.
-    pub(super) fn unqueried(&self, key: &str) -> bool {
+    pub(crate) fn unqueried(&self, key: &DeviceKey) -> bool {
         !self.by_device.contains_key(key)
     }
 
     /// Mark a read as in flight for `key`.
-    pub(super) fn mark_loading(&mut self, key: &str) {
-        self.by_device.insert(key.to_string(), Load::Loading);
+    pub(crate) fn mark_loading(&mut self, key: &DeviceKey) {
+        self.by_device.insert(key.clone(), Load::Loading);
     }
 
     /// Reset a stuck `Loading` for `key` back to unqueried — the read worker
     /// vanished (e.g. panicked) without delivering a result, so the next render
     /// re-issues instead of wedging the device on "Reading…".
-    pub(super) fn clear_loading(&mut self, key: &str) {
+    pub(crate) fn clear_loading(&mut self, key: &DeviceKey) {
         if matches!(self.by_device.get(key), Some(Load::Loading)) {
             self.by_device.remove(key);
         }
@@ -101,20 +103,20 @@ impl<T: Clone> LazyDeviceData<T> {
     /// Drop `key`'s recorded state and retry budget so the next render re-reads.
     /// Backs the "click to retry" affordance and the re-select-grants-a-retry
     /// rule for a [`Load::Failed`] device.
-    pub(super) fn retry(&mut self, key: &str) {
+    pub(crate) fn retry(&mut self, key: &DeviceKey) {
         self.by_device.remove(key);
         self.attempts.remove(key);
     }
 
     /// Forget `key` entirely — the device disappeared, or reconnected on a new
     /// route, so its cached state (keyed to the dead route) is stale.
-    pub(super) fn remove(&mut self, key: &str) {
+    pub(crate) fn remove(&mut self, key: &DeviceKey) {
         self.by_device.remove(key);
         self.attempts.remove(key);
     }
 
     /// Forget every device the `present` predicate rejects (not in the live set).
-    pub(super) fn retain_present(&mut self, present: impl Fn(&str) -> bool) {
+    pub(crate) fn retain_present(&mut self, present: impl Fn(&str) -> bool) {
         self.by_device.retain(|key, _| present(key.as_str()));
         self.attempts.retain(|key, _| present(key.as_str()));
     }
@@ -122,7 +124,7 @@ impl<T: Clone> LazyDeviceData<T> {
     /// Optimistically record a resolved value with no read involved — e.g. a
     /// just-written SmartShift config, shown until a confirming re-read replaces
     /// it. Leaves the retry budget untouched.
-    pub(super) fn set_ready(&mut self, key: String, value: T) {
+    pub(crate) fn set_ready(&mut self, key: DeviceKey, value: T) {
         self.by_device.insert(key, Load::Ready(value));
     }
 
@@ -132,9 +134,9 @@ impl<T: Clone> LazyDeviceData<T> {
     /// whether `key` exists at all. Returns the resolved value when the result
     /// settled to [`Load::Ready`], so the caller can run a side effect (the DPI
     /// panel seeds the shared current value). `label` tags the debug logs.
-    pub(super) fn store(
+    pub(crate) fn store(
         &mut self,
-        key: String,
+        key: DeviceKey,
         result: Result<T, WriteError>,
         is_permanent: impl Fn(&WriteError) -> bool,
         matches_route: bool,
@@ -142,7 +144,7 @@ impl<T: Clone> LazyDeviceData<T> {
         label: &'static str,
     ) -> Option<T> {
         if !matches_route {
-            debug!(key, label, "stale device read result ignored");
+            debug!(key = %key, label, "stale device read result ignored");
             // The device reconnected on a different route mid-read: drop the
             // orphaned `Loading` marker so the next render re-reads against the
             // live route instead of spinning on "Reading…" forever.
@@ -170,7 +172,7 @@ impl<T: Clone> LazyDeviceData<T> {
                 let attempts = self.attempts.entry(key.clone()).or_insert(0);
                 *attempts = attempts.saturating_add(1);
                 if *attempts < LOAD_MAX_ATTEMPTS {
-                    debug!(key, attempts = *attempts, error = %error, label, "transient device read error — will retry");
+                    debug!(key = %key, attempts = *attempts, error = %error, label, "transient device read error — will retry");
                     self.by_device.remove(&key);
                     return None;
                 }

--- a/crates/openlogi-gui/src/state/smartshift.rs
+++ b/crates/openlogi-gui/src/state/smartshift.rs
@@ -44,9 +44,9 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_write_status(&self) -> Option<SmartShiftWriteStatus> {
         self.current_record().and_then(|record| {
-            self.smartshift_write_status
-                .get(&record.config_key)
-                .copied()
+            self.device_ui
+                .get(&record.device_key())
+                .and_then(|entry| entry.smartshift_write_status)
         })
     }
     /// Mark SmartShift discovery as in flight for `key`.
@@ -64,7 +64,9 @@ impl AppState {
     pub fn retry_active_smartshift(&mut self) {
         if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
             self.smartshift_data.retry(&key);
-            self.smartshift_write_status.remove(key.as_str());
+            if let Some(entry) = self.device_ui.get_mut(&key) {
+                entry.smartshift_write_status = None;
+            }
         }
     }
     /// Store a SmartShift read result if it still matches the known device
@@ -77,7 +79,11 @@ impl AppState {
         write_id: Option<u64>,
         result: Result<SmartShiftStatus, WriteError>,
     ) {
-        if !smartshift_read_is_current(write_id, self.smartshift_write_status.get(key.as_str())) {
+        let current_write_status = self
+            .device_ui
+            .get(&key)
+            .and_then(|entry| entry.smartshift_write_status);
+        if !smartshift_read_is_current(write_id, current_write_status.as_ref()) {
             debug!(key = %key, ?write_id, "stale SmartShift read result ignored");
             return;
         }
@@ -89,27 +95,29 @@ impl AppState {
             .device_list
             .iter()
             .any(|record| record.device_key() == key);
-        let status_key = key.to_string();
         self.smartshift_data.store(
-            key,
+            key.clone(),
             result,
             smartshift_error_is_permanent,
             matches_route,
             still_present,
             "SmartShift",
         );
-        let expected = match self.smartshift_write_status.get(&status_key) {
-            Some(SmartShiftWriteStatus::Applying { expected, .. }) => Some(*expected),
+        let expected = match self
+            .device_ui
+            .get(&key)
+            .and_then(|entry| entry.smartshift_write_status)
+        {
+            Some(SmartShiftWriteStatus::Applying { expected, .. }) => Some(expected),
             Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
         };
-        if let Some(status) = expected.and_then(|expected| {
-            smartshift_write_outcome(
-                expected,
-                self.smartshift_data
-                    .get(&DeviceKey::from(status_key.as_str())),
-            )
-        }) {
-            self.smartshift_write_status.insert(status_key, status);
+        if let Some(status) = expected
+            .and_then(|expected| smartshift_write_outcome(expected, self.smartshift_data.get(&key)))
+        {
+            self.device_ui
+                .entry(key)
+                .or_default()
+                .smartshift_write_status = Some(status);
         }
     }
     /// Write a full SmartShift configuration to the active device (best-effort,
@@ -127,7 +135,7 @@ impl AppState {
             debug!("no active device — SmartShift change ignored");
             return;
         };
-        let key = record.config_key.clone();
+        let key = record.device_key();
         let persistent_key = record.persistent_config_key().map(str::to_string);
         let route = record.route.clone();
         let can_confirm = route.is_some();
@@ -160,46 +168,51 @@ impl AppState {
             auto_disengage,
             tunable_torque,
         };
-        self.smartshift_data
-            .set_ready(DeviceKey::from(key.as_str()), expected);
+        self.smartshift_data.set_ready(key.clone(), expected);
         let write_id = can_confirm.then(|| {
             let write_id = self.next_smartshift_write_id;
             self.next_smartshift_write_id = self.next_smartshift_write_id.saturating_add(1);
-            self.smartshift_pending_confirm
-                .insert(key.clone(), write_id);
+            self.device_ui
+                .entry(key.clone())
+                .or_default()
+                .smartshift_pending_confirm = Some(write_id);
             write_id
         });
-        self.smartshift_write_status.insert(
-            key,
-            match write_id {
-                Some(write_id) => SmartShiftWriteStatus::Applying { expected, write_id },
-                None => SmartShiftWriteStatus::Failed,
-            },
-        );
+        self.device_ui
+            .entry(key)
+            .or_default()
+            .smartshift_write_status = Some(match write_id {
+            Some(write_id) => SmartShiftWriteStatus::Applying { expected, write_id },
+            None => SmartShiftWriteStatus::Failed,
+        });
     }
-    /// Take the active device's pending SmartShift confirm, if any. Returns the
-    /// `(config_key, route, write_id)` for a one-shot re-read that replaces the
-    /// optimistic value with the device's real state; consumed once so it
-    /// doesn't re-fire.
+    /// Take the active device's pending SmartShift confirm, if any. Returns
+    /// the `(device key, route, write_id)` for a one-shot re-read that
+    /// replaces the optimistic value with the device's real state; consumed
+    /// once so it doesn't re-fire.
     pub fn take_active_smartshift_confirm(&mut self) -> Option<(DeviceKey, DeviceRoute, u64)> {
         let record = self.current_record()?;
         let key = record.device_key();
         let route = record.route.clone()?;
-        self.smartshift_pending_confirm
-            .remove(key.as_str())
-            .map(|write_id| (key, route, write_id))
+        let write_id = self
+            .device_ui
+            .get_mut(&key)?
+            .smartshift_pending_confirm
+            .take()?;
+        Some((key, route, write_id))
     }
     /// Mark a post-write confirmation as failed when its reply channel closes.
     pub fn fail_smartshift_confirm(&mut self, key: &DeviceKey, write_id: u64) {
-        if matches!(
-            self.smartshift_write_status.get(key.as_str()),
-            Some(SmartShiftWriteStatus::Applying {
-                write_id: current,
-                ..
-            }) if *current == write_id
-        ) {
-            self.smartshift_write_status
-                .insert(key.to_string(), SmartShiftWriteStatus::Failed);
+        if let Some(entry) = self.device_ui.get_mut(key)
+            && matches!(
+                entry.smartshift_write_status,
+                Some(SmartShiftWriteStatus::Applying {
+                    write_id: current,
+                    ..
+                }) if current == write_id
+            )
+        {
+            entry.smartshift_write_status = Some(SmartShiftWriteStatus::Failed);
         }
     }
 }

--- a/crates/openlogi-gui/src/state/smartshift.rs
+++ b/crates/openlogi-gui/src/state/smartshift.rs
@@ -3,6 +3,8 @@
 use openlogi_hid::{DeviceRoute, SmartShiftMode, SmartShiftStatus, WriteError};
 use tracing::debug;
 
+use super::device_key::DeviceKey;
+use super::devices::DeviceRecord;
 use super::load::SmartShiftLoad;
 use super::{AppState, SmartShiftWriteStatus};
 
@@ -12,7 +14,7 @@ impl AppState {
     pub fn current_smartshift_status(&self) -> SmartShiftLoad {
         self.current_record()
             .map_or(SmartShiftLoad::Unknown, |record| {
-                self.smartshift_data.status(&record.config_key)
+                self.smartshift_data.status(&record.device_key())
             })
     }
     /// Whether the active device still needs a SmartShift read (no status
@@ -21,7 +23,7 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_unqueried(&self) -> bool {
         self.current_record()
-            .is_some_and(|record| self.smartshift_data.unqueried(&record.config_key))
+            .is_some_and(|record| self.smartshift_data.unqueried(&record.device_key()))
     }
     /// The active device's resolved SmartShift config, if the read succeeded.
     /// Callers use it to preserve fields they don't mean to change (e.g.
@@ -29,7 +31,7 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_ready(&self) -> Option<SmartShiftStatus> {
         self.current_record()
-            .and_then(|record| self.smartshift_data.get(&record.config_key))
+            .and_then(|record| self.smartshift_data.get(&record.device_key()))
             .and_then(|status| match status {
                 SmartShiftLoad::Ready(s) => Some(*s),
                 SmartShiftLoad::Unknown
@@ -48,21 +50,21 @@ impl AppState {
         })
     }
     /// Mark SmartShift discovery as in flight for `key`.
-    pub fn mark_smartshift_loading(&mut self, key: &str) {
+    pub fn mark_smartshift_loading(&mut self, key: &DeviceKey) {
         self.smartshift_data.mark_loading(key);
     }
     /// Reset a stuck `Loading` for `key` back to `Unknown` — called when the
     /// read worker vanished without delivering a result.
-    pub fn clear_smartshift_loading(&mut self, key: &str) {
+    pub fn clear_smartshift_loading(&mut self, key: &DeviceKey) {
         self.smartshift_data.clear_loading(key);
     }
     /// Drop the active device's recorded SmartShift status so the next render
     /// re-runs discovery. Backs the "click to retry" affordance on a
     /// [`SmartShiftLoad::Failed`] device.
     pub fn retry_active_smartshift(&mut self) {
-        if let Some(key) = self.current_record().map(|r| r.config_key.clone()) {
+        if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
             self.smartshift_data.retry(&key);
-            self.smartshift_write_status.remove(&key);
+            self.smartshift_write_status.remove(key.as_str());
         }
     }
     /// Store a SmartShift read result if it still matches the known device
@@ -70,24 +72,24 @@ impl AppState {
     /// permanent-unsupported handling as [`Self::store_dpi_info`].
     pub fn store_smartshift_status(
         &mut self,
-        key: String,
+        key: DeviceKey,
         route: &DeviceRoute,
         write_id: Option<u64>,
         result: Result<SmartShiftStatus, WriteError>,
     ) {
-        if !smartshift_read_is_current(write_id, self.smartshift_write_status.get(&key)) {
-            debug!(key, ?write_id, "stale SmartShift read result ignored");
+        if !smartshift_read_is_current(write_id, self.smartshift_write_status.get(key.as_str())) {
+            debug!(key = %key, ?write_id, "stale SmartShift read result ignored");
             return;
         }
         let matches_route = self
             .device_list
             .iter()
-            .any(|record| record.config_key == key && record.route.as_ref() == Some(route));
+            .any(|record| record.device_key() == key && record.route.as_ref() == Some(route));
         let still_present = self
             .device_list
             .iter()
-            .any(|record| record.config_key == key);
-        let status_key = key.clone();
+            .any(|record| record.device_key() == key);
+        let status_key = key.to_string();
         self.smartshift_data.store(
             key,
             result,
@@ -101,7 +103,11 @@ impl AppState {
             Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
         };
         if let Some(status) = expected.and_then(|expected| {
-            smartshift_write_outcome(expected, self.smartshift_data.get(&status_key))
+            smartshift_write_outcome(
+                expected,
+                self.smartshift_data
+                    .get(&DeviceKey::from(status_key.as_str())),
+            )
         }) {
             self.smartshift_write_status.insert(status_key, status);
         }
@@ -154,7 +160,8 @@ impl AppState {
             auto_disengage,
             tunable_torque,
         };
-        self.smartshift_data.set_ready(key.clone(), expected);
+        self.smartshift_data
+            .set_ready(DeviceKey::from(key.as_str()), expected);
         let write_id = can_confirm.then(|| {
             let write_id = self.next_smartshift_write_id;
             self.next_smartshift_write_id = self.next_smartshift_write_id.saturating_add(1);
@@ -174,18 +181,18 @@ impl AppState {
     /// `(config_key, route, write_id)` for a one-shot re-read that replaces the
     /// optimistic value with the device's real state; consumed once so it
     /// doesn't re-fire.
-    pub fn take_active_smartshift_confirm(&mut self) -> Option<(String, DeviceRoute, u64)> {
+    pub fn take_active_smartshift_confirm(&mut self) -> Option<(DeviceKey, DeviceRoute, u64)> {
         let record = self.current_record()?;
-        let key = record.config_key.clone();
+        let key = record.device_key();
         let route = record.route.clone()?;
         self.smartshift_pending_confirm
-            .remove(&key)
+            .remove(key.as_str())
             .map(|write_id| (key, route, write_id))
     }
     /// Mark a post-write confirmation as failed when its reply channel closes.
-    pub fn fail_smartshift_confirm(&mut self, key: &str, write_id: u64) {
+    pub fn fail_smartshift_confirm(&mut self, key: &DeviceKey, write_id: u64) {
         if matches!(
-            self.smartshift_write_status.get(key),
+            self.smartshift_write_status.get(key.as_str()),
             Some(SmartShiftWriteStatus::Applying {
                 write_id: current,
                 ..

--- a/crates/openlogi-gui/src/state/smartshift.rs
+++ b/crates/openlogi-gui/src/state/smartshift.rs
@@ -1,37 +1,22 @@
-//! SmartShift load state, optimistic writes, and confirmation.
+//! SmartShift optimistic writes and post-write confirmation. The lazy read
+//! cache itself lives in [`super::load::LazyDeviceData`], reached directly as
+//! `self.reads.smartshift`.
 
 use openlogi_hid::{DeviceRoute, SmartShiftMode, SmartShiftStatus, WriteError};
 use tracing::debug;
 
 use super::device_key::DeviceKey;
-use super::devices::DeviceRecord;
 use super::load::SmartShiftLoad;
 use super::{AppState, SmartShiftWriteStatus};
 
 impl AppState {
-    /// SmartShift configuration status for the active device.
-    #[must_use]
-    pub fn current_smartshift_status(&self) -> SmartShiftLoad {
-        self.current_record()
-            .map_or(SmartShiftLoad::Unknown, |record| {
-                self.smartshift_data.status(&record.device_key())
-            })
-    }
-    /// Whether the active device still needs a SmartShift read (no status
-    /// recorded). Cheaper than comparing a cloned [`SmartShiftLoad`] on the
-    /// per-frame render path.
-    #[must_use]
-    pub fn current_smartshift_unqueried(&self) -> bool {
-        self.current_record()
-            .is_some_and(|record| self.smartshift_data.unqueried(&record.device_key()))
-    }
     /// The active device's resolved SmartShift config, if the read succeeded.
     /// Callers use it to preserve fields they don't mean to change (e.g.
     /// tunable torque) when writing back.
     #[must_use]
     pub fn current_smartshift_ready(&self) -> Option<SmartShiftStatus> {
         self.current_record()
-            .and_then(|record| self.smartshift_data.get(&record.device_key()))
+            .and_then(|record| self.reads.smartshift.get(&record.device_key()))
             .and_then(|status| match status {
                 SmartShiftLoad::Ready(s) => Some(*s),
                 SmartShiftLoad::Unknown
@@ -49,24 +34,14 @@ impl AppState {
                 .and_then(|entry| entry.smartshift_write_status)
         })
     }
-    /// Mark SmartShift discovery as in flight for `key`.
-    pub fn mark_smartshift_loading(&mut self, key: &DeviceKey) {
-        self.smartshift_data.mark_loading(key);
-    }
-    /// Reset a stuck `Loading` for `key` back to `Unknown` — called when the
-    /// read worker vanished without delivering a result.
-    pub fn clear_smartshift_loading(&mut self, key: &DeviceKey) {
-        self.smartshift_data.clear_loading(key);
-    }
-    /// Drop the active device's recorded SmartShift status so the next render
-    /// re-runs discovery. Backs the "click to retry" affordance on a
-    /// [`SmartShiftLoad::Failed`] device.
-    pub fn retry_active_smartshift(&mut self) {
-        if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
-            self.smartshift_data.retry(&key);
-            if let Some(entry) = self.device_ui.get_mut(&key) {
-                entry.smartshift_write_status = None;
-            }
+    /// Drop `key`'s recorded SmartShift status so the next render re-runs
+    /// discovery, and clear any post-write confirmation banner along with it.
+    /// Backs the "click to retry" affordance on a [`SmartShiftLoad::Failed`]
+    /// device and on a failed write confirmation.
+    pub fn retry_smartshift(&mut self, key: &DeviceKey) {
+        self.reads.smartshift.retry(key);
+        if let Some(entry) = self.device_ui.get_mut(key) {
+            entry.smartshift_write_status = None;
         }
     }
     /// Store a SmartShift read result if it still matches the known device
@@ -95,7 +70,7 @@ impl AppState {
             .device_list
             .iter()
             .any(|record| record.device_key() == key);
-        self.smartshift_data.store(
+        self.reads.smartshift.store(
             key.clone(),
             result,
             smartshift_error_is_permanent,
@@ -111,9 +86,9 @@ impl AppState {
             Some(SmartShiftWriteStatus::Applying { expected, .. }) => Some(expected),
             Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
         };
-        if let Some(status) = expected
-            .and_then(|expected| smartshift_write_outcome(expected, self.smartshift_data.get(&key)))
-        {
+        if let Some(status) = expected.and_then(|expected| {
+            smartshift_write_outcome(expected, self.reads.smartshift.get(&key))
+        }) {
             self.device_ui
                 .entry(key)
                 .or_default()
@@ -168,7 +143,7 @@ impl AppState {
             auto_disengage,
             tunable_torque,
         };
-        self.smartshift_data.set_ready(key.clone(), expected);
+        self.reads.smartshift.set_ready(key.clone(), expected);
         let write_id = can_confirm.then(|| {
             let write_id = self.next_smartshift_write_id;
             self.next_smartshift_write_id = self.next_smartshift_write_id.saturating_add(1);


### PR DESCRIPTION
## Summary

`AppState` (`crates/openlogi-gui/src/state.rs`) had two concrete, mechanical
problems:

- **Seven parallel `BTreeMap<String, _>`/`LazyDeviceData<_>` side tables**, all
  keyed by the same device but with nothing tying them together as one
  address space — a plain `String` computed for an unrelated purpose could be
  used against the wrong map by accident.
- **`state/dpi.rs` and `state/smartshift.rs` carried the same ~10 methods
  twice** (`mark_*_loading`, `clear_*_loading`, `retry_active_*`,
  `current_*_status`, `current_*_unqueried`), each just forwarding to the
  already-generic `LazyDeviceData<T>` after resolving the current device.

This PR is a pure state refactor — no behavior or UI change.

## Changes

Three focused commits, each independently green on the local gate:

- **`crates/openlogi-gui`**:
  - Add a `DeviceKey` newtype (`state/device_key.rs`) wrapping the device
    config key used across DPI/SmartShift reads and the per-device UI cache,
    with a canonical `DeviceRecord::device_key()` accessor replacing ~40
    `record.config_key.clone()` call sites. Re-keys `LazyDeviceData<T>` by it.
  - Consolidate `manual_light_overrides`, `volatile_light_settings`,
    `light_commands`, `inventory_misses`, `smartshift_pending_confirm`, and
    `smartshift_write_status` — six parallel `BTreeMap<String, _>` fields all
    updated in lockstep — into one `BTreeMap<DeviceKey, DeviceUiState>`
    (`state/device_ui.rs`). `light.rs`, `inventory.rs`, and `smartshift.rs`
    now read/write one row per device instead of juggling up to six lookups.
    While touching `light.rs`, extracted the rollback-computation duplicated
    between `commit_light` and `commit_manual_light_power` into two small
    helpers (kept `commit_light` under clippy's line-count lint).
  - Group the two `LazyDeviceData` caches into one `DeviceReads` holder
    (`state.reads.dpi` / `state.reads.smartshift`) and delete the ten
    forwarding wrappers that erased the generic's genericity: `dpi_status_for`,
    `current_dpi_status`, `current_dpi_unqueried`, `mark_dpi_loading`,
    `clear_dpi_loading`, `retry_active_dpi`, `current_smartshift_status`,
    `current_smartshift_unqueried`, `mark_smartshift_loading`,
    `clear_smartshift_loading`. `retry_active_smartshift` becomes
    `retry_smartshift(key)` — kept because it also clears the
    write-confirmation banner, genuine SmartShift-specific logic rather than a
    twin of the DPI version. Callers (`dpi_panel.rs`, `smartshift_panel.rs`,
    `diagnostics.rs`) now call `state.reads.dpi.retry(&key)` /
    `state.reads.smartshift.status(&key)` etc. directly.

**Not done — the `PendingWrite<T>` stretch goal.** SmartShift's optimistic
write (a scalar write-id + a 3-state confirm enum) and the standalone-light
command (a request id, an in-flight *count* since power/brightness/color are
separate device writes, partial-success/rollback tracking, and a superseded-
batch chain for a write that arrives after being replaced) are shaped too
differently to share one generic without either bloating SmartShift with
unused fields or stripping the rollback/partial-success semantics Light
genuinely needs. Left as two bespoke mechanisms rather than forcing a
lowest-common-denominator abstraction.

## Testing

Ran on the final tree:

```
direnv exec . env CARGO_BUILD_JOBS=4 cargo fmt --all -- --check
direnv exec . env CARGO_BUILD_JOBS=4 cargo clippy --workspace --all-targets -- -D warnings
direnv exec . env CARGO_BUILD_JOBS=4 cargo test --workspace
```

All green. `crates/openlogi-gui/src/state/tests.rs` (the 961-line safety net)
is unchanged in substance — no assertion, expected value, or test case was
weakened or removed; only call sites were mechanically updated for renamed
methods (all 128 `openlogi-gui` tests pass, including the untouched `i18n`
parity test — no new UI strings were added). Added two small non-tautological
tests for `DeviceKey` (`Borrow<str>` lookup, value-based equality/ordering).

**Runtime-verified against `openlogi-agent-mock`** (no hardware needed):

```
direnv exec . cargo run -p openlogi-agent --bin openlogi-agent-mock
OPENLOGI_DEV_AGENT=0 direnv exec . cargo run -p openlogi-gui   # second shell
```

Walked every panel this diff touches:

- **Pointer (DPI)**: online mouse (MX Master 3S) resolves to `1600`, range
  `200–8000 · step 50` — not stuck on "Reading…". Added and persisted a DPI
  preset (round-trips through `commit_dpi_presets`/`reads.dpi`). The offline
  mouse (MX Anywhere 3) resolves to the terminal "This device did not report
  Adjustable DPI support" state instead of hanging.
- **SmartShift**: same online mouse resolves to `Ratchet`, sensitivity `16`,
  thumb-wheel `14`. Clicked "Free spin" — `commit_smartshift` →
  `smartshift_pending_confirm` → confirming re-read → the "Done" banner
  appeared and stayed put, exercising `store_smartshift_status`/
  `smartshift_write_outcome`/`take_active_smartshift_confirm` end to end. The
  offline mouse resolves to "This device does not support SmartShift."
  instead of hanging.
- **Light**: the standalone Litra Glow's power toggle and brightness slider
  both round-trip through `commit_light`/`commit_manual_light_power`. The
  mock's `set_light`/`set_light_manual_power` reject every write for this
  device with `WriteError::DeviceNotFound` (its `light_route()` is
  `DeviceRoute::Direct`, but the GUI addresses a standalone light via
  `DeviceRoute::RawHid` — an existing `openlogi-agent-mock` mismatch, not
  something this PR touches or introduces) — which, unintentionally, gave a
  live failure to check the rollback path against: both the power toggle and
  the brightness value snapped back to their pre-write settings and the panel
  showed the `WriteError` message, confirming `apply_light_command_result`'s
  failure branch and `light_write_rollback`/`restore_manual_override` restore
  `device_ui` correctly.
- **Device list**: killed and restarted the mock mid-session. The GUI showed
  the full-window "Can't reach the background service" state while down, then
  recovered on its own with all five scripted devices intact (no duplicates,
  no drops) once the mock came back — exercising `refresh_inventories`/
  `merge_inventory_snapshot` and the `device_ui` retain-on-reconnect sweep
  across a real disconnect/reconnect cycle.

**Not exercised**: the DPI/SmartShift `Failed` (transient-error) status and
its "click to retry" affordance. The mock only ever answers a valid route with
success or a permanent `FeatureUnsupported`, and a full agent outage is
handled by the app as the global "unreachable" screen above rather than a
per-panel failure, so there was no way to provoke the transient-retry branch
through this tool without modifying the mock (out of scope). That state
machine (`LazyDeviceData::store`'s attempt counting, `Load::Failed` after
`LOAD_MAX_ATTEMPTS`) has no dedicated unit test either, before or after this
PR — this refactor only moved/retyped it, unchanged in behavior.
