### PR TITLE
chore(infra): prune the tree's lint suppressions and make the survivors expect

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -16,9 +16,12 @@ and every crate inherits it with `[lints] workspace = true` — never a private 
 the next lint added to the workspace silently skips that crate. A crate needing a
 different level opts out **in source** (the `openlogi-hook` platform modules carry
 `#![allow(unsafe_code, reason = "…")]`), because Cargo rejects mixing `workspace = true`
-with local overrides. `openlogi-hidpp` currently stays out of the table — it is a **hard
-fork**, so the "third-party code" rationale for that opt-out no longer holds; whether it
-should now inherit is an open question, costed in `crates/openlogi-hidpp/AGENTS.md`.
+with local overrides. `openlogi-hidpp` inherits the table like everything else, hard
+fork or not.
+
+Workspace-wide clippy *configuration* lives in `clippy.toml` at the root. It currently
+carries `allow-unwrap-in-tests` / `allow-expect-in-tests`, so test code never needs to
+restate that exemption by hand.
 
 The table: `unsafe_code = "deny"` (opt out per item with `#[expect(unsafe_code,
 reason = "…")]` plus a `// SAFETY:` comment), `clippy::pedantic` at warn,
@@ -31,18 +34,54 @@ a `reason`. What that changes day to day:
 - Every `unsafe` block needs a `// SAFETY:` comment saying why it is sound.
 - `assert!(r.is_ok())` / `assert!(r.is_err())` are rejected — unwrap the `Result` (in a
   test module that already allows it) or give the assertion a message.
-- A test module that wants `expect`/`unwrap` says so:
-  `#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]` on the
-  module (or on its `mod tests;` declaration). Never route around the lint with
-  `unwrap_or_else(|e| panic!("…: {e}"))` — that is the same panic with the check switched
-  off. The one honest use of that form is a *dynamic* panic message, where `expect` would
-  need a `format!` that allocates on the happy path (`expect_fun_call`).
+- Tests use `expect`/`unwrap` freely: `clippy.toml` exempts `#[cfg(test)]` modules and
+  `#[test]` functions, so **do not** add a suppression for it. The one shape clippy
+  cannot see is a free helper in a `tests/` integration file, outside any `#[test]` fn —
+  that file needs a `#![expect(clippy::expect_used, reason = "…")]`. Never route around
+  the lint with `unwrap_or_else(|e| panic!("…: {e}"))` — that is the same panic with the
+  check switched off. The one honest use of that form is a *dynamic* panic message,
+  where `expect` would need a `format!` that allocates on the happy path
+  (`expect_fun_call`).
 - A test module gated on more than `test` needs stacked attributes (`#[cfg(test)]` then
   `#[cfg(unix)]`), not `#[cfg(all(test, unix))]`, which clippy reads as a test outside a
   test module. Integration tests under `tests/` carry a file-level
   `#![expect(clippy::tests_outside_test_module, reason = "…")]`.
 - `std::process::exit` needs `#[expect(clippy::exit, reason = "…")]` naming why that call
   site cannot hand an `ExitCode` back to `main` instead.
+
+### `expect` by default, `allow` only when `expect` would break
+
+`#[allow]` goes quiet the day it stops suppressing anything, so suppressions rot in
+place — an audit in 2026-08 found 20 dead ones, including three module-wide `dead_code`
+blankets that had been inert since their modules went `pub`. `#[expect]` reports itself
+unfulfilled instead, which `-D warnings` turns into a failure. **Default to `expect`.**
+
+Three cases where `expect` is wrong and `allow` is correct — each needs a comment saying
+which one applies, or the next reader will "fix" it back:
+
+- **The lint fires only under some `cfg`.** `platform::os_version` returns `Some(…)` on
+  macOS (so `unnecessary_wraps` fires) and `None` elsewhere (so it does not). An
+  `expect` there is green on macOS and red on the other two lanes.
+- **Fulfilment differs between a crate's targets.** A `dead_code` suppression on a
+  helper that only the tests call is fulfilled in the `--lib` build and unfulfilled in
+  the `--test` build; `--all-targets` compiles both, so one of them always warns. These
+  are usually `cfg_attr`-wrapped already.
+- **The lint is raised inside a macro expansion.** rustc does not credit an expectation
+  with such a lint: it suppresses the warning *and* reports itself unfulfilled. A
+  `float_cmp` on floats compared inside `assert_eq!` is the case in this tree.
+
+Scope a suppression to the item that needs it. A file-level `#![expect(cast_…)]` also
+covers every cast added to that file later, which is how a bounded-by-construction
+argument silently becomes a blanket one. Prefer removing the need instead: `cast_signed`
+/ `cast_unsigned` for bit-reinterpreting casts, `&raw const` / `&raw mut` for raw-pointer
+coercions, `to_le_bytes` for byte splitting, or one shared conversion helper carrying the
+single suppression when a file converts the same pair of types over and over.
+
+Sweeping for rot is mechanical: rewrite every non-`cfg_attr` `allow(` to `expect(`, run
+clippy, and each "this lint expectation is unfulfilled" is a suppression to delete.
+Do it on all three lanes — `cargo clippy`, `--target x86_64-pc-windows-gnu`, and
+`--target aarch64-unknown-linux-musl` — because CI has no macOS clippy job and a
+platform-gated suppression is only ever evaluated on its own platform.
 
 Encode invariants in the type system instead of checking them at runtime:
 

--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -28,8 +28,9 @@ reason = "…")]` plus a `// SAFETY:` comment), `clippy::pedantic` at warn,
 `unwrap_used`/`expect_used` at warn, plus the shared lint set —
 `assertions_on_result_states`, `cast_possible_truncation`, `cast_possible_wrap`,
 `cast_sign_loss`, `error_impl_error`, `exit`, `or_fun_call`, `ptr_as_ptr`,
-`tests_outside_test_module`, `undocumented_unsafe_blocks`. Any lint suppression carries
-a `reason`. What that changes day to day:
+`tests_outside_test_module`, `undocumented_unsafe_blocks`. `allow_attributes` and
+`allow_attributes_without_reason` machine-check the suppression rules below. What that
+changes day to day:
 
 - Every `unsafe` block needs a `// SAFETY:` comment saying why it is sound.
 - `assert!(r.is_ok())` / `assert!(r.is_err())` are rejected — unwrap the `Result` (in a
@@ -54,18 +55,21 @@ a `reason`. What that changes day to day:
 `#[allow]` goes quiet the day it stops suppressing anything, so suppressions rot in
 place — an audit in 2026-08 found 20 dead ones, including three module-wide `dead_code`
 blankets that had been inert since their modules went `pub`. `#[expect]` reports itself
-unfulfilled instead, which `-D warnings` turns into a failure. **Default to `expect`.**
+unfulfilled instead, which `-D warnings` turns into a failure. `allow_attributes`
+enforces this — but only for outer `#[allow]`; a module-wide `#![allow(…)]`, the shape
+that rots worst, is invisible to it and is on you.
 
-Three cases where `expect` is wrong and `allow` is correct — each needs a comment saying
-which one applies, or the next reader will "fix" it back:
+Three cases where `expect` is wrong and `allow` is correct. Each keeps its `allow` plus
+an `#[expect(clippy::allow_attributes, reason = "see above")]` and a comment saying which
+case applies — riding the same `cfg_attr` predicate when there is one:
 
 - **The lint fires only under some `cfg`.** `platform::os_version` returns `Some(…)` on
   macOS (so `unnecessary_wraps` fires) and `None` elsewhere (so it does not). An
   `expect` there is green on macOS and red on the other two lanes.
 - **Fulfilment differs between a crate's targets.** A `dead_code` suppression on a
   helper that only the tests call is fulfilled in the `--lib` build and unfulfilled in
-  the `--test` build; `--all-targets` compiles both, so one of them always warns. These
-  are usually `cfg_attr`-wrapped already.
+  the `--test` build; `--all-targets` compiles both, so one of them always warns. Being
+  `cfg_attr`-wrapped is *not* itself a reason to reach for `allow` — check.
 - **The lint is raised inside a macro expansion.** rustc does not credit an expectation
   with such a lint: it suppresses the warning *and* reports itself unfulfilled. A
   `float_cmp` on floats compared inside `assert_eq!` is the case in this tree.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,12 @@ unwrap_used = "warn"
 expect_used = "warn"
 missing_errors_doc = "allow"
 doc_markdown = "allow"
+# Machine-checks the suppression policy in .claude/rules/rust.md: every
+# suppression states a reason, and reaches for `expect` unless it cannot work.
+# Blind spot worth knowing: `allow_attributes` only sees outer `#[allow]`, so a
+# module-wide `#![allow(…)]` — the shape that rots worst — still needs review.
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
 # Shared lint set, kept in sync with
 # https://gist.github.com/AprilNEA/cdf81f76840fcb883a32503ee7caa539.
 # `cast_*` and `ptr_as_ptr` are pedantic members already; they are listed

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,8 @@
+# `unwrap_used`/`expect_used` are workspace-wide warnings so production code has
+# to state its panics. In tests a panic *is* the failure report, so the lints only
+# bought ~100 copies of the same `#[allow(…, reason = "idiomatic in tests")]`.
+# Clippy silences both inside `#[cfg(test)]` modules and `#[test]` functions when
+# these are set; a free helper in a `tests/` integration file still needs a local
+# suppression, because clippy sees neither marker there.
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,8 +1,4 @@
-# `unwrap_used`/`expect_used` are workspace-wide warnings so production code has
-# to state its panics. In tests a panic *is* the failure report, so the lints only
-# bought ~100 copies of the same `#[allow(…, reason = "idiomatic in tests")]`.
-# Clippy silences both inside `#[cfg(test)]` modules and `#[test]` functions when
-# these are set; a free helper in a `tests/` integration file still needs a local
-# suppression, because clippy sees neither marker there.
+# Covers `#[cfg(test)]` modules and `#[test]` fns. A free helper in a `tests/`
+# integration file is neither, and still needs a local suppression.
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true

--- a/crates/openlogi-agent-core/src/action_ring.rs
+++ b/crates/openlogi-agent-core/src/action_ring.rs
@@ -282,7 +282,6 @@ impl ActionRingManager {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
     use openlogi_core::binding::ActionRingConfig;

--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -627,7 +627,6 @@ mod tests {
     /// forever. Uses a paused clock so the test doesn't spend `WRITE_BUDGET`
     /// (5s) of real wall-clock time.
     #[tokio::test(start_paused = true)]
-    #[allow(clippy::expect_used, reason = "expect is idiomatic in tests")]
     async fn timed_maps_an_elapsed_deadline_to_request_timed_out() {
         let handle = tokio::spawn(timed(
             HidppOperation::WriteDpi,

--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -214,10 +214,6 @@ impl ObservableState {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    reason = "unwrap is idiomatic in tests; `has_changed` can only fail once the sender is dropped, and these tests hold it"
-)]
 mod tests {
     use super::ObservableState;
     use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -123,7 +123,6 @@ impl Drop for ExclusiveRequest {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -282,7 +282,7 @@ async fn manage(
 
 /// Start one device's capture session plus its input-forwarding task, and
 /// return the manager's tracking entry for it.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "plumbing between the manager loop's channels; grouping them into \
               a struct would only relabel the same eight values"
@@ -437,7 +437,7 @@ fn dispatch(
 /// Advance one direction's accumulator by `magnitude` rotation increments and
 /// decide what to emit. Pure given `now`, so the decay/cooldown/threshold logic
 /// is unit-testable without touching the OS.
-#[allow(
+#[expect(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     reason = "magnitude/sensitivity are small integers and `lines` is a trunc'd \

--- a/crates/openlogi-agent/build.rs
+++ b/crates/openlogi-agent/build.rs
@@ -7,7 +7,7 @@
 //! exact version already in Cargo.lock as gpui's own build-dependency, so it
 //! adds an edge, not a crate, and cannot move the pinned gpui rev.
 
-#![allow(
+#![expect(
     clippy::expect_used,
     reason = "a build script fails by panicking, so expect — whose message surfaces in the build log — is the idiomatic error path"
 )]

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -319,7 +319,6 @@ fn run_systemctl(args: &[&str]) {
 
 #[cfg(test)]
 #[cfg(target_os = "macos")]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 
@@ -426,7 +425,6 @@ mod linux_tests {
         // When XDG_CONFIG_HOME is unset (or relative), falls back to $HOME/.config.
         // We can't mutate global env safely in a parallel test suite, so we test
         // the logic indirectly: unit_path() must end in the UNIT_NAME component.
-        #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
         let path = unit_path().expect("unit_path should resolve with a valid HOME");
         assert!(path.ends_with(UNIT_NAME));
         assert!(path.to_string_lossy().contains("systemd/user"));

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -567,7 +567,6 @@ pub async fn run(server: AgentServer) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use super::{ARM_BUDGET, Budget, PLAY_BUDGET};
     use std::time::{Duration, Instant};

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -176,7 +176,7 @@ unsafe extern "system" fn wnd_proc(
 /// `NIM_ADD` fails silently and the existing icon stays).
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "`cbSize` is a u32 field and NOTIFYICONDATAW is a few hundred bytes"
+    reason = "NOTIFYICONDATAW is a few hundred bytes"
 )]
 unsafe fn add_tray_icon(hwnd: HWND) {
     // SAFETY: `nid` is fully initialized below; the tip buffer is bounded.
@@ -408,7 +408,7 @@ fn spawn_gui() {
 /// are immediate).
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "`cbSize` is a u32 field and NOTIFYICONDATAW is a few hundred bytes"
+    reason = "NOTIFYICONDATAW is a few hundred bytes"
 )]
 fn quit(hwnd: HWND) {
     use sysinfo::{Pid, ProcessesToUpdate, System};

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -23,10 +23,9 @@
     unsafe_code,
     reason = "raw win32: Shell_NotifyIconW + a hidden window's message pump — localized here"
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
     reason = "win32 message plumbing round-trips ids through WPARAM/LPARAM by design"
 )]
 

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -23,12 +23,6 @@
     unsafe_code,
     reason = "raw win32: Shell_NotifyIconW + a hidden window's message pump — localized here"
 )]
-#![expect(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    reason = "win32 message plumbing round-trips ids through WPARAM/LPARAM by design"
-)]
-
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use tracing::{info, warn};
@@ -138,6 +132,11 @@ fn run_tray_loop() {
     }
 }
 
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    reason = "WM_TRAY packs the mouse message id into the low bits of LPARAM"
+)]
 unsafe extern "system" fn wnd_proc(
     hwnd: HWND,
     msg: u32,
@@ -175,6 +174,10 @@ unsafe extern "system" fn wnd_proc(
 
 /// Install the icon (idempotent enough for the re-add path: a duplicate
 /// `NIM_ADD` fails silently and the existing icon stays).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "`cbSize` is a u32 field and NOTIFYICONDATAW is a few hundred bytes"
+)]
 unsafe fn add_tray_icon(hwnd: HWND) {
     // SAFETY: `nid` is fully initialized below; the tip buffer is bounded.
     unsafe {
@@ -198,6 +201,10 @@ unsafe fn add_tray_icon(hwnd: HWND) {
 /// macOS status-item asset; `CreateIconFromResourceEx` accepts raw PNG
 /// buffers (the same PNG-compressed form .ico files carry since Vista).
 /// Falls back to the stock application icon rather than showing nothing.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the PNG is embedded at build time and is a few kilobytes"
+)]
 unsafe fn tray_icon() -> HICON {
     const BLACK: &[u8] = include_bytes!("../assets/tray-icon@2x.png");
     const WHITE: &[u8] = include_bytes!("../assets/tray-icon-white@2x.png");
@@ -235,6 +242,10 @@ fn taskbar_is_light() -> bool {
 }
 
 /// Show the context menu at the cursor and run the chosen command.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "TrackPopupMenu returns the command id it was given, never negative"
+)]
 unsafe fn show_menu(hwnd: HWND) {
     // SAFETY: menu handles are created and destroyed here; the
     // SetForegroundWindow/WM_NULL bracket is the documented TrackPopupMenu
@@ -395,6 +406,10 @@ fn spawn_gui() {
 /// the agent we are about to exit), then the icon, then the agent. Mirrors
 /// the macOS Quit semantics; the GUI holds no unsaved state (config writes
 /// are immediate).
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "`cbSize` is a u32 field and NOTIFYICONDATAW is a few hundred bytes"
+)]
 fn quit(hwnd: HWND) {
     use sysinfo::{Pid, ProcessesToUpdate, System};
     let mut system = System::new();

--- a/crates/openlogi-assets/src/http.rs
+++ b/crates/openlogi-assets/src/http.rs
@@ -381,7 +381,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
     fn write_replace_overwrites_in_place() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let dst = dir.path().join("a.png");
@@ -394,7 +393,6 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    #[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
     fn write_replace_replaces_a_planted_symlink_instead_of_following_it() {
         let dir = tempfile::tempdir().expect("create temp dir");
         let victim = dir.path().join("victim.txt");

--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -191,7 +191,6 @@ impl Index {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/crates/openlogi-assets/src/index.rs
+++ b/crates/openlogi-assets/src/index.rs
@@ -1,8 +1,3 @@
-#![allow(
-    dead_code,
-    reason = "full schema parsed; only a subset is consumed by today's callers"
-)]
-
 //! Parses the `index.json` shared by OpenLogi's asset mirrors.
 //!
 //! Schema mirrors the file the assets repo's `stage_assets.py` emits:

--- a/crates/openlogi-assets/src/manifest.rs
+++ b/crates/openlogi-assets/src/manifest.rs
@@ -32,11 +32,6 @@
 //! renders. The rest of the schema is parsed permissively so additional
 //! fields don't break older clients.
 
-#![allow(
-    dead_code,
-    reason = "schema captured in full; only `device_image` is consumed in v0.0.1"
-)]
-
 use std::path::Path;
 
 use serde::Deserialize;

--- a/crates/openlogi-assets/src/metadata.rs
+++ b/crates/openlogi-assets/src/metadata.rs
@@ -1,8 +1,3 @@
-#![allow(
-    dead_code,
-    reason = "full schema parsed; label direction codes + extra coords land in later phases"
-)]
-
 //! Parses the per-depot hotspot metadata shipped by the Logi Options+
 //! installer (and re-hosted by assets.openlogi.org) — `core_metadata.json`
 //! on newer depots, `metadata.json` on older ones. The caller picks the

--- a/crates/openlogi-assets/src/metadata.rs
+++ b/crates/openlogi-assets/src/metadata.rs
@@ -122,7 +122,6 @@ impl Metadata {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::Metadata;
 

--- a/crates/openlogi-camera/src/capture.rs
+++ b/crates/openlogi-camera/src/capture.rs
@@ -23,10 +23,8 @@
     unsafe_code,
     reason = "AVFoundation / CoreMedia / CoreVideo capture FFI"
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
     reason = "pixel dimensions and FourCC constants are bounded and copied verbatim"
 )]
 

--- a/crates/openlogi-camera/src/capture.rs
+++ b/crates/openlogi-camera/src/capture.rs
@@ -23,11 +23,6 @@
     unsafe_code,
     reason = "AVFoundation / CoreMedia / CoreVideo capture FFI"
 )]
-#![expect(
-    clippy::cast_possible_truncation,
-    reason = "pixel dimensions and FourCC constants are bounded and copied verbatim"
-)]
-
 use std::ffi::{CString, c_void};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -157,11 +152,16 @@ define_class!(
                         }
                     }
                     if let Ok(mut slot) = LATEST.lock() {
-                        *slot = Some(Arc::new(Frame {
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "CoreVideo reports sensor-sized dimensions, divided down again by `step`"
+                        )]
+                        let frame = Frame {
                             width: out_w as u32,
                             height: out_h as u32,
                             bgra,
-                        }));
+                        };
+                        *slot = Some(Arc::new(frame));
                         FRAME_GEN.fetch_add(1, Ordering::Relaxed);
                     }
                 }

--- a/crates/openlogi-camera/src/capture_linux.rs
+++ b/crates/openlogi-camera/src/capture_linux.rs
@@ -19,7 +19,7 @@
 //! [`camera_authorization`] reports `Granted`/`Denied` by probing whether the
 //! node actually opens, and never `Undetermined`: there is nothing to prompt.
 
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap,

--- a/crates/openlogi-camera/src/capture_linux.rs
+++ b/crates/openlogi-camera/src/capture_linux.rs
@@ -495,7 +495,6 @@ pub fn camera_authorization() -> CameraAuthorization {
 pub fn request_camera_access() {}
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-camera/src/capture_linux.rs
+++ b/crates/openlogi-camera/src/capture_linux.rs
@@ -19,13 +19,6 @@
 //! [`camera_authorization`] reports `Granted`/`Denied` by probing whether the
 //! node actually opens, and never `Undetermined`: there is nothing to prompt.
 
-#![expect(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    clippy::cast_possible_wrap,
-    reason = "pixel arithmetic is bounded by the negotiated frame size"
-)]
-
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -459,6 +452,10 @@ fn write_bgra(out: &mut [u8], y: i32, u: i32, v: i32) {
 }
 
 /// Saturate a fixed-point channel (scaled by 256) into a byte.
+#[expect(
+    clippy::cast_sign_loss,
+    reason = "the channel is clamped to 0..=255 before the narrowing"
+)]
 fn clamp_u8(scaled: i32) -> u8 {
     (scaled / 256).clamp(0, 255) as u8
 }

--- a/crates/openlogi-camera/src/capture_windows.rs
+++ b/crates/openlogi-camera/src/capture_windows.rs
@@ -18,8 +18,7 @@
     unsafe_code,
     reason = "Media Foundation COM (device activation + IMFSourceReader sample loop)"
 )]
-#![allow(
-    clippy::cast_possible_truncation,
+#![expect(
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
     reason = "pixel dimensions and strides are bounded and copied verbatim"

--- a/crates/openlogi-camera/src/capture_windows.rs
+++ b/crates/openlogi-camera/src/capture_windows.rs
@@ -18,11 +18,6 @@
     unsafe_code,
     reason = "Media Foundation COM (device activation + IMFSourceReader sample loop)"
 )]
-#![expect(
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    reason = "pixel dimensions and strides are bounded and copied verbatim"
-)]
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
@@ -221,7 +216,7 @@ fn pump_frames(reader: &IMFSourceReader, shared: &Shared, stride_hint: StrideHin
             let (mut flags, mut sample) = (0u32, None);
             if reader
                 .ReadSample(
-                    MF_SOURCE_READER_FIRST_VIDEO_STREAM.0 as u32,
+                    MF_SOURCE_READER_FIRST_VIDEO_STREAM.0.cast_unsigned(),
                     0,
                     None,
                     Some(&raw mut flags),
@@ -292,7 +287,7 @@ fn open_reader(
         // processor can convert to RGB32 count — a compressed 720p mode it
         // can't decode would fail below, while a convertible mode at another
         // 16:9 size still previews fine.
-        let stream = MF_SOURCE_READER_FIRST_VIDEO_STREAM.0 as u32;
+        let stream = MF_SOURCE_READER_FIRST_VIDEO_STREAM.0.cast_unsigned();
         let mut best: Option<(u32, IMFMediaType)> = None;
         let mut index = 0u32;
         while let Ok(native) = reader.GetNativeMediaType(stream, index) {
@@ -346,7 +341,7 @@ fn open_reader(
         let height = (size & 0xFFFF_FFFF) as u32;
         let stride = current
             .GetUINT32(&MF_MT_DEFAULT_STRIDE)
-            .map_or(width as i32 * 4, |s| s as i32);
+            .map_or_else(|_| width.cast_signed() * 4, u32::cast_signed);
         Ok((
             reader,
             StrideHint {
@@ -488,7 +483,8 @@ fn setup_err(e: impl std::fmt::Display) -> CaptureError {
 /// Map an activation failure to AccessDenied when the system privacy toggle
 /// is the cause (E_ACCESSDENIED), Setup otherwise.
 fn access_or_setup(e: &windows::core::Error) -> CaptureError {
-    const E_ACCESSDENIED: windows::core::HRESULT = windows::core::HRESULT(0x8007_0005_u32 as i32);
+    const E_ACCESSDENIED: windows::core::HRESULT =
+        windows::core::HRESULT(0x8007_0005_u32.cast_signed());
     if e.code() == E_ACCESSDENIED {
         CaptureError::AccessDenied
     } else {

--- a/crates/openlogi-camera/src/macos.rs
+++ b/crates/openlogi-camera/src/macos.rs
@@ -191,7 +191,7 @@ fn max_frame_rate(format: *mut AnyObject) -> u32 {
 }
 
 /// Round a frame rate to the nearest whole fps (so 59.94 reads as 60).
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     reason = "fps is rounded, finite, and clamped to a small non-negative range"

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -16,12 +16,6 @@
 //! The IOKit handles themselves live in [`iokit`], which owns every `unsafe`
 //! block in this backend and hands the descriptor up as a plain `&[u8]`.
 
-#![expect(
-    clippy::cast_possible_truncation,
-    clippy::cast_sign_loss,
-    reason = "UVC payloads are bounded 16-bit values copied verbatim"
-)]
-
 mod iokit;
 
 use std::collections::HashMap;
@@ -455,7 +449,7 @@ impl UsbDevice {
             payload,
         } = control.spec();
         let entity = self.entity(unit)?;
-        let mut buf = (value as u32).to_le_bytes();
+        let mut buf = value.cast_unsigned().to_le_bytes();
         self.transfer(
             RT_SET,
             UVC_SET_CUR,
@@ -512,6 +506,10 @@ impl UsbDevice {
             bRequest: request,
             wValue: selector << 8,
             wIndex: (u16::from(entity) << 8) | u16::from(self.vc_interface),
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "`data` is a UVC control payload — at most the 4 bytes a `ControlSpec` declares"
+            )]
             wLength: data.len() as u16,
             pData: data.as_mut_ptr().cast::<c_void>(),
             wLenDone: 0,
@@ -658,16 +656,8 @@ mod tests {
 
     /// An 8-byte VC_INPUT_TERMINAL descriptor for `entity`.
     fn input_terminal(entity: u8, terminal_type: u16) -> Vec<u8> {
-        vec![
-            8,
-            0x24,
-            0x02,
-            entity,
-            terminal_type as u8,
-            (terminal_type >> 8) as u8,
-            0,
-            0,
-        ]
+        let [type_lo, type_hi] = terminal_type.to_le_bytes();
+        vec![8, 0x24, 0x02, entity, type_lo, type_hi, 0, 0]
     }
 
     /// A minimal VC_PROCESSING_UNIT descriptor for `entity`.

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -16,9 +16,8 @@
 //! The IOKit handles themselves live in [`iokit`], which owns every `unsafe`
 //! block in this backend and hands the descriptor up as a plain `&[u8]`.
 
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
     reason = "UVC payloads are bounded 16-bit values copied verbatim"
 )]

--- a/crates/openlogi-cli/src/cmd/assets/sync.rs
+++ b/crates/openlogi-cli/src/cmd/assets/sync.rs
@@ -126,7 +126,7 @@ pub fn run(args: SyncArgs) -> Result<()> {
                 .sum::<u64>()
         })
         .sum();
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
         reason = "bundle sizes are well under 2^53 bytes; f64 precision is fine for a display string"
     )]

--- a/crates/openlogi-cli/src/cmd/diag/dpi.rs
+++ b/crates/openlogi-cli/src/cmd/diag/dpi.rs
@@ -111,7 +111,6 @@ fn summarize_dpi(capabilities: &openlogi_hid::DpiCapabilities) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod summarize_dpi_tests {
     use openlogi_hid::DpiCapabilities;
 

--- a/crates/openlogi-cli/src/cmd/diag/lighting.rs
+++ b/crates/openlogi-cli/src/cmd/diag/lighting.rs
@@ -97,11 +97,6 @@ pub async fn run(args: LightingArgs) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 mod color_validation_tests {
     use openlogi_core::color::RgbParseError;
 

--- a/crates/openlogi-cli/src/cmd/light.rs
+++ b/crates/openlogi-cli/src/cmd/light.rs
@@ -203,8 +203,6 @@ fn select<'a>(
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::expect_used, reason = "expect is idiomatic in selection tests")]
-
     use super::select;
     use openlogi_core::device::{DeviceKind, RawDeviceAddress, StandaloneDevice};
 

--- a/crates/openlogi-cli/src/lib.rs
+++ b/crates/openlogi-cli/src/lib.rs
@@ -42,7 +42,6 @@ pub async fn run() -> Result<ExitCode> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use clap::CommandFactory;
 

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -22,7 +22,6 @@ mod swipe;
 mod value;
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests;
 
 pub use action::{Action, WorkflowStep};

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -338,7 +338,6 @@ const fn default_true() -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-core/src/binding/application_target.rs
+++ b/crates/openlogi-core/src/binding/application_target.rs
@@ -83,7 +83,6 @@ impl From<ApplicationTarget> for ApplicationTargetWire {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -327,7 +327,6 @@ fn parse_key(token: &str) -> Result<KeyboardUsage, KeyComboParseError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-core/src/bindings.rs
+++ b/crates/openlogi-core/src/bindings.rs
@@ -126,7 +126,6 @@ pub fn oshook_gestures_for(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use crate::binding::default_gesture_binding;
 

--- a/crates/openlogi-core/src/color.rs
+++ b/crates/openlogi-core/src/color.rs
@@ -87,7 +87,6 @@ impl fmt::Display for Rgb {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use super::Rgb;
 

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -234,7 +234,7 @@ fn default_true() -> bool {
 }
 
 /// `skip_serializing_if` helper for `bool` fields whose default is `true`.
-#[allow(
+#[expect(
     clippy::trivially_copy_pass_by_ref,
     reason = "serde's skip_serializing_if requires a fn(&T) -> bool signature"
 )]
@@ -244,7 +244,7 @@ fn is_true(b: &bool) -> bool {
 
 /// `skip_serializing_if` helper for plain `bool` fields whose default is
 /// `false`: keeps an unset toggle out of `config.toml` entirely.
-#[allow(
+#[expect(
     clippy::trivially_copy_pass_by_ref,
     reason = "serde's skip_serializing_if requires a fn(&T) -> bool signature"
 )]

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -54,7 +54,7 @@ pub enum AssetSourcePreference {
 /// compatible — old config files just keep the default for the new field.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(
+#[expect(
     clippy::struct_excessive_bools,
     reason = "independent on/off user preferences, not a state machine"
 )]
@@ -367,7 +367,7 @@ impl LightSettings {
     }
 }
 
-#[allow(
+#[expect(
     clippy::trivially_copy_pass_by_ref,
     reason = "serde's skip_serializing_if requires a fn(&T) -> bool signature"
 )]

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -557,7 +557,6 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1,7 +1,5 @@
 //! Config load/save and binding-map tests.
 
-#![allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
-
 use std::{assert_matches, fs};
 
 use super::*;

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -422,11 +422,6 @@ pub struct DeviceInventory {
 
 #[cfg(test)]
 mod tests {
-    #![allow(
-        clippy::expect_used,
-        reason = "range fixture construction is intentionally asserted in tests"
-    )]
-
     use super::{
         BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
         DeviceModelInfo, DeviceTransports, LightValueRange, LightValueUnit, PairedDevice,

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -95,7 +95,7 @@ impl DeviceKind {
 /// actually announced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(
+#[expect(
     clippy::struct_excessive_bools,
     reason = "capabilities is a serialized feature-bit DTO; independent booleans keep the IPC/config shape explicit"
 )]
@@ -295,7 +295,7 @@ impl DeviceModelInfo {
 /// device firmware exposes. The shape is dictated by HID++ feature 0x0003;
 /// a state machine doesn't fit since a single device can announce multiple
 /// transports simultaneously.
-#[allow(
+#[expect(
     clippy::struct_excessive_bools,
     reason = "bitfield mirroring HID++ DeviceInformation; transports are independent flags"
 )]

--- a/crates/openlogi-core/src/device/light.rs
+++ b/crates/openlogi-core/src/device/light.rs
@@ -195,10 +195,6 @@ impl<'de> Deserialize<'de> for LightValueRange {
 /// advertise a control merely because the product is classified as a light.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(
-    clippy::struct_excessive_bools,
-    reason = "independent optional light controls are a serialized capability DTO"
-)]
 pub struct LightCapabilities {
     /// Whether the driver can switch the light on and off.
     pub power: bool,

--- a/crates/openlogi-core/src/diagnostics.rs
+++ b/crates/openlogi-core/src/diagnostics.rs
@@ -503,7 +503,6 @@ fn opt_num<T: std::fmt::Display>(value: Option<T>) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{
         AppInfo, AssetInfo, AssetSource, ConnectionKind, DeviceDiag, DiagnosticsReport,

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -161,7 +161,6 @@ pub fn agent_socket_path() -> Result<PathBuf, PathsError> {
 
 #[cfg(test)]
 #[cfg(unix)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-core/src/single_instance.rs
+++ b/crates/openlogi-core/src/single_instance.rs
@@ -24,10 +24,6 @@ use crate::paths::{self, PathsError};
 /// releases the underlying file lock at the same time). The `_handle` field
 /// is intentionally unused — the value is alive only for its `Drop` side
 /// effect of closing the fd.
-#[allow(
-    dead_code,
-    reason = "the File is held only so the OS keeps the lock — not read again"
-)]
 pub struct InstanceGuard {
     _handle: File,
 }

--- a/crates/openlogi-desktop/build.rs
+++ b/crates/openlogi-desktop/build.rs
@@ -19,7 +19,7 @@
 //! the exact version already in the lock as gpui's own build-dependency, which
 //! adds an edge, not a crate.
 
-#![allow(
+#![expect(
     clippy::expect_used,
     reason = "a build script fails by panicking, so expect — whose message surfaces in the build log — is the idiomatic error path"
 )]

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -580,11 +580,6 @@ impl Render for AppView {
 
 #[cfg(test)]
 mod tests {
-    #![allow(
-        clippy::expect_used,
-        reason = "capability fixture construction is intentionally asserted in tests"
-    )]
-
     use super::home::connection_icon_path;
     use super::{Capabilities, DetailTab, DeviceKind, DeviceRecord, battery_charging_no_reading};
     use openlogi_core::device::{

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -172,11 +172,10 @@ pub struct AppView {
     camera_preview: Entity<CameraPreview>,
     camera_controls: Entity<CameraControlsPanel>,
     light_panel: Entity<LightPanel>,
-    #[allow(dead_code, reason = "held to keep the appearance observer alive")]
     appearance_obs: Option<Subscription>,
     /// Re-renders the root when the device list changes so the empty state
     /// swaps to the device UI (and back) on hot-plug, without a restart.
-    #[allow(dead_code, reason = "held to keep the AppState observer alive")]
+    #[expect(dead_code, reason = "held to keep the AppState observer alive")]
     state_obs: Subscription,
     accessibility_dismissed: bool,
     /// Which section of the device-detail screen is showing.
@@ -404,7 +403,7 @@ fn app_title_bar(pal: Palette) -> impl IntoElement {
 }
 
 impl Render for AppView {
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "root view assembles every screen branch inline"
     )]

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -26,7 +26,7 @@ pub struct ActionRingPanel {
     application_input: Option<Entity<InputState>>,
     shortcut_input: Option<Entity<InputState>>,
     library_scroll: ScrollHandle,
-    #[allow(dead_code, reason = "held to keep the AppState observer alive")]
+    #[expect(dead_code, reason = "held to keep the AppState observer alive")]
     state_obs: Subscription,
 }
 

--- a/crates/openlogi-desktop/src/features/action_ring/editor.rs
+++ b/crates/openlogi-desktop/src/features/action_ring/editor.rs
@@ -317,7 +317,6 @@ fn commit_icon(slot: ActionRingSlot, icon: Option<ActionRingIcon>, cx: &mut gpui
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use gpui::{
         Context, PlatformInput, Render, ScrollDelta, ScrollHandle, ScrollWheelEvent,

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -11,10 +11,9 @@
 //! Streaming / Video call) plus user-saved customs, applied to the hardware in
 //! a single batched device-open.
 
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
-    clippy::cast_sign_loss,
     reason = "UVC control values are small integers; slider math goes through f32"
 )]
 
@@ -79,7 +78,7 @@ pub struct CameraControlsPanel {
     uid: Option<String>,
     sliders: Vec<ControlSlider>,
     autos: Vec<AutoRow>,
-    #[allow(dead_code, reason = "held to keep the AppState observer alive")]
+    #[expect(dead_code, reason = "held to keep the AppState observer alive")]
     state_obs: Subscription,
 }
 
@@ -88,7 +87,7 @@ struct ControlSlider {
     label: SharedString,
     range: ControlRange,
     state: Entity<SliderState>,
-    #[allow(dead_code, reason = "held to keep the slider subscription alive")]
+    #[expect(dead_code, reason = "held to keep the slider subscription alive")]
     sub: Subscription,
 }
 

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -11,12 +11,6 @@
 //! Streaming / Video call) plus user-saved customs, applied to the hardware in
 //! a single batched device-open.
 
-#![expect(
-    clippy::cast_possible_truncation,
-    clippy::cast_precision_loss,
-    reason = "UVC control values are small integers; slider math goes through f32"
-)]
-
 use gpui::{
     AnyElement, AppContext as _, BorrowAppContext as _, ClickEvent, Context, Entity,
     InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Render,
@@ -286,7 +280,7 @@ impl CameraControlsPanel {
         cx: &mut Context<Self>,
     ) {
         let state = cx.new(|_| {
-            let (lo, hi) = (range.min as f32, range.max as f32);
+            let (lo, hi) = (to_slider(range.min), to_slider(range.max));
             // `SliderState` defaults to [0, 100] and re-clamps its value on every
             // builder call, panicking if min > max even transiently. A fully
             // negative range (UVC exposure reports e.g. -11..-2) would make
@@ -297,7 +291,7 @@ impl CameraControlsPanel {
             } else {
                 SliderState::new().max(hi).min(lo)
             };
-            bounded.step(1.0).default_value(shown as f32)
+            bounded.step(1.0).default_value(to_slider(shown))
         });
         let uid_for_event = uid.to_string();
         let key_for_event = key.to_string();
@@ -307,7 +301,7 @@ impl CameraControlsPanel {
                 // so we don't flood the camera with intermediate values.
                 SliderEvent::Change(_) => cx.notify(),
                 SliderEvent::Release(value) => {
-                    let v = value.start().round() as i32;
+                    let v = from_slider(value.start());
                     panel.commit_release(control, &uid_for_event, &key_for_event, v, cx);
                 }
             }
@@ -391,7 +385,7 @@ impl CameraControlsPanel {
         {
             values.push((
                 slider.control,
-                slider.state.read(cx).value().start().round() as i32,
+                from_slider(slider.state.read(cx).value().start()),
             ));
         }
         if let Err(e) = openlogi_camera::apply_settings(&uid, &[(toggle, on)], &values) {
@@ -457,7 +451,7 @@ impl CameraControlsPanel {
         for (control, value) in values {
             if let Some(slider) = self.sliders.iter().find(|s| s.control == *control) {
                 slider.state.clone().update(cx, |s, cx| {
-                    s.set_value(*value as f32, window, cx);
+                    s.set_value(to_slider(*value), window, cx);
                 });
             }
         }
@@ -505,7 +499,7 @@ impl CameraControlsPanel {
             });
         }
         state.update(cx, |slider, cx| {
-            slider.set_value(default as f32, window, cx);
+            slider.set_value(to_slider(default), window, cx);
         });
         cx.update_global::<AppState, _>(|state, _| {
             state.commit_camera_control(&key, control, default);
@@ -548,8 +542,8 @@ impl CameraControlsPanel {
                     .iter()
                     .find(|(c, _)| *c == slider.control)
                     .map_or(slider.range.default, |(_, pct)| {
-                        let span = (slider.range.max - slider.range.min) as f32;
-                        slider.range.min + (span * pct).round() as i32
+                        let span = to_slider(slider.range.max - slider.range.min);
+                        slider.range.min + from_slider(span * pct)
                     });
                 values.push((
                     slider.control,
@@ -593,7 +587,7 @@ impl CameraControlsPanel {
         for slider in &self.sliders {
             snap.0.insert(
                 slider.control.name().to_string(),
-                slider.state.read(cx).value().start().round() as i32,
+                from_slider(slider.state.read(cx).value().start()),
             );
         }
         for row in &self.autos {
@@ -859,7 +853,7 @@ fn control_row(
     pal: Palette,
 ) -> AnyElement {
     let slider = &panel.sliders[ix];
-    let value = slider.state.read(cx).value().start().round() as i32;
+    let value = from_slider(slider.state.read(cx).value().start());
     let auto_on = panel.auto_state_for(slider.control);
     let dimmed = auto_on == Some(true);
 
@@ -985,4 +979,26 @@ fn control_label(control: CameraControl) -> SharedString {
         CameraControl::WhiteBalance => tr!("White balance"),
         CameraControl::Tint => tr!("Tint"),
     }
+}
+
+/// UVC control values are integers; the GPUI slider works in `f32`. Both
+/// conversions are exact for the ranges a camera reports (a few hundred at
+/// most), and routing every cast through this pair keeps the justification in
+/// one place instead of a file-wide blanket.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "a UVC control range is orders of magnitude below f32's 24-bit exact integer range"
+)]
+fn to_slider(value: i32) -> f32 {
+    value as f32
+}
+
+/// Inverse of [`to_slider`]. The slider is stepped by 1 over the reported
+/// range, so its value is already a whole number inside that range.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "rounded first, and the slider is bounded by the control's own i32 range"
+)]
+fn from_slider(value: f32) -> i32 {
+    value.round() as i32
 }

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -981,23 +981,19 @@ fn control_label(control: CameraControl) -> SharedString {
     }
 }
 
-/// UVC control values are integers; the GPUI slider works in `f32`. Both
-/// conversions are exact for the ranges a camera reports (a few hundred at
-/// most), and routing every cast through this pair keeps the justification in
-/// one place instead of a file-wide blanket.
+/// A UVC control value as the GPUI slider wants it.
 #[expect(
     clippy::cast_precision_loss,
-    reason = "a UVC control range is orders of magnitude below f32's 24-bit exact integer range"
+    reason = "a UVC control range is far below f32's exact integer range"
 )]
 fn to_slider(value: i32) -> f32 {
     value as f32
 }
 
-/// Inverse of [`to_slider`]. The slider is stepped by 1 over the reported
-/// range, so its value is already a whole number inside that range.
+/// Inverse of [`to_slider`].
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "rounded first, and the slider is bounded by the control's own i32 range"
+    reason = "the slider steps by 1 over the control's own i32 range"
 )]
 fn from_slider(value: f32) -> i32 {
     value.round() as i32

--- a/crates/openlogi-desktop/src/features/keyboard/editors.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/editors.rs
@@ -8,14 +8,11 @@
 //!
 //! [`menu_card`]: crate::features::mouse::picker::menu_card
 
-#![allow(
+#![expect(
     clippy::needless_pass_by_value,
-    clippy::redundant_closure,
     clippy::redundant_closure_for_method_calls,
     reason = "GPUI builders take owned Copy palette values; entity.update wants closures"
 )]
-
-use std::rc::Rc;
 
 use gpui::{
     AnyElement, BorrowAppContext as _, Context, Entity, FontWeight, IntoElement, ParentElement,
@@ -33,7 +30,7 @@ use openlogi_core::binding::{Action, KeyCombo, WorkflowStep};
 use openlogi_core::config::KeyTrigger;
 
 use super::function_row::FunctionRowView;
-use crate::features::mouse::picker::{PickFn, divider, menu_card, menu_row, scroll_list, title};
+use crate::features::mouse::picker::{divider, menu_card, menu_row, scroll_list, title};
 use crate::state::AppState;
 use crate::ui::theme::{Palette, Typography as _};
 
@@ -323,11 +320,6 @@ fn step_preview(step: &WorkflowStep, pal: Palette) -> AnyElement {
 
 fn key_combo_preview(combo: &KeyCombo) -> String {
     combo.rendered_label()
-}
-
-#[allow(dead_code, reason = "kept for parity with the mouse picker")]
-fn _silence_pickfn() -> PickFn {
-    Rc::new(|_a: Action, _w: &mut gpui::Window, _cx: &mut gpui::App| {})
 }
 
 #[cfg(test)]

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -11,10 +11,9 @@
 //! catalog the mouse picker uses, plus a Power User section.
 
 #![expect(
-    clippy::cast_precision_loss,
     clippy::needless_pass_by_value,
     clippy::too_many_arguments,
-    reason = "GPUI builders take owned Copy palette/slots; layout math uses small f32 counts"
+    reason = "GPUI builders take owned Copy palette values and slot tables"
 )]
 // Not `expect`: the only float_cmp sites are `assert_eq!` on layout px in the
 // tests below, and rustc does not credit an expectation with a lint raised
@@ -731,6 +730,10 @@ fn key_is_highlighted(idx: usize, selected: Option<usize>, hovered: Option<usize
 /// keys: a dense F-row (a G513 packs Esc-F12 into half the render width)
 /// would otherwise stack the bubbles into an overlapping wall. The leader
 /// lines fan from each bubble down to its true key position.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "idx/count index the function row — at most a couple of dozen keys"
+)]
 fn callout_center_x(idx: usize, count: usize, image_w: f32) -> f32 {
     let margin = KEY_CALLOUT_W / 2.0 + 4.0;
     if count <= 1 {
@@ -998,6 +1001,10 @@ fn legacy_pixel_key_points(asset: &ResolvedAsset) -> Option<Vec<KeyPoint>> {
     if img.origin.width != asset.png_width || img.origin.height != asset.png_height {
         return None;
     }
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "depot image dimensions are a few thousand pixels at most"
+    )]
     let (w, h) = (img.origin.width as f32, img.origin.height as f32);
 
     let mut markers: Vec<KeyPoint> = img
@@ -1090,6 +1097,10 @@ fn synthesized_esc_x(first_function_key_x: f32) -> f32 {
     (first_function_key_x - 0.045).max(0.02)
 }
 
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "FUNCTION_KEYS is a fixed table of a dozen entries"
+)]
 fn fallback_key_x_fractions() -> Vec<f32> {
     let step = (EVEN_SPACING_END - EVEN_SPACING_START) / (FUNCTION_KEYS.len() - 1) as f32;
     (0..FUNCTION_KEYS.len())
@@ -1320,6 +1331,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "lane counts are bounded by FUNCTION_KEYS"
+    )]
     fn staggered_function_key_callout_rows_fit_the_keyboard_width() {
         let lower_count = FUNCTION_KEYS
             .iter()

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -15,13 +15,11 @@
     clippy::too_many_arguments,
     reason = "GPUI builders take owned Copy palette values and slot tables"
 )]
-// Not `expect`: the only float_cmp sites are `assert_eq!` on layout px in the
-// tests below, and rustc does not credit an expectation with a lint raised
-// inside a macro expansion — it would suppress the warning and then report
-// itself unfulfilled, which `-D warnings` turns into an unfixable error.
+// Not `expect`: these fire inside `assert_eq!`, and rustc does not credit an
+// expectation with a lint raised in a macro expansion.
 #![allow(
     clippy::float_cmp,
-    reason = "callout layout px are computed by the same code path in test and product, so equality is exact"
+    reason = "test and product compute the callout px through the same path"
 )]
 
 use std::rc::Rc;

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -10,12 +10,19 @@
 //! [`AppState::commit_keyboard_binding`]. The panel lists the same action
 //! catalog the mouse picker uses, plus a Power User section.
 
-#![allow(
+#![expect(
     clippy::cast_precision_loss,
-    clippy::float_cmp,
     clippy::needless_pass_by_value,
     clippy::too_many_arguments,
     reason = "GPUI builders take owned Copy palette/slots; layout math uses small f32 counts"
+)]
+// Not `expect`: the only float_cmp sites are `assert_eq!` on layout px in the
+// tests below, and rustc does not credit an expectation with a lint raised
+// inside a macro expansion — it would suppress the warning and then report
+// itself unfulfilled, which `-D warnings` turns into an unfixable error.
+#![allow(
+    clippy::float_cmp,
+    reason = "callout layout px are computed by the same code path in test and product, so equality is exact"
 )]
 
 use std::rc::Rc;
@@ -159,7 +166,7 @@ impl FunctionRowView {
         self.select_key(next_selection_after_click(self.selected_key, idx), cx);
     }
 
-    #[allow(dead_code, reason = "public accessor for the selection state")]
+    #[expect(dead_code, reason = "public accessor for the selection state")]
     pub(crate) fn selected_key(&self) -> Option<usize> {
         self.selected_key
     }

--- a/crates/openlogi-desktop/src/features/lighting/device.rs
+++ b/crates/openlogi-desktop/src/features/lighting/device.rs
@@ -199,7 +199,7 @@ fn toggle(current: &Lighting, pal: Palette) -> AnyElement {
 }
 
 /// Snap a raw slider read to a 0–100 brightness percent.
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     reason = "value is rounded and clamped into 0..=100 before the cast"

--- a/crates/openlogi-desktop/src/features/lighting/standalone.rs
+++ b/crates/openlogi-desktop/src/features/lighting/standalone.rs
@@ -511,11 +511,6 @@ fn light_command_status(status: LightCommandStatus, pal: Palette) -> impl IntoEl
 
 #[cfg(test)]
 mod tests {
-    #![allow(
-        clippy::expect_used,
-        reason = "range fixture construction is intentionally asserted in tests"
-    )]
-
     use super::{format_light_value, midpoint};
     use openlogi_core::device::{LightValueRange, LightValueUnit};
 

--- a/crates/openlogi-desktop/src/features/lighting/standalone.rs
+++ b/crates/openlogi-desktop/src/features/lighting/standalone.rs
@@ -479,7 +479,7 @@ fn midpoint(range: LightValueRange) -> u16 {
     range.quantize(range.min() + (range.max() - range.min()) / 2)
 }
 
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     reason = "the slider value is clamped to the u16 range before conversion"

--- a/crates/openlogi-desktop/src/features/mouse/geometry.rs
+++ b/crates/openlogi-desktop/src/features/mouse/geometry.rs
@@ -22,7 +22,7 @@ const ASSET_HOTSPOT: f32 = 56.;
 /// is typically narrower than the full image (Logi pads transparent strips on
 /// both sides); sizing by origin causes `ObjectFit::Contain` to letterbox
 /// vertically and pulls every hotspot off the rendered button.
-#[allow(
+#[expect(
     clippy::cast_precision_loss,
     reason = "device images are < 4096 px on either axis — well within f32 mantissa"
 )]
@@ -68,7 +68,7 @@ pub fn asset_has_button_labels(asset: &ResolvedAsset) -> bool {
 /// Primary left/right clicks deliberately have no entry — Logi never
 /// exposes them as remappable (and Options+ doesn't either), so we don't
 /// invent markers for them.
-#[allow(
+#[expect(
     clippy::cast_precision_loss,
     reason = "device images are < 4096 px on either axis — well within f32 mantissa"
 )]
@@ -113,7 +113,7 @@ pub fn asset_hotspots_for_png(asset: &ResolvedAsset, mouse_w: f32, mouse_h: f32)
 /// Lay labels out on the left side, evenly spaced down the mouse's vertical
 /// extent. Slots are assigned in order of the hotspots' y position (top
 /// hotspot → top label) so leader lines don't cross.
-#[allow(
+#[expect(
     clippy::cast_precision_loss,
     reason = "hotspot count is bounded by ButtonId variants — well under f32 mantissa"
 )]

--- a/crates/openlogi-desktop/src/features/mouse/hotspots.rs
+++ b/crates/openlogi-desktop/src/features/mouse/hotspots.rs
@@ -3,11 +3,6 @@
 //! stored as plain `f32` tuples so this module stays purely data and doesn't
 //! drag in `gpui` types.
 
-#![allow(
-    dead_code,
-    reason = "scaffolding consumed by UI.md phases 3–6 (carousel, popover, hotspots)"
-)]
-
 use openlogi_core::binding::ButtonId;
 
 /// One visual target in the mouse diagram.

--- a/crates/openlogi-desktop/src/features/mouse/leader_lines.rs
+++ b/crates/openlogi-desktop/src/features/mouse/leader_lines.rs
@@ -18,7 +18,7 @@ const STUB: f32 = 10.;
 /// view (the right half of the window is reserved for the DPI / gesture
 /// column) but the routing logic is kept so labels can move later.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(
+#[expect(
     dead_code,
     reason = "Right variant kept for future right-side labelling"
 )]

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -304,7 +304,7 @@ fn breathing_art(
         .child(device_art)
 }
 
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "layout inputs + hover/active/gesture state; bundling would just hide the dependency"
 )]
@@ -382,7 +382,7 @@ where
 /// host a Popover whose trigger is the label card itself. Same picker
 /// content as the hotspot dot — clicking either entry point lands on the
 /// same binding flow.
-#[allow(
+#[expect(
     clippy::too_many_arguments,
     reason = "wrapper position + trigger \
 state both need this many inputs; bundling would just hide the dependency"

--- a/crates/openlogi-desktop/src/platform/os.rs
+++ b/crates/openlogi-desktop/src/platform/os.rs
@@ -5,8 +5,8 @@ use openlogi_core::config::Appearance;
 
 /// The OS product version (e.g. `"15.5"` on macOS), or `None` when unavailable.
 #[must_use]
-// Not `expect`: the lint only fires on the macOS arm, which always returns
-// `Some`. Off macOS the body is `None` and the expectation would go unfulfilled.
+// Not `expect`: only the macOS arm returns `Some`, so off macOS the lint never
+// fires and the expectation would go unfulfilled.
 #[allow(
     clippy::unnecessary_wraps,
     reason = "Option is the cross-platform contract; non-macOS arms return None"

--- a/crates/openlogi-desktop/src/platform/os.rs
+++ b/crates/openlogi-desktop/src/platform/os.rs
@@ -5,6 +5,8 @@ use openlogi_core::config::Appearance;
 
 /// The OS product version (e.g. `"15.5"` on macOS), or `None` when unavailable.
 #[must_use]
+// Not `expect`: the lint only fires on the macOS arm, which always returns
+// `Some`. Off macOS the body is `None` and the expectation would go unfulfilled.
 #[allow(
     clippy::unnecessary_wraps,
     reason = "Option is the cross-platform contract; non-macOS arms return None"

--- a/crates/openlogi-desktop/src/platform/os.rs
+++ b/crates/openlogi-desktop/src/platform/os.rs
@@ -7,6 +7,7 @@ use openlogi_core::config::Appearance;
 #[must_use]
 // Not `expect`: only the macOS arm returns `Some`, so off macOS the lint never
 // fires and the expectation would go unfulfilled.
+#[expect(clippy::allow_attributes, reason = "see above")]
 #[allow(
     clippy::unnecessary_wraps,
     reason = "Option is the cross-platform contract; non-macOS arms return None"

--- a/crates/openlogi-desktop/src/services/assets.rs
+++ b/crates/openlogi-desktop/src/services/assets.rs
@@ -104,10 +104,6 @@ fn open_in_file_manager(path: &Path) {
 
 #[derive(Debug, Clone)]
 pub struct ResolvedAsset {
-    #[allow(
-        dead_code,
-        reason = "depot label will be surfaced in the carousel tooltip (P0.4+)"
-    )]
     pub depot: String,
     pub display_name: String,
     /// The registry's curated device type for this model, normalized from the

--- a/crates/openlogi-desktop/src/services/assets.rs
+++ b/crates/openlogi-desktop/src/services/assets.rs
@@ -474,7 +474,6 @@ fn suffix_candidates(model: &DeviceModelInfo) -> Vec<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
     use openlogi_assets::DeviceEntry;

--- a/crates/openlogi-desktop/src/services/assets/glow.rs
+++ b/crates/openlogi-desktop/src/services/assets/glow.rs
@@ -135,7 +135,7 @@ fn compute_glow_geometry(image_path: &Path) -> Option<GlowGeometry> {
         }
     }
 
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
         reason = "mask coords are < 8192 px — well within f32 mantissa"
     )]
@@ -149,7 +149,7 @@ fn compute_glow_geometry(image_path: &Path) -> Option<GlowGeometry> {
                 while x < w && cells[(y * w + x) as usize] == 1 {
                     x += 1;
                 }
-                #[allow(
+                #[expect(
                     clippy::cast_precision_loss,
                     reason = "mask coords are < 8192 px — well within f32 mantissa"
                 )]
@@ -178,7 +178,7 @@ impl GlowGeometry {
     /// crosses a row boundary is split so every segment stays on one row.
     /// `None` if the stored dimensions are out of range or the runs don't cover
     /// exactly `width * height`.
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
         reason = "mask coords are < 8192 px — well within f32 mantissa"
     )]

--- a/crates/openlogi-desktop/src/services/assets/glow.rs
+++ b/crates/openlogi-desktop/src/services/assets/glow.rs
@@ -225,7 +225,6 @@ impl GlowGeometry {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -586,7 +586,7 @@ fn rpc_result<T>(r: Result<T, tarpc::client::RpcError>) -> Result<T, ()> {
 
 /// Reply to a read command that the agent is unreachable; writes are
 /// fire-and-forget so they have nothing to reply to.
-#[allow(
+#[expect(
     clippy::match_same_arms,
     reason = "the two read arms send the same disconnect error to differently-typed reply channels, so they can't be merged"
 )]

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -111,7 +111,10 @@ pub enum ConfigPersistence {
     /// A load error made the config unsafe to write for this process lifetime.
     ReadOnly(String),
     /// Keep changes in the in-memory [`Config`] only.
-    #[cfg_attr(not(test), allow(dead_code, reason = "test-only persistence boundary"))]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "test-only persistence boundary")
+    )]
     MemoryOnly,
 }
 

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -1,10 +1,5 @@
 //! AppState unit tests.
 
-#![allow(
-    clippy::expect_used,
-    reason = "state fixture construction is intentionally asserted in tests"
-)]
-
 use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_core::config::{
     Config, DeviceIdentity, LightSettings, Lighting, ScrollResolution, ThumbwheelSensitivity,

--- a/crates/openlogi-desktop/src/ui/carousel.rs
+++ b/crates/openlogi-desktop/src/ui/carousel.rs
@@ -60,7 +60,7 @@ pub struct Carousel {
     on_select: Option<SelectHandler>,
 }
 
-#[allow(
+#[expect(
     dead_code,
     reason = "complete, reusable carousel API — not every builder option is exercised by the current device-list call site"
 )]

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -156,9 +156,8 @@ fn start_search(cx: &mut App) {
 /// Standalone Add Device window root view.
 pub struct AddDeviceView {
     focus_handle: FocusHandle,
-    #[allow(dead_code, reason = "held to keep the appearance observer alive")]
     appearance_obs: Option<Subscription>,
-    #[allow(dead_code, reason = "held to keep the PairingUi observer alive")]
+    #[expect(dead_code, reason = "held to keep the PairingUi observer alive")]
     state_obs: Subscription,
 }
 

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -103,7 +103,6 @@ pub(super) enum ThemeFilter {
 /// Standalone Settings window root view.
 pub struct SettingsView {
     focus_handle: FocusHandle,
-    #[allow(dead_code, reason = "held to keep the appearance observer alive")]
     appearance_obs: Option<Subscription>,
     /// Which themes the Appearance grid shows (All / Light / Dark).
     theme_filter: ThemeFilter,
@@ -119,7 +118,7 @@ pub struct SettingsView {
     /// Shared app-wide updater, surfaced on the Updates page. A launch-time
     /// check result is already visible when the window opens.
     updater: Entity<Updater>,
-    #[allow(
+    #[expect(
         dead_code,
         reason = "held to re-render the Updates page on status change"
     )]
@@ -141,10 +140,6 @@ pub struct SettingsView {
 }
 
 impl SettingsView {
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "sensitivity bounds are tiny 1..=100 integers — exact in f32"
-    )]
     fn new(initial_page: SettingsPage, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         focus_handle.focus(window, cx);
@@ -253,7 +248,7 @@ impl SettingsView {
     /// Commit the thumb-wheel sensitivity slider. The label tracks the live
     /// slider value on every `Change`; persistence (and the one shared-atomic
     /// write the watcher reads) happens once on `Release`.
-    #[allow(
+    #[expect(
         clippy::unused_self,
         reason = "gpui subscription handlers must take &mut self"
     )]

--- a/crates/openlogi-desktop/src/windows/settings/assets.rs
+++ b/crates/openlogi-desktop/src/windows/settings/assets.rs
@@ -152,7 +152,7 @@ pub(super) fn assets_page(
         .group(group)
 }
 
-#[allow(
+#[expect(
     clippy::needless_pass_by_value,
     reason = "built inside an `Fn` render closure, so a `&Entity` parameter would make \
               the returned element borrow a captured variable; `Entity` is a cheap handle"
@@ -190,7 +190,7 @@ fn refresh_cache_desc_after(view: &Entity<SettingsView>, delay: Duration, cx: &m
 /// Computed once when the Settings window opens (`asset_cache_desc`), not per
 /// render.
 pub(super) fn cache_size_description() -> SharedString {
-    #[allow(
+    #[expect(
         clippy::cast_precision_loss,
         reason = "the cache is at most a few hundred MB; f64 is exact far past that, \
                   and this is a display-only size"

--- a/crates/openlogi-desktop/src/windows/settings/language.rs
+++ b/crates/openlogi-desktop/src/windows/settings/language.rs
@@ -60,7 +60,7 @@ pub(super) fn selected_language_index(
 
 /// The language picker field. "Follow system" clears the stored preference
 /// (`None`); explicit locale entries come from [`openlogi_ui::locale::SUPPORTED`].
-#[allow(
+#[expect(
     clippy::needless_pass_by_value,
     reason = "built inside an `Fn` render closure, so a `&Entity` parameter would make \
               the returned element borrow a captured variable; `Entity` is a cheap handle"

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -18,7 +18,7 @@ use openlogi_permissions as permissions;
     not(any(target_os = "macos", target_os = "linux")),
     allow(
         unused_variables,
-        reason = "`has_camera` only gates a macOS/Linux permission row; every other platform builds an empty page"
+        reason = "`has_camera` only gates a macOS/Linux row; elsewhere the page is empty"
     )
 )]
 pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -16,7 +16,10 @@ use openlogi_permissions as permissions;
 
 #[cfg_attr(
     not(any(target_os = "macos", target_os = "linux")),
-    allow(unused_variables)
+    allow(
+        unused_variables,
+        reason = "`has_camera` only gates a macOS/Linux permission row; every other platform builds an empty page"
+    )
 )]
 pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
     let page = SettingPage::new(tr!("Permissions"))

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -16,7 +16,7 @@ use openlogi_permissions as permissions;
 
 #[cfg_attr(
     not(any(target_os = "macos", target_os = "linux")),
-    allow(
+    expect(
         unused_variables,
         reason = "`has_camera` only gates a macOS/Linux row; elsewhere the page is empty"
     )

--- a/crates/openlogi-desktop/src/windows/update_consent.rs
+++ b/crates/openlogi-desktop/src/windows/update_consent.rs
@@ -26,7 +26,6 @@ use crate::windows::{self, AuxWindow};
 /// Standalone first-run update-consent window root view.
 pub struct UpdateConsentView {
     focus_handle: FocusHandle,
-    #[allow(dead_code, reason = "held to keep the appearance observer alive")]
     appearance_obs: Option<Subscription>,
 }
 

--- a/crates/openlogi-hid/src/channel/transport.rs
+++ b/crates/openlogi-hid/src/channel/transport.rs
@@ -94,8 +94,11 @@ fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
 // Windows routes short vs long by report id over the composite channel
 // (WindowsHidppChannel), so the long-only up-conversion path — and thus this
 // helper — is only reached off Windows. Still compiled + unit-tested there.
+// Not `expect`: the lint fires in the `--lib` build and not in the `--test`
+// one, so an expectation is always unfulfilled for one of them.
 #[cfg_attr(
     target_os = "windows",
+    expect(clippy::allow_attributes, reason = "see above"),
     allow(
         dead_code,
         reason = "long-only up-conversion is the non-Windows AsyncHidChannel path"

--- a/crates/openlogi-hid/src/inventory.rs
+++ b/crates/openlogi-hid/src/inventory.rs
@@ -728,5 +728,4 @@ impl Enumerator {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests;

--- a/crates/openlogi-hid/src/session/host_switch.rs
+++ b/crates/openlogi-hid/src/session/host_switch.rs
@@ -519,7 +519,6 @@ fn event_host(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/openlogi-hid/src/write.rs
+++ b/crates/openlogi-hid/src/write.rs
@@ -102,5 +102,4 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests;

--- a/crates/openlogi-hid/src/write/litra.rs
+++ b/crates/openlogi-hid/src/write/litra.rs
@@ -263,11 +263,6 @@ pub async fn apply(
 
 #[cfg(test)]
 mod tests {
-    #![allow(
-        clippy::expect_used,
-        reason = "expect is idiomatic in pure encoding tests"
-    )]
-
     use std::assert_matches;
 
     use super::{

--- a/crates/openlogi-hidpp-derive/src/lib.rs
+++ b/crates/openlogi-hidpp-derive/src/lib.rs
@@ -228,11 +228,6 @@ fn event_source_arg(ty: &Type) -> Option<Type> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "unwrap/expect are idiomatic in tests"
-)]
 mod tests {
     use quote::quote;
 

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -23,11 +23,6 @@ mod message;
 mod raw;
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 pub(crate) mod tests;
 
 pub use error::ChannelError;

--- a/crates/openlogi-hidpp/src/device.rs
+++ b/crates/openlogi-hidpp/src/device.rs
@@ -252,11 +252,6 @@ async fn read_feature_entry(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/openlogi-hidpp/src/emitter.rs
+++ b/crates/openlogi-hidpp/src/emitter.rs
@@ -36,11 +36,6 @@ impl<T: Clone> EventEmitter<T> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-hidpp/src/feature.rs
+++ b/crates/openlogi-hidpp/src/feature.rs
@@ -297,11 +297,6 @@ bitflags::bitflags! {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 mod tests {
     use super::event_payload;
     use crate::{

--- a/crates/openlogi-hidpp/src/feature/adjustable_dpi.rs
+++ b/crates/openlogi-hidpp/src/feature/adjustable_dpi.rs
@@ -109,7 +109,6 @@ fn parse_dpi_list_payload(bytes: &[u8]) -> Result<Vec<u16>, Hidpp20Error> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/backlight.rs
+++ b/crates/openlogi-hidpp/src/feature/backlight.rs
@@ -349,7 +349,6 @@ impl BacklightInfoUpdate {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{
         BacklightEffect, BacklightInfoUpdate, BacklightMode, BacklightOptions, BacklightStatus,

--- a/crates/openlogi-hidpp/src/feature/color_led_effects/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/color_led_effects/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `ColorLedEffects` payload parsing and event decoding.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/crown/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/crown/tests.rs
@@ -1,9 +1,4 @@
 //! Unit tests for `Crown` mode parsing and event decoding.
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/dual_platform.rs
+++ b/crates/openlogi-hidpp/src/feature/dual_platform.rs
@@ -85,7 +85,6 @@ impl DualPlatformFeature {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::DualPlatformSelection;
 

--- a/crates/openlogi-hidpp/src/feature/equalizer/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/equalizer/tests.rs
@@ -1,12 +1,6 @@
 //! Unit tests for `Equalizer` payload parsing, using the spec's worked example
 //! (10 bands at ±12 dB).
 
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
-
 use super::{
     EqCapabilities, EqInfo, GainLocation, GainPersistence, parse_frequency_page, parse_gains,
 };

--- a/crates/openlogi-hidpp/src/feature/extended_dpi/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/extended_dpi/tests.rs
@@ -1,11 +1,5 @@
 //! Unit tests for `ExtendedAdjustableDpi` payload parsing and event decoding.
 
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
-
 use std::assert_matches;
 
 use super::event::{ExtendedDpiEvent, decode_event};

--- a/crates/openlogi-hidpp/src/feature/fn_inversion.rs
+++ b/crates/openlogi-hidpp/src/feature/fn_inversion.rs
@@ -163,7 +163,6 @@ impl FnInversionWithDefaultStateFeature {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{
         FnInversionInfo, FnInversionState, GlobalFnInversion, set_multi_host_fn_inversion_args,

--- a/crates/openlogi-hidpp/src/feature/gestures2.rs
+++ b/crates/openlogi-hidpp/src/feature/gestures2.rs
@@ -134,7 +134,6 @@ impl Gestures2Feature {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-hidpp/src/feature/illumination/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/illumination/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `Illumination` payload parsing and event decoding.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/mouse_pointer.rs
+++ b/crates/openlogi-hidpp/src/feature/mouse_pointer.rs
@@ -87,7 +87,6 @@ impl MousePointerInfo {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{MousePointerInfo, PointerAcceleration};
 

--- a/crates/openlogi-hidpp/src/feature/per_key_lighting/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/per_key_lighting/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `PerKeyLighting` request encoding.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/persistent_remappable_action/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/persistent_remappable_action/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `PersistentRemappableAction` payload parsing.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/rgb_effects/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/rgb_effects/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `RgbEffects` payload parsing and event decoding.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use super::event::{RgbEffectsEvent, decode_event};
 use super::types::{

--- a/crates/openlogi-hidpp/src/feature/smartshift_enhanced.rs
+++ b/crates/openlogi-hidpp/src/feature/smartshift_enhanced.rs
@@ -124,7 +124,6 @@ impl SmartShiftEnhancedStatus {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{Hidpp20Error, SmartShiftEnhancedStatus, WheelMode};
 

--- a/crates/openlogi-hidpp/src/feature/solar_dashboard/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/solar_dashboard/tests.rs
@@ -1,6 +1,5 @@
 //! Unit tests for `SolarKeyboardDashboard` event decoding, using the spec's
 //! worked examples (battery 96%, light 0 / 319 lux).
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use super::LedId;
 use super::event::{SolarEvent, SolarStatus, decode_event};

--- a/crates/openlogi-hidpp/src/feature/touch_mouse_raw/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/touch_mouse_raw/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `TouchMouseRaw` info parsing and raw-event decoding.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use super::event::{TouchMousePoint, TouchMouseRawEvent, TouchMouseStatus, decode_event};
 use super::{Origin, RawMode, TouchMouseInfo};

--- a/crates/openlogi-hidpp/src/feature/touchpad_raw_xy/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/touchpad_raw_xy/tests.rs
@@ -1,5 +1,4 @@
 //! Unit tests for `TouchpadRawXy` info parsing and raw-event decoding.
-#![allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 
 use std::assert_matches;
 

--- a/crates/openlogi-hidpp/src/feature/vertical_scrolling.rs
+++ b/crates/openlogi-hidpp/src/feature/vertical_scrolling.rs
@@ -87,7 +87,6 @@ impl From<u8> for ScrollLines {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::{RollerInfo, RollerType, ScrollLines};
 

--- a/crates/openlogi-hidpp/src/receiver/bolt/event.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt/event.rs
@@ -394,11 +394,6 @@ pub enum PairingPasskeyPressType {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 mod tests {
     use super::{
         DeviceConnection, DeviceKind, Event, PairingError, PairingPasskeyPressType, decode,

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -372,11 +372,6 @@ pub enum Event {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "expect/unwrap are idiomatic in tests"
-)]
 mod tests {
     use super::{DeviceConnection, DeviceKind, Event, decode_notification};
     use crate::protocol::v10::{Message, MessageHeader};

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -18,7 +18,7 @@
 //! group) and write access to `/dev/uinput` (the `input` or `uinput` group, or
 //! a `udev` rule granting access). Without those, `start()` returns
 //! [`crate::HookError::Linux`].
-#![allow(
+#![expect(
     unsafe_code,
     reason = "the wake pipe and the Wayland toplevel listener call libc directly"
 )]

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -1014,7 +1014,6 @@ pub(crate) fn stop(inner: HookInner) {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -1,5 +1,5 @@
 //! macOS `CGEventTap` implementation of the OS-level mouse hook.
-#![allow(
+#![expect(
     unsafe_code,
     reason = "the event tap is built on Core Graphics / Core Foundation C APIs"
 )]
@@ -394,7 +394,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             let sender = event_sender_id(event);
             let device_info = sender.map(sender_device_info);
             let from_trackpad = device_info.as_ref().map_or(phase, |info| info.is_trackpad);
-            #[allow(
+            #[expect(
                 clippy::cast_possible_truncation,
                 reason = "scroll deltas are small fractional values that fit comfortably in f32"
             )]
@@ -414,7 +414,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
         | CGEventType::OtherMouseDragged => {
             let dx = event.get_integer_value_field(EventField::MOUSE_EVENT_DELTA_X);
             let dy = event.get_integer_value_field(EventField::MOUSE_EVENT_DELTA_Y);
-            #[allow(
+            #[expect(
                 clippy::cast_possible_truncation,
                 reason = "per-event pointer deltas are small integers, far within i32"
             )]
@@ -469,7 +469,7 @@ const MOMENTUM_PHASE: CGEventField = 123; // kCGScrollWheelEventMomentumPhase
 /// fixed-point, then the integer line — the order the reference tools use, so a
 /// hi-res wheel (which reports in the pixel field with the line field at 0) is
 /// not mistaken for "no scroll".
-#[allow(
+#[expect(
     clippy::cast_precision_loss,
     reason = "scroll line deltas are small integers, exact in f64"
 )]
@@ -725,7 +725,7 @@ fn spawn_lifecycle_watchdog(
 }
 
 /// Body of the background hook thread.
-#[allow(
+#[expect(
     clippy::needless_pass_by_value,
     reason = "rl_tx must be owned: dropping it signals the parent's recv() to return Err on failure paths"
 )]
@@ -892,12 +892,6 @@ fn disable_tap(tap: &CGEventTap) {
 /// `min_usec_latency`) so `CGGetEventTapList` writes into the right offsets.
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[allow(
-    dead_code,
-    reason = "events_of_interest and the latency floats are unread but must \
-              exist so the struct keeps CoreGraphics' exact 48-byte stride; \
-              CGGetEventTapList writes whole records into the buffer"
-)]
 struct CGEventTapInformation {
     event_tap_id: u32,
     tap_point: u32,

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -1,10 +1,10 @@
 //! Windows `WH_MOUSE_LL` + `WH_KEYBOARD_LL` implementation of the OS-level
 //! input hook.
-#![allow(
+#![expect(
     unsafe_code,
     reason = "the low-level input hook is built on the Win32 C API"
 )]
-#![allow(
+#![expect(
     clippy::borrow_as_ptr,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -541,7 +541,6 @@ fn last_error(context: &str) -> HookError {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -4,13 +4,6 @@
     unsafe_code,
     reason = "the low-level input hook is built on the Win32 C API"
 )]
-#![expect(
-    clippy::borrow_as_ptr,
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::needless_pass_by_value,
-    reason = "Win32 FFI uses raw pointer parameters and fixed-width message values"
-)]
 
 use std::cell::Cell;
 use std::sync::{Arc, Mutex, mpsc};
@@ -105,6 +98,10 @@ pub(crate) fn stop(mut inner: HookInner) {
     }
 }
 
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "callback and ready are moved into the thread's hook state and channel"
+)]
 fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError>>) {
     match CALLBACK.lock() {
         Ok(mut slot) if slot.is_none() => {
@@ -133,7 +130,7 @@ fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError
     // PostThreadMessageW from `stop` can't race queue creation and be lost.
     unsafe {
         PeekMessageW(
-            &mut bootstrap_msg,
+            &raw mut bootstrap_msg,
             std::ptr::null_mut(),
             WM_USER,
             WM_USER,
@@ -199,14 +196,14 @@ fn message_loop() {
     loop {
         // SAFETY: `msg` is a live, owned MSG; a null window handle retrieves
         // messages for the calling thread. Returns <= 0 on WM_QUIT or error.
-        let result = unsafe { GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0) };
+        let result = unsafe { GetMessageW(&raw mut msg, std::ptr::null_mut(), 0, 0) };
         if result <= 0 {
             break;
         }
         // SAFETY: `msg` was just populated by GetMessageW and outlives the call.
-        unsafe { TranslateMessage(&msg) };
+        unsafe { TranslateMessage(&raw const msg) };
         // SAFETY: as above — `msg` is a live, initialized MSG.
-        unsafe { DispatchMessageW(&msg) };
+        unsafe { DispatchMessageW(&raw const msg) };
     }
 }
 
@@ -232,7 +229,7 @@ fn call_next(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
 /// `code == HC_ACTION`, Windows guarantees `lparam` points to a live
 /// `MSLLHOOKSTRUCT`; [`hook_data`] relies on that contract to dereference it.
 unsafe extern "system" fn mouse_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    if code != HC_ACTION as i32 {
+    if code != HC_ACTION.cast_signed() {
         return call_next(code, wparam, lparam);
     }
 
@@ -275,6 +272,10 @@ unsafe fn hook_data(lparam: LPARAM) -> Option<MSLLHOOKSTRUCT> {
     Some(unsafe { *(lparam as *const MSLLHOOKSTRUCT) })
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "WPARAM/LPARAM are pointer-sized by ABI but carry 32-bit message payloads"
+)]
 fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
     // Every mouse message carries the cursor point, so the baseline advances on
     // all of them: injected motion is dropped below but still moves the cursor,
@@ -365,7 +366,7 @@ fn motion_delta(previous: POINT, pt: POINT) -> Option<(i32, i32)> {
 /// `KBDLLHOOKSTRUCT`; [`key_hook_data`] relies on that contract to
 /// dereference it.
 unsafe extern "system" fn keyboard_proc(code: i32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    if code != HC_ACTION as i32 {
+    if code != HC_ACTION.cast_signed() {
         return call_next(code, wparam, lparam);
     }
 
@@ -413,6 +414,10 @@ unsafe fn key_hook_data(lparam: LPARAM) -> Option<KBDLLHOOKSTRUCT> {
 /// for injected input (our own `SendInput` synthesis must not re-enter the
 /// remapper) and for keys outside the remapper's Esc/F1–F19 vocabulary, which
 /// pass through without ever reaching the callback.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "WPARAM is pointer-sized by ABI but carries a 32-bit message id"
+)]
 fn translate_key(
     wparam: WPARAM,
     data: KBDLLHOOKSTRUCT,
@@ -476,7 +481,7 @@ fn high_word(value: u32) -> u16 {
 }
 
 fn signed_high_word(value: u32) -> i16 {
-    high_word(value) as i16
+    high_word(value).cast_signed()
 }
 
 pub(crate) fn cursor_position() -> Option<CursorPosition> {
@@ -491,6 +496,10 @@ pub(crate) fn cursor_position() -> Option<CursorPosition> {
     })
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the path buffer is a fixed 32768 u16s, so its length fits a u32 by construction"
+)]
 pub(crate) fn frontmost_process_path() -> Option<String> {
     // SAFETY: GetForegroundWindow takes no arguments and returns a window handle
     // or null; no preconditions.
@@ -500,10 +509,10 @@ pub(crate) fn frontmost_process_path() -> Option<String> {
     }
 
     let mut pid = 0;
-    // SAFETY: `hwnd` is the non-null handle just returned; `&mut pid` is a valid
-    // out-pointer the call writes the owning process id into.
+    // SAFETY: `hwnd` is the non-null handle just returned; `&raw mut pid` is a
+    // valid out-pointer the call writes the owning process id into.
     unsafe {
-        GetWindowThreadProcessId(hwnd, &mut pid);
+        GetWindowThreadProcessId(hwnd, &raw mut pid);
     }
     if pid == 0 {
         return None;
@@ -521,7 +530,7 @@ pub(crate) fn frontmost_process_path() -> Option<String> {
     // SAFETY: `process` is the valid handle from OpenProcess; `buf` is a live
     // 32768-u16 buffer and `len` holds its length, so the call writes at most
     // `len` code units and updates `len` with the count written.
-    let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &mut len) };
+    let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &raw mut len) };
     // SAFETY: `process` is the handle from OpenProcess, owned here and closed
     // exactly once now that the query has returned.
     unsafe {

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -498,7 +498,7 @@ pub(crate) fn cursor_position() -> Option<CursorPosition> {
 
 #[expect(
     clippy::cast_possible_truncation,
-    reason = "the path buffer is a fixed 32768 u16s, so its length fits a u32 by construction"
+    reason = "the path buffer is a fixed 32768 u16s"
 )]
 pub(crate) fn frontmost_process_path() -> Option<String> {
     // SAFETY: GetForegroundWindow takes no arguments and returns a window handle

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -154,8 +154,11 @@ pub fn action_device_path() -> Option<std::path::PathBuf> {
 pub const SYNTHETIC_EVENT_USER_DATA: i64 = 0x4F4C_4749;
 
 /// Translate a platform-neutral USB HID keyboard usage to a Win32 virtual key.
+// Not `expect`: the lint fires in the `--lib` build and not in the `--test`
+// one, so an expectation is always unfulfilled for one of them.
 #[cfg_attr(
     not(target_os = "windows"),
+    expect(clippy::allow_attributes, reason = "see above"),
     allow(dead_code, reason = "called only by the Windows backend")
 )]
 fn hid_usage_to_windows(usage: u8) -> Option<u16> {

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -607,7 +607,6 @@ fn try_mpris_command(command: &str) -> Option<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 mod tests {
     use evdev::KeyCode;
     use openlogi_core::binding::{KeyCombo, Shortcut};

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -519,7 +519,7 @@ pub(super) fn post_horizontal_scroll(delta: i32) {
 /// Raw FFI surface for the AXUIElement/CF calls used by [`ax_browser_navigate`]
 /// and its helpers below. Kept as module-level items (rather than nested in
 /// `ax_browser_navigate`) so each helper is independently readable and short.
-#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+#[expect(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
 mod ax_nav {
     use std::ffi::c_void;
 
@@ -565,7 +565,7 @@ struct AxAttrs {
 /// SAFETY: `el` must be a valid AXUIElementRef and `attr` a valid CFStringRef
 /// (the CF memory rules — Get Rule = no extra retain, Create/Copy Rule = +1
 /// retain, caller releases — apply throughout this module).
-#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+#[expect(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
 unsafe fn copy_attr(
     el: ax_nav::AXUIElementRef,
     attr: core_foundation::string::CFStringRef,
@@ -583,7 +583,7 @@ unsafe fn copy_attr(
 /// Read an AX attribute as a String. Internally copies + releases.
 ///
 /// SAFETY: same contract as [`copy_attr`].
-#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+#[expect(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
 unsafe fn attr_string(
     el: ax_nav::AXUIElementRef,
     attr: core_foundation::string::CFStringRef,
@@ -602,7 +602,7 @@ unsafe fn attr_string(
 ///
 /// SAFETY: `el` must be a valid AXUIElementRef and every field of `attrs` a
 /// valid CFStringRef.
-#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+#[expect(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
 unsafe fn find_button(
     el: ax_nav::AXUIElementRef,
     target_id: &str,
@@ -703,7 +703,7 @@ unsafe fn find_button(
 ///
 /// SAFETY: `win` must be a valid AXUIElementRef and `attr_role`/`attr_children`
 /// valid CFStringRefs.
-#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+#[expect(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
 unsafe fn find_nav_button_by_position(
     win: ax_nav::AXUIElementRef,
     forward: bool,
@@ -823,7 +823,7 @@ unsafe fn find_nav_button_by_position(
 ///
 /// Returns `true` when an AX button was found and pressed (result `kAXErrorSuccess`),
 /// `false` on any failure — the caller should fall back to a keyboard shortcut.
-#[allow(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
+#[expect(unsafe_code, reason = "AXUIElement / CF APIs require raw FFI")]
 pub(super) fn ax_browser_navigate(forward: bool, pid: Option<i32>) -> bool {
     use objc2::rc::autoreleasepool;
     use objc2_app_kit::NSWorkspace;
@@ -929,7 +929,7 @@ use app_services::symbol as app_services_symbol;
 
 /// Shared resolver for private ApplicationServices SPI used by the Dock and
 /// symbolic-hotkey helpers.
-#[allow(
+#[expect(
     unsafe_code,
     reason = "private ApplicationServices SPI symbols are resolved via dlopen/dlsym FFI"
 )]
@@ -977,7 +977,7 @@ mod app_services {
 ///
 /// Isolated in its own submodule so the `unsafe` the `dlopen`/`dlsym` FFI
 /// needs is scoped here rather than spread across the platform helpers.
-#[allow(
+#[expect(
     unsafe_code,
     reason = "the private CoreDockSendNotification SPI is only reachable via dlopen/dlsym FFI"
 )]
@@ -1041,7 +1041,7 @@ mod dock {
 /// "Move right a space" (81). That respects the user's configured shortcut
 /// instead of assuming Ctrl+Left/Right, and temporarily enables the symbolic
 /// hotkey when the user has disabled it.
-#[allow(
+#[expect(
     unsafe_code,
     reason = "CGS symbolic hotkey SPI is only reachable via dlopen/dlsym FFI"
 )]

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -1,5 +1,5 @@
 //! Windows helpers for synthesising OS-level input events via `SendInput`.
-#![allow(unsafe_code, reason = "SendInput is the Win32 API for synthetic input")]
+#![expect(unsafe_code, reason = "SendInput is the Win32 API for synthetic input")]
 
 use std::mem::size_of;
 

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -17,10 +17,13 @@
 //! `PROTOCOL_VERSION`, update [`protocol_version_is_pinned`], and replace the
 //! golden with the actual hex from the assertion message.
 
-#![allow(clippy::expect_used, reason = "expect/unwrap are idiomatic in tests")]
 #![expect(
     clippy::tests_outside_test_module,
     reason = "an integration test file is already its own test-only crate"
+)]
+#![expect(
+    clippy::expect_used,
+    reason = "the fixture helpers below sit outside any `#[test]` fn, which is the one test shape `allow-expect-in-tests` cannot see"
 )]
 
 use std::collections::BTreeMap;

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -23,7 +23,7 @@
 )]
 #![expect(
     clippy::expect_used,
-    reason = "the fixture helpers below sit outside any `#[test]` fn, which is the one test shape `allow-expect-in-tests` cannot see"
+    reason = "the fixture helpers sit outside any `#[test]` fn, where `allow-expect-in-tests` cannot see them"
 )]
 
 use std::collections::BTreeMap;

--- a/crates/openlogi-overlay/build.rs
+++ b/crates/openlogi-overlay/build.rs
@@ -8,7 +8,7 @@
 //! Cargo.lock as gpui's own build-dependency, so it adds an edge, not a crate,
 //! and cannot move the pinned gpui rev.
 
-#![allow(
+#![expect(
     clippy::expect_used,
     reason = "a build script fails by panicking, so expect — whose message surfaces in the build log — is the idiomatic error path"
 )]

--- a/crates/openlogi-overlay/src/agent.rs
+++ b/crates/openlogi-overlay/src/agent.rs
@@ -378,11 +378,6 @@ fn retry_before(deadline: Option<Instant>) -> bool {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "panic helpers are idiomatic in tests"
-)]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -106,11 +106,6 @@ fn main() -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "panic helpers are idiomatic in tests"
-)]
 mod tests {
 
     /// The catalog this binary translates against lives in `openlogi-ui` and is

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -297,11 +297,6 @@ pub(crate) fn clamp_window_origin(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "panic helpers are idiomatic in tests"
-)]
 mod tests {
     use super::*;
 

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -216,7 +216,7 @@ impl Render for RingView {
     }
 }
 
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     reason = "native cursor coordinates are screen-sized and exactly usable as GPUI f32 pixels"
 )]

--- a/crates/openlogi-overlay/src/session.rs
+++ b/crates/openlogi-overlay/src/session.rs
@@ -141,11 +141,6 @@ pub(crate) fn spawned_by() -> Option<Run> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::expect_used,
-    clippy::unwrap_used,
-    reason = "panic helpers are idiomatic in tests"
-)]
 mod tests {
     use super::*;
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -40,8 +40,9 @@ two systemic problems, both now fixed.
 Related: the seven file-wide `cast_*` blankets were narrowed to the functions
 that need them, and most of their sites turned out not to need a suppression at
 all — `cast_signed`/`cast_unsigned`, `&raw const`/`&raw mut`, `to_le_bytes`, or
-a shared conversion helper. `capture_linux` keeps its blanket because
-`v4l2-sys-mit` runs bindgen and cannot be cross-linted from macOS.
+a shared conversion helper. Linux CI showed `capture_linux`'s file-level
+blanket was two-thirds dead (`cast_possible_truncation` /
+`cast_possible_wrap`); the remaining `cast_sign_loss` sits on `clamp_u8`.
 
 Supersedes the "`openlogi-hidpp` stays out on purpose (vendored)" note in the
 shared-lint-set entry below: the hard-fork ruling retired that, and the crate

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,6 +4,48 @@ Durable "why we did it this way" records that are not obvious from the code.
 Add a dated entry when a non-obvious architectural or dependency decision is
 made or revisited.
 
+## 2026-08: Suppressions are `expect`, and tests are exempt by config
+
+A sweep of every lint suppression in the tree (207 attributes, 247 lints) found
+two systemic problems, both now fixed.
+
+- **Tests restated the same exemption 78 times.** `unwrap_used`/`expect_used`
+  stay at warn so product code has to state its panics, but every test module
+  had copied `#[allow(…, reason = "idiomatic in tests")]` to opt out — about
+  40% of all suppressions in the workspace, carrying no information. A root
+  `clippy.toml` with `allow-unwrap-in-tests` / `allow-expect-in-tests` replaces
+  all of them. Clippy's exemption covers `#[cfg(test)]` modules and `#[test]`
+  functions; a free helper in a `tests/` integration file is the one shape it
+  cannot see, so `openlogi-ipc`'s wire-format test keeps a file-level
+  suppression. Build scripts are not tests and keep theirs too.
+- **`allow` rots silently.** 20 suppressions no longer suppressed anything,
+  including three module-wide `dead_code` blankets in `openlogi-assets` that
+  had been inert since those modules became `pub mod` — and would have hidden
+  real dead code the moment they went private again. Suppressions are now
+  `#[expect]` by default, which fails the build once it stops being needed.
+  `allow` survives only where `expect` cannot work: a lint that fires under
+  some `cfg` but not others, one whose fulfilment differs between a crate's
+  lib and test targets, and one raised inside a macro expansion (rustc does not
+  credit an expectation with those, so it both suppresses the warning and
+  reports itself unfulfilled). Each such site carries a comment saying which.
+
+Related: the seven file-wide `cast_*` blankets were narrowed to the functions
+that need them, and most of their sites turned out not to need a suppression at
+all — `cast_signed`/`cast_unsigned`, `&raw const`/`&raw mut`, `to_le_bytes`, or
+a shared conversion helper. `capture_linux` keeps its blanket because
+`v4l2-sys-mit` runs bindgen and cannot be cross-linted from macOS.
+
+Supersedes the "`openlogi-hidpp` stays out on purpose (vendored)" note in the
+shared-lint-set entry below: the hard-fork ruling retired that, and the crate
+inherits `[lints] workspace = true` like every other.
+
+Sweeping for rot is mechanical and worth repeating: rewrite every
+non-`cfg_attr` `allow(` to `expect(`, run clippy, and each "lint expectation is
+unfulfilled" is a suppression to delete. Run it on all three lanes — native,
+`--target x86_64-pc-windows-gnu`, `--target aarch64-unknown-linux-musl` —
+because CI has no macOS clippy job and a platform-gated suppression is only
+evaluated on its own platform.
+
 ## 2026-08: Shared clippy lint set
 
 The workspace adopted the shared ten-lint set (`assertions_on_result_states`,

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -28,6 +28,14 @@ two systemic problems, both now fixed.
   lib and test targets, and one raised inside a macro expansion (rustc does not
   credit an expectation with those, so it both suppresses the warning and
   reports itself unfulfilled). Each such site carries a comment saying which.
+- **Both rules are now machine-checked.** `allow_attributes` and
+  `allow_attributes_without_reason` join the lint table, costing three
+  annotated exceptions and nothing else — the sweep had already left the tree
+  compliant. One blind spot to remember: `allow_attributes` only sees outer
+  `#[allow]`, so a module-wide `#![allow(…)]` — precisely the shape that rotted
+  in `openlogi-assets` — still passes it. Adding them also disproved the
+  first-pass rule that a `cfg_attr`-wrapped suppression always needs `allow`:
+  two of the four turned out to work fine as `expect`.
 
 Related: the seven file-wide `cast_*` blankets were narrowed to the functions
 that need them, and most of their sites turned out not to need a suppression at

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787246814,
+        "narHash": "sha256-pEd4/iPY3Zm/EhhHmeB1QnIWXJSLx7gJzD/05mm2MCo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c84e121aaede7ef8c7bd9fb5154ccc1599e07816",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,24 @@
 {
   description = "OpenLogi — local-first companion for Logitech HID++ peripherals";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Workspace rust-version tracks current stable; nixpkgs' rustc lags it and
+    # cargo then refuses to build. Same overlay devenv uses for the local toolchain.
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   # The dev shell lives in devenv.nix (devenv.yaml). This flake owns the Linux
   # package, its NixOS integration, checks, and formatter.
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+    }:
     let
       systems = [
         "x86_64-linux"
@@ -14,7 +26,19 @@
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       packageFor =
-        system: nixpkgs.legacyPackages.${system}.callPackage ./packaging/linux/package.nix { src = ./.; };
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system}.extend rust-overlay.overlays.default;
+          toolchain = pkgs.rust-bin.stable.latest.minimal;
+          rustPlatform = pkgs.makeRustPlatform {
+            cargo = toolchain;
+            rustc = toolchain;
+          };
+        in
+        pkgs.callPackage ./packaging/linux/package.nix {
+          src = ./.;
+          inherit rustPlatform;
+        };
       moduleCheckFor =
         system:
         let

--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -56,6 +56,9 @@ let
       (src + "/packaging/linux/desktop")
       (src + "/packaging/linux/systemd")
       (src + "/packaging/linux/udev")
+      # xtask's packaged-bins test include_str!s this; omitting it fails
+      # `cargo test --workspace` inside the Nix sandbox.
+      (src + "/packaging/linux/nfpm.yaml")
       (src + "/xtask")
     ];
   };

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -514,7 +514,6 @@ pub(super) fn quoted_identity(line: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/xtask/src/commands/macos/bundle/identity.rs
+++ b/xtask/src/commands/macos/bundle/identity.rs
@@ -222,7 +222,6 @@ pub(crate) fn verify_icons(app: &Path, channel: Channel, components: &[Component
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/xtask/src/commands/macos/dev_bundle.rs
+++ b/xtask/src/commands/macos/dev_bundle.rs
@@ -249,7 +249,6 @@ impl Profile {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use super::*;
 

--- a/xtask/src/commands/release/latest_json.rs
+++ b/xtask/src/commands/release/latest_json.rs
@@ -209,7 +209,6 @@ fn platform_arch(stem: &str, marker: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "unwrap is idiomatic in tests")]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

An audit of every lint suppression in the tree — 207 attributes carrying 247 lints — found that most of them were not carrying information. 78 were test modules restating the same `unwrap`/`expect` exemption by hand, 20 no longer suppressed anything at all, and seven files silenced `cast_*` for their entire contents. This prunes the tree to 130 attributes / 140 lints and changes the default form from `allow` (silent when it goes stale) to `expect` (fails the build when it does): the `allow`:`expect` ratio goes from 159:48 to 6:124.

The mechanism is worth keeping: rewriting every non-`cfg_attr` `allow(` to `expect(` and running clippy turns each dead suppression into an "unfulfilled lint expectation" warning. That is how the 20 below were found, and `.claude/rules/rust.md` now documents the recipe so the sweep can be repeated.

Notable finds:

- `openlogi-assets`'s three module-wide `#![allow(dead_code)]` blankets have been inert since those modules became `pub mod` — public items are reachable, so the lint could never fire. They would have silently hidden real dead code the moment a module went private again.
- `LightCapabilities` is down to three bools, under `struct_excessive_bools`. `InstanceGuard._handle` and `CGEventTapInformation` are exempt from `dead_code` on their own.
- `_silence_pickfn` was a dead function whose only job was keeping an unused `PickFn` import "used" — a hand-rolled way around `unused_imports`. Both are gone.

Three cases where `expect` provably cannot work keep `allow`, each with a comment naming which case applies:

- **cfg-conditional**: `platform::os_version` returns `Some(…)` on macOS (so `unnecessary_wraps` fires) and `None` elsewhere (so it does not) — an `expect` there is green on macOS and red on the other two lanes.
- **lint raised inside a macro expansion**: rustc does not credit an expectation with such a lint, so `expect` suppresses the warning *and* reports itself unfulfilled — unfixable under `-D warnings`. `function_row`'s `float_cmp` on floats compared inside `assert_eq!` is the case here.
- **fulfilment differing between a crate's targets**: a `dead_code` suppression on a helper only the tests call is fulfilled in the `--lib` build and unfulfilled in the `--test` build. These were already `cfg_attr`-wrapped.

## Changes

- **root**: new `clippy.toml` with `allow-unwrap-in-tests` / `allow-expect-in-tests`. Clippy's exemption covers `#[cfg(test)]` modules and `#[test]` functions; a free helper in a `tests/` integration file is the one shape it cannot see, so `openlogi-ipc`'s wire-format test keeps a file-level suppression, as do the three build scripts (a build script is not a test — it fails by panicking).
- **openlogi-camera**: `capture_windows`'s file-wide cast blanket is gone entirely — its five sites are `cast_signed()` / `cast_unsigned()`, which say "reinterpret the bits" rather than "trust me". `uvc` builds its descriptor fixture with `to_le_bytes` and keeps two narrowly scoped suppressions; `capture` keeps one on the statement that stores frame dimensions. `capture_linux` keeps its blanket: `v4l2-sys-mit` runs bindgen, so that backend cannot be cross-linted from macOS and narrowing it would be blind work.
- **openlogi-hook**: the Win32 backend's four-lint file blanket is replaced by `&raw mut` / `&raw const` at its six FFI pointer coercions (the edition-2024 spelling, and the better one at an FFI boundary since it never materializes the intermediate reference), `cast_signed()` at three sites, and four function-scoped `expect`s for what is genuinely left.
- **openlogi-agent**: `tray_windows`'s blanket narrowed to the five functions that need it; the three build scripts' `expect_used` restated as `expect`.
- **openlogi-desktop**: `camera/controls` funnelled eleven ad-hoc `i32 as f32` / `f32 as i32` conversions through a `to_slider`/`from_slider` pair, so the UVC-range argument is made once where it belongs instead of eleven times by omission. `function_row`'s cast blanket narrowed to four functions. Nine dead `dead_code`/cast suppressions removed.
- **openlogi-core, openlogi-hidpp, openlogi-hid, openlogi-assets, openlogi-cli, openlogi-inject, openlogi-ipc, xtask**: dead suppressions removed, survivors converted to `expect`.
- **docs**: `.claude/rules/rust.md` no longer tells agents to hand-write a test-module `#[allow]`, no longer describes `openlogi-hidpp` as sitting outside the workspace lint table (its own AGENTS.md retired that), and gains the `expect`-by-default rule plus the scoping rule for cast suppressions. `docs/DECISIONS.md` records the decision with the numbers behind it.

## Testing

Full local gate on the final tree:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
```

Because a platform-gated suppression is only ever evaluated on its own platform, and because an `expect` that goes unfulfilled is a hard error under `-D warnings`, the sweep was verified on all three lint lanes rather than just the local one:

```
cargo clippy --target x86_64-pc-windows-gnu -p openlogi-core -p openlogi-hidpp -p openlogi-hid \
  -p openlogi-hook -p openlogi-agent -p openlogi-agent-core -p openlogi-inject -p openlogi-camera --all-targets
cargo clippy --target aarch64-unknown-linux-musl -p openlogi-core -p openlogi-hidpp -p openlogi-hid \
  -p openlogi-ipc -p openlogi-permissions -p openlogi-hook -p openlogi-inject -p openlogi-agent-core -p openlogi-agent --all-targets
```

Both clean. Not covered locally: the GPUI crates off macOS (no cross build) and `openlogi-camera`'s v4l2 backend (bindgen) — CI's `clippy` and `clippy (windows)` jobs own those.

This is a lint-hygiene change with no behavioural surface, so there is nothing to verify on hardware. The three code rewrites that are not pure attribute edits — `cast_signed`/`cast_unsigned`, `&raw mut`/`&raw const`, and the `to_slider`/`from_slider` pair — are each exactly equivalent to what they replace, and all of them are on Windows or in the camera panel; **not runtime-tested on hardware**.

## Follow-ups

- `capture_linux`'s file-level cast blanket stays until the v4l2 backend can be linted somewhere other than a Linux box.
- CI has no macOS clippy job. Every `#[cfg(target_os = "macos")]` suppression — the ObjC FFI surface in `openlogi-inject`, `openlogi-hook`, `openlogi-camera`, `openlogi-permissions`, and both GPUI apps — is checked only by the maintainer's local gate. That gap predates this PR, but `expect` makes it more valuable to close.
