### PR TITLE
docs(hid): stop linking a cfg-gated type so rustdoc passes on Windows

### DIFF
--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -4,9 +4,14 @@
 //! descriptor, but `async-hid 0.4` only exposes descriptors on Linux. We avoid
 //! that path by pre-filtering to the Logitech HID++ vendor collections at
 //! enumeration time (see [`HIDPP_LONG_COLLECTIONS`]) and reporting support
-//! straight from [`AsyncHidChannel::supports_short_long_hidpp`]: USB / receiver
+//! straight from `AsyncHidChannel::supports_short_long_hidpp`: USB / receiver
 //! collections carry both reports; BLE-direct collections are long-only, and the
 //! `hidpp` channel up-converts outgoing short messages to long for them.
+//!
+//! `AsyncHidChannel` is named in plain backticks rather than linked because it
+//! is `cfg(not(target_os = "windows"))` — an intra-doc link to it is
+//! unresolvable on Windows, where `deny(broken_intra_doc_links)` then fails the
+//! whole crate's docs. `node_ledger` names it the same way.
 
 #[cfg(not(target_os = "windows"))]
 use std::error::Error;


### PR DESCRIPTION
`crates/openlogi-hid/src/transport.rs`'s module doc links `AsyncHidChannel::supports_short_long_hidpp`, but the type is declared `#[cfg(not(target_os = "windows"))]` (`transport.rs:435`). On Windows the link has no target, `lib.rs:11` denies `rustdoc::broken_intra_doc_links`, and the whole crate's docs fail to build:

```
error: unresolved link to `AsyncHidChannel::supports_short_long_hidpp`
 --> crates\openlogi-hid\src\transport.rs:7
  |
7 | //! straight from [`AsyncHidChannel::supports_short_long_hidpp`]: USB / receiver
  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `AsyncHidChannel` in scope
  |
note: the lint level is defined here
 --> crates\openlogi-hid\src\lib.rs:11
  |
11 | #![deny(rustdoc::broken_intra_doc_links)]

error: could not document `openlogi-hid`
```

## Why CI is green anyway

`ci.yml`'s `rustdoc (hid crates)` job runs on `ubuntu-latest` only, where the type exists and the link resolves. The latest master run (`822c6e41`) reports that job as `success`, and it is not wrong — the break is invisible from Linux.

## Why it still matters

The cost lands on contributors rather than CI. `AGENTS.md` makes the four-command local gate a hard stop:

> **Never `git push` until the final tree has passed the full local gate.** … Run **all four** on the commit you are about to push
> … Exit non-zero on any of those → fix, re-run the **whole** set, then push. Do not push "to see if CI likes it."

On a Windows checkout of unmodified master, step four exits 101. Following the documented process to the letter is impossible, so the honest options are to skip the mandated step or to stop. That is a bad first experience for exactly the platform the README calls the young port.

It is also the failure mode `AGENTS.md` itself warns about at length under "Platform / cfg-gated code (macOS-green is a trap)" — same class, just with Linux as the green platform this time.

## Fix

Name the type in plain backticks rather than linking it. That is already how `node_ledger.rs` refers to `AsyncHidChannel` (lines 5 and 37) — this module doc was the lone outlier — and a short note inline records why, so the link does not get "helpfully" restored later.

No behaviour change; docs text only.

## Verification

Full gate from `AGENTS.md`, run on Windows 11 x86_64 (rustc 1.97.1) on the commit being pushed:

```
cargo fmt --all -- --check                                    exit=0
cargo clippy --workspace --all-targets -- -D warnings         exit=0
cargo test --workspace                                        exit=0
RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid \
  -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps \
  --document-private-items                                    exit=0
```

Before the change, that fourth command exits 101 on the same machine against clean master; I confirmed that by stashing the diff and re-running.
