### PR TITLE
fix(infra): stop ignoring the committed Amp orb lifecycle scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,13 @@ devenv.local.yaml
 /local-reference/
 
 # Claude Code skill plumbing — local per-developer, not part of the project.
-/.agents/
+# `/*` instead of the bare directory so the committed Amp orb lifecycle
+# scripts can be re-included below: git cannot un-ignore a file whose parent
+# directory is excluded, and a tracked-but-ignored file makes release-plz
+# treat every checkout as dirty (`git ls-files -ci --exclude-standard`).
+/.agents/*
+!/.agents/resume
+!/.agents/setup
 /skills-lock.json
 
 # Local planning docs — kept on disk, never committed.


### PR DESCRIPTION
## Problem

Every master push of the **Release PR** workflow has failed since `chore(infra): configure Amp orb lifecycle` landed (the last green run was the v0.7.0 release):

```
ERROR failed to update packages
Caused by:
    0: failed to determine next versions
    1: the working directory of this project has uncommitted changes. ...
       [".agents/resume", ".agents/setup"]
```

That commit force-added the two Amp orb lifecycle scripts inside `/.agents/`, which `.gitignore` ignores as per-developer Claude Code skill plumbing. The files are therefore *tracked-but-ignored* (`git ls-files -ci --exclude-standard` reports them), and release-plz hard-fails on that state in every checkout — the failures on the #631/#634/#608/#633 merge pushes were all this, not those changes.

## Fix

Switch the rule from the bare directory to `/.agents/*` and negate the two committed scripts. The bare-directory form couldn't be kept: git cannot re-include a file whose parent directory is excluded, so `!/.agents/resume` under `/.agents/` would be a no-op.

## Verification

- `git ls-files -ci --exclude-standard` → empty (the exact check release-plz runs)
- `.agents/resume` / `.agents/setup` are no longer ignored
- A scratch file dropped into `.agents/` is still ignored, so per-developer state keeps its protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
