### PR TITLE
chore(gui): bump gpui-updater to v0.0.7 for the OS-trust-store fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,8 +2845,8 @@ dependencies = [
 
 [[package]]
 name = "gpui-updater"
-version = "0.0.6"
-source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.6#e8a85768793ac3238b0c1bc1f32d6a1544667ec3"
+version = "0.0.7"
+source = "git+https://github.com/AprilNEA/gpui-updater?tag=v0.0.7#1196e5ee7832a0f9eb37f17e0be294d4ac214cff"
 dependencies = [
  "gpui",
  "minisign-verify",

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["png"] }
 rust-i18n = "4"
 sys-locale = "0.3.2"
-gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.6", features = ["gpui"] }
+gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.7", features = ["gpui"] }
 # Spawn the agent under its own macOS TCC identity (see ipc_client::spawn_agent).
 # Cross-platform: a no-op pass-through to std::process::Command off macOS.
 disclaim = "0.1"


### PR DESCRIPTION
## What

Bumps `gpui-updater` v0.0.6 → v0.0.7 to pick up AprilNEA/gpui-updater#7: the updater's HTTP agents now validate TLS against the operating system's trust store (`rustls-platform-verifier`) instead of ureq's bundled Mozilla roots.

This is the update-check half of #398 — behind an enterprise TLS-inspection proxy (Zscaler and similar), the proxy's private CA exists only in the OS store, so update checks failed with `invalid peer certificate: UnknownIssuer` even though the browser next door trusted the same connection. The asset-fetch half landed in #634; with both, #398 is fully addressed in the next release.

## Lock hygiene

The lock was re-synced with a plain `cargo fetch` (not `cargo update -p gpui-updater`, which re-resolves the branch-tracking zed tree): the `Cargo.lock` diff is the gpui-updater entry only, and the zed/gpui + gpui-component pins are unmoved. No new packages — the `rustls-platform-verifier` tree already entered the graph via #634, and feature unification covers the updater's use of it.

## Testing

- `cargo check -p openlogi-gui` compiles clean against v0.0.7 (Windows).
- gpui-updater v0.0.7's own suite (33 unit + 3 doc tests, clippy pedantic, rustfmt) passed on the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
