### PR TITLE
fix(linux): stop the agent when the package is removed

### DIFF
--- a/packaging/linux/nfpm-scripts/postremove.sh
+++ b/packaging/linux/nfpm-scripts/postremove.sh
@@ -20,6 +20,17 @@ if [ "$removing" = yes ]; then
   # agent may also have written its own copy to $XDG_CONFIG_HOME/systemd/user/ for
   # launch-at-login. Both carry the same unit name, so one disable stops whichever
   # is active and drops the .wants symlink that would otherwise start it again.
+  # Removing the unit file first does not defeat this: systemd matches .wants
+  # symlinks by unit name, so a dangling one is still cleaned up here.
+  #
+  # /run/user covers logged-in and lingering users. A logged-out user without
+  # linger keeps a dangling symlink that starts nothing (the unit file went with
+  # the package) until the package is reinstalled. That is deliberate, not an
+  # oversight: root has no route into a logged-out user's systemd instance, and
+  # the standard tooling does not try either — Fedora's %systemd_user_* macros
+  # and Debian's deb-systemd-helper both manage global enablement under
+  # /etc/systemd/user and never touch per-user config. Do not "fix" this by
+  # walking /home and deleting files inside user config directories.
   if command -v systemctl >/dev/null 2>&1; then
     if command -v runuser >/dev/null 2>&1; then
       as_user="runuser -u"

--- a/packaging/linux/nfpm-scripts/postremove.sh
+++ b/packaging/linux/nfpm-scripts/postremove.sh
@@ -1,6 +1,66 @@
 #!/bin/sh
 set -eu
 
+# Both package managers call this on upgrade as well as removal, and they spell
+# the distinction differently: dpkg passes "remove"/"purge"/"upgrade", rpm passes
+# the number of instances left behind (0 on the final removal, >=1 on upgrade).
+# Stopping the agent on an upgrade would turn autostart off on every update, so
+# only act when the package is actually going away.
+removing=no
+case "${1:-}" in
+  0 | remove | purge) removing=yes ;;
+esac
+
+if [ "$removing" = yes ]; then
+  # The agent is a *user* service, but this script runs as root under the package
+  # manager, so there is no single session to target. Walk the runtime directories
+  # of logged-in users instead.
+  #
+  # `disable --now` rather than `stop`: the unit is Restart=on-failure, and the
+  # agent may also have written its own copy to $XDG_CONFIG_HOME/systemd/user/ for
+  # launch-at-login. Both carry the same unit name, so one disable stops whichever
+  # is active and drops the .wants symlink that would otherwise start it again.
+  if command -v systemctl >/dev/null 2>&1; then
+    if command -v runuser >/dev/null 2>&1; then
+      as_user="runuser -u"
+    elif command -v sudo >/dev/null 2>&1; then
+      as_user="sudo -u"
+    else
+      as_user=""
+    fi
+
+    if [ -n "$as_user" ]; then
+      for runtime in /run/user/*; do
+        [ -d "$runtime" ] || continue
+        uid=${runtime#/run/user/}
+        case $uid in
+          '' | *[!0-9]*) continue ;;
+        esac
+        user=$(id -nu "$uid" 2>/dev/null) || continue
+        # shellcheck disable=SC2086 # as_user is a command plus its flag, split on purpose
+        $as_user "$user" -- env XDG_RUNTIME_DIR="$runtime" \
+          systemctl --user disable --now openlogi-agent.service >/dev/null 2>&1 || true
+      done
+    fi
+  fi
+
+  # An agent the desktop app launched is not under systemd at all — the GUI spawns
+  # it from beside its own executable — so the disable above cannot reach it, and
+  # it would keep serving IPC to whatever connects next. Match on the executable
+  # path so a Flatpak or source-built agent, which the user may still want, is left
+  # alone. Our binary is already gone by this point, hence the "(deleted)" form.
+  if command -v pgrep >/dev/null 2>&1; then
+    for pid in $(pgrep -x openlogi-agent 2>/dev/null || true); do
+      exe=$(readlink "/proc/${pid}/exe" 2>/dev/null) || continue
+      case "$exe" in
+        /usr/bin/openlogi-agent | "/usr/bin/openlogi-agent (deleted)")
+          kill "$pid" 2>/dev/null || true
+          ;;
+      esac
+    done
+  fi
+fi
+
 # Reload udev rules and wait for the uaccess revocation to take effect.
 if command -v udevadm >/dev/null 2>&1; then
   udevadm control --reload-rules


### PR DESCRIPTION
Summary

Removing the .deb or .rpm deleted the binaries but left the background agent running, and left its user unit enabled so it returned on the next login. postremove.sh only reloaded udev rules.

A stranded agent isn't just untidy: it keeps HID++ sessions open on the same /dev/hidraw* nodes as whatever OpenLogi is running now, and those devices admit one owner at a time — the same contention the issue template's pre-flight checklist warns about for Logi Options+. Devices then go missing or come back misdetected, with nothing pointing at a package the user already removed. When the survivor belongs to the same install as the new client, it also keeps the singleton lock and the IPC socket.

packaging/linux/uninstall.sh has always done this correctly; only the packaged path was missing it.

Related: #673 is the same family on Windows (a leftover agent holding a lock the current client can't use), following #621/#644 for the overlay.

Changes

packaging/linux/nfpm-scripts/postremove.sh

- Disable the user unit on removal. The agent is a per-user service while this script runs as root under the package manager, so there's no single session to address — walk /run/user/* and disable it for each logged-in user, mirroring the SUDO_USER + XDG_RUNTIME_DIR handling already in uninstall.sh. disable --now rather than stop: the unit is Restart=on-failure, and the agent may have written its own copy to $XDG_CONFIG_HOME/systemd/user/ for launch-at-login. Both share a unit name, so one disable covers whichever is active.
- Kill a GUI-spawned agent, which systemd can't reach, matching strictly on executable path so a Flatpak, source build, or /usr/local install is left untouched.
- Act only on removal. Both managers run this on upgrade too, spelled differently — dpkg passes remove/purge/upgrade, rpm passes the number of instances left behind. Without this, the fix would turn autostart off on every package update.

Testing

- cargo xtask ci — 7 passed, 0 failed, 2 skipped. Not run: tests (macos) (wrong host OS), cargo-deny (not installed).
- cargo xtask ci shell — shellcheck and shfmt clean.
- Argument dispatch verified against all seven forms with stubbed systemctl/runuser/udevadm: 0, remove, purge stop the agent; 1, 2, upgrade, and empty leave it alone. udevadm still runs in all seven, unchanged from before.
- Executable matcher verified to spare /app/bin/…, /usr/local/bin/…, target/release/… and the Flatpak deployment path, matching only /usr/bin/openlogi-agent and its (deleted) form.
- Runtime-tested on hardware (Fedora, x86_64), package built with cargo xtask linux package:
  - Removal: install → systemctl --user enable --now openlogi-agent.service → dnf remove → agent gone, unit no longer enabled.
  - Upgrade: install → enable → dnf reinstall (drives %postun with $1=1, same as a version bump) → agent still running with the same PID, unit still enabled.
  - Bug reproduced on the current release: installing the official 0.7.4 rpm and removing it leaves the agent running.
- Not tested: the .deb path (rpm only).