### PR TITLE
feat(agent): expose device haptics to third-party apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,6 +5153,8 @@ dependencies = [
  "openlogi-hook",
  "openlogi-ipc",
  "plist",
+ "serde",
+ "serde_json",
  "succession",
  "sysinfo 0.38.4",
  "tarpc",

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -45,6 +45,9 @@ use crate::{DpiCycleState, DpiCycles};
 struct AgentDevice {
     config_key: String,
     model_key: String,
+    /// Human-readable label, when the device supplied one. Purely for display
+    /// to a person — never matched on; `config_key` is the identity.
+    name: Option<String>,
     route: Option<DeviceRoute>,
     slot: u8,
     serial: Option<String>,
@@ -680,6 +683,45 @@ impl Orchestrator {
         buzzable(device)
     }
 
+    /// The same resolution keyed by `config_key` — the stable per-device
+    /// identifier the JSON haptics API hands to third-party callers, since a
+    /// `DeviceRoute` is an internal addressing detail they should not have to
+    /// reconstruct (and which changes when a device is re-paired).
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::haptic_route`].
+    pub fn haptic_route_for_key(&self, requested: Option<&str>) -> Result<DeviceRoute, WriteError> {
+        let device = match requested {
+            Some(key) => self.devices.iter().find(|device| device.config_key == key),
+            None => self.active_device(),
+        };
+        buzzable(device)
+    }
+
+    /// Every online device with a haptic engine, as `(key, label)` pairs for
+    /// the JSON API's device listing.
+    #[must_use]
+    pub fn haptic_devices(&self) -> Vec<(String, String)> {
+        self.devices
+            .iter()
+            .filter(|device| {
+                device.online
+                    && device.route.is_some()
+                    && device
+                        .capabilities
+                        .is_some_and(|capabilities| capabilities.haptic_feedback)
+            })
+            .map(|device| {
+                let label = device
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| device.model_key.clone());
+                (device.config_key.clone(), label)
+            })
+            .collect()
+    }
+
     fn active_device(&self) -> Option<&AgentDevice> {
         let key = self.current_key()?;
         self.devices.iter().find(|device| device.config_key == key)
@@ -879,6 +921,7 @@ fn build_devices(
             devices.push(AgentDevice {
                 config_key: config_key.into_string(),
                 model_key: model.config_key(),
+                name: paired.codename.clone(),
                 route,
                 slot: paired.slot,
                 serial: model.serial_number.clone(),
@@ -910,6 +953,7 @@ fn build_devices(
         devices.push(AgentDevice {
             config_key: config_key.into_string(),
             model_key: device.display_name.clone(),
+            name: Some(device.display_name.clone()),
             route: Some(route),
             slot: DIRECT_DEVICE_INDEX,
             serial: device.serial_number.clone(),

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -23,7 +23,7 @@ use openlogi_core::device::{
 use openlogi_core::device_order::DeviceStableId;
 use openlogi_hid::{
     CaptureChannel, ChannelPool, ChannelRegistry, DIRECT_DEVICE_INDEX, DeviceRoute,
-    KEYBOARD_KEY_CIDS,
+    KEYBOARD_KEY_CIDS, WriteError,
 };
 use openlogi_ipc::InventoryHealth;
 use tracing::{debug, info, warn};
@@ -654,6 +654,37 @@ impl Orchestrator {
         })
     }
 
+    /// Resolve the device an out-of-band haptic play should target, or say why
+    /// it cannot be played.
+    ///
+    /// `requested` names a device explicitly; `None` falls back to the active
+    /// device — the same one the Actions Ring would buzz — so a caller with no
+    /// inventory of its own can still ask for feedback on "the mouse".
+    ///
+    /// Both failure modes are worth distinguishing to the caller: a device that
+    /// is gone or asleep may come back, whereas one without `0x19b0` never
+    /// grows a haptic engine and the caller should stop asking.
+    ///
+    /// # Errors
+    ///
+    /// [`WriteError::DeviceNotFound`] when nothing online matches, and
+    /// [`WriteError::FeatureUnsupported`] when the match has no haptic engine.
+    pub fn haptic_route(&self, requested: Option<&DeviceRoute>) -> Result<DeviceRoute, WriteError> {
+        let device = match requested {
+            Some(route) => self
+                .devices
+                .iter()
+                .find(|device| device.route.as_ref() == Some(route)),
+            None => self.active_device(),
+        };
+        buzzable(device)
+    }
+
+    fn active_device(&self) -> Option<&AgentDevice> {
+        let key = self.current_key()?;
+        self.devices.iter().find(|device| device.config_key == key)
+    }
+
     /// Where enumeration stands, for the IPC `status` poll.
     #[must_use]
     pub fn inventory_health(&self) -> InventoryHealth {
@@ -802,6 +833,29 @@ fn configured_wheel_mode(
 /// `build_device_list` minus the asset/display fields: a device is included
 /// only once its HID++ DeviceInformation (`model_info`) has resolved, since the
 /// model key is derived from it.
+/// The shared tail of both haptic-route selectors: a device can be buzzed only
+/// if it was found, is online, has a haptic engine, and has a route to reach.
+///
+/// The order matters. Offline is reported as "not found" rather than
+/// "unsupported" because the two mean different things to a caller: a sleeping
+/// device is worth retrying, a device without `0x19b0` never is.
+fn buzzable(device: Option<&AgentDevice>) -> Result<DeviceRoute, WriteError> {
+    let device = device
+        .filter(|device| device.online)
+        .ok_or(WriteError::DeviceNotFound)?;
+    if !device
+        .capabilities
+        .is_some_and(|capabilities| capabilities.haptic_feedback)
+    {
+        // 0x19b0 — the same feature ID `Capabilities` derives the flag from,
+        // reported back so the caller can name what is missing.
+        return Err(WriteError::FeatureUnsupported {
+            feature_hex: 0x19b0,
+        });
+    }
+    device.route.clone().ok_or(WriteError::DeviceNotFound)
+}
+
 fn build_devices(
     inventories: &[DeviceInventory],
     standalone: &[StandaloneDevice],

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -27,6 +27,7 @@ fn dev(key: &str, slot: u8, online: bool) -> AgentDevice {
     AgentDevice {
         config_key: key.to_string(),
         model_key: key.to_string(),
+        name: None,
         route: Some(DeviceRoute::Bolt {
             receiver_uid: "AA00".to_string(),
             slot,
@@ -45,6 +46,7 @@ fn raw_light_dev(key: &str) -> AgentDevice {
     AgentDevice {
         config_key: key.to_string(),
         model_key: "Litra Glow".to_string(),
+        name: Some("Litra Glow".to_string()),
         route: Some(DeviceRoute::RawHid {
             vendor_id: 0x046d,
             product_id: 0xc900,

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -11,7 +11,7 @@ use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
-use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
+use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute, WriteError};
 use std::sync::Arc;
 
 use crate::observable::ObservableState;
@@ -768,4 +768,86 @@ fn app_switch_republishes_capture_plans() {
     );
     orch.set_current_app(Some("com.example.editor".into()));
     assert_eq!(published_back_binding(&orch), Some(Action::Undo));
+}
+
+/// A device that advertises HID++ `0x19b0`, ready to be buzzed.
+fn haptic_dev(key: &str, slot: u8, online: bool) -> AgentDevice {
+    let mut device = dev(key, slot, online);
+    device.capabilities = Some(Capabilities {
+        haptic_feedback: true,
+        ..Capabilities::default()
+    });
+    device
+}
+
+fn bolt(slot: u8) -> DeviceRoute {
+    DeviceRoute::Bolt {
+        receiver_uid: "AA00".to_string(),
+        slot,
+    }
+}
+
+/// An orchestrator whose only device is `device`, with the runtime rebuilt so
+/// the active-device pick is real rather than left at its initial value.
+fn orchestrator_with(device: AgentDevice) -> Orchestrator {
+    let mut orch = orchestrator(Config::default());
+    orch.devices = vec![device];
+    orch.rebuild();
+    orch
+}
+
+#[test]
+fn haptic_route_falls_back_to_the_active_device() {
+    let orch = orchestrator_with(haptic_dev("mouse", 1, true));
+
+    assert_eq!(orch.haptic_route(None).ok(), Some(bolt(1)));
+    // An explicit route for the same device resolves to the same place.
+    assert_eq!(orch.haptic_route(Some(&bolt(1))).ok(), Some(bolt(1)));
+}
+
+#[test]
+fn haptic_route_rejects_a_device_with_no_haptic_engine() {
+    // `dev` leaves capabilities unprobed (`None`), which must read as "no
+    // haptics" rather than optimistically buzzing a device that cannot.
+    let orch = orchestrator_with(dev("mouse", 1, true));
+
+    assert!(
+        matches!(
+            orch.haptic_route(None),
+            Err(WriteError::FeatureUnsupported {
+                feature_hex: 0x19b0
+            })
+        ),
+        "a device without 0x19b0 must be refused by feature, not by liveness"
+    );
+}
+
+#[test]
+fn haptic_route_rejects_an_offline_device() {
+    let orch = orchestrator_with(haptic_dev("mouse", 1, false));
+
+    // Asleep is not "unsupported" — the caller may usefully retry later, so
+    // the capability answer must not shadow the liveness one.
+    for requested in [Some(bolt(1)), None] {
+        assert!(
+            matches!(
+                orch.haptic_route(requested.as_ref()),
+                Err(WriteError::DeviceNotFound)
+            ),
+            "an offline device is not found, whether named or resolved: {requested:?}"
+        );
+    }
+}
+
+#[test]
+fn haptic_route_rejects_a_route_no_device_claims() {
+    let orch = orchestrator_with(haptic_dev("mouse", 1, true));
+
+    assert!(
+        matches!(
+            orch.haptic_route(Some(&bolt(7))),
+            Err(WriteError::DeviceNotFound)
+        ),
+        "a route matching no device must not fall back to the active one"
+    );
 }

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -29,6 +29,10 @@ openlogi-hook = { path = "../openlogi-hook" }
 openlogi-ipc = { path = "../openlogi-ipc" }
 tarpc = { workspace = true }
 interprocess = { workspace = true }
+serde = { workspace = true }
+# The JSON haptics API (`json_api.rs`) — the integration surface third-party
+# apps speak; the GUI-facing socket stays bincode.
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
 futures = "0.3"
 tracing = { workspace = true }

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -48,9 +48,9 @@ use openlogi_core::device::{
 use openlogi_core::hid::LOGITECH_VENDOR_ID;
 use openlogi_core::single_instance::{self, InstanceError};
 use openlogi_hid::{
-    DIRECT_DEVICE_INDEX, DeviceRoute, Dpi, DpiCapabilities, DpiInfo, LITRA_GLOW_PRODUCT_ID,
-    LightCommand, PasskeyMethod, ReceiverSelector, SmartShiftAutoDisengage, SmartShiftMode,
-    SmartShiftStatus, TunableTorque, WriteError,
+    DIRECT_DEVICE_INDEX, DeviceRoute, Dpi, DpiCapabilities, DpiInfo, HapticWaveform,
+    LITRA_GLOW_PRODUCT_ID, LightCommand, PasskeyMethod, ReceiverSelector, SmartShiftAutoDisengage,
+    SmartShiftMode, SmartShiftStatus, TunableTorque, WriteError,
 };
 use openlogi_ipc::transport;
 use openlogi_ipc::{
@@ -222,6 +222,9 @@ struct DeviceSettings {
     dpi: Option<DpiState>,
     smartshift: Option<SmartShiftStatus>,
     lighting: bool,
+    /// Whether the scripted device advertises HID++ `0x19b0`, so a client of
+    /// `play_haptic` meets both answers without hardware.
+    haptics: bool,
 }
 
 impl DeviceSettings {
@@ -230,6 +233,7 @@ impl DeviceSettings {
             dpi: None,
             smartshift: None,
             lighting: false,
+            haptics: false,
         }
     }
 }
@@ -286,6 +290,7 @@ impl State {
                     tunable_torque: Some(MOCK_TORQUE),
                 }),
                 lighting: false,
+                haptics: true,
             },
         );
         settings.insert(OFFLINE_SLOT, DeviceSettings::unsupported());
@@ -295,6 +300,7 @@ impl State {
                 dpi: None,
                 smartshift: None,
                 lighting: true,
+                haptics: false,
             },
         );
         settings.insert(
@@ -306,6 +312,7 @@ impl State {
                 }),
                 smartshift: None,
                 lighting: false,
+                haptics: false,
             },
         );
         Ok(Self {
@@ -743,6 +750,31 @@ impl Agent for MockAgent {
     }
 
     async fn action_ring_cancel(self, _: Context, _session_id: u64) {}
+
+    // No hardware, so nothing to buzz — but the call still resolves a device
+    // and honours the capability flag, so a client's error handling is
+    // exercised against the mock exactly as it would be against real hardware.
+    async fn play_haptic(
+        self,
+        _: Context,
+        route: Option<DeviceRoute>,
+        waveform: HapticWaveform,
+    ) -> Result<(), WriteError> {
+        let state = self.state.lock().await;
+        // `None` means "the active device"; the mock's stand-in for that is
+        // the online mouse, the only scripted device with a haptic engine.
+        let route = route.unwrap_or_else(|| DeviceRoute::Bolt {
+            receiver_uid: RECEIVER_UID.to_string(),
+            slot: MOUSE_SLOT,
+        });
+        if !state.settings_for(&route)?.haptics {
+            return Err(WriteError::FeatureUnsupported {
+                feature_hex: 0x19b0,
+            });
+        }
+        info!(%route, ?waveform, "play_haptic");
+        Ok(())
+    }
 
     async fn set_dpi(self, _: Context, route: DeviceRoute, dpi: Dpi) -> Result<(), WriteError> {
         let mut state = self.state.lock().await;

--- a/crates/openlogi-agent/src/json_api.rs
+++ b/crates/openlogi-agent/src/json_api.rs
@@ -1,0 +1,618 @@
+//! The JSON haptics API: a newline-delimited request/response protocol on the
+//! agent's second local socket, for third-party apps that want to trigger
+//! device haptics.
+//!
+//! # Why this lives in the agent
+//!
+//! A relay process was the obvious shape while a *websocket* was on the table —
+//! a network listener has no business inside the binary that owns the input
+//! hook and holds Accessibility. A local socket has no network reach, so that
+//! argument does not transfer: a relay would add a second binary to launch,
+//! supervise and version, another hop of latency, and one more way for the
+//! feature to be silently dead, in exchange for no boundary that isn't already
+//! there. Any local process that can open this socket can already open
+//! `agent.sock` and drive the whole agent.
+//!
+//! What *does* carry over is scope. This endpoint plays waveforms and lists
+//! what can be buzzed. It cannot write DPI, pair a device, or read config, so
+//! it is strictly weaker than the socket beside it — and it stays that way.
+//!
+//! # Protocol
+//!
+//! One JSON object per line in each direction; a response carries back the
+//! request's `id` when it had one. Requests on a connection are handled in
+//! order, so a client that only ever has one in flight can ignore `id`.
+//!
+//! ```text
+//! -> {"cmd":"hello"}
+//! <- {"ok":{"protocol":1,"agent":"0.7.1"}}
+//! -> {"id":1,"cmd":"devices"}
+//! <- {"id":1,"ok":{"devices":[{"key":"…","name":"MX Master 4"}]}}
+//! -> {"id":2,"cmd":"play","waveform":"damp"}
+//! <- {"id":2,"ok":{"accepted":true}}
+//! ```
+//!
+//! `accepted` is not `played`: the agent queues the waveform on the same
+//! single-flight worker the Actions Ring uses, so a caller cannot saturate the
+//! receiver's one in-flight HID++ transaction. See `Agent::play_haptic`.
+//!
+//! Errors are `{"error":{"code":"…","message":"…"}}`. The codes are
+//! `bad_request`, `device_not_found`, `feature_unsupported` and
+//! `device_error`; `code` is the stable half, `message` is for humans.
+
+use std::future::Future;
+use std::io;
+
+use interprocess::local_socket::ListenerOptions;
+use interprocess::local_socket::tokio::Listener;
+use interprocess::local_socket::tokio::prelude::*;
+use openlogi_core::hid::{HapticWaveform, WriteError};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tracing::{info, warn};
+
+use crate::server::AgentServer;
+
+/// Version of the JSON protocol, answered by `hello`.
+///
+/// Unlike the binary contract next door this one is self-describing, so a
+/// client can add fields without a lockstep rebuild; the number moves only if
+/// an existing field changes meaning. Additive changes do not bump it.
+const PROTOCOL: u32 = 1;
+
+/// Longest accepted request line. A JSON API on a stream needs *some* bound or
+/// a client that never sends a newline grows the agent's memory without limit;
+/// every legal request here is a few hundred bytes at most.
+///
+/// Applied per line rather than per connection, so a long-lived client that
+/// sends thousands of requests is never cut off for the crime of being useful.
+const MAX_LINE: usize = 8 * 1024;
+
+/// One request. `id`, when present, is echoed on the response so a client with
+/// several calls in flight can match them up.
+#[derive(Debug, Deserialize)]
+struct Request {
+    #[serde(default)]
+    id: Option<u64>,
+    #[serde(flatten)]
+    command: Command,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+enum Command {
+    /// Report the protocol version and the agent's own version.
+    Hello,
+    /// List the online devices that have a haptic engine.
+    Devices,
+    /// Play one waveform.
+    Play {
+        #[serde(default)]
+        waveform: Waveform,
+        /// A `key` from `devices`; omitted means the active device.
+        #[serde(default)]
+        device: Option<String>,
+    },
+}
+
+/// The waveform vocabulary as a caller spells it.
+///
+/// Deliberately its own enum rather than a serde rename on
+/// [`HapticWaveform`]: this one is a published API name and the other is an
+/// internal wire type, so neither should be able to rename the other by
+/// accident.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Waveform {
+    /// The light boundary tick.
+    #[default]
+    Subtle,
+    /// The firmer confirmation pulse.
+    Damp,
+}
+
+impl From<Waveform> for HapticWaveform {
+    fn from(waveform: Waveform) -> Self {
+        match waveform {
+            Waveform::Subtle => Self::SubtleCollision,
+            Waveform::Damp => Self::DampStateChange,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<u64>,
+    #[serde(flatten)]
+    body: Body,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Body {
+    Ok(Reply),
+    Error(ApiError),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum Reply {
+    Hello {
+        protocol: u32,
+        agent: &'static str,
+    },
+    Devices {
+        devices: Vec<DeviceEntry>,
+    },
+    /// Queued, not necessarily felt — see the module docs.
+    Played {
+        accepted: bool,
+    },
+}
+
+/// One buzzable device. `key` is stable across reconnects and reboots (it is
+/// the same identifier `config.toml` uses); `name` is for humans only.
+#[derive(Debug, Serialize)]
+struct DeviceEntry {
+    key: String,
+    name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiError {
+    code: &'static str,
+    message: String,
+}
+
+impl ApiError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            code: "bad_request",
+            message: message.into(),
+        }
+    }
+}
+
+impl From<WriteError> for ApiError {
+    fn from(error: WriteError) -> Self {
+        let code = match error {
+            WriteError::DeviceNotFound => "device_not_found",
+            WriteError::FeatureUnsupported { .. } => "feature_unsupported",
+            _ => "device_error",
+        };
+        Self {
+            code,
+            message: error.to_string(),
+        }
+    }
+}
+
+/// Serve one request. Infallible by design: every outcome is a response, so a
+/// bad line never costs the caller their connection.
+async fn handle(server: &AgentServer, command: Command) -> Body {
+    match command {
+        Command::Hello => Body::Ok(Reply::Hello {
+            protocol: PROTOCOL,
+            agent: env!("CARGO_PKG_VERSION"),
+        }),
+        Command::Devices => {
+            let devices = server
+                .orchestrator
+                .lock()
+                .await
+                .haptic_devices()
+                .into_iter()
+                .map(|(key, name)| DeviceEntry { key, name })
+                .collect();
+            Body::Ok(Reply::Devices { devices })
+        }
+        Command::Play { waveform, device } => {
+            let resolved = server
+                .orchestrator
+                .lock()
+                .await
+                .haptic_route_for_key(device.as_deref());
+            match resolved {
+                Ok(route) => {
+                    server.ring_haptics.play_external(route, waveform.into());
+                    Body::Ok(Reply::Played { accepted: true })
+                }
+                Err(error) => Body::Error(error.into()),
+            }
+        }
+    }
+}
+
+/// Read requests from one client until it disconnects, answering each through
+/// `dispatch`.
+///
+/// A malformed line is answered and the connection continues — a client
+/// debugging its JSON should see the complaint, not a closed socket. Only an
+/// I/O failure or an over-long line ends the session, the latter because the
+/// unread tail of that line would otherwise be parsed as a fresh request.
+///
+/// Generic over the stream and the dispatcher so the framing rules above can
+/// be tested over an in-memory pipe, without an agent behind them: everything
+/// this function decides is about bytes, not devices.
+async fn serve_connection<S, D, F>(stream: S, mut dispatch: D)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite,
+    D: FnMut(Command) -> F,
+    F: Future<Output = Body>,
+{
+    let (read, mut write) = tokio::io::split(stream);
+    let mut reader = BufReader::new(read);
+    loop {
+        let mut line = Vec::new();
+        // Re-`take` each pass so the cap bounds one line, not the connection.
+        let count = match (&mut reader)
+            .take(MAX_LINE as u64)
+            .read_until(b'\n', &mut line)
+            .await
+        {
+            // Clean disconnect.
+            Ok(0) => return,
+            Ok(count) => count,
+            Err(error) => {
+                warn!(%error, "haptic API read failed");
+                return;
+            }
+        };
+        // A full read with no terminator means the line outgrew the cap; the
+        // rest of it is still queued, so there is no honest way to continue.
+        if count == MAX_LINE && !line.ends_with(b"\n") {
+            let response = Response {
+                id: None,
+                body: Body::Error(ApiError::bad_request(format!(
+                    "request line exceeds {MAX_LINE} bytes"
+                ))),
+            };
+            let _ = respond(&mut write, &response).await;
+            return;
+        }
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+
+        let response = match serde_json::from_slice::<Request>(&line) {
+            Ok(request) => Response {
+                id: request.id,
+                body: dispatch(request.command).await,
+            },
+            Err(error) => Response {
+                id: None,
+                body: Body::Error(ApiError::bad_request(error.to_string())),
+            },
+        };
+        if respond(&mut write, &response).await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Write one response as a single line.
+async fn respond<W: tokio::io::AsyncWrite + Unpin>(
+    write: &mut W,
+    response: &Response,
+) -> io::Result<()> {
+    let mut encoded = serde_json::to_vec(response).map_err(io::Error::other)?;
+    encoded.push(b'\n');
+    write.write_all(&encoded).await.inspect_err(|error| {
+        warn!(%error, "haptic API write failed");
+    })
+}
+
+/// Bind the JSON haptics socket and serve it until the process exits.
+///
+/// Only called when `app_settings.haptic_api` is set; a bind failure disables
+/// the API with a warning rather than taking the agent down, since haptics for
+/// third-party apps must never be the reason device control stops working.
+pub async fn run(server: AgentServer) {
+    let listener = match bind() {
+        Ok(listener) => listener,
+        Err(error) => {
+            warn!(%error, "could not bind the JSON haptics socket; API disabled");
+            return;
+        }
+    };
+    info!("JSON haptics API listening");
+
+    loop {
+        match listener.accept().await {
+            Ok(stream) => {
+                let server = server.clone();
+                tokio::spawn(serve_connection(stream, move |command| {
+                    let server = server.clone();
+                    async move { handle(&server, command).await }
+                }));
+            }
+            Err(error) => warn!(%error, "haptic API accept failed"),
+        }
+    }
+}
+
+/// Bind the listener, reclaiming a socket left behind by an unclean exit
+/// exactly as `openlogi_ipc::transport::bind` does for the agent's own.
+///
+/// Access matches the endpoint beside it on both platforms: the runtime
+/// directory's permissions on Unix, and the default pipe DACL on Windows —
+/// which grants the creating user *and administrators*. Both are fine for a
+/// single-user desktop; neither isolates users on a shared machine, and
+/// tightening either is a hardening point rather than a property to assume.
+fn bind() -> io::Result<Listener> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+
+        let path = openlogi_core::paths::haptic_socket_path()
+            .map_err(|error| io::Error::other(error.to_string()))?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        ListenerOptions::new()
+            .name(path.to_fs_name::<GenericFilePath>()?)
+            .try_overwrite(true)
+            .create_tokio()
+    }
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+
+        ListenerOptions::new()
+            .name("openlogi-haptic.sock".to_ns_name::<GenericNamespaced>()?)
+            .try_overwrite(true)
+            .create_tokio()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
+mod tests {
+    use super::{
+        ApiError, Body, Command, MAX_LINE, Reply, Request, Response, Waveform, serve_connection,
+    };
+    use openlogi_core::hid::{HapticWaveform, WriteError};
+    use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+    fn parse(line: &str) -> Request {
+        serde_json::from_str(line).expect("a well-formed request parses")
+    }
+
+    fn encode(response: &Response) -> String {
+        serde_json::to_string(response).expect("responses encode")
+    }
+
+    #[test]
+    fn a_play_defaults_to_the_subtle_waveform_on_the_active_device() {
+        let request = parse(r#"{"cmd":"play"}"#);
+        assert_eq!(request.id, None);
+        let Command::Play { waveform, device } = request.command else {
+            panic!("expected a play command");
+        };
+        assert!(device.is_none(), "no device named means the active one");
+        assert!(matches!(
+            HapticWaveform::from(waveform),
+            HapticWaveform::SubtleCollision
+        ));
+    }
+
+    #[test]
+    fn a_play_can_name_its_waveform_and_device() {
+        let request = parse(r#"{"id":7,"cmd":"play","waveform":"damp","device":"abc"}"#);
+        assert_eq!(request.id, Some(7));
+        let Command::Play { waveform, device } = request.command else {
+            panic!("expected a play command");
+        };
+        assert_eq!(device.as_deref(), Some("abc"));
+        assert!(matches!(
+            HapticWaveform::from(waveform),
+            HapticWaveform::DampStateChange
+        ));
+    }
+
+    /// An unknown waveform must be refused, not silently played as the
+    /// default — a caller with a typo would otherwise never learn of it.
+    #[test]
+    fn an_unknown_waveform_is_rejected() {
+        let parsed = serde_json::from_str::<Request>(r#"{"cmd":"play","waveform":"buzz"}"#);
+        assert!(parsed.is_err(), "an unknown waveform must not parse");
+    }
+
+    #[test]
+    fn an_unknown_command_is_rejected() {
+        let parsed = serde_json::from_str::<Request>(r#"{"cmd":"reboot"}"#);
+        assert!(parsed.is_err(), "an unknown command must not parse");
+    }
+
+    #[test]
+    fn a_response_carries_the_request_id_back_and_omits_it_otherwise() {
+        let with_id = Response {
+            id: Some(7),
+            body: Body::Ok(Reply::Played { accepted: true }),
+        };
+        assert_eq!(encode(&with_id), r#"{"id":7,"ok":{"accepted":true}}"#);
+
+        let without = Response {
+            id: None,
+            body: Body::Ok(Reply::Played { accepted: true }),
+        };
+        assert_eq!(encode(&without), r#"{"ok":{"accepted":true}}"#);
+    }
+
+    /// The `code` is what a client branches on, so each device failure has to
+    /// keep its own — collapsing them would make "asleep" and "no haptic
+    /// engine" indistinguishable, and only one of those is worth retrying.
+    #[test]
+    fn device_failures_keep_distinguishable_codes() {
+        let not_found = ApiError::from(WriteError::DeviceNotFound);
+        assert_eq!(not_found.code, "device_not_found");
+
+        let unsupported = ApiError::from(WriteError::FeatureUnsupported {
+            feature_hex: 0x19b0,
+        });
+        assert_eq!(unsupported.code, "feature_unsupported");
+
+        let other = ApiError::from(WriteError::AgentUnavailable);
+        assert_eq!(other.code, "device_error");
+    }
+
+    #[test]
+    fn a_hello_reply_names_both_versions() {
+        let response = Response {
+            id: None,
+            body: Body::Ok(Reply::Hello {
+                protocol: 1,
+                agent: "9.9.9",
+            }),
+        };
+        assert_eq!(
+            encode(&response),
+            r#"{"ok":{"protocol":1,"agent":"9.9.9"}}"#
+        );
+    }
+
+    /// Drive `serve_connection` over an in-memory pipe with a dispatcher that
+    /// answers everything, so what is under test is the framing — not devices.
+    fn connect() -> (tokio::io::DuplexStream, tokio::task::JoinHandle<()>) {
+        let (client, server) = tokio::io::duplex(64 * 1024);
+        let task = tokio::spawn(serve_connection(server, |command| async move {
+            match command {
+                Command::Hello => Body::Ok(Reply::Hello {
+                    protocol: 1,
+                    agent: "test",
+                }),
+                Command::Devices => Body::Ok(Reply::Devices {
+                    devices: Vec::new(),
+                }),
+                Command::Play { .. } => Body::Ok(Reply::Played { accepted: true }),
+            }
+        }));
+        (client, task)
+    }
+
+    async fn send(write: &mut (impl tokio::io::AsyncWrite + Unpin), line: &str) {
+        write
+            .write_all(line.as_bytes())
+            .await
+            .expect("the connection accepts a request");
+    }
+
+    #[tokio::test]
+    async fn several_requests_share_one_connection_and_answer_in_order() {
+        let (client, _task) = connect();
+        let (read, mut write) = tokio::io::split(client);
+        let mut lines = BufReader::new(read).lines();
+
+        send(&mut write, "{\"id\":1,\"cmd\":\"hello\"}\n").await;
+        send(&mut write, "{\"id\":2,\"cmd\":\"play\"}\n").await;
+
+        let first = lines.next_line().await.expect("read").expect("a response");
+        let second = lines.next_line().await.expect("read").expect("a response");
+        assert!(first.contains(r#""id":1"#) && first.contains(r#""protocol":1"#));
+        assert!(second.contains(r#""id":2"#) && second.contains(r#""accepted":true"#));
+    }
+
+    /// The point of answering rather than hanging up: a client debugging its
+    /// JSON has to be able to fix the line and try again on the same socket.
+    #[tokio::test]
+    async fn a_malformed_line_is_answered_and_the_connection_survives() {
+        let (client, _task) = connect();
+        let (read, mut write) = tokio::io::split(client);
+        let mut lines = BufReader::new(read).lines();
+
+        send(&mut write, "not json at all\n").await;
+        let complaint = lines.next_line().await.expect("read").expect("a response");
+        assert!(
+            complaint.contains(r#""code":"bad_request""#),
+            "expected a bad_request, got {complaint}"
+        );
+
+        send(&mut write, "{\"cmd\":\"hello\"}\n").await;
+        let recovered = lines.next_line().await.expect("read").expect("a response");
+        assert!(
+            recovered.contains(r#""protocol":1"#),
+            "the connection must survive a bad line, got {recovered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn blank_lines_are_skipped_rather_than_answered() {
+        let (client, _task) = connect();
+        let (read, mut write) = tokio::io::split(client);
+        let mut lines = BufReader::new(read).lines();
+
+        send(&mut write, "\n   \n{\"cmd\":\"hello\"}\n").await;
+        let response = lines.next_line().await.expect("read").expect("a response");
+        assert!(
+            response.contains(r#""protocol":1"#),
+            "blank lines must not produce responses of their own, got {response}"
+        );
+    }
+
+    /// The cap has to bound one line, not the connection: an earlier version
+    /// took it over the whole stream, which silently killed any client after
+    /// `MAX_LINE` bytes of perfectly good traffic.
+    #[tokio::test]
+    async fn the_length_cap_applies_per_line_not_per_connection() {
+        let (client, _task) = connect();
+        let (read, mut write) = tokio::io::split(client);
+        let mut lines = BufReader::new(read).lines();
+
+        let request = "{\"cmd\":\"hello\"}\n";
+        let rounds = (MAX_LINE / request.len()) + 2;
+        for round in 0..rounds {
+            send(&mut write, request).await;
+            let response = lines.next_line().await.expect("read").expect("a response");
+            assert!(
+                response.contains(r#""protocol":1"#),
+                "connection died at request {round} of {rounds}: {response}"
+            );
+        }
+    }
+
+    /// An over-long line is refused *and* closes the socket: its unread tail
+    /// would otherwise be parsed as the next request.
+    #[tokio::test]
+    async fn an_over_long_line_is_refused_and_ends_the_connection() {
+        let (client, _task) = connect();
+        let (read, mut write) = tokio::io::split(client);
+        let mut lines = BufReader::new(read).lines();
+
+        let flood = format!(
+            "{{\"cmd\":\"hello\",\"pad\":\"{}\"}}",
+            "x".repeat(MAX_LINE * 2)
+        );
+        // The server stops reading mid-flood, so a short write may fail here.
+        let _ = write.write_all(flood.as_bytes()).await;
+
+        let complaint = lines.next_line().await.expect("read").expect("a response");
+        assert!(
+            complaint.contains(r#""code":"bad_request""#) && complaint.contains("exceeds"),
+            "expected a length complaint, got {complaint}"
+        );
+        assert_eq!(
+            lines.next_line().await.expect("read"),
+            None,
+            "the connection must close rather than parse the tail as a request"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_clean_disconnect_ends_the_loop_without_a_response() {
+        let (client, task) = connect();
+        drop(client);
+        tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("the loop returns when the client goes away")
+            .expect("and does not panic");
+    }
+
+    #[test]
+    fn a_default_waveform_is_the_subtle_one() {
+        assert!(matches!(
+            HapticWaveform::from(Waveform::default()),
+            HapticWaveform::SubtleCollision
+        ));
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -15,6 +15,7 @@
     windows_subsystem = "windows"
 )]
 
+mod json_api;
 mod launch_agent;
 mod overlay;
 mod pairing;
@@ -267,6 +268,10 @@ async fn run(
     // an agent restart, which the config docs state.
     let capture_mouse_events = config.app_settings.capture_mouse_events;
 
+    // Same startup-only rule for the JSON haptics API: it binds its own socket
+    // once, so enabling or disabling it takes an agent restart.
+    let haptic_api = config.app_settings.haptic_api;
+
     prompt_missing_permissions(capture_mouse_events);
 
     // The orchestrator is shared with the IPC server (which serves inventory /
@@ -319,6 +324,10 @@ async fn run(
         dispatcher.clone(),
     );
     let ring_haptics = server.ring_haptics.clone();
+    if haptic_api {
+        // The integration API for third-party apps — off unless asked for.
+        tokio::spawn(json_api::run(server.clone()));
+    }
     tokio::spawn(server::run(server));
 
     // The CGEventTap hook is installed once Accessibility is granted and dropped

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -286,7 +286,29 @@ impl Agent for AgentServer {
     async fn action_ring_cancel(self, _: Context, session_id: u64) {
         self.action_ring.cancel(session_id);
     }
+
+    async fn play_haptic(
+        self,
+        _: Context,
+        route: Option<DeviceRoute>,
+        waveform: HapticWaveform,
+    ) -> Result<(), WriteError> {
+        // Resolving here rather than in the player keeps the two failures the
+        // caller can act on — no such device, no haptic engine — synchronous,
+        // while the play itself stays fire-and-forget (see the trait docs).
+        let resolved = self
+            .orchestrator
+            .lock()
+            .await
+            .haptic_route(route.as_ref())?;
+        self.ring_haptics.play_external(resolved, waveform);
+        Ok(())
+    }
 }
+
+/// One queued buzz: the device to play it on, the waveform, and the short
+/// interaction name that identifies it in the logs.
+type HapticRequest = (DeviceRoute, HapticWaveform, &'static str);
 
 /// Coalescing Actions Ring haptic player: at most one waveform is in flight,
 /// and while it plays only the newest queued request survives (latest wins).
@@ -299,8 +321,13 @@ impl Agent for AgentServer {
 /// is strictly better than queueing them.
 #[derive(Clone)]
 pub struct RingHapticPlayer {
-    tx: tokio::sync::watch::Sender<Option<(DeviceRoute, HapticWaveform, &'static str)>>,
+    tx: tokio::sync::watch::Sender<Option<HapticRequest>>,
     pending_arm: Arc<std::sync::Mutex<Option<DeviceRoute>>>,
+    /// Arming state for out-of-band plays. Ring sessions arm on invocation
+    /// instead, so they never consult it — but the worker still records a
+    /// ring arm's outcome here, because an armed engine is armed whoever
+    /// asked for it.
+    external_arm: Arc<std::sync::Mutex<ArmTracker>>,
 }
 
 /// How long every attempt at one buzz may take together.
@@ -320,18 +347,88 @@ const PLAY_BUDGET: Duration = Duration::from_secs(2);
 /// attempts at the write path's budget put 10 s in front of the first buzz.
 const ARM_BUDGET: Duration = Duration::from_secs(1);
 
+/// How long an out-of-band play trusts a previous arming check on the same
+/// device.
+///
+/// Arming costs an HID++ round-trip, so doing it per call would double the
+/// traffic of an app buzzing steadily; skipping it entirely lets a device that
+/// lost the state to a power transition go silently dead, since `play` is
+/// accepted either way. Re-checking once a minute splits the difference — a
+/// burst pays for one check, and a sleep/wake is never brief enough to slip
+/// through the window unnoticed.
+const EXTERNAL_ARM_INTERVAL: Duration = Duration::from_mins(1);
+
+/// What is known about one route's firmware arming state.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ArmState {
+    /// An arming check is queued or running. Another play must not queue a
+    /// second one, but nothing is proven yet.
+    InFlight,
+    /// An arming check completed successfully at this instant.
+    Armed(Instant),
+}
+
+/// Tracks whether an out-of-band play needs to arm the firmware first.
+///
+/// Freshness has to follow the arm's *completion*, not its queueing.
+/// [`arm_firmware_haptics`] is best-effort within [`ARM_BUDGET`] and returns
+/// having armed nothing when the channel is slow or the write fails; recording
+/// the attempt as success would then suppress every retry for
+/// [`EXTERNAL_ARM_INTERVAL`], leaving a whole minute in which plays are
+/// accepted and the device — the one case arming exists for — stays silent.
+///
+/// One entry suffices: the worker is single-flight, so only the most recently
+/// armed route can be relied on.
+struct ArmTracker {
+    entry: Option<(DeviceRoute, ArmState)>,
+}
+
+impl ArmTracker {
+    const fn new() -> Self {
+        Self { entry: None }
+    }
+
+    /// Whether a play on `route` should queue an arming check, marking one
+    /// in flight when it says yes so concurrent callers queue only one.
+    fn should_arm(&mut self, route: &DeviceRoute, now: Instant) -> bool {
+        let fresh = match self.entry.as_ref() {
+            Some((armed, ArmState::InFlight)) => armed == route,
+            Some((armed, ArmState::Armed(at))) => {
+                armed == route && now.duration_since(*at) < EXTERNAL_ARM_INTERVAL
+            }
+            None => false,
+        };
+        if !fresh {
+            self.entry = Some((route.clone(), ArmState::InFlight));
+        }
+        !fresh
+    }
+
+    /// Record how an arming check ended. A failure drops the entry rather than
+    /// starting a freshness window, so the very next play tries again.
+    fn record(&mut self, route: &DeviceRoute, armed: bool, now: Instant) {
+        if armed {
+            self.entry = Some((route.clone(), ArmState::Armed(now)));
+        } else if self.entry.as_ref().is_some_and(|(known, _)| known == route) {
+            self.entry = None;
+        }
+    }
+}
+
 /// Re-assert the firmware haptic engine before the session's first buzz,
-/// within [`ARM_BUDGET`].
+/// within [`ARM_BUDGET`]. Returns whether the engine is known to be armed.
 ///
 /// Best-effort by design: a device that never lost the state plays fine
 /// without this, so a silent channel must cost the session a bounded delay
-/// rather than its whole haptic budget.
-async fn arm_firmware_haptics(shared: &SharedRuntime, route: &DeviceRoute) {
+/// rather than its whole haptic budget. The `false` return is what keeps that
+/// bounded delay from being mistaken for a successful check — see
+/// [`ArmTracker`].
+async fn arm_firmware_haptics(shared: &SharedRuntime, route: &DeviceRoute) -> bool {
     let budget = Budget::starting_at(Instant::now(), ARM_BUDGET);
     for attempt in 1..=2u8 {
         let Some(remaining) = budget.remaining(Instant::now()) else {
             warn!("firmware haptic check ran out of time — leaving it to the buzz");
-            return;
+            return false;
         };
         match tokio::time::timeout(
             remaining,
@@ -345,9 +442,9 @@ async fn arm_firmware_haptics(shared: &SharedRuntime, route: &DeviceRoute) {
         {
             Ok(Ok(true)) => {
                 info!("firmware haptics were disarmed — re-enabled");
-                return;
+                return true;
             }
-            Ok(Ok(false)) => return,
+            Ok(Ok(false)) => return true,
             Ok(Err(error)) => {
                 if attempt == 2 {
                     warn!(%error, "could not verify firmware haptic state");
@@ -357,6 +454,7 @@ async fn arm_firmware_haptics(shared: &SharedRuntime, route: &DeviceRoute) {
             Err(_elapsed) => {}
         }
     }
+    false
 }
 
 /// Play one waveform, retrying within [`PLAY_BUDGET`]. Returns whether it played.
@@ -368,7 +466,7 @@ async fn arm_firmware_haptics(shared: &SharedRuntime, route: &DeviceRoute) {
 /// single-flight.
 async fn play_within_budget(
     shared: &SharedRuntime,
-    rx: &tokio::sync::watch::Receiver<Option<(DeviceRoute, HapticWaveform, &'static str)>>,
+    rx: &tokio::sync::watch::Receiver<Option<HapticRequest>>,
     route: &DeviceRoute,
     waveform: HapticWaveform,
     interaction: &'static str,
@@ -439,24 +537,35 @@ impl Budget {
 impl RingHapticPlayer {
     /// Spawn the single-flight worker. Must be called from a tokio runtime.
     pub fn spawn(shared: SharedRuntime) -> Self {
-        let (tx, mut rx) = tokio::sync::watch::channel::<
-            Option<(DeviceRoute, HapticWaveform, &'static str)>,
-        >(None);
+        let (tx, mut rx) = tokio::sync::watch::channel::<Option<HapticRequest>>(None);
         let pending_arm = Arc::new(std::sync::Mutex::new(None::<DeviceRoute>));
         let worker_arm = Arc::clone(&pending_arm);
+        let external_arm = Arc::new(std::sync::Mutex::new(ArmTracker::new()));
+        let worker_external_arm = Arc::clone(&external_arm);
         tokio::spawn(async move {
             let mut consecutive_failures = 0u32;
             let mut cooldown_until: Option<Instant> = None;
             while rx.changed().await.is_ok() {
+                // Take the request first. `play_external` queues its arm
+                // *before* sending the play, so whatever is pending after this
+                // read is guaranteed to include the arm belonging to the
+                // request just taken — reading the other way round let a play
+                // overtake its own arm.
+                let request = rx.borrow_and_update().clone();
+                // Drain every queued arm, not just one: an arm that lands while
+                // another is in flight would otherwise sit in the slot until
+                // some later request happened to wake the worker, and its play
+                // would go out against a device nothing had armed.
+                //
                 // Firmware arming is sequenced through this worker so it is
                 // guaranteed to complete before the session's first buzz —
                 // spawning it separately let the first hover race (and lose
                 // to) a disarmed haptic engine.
-                let arm_route = worker_arm
+                while let Some(route) = worker_arm
                     .lock()
                     .ok()
-                    .and_then(|mut pending| pending.take());
-                if let Some(route) = arm_route {
+                    .and_then(|mut pending| pending.take())
+                {
                     // A new session starts the breaker over. Both counters are
                     // worker-lifetime state, so without this a session that
                     // ended two failures deep makes the next session's first
@@ -464,9 +573,11 @@ impl RingHapticPlayer {
                     // tail of one ring silences the opening of the next.
                     consecutive_failures = 0;
                     cooldown_until = None;
-                    arm_firmware_haptics(&shared, &route).await;
+                    let armed = arm_firmware_haptics(&shared, &route).await;
+                    if let Ok(mut tracker) = worker_external_arm.lock() {
+                        tracker.record(&route, armed, Instant::now());
+                    }
                 }
-                let request = rx.borrow_and_update().clone();
                 let Some((route, waveform, interaction)) = request else {
                     continue;
                 };
@@ -495,7 +606,11 @@ impl RingHapticPlayer {
                 }
             }
         });
-        Self { tx, pending_arm }
+        Self {
+            tx,
+            pending_arm,
+            external_arm,
+        }
     }
 
     /// Queue a firmware arming check to run before the session's first buzz.
@@ -522,6 +637,27 @@ impl RingHapticPlayer {
             return;
         };
         let _ = self.tx.send(Some((route, waveform, interaction)));
+    }
+
+    /// Queue `waveform` for a caller outside the Actions Ring, re-arming the
+    /// firmware first when this route's last check has aged out.
+    ///
+    /// Deliberately shares the ring's worker rather than playing directly:
+    /// single-flight and latest-wins are what keep a caller from saturating a
+    /// receiver's one in-flight HID++ transaction and timing out unrelated
+    /// writes. The cost is that a superseded buzz is dropped, which is the
+    /// right trade for feedback.
+    pub fn play_external(&self, route: DeviceRoute, waveform: HapticWaveform) {
+        // A poisoned lock must not cost the caller their buzz; the play still
+        // goes through, just without the repair check in front.
+        let needs_arm = self
+            .external_arm
+            .lock()
+            .is_ok_and(|mut tracker| tracker.should_arm(&route, Instant::now()));
+        if needs_arm {
+            self.arm(Some(route.clone()));
+        }
+        self.play(Some(route), waveform, "api");
     }
 }
 
@@ -562,7 +698,12 @@ pub async fn run(server: AgentServer) {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
-    use super::{ARM_BUDGET, Budget, PLAY_BUDGET};
+    use super::{
+        ARM_BUDGET, ArmTracker, Budget, EXTERNAL_ARM_INTERVAL, HapticRequest, PLAY_BUDGET,
+        RingHapticPlayer,
+    };
+    use openlogi_hid::{DeviceRoute, HapticWaveform};
+    use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     /// Attempts share one allowance, so the second gets what the first left —
@@ -597,5 +738,144 @@ mod tests {
     fn the_budgets_stay_within_a_ring_session() {
         assert!(ARM_BUDGET < PLAY_BUDGET);
         assert!(ARM_BUDGET + PLAY_BUDGET < Duration::from_secs(15));
+    }
+
+    /// A player with no worker behind it, so a test can inspect exactly what
+    /// `play_external` leaves for one to find.
+    fn idle_player() -> (
+        RingHapticPlayer,
+        tokio::sync::watch::Receiver<Option<HapticRequest>>,
+    ) {
+        let (tx, rx) = tokio::sync::watch::channel(None);
+        let player = RingHapticPlayer {
+            tx,
+            pending_arm: Arc::new(std::sync::Mutex::new(None)),
+            external_arm: Arc::new(std::sync::Mutex::new(ArmTracker::new())),
+        };
+        (player, rx)
+    }
+
+    /// The worker takes the request from the cell and *then* drains pending
+    /// arms, which is only sound because the arm is queued first. Reverse the
+    /// two here and a play can be served against a device nothing armed.
+    #[test]
+    fn play_external_queues_its_arm_before_publishing_the_play() {
+        let (player, rx) = idle_player();
+
+        player.play_external(route(1), HapticWaveform::SubtleCollision);
+
+        assert!(
+            player.pending_arm.lock().unwrap().is_some(),
+            "the arm must already be pending once the play is visible"
+        );
+        assert!(rx.borrow().is_some(), "the play is published");
+    }
+
+    /// A second play inside the freshness window must not re-queue an arm —
+    /// otherwise every buzz pays for a round-trip the first one already made.
+    #[test]
+    fn a_play_with_an_arm_in_flight_does_not_queue_another() {
+        let (player, _rx) = idle_player();
+
+        player.play_external(route(1), HapticWaveform::SubtleCollision);
+        player.pending_arm.lock().unwrap().take();
+        player.play_external(route(1), HapticWaveform::DampStateChange);
+
+        assert!(
+            player.pending_arm.lock().unwrap().is_none(),
+            "an arm already in flight must not be queued again"
+        );
+    }
+
+    fn route(slot: u8) -> DeviceRoute {
+        DeviceRoute::Bolt {
+            receiver_uid: "AA00".to_string(),
+            slot,
+        }
+    }
+
+    #[test]
+    fn a_first_play_arms_and_a_second_does_not_queue_a_duplicate() {
+        let mut tracker = ArmTracker::new();
+        let now = Instant::now();
+        let device = route(1);
+
+        assert!(tracker.should_arm(&device, now), "nothing is known yet");
+        assert!(
+            !tracker.should_arm(&device, now),
+            "an arm already in flight must not be queued twice"
+        );
+    }
+
+    /// The regression this type exists for: arming is best-effort within
+    /// `ARM_BUDGET` and can return having armed nothing. Recording that as a
+    /// success would suppress every retry for a whole minute, during which
+    /// plays are accepted and the device stays silent — precisely the failure
+    /// arming exists to repair.
+    #[test]
+    fn a_failed_arm_does_not_start_a_freshness_window() {
+        let mut tracker = ArmTracker::new();
+        let now = Instant::now();
+        let device = route(1);
+
+        assert!(tracker.should_arm(&device, now));
+        tracker.record(&device, false, now + ARM_BUDGET);
+
+        assert!(
+            tracker.should_arm(&device, now + ARM_BUDGET),
+            "a failed arm must leave the next play free to try again"
+        );
+    }
+
+    #[test]
+    fn a_successful_arm_holds_for_the_interval_and_then_lapses() {
+        let mut tracker = ArmTracker::new();
+        let now = Instant::now();
+        let device = route(1);
+
+        assert!(tracker.should_arm(&device, now));
+        tracker.record(&device, true, now);
+
+        assert!(
+            !tracker.should_arm(&device, now + EXTERNAL_ARM_INTERVAL / 2),
+            "a completed arm is trusted inside the window"
+        );
+        assert!(
+            tracker.should_arm(&device, now + EXTERNAL_ARM_INTERVAL),
+            "and re-checked once it lapses"
+        );
+    }
+
+    /// One entry, because the worker is single-flight — so arming one device
+    /// says nothing about another, and must not silence its check.
+    #[test]
+    fn arming_one_device_does_not_vouch_for_another() {
+        let mut tracker = ArmTracker::new();
+        let now = Instant::now();
+
+        assert!(tracker.should_arm(&route(1), now));
+        tracker.record(&route(1), true, now);
+
+        assert!(
+            tracker.should_arm(&route(2), now),
+            "a different device has its own firmware state"
+        );
+    }
+
+    /// A ring session arms through the same worker. Its failure must not
+    /// clobber a *different* route's good record.
+    #[test]
+    fn a_failed_arm_elsewhere_leaves_a_good_record_alone() {
+        let mut tracker = ArmTracker::new();
+        let now = Instant::now();
+
+        assert!(tracker.should_arm(&route(1), now));
+        tracker.record(&route(1), true, now);
+        tracker.record(&route(2), false, now);
+
+        assert!(
+            !tracker.should_arm(&route(1), now),
+            "slot 1 was armed and nothing since has disproved it"
+        );
     }
 }

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -104,6 +104,15 @@ pub struct AppSettings {
     /// Takes effect on agent restart.
     #[serde(default = "default_true")]
     pub capture_mouse_events: bool,
+    /// Whether the agent serves the JSON haptics API on its own local socket
+    /// (`haptic.sock`), so third-party apps can trigger device haptics.
+    /// **Off by default** — it is an integration surface, and a local-first
+    /// app should not open one the user never asked for. Any process running
+    /// as the same user can use it once enabled; it plays waveforms and
+    /// nothing else, and reads no device state beyond which devices have a
+    /// haptic engine. Takes effect on agent restart.
+    #[serde(default)]
+    pub haptic_api: bool,
     /// Whether the GUI automatically downloads device images from
     /// `assets.openlogi.org` when a device appears. `true` (default) keeps
     /// the current behavior; `false` makes no asset network requests at all
@@ -259,6 +268,7 @@ impl Default for AppSettings {
             update_prompt_seen: false,
             show_in_menu_bar: true,
             capture_mouse_events: true,
+            haptic_api: false,
             auto_download_assets: true,
             asset_source: AssetSourcePreference::Automatic,
             language: None,

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -778,6 +778,21 @@ fn app_settings_launch_at_login_roundtrips() {
     assert!(parsed.app_settings.launch_at_login);
 }
 
+/// The integration API must stay off unless the file says otherwise — a
+/// default that opened a socket nobody asked for would be the wrong kind of
+/// surprise for a local-first app.
+#[test]
+fn haptic_api_is_off_by_default_and_roundtrips() {
+    assert!(
+        !Config::default().app_settings.haptic_api,
+        "the JSON haptics socket is opt-in"
+    );
+
+    let mut cfg = Config::default();
+    cfg.app_settings.haptic_api = true;
+    assert!(write_and_read(&cfg).app_settings.haptic_api);
+}
+
 #[test]
 fn asset_source_preference_roundtrips() {
     let mut cfg = Config::default();

--- a/crates/openlogi-core/src/hid.rs
+++ b/crates/openlogi-core/src/hid.rs
@@ -10,6 +10,7 @@
 
 pub mod dpi;
 pub mod error;
+pub mod haptic;
 pub mod light;
 pub mod pairing;
 pub mod route;
@@ -17,6 +18,7 @@ pub mod smartshift;
 
 pub use dpi::{Dpi, DpiCapabilities, DpiInfo};
 pub use error::{HidppFeatureErrorKind, HidppOperation, WriteError};
+pub use haptic::HapticWaveform;
 pub use light::{LightCommand, commands_for_light_settings};
 pub use pairing::{Click, PairingError, PasskeyMethod, ReceiverSelector};
 pub use route::{

--- a/crates/openlogi-core/src/hid/haptic.rs
+++ b/crates/openlogi-core/src/hid/haptic.rs
@@ -1,0 +1,24 @@
+//! The haptic waveform vocabulary — pure data, no I/O.
+//!
+//! The firmware side is HID++ `0x19b0` (`playWaveform`), whose waveform IDs
+//! live in the vendored `hidpp` fork. This enum is deliberately *not* that
+//! one: it crosses the agent↔GUI IPC boundary, and the wire contract is
+//! append-only (`.claude/rules/ipc-protocol.md`), so the protocol crate must
+//! not be free to reorder its variants. `openlogi_hid` maps this to the
+//! firmware ID at the point of the write.
+
+use serde::{Deserialize, Serialize};
+
+/// A haptic waveform the device firmware can play.
+///
+/// Only the two waveforms OpenLogi has confirmed on real hardware are modeled;
+/// `0x19b0` is reverse-engineered, so an unverified ID is a silent no-op at
+/// best. **Append new variants only** — serde encodes the declaration index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HapticWaveform {
+    /// A light boundary pulse. Used for Actions Ring hover transitions —
+    /// the "you crossed into the next slot" tick.
+    SubtleCollision,
+    /// A firmer confirmation pulse. Used when an Actions Ring action runs.
+    DampStateChange,
+}

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -159,6 +159,19 @@ pub fn agent_socket_path() -> Result<PathBuf, PathsError> {
     Ok(runtime_dir()?.join("agent.sock"))
 }
 
+/// Path to the agent's optional JSON haptics socket — the integration API for
+/// third-party apps, off unless `app_settings.haptic_api` is set.
+///
+/// Deliberately a second endpoint rather than a second protocol on
+/// [`agent_socket_path`]: that socket carries the full agent contract (device
+/// writes, pairing, config reloads) in a positional binary format both ends
+/// must agree on exactly, while this one exposes haptics alone in a format a
+/// script can speak. Keeping them apart is what lets the integration surface
+/// stay small no matter how the internal one grows.
+pub fn haptic_socket_path() -> Result<PathBuf, PathsError> {
+    Ok(runtime_dir()?.join("haptic.sock"))
+}
+
 #[cfg(test)]
 #[cfg(unix)]
 #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -45,6 +45,19 @@ impl AppState {
         self.config.app_settings.show_in_menu_bar = enabled;
         self.persist_and_reload("show-in-menu-bar setting");
     }
+    /// Toggle the JSON haptics API and persist it.
+    ///
+    /// The agent binds `haptic.sock` once at startup, so — like the menu-bar
+    /// switch — this one describes the next agent launch rather than this
+    /// instant. The reload still goes out so the agent's *other* config stays
+    /// current. No-op when unchanged.
+    pub fn set_haptic_api(&mut self, enabled: bool) {
+        if self.config.app_settings.haptic_api == enabled {
+            return;
+        }
+        self.config.app_settings.haptic_api = enabled;
+        self.persist_and_reload("haptics-API setting");
+    }
     /// Toggle the opt-in update check and persist it. No immediate side
     /// effect beyond the next launch reading the new value. No-op when
     /// unchanged.

--- a/crates/openlogi-desktop/src/windows/settings/general.rs
+++ b/crates/openlogi-desktop/src/windows/settings/general.rs
@@ -77,6 +77,29 @@ pub(super) fn general_page(sensitivity_slider: Entity<SliderState>) -> SettingPa
         }),
     );
 
+    // Unconditional: the JSON haptics socket is a Unix-domain socket on Unix
+    // and a named pipe on Windows, so every platform can serve it.
+    let group = group.item(
+        SettingItem::new(
+            tr!("Haptics API for other apps"),
+            SettingField::switch(
+                |cx| {
+                    cx.try_global::<AppState>()
+                        .is_some_and(|s| s.app_settings().haptic_api)
+                },
+                |enabled, cx| {
+                    cx.update_global::<AppState, _>(move |s, _| {
+                        s.set_haptic_api(enabled);
+                    });
+                    cx.refresh_windows();
+                },
+            ),
+        )
+        .description(tr!(
+            "Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts."
+        )),
+    );
+
     SettingPage::new(tr!("General"))
         .icon(IconName::Settings)
         .resettable(false)

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -39,7 +39,6 @@ pub(crate) use haptic::clear_haptic_feature_cache_for;
 pub use haptic::{
     clear_haptic_feature_cache, ensure_haptics_armed_on, play_haptic, play_haptic_on,
 };
-pub use hidpp::feature::haptic_feedback::HapticWaveform;
 pub use hires_wheel::{
     ScrollReportingTarget, ScrollResolution, ScrollWheelMode, get_scroll_wheel_mode,
     get_scroll_wheel_mode_on, set_scroll_inversion, set_scroll_inversion_on, set_scroll_resolution,
@@ -62,6 +61,11 @@ pub use smartshift::{
 // types with no HID++ I/O, so it lives in `openlogi_core::hid::light`;
 // re-exported here unchanged so this module's own API surface doesn't churn.
 pub use openlogi_core::hid::light::commands_for_light_settings;
+
+// `HapticWaveform` likewise: it crosses the IPC wire, so it is defined in
+// `openlogi_core::hid::haptic` rather than taken from the `hidpp` fork, and
+// `haptic::play_haptic*` map it to the firmware ID on the way out.
+pub use openlogi_core::hid::HapticWaveform;
 
 pub(crate) use error::classify_hidpp_error;
 

--- a/crates/openlogi-hid/src/write/haptic.rs
+++ b/crates/openlogi-hid/src/write/haptic.rs
@@ -5,14 +5,31 @@ use hidpp::{
     device::Device,
     feature::{
         CreatableFeature as _,
-        haptic_feedback::{HapticFeedbackFeature, HapticIntensity, HapticWaveform},
+        haptic_feedback::{
+            HapticFeedbackFeature, HapticIntensity, HapticWaveform as FirmwareWaveform,
+        },
     },
 };
+
+use openlogi_core::hid::HapticWaveform;
 
 use crate::channel::route::DeviceRoute;
 use crate::{ChannelRegistry, SharedChannel};
 
 use super::{HidppOperation, WriteError, classify_hidpp_error, open_feature, with_route};
+
+/// Map the wire-side waveform to the firmware `playWaveform` ID.
+///
+/// Kept as an explicit `match` rather than a discriminant cast: the two enums
+/// answer to different masters — this one is append-only because it rides the
+/// IPC wire, the firmware one is fixed by `0x19b0` — so they must be free to
+/// disagree on ordering without either side silently playing the wrong pulse.
+const fn firmware_waveform(waveform: HapticWaveform) -> FirmwareWaveform {
+    match waveform {
+        HapticWaveform::SubtleCollision => FirmwareWaveform::SubtleCollision,
+        HapticWaveform::DampStateChange => FirmwareWaveform::DampStateChange,
+    }
+}
 
 async fn feature_on_channel(
     channel: &Arc<HidppChannel>,
@@ -222,6 +239,7 @@ pub async fn play_haptic_on(
 ) -> Result<(), WriteError> {
     let channel = shared.channel();
     let index = shared.device_index();
+    let waveform = firmware_waveform(waveform);
     if let Some(feature) = cached_feature(channel, index) {
         if feature.play(waveform).await.is_ok() {
             return Ok(());
@@ -242,6 +260,7 @@ pub async fn play_haptic_on(
 /// Play a waveform immediately by route.
 pub async fn play_haptic(route: &DeviceRoute, waveform: HapticWaveform) -> Result<(), WriteError> {
     let index = route.device_index();
+    let waveform = firmware_waveform(waveform);
     with_route(route, move |channel| async move {
         let feature = feature_on_channel(&channel, index).await?;
         feature.play(waveform).await.map_err(|error| {

--- a/crates/openlogi-ipc/Cargo.toml
+++ b/crates/openlogi-ipc/Cargo.toml
@@ -26,3 +26,6 @@ workspace = true
 
 [dev-dependencies]
 bincode = "1.3"
+# The `haptic` example is a hand-run binary, so it needs a real runtime to
+# start; the library itself only ever borrows the caller's.
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/openlogi-ipc/examples/haptic.rs
+++ b/crates/openlogi-ipc/examples/haptic.rs
@@ -1,0 +1,64 @@
+//! A minimal third-party client for the agent's `play_haptic` RPC: connect,
+//! check the protocol, buzz a device.
+//!
+//! This is the reference for integrating your own app against a running
+//! OpenLogi agent, and doubles as the manual test for the RPC — there is no
+//! `openlogi haptic` subcommand, because `openlogi-cli` is published to
+//! crates.io and `openlogi-ipc` deliberately is not.
+//!
+//! ```sh
+//! cargo run -p openlogi-ipc --example haptic              # subtle, active device
+//! cargo run -p openlogi-ipc --example haptic -- damp      # the firmer pulse
+//! ```
+//!
+//! The agent must already be running (the GUI starts it; `cargo run -p
+//! openlogi-agent` does too). Everything here goes over the same local socket
+//! the GUI uses — no network, no port, no listener.
+
+#![expect(
+    clippy::expect_used,
+    reason = "a hand-run example reports failures by panicking"
+)]
+
+use openlogi_core::hid::HapticWaveform;
+use openlogi_ipc::{PROTOCOL_VERSION, client};
+use tarpc::context;
+
+#[tokio::main]
+async fn main() {
+    let waveform = match std::env::args().nth(1).as_deref() {
+        None | Some("subtle") => HapticWaveform::SubtleCollision,
+        Some("damp") => HapticWaveform::DampStateChange,
+        Some(other) => {
+            eprintln!("unknown waveform `{other}` — expected `subtle` or `damp`");
+            return;
+        }
+    };
+
+    let connection = client::connect()
+        .await
+        .expect("the agent is running and answering on its local socket");
+
+    // The wire format is positional, so a skew is not something to work
+    // around — a real client should report it and stop, exactly like this.
+    let agent_version = connection.version;
+    assert_eq!(
+        agent_version, PROTOCOL_VERSION,
+        "protocol skew: the agent speaks v{agent_version}, this client speaks v{PROTOCOL_VERSION}"
+    );
+
+    // `None` = whichever device the agent considers active. Pass
+    // `Some(route)` — a `DeviceRoute` from `inventory()` — to target one
+    // explicitly.
+    match connection
+        .client
+        .play_haptic(context::current(), None, waveform)
+        .await
+        .expect("the agent answered the call")
+    {
+        // Accepted, not played: the agent queues the waveform on its
+        // single-flight worker so callers cannot saturate the HID++ channel.
+        Ok(()) => println!("{waveform:?} accepted"),
+        Err(error) => println!("the agent refused it: {error}"),
+    }
+}

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -16,8 +16,8 @@ use openlogi_core::binding::{ActionRingIcon, ActionRingSlot};
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
 use openlogi_core::hid::{
-    DeviceRoute, Dpi, DpiInfo, LightCommand, PairingError, PasskeyMethod, ReceiverSelector,
-    SmartShiftStatus, WriteError,
+    DeviceRoute, Dpi, DpiInfo, HapticWaveform, LightCommand, PairingError, PasskeyMethod,
+    ReceiverSelector, SmartShiftStatus, WriteError,
 };
 use serde::{Deserialize, Serialize};
 pub use succession::Identity;
@@ -52,7 +52,9 @@ pub use succession::Identity;
 ///      [`RingObservation`]).
 /// v22: DPI scalar values use the validated [`Dpi`] type end to end.
 /// v23: SmartShift writes carry one typed [`SmartShiftStatus`] value.
-pub const PROTOCOL_VERSION: u32 = 23;
+/// v24: [`Agent::play_haptic`] appended — haptics are addressable on their own,
+///      not only as a side effect of an Actions Ring interaction.
+pub const PROTOCOL_VERSION: u32 = 24;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -480,4 +482,34 @@ pub trait Agent {
     /// then return it. Same contract as [`Agent::observe`] — whole state, hold
     /// window, `0` for "seen nothing" — over the ring's own cell.
     async fn observe_action_ring(since: Generation) -> RingObservation;
+    /// Play one haptic waveform on a device, outside any Actions Ring session.
+    ///
+    /// `route` names the device; `None` means "whichever device the agent
+    /// currently considers active", so a caller that just wants to buzz the
+    /// mouse in front of the user does not have to enumerate first.
+    ///
+    /// **`Ok(())` means accepted, not played.** The waveform is queued on the
+    /// same single-flight worker the Actions Ring uses, and that worker is
+    /// latest-wins: a request that arrives while another is mid-flight
+    /// replaces any still-unplayed one. This is deliberate. HID++ is a single
+    /// in-flight transaction per channel, shared with the input-capture path,
+    /// so a caller free to queue buzzes faster than the receiver drains them
+    /// would time out every unrelated write (DPI, SmartShift) on that receiver
+    /// for seconds. A stale buzz is worthless as feedback anyway — dropping it
+    /// beats delivering it late at the cost of everything else.
+    ///
+    /// The errors are therefore the ones knowable *before* any I/O:
+    /// [`WriteError::DeviceNotFound`] when `route` matches no online device
+    /// (or `None` and nothing is active), and [`WriteError::FeatureUnsupported`]
+    /// when the device does not advertise HID++ `0x19b0`. A failure during the
+    /// play itself is logged by the agent and not reported here.
+    ///
+    /// Not gated on the per-device Actions Ring haptics setting: that toggle
+    /// scopes hover/activation feedback for the ring, and silently swallowing
+    /// an explicit API call under an unrelated preference would be worse than
+    /// surprising.
+    async fn play_haptic(
+        route: Option<DeviceRoute>,
+        waveform: HapticWaveform,
+    ) -> Result<(), WriteError>;
 }

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -35,9 +35,9 @@ use openlogi_core::device::{
     PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
 use openlogi_core::hid::{
-    Click, DeviceRoute, Dpi, DpiCapabilities, DpiInfo, HidppFeatureErrorKind, HidppOperation,
-    LightCommand, PasskeyMethod, ReceiverSelector, SmartShiftAutoDisengage, SmartShiftMode,
-    SmartShiftStatus, SmartShiftThreshold, TunableTorque, WriteError,
+    Click, DeviceRoute, Dpi, DpiCapabilities, DpiInfo, HapticWaveform, HidppFeatureErrorKind,
+    HidppOperation, LightCommand, PasskeyMethod, ReceiverSelector, SmartShiftAutoDisengage,
+    SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, TunableTorque, WriteError,
 };
 use openlogi_ipc::{
     ActionRingCommandError, ActionRingInvocation, ActionRingPresentation, AgentRequest,
@@ -82,7 +82,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 23);
+    assert_eq!(PROTOCOL_VERSION, 24);
 }
 
 #[test]
@@ -169,6 +169,33 @@ fn request_variant_order() {
     assert_wire(&AgentRequest::Identity {}, "16");
     assert_wire(&AgentRequest::Observe { since: 7 }, "1707");
     assert_wire(&AgentRequest::ObserveActionRing { since: 7 }, "1807");
+    assert_wire(
+        &AgentRequest::PlayHaptic {
+            route: None,
+            waveform: HapticWaveform::SubtleCollision,
+        },
+        "190000",
+    );
+    assert_wire(
+        &AgentRequest::PlayHaptic {
+            route: Some(DeviceRoute::Bolt {
+                receiver_uid: "F00DCAFE".into(),
+                slot: 1,
+            }),
+            waveform: HapticWaveform::DampStateChange,
+        },
+        "1901000846303044434146450101",
+    );
+}
+
+/// The waveform vocabulary is append-only for the same reason every other
+/// wire enum is: serde encodes the declaration index, so inserting a variant
+/// ahead of these two would silently turn every hover tick into some other
+/// pulse across an agent/client version skew.
+#[test]
+fn haptic_waveforms() {
+    assert_wire(&HapticWaveform::SubtleCollision, "00");
+    assert_wire(&HapticWaveform::DampStateChange, "01");
 }
 
 /// The agent identity is frozen: a helper from any build has to be able to

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Behold OpenLogis ikon i menulinjen. Når den er slået fra, forbliver det i Dock'en."
 "Show in the notification area": "Vis i meddelelsesområdet"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Behold OpenLogis ikon i proceslinjens meddelelsesområde. Træder i kraft, næste gang baggrundsagenten starter."
+"Haptics API for other apps": "Haptik-API til andre apps"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Lad apps på denne computer udløse musens haptiske feedback via en lokal socket. Slået fra som standard; træder i kraft næste gang baggrundsagenten starter."
 "Assets": "Ressourcer"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "OpenLogi-Symbol in der Menüleiste behalten. Wenn deaktiviert, bleibt es stattdessen im Dock."
 "Show in the notification area": "Im Infobereich anzeigen"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "OpenLogi-Symbol im Infobereich der Taskleiste anzeigen. Wird beim nächsten Start des Hintergrund-Agenten wirksam."
+"Haptics API for other apps": "Haptik-API für andere Apps"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Erlaubt Apps auf diesem Computer, das haptische Feedback deiner Maus über einen lokalen Socket auszulösen. Standardmäßig aus; wird beim nächsten Start des Hintergrunddienstes wirksam."
 "Assets": "Ressourcen"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Διατήρηση του εικονιδίου του OpenLogi στη γραμμή μενού. Όταν είναι ανενεργό, παραμένει στο Dock."
 "Show in the notification area": "Εμφάνιση στην περιοχή ειδοποιήσεων"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Διατηρεί το εικονίδιο του OpenLogi στην περιοχή ειδοποιήσεων της γραμμής εργασιών. Ισχύει από την επόμενη εκκίνηση της υπηρεσίας παρασκηνίου."
+"Haptics API for other apps": "API απτικής ανάδρασης για άλλες εφαρμογές"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Επιτρέψτε σε εφαρμογές αυτού του υπολογιστή να ενεργοποιούν την απτική ανάδραση του ποντικιού μέσω τοπικού socket. Ανενεργό από προεπιλογή· τίθεται σε ισχύ την επόμενη φορά που θα ξεκινήσει ο παρασκηνιακός πράκτορας."
 "Assets": "Πόροι"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead."
 "Show in the notification area": "Show in the notification area"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts."
+"Haptics API for other apps": "Haptics API for other apps"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts."
 "Assets": "Assets"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Mantén el icono de OpenLogi en la barra de menús. Si se desactiva, permanece en el Dock."
 "Show in the notification area": "Mostrar en el área de notificación"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantiene el icono de OpenLogi en el área de notificación de la barra de tareas. Surte efecto la próxima vez que se inicie el agente en segundo plano."
+"Haptics API for other apps": "API háptica para otras apps"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Permite que las apps de este equipo activen la respuesta háptica del ratón mediante un socket local. Desactivado de forma predeterminada; se aplica la próxima vez que se inicie el agente en segundo plano."
 "Assets": "Recursos"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Pidä OpenLogin kuvake valikkorivillä. Kun pois päältä, se pysyy Dockissa."
 "Show in the notification area": "Näytä ilmoitusalueella"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Pitää OpenLogin kuvakkeen tehtäväpalkin ilmoitusalueella. Tulee voimaan, kun taustaprosessi käynnistyy seuraavan kerran."
+"Haptics API for other apps": "Haptiikka-API muille sovelluksille"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Salli tämän tietokoneen sovellusten laukaista hiiren haptinen palaute paikallisen socketin kautta. Oletuksena pois päältä; tulee voimaan, kun taustaagentti käynnistyy seuraavan kerran."
 "Assets": "Resurssit"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Conserver l'icône d'OpenLogi dans la barre des menus. Si désactivé, elle reste dans le Dock."
 "Show in the notification area": "Afficher dans la zone de notification"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Garde l'icône d'OpenLogi dans la zone de notification de la barre des tâches. Prend effet au prochain démarrage de l'agent en arrière-plan."
+"Haptics API for other apps": "API haptique pour d'autres applications"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Permet aux applications de cet ordinateur de déclencher le retour haptique de votre souris via une socket locale. Désactivé par défaut ; prend effet au prochain démarrage de l'agent en arrière-plan."
 "Assets": "Ressources"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Mantieni l'icona di OpenLogi nella barra dei menu. Quando è disattivata, rimarrà invece nel Dock."
 "Show in the notification area": "Mostra nell'area di notifica"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantiene l'icona di OpenLogi nell'area di notifica della barra delle applicazioni. Ha effetto al prossimo avvio dell'agente in background."
+"Haptics API for other apps": "API aptica per altre app"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Consente alle app su questo computer di attivare il feedback aptico del mouse tramite un socket locale. Disattivato per impostazione predefinita; ha effetto al prossimo avvio dell'agente in background."
 "Assets": "Risorse"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "OpenLogi のアイコンをメニューバーに表示します。オフにすると Dock に残ります。"
 "Show in the notification area": "通知領域に表示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "タスクバーの通知領域に OpenLogi のアイコンを表示します。バックグラウンドエージェントの次回起動時に反映されます。"
+"Haptics API for other apps": "他のアプリ向けハプティクス API"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "このコンピュータ上のアプリがローカルソケット経由でマウスのハプティクスを実行できるようにします。既定ではオフです。バックグラウンドエージェントの次回起動時に反映されます。"
 "Assets": "アセット"
 "Asset source": "アセットソース"
 "Automatic (recommended)": "自動（推奨）"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "OpenLogi 아이콘을 메뉴 막대에 유지합니다. 끄면 대신 Dock에 남습니다."
 "Show in the notification area": "알림 영역에 표시"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "작업 표시줄 알림 영역에 OpenLogi 아이콘을 유지합니다. 백그라운드 에이전트가 다음에 시작될 때 적용됩니다."
+"Haptics API for other apps": "다른 앱을 위한 햅틱 API"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "이 컴퓨터의 앱이 로컬 소켓을 통해 마우스 햅틱을 실행할 수 있도록 허용합니다. 기본적으로 꺼져 있으며, 백그라운드 에이전트가 다음에 시작할 때 적용됩니다."
 "Assets": "리소스"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Behold OpenLogi-ikonet i menylinjen. Når av forblir det i Dock-en i stedet."
 "Show in the notification area": "Vis i varslingsområdet"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Beholder OpenLogi-ikonet i varslingsområdet på oppgavelinjen. Trer i kraft neste gang bakgrunnsagenten starter."
+"Haptics API for other apps": "Haptikk-API for andre apper"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "La apper på denne datamaskinen utløse musens haptiske tilbakemelding over en lokal socket. Av som standard; trer i kraft neste gang bakgrunnsagenten starter."
 "Assets": "Ressurser"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Houd het OpenLogi-pictogram in de menubalk. Indien uit, blijft het in het Dock."
 "Show in the notification area": "Weergeven in het systeemvak"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Houdt het OpenLogi-pictogram in het systeemvak van de taakbalk. Wordt van kracht wanneer de achtergrondagent opnieuw start."
+"Haptics API for other apps": "Haptics-API voor andere apps"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Laat apps op deze computer de haptische feedback van je muis activeren via een lokale socket. Standaard uit; wordt actief wanneer de achtergrondagent opnieuw start."
 "Assets": "Bronnen"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Zachowaj ikonę OpenLogi na pasku menu. Po wyłączeniu pozostanie w Docku."
 "Show in the notification area": "Pokaż w obszarze powiadomień"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Utrzymuje ikonę OpenLogi w obszarze powiadomień paska zadań. Zacznie obowiązywać przy następnym uruchomieniu agenta w tle."
+"Haptics API for other apps": "API haptyczne dla innych aplikacji"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Pozwól aplikacjom na tym komputerze wyzwalać haptykę myszy przez lokalne gniazdo. Domyślnie wyłączone; zacznie działać przy następnym uruchomieniu agenta w tle."
 "Assets": "Zasoby"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Manter o ícone do OpenLogi na barra de menus. Quando desativado, permanece no Dock."
 "Show in the notification area": "Mostrar na área de notificação"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantém o ícone do OpenLogi na área de notificação da barra de tarefas. Entra em vigor na próxima vez que o agente em segundo plano iniciar."
+"Haptics API for other apps": "API de resposta tátil para outros apps"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Permite que apps neste computador acionem a resposta tátil do mouse por um socket local. Desativado por padrão; entra em vigor na próxima vez que o agente em segundo plano iniciar."
 "Assets": "Recursos"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Manter o ícone do OpenLogi na barra de menus. Quando desativado, permanece no Dock."
 "Show in the notification area": "Mostrar na área de notificação"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Mantém o ícone do OpenLogi na área de notificação da barra de tarefas. Produz efeito no próximo arranque do agente em segundo plano."
+"Haptics API for other apps": "API tátil para outras aplicações"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Permite que as aplicações neste computador acionem a resposta tátil do rato através de um socket local. Desativado por predefinição; produz efeito no próximo arranque do agente em segundo plano."
 "Assets": "Recursos"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Оставлять значок OpenLogi в строке меню. Если выключено, приложение остаётся в Dock."
 "Show in the notification area": "Показывать в области уведомлений"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Значок OpenLogi останется в области уведомлений панели задач. Вступает в силу при следующем запуске фонового агента."
+"Haptics API for other apps": "API тактильной отдачи для других приложений"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Разрешить приложениям на этом компьютере вызывать тактильную отдачу мыши через локальный сокет. По умолчанию выключено; вступает в силу при следующем запуске фонового агента."
 "Assets": "Ресурсы"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "Behåll OpenLogis ikon i menyraden. När av stannar den i Dock i stället."
 "Show in the notification area": "Visa i meddelandefältet"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "Behåller OpenLogis ikon i aktivitetsfältets meddelandefält. Träder i kraft nästa gång bakgrundsagenten startar."
+"Haptics API for other apps": "Haptik-API för andra appar"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "Låt appar på den här datorn utlösa musens haptiska återkoppling via en lokal socket. Av som standard; börjar gälla nästa gång bakgrundsagenten startar."
 "Assets": "Resurser"
 "Asset source": "Asset source"
 "Automatic (recommended)": "Automatic (recommended)"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "在菜单栏保留 OpenLogi 图标；关闭后改为停留在程序坞中。"
 "Show in the notification area": "在通知区域显示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "在任务栏通知区域保留 OpenLogi 图标。将在后台代理下次启动时生效。"
+"Haptics API for other apps": "面向其他应用的触感 API"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "允许本机上的应用通过本地套接字触发鼠标触感反馈。默认关闭；在后台代理下次启动时生效。"
 "Assets": "资源"
 "Asset source": "资源来源"
 "Automatic (recommended)": "自动选择（推荐）"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。"
 "Show in the notification area": "在通知區域顯示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "在工作列通知區域保留 OpenLogi 圖示。將於背景代理程式下次啟動時生效。"
+"Haptics API for other apps": "俾其他應用程式用嘅觸覺 API"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "容許呢部電腦上嘅應用程式經本機通訊端觸發滑鼠觸覺回饋。預設關閉；喺背景代理下次啟動時生效。"
 "Assets": "資源"
 "Asset source": "資源來源"
 "Automatic (recommended)": "自動選擇（建議）"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -110,6 +110,8 @@ _version: 1
 "Keep OpenLogi's icon in the menu bar. When off, it stays in the Dock instead.": "在選單列保留 OpenLogi 圖示；關閉後改為停留在 Dock 中。"
 "Show in the notification area": "在通知區域顯示"
 "Keep OpenLogi's icon in the taskbar notification area. Takes effect the next time the background agent starts.": "在工作列通知區域保留 OpenLogi 圖示。將於背景代理程式下次啟動時生效。"
+"Haptics API for other apps": "供其他應用程式使用的觸覺 API"
+"Let apps on this computer trigger your mouse's haptics over a local socket. Off by default; takes effect the next time the background agent starts.": "允許本機上的應用程式透過本機通訊端觸發滑鼠觸覺回饋。預設關閉；在背景代理下次啟動時生效。"
 "Assets": "資源"
 "Asset source": "資源來源"
 "Automatic (recommended)": "自動選擇（建議）"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,6 +40,9 @@ optional physical device key.
 `[app_settings]` contains application-wide preferences:
 
 - startup, update, menu-bar / tray, input-capture, and asset-download toggles
+- `haptic_api`: serve the JSON haptics socket for third-party apps
+  (off by default; takes effect on agent restart — see
+  [HAPTIC-API.md](HAPTIC-API.md))
 - `asset_source`: `automatic`, `openlogi`, `cloudflare`, or `fastly`
 - `language`, `appearance`, optional theme names, and optional UI radius
 - `thumbwheel_sensitivity`, from `1` through `100` (`14` is 1×)

--- a/docs/HAPTIC-API.md
+++ b/docs/HAPTIC-API.md
@@ -1,0 +1,166 @@
+# The JSON haptics API
+
+OpenLogi can expose device haptics to your own apps over a local socket, so a
+script can make a supported mouse buzz. It is **off by default**.
+
+Enable it in `~/.config/openlogi/config.toml` and restart the agent:
+
+```toml
+[app_settings]
+haptic_api = true
+```
+
+The socket is `haptic.sock`, next to the agent's own socket in the runtime
+directory (usually `~/.config/openlogi/`). On Windows it is the named pipe
+`\\.\pipe\openlogi-haptic.sock`. There is no port and no network listener.
+
+Access is whatever the platform gives the endpoint beside it: on Unix, the
+runtime directory's permissions; on Windows, the default pipe DACL, which grants
+the creating user **and administrators**. Both are fine for a single-user
+desktop and neither isolates users on a shared machine.
+
+Hardware support is narrow. HID++ `0x19b0` is a reverse-engineered feature, and
+in practice this means a recent haptic-capable Logitech mouse such as the
+MX Master 4. `devices` tells you what qualifies on your machine.
+
+## Protocol
+
+One JSON object per line, in each direction. Send a request, read a response.
+If a request carries an `id`, the response carries the same one back; requests
+on a connection are answered in order, so a client with only one call in flight
+can leave `id` out entirely.
+
+### `hello`
+
+```json
+-> {"cmd":"hello"}
+<- {"ok":{"protocol":1,"agent":"0.7.1"}}
+```
+
+`protocol` moves only if an existing field changes meaning — new fields may
+appear without a bump, so parse leniently.
+
+### `devices`
+
+Lists the online devices that have a haptic engine.
+
+```json
+-> {"cmd":"devices"}
+<- {"ok":{"devices":[{"key":"receiver:aabbccdd:slot:1","name":"MX Master 4"}]}}
+```
+
+`key` is the stable per-device identifier — the same one `config.toml` uses.
+`name` is for showing a person; don't match on it.
+
+### `play`
+
+```json
+-> {"cmd":"play"}
+-> {"cmd":"play","waveform":"damp","device":"receiver:aabbccdd:slot:1"}
+<- {"ok":{"accepted":true}}
+```
+
+- `waveform`: `subtle` (default) — a light boundary tick — or `damp`, a firmer
+  confirmation pulse. These are the only two waveforms confirmed on real
+  hardware; an unknown value is an error rather than a silent default.
+- `device`: a `key` from `devices`. Omit it for whichever device the agent
+  currently considers active, which is what you want if you just mean "the
+  mouse in front of me".
+
+**`accepted` is not `played`.** The agent queues the waveform on the same
+single-flight worker the Actions Ring uses. HID++ allows one in-flight
+transaction per channel, shared with the input-capture path, so a client free
+to queue buzzes faster than the receiver drains them would time out unrelated
+device writes for seconds. If a second request arrives while one is mid-flight,
+the older unplayed one is dropped — a late buzz is worse than no buzz.
+
+Practically: don't build a waveform sequencer on this. It is for discrete
+feedback — a build finished, a message arrived.
+
+### Errors
+
+```json
+<- {"error":{"code":"device_not_found","message":"no such device"}}
+```
+
+`code` is the stable half; `message` is for humans and may change.
+
+| code | meaning |
+|---|---|
+| `bad_request` | the line was not a request this version understands |
+| `device_not_found` | no such device, or it is asleep — worth retrying later |
+| `feature_unsupported` | that device has no haptic engine — never retry |
+| `device_error` | something else went wrong talking to the device |
+
+A malformed line is answered and the connection stays open, so you can debug
+against it interactively.
+
+## Examples
+
+On Unix the endpoint is a filesystem socket; on Windows it is a named pipe. The
+protocol is identical — only the address and the connect call differ.
+
+### Unix
+
+Shell, with `socat`:
+
+```sh
+echo '{"cmd":"play","waveform":"damp"}' | socat - UNIX-CONNECT:$HOME/.config/openlogi/haptic.sock
+```
+
+Python:
+
+```python
+import json, os, socket
+
+with socket.socket(socket.AF_UNIX) as s:
+    s.connect(os.path.expanduser("~/.config/openlogi/haptic.sock"))
+    s.sendall(json.dumps({"cmd": "play", "waveform": "subtle"}).encode() + b"\n")
+    print(json.loads(s.makefile().readline()))
+```
+
+### Windows
+
+PowerShell — `NamedPipeClientStream` takes the pipe's name without the
+`\\.\pipe\` prefix:
+
+```powershell
+$pipe = New-Object System.IO.Pipes.NamedPipeClientStream '.', 'openlogi-haptic.sock', 'InOut'
+$pipe.Connect(2000)
+$writer = New-Object System.IO.StreamWriter $pipe
+$reader = New-Object System.IO.StreamReader $pipe
+$writer.WriteLine('{"cmd":"play","waveform":"damp"}')
+$writer.Flush()
+$reader.ReadLine()
+$pipe.Dispose()
+```
+
+### Node (either platform)
+
+`net.createConnection` takes a pipe path on Windows and a socket path on Unix,
+so one client covers both:
+
+```js
+import net from "node:net";
+import os from "node:os";
+
+const address =
+  process.platform === "win32"
+    ? String.raw`\\.\pipe\openlogi-haptic.sock`
+    : `${os.homedir()}/.config/openlogi/haptic.sock`;
+
+const sock = net.createConnection(address);
+sock.write(JSON.stringify({ cmd: "play", waveform: "damp" }) + "\n");
+sock.once("data", (buf) => {
+  console.log(JSON.parse(buf.toString()));
+  sock.end();
+});
+```
+
+## Scope
+
+This endpoint plays waveforms and lists what can be buzzed. It cannot change
+DPI, pair devices, or read your configuration — it is deliberately much smaller
+than the agent's own IPC socket sitting beside it, and is meant to stay that
+way. Anything that needs the full agent contract should speak that protocol
+instead (`crates/openlogi-ipc/examples/haptic.rs` is a starting point).

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -8,6 +8,8 @@ check_for_updates = false
 auto_install_updates = false
 show_in_menu_bar = true
 capture_mouse_events = true
+# Off by default. See docs/HAPTIC-API.md.
+haptic_api = false
 auto_download_assets = true
 asset_source = "automatic"
 language = "en"


### PR DESCRIPTION
## Summary

Haptics were reachable only as a side effect of an Actions Ring hover or activation, so an app that wanted to buzz the mouse had no way in. This adds two entry points on top of the existing haptic write path:

- `Agent::play_haptic` on the tarpc contract (protocol **v24**), for callers that already speak it.
- An opt-in **JSON API on a local socket** for callers that are not Rust — newline-delimited request/response, documented in [`docs/HAPTIC-API.md`](docs/HAPTIC-API.md).

Off by default (`app_settings.haptic_api`), with a toggle in General settings.

### Design notes

**The waveform type moved out of the `hidpp` fork.** It rides the IPC wire now, and that contract is append-only, so the protocol crate must not be free to reorder its variants. `openlogi-hid` maps it to the firmware `playWaveform` ID at the point of the write.

**Both entry points route through the Actions Ring's single-flight worker** rather than writing directly. HID++ allows one in-flight transaction per channel, shared with input capture, so a caller free to queue buzzes faster than the receiver drains them would time out unrelated DPI/SmartShift writes for seconds. Consequences, both documented at the API surface:

- `Ok(())` / `{"accepted":true}` means *queued*, not *played*. The two errors a caller can act on — no such device, no haptic engine — are resolved synchronously before queueing; a failure during the play itself is logged, not reported.
- A request arriving while another is mid-flight replaces any still-unplayed one. A stale buzz is worse than no buzz.

**The JSON API lives in the agent, not a relay process.** A relay is the right shape for a *websocket* — a network listener has no business inside the binary that owns the input hook and holds Accessibility. A local socket has no network reach, so that argument doesn't transfer: a relay would add a binary to launch, supervise and version for no boundary that isn't already there. Any process that can open `haptic.sock` can already open `agent.sock`. What does carry over is scope: this endpoint plays waveforms and lists what's buzzable, nothing else.

**Out-of-band plays re-arm the firmware** if the last check on that route is over a minute old. Some power transitions clear the haptic engine, after which `play` is accepted and does nothing; a per-call check would double the HID++ traffic of a steady caller.

## Changes

**`openlogi-core`** — `hid::HapticWaveform` (append-only wire enum); `paths::haptic_socket_path`; `app_settings.haptic_api`, off by default.

**`openlogi-hid`** — `play_haptic*` take the wire type and map to the firmware ID; the `hidpp` waveform is now an implementation detail of `write/haptic.rs`.

**`openlogi-ipc`** — `Agent::play_haptic(Option<DeviceRoute>, HapticWaveform)`, `PROTOCOL_VERSION` 23 → 24, wire goldens; `examples/haptic.rs` as a reference client.

**`openlogi-agent-core`** — `Orchestrator::haptic_route` / `haptic_route_for_key` / `haptic_devices`; `AgentDevice` gains a display `name`.

**`openlogi-agent`** — `json_api.rs` (protocol, listener, connection loop); `RingHapticPlayer::play_external` with the re-arm window; the RPC handler; the mock answers both.

**`openlogi-desktop` / `openlogi-ui`** — a Haptics API switch in General settings, plus the two new keys across all 20 locale catalogs.

**docs** — `HAPTIC-API.md`, `CONFIGURATION.md`, `config.example.toml`.

## Testing

Full local gate, green on the final tree:

```
cargo fmt --all -- --check                              # ok
cargo clippy --workspace --all-targets -- -D warnings   # ok
cargo test --workspace                                  # ok
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
                                                        # ok

cargo clippy --target x86_64-pc-windows-gnu \
  -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-hook \
  -p openlogi-agent -p openlogi-agent-core --all-targets -- -D warnings
                                                        # ok (cfg-gated bind)
```

New tests: the connection loop driven over an in-memory pipe (several requests
share a connection; a malformed line is answered without closing it; blank lines
are skipped; an over-long line is refused *and* closes the socket; the length cap
applies per line, not per connection — that last one was a real bug, and it fails
if the cap is moved back onto the stream); orchestrator route resolution (offline reports `DeviceNotFound`, not `FeatureUnsupported` — one is worth retrying and the other never is; unprobed capabilities read as "no haptics"), JSON protocol parsing (unknown command and unknown waveform are rejected rather than silently defaulted), `id` echo/omission, error-code distinctness, wire goldens, config default-off.

**Runtime-verified on an MX Master 4** — haptics fire as expected. `0x19b0` is
reverse-engineered, so this is the confirmation that matters; devices without the
feature are refused with `feature_unsupported` rather than silently doing nothing.

To reproduce against a running agent:

```sh
SOCK="${XDG_RUNTIME_DIR:-$HOME/.config}/openlogi/haptic.sock"
echo '{"cmd":"devices"}' | socat - "UNIX-CONNECT:$SOCK"
echo '{"cmd":"play","waveform":"damp"}' | socat - "UNIX-CONNECT:$SOCK"
```

## Notes for review

- `PROTOCOL_VERSION` is bumped and the goldens regenerated, per `.claude/rules/ipc-protocol.md`.
- `json_api::bind` is cfg-gated, so it was cross-linted with the repo's own recipe
  (`devenv.nix`'s `openlogi:check-windows`, replicated via `rustup target add
  x86_64-pc-windows-gnu`) — clean. CI's native `clippy (windows)` still has final say.
- Access matches `agent.sock` beside it: the runtime directory's permissions on Unix,
  the default pipe DACL on Windows (creating user **and administrators**). Fine for a
  single-user desktop; neither isolates users on a shared machine. Tightening either is
  a hardening point, deliberately not claimed here.
- The mock agent serves the tarpc RPC but not the JSON socket — worth a follow-up if hardware-free integration work becomes common.



