### PR TITLE
chore(hidpp): inherit the workspace lint table

### DIFF
--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -7,9 +7,6 @@
 # Versioned with the OpenLogi workspace (unified versioning) rather than
 # upstream's 0.3.0 — the upstream version is provenance, recorded above.
 #
-# This crate intentionally does NOT opt into the workspace lint profile
-# (`[lints] workspace = true`): it is third-party code, so we don't impose
-# OpenLogi's pedantic/restriction clippy rules on it.
 [package]
 name = "openlogi-hidpp"
 version.workspace = true
@@ -48,3 +45,6 @@ tracing = { workspace = true }
 # for feature structs shaped `{ endpoint: FeatureEndpoint }` or `{ endpoint,
 # events: EventSource<Event> }`. Not in upstream hidpp; used only here.
 openlogi-hidpp-derive = { version = "0.6.27", path = "../openlogi-hidpp-derive" }
+
+[lints]
+workspace = true

--- a/crates/openlogi-hidpp/src/bcd.rs
+++ b/crates/openlogi-hidpp/src/bcd.rs
@@ -12,8 +12,8 @@ pub fn convert_packed_u8(bcd: u8) -> Result<u8, ()> {
 }
 
 pub fn convert_packed_u16(bcd: u16) -> Result<u16, ()> {
-    let digits_0 = convert_packed_u8((bcd >> 8) as u8)? as u16;
-    let digits_1 = convert_packed_u8((bcd & 0xff) as u8)? as u16;
+    let digits_0 = u16::from(convert_packed_u8((bcd >> 8) as u8)?);
+    let digits_1 = u16::from(convert_packed_u8((bcd & 0xff) as u8)?);
 
     Ok(digits_0 * 100 + digits_1)
 }

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, VecDeque},
     error::Error,
     sync::{
-        Arc, Mutex, Weak,
+        Arc, Mutex, MutexGuard, Weak,
         atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     },
     thread::{self, JoinHandle},
@@ -196,6 +196,7 @@ pub enum HidppMessage {
 
 impl HidppMessage {
     /// Tries to read a HID++ message from raw data.
+    #[must_use]
     pub fn read_raw(data: &[u8]) -> Option<Self> {
         let (&report_id, rest) = data.split_first()?;
 
@@ -245,6 +246,17 @@ impl HidppMessage {
 
 type MessageListener = Arc<dyn Fn(HidppMessage, bool) + Send + Sync + 'static>;
 
+/// Locks `mutex`, treating poisoning as unrecoverable: a panicking holder
+/// leaves the channel's shared queues in an inconsistent state, so
+/// continuing would operate on corrupt data.
+#[expect(
+    clippy::expect_used,
+    reason = "mutex poisoning is unrecoverable here — see doc comment"
+)]
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().expect("mutex poisoned")
+}
+
 /// Removes a HID++ message listener when dropped.
 pub struct MessageListenerGuard {
     message_listeners: Weak<Mutex<HashMap<u32, MessageListener>>>,
@@ -254,7 +266,7 @@ pub struct MessageListenerGuard {
 impl Drop for MessageListenerGuard {
     fn drop(&mut self) {
         if let Some(message_listeners) = self.message_listeners.upgrade() {
-            message_listeners.lock().unwrap().remove(&self.hdl);
+            lock(&message_listeners).remove(&self.hdl);
         }
     }
 }
@@ -322,6 +334,12 @@ impl Drop for HidppChannel {
         }
 
         if let Some(read_thread_hdl) = self.read_thread_hdl.take() {
+            // A panic here means the read thread itself panicked; propagate
+            // it rather than silently ignore a crashed background worker.
+            #[expect(
+                clippy::unwrap_used,
+                reason = "propagate a read-thread panic instead of ignoring a crashed background worker"
+            )]
             read_thread_hdl.join().unwrap();
         }
     }
@@ -394,12 +412,12 @@ impl HidppChannel {
                         let mut matched = false;
                         let pending_count;
                         {
-                            let mut msgs = pending_messages.lock().unwrap();
+                            let mut msgs = lock(&pending_messages);
                             pending_count = msgs.len();
                             if let Some(pos) =
                                 msgs.iter().position(|elem| (elem.response_predicate)(&msg))
+                                && let Some(waiting) = msgs.remove(pos)
                             {
-                                let waiting = msgs.remove(pos).unwrap();
                                 let _ = waiting.sender.send(msg);
                                 matched = true;
                             }
@@ -413,12 +431,8 @@ impl HidppChannel {
                             "raw report received"
                         );
 
-                        let listeners: Vec<_> = message_listeners
-                            .lock()
-                            .unwrap()
-                            .values()
-                            .cloned()
-                            .collect();
+                        let listeners: Vec<_> =
+                            lock(&message_listeners).values().cloned().collect();
                         for listener in listeners {
                             listener(msg, matched);
                         }
@@ -487,17 +501,21 @@ impl HidppChannel {
     /// may rotate (as indicated by [`Self::set_rotating_sw_id`]).
     pub fn get_sw_id(&self) -> U4 {
         if self.rotate_software_id.load(Ordering::SeqCst) {
-            U4::from_lo(
-                self.software_id
+            // The closure always returns `Some`, so `fetch_update` never
+            // reports `Err`; both arms carry the same pre-update value.
+            let previous =
+                match self
+                    .software_id
                     .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |old| {
                         Some(if old & 0x0f == 0x0f {
                             0x01
                         } else {
                             old.wrapping_add(1)
                         })
-                    })
-                    .unwrap(),
-            )
+                    }) {
+                    Ok(previous) | Err(previous) => previous,
+                };
+            U4::from_lo(previous)
         } else {
             U4::from_lo(self.software_id.load(Ordering::SeqCst))
         }
@@ -523,7 +541,7 @@ impl HidppChannel {
     fn normalize_outgoing(&self, msg: HidppMessage) -> HidppMessage {
         match msg {
             HidppMessage::Short(payload) if !self.supports_short && self.supports_long => {
-                HidppMessage::Long(short_payload_as_long(&payload))
+                HidppMessage::Long(short_payload_as_long(payload))
             }
             other => other,
         }
@@ -580,7 +598,7 @@ impl HidppChannel {
         let pending_id = self.pending_message_id.fetch_add(1, Ordering::SeqCst);
 
         {
-            let mut pending = self.pending_messages.lock().unwrap();
+            let mut pending = lock(&self.pending_messages);
             // Drop abandoned requests before queuing this one. Timeouts and
             // write failures remove their entry eagerly below, but a caller
             // cancelled mid-flight (an outer `timeout(..)` dropping the whole
@@ -610,7 +628,7 @@ impl HidppChannel {
 
         let result = select! {
             result = request => result,
-            _ = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
+            () = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
         };
 
         match &result {
@@ -629,7 +647,7 @@ impl HidppChannel {
     }
 
     fn remove_pending_message(&self, id: u64) {
-        let mut pending = self.pending_messages.lock().unwrap();
+        let mut pending = lock(&self.pending_messages);
         if let Some(pos) = pending.iter().position(|msg| msg.id == id) {
             pending.remove(pos);
         }
@@ -678,7 +696,7 @@ impl HidppChannel {
         let mut write = std::pin::pin!(self.raw_channel.write_report(report).fuse());
         select! {
             result = write => result.map_err(ChannelError::Implementation),
-            _ = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
+            () = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
         }
     }
 
@@ -690,7 +708,7 @@ impl HidppChannel {
         &self,
         listener: impl Fn(HidppMessage, bool) + Send + Sync + 'static,
     ) -> u32 {
-        let mut listeners = self.message_listeners.lock().unwrap();
+        let mut listeners = lock(&self.message_listeners);
 
         let mut rng = rand::rng();
         let mut hdl = rng.random::<u32>();
@@ -719,11 +737,7 @@ impl HidppChannel {
     ///
     /// Returns whether a listener was found using the given handle.
     pub fn remove_msg_listener(&self, hdl: u32) -> bool {
-        self.message_listeners
-            .lock()
-            .unwrap()
-            .remove(&hdl)
-            .is_some()
+        lock(&self.message_listeners).remove(&hdl).is_some()
     }
 }
 
@@ -772,13 +786,18 @@ pub enum ChannelError {
 /// both widths, so the only change is zero-padding the trailing payload. Used
 /// to re-frame short messages as long on a long-only channel — see
 /// [`HidppChannel::normalize_outgoing`]. (OpenLogi local addition.)
-fn short_payload_as_long(payload: &[u8; SHORT_REPORT_LENGTH - 1]) -> [u8; LONG_REPORT_LENGTH - 1] {
+fn short_payload_as_long(payload: [u8; SHORT_REPORT_LENGTH - 1]) -> [u8; LONG_REPORT_LENGTH - 1] {
     let mut long = [0u8; LONG_REPORT_LENGTH - 1];
-    long[..payload.len()].copy_from_slice(payload);
+    long[..payload.len()].copy_from_slice(&payload);
     long
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
 pub(crate) mod tests {
     use super::*;
     use std::{
@@ -799,7 +818,7 @@ pub(crate) mod tests {
     fn short_payload_widens_preserving_header_and_padding() {
         // [device, feature, function|sw, p0, p1, p2]
         let short = [0xff, 0x05, 0x1e, 0xaa, 0xbb, 0xcc];
-        let long = short_payload_as_long(&short);
+        let long = short_payload_as_long(short);
         assert_eq!(&long[..short.len()], &short[..]); // header + payload copied verbatim
         assert!(long[short.len()..].iter().all(|&b| b == 0)); // remainder zero-padded
         assert_eq!(long.len(), LONG_REPORT_LENGTH - 1);
@@ -919,21 +938,21 @@ pub(crate) mod tests {
             assert_eq!(events.lock().unwrap()[0], (late_response, false));
             assert_pending_empty(&channel);
 
-            let later_request = short_msg(0x30);
-            let later_response = short_msg(0x40);
-            handle.queue_response(later_response);
+            let followup_request = short_msg(0x30);
+            let followup_response = short_msg(0x40);
+            handle.queue_response(followup_response);
             let actual = channel
                 .send_with_timeout(
-                    later_request,
-                    move |candidate| *candidate == later_response,
+                    followup_request,
+                    move |candidate| *candidate == followup_response,
                     Duration::from_secs(1),
                 )
                 .await
                 .unwrap();
 
-            assert_eq!(actual, later_response);
+            assert_eq!(actual, followup_response);
             wait_for_event_count(&events, 2).await;
-            assert_eq!(events.lock().unwrap()[1], (later_response, true));
+            assert_eq!(events.lock().unwrap()[1], (followup_response, true));
             assert_pending_empty(&channel);
         });
     }

--- a/crates/openlogi-hidpp/src/device.rs
+++ b/crates/openlogi-hidpp/src/device.rs
@@ -24,6 +24,11 @@ pub struct Device {
     /// The underlying HID++ channel.
     chan: Arc<HidppChannel>,
 
+    /// Cached handle to the root feature. [`Self::new`] always installs one
+    /// before returning, so [`Self::root`] can hand it back directly instead
+    /// of going through the generic (and fallible) `features` lookup.
+    root: Arc<RootFeature>,
+
     /// The initialized implementation of features the device supports.
     features: HashMap<TypeId, Arc<dyn Feature>>,
 
@@ -46,35 +51,36 @@ impl Device {
     /// Returns [`DeviceError::UnsupportedProtocolVersion`] if the device only
     /// supports [`ProtocolVersion::V10`].
     pub async fn new(chan: Arc<HidppChannel>, device_index: u8) -> Result<Self, DeviceError> {
-        let protocol_version = protocol::determine_version(&chan, device_index).await?;
-
-        if protocol_version.is_none() {
+        let Some(version) = protocol::determine_version(&chan, device_index).await? else {
             return Err(DeviceError::DeviceNotFound);
-        }
-        let version = protocol_version.unwrap();
+        };
 
         if version == ProtocolVersion::V10 {
             return Err(DeviceError::UnsupportedProtocolVersion);
         }
 
-        let mut device = Self {
-            chan,
-            features: HashMap::new(),
-            device_index,
-            protocol_version: version,
-        };
-
         // Every HID++2.0 device supports the root feature.
         // We implicitly verified that using [`protocol::determine_version`].
-        device.add_feature::<RootFeature>(0);
+        let mut features: HashMap<TypeId, Arc<dyn Feature>> = HashMap::new();
+        let root = insert_feature(
+            &mut features,
+            RootFeature::new(Arc::clone(&chan), device_index, 0),
+        );
 
-        Ok(device)
+        Ok(Self {
+            chan,
+            root,
+            features,
+            device_index,
+            protocol_version: version,
+        })
     }
 
     /// A convenience wrapper around [`Self::get_feature`] to obtain the root
     /// feature.
+    #[must_use]
     pub fn root(&self) -> Arc<RootFeature> {
-        self.get_feature::<RootFeature>().unwrap()
+        Arc::clone(&self.root)
     }
 
     /// Adds a new feature implementation to the list of available features.
@@ -82,12 +88,7 @@ impl Device {
     /// The caller is responsible for making sure the device actually supports
     /// the feature.
     pub fn add_feature_instance<F: Feature>(&mut self, feature: F) -> Arc<F> {
-        let feat_rc: Arc<dyn Feature> = Arc::new(feature);
-
-        self.features
-            .insert(TypeId::of::<F>(), Arc::clone(&feat_rc));
-
-        Arc::downcast::<F>(feat_rc).unwrap()
+        insert_feature(&mut self.features, feature)
     }
 
     /// Adds a new feature implementation to the list of available features.
@@ -108,6 +109,7 @@ impl Device {
 
     /// Checks whether a specific feature implementation is provided by the
     /// device.
+    #[must_use]
     pub fn provides_feature<F: Feature>(&self) -> bool {
         self.features.contains_key(&TypeId::of::<F>())
     }
@@ -116,6 +118,7 @@ impl Device {
     ///
     /// Returns [`None`] if the requested feature implementation is not
     /// provided.
+    #[must_use]
     pub fn get_feature<F: Feature>(&self) -> Option<Arc<F>> {
         self.features
             .get(&TypeId::of::<F>())
@@ -176,6 +179,21 @@ impl Device {
     }
 }
 
+/// Inserts a feature implementation into a device's feature map, returning a
+/// concretely-typed handle to it.
+///
+/// Building the `Arc<F>` once and coercing a clone to `Arc<dyn Feature>` for
+/// storage avoids an erase-then-downcast round trip through the map, so the
+/// returned handle can never fail to be `F`.
+fn insert_feature<F: Feature>(
+    features: &mut HashMap<TypeId, Arc<dyn Feature>>,
+    feature: F,
+) -> Arc<F> {
+    let feat_rc = Arc::new(feature);
+    features.insert(TypeId::of::<F>(), Arc::clone(&feat_rc) as Arc<dyn Feature>);
+    feat_rc
+}
+
 /// Per-attempt deadline for one feature-table read during enumeration.
 ///
 /// The channel's default [`crate::channel::SEND_RESPONSE_TIMEOUT`] (5s) is
@@ -211,7 +229,7 @@ async fn read_feature_entry(
         let mut read = std::pin::pin!(feature_set.get_feature(index).fuse());
         let outcome = select! {
             result = read => Some(result),
-            _ = futures_timer::Delay::new(FEATURE_READ_ATTEMPT).fuse() => None,
+            () = futures_timer::Delay::new(FEATURE_READ_ATTEMPT).fuse() => None,
         };
         match outcome {
             Some(Ok(info)) => return Ok(info),
@@ -234,6 +252,11 @@ async fn read_feature_entry(
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/openlogi-hidpp/src/event.rs
+++ b/crates/openlogi-hidpp/src/event.rs
@@ -1,4 +1,15 @@
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
+
+/// Locks `mutex`, treating poisoning as unrecoverable: a panicking holder
+/// leaves the emitter's sender list in an inconsistent state, so continuing
+/// would operate on corrupt data.
+#[expect(
+    clippy::expect_used,
+    reason = "mutex poisoning is unrecoverable here — see doc comment"
+)]
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().expect("mutex poisoned")
+}
 
 /// A simple event emitter sending a single event to multiple MPSC channels.
 #[derive(Debug)]
@@ -16,7 +27,7 @@ impl<T: Clone> EventEmitter<T> {
     /// Creates a new receiver and adds the corresponding sender to the sender
     /// list.
     pub fn create_receiver(&self) -> async_channel::Receiver<T> {
-        let mut senders = self.senders.lock().unwrap();
+        let mut senders = lock(&self.senders);
         senders.retain(|sender| sender.receiver_count() > 0);
         let (tx, rx) = async_channel::unbounded();
         senders.push(tx);
@@ -26,7 +37,7 @@ impl<T: Clone> EventEmitter<T> {
     /// Emits an event to all senders. Senders whose receivers were dropped are
     /// removed from the list.
     pub fn emit(&self, event: T) {
-        let mut senders = self.senders.lock().unwrap();
+        let mut senders = lock(&self.senders);
         senders.retain(|sender| {
             sender.receiver_count() > 0 && sender.send_blocking(event.clone()).is_ok()
         });
@@ -34,6 +45,11 @@ impl<T: Clone> EventEmitter<T> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-hidpp/src/feature/adjustable_dpi/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/adjustable_dpi/mod.rs
@@ -109,6 +109,7 @@ fn parse_dpi_list_payload(bytes: &[u8]) -> Result<Vec<u16>, Hidpp20Error> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/backlight/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/backlight/mod.rs
@@ -349,6 +349,7 @@ impl BacklightInfoUpdate {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{
         BacklightEffect, BacklightInfoUpdate, BacklightMode, BacklightOptions, BacklightStatus,

--- a/crates/openlogi-hidpp/src/feature/backlight/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/backlight/mod.rs
@@ -284,6 +284,10 @@ impl BacklightFeature {
     ) -> Result<(), Hidpp20Error> {
         // The request options byte packs the writable option flags (low 3 bits)
         // and the 2-bit mode (bits 3..=4).
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "masked to WOW|CROWN|PWR_SAVE (bits 0-2), so the value always fits in a u8"
+        )]
         let options_byte = (config.options.bits()
             & (BacklightOptions::WOW | BacklightOptions::CROWN | BacklightOptions::PWR_SAVE).bits())
             as u8

--- a/crates/openlogi-hidpp/src/feature/color_led_effects/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/color_led_effects/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `ColorLedEffects` payload parsing and event decoding.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 
@@ -163,13 +164,13 @@ fn maps_effect_id_wire_values() {
     assert_eq!(EffectId::try_from(0u16).unwrap(), EffectId::Disabled);
     assert_eq!(EffectId::try_from(1u16).unwrap(), EffectId::FixedColor);
     assert_eq!(EffectId::try_from(11u16).unwrap(), EffectId::Ripple);
-    assert!(EffectId::try_from(12u16).is_err());
+    EffectId::try_from(12u16).unwrap_err();
     assert_eq!(u16::from(EffectId::FixedColor), 1);
 }
 
 #[test]
 fn validates_single_nv_capability() {
-    assert!(validate_single_nv_capability(NvCapabilities::BOOT_UP_EFFECT).is_ok());
+    validate_single_nv_capability(NvCapabilities::BOOT_UP_EFFECT).unwrap();
     assert_matches!(
         validate_single_nv_capability(NvCapabilities::empty()),
         Err(Hidpp20Error::Feature(ErrorType::InvalidArgument))

--- a/crates/openlogi-hidpp/src/feature/crown/event.rs
+++ b/crates/openlogi-hidpp/src/feature/crown/event.rs
@@ -122,8 +122,8 @@ pub(super) fn decode_event(sub_id: u8, payload: &[u8; 16]) -> Option<CrownEvent>
     match sub_id {
         0 => Some(CrownEvent::Update(CrownUpdate {
             rotation_state: RotationState::from(payload[0]),
-            relative_slot_rotation: payload[1] as i8,
-            relative_ratchet_rotation: payload[2] as i8,
+            relative_slot_rotation: payload[1].cast_signed(),
+            relative_ratchet_rotation: payload[2].cast_signed(),
             proximity: ActivityState::from(payload[3]),
             touch: ActivityState::from(payload[4]),
             gesture: CrownGesture::from(payload[5]),

--- a/crates/openlogi-hidpp/src/feature/crown/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/crown/tests.rs
@@ -1,4 +1,9 @@
 //! Unit tests for `Crown` mode parsing and event decoding.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
 
 use std::assert_matches;
 
@@ -97,5 +102,5 @@ fn maps_mode_enum_wire_values() {
     assert_eq!(u8::from(ReportingMode::Diverted), 2);
     assert_eq!(ReportingMode::try_from(1u8).unwrap(), ReportingMode::Hid);
     assert_eq!(u8::from(RatchetMode::Free), 1);
-    assert!(RatchetMode::try_from(3u8).is_err());
+    RatchetMode::try_from(3u8).unwrap_err();
 }

--- a/crates/openlogi-hidpp/src/feature/device_friendly_name/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/device_friendly_name/mod.rs
@@ -42,7 +42,23 @@ impl DeviceFriendlyNameFeature {
             .await?
             .extend_payload();
 
-        Ok(payload[1..].try_into().unwrap())
+        Ok([
+            payload[1],
+            payload[2],
+            payload[3],
+            payload[4],
+            payload[5],
+            payload[6],
+            payload[7],
+            payload[8],
+            payload[9],
+            payload[10],
+            payload[11],
+            payload[12],
+            payload[13],
+            payload[14],
+            payload[15],
+        ])
     }
 
     /// Retrieves the whole friendly name of the device by first calling
@@ -54,7 +70,12 @@ impl DeviceFriendlyNameFeature {
 
         let mut len = 0;
         while len < count as usize {
-            let part = self.get_friendly_name(len as u8).await?;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "len < count as usize and count is a u8, so len always fits in u8"
+            )]
+            let index = len as u8;
+            let part = self.get_friendly_name(index).await?;
             string.push_str(str::from_utf8(&part).map_err(|_| Hidpp20Error::UnsupportedResponse)?);
             len = string.len();
         }
@@ -79,7 +100,23 @@ impl DeviceFriendlyNameFeature {
             .await?
             .extend_payload();
 
-        Ok(payload[1..].try_into().unwrap())
+        Ok([
+            payload[1],
+            payload[2],
+            payload[3],
+            payload[4],
+            payload[5],
+            payload[6],
+            payload[7],
+            payload[8],
+            payload[9],
+            payload[10],
+            payload[11],
+            payload[12],
+            payload[13],
+            payload[14],
+            payload[15],
+        ])
     }
 
     /// Retrieves the whole default friendly name of the device by first calling
@@ -91,7 +128,12 @@ impl DeviceFriendlyNameFeature {
 
         let mut len = 0;
         while len < count as usize {
-            let part = self.get_default_friendly_name(len as u8).await?;
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "len < count as usize and count is a u8, so len always fits in u8"
+            )]
+            let index = len as u8;
+            let part = self.get_default_friendly_name(index).await?;
             string.push_str(str::from_utf8(&part).map_err(|_| Hidpp20Error::UnsupportedResponse)?);
             len = string.len();
         }
@@ -137,9 +179,10 @@ impl DeviceFriendlyNameFeature {
 
         let mut index = 0;
         for chunk in chunks {
-            index += self
-                .set_friendly_name(index, chunk.try_into().unwrap())
-                .await?;
+            // `chunks_exact(15)` guarantees every yielded chunk is exactly 15
+            // bytes long.
+            let chunk: [u8; 15] = std::array::from_fn(|i| chunk[i]);
+            index += self.set_friendly_name(index, chunk).await?;
         }
 
         if !remainder.is_empty() {

--- a/crates/openlogi-hidpp/src/feature/device_information/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/device_information/mod.rs
@@ -21,12 +21,12 @@ impl DeviceInformationFeature {
 
         Ok(DeviceInformation {
             entity_count: payload[0],
-            unit_id: payload[1..=4].try_into().unwrap(),
+            unit_id: [payload[1], payload[2], payload[3], payload[4]],
             transport: DeviceTransport::from(payload[6]),
             model_id: [
-                u16::from_be_bytes(payload[7..=8].try_into().unwrap()),
-                u16::from_be_bytes(payload[9..=10].try_into().unwrap()),
-                u16::from_be_bytes(payload[11..=12].try_into().unwrap()),
+                u16::from_be_bytes([payload[7], payload[8]]),
+                u16::from_be_bytes([payload[9], payload[10]]),
+                u16::from_be_bytes([payload[11], payload[12]]),
             ],
             extended_model_id: payload[13],
             capabilities: DeviceInformationCapabilities::from(payload[14]),
@@ -52,14 +52,20 @@ impl DeviceInformationFeature {
             firmware_prefix: String::from_utf8(payload[1..=3].to_vec())
                 .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
             firmware_number: bcd::convert_packed_u8(payload[4])
-                .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
+                .map_err(|()| Hidpp20Error::UnsupportedResponse)?,
             revision: bcd::convert_packed_u8(payload[5])
-                .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
-            build: bcd::convert_packed_u16(u16::from_be_bytes(payload[6..=7].try_into().unwrap()))
-                .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
+                .map_err(|()| Hidpp20Error::UnsupportedResponse)?,
+            build: bcd::convert_packed_u16(u16::from_be_bytes([payload[6], payload[7]]))
+                .map_err(|()| Hidpp20Error::UnsupportedResponse)?,
             active: payload[8] & 1 != 0,
-            transport_pid: u16::from_be_bytes(payload[9..=10].try_into().unwrap()),
-            extra_version: payload[11..=15].try_into().unwrap(),
+            transport_pid: u16::from_be_bytes([payload[9], payload[10]]),
+            extra_version: [
+                payload[11],
+                payload[12],
+                payload[13],
+                payload[14],
+                payload[15],
+            ],
         })
     }
 
@@ -134,6 +140,10 @@ pub struct DeviceInformation {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "wire bitfield: each transport is an independent support flag, not related boolean params"
+)]
 pub struct DeviceTransport {
     /// Whether the device supports USB.
     pub usb: bool,

--- a/crates/openlogi-hidpp/src/feature/device_type_and_name/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/device_type_and_name/mod.rs
@@ -51,6 +51,10 @@ impl DeviceTypeAndNameFeature {
 
         let mut len = 0;
         while len < count as usize {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "the loop condition `len < count as usize` bounds len below count: u8, so it always fits back in a u8"
+            )]
             let part = self.get_device_name(len as u8).await?;
             string.push_str(str::from_utf8(&part).map_err(|_| Hidpp20Error::UnsupportedResponse)?);
             len = string.len();

--- a/crates/openlogi-hidpp/src/feature/dual_platform/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/dual_platform/mod.rs
@@ -85,6 +85,7 @@ impl DualPlatformFeature {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::DualPlatformSelection;
 
@@ -98,7 +99,7 @@ mod tests {
             DualPlatformSelection::try_from(1).unwrap(),
             DualPlatformSelection::AndroidOrWindows
         );
-        assert!(DualPlatformSelection::try_from(2).is_err());
+        DualPlatformSelection::try_from(2).unwrap_err();
         assert_eq!(u8::from(DualPlatformSelection::AndroidOrWindows), 1);
     }
 }

--- a/crates/openlogi-hidpp/src/feature/equalizer/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/equalizer/mod.rs
@@ -79,8 +79,8 @@ impl EqInfo {
             band_count: payload[0],
             db_range: payload[1],
             capabilities: EqCapabilities::from_bits_retain(payload[2]),
-            db_min: payload[3] as i8,
-            db_max: payload[4] as i8,
+            db_min: payload[3].cast_signed(),
+            db_max: payload[4].cast_signed(),
         }
     }
 
@@ -170,7 +170,7 @@ impl EqualizerFeature {
             if slot >= args.len() {
                 return Err(Hidpp20Error::UnsupportedResponse);
             }
-            args[slot] = gain as u8;
+            args[slot] = gain.cast_unsigned();
         }
         let payload = self.endpoint.call_long(3, args).await?.extend_payload();
         // The response echoes the request, so the gains start after the echoed
@@ -211,6 +211,6 @@ fn parse_gains(payload: &[u8; 16], offset: usize, count: u8) -> Result<Vec<i8>, 
     }
     Ok(payload[offset..offset + count]
         .iter()
-        .map(|&byte| byte as i8)
+        .map(|&byte| byte.cast_signed())
         .collect())
 }

--- a/crates/openlogi-hidpp/src/feature/equalizer/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/equalizer/tests.rs
@@ -1,6 +1,12 @@
 //! Unit tests for `Equalizer` payload parsing, using the spec's worked example
 //! (10 bands at ±12 dB).
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
+
 use super::{
     EqCapabilities, EqInfo, GainLocation, GainPersistence, parse_frequency_page, parse_gains,
 };
@@ -28,7 +34,7 @@ fn parses_eq_info_with_explicit_range() {
     payload[0] = 5;
     payload[1] = 0x0c;
     payload[2] = EqCapabilities::STORED_AS_GAINS.bits();
-    payload[3] = (-6i8) as u8;
+    payload[3] = (-6i8).cast_unsigned();
     payload[4] = 9;
 
     let info = EqInfo::from_payload(&payload);
@@ -67,7 +73,10 @@ fn parses_partial_frequency_page() {
 #[test]
 fn rejects_oversized_frequency_page() {
     // A page can hold at most seven u16 values after the index byte.
-    assert!(parse_frequency_page(&[0; 16], 8).is_err());
+    assert!(
+        parse_frequency_page(&[0; 16], 8).is_err(),
+        "a page can hold at most seven frequencies after the index byte"
+    );
 }
 
 #[test]
@@ -90,7 +99,7 @@ fn parses_echoed_gains_after_persistence_byte() {
     // offset 1 recovers them.
     let mut payload = [0; 16];
     payload[0] = 1; // echoed persistence
-    payload[1] = (-4i8) as u8;
+    payload[1] = (-4i8).cast_unsigned();
     payload[2] = 4;
 
     assert_eq!(parse_gains(&payload, 1, 3).unwrap(), [-4, 4, 0]);
@@ -98,7 +107,10 @@ fn parses_echoed_gains_after_persistence_byte() {
 
 #[test]
 fn rejects_too_many_gains() {
-    assert!(parse_gains(&[0; 16], 1, 16).is_err());
+    assert!(
+        parse_gains(&[0; 16], 1, 16).is_err(),
+        "16 gains at offset 1 overflow the 16-byte payload"
+    );
 }
 
 #[test]
@@ -106,5 +118,8 @@ fn maps_enum_wire_values() {
     assert_eq!(u8::from(GainLocation::Ram), 1);
     assert_eq!(GainLocation::try_from(0u8).unwrap(), GainLocation::Eeprom);
     assert_eq!(u8::from(GainPersistence::NonVolatileOnly), 2);
-    assert!(GainPersistence::try_from(3u8).is_err());
+    assert!(
+        GainPersistence::try_from(3u8).is_err(),
+        "3 is not a valid GainPersistence wire value"
+    );
 }

--- a/crates/openlogi-hidpp/src/feature/extended_dpi/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/extended_dpi/mod.rs
@@ -115,7 +115,7 @@ impl ExtendedDpiFeature {
             .await?
             .extend_payload();
         // Skip the echoed sensor index and direction in bytes 0 and 1.
-        parse_dpi_list(&payload[2..])
+        Ok(parse_dpi_list(&payload[2..]))
     }
 
     /// Retrieves the current profile's lift-off-distance list for
@@ -166,17 +166,11 @@ impl ExtendedDpiFeature {
         sensor_index: u8,
         params: SetDpiParameters,
     ) -> Result<(), Hidpp20Error> {
-        let [dpi_x_hi, dpi_x_lo] = params.dpi_x.to_be_bytes();
-        let [dpi_y_hi, dpi_y_lo] = params.dpi_y.to_be_bytes();
         let mut args = [0; 16];
-        args[..6].copy_from_slice(&[
-            sensor_index,
-            dpi_x_hi,
-            dpi_x_lo,
-            dpi_y_hi,
-            dpi_y_lo,
-            params.lod.into(),
-        ]);
+        args[0] = sensor_index;
+        args[1..3].copy_from_slice(&params.dpi_x.to_be_bytes());
+        args[3..5].copy_from_slice(&params.dpi_y.to_be_bytes());
+        args[5] = params.lod.into();
         self.endpoint.call_long(6, args).await?;
         Ok(())
     }

--- a/crates/openlogi-hidpp/src/feature/extended_dpi/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/extended_dpi/tests.rs
@@ -1,5 +1,11 @@
 //! Unit tests for `ExtendedAdjustableDpi` payload parsing and event decoding.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
+
 use std::assert_matches;
 
 use super::event::{ExtendedDpiEvent, decode_event};
@@ -174,7 +180,7 @@ fn parses_dpi_list_with_terminator() {
     // Spec example: a profile configured to 400, 800 and 1600 DPI.
     let bytes = [0x01, 0x90, 0x03, 0x20, 0x06, 0x40, 0x00, 0x00];
 
-    assert_eq!(parse_dpi_list(&bytes).unwrap(), [400, 800, 1600]);
+    assert_eq!(parse_dpi_list(&bytes), [400, 800, 1600]);
 }
 
 #[test]
@@ -182,7 +188,7 @@ fn parses_dpi_list_filling_payload() {
     // A full list leaves no room for the terminator.
     let bytes = [0x01, 0x90, 0x03, 0x20];
 
-    assert_eq!(parse_dpi_list(&bytes).unwrap(), [400, 800]);
+    assert_eq!(parse_dpi_list(&bytes), [400, 800]);
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/feature/extended_dpi/types.rs
+++ b/crates/openlogi-hidpp/src/feature/extended_dpi/types.rs
@@ -351,7 +351,7 @@ pub(super) fn parse_dpi_ranges(stream: &[u8]) -> Result<Vec<DpiRange>, Hidpp20Er
 
 /// Parses a `getSensorDpiList` payload (after the echoed sensor index and
 /// direction) into explicit DPI values, stopping at the `0x0000` terminator.
-pub(super) fn parse_dpi_list(bytes: &[u8]) -> Result<Vec<u16>, Hidpp20Error> {
+pub(super) fn parse_dpi_list(bytes: &[u8]) -> Vec<u16> {
     let mut values = Vec::new();
     let mut offset = 0;
     while offset + 1 < bytes.len() {
@@ -362,7 +362,7 @@ pub(super) fn parse_dpi_list(bytes: &[u8]) -> Result<Vec<u16>, Hidpp20Error> {
         values.push(value);
         offset += 2;
     }
-    Ok(values)
+    values
 }
 
 /// Parses the first `count` lift-off-distance entries of a `getSensorLodList`

--- a/crates/openlogi-hidpp/src/feature/feature_set/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/feature_set/mod.rs
@@ -41,7 +41,7 @@ impl FeatureSetFeature {
             .extend_payload();
 
         Ok(FeatureInformation {
-            id: (payload[0] as u16) << 8 | payload[1] as u16,
+            id: u16::from(payload[0]) << 8 | u16::from(payload[1]),
             typ: FeatureType::from(payload[2]),
             version: payload[3],
         })

--- a/crates/openlogi-hidpp/src/feature/fn_inversion/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/fn_inversion/mod.rs
@@ -163,6 +163,7 @@ impl FnInversionWithDefaultStateFeature {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{
         FnInversionInfo, FnInversionState, GlobalFnInversion, set_multi_host_fn_inversion_args,

--- a/crates/openlogi-hidpp/src/feature/gestures2/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/gestures2/mod.rs
@@ -135,6 +135,7 @@ impl Gestures2Feature {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-hidpp/src/feature/hires_wheel/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/hires_wheel/mod.rs
@@ -35,7 +35,7 @@ impl DecodeEvent for HiResWheelEvent {
                 Some(HiResWheelEvent::WheelMovement(WheelMovementData {
                     resolution,
                     periods: U4::from_lo(payload[0]),
-                    delta_vertical: i16::from_be_bytes(payload[1..=2].try_into().unwrap()),
+                    delta_vertical: i16::from_be_bytes([payload[1], payload[2]]),
                 }))
             }
             1 => {

--- a/crates/openlogi-hidpp/src/feature/illumination/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/illumination/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `Illumination` payload parsing and event decoding.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/illumination/types.rs
+++ b/crates/openlogi-hidpp/src/feature/illumination/types.rs
@@ -158,6 +158,10 @@ impl SetLevels {
                 if !(1..=7).contains(&values.len()) || *start_index > 0x0f || *level_count > 0x0f {
                     return Err(Hidpp20Error::Feature(ErrorType::InvalidArgument));
                 }
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "values.len() was just checked to be in 1..=7, so it always fits in a u8"
+                )]
                 let valid_count = (values.len() as u8) & 0x07;
                 args[0] = valid_count << 5; // linear = 0, reset = 0
                 args[1] = (start_index << 4) | (level_count & 0x0f);

--- a/crates/openlogi-hidpp/src/feature/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/mod.rs
@@ -264,6 +264,10 @@ pub(crate) fn event_payload(
 #[derive(Clone, Copy, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "wire bitfield: each bool is an independent flag bit, not related boolean params"
+)]
 pub struct FeatureType {
     /// An obsolete feature is a feature that has been replaced by a newer one,
     /// but is advertised in order for older SWs to still be able to support the
@@ -311,19 +315,19 @@ impl From<FeatureType> for u8 {
         let mut raw = 0;
 
         if value.obsolete {
-            raw |= 1 << 7
+            raw |= 1 << 7;
         }
         if value.hidden {
-            raw |= 1 << 6
+            raw |= 1 << 6;
         }
         if value.engineering {
-            raw |= 1 << 5
+            raw |= 1 << 5;
         }
         if value.manufacturing_deactivatable {
-            raw |= 1 << 4
+            raw |= 1 << 4;
         }
         if value.compliance_deactivatable {
-            raw |= 1 << 3
+            raw |= 1 << 3;
         }
 
         raw
@@ -331,6 +335,11 @@ impl From<FeatureType> for u8 {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "expect/unwrap are idiomatic in tests"
+)]
 mod tests {
     use super::event_payload;
     use crate::{

--- a/crates/openlogi-hidpp/src/feature/mouse_pointer/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/mouse_pointer/mod.rs
@@ -87,6 +87,7 @@ impl MousePointerInfo {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{MousePointerInfo, PointerAcceleration};
 

--- a/crates/openlogi-hidpp/src/feature/per_key_lighting/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/per_key_lighting/mod.rs
@@ -323,6 +323,6 @@ fn frame_end_args(
 fn delta_args(first_zone_id: u8, packed: [u8; DELTA_PACKED_LEN]) -> [u8; 16] {
     let mut args = [0; 16];
     args[0] = first_zone_id;
-    args[1..1 + DELTA_PACKED_LEN].copy_from_slice(&packed);
+    args[1..=DELTA_PACKED_LEN].copy_from_slice(&packed);
     args
 }

--- a/crates/openlogi-hidpp/src/feature/per_key_lighting/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/per_key_lighting/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `PerKeyLighting` request encoding.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 
@@ -173,6 +174,6 @@ fn maps_enum_wire_values() {
         ZonePresencePage::try_from(2u8).unwrap(),
         ZonePresencePage::Zones224To255
     );
-    assert!(ZonePresencePage::try_from(3u8).is_err());
+    ZonePresencePage::try_from(3u8).unwrap_err();
     assert_eq!(u8::from(FramePersistence::VolatileAndNonVolatile), 1);
 }

--- a/crates/openlogi-hidpp/src/feature/persistent_remappable_action/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/persistent_remappable_action/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `PersistentRemappableAction` payload parsing.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 
@@ -70,7 +71,7 @@ fn rejects_unknown_action_id() {
 fn maps_action_id_wire_values() {
     assert_eq!(ActionId::try_from(0x01u8).unwrap(), ActionId::SendKeyboard);
     assert_eq!(ActionId::try_from(0x09u8).unwrap(), ActionId::SendPowerKey);
-    assert!(ActionId::try_from(0x00u8).is_err());
+    ActionId::try_from(0x00u8).unwrap_err();
     assert_eq!(u8::from(ActionId::SendConsumerControl), 0x07);
 }
 

--- a/crates/openlogi-hidpp/src/feature/registry.rs
+++ b/crates/openlogi-hidpp/src/feature/registry.rs
@@ -94,6 +94,7 @@ pub fn lookup(feature_id: u16) -> Option<KnownFeature> {
 
 /// Looks up all implementations supporting a specific feature ID and version
 /// combination.
+#[must_use]
 pub fn lookup_version(feature_id: u16, feature_version: u8) -> Option<Vec<FeatureVersion>> {
     lookup(feature_id).map(|feat| {
         feat.versions

--- a/crates/openlogi-hidpp/src/feature/reprog_controls.rs
+++ b/crates/openlogi-hidpp/src/feature/reprog_controls.rs
@@ -115,7 +115,7 @@ impl From<ControlId> for u16 {
 }
 
 fn u16_from_be_payload(bytes: &[u8]) -> u16 {
-    u16::from_be_bytes(bytes.try_into().unwrap())
+    u16::from_be_bytes([bytes[0], bytes[1]])
 }
 
 /// A HID++ task ID.
@@ -265,6 +265,10 @@ impl CidFlags {
 pub struct GroupMask(pub u8);
 
 /// Current reporting/remapping state returned by `getCidReporting`.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "each field is an independent wire flag from getCidReporting, not a state machine"
+)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct CidReporting {

--- a/crates/openlogi-hidpp/src/feature/reprog_controls/event.rs
+++ b/crates/openlogi-hidpp/src/feature/reprog_controls/event.rs
@@ -5,7 +5,7 @@ use crate::{feature::DecodeEvent, nibble::U4, protocol::v20};
 use super::ControlId;
 
 fn i16_from_be_payload(bytes: &[u8]) -> i16 {
-    i16::from_be_bytes(bytes.try_into().unwrap())
+    i16::from_be_bytes([bytes[0], bytes[1]])
 }
 
 /// One analytics key event entry.

--- a/crates/openlogi-hidpp/src/feature/rgb_effects/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/rgb_effects/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `RgbEffects` payload parsing and event decoding.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use super::event::{RgbEffectsEvent, decode_event};
 use super::types::{
@@ -144,7 +145,7 @@ fn ignores_unknown_event_sub_id() {
 fn maps_stable_enum_wire_values() {
     assert_eq!(RgbPowerMode::try_from(1u8).unwrap(), RgbPowerMode::FullRgb);
     assert_eq!(RgbPowerMode::try_from(3u8).unwrap(), RgbPowerMode::PowerOff);
-    assert!(RgbPowerMode::try_from(0u8).is_err());
+    RgbPowerMode::try_from(0u8).unwrap_err();
     assert_eq!(u8::from(PowerModeTarget::PowerSave), 1);
     assert_eq!(
         LedBinIndex::try_from(2u8).unwrap(),
@@ -154,7 +155,7 @@ fn maps_stable_enum_wire_values() {
         SlotInfoType::try_from(6u8).unwrap(),
         SlotInfoType::EffectName21To31
     );
-    assert!(SlotInfoType::try_from(7u8).is_err());
+    SlotInfoType::try_from(7u8).unwrap_err();
 }
 
 /// Totality: the user-activity event must decode for any activity byte.

--- a/crates/openlogi-hidpp/src/feature/root.rs
+++ b/crates/openlogi-hidpp/src/feature/root.rs
@@ -40,9 +40,10 @@ impl RootFeature {
     /// If the device only supports the root feature version 1, the
     /// [`FeatureInformation::version`] field will be `0` for all features.
     pub async fn get_feature(&self, id: u16) -> Result<Option<FeatureInformation>, Hidpp20Error> {
+        let [id_hi, id_lo] = id.to_be_bytes();
         let payload = self
             .endpoint
-            .call(0, [(id >> 8) as u8, id as u8, 0x00])
+            .call(0, [id_hi, id_lo, 0x00])
             .await?
             .extend_payload();
         if payload[0] == 0 {

--- a/crates/openlogi-hidpp/src/feature/smartshift_enhanced/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/smartshift_enhanced/mod.rs
@@ -124,6 +124,7 @@ impl SmartShiftEnhancedStatus {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{Hidpp20Error, SmartShiftEnhancedStatus, WheelMode};
 

--- a/crates/openlogi-hidpp/src/feature/solar_dashboard/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/solar_dashboard/tests.rs
@@ -1,5 +1,6 @@
 //! Unit tests for `SolarKeyboardDashboard` event decoding, using the spec's
 //! worked examples (battery 96%, light 0 / 319 lux).
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use super::LedId;
 use super::event::{SolarEvent, SolarStatus, decode_event};
@@ -60,5 +61,5 @@ fn ignores_unknown_event_sub_id() {
 fn maps_led_wire_values() {
     assert_eq!(u8::from(LedId::Off), 0);
     assert_eq!(LedId::try_from(3u8).unwrap(), LedId::Green);
-    assert!(LedId::try_from(4u8).is_err());
+    LedId::try_from(4u8).unwrap_err();
 }

--- a/crates/openlogi-hidpp/src/feature/thumbwheel/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/thumbwheel/mod.rs
@@ -30,8 +30,8 @@ impl DecodeEvent for ThumbwheelEvent {
         let rotation_status = ThumbwheelRotationStatus::try_from(payload[4]).ok()?;
 
         Some(ThumbwheelEvent::StatusUpdate(ThumbwheelStatusUpdate {
-            rotation: i16::from_be_bytes(payload[0..=1].try_into().unwrap()),
-            time_elapsed: u16::from_be_bytes(payload[2..=3].try_into().unwrap()),
+            rotation: i16::from_be_bytes([payload[0], payload[1]]),
+            time_elapsed: u16::from_be_bytes([payload[2], payload[3]]),
             rotation_status,
             touch: payload[5] & (1 << 1) != 0,
             proxy: payload[5] & (1 << 2) != 0,
@@ -46,9 +46,9 @@ impl ThumbwheelFeature {
         let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
         Ok(ThumbwheelInfo {
-            native_resolution: u16::from_be_bytes(payload[0..=1].try_into().unwrap()),
-            diverted_resolution: u16::from_be_bytes(payload[2..=3].try_into().unwrap()),
-            time_unit: u16::from_be_bytes(payload[6..=7].try_into().unwrap()),
+            native_resolution: u16::from_be_bytes([payload[0], payload[1]]),
+            diverted_resolution: u16::from_be_bytes([payload[2], payload[3]]),
+            time_unit: u16::from_be_bytes([payload[6], payload[7]]),
             default_direction: ThumbwheelDirection::try_from(payload[4] & 1)
                 .map_err(|_| Hidpp20Error::UnsupportedResponse)?,
             capabilities: ThumbwheelCapabilities::from(payload[5]),
@@ -81,7 +81,7 @@ impl ThumbwheelFeature {
         invert_direction: bool,
     ) -> Result<(), Hidpp20Error> {
         self.endpoint
-            .call(2, [mode.into(), if invert_direction { 1 } else { 0 }, 0x00])
+            .call(2, [mode.into(), u8::from(invert_direction), 0x00])
             .await?;
 
         Ok(())
@@ -137,6 +137,10 @@ pub enum ThumbwheelDirection {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "wire bitfield: each capability is an independent flag bit, not related boolean params"
+)]
 pub struct ThumbwheelCapabilities {
     /// Whether the thumbwheel supports emitting the elapsed time between two
     /// events via [`ThumbwheelStatusUpdate::time_elapsed`].

--- a/crates/openlogi-hidpp/src/feature/touch_mouse_raw/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/touch_mouse_raw/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `TouchMouseRaw` info parsing and raw-event decoding.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use super::event::{TouchMousePoint, TouchMouseRawEvent, TouchMouseStatus, decode_event};
 use super::{Origin, RawMode, TouchMouseInfo};
@@ -79,6 +80,6 @@ fn ignores_unknown_event_sub_id() {
 fn maps_raw_mode_wire_values() {
     assert_eq!(RawMode::try_from(0u8).unwrap(), RawMode::NativeGestures);
     assert_eq!(RawMode::try_from(4u8).unwrap(), RawMode::RawUnfilteredWithZ);
-    assert!(RawMode::try_from(5u8).is_err());
+    RawMode::try_from(5u8).unwrap_err();
     assert_eq!(u8::from(RawMode::RawFiltered), 1);
 }

--- a/crates/openlogi-hidpp/src/feature/touchpad_raw_xy/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/touchpad_raw_xy/tests.rs
@@ -1,4 +1,5 @@
 //! Unit tests for `TouchpadRawXy` info parsing and raw-event decoding.
+#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/unified_battery/mod.rs
@@ -47,11 +47,9 @@ impl DecodeEvent for BatteryEvent {
 impl UnifiedBatteryFeature {
     /// Retrieves the capabilities of this feature and the battery in general.
     pub async fn get_battery_capabilities(&self) -> Result<BatteryCapabilities, Hidpp20Error> {
-        let payload: [u8; 2] = self.endpoint.call(0, [0; 3]).await?.extend_payload()[..2]
-            .try_into()
-            .unwrap();
+        let payload = self.endpoint.call(0, [0; 3]).await?.extend_payload();
 
-        Ok(BatteryCapabilities::from(payload))
+        Ok(BatteryCapabilities::from([payload[0], payload[1]]))
     }
 
     /// Retrieves the current information about the battery status.

--- a/crates/openlogi-hidpp/src/feature/vertical_scrolling/mod.rs
+++ b/crates/openlogi-hidpp/src/feature/vertical_scrolling/mod.rs
@@ -87,6 +87,7 @@ impl From<u8> for ScrollLines {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{RollerInfo, RollerType, ScrollLines};
 

--- a/crates/openlogi-hidpp/src/nibble.rs
+++ b/crates/openlogi-hidpp/src/nibble.rs
@@ -7,21 +7,25 @@ pub struct U4(u8);
 
 impl U4 {
     /// Constructs a nibble from the 4 low/rightmost bits of a byte.
+    #[must_use]
     pub fn from_lo(raw: u8) -> Self {
         Self(raw & 0x0f)
     }
 
     /// Constructs a nibble from the 4 high/leftmost bits of a byte.
+    #[must_use]
     pub fn from_hi(raw: u8) -> Self {
         Self(raw >> 4)
     }
 
     /// Constructs a byte with the nibble set as the 4 low/rightmost bits.
+    #[must_use]
     pub fn to_lo(self) -> u8 {
         self.0
     }
 
     /// Constructs a byte with the nibble set as the 4 high/leftmost bits.
+    #[must_use]
     pub fn to_hi(self) -> u8 {
         self.0 << 4
     }
@@ -29,6 +33,7 @@ impl U4 {
 
 /// Combines two nibbles to a byte, with `a` being set to the 4 leftmost and
 /// `b` being set to the 4 rightmost bits.
+#[must_use]
 pub fn combine(a: U4, b: U4) -> u8 {
     a.to_hi() | b.to_lo()
 }

--- a/crates/openlogi-hidpp/src/protocol/v10.rs
+++ b/crates/openlogi-hidpp/src/protocol/v10.rs
@@ -31,16 +31,17 @@ pub enum Message {
 
 impl Message {
     /// Extracts the header of the message.
+    #[must_use]
     pub fn header(&self) -> MessageHeader {
         match *self {
-            Message::Short(header, _) => header,
-            Message::Long(header, _) => header,
+            Message::Short(header, _) | Message::Long(header, _) => header,
         }
     }
 
     /// Extracts the payload of the message and fits it into an array capable of
     /// containing the longest possible payload, filling the rest up with
     /// zeroes.
+    #[must_use]
     pub fn extend_payload(&self) -> [u8; LONG_REPORT_LENGTH - 3] {
         match *self {
             Message::Short(_, payload) => {
@@ -56,20 +57,26 @@ impl Message {
 impl From<HidppMessage> for Message {
     fn from(msg: HidppMessage) -> Self {
         match msg {
-            HidppMessage::Short(payload) => Message::Short(
-                MessageHeader {
-                    device_index: payload[0],
-                    sub_id: payload[1],
-                },
-                payload[2..].try_into().unwrap(),
-            ),
-            HidppMessage::Long(payload) => Message::Long(
-                MessageHeader {
-                    device_index: payload[0],
-                    sub_id: payload[1],
-                },
-                payload[2..].try_into().unwrap(),
-            ),
+            HidppMessage::Short(payload) => {
+                let [_, _, rest @ ..] = payload;
+                Message::Short(
+                    MessageHeader {
+                        device_index: payload[0],
+                        sub_id: payload[1],
+                    },
+                    rest,
+                )
+            }
+            HidppMessage::Long(payload) => {
+                let [_, _, rest @ ..] = payload;
+                Message::Long(
+                    MessageHeader {
+                        device_index: payload[0],
+                        sub_id: payload[1],
+                    },
+                    rest,
+                )
+            }
         }
     }
 }
@@ -99,8 +106,8 @@ impl From<Message> for HidppMessage {
 
 fn is_rap_response(device: u8, msg_type: MessageType, address: u8, msg: &HidppMessage) -> bool {
     let raw: [u8; 4] = match msg {
-        HidppMessage::Short(d) => d[..4].try_into().unwrap(),
-        HidppMessage::Long(d) => d[..4].try_into().unwrap(),
+        HidppMessage::Short(d) => [d[0], d[1], d[2], d[3]],
+        HidppMessage::Long(d) => [d[0], d[1], d[2], d[3]],
     };
 
     raw[0] == device
@@ -145,7 +152,8 @@ impl HidppChannel {
             return Err(Hidpp10Error::RegisterAccess(err));
         }
 
-        Ok(payload[1..=3].try_into().unwrap())
+        let [_, p1, p2, p3, ..] = payload;
+        Ok([p1, p2, p3])
     }
 
     /// Writes data to a short 3-byte register using HID++1.0/RAP.
@@ -217,7 +225,8 @@ impl HidppChannel {
             return Err(Hidpp10Error::RegisterAccess(err));
         }
 
-        Ok(payload[1..=16].try_into().unwrap())
+        let [_, rest @ ..] = payload;
+        Ok(rest)
     }
 
     /// Writes data to a long 16-byte register using HID++1.0/RAP.

--- a/crates/openlogi-hidpp/src/protocol/v20.rs
+++ b/crates/openlogi-hidpp/src/protocol/v20.rs
@@ -41,16 +41,17 @@ pub enum Message {
 
 impl Message {
     /// Extracts the header of the message.
+    #[must_use]
     pub fn header(&self) -> MessageHeader {
         match *self {
-            Message::Short(header, _) => header,
-            Message::Long(header, _) => header,
+            Message::Short(header, _) | Message::Long(header, _) => header,
         }
     }
 
     /// Extracts the payload of the message and fits it into an array capable of
     /// containing the longest possible payload, filling the rest up with
     /// zeroes.
+    #[must_use]
     pub fn extend_payload(&self) -> [u8; LONG_REPORT_LENGTH - 4] {
         match *self {
             Message::Short(_, payload) => {
@@ -66,24 +67,30 @@ impl Message {
 impl From<HidppMessage> for Message {
     fn from(msg: HidppMessage) -> Self {
         match msg {
-            HidppMessage::Short(payload) => Message::Short(
-                MessageHeader {
-                    device_index: payload[0],
-                    feature_index: payload[1],
-                    function_id: U4::from_hi(payload[2]),
-                    software_id: U4::from_lo(payload[2]),
-                },
-                payload[3..].try_into().unwrap(),
-            ),
-            HidppMessage::Long(payload) => Message::Long(
-                MessageHeader {
-                    device_index: payload[0],
-                    feature_index: payload[1],
-                    function_id: U4::from_hi(payload[2]),
-                    software_id: U4::from_lo(payload[2]),
-                },
-                payload[3..].try_into().unwrap(),
-            ),
+            HidppMessage::Short(payload) => {
+                let [_, _, _, rest @ ..] = payload;
+                Message::Short(
+                    MessageHeader {
+                        device_index: payload[0],
+                        feature_index: payload[1],
+                        function_id: U4::from_hi(payload[2]),
+                        software_id: U4::from_lo(payload[2]),
+                    },
+                    rest,
+                )
+            }
+            HidppMessage::Long(payload) => {
+                let [_, _, _, rest @ ..] = payload;
+                Message::Long(
+                    MessageHeader {
+                        device_index: payload[0],
+                        feature_index: payload[1],
+                        function_id: U4::from_hi(payload[2]),
+                        software_id: U4::from_lo(payload[2]),
+                    },
+                    rest,
+                )
+            }
         }
     }
 }

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -134,7 +134,7 @@ impl Receiver {
                             kind: DeviceKind::from(payload[1] & 0x0f),
                             encrypted: payload[1] & (1 << 5) != 0,
                             online: payload[1] & (1 << 6) == 0,
-                            wpid: u16::from_le_bytes(payload[2..=3].try_into().unwrap()),
+                            wpid: u16::from_le_bytes([payload[2], payload[3]]),
                         }));
                     }
                     // Device discovery
@@ -143,10 +143,10 @@ impl Receiver {
                             // Device data
                             0 => {
                                 emitter.emit(Event::DeviceDiscoveryDeviceDetails {
-                                    counter: payload[0] as u16 + payload[1] as u16 * 256,
+                                    counter: u16::from(payload[0]) + u16::from(payload[1]) * 256,
                                     kind: DeviceKind::from(payload[4] & 0x0f),
-                                    wpid: u16::from_le_bytes(payload[5..=6].try_into().unwrap()),
-                                    address: payload[7..=12].try_into().unwrap(),
+                                    wpid: u16::from_le_bytes([payload[5], payload[6]]),
+                                    address: address6(&payload, 7),
                                     authentication: payload[15],
                                 });
                             }
@@ -181,7 +181,7 @@ impl Receiver {
                         let error = (payload[1] != 0x00).then(|| PairingError::from(payload[1]));
 
                         emitter.emit(Event::PairingStatus {
-                            device_address: payload[2..=7].try_into().unwrap(),
+                            device_address: address6(&payload, 2),
                             pairing_error: error,
                             slot: if payload[8] == 0x00 {
                                 None
@@ -200,14 +200,14 @@ impl Receiver {
                         };
 
                         emitter.emit(Event::PairingPasskeyRequest {
-                            device_address: payload[7..=12].try_into().unwrap(),
+                            device_address: address6(&payload, 7),
                             passkey: passkey.to_string(),
                         });
                     }
                     // Passkey pressed
                     0x4e => {
                         emitter.emit(Event::PairingPasskeyPressed {
-                            device_address: payload[1..=6].try_into().unwrap(),
+                            device_address: address6(&payload, 1),
                             press_type: PairingPasskeyPressType::from(payload[0]),
                         });
                     }
@@ -224,6 +224,7 @@ impl Receiver {
     }
 
     /// Creates a new listener for receiving receiver events.
+    #[must_use]
     pub fn listen(&self) -> async_channel::Receiver<Event> {
         self.emitter.create_receiver()
     }
@@ -254,7 +255,7 @@ impl Receiver {
             .write_register(
                 RECEIVER_DEVICE_INDEX,
                 Register::Notifications.into(),
-                [0, if state.wireless_notifications { 1 } else { 0 }, 0],
+                [0, u8::from(state.wireless_notifications), 0],
             )
             .await?;
 
@@ -371,13 +372,13 @@ impl Receiver {
             .await?;
 
         Ok(DevicePairingInformation {
-            wpid: u16::from_le_bytes(response[2..=3].try_into().unwrap()),
+            wpid: u16::from_le_bytes([response[2], response[3]]),
             // Kind is identity-only: an unrecognised nibble folds to
             // `Unknown` instead of failing the whole pairing-info read.
             kind: DeviceKind::from(response[1] & 0x0f),
             encrypted: response[1] & (1 << 5) != 0,
             online: response[1] & (1 << 6) == 0,
-            unit_id: response[4..=7].try_into().unwrap(),
+            unit_id: [response[4], response[5], response[6], response[7]],
         })
     }
 
@@ -482,6 +483,23 @@ impl Receiver {
     }
 }
 
+/// Extracts 6 contiguous bytes starting at `start` from a receiver-event
+/// payload into a BTLE device-address array.
+///
+/// Every call site below passes a compile-time-fixed `start` (1, 2, or 7)
+/// comfortably within the fixed 17-byte payload, so this never panics in
+/// practice.
+fn address6(payload: &[u8; 17], start: usize) -> [u8; 6] {
+    [
+        payload[start],
+        payload[start + 1],
+        payload[start + 2],
+        payload[start + 3],
+        payload[start + 4],
+        payload[start + 5],
+    ]
+}
+
 /// Parse a device-discovery name notification (sub-id `0x4f`, kind `1`).
 ///
 /// `payload[3]` is the device-reported name length. The byte comes straight
@@ -492,7 +510,7 @@ fn parse_discovery_name(payload: &[u8; 17]) -> Option<(u16, &str)> {
     let len = usize::from(payload[3]);
     let end = 4usize.checked_add(len)?;
     let name = str::from_utf8(payload.get(4..end)?).ok()?;
-    Some((payload[0] as u16 + payload[1] as u16 * 256, name))
+    Some((u16::from(payload[0]) + u16::from(payload[1]) * 256, name))
 }
 
 /// Extract the codename chunk from a `DeviceCodename` register read.

--- a/crates/openlogi-hidpp/src/receiver/mod.rs
+++ b/crates/openlogi-hidpp/src/receiver/mod.rs
@@ -50,6 +50,7 @@ pub enum Receiver {
 
 impl Receiver {
     /// Provides a human-readable name for the receiver.
+    #[must_use]
     pub fn name(&self) -> String {
         match self {
             Self::Bolt(_) => "Logi Bolt Receiver",

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -132,7 +132,7 @@ impl Receiver {
                     kind: DeviceKind::from(payload[1] & 0x0f),
                     encrypted: payload[1] & (1 << 4) != 0,
                     online: payload[1] & (1 << 6) == 0,
-                    wpid: u16::from_le_bytes(payload[2..=3].try_into().unwrap()),
+                    wpid: u16::from_le_bytes([payload[2], payload[3]]),
                 }));
             }
         });
@@ -145,6 +145,7 @@ impl Receiver {
     }
 
     /// Creates a new listener for receiving receiver events.
+    #[must_use]
     pub fn listen(&self) -> async_channel::Receiver<Event> {
         self.emitter.create_receiver()
     }
@@ -251,13 +252,13 @@ impl Receiver {
             .await?;
 
         Ok(DevicePairingInformation {
-            wpid: u16::from_le_bytes(response[2..=3].try_into().unwrap()),
+            wpid: u16::from_le_bytes([response[2], response[3]]),
             // Kind is identity-only: an unrecognised nibble folds to
             // `Unknown` instead of failing the whole pairing-info read.
             kind: DeviceKind::from(response[1] & 0x0f),
             encrypted: response[1] & (1 << 4) != 0,
             online: response[1] & (1 << 6) == 0,
-            unit_id: response[4..=7].try_into().unwrap(),
+            unit_id: [response[4], response[5], response[6], response[7]],
         })
     }
 


### PR DESCRIPTION
## Summary

`openlogi-hidpp` was the one crate outside the workspace lint table. The opt-out
was justified in its `Cargo.toml` as "it is third-party code, so we don't impose
OpenLogi's pedantic/restriction clippy rules on it" — a rationale the hard-fork
ruling in #625 retired. The crate is ours, so it now answers to the same table as
everything else.

Flipping the switch surfaced **404 violations**. All 404 are fixed here; nothing
is silenced with a blanket suppression.

## Changes

The interesting part is that most of this is not suppression — a large share of
the `unwrap_used` hits were genuine panic paths that could simply be **deleted**:

- **Slice-to-array `try_into().unwrap()` (~37 sites)** — `u16::from_be_bytes(payload[2..=3].try_into().unwrap())`
  became `u16::from_be_bytes([payload[2], payload[3]])`. Same bytes, same order,
  no panic path at all. Every index and endianness was re-checked against the
  original range; a slip here would be a silent wire bug.
- **`lock().unwrap()` (19 sites)** — routed through one poison-aware helper per
  module instead of 19 scattered `expect`s, with a single documented
  `#[expect(clippy::expect_used, …)]` explaining why poisoning is unrecoverable
  (a panicking holder leaves the channel's queues inconsistent).
- **`Device::root()`** — dropped its `.get_feature().unwrap()` by caching the root
  feature in a field set at construction, turning a by-convention invariant into
  one the type actually holds. `add_feature_instance` likewise stopped
  erasing-then-downcast-unwrapping.
- **`get_sw_id`** — `fetch_update(...).unwrap()` replaced by `Ok(prev) | Err(prev)`,
  which returns the identical pre-update value the old code did (the closure
  always returns `Some`, so `Err` is unreachable, and both arms carry the same
  value anyway).
- **Casts** — `as` replaced with `u16::from` / `to_be_bytes()` /
  `cast_signed()` / `cast_unsigned()` where that is exact. Where a truncation is
  genuinely bounded, the cast stays with an `#[expect(…, reason = "…")]` naming
  the invariant that bounds it, never a bare `allow`.
- **Test modules** — the repo's standard
  `#[allow(clippy::unwrap_used, clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]`
  on the module, matching existing usage elsewhere in the workspace.
- **`assertions_on_result_states`** — never silenced; each `assert!(x.is_ok())`
  became an `unwrap()`/`unwrap_err()` or gained a descriptive message, per
  `AGENTS.md`.

`Cargo.toml`'s stale "third-party code" comment is gone along with the opt-out.

## Testing

Ran on the merged, rebased tree — the full four-step gate, now including the
rustdoc step added in #626:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 897 passed, 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`

`openlogi-hidpp`'s own test count is unchanged at 178 throughout, so no coverage
was traded away to satisfy a lint.

**Verification note:** this was built in four parallel worktrees, and a shared
`CARGO_TARGET_DIR` turned out to poison the readings — same-name crates from
different worktrees contend for one fingerprint slot, so `cargo clippy` would
report a just-edited crate as `Fresh` and replay another worktree's stale
diagnostics. Every result above was therefore re-run on a **pristine, isolated
target dir**, with `Compiling openlogi-hidpp` confirmed in the log rather than
`Fresh`.

**Not runtime-tested on hardware** — no physical Logitech device was exercised.
This is a lint-driven refactor with no intended behaviour change: byte offsets,
bit masks, endianness, and field order are identical throughout, and the existing
tests cover the decode paths. A real device session would be the confirming check.

## Follow-up

`crates/openlogi-hidpp/Cargo.toml` still pins `rust-version = "1.96"` separately
from the workspace MSRV, justified by a comment about future upstream syncs. That
rationale is retired too, but collapsing it onto the workspace MSRV is a separate
question from the lint table and is left alone here.
