### PR TITLE
fix(core): apply application selectors to Actions Ring layouts

### DIFF
--- a/crates/openlogi-core/src/app_selector.rs
+++ b/crates/openlogi-core/src/app_selector.rs
@@ -1,0 +1,114 @@
+//! Resolving a foreground-application identifier against per-app config keys.
+//!
+//! Per-app overlays are keyed by whatever the platform reports as the frontmost
+//! application: a bundle identifier on macOS, a `WM_CLASS` or xdg app id on
+//! Linux, and a lower-cased executable path on Windows. A Windows path is not
+//! stable — Store and self-updating applications live under a versioned
+//! directory that changes from under the config — so `exe:<filename>.exe` is
+//! accepted as a fallback selector for the same overlay maps.
+//!
+//! Every map keyed by that identifier resolves through [`overlay_for`], so a
+//! selector means the same thing wherever it is written: button overlays and
+//! Actions Ring layouts cannot disagree about which application is in front.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Resolve the most specific overlay for a foreground identifier.
+///
+/// An exact key always wins, so a per-path overlay still beats the
+/// executable-name fallback when a config carries both.
+pub(crate) fn overlay_for<'a, T>(overlays: &'a BTreeMap<String, T>, app: &str) -> Option<&'a T> {
+    if let Some(exact) = overlays.get(app) {
+        return Some(exact);
+    }
+
+    overlays.get(&executable_selector(app)?)
+}
+
+/// The `exe:<filename>` selector a Windows-style identifier falls back to, or
+/// `None` for an identifier that does not name an executable — macOS bundle ids
+/// and Linux application classes must never acquire one by accident.
+fn executable_selector(app: &str) -> Option<String> {
+    // `rsplit` always yields, so this is the trailing path component, or the
+    // whole identifier when it carries no separator. Both separators are
+    // recognized so a Windows config stays inspectable on any platform.
+    let executable_name = app.rsplit(['\\', '/']).next().unwrap_or(app);
+    if executable_name.is_empty()
+        || !Path::new(executable_name)
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("exe"))
+    {
+        return None;
+    }
+    Some(format!("exe:{}", executable_name.to_ascii_lowercase()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn overlays(keys: &[&str]) -> BTreeMap<String, &'static str> {
+        keys.iter()
+            .map(|key| ((*key).to_string(), "overlay"))
+            .collect()
+    }
+
+    #[test]
+    fn exact_key_wins_over_the_executable_fallback() {
+        let mut map = BTreeMap::new();
+        map.insert(
+            r"c:\program files\windowsapps\sharex_16.0_x64\sharex.exe".to_string(),
+            "exact",
+        );
+        map.insert("exe:sharex.exe".to_string(), "fallback");
+        assert_eq!(
+            overlay_for(
+                &map,
+                r"c:\program files\windowsapps\sharex_16.0_x64\sharex.exe"
+            ),
+            Some(&"exact")
+        );
+    }
+
+    #[test]
+    fn a_versioned_path_falls_back_to_the_executable_name() {
+        let map = overlays(&["exe:sharex.exe"]);
+        // The install directory carries the version, so only the basename is
+        // stable across updates.
+        for path in [
+            r"c:\program files\windowsapps\sharex_16.0_x64\sharex.exe",
+            r"c:\program files\windowsapps\sharex_17.1_x64\sharex.exe",
+            "/c/program files/sharex/sharex.exe",
+            "sharex.exe",
+        ] {
+            assert_eq!(overlay_for(&map, path), Some(&"overlay"), "{path}");
+        }
+    }
+
+    #[test]
+    fn identifiers_that_name_no_executable_never_fall_back() {
+        let map = overlays(&["exe:code.exe", "exe:.exe"]);
+        // macOS bundle ids and Linux classes must not be reinterpreted as paths,
+        // and a path with no executable name has nothing stable to match on.
+        for app in [
+            "com.microsoft.VSCode",
+            "Firefox",
+            "org.mozilla.firefox",
+            r"c:\program files\microsoft vs code\code.exe.bak",
+            r"c:\program files\microsoft vs code\",
+            "",
+        ] {
+            assert_eq!(overlay_for(&map, app), None, "{app}");
+        }
+    }
+
+    #[test]
+    fn a_bundle_id_ending_in_exe_still_resolves_by_its_own_key() {
+        // Contrived, but it must not be swallowed by the fallback: the exact
+        // key is what the platform reported.
+        let mut map = BTreeMap::new();
+        map.insert("com.example.exe".to_string(), "exact");
+        assert_eq!(overlay_for(&map, "com.example.exe"), Some(&"exact"));
+    }
+}

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use thiserror::Error;
 
 use super::Action;
+use crate::app_selector::overlay_for;
 
 mod icon;
 
@@ -301,10 +302,14 @@ impl ActionRingConfig {
     }
 
     /// Resolve the complete layout for the foreground application.
+    ///
+    /// Keys are matched the same way as every other per-app overlay (see
+    /// [`crate::app_selector`]), so a Windows `exe:<filename>.exe` selector
+    /// covers the ring as well as the button bindings.
     #[must_use]
     pub fn effective_layout(&self, app_id: Option<&str>) -> ActionRingLayout {
         app_id
-            .and_then(|app| self.per_app.get(app))
+            .and_then(|app| overlay_for(&self.per_app, app))
             .cloned()
             .unwrap_or_else(|| self.default.clone())
     }
@@ -470,5 +475,52 @@ Bottom = { action = { CustomShortcut = "Cmd+Shift+P" } }
 
         assert_eq!(config.effective_layout(Some("com.apple.Safari")), safari);
         assert_eq!(config.effective_layout(Some("other")), config.default);
+    }
+
+    fn single_slot_layout(action: Action) -> ActionRingLayout {
+        ActionRingLayout {
+            slots: BTreeMap::from([(
+                ActionRingSlot::Top,
+                ActionRingEntry::new(
+                    RingAction::new(action).unwrap_or_else(|error| panic!("{error}")),
+                ),
+            )]),
+        }
+    }
+
+    #[test]
+    fn a_windows_executable_selector_covers_the_ring() {
+        let mut config = ActionRingConfig::default();
+        let sharex = single_slot_layout(Action::Copy);
+        config
+            .per_app
+            .insert("exe:sharex.exe".to_string(), sharex.clone());
+
+        // The install directory carries the version, so the layout has to
+        // survive an update that moves the executable.
+        assert_eq!(
+            config.effective_layout(Some(
+                r"c:\program files\windowsapps\sharex_17.1_x64\sharex.exe"
+            )),
+            sharex
+        );
+        assert_eq!(
+            config.effective_layout(Some(r"c:\program files\microsoft vs code\code.exe")),
+            config.default
+        );
+    }
+
+    #[test]
+    fn an_exact_ring_path_outranks_the_executable_selector() {
+        let mut config = ActionRingConfig::default();
+        let exact = single_slot_layout(Action::Copy);
+        let fallback = single_slot_layout(Action::Paste);
+        let path = r"c:\program files\windowsapps\sharex_17.1_x64\sharex.exe";
+        config.per_app.insert(path.to_string(), exact.clone());
+        config
+            .per_app
+            .insert("exe:sharex.exe".to_string(), fallback);
+
+        assert_eq!(config.effective_layout(Some(path)), exact);
     }
 }

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -6,7 +6,7 @@
 //! as `"receiver:abc123:slot:2"`. Schema migrations branch on
 //! [`Config::schema_version`].
 
-use std::{collections::BTreeMap, path::Path};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -31,6 +31,7 @@ pub use settings::{
     WheelMode, clamp_thumbwheel_sensitivity,
 };
 
+use crate::app_selector::overlay_for;
 use crate::binding::{
     Action, ActionRingConfig, ActionRingIcon, ActionRingSlot, Binding, ButtonId, GestureDirection,
     RingAction, default_binding, default_binding_for, default_gesture_binding,
@@ -409,7 +410,7 @@ impl Config {
         };
         let mut out = device.bindings.clone();
         if let Some(bid) = bundle_id
-            && let Some(overlay) = app_overlay(&device.per_app_bindings, bid)
+            && let Some(overlay) = overlay_for(&device.per_app_bindings, bid)
         {
             for (k, v) in overlay {
                 out.insert(*k, Binding::Single(v.clone()));
@@ -564,7 +565,7 @@ impl Config {
     #[must_use]
     pub fn has_app_override(&self, device_key: &str, app: &str) -> bool {
         self.devices.get(device_key).is_some_and(|d| {
-            app_overlay(&d.per_app_bindings, app).is_some_and(|overlay| !overlay.is_empty())
+            overlay_for(&d.per_app_bindings, app).is_some_and(|overlay| !overlay.is_empty())
         })
     }
 
@@ -779,27 +780,4 @@ impl Config {
             .or_default()
             .thumbwheel_sensitivity = sensitivity.map(clamp_thumbwheel_sensitivity);
     }
-}
-
-/// Resolve the most specific application overlay for a foreground identifier.
-///
-/// Exact keys retain precedence. On Windows the foreground identifier is a
-/// lower-cased executable path, so `exe:<filename>` provides a stable fallback
-/// for Store and self-updating applications whose install directory changes
-/// between versions. Recognizing both path separators keeps hand-authored
-/// Windows config inspectable on every platform without changing macOS bundle
-/// identifiers or Linux application classes.
-fn app_overlay<'a, T>(overlays: &'a BTreeMap<String, T>, app: &str) -> Option<&'a T> {
-    overlays.get(app).or_else(|| {
-        let executable_name = app.rsplit(['\\', '/']).next()?;
-        if executable_name.is_empty()
-            || !Path::new(executable_name)
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"))
-        {
-            return None;
-        }
-
-        overlays.get(&format!("exe:{}", executable_name.to_ascii_lowercase()))
-    })
 }

--- a/crates/openlogi-core/src/lib.rs
+++ b/crates/openlogi-core/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_docs)]
 
 pub mod action_ring;
+mod app_selector;
 pub mod binding;
 pub mod bindings;
 pub mod brand;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,7 +56,8 @@ Common device fields are:
 - `per_app_bindings`: sparse action overlays keyed by macOS bundle id, Linux
   application id, exact lower-cased Windows executable path, or
   `exe:<filename>.exe`
-- `action_ring`: default and complete per-application eight-slot layouts
+- `action_ring`: default and complete per-application eight-slot layouts;
+  `action_ring.per_app` takes the same selectors as `per_app_bindings`
 - `lighting`, `smartshift`, standalone `light`, and camera controls / profiles
 - `host_switch_targets` and `fn_lock` for compatible keyboards
 - `identity` and `disabled_gestures`, which are application-managed metadata


### PR DESCRIPTION
## Summary

#572 taught `per_app_bindings` to fall back to `exe:<filename>.exe` when the
foreground identifier is a Windows path, but `action_ring.per_app` kept looking
that identifier up verbatim. Both maps are keyed by the same identifier, so on
Windows a Store or self-updating application could keep its button overlay
across an update while silently losing its ring layout — the versioned path the
ring was keyed by no longer exists.

The resolution moves into a shared `app_selector` module that both maps use, so
a selector cannot mean one thing for buttons and another for the ring. Behavior
for macOS bundle ids and Linux application classes is unchanged: an identifier
that names no `.exe` never acquires a fallback, and an exact key still wins over
the fallback.

## Changes

**`openlogi-core`**

- Add `app_selector`, a private module owning foreground-identifier resolution:
  `overlay_for` (exact key, then `exe:<filename>` fallback) and the
  `executable_selector` derivation, with tests for the fallback, the exact-key
  precedence, and the identifiers that must never acquire one.
- `ActionRingConfig::effective_layout` resolves through `overlay_for` instead of
  `per_app.get(app)`, with tests covering a versioned Windows path matching an
  `exe:` layout and an exact path outranking it.
- `Config::effective_bindings` and `Config::has_app_override` call the shared
  helper; `config.rs` loses its local `app_overlay` copy.

**Docs**

- `docs/CONFIGURATION.md`: state that `action_ring.per_app` takes the same
  application selectors as `per_app_bindings`.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
  -p openlogi-hidpp-derive --no-deps --document-private-items
```

All green. `openlogi-core` runs 196 tests, including the four new
`app_selector` cases and the two new `action_ring` cases.

Not runtime-tested on hardware, and not tested on Windows: the change is pure
configuration-resolution logic in `openlogi-core` with no platform-gated code.
It reproduces from a hand-written `config.toml` — give a device an
`action_ring.per_app."exe:sharex.exe"` layout and confirm it applies while
ShareX is frontmost.
