### PR TITLE
docs(ci): add rustdoc to the local gate and cover the derive crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc -p openlogi-hidpp --no-deps --document-private-items
+      - name: cargo doc (openlogi-hidpp-derive)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc -p openlogi-hidpp-derive --no-deps --document-private-items
 
   # openlogi-core / openlogi-hid / openlogi-assets / openlogi / openlogi-hook
   # all compile on Linux today (the hook crate has stubs for non-macOS targets).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,17 +57,30 @@ direnv exec . git commit …
 
 **Never `git push` until the final tree has passed the full local gate.**
 `cargo check` alone is not enough. Conflict resolution + "it compiles on my
-Mac" is not enough. Run **all three** on the commit you are about to push:
+Mac" is not enough. Run **all four** on the commit you are about to push:
 
 ```sh
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
+RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
+  -p openlogi-hidpp-derive --no-deps --document-private-items
 # or: devenv tasks run openlogi:check
 ```
 
-Exit non-zero on any of those → fix, re-run the **whole** triple, then push.
+Exit non-zero on any of those → fix, re-run the **whole** set, then push.
 Do not push "to see if CI likes it." CI is confirmation, not the first compile.
+
+The rustdoc step mirrors CI's `rustdoc (hid crates)` job and catches what the
+other three cannot: a broken intra-doc link is neither a compile error nor a
+clippy lint. How it bites is non-obvious — rustdoc resolves a
+`Type::trait_method` link only while that trait is **in scope**, so handing a
+hand-written trait impl over to a derive macro deletes the now-unused `use` and
+silently breaks every such link. Re-adding the import does not fix it either: a
+doc link does not count as a use, so that just trades the broken link for an
+`unused_imports` failure — write the trait method's full path instead. After any
+refactor that moves impls between hand-written and generated, grep for doc links
+naming that trait's methods.
 
 prek hooks (`prek.toml`): `cargo fmt` at commit; full-workspace clippy at push
 (rust-scoped, so non-Rust pushes skip it). Hooks are a backstop, not a substitute

--- a/devenv.nix
+++ b/devenv.nix
@@ -94,13 +94,17 @@ in
       '';
     };
     "openlogi:check" = {
-      description = "Run fmt, clippy, and tests.";
+      description = "Run fmt, clippy, tests, and rustdoc.";
       exec = ''
         set -e
         ${requireXcodeMetal}
         cargo fmt --all -- --check
         cargo clippy --workspace --all-targets -- -D warnings
         cargo test --workspace
+        # Mirrors CI's `rustdoc (hid crates)` job: a broken intra-doc link is
+        # neither a compile error nor a clippy lint, so nothing above catches it.
+        RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
+          -p openlogi-hidpp-derive --no-deps --document-private-items
       '';
     };
     "openlogi:i18n-upload" = {


### PR DESCRIPTION
## Summary

The documented local gate was fmt + clippy + test. None of those can see a
broken intra-doc link, so CI's `rustdoc (hid crates)` job was a step every
contributor had to know about but nothing told them to run.

#625 hit exactly that: green locally, red on CI.

## Changes

- `AGENTS.md` — the gate is now four steps, with the rustdoc invocation spelled
  out, and a note on how the failure mode actually bites: rustdoc resolves a
  `Type::trait_method` link only while that trait is **in scope**, so handing a
  hand-written trait impl to a derive macro deletes the now-unused `use` and
  silently breaks every such link. Re-adding the import is not the fix — a doc
  link doesn't count as a use, so that only trades the broken link for an
  `unused_imports` failure; write the trait method's full path instead.
- `devenv.nix` — `openlogi:check` gains the same step, so the
  "or: devenv tasks run openlogi:check" shortcut sitting next to the list stays
  equivalent to it rather than quietly covering less.
- `.github/workflows/ci.yml` — document `openlogi-hidpp-derive` too. The crate
  landed in #625 without rustdoc coverage.

## Testing

- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items` — clean, and confirms the exact command now written in both files works as one invocation (CI runs it as separate steps).
- `yq` parses the edited workflow; the `docs-hid` job lists the three expected steps.

Docs and CI config only — no product code changed.
