### PR TITLE
fix(linux): load uinput rather than rely on another daemon

### DIFF
--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -87,6 +87,18 @@ echo "Installing udev rules …"
 sudo install -Dm644 "${SCRIPT_DIR}/udev/70-openlogi.rules" \
   /etc/udev/rules.d/70-openlogi.rules
 
+# The rule grants /dev/uinput with TAG+="uaccess", which logind applies in
+# response to a device event. A host that has never loaded the uinput module has
+# no such device, so the trigger below matches nothing and the node stays
+# root-owned — the hook then cannot create its virtual device and button
+# remapping silently does nothing. Load it now, and register it for every boot.
+echo "Loading the uinput module …"
+sudo install -Dm644 "${SCRIPT_DIR}/modules-load/openlogi.conf" \
+  /etc/modules-load.d/openlogi.conf
+if command -v modprobe >/dev/null 2>&1; then
+  sudo modprobe uinput || true
+fi
+
 if command -v udevadm >/dev/null 2>&1; then
   echo "Reloading udev rules …"
   sudo udevadm control --reload-rules

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -105,6 +105,10 @@ if command -v udevadm >/dev/null 2>&1; then
   sudo udevadm trigger --subsystem-match=hidraw
   sudo udevadm trigger --subsystem-match=input
   sudo udevadm trigger --subsystem-match=misc --attr-match=name=uinput 2>/dev/null || true
+  # trigger only queues the events. Without settle the script can return before
+  # udev has applied the uaccess ACLs, so the next thing the user does — start
+  # the agent — still hits EACCES on a correctly configured system.
+  sudo udevadm settle 2>/dev/null || true
 fi
 
 # ── systemd user unit ─────────────────────────────────────────────────────────

--- a/packaging/linux/modules-load/openlogi.conf
+++ b/packaging/linux/modules-load/openlogi.conf
@@ -1,0 +1,11 @@
+# Load uinput at boot for OpenLogi.
+#
+# 70-openlogi.rules grants access to /dev/uinput with TAG+="uaccess", which
+# systemd-logind applies in response to a device event. A machine that has never
+# loaded the uinput module has no such device: OPTIONS+="static_node=uinput"
+# creates the node so that opening it can autoload the module, but the node is
+# created with default permissions and no ACL, and opening it is precisely what
+# the missing permission forbids.
+#
+# Loading the module makes the device appear, which lets the rule tag it.
+uinput

--- a/packaging/linux/nfpm-scripts/postinstall.sh
+++ b/packaging/linux/nfpm-scripts/postinstall.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
 set -eu
 
+# /etc/modules-load.d/openlogi.conf loads uinput from the next boot on; load it
+# now so the first session after installing works too. Without the module there
+# is no uinput device for the rule's uaccess tag to apply to — the node exists
+# via static_node= but stays root-owned, so the agent's hook cannot open it and
+# button remapping silently does nothing while HID++ keeps working.
+if command -v modprobe >/dev/null 2>&1; then
+  modprobe uinput || true
+fi
+
 # Reload udev rules and wait for the new uaccess tags to be applied.
 # udevadm trigger is asynchronous — settle ensures the tags are in place
-# before the script exits so the agent can open /dev/hidraw* and the mouse's
-# /dev/input/event* node immediately, even for a device connected before the
-# install.
+# before the script exits so the agent can open /dev/hidraw*, /dev/uinput and
+# the mouse's /dev/input/event* node immediately, even for a device connected
+# before the install.
 if command -v udevadm >/dev/null 2>&1; then
   udevadm control --reload-rules
   udevadm trigger --subsystem-match=hidraw

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -47,6 +47,14 @@ contents:
     file_info:
       mode: 0644
 
+  # ── uinput module load ──────────────────────────────────────────────────────
+  # The udev rule alone cannot grant /dev/uinput on a machine that has never
+  # loaded the module; see the file's own comment.
+  - src: packaging/linux/modules-load/openlogi.conf
+    dst: /etc/modules-load.d/openlogi.conf
+    file_info:
+      mode: 0644
+
   # ── systemd user unit ───────────────────────────────────────────────────────
   - src: packaging/linux/systemd/openlogi-agent.service
     dst: /usr/lib/systemd/user/openlogi-agent.service

--- a/packaging/linux/nixos-module.nix
+++ b/packaging/linux/nixos-module.nix
@@ -25,6 +25,14 @@ in
     environment.systemPackages = [ cfg.package ];
     services.udev.packages = [ cfg.package ];
 
+    # The udev rule grants /dev/uinput with TAG+="uaccess", which logind applies
+    # in response to a device event — and a host that has never loaded the
+    # uinput module has no such device, so the node stays root-owned and the
+    # agent cannot create the virtual device button remapping needs. The other
+    # packaging paths ship /etc/modules-load.d/openlogi.conf for this; on NixOS
+    # the equivalent is asking for the module here.
+    boot.kernelModules = [ "uinput" ];
+
     systemd.user.services.openlogi-agent = {
       description = "OpenLogi background agent";
       wantedBy = lib.optionals cfg.launchAtLogin [ "graphical-session.target" ];

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -52,6 +52,9 @@ sudo rm -f "${BINDIR}/openlogi" "${BINDIR}/openlogi-desktop" \
 
 echo "Removing udev rules …"
 sudo rm -f /etc/udev/rules.d/70-openlogi.rules
+# Leave the module loaded: other software may be using it by now. Only stop
+# asking for it at boot.
+sudo rm -f /etc/modules-load.d/openlogi.conf
 if command -v udevadm >/dev/null 2>&1; then
   sudo udevadm control --reload-rules
   sudo udevadm trigger --subsystem-match=hidraw


### PR DESCRIPTION
## Summary

The Linux packages ship `70-openlogi.rules`, which grants `/dev/uinput` with
`TAG+="uaccess"` — an ACL logind applies **in response to a device event**. On a
machine that has never loaded the `uinput` module there is no such device, so
`postinstall`'s `udevadm trigger --attr-match=name=uinput` matches nothing. It is
a no-op, and its `|| true` hides that. `OPTIONS+="static_node=uinput"` does create
the node, but a static node gets default permissions and no ACL: opening it would
autoload the module, except opening is exactly what the missing permission forbids.

Nothing in the package breaks that cycle, so today it is broken by whatever else
happens to open `/dev/uinput` first. On a typical desktop something does —
`bluetoothd` opens it seconds after boot, and Steam and logiops do too — and
OpenLogi works. **Where nothing does, the agent starts, reports the device,
battery and DPI normally over HID++, and button remapping silently never works**,
with only a journal warning to say so.

systemd's own rules show the shape of the fix: `snd/seq` and `snd/timer` carry a
real `GROUP=` in `50-udev-default.rules` *alongside* `TAG+="uaccess"` in
`70-uaccess.rules`, precisely because uaccess cannot cover the pre-module node.

## Changes

- **`packaging/linux/modules-load/openlogi.conf`** (new) — loads `uinput` at boot.
  Package content rather than something the script writes, so uninstalling removes
  it.
- **`packaging/linux/nfpm.yaml`** — ships the above to `/etc/modules-load.d/` at
  `0644`.
- **`packaging/linux/nfpm-scripts/postinstall.sh`** — `modprobe uinput` before the
  `udevadm` block, so the session that installed the package works too and not
  only the next boot.

No Rust changes; `.deb`, `.rpm` and `.pkg.tar.zst` all pick this up from the
shared nfpm config.

## Reproducing

Any machine, ~30 seconds. Unloading the module and dropping the ACL leaves the
static node at `root:root 0600` with no ACL — byte-for-byte the state a
never-loaded machine boots into.

```sh
systemctl --user stop openlogi-agent.service
sudo systemctl stop bluetooth          # or whatever holds /dev/uinput; check with: sudo lsof /dev/uinput
sudo modprobe -r uinput
sudo setfacl -x "u:$USER" /dev/uinput

test -w /dev/uinput && echo "WRITABLE — precondition not met" || echo "NOT WRITABLE — ready"

systemctl --user start openlogi-agent.service
journalctl --user -u openlogi-agent -n 5 --no-pager
```

Before this change:

```
WARN openlogi_agent_core::hook_runtime: could not install OS input hook —
  events will not be captured error=Linux input error: Permission denied (os error 13)
```

`openlogi list` still shows the mouse and its battery throughout, which is what
makes this easy to miss.

Restore with `sudo systemctl start bluetooth && sudo modprobe uinput && sudo udevadm trigger`.

> Check the mouse's `/dev/input/event*` node is readable first. If it is not, the
> hook fails earlier with `no mouse device found under /dev/input` and never
> reaches `/dev/uinput` — a different problem.

## Testing

Fedora 44, x86_64, on real hardware (MX Master 3S over Bluetooth).

**Bug reproduced on two machines**, both running released packages, neither with
this change:

- `openlogi-v0.7.4-linux-amd64.rpm`, with logiops and Solaar removed
- a second machine running the 0.7.3 package, with the mouse's event node
  confirmed readable first so the failure could only be the uinput side

Both produced `Permission denied (os error 13)` and created no virtual input
device. In its untouched state the second machine does **not** fail — `bluetoothd`
had held `/dev/uinput` since 14 s after boot.

**Fix verified as shipped**, not just by hand:

```sh
cargo run -p xtask -- linux package
rpm -qlp target/release/openlogi-0.7.4-1.x86_64.rpm | grep modules-load
#   /etc/modules-load.d/openlogi.conf
rpm -qp --dump target/release/openlogi-0.7.4-1.x86_64.rpm | grep modules-load
#   mode 0100644 root root
rpm -qp --scripts target/release/openlogi-0.7.4-1.x86_64.rpm | grep modprobe
#   modprobe uinput || true

sudo dnf install -y target/release/openlogi-0.7.4-1.x86_64.rpm
#   -> uinput module loaded, /dev/uinput writable, hook installs,
#      "OpenLogi virtual mouse" node created
sudo dnf remove -y openlogi
#   -> /etc/modules-load.d/openlogi.conf removed, no .rpmsave left behind
```

The `.deb` was checked the same way (`ar p … data.tar.gz | tar tzf -`) and carries
both the config file and the `modprobe` line.

**CI:**

```sh
cargo xtask ci
#   7 passed, 0 failed, 2 skipped
```

Includes the `shell` job (`shellcheck` + `shfmt -d`), which gates
`postinstall.sh`. **Not run: `tests (macos)`** (wrong host) and **`cargo-deny`**
(not installed locally) — neither is affected by a packaging-only change, but
neither was executed.