### PR TITLE
build(windows): ship the openlogi CLI in the zip and MSI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,9 +419,9 @@ jobs:
           : "${OPENLOGI_UPDATE_BASE_URL:?Configure OPENLOGI_UPDATE_BASE_URL in the R2 1Password item}"
           : "${OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY:?Configure OPENLOGI_UPDATE_MINISIGN_PUBLIC_KEY in the R2 1Password item}"
 
-      # No separate CLI artifact will ever ship on Windows (cargo install
-      # covers that audience), so job and artifact names carry no GUI
-      # qualifier. The GUI is a thin IPC client; the headless agent (ported in
+      # The CLI ships inside the same zip and MSI rather than as a separate
+      # artifact, so job and artifact names carry no GUI qualifier. The GUI is
+      # a thin IPC client; the headless agent (ported in
       # #167) owns the device I/O, input hook, and IPC server, and the GUI
       # spawns a sibling `openlogi-agent.exe` when the pipe is absent — so the
       # agent MUST ship next to the GUI or the app connects to nothing (#347).
@@ -429,7 +429,7 @@ jobs:
       # key and manifest URL via option_env! at compile time. Unsigned builds
       # get empty values and keep the fail-closed dev behaviour, so the
       # manifest-URL export is guarded rather than derived from an empty base.
-      - name: Build OpenLogi (GUI + agent)
+      - name: Build OpenLogi executables
         shell: bash
         env:
           OPENLOGI_UPDATE_BASE_URL: ${{ steps.update_config.outputs.OPENLOGI_UPDATE_BASE_URL }}
@@ -439,7 +439,7 @@ jobs:
           if [ -n "$OPENLOGI_UPDATE_BASE_URL" ]; then
             export OPENLOGI_UPDATE_MANIFEST_URL="${OPENLOGI_UPDATE_BASE_URL%/}/channels/stable/latest.json"
           fi
-          cargo build --release -p openlogi-desktop -p openlogi-overlay -p openlogi-agent --target ${{ matrix.target }}
+          cargo build --release -p openlogi-desktop -p openlogi-overlay -p openlogi-agent -p openlogi --target ${{ matrix.target }}
 
       # Federated (passwordless) login. Requires an app registration whose federated
       # credential subject is `repo:AprilNEA/OpenLogi:environment:release`, granted the
@@ -475,11 +475,12 @@ jobs:
           endpoint: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
-          # `files` is a newline-separated list; one call signs both PE files.
+          # `files` is a newline-separated list; one call signs every PE file.
           files: |
             ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi-desktop.exe
             ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi-overlay.exe
             ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi-agent.exe
+            ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi.exe
           # Timestamping is mandatory: without it the signature expires after
           # 3 days. The URL must stay http — SignTool rejects an https /tr up
           # front ("SignTool Error: Invalid Timestamp URL", v0.6.5) before
@@ -500,7 +501,7 @@ jobs:
           # HashMismatch (bytes no longer match the signature) are trust-store
           # independent and always ship-blockers; NotTrusted/UnknownError depend
           # on the runner's trust store, so they stay log-only.
-          foreach ($exe in 'openlogi-desktop.exe', 'openlogi-overlay.exe', 'openlogi-agent.exe') {
+          foreach ($exe in 'openlogi-desktop.exe', 'openlogi-overlay.exe', 'openlogi-agent.exe', 'openlogi.exe') {
             $sig = Get-AuthenticodeSignature "target\${{ matrix.target }}\release\$exe"
             $sig | Format-List
             if ($null -eq $sig.SignerCertificate -or
@@ -510,17 +511,31 @@ jobs:
             }
           }
 
-      # The portable artifact is a zip of both exes: a bare exe has nowhere to
+      # The portable artifact is a zip of every exe: a bare exe has nowhere to
       # put the agent, and GUI-only can never work (#347). Inside the zip the
       # GUI carries the product name (`OpenLogi.exe`, matching the MSI layout)
       # and the agent keeps the exact name the GUI's sibling lookup expects.
+      # `openlogi.exe` is the CLI the docs and both issue templates ask users to
+      # run; it is the same binary Linux installs to /usr/bin and macOS embeds
+      # at Contents/MacOS/openlogi. It goes in `bin\` rather than beside the
+      # GUI because Windows path comparison is case-insensitive: staging it as
+      # `stage\openlogi.exe` would overwrite `stage\OpenLogi.exe` and ship a zip
+      # with the CLI wearing the GUI's name. The MSI splits them the same way.
       - name: Collect signed portable zip artifact
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path dist, stage | Out-Null
+          New-Item -ItemType Directory -Force -Path dist, stage, stage\bin | Out-Null
           Copy-Item target\${{ matrix.target }}\release\openlogi-desktop.exe stage\OpenLogi.exe
           Copy-Item target\${{ matrix.target }}\release\openlogi-overlay.exe stage\openlogi-overlay.exe
           Copy-Item target\${{ matrix.target }}\release\openlogi-agent.exe stage\openlogi-agent.exe
+          Copy-Item target\${{ matrix.target }}\release\openlogi.exe stage\bin\openlogi.exe
+          # Guard the collision above: four inputs must produce four staged
+          # files. A case-insensitive overwrite would silently leave three.
+          $staged = (Get-ChildItem stage -Recurse -File).Count
+          if ($staged -ne 4) {
+            Write-Error "expected 4 staged files, found $staged — a name collision dropped one"
+            exit 1
+          }
           # Zipping after signing is safe: Authenticode lives in the PE files.
           $ref = $env:GITHUB_REF_NAME -replace '/', '-'
           Compress-Archive -Path stage\* -DestinationPath "dist\OpenLogi-$ref-windows-${{ matrix.arch }}.zip"
@@ -564,8 +579,9 @@ jobs:
       - uses: actions/checkout@v6
 
       # The portable zip from this arch's windows leg, containing the
-      # already-signed OpenLogi.exe and openlogi-agent.exe. The MSI packages
-      # exactly the bytes the portable artifact ships.
+      # already-signed OpenLogi.exe, openlogi-agent.exe, openlogi-overlay.exe,
+      # and openlogi.exe. The MSI packages exactly the bytes the portable
+      # artifact ships.
       - uses: actions/download-artifact@v8
         with:
           name: OpenLogi-windows-${{ matrix.arch }}
@@ -635,17 +651,18 @@ jobs:
           } else {
             $version = '0.0.0'
           }
-          # Selected by exact name, never by glob order: the zip carries two
-          # exes, and Get-ChildItem's alphabetical sort would put the agent
-          # first. Upstream invariants (upload's if-no-files-found: error, the
+          # Selected by exact name, never by glob order: the zip carries multiple
+          # executables, and Get-ChildItem's alphabetical sort would put the
+          # agent first. Upstream invariants (upload's if-no-files-found: error, the
           # by-name download, the extract step's guard) should make the misses
           # unreachable; the guards turn a confusing "$null.FullName -> empty
           # -d" wix error into a named cause if those invariants ever shift.
           $gui = Get-Item signed-exe\OpenLogi.exe -ErrorAction SilentlyContinue
           $overlay = Get-Item signed-exe\openlogi-overlay.exe -ErrorAction SilentlyContinue
           $agent = Get-Item signed-exe\openlogi-agent.exe -ErrorAction SilentlyContinue
-          if ($null -eq $gui -or $null -eq $overlay -or $null -eq $agent) {
-            Write-Error "signed-exe\ must contain OpenLogi.exe, openlogi-overlay.exe, and openlogi-agent.exe — nothing to package"
+          $cli = Get-Item signed-exe\bin\openlogi.exe -ErrorAction SilentlyContinue
+          if ($null -eq $gui -or $null -eq $overlay -or $null -eq $agent -or $null -eq $cli) {
+            Write-Error "signed-exe\ must contain OpenLogi.exe, openlogi-overlay.exe, openlogi-agent.exe, and bin\openlogi.exe — nothing to package"
             exit 1
           }
           New-Item -ItemType Directory -Force -Path out | Out-Null
@@ -656,6 +673,7 @@ jobs:
             -d ExeFile="$($gui.FullName)" `
             -d AgentExeFile="$($agent.FullName)" `
             -d OverlayExeFile="$($overlay.FullName)" `
+            -d CliExeFile="$($cli.FullName)" `
             -o out\OpenLogi.msi
 
       - name: Azure login (OIDC)

--- a/.github/workflows/windows-sign-dryrun.yml
+++ b/.github/workflows/windows-sign-dryrun.yml
@@ -74,8 +74,8 @@ jobs:
           : "${AZURE_SIGNING_ACCOUNT:?Configure AZURE_SIGNING_ACCOUNT in the Azure 1Password item}"
           : "${AZURE_CERT_PROFILE:?Configure AZURE_CERT_PROFILE in the Azure 1Password item}"
 
-      - name: Build OpenLogi (GUI + agent)
-        run: cargo build --release -p openlogi-desktop -p openlogi-agent --target ${{ matrix.target }}
+      - name: Build OpenLogi executables
+        run: cargo build --release -p openlogi-desktop -p openlogi-overlay -p openlogi-agent -p openlogi --target ${{ matrix.target }}
 
       - name: Azure login (OIDC)
         uses: azure/login@v3
@@ -90,11 +90,15 @@ jobs:
           endpoint: ${{ steps.azure_config.outputs.AZURE_SIGNING_ENDPOINT }}
           signing-account-name: ${{ steps.azure_config.outputs.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ steps.azure_config.outputs.AZURE_CERT_PROFILE }}
-          # `files` is a newline-separated list; one call signs both PE files.
+          # `files` is a newline-separated list; one call signs every PE file.
+          # Must stay in step with the same list in build.yml — this job is the
+          # rehearsal for that signing step, so a binary missing here is a
+          # signing failure the dry run can no longer catch.
           files: |
             ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi-desktop.exe
             ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi-overlay.exe
             ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi-agent.exe
+            ${{ github.workspace }}\target\${{ matrix.target }}\release\openlogi.exe
           # Must stay http — SignTool rejects an https /tr ("Invalid Timestamp
           # URL", v0.6.5). The RFC3161 response is itself signed.
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
@@ -106,7 +110,7 @@ jobs:
           # NotSigned and HashMismatch are trust-store independent and always
           # ship-blockers; NotTrusted/UnknownError depend on the runner's
           # trust store, so they stay log-only.
-          foreach ($exe in 'openlogi-desktop.exe', 'openlogi-overlay.exe', 'openlogi-agent.exe') {
+          foreach ($exe in 'openlogi-desktop.exe', 'openlogi-overlay.exe', 'openlogi-agent.exe', 'openlogi.exe') {
             $sig = Get-AuthenticodeSignature "target\${{ matrix.target }}\release\$exe"
             $sig | Format-List
             if ($null -eq $sig.SignerCertificate -or

--- a/packaging/windows/OpenLogi.wxs
+++ b/packaging/windows/OpenLogi.wxs
@@ -13,6 +13,7 @@
       ExeFile       path to the signed openlogi-desktop exe to package
       AgentExeFile  path to the signed openlogi-agent exe to package
       OverlayExeFile path to the signed openlogi-overlay exe to package
+      CliExeFile    path to the signed openlogi (CLI) exe to package
       IconFile      optional override for the app .ico (Add/Remove Programs
                     entry); defaults to the committed design/icon/openlogi.ico
                     below, so the release workflow needs no extra define
@@ -53,7 +54,16 @@
 
     <StandardDirectory Id="LocalAppDataFolder">
       <Directory Id="ProgramsFolder" Name="Programs">
-        <Directory Id="INSTALLFOLDER" Name="OpenLogi" />
+        <Directory Id="INSTALLFOLDER" Name="OpenLogi">
+          <!-- The CLI cannot sit beside the GUI: Windows paths are
+               case-insensitive, so `openlogi.exe` and the GUI's `OpenLogi.exe`
+               are the same file name in one directory. WiX catches it as
+               duplicate component GUIDs (WIX0369) — and the portable zip's
+               staging would silently overwrite the GUI with the CLI. A `bin`
+               subdirectory keeps the documented command name intact, and it is
+               `bin` (not INSTALLFOLDER) that goes on PATH. -->
+          <Directory Id="BINFOLDER" Name="bin" />
+        </Directory>
       </Directory>
     </StandardDirectory>
 
@@ -73,6 +83,34 @@
       <Component Id="OverlayExecutable">
         <!-- Warm, non-activating GPUI host for the Actions Ring. -->
         <File Id="OpenLogiOverlayExe" Name="openlogi-overlay.exe" Source="$(var.OverlayExeFile)" KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Cli" Directory="BINFOLDER">
+      <Component Id="CliExecutable">
+        <!-- The `openlogi` CLI: device inventory and the HID++ diagnostics
+             (`openlogi list`, `openlogi diag features`) that docs/USAGE.md and
+             both issue templates ask users to paste into reports. Linux
+             installs the same binary to /usr/bin/openlogi and macOS embeds it
+             at Contents/MacOS/openlogi; Windows shipped no CLI at all, so
+             device reports from Windows arrived with the diagnostic blocks
+             empty. The name must stay `openlogi.exe` — that is the command
+             every doc spells out, which is exactly why it needs its own
+             directory (see BINFOLDER above).
+
+             BINFOLDER joins the user's PATH so the command actually resolves
+             in a shell. System="no" keeps that to HKCU\Environment, matching
+             the package's perUser scope: no elevation, and an uninstall
+             removes the entry again (Permanent="no"). Part="last" appends
+             rather than shadowing anything already on PATH. -->
+        <File Id="OpenLogiCliExe" Name="openlogi.exe" Source="$(var.CliExeFile)" KeyPath="yes" />
+        <Environment Id="OpenLogiCliPath"
+                     Name="PATH"
+                     Value="[BINFOLDER]"
+                     Action="set"
+                     Part="last"
+                     Permanent="no"
+                     System="no" />
       </Component>
     </ComponentGroup>
 
@@ -108,6 +146,14 @@
                            RebootPrompt="no"
                            Timeout="2"
                            TerminateProcess="0" />
+    <!--
+      Target matching is case-insensitive, so this row also matches a running
+      `openlogi.exe` (the CLI). That is harmless and needs no row of its own:
+      the CLI is short-lived and holds no state, no lock, and no IPC pipe, so
+      terminating one mid-upgrade costs the user a re-run at worst — while
+      leaving it out of the match would let a long `assets sync` hold the
+      install directory and stall the upgrade on a FilesInUse prompt.
+    -->
     <util:CloseApplication Id="CloseGui"
                            Target="OpenLogi.exe"
                            CloseMessage="yes"
@@ -133,8 +179,9 @@
     </StandardDirectory>
 
     <Feature Id="Main">
-      <!-- ComponentGroupRef pulls in both MainExecutable and AgentExecutable. -->
+      <!-- App pulls in the GUI, agent, and overlay; Cli adds bin\openlogi.exe. -->
       <ComponentGroupRef Id="App" />
+      <ComponentGroupRef Id="Cli" />
       <ComponentRef Id="StartMenuShortcut" />
     </Feature>
 


### PR DESCRIPTION
Closes #658.

The `windows` job never built `-p openlogi`, so the CLI was absent from both the portable zip and the MSI. macOS and Linux ship the same binary, the docs describe it without a platform caveat, and both issue templates ask users to paste its output — so Windows device reports arrive with the diagnostic blocks empty (#392, #462, #448).

## Changes

### `.github/workflows/build.yml`
- `windows` job builds `-p openlogi` alongside the GUI and agent.
- `openlogi.exe` joins the Authenticode signing list and the signature-verification loop, so it ships signed like the other three.
- Staged into the portable zip.
- `windows-msi` job extracts it and passes it to WiX via a new `CliExeFile` define, with the same null-guard the other exes get.

### `.github/workflows/windows-sign-dryrun.yml`
Same build and signing list. This job is the rehearsal for the real signing step, so a binary missing here is a signing failure the dry run can no longer catch.

### `packaging/windows/OpenLogi.wxs`
- New `BINFOLDER` (`bin`) directory and a `Cli` component group carrying `openlogi.exe`.
- `BINFOLDER` joins the user's `PATH` so the documented commands actually resolve in a shell. `System="no"` keeps that in `HKCU\Environment`, matching the package's `perUser` scope — no elevation, appended rather than shadowing, and `Permanent="no"` removes the entry on uninstall.

The portable `.zip` deliberately does not touch `PATH`; extract-and-run leaves no machine state. Say the word if you'd rather it did.

## Why the CLI lives in `bin\`

Not cosmetic — the obvious layout does not build. Windows path comparison is case-insensitive, so `openlogi.exe` and the GUI's `OpenLogi.exe` are **one name in one directory**. Putting them side by side fails two ways:

```
error WIX0369: Component/@Id='MainExecutable' ... has a @Guid value
  '{A056D440-...}' that duplicates another component in this package.
error WIX0369: Component/@Id='CliExecutable'  ... (same GUID)
```

and, more quietly, `Copy-Item ... stage\openlogi.exe` overwrites `stage\OpenLogi.exe` — the zip would have shipped the CLI wearing the GUI's name, with the GUI gone. The staging step now asserts four files survive so a future collision fails loudly rather than dropping a binary.

## Verification

`crates/openlogi` was already Windows-clean — `ci.yml`'s `clippy-windows` job runs `cargo clippy --workspace --all-targets -- -D warnings` on `windows-latest` every PR, and `openlogi-cli` has no `cfg(target_os)` gates. This PR only packages what already compiled.

Built and run against real hardware on Windows 11 (26200.8973, x86_64), `cargo build --release -p openlogi` — clean, 4m17s:

```
> openlogi.exe list
Unifying Receiver (82839805, vid=046d pid=c539)
  └─ slot 1 ● G502 (mouse, wpid=407f, battery=43% low (discharging))
          model_ids=[407f,c08d,0000] ext=00 serial=— unit_id=6be9d300 transports=usb+equad

> openlogi.exe diag features
device: G502 (slot 1 on receiver 82839805)
  (30 feature entries, incl. 0x8100, 0x8110, 0x8060, 0x2201, 0x8070)

> openlogi.exe diag controls
Error: device does not expose HID++ feature 0x1b04
```

The MSI was built locally with the pinned toolset (`wix 6.0.2` + `WixToolset.Util.wixext/6.0.2`, matching the `windows-msi` job) and its tables inspected:

```
=== File ===
OpenLogiExe        | MainExecutable   | OpenLogi.exe
OpenLogiAgentExe   | AgentExecutable  | openlogi-agent.exe
OpenLogiOverlayExe | OverlayExecutable| openlogi-overlay.exe
OpenLogiCliExe     | CliExecutable    | openlogi.exe

=== Environment ===
OpenLogiCliPath | =-PATH | [~];[BINFOLDER] | CliExecutable

=== Directory ===
BINFOLDER | INSTALLFOLDER | bin
```

`=-` is set-on-install / remove-on-uninstall and `[~];` appends, so the entry neither shadows an existing `PATH` nor outlives the install.

## Note

`util:CloseApplication`'s `Target` matching is case-insensitive, so the existing `OpenLogi.exe` row now also matches a running `openlogi.exe`. That is deliberate and documented inline: the CLI is short-lived and holds no lock, state, or IPC pipe, so terminating one mid-upgrade costs a re-run at worst — while excluding it would let a long `assets sync` hold the install directory and stall the upgrade on a FilesInUse prompt.
