### PR TITLE
fix(overlay): prevent GPUI from exiting on window close

### DIFF
--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -48,7 +48,8 @@ fn main() -> Result<()> {
         commands,
     } = spawn_ipc();
 
-    let app = gpui_platform::application().with_assets(openlogi_ui::action_icons::ActionIcons);
+    let mut app = gpui_platform::application().with_assets(openlogi_ui::action_icons::ActionIcons);
+    app = app.with_quit_mode(gpui::QuitMode::Explicit);
     app.run(move |cx| {
         platform::configure_application();
         let live_session = Arc::new(ClickAwaySession::new());


### PR DESCRIPTION
## Summary
On Linux, GPUI closes the application when the last window is closed by default. This causes the `openlogi-overlay` process to exit every time the Actions Ring is dismissed, leading to a long GPU reinitialization delay upon the next invocation.

This PR sets `QuitMode::Explicit` on the GPUI app to keep the overlay alive in the background, making subsequent ring invocations instant.

## Changes
- `crates/openlogi-overlay/src/main.rs`: added `app.with_quit_mode(gpui::QuitMode::Explicit)`.

## Testing
- Verified on Ubuntu 26.04. The Actions Ring now closes properly and re-opens instantly without tearing down the overlay process.

Fixes # (no issue, observed locally)