### PR TITLE
feat(hid): support G602 nano receiver

### DIFF
--- a/crates/openlogi-core/src/hid/route.rs
+++ b/crates/openlogi-core/src/hid/route.rs
@@ -84,10 +84,11 @@ pub const BOLT_PIDS: &[u16] = &[0xc548];
 /// USB product IDs that identify Logi Unifying receivers. Used by callers that
 /// need to construct the correct [`DeviceRoute`] variant from a raw inventory.
 ///
-/// `0xc539` is the Lightspeed gaming receiver: a distinct product line, but it
-/// answers the same HID++ 1.0 enumeration and pairing-information registers as
-/// Unifying, so it routes as [`DeviceRoute::Unifying`].
-pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532, 0xc539];
+/// `0xc537` is the Nano receiver bundled with the G602 and `0xc539` is a
+/// Lightspeed gaming receiver. Both answer the same HID++ 1.0 enumeration and
+/// pairing-information registers as Unifying, so they route as
+/// [`DeviceRoute::Unifying`].
+pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532, 0xc537, 0xc539];
 
 /// USB product IDs that identify Logitech Lightspeed receivers — the
 /// receivers bundled with G-series wireless devices. `0xc53f` is the nano

--- a/crates/openlogi-hid/src/channel/transport.rs
+++ b/crates/openlogi-hid/src/channel/transport.rs
@@ -4,7 +4,7 @@
 //! descriptor, but `async-hid 0.4` only exposes descriptors on Linux. We avoid
 //! that path by pre-filtering to the Logitech HID++ vendor collections at
 //! enumeration time (see [`HIDPP_LONG_COLLECTIONS`]) and reporting support
-//! straight from [`AsyncHidChannel::supports_short_long_hidpp`]: USB / receiver
+//! straight from [`hidpp::channel::RawHidChannel::supports_short_long_hidpp`]: USB / receiver
 //! collections carry both reports; BLE-direct collections are long-only, and the
 //! `hidpp` channel up-converts outgoing short messages to long for them.
 

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -22,6 +22,7 @@ use crate::{
 /// All USB vendor & product ID pairs that are known to identify Unifying
 /// receivers.
 ///
+/// `046d:c537` is the Nano receiver bundled with the G602;
 /// `046d:c539` is the Lightspeed gaming receiver; `046d:c53f` is the Lightspeed
 /// nano receiver (bundled with G-series wireless mice such as the G305);
 /// `046d:c547` is the Lightspeed receiver bundled with newer G-series devices
@@ -34,6 +35,7 @@ use crate::{
 pub const VPID_PAIRS: &[(u16, u16)] = &[
     (0x046d, 0xc52b),
     (0x046d, 0xc532),
+    (0x046d, 0xc537),
     (0x046d, 0xc539),
     (0x046d, 0xc53f),
     (0x046d, 0xc547),


### PR DESCRIPTION
## Summary
Add initial support for the G602's `046d:c537` Nano receiver.

## Changes
- `openlogi-core` / `openlogi-hidpp`: recognize `c537` through the existing Unifying-compatible receiver path
- `openlogi-hid`: fix a Windows rustdoc link exposed by the local gate

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`
- Not runtime-tested on G602 hardware

Fixes #448