### PR TITLE
fix(ipc,agent,desktop): surface Input Monitoring via agent status and fix registry bincode

### DIFF
--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -50,6 +50,7 @@ impl ObservableState {
                     inventory: InventoryHealth::Scanning,
                     protocol_version: PROTOCOL_VERSION,
                     agent_version,
+                    input_monitoring_granted: openlogi_hid::permissions::has_access(),
                 },
                 inventory: Vec::new(),
                 standalone: Vec::new(),
@@ -164,6 +165,18 @@ impl ObservableState {
                 return false;
             }
             snapshot.status.accessibility_granted = granted;
+            true
+        });
+    }
+
+    /// Publish an Input Monitoring trust change, as observed by
+    /// [`watchers::input_monitoring`](crate::watchers::input_monitoring).
+    pub fn set_input_monitoring_granted(&self, granted: bool) {
+        self.update(|snapshot| {
+            if snapshot.status.input_monitoring_granted == granted {
+                return false;
+            }
+            snapshot.status.input_monitoring_granted = granted;
             true
         });
     }

--- a/crates/openlogi-agent-core/src/watchers/input_monitoring.rs
+++ b/crates/openlogi-agent-core/src/watchers/input_monitoring.rs
@@ -1,0 +1,40 @@
+//! Input Monitoring permission polling watcher.
+
+use std::thread;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+/// Watch macOS Input Monitoring permission changes.
+pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<bool> {
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    if !cfg!(target_os = "macos") {
+        let _ = tx.send(true);
+        let _ = period;
+        return rx;
+    }
+
+    let spawn_result = thread::Builder::new()
+        .name("openlogi-input-monitoring-watcher".into())
+        .spawn(move || {
+            let mut last: Option<bool> = None;
+            loop {
+                let granted = openlogi_hid::permissions::has_access();
+                if last != Some(granted) {
+                    debug!(granted, "input monitoring trust changed");
+                    if tx.send(granted).is_err() {
+                        debug!("input monitoring watcher receiver dropped — exiting");
+                        return;
+                    }
+                    last = Some(granted);
+                }
+                thread::sleep(period);
+            }
+        });
+    if let Err(e) = spawn_result {
+        warn!(error = %e, "could not spawn input monitoring watcher — status won't auto-refresh");
+    }
+    rx
+}

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -7,6 +7,7 @@ pub mod camera;
 pub mod foreground_app;
 pub mod gesture;
 pub mod host_switch;
+pub mod input_monitoring;
 pub mod inventory;
 pub mod keyboard;
 pub mod pairing;

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -429,10 +429,7 @@ fn standalone_light() -> StandaloneDevice {
             zones: false,
         }),
         driver_id: "litra".to_string(),
-        // Must stay `Some` until #571 is fixed: `registry_model_id` is
-        // `skip_serializing_if`, which truncates the bincode stream when it is
-        // `None` and makes the whole snapshot undecodable. `8c900` is also the
-        // real registry id for a Litra Glow, so the asset lookup resolves.
+        // `8c900` is the real registry id for a Litra Glow, so the asset lookup resolves.
         registry_model_id: Some("8c900".to_string()),
     }
 }
@@ -629,6 +626,7 @@ fn agent_status() -> AgentStatus {
         // The "-mock" marker shows up anywhere the GUI displays the agent
         // version, so a mock session can't be mistaken for a live one.
         agent_version: concat!(env!("CARGO_PKG_VERSION"), "-mock").to_string(),
+        input_monitoring_granted: true,
     }
 }
 

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -425,6 +425,7 @@ async fn run(
     let mut camera_rx = watchers::camera::spawn(Duration::from_secs(1));
     let mut app_rx = watchers::foreground_app::spawn(Duration::from_secs(1));
     let mut accessibility_rx = watchers::accessibility::spawn(Duration::from_millis(1200));
+    let mut input_monitoring_rx = watchers::input_monitoring::spawn(Duration::from_millis(1200));
 
     let (mut sigterm, mut sigint) = shutdown_signals();
 
@@ -507,6 +508,9 @@ async fn run(
             // through the same door, so the event tap goes with us (#807).
             Some(()) = uninstalled.recv() => {
                 release_hook_and_exit(hook.take(), "the app was uninstalled")
+            }
+            Some(granted) = input_monitoring_rx.recv() => {
+                observable.set_input_monitoring_granted(granted);
             }
             else => break,
         }

--- a/crates/openlogi-core/src/device.rs
+++ b/crates/openlogi-core/src/device.rs
@@ -407,7 +407,7 @@ pub struct StandaloneDevice {
     ///
     /// This is deliberately appended: `StandaloneDevice` crosses the
     /// append-only GUI↔agent bincode wire format.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub registry_model_id: Option<String>,
 }
 

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -51,7 +51,11 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
                 tr!("Input Monitoring"),
                 tr!("Needed to read HID++ data, including Bluetooth-direct mice."),
                 Permission::InputMonitoring,
-                |_| permissions::input_monitoring(),
+                |cx| match cx.try_global::<AppState>().and_then(AppState::agent_status) {
+                    Some(status) if status.input_monitoring_granted => PermissionStatus::Granted,
+                    Some(_) => PermissionStatus::Denied,
+                    None => PermissionStatus::Unknown,
+                },
                 pal,
             ))
             .item(permission_item(

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -52,7 +52,9 @@ pub use succession::Identity;
 ///      [`RingObservation`]).
 /// v22: DPI scalar values use the validated [`Dpi`] type end to end.
 /// v23: SmartShift writes carry one typed [`SmartShiftStatus`] value.
-pub const PROTOCOL_VERSION: u32 = 23;
+/// v24: `StandaloneDevice::registry_model_id` is always encoded (bincode fix).
+/// v25: `AgentStatus::input_monitoring_granted` appended.
+pub const PROTOCOL_VERSION: u32 = 25;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -91,6 +93,10 @@ pub enum InventoryHealth {
 /// Agent health the GUI surfaces: the Accessibility gate, whether the hook is
 /// live, the autostart toggle state, and enumeration progress.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "AgentStatus is a serialized health DTO; bools keep the IPC shape explicit"
+)]
 pub struct AgentStatus {
     pub accessibility_granted: bool,
     pub hook_installed: bool,
@@ -99,6 +105,8 @@ pub struct AgentStatus {
     pub inventory: InventoryHealth,
     pub protocol_version: u32,
     pub agent_version: String,
+    /// Whether the agent process holds Input Monitoring (HID) access.
+    pub input_monitoring_granted: bool,
 }
 
 /// Status and inventory as one poll result. Kept together so the GUI never

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -63,11 +63,26 @@ fn wire_bytes<T: serde::Serialize>(value: &T) -> String {
 }
 
 #[track_caller]
-fn assert_wire<T: serde::Serialize>(value: &T, golden: &str) {
+fn assert_wire<T>(value: &T, golden: &str)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug,
+{
+    let hex = wire_bytes(value);
     assert_eq!(
-        wire_bytes(value),
-        golden,
+        hex, golden,
         "wire encoding changed — if intentional, bump PROTOCOL_VERSION and regenerate this golden"
+    );
+    let bytes = (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("valid hex"))
+        .collect::<Vec<u8>>();
+    let decoded: T = bincode::DefaultOptions::new()
+        .deserialize(&bytes)
+        .expect("wire types deserialize");
+    let re_hex = wire_bytes(&decoded);
+    assert_eq!(
+        hex, re_hex,
+        "wire round-trip failed — re-encoded bytes differ"
     );
 }
 
@@ -85,7 +100,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 23);
+    assert_eq!(PROTOCOL_VERSION, 25);
 }
 
 #[test]
@@ -255,8 +270,9 @@ fn agent_status() {
         // the version must not churn this golden.
         protocol_version: 7,
         agent_version: "0.6.6".into(),
+        input_monitoring_granted: true,
     };
-    assert_wire(&status, "010001010705302e362e36");
+    assert_wire(&status, "010001010705302e362e3601");
 
     assert_wire(&InventoryHealth::Scanning, "00");
     assert_wire(&InventoryHealth::Ready, "01");
@@ -273,20 +289,21 @@ fn agent_snapshot() {
             inventory: InventoryHealth::Ready,
             protocol_version: 7,
             agent_version: "0.6.6".into(),
+            input_monitoring_granted: true,
         },
         inventory: Vec::new(),
         standalone: Vec::new(),
         camera_active: false,
         pairing: None,
     };
-    assert_wire(&snapshot, "010001010705302e362e3600000000");
+    assert_wire(&snapshot, "010001010705302e362e360100000000");
 
     // The observation is the snapshot with its generation in front.
     let observed = Observation {
         generation: 3,
         snapshot,
     };
-    assert_wire(&observed, "03010001010705302e362e3600000000");
+    assert_wire(&observed, "03010001010705302e362e360100000000");
 }
 
 /// The pairing session is state, so its phases are wire format like any enum.
@@ -511,7 +528,7 @@ fn standalone_light_dtos_commands_and_errors() {
     legacy.registry_model_id = None;
     assert_wire(
         &legacy,
-        "fb6d04fb00c9fb43fffb02020d73657269616c3a676c6f772d310a4c6974726120476c6f7701044c6f67690106676c6f772d31000000000d010001010114fa010101fb8c0afb641964020000056c69747261",
+        "fb6d04fb00c9fb43fffb02020d73657269616c3a676c6f772d310a4c6974726120476c6f7701044c6f67690106676c6f772d31000000000d010001010114fa010101fb8c0afb641964020000056c6974726100",
     );
     assert_wire(&capabilities, "010114fa010101fb8c0afb641964020000");
     assert_wire(&brightness, "14fa0101");


### PR DESCRIPTION
## Summary

Fixes #606 and #571.

**#606:** Settings → Permissions → Input Monitoring checked `IOHIDCheckAccess` in the GUI process (`openlogi-permissions::input_monitoring()`), but HID devices are opened by the agent under a distinct code-signing identity (`org.openlogi.agent`). The row therefore showed the GUI's grant, not whether discovery can actually open HID. This mirrors the already-correct Accessibility handling.

**#571:** `StandaloneDevice::registry_model_id` used `skip_serializing_if`, truncating bincode when `None` and making every `AgentSnapshot` undecodable while such a device is present.

## Changes

- `crates/openlogi-ipc/src/ipc.rs:55` — bump `PROTOCOL_VERSION` 23→25: v24 fixes bincode for `registry_model_id`, v25 appends `AgentStatus::input_monitoring_granted` (with `#[expect(clippy::struct_excessive_bools)]`)
- `crates/openlogi-core/src/device.rs:410` — drop `skip_serializing_if`, keep `#[serde(default)]`
- `crates/openlogi-agent-core/src/watchers/input_monitoring.rs` (new) + `watchers/mod.rs` — poll `openlogi_hid::permissions::has_access()` like the accessibility watcher
- `crates/openlogi-agent-core/src/observable.rs:46` — seed and publish `input_monitoring_granted`; add `set_input_monitoring_granted`
- `crates/openlogi-agent/src/main.rs:318` — spawn watcher and handle `input_monitoring_rx`; `#[expect(clippy::too_many_lines)]` for select
- `crates/openlogi-agent/src/bin/mock_agent.rs:620` — mock status granted, remove #571 workaround comment
- `crates/openlogi-desktop/src/windows/settings/permissions.rs:54` — read `AppState::agent_status().input_monitoring_granted` instead of local `permissions::input_monitoring()` (Unknown while not connected)
- `crates/openlogi-ipc/tests/wire_format.rs:66` — make `assert_wire` round-trip (deserialize + re-encode) without requiring `PartialEq` on tarpc types; regenerate goldens for `AgentStatus`/snapshot/observation and `registry_model_id = None` (`…6100`)

## Testing

- `DEVELOPER_DIR=/Library/Developer/CommandLineTools cargo test -p openlogi-ipc --test wire_format` — 13 passed (snapshot/observation with new bool, standalone None now decodable)
- `cargo test -p openlogi-agent-core --lib observable` — 10 passed
- `cargo clippy -p openlogi-core -p openlogi-ipc -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings` — clean (after adding expects)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay` — clean
- Manual: not runtime-tested on hardware — logic is polling `has_access()` and wiring through IPC; mock serves granted.

## Notes

Depends on #759 (v24). This branch stacks v25 on top and currently includes #571's fix as well; will rebase to keep 24→25 sequential once #759 merges (or this can supersede #759 if preferred).

Fixes #571
Fixes #606
