### PR TITLE
fix(agent): relaunch after granting Input Monitoring

### DIFF
--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -227,30 +227,40 @@ async fn begin_action_ring(
     }
 }
 
-/// Fire the macOS permission prompts this process needs, at startup.
-///
-/// The agent (not the GUI) owns both the CGEventTap and every HID++ device
-/// open, so it must be the binary the user authorizes for Accessibility and
-/// Input Monitoring — a grant is scoped to the code-signing identity that
-/// asks for it. macOS only shows a dialog when the process isn't already
-/// listed, so this doesn't nag on every login. The GUI's Accessibility grant
-/// button drives the same prompt on demand over IPC
-/// (`request_accessibility_prompt`); Input Monitoring has no on-demand IPC
-/// path yet, so it is only requested here, at startup.
-fn prompt_missing_permissions(capture_mouse_events: bool) {
+/// Prompt for Accessibility when the enabled mouse hook needs it.
+fn prompt_missing_accessibility(capture_mouse_events: bool) {
     // With the hook disabled the agent needs no Accessibility at all, so the
     // opt-out also silences that prompt.
     if capture_mouse_events && !Hook::has_accessibility() {
         Hook::prompt_accessibility();
     }
+}
 
+/// Request Input Monitoring before starting the HID inventory on macOS.
+///
+/// The agent (not the GUI) owns every HID++ device open, so it must be the
+/// binary the user authorizes. A newly granted permission requires a process
+/// relaunch before macOS lets the agent open HID devices.
+#[cfg(target_os = "macos")]
+async fn request_input_monitoring() {
     // Without this, macOS never registers a decision at all:
     // `IOHIDDeviceOpen` is silently denied, the permission never appears in
     // System Settings for the user to grant, and no HID++ device is ever
-    // discovered. `request_access` blocks on the consent dialog, so it runs
-    // on a blocking thread rather than stalling startup.
+    // discovered. Wait for the blocking consent dialog before starting the
+    // inventory so it cannot cache the pre-grant access state.
     if !openlogi_hid::permissions::has_access() {
-        tokio::task::spawn_blocking(openlogi_hid::permissions::request_access);
+        let access_after_prompt = tokio::task::spawn_blocking(|| {
+            openlogi_hid::permissions::request_access();
+            openlogi_hid::permissions::has_access()
+        })
+        .await;
+        match access_after_prompt {
+            Ok(true) => self_restart::relaunch_after_input_monitoring_grant(),
+            Ok(false) => {}
+            Err(e) => {
+                warn!(error = %e, "Input Monitoring permission request task failed");
+            }
+        }
     }
 }
 
@@ -267,7 +277,9 @@ async fn run(
     // an agent restart, which the config docs state.
     let capture_mouse_events = config.app_settings.capture_mouse_events;
 
-    prompt_missing_permissions(capture_mouse_events);
+    prompt_missing_accessibility(capture_mouse_events);
+    #[cfg(target_os = "macos")]
+    request_input_monitoring().await;
 
     // The orchestrator is shared with the IPC server (which serves inventory /
     // reload / status) and mutated by the watcher select loop, so it lives

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -7,10 +7,10 @@
 //! IPC protocol on a version bump, sitting on its connecting screen with no way
 //! forward. Watching our own executable and replacing the process image once it
 //! changes keeps "the running agent is the installed binary" true within a few
-//! ticks, with no launchd or GUI involvement. On macOS the replacement is a
-//! short delayed relaunch rather than an in-thread `exec`: the agent owns an
-//! AppKit status item, and the new AppKit process must start from the normal
-//! process main thread or the menu-bar item can render as an empty slot.
+//! ticks, with no launchd or GUI involvement. On macOS restarts use a short
+//! delayed relaunch rather than an in-thread `exec`: the agent owns an AppKit
+//! status item, and the new AppKit process must start from the normal process
+//! main thread or the menu-bar item can render as an empty slot.
 //!
 //! Limitation: the path is resolved once via `current_exe`, which returns the
 //! fully-resolved target (`/proc/self/exe` on Linux). Installs that update by
@@ -132,15 +132,29 @@ fn restart(path: &Path) {
         path = %path.display(),
         "executable changed on disk — relaunching as the new macOS agent"
     );
-    match schedule_macos_relaunch(path) {
-        #[expect(
-            clippy::exit,
-            reason = "the successor is already scheduled and waits on this process releasing the singleton lock and IPC socket; this watcher thread cannot return a status to `main`, which is parked in the AppKit run loop"
-        )]
-        Ok(()) => std::process::exit(0),
+    if let Err(e) = schedule_macos_relaunch_and_exit(path) {
+        warn!(error = %e, "could not schedule updated agent relaunch — keeping the current image and retrying");
+    }
+}
+
+/// Relaunch the macOS agent after Input Monitoring is granted.
+///
+/// macOS does not apply a new Input Monitoring grant to the running process.
+/// The successor starts only after this process exits and releases its
+/// singleton lock and IPC socket. If the relaunch cannot be scheduled, the
+/// current process stays alive so the user can restart it manually.
+#[cfg(target_os = "macos")]
+pub fn relaunch_after_input_monitoring_grant() {
+    let path = match std::env::current_exe() {
+        Ok(path) => path,
         Err(e) => {
-            warn!(error = %e, "could not schedule updated agent relaunch — keeping the current image and retrying");
+            warn!(error = %e, "could not resolve own executable after Input Monitoring was granted — restart the agent manually");
+            return;
         }
+    };
+    info!("Input Monitoring granted — relaunching the macOS agent");
+    if let Err(e) = schedule_macos_relaunch_and_exit(&path) {
+        warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
     }
 }
 
@@ -162,6 +176,16 @@ fn schedule_macos_relaunch(path: &Path) -> std::io::Result<()> {
             .args(std::env::args_os().skip(1));
     }
     command.spawn().map(|_| ())
+}
+
+#[cfg(target_os = "macos")]
+fn schedule_macos_relaunch_and_exit(path: &Path) -> std::io::Result<()> {
+    schedule_macos_relaunch(path)?;
+    #[expect(
+        clippy::exit,
+        reason = "the delayed successor is already scheduled and waits for this process to release the singleton lock and IPC socket"
+    )]
+    std::process::exit(0)
 }
 
 /// The `.app` root of a packaged helper binary, `None` for a bare dev binary.


### PR DESCRIPTION
## Summary

OpenLogi v0.7.1 began requesting macOS Input Monitoring at agent startup, but it launched that blocking request as a detached task and immediately started HID inventory. The inventory could therefore open devices with the pre-grant access state, and a newly granted Input Monitoring permission was never followed by the quit-and-reopen macOS requires. Replacing the agent executable during a downgrade happened to force that missing restart, which is consistent with the reported v0.7.1 → v0.6.27 A/B result.

This makes the permission request part of the startup sequence and relaunches the agent only when that request changes Input Monitoring from not granted to granted. An agent that already has access skips both the request and relaunch, so this cannot create a restart loop.

## Changes

- **`openlogi-agent`** — await the blocking Input Monitoring request before starting HID inventory, then re-check access and relaunch after a new grant.
- **`openlogi-agent`** — reuse the existing delayed macOS LaunchServices relaunch path, which preserves the packaged helper's TCC identity and waits for the singleton lock and IPC socket to be released.

## Testing

Full local gate, green on the final tree:

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent
```

The cfg-gated agent paths also pass the repository's Windows cross-lint recipe:

```sh
cargo clippy --target x86_64-pc-windows-gnu \
  -p openlogi-core -p openlogi-hidpp -p openlogi-hid -p openlogi-hook \
  -p openlogi-agent -p openlogi-agent-core --all-targets -- -D warnings
```

Not runtime-tested on hardware: verification deliberately did not trigger or reset macOS privacy permissions. To verify manually, start with the agent absent from Input Monitoring, grant the prompted permission, and confirm the agent relaunches once and discovers the paired device.

Closes #25
