### PR TITLE
build(nix): make Linux packaging first-class

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -1,0 +1,43 @@
+name: devenv CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".envrc"
+      - "devenv.nix"
+      - "devenv.yaml"
+      - "devenv.lock"
+      - ".github/workflows/devenv.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: devenv-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell:
+    name: build developer shell
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Install upstream Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      - name: Check devenv formatting
+        run: nix fmt -- --check devenv.nix
+      - name: Configure devenv binary cache
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: devenv
+      - name: Install pinned devenv CLI
+        run: |
+          rev="$(jq -er '.nodes.devenv.locked.rev' devenv.lock)"
+          nix profile add "github:cachix/devenv/${rev}" --accept-flake-config
+      - name: Build and enter developer shell
+        run: devenv --no-tui shell -- true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,22 +1,12 @@
 name: Nix CI
 
-# Build the Nix package (flake `.#openlogi`) so it can't silently rot — the
-# failure mode that killed the previous flake (#262).
+# Evaluate every advertised Flake output, then build and test the package on
+# both supported Linux architectures. Dependency graph and packaging changes
+# run immediately on PRs; the weekly build catches source-only integration
+# drift without adding a full Nix rebuild to every Rust change.
 #
-# It runs weekly rather than per change, because the cost and the risk are
-# wildly mismatched. A full Linux build of this workspace takes ~20 minutes
-# and is by far the most expensive job in CI, while in 60 runs this one has
-# never failed — and the flake is not an install path anyone is pointed at:
-# the README ships `.deb` / `.rpm` / `.pkg.tar.zst` for Linux. What can rot it
-# is nixpkgs-unstable drifting, a new `-sys` dependency needing a buildInput,
-# or a bumped git pin invalidating an `outputHashes` entry. None of those are
-# urgent enough to make every contributor wait for them; noticing within a
-# week is fine, and the failing build prints the hash to paste.
-#
-# Editing the flake or the package expression *is* the moment a break is
-# likely and the feedback is worth having immediately, so those paths still
-# trigger it on their own PR. `workflow_dispatch` covers "I want to check
-# this now" — e.g. after bumping a git pin in Cargo.lock.
+# flake.lock pins nixpkgs exactly; update-flake-lock.yml advances it in a tested
+# PR instead of allowing an unreviewed upstream channel to drift under builds.
 on:
   schedule:
     # Mondays, 04:17 UTC. Off-peak, and far from the release cadence.
@@ -24,27 +14,83 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "crates/**/build.rs"
+      - "design/icon/openlogi.png"
+      - "docs/config.example.toml"
       - "flake.nix"
       - "flake.lock"
-      - "nix/**"
+      - "packaging/linux/package.nix"
+      - "packaging/linux/nixos-module.nix"
+      - "packaging/linux/desktop/**"
+      - "packaging/linux/systemd/**"
+      - "packaging/linux/udev/**"
       - ".github/workflows/nix.yml"
+      - ".github/workflows/update-flake-lock.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    name: nix build (Linux)
-    runs-on: ubuntu-latest
-    # GHA cache upload for store paths (magic-nix-cache). Read is enough for
-    # restoring; write is needed when the job is allowed to populate the cache
-    # (push to master / same-repo PR). Fork PRs still restore but cannot write.
-    permissions:
-      contents: read
-      actions: write
+  evaluate:
+    name: flake evaluation and formatting
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          # Prefer GitHub Actions cache only — no FlakeHub account required.
+          persist-credentials: false
+      - name: Install upstream Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      - name: Check Nix formatting
+        run: >-
+          nix fmt -- --check
+          flake.nix
+          devenv.nix
+          packaging/linux/package.nix
+          packaging/linux/nixos-module.nix
+      - name: Evaluate all Flake outputs
+        run: nix flake check --all-systems --no-build --show-trace
+
+  build:
+    name: nix build (${{ matrix.system }})
+    needs: evaluate
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            machine: x86_64
+            runner: ubuntu-24.04
+          - system: aarch64-linux
+            machine: aarch64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Verify runner architecture
+        run: test "$(uname -m)" = "${{ matrix.machine }}"
+      - name: Install upstream Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      - name: Restore and save Nix store paths
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+        with:
           use-gha-cache: enabled
           use-flakehub: disabled
-      - run: nix build .#openlogi -L
+      - name: Build package and NixOS module check
+        run: |
+          nix build \
+            ".#checks.${{ matrix.system }}.package" \
+            ".#checks.${{ matrix.system }}.nixos-module" \
+            -L

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,55 @@
+name: Update flake.lock
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Refresh pinned nixpkgs monthly; the resulting PR runs the full Nix CI.
+    - cron: "23 5 1 * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: update locked Nix inputs
+    if: github.repository == 'AprilNEA/OpenLogi'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Install upstream Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      # An App token, rather than GITHUB_TOKEN, makes the generated PR trigger
+      # Nix CI. Credentials stay in the existing release 1Password item.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: ./.github/actions/github-app-token-from-1password
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          op-github-app-item: ${{ secrets.OP_GITHUB_APP_ITEM }}
+      - name: Update flake.lock and open a PR
+        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: automation/update-flake-lock
+          commit-msg: "chore(nix): update flake.lock"
+          pr-title: "chore(nix): update flake.lock"
+          pr-body: |
+            ## Summary
+
+            Refresh the pinned Nix inputs used to build OpenLogi.
+
+            ## Changes
+
+            - Update `flake.lock` from the declared `nixpkgs-unstable` input.
+
+            ## Testing
+
+            - The generated PR triggers the x86_64 and aarch64 Nix CI builds.

--- a/README.md
+++ b/README.md
@@ -145,17 +145,40 @@ sudo pacman -U openlogi-*.pkg.tar.zst
 
 Packages are published for both `x86_64`/`amd64` and `arm64`/`aarch64`.
 
-The package installs udev rules that grant your user access to
+NixOS users can instead import the repository's module, which installs the
+package and udev rules and starts the agent with the graphical session:
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.openlogi = {
+    url = "github:AprilNEA/OpenLogi";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, openlogi, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux"; # or aarch64-linux
+      modules = [
+        openlogi.nixosModules.default
+        { programs.openlogi.enable = true; }
+      ];
+    };
+  };
+}
+```
+
+All Linux packages install udev rules that grant your user access to
 `/dev/hidraw*`, `/dev/uinput` and your Logitech mouse's `/dev/input/event*`
-node without `sudo`. After installation,
-enable the background agent for your user:
+node without `sudo`. The NixOS module starts the agent automatically; after a
+`.deb`, `.rpm`, or `.pkg.tar.zst` installation, enable it for your user:
 
 ```sh
 systemctl --user enable --now openlogi-agent.service
 ```
 
-See [docs/INSTALL-linux.md](docs/INSTALL-linux.md) for manual / source installs
-and distros without systemd.
+See [docs/INSTALL-linux.md](docs/INSTALL-linux.md) for complete NixOS options,
+manual / source installs, and distros without systemd.
 
 ### Windows
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 let
   # GPUI's build compiles Metal shaders against the real Xcode toolchain.
@@ -23,10 +23,19 @@ in
   apple.sdk = null;
 
   env = {
-    GREET = "devenv";
     RUSTC_WRAPPER = "sccache";
   }
-  // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+  // lib.optionalAttrs pkgs.stdenv.isLinux {
+    # GPUI loads its graphics backends dynamically, so they do not appear in
+    # the development binary's RUNPATH until it is packaged.
+    LD_LIBRARY_PATH = lib.makeLibraryPath [
+      pkgs.libGL
+      pkgs.wayland
+      pkgs.vulkan-loader
+    ];
+    LIBCLANG_PATH = lib.makeLibraryPath [ pkgs.llvmPackages.libclang ];
+  }
+  // lib.optionalAttrs pkgs.stdenv.isDarwin {
     DEVELOPER_DIR = xcodeDeveloperDir;
     SDKROOT = xcodeSdkRoot;
   };
@@ -38,21 +47,22 @@ in
       cmake
       sccache
       prek
-      crowdin-cli
     ]
     # create-dmg is macOS-only (meta.platforms = darwin); an unconditional entry
     # breaks evaluation of the shell on Linux.
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ create-dmg ]
-    # The Linux build links a handful of system libraries the shell must
-    # provide rather than rely on whatever the ambient user environment
-    # happens to expose: fontconfig via pkg-config (GPUI text rendering via
-    # yeslogic-fontconfig-sys), libxcb (x11rb in the hook and GPUI's X11
-    # backend), and libxkbcommon (GPUI keyboard handling).
+    # The Linux build and GUI runtime use these libraries directly; declare
+    # them instead of relying on transitive packages or the host environment.
     ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
       pkg-config
       fontconfig
-      xorg.libxcb
+      freetype
+      libGL
+      nfpm
+      libxcb
       libxkbcommon
+      wayland
+      vulkan-loader
     ];
 
   languages.rust = {
@@ -111,8 +121,8 @@ in
       description = "Upload en.yml sources and per-language translations to Crowdin.";
       exec = ''
         set -e
-        crowdin upload sources
-        crowdin upload translations
+        ${pkgs.crowdin-cli}/bin/crowdin upload sources
+        ${pkgs.crowdin-cli}/bin/crowdin upload translations
       '';
     };
     "openlogi:i18n-download" = {
@@ -120,15 +130,15 @@ in
       exec = ''
         set -e
         ${requireXcodeMetal}
-        python3 scripts/i18n/merge_crowdin_download.py --self-test
+        ${pkgs.python3}/bin/python3 scripts/i18n/merge_crowdin_download.py --self-test
         before="$(mktemp -d)"
+        trap 'rm -rf "$before"' EXIT
         cp crates/openlogi-gui/locales/*.yml "$before/"
-        crowdin download --skip-untranslated-strings
-        python3 scripts/i18n/merge_crowdin_download.py \
+        ${pkgs.crowdin-cli}/bin/crowdin download --skip-untranslated-strings
+        ${pkgs.python3}/bin/python3 scripts/i18n/merge_crowdin_download.py \
           --before "$before" \
           --locales crates/openlogi-gui/locales \
           --en crates/openlogi-gui/locales/en.yml
-        rm -rf "$before"
         cargo test -p openlogi-gui i18n
       '';
     };

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,8 +37,9 @@ and keep working.
 
 ### With devenv (optional)
 
-`devenv.nix` provisions sccache, the stable Rust toolchain, packaging helpers,
-and the macOS env overrides GPUI needs (`DEVELOPER_DIR` / `SDKROOT`). Tasks:
+`devenv.nix` provisions sccache, the stable Rust toolchain, platform libraries,
+nfpm on Linux, and the macOS packaging/env helpers GPUI needs
+(`create-dmg`, `DEVELOPER_DIR`, and `SDKROOT`). Tasks:
 
 ```sh
 devenv tasks run openlogi:gui      # run the desktop app
@@ -58,6 +59,21 @@ Without that, GPUI's `gpui_macos` build script can't find Apple's `metal`
 shader compiler, and link errors about missing `_write` / `_sysconf` /
 `_waitpid` symbols show up because the Nix `apple-sdk-14.4` stub doesn't
 expose `libSystem` the way Apple's real linker wants.
+
+### Nix package
+
+The root Flake exposes native `x86_64-linux` and `aarch64-linux` packages plus
+the NixOS module. It is separate from the devenv shell:
+
+```sh
+nix flake check --all-systems --no-build  # evaluate every output
+nix build .#openlogi                      # build + test this host's package
+nix run .#openlogi -- list                # run the packaged CLI
+```
+
+The package expression and NixOS module live beside the other Linux packaging
+inputs in `packaging/linux/`. `nix fmt` formats all Nix expressions through the
+Flake's pinned formatter.
 
 ### Dev app bundle (macOS)
 
@@ -186,6 +202,10 @@ cargo run -p xtask -- linux package
 
 The package contents (binaries, udev rules, systemd user unit, desktop entry,
 icon) are declared in `packaging/linux/nfpm.yaml`.
+
+The Nix package uses the same shared resources and is declared in
+`packaging/linux/package.nix`; see the Nix package section above for its build
+commands.
 
 ## Release updater publishing
 

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -13,6 +13,49 @@
   distros).
 - `systemd` + `udev` (standard on Ubuntu, Fedora, Arch, Debian, openSUSE, …).
 
+## NixOS
+
+The repository Flake provides a package and a NixOS module for x86_64 and
+aarch64 Linux. Importing the module is preferred over adding the package to
+`environment.systemPackages` by itself: the module also registers the udev
+rules required for device access and manages the agent's user service.
+
+```nix
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.openlogi = {
+    url = "github:AprilNEA/OpenLogi";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, openlogi, ... }: {
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux"; # or aarch64-linux
+      modules = [
+        openlogi.nixosModules.default
+        {
+          programs.openlogi = {
+            enable = true;
+            # Starts openlogi-agent with graphical-session.target by default.
+            launchAtLogin = true;
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+Set `programs.openlogi.launchAtLogin = false` to install the package and udev
+rules without automatically starting the agent. It remains available as
+`systemctl --user start openlogi-agent.service`.
+
+For a build without installing the module:
+
+```sh
+nix build github:AprilNEA/OpenLogi#openlogi
+```
+
 ## Build from source
 
 Pre-built `.deb` and `.rpm` packages are available on the
@@ -23,15 +66,16 @@ from source instead, use the stable Rust toolchain:
 ```sh
 git clone https://github.com/AprilNEA/OpenLogi
 cd OpenLogi
-cargo build --release
+cargo build --release -p openlogi -p openlogi-gui -p openlogi-agent
 ```
 
-The three binaries land in `target/release/`:
+Four production executables land in `target/release/`:
 
 | Binary | Role |
 |---|---|
 | `openlogi` | CLI — inventory, diagnostics, asset sync |
 | `openlogi-gui` | Desktop GUI |
+| `openlogi-overlay` | Actions Ring overlay helper |
 | `openlogi-agent` | Background agent — HID++ loop, input hook |
 
 ## Device access: udev rules

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,8 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  # The dev shell lives in devenv.nix (devenv.yaml); this flake only exposes
-  # the buildable Linux package so `nix build` / `nix run` are first-class.
-  # See nix/package.nix for why this vendoring approach avoids the cargoHash
-  # churn that led to the previous flake's removal (#262).
+  # The dev shell lives in devenv.nix (devenv.yaml). This flake owns the Linux
+  # package, its NixOS integration, checks, and formatter.
   outputs =
     { self, nixpkgs }:
     let
@@ -15,11 +13,76 @@
         "aarch64-linux"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
+      packageFor =
+        system: nixpkgs.legacyPackages.${system}.callPackage ./packaging/linux/package.nix { src = ./.; };
+      moduleCheckFor =
+        system:
+        let
+          lib = nixpkgs.lib;
+          pkgs = nixpkgs.legacyPackages.${system};
+          package = self.packages.${system}.openlogi;
+          evaluate =
+            launchAtLogin:
+            (lib.nixosSystem {
+              inherit system;
+              modules = [
+                self.nixosModules.default
+                {
+                  programs.openlogi = {
+                    enable = true;
+                    inherit launchAtLogin;
+                  };
+                  system.stateVersion = "26.05";
+                }
+              ];
+            }).config;
+          enabled = evaluate true;
+          manual = evaluate false;
+        in
+        assert lib.elem package enabled.environment.systemPackages;
+        assert lib.elem package enabled.services.udev.packages;
+        assert enabled.systemd.user.services.openlogi-agent.wantedBy == [ "graphical-session.target" ];
+        assert manual.systemd.user.services.openlogi-agent.wantedBy == [ ];
+        assert enabled.systemd.user.services.openlogi-agent.after == [ "graphical-session.target" ];
+        assert enabled.systemd.user.services.openlogi-agent.partOf == [ "graphical-session.target" ];
+        assert
+          enabled.systemd.user.services.openlogi-agent.serviceConfig.ExecStart
+          == "${package}/bin/openlogi-agent";
+        pkgs.runCommand "openlogi-nixos-module-check" { } ''
+          touch "$out"
+        '';
     in
     {
-      packages = forAllSystems (system: {
-        openlogi = nixpkgs.legacyPackages.${system}.callPackage ./nix/package.nix { src = self; };
-        default = self.packages.${system}.openlogi;
+      packages = forAllSystems (
+        system:
+        let
+          openlogi = packageFor system;
+        in
+        {
+          inherit openlogi;
+          default = openlogi;
+        }
+      );
+
+      checks = forAllSystems (system: {
+        package = self.packages.${system}.openlogi;
+        nixos-module = moduleCheckFor system;
       });
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
+
+      nixosModules = {
+        openlogi =
+          {
+            lib,
+            pkgs,
+            ...
+          }:
+          {
+            imports = [ ./packaging/linux/nixos-module.nix ];
+            programs.openlogi.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.openlogi;
+          };
+        default = self.nixosModules.openlogi;
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
         assert manual.systemd.user.services.openlogi-agent.wantedBy == [ ];
         assert enabled.systemd.user.services.openlogi-agent.after == [ "graphical-session.target" ];
         assert enabled.systemd.user.services.openlogi-agent.partOf == [ "graphical-session.target" ];
+        assert manual.systemd.user.services.openlogi-agent.partOf == [ ];
         assert
           enabled.systemd.user.services.openlogi-agent.serviceConfig.ExecStart
           == "${package}/bin/openlogi-agent";

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # OpenLogi Linux install script.
 #
-# Installs the three OpenLogi binaries plus udev rules, the systemd user-unit
+# Installs the four OpenLogi executables plus udev rules, the systemd user-unit
 # template, the .desktop launcher, and the app icon. Requires sudo for the
 # system-wide paths.
 #
@@ -45,7 +45,7 @@ The script installs:
   /etc/udev/rules.d/70-openlogi.rules
   /usr/lib/systemd/user/openlogi-agent.service  (if systemd is present)
   /usr/share/applications/openlogi.desktop
-  /usr/share/icons/hicolor/512x512/apps/openlogi.png
+  /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
 EOF
     exit 0
 fi
@@ -62,7 +62,7 @@ BUILD_DIR="${REPO_ROOT}/target/release"
 for bin in openlogi openlogi-gui openlogi-overlay openlogi-agent; do
     if [ ! -x "${BUILD_DIR}/${bin}" ]; then
         echo "Error: ${BUILD_DIR}/${bin} not found." >&2
-        echo "Build first: cargo build --release" >&2
+        echo "Build first: cargo build --release -p openlogi -p openlogi-gui -p openlogi-agent" >&2
         exit 1
     fi
 done
@@ -122,7 +122,7 @@ ICON_SRC="${REPO_ROOT}/design/icon/openlogi.png"
 if [ -f "$ICON_SRC" ]; then
     echo "Installing icon …"
     sudo install -Dm644 "$ICON_SRC" \
-        /usr/share/icons/hicolor/512x512/apps/openlogi.png
+        /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
     if command -v gtk-update-icon-cache > /dev/null 2>&1; then
         sudo gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
     fi

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -61,7 +61,7 @@ contents:
 
   # ── icon ────────────────────────────────────────────────────────────────────
   - src: design/icon/openlogi.png
-    dst: /usr/share/icons/hicolor/512x512/apps/openlogi.png
+    dst: /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
     file_info:
       mode: 0644
 

--- a/packaging/linux/nixos-module.nix
+++ b/packaging/linux/nixos-module.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.openlogi;
+in
+{
+  options.programs.openlogi = {
+    enable = lib.mkEnableOption "OpenLogi, a local-first Logitech device manager";
+
+    package = lib.mkPackageOption pkgs "openlogi" { };
+
+    launchAtLogin = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to start the OpenLogi agent with graphical sessions.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+
+    systemd.user.services.openlogi-agent = {
+      description = "OpenLogi background agent";
+      wantedBy = lib.optionals cfg.launchAtLogin [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe' cfg.package "openlogi-agent";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+  };
+}

--- a/packaging/linux/nixos-module.nix
+++ b/packaging/linux/nixos-module.nix
@@ -29,7 +29,7 @@ in
       description = "OpenLogi background agent";
       wantedBy = lib.optionals cfg.launchAtLogin [ "graphical-session.target" ];
       after = [ "graphical-session.target" ];
-      partOf = [ "graphical-session.target" ];
+      partOf = lib.optionals cfg.launchAtLogin [ "graphical-session.target" ];
 
       serviceConfig = {
         ExecStart = lib.getExe' cfg.package "openlogi-agent";

--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -1,4 +1,4 @@
-# Nix package for OpenLogi on Linux (CLI + agent + GUI).
+# Nix package for OpenLogi on Linux (CLI + agent + GUI/overlay).
 #
 # Build via the flake:
 #   nix build .#openlogi
@@ -20,17 +20,20 @@
 #
 # The only recurring maintenance is: when a git pin (gpui, gpui-component,
 # ...) is bumped, update the corresponding entry below — the failing build
-# prints the correct hash to paste. The nix.yml workflow makes that failure
-# happen in the PR that bumps the pin, not silently on master afterwards.
+# prints the correct hash to paste. Nix CI watches Cargo.lock and the workspace
+# manifests so that failure happens in the PR that moves the pin.
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchgit,
   src,
   pkg-config,
-  makeWrapper,
+  patchelf,
+  versionCheckHook,
   fontconfig,
   freetype,
+  libGL,
   libxkbcommon,
   wayland,
   vulkan-loader,
@@ -38,15 +41,37 @@
 }:
 
 let
-  # Single source of truth for the version: [workspace.package] in the
-  # workspace Cargo.toml (every crate uses version.workspace = true).
-  version = (builtins.fromTOML (builtins.readFile "${src}/Cargo.toml")).workspace.package.version;
+  # Keep documentation, CI metadata, and unrelated release tooling out of the
+  # source derivation so editing them does not rebuild the application.
+  source = lib.fileset.toSource {
+    root = src;
+    fileset = lib.fileset.unions [
+      (src + "/Cargo.lock")
+      (src + "/Cargo.toml")
+      (src + "/LICENSE-APACHE")
+      (src + "/LICENSE-MIT")
+      (src + "/crates")
+      (src + "/design/icon/openlogi.png")
+      (src + "/docs/config.example.toml")
+      (src + "/packaging/linux/desktop")
+      (src + "/packaging/linux/systemd")
+      (src + "/packaging/linux/udev")
+      (src + "/src")
+      (src + "/xtask")
+    ];
+  };
 
-  # GPUI dlopens libwayland-client / libvulkan at runtime instead of linking
-  # them, so they are absent from the binary's RUNPATH. Supply them through a
-  # wrapper; everything else (libxkbcommon, xcb, fontconfig) resolves via
-  # RUNPATH as usual.
+  # Single source of truth for the version: [workspace.package] in the
+  # workspace Cargo.toml (every crate uses version.workspace = true). Read it
+  # through the flake source accessor so package evaluation does not require
+  # materialising the filtered build source first.
+  version = (builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"))).workspace.package.version;
+
+  # GPUI discovers these graphics backends at runtime instead of linking them,
+  # so normal fixup cannot infer their store paths. Add only those paths to the
+  # GUI's RUNPATH; linked xkbcommon/xcb/font libraries are fixed up normally.
   runtimeLibs = lib.makeLibraryPath [
+    libGL
     wayland
     vulkan-loader
   ];
@@ -68,10 +93,14 @@ let
 in
 rustPlatform.buildRustPackage {
   pname = "openlogi";
-  inherit version src;
+  inherit version;
+  src = source;
+  strictDeps = true;
 
   cargoLock = {
-    lockFile = "${src}/Cargo.lock";
+    # Parse dependency metadata through the flake source accessor as above;
+    # only the actual build consumes the filtered source derivation.
+    lockFile = src + "/Cargo.lock";
     # One hash per git repository, keyed by any crate from that repo.
     # Obtain new values from the error message of a failing build, or with
     # `nix-prefetch-git <url> --rev <rev>`.
@@ -99,63 +128,92 @@ rustPlatform.buildRustPackage {
       exit 1
     fi
     ln -sfn "''${assets[0]}" "$cargoDepsCopy/assets"
-
-    # The workspace cargo config is dev-shell tooling: a macOS-scoped linker
-    # and runner (inert on Linux), a default DEVELOPER_DIR, cargo aliases.
-    # Nothing the sandboxed build needs — drop it so the build stays hermetic
-    # rather than tracking whatever dev ergonomics land there next.
-    rm -f .cargo/config.toml
   '';
 
   env.OPENLOGI_THEMES_DIR = "${gpuiComponentSrc}/themes";
 
   nativeBuildInputs = [
     pkg-config
-    makeWrapper
+    patchelf
     rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
   ];
 
-  # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls;
-  # evdev/hidraw are opened directly (pure Rust); vulkan is dlopened, so it
-  # belongs in runtimeLibs above, not here.
+  # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls and
+  # evdev/hidraw are opened directly. Runtime-selected graphics libraries also
+  # appear here when their headers/pkg-config metadata are needed at build time.
   buildInputs = [
     fontconfig # GPUI text rendering (yeslogic-fontconfig-sys)
     freetype # font-kit (freetype-sys)
+    libGL # GPUI's OpenGL fallback
     libxkbcommon # GPUI keyboard handling
     wayland # wayland-sys
+    vulkan-loader # GPUI's primary Linux renderer
     libxcb # xcb / x11rb — the hook and GPUI's X11 backend
   ];
 
-  # The three shipped binaries; xtask (macOS bundling/DMG) is not used on
-  # Linux.
+  # Select production binaries explicitly: selecting the agent package alone
+  # also builds the development-only openlogi-agent-mock target.
   cargoBuildFlags = [
     "--package=openlogi"
+    "--bin=openlogi"
     "--package=openlogi-agent"
+    "--bin=openlogi-agent"
     "--package=openlogi-gui"
+    "--bin=openlogi-gui"
+    "--bin=openlogi-overlay"
   ];
 
-  # Some tests require real Logitech hardware, D-Bus, or uinput — none of
-  # which exist in the sandbox. The Rust CI workflow runs the test suite.
-  doCheck = false;
+  # Match Linux CI: the pure workspace tests run in the sandbox; GUI tests are
+  # exercised on macOS because GPUI's Linux test harness is not headless.
+  cargoTestFlags = [
+    "--workspace"
+    "--exclude=openlogi-gui"
+  ];
 
-  postInstall = ''
+  installPhase = ''
+    runHook preInstall
+
+    releaseDir=target/${stdenv.hostPlatform.rust.rustcTarget}/release
+    for binary in openlogi openlogi-agent openlogi-gui openlogi-overlay; do
+      install -Dm755 "$releaseDir/$binary" "$out/bin/$binary"
+    done
+
     install -Dm644 packaging/linux/desktop/openlogi.desktop \
       "$out/share/applications/openlogi.desktop"
     install -Dm644 design/icon/openlogi.png \
-      "$out/share/icons/hicolor/512x512/apps/openlogi.png"
+      "$out/share/icons/hicolor/1024x1024/apps/openlogi.png"
     install -Dm644 packaging/linux/udev/70-openlogi.rules \
       "$out/lib/udev/rules.d/70-openlogi.rules"
     install -Dm644 packaging/linux/systemd/openlogi-agent.service \
-      "$out/lib/systemd/user/openlogi-agent.service"
+      "$out/share/systemd/user/openlogi-agent.service"
+    install -Dm644 LICENSE-APACHE "$out/share/licenses/openlogi/LICENSE-APACHE"
+    install -Dm644 LICENSE-MIT "$out/share/licenses/openlogi/LICENSE-MIT"
+
+    substituteInPlace "$out/share/systemd/user/openlogi-agent.service" \
+      --replace-fail \
+        "ExecStart=/usr/bin/openlogi-agent" \
+        "ExecStart=$out/bin/openlogi-agent"
+
+    runHook postInstall
   '';
 
   postFixup = ''
-    wrapProgram "$out/bin/openlogi-gui" \
-      --prefix LD_LIBRARY_PATH : "${runtimeLibs}"
+    patchelf --add-rpath "${runtimeLibs}" "$out/bin/openlogi-gui"
+  '';
 
-    # The packaged unit hardcodes /usr/bin; point it at this output.
-    substituteInPlace "$out/lib/systemd/user/openlogi-agent.service" \
-      --replace-fail /usr/bin/openlogi-agent "$out/bin/openlogi-agent"
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  preInstallCheck = ''
+    for binary in openlogi openlogi-agent openlogi-gui openlogi-overlay; do
+      test -x "$out/bin/$binary"
+    done
+    test ! -e "$out/bin/openlogi-agent-mock"
+    test -f "$out/lib/udev/rules.d/70-openlogi.rules"
+    test -f "$out/share/applications/openlogi.desktop"
+    test -f "$out/share/icons/hicolor/1024x1024/apps/openlogi.png"
+    grep -Fqx \
+      "ExecStart=$out/bin/openlogi-agent" \
+      "$out/share/systemd/user/openlogi-agent.service"
   '';
 
   meta = {

--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -107,7 +107,7 @@ rustPlatform.buildRustPackage {
     outputHashes = {
       "gpui-0.2.2" = "sha256-Av+unZNI39dEb+zwSIU+SkEjqagHWrc7W8KehEgQ4H8=";
       "gpui-component-0.5.2" = gpuiComponentHash;
-      "gpui-updater-0.0.6" = "sha256-v8rn8tEkKBi8T2LtBV92uB+XtEeuBwj0qxGcDqEIwIw=";
+      "gpui-updater-0.0.7" = "sha256-hxdATcCif7csqKLNoi41ETe09Ym6zM4rVzYvBDEvVg4=";
       "proptest-1.10.0" = "sha256-p5NTcHhruI8QQvANACg8AMRVNmuvGxs2NLit+/8PaWo=";
       "zed-font-kit-0.14.1-zed" = "sha256-KXygi0olNQi5yM8eaJVykNDtbPMDjT+cWPBF8UrtXR4=";
       "zed-reqwest-0.12.15-zed" = "sha256-p4SiUrOrbTlk/3bBrzN/mq/t+1Gzy2ot4nso6w6S+F8=";

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -61,7 +61,7 @@ sudo rm -f /usr/lib/systemd/user/openlogi-agent.service
 
 echo "Removing desktop entry and icon …"
 sudo rm -f /usr/share/applications/openlogi.desktop
-sudo rm -f /usr/share/icons/hicolor/512x512/apps/openlogi.png
+sudo rm -f /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
 
 if command -v gtk-update-icon-cache > /dev/null 2>&1; then
     sudo gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true


### PR DESCRIPTION
## Summary

Make the Nix package a first-class Linux packaging path, remove the standalone `nix/` directory, and give both the package and developer shell CI coverage.

## Changes

- Move the package expression to `packaging/linux/package.nix` and use a precise `lib.fileset` source, strict dependencies, workspace tests/doctests, version checks, and runtime RUNPATH fixups.
- Install all four production executables while excluding `openlogi-agent-mock`, plus the shared desktop, udev, systemd, icon, and license assets.
- Add `programs.openlogi` as a NixOS module with configurable package and graphical-session startup.
- Advertise and check native `x86_64-linux` and `aarch64-linux` Flake outputs.
- Expand Nix CI with formatting, all-system evaluation, native dual-architecture builds, pinned actions, minimal permissions, timeouts, concurrency, and focused path filters.
- Add a pinned devenv shell workflow and a monthly, PR-based `flake.lock` update workflow using the existing GitHub App credential flow.
- Complete Linux devenv build/runtime dependencies and keep i18n task tools explicit and reproducible.
- Align Linux docs and packaging on the four executables, NixOS usage, and the icon's actual 1024×1024 size.

## Testing

- `nix fmt -- --check flake.nix devenv.nix packaging/linux/package.nix packaging/linux/nixos-module.nix`
- `nix flake check --all-systems --no-build --show-trace -L`
- `nix flake check --show-trace -L` (native x86_64 package and NixOS module build; workspace tests and doctests included)
- `devenv --no-tui shell -- true`
- `devenv --no-tui tasks run openlogi:check`
- `nix run nixpkgs#actionlint -- -color .github/workflows/*.yml`
- `nix run nixpkgs#shellcheck -- packaging/linux/install.sh packaging/linux/uninstall.sh`
- Native aarch64 build delegated to the PR's `ubuntu-24.04-arm` CI job.
- Not runtime-tested on physical Logitech hardware.
