### PR TITLE
build(infra): drop dependency debuginfo in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,12 @@ ptr_as_ptr = "warn"
 tests_outside_test_module = "warn"
 undocumented_unsafe_blocks = "warn"
 
+[profile.dev]
+debug = "limited"
+
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
## Summary

Dev builds compiled full (`debug = 2`) debuginfo for every one of the ~650
dependency crates the desktop app pulls in — the workspace had no
`[profile.dev]` tuning at all. That dominated cold-build time, rlib size, and
link input: a cold incremental rebuild after touching one file in
`openlogi-desktop` measured **9 minutes**, and `target/debug/deps` carried
100 GB of artifacts. (For reference, zed itself develops with
`debug = "limited"`.)

Dependencies now build with no debuginfo; workspace crates keep line tables so
backtraces stay readable. Stepping into a dependency with a debugger is a
temporary one-line per-package override — the comment above the table shows it.

## Changes

- root `Cargo.toml`: add `[profile.dev] debug = "limited"` and
  `[profile.dev.package."*"] debug = false` (the `"*"` wildcard exempts
  workspace members, so our own crates keep line tables).

No dependency changes; `Cargo.lock` is untouched and the `gpui` /
`gpui-component` pins are unchanged.

## Testing

Full local gate on a fresh worktree + fresh target directory:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace                     # 31 test suites, 0 failures
RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp \
  -p openlogi-hidpp-derive --no-deps --document-private-items
```

The complete pass leaves a 5.7 GB target directory where the old profile's
equivalent carried ~100 GB of dependency artifacts alone.

Note for everyone's next `cargo build` after this merges: the profile change
invalidates existing dev artifacts, so the first build recompiles the
dependency tree once (faster than before, since it no longer emits debuginfo).

Not runtime-tested on hardware — the change affects only build outputs, not
behavior.
