### PR TITLE
fix(camera): read WhiteBalance, not ColorEnable, on Windows

### DIFF
--- a/crates/openlogi-camera/src/uvc_windows.rs
+++ b/crates/openlogi-camera/src/uvc_windows.rs
@@ -45,7 +45,10 @@ const VPA_CONTRAST: i32 = 1;
 const VPA_HUE: i32 = 2;
 const VPA_SATURATION: i32 = 3;
 const VPA_SHARPNESS: i32 = 4;
-const VPA_WHITE_BALANCE: i32 = 6;
+// 5 and 6 are Gamma and ColorEnable — no control maps to them, but the enum is
+// contiguous, so WhiteBalance is 7 and not the next id after Sharpness. Counting
+// on from the last mapped value is how this read ColorEnable instead.
+const VPA_WHITE_BALANCE: i32 = 7;
 const CC_ZOOM: i32 = 3;
 const CC_EXPOSURE: i32 = 4;
 const CC_FOCUS: i32 = 6;


### PR DESCRIPTION
`VPA_WHITE_BALANCE` was `6`. In `VideoProcAmpProperty` (strmif.h), `6` is `ColorEnable` — `WhiteBalance` is `7`.

The constants above it are correct and contiguous through `Sharpness` (4), so the value reads like the next id counted on from Sharpness, skipping the two properties this backend does not map: `Gamma` (5) and `ColorEnable` (6).

## Effect

Depends on the camera, and neither outcome is good:

- **Device does not support ColorEnable** → the range read fails, and `read_camera_state` drops any control whose range errors. White balance and its auto toggle silently vanish for a camera that supports both. This is what a C930e does.
- **Device does support ColorEnable** → the read succeeds and the control labelled `white_balance` reads and writes an unrelated boolean property.

## Scope

Windows only. I checked the other two backends and both are already correct:

| backend | white balance id | correct? |
|---|---|---|
| `uvc.rs` (macOS, raw UVC) | `(Processing, 0x0A)` — `PU_WHITE_BALANCE_TEMPERATURE_CONTROL` | yes |
| `uvc_linux.rs` (V4L2) | `0x0098_091a` — `V4L2_CID_WHITE_BALANCE_TEMPERATURE` | yes |
| `uvc_windows.rs` (DirectShow) | `6` — `ColorEnable` | **no** |

That is likely why it went unnoticed: the id is per-backend by nature (UVC selectors, V4L2 CIDs, and the DirectShow enum are three unrelated namespaces), and Windows is the newest backend.

## Verification

On a Logitech C930e. Before — seven controls, two auto toggles, no white balance:

```
> openlogi camera get
  zoom: min=100 max=400 default=100 current=100
  focus: min=0 max=255 default=0 current=0
  exposure: min=-11 max=-2 default=-5 current=-5
  brightness / contrast / saturation / sharpness: min=0 max=255 default=128
  focus_auto: current=true default=true
  exposure_auto: current=true default=true
```

After:

```
  white_balance: min=2000 max=7500 default=4000 current=4000
  white_balance_auto: current=true default=true
```

Those bounds are corroborated by an independent DirectShow probe I wrote against the same device, which also pins the id — querying by raw property number:

```
[IAMVideoProcAmp]
  Gamma                  UNSUPPORTED (hr=0x80070490)
  ColorEnable            UNSUPPORTED (hr=0x80070490)     <- property 6
  WhiteBalance           min=2000 max=7500 step=1 default=4000 caps=0x3 (auto=yes)   <- property 7
```

A 2000..7500 range with auto capability is a Kelvin temperature; `ColorEnable` is a 0/1 boolean and could never report it.

## Gate

Run on Windows 11 x86_64 (rustc 1.97.1):

```
cargo fmt --all -- --check                              exit=0
cargo clippy --workspace --all-targets -- -D warnings   exit=0
cargo test --workspace                                  exit=0
RUSTDOCFLAGS="-D warnings" cargo doc …                  exit=101
```

That last one fails on unmodified master too, for an unrelated reason: `openlogi-hid`'s module doc links a `cfg(not(windows))` type, so rustdoc cannot build that crate on Windows at all. #661 fixes it. With #661 applied on top of this branch, all four exit 0 — I verified that locally before dropping the cherry-pick so this PR stays independent.

## Related

While probing, the same device reported four controls that `CameraControl` has no variant for at all — Pan, Tilt, Gain, and BacklightCompensation. Filed separately as an enhancement; not touched here.
