### PR TITLE
chore(infra): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,26 @@
 *                               @AprilNEA
 
 # ── Windows port ───────────────────────────────────────────────────────────
-# Source only. The installer manifest (packaging/windows) and the signing
-# workflow stay with the maintainer — see the supply-chain block below.
-/crates/**/*windows*.rs         @AprilNEA @davidbudnick
+# Listed file by file rather than by a `*windows*` glob: in this repo the word
+# means two different things, and `openlogi-gui/src/windows.rs` is the app's
+# auxiliary-window registry (Settings, Add Device), not Win32 code.
+#
+# Windows-only branches living in multi-platform files (openlogi-agent's
+# main.rs / launch_agent.rs / self_restart.rs / takeover.rs, hid/transport.rs,
+# hook/lib.rs, …) stay with the maintainer: CODEOWNERS scopes by path, so it
+# cannot hand out ownership of a single `#[cfg(windows)]` branch.
+#
+# The installer manifest (packaging/windows) and the signing workflow also stay
+# with the maintainer — see the supply-chain block below.
+/crates/openlogi-agent/src/resume_windows.rs    @AprilNEA @davidbudnick
+/crates/openlogi-agent/src/tray_windows.rs      @AprilNEA @davidbudnick
+/crates/openlogi-camera/src/capture_windows.rs  @AprilNEA @davidbudnick
+/crates/openlogi-camera/src/com_windows.rs      @AprilNEA @davidbudnick
+/crates/openlogi-camera/src/uvc_windows.rs      @AprilNEA @davidbudnick
+/crates/openlogi-hid/src/transport/windows.rs   @AprilNEA @davidbudnick
+/crates/openlogi-hid/src/windows_hid.rs         @AprilNEA @davidbudnick
+/crates/openlogi-hook/src/windows.rs            @AprilNEA @davidbudnick
+/crates/openlogi-inject/src/inject/windows.rs   @AprilNEA @davidbudnick
 
 # ── Release, packaging, supply chain ───────────────────────────────────────
 # Anything here can reach the release pipeline's signing and notarization

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,61 @@
+# Code owners for AprilNEA/OpenLogi.
+#
+# This is a personal repository, so every owner must be an individual account
+# with write access — `@org/team` entries do not exist here, and an owner
+# without write access is silently ignored by GitHub. Grant write access
+# before adding someone below.
+#
+# The LAST matching pattern wins. The order is deliberate: a broad default,
+# then delegated paths, then the high-risk paths that always narrow back to
+# the maintainer.
+
+# ── Default ────────────────────────────────────────────────────────────────
+*                               @AprilNEA
+
+# ── Windows port ───────────────────────────────────────────────────────────
+# Source only. The installer manifest (packaging/windows) and the signing
+# workflow stay with the maintainer — see the supply-chain block below.
+/crates/**/*windows*.rs         @AprilNEA @davidbudnick
+
+# ── Release, packaging, supply chain ───────────────────────────────────────
+# Anything here can reach the release pipeline's signing and notarization
+# credentials, or change what ends up inside a published artifact.
+/.github/                       @AprilNEA
+/xtask/                         @AprilNEA
+/packaging/                     @AprilNEA
+/scripts/                       @AprilNEA
+/.cargo/                        @AprilNEA
+/Cargo.toml                     @AprilNEA
+/Cargo.lock                     @AprilNEA
+/release-plz.toml               @AprilNEA
+/cliff.toml                     @AprilNEA
+/deny.toml                      @AprilNEA
+/crowdin.yml                    @AprilNEA
+/rust-toolchain.toml            @AprilNEA
+/rustfmt.toml                   @AprilNEA
+/prek.toml                      @AprilNEA
+/flake.nix                      @AprilNEA
+/flake.lock                     @AprilNEA
+/devenv.nix                     @AprilNEA
+/devenv.yaml                    @AprilNEA
+/devenv.lock                    @AprilNEA
+
+# ── Licensing and brand ────────────────────────────────────────────────────
+# design/ is proprietary; the license files define the dual-license boundary.
+/LICENSE-MIT                    @AprilNEA
+/LICENSE-APACHE                 @AprilNEA
+/design/                        @AprilNEA
+
+# ── Cross-crate contracts ──────────────────────────────────────────────────
+# openlogi-ipc is an append-only wire format, openlogi-core is the shared
+# config and device model, openlogi-hidpp is a hard fork with its own rules.
+/crates/openlogi-ipc/           @AprilNEA
+/crates/openlogi-core/          @AprilNEA
+/crates/openlogi-hidpp/         @AprilNEA
+/crates/openlogi-hidpp-derive/  @AprilNEA
+
+# ── Agent guides ───────────────────────────────────────────────────────────
+/AGENTS.md                      @AprilNEA
+/CLAUDE.md                      @AprilNEA
+/.claude/                       @AprilNEA
+/.agents/                       @AprilNEA


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so review routing is explicit, and so the branch
ruleset can require code owner approval on the default branch.

This is a personal repository, so owners are individual accounts with write
access — `@org/team` is unavailable, and an owner without write access is
silently dropped by GitHub. Ownership is therefore split by **risk tier**
rather than by crate, since splitting by crate would resolve to the same
single owner on every line and buy nothing.

## Changes

- `.github/CODEOWNERS`:
  - default `*` → `@AprilNEA`
  - Windows port source (`/crates/**/*windows*.rs`) → `@AprilNEA @davidbudnick`
    (any-of). The installer manifest and signing workflow deliberately stay
    with the maintainer.
  - narrowed back to `@AprilNEA` only: release/packaging/supply-chain paths
    (`.github/`, `xtask/`, `packaging/`, `scripts/`, `Cargo.toml`, lockfile,
    release-plz/cliff/deny/crowdin config, toolchain and nix/devenv files),
    licensing and brand assets (`LICENSE-*`, `design/`), cross-crate contracts
    (`openlogi-ipc`, `openlogi-core`, `openlogi-hidpp`, `openlogi-hidpp-derive`),
    and the agent guides (`AGENTS.md`, `CLAUDE.md`, `.claude/`, `.agents/`).

Patterns are ordered so the narrowed high-risk entries always win over both
the default and the delegated Windows entry (last match wins).

## Testing

- `GET /repos/AprilNEA/OpenLogi/codeowners/errors?ref=chore/codeowners` →
  `{"errors": []}` (valid syntax, both owners resolve with write access).
- No Rust files touched; prek hooks ran and skipped the fmt/clippy stages.
- Follow-up after merge: flip `require_code_owner_review` on the
  "Protect main branch" ruleset (admin bypass stays, so maintainer PRs are
  not blocked), then confirm routing with a scratch PR touching a
  `*windows*.rs` file.