### PR TITLE
fix: discard first raw-XY sample for all gesture sources

### DIFF
--- a/crates/openlogi-hid/src/session/gesture.rs
+++ b/crates/openlogi-hid/src/session/gesture.rs
@@ -656,8 +656,12 @@ fn handle_reprog(
                         acc.gesture_source = Some((cid, button));
                         acc.swipe.begin();
                         acc.overlap = held.len() > 1;
-                        acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID
-                            && !acc.gestures_down.contains(&cid);
+                        // The HID++ raw-XY divert buffer accumulates deltas from the moment
+                        // diversion is activated, not from when the user starts moving.
+                        // The first sample after any gesture source press carries this
+                        // buffered noise and must be discarded for all gesture sources,
+                        // not just the haptic panel.
+                        acc.skip_first_raw_xy = !acc.gestures_down.contains(&cid);
                     }
                 }
             }

--- a/crates/openlogi-hid/src/session/gesture/tests.rs
+++ b/crates/openlogi-hid/src/session/gesture/tests.rs
@@ -382,14 +382,30 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
 }
 
 #[test]
-fn the_dedicated_buttons_first_sample_is_not_discarded() {
-    // The discard is a panel quirk: the dedicated button's raw-XY stream is
-    // relative from the first sample, which must keep committing as-is.
+fn the_dedicated_buttons_first_sample_is_also_discarded() {
+    // The HID++ raw-XY divert buffer accumulates noise from the moment diversion
+    // is activated, not from when the user starts moving. The first sample after
+    // any gesture source press must be discarded for ALL gesture sources, not
+    // just the haptic panel.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
     acc.swipe.backdate_hold_for_test();
+    // First sample (buffered noise) — must be discarded.
+    handle_reprog(
+        &mut acc,
+        RawControlEvent::RawXy { dx: -3000, dy: 40 },
+        GESTURE,
+        &[],
+        &[],
+        &tx,
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "the dedicated button's first sample (buffered noise) must not commit a swipe"
+    );
+    // Second sample (real movement) — commits correctly.
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
@@ -398,14 +414,13 @@ fn the_dedicated_buttons_first_sample_is_not_discarded() {
         &[],
         &tx,
     );
-
     assert_eq!(
         rx.try_recv(),
         Ok(CapturedInput::Gesture(
             ButtonId::GestureButton,
             GestureDirection::Right
         )),
-        "the dedicated button's very first sample still counts"
+        "the second sample commits the swipe"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #752

The HID++ raw-XY divert buffer accumulates deltas from the moment diversion is activated, not from when the user starts moving. The first sample after any gesture source press carries this buffered noise and must be discarded for ALL gesture sources, not just the haptic panel.

## Problem

Previously, only the HapticPanel (CID 0x01A0) discarded its first raw-XY sample via `skip_first_raw_xy`. The GestureButton (CID 0x00C3), the primary gesture source on most MX mice, did not, causing the SwipeAccumulator to be poisoned with spurious deltas, resulting in wrong-direction commits.

Example from the issue:
```
swipe accumulate raw_dx=-81 raw_dy=592  ← first sample, massive dy (buffered noise)
swipe accumulate raw_dx=0  raw_dy=1    accum_dx=-81 accum_dy=593
swipe accumulate raw_dx=3  raw_dy=0    accum_dx=-78 accum_dy=593
...
swipe accumulate raw_dx=28 raw_dy=0    accum_dx=142 accum_dy=598 held_long_enough=true
swipe COMMIT dir=Down accum_dx=142 accum_dy=598  ← wrong direction (should be Right)
```

All deltas after the first are dx>0, dy=0 (clear rightward swipe), but dy=598 from the first sample dominates the accumulator and forces Down.

## Root Cause

In `openlogi-hid/src/session/gesture.rs`, the `skip_first_raw_xy` logic was:

```rust
acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID
    && !acc.gestures_down.contains(&cid);
```

Only the HapticPanel got the discard, despite the GestureButton exhibiting the same first-sample noise from the HID++ raw-XY divert buffer.

## Fix

Changed the logic to apply to ALL gesture sources:

```rust
acc.skip_first_raw_xy = !acc.gestures_down.contains(&cid);
```

Now any newly-pressed gesture source will have its first raw-XY sample discarded, preventing buffered noise from poisoning the SwipeAccumulator.

## Testing

Updated the test `the_dedicated_buttons_first_sample_is_also_discarded` (formerly `the_dedicated_buttons_first_sample_is_not_discarded`) to verify the new behavior: the first sample is now discarded and the second sample commits the swipe correctly.

## Devices Affected

- MX Master 3/3S/4 with GestureButton (CID 0x00C3)
- MX Master 4 HapticPanel (CID 0x01A0) already worked, no change in behavior