### PR TITLE
fix(hook): remap aux buttons that arrive without HID attribution on macOS 26

### DIFF
--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -221,14 +221,19 @@ thread_local! {
 /// trackpad can never be swallowed. Linux/Windows often lack attribution
 /// (`device: None`); those platforms already restrict which devices the hook
 /// attaches to, so unknown sources stay remappable.
-fn button_source_may_remap(device: Option<&EventDevice>) -> bool {
+fn button_source_may_remap(id: ButtonId, device: Option<&EventDevice>) -> bool {
     match device {
         Some(d) => source_is_remappable(Some(d)),
         None => {
             // Attribution missing: safe on Linux/Windows (device selection is
-            // upstream of the callback). On macOS fail closed — an unattributed
-            // event is more likely a trackpad/system source than a Logi mouse.
-            !cfg!(target_os = "macos")
+            // upstream of the callback). On macOS this used to mean a
+            // trackpad/system source and failed closed — but macOS 26 delivers
+            // aux-button (other-mouse) events with no backing IOHIDEvent at
+            // all (`CGEventCopyIOHIDEvent` returns null), which disabled
+            // remapping of Middle/Back/Forward entirely. Built-in trackpads
+            // never emit those buttons, so an unattributed aux button is safe
+            // to remap; anything else keeps failing closed.
+            !cfg!(target_os = "macos") || id.is_os_hook_button()
         }
     }
 }
@@ -266,7 +271,7 @@ fn handle_button(
     action_tx: &mpsc::SyncSender<Action>,
 ) -> EventDisposition {
     // Primary L/R always pass through (suppressing them would brick the mouse).
-    if !id.is_os_hook_button() || !button_source_may_remap(device) {
+    if !id.is_os_hook_button() || !button_source_may_remap(id, device) {
         return EventDisposition::PassThrough;
     }
 


### PR DESCRIPTION
## Problem

On macOS 26, all OS-hook button remaps and hold+swipe gestures silently stop working, while HID++-diverted single-action bindings keep working. This makes the breakage look device-specific (it isn't) — observed with an ERGO M575 over both Bluetooth LE and a Unifying receiver, and it should affect every device whose Middle/Back/Forward go through the CGEventTap hook.

## Root cause

macOS 26 delivers other-mouse (aux button) CGEvents **without a backing IOHIDEvent** — `CGEventCopyIOHIDEvent` returns null — so `event_sender_id` yields `None` and `button_source_may_remap` fails closed, passing every Middle/Back/Forward press through untouched.

Verified with a listen-only diagnostic tap on macOS 26.6.2 (arm64), pressing buttons on the same physical device:

```
event type=1  button=0 hidEvent=yes senderID=0x10001e970 Product=USB Receiver VendorID=1133   ← left click: attribution intact
event type=25 button=4 hidEvent=NULL                                                          ← aux button: no HID backing
event type=26 button=4 hidEvent=NULL
```

Left clicks still attribute correctly, so the regression is specific to aux-button events in the macOS 26 input pipeline.

## Fix

Allow an **unattributed** event through the gate only for the OS-hook buttons (Middle/Back/Forward). The fail-closed rule exists so the built-in trackpad can never be swallowed — but trackpads never emit those buttons, so that rationale doesn't apply to them. Attributed events keep the existing Logitech/non-trackpad check, and everything else keeps failing closed.

## Testing

- macOS 26.6.2 (arm64), ERGO M575 via Bluetooth LE and via Unifying receiver (slot 2)
- Click remaps and all five per-direction gesture slots on Back/Forward work again; Middle unaffected as a single-action HID++ divert and works as a gesture owner too
- Trackpad input unaffected (left/right/primary pass-through preserved)

## Possible follow-up (not in this PR)

The M575 (and likely other non-MX devices) reports `divertable, raw-xy` on CIDs 0x52/0x53/0x56 (`openlogi diag controls`), so per-direction gestures for these buttons could be delivered over HID++ raw-XY diversion like the MX gesture button — transport-independent and immune to CGEvent pipeline changes like this one. Happy to file a separate issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related to #920