### PR TITLE
ci(shell): gate every shell script with shellcheck and shfmt

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -50,8 +50,8 @@ if [[ -f "$HOME/.cargo/env" ]]; then
   source "$HOME/.cargo/env"
 fi
 if ! command -v rustup >/dev/null 2>&1; then
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | sh -s -- -y --profile minimal --no-modify-path
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sh -s -- -y --profile minimal --no-modify-path
   # shellcheck disable=SC1091
   source "$HOME/.cargo/env"
 fi

--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -2,6 +2,7 @@
 paths:
   - ".github/workflows/**"
   - ".github/scripts/ci-local.sh"
+  - ".editorconfig"
   - "deny.toml"
   - "rust-toolchain.toml"
   - "prek.toml"
@@ -16,7 +17,7 @@ this file and `.github/scripts/ci-local.sh` is a bug.
 
 `devenv tasks run openlogi:check` is the **host-OS pre-push gate** (fmt, clippy,
 tests, rustdoc). It is **not** the pipeline. macOS-green clippy does not compile
-linux cfg; it does not run MSRV, cargo-deny, or Windows clippy.
+linux cfg; it does not run MSRV, cargo-deny, Windows clippy, or the shell lint.
 
 Do not claim a skipped job passed. Name it as not run in the PR Testing section.
 
@@ -38,6 +39,7 @@ that host clippy `-D warnings` does not surface still fails CI.
 | CI job | Local command | Who can run it |
 |---|---|---|
 | `rustfmt` | `cargo fmt --all -- --check` | any |
+| `shell` | `git ls-files -z \| xargs -0 shfmt -f` piped into `xargs shellcheck` and `xargs shfmt -d` | any (needs `shellcheck` + `shfmt`; both are in the devenv shell) |
 | `clippy` | `cargo clippy --workspace --all-targets -- -D warnings` | **Linux** is the CI job. Host clippy on macOS/Windows compiles a different `cfg` |
 | `MSRV (cargo check, <os>)` | `RUSTUP_TOOLCHAIN=<rust-version> cargo check --workspace --all-targets` | macOS and Linux. `<rust-version>` is `rust-version` in the root `Cargo.toml` |
 | `rustdoc (non-GUI crates)` | `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent` | any |
@@ -77,6 +79,7 @@ only on macOS CI (`cargo test -p openlogi-desktop i18n`).
 | Diff | Run |
 |---|---|
 | anything Rust | `rustfmt`; crate-scoped clippy + tests while iterating; host `clippy` / `tests` before push |
+| any `*.sh`, any file with a shell shebang, `.editorconfig` | `shell` (the prek hooks run the same two tools at commit) |
 | `#[cfg(target_os = …)]`, hook/inject/hid/camera platform files | `clippy-windows` proxy + the linux-musl recipe; say so if you cannot |
 | `Cargo.lock` / `deny.toml` / new deps | `cargo-deny` |
 | `rust-version` or a newly stabilized API | `MSRV` |

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[[shell]]
+indent_style = space
+indent_size = 2
+switch_case_indent = true

--- a/.github/scripts/ci-local.sh
+++ b/.github/scripts/ci-local.sh
@@ -37,7 +37,7 @@ Usage:
   .github/scripts/ci-local.sh --dry-run    print commands, do not run them
   .github/scripts/ci-local.sh rustfmt docs named jobs (CI name: or job id)
 
-Jobs: rustfmt clippy msrv rustdoc tests cargo-deny clippy-windows
+Jobs: rustfmt shell clippy msrv rustdoc tests cargo-deny clippy-windows
 Also:  i18n wire   (focused suites that fail the macOS test job)
 EOF
 }
@@ -103,6 +103,35 @@ run_cmd() {
 
 job_fmt() {
   run_cmd "rustfmt" cargo fmt --all -- --check
+}
+
+job_shell() {
+  printf '\n==> shell\n'
+  note "shellcheck + shfmt -d over every tracked shell script"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    pass_job "shell (dry-run)"
+    return 0
+  fi
+  if ! command -v shellcheck >/dev/null 2>&1 || ! command -v shfmt >/dev/null 2>&1; then
+    skip_job "shell" "needs shellcheck and shfmt (both are in the devenv shell)"
+    return 0
+  fi
+  # shfmt decides what counts as a shell script — by extension, and by shebang
+  # for the extensionless ones. Listing once keeps both tools on one file set.
+  local list status
+  list="$(mktemp)"
+  git ls-files -z | xargs -0 shfmt -f >"$list"
+  status=0
+  xargs shellcheck <"$list" || status=1
+  # No printer flags: they would make shfmt ignore .editorconfig, where this
+  # repo's formatting options live.
+  xargs shfmt -d <"$list" || status=1
+  rm -f "$list"
+  if [ "$status" -eq 0 ]; then
+    pass_job "shell"
+  else
+    fail_job "shell"
+  fi
 }
 
 job_clippy() {
@@ -297,6 +326,11 @@ print_list() {
 CI job (ci.yml)              Local command                                      This host
 ---------------------------  -------------------------------------------------  ---------
 rustfmt                      cargo fmt --all -- --check                         any
+shell                        git ls-files -z | xargs -0 shfmt -f > LIST         any
+                               xargs shellcheck < LIST
+                               xargs shfmt -d < LIST
+                             Formatting options come from .editorconfig; a
+                             printer flag would make shfmt ignore it.
 clippy                       cargo clippy --workspace --all-targets -- -D warnings
                              CI runs this on ubuntu-latest (linux cfg). Host
                              clippy on macOS/Windows is a different compilation.
@@ -341,6 +375,7 @@ EOF
 run_named() {
   case "$1" in
     rustfmt | fmt) job_fmt ;;
+    shell) job_shell ;;
     clippy) job_clippy ;;
     msrv | MSRV | \
       "MSRV (cargo check, macos-latest)" | "MSRV (cargo check, ubuntu-latest)" | \
@@ -373,6 +408,7 @@ run_named() {
 
 run_default() {
   job_fmt
+  job_shell
   job_clippy
   job_msrv
   job_docs

--- a/.github/scripts/ci-local.sh
+++ b/.github/scripts/ci-local.sh
@@ -46,7 +46,7 @@ is_linux() { [ "$UNAME" = Linux ]; }
 is_darwin() { [ "$UNAME" = Darwin ]; }
 is_windows() {
   case "$UNAME" in
-    MINGW*|MSYS*|CYGWIN*|Windows*) return 0 ;;
+    MINGW* | MSYS* | CYGWIN* | Windows*) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -340,22 +340,28 @@ EOF
 
 run_named() {
   case "$1" in
-    rustfmt|fmt) job_fmt ;;
+    rustfmt | fmt) job_fmt ;;
     clippy) job_clippy ;;
-    msrv|MSRV|\
-    "MSRV (cargo check, macos-latest)"|"MSRV (cargo check, ubuntu-latest)"|\
-    "MSRV (cargo check, <os>)"|"MSRV (cargo check"*) job_msrv ;;
-    rustdoc|docs|"rustdoc (non-GUI crates)") job_docs ;;
+    msrv | MSRV | \
+      "MSRV (cargo check, macos-latest)" | "MSRV (cargo check, ubuntu-latest)" | \
+      "MSRV (cargo check, <os>)" | "MSRV (cargo check"*) job_msrv ;;
+    rustdoc | docs | "rustdoc (non-GUI crates)") job_docs ;;
     tests) job_tests ;;
-    test-linux|"tests (linux)") job_test_linux ;;
-    test-macos|"tests (macos)"|"tests (macos, arm64)"|"tests (macos, x86_64)"|\
-    "tests (macos, <arch>)"|"tests (macos"*) job_test_macos ;;
-    cargo-deny|deny) job_deny ;;
-    clippy-windows|"clippy (windows)") job_clippy_windows ;;
+    test-linux | "tests (linux)") job_test_linux ;;
+    test-macos | "tests (macos)" | "tests (macos, arm64)" | "tests (macos, x86_64)" | \
+      "tests (macos, <arch>)" | "tests (macos"*) job_test_macos ;;
+    cargo-deny | deny) job_deny ;;
+    clippy-windows | "clippy (windows)") job_clippy_windows ;;
     i18n) job_i18n ;;
-    wire|wire_format) job_wire ;;
-    -h|--help|help) usage; exit 0 ;;
-    --list|list) print_list; exit 0 ;;
+    wire | wire_format) job_wire ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    --list | list)
+      print_list
+      exit 0
+      ;;
     --dry-run) DRY_RUN=1 ;;
     *)
       echo "unknown job: $1" >&2
@@ -393,8 +399,11 @@ summarize() {
 args=()
 for arg in "$@"; do
   case "$arg" in
-    -h|--help|help) usage; exit 0 ;;
-    --list|list) LIST_ONLY=1 ;;
+    -h | --help | help)
+      usage
+      exit 0
+      ;;
+    --list | list) LIST_ONLY=1 ;;
     --dry-run) DRY_RUN=1 ;;
     *) args+=("$arg") ;;
   esac

--- a/.github/scripts/release/write-changelog.sh
+++ b/.github/scripts/release/write-changelog.sh
@@ -19,10 +19,10 @@ PY
 tag="v${version}"
 
 last_tag="$(
-  git tag --list 'v*' \
-    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-    | sort -V \
-    | tail -n1
+  git tag --list 'v*' |
+    grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+    sort -V |
+    tail -n1
 )"
 if [[ -z "${last_tag}" ]]; then
   echo "error: no previous vX.Y.Z tag" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,26 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  # The shell equivalent of `rustfmt` + `clippy`. The file set is every tracked
+  # file shfmt recognises as a shell script, so a new script is covered the day
+  # it lands — including the extensionless `.agents/*` ones, which it detects by
+  # shebang. shfmt's formatting options come from `.editorconfig`; passing it a
+  # printer flag here would silently discard that file.
+  shell:
+    name: shell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: shellcheck,shfmt
+      - name: List tracked shell scripts
+        run: git ls-files -z | xargs -0 shfmt -f | tee "${RUNNER_TEMP}/shell-scripts"
+      - name: shellcheck
+        run: xargs shellcheck < "${RUNNER_TEMP}/shell-scripts"
+      - name: shfmt
+        run: xargs shfmt -d < "${RUNNER_TEMP}/shell-scripts"
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,8 @@ impl to a derive macro kills every `Type::trait_method` doc link — is explaine
 
 The local gate is the host-OS subset. The pipeline is `.github/workflows/ci.yml`
 (Linux clippy, macOS+Linux MSRV, rustdoc, Linux tests excluding desktop, macOS
-`--all-targets` tests, cargo-deny, Windows clippy). macOS-green is not that
-matrix. To run every job this machine can reproduce:
+`--all-targets` tests, cargo-deny, Windows clippy, shell lint). macOS-green is
+not that matrix. To run every job this machine can reproduce:
 
 ```sh
 .github/scripts/ci-local.sh

--- a/devenv.nix
+++ b/devenv.nix
@@ -47,6 +47,9 @@ in
       cmake
       sccache
       prek
+      # The `shell` CI job and the prek hooks of the same name.
+      shellcheck
+      shfmt
     ]
     # create-dmg is macOS-only (meta.platforms = darwin); an unconditional entry
     # breaks evaluation of the shell on Linux.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -201,8 +201,8 @@ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
 ```
 
 Equivalent to `devenv tasks run openlogi:check`. That is **not** the full
-pipeline: Linux clippy, Windows clippy, MSRV, and cargo-deny are separate CI
-jobs. Reproduce those with `ci-local.sh` or the commands in `.claude/rules/ci.md`.
+pipeline: Linux clippy, Windows clippy, MSRV, cargo-deny, and the shell lint
+(shellcheck + shfmt) are separate CI jobs. Reproduce those with `ci-local.sh` or the commands in `.claude/rules/ci.md`.
 
 ## Packaging the macOS DMG
 

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -21,16 +21,22 @@ BINDIR=
 PRINT_HELP=0
 
 for arg in "$@"; do
-    case "$arg" in
-        --prefix=*) PREFIX="${arg#--prefix=}" ;;
-        --prefix)   echo "--prefix requires a value, e.g. --prefix=/usr" >&2; exit 1 ;;
-        --help|-h)  PRINT_HELP=1 ;;
-        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
-    esac
+  case "$arg" in
+    --prefix=*) PREFIX="${arg#--prefix=}" ;;
+    --prefix)
+      echo "--prefix requires a value, e.g. --prefix=/usr" >&2
+      exit 1
+      ;;
+    --help | -h) PRINT_HELP=1 ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
 done
 
 if [ "$PRINT_HELP" -eq 1 ]; then
-    cat <<EOF
+  cat <<EOF
 Usage: $0 [--prefix PREFIX]
 
 Options:
@@ -47,7 +53,7 @@ The script installs:
   /usr/share/applications/openlogi.desktop
   /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
 EOF
-    exit 0
+  exit 0
 fi
 
 BINDIR="${PREFIX}/bin"
@@ -60,76 +66,76 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BUILD_DIR="${REPO_ROOT}/target/release"
 
 for bin in openlogi openlogi-desktop openlogi-overlay openlogi-agent; do
-    if [ ! -x "${BUILD_DIR}/${bin}" ]; then
-        echo "Error: ${BUILD_DIR}/${bin} not found." >&2
-        echo "Build first: cargo build --release -p openlogi -p openlogi-desktop -p openlogi-overlay -p openlogi-agent" >&2
-        exit 1
-    fi
+  if [ ! -x "${BUILD_DIR}/${bin}" ]; then
+    echo "Error: ${BUILD_DIR}/${bin} not found." >&2
+    echo "Build first: cargo build --release -p openlogi -p openlogi-desktop -p openlogi-overlay -p openlogi-agent" >&2
+    exit 1
+  fi
 done
 
 # ── install binaries ───────────────────────────────────────────────────────────
 
 echo "Installing binaries to ${BINDIR} …"
-sudo install -Dm755 "${BUILD_DIR}/openlogi"       "${BINDIR}/openlogi"
-sudo install -Dm755 "${BUILD_DIR}/openlogi-desktop"     "${BINDIR}/openlogi-desktop"
+sudo install -Dm755 "${BUILD_DIR}/openlogi" "${BINDIR}/openlogi"
+sudo install -Dm755 "${BUILD_DIR}/openlogi-desktop" "${BINDIR}/openlogi-desktop"
 sudo install -Dm755 "${BUILD_DIR}/openlogi-overlay" "${BINDIR}/openlogi-overlay"
-sudo install -Dm755 "${BUILD_DIR}/openlogi-agent"   "${BINDIR}/openlogi-agent"
+sudo install -Dm755 "${BUILD_DIR}/openlogi-agent" "${BINDIR}/openlogi-agent"
 
 # ── udev rules ────────────────────────────────────────────────────────────────
 
 echo "Installing udev rules …"
 sudo install -Dm644 "${SCRIPT_DIR}/udev/70-openlogi.rules" \
-    /etc/udev/rules.d/70-openlogi.rules
+  /etc/udev/rules.d/70-openlogi.rules
 
-if command -v udevadm > /dev/null 2>&1; then
-    echo "Reloading udev rules …"
-    sudo udevadm control --reload-rules
-    sudo udevadm trigger --subsystem-match=hidraw
-    sudo udevadm trigger --subsystem-match=input
-    sudo udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
+if command -v udevadm >/dev/null 2>&1; then
+  echo "Reloading udev rules …"
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=hidraw
+  sudo udevadm trigger --subsystem-match=input
+  sudo udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
 fi
 
 # ── systemd user unit ─────────────────────────────────────────────────────────
 
 SYSTEMD_UNIT_DIR=/usr/lib/systemd/user
-if [ -d "$SYSTEMD_UNIT_DIR" ] || command -v systemctl > /dev/null 2>&1; then
-    echo "Installing systemd user unit …"
-    # Rewrite the packaged /usr/bin path to match the requested install prefix.
-    # Escape the replacement so sed metacharacters (& \ |) in the path are literal.
-    ESCAPED_BINDIR="$(printf '%s\n' "${BINDIR}" | sed 's|[&\\|]|\\&|g')"
-    sed "s|^ExecStart=/usr/bin/openlogi-agent$|ExecStart=${ESCAPED_BINDIR}/openlogi-agent|" \
-        "${SCRIPT_DIR}/systemd/openlogi-agent.service" \
-        | sudo tee "${SYSTEMD_UNIT_DIR}/openlogi-agent.service" > /dev/null
-    # Best-effort daemon-reload for the invoking user so a reinstall picks up
-    # the updated unit without requiring a manual reload.
-    INSTALL_USER="${SUDO_USER:-$USER}"
-    sudo -u "$INSTALL_USER" \
-        XDG_RUNTIME_DIR="/run/user/$(id -u "$INSTALL_USER")" \
-        systemctl --user daemon-reload 2>/dev/null || true
-    echo "Enable the agent for your user with:"
-    echo "  systemctl --user enable --now openlogi-agent.service"
+if [ -d "$SYSTEMD_UNIT_DIR" ] || command -v systemctl >/dev/null 2>&1; then
+  echo "Installing systemd user unit …"
+  # Rewrite the packaged /usr/bin path to match the requested install prefix.
+  # Escape the replacement so sed metacharacters (& \ |) in the path are literal.
+  ESCAPED_BINDIR="$(printf '%s\n' "${BINDIR}" | sed 's|[&\\|]|\\&|g')"
+  sed "s|^ExecStart=/usr/bin/openlogi-agent$|ExecStart=${ESCAPED_BINDIR}/openlogi-agent|" \
+    "${SCRIPT_DIR}/systemd/openlogi-agent.service" |
+    sudo tee "${SYSTEMD_UNIT_DIR}/openlogi-agent.service" >/dev/null
+  # Best-effort daemon-reload for the invoking user so a reinstall picks up
+  # the updated unit without requiring a manual reload.
+  INSTALL_USER="${SUDO_USER:-$USER}"
+  sudo -u "$INSTALL_USER" \
+    XDG_RUNTIME_DIR="/run/user/$(id -u "$INSTALL_USER")" \
+    systemctl --user daemon-reload 2>/dev/null || true
+  echo "Enable the agent for your user with:"
+  echo "  systemctl --user enable --now openlogi-agent.service"
 fi
 
 # ── desktop entry ─────────────────────────────────────────────────────────────
 
 echo "Installing desktop entry …"
 sudo install -Dm644 "${SCRIPT_DIR}/desktop/openlogi.desktop" \
-    /usr/share/applications/openlogi.desktop
+  /usr/share/applications/openlogi.desktop
 
 # ── icon ──────────────────────────────────────────────────────────────────────
 
 ICON_SRC="${REPO_ROOT}/design/icon/openlogi.png"
 if [ -f "$ICON_SRC" ]; then
-    echo "Installing icon …"
-    sudo install -Dm644 "$ICON_SRC" \
-        /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
-    if command -v gtk-update-icon-cache > /dev/null 2>&1; then
-        sudo gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
-    fi
+  echo "Installing icon …"
+  sudo install -Dm644 "$ICON_SRC" \
+    /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
+  if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    sudo gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
+  fi
 fi
 
-if command -v update-desktop-database > /dev/null 2>&1; then
-    sudo update-desktop-database -q /usr/share/applications || true
+if command -v update-desktop-database >/dev/null 2>&1; then
+  sudo update-desktop-database -q /usr/share/applications || true
 fi
 
 echo ""

--- a/packaging/linux/nfpm-scripts/postinstall.sh
+++ b/packaging/linux/nfpm-scripts/postinstall.sh
@@ -6,20 +6,20 @@ set -eu
 # before the script exits so the agent can open /dev/hidraw* and the mouse's
 # /dev/input/event* node immediately, even for a device connected before the
 # install.
-if command -v udevadm > /dev/null 2>&1; then
-    udevadm control --reload-rules
-    udevadm trigger --subsystem-match=hidraw
-    udevadm trigger --subsystem-match=input
-    udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
-    udevadm settle 2>/dev/null || true
+if command -v udevadm >/dev/null 2>&1; then
+  udevadm control --reload-rules
+  udevadm trigger --subsystem-match=hidraw
+  udevadm trigger --subsystem-match=input
+  udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
+  udevadm settle 2>/dev/null || true
 fi
 
 # Refresh icon and desktop caches (best-effort).
-if command -v gtk-update-icon-cache > /dev/null 2>&1; then
-    gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
 fi
-if command -v update-desktop-database > /dev/null 2>&1; then
-    update-desktop-database -q /usr/share/applications || true
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database -q /usr/share/applications || true
 fi
 
 echo "OpenLogi installed. Enable the background agent for your user with:"

--- a/packaging/linux/nfpm-scripts/postremove.sh
+++ b/packaging/linux/nfpm-scripts/postremove.sh
@@ -2,9 +2,9 @@
 set -eu
 
 # Reload udev rules and wait for the uaccess revocation to take effect.
-if command -v udevadm > /dev/null 2>&1; then
-    udevadm control --reload-rules
-    udevadm trigger --subsystem-match=hidraw
-    udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
-    udevadm settle 2>/dev/null || true
+if command -v udevadm >/dev/null 2>&1; then
+  udevadm control --reload-rules
+  udevadm trigger --subsystem-match=hidraw
+  udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
+  udevadm settle 2>/dev/null || true
 fi

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -11,11 +11,17 @@ set -eu
 PREFIX=/usr/local
 
 for arg in "$@"; do
-    case "$arg" in
-        --prefix=*) PREFIX="${arg#--prefix=}" ;;
-        --prefix)   echo "--prefix requires a value" >&2; exit 1 ;;
-        *) echo "Unknown argument: $arg" >&2; exit 1 ;;
-    esac
+  case "$arg" in
+    --prefix=*) PREFIX="${arg#--prefix=}" ;;
+    --prefix)
+      echo "--prefix requires a value" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
 done
 
 BINDIR="${PREFIX}/bin"
@@ -28,12 +34,12 @@ BINDIR="${PREFIX}/bin"
 REAL_USER="${SUDO_USER:-$USER}"
 REAL_UID="$(id -u "$REAL_USER")"
 
-if command -v systemctl > /dev/null 2>&1; then
-    echo "Disabling and stopping the agent …"
-    # Set XDG_RUNTIME_DIR explicitly: sudo -u strips the environment so
-    # systemctl --user cannot locate the user's D-Bus socket without it.
-    sudo -u "$REAL_USER" XDG_RUNTIME_DIR="/run/user/${REAL_UID}" \
-        systemctl --user disable --now openlogi-agent.service 2>/dev/null || true
+if command -v systemctl >/dev/null 2>&1; then
+  echo "Disabling and stopping the agent …"
+  # Set XDG_RUNTIME_DIR explicitly: sudo -u strips the environment so
+  # systemctl --user cannot locate the user's D-Bus socket without it.
+  sudo -u "$REAL_USER" XDG_RUNTIME_DIR="/run/user/${REAL_UID}" \
+    systemctl --user disable --now openlogi-agent.service 2>/dev/null || true
 fi
 
 # ── remove binaries ───────────────────────────────────────────────────────────
@@ -46,10 +52,10 @@ sudo rm -f "${BINDIR}/openlogi" "${BINDIR}/openlogi-desktop" \
 
 echo "Removing udev rules …"
 sudo rm -f /etc/udev/rules.d/70-openlogi.rules
-if command -v udevadm > /dev/null 2>&1; then
-    sudo udevadm control --reload-rules
-    sudo udevadm trigger --subsystem-match=hidraw
-    sudo udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
+if command -v udevadm >/dev/null 2>&1; then
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger --subsystem-match=hidraw
+  sudo udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
 fi
 
 # ── systemd user unit ─────────────────────────────────────────────────────────
@@ -63,11 +69,11 @@ echo "Removing desktop entry and icon …"
 sudo rm -f /usr/share/applications/openlogi.desktop
 sudo rm -f /usr/share/icons/hicolor/1024x1024/apps/openlogi.png
 
-if command -v gtk-update-icon-cache > /dev/null 2>&1; then
-    sudo gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  sudo gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
 fi
-if command -v update-desktop-database > /dev/null 2>&1; then
-    sudo update-desktop-database -q /usr/share/applications || true
+if command -v update-desktop-database >/dev/null 2>&1; then
+  sudo update-desktop-database -q /usr/share/applications || true
 fi
 
 echo "OpenLogi uninstalled."

--- a/prek.toml
+++ b/prek.toml
@@ -48,3 +48,31 @@ language = "system"
 types = ["rust"]
 pass_filenames = false
 stages = ["pre-push"]
+
+# Shell scripts: shellcheck lints, shfmt formats. Both are in the devenv shell
+# and in CI's `shell` job.
+#
+# shfmt's formatting options live in `.editorconfig`, and it discards that file
+# entirely the moment a printer flag (`-i`, `-ci`, `-bn`, …) appears on the
+# command line — so this entry, the CI job and the local runner all invoke it
+# bare. Its `[[shell]]` section matches by shebang as well as by extension,
+# which is what covers the extensionless `.agents/*` scripts.
+#
+# `types = ["shell"]` matches the same way. `.envrc` is excluded to keep this
+# set identical to the one CI checks (`shfmt -f` over tracked files): direnv
+# sources it, it carries no shebang, and shfmt does not consider it a script.
+[[repos.hooks]]
+id = "shellcheck"
+name = "shellcheck"
+entry = "shellcheck"
+language = "system"
+types = ["shell"]
+exclude = "^\\.envrc$"
+
+[[repos.hooks]]
+id = "shfmt"
+name = "shfmt"
+entry = "shfmt --write"
+language = "system"
+types = ["shell"]
+exclude = "^\\.envrc$"


### PR DESCRIPTION
## Summary

Nothing in this repo checked its shell until now: no linter, no formatter, no CI job — while every Rust file passes four gates. This adds shellcheck and shfmt over the nine tracked shell scripts, wired the same way the Rust gates are: a CI job, a local counterpart in `ci-local.sh`, and prek hooks at commit time.

All nine scripts already pass shellcheck at its default severity (which includes style-level findings), so this lands as a gate, not a cleanup. The only code churn is the shfmt reformat in the first commit.

## Changes

- `.editorconfig` (new) — shfmt's formatting options, and the only place they exist. shfmt discards every EditorConfig file the moment a printer flag appears on the command line, so each call site invokes it bare; the reasoning lives in the `prek.toml` comment rather than in the config file. The `[[shell]]` section is shfmt's own extension: it matches by shebang as well as by extension, which is how the extensionless `.agents/*` scripts get the same rules as `*.sh`. `indent_size = 2` costs 393 diff lines against the tree; four spaces would have cost 972, and shfmt's own default (tabs) another 1150 on top.
- shell scripts — reformatted with shfmt. No behaviour change: shfmt reprints a parsed AST, and each script still passes its shell's `-n` syntax check.
- `.github/workflows/ci.yml` — new `shell` job (ubuntu, `taiki-e/install-action` for both tools, matching the `cargo-deny` job's install path). The file set is whatever `shfmt -f` recognises among tracked files, so a new script is covered the day it lands and `.devenv/`'s thousands of generated scripts stay out.
- `.github/scripts/ci-local.sh` — `job_shell`, in the default run, the `--list` table, and the named-job dispatch. Skips with a reason when the tools are missing rather than passing silently.
- `prek.toml` — `shellcheck` and `shfmt --write` at commit time, `types = ["shell"]`. `.envrc` is excluded so this set stays identical to the one CI checks: direnv sources it, it has no shebang, and shfmt's discovery does not consider it a script.
- `devenv.nix` — `shellcheck` and `shfmt` packages.
- `AGENTS.md`, `docs/DEVELOPMENT.md`, `.claude/rules/ci.md` — the new job in the pipeline summaries, the job map, and the "if you changed X, run Y" table.

## Testing

- `.github/scripts/ci-local.sh shell` — PASS.
- Negative test: staged a script with a shellcheck finding and wrong indentation; the job reported both and exited non-zero.
- `prek run --all-files shellcheck` / `prek run --all-files shfmt` — both Passed, no files rewritten (the tree is already shfmt-stable under `.editorconfig`).
- Syntax check after the reformat: `sh -n` for the `#!/bin/sh` scripts, `bash -n` for the rest — all clean.
- Not runtime-tested: the packaging scripts (`install.sh`, `uninstall.sh`, the nfpm maintainer scripts) were reformatted but not executed on a Linux host.
