### PR TITLE
feat(hid): rebind POP Keys' dedicated emoji keys

### DIFF
--- a/crates/openlogi-core/src/binding/button.rs
+++ b/crates/openlogi-core/src/binding/button.rs
@@ -73,10 +73,25 @@ pub enum ButtonId {
     /// Tilting the main wheel right — `0x1b04` CID `0x005d` ("Right Scroll"),
     /// Logi metadata slot `SLOT_NAME_RIGHT_SCROLL_BUTTON`. Counterpart to
     /// [`ButtonId::WheelTiltLeft`].
-    ///
-    /// Declared last: the TOML config and any serialized form encode the
-    /// variant identifier / index, so new buttons are append-only.
     WheelTiltRight,
+    /// Keyboard "Smiling face with heart-shaped eyes" emoji control (CID
+    /// `0x0104`) — one of the five dedicated emoji keys on the POP Keys
+    /// series, distinct from the F-row keys above. Named with the shared
+    /// `KeyEmoji*` prefix so future dedicated emoji keys slot in beside it.
+    KeyEmojiHeartEyes,
+    /// Keyboard "Loudly crying face" emoji control (CID `0x0105`) — one of
+    /// the five dedicated emoji keys on the POP Keys series.
+    KeyEmojiCrying,
+    /// Keyboard "Emoji Smiley" control (CID `0x0106`) — one of the five
+    /// dedicated emoji keys on the POP Keys series. Distinct from
+    /// [`ButtonId::KeyEmoji`] (CID `0x0108`, the emoji-panel opener).
+    KeyEmojiSmiley,
+    /// Keyboard "Emoji smiley with tears" control (CID `0x0107`) — one of
+    /// the five dedicated emoji keys on the POP Keys series.
+    ///
+    /// The TOML config and any serialized form encode the variant
+    /// identifier / index, so new buttons are appended after this one.
+    KeyEmojiTears,
 }
 
 impl ButtonId {
@@ -103,9 +118,13 @@ impl ButtonId {
     /// [`ButtonId::ALL`]: that array seeds mouse defaults and the mouse
     /// popover trigger list, while keyboard keys stay native unless the user
     /// binds them (an unbound key is never diverted).
-    pub const KEYBOARD_KEYS: [ButtonId; 9] = [
+    pub const KEYBOARD_KEYS: [ButtonId; 13] = [
         ButtonId::KeySearch,
         ButtonId::KeyDictation,
+        ButtonId::KeyEmojiHeartEyes,
+        ButtonId::KeyEmojiCrying,
+        ButtonId::KeyEmojiSmiley,
+        ButtonId::KeyEmojiTears,
         ButtonId::KeyEmoji,
         ButtonId::KeyScreenCapture,
         ButtonId::KeyMicMute,
@@ -166,6 +185,10 @@ impl ButtonId {
             ButtonId::KeyVolumeDown => "Volume Down Key",
             ButtonId::KeyVolumeUp => "Volume Up Key",
             ButtonId::HapticPanel => "Haptic Panel",
+            ButtonId::KeyEmojiHeartEyes => "Smiley Heart Eyes Key",
+            ButtonId::KeyEmojiCrying => "Loudly Crying Face Key",
+            ButtonId::KeyEmojiSmiley => "Smiley Key",
+            ButtonId::KeyEmojiTears => "Smiley With Tears Key",
         }
     }
 }

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -77,7 +77,11 @@ pub fn default_binding(button: ButtonId) -> Action {
         | ButtonId::KeyPlayPause
         | ButtonId::KeyMute
         | ButtonId::KeyVolumeDown
-        | ButtonId::KeyVolumeUp => Action::None,
+        | ButtonId::KeyVolumeUp
+        | ButtonId::KeyEmojiHeartEyes
+        | ButtonId::KeyEmojiCrying
+        | ButtonId::KeyEmojiSmiley
+        | ButtonId::KeyEmojiTears => Action::None,
     }
 }
 

--- a/crates/openlogi-device/src/session/keyboard.rs
+++ b/crates/openlogi-device/src/session/keyboard.rs
@@ -39,10 +39,17 @@ use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 /// The divertable keyboard F-row controls OpenLogi models, as
 /// `(0x1b04 control ID, ButtonId)` pairs. CID values match Logitech's control
 /// catalog (cross-checked against Solaar's `special_keys.py`); the F-row
-/// positions are the Signature-series layout.
-pub const KEYBOARD_KEY_CIDS: [(u16, ButtonId); 9] = [
+/// positions are the Signature-series layout. The four `KeyEmoji*` face
+/// entries aren't F-row keys — they're the dedicated emoji row on the POP
+/// Keys series — but they divert over the same `0x1b04` mechanism, so they
+/// share this table.
+pub const KEYBOARD_KEY_CIDS: [(u16, ButtonId); 13] = [
     (0x00d4, ButtonId::KeySearch),
     (0x0103, ButtonId::KeyDictation),
+    (0x0104, ButtonId::KeyEmojiHeartEyes),
+    (0x0105, ButtonId::KeyEmojiCrying),
+    (0x0106, ButtonId::KeyEmojiSmiley),
+    (0x0107, ButtonId::KeyEmojiTears),
     (0x0108, ButtonId::KeyEmoji),
     (0x010a, ButtonId::KeyScreenCapture),
     (0x011c, ButtonId::KeyMicMute),

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -71,6 +71,9 @@ fn_lock = false
 [devices."receiver:aabbccdd:slot:2".bindings]
 KeySearch = "MissionControl"
 KeyScreenCapture = "Sleep"
+# POP Keys' dedicated emoji row (separate from KeyEmoji, its "open emoji
+# panel" key) binds the same way.
+KeyEmojiSmiley = "LockScreen"
 
 # Global function-key remapping, independent of a device.
 [keyboard.bindings]


### PR DESCRIPTION
I recently picked up a POP Keys keyboard and wanted to remap the emoji row the same way I remap everything else on my Logi gear (I've actually swapped in some of the spare keycaps it ships with, so what's printed on my keys right now isn't even the stock heart-eyes/crying/smiley/tears set — more on why that doesn't matter below). Turns out OpenLogi has no way to bind those keys at all — 4 of POP Keys' 5 dedicated emoji keys aren't modeled as a `ButtonId` anywhere. Only the "open emoji panel" key was already covered (`KeyEmoji`).

This PR adds the missing four as new `ButtonId` variants (`KeyEmojiHeartEyes`, `KeyEmojiCrying`, `KeyEmojiSmiley`, `KeyEmojiTears`) and wires their CIDs (`0x104`–`0x107`) into the `0x1b04` diversion table, so they're bindable in `config.toml` the same way `KeySearch`/`KeyDictation`/etc. already are. The naming/binding is by HID++ control ID, not by whatever's printed on the cap — since POP Keys keycaps are swappable, that's the only thing that actually stays stable per key.

I only did the config-side plumbing, not a dashboard entry — figured this counts as a small fix rather than a new feature. The Keys tab doesn't render this category of key at all yet (not even the existing 9), so a proper POP Keys render in the dashboard felt like its own, bigger effort and probably deserves a separate PR.

Tested locally on macOS — `fmt`/`clippy`/`test --workspace` all pass, and I confirmed live on my own POP Keys (spare caps and all) that it actually works:

```toml
[devices."direct:046d:b365:serial:xxxxxxxx".bindings]
KeyEmojiHeartEyes = { TypeText = "👍" }
KeyEmojiCrying = { TypeText = "❤️" }
KeyEmojiSmiley = { TypeText = "🔥" }
KeyEmojiTears = { TypeText = "😂" }
```

Happy to adjust naming or scope if you'd rather it done differently.

Fixes #1005