### PR TITLE
fix(gui): use the GPUI executor timer, not tokio::time::interval, for camera scans

### DIFF
--- a/crates/openlogi-desktop/src/main.rs
+++ b/crates/openlogi-desktop/src/main.rs
@@ -465,8 +465,15 @@ fn main() -> Result<()> {
             // the merge without waiting for the agent to change something of
             // its own.
             let mut latest_snapshot: Option<openlogi_ipc::AgentSnapshot> = None;
-            let mut camera_scan = tokio::time::interval(CAMERA_SCAN_PERIOD);
-            camera_scan.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // GPUI drives this task on its own executor, never inside a Tokio
+            // runtime, so a `tokio::time::interval` panics the moment it is
+            // built ("there is no reactor running"). The background executor's
+            // timer is what the rest of the app schedules on. It is armed once
+            // and re-armed only after it fires, so a busy IPC arm cannot keep
+            // starving the scan the way a per-iteration timer would, and a late
+            // tick simply runs late instead of catching up — the same behaviour
+            // `MissedTickBehavior::Delay` asked for.
+            let mut camera_scan = Box::pin(cx.background_executor().timer(CAMERA_SCAN_PERIOD));
             // Cleared when the IPC update channel closes (the client thread
             // died), so the select stops polling a closed receiver.
             let mut ipc_open = true;
@@ -525,7 +532,8 @@ fn main() -> Result<()> {
                             cx.update(|cx| set_agent_link(state::AgentLink::Unreachable, cx));
                         }
                     },
-                    _ = camera_scan.tick() => {
+                    () = &mut camera_scan => {
+                        camera_scan.set(cx.background_executor().timer(CAMERA_SCAN_PERIOD));
                         // Nothing to show it to. The app runs from the menu bar
                         // with every window closed, and this scan is the only
                         // work left that is not driven by an agent change — so


### PR DESCRIPTION
This app crashes on every launch on macOS: the GUI opens the agent/overlay then aborts before a window ever appears.

## Root cause

`tokio::time::interval()` in `main.rs`'s camera-scan loop panics immediately — `"there is no reactor running, must be called from the context of a Tokio 1.x runtime"` — because the GUI's main task runs on GPUI's own executor. The only Tokio runtime in the process lives on the dedicated `openlogi-ipc-client` thread (`services/ipc.rs`). Since this happens on the main thread, the panic aborts the whole process (`SIGABRT`).

Introduced in 2d117e7 (refactor(ipc): let the agent say when its state changed).

## Crash trace (macOS 26.5.2, Apple M4 Pro)

```
thread 'main' panicked at tokio-1.52.3/src/time/interval.rs:138:26:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
fatal runtime error: failed to initiate panic, error 3, aborting
```

## Fix

Every other timing site in `openlogi-desktop` already schedules through `cx.background_executor().timer(...)` — see `platform/permissions.rs`, `features/camera/preview.rs`, `windows/settings.rs`, `windows/settings/about.rs`, `windows/settings/assets.rs`. This swaps the camera-scan interval to the same primitive, re-arming it after each fire to preserve the original `MissedTickBehavior::Delay` semantics (a late tick just runs late instead of catching up, and a busy IPC arm in the same `select!` can't starve it since the timer isn't recreated per-iteration).

## Testing

- `cargo build --release -p openlogi-desktop` — clean
- Ran the built binary directly and via `open OpenLogi.app`: agent, overlay, and desktop process all start and stay running past the point where they previously aborted; menu-bar item and input hook install successfully.
