### PR TITLE
refactor(xtask): split bundle.rs along what it actually does

### DIFF
--- a/xtask/README.md
+++ b/xtask/README.md
@@ -92,11 +92,16 @@ xtask/
           tests.rs
       macos.rs               # macOS domain entry
       macos/
-        bundle.rs
+        bundle.rs              # the assembly order, and what it means
         bundle/
-          identity.rs
+          embed.rs             # login-item helpers, the CLI, required binaries
+          embed/tests.rs
+          icns.rs              # the app icon
+          identity.rs          # bundle ids, names, icons per channel
           identity/tests.rs
-          tests.rs
+          info_plist.rs        # reading and stamping plist keys
+          signing.rs           # codesign, inside out
+          signing/tests.rs
         dev_bundle.rs
         dev_bundle/
           processes.rs

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -1,69 +1,26 @@
+//! Assembling `OpenLogi.app`: the order the pieces go in, and why.
+
+mod embed;
+mod icns;
 pub(crate) mod identity;
+mod info_plist;
+mod signing;
 
 use std::env;
 use std::path::Path;
 
 use anyhow::{Context as _, Result};
-use plist::Value;
+use strum::VariantArray as _;
 use xshell::{Shell, cmd};
 
-use strum::VariantArray as _;
-
-use crate::support::fs::{command_exists, ensure_dir, ensure_file, repo_root};
+use crate::support::fs::{command_exists, ensure_dir, repo_root};
 use identity::{Channel, Component};
 
-pub(crate) fn generate_icns() -> Result<()> {
-    let root = repo_root()?;
-    let sh = Shell::new()?;
-    let master = root.join("design/icon/openlogi.png");
-    let output_dir = root.join("crates/openlogi-desktop/icon");
-    let output = output_dir.join("AppIcon.icns");
-
-    ensure_file(&master)?;
-    fs_err::create_dir_all(&output_dir).with_context(|| {
-        format!(
-            "could not create icon output directory {}",
-            output_dir.display()
-        )
-    })?;
-
-    let work = tempfile::Builder::new()
-        .prefix("openlogi-icns-")
-        .tempdir()
-        .context("could not create temporary iconset directory")?;
-    let iconset = work.path().join("AppIcon.iconset");
-    fs_err::create_dir_all(&iconset)
-        .with_context(|| format!("could not create iconset directory {}", iconset.display()))?;
-
-    render_iconset(&iconset, |size, output| {
-        let size = size.to_string();
-        cmd!(sh, "sips -z {size} {size} {master} --out {output}")
-            .ignore_stdout()
-            .run()?;
-        Ok(())
-    })?;
-
-    // Let Apple's encoder choose the ICNS chunk layout. The Rust `icns` crate
-    // emits `icp4`/`icp5` PNG chunks that current macOS releases decode as
-    // corrupted pixels in small-icon surfaces such as Login Items.
-    cmd!(sh, "iconutil -c icns {iconset} -o {output}").run()?;
-    println!("wrote {}", output.display());
-    Ok(())
-}
-
-fn render_iconset<F>(iconset: &Path, mut render: F) -> Result<()>
-where
-    F: FnMut(u16, &Path) -> Result<()>,
-{
-    for size in [16, 32, 128, 256, 512] {
-        render(size, &iconset.join(format!("icon_{size}x{size}.png")))?;
-        render(
-            size * 2,
-            &iconset.join(format!("icon_{size}x{size}@2x.png")),
-        )?;
-    }
-    Ok(())
-}
+// The rest of the macOS domain reaches these through `bundle::`, which is the
+// module that owns them conceptually even now that the code sits deeper.
+pub(super) use embed::{HELPERS, Helper};
+pub(crate) use icns::generate_icns;
+pub(super) use signing::quoted_identity;
 
 /// Build `OpenLogi.app` wearing `channel`'s identity, signing it with whatever
 /// local identity is available (dev) or leaving it unsigned (production).
@@ -120,10 +77,10 @@ fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()>
 
     let app = root.join("target/release/bundle/osx/OpenLogi.app");
     ensure_dir(&app)?;
-    embed_helpers(&root, &app, &xcode_env, channel)?;
-    embed_cli(&root, &app, &xcode_env)?;
-    verify_bundle_binaries(&app, channel)?;
-    stamp_privacy_usage_descriptions(&app)?;
+    embed::embed_helpers(&root, &app, &xcode_env, channel)?;
+    embed::embed_cli(&root, &app, &xcode_env)?;
+    embed::verify_bundle_binaries(&app, channel)?;
+    info_plist::stamp_privacy_usage_descriptions(&app)?;
     // Identity first, then the checks, then signing — a signature seals the
     // `Info.plist` files, so nothing may rewrite them afterwards.
     identity::stamp(&app, channel, Component::VARIANTS)?;
@@ -131,12 +88,12 @@ fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()>
     identity::verify_icons(&app, channel, Component::VARIANTS)?;
     match (channel, sign_identity) {
         (Channel::Production, Some(identity)) => {
-            sign_app_with_timestamp(identity, TimestampMode::Secure, channel)?;
+            signing::sign_app_with_timestamp(identity, signing::TimestampMode::Secure, channel)?;
         }
         (Channel::Production, None) => {
             println!("==> codesign: skipped (unsigned — set OPENLOGI_SIGN_IDENTITY to sign)");
         }
-        (Channel::Dev, _) => local_sign_app_if_available(channel)?,
+        (Channel::Dev, _) => signing::local_sign_app_if_available(channel)?,
     }
     println!();
     println!("Bundle ready: {}", app.display());
@@ -155,177 +112,6 @@ fn remove_cargo_bundle_dmg(root: &Path) -> Result<()> {
     Ok(())
 }
 
-/// A nested login-item helper embedded under `Contents/Library/LoginItems`.
-pub(super) struct Helper {
-    /// Identity component, which also locates the helper inside the app bundle.
-    pub(super) component: Component,
-    /// Cargo package that builds it.
-    pub(super) package: &'static str,
-    /// Binary name, both in the profile directory and inside the helper bundle.
-    pub(super) binary: &'static str,
-    /// Checked-in `Info.plist` template, relative to the repo root. It carries
-    /// the shipped identity; [`identity::stamp`] writes the building channel's
-    /// over it, so the dev bundle needs no template of its own.
-    pub(super) info_plist: &'static str,
-    /// What the build log calls it.
-    pub(super) label: &'static str,
-}
-
-/// Every helper the app bundle ships.
-pub(super) const HELPERS: [Helper; 2] = [
-    Helper {
-        component: Component::Agent,
-        package: "openlogi-agent",
-        binary: "openlogi-agent",
-        info_plist: "crates/openlogi-desktop/bundle/agent-release/Info.plist",
-        label: "agent helper",
-    },
-    Helper {
-        component: Component::Overlay,
-        package: "openlogi-overlay",
-        binary: "openlogi-overlay",
-        info_plist: "crates/openlogi-desktop/bundle/overlay-release/Info.plist",
-        label: "Actions Ring overlay helper",
-    },
-];
-
-/// Build each helper and embed it as a nested login-item bundle.
-///
-/// The agent is the always-on process (hook + device I/O + menu bar); shipping
-/// it inside the GUI bundle keeps one notarized artifact, lets `open -b`
-/// foreground the GUI from the agent's menu, and gives the agent a stable
-/// signed identity so its Accessibility (TCC) grant survives app updates.
-///
-/// Every helper gets the GUI's icon, so each shows the OpenLogi mark rather than
-/// a generic blank wherever macOS lists it — System Settings' Accessibility
-/// pane, Login Items. Icon generation already ran, so the icns is on disk.
-fn embed_helpers(
-    root: &Path,
-    app: &Path,
-    xcode_env: &[(String, String)],
-    channel: Channel,
-) -> Result<()> {
-    let icon = root.join("crates/openlogi-desktop/icon/AppIcon.icns");
-    ensure_file(&icon)?;
-    for helper in &HELPERS {
-        embed_helper(root, app, xcode_env, helper, &icon, channel)?;
-    }
-    Ok(())
-}
-
-fn embed_helper(
-    root: &Path,
-    app: &Path,
-    xcode_env: &[(String, String)],
-    helper: &Helper,
-    icon: &Path,
-    channel: Channel,
-) -> Result<()> {
-    let sh = Shell::new()?;
-    let _repo = sh.push_dir(root);
-    let Helper {
-        package,
-        binary,
-        label,
-        ..
-    } = *helper;
-    println!("==> {label} (build)");
-    cmd!(sh, "cargo build -p {package} --bin {binary} --release")
-        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-        .run()?;
-    let built = root.join("target/release").join(binary);
-    ensure_file(&built)?;
-
-    let bundle = helper.component.root(app, channel);
-    let bundle_macos = bundle.join("Contents/MacOS");
-    fs_err::create_dir_all(&bundle_macos)
-        .with_context(|| format!("could not create {}", bundle_macos.display()))?;
-    fs_err::copy(&built, bundle_macos.join(binary))
-        .with_context(|| format!("could not copy {binary} into the helper bundle"))?;
-
-    let info_src = root.join(helper.info_plist);
-    ensure_file(&info_src)?;
-    let info_dst = helper.component.info_plist(app, channel);
-    fs_err::copy(&info_src, &info_dst)
-        .with_context(|| format!("could not write the {label} Info.plist"))?;
-    stamp_bundle_version(&info_dst, env!("CARGO_PKG_VERSION"))?;
-
-    let resources = bundle.join("Contents/Resources");
-    fs_err::create_dir_all(&resources)
-        .with_context(|| format!("could not create {}", resources.display()))?;
-    fs_err::copy(icon, helper.component.icon(app, channel))
-        .with_context(|| format!("could not copy the app icon into the {label} bundle"))?;
-
-    println!("    embedded {}", bundle.display());
-    Ok(())
-}
-
-fn embed_cli(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
-    let sh = Shell::new()?;
-    let _repo = sh.push_dir(root);
-    println!("==> cli (build)");
-    cmd!(sh, "cargo build -p openlogi --release")
-        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-        .run()?;
-    let cli_bin = root.join("target/release/openlogi");
-    ensure_file(&cli_bin)?;
-
-    let macos = app.join("Contents/MacOS");
-    fs_err::copy(&cli_bin, macos.join("openlogi"))
-        .with_context(|| "could not copy the CLI binary into the app bundle".to_string())?;
-
-    println!("    embedded {}", macos.join("openlogi").display());
-    Ok(())
-}
-
-/// Every Mach-O the finished bundle must ship, for `channel`'s helper layout.
-fn required_bundle_binaries(app: &Path, channel: Channel) -> Vec<std::path::PathBuf> {
-    let macos = app.join("Contents/MacOS");
-    let mut required = vec![macos.join("openlogi"), macos.join("openlogi-desktop")];
-    required.extend(HELPERS.iter().map(|helper| {
-        helper
-            .component
-            .root(app, channel)
-            .join("Contents/MacOS")
-            .join(helper.binary)
-    }));
-    required
-}
-
-fn verify_bundle_binaries(app: &Path, channel: Channel) -> Result<()> {
-    for path in required_bundle_binaries(app, channel) {
-        ensure_file(&path)
-            .with_context(|| format!("missing required bundle binary {}", path.display()))?;
-    }
-    Ok(())
-}
-
-/// Stamp `NSCameraUsageDescription` (cargo-bundle can't; matches the dev plist) so camera requests prompt instead of killing the app.
-fn stamp_privacy_usage_descriptions(app: &Path) -> Result<()> {
-    println!("==> privacy usage descriptions");
-    stamp_plist_strings(
-        &app.join("Contents/Info.plist"),
-        &[(
-            "NSCameraUsageDescription",
-            "OpenLogi previews your Logitech webcam locally. Video never leaves your Mac.",
-        )],
-    )
-}
-
-pub(super) fn stamp_bundle_version(info_plist: &Path, version: &str) -> Result<()> {
-    let mut plist = Value::from_file(info_plist)
-        .with_context(|| format!("could not read {}", info_plist.display()))?;
-    let dict = plist
-        .as_dictionary_mut()
-        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
-    for key in ["CFBundleShortVersionString", "CFBundleVersion"] {
-        dict.insert(key.into(), Value::String(version.to_string()));
-    }
-    plist
-        .to_file_xml(info_plist)
-        .with_context(|| format!("could not write {}", info_plist.display()))
-}
-
 pub(super) fn xcode_env() -> Result<Vec<(String, String)>> {
     let sh = Shell::new()?;
     let developer_dir = env::var("OPENLOGI_DEVELOPER_DIR")
@@ -338,180 +124,3 @@ pub(super) fn xcode_env() -> Result<Vec<(String, String)>> {
         ("SDKROOT".to_string(), sdkroot.trim().to_string()),
     ])
 }
-
-/// Read one string value from an `Info.plist`; `None` when the key is absent.
-fn read_plist_string(info_plist: &Path, key: &str) -> Result<Option<String>> {
-    let plist = Value::from_file(info_plist)
-        .with_context(|| format!("could not read {}", info_plist.display()))?;
-    let dict = plist
-        .as_dictionary()
-        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
-    Ok(dict.get(key).and_then(Value::as_string).map(str::to_owned))
-}
-
-fn stamp_plist_strings(info_plist: &Path, entries: &[(&str, &str)]) -> Result<()> {
-    let mut plist = Value::from_file(info_plist)
-        .with_context(|| format!("could not read {}", info_plist.display()))?;
-    let dict = plist
-        .as_dictionary_mut()
-        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
-    for (key, value) in entries {
-        dict.insert((*key).into(), Value::String((*value).to_string()));
-    }
-    plist
-        .to_file_xml(info_plist)
-        .with_context(|| format!("could not write {}", info_plist.display()))
-}
-
-fn local_sign_app_if_available(channel: Channel) -> Result<()> {
-    if env::var("OPENLOGI_LOCAL_CODESIGN").as_deref() == Ok("0") {
-        println!("==> local codesign: skipped (OPENLOGI_LOCAL_CODESIGN=0)");
-        return Ok(());
-    }
-
-    if let Some(identity) = env_nonempty("OPENLOGI_SIGN_IDENTITY") {
-        sign_app_with_timestamp(&identity, TimestampMode::Secure, channel)?;
-        return Ok(());
-    }
-
-    if let Some(identity) = env_nonempty("OPENLOGI_LOCAL_CODESIGN_IDENTITY") {
-        sign_app_with_timestamp(&identity, TimestampMode::None, channel)?;
-        return Ok(());
-    }
-
-    if let Some(identity) = first_apple_development_identity()? {
-        sign_app_with_timestamp(&identity, TimestampMode::None, channel)?;
-        return Ok(());
-    }
-
-    println!(
-        "==> local codesign: skipped (no Apple Development identity found;          set OPENLOGI_LOCAL_CODESIGN_IDENTITY or OPENLOGI_SIGN_IDENTITY to sign)"
-    );
-    println!(
-        "    warning: an unsigned bundle is re-signed ad-hoc on every build, so its own Accessibility grant goes stale each time"
-    );
-    Ok(())
-}
-
-fn sign_app_with_timestamp(
-    identity: &str,
-    timestamp: TimestampMode,
-    channel: Channel,
-) -> Result<()> {
-    let sh = Shell::new()?;
-    let root = repo_root()?;
-    let app = root.join("target/release/bundle/osx/OpenLogi.app");
-    let helper = Component::Agent.root(&app, channel);
-    let overlay = Component::Overlay.root(&app, channel);
-    // GUI + embedded CLI open the camera (preview / snapshot). The agent and
-    // overlay helpers do not — leave them without camera entitlements.
-    let camera_ents = camera_entitlements_path(&root);
-    ensure_file(&camera_ents)?;
-    println!("==> codesign ({identity})");
-    // Inside-out signing: seal the nested helper with its own signature first,
-    // then the outer app (which seals the already-signed helper). `--deep` is
-    // deprecated and can't give the helper an independent signature — but a
-    // stable, separately-signed helper identity is exactly what lets the agent's
-    // Accessibility (TCC) grant persist across updates. So sign each explicitly.
-    if helper.exists() {
-        codesign_runtime(identity, &helper, timestamp, None)?;
-    }
-    if overlay.exists() {
-        codesign_runtime(identity, &overlay, timestamp, None)?;
-    }
-    // The embedded CLI is a second Mach-O under Contents/MacOS; sign it with the
-    // hardened runtime before the outer app so it carries a Developer ID
-    // signature (its as-built ad-hoc signature would fail notarization).
-    let cli = app.join("Contents/MacOS/openlogi");
-    if cli.exists() {
-        codesign_runtime(identity, &cli, timestamp, Some(&camera_ents))?;
-    }
-    codesign_runtime(identity, &app, timestamp, Some(&camera_ents))?;
-    cmd!(sh, "codesign --verify --strict {app}").run()?;
-    if helper.exists() {
-        cmd!(sh, "codesign --verify --strict {helper}").run()?;
-    }
-    if overlay.exists() {
-        cmd!(sh, "codesign --verify --strict {overlay}").run()?;
-    }
-    if cli.exists() {
-        cmd!(sh, "codesign --verify --strict {cli}").run()?;
-    }
-    Ok(())
-}
-
-/// Path to the GUI/CLI entitlements (camera hardened-runtime exception).
-fn camera_entitlements_path(root: &Path) -> std::path::PathBuf {
-    root.join("crates/openlogi-desktop/bundle/OpenLogi.entitlements")
-}
-
-/// Sign one target with the hardened runtime and the requested timestamp mode.
-fn codesign_runtime(
-    identity: &str,
-    target: &Path,
-    timestamp: TimestampMode,
-    entitlements: Option<&Path>,
-) -> Result<()> {
-    let sh = Shell::new()?;
-    match (timestamp, entitlements) {
-        (TimestampMode::Secure, Some(ents)) => {
-            cmd!(
-                sh,
-                "codesign --force --options runtime --timestamp --entitlements {ents} --sign {identity} {target}"
-            )
-            .run()?;
-        }
-        (TimestampMode::Secure, None) => {
-            cmd!(
-                sh,
-                "codesign --force --options runtime --timestamp --sign {identity} {target}"
-            )
-            .run()?;
-        }
-        (TimestampMode::None, Some(ents)) => {
-            cmd!(
-                sh,
-                "codesign --force --options runtime --timestamp=none --entitlements {ents} --sign {identity} {target}"
-            )
-            .run()?;
-        }
-        (TimestampMode::None, None) => {
-            cmd!(
-                sh,
-                "codesign --force --options runtime --timestamp=none --sign {identity} {target}"
-            )
-            .run()?;
-        }
-    }
-    Ok(())
-}
-
-#[derive(Clone, Copy)]
-enum TimestampMode {
-    Secure,
-    None,
-}
-
-fn env_nonempty(name: &str) -> Option<String> {
-    env::var(name).ok().filter(|value| !value.trim().is_empty())
-}
-
-fn first_apple_development_identity() -> Result<Option<String>> {
-    let sh = Shell::new()?;
-    let Ok(output) = cmd!(sh, "security find-identity -v -p codesigning").read() else {
-        return Ok(None);
-    };
-    Ok(output
-        .lines()
-        .filter_map(quoted_identity)
-        .find(|identity| identity.starts_with("Apple Development:")))
-}
-
-pub(super) fn quoted_identity(line: &str) -> Option<String> {
-    let start = line.find('"')? + 1;
-    let end = line[start..].find('"')?;
-    Some(line[start..start + end].to_string())
-}
-
-#[cfg(test)]
-mod tests;

--- a/xtask/src/commands/macos/bundle/embed.rs
+++ b/xtask/src/commands/macos/bundle/embed.rs
@@ -1,0 +1,159 @@
+//! What goes inside the finished `.app`: the login-item helpers, the CLI, and
+//! the check that every Mach-O the bundle promises is actually there.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+use xshell::{Shell, cmd};
+
+use super::identity::{Channel, Component};
+use super::info_plist::stamp_bundle_version;
+use crate::support::fs::ensure_file;
+
+/// A nested login-item helper embedded under `Contents/Library/LoginItems`.
+pub(crate) struct Helper {
+    /// Identity component, which also locates the helper inside the app bundle.
+    pub(crate) component: Component,
+    /// Cargo package that builds it.
+    pub(crate) package: &'static str,
+    /// Binary name, both in the profile directory and inside the helper bundle.
+    pub(crate) binary: &'static str,
+    /// Checked-in `Info.plist` template, relative to the repo root. It carries
+    /// the shipped identity; [`super::identity::stamp`] writes the building channel's
+    /// over it, so the dev bundle needs no template of its own.
+    pub(crate) info_plist: &'static str,
+    /// What the build log calls it.
+    pub(crate) label: &'static str,
+}
+
+/// Every helper the app bundle ships.
+pub(crate) const HELPERS: [Helper; 2] = [
+    Helper {
+        component: Component::Agent,
+        package: "openlogi-agent",
+        binary: "openlogi-agent",
+        info_plist: "crates/openlogi-desktop/bundle/agent-release/Info.plist",
+        label: "agent helper",
+    },
+    Helper {
+        component: Component::Overlay,
+        package: "openlogi-overlay",
+        binary: "openlogi-overlay",
+        info_plist: "crates/openlogi-desktop/bundle/overlay-release/Info.plist",
+        label: "Actions Ring overlay helper",
+    },
+];
+
+/// Build each helper and embed it as a nested login-item bundle.
+///
+/// The agent is the always-on process (hook + device I/O + menu bar); shipping
+/// it inside the GUI bundle keeps one notarized artifact, lets `open -b`
+/// foreground the GUI from the agent's menu, and gives the agent a stable
+/// signed identity so its Accessibility (TCC) grant survives app updates.
+///
+/// Every helper gets the GUI's icon, so each shows the OpenLogi mark rather than
+/// a generic blank wherever macOS lists it — System Settings' Accessibility
+/// pane, Login Items. Icon generation already ran, so the icns is on disk.
+pub(super) fn embed_helpers(
+    root: &Path,
+    app: &Path,
+    xcode_env: &[(String, String)],
+    channel: Channel,
+) -> Result<()> {
+    let icon = root.join("crates/openlogi-desktop/icon/AppIcon.icns");
+    ensure_file(&icon)?;
+    for helper in &HELPERS {
+        embed_helper(root, app, xcode_env, helper, &icon, channel)?;
+    }
+    Ok(())
+}
+
+fn embed_helper(
+    root: &Path,
+    app: &Path,
+    xcode_env: &[(String, String)],
+    helper: &Helper,
+    icon: &Path,
+    channel: Channel,
+) -> Result<()> {
+    let sh = Shell::new()?;
+    let _repo = sh.push_dir(root);
+    let Helper {
+        package,
+        binary,
+        label,
+        ..
+    } = *helper;
+    println!("==> {label} (build)");
+    cmd!(sh, "cargo build -p {package} --bin {binary} --release")
+        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+        .run()?;
+    let built = root.join("target/release").join(binary);
+    ensure_file(&built)?;
+
+    let bundle = helper.component.root(app, channel);
+    let bundle_macos = bundle.join("Contents/MacOS");
+    fs_err::create_dir_all(&bundle_macos)
+        .with_context(|| format!("could not create {}", bundle_macos.display()))?;
+    fs_err::copy(&built, bundle_macos.join(binary))
+        .with_context(|| format!("could not copy {binary} into the helper bundle"))?;
+
+    let info_src = root.join(helper.info_plist);
+    ensure_file(&info_src)?;
+    let info_dst = helper.component.info_plist(app, channel);
+    fs_err::copy(&info_src, &info_dst)
+        .with_context(|| format!("could not write the {label} Info.plist"))?;
+    stamp_bundle_version(&info_dst, env!("CARGO_PKG_VERSION"))?;
+
+    let resources = bundle.join("Contents/Resources");
+    fs_err::create_dir_all(&resources)
+        .with_context(|| format!("could not create {}", resources.display()))?;
+    fs_err::copy(icon, helper.component.icon(app, channel))
+        .with_context(|| format!("could not copy the app icon into the {label} bundle"))?;
+
+    println!("    embedded {}", bundle.display());
+    Ok(())
+}
+
+pub(super) fn embed_cli(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
+    let sh = Shell::new()?;
+    let _repo = sh.push_dir(root);
+    println!("==> cli (build)");
+    cmd!(sh, "cargo build -p openlogi --release")
+        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+        .run()?;
+    let cli_bin = root.join("target/release/openlogi");
+    ensure_file(&cli_bin)?;
+
+    let macos = app.join("Contents/MacOS");
+    fs_err::copy(&cli_bin, macos.join("openlogi"))
+        .with_context(|| "could not copy the CLI binary into the app bundle".to_string())?;
+
+    println!("    embedded {}", macos.join("openlogi").display());
+    Ok(())
+}
+
+/// Every Mach-O the finished bundle must ship, for `channel`'s helper layout.
+fn required_bundle_binaries(app: &Path, channel: Channel) -> Vec<PathBuf> {
+    let macos = app.join("Contents/MacOS");
+    let mut required = vec![macos.join("openlogi"), macos.join("openlogi-desktop")];
+    required.extend(HELPERS.iter().map(|helper| {
+        helper
+            .component
+            .root(app, channel)
+            .join("Contents/MacOS")
+            .join(helper.binary)
+    }));
+    required
+}
+
+pub(super) fn verify_bundle_binaries(app: &Path, channel: Channel) -> Result<()> {
+    for path in required_bundle_binaries(app, channel) {
+        ensure_file(&path)
+            .with_context(|| format!("missing required bundle binary {}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/xtask/src/commands/macos/bundle/embed/tests.rs
+++ b/xtask/src/commands/macos/bundle/embed/tests.rs
@@ -1,4 +1,9 @@
+use strum::VariantArray as _;
+
+use super::super::identity;
+use super::super::info_plist::read_plist_string;
 use super::*;
+use crate::support::fs::repo_root;
 
 /// Identity work iterates every `Component`, so a component added without a
 /// `Helper` to embed it would only surface as a stamping failure during a
@@ -31,19 +36,6 @@ fn verify_bundle_binaries_accepts_a_complete_bundle() {
 
         verify_bundle_binaries(app.path(), channel).unwrap();
     }
-}
-
-#[test]
-fn camera_entitlements_declare_device_camera() {
-    let path = camera_entitlements_path(&repo_root().unwrap());
-    let plist = Value::from_file(&path).unwrap();
-    let dict = plist.as_dictionary().unwrap();
-    assert_eq!(
-        dict.get("com.apple.security.device.camera")
-            .and_then(Value::as_boolean),
-        Some(true),
-        "hardened-runtime camera capture needs this entitlement"
-    );
 }
 
 /// The checked-in helper plists are what a fresh bundle starts from, so a

--- a/xtask/src/commands/macos/bundle/icns.rs
+++ b/xtask/src/commands/macos/bundle/icns.rs
@@ -1,0 +1,62 @@
+//! The app icon: one committed 1024² master, rendered into an iconset and
+//! encoded by Apple's own tool.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use xshell::{Shell, cmd};
+
+use crate::support::fs::{ensure_file, repo_root};
+
+pub(crate) fn generate_icns() -> Result<()> {
+    let root = repo_root()?;
+    let sh = Shell::new()?;
+    let master = root.join("design/icon/openlogi.png");
+    let output_dir = root.join("crates/openlogi-desktop/icon");
+    let output = output_dir.join("AppIcon.icns");
+
+    ensure_file(&master)?;
+    fs_err::create_dir_all(&output_dir).with_context(|| {
+        format!(
+            "could not create icon output directory {}",
+            output_dir.display()
+        )
+    })?;
+
+    let work = tempfile::Builder::new()
+        .prefix("openlogi-icns-")
+        .tempdir()
+        .context("could not create temporary iconset directory")?;
+    let iconset = work.path().join("AppIcon.iconset");
+    fs_err::create_dir_all(&iconset)
+        .with_context(|| format!("could not create iconset directory {}", iconset.display()))?;
+
+    render_iconset(&iconset, |size, output| {
+        let size = size.to_string();
+        cmd!(sh, "sips -z {size} {size} {master} --out {output}")
+            .ignore_stdout()
+            .run()?;
+        Ok(())
+    })?;
+
+    // Let Apple's encoder choose the ICNS chunk layout. The Rust `icns` crate
+    // emits `icp4`/`icp5` PNG chunks that current macOS releases decode as
+    // corrupted pixels in small-icon surfaces such as Login Items.
+    cmd!(sh, "iconutil -c icns {iconset} -o {output}").run()?;
+    println!("wrote {}", output.display());
+    Ok(())
+}
+
+fn render_iconset<F>(iconset: &Path, mut render: F) -> Result<()>
+where
+    F: FnMut(u16, &Path) -> Result<()>,
+{
+    for size in [16, 32, 128, 256, 512] {
+        render(size, &iconset.join(format!("icon_{size}x{size}.png")))?;
+        render(
+            size * 2,
+            &iconset.join(format!("icon_{size}x{size}@2x.png")),
+        )?;
+    }
+    Ok(())
+}

--- a/xtask/src/commands/macos/bundle/identity.rs
+++ b/xtask/src/commands/macos/bundle/identity.rs
@@ -19,7 +19,7 @@ use clap::ValueEnum;
 use openlogi_core::brand;
 use strum::{Display, VariantArray};
 
-use super::{read_plist_string, stamp_plist_strings};
+use super::info_plist::{read_plist_string, stamp_plist_strings};
 
 /// The icon every component shares, as `CFBundleIconFile` spells it (the `.icns`
 /// extension is optional there, so it is trimmed before comparing).

--- a/xtask/src/commands/macos/bundle/info_plist.rs
+++ b/xtask/src/commands/macos/bundle/info_plist.rs
@@ -1,0 +1,59 @@
+//! Reading and stamping `Info.plist` keys.
+//!
+//! Every write here has to happen before signing: a signature seals the plists,
+//! so a later rewrite invalidates it.
+
+use std::path::Path;
+
+use anyhow::{Context as _, Result};
+use plist::Value;
+
+/// Stamp `NSCameraUsageDescription` (cargo-bundle can't; matches the dev plist) so camera requests prompt instead of killing the app.
+pub(super) fn stamp_privacy_usage_descriptions(app: &Path) -> Result<()> {
+    println!("==> privacy usage descriptions");
+    stamp_plist_strings(
+        &app.join("Contents/Info.plist"),
+        &[(
+            "NSCameraUsageDescription",
+            "OpenLogi previews your Logitech webcam locally. Video never leaves your Mac.",
+        )],
+    )
+}
+
+pub(super) fn stamp_bundle_version(info_plist: &Path, version: &str) -> Result<()> {
+    let mut plist = Value::from_file(info_plist)
+        .with_context(|| format!("could not read {}", info_plist.display()))?;
+    let dict = plist
+        .as_dictionary_mut()
+        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
+    for key in ["CFBundleShortVersionString", "CFBundleVersion"] {
+        dict.insert(key.into(), Value::String(version.to_string()));
+    }
+    plist
+        .to_file_xml(info_plist)
+        .with_context(|| format!("could not write {}", info_plist.display()))
+}
+
+/// Read one string value from an `Info.plist`; `None` when the key is absent.
+pub(super) fn read_plist_string(info_plist: &Path, key: &str) -> Result<Option<String>> {
+    let plist = Value::from_file(info_plist)
+        .with_context(|| format!("could not read {}", info_plist.display()))?;
+    let dict = plist
+        .as_dictionary()
+        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
+    Ok(dict.get(key).and_then(Value::as_string).map(str::to_owned))
+}
+
+pub(super) fn stamp_plist_strings(info_plist: &Path, entries: &[(&str, &str)]) -> Result<()> {
+    let mut plist = Value::from_file(info_plist)
+        .with_context(|| format!("could not read {}", info_plist.display()))?;
+    let dict = plist
+        .as_dictionary_mut()
+        .with_context(|| format!("{} is not a plist dictionary", info_plist.display()))?;
+    for (key, value) in entries {
+        dict.insert((*key).into(), Value::String((*value).to_string()));
+    }
+    plist
+        .to_file_xml(info_plist)
+        .with_context(|| format!("could not write {}", info_plist.display()))
+}

--- a/xtask/src/commands/macos/bundle/signing.rs
+++ b/xtask/src/commands/macos/bundle/signing.rs
@@ -1,0 +1,167 @@
+//! Signing the shipped bundle, inside out.
+//!
+//! Which identity is used and whether it carries a secure timestamp is the
+//! difference between a build that notarizes and one that only runs locally,
+//! so both are decided here rather than at the call site.
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use xshell::{Shell, cmd};
+
+use super::identity::{Channel, Component};
+use crate::support::fs::{ensure_file, repo_root};
+
+pub(super) fn local_sign_app_if_available(channel: Channel) -> Result<()> {
+    if env::var("OPENLOGI_LOCAL_CODESIGN").as_deref() == Ok("0") {
+        println!("==> local codesign: skipped (OPENLOGI_LOCAL_CODESIGN=0)");
+        return Ok(());
+    }
+
+    if let Some(identity) = env_nonempty("OPENLOGI_SIGN_IDENTITY") {
+        sign_app_with_timestamp(&identity, TimestampMode::Secure, channel)?;
+        return Ok(());
+    }
+
+    if let Some(identity) = env_nonempty("OPENLOGI_LOCAL_CODESIGN_IDENTITY") {
+        sign_app_with_timestamp(&identity, TimestampMode::None, channel)?;
+        return Ok(());
+    }
+
+    if let Some(identity) = first_apple_development_identity()? {
+        sign_app_with_timestamp(&identity, TimestampMode::None, channel)?;
+        return Ok(());
+    }
+
+    println!(
+        "==> local codesign: skipped (no Apple Development identity found;          set OPENLOGI_LOCAL_CODESIGN_IDENTITY or OPENLOGI_SIGN_IDENTITY to sign)"
+    );
+    println!(
+        "    warning: an unsigned bundle is re-signed ad-hoc on every build, so its own Accessibility grant goes stale each time"
+    );
+    Ok(())
+}
+
+pub(super) fn sign_app_with_timestamp(
+    identity: &str,
+    timestamp: TimestampMode,
+    channel: Channel,
+) -> Result<()> {
+    let sh = Shell::new()?;
+    let root = repo_root()?;
+    let app = root.join("target/release/bundle/osx/OpenLogi.app");
+    let helper = Component::Agent.root(&app, channel);
+    let overlay = Component::Overlay.root(&app, channel);
+    // GUI + embedded CLI open the camera (preview / snapshot). The agent and
+    // overlay helpers do not — leave them without camera entitlements.
+    let camera_ents = camera_entitlements_path(&root);
+    ensure_file(&camera_ents)?;
+    println!("==> codesign ({identity})");
+    // Inside-out signing: seal the nested helper with its own signature first,
+    // then the outer app (which seals the already-signed helper). `--deep` is
+    // deprecated and can't give the helper an independent signature — but a
+    // stable, separately-signed helper identity is exactly what lets the agent's
+    // Accessibility (TCC) grant persist across updates. So sign each explicitly.
+    if helper.exists() {
+        codesign_runtime(identity, &helper, timestamp, None)?;
+    }
+    if overlay.exists() {
+        codesign_runtime(identity, &overlay, timestamp, None)?;
+    }
+    // The embedded CLI is a second Mach-O under Contents/MacOS; sign it with the
+    // hardened runtime before the outer app so it carries a Developer ID
+    // signature (its as-built ad-hoc signature would fail notarization).
+    let cli = app.join("Contents/MacOS/openlogi");
+    if cli.exists() {
+        codesign_runtime(identity, &cli, timestamp, Some(&camera_ents))?;
+    }
+    codesign_runtime(identity, &app, timestamp, Some(&camera_ents))?;
+    cmd!(sh, "codesign --verify --strict {app}").run()?;
+    if helper.exists() {
+        cmd!(sh, "codesign --verify --strict {helper}").run()?;
+    }
+    if overlay.exists() {
+        cmd!(sh, "codesign --verify --strict {overlay}").run()?;
+    }
+    if cli.exists() {
+        cmd!(sh, "codesign --verify --strict {cli}").run()?;
+    }
+    Ok(())
+}
+
+/// Path to the GUI/CLI entitlements (camera hardened-runtime exception).
+fn camera_entitlements_path(root: &Path) -> PathBuf {
+    root.join("crates/openlogi-desktop/bundle/OpenLogi.entitlements")
+}
+
+/// Sign one target with the hardened runtime and the requested timestamp mode.
+fn codesign_runtime(
+    identity: &str,
+    target: &Path,
+    timestamp: TimestampMode,
+    entitlements: Option<&Path>,
+) -> Result<()> {
+    let sh = Shell::new()?;
+    match (timestamp, entitlements) {
+        (TimestampMode::Secure, Some(ents)) => {
+            cmd!(
+                sh,
+                "codesign --force --options runtime --timestamp --entitlements {ents} --sign {identity} {target}"
+            )
+            .run()?;
+        }
+        (TimestampMode::Secure, None) => {
+            cmd!(
+                sh,
+                "codesign --force --options runtime --timestamp --sign {identity} {target}"
+            )
+            .run()?;
+        }
+        (TimestampMode::None, Some(ents)) => {
+            cmd!(
+                sh,
+                "codesign --force --options runtime --timestamp=none --entitlements {ents} --sign {identity} {target}"
+            )
+            .run()?;
+        }
+        (TimestampMode::None, None) => {
+            cmd!(
+                sh,
+                "codesign --force --options runtime --timestamp=none --sign {identity} {target}"
+            )
+            .run()?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum TimestampMode {
+    Secure,
+    None,
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.trim().is_empty())
+}
+
+fn first_apple_development_identity() -> Result<Option<String>> {
+    let sh = Shell::new()?;
+    let Ok(output) = cmd!(sh, "security find-identity -v -p codesigning").read() else {
+        return Ok(None);
+    };
+    Ok(output
+        .lines()
+        .filter_map(quoted_identity)
+        .find(|identity| identity.starts_with("Apple Development:")))
+}
+
+pub(crate) fn quoted_identity(line: &str) -> Option<String> {
+    let start = line.find('"')? + 1;
+    let end = line[start..].find('"')?;
+    Some(line[start..start + end].to_string())
+}
+
+#[cfg(test)]
+mod tests;

--- a/xtask/src/commands/macos/bundle/signing/tests.rs
+++ b/xtask/src/commands/macos/bundle/signing/tests.rs
@@ -1,0 +1,17 @@
+use plist::Value;
+
+use super::camera_entitlements_path;
+use crate::support::fs::repo_root;
+
+#[test]
+fn camera_entitlements_declare_device_camera() {
+    let path = camera_entitlements_path(&repo_root().unwrap());
+    let plist = Value::from_file(&path).unwrap();
+    let dict = plist.as_dictionary().unwrap();
+    assert_eq!(
+        dict.get("com.apple.security.device.camera")
+            .and_then(Value::as_boolean),
+        Some(true),
+        "hardened-runtime camera capture needs this entitlement"
+    );
+}


### PR DESCRIPTION
## Summary

`bundle.rs` was 517 lines holding five separate jobs: rendering the app icon, embedding the login-item helpers and the CLI, stamping `Info.plist` keys, signing, and the assembly order that drives all of them. Only the last one is what "bundle" means. The other four move into modules named after themselves and `bundle.rs` is down to 126 lines.

No behaviour change — this is a move, plus one dead export removed and one doc link repaired.

## Changes

- `bundle/icns.rs` (62) — `generate_icns` and the iconset renderer.
- `bundle/embed.rs` (159) — the `Helper` table, helper and CLI embedding, and the required-binary check.
- `bundle/info_plist.rs` (59) — reading and stamping plist keys. Its module doc states the constraint that ties these together: every write has to happen before signing, because a signature seals the plists.
- `bundle/signing.rs` (167) — identity selection, timestamp mode, and the inside-out `codesign` sequence.
- `bundle.rs` (126) — the assembly order, `xcode_env`, and the facade.

The rest of the macOS domain still reaches `bundle::HELPERS`, `bundle::generate_icns` and `bundle::quoted_identity`, so `dev_bundle.rs`, `dev_bundle/signing.rs`, `dmg.rs` and `macos.rs` needed no edit at all — `bundle.rs` re-exports them, which is honest: it is the module that owns those concepts even now that the code sits deeper.

`stamp_bundle_version` did not survive that treatment. It was `pub(super)`, i.e. offered to the whole macOS domain, and nothing outside `bundle` ever called it; it is now scoped to the one module that does.

Tests move next to what they pin, following the convention `xtask` adopted in #746: the helper-table and required-binary tests to `embed/tests.rs`, the camera-entitlements test to `signing/tests.rs`. `bundle/tests.rs` is gone and the count is unchanged at 46.

## Testing

- Full local gate on the final tree: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `RUSTDOCFLAGS="-D warnings" cargo doc …` — all pass.
- rustdoc earned its place in that gate here: it caught a `[`identity::stamp`]` intra-doc link that resolved from `bundle.rs` and does not from `embed.rs`. Neither the compiler nor clippy sees that.
- Not runtime-tested: no bundle was built. `macos bundle` / `macos package` need Xcode and a signing identity, and this change moves code without altering the sequence — the ordering comment about signing sealing the plists is preserved verbatim in `run_with_channel`.
