### PR TITLE
fix(hid): preserve delayed macOS HID++ responses

### DIFF
--- a/crates/openlogi-hid/src/pairing/tests.rs
+++ b/crates/openlogi-hid/src/pairing/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::{error::Error, io, time::Duration};
 
 use hidpp::{
-    channel::{LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel},
+    channel::{LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel, RawHidWriteError},
     protocol::v10::MessageType,
 };
 
@@ -149,10 +149,10 @@ impl RawHidChannel for EchoRawHidChannel {
         0xc548
     }
 
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Sync + Send>> {
+    async fn write_report(&self, src: &[u8]) -> Result<usize, RawHidWriteError> {
         let report = src.to_vec();
         if self.written_tx.send(report.clone()).is_err() || self.incoming_tx.send(report).is_err() {
-            return Err(mock_error());
+            return Err(RawHidWriteError::failed(mock_error()));
         }
         Ok(src.len())
     }

--- a/crates/openlogi-hid/src/scripted_channel.rs
+++ b/crates/openlogi-hid/src/scripted_channel.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 use std::io;
 use std::sync::{Arc, Mutex, PoisonError};
 
-use hidpp::channel::RawHidChannel;
+use hidpp::channel::{RawHidChannel, RawHidWriteError};
 use tokio::sync::mpsc;
 
 #[derive(Clone)]
@@ -64,13 +64,15 @@ impl RawHidChannel for ScriptedRawHidChannel {
         0xb35b
     }
 
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+    async fn write_report(&self, src: &[u8]) -> Result<usize, RawHidWriteError> {
         self.written
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .push(src.to_vec());
         if let Some(response) = (self.responder)(src) {
-            self.incoming_tx.send(response).map_err(|_| mock_error())?;
+            self.incoming_tx
+                .send(response)
+                .map_err(|_| RawHidWriteError::failed(mock_error()))?;
         }
         Ok(src.len())
     }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -20,6 +20,8 @@ use async_hid::{AsyncHidRead, AsyncHidWrite, DeviceReader};
 use async_hid::{DeviceInfo, DeviceWriter, HidBackend};
 use futures_lite::StreamExt as _;
 use hidpp::channel::HidppChannel;
+#[cfg(not(target_os = "windows"))]
+use hidpp::channel::RawHidWriteError;
 use hidpp::nibble::U4;
 #[cfg(not(target_os = "windows"))]
 use hidpp::{async_trait, channel::RawHidChannel};
@@ -478,7 +480,7 @@ impl RawHidChannel for AsyncHidChannel {
         self.info.product_id
     }
 
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+    async fn write_report(&self, src: &[u8]) -> Result<usize, RawHidWriteError> {
         let mut w = self.writer.lock().await;
         match w.write_output_report(src).await {
             Ok(()) => Ok(src.len()),
@@ -486,7 +488,7 @@ impl RawHidChannel for AsyncHidChannel {
                 if matches!(e, async_hid::HidError::Disconnected) {
                     self.mark_disconnected();
                 }
-                Err(e.into())
+                Err(RawHidWriteError::failed(e))
             }
         }
     }

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -80,6 +80,27 @@ const HIDPP_LONG_COLLECTIONS: [(u16, u16, bool); 3] = [
     (0xff43, 0x0602, false),
 ];
 
+/// `async-hid 0.5.2` renders the macOS report-writer callback status as an
+/// unstructured message, so this adapter must match the one IOKit status whose
+/// semantics it can narrow. `0xE00002D6` is `kIOReturnTimeout`: the callback
+/// stopped waiting, but report delivery remains unknown.
+#[cfg(target_os = "macos")]
+const MACOS_WRITE_CALLBACK_TIMEOUT: &str = "report writer callback error: 0xE00002D6";
+
+#[cfg(not(target_os = "windows"))]
+fn classify_output_write_error(error: async_hid::HidError) -> RawHidWriteError {
+    #[cfg(target_os = "macos")]
+    if matches!(
+        &error,
+        async_hid::HidError::Message(message)
+            if message.as_ref() == MACOS_WRITE_CALLBACK_TIMEOUT
+    ) {
+        return RawHidWriteError::completion_unknown(error);
+    }
+
+    RawHidWriteError::failed(error)
+}
+
 /// Whether `(usage_page, usage_id)` is one of the HID++ long-report collections.
 fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
     HIDPP_LONG_COLLECTIONS
@@ -488,7 +509,7 @@ impl RawHidChannel for AsyncHidChannel {
                 if matches!(e, async_hid::HidError::Disconnected) {
                     self.mark_disconnected();
                 }
-                Err(RawHidWriteError::failed(e))
+                Err(classify_output_write_error(e))
             }
         }
     }

--- a/crates/openlogi-hid/src/transport/tests.rs
+++ b/crates/openlogi-hid/src/transport/tests.rs
@@ -115,3 +115,34 @@ fn child_of_lightspeed_receiver_is_detected() {
 fn unrelated_device_is_not_a_child() {
     assert!(!is_receiver_child_sysfs_path(UNRELATED));
 }
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_writer_callback_timeout_has_unknown_completion() {
+    let error = async_hid::HidError::message("report writer callback error: 0xE00002D6");
+
+    assert!(matches!(
+        classify_output_write_error(error),
+        RawHidWriteError::CompletionUnknown(_)
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn another_macos_writer_callback_error_is_definitive() {
+    let error = async_hid::HidError::message("report writer callback error: 0xE00002C0");
+
+    assert!(matches!(
+        classify_output_write_error(error),
+        RawHidWriteError::Failed(_)
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn disconnected_write_error_is_definitive() {
+    assert!(matches!(
+        classify_output_write_error(async_hid::HidError::Disconnected),
+        RawHidWriteError::Failed(_)
+    ));
+}

--- a/crates/openlogi-hid/src/transport/windows.rs
+++ b/crates/openlogi-hid/src/transport/windows.rs
@@ -9,7 +9,7 @@ use hidpp::channel::{LONG_REPORT_ID, SHORT_REPORT_ID};
 #[cfg(target_os = "windows")]
 use hidpp::{
     async_trait,
-    channel::{LONG_REPORT_LENGTH, RawHidChannel, SHORT_REPORT_LENGTH},
+    channel::{LONG_REPORT_LENGTH, RawHidChannel, RawHidWriteError, SHORT_REPORT_LENGTH},
 };
 #[cfg(target_os = "windows")]
 use tokio::sync::Mutex;
@@ -203,7 +203,7 @@ impl RawHidChannel for WindowsHidppChannel {
         self.info.product_id
     }
 
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
+    async fn write_report(&self, src: &[u8]) -> Result<usize, RawHidWriteError> {
         let endpoint = match src.first().copied().and_then(endpoint_for_report_id) {
             Some(ReportEndpoint::Short) => self.short.as_ref(),
             Some(ReportEndpoint::Long) => self.long.as_ref(),
@@ -217,9 +217,13 @@ impl RawHidChannel for WindowsHidppChannel {
                     src.first().copied().unwrap_or_default()
                 ),
             )
-        })?;
+        })
+        .map_err(RawHidWriteError::failed)?;
 
-        endpoint.write_report(src).await
+        endpoint
+            .write_report(src)
+            .await
+            .map_err(RawHidWriteError::failed)
     }
 
     async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -34,7 +34,7 @@ pub use error::ChannelError;
 pub use message::{
     HidppMessage, LONG_REPORT_ID, LONG_REPORT_LENGTH, SHORT_REPORT_ID, SHORT_REPORT_LENGTH,
 };
-pub use raw::RawHidChannel;
+pub use raw::{RawHidChannel, RawHidWriteError};
 
 use raw::supports_short_long_hidpp;
 
@@ -376,7 +376,19 @@ impl HidppChannel {
         // park `send` forever before the response wait even starts.
         let mut request = std::pin::pin!(
             async {
-                self.send_and_forget(msg).await?;
+                match self.write_message(msg).await {
+                    Ok(()) => {}
+                    Err(RawHidWriteError::CompletionUnknown(error)) => {
+                        trace!(
+                            dev,
+                            feat,
+                            func,
+                            error = %error,
+                            "HID write completion unknown; awaiting response"
+                        );
+                    }
+                    Err(error) => return Err(raw_write_channel_error(error)),
+                }
                 receiver.await.map_err(|_| ChannelError::NoResponse)
             }
             .fuse()
@@ -419,13 +431,15 @@ impl HidppChannel {
             return Err(ChannelError::MessageTypeNotSupported);
         }
 
+        self.write_message(msg)
+            .await
+            .map_err(raw_write_channel_error)
+    }
+
+    async fn write_message(&self, msg: HidppMessage) -> Result<(), RawHidWriteError> {
         let mut buf = [0u8; LONG_REPORT_LENGTH];
         let len = msg.write_raw(&mut buf);
-        self.raw_channel
-            .write_report(&buf[..len])
-            .await
-            .map(|_| ())
-            .map_err(ChannelError::Implementation)
+        self.raw_channel.write_report(&buf[..len]).await.map(|_| ())
     }
 
     /// Write one raw HID report through this channel's already-owned transport.
@@ -451,7 +465,7 @@ impl HidppChannel {
 
         let mut write = std::pin::pin!(self.raw_channel.write_report(report).fuse());
         select! {
-            result = write => result.map_err(ChannelError::Implementation),
+            result = write => result.map_err(raw_write_channel_error),
             () = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
         }
     }
@@ -495,6 +509,10 @@ impl HidppChannel {
     pub fn remove_msg_listener(&self, hdl: u32) -> bool {
         lock(&self.message_listeners).remove(&hdl).is_some()
     }
+}
+
+fn raw_write_channel_error(error: RawHidWriteError) -> ChannelError {
+    ChannelError::Implementation(Box::new(error))
 }
 
 /// Reads reports from `raw_channel` until `close` fires, resolving each one

--- a/crates/openlogi-hidpp/src/channel/raw.rs
+++ b/crates/openlogi-hidpp/src/channel/raw.rs
@@ -22,6 +22,34 @@ const SHORT_REPORT_USAGE: u16 = 0x0001;
 /// The HID usage ID identifying long HID++ message reports.
 const LONG_REPORT_USAGE: u16 = 0x0002;
 
+/// Failure reported while writing one raw HID output report.
+///
+/// A transport may know that a write failed, or it may only know that its
+/// completion callback stopped waiting. The latter is not success, but a
+/// response-bearing protocol can still confirm delivery from a matching reply.
+#[derive(Debug, thiserror::Error)]
+pub enum RawHidWriteError {
+    /// The transport established that the report write failed.
+    #[error("the HID report write failed")]
+    Failed(#[source] Box<dyn Error + Send + Sync>),
+
+    /// The transport could not establish whether the report was delivered.
+    #[error("the HID report write completion is unknown")]
+    CompletionUnknown(#[source] Box<dyn Error + Send + Sync>),
+}
+
+impl RawHidWriteError {
+    /// Wrap a transport error that establishes a failed write.
+    pub fn failed(error: impl Into<Box<dyn Error + Send + Sync>>) -> Self {
+        Self::Failed(error.into())
+    }
+
+    /// Wrap a transport error that leaves report delivery unknown.
+    pub fn completion_unknown(error: impl Into<Box<dyn Error + Send + Sync>>) -> Self {
+        Self::CompletionUnknown(error.into())
+    }
+}
+
 /// Represents an arbitrary HID communication channel that is both readable and
 /// writable. It has to support async I/O.
 ///
@@ -40,7 +68,7 @@ pub trait RawHidChannel: Sync + Send + 'static {
     /// Writes a raw report to the channel.
     ///
     /// Returns the exact amount of written bytes on success.
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Sync + Send>>;
+    async fn write_report(&self, src: &[u8]) -> Result<usize, RawHidWriteError>;
 
     /// Reads a raw report from the channel.
     ///

--- a/crates/openlogi-hidpp/src/channel/tests.rs
+++ b/crates/openlogi-hidpp/src/channel/tests.rs
@@ -9,7 +9,7 @@ use std::{
     io,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -61,6 +61,87 @@ fn send_returns_response_before_timeout() {
 
         assert_eq!(actual, response);
         assert_eq!(handle.written_reports().len(), 1);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn unknown_write_completion_can_be_confirmed_by_a_delayed_response() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+        let response = short_msg(0x20);
+        handle.fail_next_write_with_unknown_completion();
+
+        let send = channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == response,
+            Duration::from_secs(1),
+        );
+        let respond = async {
+            futures_timer::Delay::new(Duration::from_millis(50)).await;
+            handle.send_incoming(response).await;
+        };
+
+        let (actual, ()) = futures::join!(send, respond);
+
+        assert_eq!(actual.unwrap(), response);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn unknown_write_completion_without_response_reaches_request_timeout() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+        handle.fail_next_write_with_unknown_completion();
+
+        let error = channel
+            .send_with_timeout(short_msg(0x10), |_| false, Duration::from_millis(25))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ChannelError::Timeout));
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn definitive_write_failure_returns_immediately() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+        handle.fail_next_write();
+
+        let started = Instant::now();
+        let error = channel
+            .send_with_timeout(short_msg(0x10), |_| false, Duration::from_secs(1))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ChannelError::Implementation(_)));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn response_less_writes_surface_unknown_completion() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+
+        handle.fail_next_write_with_unknown_completion();
+        let message_error = channel.send_and_forget(short_msg(0x10)).await.unwrap_err();
+        assert!(matches!(message_error, ChannelError::Implementation(_)));
+
+        handle.fail_next_write_with_unknown_completion();
+        let raw_error = channel
+            .write_raw_report(&[0x12; MAX_RAW_REPORT_LENGTH])
+            .await
+            .unwrap_err();
+        assert!(matches!(raw_error, ChannelError::Implementation(_)));
         assert_pending_empty(&channel);
     });
 }
@@ -491,6 +572,7 @@ pub(crate) struct MockRawHidHandle {
     written_reports: Arc<Mutex<Vec<Vec<u8>>>>,
     responses_on_write: Arc<Mutex<VecDeque<Vec<u8>>>>,
     park_writes: Arc<AtomicBool>,
+    next_write_error: Arc<AtomicU8>,
 }
 
 impl MockRawHidHandle {
@@ -512,6 +594,14 @@ impl MockRawHidHandle {
     fn park_writes(&self) {
         self.park_writes.store(true, Ordering::SeqCst);
     }
+
+    fn fail_next_write(&self) {
+        self.next_write_error.store(1, Ordering::SeqCst);
+    }
+
+    fn fail_next_write_with_unknown_completion(&self) {
+        self.next_write_error.store(2, Ordering::SeqCst);
+    }
 }
 
 pub(crate) struct MockRawHidChannel {
@@ -520,6 +610,7 @@ pub(crate) struct MockRawHidChannel {
     written_reports: Arc<Mutex<Vec<Vec<u8>>>>,
     responses_on_write: Arc<Mutex<VecDeque<Vec<u8>>>>,
     park_writes: Arc<AtomicBool>,
+    next_write_error: Arc<AtomicU8>,
 }
 
 impl MockRawHidChannel {
@@ -528,12 +619,14 @@ impl MockRawHidChannel {
         let written_reports = Arc::new(Mutex::new(Vec::new()));
         let responses_on_write = Arc::new(Mutex::new(VecDeque::new()));
         let park_writes = Arc::new(AtomicBool::new(false));
+        let next_write_error = Arc::new(AtomicU8::new(0));
 
         let handle = MockRawHidHandle {
             incoming_tx: incoming_tx.clone(),
             written_reports: Arc::clone(&written_reports),
             responses_on_write: Arc::clone(&responses_on_write),
             park_writes: Arc::clone(&park_writes),
+            next_write_error: Arc::clone(&next_write_error),
         };
 
         (
@@ -543,6 +636,7 @@ impl MockRawHidChannel {
                 written_reports,
                 responses_on_write,
                 park_writes,
+                next_write_error,
             },
             handle,
         )
@@ -559,10 +653,15 @@ impl RawHidChannel for MockRawHidChannel {
         0xc539
     }
 
-    async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Sync + Send>> {
+    async fn write_report(&self, src: &[u8]) -> Result<usize, RawHidWriteError> {
         self.written_reports.lock().unwrap().push(src.to_vec());
         if self.park_writes.load(Ordering::SeqCst) {
             return std::future::pending().await;
+        }
+        match self.next_write_error.swap(0, Ordering::SeqCst) {
+            1 => return Err(RawHidWriteError::failed(mock_error())),
+            2 => return Err(RawHidWriteError::completion_unknown(mock_error())),
+            _ => {}
         }
         let response = self.responses_on_write.lock().unwrap().pop_front();
         if let Some(response) = response {

--- a/docs/superpowers/plans/2026-08-17-macos-hid-write-timeout.md
+++ b/docs/superpowers/plans/2026-08-17-macos-hid-write-timeout.md
@@ -1,0 +1,400 @@
+# macOS HID Write Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep a HID++ request alive when macOS reports the known ambiguous write-callback timeout, while preserving errors for definitive and response-less writes.
+
+**Architecture:** Add a typed raw-write error at the `RawHidChannel` boundary. The macOS `async-hid` adapter classifies only `0xE00002D6` as unknown completion; the HID++ request path may then await a matching response until its existing deadline, while all response-less paths continue returning the error.
+
+**Tech Stack:** Rust 2024, `async_trait`, `thiserror`, `futures`, `async-hid`, IOKit-backed HID on macOS.
+
+**Design:** `docs/superpowers/specs/2026-08-17-macos-hid-write-timeout-design.md`
+
+---
+
+## Chunk 1: Typed transport semantics
+
+### Task 1: Preserve response-bearing requests after an unknown write completion
+
+**Files:**
+- Modify: `crates/openlogi-hidpp/src/channel/raw.rs`
+- Modify: `crates/openlogi-hidpp/src/channel.rs`
+- Modify: `crates/openlogi-hidpp/src/channel/tests.rs`
+- Modify: `crates/openlogi-hid/src/transport.rs`
+- Modify: `crates/openlogi-hid/src/transport/windows.rs`
+- Modify: `crates/openlogi-hid/src/scripted_channel.rs`
+- Modify: `crates/openlogi-hid/src/pairing/tests.rs`
+
+- [ ] **Step 1: Add failing channel characterization tests**
+
+Extend `MockRawHidChannel` with a one-shot write result selector and add tests equivalent to:
+
+```rust
+#[test]
+fn unknown_write_completion_can_be_confirmed_by_a_delayed_response() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = HidppChannel::from_raw_channel(raw).await.unwrap();
+        let response = short_msg(0x20);
+        handle.fail_next_write_with_unknown_completion();
+
+        let send = channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == response,
+            Duration::from_secs(1),
+        );
+        let respond = async {
+            futures_timer::Delay::new(Duration::from_millis(50)).await;
+            handle.send_incoming(response).await;
+        };
+
+        let (actual, ()) = futures::join!(send, respond);
+        assert_eq!(actual.unwrap(), response);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn unknown_write_completion_without_response_reaches_request_timeout() {
+    // Configure CompletionUnknown, use a 25 ms deadline, assert Timeout and an
+    // empty pending queue.
+}
+
+#[test]
+fn definitive_write_failure_returns_immediately() {
+    // Configure Failed, use a one-second deadline, assert Implementation,
+    // elapsed < one second, and an empty pending queue.
+}
+
+#[test]
+fn response_less_writes_surface_unknown_completion() {
+    // Assert both send_and_forget and write_raw_report return Implementation.
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```sh
+cargo test -p openlogi-hidpp unknown_write_completion
+cargo test -p openlogi-hidpp definitive_write_failure
+cargo test -p openlogi-hidpp response_less_writes_surface_unknown_completion
+```
+
+Expected: compilation/test failure because the typed write outcome and channel handling do not exist yet.
+
+- [ ] **Step 3: Add the typed raw-write error**
+
+In `channel/raw.rs`, add a public error preserving its source:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum RawHidWriteError {
+    #[error("the HID report write failed")]
+    Failed(#[source] Box<dyn Error + Send + Sync>),
+    #[error("the HID report write completion is unknown")]
+    CompletionUnknown(#[source] Box<dyn Error + Send + Sync>),
+}
+
+impl RawHidWriteError {
+    pub fn failed(error: impl Into<Box<dyn Error + Send + Sync>>) -> Self {
+        Self::Failed(error.into())
+    }
+
+    pub fn completion_unknown(error: impl Into<Box<dyn Error + Send + Sync>>) -> Self {
+        Self::CompletionUnknown(error.into())
+    }
+}
+```
+
+Add rustdoc to the enum, variants, and constructors. Change only
+`RawHidChannel::write_report` to return `Result<usize, RawHidWriteError>` and
+re-export `RawHidWriteError` from `channel.rs`.
+
+- [ ] **Step 4: Adapt all raw-channel implementations**
+
+Update the five implementations found by:
+
+```sh
+rg -n 'impl RawHidChannel for' crates
+```
+
+All existing errors map to `RawHidWriteError::failed`. Do not classify any
+error as unknown in this step. Preserve the Windows native fallback and the
+macOS disconnect state transition exactly.
+
+- [ ] **Step 5: Implement the request/response semantics**
+
+Extract the message framing/write portion of `send_and_forget` into a private
+helper returning `RawHidWriteError`. In `send_with_timeout`, keep the existing
+single overall deadline and use this shape inside it:
+
+```rust
+match self.write_message(msg).await {
+    Ok(()) => {}
+    Err(RawHidWriteError::CompletionUnknown(error)) => {
+        trace!(dev, feat, error = %error, "HID write completion unknown; awaiting response");
+    }
+    Err(error) => return Err(ChannelError::Implementation(Box::new(error))),
+}
+receiver.await.map_err(|_| ChannelError::NoResponse)
+```
+
+`send_and_forget` and `write_raw_report_with_timeout` must map either variant to
+`ChannelError::Implementation`. Do not retry writes. Keep final-timeout cleanup
+and listener matching unchanged.
+
+- [ ] **Step 6: Run focused HID++ tests**
+
+Run:
+
+```sh
+cargo test -p openlogi-hidpp channel::tests
+```
+
+Expected: all channel tests pass, including the pre-existing final-timeout and
+late-response tests.
+
+- [ ] **Step 7: Run dependent-crate tests**
+
+Run:
+
+```sh
+cargo test -p openlogi-hid
+```
+
+Expected: all tests pass and every `RawHidChannel` implementation compiles.
+
+- [ ] **Step 8: Commit the typed request semantics**
+
+```sh
+git add crates/openlogi-hidpp/src/channel/raw.rs \
+  crates/openlogi-hidpp/src/channel.rs \
+  crates/openlogi-hidpp/src/channel/tests.rs \
+  crates/openlogi-hid/src/transport.rs \
+  crates/openlogi-hid/src/transport/windows.rs \
+  crates/openlogi-hid/src/scripted_channel.rs \
+  crates/openlogi-hid/src/pairing/tests.rs
+git commit -m "fix(hidpp): await responses after unknown writes"
+```
+
+## Chunk 2: macOS classification and verification
+
+### Task 2: Classify the IOKit callback timeout at the async-hid adapter
+
+**Files:**
+- Modify: `crates/openlogi-hid/src/transport.rs`
+- Modify: `crates/openlogi-hid/src/transport/tests.rs`
+
+- [ ] **Step 1: Add failing macOS classifier tests**
+
+Add a pure helper test on macOS:
+
+```rust
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_writer_callback_timeout_has_unknown_completion() {
+    let error = async_hid::HidError::message(
+        "report writer callback error: 0xE00002D6",
+    );
+    assert!(matches!(
+        classify_output_write_error(error),
+        RawHidWriteError::CompletionUnknown(_)
+    ));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn another_macos_writer_callback_error_is_definitive() {
+    let error = async_hid::HidError::message(
+        "report writer callback error: 0xE00002C0",
+    );
+    assert!(matches!(
+        classify_output_write_error(error),
+        RawHidWriteError::Failed(_)
+    ));
+}
+```
+
+Also assert `HidError::Disconnected` maps to `Failed`.
+
+- [ ] **Step 2: Run the classifier tests and verify they fail**
+
+Run:
+
+```sh
+cargo test -p openlogi-hid macos_writer_callback
+```
+
+Expected: compilation failure because `classify_output_write_error` does not exist.
+
+- [ ] **Step 3: Implement the exact macOS classifier**
+
+In `transport.rs`, add a macOS-only message constant and a platform-bounded
+classifier:
+
+```rust
+#[cfg(target_os = "macos")]
+const MACOS_WRITE_CALLBACK_TIMEOUT: &str =
+    "report writer callback error: 0xE00002D6";
+
+fn classify_output_write_error(error: async_hid::HidError) -> RawHidWriteError {
+    #[cfg(target_os = "macos")]
+    if matches!(
+        &error,
+        async_hid::HidError::Message(message)
+            if message.as_ref() == MACOS_WRITE_CALLBACK_TIMEOUT
+    ) {
+        return RawHidWriteError::completion_unknown(error);
+    }
+    RawHidWriteError::failed(error)
+}
+```
+
+Call it from `AsyncHidChannel::write_report` after preserving the existing
+`Disconnected` handling. Document why exact string matching is necessary with
+`async-hid 0.5.2` and why it is confined to macOS.
+
+- [ ] **Step 4: Run focused transport and channel tests**
+
+Run:
+
+```sh
+cargo test -p openlogi-hid macos_writer_callback
+cargo test -p openlogi-hidpp channel::tests
+cargo test -p openlogi-hid
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit the adapter classification**
+
+```sh
+git add crates/openlogi-hid/src/transport.rs crates/openlogi-hid/src/transport/tests.rs
+git commit -m "fix(hid): classify macos callback timeout as unknown"
+```
+
+### Task 3: Run the complete software gate
+
+**Files:**
+- Verify only; modify code only to fix confirmed gate findings.
+
+- [ ] **Step 1: Format and inspect the diff**
+
+```sh
+cargo fmt --all
+git diff --check
+git diff --stat upstream/master...HEAD
+git diff upstream/master...HEAD -- crates/openlogi-hidpp crates/openlogi-hid
+```
+
+- [ ] **Step 2: Run every required local gate**
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
+  -p openlogi-hidpp-derive --no-deps --document-private-items
+```
+
+Expected: all four commands exit zero. If Xcode's Metal cache is sandbox-blocked,
+rerun the unchanged command with the required filesystem permission; do not
+weaken the gate.
+
+- [ ] **Step 3: Re-fetch and rebase before delivery**
+
+```sh
+git fetch upstream master
+git rebase upstream/master
+```
+
+Rerun the entire four-command gate after any rebase that changes the commit.
+
+## Chunk 3: Exact hardware and public communication
+
+### Task 4: Validate the original MX Keys safely
+
+**Files:**
+- No source changes expected.
+- Record exact commands, revisions, timings, and outcomes for the PR and issue drafts.
+
+- [ ] **Step 1: Confirm exact hardware and process state**
+
+Use `system_profiler SPBluetoothDataType` to confirm `046d:b35b`, firmware,
+battery, and BLE connection. Ensure no official OpenLogi or Logi Options+
+process competes for the HID channel.
+
+- [ ] **Step 2: Re-run traced CLI discovery and feature reads**
+
+Run the branch CLI repeatedly with `OPENLOGI_LOG=trace`. Expected: no early
+failure at 251 ms; delayed responses match their pending requests; repeated
+inventory/features/battery reads are stable.
+
+- [ ] **Step 3: Verify Agent and GUI inventory**
+
+Run the branch Agent and GUI using the development profile. Expected: MX Keys
+appears in inventory and GUI while normal typing continues.
+
+- [ ] **Step 4: Perform reversible settings checks**
+
+Read each initial value before writing. Test backlight and Fn-lock only when the
+initial value can be read and the same value can be restored. Record every
+before/change/restore result.
+
+- [ ] **Step 5: Verify reconnect behavior**
+
+With user coordination, reconnect or power-cycle the keyboard. Confirm stable
+rediscovery and any expected volatile-setting reapplication. Do not claim this
+step if the hardware action was not performed.
+
+### Task 5: Prepare and publish issue #521 update
+
+**Files:**
+- Draft only; no repository file required unless the user requests one.
+
+- [ ] **Step 1: Draft the English issue comment**
+
+Include:
+
+- exact device/OS/release/master/branch revisions;
+- measured callback and response timing;
+- the distinction between IOKit wait timeout and proven delivery failure;
+- the early pending-removal mechanism and GUI consequence;
+- the narrow typed fix and raw-write safety boundary;
+- exact local gate and hardware outcomes;
+- the separate planned `async-hid` follow-up.
+
+- [ ] **Step 2: Present the draft to the user**
+
+Repository policy requires approval before public posting. Do not publish until
+the user approves the exact English text.
+
+- [ ] **Step 3: Publish the approved comment**
+
+Use the authenticated GitHub session to post to
+`https://github.com/AprilNEA/OpenLogi/issues/521`, then reopen the page and
+verify the comment URL and rendered content.
+
+### Task 6: Prepare PR delivery artifacts
+
+**Files:**
+- Draft only; no repository file required unless the user requests one.
+
+- [ ] **Step 1: Prepare the PR title and body**
+
+Title:
+
+```text
+fix(hid): preserve delayed macOS HID++ responses
+```
+
+Body sections must follow repository policy: `## Summary`, `## Changes`,
+`## Testing`, and a final `Fixes #521` only if this PR completes the full issue.
+If other MX Keys feature PRs remain, use `Part of #521` instead of closing it.
+
+- [ ] **Step 2: Show the exact branch diff and drafts to the user**
+
+Report commit list, changed files, all gate results, hardware limitations, and
+the proposed PR title/body. Push or open the PR only after user approval.

--- a/docs/superpowers/specs/2026-08-17-macos-hid-write-timeout-design.md
+++ b/docs/superpowers/specs/2026-08-17-macos-hid-write-timeout-design.md
@@ -1,0 +1,164 @@
+# macOS HID Write Completion Design
+
+## Context
+
+OpenLogi issue #521 tracks Logitech MX Keys support. Exact-device validation on
+an MX Keys connected directly over Bluetooth LE (`046d:b35b`) reproduced the
+same transport symptom previously observed on an MX Keys Mini:
+
+- `async-hid` asks `IOHIDDeviceSetReportWithCallback` to wait 250 ms;
+- macOS completes the callback with `0xE00002D6` (`kIOReturnTimeout`) at about
+  251 ms;
+- the keyboard's valid HID++ response arrives about 500-685 ms after the write;
+- OpenLogi has already treated the callback error as a definitive write failure,
+  removed the pending request, and therefore logs the response as unmatched.
+
+The report's delivery is unknown when the callback times out. The timeout proves
+that macOS stopped waiting for write completion; it does not prove that the
+device did not receive the report. A later matching HID++ response is stronger
+evidence that it did.
+
+## Goals
+
+- Preserve a pending HID++ request after the one known macOS callback timeout.
+- Accept a later matching response within OpenLogi's existing five-second
+  request deadline.
+- Keep definitive write failures immediate.
+- Keep response-less writes honest: raw lighting writes and `send_and_forget`
+  must still report an unknown completion as an error.
+- Make the distinction typed at the raw-HID boundary rather than teaching the
+  protocol channel about an `async-hid` error string.
+- Leave Linux, Windows, IPC, configuration, and HID++ wire formats unchanged.
+
+## Non-goals
+
+- Do not change or patch the `async-hid` dependency in this PR.
+- Do not globally extend all HID write callback timeouts.
+- Do not retry a report whose delivery is unknown; that could duplicate a
+  non-idempotent device operation.
+- Do not treat every timeout-looking string as an unknown completion.
+- Do not hide the error for operations that have no response to confirm delivery.
+
+An upstream `async-hid` issue/PR is a separate second step after this OpenLogi PR.
+
+## Design
+
+### Typed raw-write failure
+
+`openlogi-hidpp` will define a public `RawHidWriteError` at the
+`RawHidChannel` boundary with two variants:
+
+- `Failed`: the transport reports a definitive write failure;
+- `CompletionUnknown`: the transport stopped waiting without establishing
+  whether the report reached the device.
+
+Both variants retain the original error as their source. `RawHidChannel::write_report`
+will return this type. The five in-workspace implementations will map their
+existing failures to `Failed` unless the concrete transport can establish the
+narrower `CompletionUnknown` meaning.
+
+### macOS transport classification
+
+`AsyncHidChannel` owns the dependency-specific classification. On macOS only,
+the exact `async_hid::HidError::Message` value
+`report writer callback error: 0xE00002D6` maps to `CompletionUnknown`.
+All other `async-hid` errors map to `Failed`; `Disconnected` continues to mark
+the channel disconnected.
+
+The exact text comparison is intentionally isolated to this adapter because
+`async-hid 0.5.2` exposes the IOKit callback code only through an unstructured
+message. Neither `openlogi-hidpp` nor callers will match dependency strings.
+
+### HID++ request flow
+
+`HidppChannel::send_with_timeout` will use a private typed message-write helper
+instead of calling the public response-less `send_and_forget` path.
+
+1. Register the pending response matcher.
+2. Start the report write under the existing overall request deadline.
+3. On success, wait for the matching response.
+4. On `CompletionUnknown`, do not retry and do not remove the matcher; continue
+   waiting for the matching response.
+5. On `Failed`, return immediately and remove only this pending matcher.
+6. On the overall deadline, return `ChannelError::Timeout` and remove only this
+   pending matcher.
+
+If the response arrived before the macOS callback completed, the oneshot retains
+it and the request resolves as soon as the write result is classified.
+
+### Response-less writes
+
+`HidppChannel::send_and_forget` and `write_raw_report_with_timeout` will map
+either raw-write error variant to `ChannelError::Implementation`. They have no
+matching response that can turn unknown delivery into confirmed delivery.
+
+This is especially important for the 64-byte `0x12` per-key lighting path: an
+unknown completion must remain visible rather than being reported as success.
+
+## Error handling and observability
+
+- An unknown completion followed by a matching response is successful.
+- An unknown completion without a response ends as the existing
+  `ChannelError::Timeout` at the request deadline.
+- A definitive write failure remains `ChannelError::Implementation`.
+- The unknown-completion branch emits a trace message with the request header and
+  source error so future diagnostics show why OpenLogi kept waiting.
+- Existing late-response-after-final-timeout behavior remains unchanged: once
+  the five-second deadline expires, a later response is unmatched.
+
+## Tests
+
+`openlogi-hidpp` channel tests will cover:
+
+- unknown write completion followed by a delayed matching response succeeds;
+- unknown completion without a response reaches the overall timeout and cleans
+  the pending matcher;
+- definitive write failure returns immediately and cleans the pending matcher;
+- `send_and_forget` still returns an unknown-completion error;
+- raw report writes still return an unknown-completion error;
+- existing final-timeout and late-response tests continue to pass.
+
+`openlogi-hid` transport tests will cover:
+
+- the exact macOS callback timeout message maps to `CompletionUnknown` on macOS;
+- another callback code remains `Failed`;
+- disconnected errors remain definitive and preserve disconnect handling.
+
+The final commit must pass the repository's full local gate:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
+  -p openlogi-hidpp-derive --no-deps --document-private-items
+```
+
+## Exact-device validation
+
+After the software gate, validate on the connected original MX Keys (`046d:b35b`):
+
+1. stable repeated CLI inventory and feature reads;
+2. device visible in Agent inventory and GUI;
+3. battery read;
+4. backlight read, reversible off/on change, and restoration;
+5. Fn-lock read, reversible change, and restoration when exposed by the UI/CLI;
+6. reconnect or power-cycle discovery and restoration of volatile state;
+7. normal keyboard input throughout the test.
+
+No write test runs unless the initial value can be read and restored.
+
+## Issue communication
+
+Before publication, present an English draft for user approval. The issue #521
+comment will state:
+
+- exact hardware, transport, OS, release, and master revision tested;
+- the measured 251 ms callback timeout and 500-685 ms valid response latency;
+- why `kIOReturnTimeout` means unknown completion rather than proven delivery
+  failure in this observed request/response flow;
+- why OpenLogi removed the matcher too early and omitted the device from GUI
+  inventory;
+- the narrow OpenLogi fix and its response-less-write safety boundary;
+- exact software and hardware validation results;
+- that an `async-hid` upstream follow-up will be handled separately.


### PR DESCRIPTION
## Summary

- Preserve delayed HID++ responses after a macOS output-write callback timeout.
- Treat only the exact `kIOReturnTimeout` callback status as an unknown completion result.
- Keep the existing total request timeout and avoid retrying potentially delivered reports.

## Changes

- **hidpp:** add a typed raw-write outcome that distinguishes definitive failures from unknown completion.
- **hidpp:** keep the pending response matcher after unknown completion and wait within the existing request budget.
- **hidpp:** continue surfacing unknown completion as an error for response-less and raw report writes.
- **hid:** classify the exact macOS `0xE00002D6` callback status without changing other platform behavior.
- **tests:** cover delayed responses, request timeout, definitive failures, response-less writes, and macOS error classification.
- **docs:** document the observed macOS behavior and implementation plan.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`
- `cargo clippy -p openlogi-hidpp -p openlogi-hid --all-targets --target x86_64-pc-windows-gnu -- -D warnings`

Hardware validation:

- macOS 26.6.1 on Apple Silicon.
- Original MX Keys over direct Bluetooth (`046d:b35b`, firmware `MPK12.01_0013`).
- Five sequential probes succeeded; three exercised the `0xE00002D6` path and matched the delayed response.
- The keyboard appeared in the GUI and remained available after a power cycle and reconnect.
- Feature discovery, controls, battery, and Backlight2 reads succeeded.
- Backlight off/on writes were confirmed by read-back and the original enabled state was restored.

Part of #521