### PR TITLE
fix(gui): replace tokio interval with gpui timer to prevent panic

### DIFF
--- a/crates/openlogi-desktop/src/main.rs
+++ b/crates/openlogi-desktop/src/main.rs
@@ -465,8 +465,8 @@ fn main() -> Result<()> {
             // the merge without waiting for the agent to change something of
             // its own.
             let mut latest_snapshot: Option<openlogi_ipc::AgentSnapshot> = None;
-            let mut camera_scan = tokio::time::interval(CAMERA_SCAN_PERIOD);
-            camera_scan.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut camera_scan_timer = cx.background_executor().timer(CAMERA_SCAN_PERIOD);
+
             // Cleared when the IPC update channel closes (the client thread
             // died), so the select stops polling a closed receiver.
             let mut ipc_open = true;
@@ -525,7 +525,8 @@ fn main() -> Result<()> {
                             cx.update(|cx| set_agent_link(state::AgentLink::Unreachable, cx));
                         }
                     },
-                    _ = camera_scan.tick() => {
+                    _ = &mut camera_scan_timer => {
+                        camera_scan_timer = cx.background_executor().timer(CAMERA_SCAN_PERIOD);
                         // Nothing to show it to. The app runs from the menu bar
                         // with every window closed, and this scan is the only
                         // work left that is not driven by an agent change — so

--- a/crates/openlogi-desktop/src/main.rs
+++ b/crates/openlogi-desktop/src/main.rs
@@ -525,7 +525,7 @@ fn main() -> Result<()> {
                             cx.update(|cx| set_agent_link(state::AgentLink::Unreachable, cx));
                         }
                     },
-                    _ = &mut camera_scan_timer => {
+                    () = &mut camera_scan_timer => {
                         camera_scan_timer = cx.background_executor().timer(CAMERA_SCAN_PERIOD);
                         // Nothing to show it to. The app runs from the menu bar
                         // with every window closed, and this scan is the only


### PR DESCRIPTION
## Summary
The recent commit `a2613f5684f4` added a `tokio::time::interval` to the GUI's background loop, but `openlogi-desktop` runs its async block on GPUI's executor (`smol`), not a Tokio reactor. This causes an immediate panic on startup: `there is no reactor running, must be called from the context of a Tokio 1.x runtime`.

This PR replaces the Tokio interval with GPUI's native `cx.background_executor().timer()`, which correctly yields on the GPUI executor.

## Changes
- `crates/openlogi-desktop/src/main.rs`: swapped `tokio::time::interval` for `gpui::Timer` to avoid Tokio dependency in the UI loop.

## Testing
- Verified on Ubuntu 26.04. The app now launches successfully and connects to the agent without panicking.

Fixes # (no issue, observed locally)