### PR TITLE
fix(agent): reapply volatile settings after Windows resume

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -144,8 +144,9 @@ pub struct Orchestrator {
     /// set/route/online state looks identical across the sleep gap, so the
     /// next refresh re-applies volatile settings to every online device.
     reapply_all_next_refresh: bool,
-    /// Config keys of devices first sighted recently, with remaining confirming
-    /// re-apply budget: the first write can race the device's own boot and be lost.
+    /// Config keys of devices first sighted (or wake-flagged) recently, with
+    /// remaining confirming re-apply budget: the first write can race the
+    /// device's own boot or reconnect and be lost.
     reapply_followup: HashMap<String, u8>,
     /// Last successful aggregate camera-use sample. `None` means the macOS
     /// watcher has not produced its first usable observation yet.
@@ -934,18 +935,21 @@ fn any_device_needs_capture_rearm(
     !reapply_targets(prev, next, reapply_all).is_empty()
 }
 
-/// How many inventory ticks a first-sighted device keeps re-applying its
-/// volatile settings after the initial write. A cold restart leaves a Bolt/
-/// Unifying mouse slow to enumerate, so the first write (and a single confirm)
-/// can both time out against a still-booting device; retrying for ~8s at the 2s
-/// cadence lets the write land once it finishes booting.
+/// How many inventory ticks a first-sighted or wake-flagged device keeps
+/// re-applying its volatile settings after the initial write. A cold restart
+/// leaves a Bolt/Unifying mouse slow to enumerate — and a system wake can
+/// enumerate a receiver whose mouse link is still re-establishing — so the
+/// first write (and a single confirm) can both time out against a
+/// still-booting device; retrying for ~8s at the 2s cadence lets the write
+/// land once it finishes booting.
 const VOLATILE_REAPPLY_CONFIRM_RETRIES: u8 = 4;
 
 /// Plan this refresh's volatile-settings writes: the [`reapply_targets`] set
 /// plus a bounded run of confirming re-applies for devices first sighted
-/// recently, and the follow-up keys (with remaining retry counts) to confirm
-/// next refresh. Reconnects (offline→online) re-apply once — the device was
-/// already booted, so it needs no boot-race retry.
+/// recently or targeted by a system wake, and the follow-up keys (with
+/// remaining retry counts) to confirm next refresh. Reconnects
+/// (offline→online) re-apply once — the device was already booted, so it
+/// needs no boot-race retry.
 fn plan_reapply(
     prev: &[AgentDevice],
     next: &[AgentDevice],
@@ -956,8 +960,10 @@ fn plan_reapply(
     let mut next_followup: HashMap<String, u8> = targets
         .iter()
         .filter(|&&idx| {
-            let id = stable_id(&next[idx]);
-            !prev.iter().any(|p| stable_id(p) == id)
+            reapply_all || {
+                let id = stable_id(&next[idx]);
+                !prev.iter().any(|p| stable_id(p) == id)
+            }
         })
         .map(|&idx| {
             (

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -463,6 +463,30 @@ fn plan_reapply_transitions_are_not_queued_for_confirmation() {
 }
 
 #[test]
+fn plan_reapply_wake_targets_get_a_confirm_retry_run() {
+    use std::collections::HashMap;
+    // A system wake re-applies to every online device *and* queues the same
+    // confirm-retry run a first sighting gets: post-wake, a receiver can
+    // enumerate while its mouse link is still re-establishing, so the first
+    // write can time out just like the cold-boot race (#527). Offline devices
+    // stay untargeted and unqueued; they re-apply on their own transition.
+    let prev = [dev("a", 1, true), dev("b", 2, false)];
+    let (targets, followup) = plan_reapply(&prev, &prev, &HashMap::new(), true);
+    assert_eq!(targets, vec![0]);
+    assert_eq!(
+        followup,
+        HashMap::from([("a".to_string(), VOLATILE_REAPPLY_CONFIRM_RETRIES)])
+    );
+    // The run then drains at the usual cadence on steady ticks.
+    let (targets, followup) = plan_reapply(&prev, &prev, &followup, false);
+    assert_eq!(targets, vec![0]);
+    assert_eq!(
+        followup,
+        HashMap::from([("a".to_string(), VOLATILE_REAPPLY_CONFIRM_RETRIES - 1)])
+    );
+}
+
+#[test]
 fn plan_reapply_skips_a_followup_that_went_offline() {
     use std::collections::HashMap;
     let prev = [dev("a", 1, true)];

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -53,13 +53,15 @@ plist = "1.10.0"
 
 # Autostart via the HKCU Run key (launch_agent.rs); winreg also answers the
 # taskbar light/dark theme read for the tray glyph (tray_windows.rs). The
-# notification-area icon itself is raw win32 via the workspace windows-sys.
+# notification-area icon and the suspend/resume listener (resume_windows.rs)
+# are raw win32 via the workspace windows-sys.
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",
+    "Win32_System_Power",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -18,6 +18,8 @@
 mod launch_agent;
 mod overlay;
 mod pairing;
+#[cfg(target_os = "windows")]
+mod resume_windows;
 mod self_restart;
 mod server;
 #[cfg(target_os = "macos")]
@@ -121,7 +123,16 @@ fn main() {
         // Windows hosts the notification-area icon on its own win32 thread
         // (message pump included); the async core keeps the main thread.
         #[cfg(target_os = "windows")]
-        tray_windows::spawn(config.app_settings.show_in_menu_bar);
+        {
+            tray_windows::spawn(config.app_settings.show_in_menu_bar);
+            // Native resume notifications feed the same seam the macOS
+            // workspace observer does: the core replays volatile settings
+            // when the flag is set.
+            let resume_pending = Arc::new(AtomicBool::new(false));
+            resume_windows::register(Arc::clone(&resume_pending));
+            runtime.block_on(run(config, resume_pending));
+        }
+        #[cfg(not(target_os = "windows"))]
         runtime.block_on(run(config));
     }
 }
@@ -214,7 +225,10 @@ fn prompt_missing_permissions(capture_mouse_events: bool) {
     }
 }
 
-async fn run(config: Config, #[cfg(target_os = "macos")] resume_pending: Arc<AtomicBool>) {
+async fn run(
+    config: Config,
+    #[cfg(any(target_os = "macos", target_os = "windows"))] resume_pending: Arc<AtomicBool>,
+) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
     // LaunchAgent, before `config` moves into the orchestrator.
     launch_agent::reconcile(config.app_settings.launch_at_login);
@@ -285,12 +299,13 @@ async fn run(config: Config, #[cfg(target_os = "macos")] resume_pending: Arc<Ato
                 Some(watchers::inventory::InventoryEvent::Snapshot { inventories, standalone }) => {
                     let mut orchestrator = orchestrator.lock().await;
                     // The portable watcher catches long sleeps from a polling
-                    // gap. Native macOS notifications also cover short sleeps,
-                    // display wakes, and returning user sessions; consume the
-                    // coalesced signal at the exact point that can replay it.
-                    #[cfg(target_os = "macos")]
+                    // gap. Native notifications (macOS workspace wakes,
+                    // Windows suspend/resume) also cover the sleeps that gap
+                    // misses; consume the coalesced signal at the exact point
+                    // that can replay it.
+                    #[cfg(any(target_os = "macos", target_os = "windows"))]
                     if resume_pending.swap(false, Ordering::Relaxed) {
-                        info!("macOS resume notification — replaying volatile settings");
+                        info!("native resume notification — replaying volatile settings");
                         orchestrator.reapply_volatile_on_next_refresh();
                     }
                     orchestrator.refresh_inventory(&inventories, &standalone);

--- a/crates/openlogi-agent/src/resume_windows.rs
+++ b/crates/openlogi-agent/src/resume_windows.rs
@@ -38,19 +38,18 @@ pub fn register(pending: Arc<AtomicBool>) {
     // Leaked on purpose: the subscription is never unregistered, so the
     // callback may read the flag until process exit.
     let context = Arc::into_raw(pending);
-    let params = DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
+    // Also leaked: with `DEVICE_NOTIFY_CALLBACK` the recipient *is* this
+    // parameter block, and the subscription may hold the pointer for its
+    // whole lifetime — a stack-local here would dangle once this returns.
+    let params = Box::into_raw(Box::new(DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
         Callback: Some(on_power_event),
         Context: context.cast_mut().cast::<c_void>(),
-    };
-    // SAFETY: with `DEVICE_NOTIFY_CALLBACK` the recipient is a pointer to
-    // `params`, which only needs to outlive the call (the system copies the
-    // registration); the callback matches `PDEVICE_NOTIFY_CALLBACK_ROUTINE`
-    // and its context stays valid forever via the leaked Arc.
+    }));
+    // SAFETY: `params` and the Arc behind its context are both leaked for the
+    // process lifetime, matching the never-unregistered subscription, and the
+    // callback matches `PDEVICE_NOTIFY_CALLBACK_ROUTINE`.
     let handle = unsafe {
-        RegisterSuspendResumeNotification(
-            (&raw const params).cast_mut().cast::<c_void>(),
-            DEVICE_NOTIFY_CALLBACK,
-        )
+        RegisterSuspendResumeNotification(params.cast::<c_void>(), DEVICE_NOTIFY_CALLBACK)
     };
     if handle == 0 {
         warn!("suspend/resume registration failed — only the polling-gap heuristic detects wakes");

--- a/crates/openlogi-agent/src/resume_windows.rs
+++ b/crates/openlogi-agent/src/resume_windows.rs
@@ -1,0 +1,104 @@
+//! Native Windows suspend/resume notifications for the agent core.
+//!
+//! Mirrors the macOS workspace-wake observer in [`crate::tray`]: volatile
+//! HID++ settings (DPI, SmartShift, wheel mode, lighting) live in device RAM
+//! and clear when devices power-cycle across a system sleep, but the first
+//! post-wake inventory snapshot can look identical to the last pre-sleep one,
+//! so no per-device transition re-applies them (#393, #527). The inventory
+//! watcher's wall-clock-gap heuristic only catches sleeps longer than a
+//! minute; the native notification covers the rest.
+//!
+//! `RegisterSuspendResumeNotification` with `DEVICE_NOTIFY_CALLBACK` rather
+//! than a `WM_POWERBROADCAST` window: it needs no message pump, and it fires
+//! regardless of the tray preference — the tray window only exists when
+//! `show_in_menu_bar` is on.
+
+#![expect(
+    unsafe_code,
+    reason = "raw win32: RegisterSuspendResumeNotification + its callback — localized here"
+)]
+
+use std::ffi::c_void;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tracing::{info, warn};
+use windows_sys::Win32::System::Power::{
+    DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS, RegisterSuspendResumeNotification,
+};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    DEVICE_NOTIFY_CALLBACK, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND,
+};
+
+/// Register for suspend/resume notifications for the process lifetime; the
+/// system invokes [`on_power_event`] and each resume sets `pending`. Failure
+/// is logged, never fatal — the polling-gap heuristic still covers long
+/// sleeps.
+pub fn register(pending: Arc<AtomicBool>) {
+    // Leaked on purpose: the subscription is never unregistered, so the
+    // callback may read the flag until process exit.
+    let context = Arc::into_raw(pending);
+    let params = DEVICE_NOTIFY_SUBSCRIBE_PARAMETERS {
+        Callback: Some(on_power_event),
+        Context: context.cast_mut().cast::<c_void>(),
+    };
+    // SAFETY: with `DEVICE_NOTIFY_CALLBACK` the recipient is a pointer to
+    // `params`, which only needs to outlive the call (the system copies the
+    // registration); the callback matches `PDEVICE_NOTIFY_CALLBACK_ROUTINE`
+    // and its context stays valid forever via the leaked Arc.
+    let handle = unsafe {
+        RegisterSuspendResumeNotification(
+            (&raw const params).cast_mut().cast::<c_void>(),
+            DEVICE_NOTIFY_CALLBACK,
+        )
+    };
+    if handle == 0 {
+        warn!("suspend/resume registration failed — only the polling-gap heuristic detects wakes");
+    } else {
+        info!("suspend/resume notifications registered");
+    }
+}
+
+/// Whether a `PBT_*` power event means the system just resumed.
+/// `PBT_APMRESUMEAUTOMATIC` fires on every wake, `PBT_APMRESUMESUSPEND`
+/// additionally once user input confirms it — both can arrive for one wake,
+/// and the flag coalesces them.
+fn is_resume_event(event: u32) -> bool {
+    matches!(event, PBT_APMRESUMEAUTOMATIC | PBT_APMRESUMESUSPEND)
+}
+
+/// Invoked by the system on an arbitrary thread; only touches the atomic.
+unsafe extern "system" fn on_power_event(
+    context: *const c_void,
+    event: u32,
+    _setting: *const c_void,
+) -> u32 {
+    if is_resume_event(event) {
+        // SAFETY: `context` is the `Arc<AtomicBool>` this module leaked at
+        // registration, alive for the process lifetime.
+        let pending = unsafe { &*context.cast::<AtomicBool>() };
+        pending.store(true, Ordering::Relaxed);
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows_sys::Win32::UI::WindowsAndMessaging::PBT_APMSUSPEND;
+
+    #[test]
+    fn resume_events_set_the_flag_and_a_suspend_does_not() {
+        let pending = AtomicBool::new(false);
+        let context = (&raw const pending).cast::<c_void>();
+        for event in [PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND] {
+            // SAFETY: `context` points at the flag above, live for the whole
+            // test; the callback runs synchronously here.
+            unsafe { on_power_event(context, event, std::ptr::null()) };
+            assert!(pending.swap(false, Ordering::Relaxed), "event {event}");
+        }
+        // SAFETY: same live context; a suspend must not request a re-apply.
+        unsafe { on_power_event(context, PBT_APMSUSPEND, std::ptr::null()) };
+        assert!(!pending.load(Ordering::Relaxed));
+    }
+}


### PR DESCRIPTION
## Summary

**Symptom:** DPI / SmartShift / wheel-mode / lighting settings are lost after Windows sleep or hibernation (#527, and the wake-from-sleep reports in #393). These settings live in the device's volatile RAM and clear when it power-cycles during the sleep.

**Root cause:** the agent only re-applies volatile settings on an observable per-device transition (first sighting, replug, offline→online) or on a detected system wake — but on Windows the only wake detector was the inventory watcher's wall-clock-gap heuristic, which needs a >1-minute gap. Most sleep/hibernate wakes come back with a first post-wake snapshot identical to the pre-sleep one (same set, same routes, already online), so nothing fired. macOS got a native resume hook in #506; Windows had no equivalent.

**Approach:** mirror #506's seam exactly. A native listener sets a shared `Arc<AtomicBool>`; the core consumes the coalesced flag right before `refresh_inventory` and calls `reapply_volatile_on_next_refresh()` — same wiring, same replay point, one new platform module. The listener uses `RegisterSuspendResumeNotification` with `DEVICE_NOTIFY_CALLBACK` (`PBT_APMRESUMEAUTOMATIC` / `PBT_APMRESUMESUSPEND`) rather than a `WM_POWERBROADCAST` window: no message pump, and it works regardless of the tray preference — the agent's only Windows window (`tray_windows.rs`) doesn't exist when `show_in_menu_bar` is off.

Additionally, wake-flagged reapply targets now get the same bounded confirm-retry run (~8s at the 2s cadence, from #449) that first-sighted devices get, instead of a one-shot write: post-wake, a receiver can enumerate while its paired mouse's link is still re-establishing, so the first write can time out exactly like the cold-boot race. This also hardens the macOS and polling-gap wake paths.

## Changes

- `crates/openlogi-agent`
  - new `src/resume_windows.rs`: process-lifetime `RegisterSuspendResumeNotification(DEVICE_NOTIFY_CALLBACK)` registration; the callback coalesces resume events into the shared flag. Registration failure is logged, never fatal (the polling-gap heuristic remains as fallback).
  - `src/main.rs`: create/register the flag on Windows, widen the existing macOS-only consume site to `any(macos, windows)`.
  - `Cargo.toml`: add the `Win32_System_Power` feature to the existing workspace `windows-sys` dependency (no new crates; `Cargo.lock` untouched, gpui pins unmoved).
- `crates/openlogi-agent-core`
  - `src/orchestrator.rs`: `plan_reapply` seeds the `VOLATILE_REAPPLY_CONFIRM_RETRIES` follow-up run for wake (`reapply_all`) targets, not just first sightings.
  - `src/orchestrator/tests.rs`: new test covering the wake retry run (targets online devices only, queues and drains the budget).

## Testing

All run on real Windows 11 (native compile):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (the exact `clippy-windows` CI job)
- `cargo test --workspace` — all green, including the two new tests (`resume_windows::tests::resume_events_set_the_flag_and_a_suspend_does_not`, `orchestrator::tests::plan_reapply_wake_targets_get_a_confirm_retry_run`)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid …` — fails on a pre-existing `AsyncHidChannel::supports_short_long_hidpp` intra-doc link in `openlogi-hid/src/transport.rs` when run **on Windows** (cfg-gated scope); that crate is untouched by this diff and the CI rustdoc job runs on ubuntu, where it passes.

**Not runtime-tested on hardware.** Manual validation for a maintainer with a Windows machine and an MX Master 3S (or similar): set a non-default DPI, sleep or hibernate the machine, wake it, and confirm the agent logs `native resume notification — replaying volatile settings` followed by the re-apply, and that the pointer speed/DPI is back to the configured value within a few seconds of wake (previously it stayed at the firmware default until a replug or agent restart).

Fixes #527
Also addresses the wake-from-sleep reports in #393 (the cold-boot half was fixed by #449).

