### PR TITLE
docs(core): scope the unit-identifier scrub to what it actually removes

### DIFF
--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -61,7 +61,19 @@ pub struct DeviceIdentity {
 }
 
 impl DeviceIdentity {
-    /// Remove per-unit identifiers before this model snapshot is persisted.
+    /// Drop the serial number and unit id from this model snapshot before it
+    /// is persisted, leaving the identity body with model-level fields only.
+    ///
+    /// This does **not** make the saved file free of per-unit identifiers. A
+    /// device's configuration key has to be stable and unique per physical
+    /// unit, so [`runtime_key`] embeds one directly: `direct:` and `unknown:`
+    /// keys carry the device's own serial number or unit id, `raw:` keys carry
+    /// an OS-node- or serial-derived route identity, and a `receiver:` key
+    /// carries the receiver's UID. Stripping the body only keeps a device's
+    /// identifiers out of the file for `receiver:` keys, where the key names
+    /// the receiver and pairing slot rather than the paired device itself.
+    ///
+    /// [`runtime_key`]: crate::device_order::DeviceStableId::runtime_key
     #[must_use]
     pub fn without_unit_identifiers(mut self) -> Self {
         if let Some(model) = &mut self.model_info {


### PR DESCRIPTION
## Summary

`DeviceIdentity::without_unit_identifiers` is documented as:

> Remove per-unit identifiers before this model snapshot is persisted.

It removes them from the identity **body** only (`model_info.serial_number`, `model_info.unit_id`). The saved file still names them elsewhere.

Since #876 keyed device settings by identity, `canonical_device_key` makes the entry key itself a `serial:<serial>` or `unit:<hex>` fragment whenever the device reported one, on any transport, receiver-paired devices included. Only a device with no usable identity falls back to a route-derived key such as `receiver:<uid>:slot:<n>`.

The entry's `links` table is keyed by `DeviceStableId::route_key`, which persists receiver UIDs and, for `raw:` and `unknown:` routes, an OS-node- or serial-derived identity.

So the identifiers the comment says are removed are, for any identified device, the name of the table they were removed from.

## Change

Doc comment only. It now says the body is stripped, and names where per-unit identifiers still land in the file: the entry key via `canonical_device_key` and the route index via `route_key`. No behavior or signature change.

Rewritten on this rebase: the previous revision described the pre-#876 `runtime_key` model, where `receiver:` keys kept a device's identifiers out of the file. That is no longer true.

## Not addressed here

Whether this is the intended privacy posture is a maintainer call. Any alternative (hashing the identifier into the key) would invalidate every existing config. This PR only stops the comment from overstating the guarantee.

## Testing

Windows 11 Pro, rebased onto `master` at `a8d714a2`.

- `cargo fmt --all -- --check`: pass
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-core --no-deps --document-private-items`: pass (both new intra-doc links resolve), and the same without `--document-private-items`
- Workspace clippy/tests not rerun for this comment-only diff; the same `master` tip passed workspace clippy and tests on the #942 branch, apart from the Windows-only xtask `ci_yml_runs_what_this_runner_runs` failure and the `PermissionStatus::Unknown` rustdoc link error that #970 fixes.

Docs-only change: no behavior, no hardware.
