### PR TITLE
feat: Improve Actions Ring latency, shape, positioning, and focus behavior

### DIFF
--- a/crates/openlogi-core/src/binding/swipe.rs
+++ b/crates/openlogi-core/src/binding/swipe.rs
@@ -18,6 +18,11 @@ pub const GESTURE_SWIPE_DEADZONE: i32 = 40;
 /// cursor happened to be moving. Shared by both gesture paths (the HID++ thumb
 /// pad and the OS-hook Middle/Back/Forward).
 pub const GESTURE_HOLD_FOR_SWIPE: std::time::Duration = std::time::Duration::from_millis(160);
+/// Minimum movement that must arrive *after* the hold gate opens before a
+/// direction can commit. Motion collected during the initial click-grace
+/// window still contributes to the eventual direction, but cannot turn a
+/// mostly-stationary long click into a swipe because of one tiny late sample.
+const GESTURE_POST_HOLD_CONFIRM_THRESHOLD: i32 = 20;
 
 /// Classify the *running* raw-XY travel of a held gesture button into a
 /// directional swipe, the instant it commits — or `None` while it's still too
@@ -88,6 +93,11 @@ pub struct SwipeAccumulator {
     /// arbitrarily long hold can never overflow).
     dx: i32,
     dy: i32,
+    /// Travel received after the hold gate became eligible for a swipe. This
+    /// provides hysteresis between a long click and a deliberate continued
+    /// swipe: pre-gate cursor drift alone cannot arm a direction.
+    post_gate_dx: i32,
+    post_gate_dy: i32,
     /// Set once a direction has committed this hold, so it fires exactly once
     /// and the release isn't then also read as a click.
     fired: bool,
@@ -99,6 +109,8 @@ impl SwipeAccumulator {
         self.held_since = Some(Instant::now());
         self.dx = 0;
         self.dy = 0;
+        self.post_gate_dx = 0;
+        self.post_gate_dy = 0;
         self.fired = false;
     }
 
@@ -122,7 +134,21 @@ impl SwipeAccumulator {
         let held_long_enough = self
             .held_since
             .is_some_and(|t| t.elapsed() >= GESTURE_HOLD_FOR_SWIPE);
-        if held_long_enough && let Some(dir) = detect_swipe(self.dx, self.dy) {
+        if !held_long_enough {
+            return None;
+        }
+
+        self.post_gate_dx = self.post_gate_dx.saturating_add(dx);
+        self.post_gate_dy = self.post_gate_dy.saturating_add(dy);
+        let post_gate_travel = self
+            .post_gate_dx
+            .saturating_abs()
+            .max(self.post_gate_dy.saturating_abs());
+        if post_gate_travel < GESTURE_POST_HOLD_CONFIRM_THRESHOLD {
+            return None;
+        }
+
+        if let Some(dir) = detect_swipe(self.dx, self.dy) {
             self.fired = true;
             return Some(dir);
         }
@@ -236,6 +262,39 @@ mod tests {
         // Once held long enough, the next delta commits.
         acc.backdate_hold_for_test();
         assert!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 100, 0).is_some());
+    }
+
+    #[test]
+    fn accumulator_does_not_turn_pre_gate_drift_into_a_swipe_from_one_tiny_late_sample() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        // Cursor travel during the click-grace window may already exceed the
+        // directional threshold (pressing a thumb button can nudge the mouse).
+        assert_eq!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 30, 0), None);
+
+        // Once the hold gate opens, one tiny follow-up report must not retroactively
+        // classify all of that earlier drift as a swipe. Releasing is still a click.
+        acc.backdate_hold_for_test();
+        assert_eq!(acc.accumulate(1, 0), None);
+        assert!(
+            acc.end(),
+            "pre-gate drift plus a tiny late sample stays a click"
+        );
+    }
+
+    #[test]
+    fn accumulator_commits_when_motion_continues_after_the_hold_gate() {
+        let mut acc = SwipeAccumulator::default();
+        acc.begin();
+        assert_eq!(acc.accumulate(GESTURE_SWIPE_THRESHOLD + 30, 0), None);
+
+        acc.backdate_hold_for_test();
+        assert_eq!(
+            acc.accumulate(GESTURE_POST_HOLD_CONFIRM_THRESHOLD, 0),
+            Some(GestureDirection::Right),
+            "continued movement after the hold gate confirms the deliberate swipe"
+        );
+        assert!(!acc.end(), "a confirmed swipe must not also emit Click");
     }
 
     #[test]

--- a/crates/openlogi-overlay/Cargo.toml
+++ b/crates/openlogi-overlay/Cargo.toml
@@ -34,13 +34,31 @@ tracing-subscriber = { workspace = true }
 [build-dependencies]
 embed-resource = "3.0.9"
 
+# The warm Actions Ring keeps one native window alive where the backend exposes
+# safe hide/show/reposition primitives.
+[target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
+raw-window-handle = "0.6.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+x11rb = "0.13.2"
+
+# Native window policy for the ring panel — see src/platform.rs, and
+# crates/openlogi-desktop/src/platform/AGENTS.md for the rules this code follows.
 [target.'cfg(target_os = "macos")'.dependencies]
 # CGGetActiveDisplayList/CGDisplayBounds: placing the ring on the cursor's
 # display needs global display bounds, which GPUI's display API doesn't expose
 # (its bounds are display-relative). C FFI, so core-graphics.
 core-graphics = { workspace = true }
+core-foundation = { workspace = true }
 objc2 = { workspace = true }
-objc2-app-kit = { workspace = true, features = ["NSApplication", "NSResponder", "NSWindow", "NSEvent", "block2"] }
+objc2-app-kit = { workspace = true, features = ["NSApplication", "NSResponder", "NSWindow", "NSGraphics", "NSWorkspace", "NSRunningApplication", "NSEvent", "NSScreen", "block2", "libc"] }
 # NSEvent global-monitor handlers are ObjC blocks (click-away dismissal).
 block2 = { workspace = true }
 

--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -9,9 +9,6 @@
     windows_subsystem = "windows"
 )]
 
-// `t!` resolves against a backend the invoking crate must generate itself, so
-// both binaries expand `i18n!` over the one catalog in `openlogi-ui` — the same
-// crate this one already depends on for locale negotiation.
 rust_i18n::i18n!("../openlogi-ui/locales", fallback = "en");
 
 mod agent;
@@ -19,14 +16,15 @@ mod platform;
 mod ring;
 mod session;
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use anyhow::Result;
 use gpui::AppContext as _;
-use tracing::warn;
+use tracing::{debug, warn};
 use tracing_subscriber::EnvFilter;
 
 use openlogi_core::action_ring::DISPLAY_LIFETIME;
+use openlogi_ipc::ActionRingInvocation;
 
 use crate::agent::{Ipc, OverlayCommand, spawn_ipc};
 use crate::ring::{RingView, ring_window_options};
@@ -41,7 +39,6 @@ fn main() -> Result<()> {
         .init();
 
     openlogi_core::locale::activate(None);
-    // Held for the whole run: dropping it hands the role to the replacement.
     let _tenancy = claim_the_role()?;
     let Ipc {
         mut invocations,
@@ -54,53 +51,165 @@ fn main() -> Result<()> {
         platform::configure_application();
         let live_session = Arc::new(ClickAwaySession::new());
         spawn_click_away_dismissal(cx, Arc::clone(&live_session));
+        let warm_window = create_warm_window(cx, commands.clone(), Arc::clone(&live_session));
+
         cx.spawn(async move |cx| {
             while let Some(observed) = invocations.recv().await {
-                // No ring is what a dismissal looks like: close whatever is
-                // showing and open nothing. The agent has already forgotten the
-                // session, so there is nothing to acknowledge either.
-                let Some(invocation) = observed else {
-                    cx.update(|cx| {
-                        for handle in cx.windows() {
-                            let _ = handle.update(cx, |_, window, _| window.remove_window());
-                        }
-                    });
-                    continue;
-                };
-                openlogi_core::locale::activate(invocation.language.as_deref());
-                cx.update(|cx| {
-                    for handle in cx.windows() {
-                        let _ = handle.update(cx, |_, window, _| window.remove_window());
-                    }
-                    let options = ring_window_options(cx);
-                    let commands = commands.clone();
-                    let timeout_commands = commands.clone();
-                    let session_id = invocation.session_id;
-                    match cx.open_window(options, |_, cx| {
-                        cx.new(|_| RingView::new(invocation, commands, &live_session))
-                    }) {
-                        Ok(handle) => {
-                            platform::configure_windows();
-                            cx.spawn(async move |cx| {
-                                cx.background_executor().timer(DISPLAY_LIFETIME).await;
-                                if handle
-                                    .update(cx, |_, window, _| window.remove_window())
-                                    .is_ok()
-                                {
-                                    let _ = timeout_commands
-                                        .send(OverlayCommand::Cancel { session_id });
-                                }
-                            })
-                            .detach();
-                        }
-                        Err(error) => warn!(%error, "could not open Actions Ring window"),
-                    }
-                });
+                if let Some(warm_window) = warm_window.as_ref() {
+                    handle_warm_observation(cx, warm_window, observed, &commands, &live_session);
+                } else {
+                    handle_cold_observation(cx, observed, &commands, &live_session);
+                }
             }
         })
         .detach();
     });
     Ok(())
+}
+
+fn create_warm_window(
+    cx: &mut gpui::App,
+    commands: tokio::sync::mpsc::UnboundedSender<OverlayCommand>,
+    live_session: Arc<ClickAwaySession>,
+) -> Option<gpui::WindowHandle<RingView>> {
+    let options = ring_window_options(cx, true);
+    let handle = match cx.open_window(options, |_, cx| {
+        cx.new(|_| RingView::idle(commands, live_session))
+    }) {
+        Ok(handle) => handle,
+        Err(error) => {
+            warn!(%error, "could not pre-create Actions Ring window; using cold overlay path");
+            return None;
+        }
+    };
+    platform::configure_windows();
+
+    let reusable = handle
+        .update(cx, |_, window, _| {
+            platform::supports_warm_window(window) && platform::hide_window(window)
+        })
+        .unwrap_or(false);
+    if reusable {
+        debug!("Actions Ring native window warmed and waiting hidden");
+        Some(handle)
+    } else {
+        let _ = handle.update(cx, |_, window, _| window.remove_window());
+        debug!("Actions Ring backend requires cold window creation");
+        None
+    }
+}
+
+fn handle_warm_observation(
+    cx: &mut gpui::AsyncApp,
+    warm_window: &gpui::WindowHandle<RingView>,
+    observed: Option<ActionRingInvocation>,
+    commands: &tokio::sync::mpsc::UnboundedSender<OverlayCommand>,
+    live_session: &Arc<ClickAwaySession>,
+) {
+    let Some(invocation) = observed else {
+        cx.update(|cx| {
+            let _ = warm_window.update(cx, |view, window, cx| {
+                if let Some(open_session) = view.current_session() {
+                    view.dismiss(open_session, window, cx);
+                } else {
+                    live_session.clear();
+                    if !platform::hide_window(window) {
+                        warn!("could not hide warm Actions Ring window");
+                    }
+                }
+            });
+        });
+        return;
+    };
+
+    openlogi_core::locale::activate(invocation.language.as_deref());
+    let session_id = invocation.session_id;
+    let timeout_commands = commands.clone();
+    let show_started = Instant::now();
+    let shown = cx.update(|cx| {
+        warm_window
+            .update(cx, |view, window, cx| {
+                view.install(invocation, cx);
+                window.refresh();
+                if platform::show_window_at_cursor(window) {
+                    live_session.set(session_id);
+                    true
+                } else {
+                    warn!("could not position/show warm Actions Ring window");
+                    view.dismiss(session_id, window, cx);
+                    false
+                }
+            })
+            .unwrap_or(false)
+    });
+
+    if !shown {
+        let _ = commands.send(OverlayCommand::Cancel { session_id });
+        return;
+    }
+    debug!(session_id, elapsed = ?show_started.elapsed(), "Actions Ring warm window shown");
+
+    let timeout_window = *warm_window;
+    cx.spawn(async move |cx| {
+        cx.background_executor().timer(DISPLAY_LIFETIME).await;
+        let dismissed = timeout_window
+            .update(cx, |view, window, cx| view.dismiss(session_id, window, cx))
+            .unwrap_or(false);
+        if dismissed {
+            let _ = timeout_commands.send(OverlayCommand::Cancel { session_id });
+        }
+    })
+    .detach();
+}
+
+fn handle_cold_observation(
+    cx: &mut gpui::AsyncApp,
+    observed: Option<ActionRingInvocation>,
+    commands: &tokio::sync::mpsc::UnboundedSender<OverlayCommand>,
+    live_session: &Arc<ClickAwaySession>,
+) {
+    let Some(invocation) = observed else {
+        cx.update(|cx| {
+            live_session.clear();
+            for handle in cx.windows() {
+                let _ = handle.update(cx, |_, window, _| window.remove_window());
+            }
+        });
+        return;
+    };
+
+    openlogi_core::locale::activate(invocation.language.as_deref());
+    let commands = commands.clone();
+    let timeout_commands = commands.clone();
+    let live_session = Arc::clone(live_session);
+    cx.update(|cx| {
+        let previous_windows = cx.windows();
+        let options = ring_window_options(cx, true);
+        let session_id = invocation.session_id;
+        match cx.open_window(options, |_, cx| {
+            cx.new(|_| RingView::new(invocation, commands, Arc::clone(&live_session)))
+        }) {
+            Ok(handle) => {
+                let _ = handle.update(cx, |_, window, _| platform::apply_circular_shape(window));
+                live_session.set(session_id);
+                for previous in previous_windows {
+                    let _ = previous.update(cx, |_, window, _| window.remove_window());
+                }
+                platform::configure_windows();
+                cx.spawn(async move |cx| {
+                    cx.background_executor().timer(DISPLAY_LIFETIME).await;
+                    let dismissed = handle
+                        .update(cx, |view, window, cx| view.dismiss(session_id, window, cx))
+                        .unwrap_or(false);
+                    if dismissed {
+                        let _ = timeout_commands.send(OverlayCommand::Cancel { session_id });
+                    }
+                })
+                .detach();
+            }
+            Err(error) => warn!(%error, "could not open Actions Ring window"),
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/openlogi-overlay/src/platform.rs
+++ b/crates/openlogi-overlay/src/platform.rs
@@ -1,5 +1,141 @@
 //! Native window policy for the standalone Actions Ring overlay.
 
+#[cfg(any(target_os = "windows", test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RelativeStackTarget<T> {
+    Keep,
+    After(T),
+    Top,
+    Topmost,
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn choose_windows_stack_target<T: Copy + Eq>(
+    overlay: T,
+    foreground: Option<T>,
+    predecessor: Option<T>,
+    overlay_is_topmost: bool,
+    foreground_is_topmost: bool,
+    predecessor_is_topmost: bool,
+) -> RelativeStackTarget<T> {
+    let Some(foreground) = foreground.filter(|candidate| *candidate != overlay) else {
+        return RelativeStackTarget::Top;
+    };
+    if predecessor == Some(overlay) && overlay_is_topmost == foreground_is_topmost {
+        return RelativeStackTarget::Keep;
+    }
+    if overlay_is_topmost == foreground_is_topmost
+        && foreground_is_topmost == predecessor_is_topmost
+        && let Some(predecessor) = predecessor.filter(|candidate| *candidate != foreground)
+    {
+        return RelativeStackTarget::After(predecessor);
+    }
+    if foreground_is_topmost {
+        RelativeStackTarget::Topmost
+    } else {
+        RelativeStackTarget::Top
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug)]
+struct MacWindowCandidate {
+    number: isize,
+    owner_pid: i32,
+    layer: i32,
+    bounds: core_graphics::geometry::CGRect,
+}
+
+#[cfg(target_os = "macos")]
+fn select_frontmost_macos_window(
+    frontmost_pid: i32,
+    overlay_window_number: isize,
+    cursor: Option<core_graphics::geometry::CGPoint>,
+    candidates: impl IntoIterator<Item = MacWindowCandidate>,
+) -> Option<isize> {
+    let mut fallback = None;
+    for candidate in candidates.into_iter().filter(|candidate| {
+        candidate.owner_pid == frontmost_pid
+            && candidate.number != overlay_window_number
+            && candidate.layer == 0
+    }) {
+        fallback.get_or_insert(candidate.number);
+        if cursor.is_some_and(|cursor| candidate.bounds.contains(&cursor)) {
+            return Some(candidate.number);
+        }
+    }
+    fallback
+}
+
+#[cfg(target_os = "macos")]
+#[expect(
+    unsafe_code,
+    reason = "CoreGraphics exposes CGWindow metadata keys as extern static CFStringRef values"
+)]
+fn frontmost_macos_window_number(
+    overlay_window_number: isize,
+    cursor: Option<core_graphics::geometry::CGPoint>,
+) -> Option<isize> {
+    use core_foundation::{dictionary::CFDictionary, number::CFNumber};
+    use core_graphics::{
+        geometry::CGRect,
+        window::{
+            create_description_from_array, create_window_list, kCGNullWindowID, kCGWindowBounds,
+            kCGWindowLayer, kCGWindowListExcludeDesktopElements, kCGWindowListOptionOnScreenOnly,
+            kCGWindowNumber, kCGWindowOwnerPID,
+        },
+    };
+    use objc2_app_kit::NSWorkspace;
+
+    fn number(
+        dictionary: &core_foundation::dictionary::CFDictionary<
+            core_foundation::string::CFString,
+            core_foundation::base::CFType,
+        >,
+        key: core_foundation::string::CFStringRef,
+    ) -> Option<i64> {
+        dictionary.find(key)?.downcast::<CFNumber>()?.to_i64()
+    }
+
+    let frontmost_pid = NSWorkspace::sharedWorkspace()
+        .frontmostApplication()?
+        .processIdentifier();
+    if frontmost_pid < 0 {
+        return None;
+    }
+
+    let window_ids = create_window_list(
+        kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+        kCGNullWindowID,
+    )?;
+    let descriptions = create_description_from_array(window_ids)?;
+    // SAFETY: these are immutable CoreGraphics metadata-key constants exported
+    // by the framework and valid for the lifetime of the process.
+    let (owner_pid_key, number_key, layer_key, bounds_key) = unsafe {
+        (
+            kCGWindowOwnerPID,
+            kCGWindowNumber,
+            kCGWindowLayer,
+            kCGWindowBounds,
+        )
+    };
+    let candidates = descriptions.iter().filter_map(|description| {
+        let owner_pid = i32::try_from(number(&description, owner_pid_key)?).ok()?;
+        let window_number = isize::try_from(number(&description, number_key)?).ok()?;
+        let layer = i32::try_from(number(&description, layer_key)?).ok()?;
+        let bounds = description.find(bounds_key)?.downcast::<CFDictionary>()?;
+        let bounds = CGRect::from_dict_representation(&bounds)?;
+        Some(MacWindowCandidate {
+            number: window_number,
+            owner_pid,
+            layer,
+            bounds,
+        })
+    });
+
+    select_frontmost_macos_window(frontmost_pid, overlay_window_number, cursor, candidates)
+}
+
 /// Keep the overlay out of the Dock and app switcher.
 #[cfg(target_os = "macos")]
 pub fn configure_application() {
@@ -140,4 +276,662 @@ pub fn display_containing(x: f64, y: f64) -> Option<CursorDisplay> {
 #[cfg(not(target_os = "macos"))]
 pub fn display_containing(_x: f64, _y: f64) -> Option<CursorDisplay> {
     None
+}
+
+/// Whether this native backend can keep one Actions Ring window allocated and
+/// later hide/show/reposition it without rebuilding GPUI's renderer.
+#[cfg(target_os = "windows")]
+pub fn supports_warm_window(window: &gpui::Window) -> bool {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    HasWindowHandle::window_handle(window)
+        .is_ok_and(|handle| matches!(handle.as_raw(), RawWindowHandle::Win32(_)))
+}
+
+#[cfg(target_os = "macos")]
+pub const fn supports_warm_window(_window: &gpui::Window) -> bool {
+    true
+}
+
+#[cfg(target_os = "linux")]
+pub fn supports_warm_window(window: &gpui::Window) -> bool {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    HasWindowHandle::window_handle(window).is_ok_and(|handle| {
+        matches!(
+            handle.as_raw(),
+            RawWindowHandle::Xcb(_) | RawWindowHandle::Xlib(_)
+        )
+    })
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+pub const fn supports_warm_window(_window: &gpui::Window) -> bool {
+    false
+}
+
+// `SetWindowRgn` consumes device-unit coordinates, so the Windows helper
+// derives the circular region from the live HWND after DPI has settled.
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "windows-sys 0.61.2 omits SetWindowRgn, so bind its documented User32 ABI locally"
+)]
+#[link(name = "user32")]
+unsafe extern "system" {
+    fn SetWindowRgn(
+        hwnd: windows_sys::Win32::Foundation::HWND,
+        region: windows_sys::Win32::Graphics::Gdi::HRGN,
+        redraw: i32,
+    ) -> i32;
+}
+
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "Win32 window regions are the native input/visibility shape primitive for a circular popup"
+)]
+pub fn apply_circular_shape(window: &gpui::Window) -> bool {
+    use windows_sys::Win32::{
+        Foundation::RECT,
+        Graphics::Gdi::{CreateEllipticRgn, DeleteObject},
+        UI::WindowsAndMessaging::GetWindowRect,
+    };
+
+    let Some(hwnd) = hwnd(window) else {
+        return false;
+    };
+    let mut window_rect = RECT::default();
+    // SAFETY: `window_rect` is a valid writable RECT and `hwnd` belongs to the
+    // live GPUI window.
+    if unsafe { GetWindowRect(hwnd, &raw mut window_rect) } == 0 {
+        return false;
+    }
+    let width = (window_rect.right - window_rect.left).max(1);
+    let height = (window_rect.bottom - window_rect.top).max(1);
+    // SAFETY: CreateEllipticRgn only consumes integer bounds and returns an
+    // owned GDI region handle on success.
+    let region = unsafe { CreateEllipticRgn(0, 0, width, height) };
+    if region.is_null() {
+        return false;
+    }
+    // SAFETY: `hwnd` belongs to the live GPUI window. On success Windows
+    // takes ownership of `region`; on failure ownership remains here.
+    let applied = unsafe { SetWindowRgn(hwnd, region, 1) } != 0;
+    if !applied {
+        // SAFETY: SetWindowRgn failed, so the region is still caller-owned.
+        unsafe { DeleteObject(region) };
+    }
+    applied
+}
+
+#[cfg(not(target_os = "windows"))]
+pub const fn apply_circular_shape(_window: &gpui::Window) -> bool {
+    false
+}
+
+/// Hide the warm Actions Ring window without destroying its renderer or GPUI
+/// view. A hidden native window cannot steal pointer input.
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "ShowWindow is the Win32 visibility primitive; HWND comes from GPUI's raw window handle"
+)]
+pub fn hide_window(window: &gpui::Window) -> bool {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, ShowWindow};
+
+    let Some(hwnd) = hwnd(window) else {
+        return false;
+    };
+    // SAFETY: `hwnd` belongs to the live GPUI window passed by reference.
+    unsafe { ShowWindow(hwnd, SW_HIDE) };
+    true
+}
+
+/// Add the native non-activating style without disturbing GPUI's other extended styles.
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "the Win32 extended style is the native guarantee that the ring cannot take foreground focus"
+)]
+fn ensure_windows_no_activate(hwnd: windows_sys::Win32::Foundation::HWND) -> bool {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GWL_EXSTYLE, GetWindowLongPtrW, SetWindowLongPtrW, WS_EX_NOACTIVATE,
+    };
+
+    let Ok(no_activate_style) = isize::try_from(WS_EX_NOACTIVATE) else {
+        return false;
+    };
+    // SAFETY: `hwnd` is the live GPUI overlay. Reading and rewriting the
+    // extended style preserves every GPUI bit and only adds WS_EX_NOACTIVATE.
+    let current_style = unsafe { GetWindowLongPtrW(hwnd, GWL_EXSTYLE) };
+    if current_style & no_activate_style == 0 {
+        // SAFETY: `hwnd` is live and the new value is the existing style with
+        // the documented non-activating bit added.
+        unsafe { SetWindowLongPtrW(hwnd, GWL_EXSTYLE, current_style | no_activate_style) };
+        // SAFETY: same live HWND; re-reading verifies that the style change
+        // actually took effect before the popup can become interactive.
+        let updated_style = unsafe { GetWindowLongPtrW(hwnd, GWL_EXSTYLE) };
+        if updated_style & no_activate_style == 0 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Reposition the hidden HWND around the cursor after settling any cross-DPI
+/// monitor transition. The caller keeps it hidden until the circular region is
+/// rebuilt from the settled native size.
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "Win32 cursor/monitor/window placement is required because GPUI exposes no public move API for an existing window"
+)]
+fn position_windows_overlay_at_cursor(hwnd: windows_sys::Win32::Foundation::HWND) -> bool {
+    use windows_sys::Win32::{
+        Foundation::{POINT, RECT},
+        Graphics::Gdi::{GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromPoint},
+        UI::WindowsAndMessaging::{
+            GetCursorPos, GetWindowRect, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, SetWindowPos,
+        },
+    };
+
+    let mut cursor = POINT::default();
+    // SAFETY: `cursor` is a valid writable POINT.
+    if unsafe { GetCursorPos(&raw mut cursor) } == 0 {
+        return false;
+    }
+
+    // SAFETY: `cursor` is a plain screen-space point.
+    let monitor = unsafe { MonitorFromPoint(cursor, MONITOR_DEFAULTTONEAREST) };
+    if monitor.is_null() {
+        return false;
+    }
+    let Ok(cb_size) = u32::try_from(std::mem::size_of::<MONITORINFO>()) else {
+        return false;
+    };
+    let mut monitor_info = MONITORINFO {
+        cbSize: cb_size,
+        ..Default::default()
+    };
+    // SAFETY: `monitor` is returned by MonitorFromPoint and the struct size is
+    // initialized as required by GetMonitorInfoW.
+    if unsafe { GetMonitorInfoW(monitor, &raw mut monitor_info) } == 0 {
+        return false;
+    }
+
+    // Drop the old region before a possible DPI resize. The window is still
+    // hidden, so this cannot flash a rectangular frame on screen.
+    // SAFETY: a null HRGN removes the current region; `hwnd` is live.
+    unsafe { SetWindowRgn(hwnd, std::ptr::null_mut(), 0) };
+
+    // Stage the hidden window on the target monitor so GPUI can process a
+    // synchronous WM_DPICHANGED before the authoritative native size is read.
+    // SAFETY: the monitor origin is valid screen space and SWP_NOSIZE preserves
+    // the existing renderer allocation during the staging move.
+    if unsafe {
+        SetWindowPos(
+            hwnd,
+            std::ptr::null_mut(),
+            monitor_info.rcMonitor.left,
+            monitor_info.rcMonitor.top,
+            0,
+            0,
+            SWP_NOACTIVATE | SWP_NOSIZE | SWP_NOZORDER,
+        )
+    } == 0
+    {
+        return false;
+    }
+
+    let mut window_rect = RECT::default();
+    // SAFETY: the staging move has settled any DPI-triggered native resize, so
+    // this RECT is the authoritative device-pixel window size.
+    if unsafe { GetWindowRect(hwnd, &raw mut window_rect) } == 0 {
+        return false;
+    }
+    let width = (window_rect.right - window_rect.left).max(1);
+    let height = (window_rect.bottom - window_rect.top).max(1);
+    let desired_x = cursor.x - width / 2;
+    let desired_y = cursor.y - height / 2;
+    let max_x = (monitor_info.rcMonitor.right - width).max(monitor_info.rcMonitor.left);
+    let max_y = (monitor_info.rcMonitor.bottom - height).max(monitor_info.rcMonitor.top);
+    let x = desired_x.clamp(monitor_info.rcMonitor.left, max_x);
+    let y = desired_y.clamp(monitor_info.rcMonitor.top, max_y);
+
+    // SAFETY: x/y are clamped to the cursor's monitor and the window remains
+    // hidden until its circular region has been rebuilt.
+    let positioned = unsafe {
+        SetWindowPos(
+            hwnd,
+            std::ptr::null_mut(),
+            x,
+            y,
+            0,
+            0,
+            SWP_NOACTIVATE | SWP_NOSIZE | SWP_NOZORDER,
+        )
+    };
+    positioned != 0
+}
+
+/// Reveal the shaped overlay immediately above the foreground window without
+/// activating it or globally pinning it above unrelated windows.
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    reason = "Win32 exposes foreground-relative z-order only through HWND inspection and SetWindowPos"
+)]
+fn show_windows_above_foreground(hwnd: windows_sys::Win32::Foundation::HWND) -> bool {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GW_HWNDPREV, GWL_EXSTYLE, GetForegroundWindow, GetWindow, GetWindowLongPtrW,
+        HWND_NOTOPMOST, HWND_TOPMOST, IsWindow, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOOWNERZORDER,
+        SWP_NOSIZE, SWP_NOZORDER, SWP_SHOWWINDOW, SetWindowPos, WS_EX_TOPMOST,
+    };
+
+    // SAFETY: GetForegroundWindow only reads the desktop foreground state.
+    let foreground = unsafe { GetForegroundWindow() };
+    let foreground = if foreground.is_null() || foreground == hwnd {
+        None
+    } else {
+        // SAFETY: IsWindow only validates the HWND value returned above.
+        let valid = unsafe { IsWindow(foreground) } != 0;
+        valid.then_some(foreground)
+    };
+    let predecessor = foreground.and_then(|foreground| {
+        // SAFETY: `foreground` was validated as a live top-level HWND.
+        let predecessor = unsafe { GetWindow(foreground, GW_HWNDPREV) };
+        (!predecessor.is_null()).then_some(predecessor)
+    });
+    let Ok(topmost_style) = isize::try_from(WS_EX_TOPMOST) else {
+        return false;
+    };
+    let is_topmost = |candidate| {
+        // SAFETY: candidates are the live overlay HWND or handles returned from
+        // the validated foreground window's z-order chain.
+        let ex_style = unsafe { GetWindowLongPtrW(candidate, GWL_EXSTYLE) };
+        ex_style & topmost_style != 0
+    };
+    let overlay_is_topmost = is_topmost(hwnd);
+    let foreground_is_topmost = foreground.is_some_and(is_topmost);
+    let predecessor_is_topmost = predecessor.is_some_and(is_topmost);
+    let stack_target = choose_windows_stack_target(
+        hwnd,
+        foreground,
+        predecessor,
+        overlay_is_topmost,
+        foreground_is_topmost,
+        predecessor_is_topmost,
+    );
+    let (insert_after, keep_z_order) = match stack_target {
+        RelativeStackTarget::Keep => (std::ptr::null_mut(), true),
+        RelativeStackTarget::After(predecessor) => (predecessor, false),
+        RelativeStackTarget::Top => (HWND_NOTOPMOST, false),
+        RelativeStackTarget::Topmost => (HWND_TOPMOST, false),
+    };
+    let mut flags = SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_SHOWWINDOW;
+    if keep_z_order {
+        flags |= SWP_NOZORDER;
+    }
+
+    // SAFETY: the HWND is already positioned and shaped. SWP_NOACTIVATE keeps
+    // keyboard focus in the current app while the insertion handle changes only
+    // this reveal's relative z-order.
+    let shown = unsafe { SetWindowPos(hwnd, insert_after, 0, 0, 0, 0, flags) };
+    shown != 0
+}
+
+/// Reposition the already-created ring around the current cursor and reveal it
+/// without activating it. The HWND remains warm between invocations.
+#[cfg(target_os = "windows")]
+pub fn show_window_at_cursor(window: &gpui::Window) -> bool {
+    let Some(hwnd) = hwnd(window) else {
+        return false;
+    };
+    ensure_windows_no_activate(hwnd)
+        && position_windows_overlay_at_cursor(hwnd)
+        && apply_circular_shape(window)
+        && show_windows_above_foreground(hwnd)
+}
+
+#[cfg(target_os = "windows")]
+fn hwnd(window: &gpui::Window) -> Option<windows_sys::Win32::Foundation::HWND> {
+    use raw_window_handle::RawWindowHandle;
+
+    let handle = raw_window_handle::HasWindowHandle::window_handle(window)
+        .ok()?
+        .as_raw();
+    match handle {
+        RawWindowHandle::Win32(handle) => Some(handle.hwnd.get() as _),
+        _ => None,
+    }
+}
+
+/// AppKit keeps the GPUI NSWindow allocated while `orderOut` removes it from
+/// the screen, so subsequent ring opens avoid NSWindow/Metal reconstruction.
+#[cfg(target_os = "macos")]
+pub fn hide_window(_window: &gpui::Window) -> bool {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+
+    let Some(marker) = MainThreadMarker::new() else {
+        return false;
+    };
+    let windows = NSApplication::sharedApplication(marker).windows();
+    let mut found = false;
+    for window in windows {
+        found = true;
+        window.orderOut(None);
+    }
+    found
+}
+
+/// Move the retained NSWindow to the screen under the cursor and order it
+/// immediately above the frontmost application's window without activating the
+/// accessory overlay application.
+#[cfg(target_os = "macos")]
+pub fn show_window_at_cursor(_window: &gpui::Window) -> bool {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSApplication, NSEvent, NSScreen, NSWindowOrderingMode};
+
+    let Some(marker) = MainThreadMarker::new() else {
+        return false;
+    };
+    let app = NSApplication::sharedApplication(marker);
+    let Some(window) = app.windows().into_iter().next() else {
+        return false;
+    };
+    let cursor = NSEvent::mouseLocation();
+    let screens = NSScreen::screens(marker);
+    let screen_frame = screens
+        .into_iter()
+        .find_map(|screen| {
+            let frame = screen.frame();
+            let inside = cursor.x >= frame.origin.x
+                && cursor.x < frame.origin.x + frame.size.width
+                && cursor.y >= frame.origin.y
+                && cursor.y < frame.origin.y + frame.size.height;
+            inside.then_some(frame)
+        })
+        .or_else(|| NSScreen::mainScreen(marker).map(|screen| screen.frame()));
+    let Some(screen) = screen_frame else {
+        return false;
+    };
+
+    let frame = window.frame();
+    let max_x = (screen.origin.x + screen.size.width - frame.size.width).max(screen.origin.x);
+    let max_y = (screen.origin.y + screen.size.height - frame.size.height).max(screen.origin.y);
+    let mut origin = frame.origin;
+    origin.x = (cursor.x - frame.size.width / 2.0).clamp(screen.origin.x, max_x);
+    origin.y = (cursor.y - frame.size.height / 2.0).clamp(screen.origin.y, max_y);
+    window.setFrameOrigin(origin);
+
+    // CoreGraphics uses the same top-left global coordinate space as the
+    // low-level hook cursor helper, unlike AppKit's bottom-left screen space.
+    let cg_cursor = openlogi_hook::cursor_position()
+        .map(|cursor| core_graphics::geometry::CGPoint::new(cursor.x, cursor.y));
+    let target = frontmost_macos_window_number(window.windowNumber(), cg_cursor);
+    if let Some(target) = target {
+        window.orderWindow_relativeTo(NSWindowOrderingMode::Above, target);
+    } else {
+        window.orderFrontRegardless();
+    }
+    true
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn select_x11_active_sibling(overlay: u32, active_root_child: Option<u32>) -> Option<u32> {
+    active_root_child.filter(|active| *active != 0 && *active != overlay)
+}
+
+#[cfg(target_os = "linux")]
+fn x11_root_child_for_window(
+    connection: &x11rb::rust_connection::RustConnection,
+    root: u32,
+    window: u32,
+) -> Option<u32> {
+    use x11rb::protocol::xproto::ConnectionExt as _;
+
+    if window == 0 || window == root {
+        return None;
+    }
+    let mut current = window;
+    for _ in 0..32 {
+        let tree = connection.query_tree(current).ok()?.reply().ok()?;
+        if tree.root != root {
+            return None;
+        }
+        if tree.parent == root {
+            return Some(current);
+        }
+        if tree.parent == 0 || tree.parent == current {
+            return None;
+        }
+        current = tree.parent;
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+thread_local! {
+    static X11_CONNECTION: std::cell::RefCell<Option<x11rb::rust_connection::RustConnection>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(target_os = "linux")]
+fn with_x11_connection<R>(
+    operation: impl FnOnce(&x11rb::rust_connection::RustConnection) -> Option<R>,
+) -> Option<R> {
+    X11_CONNECTION.with(|slot| {
+        if slot.borrow().is_none() {
+            let (connection, _) = x11rb::connect(None).ok()?;
+            *slot.borrow_mut() = Some(connection);
+        }
+        let connection = slot.borrow();
+        operation(connection.as_ref()?)
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn x11_window_id(window: &gpui::Window) -> Option<u32> {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    match HasWindowHandle::window_handle(window).ok()?.as_raw() {
+        RawWindowHandle::Xcb(handle) => Some(handle.window.get()),
+        RawWindowHandle::Xlib(handle) => u32::try_from(handle.window).ok(),
+        _ => None,
+    }
+}
+
+/// X11 can unmap an existing client window without destroying it. Wayland does
+/// not expose equivalent global positioning/remapping semantics for this popup,
+/// so Wayland deliberately stays on the existing create/destroy fallback.
+#[cfg(target_os = "linux")]
+pub fn hide_window(window: &gpui::Window) -> bool {
+    use x11rb::{connection::Connection as _, protocol::xproto::ConnectionExt as _};
+
+    let Some(window_id) = x11_window_id(window) else {
+        return false;
+    };
+    with_x11_connection(|connection| {
+        connection.unmap_window(window_id).ok()?;
+        connection.flush().ok()?;
+        Some(())
+    })
+    .is_some()
+}
+
+/// Reposition and map the retained X11 window around the current root-pointer,
+/// stacking it immediately above the EWMH active window when that sibling is
+/// valid on the same root. The cached connection avoids reconnecting on the hot
+/// path and no focus request is sent.
+#[cfg(target_os = "linux")]
+pub fn show_window_at_cursor(window: &gpui::Window) -> bool {
+    use x11rb::{
+        connection::Connection as _,
+        protocol::xproto::{AtomEnum, ConfigureWindowAux, ConnectionExt as _, StackMode},
+    };
+
+    let Some(window_id) = x11_window_id(window) else {
+        return false;
+    };
+    with_x11_connection(|connection| {
+        let geometry = connection.get_geometry(window_id).ok()?.reply().ok()?;
+        let pointer = connection.query_pointer(geometry.root).ok()?.reply().ok()?;
+        let screen = connection
+            .setup()
+            .roots
+            .iter()
+            .find(|screen| screen.root == geometry.root)?;
+
+        let width = i32::from(geometry.width).max(1);
+        let height = i32::from(geometry.height).max(1);
+        let max_x = (i32::from(screen.width_in_pixels) - width).max(0);
+        let max_y = (i32::from(screen.height_in_pixels) - height).max(0);
+        let x = (i32::from(pointer.root_x) - width / 2).clamp(0, max_x);
+        let y = (i32::from(pointer.root_y) - height / 2).clamp(0, max_y);
+
+        let active_sibling = (|| {
+            let active_atom = connection
+                .intern_atom(false, b"_NET_ACTIVE_WINDOW")
+                .ok()?
+                .reply()
+                .ok()?
+                .atom;
+            let active = connection
+                .get_property(false, geometry.root, active_atom, AtomEnum::WINDOW, 0, 1)
+                .ok()?
+                .reply()
+                .ok()?
+                .value32()?
+                .next()?;
+            let active_root_child = x11_root_child_for_window(connection, geometry.root, active);
+            select_x11_active_sibling(window_id, active_root_child)
+        })();
+
+        let mut configure = ConfigureWindowAux::new()
+            .x(x)
+            .y(y)
+            .stack_mode(StackMode::ABOVE);
+        if let Some(active_sibling) = active_sibling {
+            configure = configure.sibling(active_sibling);
+        }
+        connection.configure_window(window_id, &configure).ok()?;
+        connection.map_window(window_id).ok()?;
+        connection.flush().ok()?;
+        Some(())
+    })
+    .is_some()
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+pub const fn hide_window(_window: &gpui::Window) -> bool {
+    false
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+pub const fn show_window_at_cursor(_window: &gpui::Window) -> bool {
+    false
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::{MacWindowCandidate, select_frontmost_macos_window};
+    use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+
+    fn candidate(number: isize, owner_pid: i32, x: f64) -> MacWindowCandidate {
+        MacWindowCandidate {
+            number,
+            owner_pid,
+            layer: 0,
+            bounds: CGRect::new(&CGPoint::new(x, 0.0), &CGSize::new(100.0, 100.0)),
+        }
+    }
+
+    #[test]
+    fn macos_relative_stack_prefers_frontmost_app_window_under_cursor() {
+        let candidates = [candidate(10, 7, 0.0), candidate(11, 7, 200.0)];
+        assert_eq!(
+            select_frontmost_macos_window(7, 99, Some(CGPoint::new(250.0, 50.0)), candidates),
+            Some(11),
+        );
+    }
+
+    #[test]
+    fn macos_relative_stack_falls_back_to_frontmost_normal_window() {
+        let candidates = [candidate(10, 7, 0.0), candidate(11, 8, 200.0)];
+        assert_eq!(
+            select_frontmost_macos_window(7, 99, None, candidates),
+            Some(10),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RelativeStackTarget, choose_windows_stack_target, select_x11_active_sibling};
+
+    #[test]
+    fn windows_relative_stack_uses_predecessor() {
+        assert_eq!(
+            choose_windows_stack_target(99_u32, Some(10), Some(20), false, false, false),
+            RelativeStackTarget::After(20),
+        );
+    }
+
+    #[test]
+    fn windows_relative_stack_does_not_cross_into_topmost_band() {
+        assert_eq!(
+            choose_windows_stack_target(99_u32, Some(10), Some(20), false, false, true),
+            RelativeStackTarget::Top,
+        );
+    }
+
+    #[test]
+    fn windows_relative_stack_keeps_existing_immediate_position() {
+        assert_eq!(
+            choose_windows_stack_target(99_u32, Some(10), Some(99), false, false, false),
+            RelativeStackTarget::Keep,
+        );
+    }
+
+    #[test]
+    fn windows_relative_stack_demotes_stale_topmost_overlay() {
+        assert_eq!(
+            choose_windows_stack_target(99_u32, Some(10), Some(99), true, false, true),
+            RelativeStackTarget::Top,
+        );
+    }
+
+    #[test]
+    fn windows_relative_stack_falls_back_to_normal_top() {
+        assert_eq!(
+            choose_windows_stack_target(99_u32, None, None, false, false, false),
+            RelativeStackTarget::Top,
+        );
+        assert_eq!(
+            choose_windows_stack_target(99_u32, Some(99), None, false, false, false),
+            RelativeStackTarget::Top,
+        );
+    }
+
+    #[test]
+    fn windows_relative_stack_preserves_topmost_band_only_when_required() {
+        assert_eq!(
+            choose_windows_stack_target(99_u32, Some(10), None, true, true, false),
+            RelativeStackTarget::Topmost,
+        );
+    }
+
+    #[test]
+    fn x11_relative_stack_uses_active_window_on_same_root() {
+        assert_eq!(select_x11_active_sibling(99, Some(10)), Some(10),);
+    }
+
+    #[test]
+    fn x11_relative_stack_rejects_missing_self_and_other_root_targets() {
+        assert_eq!(select_x11_active_sibling(99, None), None);
+        assert_eq!(select_x11_active_sibling(99, Some(99)), None);
+        assert_eq!(select_x11_active_sibling(99, Some(0)), None);
+    }
 }

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -4,6 +4,8 @@
 //! clamped to the display it came up on, so a ring raised near a screen edge
 //! stays whole instead of being cut off.
 
+use std::sync::Arc;
+
 use gpui::{
     Bounds, Context, Hsla, InteractiveElement, IntoElement, ParentElement, Pixels, Point, Render,
     SharedString, Size, StatefulInteractiveElement as _, Styled, Window,
@@ -14,21 +16,17 @@ use openlogi_core::binding::{Action, ActionRingSlot};
 use openlogi_ipc::ActionRingInvocation;
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
 use openlogi_ui::color;
-use std::sync::Arc;
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use crate::agent::OverlayCommand;
 use crate::platform;
-use crate::session::{ClickAwaySession, ShowingRing};
+use crate::session::ClickAwaySession;
 
-pub(crate) const WINDOW_SIZE: f32 = 360.0;
+pub(crate) const WINDOW_SIZE: f32 = 324.0;
 pub(crate) const SLOT_SIZE: f32 = 54.0;
 pub(crate) const RADIUS: f32 = 122.0;
 
-/// The ring's own neutral scale. It floats over whatever is on the desktop, so
-/// unlike the settings app it cannot take its surfaces from the OS appearance —
-/// it commits to a dark panel and rides its own contrast. Only the accent is
-/// shared (`openlogi_ui::color`); these greys are local by nature.
 const PANEL: Hsla = neutral(0.06, 0.82);
 const SLOT_RESTING: Hsla = neutral(0.16, 0.98);
 const CANCEL_RESTING: Hsla = neutral(0.20, 0.98);
@@ -45,47 +43,91 @@ const fn neutral(lightness: f32, alpha: f32) -> Hsla {
     }
 }
 
-/// The accent deepened for the dark panel: the brand lightness sits too close to
-/// the white glyph a selected slot carries, so the fill drops to `0.48` and the
-/// ring around it rises to `0.78`. Both keep the brand hue and saturation.
 const SELECTED_FILL_L: f32 = 0.48;
 const SELECTED_BORDER_L: f32 = 0.78;
 
 pub(crate) struct RingView {
-    invocation: ActionRingInvocation,
+    invocation: Option<ActionRingInvocation>,
     commands: mpsc::UnboundedSender<OverlayCommand>,
     hovered: Option<ActionRingSlot>,
-    /// Publishes click-away identity for exactly this view's lifetime.
-    _showing: ShowingRing,
+    live_session: Arc<ClickAwaySession>,
+    persistent: bool,
 }
 
 impl RingView {
-    /// Open a view on `invocation`, reporting interactions through `commands`.
     pub(crate) fn new(
         invocation: ActionRingInvocation,
         commands: mpsc::UnboundedSender<OverlayCommand>,
-        live: &Arc<ClickAwaySession>,
+        live_session: Arc<ClickAwaySession>,
     ) -> Self {
-        let showing = live.showing(invocation.session_id);
         Self {
-            invocation,
+            invocation: Some(invocation),
             commands,
             hovered: None,
-            _showing: showing,
+            live_session,
+            persistent: false,
         }
     }
 
-    /// The ring session this view is showing.
-    pub(crate) const fn session_id(&self) -> u64 {
-        self.invocation.session_id
+    pub(crate) fn idle(
+        commands: mpsc::UnboundedSender<OverlayCommand>,
+        live_session: Arc<ClickAwaySession>,
+    ) -> Self {
+        Self {
+            invocation: None,
+            commands,
+            hovered: None,
+            live_session,
+            persistent: true,
+        }
     }
 
-    /// Report this ring cancelled. The window is closed by the caller, which
-    /// is the only one holding the handle.
+    pub(crate) fn current_session(&self) -> Option<u64> {
+        self.invocation
+            .as_ref()
+            .map(|invocation| invocation.session_id)
+    }
+
+    pub(crate) fn install(&mut self, invocation: ActionRingInvocation, cx: &mut Context<Self>) {
+        self.hovered = None;
+        self.invocation = Some(invocation);
+        cx.notify();
+    }
+
+    pub(crate) fn hide(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let session_id = self.current_session();
+        self.hovered = None;
+        self.invocation = None;
+        if let Some(session_id) = session_id {
+            self.live_session.clear_if(session_id);
+        }
+        cx.notify();
+        if self.persistent {
+            if !platform::hide_window(window) {
+                warn!("could not hide warm Actions Ring window");
+            }
+        } else {
+            window.remove_window();
+        }
+    }
+
+    pub(crate) fn dismiss(
+        &mut self,
+        session_id: u64,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if !session_targets(session_id, self.current_session()) {
+            return false;
+        }
+        self.hide(window, cx);
+        true
+    }
+
     pub(crate) fn cancel(&self) {
-        let _ = self.commands.send(OverlayCommand::Cancel {
-            session_id: self.invocation.session_id,
-        });
+        if let Some(session_id) = self.current_session() {
+            let _ = self.commands.send(OverlayCommand::Cancel { session_id });
+        }
     }
 
     fn slot_element(
@@ -93,11 +135,12 @@ impl RingView {
         slot: ActionRingSlot,
         cx: &mut Context<Self>,
     ) -> Option<gpui::AnyElement> {
-        let presentation = self.invocation.slots.get(&slot)?;
+        let invocation = self.invocation.as_ref()?;
+        let presentation = invocation.slots.get(&slot)?;
         let icon_path = presentation.icon.asset_path();
         let selected = self.hovered == Some(slot);
         let (left, top) = slot.placement(WINDOW_SIZE, RADIUS, SLOT_SIZE);
-        let session_id = self.invocation.session_id;
+        let session_id = invocation.session_id;
         let activate = self.commands.clone();
         Some(
             div()
@@ -135,26 +178,31 @@ impl RingView {
                         cx.notify();
                     }
                 }))
-                .on_click(move |_, window, cx| {
+                .on_click(cx.listener(move |this, _, window, cx| {
                     cx.stop_propagation();
                     let _ = activate.send(OverlayCommand::Activate { session_id, slot });
-                    window.remove_window();
-                })
+                    this.dismiss(session_id, window, cx);
+                }))
                 .into_any_element(),
         )
     }
 }
 
+#[must_use]
+const fn session_targets(session_id: u64, open_session: Option<u64>) -> bool {
+    matches!(open_session, Some(open) if open == session_id)
+}
+
 impl Render for RingView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let session_id = self.invocation.session_id;
+        let Some(invocation) = self.invocation.clone() else {
+            return div().id("ring-root-idle").size_full();
+        };
+        let session_id = invocation.session_id;
         let root_commands = self.commands.clone();
         let center_commands = self.commands.clone();
         let hovered_label = self.hovered.and_then(|slot| {
-            let presentation = self.invocation.slots.get(&slot)?;
-            // User-authored labels render verbatim: passing them through the
-            // localization table would translate any label that happens to
-            // collide with a known key ("Copy" → "Copier" under fr).
+            let presentation = invocation.slots.get(&slot)?;
             let label = if presentation.literal {
                 presentation.label.clone()
             } else if let Some(key) = Action::translation_key_for_label(&presentation.label) {
@@ -173,16 +221,8 @@ impl Render for RingView {
             .id("ring-root")
             .relative()
             .size_full()
-            .child(
-                div()
-                    .absolute()
-                    .left(px(18.0))
-                    .top(px(18.0))
-                    .size(px(WINDOW_SIZE - 36.0))
-                    .rounded_full()
-                    .bg(PANEL)
-                    .shadow_lg(),
-            )
+            .rounded_full()
+            .bg(PANEL)
             .children(slots)
             .child(
                 div()
@@ -199,11 +239,11 @@ impl Render for RingView {
                     .text_color(CANCEL_GLYPH)
                     .cursor_pointer()
                     .child(svg().path(RING_CANCEL_ICON).size(px(20.0)).flex_none())
-                    .on_click(move |_, window, cx| {
+                    .on_click(cx.listener(move |this, _, window, cx| {
                         cx.stop_propagation();
                         let _ = center_commands.send(OverlayCommand::Cancel { session_id });
-                        window.remove_window();
-                    }),
+                        this.dismiss(session_id, window, cx);
+                    })),
             )
             .when_some(hovered_label, |ring, label| {
                 ring.child(
@@ -218,44 +258,138 @@ impl Render for RingView {
                         .child(label),
                 )
             })
-            .on_click(move |_, window, _| {
+            .on_click(cx.listener(move |this, _, window, cx| {
                 let _ = root_commands.send(OverlayCommand::Cancel { session_id });
-                window.remove_window();
-            })
+                this.dismiss(session_id, window, cx);
+            }))
     }
+}
+
+#[cfg(any(target_os = "windows", test))]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "monitor-sized logical coordinates retain sufficient precision as GPUI f32 pixels"
+)]
+fn cursor_in_logical_display(
+    cursor: (f64, f64),
+    native_origin: (f64, f64),
+    native_size: (f64, f64),
+    logical_bounds: &Bounds<Pixels>,
+) -> Option<Point<Pixels>> {
+    let logical_width = f64::from(logical_bounds.size.width.as_f32());
+    let logical_height = f64::from(logical_bounds.size.height.as_f32());
+    if native_size.0 <= 0.0 || native_size.1 <= 0.0 || logical_width <= 0.0 || logical_height <= 0.0
+    {
+        return None;
+    }
+    let scale_x = native_size.0 / logical_width;
+    let scale_y = native_size.1 / logical_height;
+    if !scale_x.is_finite() || !scale_y.is_finite() || scale_x <= 0.0 || scale_y <= 0.0 {
+        return None;
+    }
+    Some(point(
+        logical_bounds.origin.x + px(((cursor.0 - native_origin.0) / scale_x) as f32),
+        logical_bounds.origin.y + px(((cursor.1 - native_origin.1) / scale_y) as f32),
+    ))
 }
 
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "native cursor coordinates are screen-sized and exactly usable as GPUI f32 pixels"
+    reason = "native display coordinates are monitor-sized and retain sufficient precision as GPUI f32 pixels"
 )]
-pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
+fn platform_cursor_placement(
+    x: f64,
+    y: f64,
+) -> Option<(gpui::DisplayId, Point<Pixels>, Bounds<Pixels>)> {
+    let display = platform::display_containing(x, y)?;
+    Some((
+        gpui::DisplayId::from(display.id),
+        point(
+            px((x - display.origin.0) as f32),
+            px((y - display.origin.1) as f32),
+        ),
+        Bounds::new(
+            Point::default(),
+            Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
+        ),
+    ))
+}
+
+#[cfg(target_os = "windows")]
+#[expect(
+    unsafe_code,
+    clippy::cast_possible_truncation,
+    reason = "Win32 monitor lookup consumes i32 device pixels and GPUI DisplayId mirrors the HMONITOR value"
+)]
+fn native_cursor_placement(
+    cx: &mut gpui::App,
+    x: f64,
+    y: f64,
+) -> Option<(gpui::DisplayId, Point<Pixels>, Bounds<Pixels>)> {
+    use windows_sys::Win32::{
+        Foundation::POINT as NativePoint,
+        Graphics::Gdi::{GetMonitorInfoW, MONITOR_DEFAULTTONEAREST, MONITORINFO, MonitorFromPoint},
+    };
+
+    let cursor = NativePoint {
+        x: x.round() as i32,
+        y: y.round() as i32,
+    };
+    // SAFETY: MonitorFromPoint consumes a by-value POINT and does not dereference caller-owned pointers.
+    let monitor = unsafe { MonitorFromPoint(cursor, MONITOR_DEFAULTTONEAREST) };
+    if monitor.is_null() {
+        return platform_cursor_placement(x, y);
+    }
+    let display_id = gpui::DisplayId::from(u64::try_from(monitor as usize).ok()?);
+    let logical_bounds = cx
+        .displays()
+        .into_iter()
+        .find(|display| display.id() == display_id)?
+        .bounds();
+
+    let mut monitor_info = MONITORINFO {
+        cbSize: u32::try_from(std::mem::size_of::<MONITORINFO>()).ok()?,
+        ..Default::default()
+    };
+    // SAFETY: monitor is a non-null HMONITOR returned by MonitorFromPoint, and monitor_info is a valid writable MONITORINFO with cbSize initialized.
+    if unsafe { GetMonitorInfoW(monitor, &raw mut monitor_info) } == 0 {
+        return None;
+    }
+    let native_origin = (
+        f64::from(monitor_info.rcMonitor.left),
+        f64::from(monitor_info.rcMonitor.top),
+    );
+    let native_size = (
+        f64::from(monitor_info.rcMonitor.right - monitor_info.rcMonitor.left),
+        f64::from(monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top),
+    );
+    let center = cursor_in_logical_display((x, y), native_origin, native_size, &logical_bounds)?;
+    Some((display_id, center, logical_bounds))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn native_cursor_placement(
+    _cx: &mut gpui::App,
+    x: f64,
+    y: f64,
+) -> Option<(gpui::DisplayId, Point<Pixels>, Bounds<Pixels>)> {
+    platform_cursor_placement(x, y)
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "native cursor coordinates are screen-sized and retain sufficient precision as GPUI f32 pixels"
+)]
+pub(crate) fn ring_window_options(cx: &mut gpui::App, show: bool) -> WindowOptions {
     let cursor = openlogi_hook::cursor_position();
     let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
-    // GPUI window bounds are display-relative (`display.bounds()` zeroes every
-    // origin) while the hook reports the cursor in global coordinates, so the
-    // cursor's display must be resolved natively and the cursor translated into
-    // that display's space. Feeding the global point straight into the clamp
-    // pins a ring triggered on a secondary display to the primary one's edge.
-    let native_display = cursor
+    let native_placement = cursor
         .as_ref()
-        .and_then(|cursor| platform::display_containing(cursor.x, cursor.y));
+        .and_then(|cursor| native_cursor_placement(cx, cursor.x, cursor.y));
     let (display_id, center, display_bounds) =
-        if let (Some(cursor), Some(display)) = (&cursor, native_display) {
-            (
-                Some(gpui::DisplayId::from(display.id)),
-                point(
-                    px((cursor.x - display.origin.0) as f32),
-                    px((cursor.y - display.origin.1) as f32),
-                ),
-                Some(Bounds::new(
-                    Point::default(),
-                    Size::new(px(display.size.0 as f32), px(display.size.1 as f32)),
-                )),
-            )
+        if let Some((display_id, center, display_bounds)) = native_placement {
+            (Some(display_id), center, Some(display_bounds))
         } else {
-            // No cursor or no native lookup (non-macOS): GPUI's own display
-            // list, centering on the display when the cursor is unknown.
             let cursor_point = cursor
                 .as_ref()
                 .map(|cursor| point(px(cursor.x as f32), px(cursor.y as f32)));
@@ -281,7 +415,7 @@ pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
         window_bounds: Some(WindowBounds::Windowed(bounds)),
         titlebar: None,
         focus: false,
-        show: true,
+        show,
         kind: WindowKind::PopUp,
         is_movable: false,
         is_resizable: false,
@@ -308,6 +442,28 @@ pub(crate) fn clamp_window_origin(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn session_target_requires_the_open_session() {
+        assert!(session_targets(12, Some(12)));
+        assert!(!session_targets(11, Some(12)));
+        assert!(!session_targets(12, None));
+    }
+
+    #[test]
+    fn windows_mixed_dpi_secondary_cursor_maps_to_gpui_space() {
+        let logical_bounds =
+            Bounds::new(point(px(1280.0), px(0.0)), Size::new(px(1280.0), px(720.0)));
+        assert_eq!(
+            cursor_in_logical_display(
+                (2880.0, 540.0),
+                (1920.0, 0.0),
+                (1920.0, 1080.0),
+                &logical_bounds,
+            ),
+            Some(point(px(1920.0), px(360.0)))
+        );
+    }
 
     #[test]
     fn overlay_origin_is_clamped_to_the_display() {

--- a/crates/openlogi-overlay/src/session.rs
+++ b/crates/openlogi-overlay/src/session.rs
@@ -18,31 +18,25 @@ use crate::ring::RingView;
 
 pub(crate) struct ClickAwaySession(AtomicU64);
 
-/// Publication guard tied to the lifetime of one ring view.
-///
-/// Dropping an older view cannot clear a replacement's session: teardown uses
-/// a compare-and-exchange against the id this guard published.
-#[must_use = "the guard must live as long as its ring view"]
-pub(crate) struct ShowingRing {
-    live: Arc<ClickAwaySession>,
-    session_id: u64,
-}
-
 impl ClickAwaySession {
     pub(crate) const fn new() -> Self {
         Self(AtomicU64::new(0))
     }
 
-    /// Publish `session_id` until the returned ring-lifetime guard is dropped.
-    pub(crate) fn showing(self: &Arc<Self>, session_id: u64) -> ShowingRing {
+    pub(crate) fn set(&self, session_id: u64) {
         self.0.store(session_id, Ordering::Release);
-        ShowingRing {
-            live: Arc::clone(self),
-            session_id,
-        }
     }
 
-    /// Session id at click time, or `None` when no ring is showing.
+    pub(crate) fn clear(&self) {
+        self.set(0);
+    }
+
+    pub(crate) fn clear_if(&self, session_id: u64) {
+        let _ = self
+            .0
+            .compare_exchange(session_id, 0, Ordering::AcqRel, Ordering::Acquire);
+    }
+
     #[must_use]
     fn observe(&self) -> Option<u64> {
         match self.0.load(Ordering::Acquire) {
@@ -52,32 +46,11 @@ impl ClickAwaySession {
     }
 }
 
-impl Drop for ShowingRing {
-    fn drop(&mut self) {
-        let _ =
-            self.live
-                .0
-                .compare_exchange(self.session_id, 0, Ordering::AcqRel, Ordering::Acquire);
-    }
-}
-
-/// True when the click still names the ring that is open.
 #[must_use]
 pub(crate) const fn click_away_targets(observed: u64, open: u64) -> bool {
     observed != 0 && observed == open
 }
 
-/// Dismiss a showing ring when the user clicks anywhere off it, the way a
-/// transient popup closes on click-away — without swallowing that click.
-///
-/// The ring window only covers its own 360×360 bounds, so an outside click
-/// never reaches the window's handlers. A global monitor closes the gap:
-/// macOS only delivers it events routed to *other* applications, so clicks on
-/// the ring itself can't race the slot/cancel handlers, and monitors can't
-/// consume events, so the click lands where the user aimed it. The handler
-/// snapshots the showing session onto a channel; teardown runs on the GPUI
-/// side, and only that session is cancelled so a queued click cannot close a
-/// ring that opened afterward.
 pub(crate) fn spawn_click_away_dismissal(cx: &mut gpui::App, live: Arc<ClickAwaySession>) {
     let (clicks_tx, mut clicks) = mpsc::unbounded_channel();
     let monitor = platform::watch_clicks_outside(move || {
@@ -102,22 +75,23 @@ pub(crate) fn spawn_click_away_dismissal(cx: &mut gpui::App, live: Arc<ClickAway
     .detach();
 }
 
-/// Drop the stub monitor; non-macOS has no native owner to keep alive.
 #[cfg(not(target_os = "macos"))]
 const fn drop_unused_click_away_monitor(_monitor: Option<platform::ClickAwayMonitor>) {}
 
-/// Cancel the open ring only if it is still the session the click named.
 pub(crate) fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
     for handle in cx.windows() {
         let Some(ring) = handle.downcast::<RingView>() else {
             continue;
         };
-        let _ = ring.update(cx, |view, window, _| {
-            if !click_away_targets(session_id, view.session_id()) {
+        let _ = ring.update(cx, |view, window, cx| {
+            let Some(open_session) = view.current_session() else {
+                return;
+            };
+            if !click_away_targets(session_id, open_session) {
                 return;
             }
             view.cancel();
-            window.remove_window();
+            view.dismiss(open_session, window, cx);
         });
     }
 }
@@ -125,10 +99,6 @@ pub(crate) fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
 pub(crate) fn claim_the_role() -> Result<Tenancy> {
     let directory = openlogi_core::paths::config_dir().context("resolving the config directory")?;
     let serving = spawned_by().unwrap_or_else(Run::mint);
-    // Identity comes with the claim: an overlay the agent cannot recognize
-    // holds the role while being unevictable by the ordinary path, so failing
-    // here and letting the supervisor start a replacement beats running as
-    // one (#842).
     Role::new(directory, "overlay")
         .claim(&Record::new(
             Identity::new(serving, Compat::from(PROTOCOL_VERSION)),
@@ -137,11 +107,6 @@ pub(crate) fn claim_the_role() -> Result<Tenancy> {
         .context("Actions Ring overlay single-instance check")
 }
 
-/// The agent run this overlay serves.
-///
-/// Seeded from the run token the supervisor passes in the environment, so even
-/// the first handshake catches an overlay left behind by a previous agent; a
-/// hand-started overlay adopts whichever run answers first.
 pub(crate) fn allegiance() -> &'static Allegiance {
     static SERVING: OnceLock<Allegiance> = OnceLock::new();
     SERVING.get_or_init(|| {
@@ -153,7 +118,6 @@ pub(crate) fn allegiance() -> &'static Allegiance {
     })
 }
 
-/// The run token of the agent that started this process, when there is one.
 pub(crate) fn spawned_by() -> Option<Run> {
     std::env::var(RUN_ENV).ok()?.parse().ok().map(Run::from_raw)
 }
@@ -164,33 +128,40 @@ mod tests {
 
     #[test]
     fn no_click_is_observed_when_no_ring_is_showing() {
-        let live = Arc::new(ClickAwaySession::new());
+        let live = ClickAwaySession::new();
         assert_eq!(live.observe(), None);
-        let showing = live.showing(11);
-        assert_eq!(live.observe(), Some(11));
-        drop(showing);
+        live.set(11);
+        live.clear();
+        assert_eq!(live.observe(), None);
+    }
+
+    #[test]
+    fn stale_clear_cannot_erase_replacement_session() {
+        let live = ClickAwaySession::new();
+        live.set(11);
+        live.set(12);
+        live.clear_if(11);
+        assert_eq!(live.observe(), Some(12));
+        live.clear_if(12);
         assert_eq!(live.observe(), None);
     }
 
     #[test]
     fn a_click_queued_before_a_new_ring_does_not_target_it() {
-        let live = Arc::new(ClickAwaySession::new());
-        let previous = live.showing(11);
+        let live = ClickAwaySession::new();
+        live.set(11);
         let queued = live.observe().expect("a showing ring is observable");
-        let replacement = live.showing(12);
-        drop(previous);
+        live.set(12);
         assert!(
             !click_away_targets(queued, live.observe().expect("replacement is showing")),
             "a click snapshotted against the previous session must not close the new ring"
         );
-        drop(replacement);
-        assert_eq!(live.observe(), None);
     }
 
     #[test]
     fn a_click_against_the_showing_ring_targets_it() {
-        let live = Arc::new(ClickAwaySession::new());
-        let _showing = live.showing(7);
+        let live = ClickAwaySession::new();
+        live.set(7);
         let queued = live.observe().expect("a showing ring is observable");
         assert!(click_away_targets(queued, 7));
     }


### PR DESCRIPTION
## Summary

Hi, I want `OpenLogi ` also help MX Master 2/3 user like me also can use action rings.

Improve the Actions Ring overlay so it behaves like a lightweight native gesture overlay instead of a normal application window.

This keeps the existing Actions Ring interaction semantics while reducing startup latency, fixing DPI/positioning issues, tightening the overlay to the visible ring, and ensuring it appears above the application currently being used without stealing focus.

## Changes

- Add `ShowActionsRing` as a selectable system action.
- Keep a persistent warm overlay process/window instead of creating a new overlay window for every invocation.
- Preserve the existing toggle behavior:
  - first trigger opens the Actions Ring
  - second trigger while visible dismisses it
  - a later trigger can open it again
- Reduce the overlay from the previous oversized transparent window to the actual ring size.
- Make the visible ring fill the overlay bounds.
- Remove the unnecessary outer inset/shadow area.
- Add a circular native hit region on Windows so transparent corners are not clickable.
- Derive the Windows region from the actual native HWND size instead of a hard-coded pixel diameter, keeping it correct under display scaling.
- Fix warm-window initialization so GPUI establishes the correct native size before the HWND is hidden and reused.
- Fix cursor-centered placement across monitors with different DPI settings.
- Handle GPUI/Windows `WM_DPICHANGED` behavior when moving the persistent overlay between monitors.
- Keep the overlay hidden while intermediate DPI/position adjustments happen
  to avoid visible jumps or rectangular flashes.
- Show the Actions Ring relative to the currently focused application instead of making it permanently always-on-top.
- Keep the previously focused application active while the Actions Ring is displayed and interacted with.

Now it will be like this:
<img width="908" height="549" alt="image" src="https://github.com/user-attachments/assets/d764b8a9-b572-4c2b-8866-342ab50c2bb1" />
### Platform behavior

**Windows**
- Position the ring directly above the current foreground window in Z-order.
- Do not make the overlay permanently `HWND_TOPMOST`.
- Use non-activating window behavior so the foreground application retains keyboard focus.
- Preserve the circular native window/input region.
- Keep DPI-aware placement and sizing.

**macOS**
- Reuse the persistent overlay window.
- Order the Actions Ring above the frontmost application's relevant window.
- Preserve the non-activating panel behavior so the current application remains focused.

**Linux / X11**
- Reuse the persistent overlay.
- Resolve `_NET_ACTIVE_WINDOW` and stack the ring directly above the active application's root-level window.
- Do not request keyboard focus.

**Linux / Wayland**
- Keep the existing safe compositor-managed fallback.
- Do not assume access to global window ordering, since Wayland does not expose
  the same relative Z-order controls as Windows, macOS, or X11.

## Why

The previous overlay behavior had several issues:

- creating/showing the ring could feel slower than necessary
- the native window was larger than the visible circle
- transparent corners could still participate in input handling
- hard-coded native dimensions broke under Windows display scaling
- moving the warm window between monitors could conflict with GPUI's  `WM_DPICHANGED` handling
- a hidden GPUI window did not initially have the requested native dimensions
- preserving the existing Z-order could leave the ring behind the currently focused application
- using a globally topmost window would unnecessarily place the ring above unrelated floating/system windows

The updated implementation keeps the overlay warm, sizes and positions it using its actual native bounds, and only elevates it as much as needed to appear above the application the user is currently working in.

## Focus behavior

Opening or clicking the Actions Ring must not move keyboard focus away from the application that was active before the ring appeared.

For example:

```text
Other window
Actions Ring
Focused application  <- remains active
Other windows
```

## Related issues:
- https://github.com/AprilNEA/OpenLogi/issues/630 -> maybe this PR help