### PR TITLE
fix: bind the Actions Ring overlay to one agent run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5102,6 +5102,7 @@ dependencies = [
  "openlogi-hook",
  "openlogi-ipc",
  "plist",
+ "succession",
  "sysinfo 0.38.4",
  "tarpc",
  "tokio",
@@ -5221,6 +5222,7 @@ dependencies = [
  "rust-i18n",
  "serde",
  "serde_json",
+ "succession",
  "sys-locale",
  "tarpc",
  "tempfile",
@@ -5340,6 +5342,7 @@ dependencies = [
  "interprocess",
  "openlogi-core",
  "serde",
+ "succession",
  "tarpc",
  "tokio",
 ]
@@ -6609,7 +6612,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7259,6 +7262,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "succession"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df31a32bd0059852bec1a32bebadaa29ea6688c07795f56c7d030fc73d76da7"
+dependencies = [
+ "serde",
+ "sysinfo 0.38.4",
+]
 
 [[package]]
 name = "sum_tree"

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 opener = { workspace = true }
+succession = { version = "0.1", features = ["supervision", "eviction"] }
 
 # Windows exe resources (app icon + VERSIONINFO) — see build.rs. The exact
 # version already in Cargo.lock as gpui's own build-dependency, so the resolve

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -52,9 +52,10 @@ use openlogi_hid::{
 use openlogi_ipc::transport;
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus,
-    ConfigReloadError, FoundDevice, InventoryHealth, MonitorEvent, PROTOCOL_VERSION,
+    ConfigReloadError, FoundDevice, Identity, InventoryHealth, MonitorEvent, PROTOCOL_VERSION,
     PairingCommandError, PairingFailure, PairingUpdate,
 };
+use succession::Compat;
 use tarpc::context::Context;
 use tarpc::server::{BaseChannel, Channel as _};
 use tokio::sync::Mutex;
@@ -632,6 +633,10 @@ impl MockAgent {
 impl Agent for MockAgent {
     async fn protocol_version(self, _: Context) -> u32 {
         PROTOCOL_VERSION
+    }
+
+    async fn identity(self, _: Context) -> Identity {
+        Identity::mine(Compat::from(PROTOCOL_VERSION))
     }
 
     async fn status(self, _: Context) -> AgentStatus {

--- a/crates/openlogi-agent/src/overlay.rs
+++ b/crates/openlogi-agent/src/overlay.rs
@@ -2,14 +2,50 @@
 //!
 //! The helper owns no device state and exits harmlessly when its binary is not
 //! packaged. Keeping it warm removes process-start latency from panel presses.
+//!
+//! Exactly one overlay may exist, enforced by the `overlay.lock` single-instance
+//! guard the helper takes at startup. This supervisor therefore waits for that
+//! role to be free instead of launching into it: an agent restart can leave the
+//! previous agent's overlay running for a few seconds, and starting copies that
+//! immediately die on the lock is pure churn — on Windows each doomed launch
+//! flashes the global busy cursor (#621). The orphan yields on its own once it
+//! sees this agent's instance token, which is what frees the lock.
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tracing::{info, warn};
 
+/// Lock file the overlay holds for its whole life.
+const OVERLAY_LOCK: &str = "overlay.lock";
+
+/// How often to re-probe an occupied overlay role.
+const LOCK_POLL: Duration = Duration::from_millis(500);
+
+/// Restart delay after an overlay that had actually been running exits.
 const RESTART_DELAY: Duration = Duration::from_secs(2);
+
+/// Ceiling for the backoff applied to an overlay that keeps dying at startup.
+const MAX_RESTART_DELAY: Duration = Duration::from_mins(1);
+
+/// How long a run has to last to count as "it worked, then it stopped" rather
+/// than "it cannot start", which is what resets the backoff.
+const HEALTHY_RUN: Duration = Duration::from_secs(30);
+
+/// The delay before the next start attempt, given the previous delay and how
+/// long the run that just ended lasted.
+///
+/// A helper that cannot start at all (a broken binary, a missing display) would
+/// otherwise be relaunched twice a second forever; backing off keeps that
+/// failure quiet without giving up on it.
+fn next_delay(previous: Duration, ran_for: Duration) -> Duration {
+    if ran_for >= HEALTHY_RUN {
+        RESTART_DELAY
+    } else {
+        (previous * 2).min(MAX_RESTART_DELAY)
+    }
+}
 
 /// Start the overlay supervisor on a dedicated thread.
 pub fn spawn() {
@@ -19,18 +55,28 @@ pub fn spawn() {
     };
     let result = std::thread::Builder::new()
         .name("openlogi-overlay-supervisor".into())
-        .spawn(move || loop {
-            match Command::new(&binary).spawn() {
-                Ok(mut child) => {
-                    info!(path = %binary.display(), "Actions Ring overlay started");
-                    match child.wait() {
-                        Ok(status) => warn!(?status, "Actions Ring overlay exited; restarting"),
-                        Err(error) => warn!(%error, "could not wait for Actions Ring overlay"),
+        .spawn(move || {
+            let mut delay = RESTART_DELAY;
+            loop {
+                while openlogi_core::single_instance::is_held(OVERLAY_LOCK) {
+                    std::thread::sleep(LOCK_POLL);
+                }
+                let started = Instant::now();
+                match Command::new(&binary).spawn() {
+                    Ok(mut child) => {
+                        info!(path = %binary.display(), "Actions Ring overlay started");
+                        match child.wait() {
+                            Ok(status) => info!(?status, "Actions Ring overlay exited"),
+                            Err(error) => warn!(%error, "could not wait for Actions Ring overlay"),
+                        }
+                    }
+                    Err(error) => {
+                        warn!(%error, path = %binary.display(), "could not start Actions Ring overlay");
                     }
                 }
-                Err(error) => warn!(%error, path = %binary.display(), "could not start Actions Ring overlay"),
+                delay = next_delay(delay, started.elapsed());
+                std::thread::sleep(delay);
             }
-            std::thread::sleep(RESTART_DELAY);
         });
     if let Err(error) = result {
         warn!(%error, "could not start Actions Ring overlay supervisor");
@@ -75,6 +121,24 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn a_helper_that_dies_at_startup_is_retried_ever_more_slowly() {
+        let instant = Duration::from_millis(20);
+        let first = next_delay(RESTART_DELAY, instant);
+        assert_eq!(first, RESTART_DELAY * 2);
+        // The ceiling holds however long the failure persists.
+        let mut delay = first;
+        for _ in 0..10 {
+            delay = next_delay(delay, instant);
+        }
+        assert_eq!(delay, MAX_RESTART_DELAY);
+    }
+
+    #[test]
+    fn a_run_that_lasted_resets_the_backoff() {
+        assert_eq!(next_delay(MAX_RESTART_DELAY, HEALTHY_RUN), RESTART_DELAY);
+    }
 
     #[test]
     fn path_search_returns_none_for_an_impossible_name() {

--- a/crates/openlogi-agent/src/overlay.rs
+++ b/crates/openlogi-agent/src/overlay.rs
@@ -3,49 +3,22 @@
 //! The helper owns no device state and exits harmlessly when its binary is not
 //! packaged. Keeping it warm removes process-start latency from panel presses.
 //!
-//! Exactly one overlay may exist, enforced by the `overlay.lock` single-instance
-//! guard the helper takes at startup. This supervisor therefore waits for that
-//! role to be free instead of launching into it: an agent restart can leave the
-//! previous agent's overlay running for a few seconds, and starting copies that
-//! immediately die on the lock is pure churn — on Windows each doomed launch
-//! flashes the global busy cursor (#621). The orphan yields on its own once it
-//! sees this agent's instance token, which is what frees the lock.
+//! Exactly one overlay may exist, and it belongs to one agent run. Both halves
+//! are enforced by the `succession` crate: this supervisor waits while the role
+//! is filled by its own child, and evicts a tenant left behind by a previous
+//! agent — which is what stops an orphaned overlay from wedging its
+//! replacement out of the lock forever (#621, #644). The run token travels to
+//! the child in the environment, so a helper started by a previous agent is
+//! recognizable on sight rather than after a timeout.
 
 use std::path::PathBuf;
 use std::process::Command;
-use std::time::{Duration, Instant};
 
+use openlogi_ipc::RUN_ENV;
+use succession::eviction::{self, Policy};
+use succession::supervision::{Event, Supervisor};
+use succession::{Role, Run};
 use tracing::{info, warn};
-
-/// Lock file the overlay holds for its whole life.
-const OVERLAY_LOCK: &str = "overlay.lock";
-
-/// How often to re-probe an occupied overlay role.
-const LOCK_POLL: Duration = Duration::from_millis(500);
-
-/// Restart delay after an overlay that had actually been running exits.
-const RESTART_DELAY: Duration = Duration::from_secs(2);
-
-/// Ceiling for the backoff applied to an overlay that keeps dying at startup.
-const MAX_RESTART_DELAY: Duration = Duration::from_mins(1);
-
-/// How long a run has to last to count as "it worked, then it stopped" rather
-/// than "it cannot start", which is what resets the backoff.
-const HEALTHY_RUN: Duration = Duration::from_secs(30);
-
-/// The delay before the next start attempt, given the previous delay and how
-/// long the run that just ended lasted.
-///
-/// A helper that cannot start at all (a broken binary, a missing display) would
-/// otherwise be relaunched twice a second forever; backing off keeps that
-/// failure quiet without giving up on it.
-fn next_delay(previous: Duration, ran_for: Duration) -> Duration {
-    if ran_for >= HEALTHY_RUN {
-        RESTART_DELAY
-    } else {
-        (previous * 2).min(MAX_RESTART_DELAY)
-    }
-}
 
 /// Start the overlay supervisor on a dedicated thread.
 pub fn spawn() {
@@ -53,33 +26,58 @@ pub fn spawn() {
         warn!("Actions Ring overlay binary not found — overlay disabled");
         return;
     };
+    let Ok(directory) = openlogi_core::paths::config_dir() else {
+        warn!("could not resolve the config directory — overlay disabled");
+        return;
+    };
+    let mine = Run::mint();
+    let mut supervisor = Supervisor::new(Role::new(directory, "overlay"), mine);
     let result = std::thread::Builder::new()
         .name("openlogi-overlay-supervisor".into())
         .spawn(move || {
-            let mut delay = RESTART_DELAY;
+            let mut spawn = move || {
+                Command::new(&binary)
+                    .env(RUN_ENV, mine.get().to_string())
+                    .spawn()
+            };
             loop {
-                while openlogi_core::single_instance::is_held(OVERLAY_LOCK) {
-                    std::thread::sleep(LOCK_POLL);
+                if let Err(error) = supervisor.tick(&mut spawn, &mut |event| report(&event)) {
+                    // A role that cannot be probed is treated as free by the
+                    // next tick; refusing to look again would wait forever.
+                    warn!(%error, "could not read the Actions Ring overlay role");
                 }
-                let started = Instant::now();
-                match Command::new(&binary).spawn() {
-                    Ok(mut child) => {
-                        info!(path = %binary.display(), "Actions Ring overlay started");
-                        match child.wait() {
-                            Ok(status) => info!(?status, "Actions Ring overlay exited"),
-                            Err(error) => warn!(%error, "could not wait for Actions Ring overlay"),
-                        }
-                    }
-                    Err(error) => {
-                        warn!(%error, path = %binary.display(), "could not start Actions Ring overlay");
-                    }
-                }
-                delay = next_delay(delay, started.elapsed());
-                std::thread::sleep(delay);
             }
         });
     if let Err(error) = result {
-        warn!(%error, "could not start Actions Ring overlay supervisor");
+        warn!(%error, "could not start the Actions Ring overlay supervisor");
+    }
+}
+
+/// Log what the supervisor did, and evict a tenant from a finished run.
+///
+/// Eviction is the migration path: an overlay that predates the claim record
+/// cannot recognize this agent as a different run, so it never yields on its
+/// own. Signalling is refused unless the live process still matches the record
+/// (see [`succession::Tenant::compare`]) — a pid alone never justifies it.
+fn report(event: &Event<'_>) {
+    match *event {
+        Event::Superseded(record) => {
+            info!("{event}");
+            match eviction::evict(record, &Policy::default()) {
+                eviction::Outcome::Refused(sameness) => {
+                    warn!(
+                        ?sameness,
+                        "left the overlay alone — its pid no longer matches"
+                    );
+                }
+                outcome => info!(?outcome, "asked the superseded overlay to leave"),
+            }
+        }
+        Event::SupersededAnonymously => {
+            warn!("{event}");
+        }
+        Event::Occupied(_) => tracing::debug!("{event}"),
+        _ => info!("{event}"),
     }
 }
 
@@ -121,24 +119,6 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-
-    #[test]
-    fn a_helper_that_dies_at_startup_is_retried_ever_more_slowly() {
-        let instant = Duration::from_millis(20);
-        let first = next_delay(RESTART_DELAY, instant);
-        assert_eq!(first, RESTART_DELAY * 2);
-        // The ceiling holds however long the failure persists.
-        let mut delay = first;
-        for _ in 0..10 {
-            delay = next_delay(delay, instant);
-        }
-        assert_eq!(delay, MAX_RESTART_DELAY);
-    }
-
-    #[test]
-    fn a_run_that_lasted_resets_the_backoff() {
-        assert_eq!(next_delay(MAX_RESTART_DELAY, HEALTHY_RUN), RESTART_DELAY);
-    }
 
     #[test]
     fn path_search_returns_none_for_an_impossible_name() {

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -25,8 +25,10 @@ use openlogi_hid::{
 use openlogi_ipc::transport;
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, Agent, AgentSnapshot, AgentStatus,
-    ConfigReloadError, MonitorEvent, PROTOCOL_VERSION, PairingCommandError, PairingUpdate,
+    ConfigReloadError, Identity, MonitorEvent, PROTOCOL_VERSION, PairingCommandError,
+    PairingUpdate,
 };
+use succession::Compat;
 
 use crate::pairing::PairingManager;
 // Brings `Listener::accept` into scope for the concrete listener `transport::bind`
@@ -79,6 +81,12 @@ impl AgentServer {
 impl Agent for AgentServer {
     async fn protocol_version(self, _: Context) -> u32 {
         PROTOCOL_VERSION
+    }
+
+    /// `Run::mint` is process-global, so the overlay supervisor hands its
+    /// child the very same run this answers with.
+    async fn identity(self, _: Context) -> Identity {
+        Identity::mine(Compat::from(PROTOCOL_VERSION))
     }
 
     async fn status(self, _: Context) -> AgentStatus {

--- a/crates/openlogi-core/src/single_instance.rs
+++ b/crates/openlogi-core/src/single_instance.rs
@@ -107,19 +107,3 @@ pub fn acquire(lock_name: &str) -> Result<InstanceGuard, InstanceError> {
         Err(TryLockError::Error(source)) => Err(InstanceError::LockFailed { path, source }),
     }
 }
-
-/// Whether some other process currently holds `lock_name`.
-///
-/// For a supervisor deciding whether the role it manages is already filled —
-/// starting a process that would only die on the lock is pure churn. The probe
-/// acquires and immediately releases, so the answer is a snapshot: a caller
-/// acting on `false` must still tolerate losing the race to another starter.
-/// Filesystem trouble reads as "not held" and surfaces on the real attempt,
-/// which reports the error properly.
-#[must_use]
-pub fn is_held(lock_name: &str) -> bool {
-    matches!(
-        acquire(lock_name),
-        Err(InstanceError::AlreadyRunning { .. })
-    )
-}

--- a/crates/openlogi-core/src/single_instance.rs
+++ b/crates/openlogi-core/src/single_instance.rs
@@ -107,3 +107,19 @@ pub fn acquire(lock_name: &str) -> Result<InstanceGuard, InstanceError> {
         Err(TryLockError::Error(source)) => Err(InstanceError::LockFailed { path, source }),
     }
 }
+
+/// Whether some other process currently holds `lock_name`.
+///
+/// For a supervisor deciding whether the role it manages is already filled —
+/// starting a process that would only die on the lock is pure churn. The probe
+/// acquires and immediately releases, so the answer is a snapshot: a caller
+/// acting on `false` must still tolerate losing the race to another starter.
+/// Filesystem trouble reads as "not held" and surfaces on the real attempt,
+/// which reports the error properly.
+#[must_use]
+pub fn is_held(lock_name: &str) -> bool {
+    matches!(
+        acquire(lock_name),
+        Err(InstanceError::AlreadyRunning { .. })
+    )
+}

--- a/crates/openlogi-gui/Cargo.toml
+++ b/crates/openlogi-gui/Cargo.toml
@@ -51,6 +51,7 @@ walkdir = "2.5.0"
 fluent-langneg = "0.14.2"
 backon.workspace = true
 opener = { workspace = true }
+succession = "0.1"
 
 # Windows exe resources (app icon + VERSIONINFO) — see build.rs. The exact
 # version already in Cargo.lock as gpui's own build-dependency, so the resolve

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -26,7 +26,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, OnceLock,
         atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -44,7 +44,7 @@ use openlogi_core::binding::ActionRingSlot;
 use openlogi_ipc::{ActionRingInvocation, AgentClient, PROTOCOL_VERSION};
 use tarpc::{client, context};
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
 
 const WINDOW_SIZE: f32 = 360.0;
@@ -509,12 +509,100 @@ fn spawn_ipc() -> Ipc {
     }
 }
 
-async fn connect() -> Option<AgentClient> {
-    let stream = openlogi_ipc::transport::connect().await.ok()?;
+/// The agent run this overlay serves, latched on the first handshake.
+///
+/// The overlay is a supervised helper: the agent starts one and only one, and
+/// that copy holds `overlay.lock` for as long as it lives. Binding to a single
+/// run is what keeps a copy orphaned by an agent restart from wedging its
+/// replacement out of the lock forever.
+static AGENT_INSTANCE: OnceLock<u64> = OnceLock::new();
+
+/// Why this overlay is no longer the one its agent expects.
+#[derive(Debug, PartialEq, Eq)]
+enum Superseded {
+    /// The agent speaks another wire protocol, so this binary is from a
+    /// superseded install and could not serve the ring even if it stayed.
+    Protocol { agent: u32 },
+    /// The agent is a different run than the one this overlay was started by.
+    Instance { latched: u64, agent: u64 },
+}
+
+/// Outcome of one connection attempt.
+enum Handshake {
+    /// Connected to the agent run this overlay belongs to.
+    Ready(AgentClient),
+    /// Nothing answered on the socket, or the answer was cut short — the agent
+    /// may simply be starting. Retry.
+    Unavailable,
+    /// This overlay has been superseded; it must yield its lock.
+    Superseded(Superseded),
+}
+
+/// Whether an agent reporting run `agent` supersedes the latched one.
+///
+/// The first sighting must never supersede: an overlay that yields before it
+/// has served anything would be restarted into the same verdict forever.
+fn superseded_by(latched: Option<u64>, agent: u64) -> Option<Superseded> {
+    match latched {
+        Some(latched) if latched != agent => Some(Superseded::Instance { latched, agent }),
+        _ => None,
+    }
+}
+
+async fn handshake() -> Handshake {
+    let Ok(stream) = openlogi_ipc::transport::connect().await else {
+        return Handshake::Unavailable;
+    };
     let transport = openlogi_ipc::transport::wrap(stream);
     let client = AgentClient::new(client::Config::default(), transport).spawn();
-    let version = client.protocol_version(context::current()).await.ok()?;
-    (version == PROTOCOL_VERSION).then_some(client)
+    // `protocol_version` is method 0 and wire-stable across every version, so
+    // it is the only call worth making before the two versions agree.
+    let Ok(version) = client.protocol_version(context::current()).await else {
+        return Handshake::Unavailable;
+    };
+    if version != PROTOCOL_VERSION {
+        return Handshake::Superseded(Superseded::Protocol { agent: version });
+    }
+    let Ok(status) = client.status(context::current()).await else {
+        return Handshake::Unavailable;
+    };
+    if let Some(reason) = superseded_by(AGENT_INSTANCE.get().copied(), status.instance_id) {
+        return Handshake::Superseded(reason);
+    }
+    let _ = AGENT_INSTANCE.set(status.instance_id);
+    Handshake::Ready(client)
+}
+
+async fn connect() -> Option<AgentClient> {
+    match handshake().await {
+        Handshake::Ready(client) => Some(client),
+        Handshake::Unavailable => None,
+        Handshake::Superseded(reason) => yield_to_replacement(&reason),
+    }
+}
+
+/// Exit so the replacement overlay can take `overlay.lock`.
+///
+/// Staying alive would be worse than useless: this process cannot serve a ring
+/// it can no longer be asked about, and its lock is exactly what stops the
+/// agent's supervisor from starting the overlay that can.
+#[expect(
+    clippy::exit,
+    reason = "the IPC tasks run off the GPUI main thread and cannot return a status to `main`, which is parked in the application run loop; releasing the single-instance lock by exiting is the point"
+)]
+fn yield_to_replacement(reason: &Superseded) -> ! {
+    match *reason {
+        Superseded::Protocol { agent } => info!(
+            agent,
+            overlay = PROTOCOL_VERSION,
+            "agent speaks another protocol — exiting so the matching overlay can start"
+        ),
+        Superseded::Instance { latched, agent } => info!(
+            latched,
+            agent, "agent restarted — exiting so its own overlay can start"
+        ),
+    }
+    std::process::exit(0)
 }
 
 async fn poll_invocations(tx: mpsc::UnboundedSender<ActionRingInvocation>) {
@@ -745,6 +833,25 @@ fn retry_before(deadline: Option<Instant>) -> bool {
 )]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_first_agent_run_seen_is_adopted_not_refused() {
+        // An overlay that yielded on its very first handshake would be
+        // restarted straight back into the same verdict.
+        assert_eq!(superseded_by(None, 7), None);
+    }
+
+    #[test]
+    fn a_restarted_agent_supersedes_the_latched_run() {
+        assert_eq!(superseded_by(Some(7), 7), None);
+        assert_eq!(
+            superseded_by(Some(7), 9),
+            Some(Superseded::Instance {
+                latched: 7,
+                agent: 9
+            })
+        );
+    }
 
     #[test]
     fn overlay_origin_is_clamped_to_the_display() {

--- a/crates/openlogi-gui/src/bin/openlogi-overlay.rs
+++ b/crates/openlogi-gui/src/bin/openlogi-overlay.rs
@@ -41,7 +41,8 @@ use gpui::{
 };
 use openlogi_core::action_ring::DISPLAY_LIFETIME;
 use openlogi_core::binding::ActionRingSlot;
-use openlogi_ipc::{ActionRingInvocation, AgentClient, PROTOCOL_VERSION};
+use openlogi_ipc::{ActionRingInvocation, AgentClient, Identity, PROTOCOL_VERSION, RUN_ENV};
+use succession::{Allegiance, Compat, Record, Role, Run, Standing, Tenancy, Tenant};
 use tarpc::{client, context};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -241,8 +242,8 @@ fn main() -> Result<()> {
         .init();
 
     rust_i18n::set_locale(locale::resolve(None));
-    let _guard = openlogi_core::single_instance::acquire("overlay.lock")
-        .context("Actions Ring overlay single-instance check")?;
+    // Held for the whole run: dropping it hands the role to the replacement.
+    let _tenancy = claim_the_role()?;
     let Ipc {
         mut invocations,
         commands,
@@ -509,99 +510,79 @@ fn spawn_ipc() -> Ipc {
     }
 }
 
-/// The agent run this overlay serves, latched on the first handshake.
+/// Take the overlay role and publish who is holding it.
 ///
-/// The overlay is a supervised helper: the agent starts one and only one, and
-/// that copy holds `overlay.lock` for as long as it lives. Binding to a single
-/// run is what keeps a copy orphaned by an agent restart from wedging its
-/// replacement out of the lock forever.
-static AGENT_INSTANCE: OnceLock<u64> = OnceLock::new();
-
-/// Why this overlay is no longer the one its agent expects.
-#[derive(Debug, PartialEq, Eq)]
-enum Superseded {
-    /// The agent speaks another wire protocol, so this binary is from a
-    /// superseded install and could not serve the ring even if it stayed.
-    Protocol { agent: u32 },
-    /// The agent is a different run than the one this overlay was started by.
-    Instance { latched: u64, agent: u64 },
+/// The record is what lets the agent recognize this process later — as its own
+/// helper, or as one left behind by a previous run. Publishing is advisory:
+/// failing it costs identification, not the role, so a helper that cannot write
+/// still runs (and is treated as an unidentified tenant).
+fn claim_the_role() -> Result<Tenancy> {
+    let directory = openlogi_core::paths::config_dir().context("resolving the config directory")?;
+    let tenancy = Role::new(directory, "overlay")
+        .claim()
+        .context("Actions Ring overlay single-instance check")?;
+    let serving = spawned_by().unwrap_or_else(Run::mint);
+    if let Err(error) = tenancy.publish(&Record::new(
+        Identity::new(serving, Compat::from(PROTOCOL_VERSION)),
+        Tenant::current(),
+    )) {
+        warn!(%error, "could not publish the overlay claim record");
+    }
+    Ok(tenancy)
 }
 
-/// Outcome of one connection attempt.
-enum Handshake {
-    /// Connected to the agent run this overlay belongs to.
-    Ready(AgentClient),
-    /// Nothing answered on the socket, or the answer was cut short — the agent
-    /// may simply be starting. Retry.
-    Unavailable,
-    /// This overlay has been superseded; it must yield its lock.
-    Superseded(Superseded),
-}
-
-/// Whether an agent reporting run `agent` supersedes the latched one.
+/// The agent run this overlay serves.
 ///
-/// The first sighting must never supersede: an overlay that yields before it
-/// has served anything would be restarted into the same verdict forever.
-fn superseded_by(latched: Option<u64>, agent: u64) -> Option<Superseded> {
-    match latched {
-        Some(latched) if latched != agent => Some(Superseded::Instance { latched, agent }),
-        _ => None,
-    }
+/// Seeded from the run token the supervisor passes in the environment, so even
+/// the first handshake catches an overlay left behind by a previous agent; a
+/// hand-started overlay adopts whichever run answers first.
+fn allegiance() -> &'static Allegiance {
+    static SERVING: OnceLock<Allegiance> = OnceLock::new();
+    SERVING.get_or_init(|| {
+        let ours = Compat::from(PROTOCOL_VERSION);
+        match spawned_by() {
+            Some(run) => Allegiance::to(ours, run),
+            None => Allegiance::new(ours),
+        }
+    })
 }
 
-async fn handshake() -> Handshake {
-    let Ok(stream) = openlogi_ipc::transport::connect().await else {
-        return Handshake::Unavailable;
-    };
-    let transport = openlogi_ipc::transport::wrap(stream);
-    let client = AgentClient::new(client::Config::default(), transport).spawn();
-    // `protocol_version` is method 0 and wire-stable across every version, so
-    // it is the only call worth making before the two versions agree.
-    let Ok(version) = client.protocol_version(context::current()).await else {
-        return Handshake::Unavailable;
-    };
-    if version != PROTOCOL_VERSION {
-        return Handshake::Superseded(Superseded::Protocol { agent: version });
-    }
-    let Ok(status) = client.status(context::current()).await else {
-        return Handshake::Unavailable;
-    };
-    if let Some(reason) = superseded_by(AGENT_INSTANCE.get().copied(), status.instance_id) {
-        return Handshake::Superseded(reason);
-    }
-    let _ = AGENT_INSTANCE.set(status.instance_id);
-    Handshake::Ready(client)
+/// The run token of the agent that started this process, when there is one.
+fn spawned_by() -> Option<Run> {
+    std::env::var(RUN_ENV).ok()?.parse().ok().map(Run::from_raw)
 }
 
 async fn connect() -> Option<AgentClient> {
-    match handshake().await {
-        Handshake::Ready(client) => Some(client),
-        Handshake::Unavailable => None,
-        Handshake::Superseded(reason) => yield_to_replacement(&reason),
+    let stream = openlogi_ipc::transport::connect().await.ok()?;
+    let transport = openlogi_ipc::transport::wrap(stream);
+    let client = AgentClient::new(client::Config::default(), transport).spawn();
+    // `protocol_version` is method 0 and wire-stable across every version, so
+    // it is the only call worth making before the two versions agree. A
+    // mismatch is not transient — this binary is from a superseded install.
+    let version = client.protocol_version(context::current()).await.ok()?;
+    if version != PROTOCOL_VERSION {
+        yield_to_replacement(&format!(
+            "agent speaks protocol {version} and this overlay speaks {PROTOCOL_VERSION}"
+        ));
     }
+    let identity = client.identity(context::current()).await.ok()?;
+    if let Standing::Superseded(because) = allegiance().observe(identity) {
+        yield_to_replacement(&because.to_string());
+    }
+    Some(client)
 }
 
-/// Exit so the replacement overlay can take `overlay.lock`.
+/// Exit so the replacement overlay can take the role.
 ///
 /// Staying alive would be worse than useless: this process cannot serve a ring
-/// it can no longer be asked about, and its lock is exactly what stops the
-/// agent's supervisor from starting the overlay that can.
+/// it can no longer be asked about, and its claim on the role is exactly what
+/// stops the agent's supervisor from starting the overlay that can.
 #[expect(
     clippy::exit,
-    reason = "the IPC tasks run off the GPUI main thread and cannot return a status to `main`, which is parked in the application run loop; releasing the single-instance lock by exiting is the point"
+    reason = "the IPC tasks run off the GPUI main thread and cannot return a status to `main`, which is parked in the application run loop; releasing the role by exiting is the point"
 )]
-fn yield_to_replacement(reason: &Superseded) -> ! {
-    match *reason {
-        Superseded::Protocol { agent } => info!(
-            agent,
-            overlay = PROTOCOL_VERSION,
-            "agent speaks another protocol — exiting so the matching overlay can start"
-        ),
-        Superseded::Instance { latched, agent } => info!(
-            latched,
-            agent, "agent restarted — exiting so its own overlay can start"
-        ),
-    }
+fn yield_to_replacement(because: &str) -> ! {
+    info!("{because} — exiting so the agent's own overlay can start");
     std::process::exit(0)
 }
 
@@ -833,25 +814,6 @@ fn retry_before(deadline: Option<Instant>) -> bool {
 )]
 mod tests {
     use super::*;
-
-    #[test]
-    fn the_first_agent_run_seen_is_adopted_not_refused() {
-        // An overlay that yielded on its very first handshake would be
-        // restarted straight back into the same verdict.
-        assert_eq!(superseded_by(None, 7), None);
-    }
-
-    #[test]
-    fn a_restarted_agent_supersedes_the_latched_run() {
-        assert_eq!(superseded_by(Some(7), 7), None);
-        assert_eq!(
-            superseded_by(Some(7), 9),
-            Some(Superseded::Instance {
-                latched: 7,
-                agent: 9
-            })
-        );
-    }
 
     #[test]
     fn overlay_origin_is_clamped_to_the_display() {

--- a/crates/openlogi-ipc/Cargo.toml
+++ b/crates/openlogi-ipc/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 tarpc = { workspace = true }
 interprocess = { workspace = true }
 tokio = { workspace = true }
+succession = { version = "0.1", features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -16,6 +16,7 @@ use openlogi_core::hid::{
     SmartShiftMode, SmartShiftStatus, WriteError,
 };
 use serde::{Deserialize, Serialize};
+pub use succession::Identity;
 
 /// Wire-protocol version. Bumped only on a breaking change to the types below —
 /// independent of the crate version. The GUI checks it via
@@ -39,7 +40,14 @@ use serde::{Deserialize, Serialize};
 /// v16: `ActionRingPresentation::literal` inserted (custom labels render
 ///      verbatim instead of passing through localization).
 /// v17: `reload_config` returns a typed parse/validation result.
-pub const PROTOCOL_VERSION: u32 = 17;
+/// v18: `identity` appended (supervised helpers bind to one agent run).
+pub const PROTOCOL_VERSION: u32 = 18;
+
+/// Environment variable through which the agent hands a supervised helper the
+/// run token it will serve, so the helper knows which agent it belongs to
+/// before it has spoken to one. Absent for a hand-started helper, which then
+/// adopts whichever run answers first.
+pub const RUN_ENV: &str = "OPENLOGI_RUN";
 
 /// Why the agent refused to adopt the config currently on disk.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -356,4 +364,15 @@ pub trait Agent {
     ) -> Result<(), ActionRingCommandError>;
     /// Close a ring without executing an action.
     async fn action_ring_cancel(session_id: u64);
+    /// Identity of this agent *run* — the Actions Ring overlay latches it and
+    /// exits when it changes, so a helper orphaned by an agent restart yields
+    /// the `overlay.lock` role instead of wedging its replacement out of it
+    /// (#621, #644).
+    ///
+    /// **Frozen.** Both halves of [`Identity`] are plain `u64`s and this
+    /// method's position never changes, so any past or future build can read
+    /// it. New facts about the agent go on a new method or in [`AgentStatus`],
+    /// never in here — an identity a helper cannot decode is an identity that
+    /// cannot tell it to leave.
+    async fn identity() -> Identity;
 }

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -40,9 +40,10 @@ use openlogi_core::hid::{
 };
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, ActionRingPresentation, AgentRequest,
-    AgentSnapshot, AgentStatus, ConfigReloadError, FoundDevice, InventoryHealth, MonitorEvent,
-    PROTOCOL_VERSION, PairingCommandError, PairingFailure, PairingUpdate,
+    AgentSnapshot, AgentStatus, ConfigReloadError, FoundDevice, Identity, InventoryHealth,
+    MonitorEvent, PROTOCOL_VERSION, PairingCommandError, PairingFailure, PairingUpdate,
 };
+use succession::{Compat, Run};
 
 /// Serialize exactly as the transport does (`tokio_serde::formats::Bincode`
 /// with its default `O = bincode::DefaultOptions`).
@@ -69,7 +70,7 @@ fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 17);
+    assert_eq!(PROTOCOL_VERSION, 18);
 }
 
 #[test]
@@ -143,6 +144,17 @@ fn request_variant_order() {
         "142a01",
     );
     assert_wire(&AgentRequest::ActionRingCancel { session_id: 42 }, "152a");
+    assert_wire(&AgentRequest::Identity {}, "16");
+}
+
+/// The agent identity is frozen: a helper from any build has to be able to
+/// decode it, so both halves stay plain `u64`s and this golden never changes.
+#[test]
+fn agent_identity_is_two_plain_integers() {
+    assert_wire(
+        &Identity::new(Run::from_raw(7), Compat::from_raw(18)),
+        "0712",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The Actions Ring overlay is a supervised helper process that holds
`overlay.lock` for its whole life, but nothing bound it to the agent that
started it. An agent restart therefore left an orphan holding the role while
the new agent's supervisor spawned copies that died on it — every two seconds,
forever. Two user-visible failures came out of that one gap:

- **#644** — after an auto-update the ring silently stops opening. The orphan is
  from the old bundle, so its protocol version no longer matches and it can
  never obtain a client; the ring is dead until the machine is rebooted or the
  process is killed by hand.
- **#621** — on Windows the doomed relaunches flash the global `AppStarting`
  cursor at 0.5 Hz while the agent is idle.

The fix gives the helper an identity to bind to, and gives the supervisor a way
to tell its own helper from one left behind.

## What changed since the first version of this PR

The mechanism was written by hand here first. It is now the
[`succession`](https://crates.io/crates/succession) crate — the same design,
with the parts this PR was missing:

- **A claim record.** The tenant publishes who it is beside the lock, so an
  onlooker can tell *which run* holds the role instead of only that someone
  does. Without it the supervisor could only wait, and waiting is useless
  against an orphan that cannot yield.
- **Verified eviction.** Overlays already installed cannot recognize a new
  agent, so they never yield on their own; the first update after this ships
  would still leave the ring dead. They are now evicted — but only after the
  live process is compared against the record, because a pid can be reused. A
  pid alone never justifies a signal.
- **Frozen identity.** The run token moved off `AgentStatus` (a struct that
  keeps evolving) onto a dedicated `identity` method whose encoding never
  changes. A helper reads it to decide whether to stay, so that read must not
  depend on the two sides agreeing about anything else.

Net effect on this repository: about 200 lines of hand-rolled supervision,
backoff and handshake logic deleted, and the migration path gained.

## Changes

**`openlogi-ipc`**

- `identity` appended to the service, returning `succession::Identity` (a
  per-run token plus the compatibility fingerprint). Frozen: `protocol_version`
  stays method 0 and is checked first; both halves stay plain `u64`s.
- `RUN_ENV`, the environment variable through which the agent hands a helper
  the run it serves.
- `PROTOCOL_VERSION` 17 → 18; goldens pin the appended method index and the
  frozen identity encoding.

**`openlogi-gui` (overlay binary)**

- Claims the role through `succession::Role` and publishes a claim record
  instead of taking a bare lock.
- Compares the agent's identity on every handshake through
  `succession::Allegiance`; a different run — or a protocol mismatch — exits,
  which releases the role.

**`openlogi-agent`**

- The supervisor is now `succession::supervision::Supervisor`: wait while the
  role is filled, start when free, back off when a helper will not stay up.
- A tenant from a finished run is evicted (`succession::eviction`) rather than
  waited on.
- The real and mock agents answer `identity`.

**`openlogi-core`**

- Drops `single_instance::is_held`, which only existed for the hand-rolled wait.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
cargo test -p openlogi-ipc --test wire_format
RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
  -p openlogi-hidpp-derive --no-deps --document-private-items
```

All green.

**End-to-end, against the mock agent** (`OPENLOGI_PROFILE=dev`, so the installed
production agent is untouched):

1. Started `openlogi-agent-mock`, then the overlay. It claimed the role and
   published a readable record:
   ```
   # succession 1
   run = 1606033816402008778
   compat = 18
   pid = 7980
   started_at = 1786887831
   image = ./target/debug/openlogi-overlay
   ```
2. Killed the mock and started a fresh one. The overlay logged
   `owner is run 15234069137034583146 and this helper serves run
   3560673700486144056 — exiting so the agent's own overlay can start` and
   exited, releasing the role.

Not runtime-tested: the supervisor's own wait/evict/back-off loop, which needs
an installed build to exercise (the real agent opens HID devices and installs
the event tap, so running it beside the production agent is not a safe local
test). Its decisions are unit-tested in `succession`, whose CI covers macOS,
Linux and Windows — including the Windows path #621 reports, which this
repository cannot test today.

Fixes #644
Fixes #621
