### PR TITLE
fix(hid): drive the DPI and lighting features whose predecessors we hardcoded

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag/dpi.rs
+++ b/crates/openlogi-cli/src/cmd/diag/dpi.rs
@@ -20,8 +20,9 @@ pub struct DpiArgs {
 }
 
 pub async fn run(args: DpiArgs) -> Result<()> {
-    // 0x2201 = AdjustableDpi — auto-skip devices (keyboards) that lack it.
-    let (route, name) = select_device(args.device.as_deref(), &[0x2201]).await?;
+    // 0x2201 AdjustableDpi / 0x2202 ExtendedAdjustableDpi — auto-skip devices
+    // (keyboards) that expose neither. Newer mice ship only 0x2202.
+    let (route, name) = select_device(args.device.as_deref(), &[0x2201, 0x2202]).await?;
     println!("device: {name} ({route})");
 
     let info = openlogi_hid::get_dpi_info(&route)

--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -1,5 +1,5 @@
 //! `openlogi diag lighting <RRGGBB>` — set a wired RGB keyboard to a solid
-//! colour via HID++ `PerKeyLighting` (0x8080).
+//! colour via one of the HID++ lighting features (0x8070 / 0x8081 / 0x8080).
 //!
 //! Targets the first online direct-attached (USB) Logitech device — i.e. a
 //! wired G-series keyboard — by VID/PID, so it isn't tied to one model.
@@ -11,12 +11,15 @@ use openlogi_hid::{DeviceRoute, LightingMethod};
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Method {
-    /// Prefer 0x8070 ColorLedEffects, fall back to 0x8080 per-key (default).
+    /// Prefer 0x8070 ColorLedEffects, fall back to 0x8081 then 0x8080
+    /// per-key (default).
     Auto,
     /// Force 0x8070 ColorLedEffects (the fixed-effect onboard override).
     Effects,
-    /// Force 0x8080 PerKeyLighting (the per-key stream).
+    /// Force 0x8080 PerKeyLighting (the raw per-key stream).
     Perkey,
+    /// Force 0x8081 PerKeyLighting2 (the zone-addressed successor).
+    Perkeyv2,
 }
 
 impl From<Method> for LightingMethod {
@@ -25,6 +28,7 @@ impl From<Method> for LightingMethod {
             Method::Auto => Self::Auto,
             Method::Effects => Self::Effects,
             Method::Perkey => Self::PerKey,
+            Method::Perkeyv2 => Self::PerKeyV2,
         }
     }
 }

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -136,11 +136,12 @@ impl Capabilities {
     pub fn from_feature_ids(ids: &[u16]) -> Self {
         const BUTTONS: [u16; 5] = [0x1b00, 0x1b01, 0x1b02, 0x1b03, 0x1b04];
         const POINTER: [u16; 2] = [0x2201, 0x2202];
-        // PerKeyLighting (0x8080) and ColorLedEffects (0x8070) — both now driven
-        // by `set_keyboard_color` (it prefers 0x8070's fixed effect to override a
-        // running onboard profile, falling back to 0x8080 per-key). Other families
-        // (backlight 0x198x) stay out so they don't earn a tab the panel can't drive.
-        const LIGHTING: [u16; 2] = [0x8080, 0x8070];
+        // ColorLedEffects (0x8070), PerKeyLighting2 (0x8081) and PerKeyLighting
+        // (0x8080) — all three driven by `set_keyboard_color`, which prefers
+        // 0x8070's fixed effect to override a running onboard profile and falls
+        // back through 0x8081 to 0x8080. Other families (backlight 0x198x) stay
+        // out so they don't earn a tab the panel can't drive.
+        const LIGHTING: [u16; 3] = [0x8080, 0x8070, 0x8081];
         let has = |family: &[u16]| ids.iter().any(|id| family.contains(id));
         Self {
             buttons: has(&BUTTONS),
@@ -560,6 +561,22 @@ mod tests {
             Capabilities::from_feature_ids(&[0x0000, 0x0003]),
             Capabilities::default()
         );
+    }
+
+    #[test]
+    fn every_driveable_lighting_family_earns_the_tab() {
+        // `set_keyboard_color` walks 0x8070 → 0x8081 → 0x8080, so a keyboard
+        // exposing any one of them can be coloured and must get the tab.
+        // 0x8081 was missing here, which left such a keyboard with no lighting
+        // UI at all.
+        for id in [0x8070, 0x8080, 0x8081] {
+            assert!(
+                Capabilities::from_feature_ids(&[0x0001, id]).lighting,
+                "0x{id:04x} must offer the lighting tab"
+            );
+        }
+        // Backlight (0x198x) stays out — the panel cannot drive it.
+        assert!(!Capabilities::from_feature_ids(&[0x0001, 0x1982]).lighting);
     }
 
     #[test]

--- a/crates/openlogi-gui/src/components/dpi_panel.rs
+++ b/crates/openlogi-gui/src/components/dpi_panel.rs
@@ -1,8 +1,9 @@
 //! DPI slider for the right-side config column.
 //!
-//! The slider range comes from the selected device's HID++ AdjustableDpi
-//! capability (`0x2201`). Capability discovery runs in the background and the
-//! UI only exposes exact device-supported values once the list is known.
+//! The slider range comes from the selected device's HID++ DPI capability
+//! (`0x2201` AdjustableDpi or `0x2202` ExtendedAdjustableDpi, whichever it
+//! reports). Capability discovery runs in the background and the UI only
+//! exposes exact device-supported values once the list is known.
 
 use gpui::{
     AnyElement, AppContext as _, BorrowAppContext as _, Context, Entity, InteractiveElement,

--- a/crates/openlogi-hid/src/write/diagnostics.rs
+++ b/crates/openlogi-hid/src/write/diagnostics.rs
@@ -44,8 +44,9 @@ impl From<CidInfo> for ReprogControlEntry {
 
 /// Enumerate every HID++ feature the device on `route` reports — used by
 /// `openlogi diag features` to confirm which DPI / SmartShift / etc.
-/// feature IDs a given peripheral actually exposes (e.g. some mice use
-/// `0x2202 ExtendedAdjustableDpi` instead of `0x2201 AdjustableDpi`).
+/// feature IDs a given peripheral actually exposes (e.g. whether a mouse
+/// speaks `0x2201 AdjustableDpi`, `0x2202 ExtendedAdjustableDpi`, or both —
+/// `write::dpi` drives either).
 pub async fn dump_features(route: &DeviceRoute) -> Result<Vec<FeatureEntry>, WriteError> {
     let index = route.device_index();
     with_route(route, move |channel| async move {

--- a/crates/openlogi-hid/src/write/dpi.rs
+++ b/crates/openlogi-hid/src/write/dpi.rs
@@ -2,19 +2,180 @@ use std::sync::Arc;
 
 use hidpp::{
     device::Device,
-    feature::{CreatableFeature, adjustable_dpi::AdjustableDpiFeature},
+    feature::{
+        CreatableFeature,
+        adjustable_dpi::AdjustableDpiFeature,
+        extended_dpi::{DpiDirection, DpiRange, ExtendedDpiFeature, SetDpiParameters},
+    },
     protocol::v20::{ErrorType, Hidpp20Error},
 };
 use tracing::debug;
 
 use crate::route::DeviceRoute;
 
-use super::{HidppOperation, WriteError, classify_hidpp_error, open_feature, with_route};
+use super::{HidppOperation, WriteError, classify_hidpp_error, with_route};
 
 // DpiCapabilities and DpiInfo are pure IPC wire data with no HID++ I/O, so
 // they live in `openlogi_core::hid::dpi`; re-exported here unchanged so this
 // module's own API surface doesn't churn.
 pub use openlogi_core::hid::dpi::{DpiCapabilities, DpiInfo};
+
+/// Sensor 0 is the only sensor OpenLogi drives: the UI exposes one DPI value
+/// per device, and every Logitech pointing device reports its pointer sensor
+/// first.
+const SENSOR: u8 = 0;
+
+/// Whichever DPI feature a device actually exposes.
+///
+/// `0x2201 AdjustableDpi` is the original; `0x2202 ExtendedAdjustableDpi` is
+/// its successor, and some mice expose only the latter (`openlogi diag
+/// features` shows which). `Capabilities::from_feature_ids` turns the DPI panel
+/// on for *either* ID, so both have to be drivable from here — otherwise a
+/// `0x2202`-only mouse gets a panel that cannot read or write anything.
+enum DpiFeature {
+    /// `0x2201` — one DPI per sensor, described as a flat list of values.
+    Adjustable(Arc<AdjustableDpiFeature>),
+
+    /// `0x2202` — independent X/Y DPI plus lift-off distance, described as a
+    /// mix of fixed values and stepped ranges.
+    Extended(Arc<ExtendedDpiFeature>),
+}
+
+impl DpiFeature {
+    /// Opens whichever DPI feature `device` exposes, preferring `0x2201`.
+    ///
+    /// The preference is deliberate and not protocol-driven: `0x2201` is the
+    /// path every device that works today already takes, so trying it first
+    /// keeps `0x2202` support purely additive. A device exposing both behaves
+    /// exactly as it did before.
+    async fn open(device: &mut Device) -> Result<Self, WriteError> {
+        if let Some(index) = feature_index(device, AdjustableDpiFeature::ID).await? {
+            return Ok(Self::Adjustable(device.add_feature(index)));
+        }
+        if let Some(index) = feature_index(device, ExtendedDpiFeature::ID).await? {
+            return Ok(Self::Extended(device.add_feature(index)));
+        }
+        // Neither ID is present. Name the canonical one in the error: a caller
+        // reading "0x2201 unsupported" is being told this device has no DPI
+        // feature at all, which is what happened.
+        Err(WriteError::FeatureUnsupported {
+            feature_hex: AdjustableDpiFeature::ID,
+        })
+    }
+
+    /// The HID++ feature ID being driven, for error reporting.
+    const fn id(&self) -> u16 {
+        match self {
+            Self::Adjustable(_) => AdjustableDpiFeature::ID,
+            Self::Extended(_) => ExtendedDpiFeature::ID,
+        }
+    }
+
+    /// The number of motion sensors the device reports.
+    async fn sensor_count(&self) -> Result<u8, Hidpp20Error> {
+        match self {
+            Self::Adjustable(feature) => feature.get_sensor_count().await,
+            Self::Extended(feature) => feature.get_sensor_count().await,
+        }
+    }
+
+    /// The DPI currently configured on [`SENSOR`].
+    async fn current_dpi(&self) -> Result<u16, Hidpp20Error> {
+        match self {
+            Self::Adjustable(feature) => feature.get_sensor_dpi(SENSOR).await,
+            Self::Extended(feature) => Ok(feature.get_sensor_dpi_parameters(SENSOR).await?.dpi_x),
+        }
+    }
+
+    /// Every DPI value [`SENSOR`] accepts, as a flat list.
+    async fn supported_dpi(&self) -> Result<Vec<u16>, Hidpp20Error> {
+        match self {
+            Self::Adjustable(feature) => feature.get_sensor_dpi_list(SENSOR).await,
+            Self::Extended(feature) => {
+                // `getSensorDpiList` (function 3) only answers on sensors that
+                // support profiles; the range description is the one every
+                // 0x2202 sensor reports. X is the axis the UI drives.
+                let ranges = feature
+                    .get_sensor_dpi_ranges(SENSOR, DpiDirection::X)
+                    .await?;
+                Ok(expand_dpi_ranges(&ranges))
+            }
+        }
+    }
+
+    /// Sets [`SENSOR`]'s DPI.
+    async fn set_dpi(&self, dpi: u16) -> Result<(), Hidpp20Error> {
+        match self {
+            Self::Adjustable(feature) => feature.set_sensor_dpi(SENSOR, dpi).await,
+            Self::Extended(feature) => {
+                // `setSensorDpiParameters` writes DPI X, DPI Y and lift-off
+                // distance in one packet with no "leave unchanged" encoding, so
+                // read the current parameters first and put back what we are
+                // not asked to change. Writing a bare `lod` would silently
+                // retune the sensor's lift-off height.
+                let current = feature.get_sensor_dpi_parameters(SENSOR).await?;
+                feature
+                    .set_sensor_dpi_parameters(
+                        SENSOR,
+                        SetDpiParameters {
+                            dpi_x: dpi,
+                            // The spec has the host send 0 for dpiY when the
+                            // sensor has no independent Y axis, and reports 0
+                            // on read in exactly that case. When it does have
+                            // one, keep the axes locked together — the UI
+                            // exposes a single DPI.
+                            dpi_y: if current.dpi_y == 0 { 0 } else { dpi },
+                            lod: current.lod,
+                        },
+                    )
+                    .await
+            }
+        }
+    }
+}
+
+/// Resolves `feature_hex` to its runtime index, or `None` when the device does
+/// not expose it.
+///
+/// Unlike [`open_feature`](super::open_feature) an absent feature is not an
+/// error here — [`DpiFeature::open`] uses absence to fall through to the next
+/// candidate, and only a transport failure should abort the probe.
+async fn feature_index(device: &mut Device, feature_hex: u16) -> Result<Option<u8>, WriteError> {
+    Ok(device
+        .root()
+        .get_feature(feature_hex)
+        .await
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::ResolveFeature, feature_hex))?
+        .map(|info| info.index))
+}
+
+/// Flattens `0x2202`'s fixed-value / stepped-range description into the flat
+/// list [`DpiCapabilities`] is built from.
+///
+/// A stepped range's endpoints are inclusive and the high endpoint is always
+/// selectable even when it is not an exact multiple of `step` from the low one.
+/// Adjacent ranges may share an endpoint; `DpiCapabilities::new` deduplicates.
+pub(super) fn expand_dpi_ranges(ranges: &[DpiRange]) -> Vec<u16> {
+    let mut values = Vec::new();
+    for range in ranges {
+        match *range {
+            DpiRange::Fixed(value) => values.push(value),
+            DpiRange::Stepped { from, to, step } => {
+                // `step` is never 0 and `to >= from` — the decoder rejects both
+                // as a malformed response — so this terminates.
+                let mut value = u32::from(from);
+                while value < u32::from(to) {
+                    if let Ok(value) = u16::try_from(value) {
+                        values.push(value);
+                    }
+                    value += u32::from(step);
+                }
+                values.push(to);
+            }
+        }
+    }
+    values
+}
 
 /// Read the device's current DPI on sensor 0 — companion to [`set_dpi`].
 /// Used by `openlogi diag dpi` and any future Settings → Diagnostics
@@ -34,30 +195,24 @@ async fn get_dpi_on_channel(
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
+    let feature = DpiFeature::open(&mut device).await?;
     feature
-        .get_sensor_dpi(0)
+        .current_dpi()
         .await
-        .map_err(|e| classify_hidpp_error(e, HidppOperation::ReadDpi, AdjustableDpiFeature::ID))
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::ReadDpi, feature.id()))
 }
 
-/// Classify a HID++ error from the AdjustableDpi functions. A device that
-/// announces `0x2201` but rejects a function (`Unsupported` /
-/// `InvalidFunctionId`) or returns a structurally invalid DPI list
+/// Classify a HID++ error from the DPI functions of `feature_hex`. A device
+/// that announces the feature but rejects a function (`Unsupported` /
+/// `InvalidFunctionId`) or returns a structurally invalid DPI description
 /// (`UnsupportedResponse`) will keep doing so, so these map to the permanent
 /// [`WriteError::FeatureUnsupported`]; channel/timeout and other errors are
 /// forwarded through [`classify_hidpp_error`] as transient so callers may retry.
-fn classify_dpi_error(error: Hidpp20Error) -> WriteError {
+fn classify_dpi_error(feature_hex: u16, error: Hidpp20Error) -> WriteError {
     match error {
         Hidpp20Error::Feature(ErrorType::Unsupported | ErrorType::InvalidFunctionId)
-        | Hidpp20Error::UnsupportedResponse => WriteError::FeatureUnsupported {
-            feature_hex: AdjustableDpiFeature::ID,
-        },
-        other => classify_hidpp_error(
-            other,
-            HidppOperation::ReadDpiCapabilities,
-            AdjustableDpiFeature::ID,
-        ),
+        | Hidpp20Error::UnsupportedResponse => WriteError::FeatureUnsupported { feature_hex },
+        other => classify_hidpp_error(other, HidppOperation::ReadDpiCapabilities, feature_hex),
     }
 }
 
@@ -78,26 +233,25 @@ pub(super) async fn get_dpi_info_on_channel(
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
+    let feature = DpiFeature::open(&mut device).await?;
+    let feature_hex = feature.id();
     let sensor_count = feature
-        .get_sensor_count()
+        .sensor_count()
         .await
-        .map_err(classify_dpi_error)?;
+        .map_err(|e| classify_dpi_error(feature_hex, e))?;
     if sensor_count == 0 {
-        // The device claims AdjustableDpi but exposes no sensor — it cannot
+        // The device claims a DPI feature but exposes no sensor — it cannot
         // report DPI, and that won't change on retry.
-        return Err(WriteError::FeatureUnsupported {
-            feature_hex: AdjustableDpiFeature::ID,
-        });
+        return Err(WriteError::FeatureUnsupported { feature_hex });
     }
     let current = feature
-        .get_sensor_dpi(0)
+        .current_dpi()
         .await
-        .map_err(classify_dpi_error)?;
+        .map_err(|e| classify_dpi_error(feature_hex, e))?;
     let values = feature
-        .get_sensor_dpi_list(0)
+        .supported_dpi()
         .await
-        .map_err(classify_dpi_error)?;
+        .map_err(|e| classify_dpi_error(feature_hex, e))?;
     Ok(DpiInfo {
         current,
         capabilities: DpiCapabilities::new(values)?,
@@ -124,17 +278,17 @@ pub(super) async fn set_dpi_on_channel(
     let mut device = Device::new(Arc::clone(channel), index)
         .await
         .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = open_feature::<AdjustableDpiFeature>(&mut device).await?;
+    let feature = DpiFeature::open(&mut device).await?;
     feature
-        .set_sensor_dpi(0, dpi)
+        .set_dpi(dpi)
         .await
-        .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteDpi, AdjustableDpiFeature::ID))?;
+        .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteDpi, feature.id()))?;
     // Read back to confirm the firmware accepted the value. A mismatch is a
     // silent failure mode that's otherwise invisible — devices in low-power
     // states or with unsupported DPI ranges can ACK the write yet keep the old
     // value. We log a warning but still return Ok because the request reached
     // the device.
-    if let Ok(actual) = feature.get_sensor_dpi(0).await {
+    if let Ok(actual) = feature.current_dpi().await {
         if actual == dpi {
             debug!(index, dpi, "wrote DPI (verified)");
         } else {

--- a/crates/openlogi-hid/src/write/lighting.rs
+++ b/crates/openlogi-hid/src/write/lighting.rs
@@ -7,6 +7,10 @@ use hidpp::{
     feature::{
         CreatableFeature,
         color_led_effects::{ColorLedEffectsFeature, Persistence, ZONE_EFFECT_PARAM_COUNT},
+        per_key_lighting::{
+            FramePersistence, MAX_SINGLE_VALUE_ZONES, PerKeyLightingFeature, Rgb,
+            ZONE_PRESENCE_PAGE_LEN, ZonePresencePage,
+        },
     },
 };
 use tracing::debug;
@@ -59,13 +63,17 @@ const FRAME_GAP: Duration = Duration::from_millis(8);
 /// [`Auto`]: LightingMethod::Auto
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LightingMethod {
-    /// Prefer `ColorLedEffects` (`0x8070`), falling back to `PerKeyLighting`
-    /// (`0x8080`) when the device exposes no effect engine.
+    /// Prefer `ColorLedEffects` (`0x8070`), falling back to `PerKeyLighting2`
+    /// (`0x8081`) and then `PerKeyLighting` (`0x8080`) when the device exposes
+    /// no effect engine.
     Auto,
     /// Force `ColorLedEffects` (`0x8070`) — the fixed-effect override.
     Effects,
-    /// Force `PerKeyLighting` (`0x8080`) — the per-key stream.
+    /// Force `PerKeyLighting` (`0x8080`) — the raw per-key stream.
     PerKey,
+    /// Force `PerKeyLighting2` (`0x8081`) — the zone-addressed successor to
+    /// `0x8080`.
+    PerKeyV2,
 }
 
 /// Set a keyboard to a solid `(r, g, b)` colour, choosing the HID++ path
@@ -108,13 +116,26 @@ pub(super) async fn set_keyboard_color_with_on_channel(
 ) -> Result<(), WriteError> {
     match method {
         LightingMethod::PerKey => set_color_per_key(channel, device_index, r, g, b).await,
+        LightingMethod::PerKeyV2 => set_color_per_key_v2(channel, device_index, r, g, b).await,
         LightingMethod::Effects => set_color_effects(channel, device_index, r, g, b).await,
         LightingMethod::Auto => match set_color_effects(channel, device_index, r, g, b).await {
             Err(WriteError::FeatureUnsupported { feature_hex })
                 if feature_hex == COLOR_LED_EFFECTS_FEATURE =>
             {
-                debug!("no 0x8070 effect engine — falling back to 0x8080 per-key");
-                set_color_per_key(channel, device_index, r, g, b).await
+                debug!("no 0x8070 effect engine — trying the per-key paths");
+                // 0x8081 supersedes 0x8080 and is the one newer keyboards ship,
+                // so it is tried first; a device with neither reports the
+                // original 0x8080 as missing, which is the error this fallback
+                // chain has always ended with.
+                match set_color_per_key_v2(channel, device_index, r, g, b).await {
+                    Err(WriteError::FeatureUnsupported { feature_hex })
+                        if feature_hex == PerKeyLightingFeature::ID =>
+                    {
+                        debug!("no 0x8081 per-key zones — falling back to 0x8080 per-key");
+                        set_color_per_key(channel, device_index, r, g, b).await
+                    }
+                    other => other,
+                }
             }
             other => other,
         },
@@ -205,6 +226,126 @@ async fn set_color_effects(
 /// Classify a HID++ error from the `ColorLedEffects` functions.
 fn classify_lighting_error(error: hidpp::protocol::v20::Hidpp20Error) -> WriteError {
     classify_hidpp_error(error, HidppOperation::Lighting, ColorLedEffectsFeature::ID)
+}
+
+/// Set a solid colour via `PerKeyLighting2` (`0x8081`): paint every zone the
+/// device reports as present, then commit the frame. `FeatureUnsupported` when
+/// the device exposes no `0x8081` or reports no zones.
+///
+/// `0x8081` supersedes `0x8080`. It addresses *zones* rather than HID key
+/// usages and answers each request, so unlike the raw `0x8080` stream a write
+/// to a zone the device does not have surfaces as an error instead of being
+/// swallowed. Nothing had ever driven it, which left a keyboard exposing only
+/// `0x8081` with no way to set its colour at all.
+///
+/// Committed volatilely for the same reason as the `0x8070` path: the colour
+/// shows live without a flash write on every colour pick, and the agent
+/// re-applies the saved colour on device arrival.
+async fn set_color_per_key_v2(
+    channel: &Arc<HidppChannel>,
+    index: u8,
+    r: u8,
+    g: u8,
+    b: u8,
+) -> Result<(), WriteError> {
+    let mut device = Device::new(Arc::clone(channel), index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable { index })?;
+    let feature = open_feature::<PerKeyLightingFeature>(&mut device).await?;
+
+    let zones = present_zones(&feature).await?;
+    if zones.is_empty() {
+        // The device announces 0x8081 but claims no zones, so there is nothing
+        // to paint — and that won't change on retry. Reported as unsupported so
+        // `Auto` falls through to the 0x8080 stream.
+        debug!(index, "0x8081 reported no present zones");
+        return Err(WriteError::FeatureUnsupported {
+            feature_hex: PerKeyLightingFeature::ID,
+        });
+    }
+
+    let color = Rgb {
+        red: r,
+        green: g,
+        blue: b,
+    };
+    // One request carries at most MAX_SINGLE_VALUE_ZONES ids and silently
+    // ignores the rest, so the chunking is the caller's job.
+    for chunk in zones.chunks(MAX_SINGLE_VALUE_ZONES) {
+        feature
+            .set_rgb_zones_single_value(color, chunk)
+            .await
+            .map_err(classify_per_key_v2_error)?;
+    }
+    feature
+        .frame_end(FramePersistence::Volatile, 0, 0)
+        .await
+        .map_err(classify_per_key_v2_error)?;
+
+    debug!(
+        index,
+        zone_count = zones.len(),
+        r,
+        g,
+        b,
+        "set keyboard colour via typed 0x8081"
+    );
+    Ok(())
+}
+
+/// Every zone id `0x8081` reports as present, read across all three presence
+/// pages.
+///
+/// Ids `0` and `0xff` are end-of-list sentinels the feature rejects, so they
+/// are skipped even if a device sets their bits.
+async fn present_zones(feature: &PerKeyLightingFeature) -> Result<Vec<u8>, WriteError> {
+    let mut zones = Vec::new();
+    for (page, base) in [
+        (ZonePresencePage::Zones0To111, 0u16),
+        (ZonePresencePage::Zones112To223, 112),
+        (ZonePresencePage::Zones224To255, 224),
+    ] {
+        let bitfield = feature
+            .get_rgb_zone_presence(page)
+            .await
+            .map_err(classify_per_key_v2_error)?;
+        collect_present_zones(base, &bitfield, &mut zones);
+    }
+    Ok(zones)
+}
+
+/// Appends the zone ids whose presence bit is set in `bitfield`, a 112-bit
+/// field covering ids `base..base + 112` (bit `i` LSB-first within each byte).
+///
+/// The last page covers only 224..=255, so its high bits are padding; ids past
+/// 255 are skipped rather than wrapped. Ids `0` and `0xff` are the feature's
+/// end-of-list sentinels and are skipped even if a device sets their bits.
+pub(super) fn collect_present_zones(
+    base: u16,
+    bitfield: &[u8; ZONE_PRESENCE_PAGE_LEN],
+    zones: &mut Vec<u8>,
+) {
+    for (byte_index, byte) in bitfield.iter().enumerate() {
+        for bit in 0..8u16 {
+            if byte & (1 << bit) == 0 {
+                continue;
+            }
+            let Ok(offset) = u16::try_from(byte_index * 8) else {
+                continue;
+            };
+            let Ok(zone_id) = u8::try_from(base + offset + bit) else {
+                continue;
+            };
+            if !matches!(zone_id, 0 | 0xff) {
+                zones.push(zone_id);
+            }
+        }
+    }
+}
+
+/// Classify a HID++ error from the `PerKeyLighting2` functions.
+fn classify_per_key_v2_error(error: hidpp::protocol::v20::Hidpp20Error) -> WriteError {
+    classify_hidpp_error(error, HidppOperation::Lighting, PerKeyLightingFeature::ID)
 }
 
 /// Set a solid colour via `PerKeyLighting` (`0x8080`): stream every key's colour

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -5,13 +5,14 @@ use std::sync::{Arc, Mutex, PoisonError};
 use super::*;
 use hidpp::channel::{HidppChannel, RawHidChannel};
 use hidpp::feature::extended_dpi::{DpiRange, Lod};
+use hidpp::feature::per_key_lighting::FramePersistence;
 use hidpp::feature::smartshift::WheelMode;
 use tokio::sync::mpsc;
 
 use crate::SmartShiftMode;
 use crate::SmartShiftStatus;
 use crate::write::dpi::expand_dpi_ranges;
-use crate::write::lighting::per_key_reports;
+use crate::write::lighting::{collect_present_zones, per_key_reports};
 use crate::write::smartshift::{
     is_missing_enhanced, is_transient_smartshift_error, smartshift_to_wheel,
     status_matches_desired, wheel_mode_to_smartshift,
@@ -335,6 +336,94 @@ async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Resul
     Ok(())
 }
 
+#[test]
+fn zone_presence_bits_decode_lsb_first_from_the_page_base() {
+    let mut bitfield = [0u8; 14];
+    bitfield[0] = 0b0000_0110; // zones 1 and 2
+    bitfield[1] = 0b1000_0000; // zone 15
+    let mut zones = Vec::new();
+
+    collect_present_zones(0, &bitfield, &mut zones);
+
+    assert_eq!(zones, [1, 2, 15]);
+}
+
+#[test]
+fn zone_presence_pages_are_offset_by_their_base() {
+    let mut bitfield = [0u8; 14];
+    bitfield[0] = 0b0000_0001;
+    let mut zones = Vec::new();
+
+    collect_present_zones(112, &bitfield, &mut zones);
+
+    assert_eq!(zones, [112]);
+}
+
+#[test]
+fn zone_presence_skips_sentinels_and_padding_past_255() {
+    // The last page covers only 224..=255, so the rest of its 112 bits are
+    // padding — decoding them would wrap back onto low zone ids. Ids 0 and
+    // 0xff are the feature's own end-of-list sentinels.
+    let mut zones = Vec::new();
+    collect_present_zones(0, &[0b0000_0001; 14], &mut zones);
+    assert!(!zones.contains(&0), "zone 0 is an end-of-list sentinel");
+
+    let mut last_page = [0u8; 14];
+    last_page[3] = 0b1000_0000; // id 255 — the other sentinel
+    last_page[5] = 0b0000_0001; // id 264 — past the addressable range
+    let mut zones = Vec::new();
+    collect_present_zones(224, &last_page, &mut zones);
+    assert!(zones.is_empty(), "got {zones:?}");
+}
+
+#[tokio::test]
+async fn a_keyboard_with_only_per_key_v2_can_be_coloured() -> Result<(), WriteError> {
+    // 0x8081 supersedes 0x8080 but nothing had ever driven it, so a keyboard
+    // exposing only 0x8081 could not be coloured at all.
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(per_key_v2_scripted_response);
+    let channel = Arc::new(
+        HidppChannel::from_raw_channel(raw)
+            .await
+            .expect("scripted HID++ channel must open"),
+    );
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc339,
+        },
+    );
+
+    set_keyboard_color_on(&shared, 0x11, 0x22, 0x33).await?;
+
+    let written = handle.written_reports();
+    let long_on = |function: u8| {
+        written
+            .iter()
+            .filter(move |report| {
+                report.len() == 20 && report[2] == 0x07 && report[3] >> 4 == function
+            })
+            .collect::<Vec<_>>()
+    };
+
+    // One setRgbZonesSingleValue carrying the colour and every present zone —
+    // four zones fit in a single request.
+    let paints = long_on(0x06);
+    assert_eq!(paints.len(), 1);
+    assert_eq!(&paints[0][4..7], &[0x11, 0x22, 0x33]);
+    assert_eq!(&paints[0][7..11], &[1, 2, 3, 4]);
+
+    // Then exactly one frameEnd, volatile so the colour does not burn flash on
+    // every pick.
+    let commits = long_on(0x07);
+    assert_eq!(commits.len(), 1);
+    assert_eq!(commits[0][4], u8::from(FramePersistence::Volatile));
+
+    // The raw 0x8080 stream must not have run — this device has no 0x8080.
+    assert!(written.iter().all(|report| report.first() != Some(&0x12)));
+    Ok(())
+}
+
 #[derive(Clone)]
 struct ScriptedRawHidHandle {
     written: Arc<Mutex<Vec<Vec<u8>>>>,
@@ -523,6 +612,53 @@ fn extended_dpi_scripted_response(request: &[u8]) -> Option<Vec<u8>> {
         // setSensorDpiParameters: echo the request back.
         (0x05, 0x06) => {
             payload[..6].copy_from_slice(&request[4..10]);
+            true
+        }
+        _ => return None,
+    };
+
+    let mut response = vec![0u8; if long { 20 } else { 7 }];
+    response[0] = if long { 0x11 } else { 0x10 };
+    response[1..4].copy_from_slice(&request[1..4]);
+    let payload_len = response.len() - 4;
+    response[4..].copy_from_slice(&payload[..payload_len]);
+    Some(response)
+}
+
+/// A keyboard that exposes `0x8081 PerKeyLighting2` and neither `0x8070`
+/// ColorLedEffects nor `0x8080` PerKeyLighting — the shape that had no way to
+/// set a colour at all, since nothing ever drove 0x8081.
+fn per_key_v2_scripted_response(request: &[u8]) -> Option<Vec<u8>> {
+    if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
+        return None;
+    }
+    let feature_index = request[2];
+    let function = request[3] >> 4;
+    let mut payload = [0u8; 16];
+    let long = match (feature_index, function) {
+        // Root ping used by Device::new.
+        (0x00, 0x01) => {
+            payload[0] = 4;
+            false
+        }
+        // Root feature lookup. Only 0x8081 is present.
+        (0x00, 0x00) => {
+            let feature_id = u16::from_be_bytes([request[4], request[5]]);
+            payload[0] = u8::from(feature_id == 0x8081) * 0x07;
+            false
+        }
+        // getRgbZonePresence: echo (typeOfInfo, page) then the 14-byte
+        // bitfield. Page 0 reports zones 1..=4 present; the others are empty.
+        (0x07, 0x00) => {
+            payload[..2].copy_from_slice(&request[4..6]);
+            if request[5] == 0 {
+                payload[2] = 0b0001_1110;
+            }
+            true
+        }
+        // setRgbZonesSingleValue and frameEnd: echo the request back.
+        (0x07, 0x06 | 0x07) => {
+            payload[..12].copy_from_slice(&request[4..16]);
             true
         }
         _ => return None,

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -4,11 +4,13 @@ use std::sync::{Arc, Mutex, PoisonError};
 
 use super::*;
 use hidpp::channel::{HidppChannel, RawHidChannel};
+use hidpp::feature::extended_dpi::{DpiRange, Lod};
 use hidpp::feature::smartshift::WheelMode;
 use tokio::sync::mpsc;
 
 use crate::SmartShiftMode;
 use crate::SmartShiftStatus;
+use crate::write::dpi::expand_dpi_ranges;
 use crate::write::lighting::per_key_reports;
 use crate::write::smartshift::{
     is_missing_enhanced, is_transient_smartshift_error, smartshift_to_wheel,
@@ -211,6 +213,128 @@ async fn shared_read_and_lighting_apis_use_the_supplied_channel() -> Result<(), 
     Ok(())
 }
 
+#[test]
+fn stepped_dpi_ranges_expand_onto_their_step_grid() {
+    assert_eq!(
+        expand_dpi_ranges(&[DpiRange::Stepped {
+            from: 400,
+            to: 800,
+            step: 100,
+        }]),
+        [400, 500, 600, 700, 800]
+    );
+}
+
+#[test]
+fn a_stepped_range_always_offers_its_high_endpoint() {
+    // 1000 is not an exact multiple of 300 from 100, but the spec makes the
+    // high endpoint selectable regardless — dropping it would put a device's
+    // maximum DPI out of reach.
+    assert_eq!(
+        expand_dpi_ranges(&[DpiRange::Stepped {
+            from: 100,
+            to: 1000,
+            step: 300,
+        }]),
+        [100, 400, 700, 1000]
+    );
+}
+
+#[test]
+fn fixed_and_stepped_ranges_mix_in_one_description() {
+    assert_eq!(
+        expand_dpi_ranges(&[
+            DpiRange::Fixed(200),
+            DpiRange::Stepped {
+                from: 400,
+                to: 600,
+                step: 100,
+            },
+            DpiRange::Fixed(1600),
+        ]),
+        [200, 400, 500, 600, 1600]
+    );
+}
+
+#[test]
+fn adjacent_ranges_may_share_an_endpoint() {
+    // The device reports one range's high value as the next one's low value;
+    // `DpiCapabilities::new` is what deduplicates, so the raw expansion is
+    // allowed to repeat it.
+    let values = expand_dpi_ranges(&[
+        DpiRange::Stepped {
+            from: 100,
+            to: 300,
+            step: 100,
+        },
+        DpiRange::Stepped {
+            from: 300,
+            to: 500,
+            step: 100,
+        },
+    ]);
+    assert_eq!(values, [100, 200, 300, 300, 400, 500]);
+    assert_eq!(
+        DpiCapabilities::new(values).expect("non-empty").values(),
+        [100, 200, 300, 400, 500]
+    );
+}
+
+#[test]
+fn a_single_value_range_yields_just_that_value() {
+    assert_eq!(
+        expand_dpi_ranges(&[DpiRange::Stepped {
+            from: 800,
+            to: 800,
+            step: 50,
+        }]),
+        [800]
+    );
+}
+
+#[tokio::test]
+async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Result<(), WriteError> {
+    // `Capabilities::from_feature_ids` turns the DPI panel on for 0x2201 *or*
+    // 0x2202, so a mouse that only speaks 0x2202 has to be drivable — it used
+    // to get a panel that failed every read and write.
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(extended_dpi_scripted_response);
+    let channel = Arc::new(
+        HidppChannel::from_raw_channel(raw)
+            .await
+            .expect("scripted HID++ channel must open"),
+    );
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    let dpi = get_dpi_info_on(&shared).await?;
+    assert_eq!(dpi.current, 800);
+    // The stepped 400..800 range expands onto its step grid and the trailing
+    // fixed value survives.
+    assert_eq!(dpi.capabilities.values(), [400, 500, 600, 700, 800, 1200]);
+
+    set_dpi_on(&shared, 1200).await?;
+
+    // setSensorDpiParameters is a long request on function 6 of feature index
+    // 0x05: [dpiX, dpiY, lod] after the echoed sensor index.
+    let write = handle
+        .written_reports()
+        .into_iter()
+        .find(|report| report.len() == 20 && report[2] == 0x05 && report[3] >> 4 == 0x06)
+        .expect("a DPI write must reach the device");
+    assert_eq!(u16::from_be_bytes([write[5], write[6]]), 1200);
+    // No independent Y axis on this sensor, so the spec has the host send 0.
+    assert_eq!(u16::from_be_bytes([write[7], write[8]]), 0);
+    // Lift-off distance is read back and rewritten unchanged — the packet has
+    // no "leave alone" encoding, so writing a bare 0 would retune the sensor.
+    assert_eq!(write[9], u8::from(Lod::Medium));
+    Ok(())
+}
+
 #[derive(Clone)]
 struct ScriptedRawHidHandle {
     written: Arc<Mutex<Vec<Vec<u8>>>>,
@@ -225,14 +349,24 @@ impl ScriptedRawHidHandle {
     }
 }
 
+/// Answers a HID++ request as a particular scripted device would.
+type Responder = fn(&[u8]) -> Option<Vec<u8>>;
+
 struct ScriptedRawHidChannel {
     incoming_tx: mpsc::UnboundedSender<Vec<u8>>,
     incoming_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
     written: Arc<Mutex<Vec<Vec<u8>>>>,
+    responder: Responder,
 }
 
 impl ScriptedRawHidChannel {
     fn new() -> (Self, ScriptedRawHidHandle) {
+        Self::with_responder(scripted_response)
+    }
+
+    /// A channel answering as `responder`'s device, for tests that need a
+    /// different feature table than [`scripted_response`]'s.
+    fn with_responder(responder: Responder) -> (Self, ScriptedRawHidHandle) {
         let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
         let written = Arc::new(Mutex::new(Vec::new()));
         (
@@ -240,6 +374,7 @@ impl ScriptedRawHidChannel {
                 incoming_tx,
                 incoming_rx: tokio::sync::Mutex::new(incoming_rx),
                 written: Arc::clone(&written),
+                responder,
             },
             ScriptedRawHidHandle { written },
         )
@@ -261,7 +396,7 @@ impl RawHidChannel for ScriptedRawHidChannel {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .push(src.to_vec());
-        if let Some(response) = scripted_response(src) {
+        if let Some(response) = (self.responder)(src) {
             self.incoming_tx.send(response).map_err(|_| mock_error())?;
         }
         Ok(src.len())
@@ -331,6 +466,65 @@ fn scripted_response(request: &[u8]) -> Option<Vec<u8>> {
             false
         }
         // Raw per-key frame commit expects no reply.
+        _ => return None,
+    };
+
+    let mut response = vec![0u8; if long { 20 } else { 7 }];
+    response[0] = if long { 0x11 } else { 0x10 };
+    response[1..4].copy_from_slice(&request[1..4]);
+    let payload_len = response.len() - 4;
+    response[4..].copy_from_slice(&payload[..payload_len]);
+    Some(response)
+}
+
+/// A mouse that exposes `0x2202 ExtendedAdjustableDpi` and **no**
+/// `0x2201 AdjustableDpi` — the shape `Capabilities::from_feature_ids` lights
+/// the DPI panel up for but the write path could not drive.
+fn extended_dpi_scripted_response(request: &[u8]) -> Option<Vec<u8>> {
+    if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
+        return None;
+    }
+    let feature_index = request[2];
+    let function = request[3] >> 4;
+    let mut payload = [0u8; 16];
+    let long = match (feature_index, function) {
+        // Root ping used by Device::new.
+        (0x00, 0x01) => {
+            payload[0] = 4;
+            false
+        }
+        // Root feature lookup. 0x2201 is deliberately absent.
+        (0x00, 0x00) => {
+            let feature_id = u16::from_be_bytes([request[4], request[5]]);
+            payload[0] = u8::from(feature_id == 0x2202) * 0x05;
+            false
+        }
+        // getSensorCount.
+        (0x05, 0x00) => {
+            payload[0] = 1;
+            false
+        }
+        // getSensorDpiRanges: echo (sensorIdx, direction, page), then 400 with
+        // a step-100 hyphen up to 800, a fixed 1200, and the end-of-list word.
+        (0x05, 0x02) => {
+            payload[..3].copy_from_slice(&request[4..7]);
+            payload[3..13]
+                .copy_from_slice(&[0x01, 0x90, 0xe0, 0x64, 0x03, 0x20, 0x04, 0xb0, 0x00, 0x00]);
+            true
+        }
+        // getSensorDpiParameters: 800 DPI now and by default, no independent Y
+        // axis (dpiY reads 0), lift-off distance MEDIUM.
+        (0x05, 0x05) => {
+            payload[1..3].copy_from_slice(&800u16.to_be_bytes());
+            payload[3..5].copy_from_slice(&800u16.to_be_bytes());
+            payload[9] = u8::from(Lod::Medium);
+            true
+        }
+        // setSensorDpiParameters: echo the request back.
+        (0x05, 0x06) => {
+            payload[..6].copy_from_slice(&request[4..10]);
+            true
+        }
         _ => return None,
     };
 

--- a/crates/openlogi-hidpp/src/feature/per_key_lighting.rs
+++ b/crates/openlogi-hidpp/src/feature/per_key_lighting.rs
@@ -31,7 +31,11 @@ const CONSECUTIVE_ZONES: usize = 5;
 /// Maximum ranges per `setRangeRgbZones` request.
 const MAX_RANGES: usize = 3;
 /// Maximum zones per `setRgbZonesSingleValue` request.
-const MAX_SINGLE_VALUE_ZONES: usize = 13;
+///
+/// Public because [`PerKeyLightingFeature::set_rgb_zones_single_value`] ignores
+/// zones past this limit: a caller with more zones than one request holds has
+/// to chunk them itself, and cannot do that without knowing the chunk size.
+pub const MAX_SINGLE_VALUE_ZONES: usize = 13;
 
 /// An 8-bit-per-channel RGB color.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Summary

Auditing which HID++ features `openlogi-hidpp` implements against which ones
anything actually drives turned up two devices shapes the workspace mishandles.
Both follow the same pattern: a feature has a successor, `Capabilities` (or the
fallback chain) knows about one of them, and the typed wrapper for the other has
existed since the HID++ API completion pass without ever being reached for.

| | old | successor | symptom |
|---|---|---|---|
| DPI | `0x2201 AdjustableDpi` | `0x2202 ExtendedAdjustableDpi` | panel shown, every read/write fails |
| Lighting | `0x8080 PerKeyLighting` | `0x8081 PerKeyLighting2` | no lighting tab at all |

Both are fixed here, each with an end-to-end test over a scripted device of the
affected shape that fails on master with the exact error the bug produces.

## Changes

### `fix(hid): drive DPI on devices that expose only 0x2202`

`Capabilities::from_feature_ids` turns the DPI panel on for `0x2201` **or**
`0x2202`, but `write/dpi.rs` only ever opened `0x2201`. A mouse exposing only
`0x2202` therefore got a DPI panel whose every read and write failed with
`FeatureUnsupported { feature_hex: 0x2201 }`, and `openlogi diag dpi` skipped it
outright because its device filter asked for `0x2201` alone.

A `DpiFeature` enum now picks whichever of the two a device reports, so
`get_dpi`, `get_dpi_info` and `set_dpi` are feature-agnostic. **`0x2201` is
tried first on purpose**: it is the path every device that works today already
takes, so this is purely additive — a device exposing both behaves exactly as
before.

Two details of `0x2202` that are easy to get wrong, both read out of the feature
spec rather than inferred:

- `setSensorDpiParameters` writes DPI X, DPI Y and lift-off distance in one
  packet with **no "leave unchanged" encoding**. The current parameters are read
  first and the LOD written back untouched; sending a bare `0` would silently
  retune the sensor's lift-off height.
- The host sends `dpiY = 0` when the sensor has no independent Y axis, and the
  device reports `0` on read in exactly that case. Where there *is* a Y axis the
  two are kept equal — the UI exposes a single DPI, and letting them drift would
  make the pointer move at different speeds per axis.

`0x2202` describes supported DPI as a mix of fixed values and stepped ranges
rather than `0x2201`'s flat list, so `expand_dpi_ranges` flattens it onto the
shape `DpiCapabilities` is built from, keeping each range's high endpoint even
when it is not an exact multiple of the step.

### `feat(hid): colour keyboards that expose only 0x8081`

`set_keyboard_color` walked `0x8070` and then the raw `0x8080` stream. `0x8081`
was in neither the fallback chain nor the lighting capability gate, so a
keyboard exposing only `0x8081` got no lighting tab and no way to set its
colour.

`Auto` now walks `0x8070` → `0x8081` → `0x8080`. The order puts the newer
per-key feature first but keeps `0x8080` last, so the error a device with none
of them reports is unchanged. `diag lighting --method perkeyv2` drives it
explicitly.

Unlike the raw `0x8080` stream, `0x8081` addresses zones rather than HID key
usages and answers every request, so a write to a zone the device does not have
surfaces as an error instead of being swallowed. Zones come from the feature's
own presence bitfield rather than a guessed range: all three pages are read, ids
`0` and `0xff` are skipped as the feature's end-of-list sentinels, and the last
page's padding bits are dropped rather than wrapped back onto low ids. The frame
is committed volatilely for the same reason the `0x8070` path is.

`MAX_SINGLE_VALUE_ZONES` becomes public because `set_rgb_zones_single_value`
silently ignores zones past that limit — a caller with more zones than one
request holds has to chunk them itself, and cannot without knowing the size.

## Testing

Full four-step local gate on an isolated target dir:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — **908 passed, 0 failed** (897 on master, +11)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`

Both regressions were confirmed by removing the fix and watching the new test
fail with the production error:

- DPI: `FeatureUnsupported { feature_hex: 8705 }` (`0x2201`)
- Lighting: `FeatureUnsupported { feature_hex: 32896 }` (`0x8080`)

The scripted HID channel now takes a responder, so a test can present a
different feature table than the shared one; the two new device shapes use that.

No wire types changed, so no `PROTOCOL_VERSION` bump — `Capabilities`' gate is
logic, not layout, and `LightingMethod` does not cross IPC.

**Not runtime-tested on hardware.** I have no `0x2202`-only mouse or
`0x8081`-only keyboard to try, and that is exactly what would confirm these:

- `openlogi diag features` on the device to confirm which IDs it reports
- `openlogi diag dpi` — should now find the device and read/write its DPI
- `openlogi diag lighting <RRGGBB> --method perkeyv2` — should set the colour;
  the `0x2202` LOD read-back is the part most worth watching, since a
  regression there changes lift-off height silently rather than visibly.

## Note for merging

Touches `crates/openlogi-hidpp/src/feature/per_key_lighting/mod.rs`, which #628
renames to `per_key_lighting.rs`. Git resolves rename-vs-edit automatically, but
whichever merges second should confirm the edit landed on the renamed file.

## Not done

`0x1815 HostsInfo` is also unimplemented-in-practice while its sibling `0x1814
ChangeHost` is driven, but it is not the same kind of gap. `host_switch.rs` is a
background sync mechanism — the keyboard's own host keys are diverted and the
linked mouse follows — and OpenLogi has no host UI and no host field on the IPC.
Reading host names and occupancy would produce data with nothing to display it,
and `host_channel` already derives the available channels from the control table
the device reports rather than assuming a count, so there is no internal use
either. That is a product decision (should there be a host surface?), not a bug,
and it would need an IPC field and a GUI panel to be worth anything.
