### PR TITLE
feat: add a GNOME Overview button action

### DIFF
--- a/crates/openlogi-core/src/binding/action.rs
+++ b/crates/openlogi-core/src/binding/action.rs
@@ -96,6 +96,9 @@ pub enum Action {
     ShowDesktop,
     /// Open Launchpad.
     LaunchpadShow,
+    /// Open the GNOME Shell Activities Overview by tapping the bare Super
+    /// key. GNOME/Linux-only; no-op elsewhere (see [`Action::effect`]).
+    GnomeOverview,
 
     // ── System ────────────────────────────────────────────────────────────────
     /// Lock the screen (⌘⌃Q on macOS).
@@ -254,6 +257,7 @@ macro_rules! for_each_unit_action {
             NextDesktop "Next Desktop" Navigation NextDesktop,
             ShowDesktop "Show Desktop" Navigation Monitor,
             LaunchpadShow "Launchpad" Navigation Applications,
+            GnomeOverview "GNOME Overview" Navigation Grid,
             // System
             None "Do Nothing" System Ban,
             LockScreen "Lock Screen" System Lock,

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -179,6 +179,8 @@ pub enum NativeAction {
     ShowDesktop,
     /// Open the application launcher.
     LaunchpadShow,
+    /// Open the GNOME Shell Activities Overview.
+    GnomeOverview,
     /// Lock the screen.
     LockScreen,
     /// Capture a full-screen screenshot.
@@ -243,6 +245,7 @@ impl Action {
             Action::NextDesktop => Effect::Native(NativeAction::NextDesktop),
             Action::ShowDesktop => Effect::Native(NativeAction::ShowDesktop),
             Action::LaunchpadShow => Effect::Native(NativeAction::LaunchpadShow),
+            Action::GnomeOverview => Effect::Native(NativeAction::GnomeOverview),
 
             Action::LockScreen => Effect::Native(NativeAction::LockScreen),
             Action::Screenshot => Effect::Native(NativeAction::Screenshot),

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -291,6 +291,7 @@ fn persisted_action_variant_names_are_stable() {
         "Cut",
         "CycleDpiPresets",
         "Find",
+        "GnomeOverview",
         "HorizontalScrollLeft",
         "HorizontalScrollRight",
         "LaunchpadShow",

--- a/crates/openlogi-gui/locales/da.yml
+++ b/crates/openlogi-gui/locales/da.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Næste skrivebord"
 "Show Desktop": "Vis skrivebord"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Lås skærm"
 "Screenshot": "Skærmbillede"
 "Sleep": "Slumre"

--- a/crates/openlogi-gui/locales/de.yml
+++ b/crates/openlogi-gui/locales/de.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Nächster Schreibtisch"
 "Show Desktop": "Schreibtisch anzeigen"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Bildschirm sperren"
 "Screenshot": "Bildschirmfoto"
 "Sleep": "Ruhezustand"

--- a/crates/openlogi-gui/locales/el.yml
+++ b/crates/openlogi-gui/locales/el.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Επόμενο γραφείο εργασίας"
 "Show Desktop": "Εμφάνιση γραφείου εργασίας"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Κλείδωμα οθόνης"
 "Screenshot": "Στιγμιότυπο οθόνης"
 "Sleep": "Ύπνωση"

--- a/crates/openlogi-gui/locales/en.yml
+++ b/crates/openlogi-gui/locales/en.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Next Desktop"
 "Show Desktop": "Show Desktop"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Lock Screen"
 "Screenshot": "Screenshot"
 "Sleep": "Sleep"

--- a/crates/openlogi-gui/locales/es.yml
+++ b/crates/openlogi-gui/locales/es.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Escritorio siguiente"
 "Show Desktop": "Mostrar escritorio"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Bloquear pantalla"
 "Screenshot": "Captura de pantalla"
 "Sleep": "Reposo"

--- a/crates/openlogi-gui/locales/fi.yml
+++ b/crates/openlogi-gui/locales/fi.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Seuraava työpöytä"
 "Show Desktop": "Näytä työpöytä"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Lukitse näyttö"
 "Screenshot": "Kuvakaappaus"
 "Sleep": "Lepotila"

--- a/crates/openlogi-gui/locales/fr.yml
+++ b/crates/openlogi-gui/locales/fr.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Bureau suivant"
 "Show Desktop": "Afficher le bureau"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Verrouiller l'écran"
 "Screenshot": "Capture d'écran"
 "Sleep": "Suspendre l'activité"

--- a/crates/openlogi-gui/locales/it.yml
+++ b/crates/openlogi-gui/locales/it.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Scrivania successiva"
 "Show Desktop": "Mostra scrivania"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Blocca schermo"
 "Screenshot": "Istantanea schermo"
 "Sleep": "Stop"

--- a/crates/openlogi-gui/locales/ja.yml
+++ b/crates/openlogi-gui/locales/ja.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "次のデスクトップ"
 "Show Desktop": "デスクトップを表示"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "画面をロック"
 "Screenshot": "スクリーンショット"
 "Sleep": "スリープ"

--- a/crates/openlogi-gui/locales/ko.yml
+++ b/crates/openlogi-gui/locales/ko.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "다음 데스크탑"
 "Show Desktop": "데스크탑 보기"
 "Launchpad": "런치패드"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "화면 잠금"
 "Screenshot": "스크린샷"
 "Sleep": "잠자기"

--- a/crates/openlogi-gui/locales/nb.yml
+++ b/crates/openlogi-gui/locales/nb.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Neste skrivebord"
 "Show Desktop": "Vis skrivebord"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Lås skjerm"
 "Screenshot": "Skjermbilde"
 "Sleep": "Dvale"

--- a/crates/openlogi-gui/locales/nl.yml
+++ b/crates/openlogi-gui/locales/nl.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Volgend bureaublad"
 "Show Desktop": "Bureaublad tonen"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Scherm vergrendelen"
 "Screenshot": "Schermafbeelding"
 "Sleep": "Sluimer"

--- a/crates/openlogi-gui/locales/pl.yml
+++ b/crates/openlogi-gui/locales/pl.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Następny pulpit"
 "Show Desktop": "Pokaż biurko"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Zablokuj ekran"
 "Screenshot": "Zrzut ekranu"
 "Sleep": "Uśpij"

--- a/crates/openlogi-gui/locales/pt-BR.yml
+++ b/crates/openlogi-gui/locales/pt-BR.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Próxima Mesa"
 "Show Desktop": "Mostrar Mesa"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Bloquear Tela"
 "Screenshot": "Captura de Tela"
 "Sleep": "Repouso"

--- a/crates/openlogi-gui/locales/pt-PT.yml
+++ b/crates/openlogi-gui/locales/pt-PT.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Secretária seguinte"
 "Show Desktop": "Mostrar secretária"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Bloquear ecrã"
 "Screenshot": "Captura de ecrã"
 "Sleep": "Pausa"

--- a/crates/openlogi-gui/locales/ru.yml
+++ b/crates/openlogi-gui/locales/ru.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Следующий рабочий стол"
 "Show Desktop": "Показать рабочий стол"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Заблокировать экран"
 "Screenshot": "Снимок экрана"
 "Sleep": "Режим сна"

--- a/crates/openlogi-gui/locales/sv.yml
+++ b/crates/openlogi-gui/locales/sv.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "Nästa skrivbord"
 "Show Desktop": "Visa skrivbordet"
 "Launchpad": "Launchpad"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "Lås skärmen"
 "Screenshot": "Skärmavbild"
 "Sleep": "Vila"

--- a/crates/openlogi-gui/locales/zh-CN.yml
+++ b/crates/openlogi-gui/locales/zh-CN.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "下一个桌面"
 "Show Desktop": "显示桌面"
 "Launchpad": "启动台"
+"GNOME Overview": "GNOME 概览"
 "Lock Screen": "锁定屏幕"
 "Screenshot": "截屏"
 "Sleep": "睡眠"

--- a/crates/openlogi-gui/locales/zh-HK.yml
+++ b/crates/openlogi-gui/locales/zh-HK.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "下一個桌面"
 "Show Desktop": "顯示桌面"
 "Launchpad": "啟動台"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "鎖定螢幕"
 "Screenshot": "截圖"
 "Sleep": "睡眠"

--- a/crates/openlogi-gui/locales/zh-TW.yml
+++ b/crates/openlogi-gui/locales/zh-TW.yml
@@ -202,6 +202,7 @@ _version: 1
 "Next Desktop": "下一個桌面"
 "Show Desktop": "顯示桌面"
 "Launchpad": "啟動台"
+"GNOME Overview": "GNOME Overview"
 "Lock Screen": "鎖定螢幕"
 "Screenshot": "截圖"
 "Sleep": "睡眠"

--- a/crates/openlogi-gui/src/action_visibility.rs
+++ b/crates/openlogi-gui/src/action_visibility.rs
@@ -1,0 +1,87 @@
+//! Which [`Action`]s are worth offering as a *new* pick on this host, as
+//! opposed to which ones execute successfully — every action still executes
+//! (or debug-logs a no-op) on every platform per `openlogi_inject::execute`,
+//! this only controls what shows up in the picker/Actions Ring catalogs so a
+//! desktop-specific action doesn't clutter the list on a host that can't use
+//! it. An already-persisted binding is unaffected: it keeps rendering via
+//! [`Action::label`] and keeps firing normally, it just can't be picked again
+//! from a catalog that hides it.
+
+use openlogi_core::binding::Action;
+
+/// Whether `action` should appear in a pickable catalog on this host.
+pub(crate) fn is_offered_here(action: &Action) -> bool {
+    match action {
+        Action::GnomeOverview => is_gnome_session(),
+        _ => true,
+    }
+}
+
+/// Whether the current session's desktop environment is GNOME (or a
+/// GNOME-based session, e.g. GNOME Classic/Flashback).
+///
+/// Reads `$XDG_CURRENT_DESKTOP`, the same colon-separated variable `.desktop`
+/// entries use for `OnlyShowIn=GNOME;` filtering — there is no more
+/// authoritative cross-desktop-environment signal than the one the desktop
+/// entry spec itself standardized for this exact purpose. Cached: the
+/// session's desktop environment cannot change without a re-login, and this
+/// is read on every popover render.
+#[cfg(target_os = "linux")]
+fn is_gnome_session() -> bool {
+    static IS_GNOME: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *IS_GNOME.get_or_init(|| current_desktop_is_gnome(std::env::var("XDG_CURRENT_DESKTOP").ok()))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_gnome_session() -> bool {
+    false
+}
+
+/// Pure parse of `$XDG_CURRENT_DESKTOP`'s value, split out from
+/// [`is_gnome_session`] so the colon-list/case-insensitivity handling is
+/// testable without mutating the process-global environment (racy under a
+/// parallel test harness) or fighting the `OnceLock` cache.
+#[cfg_attr(
+    not(target_os = "linux"),
+    allow(dead_code, reason = "linux-only caller")
+)]
+fn current_desktop_is_gnome(xdg_current_desktop: Option<String>) -> bool {
+    xdg_current_desktop.is_some_and(|value| {
+        value
+            .split(':')
+            .any(|part| part.eq_ignore_ascii_case("GNOME"))
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_gated_actions_are_always_offered() {
+        assert!(is_offered_here(&Action::LeftClick));
+        assert!(is_offered_here(&Action::MissionControl));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn gnome_overview_is_hidden_off_linux() {
+        assert!(!is_offered_here(&Action::GnomeOverview));
+    }
+
+    #[test]
+    fn recognizes_plain_and_prefixed_gnome_desktop() {
+        assert!(current_desktop_is_gnome(Some("GNOME".into())));
+        assert!(current_desktop_is_gnome(Some("ubuntu:GNOME".into())));
+        assert!(current_desktop_is_gnome(Some("GNOME-classic:GNOME".into())));
+        assert!(current_desktop_is_gnome(Some("gnome".into())));
+    }
+
+    #[test]
+    fn rejects_other_or_missing_desktops() {
+        assert!(!current_desktop_is_gnome(Some("KDE".into())));
+        assert!(!current_desktop_is_gnome(Some("XFCE".into())));
+        assert!(!current_desktop_is_gnome(None));
+    }
+}

--- a/crates/openlogi-gui/src/components/action_ring_panel/editor.rs
+++ b/crates/openlogi-gui/src/components/action_ring_panel/editor.rs
@@ -294,6 +294,9 @@ fn ring_catalog() -> Vec<(Category, Vec<Action>)> {
         if RingAction::new(action.clone()).is_err() {
             continue;
         }
+        if !crate::action_visibility::is_offered_here(&action) {
+            continue;
+        }
         let category = action.category();
         if let Some((_, actions)) = sections
             .iter_mut()

--- a/crates/openlogi-gui/src/main.rs
+++ b/crates/openlogi-gui/src/main.rs
@@ -32,6 +32,7 @@ macro_rules! tr {
 mod action_icons;
 mod action_ring_geometry;
 mod action_ring_icons;
+mod action_visibility;
 mod app;
 mod app_assets;
 mod app_menu;

--- a/crates/openlogi-gui/src/mouse_model/picker.rs
+++ b/crates/openlogi-gui/src/mouse_model/picker.rs
@@ -484,6 +484,9 @@ pub(crate) type PickFn = Rc<dyn Fn(Action, &mut Window, &mut App)>;
 pub(crate) fn grouped_catalog() -> Vec<(Category, Vec<Action>)> {
     let mut sections: Vec<(Category, Vec<Action>)> = Vec::new();
     for action in Action::catalog() {
+        if !crate::action_visibility::is_offered_here(&action) {
+            continue;
+        }
         let cat = action.category();
         if let Some(sec) = sections.iter_mut().find(|(c, _)| *c == cat) {
             sec.1.push(action);
@@ -528,7 +531,9 @@ pub(crate) fn action_icon_path(action: &Action) -> &'static str {
         Action::NextTab => "action-icons/chevron-right.svg",
         Action::PrevTab => "action-icons/chevron-left.svg",
         Action::ReloadPage => "action-icons/rotate-cw.svg",
-        Action::MissionControl | Action::ShowActionsRing => "action-icons/layout-grid.svg",
+        Action::MissionControl | Action::ShowActionsRing | Action::GnomeOverview => {
+            "action-icons/layout-grid.svg"
+        }
         Action::AppExpose => "action-icons/layers.svg",
         Action::PreviousDesktop => "action-icons/square-arrow-left.svg",
         Action::NextDesktop => "action-icons/square-arrow-right.svg",

--- a/crates/openlogi-inject/examples/inject_action.rs
+++ b/crates/openlogi-inject/examples/inject_action.rs
@@ -30,6 +30,7 @@
 //! Copy Paste Cut Undo Redo SelectAll Find Save
 //! BrowserBack BrowserForward NewTab CloseTab ReopenTab NextTab PrevTab ReloadPage
 //! MissionControl AppExpose PreviousDesktop NextDesktop ShowDesktop LaunchpadShow
+//! GnomeOverview
 //! LockScreen Screenshot
 //! PlayPause NextTrack PrevTrack VolumeUp VolumeDown MuteVolume
 //! CycleDpiPresets ToggleSmartShift
@@ -175,7 +176,7 @@ fn print_usage() {
                   BrowserBack BrowserForward NewTab CloseTab ReopenTab\n\
                   NextTab PrevTab ReloadPage\n\
                   MissionControl AppExpose PreviousDesktop NextDesktop\n\
-                  ShowDesktop LaunchpadShow\n\
+                  ShowDesktop LaunchpadShow GnomeOverview\n\
                   LockScreen Screenshot\n\
                   PlayPause NextTrack PrevTrack VolumeUp VolumeDown MuteVolume\n\
                   CycleDpiPresets ToggleSmartShift\n\

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -132,6 +132,16 @@ fn dispatch_native(action: &Action, native: NativeAction) {
                 "no Linux equivalent — action skipped"
             );
         }
+        // Tap the bare Super key: GNOME Shell's default overlay-key setting
+        // toggles the Activities Overview on Super pressed and released
+        // alone. No portable D-Bus call exists for this
+        // (`org.gnome.Shell.Eval` is disabled by default on stock GNOME); a
+        // user who rebinds/disables the overlay-key will see this silently
+        // no-op, same tradeoff as the LockScreen Super+L fallback below.
+        NativeAction::GnomeOverview => {
+            tracing::debug!("GnomeOverview via bare Super tap");
+            press_key(&[], KeyCode::KEY_LEFTMETA);
+        }
         // Ctrl+Alt+←/→ is the default in GNOME and KDE.
         NativeAction::PreviousDesktop => press_key(&[ctrl, alt], KeyCode::KEY_LEFT),
         NativeAction::NextDesktop => press_key(&[ctrl, alt], KeyCode::KEY_RIGHT),

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -116,6 +116,11 @@ fn dispatch_native(native: NativeAction) {
         NativeAction::NextDesktop => next_desktop(),
         NativeAction::ShowDesktop => show_desktop(),
         NativeAction::LaunchpadShow => launchpad(),
+        // GNOME-only; macOS has no Activities Overview equivalent (use
+        // Action::MissionControl for the macOS analog instead).
+        NativeAction::GnomeOverview => {
+            tracing::debug!("GnomeOverview has no macOS equivalent — action skipped");
+        }
         // Lock screen = Cmd+Ctrl+Q (kVK_ANSI_Q = 0x0C)
         NativeAction::LockScreen => post_key(0x0C, cmd | ctrl),
         // Screenshot = Cmd+Shift+3 (kVK_ANSI_3 = 0x14)

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -126,6 +126,10 @@ fn dispatch_native(native: NativeAction) {
         NativeAction::NextDesktop => post_key(VK_RIGHT, &[VK_LWIN, VK_CONTROL]),
         NativeAction::ShowDesktop => post_key(VK_D, &[VK_LWIN]),
         NativeAction::LaunchpadShow => post_key(VK_LWIN, &[]),
+        // GNOME-only; Windows has no Activities Overview equivalent.
+        NativeAction::GnomeOverview => {
+            tracing::debug!("GnomeOverview has no Windows equivalent — action skipped");
+        }
         NativeAction::LockScreen => post_key(VK_L, &[VK_LWIN]),
         // Win+Shift+S opens the snip overlay, which serves both full-screen
         // and region capture on Windows.


### PR DESCRIPTION
## Summary

Adds a new button/gesture action, "GNOME Overview," that opens the GNOME
Shell Activities Overview — a natural fit for the MX Master 3/3S gesture
button. Linux/GNOME-real; a debug-logged no-op on macOS/Windows, and hidden
from every picker unless the session actually reports GNOME.

## Changes

- **openlogi-core**: new `Action::GnomeOverview` / `NativeAction::GnomeOverview`
  variant, appended per the append-only stability contract; reuses the
  existing `Grid` icon so no `ActionRingIcon` change (and therefore no IPC
  `PROTOCOL_VERSION` bump) is needed.
- **openlogi-inject**: Linux taps the bare Super key via uinput
  (`press_key(&[], KEY_LEFTMETA)`), relying on GNOME Shell's default
  overlay-key behavior — the same primitive already used for `LockScreen`'s
  Super+L fallback. macOS/Windows debug-log a no-op, matching the existing
  precedent for actions with no cross-platform equivalent.
- **openlogi-gui**: wires the new action into the button picker, gesture
  flyout, keyboard function-row picker, and Actions Ring editor (all share
  the same catalog helpers). Adds a new `action_visibility` module that
  hides `GnomeOverview` from all of those catalogs unless
  `$XDG_CURRENT_DESKTOP` reports a GNOME session — the same variable
  `.desktop` entries use for `OnlyShowIn=GNOME;`. An already-persisted
  binding keeps working even when hidden from the picker.
- **i18n**: adds the `"GNOME Overview"` key to all 20 locale files; `zh-CN`
  gets a real translation ("GNOME 概览") since that locale is exhaustively
  checked against the full action catalog.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p openlogi-gui i18n` (locale parity + zh-CN coverage)
- `cargo test -p openlogi-ipc --test wire_format` (confirms no wire-format
  change — `Action`/`NativeAction` aren't part of the IPC contract)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`
- Not runtime-tested on a live GNOME session (no GNOME desktop available in
  this environment) — the Super-key-tap mechanism and the picker's
  GNOME-only gating should be sanity-checked on real hardware/session before
  merge.