### PR TITLE
refactor(cli): render diagnostics with display adapters

### DIFF
--- a/crates/openlogi-cli/src/cmd/diag/features.rs
+++ b/crates/openlogi-cli/src/cmd/diag/features.rs
@@ -4,6 +4,8 @@
 //! given peripheral exposes when the default wrappers (0x2201, 0x2111)
 //! aren't recognised.
 
+use std::fmt;
+
 use anyhow::Result;
 use clap::Args;
 use openlogi_hid::{DeviceRoute, FeatureType, FirmwareEntity};
@@ -36,7 +38,7 @@ pub async fn run(_args: FeaturesArgs) -> Result<()> {
                             idx,
                             entry.id,
                             entry.version,
-                            format_feature_flags(entry.typ)
+                            FeatureFlagsDisplay(entry.typ)
                         );
                     }
                     println!("  ({} feature entries)\n", entries.len());
@@ -46,7 +48,7 @@ pub async fn run(_args: FeaturesArgs) -> Result<()> {
             match openlogi_hid::dump_firmware_entities(&route).await {
                 Ok(entries) => {
                     for entry in &entries {
-                        println!("  {}", format_firmware_entity(entry));
+                        println!("  {}", FirmwareEntityDisplay(entry));
                     }
                 }
                 Err(e) => println!("  firmware dump failed: {e:#}"),
@@ -67,31 +69,39 @@ pub async fn run(_args: FeaturesArgs) -> Result<()> {
 /// and an undocumented bit on a new device is exactly what this column exists
 /// to surface. Dropping either would make the column a partial view of a
 /// response it is meant to report verbatim.
-fn format_feature_flags(typ: FeatureType) -> String {
-    const NAMED: [(FeatureType, &str); 5] = [
-        (FeatureType::OBSOLETE, "obsolete"),
-        (FeatureType::HIDDEN, "hidden"),
-        (FeatureType::ENGINEERING, "engineering"),
-        (
-            FeatureType::MANUFACTURING_DEACTIVATABLE,
-            "manufacturing-deactivatable",
-        ),
-        (
-            FeatureType::COMPLIANCE_DEACTIVATABLE,
-            "compliance-deactivatable",
-        ),
-    ];
+struct FeatureFlagsDisplay(FeatureType);
 
-    let mut flags: Vec<String> = NAMED
-        .iter()
-        .filter(|(flag, _)| typ.contains(*flag))
-        .map(|(_, name)| (*name).to_owned())
-        .collect();
-    let unknown = typ.bits() & !FeatureType::all().bits();
-    if unknown != 0 {
-        flags.push(format!("unknown=0x{unknown:02x}"));
+impl fmt::Display for FeatureFlagsDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const NAMED: [(FeatureType, &str); 5] = [
+            (FeatureType::OBSOLETE, "obsolete"),
+            (FeatureType::HIDDEN, "hidden"),
+            (FeatureType::ENGINEERING, "engineering"),
+            (
+                FeatureType::MANUFACTURING_DEACTIVATABLE,
+                "manufacturing-deactivatable",
+            ),
+            (
+                FeatureType::COMPLIANCE_DEACTIVATABLE,
+                "compliance-deactivatable",
+            ),
+        ];
+
+        let mut separator = "";
+        for (flag, name) in NAMED {
+            if self.0.contains(flag) {
+                write!(f, "{separator}{name}")?;
+                separator = ",";
+            }
+        }
+
+        let unknown = self.0.bits() & !FeatureType::all().bits();
+        if unknown != 0 {
+            write!(f, "{separator}unknown=0x{unknown:02x}")?;
+        }
+
+        Ok(())
     }
-    flags.join(",")
 }
 
 /// Render one firmware entity as a single diagnostics line.
@@ -99,28 +109,43 @@ fn format_feature_flags(typ: FeatureType) -> String {
 /// An entity the device declared but could not describe is reported rather
 /// than dropped: a device that cannot describe one of its own firmware images
 /// is exactly what a bug report needs to say.
-fn format_firmware_entity(entry: &FirmwareEntity) -> String {
-    match entry {
-        FirmwareEntity::Readable { index, info } => {
-            let active = if info.active { " [active]" } else { "" };
-            // `extra_version` is optional by spec, and all-zero is how a
-            // device says it has none — so an empty field is absence, not a
-            // value being hidden. The PID above is not optional and is printed
-            // even when the device answers zero, which only a dormant entity
-            // is allowed to do.
-            let [v0, v1, v2, v3, v4] = info.extra_version;
-            let extra = if info.extra_version == [0; 5] {
-                String::new()
-            } else {
-                format!(" extra={v0:02x}{v1:02x}{v2:02x}{v3:02x}{v4:02x}")
-            };
-            format!(
-                "fw {index}: {:?} {}{:02}.{:02}_B{:04} pid={:04x}{active}{extra}",
-                info.kind, info.prefix, info.number, info.revision, info.build, info.transport_pid
-            )
-        }
-        FirmwareEntity::Unreadable { index, error } => {
-            format!("fw {index}: unreadable ({error})")
+struct FirmwareEntityDisplay<'a>(&'a FirmwareEntity);
+
+impl fmt::Display for FirmwareEntityDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            FirmwareEntity::Readable { index, info } => {
+                write!(
+                    f,
+                    "fw {index}: {:?} {}{:02}.{:02}_B{:04} pid={:04x}",
+                    info.kind,
+                    info.prefix,
+                    info.number,
+                    info.revision,
+                    info.build,
+                    info.transport_pid
+                )?;
+                if info.active {
+                    write!(f, " [active]")?;
+                }
+
+                // `extra_version` is optional by spec, and all-zero is how a
+                // device says it has none — so an empty field is absence, not
+                // a value being hidden. The PID above is not optional and is
+                // printed even when the device answers zero, which only a
+                // dormant entity is allowed to do.
+                if info.extra_version != [0; 5] {
+                    write!(f, " extra=")?;
+                    for byte in info.extra_version {
+                        write!(f, "{byte:02x}")?;
+                    }
+                }
+
+                Ok(())
+            }
+            FirmwareEntity::Unreadable { index, error } => {
+                write!(f, "fw {index}: unreadable ({error})")
+            }
         }
     }
 }
@@ -132,7 +157,7 @@ mod tests {
         WriteError,
     };
 
-    use super::{format_feature_flags, format_firmware_entity};
+    use super::{FeatureFlagsDisplay, FirmwareEntityDisplay};
 
     fn entry() -> FirmwareEntity {
         FirmwareEntity::Readable {
@@ -160,7 +185,7 @@ mod tests {
     #[test]
     fn the_running_entity_is_marked_active() {
         assert_eq!(
-            format_firmware_entity(&entry()),
+            FirmwareEntityDisplay(&entry()).to_string(),
             "fw 1: MainApplication MPM17.00_B0008 pid=c08d [active]"
         );
     }
@@ -170,7 +195,7 @@ mod tests {
         let mut e = entry();
         info(&mut e).active = false;
         assert_eq!(
-            format_firmware_entity(&e),
+            FirmwareEntityDisplay(&e).to_string(),
             "fw 1: MainApplication MPM17.00_B0008 pid=c08d"
         );
     }
@@ -183,7 +208,7 @@ mod tests {
         info(&mut e).active = false;
         info(&mut e).transport_pid = 0;
         assert_eq!(
-            format_firmware_entity(&e),
+            FirmwareEntityDisplay(&e).to_string(),
             "fw 1: MainApplication MPM17.00_B0008 pid=0000"
         );
     }
@@ -195,7 +220,7 @@ mod tests {
         let mut e = entry();
         info(&mut e).extra_version = [0x01, 0x02, 0x00, 0xff, 0x10];
         assert_eq!(
-            format_firmware_entity(&e),
+            FirmwareEntityDisplay(&e).to_string(),
             "fw 1: MainApplication MPM17.00_B0008 pid=c08d [active] extra=010200ff10"
         );
     }
@@ -213,20 +238,20 @@ mod tests {
             },
         };
         assert_eq!(
-            format_firmware_entity(&e),
+            FirmwareEntityDisplay(&e).to_string(),
             "fw 2: unreadable (HID++ unsupported response during DumpFeatures for feature 0x0003)"
         );
     }
 
     #[test]
     fn a_feature_with_no_flags_renders_empty() {
-        assert_eq!(format_feature_flags(FeatureType::empty()), "");
+        assert_eq!(FeatureFlagsDisplay(FeatureType::empty()).to_string(), "");
     }
 
     #[test]
     fn every_known_flag_is_named() {
         assert_eq!(
-            format_feature_flags(FeatureType::all()),
+            FeatureFlagsDisplay(FeatureType::all()).to_string(),
             "obsolete,hidden,engineering,manufacturing-deactivatable,compliance-deactivatable"
         );
     }
@@ -236,7 +261,8 @@ mod tests {
     #[test]
     fn the_version_two_flags_are_not_dropped() {
         assert_eq!(
-            format_feature_flags(FeatureType::HIDDEN | FeatureType::COMPLIANCE_DEACTIVATABLE),
+            FeatureFlagsDisplay(FeatureType::HIDDEN | FeatureType::COMPLIANCE_DEACTIVATABLE)
+                .to_string(),
             "hidden,compliance-deactivatable"
         );
     }
@@ -247,7 +273,7 @@ mod tests {
     #[test]
     fn unknown_bits_are_reported_as_a_raw_mask() {
         assert_eq!(
-            format_feature_flags(FeatureType::from_bits_retain(0b0100_0100)),
+            FeatureFlagsDisplay(FeatureType::from_bits_retain(0b0100_0100)).to_string(),
             "hidden,unknown=0x04"
         );
     }
@@ -255,7 +281,7 @@ mod tests {
     #[test]
     fn unknown_bits_alone_still_render() {
         assert_eq!(
-            format_feature_flags(FeatureType::from_bits_retain(0b0000_0011)),
+            FeatureFlagsDisplay(FeatureType::from_bits_retain(0b0000_0011)).to_string(),
             "unknown=0x03"
         );
     }


### PR DESCRIPTION
## Summary

Replace the allocation-returning diagnostic formatter functions added in #690 with CLI-private `Display` adapters. The output stays byte-for-byte identical while formatting writes directly into the caller's formatter.

## Changes

- replace `format_feature_flags` with `FeatureFlagsDisplay`
- replace `format_firmware_entity` with the borrowing `FirmwareEntityDisplay`
- stream flag names, unknown masks, active markers, and extra-version bytes without intermediate `Vec<String>` or line `String` allocations
- keep the existing ten output assertions, now exercising the adapters through `ToString`

## Testing

- `cargo test -p openlogi-cli cmd::diag::features::tests` — 10 passed
- `cargo clippy -p openlogi-cli --all-targets -- -D warnings` — passed
- full local gate: `cargo fmt --all -- --check`, workspace Clippy, workspace tests, and non-GUI rustdoc — passed
- `cargo xtask ci` — 6 passed, 3 skipped: shell tools unavailable, macOS tests unavailable on Linux, and `cargo-deny` unavailable
- Hardware: not runtime-tested on hardware; all diagnostic output variants remain pinned by the existing formatter tests

Follow-up to #690.