### PR TITLE
fix(release): put openlogi-camera in the workspace version group

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -63,6 +63,16 @@ version_group = "openlogi"
 name = "openlogi-assets"
 version_group = "openlogi"
 
+# UVC webcam discovery. Published because `openlogi-cli` (published) depends on
+# it by an exact version — a crates.io package cannot depend on an unpublished
+# path dependency. It must stay in the version group for that same reason: with
+# an independently computed next version it can disagree with the group on the
+# single shared `version.workspace` field, and a cli published against a
+# camera version that was never pushed to crates.io is a hard publish failure.
+[[package]]
+name = "openlogi-camera"
+version_group = "openlogi"
+
 [[package]]
 name = "openlogi-cli"
 version_group = "openlogi"


### PR DESCRIPTION
## Summary

`openlogi-camera` was the only workspace member neither listed in `release-plz.toml` nor marked `publish = false` in its own manifest, so release-plz computed its next version independently of the `openlogi` version group.

Found while extracting `openlogi-ipc` in #617 (noted in that PR body, deliberately not fixed there).

## Why it matters

- `openlogi-camera` **is** published — crates.io has 0.6.27 — because `openlogi-cli` (published, in the version group) depends on it by an exact version: `openlogi-camera = { path = "../openlogi-camera", version = "0.6.27" }`. A crates.io package cannot depend on an unpublished path dependency, so it has to be published.
- Every crate inherits `version.workspace = true`, i.e. one shared version field. Outside the version group, release-plz derives camera's next version from its own commits alone, which can disagree with the group's answer for that same field.
- The failure mode is a release that publishes `openlogi-cli` at version X depending on `openlogi-camera = "X"` that was never pushed to crates.io — a hard publish failure. Published releases are immutable and failed release jobs must not be re-run, so this is expensive to hit and awkward to recover from.

It has not bitten yet: 0.6.27 went out consistent across all published crates. This closes the gap before a release where the independent computation diverges.

## Changes

- `release-plz.toml`: add a `[[package]]` entry for `openlogi-camera` with `version_group = "openlogi"`, placed next to its published siblings and above `openlogi-cli` (its dependent), with a comment recording why it must be published and grouped.

## Testing

Config-only change; no Rust code touched.

- TOML parses (`tomllib`), and the repo's `check toml` pre-commit hook passes.
- Cross-checked the invariant that motivated the fix — every workspace member is either listed in `release-plz.toml` or carries `publish = false`:

```
openlogi               release-plz=yes publish=false=no   ok
openlogi-agent         release-plz=yes publish=false=yes  ok
openlogi-agent-core    release-plz=yes publish=false=yes  ok
openlogi-assets        release-plz=yes publish=false=no   ok
openlogi-camera        release-plz=yes publish=false=no   ok   <- was UNCOVERED
openlogi-cli           release-plz=yes publish=false=no   ok
openlogi-core          release-plz=yes publish=false=no   ok
openlogi-gui           release-plz=yes publish=false=yes  ok
openlogi-hid           release-plz=yes publish=false=no   ok
openlogi-hidpp         release-plz=yes publish=false=no   ok
openlogi-hook          release-plz=yes publish=false=no   ok
openlogi-inject        release-plz=yes publish=false=no   ok
openlogi-ipc           release-plz=yes publish=false=yes  ok
xtask                  release-plz=no  publish=false=yes  ok
```

`xtask` is correctly excluded by its own `publish = false`.

**Not verified against a real release run** — the release-plz CLI is not installed locally, and I did not dry-run a release. The next release PR is the first real exercise of this entry.
