### PR TITLE
fix(agent): reload control capture across app switches

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -32,9 +32,9 @@ pub struct DeviceCapturePlan {
     /// keyed by the button its captured swipes dispatch as; empty when none
     /// gestures.
     pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
-    /// Standard buttons whose device or per-app binding leaves the default —
-    /// divert over `0x1b04`. A button that stays at its default everywhere
-    /// keeps its native HID behavior, so no re-synthesis is ever needed.
+    /// Standard buttons whose binding leaves the default — divert over
+    /// `0x1b04`. A button at its default keeps its native HID behavior, so no
+    /// re-synthesis is ever needed.
     pub divert_buttons: Vec<(u16, ButtonId)>,
     /// Whether any thumbwheel binding leaves its default. Combined with the
     /// sensitivity to decide thumb-wheel diversion.
@@ -50,18 +50,6 @@ pub struct DeviceCapturePlan {
 /// Shared plan list, rewritten by the orchestrator and read by the watcher.
 pub type SharedCapturePlans = Arc<RwLock<Vec<DeviceCapturePlan>>>;
 
-/// Whether a single-mode HID++ control must be diverted for `action`.
-fn action_requires_diversion(button: ButtonId, action: &Action) -> bool {
-    // The panel has no useful native click to preserve: None alone means leave
-    // its firmware haptics untouched. Other controls stay native at their
-    // canonical default and need capture only for a real override.
-    if button == ButtonId::HapticPanel {
-        *action != Action::None
-    } else {
-        *action != default_binding(button)
-    }
-}
-
 /// Build one device's plan from the config (per-app effective for `app`).
 #[must_use]
 pub fn plan_for_device(
@@ -72,7 +60,9 @@ pub fn plan_for_device(
     rearm_generation: u64,
 ) -> DeviceCapturePlan {
     let bindings = bindings_for(config, Some(config_key), app);
-    let global_bindings = bindings_for(config, Some(config_key), None);
+    // A gesture-mode OS-hook button must stay native: the hook needs to see
+    // its press to run hold+swipe detection, and diverting it would starve the
+    // hook of events.
     let oshook = oshook_gestures_for(config, Some(config_key), app);
     // One direction map per HID++ source in gesture mode — several may
     // gesture at once, each armed with its own raw-XY divert (the watcher
@@ -85,42 +75,22 @@ pub fn plan_for_device(
     let plain_sources = GESTURE_SOURCE_BUTTONS
         .into_iter()
         .filter(|(_, button)| !gesture_bindings.contains_key(button));
-    // Capture ownership is device-scoped, not foreground-app-scoped. If any
-    // app needs a single-mode control diverted, keep it diverted continuously
-    // and resolve each press through the current effective `bindings` map.
-    // Otherwise entering/leaving that app restarts the whole device session,
-    // briefly restoring unrelated gesture controls to their firmware actions.
-    let requires_stable_diversion = |button: ButtonId| {
-        if config.is_gesture_mode(config_key, button) {
-            // Preserve the existing app-specific handoff: the OS hook needs
-            // native events while the button gestures, while a per-app single
-            // override may need HID++ diversion on devices without that path.
-            return !oshook.contains_key(&button)
-                && bindings
-                    .get(&button)
-                    .is_some_and(|action| action_requires_diversion(button, action));
-        }
-        global_bindings
-            .get(&button)
-            .is_some_and(|action| action_requires_diversion(button, action))
-            || config.devices.get(config_key).is_some_and(|device| {
-                device.per_app_bindings.values().any(|app_bindings| {
-                    app_bindings
-                        .get(&button)
-                        .is_some_and(|action| action_requires_diversion(button, action))
-                })
-            })
-    };
     let divert_buttons: Vec<(u16, ButtonId)> = DIVERTABLE_STANDARD_BUTTONS
         .into_iter()
-        .filter(|(_, button)| requires_stable_diversion(*button))
-        // Gesture-source single bindings retain their existing current-app
-        // semantics, especially HapticPanel=None meaning native haptics.
-        .chain(plain_sources.filter(|(_, button)| {
-            bindings
-                .get(button)
-                .is_some_and(|action| action_requires_diversion(*button, action))
-        }))
+        .chain(plain_sources)
+        .filter(|(_, button)| !oshook.contains_key(button))
+        .filter(|(_, button)| {
+            bindings.get(button).is_some_and(|action| {
+                // The panel's default is ShowActionsRing, which must be
+                // diverted to open the ring. Action::None means "leave native
+                // firmware haptics alone", so treat None as the only non-divert.
+                if *button == ButtonId::HapticPanel {
+                    *action != Action::None
+                } else {
+                    *action != default_binding(*button)
+                }
+            })
+        })
         .collect();
     let thumbwheel_bindings_nondefault = [
         ButtonId::Thumbwheel,
@@ -324,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn per_app_single_button_override_does_not_change_the_divert_set() {
+    fn per_app_single_button_override_changes_only_that_apps_divert_set() {
         let mut cfg = Config::default();
         cfg.set_per_app_binding(
             "2b042",
@@ -336,42 +306,19 @@ mod tests {
         let global = plan_for_device(&cfg, "2b042", route(), None, 0);
         let editor = plan_for_device(&cfg, "2b042", route(), Some("com.example.Editor"), 0);
 
-        assert_eq!(
-            global.divert_buttons, editor.divert_buttons,
-            "foreground-app changes must not restart capture for a single-mode button"
-        );
         assert!(
-            global
+            !global
                 .divert_buttons
                 .iter()
                 .any(|&(_, button)| button == ButtonId::Back),
-            "the per-app override still needs a continuously diverted Back button"
+            "the global default keeps Back on its original path"
         );
-        assert_ne!(
-            global.bindings.get(&ButtonId::Back),
-            editor.bindings.get(&ButtonId::Back),
-            "dispatch must still use the foreground app's effective action"
-        );
-    }
-
-    #[test]
-    fn per_app_none_keeps_haptic_panel_native_in_that_app() {
-        let mut cfg = Config::default();
-        cfg.set_per_app_binding(
-            "2b042",
-            "com.example.Editor",
-            ButtonId::HapticPanel,
-            Some(Action::None),
-        );
-
-        let editor = plan_for_device(&cfg, "2b042", route(), Some("com.example.Editor"), 0);
-
         assert!(
-            !editor
+            editor
                 .divert_buttons
                 .iter()
-                .any(|&(_, button)| button == ButtonId::HapticPanel),
-            "HapticPanel=None means leave firmware haptics native"
+                .any(|&(_, button)| button == ButtonId::Back),
+            "the app override diverts Back only in that app"
         );
     }
 }

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -32,9 +32,9 @@ pub struct DeviceCapturePlan {
     /// keyed by the button its captured swipes dispatch as; empty when none
     /// gestures.
     pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
-    /// Standard buttons whose binding leaves the default — divert over
-    /// `0x1b04`. A button at its default keeps its native HID behavior, so no
-    /// re-synthesis is ever needed.
+    /// Standard buttons whose device or per-app binding leaves the default —
+    /// divert over `0x1b04`. A button that stays at its default everywhere
+    /// keeps its native HID behavior, so no re-synthesis is ever needed.
     pub divert_buttons: Vec<(u16, ButtonId)>,
     /// Whether any thumbwheel binding leaves its default. Combined with the
     /// sensitivity to decide thumb-wheel diversion.
@@ -50,6 +50,18 @@ pub struct DeviceCapturePlan {
 /// Shared plan list, rewritten by the orchestrator and read by the watcher.
 pub type SharedCapturePlans = Arc<RwLock<Vec<DeviceCapturePlan>>>;
 
+/// Whether a single-mode HID++ control must be diverted for `action`.
+fn action_requires_diversion(button: ButtonId, action: &Action) -> bool {
+    // The panel has no useful native click to preserve: None alone means leave
+    // its firmware haptics untouched. Other controls stay native at their
+    // canonical default and need capture only for a real override.
+    if button == ButtonId::HapticPanel {
+        *action != Action::None
+    } else {
+        *action != default_binding(button)
+    }
+}
+
 /// Build one device's plan from the config (per-app effective for `app`).
 #[must_use]
 pub fn plan_for_device(
@@ -60,9 +72,7 @@ pub fn plan_for_device(
     rearm_generation: u64,
 ) -> DeviceCapturePlan {
     let bindings = bindings_for(config, Some(config_key), app);
-    // A gesture-mode OS-hook button must stay native: the hook needs to see
-    // its press to run hold+swipe detection, and diverting it would starve the
-    // hook of events.
+    let global_bindings = bindings_for(config, Some(config_key), None);
     let oshook = oshook_gestures_for(config, Some(config_key), app);
     // One direction map per HID++ source in gesture mode — several may
     // gesture at once, each armed with its own raw-XY divert (the watcher
@@ -75,22 +85,42 @@ pub fn plan_for_device(
     let plain_sources = GESTURE_SOURCE_BUTTONS
         .into_iter()
         .filter(|(_, button)| !gesture_bindings.contains_key(button));
+    // Capture ownership is device-scoped, not foreground-app-scoped. If any
+    // app needs a single-mode control diverted, keep it diverted continuously
+    // and resolve each press through the current effective `bindings` map.
+    // Otherwise entering/leaving that app restarts the whole device session,
+    // briefly restoring unrelated gesture controls to their firmware actions.
+    let requires_stable_diversion = |button: ButtonId| {
+        if config.is_gesture_mode(config_key, button) {
+            // Preserve the existing app-specific handoff: the OS hook needs
+            // native events while the button gestures, while a per-app single
+            // override may need HID++ diversion on devices without that path.
+            return !oshook.contains_key(&button)
+                && bindings
+                    .get(&button)
+                    .is_some_and(|action| action_requires_diversion(button, action));
+        }
+        global_bindings
+            .get(&button)
+            .is_some_and(|action| action_requires_diversion(button, action))
+            || config.devices.get(config_key).is_some_and(|device| {
+                device.per_app_bindings.values().any(|app_bindings| {
+                    app_bindings
+                        .get(&button)
+                        .is_some_and(|action| action_requires_diversion(button, action))
+                })
+            })
+    };
     let divert_buttons: Vec<(u16, ButtonId)> = DIVERTABLE_STANDARD_BUTTONS
         .into_iter()
-        .chain(plain_sources)
-        .filter(|(_, button)| !oshook.contains_key(button))
-        .filter(|(_, button)| {
-            bindings.get(button).is_some_and(|action| {
-                // The panel's default is ShowActionsRing, which must be
-                // diverted to open the ring. Action::None means "leave native
-                // firmware haptics alone", so treat None as the only non-divert.
-                if *button == ButtonId::HapticPanel {
-                    *action != Action::None
-                } else {
-                    *action != default_binding(*button)
-                }
-            })
-        })
+        .filter(|(_, button)| requires_stable_diversion(*button))
+        // Gesture-source single bindings retain their existing current-app
+        // semantics, especially HapticPanel=None meaning native haptics.
+        .chain(plain_sources.filter(|(_, button)| {
+            bindings
+                .get(button)
+                .is_some_and(|action| action_requires_diversion(*button, action))
+        }))
         .collect();
     let thumbwheel_bindings_nondefault = [
         ButtonId::Thumbwheel,
@@ -290,6 +320,58 @@ mod tests {
                 .iter()
                 .any(|&(cid, _)| cid == GESTURE_BUTTON_CID),
             "an unbound gesture button must not be captured"
+        );
+    }
+
+    #[test]
+    fn per_app_single_button_override_does_not_change_the_divert_set() {
+        let mut cfg = Config::default();
+        cfg.set_per_app_binding(
+            "2b042",
+            "com.example.Editor",
+            ButtonId::Back,
+            Some(Action::Undo),
+        );
+
+        let global = plan_for_device(&cfg, "2b042", route(), None, 0);
+        let editor = plan_for_device(&cfg, "2b042", route(), Some("com.example.Editor"), 0);
+
+        assert_eq!(
+            global.divert_buttons, editor.divert_buttons,
+            "foreground-app changes must not restart capture for a single-mode button"
+        );
+        assert!(
+            global
+                .divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::Back),
+            "the per-app override still needs a continuously diverted Back button"
+        );
+        assert_ne!(
+            global.bindings.get(&ButtonId::Back),
+            editor.bindings.get(&ButtonId::Back),
+            "dispatch must still use the foreground app's effective action"
+        );
+    }
+
+    #[test]
+    fn per_app_none_keeps_haptic_panel_native_in_that_app() {
+        let mut cfg = Config::default();
+        cfg.set_per_app_binding(
+            "2b042",
+            "com.example.Editor",
+            ButtonId::HapticPanel,
+            Some(Action::None),
+        );
+
+        let editor = plan_for_device(&cfg, "2b042", route(), Some("com.example.Editor"), 0);
+
+        assert!(
+            !editor
+                .divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::HapticPanel),
+            "HapticPanel=None means leave firmware haptics native"
         );
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -1,9 +1,9 @@
 //! Background HID++ control-capture watcher, one session per online device.
 //!
 //! Runs [`openlogi_hid::run_capture_session`] concurrently for every device in
-//! the shared capture-plan list (not just the GUI's selection), restarts a
-//! session when its device's plan — route, diverted controls, thumb-wheel
-//! arming — changes, and dispatches each captured input against the binding
+//! the shared capture-plan list (not just the GUI's selection), reloads its
+//! control capture when a plan changes, and dispatches each captured input
+//! against the binding
 //! maps of the device it arrived on:
 //!
 //! - a gesture swipe through the gesture binding map,
@@ -27,8 +27,10 @@ use std::time::{Duration, Instant};
 use openlogi_core::binding::{Action, ButtonId, default_binding};
 use openlogi_core::config::DEFAULT_THUMBWHEEL_SENSITIVITY;
 use openlogi_hid::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
-use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
-use tokio::sync::{mpsc, oneshot};
+use openlogi_hid::{
+    CaptureChannel, CapturedInput, DeviceRoute, run_capture_session_with_spec_updates,
+};
+use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, warn};
 
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
@@ -126,7 +128,39 @@ struct RunningSession {
     /// the session is draining — deliberately stopped, but its task (and the
     /// control-restore writes in its teardown) may still be in flight.
     stop: Option<oneshot::Sender<()>>,
+    /// Latest complete capture spec for the live session. Plan changes use this
+    /// path instead of cycling the HID++ channel and listener.
+    spec_updates: watch::Sender<CaptureSpec>,
     epoch: u64,
+}
+
+type WantedSessions = HashMap<String, (DeviceRoute, CaptureSpec, u64)>;
+
+/// Reload plans on the live channel, and stop only sessions whose route or
+/// reconnect generation changed or whose device disappeared.
+fn reconcile_running_sessions(
+    sessions: &mut HashMap<String, RunningSession>,
+    want: &WantedSessions,
+) {
+    for (key, session) in sessions {
+        let keep = want.get(key).is_some_and(|(route, spec, rearm)| {
+            if *route != session.route || *rearm != session.rearm_generation {
+                return false;
+            }
+            if session.spec == *spec {
+                return true;
+            }
+            if session.spec_updates.send(spec.clone()).is_err() {
+                false
+            } else {
+                session.spec.clone_from(spec);
+                true
+            }
+        });
+        if !keep && let Some(stop) = session.stop.take() {
+            let _ = stop.send(());
+        }
+    }
 }
 
 /// What the manager should do with one session-completion report.
@@ -162,9 +196,9 @@ fn on_done(done_epoch: u64, live: Option<&RunningSession>) -> DoneAction {
     }
 }
 
-/// Keep one capture session alive per online device, restarting a session when
-/// its device's plan changes, and dispatch incoming inputs against the plan of
-/// the device they arrived on. Runs for the lifetime of the process.
+/// Keep one capture session alive per online device, reloading its capture spec
+/// when the plan changes, and dispatch incoming inputs against the plan of the
+/// device they arrived on. Runs for the lifetime of the process.
 async fn manage(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
@@ -204,7 +238,7 @@ async fn manage(
                 // While pairing is waiting or active, release every capture
                 // session so run_pairing can own the receiver's HID node (one
                 // process can't read it through two channels).
-                let want: HashMap<String, (DeviceRoute, CaptureSpec, u64)> =
+                let want: WantedSessions =
                     if receiver_access.exclusive_requested() {
                         HashMap::new()
                     } else {
@@ -227,8 +261,9 @@ async fn manage(
                             })
                             .unwrap_or_default()
                     };
-                // Stop sessions whose device disappeared or whose plan changed.
-                // Sending on the oneshot lets the session restore its controls.
+                // Reload capture changes on the existing channel. Stop only
+                // when the route/generation changes or the device disappears.
+                // Sending on the oneshot lets a stopped session restore its controls.
                 // A stopped session stays tracked — stop sender taken — until
                 // its task reports completion below, and a tracked key is never
                 // re-armed: arming the replacement while the old task may still
@@ -236,16 +271,7 @@ async fn manage(
                 // restore writes on the same device, leaving a control
                 // un-diverted while the new session believes it owns it,
                 // however many ticks the restore takes.
-                for (key, session) in &mut sessions {
-                    let keep = want.get(key).is_some_and(|(route, spec, rearm)| {
-                        *route == session.route
-                            && *spec == session.spec
-                            && *rearm == session.rearm_generation
-                    });
-                    if !keep && let Some(stop) = session.stop.take() {
-                        let _ = stop.send(());
-                    }
-                }
+                reconcile_running_sessions(&mut sessions, &want);
                 accumulators.retain(|key, _| want.contains_key(key));
                 for (key, (route, spec, rearm_generation)) in want {
                     if sessions.contains_key(&key) {
@@ -315,6 +341,7 @@ fn spawn_session(
     capture_channel: &CaptureChannel,
 ) -> RunningSession {
     let (stop_tx, stop_rx) = oneshot::channel();
+    let (spec_update_tx, spec_update_rx) = watch::channel(spec.clone());
     // Tag this session's inputs with its device key so dispatch resolves them
     // against the right plan.
     let (session_tx, mut session_rx) = mpsc::unbounded_channel::<CapturedInput>();
@@ -327,12 +354,17 @@ fn spawn_session(
     });
     let done = done.clone();
     let session_route = route.clone();
-    let session_spec = spec.clone();
     let slot = Arc::clone(capture_channel);
     tokio::spawn(async move {
         let _lease = lease;
-        if let Err(e) =
-            run_capture_session(session_route, session_spec, session_tx, stop_rx, slot).await
+        if let Err(e) = run_capture_session_with_spec_updates(
+            session_route,
+            session_tx,
+            spec_update_rx,
+            stop_rx,
+            slot,
+        )
+        .await
         {
             debug!(error = %e, "capture session ended");
         }
@@ -345,6 +377,7 @@ fn spawn_session(
         spec,
         rearm_generation,
         stop: Some(stop_tx),
+        spec_updates: spec_update_tx,
         epoch,
     }
 }
@@ -655,6 +688,7 @@ mod tests {
 
     /// A session whose stop sender is already gone (taken by a deliberate stop).
     fn stopped_session_with_epoch(epoch: u64) -> RunningSession {
+        let (spec_updates, _updates) = watch::channel(CaptureSpec::default());
         RunningSession {
             route: DeviceRoute::Direct {
                 vendor_id: 0x046d,
@@ -663,6 +697,7 @@ mod tests {
             spec: CaptureSpec::default(),
             rearm_generation: 0,
             stop: None,
+            spec_updates,
             epoch,
         }
     }
@@ -712,5 +747,97 @@ mod tests {
             on_done(7, Some(&stopped_session_with_epoch(7))),
             DoneAction::Remove { unexpected: false }
         );
+    }
+
+    #[test]
+    fn every_spec_change_keeps_the_session_and_publishes_the_complete_spec() {
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+        };
+        let changed_specs = [
+            CaptureSpec {
+                divert_buttons: vec![(0x0053, ButtonId::Back)],
+                ..CaptureSpec::default()
+            },
+            CaptureSpec {
+                divert_gesture_sources: vec![0x00c3],
+                ..CaptureSpec::default()
+            },
+            CaptureSpec {
+                capture_thumbwheel: true,
+                ..CaptureSpec::default()
+            },
+        ];
+
+        for wanted in changed_specs {
+            let (stop, _stopped) = oneshot::channel();
+            let (spec_updates, mut updates) = watch::channel(CaptureSpec::default());
+            let mut sessions = HashMap::from([(
+                "mouse".to_owned(),
+                RunningSession {
+                    route: route.clone(),
+                    spec: CaptureSpec::default(),
+                    rearm_generation: 0,
+                    stop: Some(stop),
+                    spec_updates,
+                    epoch: 1,
+                },
+            )]);
+            let want = HashMap::from([("mouse".to_owned(), (route.clone(), wanted.clone(), 0))]);
+
+            reconcile_running_sessions(&mut sessions, &want);
+
+            let session = &sessions["mouse"];
+            assert!(
+                session.stop.is_some(),
+                "a capture-spec change must not stop the capture session"
+            );
+            assert_eq!(session.spec, wanted);
+            assert!(updates.has_changed().unwrap_or(false));
+            assert_eq!(*updates.borrow_and_update(), wanted);
+        }
+    }
+
+    #[test]
+    fn route_or_rearm_change_stops_the_session() {
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+        };
+        let changed_targets = [
+            (
+                DeviceRoute::Direct {
+                    vendor_id: 0x046d,
+                    product_id: 0xb023,
+                },
+                0,
+            ),
+            (route.clone(), 1),
+        ];
+
+        for (wanted_route, wanted_generation) in changed_targets {
+            let (stop, _stopped) = oneshot::channel();
+            let (spec_updates, _updates) = watch::channel(CaptureSpec::default());
+            let mut sessions = HashMap::from([(
+                "mouse".to_owned(),
+                RunningSession {
+                    route: route.clone(),
+                    spec: CaptureSpec::default(),
+                    rearm_generation: 0,
+                    stop: Some(stop),
+                    spec_updates,
+                    epoch: 1,
+                },
+            )]);
+            let want = HashMap::from([(
+                "mouse".to_owned(),
+                (wanted_route, CaptureSpec::default(), wanted_generation),
+            )]);
+
+            reconcile_running_sessions(&mut sessions, &want);
+
+            assert!(sessions["mouse"].stop.is_none());
+        }
     }
 }

--- a/crates/openlogi-hid/src/gesture.rs
+++ b/crates/openlogi-hid/src/gesture.rs
@@ -19,11 +19,15 @@
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
-use hidpp::{channel::HidppChannel, device::Device, protocol::v20};
+use hidpp::{
+    channel::{HidppChannel, MessageListenerGuard},
+    device::Device,
+    protocol::v20,
+};
 use openlogi_core::binding::{ButtonId, GestureDirection, SwipeAccumulator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{debug, info, warn};
 
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
@@ -39,6 +43,10 @@ const LIVENESS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// dead. Two, so one ping lost to transient receiver congestion (which does
 /// happen under pointer load) doesn't churn the session.
 const LIVENESS_PING_STRIKES: u8 = 2;
+
+/// Delay before retrying a capture-spec update that the device did not
+/// acknowledge. The listener stays live while these writes retry.
+const SPEC_UPDATE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Shared slot holding the active capture session's open channel, so DPI /
 /// SmartShift writes can reuse it instead of opening a fresh one. `None`
@@ -120,6 +128,14 @@ struct CaptureAccum {
     buttons_down: Vec<u16>,
 }
 
+#[derive(Default)]
+struct CaptureRuntimeState {
+    accum: CaptureAccum,
+    gesture_cids: Vec<u16>,
+    button_cids: Vec<(u16, ButtonId)>,
+    thumbwheel_diverted: bool,
+}
+
 /// HID++-divertable standard buttons: the `0x1b04` control ID and the
 /// [`ButtonId`] its press dispatches as. A button is diverted per device only
 /// when its binding leaves the default, so an unbound button keeps its native
@@ -178,11 +194,29 @@ pub async fn run_capture_session(
     shutdown: oneshot::Receiver<()>,
     channel_slot: CaptureChannel,
 ) -> Result<(), GestureError> {
+    let (_spec_updates, spec_update_rx) = watch::channel(spec);
+    run_capture_session_with_spec_updates(route, sink, spec_update_rx, shutdown, channel_slot).await
+}
+
+/// Capture controls like [`run_capture_session`], while applying new capture
+/// specs on the open channel instead of restarting the session.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the linear session lifecycle shares listener, channel, and teardown ownership"
+)]
+pub async fn run_capture_session_with_spec_updates(
+    route: DeviceRoute,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    mut spec_updates: watch::Receiver<CaptureSpec>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let spec = spec_updates.borrow().clone();
     let chan = open_route_channel(&route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
     let device_index = route.device_index();
-    let armed = arm_controls(&chan, device_index, &spec).await?;
+    let mut armed = arm_controls(&chan, device_index, &spec).await?;
 
     // Publish this device's open channel so DPI/SmartShift writes reuse it
     // instead of opening their own. Cleared on the way out.
@@ -190,48 +224,20 @@ pub async fn run_capture_session(
         *slot = Some(SharedChannel::new(Arc::clone(&chan), route.clone()));
     }
 
-    let accum = Arc::new(Mutex::new(CaptureAccum::default()));
-    let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
-    let gesture_cids = armed.gesture_cids.clone();
-    let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
-    let dpi_set = armed.dpi_cids.clone();
-    let button_set = armed.button_cids.clone();
-    let listener = chan.add_msg_listener_guarded({
-        let accum = Arc::clone(&accum);
-        let sink = sink.clone();
-        move |raw, matched| {
-            if matched {
-                return;
-            }
-            let msg = v20::Message::from(raw);
-            if let Some(idx) = reprog_index
-                && let Some(event) = reprog_controls::decode_event(&msg, device_index, idx)
-            {
-                // Recover the guard even if a prior holder panicked — the
-                // critical section is panic-free, so the data is consistent.
-                let mut acc = accum.lock().unwrap_or_else(PoisonError::into_inner);
-                handle_reprog(&mut acc, event, &gesture_cids, &dpi_set, &button_set, &sink);
-                return;
-            }
-            if let Some(idx) = thumb_index
-                && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
-            {
-                if event.single_tap {
-                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None));
-                }
-                if event.rotation != 0 {
-                    let _ = sink.send(CapturedInput::Scroll(event.rotation));
-                }
-            }
-        }
-    });
+    let runtime = Arc::new(Mutex::new(CaptureRuntimeState {
+        gesture_cids: armed.gesture_cids.clone(),
+        button_cids: armed.button_cids.clone(),
+        thumbwheel_diverted: armed.thumbwheel_diverted,
+        ..CaptureRuntimeState::default()
+    }));
+    let listener = add_capture_listener(&chan, &armed, device_index, &runtime, &sink);
 
     info!(
         index = device_index,
         gesture_sources = armed.gesture_cids.len(),
         dpi_buttons = armed.dpi_cids.len(),
         buttons = armed.button_cids.len(),
-        thumbwheel = armed.thumb.is_some(),
+        thumbwheel = armed.thumbwheel_diverted,
         "control capture active"
     );
 
@@ -250,11 +256,44 @@ pub async fn run_capture_session(
         0,
     );
     let mut shutdown = std::pin::pin!(shutdown);
+    let mut requested_spec = spec;
     let mut silent_pings = 0u8;
+    let mut updates_open = true;
+    let mut update_retry_pending = false;
+    let update_retry = tokio::time::sleep(SPEC_UPDATE_RETRY_INTERVAL);
+    let liveness_ping = tokio::time::sleep(LIVENESS_PING_INTERVAL);
+    tokio::pin!(update_retry);
+    tokio::pin!(liveness_ping);
     let channel_dead = loop {
         tokio::select! {
             _ = &mut shutdown => break false,
-            () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
+            changed = spec_updates.changed(), if updates_open => {
+                if changed.is_err() {
+                    updates_open = false;
+                    continue;
+                }
+                let next = spec_updates.borrow_and_update().clone();
+                if next == requested_spec && !update_retry_pending {
+                    continue;
+                }
+                requested_spec = next;
+                update_retry_pending = !try_apply_spec_update(
+                    &mut armed, &requested_spec, &runtime, device_index,
+                ).await;
+                if update_retry_pending {
+                    reset_timer(update_retry.as_mut(), SPEC_UPDATE_RETRY_INTERVAL);
+                }
+            }
+            () = &mut update_retry, if update_retry_pending => {
+                requested_spec = spec_updates.borrow_and_update().clone();
+                update_retry_pending = !try_apply_spec_update(
+                    &mut armed, &requested_spec, &runtime, device_index,
+                ).await;
+                if update_retry_pending {
+                    reset_timer(update_retry.as_mut(), SPEC_UPDATE_RETRY_INTERVAL);
+                }
+            }
+            () = &mut liveness_ping => {
                 match root.ping(0x5a).await {
                     Err(v20::Hidpp20Error::Channel(
                         hidpp::channel::ChannelError::Timeout
@@ -273,6 +312,7 @@ pub async fn run_capture_session(
                     // error — proves the channel still delivers.
                     _ => silent_pings = 0,
                 }
+                reset_timer(liveness_ping.as_mut(), LIVENESS_PING_INTERVAL);
             }
         }
     };
@@ -300,6 +340,116 @@ pub async fn run_capture_session(
     }
     debug!(index = device_index, "control capture stopped");
     Ok(())
+}
+
+fn reset_timer(timer: std::pin::Pin<&mut tokio::time::Sleep>, delay: std::time::Duration) {
+    timer.reset(tokio::time::Instant::now() + delay);
+}
+
+fn add_capture_listener(
+    chan: &HidppChannel,
+    armed: &ArmedControls,
+    device_index: u8,
+    runtime: &Arc<Mutex<CaptureRuntimeState>>,
+    sink: &mpsc::UnboundedSender<CapturedInput>,
+) -> MessageListenerGuard {
+    let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
+    let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
+    let dpi_cids = armed.dpi_cids.clone();
+    let runtime = Arc::clone(runtime);
+    let sink = sink.clone();
+    chan.add_msg_listener_guarded(move |raw, matched| {
+        if matched {
+            return;
+        }
+        let msg = v20::Message::from(raw);
+        if let Some(idx) = reprog_index
+            && let Some(event) = reprog_controls::decode_event(&msg, device_index, idx)
+        {
+            // Recover the guard even if a prior holder panicked — the critical
+            // section is panic-free, so the data is consistent.
+            let mut runtime = runtime.lock().unwrap_or_else(PoisonError::into_inner);
+            let CaptureRuntimeState {
+                accum,
+                gesture_cids,
+                button_cids,
+                ..
+            } = &mut *runtime;
+            handle_reprog(accum, event, gesture_cids, &dpi_cids, button_cids, &sink);
+            return;
+        }
+        if let Some(idx) = thumb_index
+            && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
+        {
+            let diverted = runtime
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .thumbwheel_diverted;
+            if !diverted {
+                return;
+            }
+            if event.single_tap {
+                let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None));
+            }
+            if event.rotation != 0 {
+                let _ = sink.send(CapturedInput::Scroll(event.rotation));
+            }
+        }
+    })
+}
+
+async fn try_apply_spec_update(
+    armed: &mut ArmedControls,
+    requested: &CaptureSpec,
+    runtime: &Mutex<CaptureRuntimeState>,
+    device_index: u8,
+) -> bool {
+    match apply_spec_update(armed, requested, runtime, device_index).await {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(
+                index = device_index,
+                error = %error,
+                "control capture reload failed; keeping session active and retrying"
+            );
+            false
+        }
+    }
+}
+
+async fn apply_spec_update(
+    armed: &mut ArmedControls,
+    requested: &CaptureSpec,
+    runtime: &Mutex<CaptureRuntimeState>,
+    device_index: u8,
+) -> Result<(), GestureError> {
+    let result = armed.reconfigure(requested).await;
+    let mut runtime = runtime.lock().unwrap_or_else(PoisonError::into_inner);
+    if runtime.gesture_cids != armed.gesture_cids {
+        runtime.accum.swipe = SwipeAccumulator::default();
+        runtime.accum.gesture_source = None;
+        runtime.accum.overlap = false;
+        runtime.accum.gestures_down.clear();
+        runtime.accum.skip_first_raw_xy = false;
+    }
+    runtime.gesture_cids.clone_from(&armed.gesture_cids);
+    runtime.button_cids.clone_from(&armed.button_cids);
+    runtime.thumbwheel_diverted = armed.thumbwheel_diverted;
+    let active_cids: Vec<u16> = runtime.button_cids.iter().map(|(cid, _)| *cid).collect();
+    runtime
+        .accum
+        .buttons_down
+        .retain(|cid| active_cids.contains(cid));
+    if result.is_ok() {
+        debug!(
+            index = device_index,
+            gesture_sources = armed.gesture_cids.len(),
+            buttons = armed.button_cids.len(),
+            thumbwheel = armed.thumbwheel_diverted,
+            "control capture reloaded"
+        );
+    }
+    result
 }
 
 /// Reason-aware capture: maps stop reasons onto a unit oneshot shutdown.
@@ -366,15 +516,41 @@ struct ArmedControls {
     button_cids: Vec<(u16, ButtonId)>,
     /// Original reporting state for every diverted `0x1b04` control.
     reporting: Vec<ArmedCid>,
-    /// `0x2150` accessor + feature index, present when the thumb wheel is
-    /// diverted.
+    /// Full `0x1b04` control table, retained so spec reloads can change a
+    /// control between native, plain-diverted, and raw-XY modes in place.
+    available_reprog_controls: Vec<reprog_controls::CtrlIdInfo>,
+    /// `0x2150` accessor + feature index, retained even while the wheel is
+    /// native so a later spec can divert it without reopening the channel.
     thumb: Option<(Thumbwheel, u8)>,
+    /// Whether the thumb wheel currently reports diverted HID++ events.
+    thumbwheel_diverted: bool,
 }
 
 #[derive(Clone, Copy)]
 struct ArmedCid {
     cid: u16,
     original: reprog_controls::CidReporting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReprogMode {
+    Native,
+    Plain(ButtonId),
+    RawXy,
+}
+
+fn requested_reprog_mode(spec: &CaptureSpec, cid: u16) -> ReprogMode {
+    if spec.divert_gesture_sources.contains(&cid) {
+        ReprogMode::RawXy
+    } else if let Some(&(_, button)) = spec
+        .divert_buttons
+        .iter()
+        .find(|(requested, _)| *requested == cid)
+    {
+        ReprogMode::Plain(button)
+    } else {
+        ReprogMode::Native
+    }
 }
 
 impl ArmedControls {
@@ -385,9 +561,147 @@ impl ArmedControls {
                 restore_reporting(rc, reporting, "captured control").await;
             }
         }
-        if let Some((tw, _)) = self.thumb.as_ref() {
+        if self.thumbwheel_diverted
+            && let Some((tw, _)) = self.thumb.as_ref()
+        {
             restore(tw.set_reporting(false, false).await, "thumb wheel");
         }
+    }
+
+    async fn reconfigure(&mut self, spec: &CaptureSpec) -> Result<(), GestureError> {
+        self.reconfigure_reprog(spec).await?;
+        self.reconfigure_thumbwheel(spec.capture_thumbwheel).await
+    }
+
+    async fn reconfigure_reprog(&mut self, spec: &CaptureSpec) -> Result<(), GestureError> {
+        let Some((rc, _)) = self.reprog.clone() else {
+            self.gesture_cids.clear();
+            self.button_cids.clear();
+            return Ok(());
+        };
+
+        for control in self.available_reprog_controls.clone() {
+            if self.dpi_cids.contains(&control.cid) {
+                continue;
+            }
+            let requested = requested_reprog_mode(spec, control.cid);
+            let desired = match requested {
+                ReprogMode::RawXy if control.supports_raw_xy() => requested,
+                ReprogMode::Plain(_) if control.is_divertable() => requested,
+                _ => ReprogMode::Native,
+            };
+            self.set_reprog_mode(&rc, control.cid, desired).await?;
+        }
+
+        self.gesture_cids.sort_by_key(|cid| {
+            spec.divert_gesture_sources
+                .iter()
+                .position(|wanted| wanted == cid)
+                .unwrap_or(usize::MAX)
+        });
+        self.button_cids.sort_by_key(|(cid, _)| {
+            spec.divert_buttons
+                .iter()
+                .position(|(wanted, _)| wanted == cid)
+                .unwrap_or(usize::MAX)
+        });
+        Ok(())
+    }
+
+    fn reprog_mode(&self, cid: u16) -> ReprogMode {
+        if self.gesture_cids.contains(&cid) {
+            ReprogMode::RawXy
+        } else if let Some(&(_, button)) = self.button_cids.iter().find(|(armed, _)| *armed == cid)
+        {
+            ReprogMode::Plain(button)
+        } else {
+            ReprogMode::Native
+        }
+    }
+
+    async fn set_reprog_mode(
+        &mut self,
+        rc: &ReprogControlsV4,
+        cid: u16,
+        desired: ReprogMode,
+    ) -> Result<(), GestureError> {
+        let current = self.reprog_mode(cid);
+        if current == desired {
+            return Ok(());
+        }
+
+        match (current, desired) {
+            (ReprogMode::Native, ReprogMode::Plain(button)) => {
+                let reporting = arm_reprog_control(rc, cid, false).await?;
+                self.reporting.push(reporting);
+                self.button_cids.push((cid, button));
+            }
+            (ReprogMode::Native, ReprogMode::RawXy) => {
+                let reporting = arm_reprog_control(rc, cid, true).await?;
+                self.reporting.push(reporting);
+                self.gesture_cids.push(cid);
+            }
+            (ReprogMode::Plain(_), ReprogMode::Plain(button)) => {
+                if let Some((_, armed_button)) =
+                    self.button_cids.iter_mut().find(|(armed, _)| *armed == cid)
+                {
+                    *armed_button = button;
+                }
+            }
+            (ReprogMode::Plain(_), ReprogMode::RawXy)
+            | (ReprogMode::RawXy, ReprogMode::Plain(_)) => {
+                let reporting = self
+                    .reporting
+                    .iter()
+                    .find(|armed| armed.cid == cid)
+                    .copied()
+                    .ok_or_else(|| {
+                        GestureError::Hidpp(format!(
+                            "captured control {cid:#06x} has no restore state"
+                        ))
+                    })?;
+                set_reporting_mode(rc, reporting, desired == ReprogMode::RawXy).await?;
+                self.gesture_cids.retain(|armed| *armed != cid);
+                self.button_cids.retain(|(armed, _)| *armed != cid);
+                match desired {
+                    ReprogMode::Plain(button) => self.button_cids.push((cid, button)),
+                    ReprogMode::RawXy => self.gesture_cids.push(cid),
+                    ReprogMode::Native => {}
+                }
+            }
+            (ReprogMode::Plain(_) | ReprogMode::RawXy, ReprogMode::Native) => {
+                let Some(reporting_index) =
+                    self.reporting.iter().position(|armed| armed.cid == cid)
+                else {
+                    return Err(GestureError::Hidpp(format!(
+                        "captured control {cid:#06x} has no restore state"
+                    )));
+                };
+                let reporting = self.reporting[reporting_index];
+                restore_reporting_checked(rc, reporting).await?;
+                self.reporting.remove(reporting_index);
+                self.gesture_cids.retain(|armed| *armed != cid);
+                self.button_cids.retain(|(armed, _)| *armed != cid);
+            }
+            (ReprogMode::Native, ReprogMode::Native) | (ReprogMode::RawXy, ReprogMode::RawXy) => {}
+        }
+        Ok(())
+    }
+
+    async fn reconfigure_thumbwheel(&mut self, desired: bool) -> Result<(), GestureError> {
+        if desired == self.thumbwheel_diverted {
+            return Ok(());
+        }
+        let Some((thumbwheel, _)) = self.thumb.as_ref() else {
+            self.thumbwheel_diverted = false;
+            return Ok(());
+        };
+        thumbwheel
+            .set_reporting(desired, false)
+            .await
+            .map_err(|error| GestureError::Hidpp(format!("{error:?}")))?;
+        self.thumbwheel_diverted = desired;
+        Ok(())
     }
 }
 
@@ -417,7 +731,7 @@ async fn arm_controls(
     if armed.gesture_cids.is_empty()
         && armed.dpi_cids.is_empty()
         && armed.button_cids.is_empty()
-        && armed.thumb.is_none()
+        && !armed.thumbwheel_diverted
     {
         debug!(slot, "no capturable controls — idle session");
     }
@@ -445,16 +759,8 @@ async fn arm_controls_into(
         // Register an accessor before the first divert, so a failure on any
         // divert (including the first) can be handed back via `disarm`.
         armed.reprog = Some((rc.clone(), info.index));
+        armed.available_reprog_controls.clone_from(&controls);
 
-        // Divert each gesture-mode source; a source not listed stays native
-        // (an idle HID++ control must not be captured-and-dropped).
-        for &cid in &spec.divert_gesture_sources {
-            if controls.iter().any(|c| c.cid == cid && c.supports_raw_xy()) {
-                let reporting = arm_reprog_control(&rc, cid, true).await?;
-                armed.reporting.push(reporting);
-                armed.gesture_cids.push(cid);
-            }
-        }
         for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
                 let reporting = arm_reprog_control(&rc, cid, false).await?;
@@ -462,55 +768,45 @@ async fn arm_controls_into(
                 armed.dpi_cids.push(cid);
             }
         }
-        for &(cid, button) in &spec.divert_buttons {
-            // The plan never lists a raw-XY-diverted gesture source, but
-            // guard anyway: a plain (divert, no raw-XY) write here would strip
-            // the raw-XY reporting armed above.
-            if armed.gesture_cids.contains(&cid) {
-                continue;
-            }
-            if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-                let reporting = arm_reprog_control(&rc, cid, false).await?;
-                armed.reporting.push(reporting);
-                armed.button_cids.push((cid, button));
-            }
-        }
+        armed.reconfigure_reprog(spec).await?;
     }
 
-    if spec.capture_thumbwheel
-        && let Some(info) = device
-            .root()
-            .get_feature(thumbwheel::FEATURE_ID)
-            .await
-            .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
+    if let Some(info) = device
+        .root()
+        .get_feature(thumbwheel::FEATURE_ID)
+        .await
+        .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?
     {
         let tw = Thumbwheel::new(Arc::clone(chan), slot, info.index);
-        // Consume the getInfo error here, before the next await: Hidpp20Error
-        // isn't Send, so holding it across an await would make this future
-        // (spawned on tokio) non-Send.
-        let supports_single_tap = match tw.get_info().await {
-            Ok(twinfo) => twinfo.supports_single_tap,
-            Err(e) => {
-                warn!(error = ?e, "thumb wheel getInfo failed");
-                false
+        armed.thumb = Some((tw.clone(), info.index));
+        if spec.capture_thumbwheel {
+            // Consume the getInfo error here, before the next await: Hidpp20Error
+            // isn't Send, so holding it across an await would make this future
+            // (spawned on tokio) non-Send.
+            let supports_single_tap = match tw.get_info().await {
+                Ok(twinfo) => twinfo.supports_single_tap,
+                Err(e) => {
+                    warn!(error = ?e, "thumb wheel getInfo failed");
+                    false
+                }
+            };
+            // Divert whenever capture was requested: rotation rebinds and the
+            // sensitivity multiplier need the diverted event stream even on wheels
+            // that report no single-tap capability (e.g. MX Master 4) — lacking the
+            // tap only means a bound click can never fire.
+            if !supports_single_tap {
+                debug!("thumb wheel reports no single tap — click not capturable");
             }
-        };
-        // Divert whenever capture was requested: rotation rebinds and the
-        // sensitivity multiplier need the diverted event stream even on wheels
-        // that report no single-tap capability (e.g. MX Master 4) — lacking the
-        // tap only means a bound click can never fire.
-        if !supports_single_tap {
-            debug!("thumb wheel reports no single tap — click not capturable");
+            if let Err(error) = tw.set_reporting(true, false).await {
+                let error = GestureError::Hidpp(format!("{error:?}"));
+                restore(
+                    tw.set_reporting(false, false).await,
+                    "failed thumb wheel diversion",
+                );
+                return Err(error);
+            }
+            armed.thumbwheel_diverted = true;
         }
-        if let Err(error) = tw.set_reporting(true, false).await {
-            let error = GestureError::Hidpp(format!("{error:?}"));
-            restore(
-                tw.set_reporting(false, false).await,
-                "failed thumb wheel diversion",
-            );
-            return Err(error);
-        }
-        armed.thumb = Some((tw, info.index));
     }
     Ok(())
 }
@@ -540,6 +836,19 @@ async fn arm_reprog_control(
     Ok(ArmedCid { cid, original })
 }
 
+async fn set_reporting_mode(
+    rc: &ReprogControlsV4,
+    armed: ArmedCid,
+    raw_xy: bool,
+) -> Result<(), GestureError> {
+    let mut change = reprog_controls::CidReportingChange::temporary_diversion(true, raw_xy);
+    change.remap = armed.original.remap;
+    rc.set_cid_reporting_full(armed.cid, change)
+        .await
+        .map(|_| ())
+        .map_err(|error| GestureError::Hidpp(format!("{error:?}")))
+}
+
 /// The mirror image of arming: clear the diversion this session turned on and
 /// hand the control's remap target back untouched.
 ///
@@ -560,11 +869,18 @@ fn undivert_change(
 }
 
 async fn restore_reporting(rc: &ReprogControlsV4, armed: ArmedCid, what: &str) {
-    let result = rc
-        .set_cid_reporting_full(armed.cid, undivert_change(armed.original))
-        .await
-        .map(|_| ());
+    let result = restore_reporting_checked(rc, armed).await;
     restore(result, what);
+}
+
+async fn restore_reporting_checked(
+    rc: &ReprogControlsV4,
+    armed: ArmedCid,
+) -> Result<(), GestureError> {
+    rc.set_cid_reporting_full(armed.cid, undivert_change(armed.original))
+        .await
+        .map(|_| ())
+        .map_err(|error| GestureError::Hidpp(format!("{error:?}")))
 }
 
 /// The [`ButtonId`] a gesture-source CID dispatches as, per

--- a/crates/openlogi-hid/src/gesture/tests.rs
+++ b/crates/openlogi-hid/src/gesture/tests.rs
@@ -23,6 +23,71 @@ fn reporting(
     }
 }
 
+#[test]
+fn requested_mode_is_native_when_a_control_is_absent() {
+    assert_eq!(
+        requested_reprog_mode(&CaptureSpec::default(), reprog_controls::GESTURE_BUTTON_CID),
+        ReprogMode::Native
+    );
+}
+
+#[test]
+fn requested_mode_is_plain_for_a_diverted_button() {
+    let spec = CaptureSpec {
+        divert_buttons: vec![(reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)],
+        ..CaptureSpec::default()
+    };
+
+    assert_eq!(
+        requested_reprog_mode(&spec, reprog_controls::GESTURE_BUTTON_CID),
+        ReprogMode::Plain(ButtonId::GestureButton)
+    );
+}
+
+#[test]
+fn raw_xy_takes_precedence_over_a_duplicate_plain_divert() {
+    let spec = CaptureSpec {
+        divert_gesture_sources: vec![reprog_controls::GESTURE_BUTTON_CID],
+        divert_buttons: vec![(reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)],
+        ..CaptureSpec::default()
+    };
+
+    assert_eq!(
+        requested_reprog_mode(&spec, reprog_controls::GESTURE_BUTTON_CID),
+        ReprogMode::RawXy
+    );
+}
+
+#[tokio::test]
+async fn removing_a_gesture_source_resets_its_in_progress_hold() {
+    let mut armed = ArmedControls {
+        gesture_cids: GESTURE.to_vec(),
+        ..ArmedControls::default()
+    };
+    let runtime = Mutex::new(CaptureRuntimeState {
+        gesture_cids: GESTURE.to_vec(),
+        accum: CaptureAccum {
+            gesture_source: Some((reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton)),
+            overlap: true,
+            gestures_down: GESTURE.to_vec(),
+            skip_first_raw_xy: true,
+            ..CaptureAccum::default()
+        },
+        ..CaptureRuntimeState::default()
+    });
+
+    let Ok(()) = apply_spec_update(&mut armed, &CaptureSpec::default(), &runtime, 1).await else {
+        panic!("a hardware-free update should succeed");
+    };
+
+    let runtime = runtime.lock().unwrap_or_else(PoisonError::into_inner);
+    assert!(runtime.gesture_cids.is_empty());
+    assert!(runtime.accum.gesture_source.is_none());
+    assert!(!runtime.accum.overlap);
+    assert!(runtime.accum.gestures_down.is_empty());
+    assert!(!runtime.accum.skip_first_raw_xy);
+}
+
 /// A control that was *already* diverted when the session armed it — an agent
 /// killed mid-session, or another Logitech app — must not be handed that state
 /// back. Replaying it leaves the button diverted with no listener: no OS event

--- a/crates/openlogi-hid/src/lib.rs
+++ b/crates/openlogi-hid/src/lib.rs
@@ -47,7 +47,8 @@ pub use channel_pool::ChannelPool;
 pub use channel_registry::ChannelRegistry;
 pub use gesture::{
     CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
-    run_capture_session_with_registry, run_capture_session_with_stop_reason,
+    run_capture_session_with_registry, run_capture_session_with_spec_updates,
+    run_capture_session_with_stop_reason,
 };
 pub use hires_wheel::{
     ScrollReportingTarget, ScrollResolution, ScrollWheelMode, get_scroll_wheel_mode,


### PR DESCRIPTION
## Summary

Foreground-app changes previously stopped and rebuilt the HID++ control-capture session so the new app-specific configuration could take effect. On the tested MX Master 3, rebuilding left a gap of more than one second between `control capture stopped` and `control capture active`.

During that gap, diverted controls temporarily returned to their firmware-native behavior. In practice, using the auxiliary button could open the macOS application switcher instead of executing the active OpenLogi binding.

This change keeps the existing capture channel, listener, and session alive across normal app switches and reloads the complete app-specific `CaptureSpec` in place.

## Changes

- Agent core: publish each complete app-specific `CaptureSpec` to the active capture session instead of restarting it.
- HID: incrementally transition controls between native, plain-diverted, raw-XY, and thumb-wheel modes.
- HID: avoid hardware writes when only the action assigned to an already-captured control changes.
- HID: keep the listener active and retry the latest specification after a failed HID++ reload.
- Agent core: continue restarting capture when the route or re-arm generation changes, pairing takes ownership, the device is removed, or the capture channel dies.
- Tests: cover per-app capture-plan differences, session continuity across specification changes, requested control modes, and gesture-state cleanup when a source is removed.

## Behavior

Before this change:

- Switching the frontmost app stopped the current capture session.
- Diverted buttons were restored to native behavior while a replacement session was created.
- The observed stop/start gap could exceed one second.
- Input during that gap could trigger the device or macOS default action instead of the configured OpenLogi action.

After this change:

- Normal app switches produce `control capture reloaded` without `control capture stopped`.
- The capture channel, event listener, and session remain active.
- The new app-specific rules take effect without the previous stop/start gap.
- Only hardware capture modes that actually changed require HID++ writes; action-only changes require none.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`
- Runtime-tested with an MX Master 3: repeated foreground-app switches logged `control capture reloaded` without `control capture stopped`, and the configured auxiliary-button behavior remained active across app switches.
- The final tree includes a control-flow-only simplification made after the hardware test and has passed the full automated gate.

Related to #878