### PR TITLE
fix(hid): never switch a device to a host slot it is not paired on

### DIFF
--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -11,7 +11,11 @@ use std::{future::Future, sync::Arc, time::Duration};
 use hidpp::{
     channel::HidppChannel,
     device::Device,
-    feature::{CreatableFeature, change_host::ChangeHostFeature},
+    feature::{
+        CreatableFeature,
+        change_host::ChangeHostFeature,
+        hosts_info::{HostIndex, HostSlotStatus, HostsInfoFeature},
+    },
     protocol::v20,
 };
 use thiserror::Error;
@@ -86,6 +90,13 @@ pub enum HostSwitchError {
     /// The keyboard cannot report its host switch controls to software.
     #[error("keyboard exposes no reportable host switch controls")]
     UnsupportedKeyboard,
+    /// The device reports the requested host slot as unpaired, so switching to
+    /// it would strand the device.
+    #[error("host {host} is not paired on this device")]
+    HostSlotEmpty {
+        /// The zero-based host slot that has no pairing.
+        host: u8,
+    },
 }
 
 /// Capture host switch keys on `keyboard` until one is pressed or `shutdown`
@@ -167,6 +178,13 @@ pub async fn switch_linked_hosts(
     let channel = open_channel(channel_pool, keyboard, "opening keyboard channel")
         .await?
         .ok_or(HostSwitchError::KeyboardNotFound)?;
+    // Validate the keyboard's own move before touching anything: preparation is
+    // read-only, but it is the step that rejects an unpaired host slot, and
+    // discovering that *after* the mice have moved would strand them on a host
+    // the keyboard never reaches. Applying it still happens last, because once
+    // the keyboard leaves this host its channel can no longer command a mouse
+    // sharing the same receiver.
+    let keyboard_change = prepare_host_change_on(&channel, keyboard.device_index(), host).await?;
     for target in targets {
         match prepare_host_change(target, host, keyboard, &channel, channel_pool).await {
             Ok(change) => {
@@ -179,7 +197,6 @@ pub async fn switch_linked_hosts(
             }
         }
     }
-    let keyboard_change = prepare_host_change_on(&channel, keyboard.device_index(), host).await?;
     let changed = apply_host_change(keyboard_change).await?;
     if changed {
         debug!(host, route = %keyboard, "keyboard host switched");
@@ -354,6 +371,9 @@ async fn prepare_host_change_on(
     let change_host = device.add_feature::<ChangeHostFeature>(info.index);
     let state = timed_hidpp("reading current host", change_host.get_host_info()).await?;
     let required = host_change_required(state.current_host, state.host_count, host)?;
+    if required && !host_slot_is_paired(&mut device, host).await? {
+        return Err(HostSwitchError::HostSlotEmpty { host });
+    }
     Ok(PreparedHostChange {
         feature: change_host,
         device_index,
@@ -400,6 +420,37 @@ where
         .await
         .map_err(|_| HostSwitchError::TimedOut { operation })?
         .map_err(|error| hidpp_error(operation, error))
+}
+
+/// Whether `host` is a slot this device is actually paired on.
+///
+/// `ChangeHost`'s `host_count` counts the device's RF channels, not the ones
+/// that have a pairing. Switching to an empty slot is not refused by the
+/// device: `setCurrentHost` is fire-and-forget and a successful switch usually
+/// resets the device, so it simply drops off this host and does not come back
+/// until the user pairs that slot or presses the device's own host button. A
+/// keyboard with three host keys paired to two machines is enough to hit this.
+///
+/// `HostsInfo` (`0x1815`) is the only feature that reports per-slot pairing
+/// status. A device that does not expose it, or that fails the read, is
+/// treated as pairable so the switch is still attempted — this guard only ever
+/// blocks on a device that explicitly says the slot is empty.
+async fn host_slot_is_paired(device: &mut Device, host: u8) -> Result<bool, HostSwitchError> {
+    let Some(info) = timed_hidpp(
+        "locating hosts-info feature",
+        device.root().get_feature(HostsInfoFeature::ID),
+    )
+    .await?
+    else {
+        return Ok(true);
+    };
+    let hosts_info = device.add_feature::<HostsInfoFeature>(info.index);
+    let slot = timed_hidpp(
+        "reading host slot status",
+        hosts_info.get_host_info(HostIndex::Slot(host)),
+    )
+    .await?;
+    Ok(slot.status == HostSlotStatus::Paired)
 }
 
 fn host_change_required(
@@ -456,15 +507,135 @@ fn event_host(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
+    use std::sync::Arc;
+
+    use hidpp::channel::HidppChannel;
+
     use super::{
-        ArmedControl, ReportingMode, event_host, host_change_required, host_channel,
-        restoration_change, shares_channel,
+        ArmedControl, HostSwitchError, ReportingMode, event_host, host_change_required,
+        host_channel, prepare_host_change_on, restoration_change, shares_channel,
     };
     use crate::DeviceRoute;
     use crate::reprog_controls::{
         AnalyticsKeyEvent, CidReporting, ControlId, CtrlIdInfo, ReprogControlsEvent,
     };
+    use crate::scripted_channel::ScriptedRawHidChannel;
+
+    /// Feature index the scripted keyboard reports for `0x1814 ChangeHost`.
+    const CHANGE_HOST_INDEX: u8 = 0x04;
+    /// Feature index the scripted keyboard reports for `0x1815 HostsInfo`.
+    const HOSTS_INFO_INDEX: u8 = 0x05;
+
+    /// A three-channel keyboard currently on host 0, paired on hosts 0 and 1
+    /// but **not** on host 2 — a keyboard with three host keys and only two
+    /// machines paired, which is the shape that used to strand devices.
+    fn keyboard_with_an_empty_third_slot(request: &[u8]) -> Option<Vec<u8>> {
+        scripted_keyboard(request, true)
+    }
+
+    /// The same keyboard without `0x1815`, so its slot pairing is unknowable.
+    fn keyboard_without_hosts_info(request: &[u8]) -> Option<Vec<u8>> {
+        scripted_keyboard(request, false)
+    }
+
+    fn scripted_keyboard(request: &[u8], hosts_info: bool) -> Option<Vec<u8>> {
+        if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
+            return None;
+        }
+        let mut payload = [0u8; 16];
+        match (request[2], request[3] >> 4) {
+            // Root ping used by Device::new.
+            (0x00, 0x01) => payload[0] = 4,
+            // Root feature lookup.
+            (0x00, 0x00) => {
+                payload[0] = match u16::from_be_bytes([request[4], request[5]]) {
+                    0x1814 => CHANGE_HOST_INDEX,
+                    0x1815 if hosts_info => HOSTS_INFO_INDEX,
+                    _ => 0x00,
+                };
+            }
+            // ChangeHost getHostInfo: three RF channels, currently on host 0.
+            (CHANGE_HOST_INDEX, 0x00) => payload[..2].copy_from_slice(&[3, 0]),
+            // HostsInfo getHostInfo: echo the slot, then its pairing status.
+            (HOSTS_INFO_INDEX, 0x01) => {
+                payload[0] = request[4];
+                payload[1] = u8::from(request[4] < 2);
+            }
+            _ => return None,
+        }
+
+        let mut response = vec![0u8; 7];
+        response[0] = 0x10;
+        response[1..4].copy_from_slice(&request[1..4]);
+        response[4..].copy_from_slice(&payload[..3]);
+        Some(response)
+    }
+
+    async fn scripted_channel(responder: crate::scripted_channel::Responder) -> Arc<HidppChannel> {
+        let (raw, _handle) = ScriptedRawHidChannel::with_responder(responder);
+        Arc::new(
+            HidppChannel::from_raw_channel(raw)
+                .await
+                .expect("scripted HID++ channel must open"),
+        )
+    }
+
+    #[tokio::test]
+    async fn switching_to_an_unpaired_slot_is_refused() {
+        // ChangeHost would allow it: host 2 is within the device's channel
+        // count. But nothing is paired there, and `setCurrentHost` is
+        // fire-and-forget — the device would simply leave and not come back.
+        let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+
+        let Err(error) = prepare_host_change_on(&channel, 1, 2).await else {
+            panic!("an unpaired slot must not be switched to");
+        };
+
+        assert!(
+            matches!(error, HostSwitchError::HostSlotEmpty { host: 2 }),
+            "got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn switching_to_a_paired_slot_proceeds() {
+        let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+
+        let change = prepare_host_change_on(&channel, 1, 1)
+            .await
+            .expect("a paired slot must be switchable");
+
+        assert!(change.required, "host 1 differs from the current host 0");
+    }
+
+    #[tokio::test]
+    async fn a_device_without_hosts_info_is_still_switched() {
+        // 0x1815 is the only source of per-slot pairing status. Without it the
+        // guard must not block, or this change would regress every device that
+        // does not implement it.
+        let channel = scripted_channel(keyboard_without_hosts_info).await;
+
+        let change = prepare_host_change_on(&channel, 1, 2)
+            .await
+            .expect("a device that cannot report slot status must still switch");
+
+        assert!(change.required);
+    }
+
+    #[tokio::test]
+    async fn a_switch_to_the_current_host_never_consults_slot_status() {
+        // Already-there is decided before the pairing check, so a device on an
+        // unpaired-looking slot is not blocked from staying put.
+        let channel = scripted_channel(keyboard_with_an_empty_third_slot).await;
+
+        let change = prepare_host_change_on(&channel, 1, 0)
+            .await
+            .expect("staying on the current host is always fine");
+
+        assert!(!change.required);
+    }
 
     fn reporting(diverted: bool, raw_xy: bool, analytics_key_events: bool) -> CidReporting {
         CidReporting {

--- a/crates/openlogi-hid/src/host_switch.rs
+++ b/crates/openlogi-hid/src/host_switch.rs
@@ -371,7 +371,7 @@ async fn prepare_host_change_on(
     let change_host = device.add_feature::<ChangeHostFeature>(info.index);
     let state = timed_hidpp("reading current host", change_host.get_host_info()).await?;
     let required = host_change_required(state.current_host, state.host_count, host)?;
-    if required && !host_slot_is_paired(&mut device, host).await? {
+    if required && host_slot_is_empty(&mut device, host).await {
         return Err(HostSwitchError::HostSlotEmpty { host });
     }
     Ok(PreparedHostChange {
@@ -422,7 +422,7 @@ where
         .map_err(|error| hidpp_error(operation, error))
 }
 
-/// Whether `host` is a slot this device is actually paired on.
+/// Whether the device explicitly reports `host` as an empty slot.
 ///
 /// `ChangeHost`'s `host_count` counts the device's RF channels, not the ones
 /// that have a pairing. Switching to an empty slot is not refused by the
@@ -432,25 +432,38 @@ where
 /// keyboard with three host keys paired to two machines is enough to hit this.
 ///
 /// `HostsInfo` (`0x1815`) is the only feature that reports per-slot pairing
-/// status. A device that does not expose it, or that fails the read, is
-/// treated as pairable so the switch is still attempted — this guard only ever
-/// blocks on a device that explicitly says the slot is empty.
-async fn host_slot_is_paired(device: &mut Device, host: u8) -> Result<bool, HostSwitchError> {
-    let Some(info) = timed_hidpp(
+/// status, and asking is advisory: a device that does not implement it, times
+/// out, returns a feature error, or answers with a status byte outside the
+/// spec has not said the slot is empty, and must still be allowed to switch.
+/// Only an explicit `Empty` refuses, so this returns a plain `bool` — an
+/// unreadable status can never abort the transition it was meant to protect.
+async fn host_slot_is_empty(device: &mut Device, host: u8) -> bool {
+    let feature = timed_hidpp(
         "locating hosts-info feature",
         device.root().get_feature(HostsInfoFeature::ID),
     )
-    .await?
-    else {
-        return Ok(true);
+    .await;
+    let index = match feature {
+        Ok(Some(info)) => info.index,
+        Ok(None) => return false,
+        Err(error) => {
+            debug!(host, %error, "hosts-info lookup failed; treating the slot as usable");
+            return false;
+        }
     };
-    let hosts_info = device.add_feature::<HostsInfoFeature>(info.index);
-    let slot = timed_hidpp(
+    let hosts_info = device.add_feature::<HostsInfoFeature>(index);
+    match timed_hidpp(
         "reading host slot status",
         hosts_info.get_host_info(HostIndex::Slot(host)),
     )
-    .await?;
-    Ok(slot.status == HostSlotStatus::Paired)
+    .await
+    {
+        Ok(slot) => slot.status == HostSlotStatus::Empty,
+        Err(error) => {
+            debug!(host, %error, "host slot status is unreadable; treating the slot as usable");
+            false
+        }
+    }
 }
 
 fn host_change_required(
@@ -528,19 +541,46 @@ mod tests {
     /// Feature index the scripted keyboard reports for `0x1815 HostsInfo`.
     const HOSTS_INFO_INDEX: u8 = 0x05;
 
+    /// `ErrorType::Busy`, the failure a scripted device answers with.
+    const BUSY: u8 = 0x08;
+
+    /// What the scripted keyboard's firmware does when asked about `0x1815`.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum SlotStatus {
+        /// Answers the query: hosts 0 and 1 paired, host 2 empty.
+        Reported,
+        /// Reports the feature as unimplemented, the usual index-0 lookup miss.
+        Unimplemented,
+        /// Errors on the lookup itself, as firmware that refuses unknown
+        /// feature ids rather than reporting index 0 does.
+        LookupErrors,
+        /// Implements the feature but errors on the status read.
+        ReadErrors,
+    }
+
     /// A three-channel keyboard currently on host 0, paired on hosts 0 and 1
     /// but **not** on host 2 — a keyboard with three host keys and only two
     /// machines paired, which is the shape that used to strand devices.
     fn keyboard_with_an_empty_third_slot(request: &[u8]) -> Option<Vec<u8>> {
-        scripted_keyboard(request, true)
+        scripted_keyboard(request, SlotStatus::Reported)
     }
 
     /// The same keyboard without `0x1815`, so its slot pairing is unknowable.
     fn keyboard_without_hosts_info(request: &[u8]) -> Option<Vec<u8>> {
-        scripted_keyboard(request, false)
+        scripted_keyboard(request, SlotStatus::Unimplemented)
     }
 
-    fn scripted_keyboard(request: &[u8], hosts_info: bool) -> Option<Vec<u8>> {
+    /// The same keyboard, whose firmware errors when asked for `0x1815`.
+    fn keyboard_erroring_on_hosts_info_lookup(request: &[u8]) -> Option<Vec<u8>> {
+        scripted_keyboard(request, SlotStatus::LookupErrors)
+    }
+
+    /// The same keyboard, whose `0x1815` reads come back an error.
+    fn keyboard_erroring_on_slot_status(request: &[u8]) -> Option<Vec<u8>> {
+        scripted_keyboard(request, SlotStatus::ReadErrors)
+    }
+
+    fn scripted_keyboard(request: &[u8], slot_status: SlotStatus) -> Option<Vec<u8>> {
         if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
             return None;
         }
@@ -552,7 +592,11 @@ mod tests {
             (0x00, 0x00) => {
                 payload[0] = match u16::from_be_bytes([request[4], request[5]]) {
                     0x1814 => CHANGE_HOST_INDEX,
-                    0x1815 if hosts_info => HOSTS_INFO_INDEX,
+                    0x1815 => match slot_status {
+                        SlotStatus::Unimplemented => 0x00,
+                        SlotStatus::LookupErrors => return Some(feature_error(request, BUSY)),
+                        SlotStatus::Reported | SlotStatus::ReadErrors => HOSTS_INFO_INDEX,
+                    },
                     _ => 0x00,
                 };
             }
@@ -560,6 +604,9 @@ mod tests {
             (CHANGE_HOST_INDEX, 0x00) => payload[..2].copy_from_slice(&[3, 0]),
             // HostsInfo getHostInfo: echo the slot, then its pairing status.
             (HOSTS_INFO_INDEX, 0x01) => {
+                if slot_status == SlotStatus::ReadErrors {
+                    return Some(feature_error(request, BUSY));
+                }
                 payload[0] = request[4];
                 payload[1] = u8::from(request[4] < 2);
             }
@@ -571,6 +618,19 @@ mod tests {
         response[1..4].copy_from_slice(&request[1..4]);
         response[4..].copy_from_slice(&payload[..3]);
         Some(response)
+    }
+
+    /// A HID++ 2.0 error response to `request`: feature index `0xff`, then the
+    /// addressed feature index, the function/software id, and the error code.
+    fn feature_error(request: &[u8], error: u8) -> Vec<u8> {
+        let mut response = vec![0u8; 7];
+        response[0] = 0x10;
+        response[1] = request[1];
+        response[2] = 0xff;
+        response[3] = request[2];
+        response[4] = request[3];
+        response[5] = error;
+        response
     }
 
     async fn scripted_channel(responder: crate::scripted_channel::Responder) -> Arc<HidppChannel> {
@@ -620,6 +680,34 @@ mod tests {
         let change = prepare_host_change_on(&channel, 1, 2)
             .await
             .expect("a device that cannot report slot status must still switch");
+
+        assert!(change.required);
+    }
+
+    #[tokio::test]
+    async fn a_failed_hosts_info_lookup_does_not_block_the_switch() {
+        // Firmware that answers an unknown feature id with an error rather than
+        // index 0 must read the same as not implementing 0x1815 at all: the
+        // pairing status is unknowable, which is not a reason to refuse.
+        let channel = scripted_channel(keyboard_erroring_on_hosts_info_lookup).await;
+
+        let change = prepare_host_change_on(&channel, 1, 2)
+            .await
+            .expect("an errored feature lookup must not abort the switch");
+
+        assert!(change.required);
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_slot_status_does_not_block_the_switch() {
+        // The guard is advisory. A device that has 0x1815 but cannot answer for
+        // it right now has not said the slot is empty, so refusing here would
+        // turn a transient read failure into a dead host key.
+        let channel = scripted_channel(keyboard_erroring_on_slot_status).await;
+
+        let change = prepare_host_change_on(&channel, 1, 2)
+            .await
+            .expect("an errored status read must not abort the switch");
 
         assert!(change.required);
     }

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -16,6 +16,8 @@ pub mod host_switch;
 mod mappings;
 mod node_ledger;
 mod route;
+#[cfg(test)]
+pub(crate) mod scripted_channel;
 mod standalone;
 mod transport;
 // Native Win32 HID report-write fallback, used by the Windows composite channel

--- a/crates/openlogi-hid/src/scripted_channel.rs
+++ b/crates/openlogi-hid/src/scripted_channel.rs
@@ -1,0 +1,104 @@
+//! A scripted HID++ transport for tests: it answers requests from a per-device
+//! responder instead of talking to hardware.
+//!
+//! Shared because more than one module needs a device with a feature table of
+//! its choosing — `write` drives DPI and lighting against one, `host_switch`
+//! needs a keyboard whose host slots it can dictate. Each module keeps its own
+//! responder; only the plumbing lives here.
+
+use std::error::Error;
+use std::io;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use hidpp::channel::RawHidChannel;
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+pub(crate) struct ScriptedRawHidHandle {
+    written: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl ScriptedRawHidHandle {
+    pub(crate) fn written_reports(&self) -> Vec<Vec<u8>> {
+        self.written
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+}
+
+/// Answers a HID++ request as a particular scripted device would.
+pub(crate) type Responder = fn(&[u8]) -> Option<Vec<u8>>;
+
+pub(crate) struct ScriptedRawHidChannel {
+    incoming_tx: mpsc::UnboundedSender<Vec<u8>>,
+    incoming_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
+    written: Arc<Mutex<Vec<Vec<u8>>>>,
+    responder: Responder,
+}
+
+impl ScriptedRawHidChannel {
+    /// A channel answering as `responder`'s device.
+    pub(crate) fn with_responder(responder: Responder) -> (Self, ScriptedRawHidHandle) {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let written = Arc::new(Mutex::new(Vec::new()));
+        (
+            Self {
+                incoming_tx,
+                incoming_rx: tokio::sync::Mutex::new(incoming_rx),
+                written: Arc::clone(&written),
+                responder,
+            },
+            ScriptedRawHidHandle { written },
+        )
+    }
+}
+
+#[hidpp::async_trait]
+impl RawHidChannel for ScriptedRawHidChannel {
+    fn vendor_id(&self) -> u16 {
+        0x046d
+    }
+
+    fn product_id(&self) -> u16 {
+        0xb35b
+    }
+
+    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        self.written
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(src.to_vec());
+        if let Some(response) = (self.responder)(src) {
+            self.incoming_tx.send(response).map_err(|_| mock_error())?;
+        }
+        Ok(src.len())
+    }
+
+    async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        let Some(report) = self.incoming_rx.lock().await.recv().await else {
+            return Err(mock_error());
+        };
+        let len = report.len().min(buf.len());
+        buf[..len].copy_from_slice(&report[..len]);
+        Ok(len)
+    }
+
+    fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
+        Some((true, true))
+    }
+
+    async fn get_report_descriptor(
+        &self,
+        _buf: &mut [u8],
+    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        unreachable!("scripted channel declares HID++ support")
+    }
+}
+
+pub(crate) fn mock_error() -> Box<dyn Error + Send + Sync> {
+    Box::new(io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "scripted HID channel closed",
+    ))
+}

--- a/crates/openlogi-hid/src/write/tests.rs
+++ b/crates/openlogi-hid/src/write/tests.rs
@@ -1,16 +1,14 @@
-use std::error::Error;
-use std::io;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::Arc;
 
 use super::*;
-use hidpp::channel::{HidppChannel, RawHidChannel};
+use hidpp::channel::HidppChannel;
 use hidpp::feature::extended_dpi::{DpiRange, Lod};
 use hidpp::feature::per_key_lighting::FramePersistence;
 use hidpp::feature::smartshift::WheelMode;
-use tokio::sync::mpsc;
 
 use crate::SmartShiftMode;
 use crate::SmartShiftStatus;
+use crate::scripted_channel::ScriptedRawHidChannel;
 use crate::write::dpi::expand_dpi_ranges;
 use crate::write::lighting::{collect_present_zones, per_key_reports};
 use crate::write::smartshift::{
@@ -170,7 +168,7 @@ fn per_key_lighting_builds_only_very_long_frames_then_one_long_commit() {
 
 #[tokio::test]
 async fn shared_read_and_lighting_apis_use_the_supplied_channel() -> Result<(), WriteError> {
-    let (raw, handle) = ScriptedRawHidChannel::new();
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(scripted_response);
     let channel = Arc::new(
         HidppChannel::from_raw_channel(raw)
             .await
@@ -424,94 +422,6 @@ async fn a_keyboard_with_only_per_key_v2_can_be_coloured() -> Result<(), WriteEr
     Ok(())
 }
 
-#[derive(Clone)]
-struct ScriptedRawHidHandle {
-    written: Arc<Mutex<Vec<Vec<u8>>>>,
-}
-
-impl ScriptedRawHidHandle {
-    fn written_reports(&self) -> Vec<Vec<u8>> {
-        self.written
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .clone()
-    }
-}
-
-/// Answers a HID++ request as a particular scripted device would.
-type Responder = fn(&[u8]) -> Option<Vec<u8>>;
-
-struct ScriptedRawHidChannel {
-    incoming_tx: mpsc::UnboundedSender<Vec<u8>>,
-    incoming_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>,
-    written: Arc<Mutex<Vec<Vec<u8>>>>,
-    responder: Responder,
-}
-
-impl ScriptedRawHidChannel {
-    fn new() -> (Self, ScriptedRawHidHandle) {
-        Self::with_responder(scripted_response)
-    }
-
-    /// A channel answering as `responder`'s device, for tests that need a
-    /// different feature table than [`scripted_response`]'s.
-    fn with_responder(responder: Responder) -> (Self, ScriptedRawHidHandle) {
-        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
-        let written = Arc::new(Mutex::new(Vec::new()));
-        (
-            Self {
-                incoming_tx,
-                incoming_rx: tokio::sync::Mutex::new(incoming_rx),
-                written: Arc::clone(&written),
-                responder,
-            },
-            ScriptedRawHidHandle { written },
-        )
-    }
-}
-
-#[hidpp::async_trait]
-impl RawHidChannel for ScriptedRawHidChannel {
-    fn vendor_id(&self) -> u16 {
-        0x046d
-    }
-
-    fn product_id(&self) -> u16 {
-        0xb35b
-    }
-
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
-        self.written
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push(src.to_vec());
-        if let Some(response) = (self.responder)(src) {
-            self.incoming_tx.send(response).map_err(|_| mock_error())?;
-        }
-        Ok(src.len())
-    }
-
-    async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
-        let Some(report) = self.incoming_rx.lock().await.recv().await else {
-            return Err(mock_error());
-        };
-        let len = report.len().min(buf.len());
-        buf[..len].copy_from_slice(&report[..len]);
-        Ok(len)
-    }
-
-    fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
-        Some((true, true))
-    }
-
-    async fn get_report_descriptor(
-        &self,
-        _buf: &mut [u8],
-    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
-        unreachable!("scripted channel declares HID++ support")
-    }
-}
-
 fn scripted_response(request: &[u8]) -> Option<Vec<u8>> {
     if request.len() < 7 || !matches!(request[0], 0x10 | 0x11) {
         return None;
@@ -670,11 +580,4 @@ fn per_key_v2_scripted_response(request: &[u8]) -> Option<Vec<u8>> {
     let payload_len = response.len() - 4;
     response[4..].copy_from_slice(&payload[..payload_len]);
     Some(response)
-}
-
-fn mock_error() -> Box<dyn Error + Send + Sync> {
-    Box::new(io::Error::new(
-        io::ErrorKind::BrokenPipe,
-        "scripted HID channel closed",
-    ))
 }


### PR DESCRIPTION
## Summary

`0x1815 HostsInfo` was implemented in `openlogi-hidpp` and driven by nothing.
Looking for a consumer turned up a bug it is the only cure for.

`host_change_required` guards a host switch with `requested_host < host_count`.
But `ChangeHost`'s host count is the number of RF **channels** the device has,
not the number that have a **pairing**. `setCurrentHost` is fire-and-forget and
a successful switch usually resets the device, so nothing refuses a switch to an
empty slot — the device just leaves this host and does not come back until the
user pairs that slot or presses its own host button.

A keyboard with three host keys and two machines paired is enough to reach it:
press host 3, and the linked mice disappear.

## Changes

`host_slot_is_empty` reads the target slot's status over `0x1815` before the
switch and refuses an `Empty` one with a named `HostSwitchError::HostSlotEmpty`.

The read is advisory, and the guard is built so it cannot be anything else: it
returns a plain `bool`, not a `Result`, so there is no error channel through
which an optional check could cancel the transition it exists to protect. A
device without `0x1815`, one whose firmware errors on the feature lookup rather
than reporting index 0, one that times out, and one that answers with a status
byte outside the spec all read the same — *not known to be empty* — and still
switch. Only a decoded `Empty` refuses, so nothing that works today starts
refusing.

The keyboard's own change is now **prepared before** the linked devices move
instead of after. Preparation is read-only, but it is the step that rejects an
unpaired slot, and discovering that after the mice had already moved would
strand them on a host the keyboard never reaches. Applying it still happens
last, because once the keyboard leaves this host its channel can no longer
command a mouse sharing the same receiver.

### Test support

The scripted HID++ transport moves out of `write::tests` into a shared
`scripted_channel` module, so more than one module can present a device with a
feature table of its choosing. Each module keeps its own responder; only the
plumbing is shared, and `ScriptedRawHidChannel::new()` is gone in favour of
always naming a responder — the shared code should not know about any one
device.

## Testing

Full four-step local gate on a clean target dir:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — **949 passed, 0 failed** (943 before, +6)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp --no-deps --document-private-items`

The new tests script a three-channel keyboard on host 0, paired on hosts 0 and
1 only, and cover every path through the guard:

| case | expected |
|---|---|
| switch to host 2 (unpaired) | refused with `HostSlotEmpty { host: 2 }` |
| switch to host 1 (paired) | proceeds, `required` |
| same keyboard without `0x1815` | proceeds — status is unknowable, don't block |
| firmware that errors on the `0x1815` lookup | proceeds |
| firmware that errors on the status read | proceeds |
| switch to host 0 (current) | `!required`, slot status never consulted |

Both directions are pinned by mutation: removing the guard fails the first test,
and making an unreadable status refuse fails the two error-path tests while the
rest stay green.

**Not runtime-tested on hardware** — I have no multi-host keyboard with a
deliberately unpaired slot. The confirming check is: pair a keyboard to two
machines, leave the third slot empty, press its host-3 key, and watch whether
the linked mouse stays put (fixed) or disappears (the bug).
