### PR TITLE
refactor: stream display-only formatting

### DIFF
--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -34,6 +34,8 @@
 
 use tracing::debug;
 
+#[cfg(target_os = "linux")]
+use std::fmt;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::io;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -298,7 +300,7 @@ fn escape_systemd_exec(s: &str) -> String {
 /// best-effort (e.g. the session D-Bus may be unavailable in some environments).
 #[cfg(target_os = "linux")]
 fn run_systemctl(args: &[&str]) {
-    let label = args.join(" ");
+    let label = SystemctlArgsDisplay(args);
     let mut cmd = std::process::Command::new("systemctl");
     cmd.arg("--user").args(args);
     match cmd.output() {
@@ -312,6 +314,21 @@ fn run_systemctl(args: &[&str]) {
             );
         }
         Err(e) => warn!("systemctl --user {label} failed to spawn: {e}"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct SystemctlArgsDisplay<'a, 'b>(&'a [&'b str]);
+
+#[cfg(target_os = "linux")]
+impl fmt::Display for SystemctlArgsDisplay<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut separator = "";
+        for arg in self.0 {
+            write!(f, "{separator}{arg}")?;
+            separator = " ";
+        }
+        Ok(())
     }
 }
 
@@ -418,6 +435,14 @@ mod linux_tests {
     fn escape_systemd_exec_plain_path_unchanged() {
         let path = "/usr/local/bin/openlogi-agent";
         assert_eq!(escape_systemd_exec(path), path);
+    }
+
+    #[test]
+    fn systemctl_arguments_render_as_a_command_suffix() {
+        assert_eq!(
+            SystemctlArgsDisplay(&["enable", UNIT_NAME]).to_string(),
+            "enable openlogi-agent.service"
+        );
     }
 
     #[test]

--- a/crates/openlogi-cli/src/cmd/diag/controls.rs
+++ b/crates/openlogi-cli/src/cmd/diag/controls.rs
@@ -1,5 +1,7 @@
 //! `openlogi diag controls` — dump HID++ reprogrammable controls.
 
+use std::fmt;
+
 use anyhow::{Context, Result};
 use clap::Args;
 use openlogi_hid::ReprogControlEntry;
@@ -38,33 +40,34 @@ pub async fn run(args: ControlsArgs) -> Result<()> {
             control.cid,
             control.task_id,
             control.flags.raw(),
-            summarize_capabilities(control)
+            ControlCapabilitiesDisplay(control)
         );
     }
     Ok(())
 }
 
-fn summarize_capabilities(control: ReprogControlEntry) -> String {
-    let mut caps = Vec::new();
-    if control.flags.is_divertable() {
-        caps.push("divertable");
-    }
-    if control.flags.supports_raw_xy() {
-        caps.push("raw-xy");
-    }
-    if control.flags.supports_force_raw_xy() {
-        caps.push("force-raw-xy");
-    }
-    if control.flags.supports_analytics_key_events() {
-        caps.push("analytics-events");
-    }
-    if control.flags.supports_raw_wheel() {
-        caps.push("raw-wheel");
-    }
-    if caps.is_empty() {
-        "-".to_string()
-    } else {
-        caps.join(", ")
+struct ControlCapabilitiesDisplay(ReprogControlEntry);
+
+impl fmt::Display for ControlCapabilitiesDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let flags = self.0.flags;
+        let mut separator = "";
+        for (enabled, name) in [
+            (flags.is_divertable(), "divertable"),
+            (flags.supports_raw_xy(), "raw-xy"),
+            (flags.supports_force_raw_xy(), "force-raw-xy"),
+            (flags.supports_analytics_key_events(), "analytics-events"),
+            (flags.supports_raw_wheel(), "raw-wheel"),
+        ] {
+            if enabled {
+                write!(f, "{separator}{name}")?;
+                separator = ", ";
+            }
+        }
+        if separator.is_empty() {
+            write!(f, "-")?;
+        }
+        Ok(())
     }
 }
 
@@ -80,7 +83,7 @@ mod tests {
             flags: openlogi_hid::reprog_controls::CidFlags::default(),
         };
 
-        assert_eq!(summarize_capabilities(entry), "-");
+        assert_eq!(ControlCapabilitiesDisplay(entry).to_string(), "-");
     }
 
     #[test]
@@ -94,7 +97,7 @@ mod tests {
         };
 
         assert_eq!(
-            summarize_capabilities(entry),
+            ControlCapabilitiesDisplay(entry).to_string(),
             "divertable, force-raw-xy, analytics-events"
         );
     }

--- a/crates/openlogi-cli/src/cmd/diag/dpi.rs
+++ b/crates/openlogi-cli/src/cmd/diag/dpi.rs
@@ -1,7 +1,10 @@
 //! `openlogi diag dpi` — DPI write round-trip.
 
+use std::fmt;
+
 use anyhow::{Context, Result};
 use clap::Args;
+use openlogi_hid::DpiCapabilities;
 
 use crate::cmd::diag::select_device;
 
@@ -30,7 +33,7 @@ pub async fn run(args: DpiArgs) -> Result<()> {
         .context("read DPI capabilities")?;
     let before = info.current;
     println!("  current DPI: {before}");
-    println!("  supported DPI: {}", summarize_dpi(&info.capabilities));
+    println!("  supported DPI: {}", DpiSummaryDisplay(&info.capabilities));
 
     let target = match args.target {
         Some(target) => {
@@ -38,7 +41,7 @@ pub async fn run(args: DpiArgs) -> Result<()> {
             if !info.capabilities.contains(target) {
                 anyhow::bail!(
                     "target {target} is not in the device-reported DPI list ({})",
-                    summarize_dpi(&info.capabilities)
+                    DpiSummaryDisplay(&info.capabilities)
                 );
             }
             target
@@ -92,29 +95,36 @@ pub async fn run(args: DpiArgs) -> Result<()> {
     Ok(())
 }
 
-fn summarize_dpi(capabilities: &openlogi_hid::DpiCapabilities) -> String {
-    let values = capabilities.values();
-    let step = capabilities.step_hint();
-    if values.len() <= 12 {
-        return values
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
+struct DpiSummaryDisplay<'a>(&'a DpiCapabilities);
+
+impl fmt::Display for DpiSummaryDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let capabilities = self.0;
+        let values = capabilities.values();
+        if values.len() <= 12 {
+            let mut separator = "";
+            for value in values {
+                write!(f, "{separator}{value}")?;
+                separator = ", ";
+            }
+            return Ok(());
+        }
+        write!(
+            f,
+            "{}..{} (step ≈ {}, {} values)",
+            capabilities.min(),
+            capabilities.max(),
+            capabilities.step_hint(),
+            values.len()
+        )
     }
-    format!(
-        "{}..{} (step ≈ {step}, {} values)",
-        capabilities.min(),
-        capabilities.max(),
-        values.len()
-    )
 }
 
 #[cfg(test)]
 mod summarize_dpi_tests {
     use openlogi_hid::DpiCapabilities;
 
-    use super::summarize_dpi;
+    use super::DpiSummaryDisplay;
 
     #[test]
     fn lists_values_verbatim_at_the_twelve_value_boundary() {
@@ -122,7 +132,7 @@ mod summarize_dpi_tests {
         let caps = DpiCapabilities::new(values).expect("non-empty");
 
         assert_eq!(
-            summarize_dpi(&caps),
+            DpiSummaryDisplay(&caps).to_string(),
             "100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200"
         );
     }
@@ -132,6 +142,9 @@ mod summarize_dpi_tests {
         let values: Vec<u16> = (1..=13).map(|n| n * 100).collect();
         let caps = DpiCapabilities::new(values).expect("non-empty");
 
-        assert_eq!(summarize_dpi(&caps), "100..1300 (step ≈ 100, 13 values)");
+        assert_eq!(
+            DpiSummaryDisplay(&caps).to_string(),
+            "100..1300 (step ≈ 100, 13 values)"
+        );
     }
 }

--- a/crates/openlogi-cli/src/cmd/diag/features.rs
+++ b/crates/openlogi-cli/src/cmd/diag/features.rs
@@ -24,11 +24,10 @@ pub async fn run(_args: FeaturesArgs) -> Result<()> {
                     vendor_id: inv.receiver.vendor_id,
                     product_id: inv.receiver.product_id,
                 });
-            let name = paired
-                .codename
-                .clone()
-                .unwrap_or_else(|| format!("Slot {}", paired.slot));
-            println!("device: {name} ({route})");
+            match paired.codename.as_deref() {
+                Some(name) => println!("device: {name} ({route})"),
+                None => println!("device: Slot {} ({route})", paired.slot),
+            }
             match openlogi_hid::dump_features(&route).await {
                 Ok(entries) => {
                     println!("  {:>4}  {:>6}  {:<4}  flags", "idx", "id", "ver");

--- a/crates/openlogi-cli/src/cmd/list.rs
+++ b/crates/openlogi-cli/src/cmd/list.rs
@@ -1,4 +1,7 @@
-use std::process::ExitCode;
+use std::{
+    fmt::{self, Write as _},
+    process::ExitCode,
+};
 
 use anyhow::{Context, Result};
 use clap::Args;
@@ -61,15 +64,34 @@ fn print_cameras(cameras: &[Camera]) {
     let last = cameras.len() - 1;
     for (i, cam) in cameras.iter().enumerate() {
         let prefix = if i == last { "  └─" } else { "  ├─" };
-        let caps = match (cam.max_resolution, cam.max_fps) {
-            (Some((w, h)), Some(fps)) => format!(", up to {w}x{h}@{fps}"),
-            (Some((w, h)), None) => format!(", up to {w}x{h}"),
-            _ => String::new(),
-        };
         println!(
             "{prefix} ● {} (camera, vid={:04x} pid={:04x}{caps}, id={})",
-            cam.name, cam.vendor_id, cam.product_id, cam.unique_id
+            cam.name,
+            cam.vendor_id,
+            cam.product_id,
+            cam.unique_id,
+            caps = CameraCapabilitiesDisplay {
+                resolution: cam.max_resolution,
+                fps: cam.max_fps,
+            },
         );
+    }
+}
+
+struct CameraCapabilitiesDisplay {
+    resolution: Option<(u32, u32)>,
+    fps: Option<u32>,
+}
+
+impl fmt::Display for CameraCapabilitiesDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.resolution, self.fps) {
+            (Some((width, height)), Some(fps)) => {
+                write!(f, ", up to {width}x{height}@{fps}")
+            }
+            (Some((width, height)), None) => write!(f, ", up to {width}x{height}"),
+            _ => Ok(()),
+        }
     }
 }
 
@@ -88,82 +110,126 @@ fn print_inventory(inv: &DeviceInventory) {
     let last = inv.paired.len() - 1;
     for (i, d) in inv.paired.iter().enumerate() {
         let prefix = if i == last { "  └─" } else { "  ├─" };
-        println!("{prefix} {}", format_device(d));
+        println!("{prefix} {}", PairedDeviceDisplay(d));
         if let Some(model) = d.model_info.as_ref() {
             let cont = if i == last { "     " } else { "  │  " };
-            println!("{cont}{}", format_model(model));
+            println!("{cont}{}", DeviceModelDisplay(model));
         }
     }
 }
 
-fn format_device(d: &PairedDevice) -> String {
-    let dot = if d.online { "●" } else { "○" };
-    let codename = d.codename.as_deref().unwrap_or("Unknown device");
-    let wpid = d
-        .wpid
-        .map_or_else(|| "wpid=?".to_string(), |w| format!("wpid={w:04x}"));
-    let battery = d
-        .battery
-        .as_ref()
-        .map_or_else(|| "battery=—".to_string(), format_battery);
-    let kind = format!("{:?}", d.kind).to_lowercase();
-    format!(
-        "slot {} {dot} {codename} ({kind}, {wpid}, {battery})",
-        d.slot
-    )
-}
+struct PairedDeviceDisplay<'a>(&'a PairedDevice);
 
-fn format_battery(b: &BatteryInfo) -> String {
-    let level = format!("{:?}", b.level).to_lowercase();
-    let status = format!("{:?}", b.status).to_lowercase();
-    format!("battery={}% {level} ({status})", b.percentage)
-}
-
-fn format_model(m: &DeviceModelInfo) -> String {
-    let transports = {
-        let mut t = Vec::new();
-        if m.transports.usb {
-            t.push("usb");
+impl fmt::Display for PairedDeviceDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let device = self.0;
+        let dot = if device.online { "●" } else { "○" };
+        let codename = device.codename.as_deref().unwrap_or("Unknown device");
+        write!(
+            f,
+            "slot {} {dot} {codename} ({}, ",
+            device.slot,
+            LowercaseDebug(device.kind)
+        )?;
+        match device.wpid {
+            Some(wpid) => write!(f, "wpid={wpid:04x}, ")?,
+            None => write!(f, "wpid=?, ")?,
         }
-        if m.transports.equad {
-            t.push("equad");
+        match device.battery.as_ref() {
+            Some(battery) => write!(f, "{}", BatteryDisplay(battery))?,
+            None => write!(f, "battery=—")?,
         }
-        if m.transports.btle {
-            t.push("btle");
-        }
-        if m.transports.bluetooth {
-            t.push("bt");
-        }
-        if t.is_empty() {
-            "—".to_string()
-        } else {
-            t.join("+")
-        }
-    };
-    let ids = m
-        .model_ids
-        .iter()
-        .map(|id| format!("{id:04x}"))
-        .collect::<Vec<_>>()
-        .join(",");
-    let mut unit = String::with_capacity(8);
-    for b in m.unit_id {
-        use std::fmt::Write as _;
-        let _ = write!(unit, "{b:02x}");
+        write!(f, ")")
     }
-    let serial = m.serial_number.as_deref().unwrap_or("—");
-    format!(
-        "     model_ids=[{ids}] ext={:02x} serial={serial} unit_id={unit} transports={transports}",
-        m.extended_model_id
-    )
+}
+
+struct BatteryDisplay<'a>(&'a BatteryInfo);
+
+impl fmt::Display for BatteryDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let battery = self.0;
+        write!(
+            f,
+            "battery={}% {} ({})",
+            battery.percentage,
+            LowercaseDebug(battery.level),
+            LowercaseDebug(battery.status)
+        )
+    }
+}
+
+struct DeviceModelDisplay<'a>(&'a DeviceModelInfo);
+
+impl fmt::Display for DeviceModelDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let model = self.0;
+        write!(f, "     model_ids=[")?;
+        let mut separator = "";
+        for id in model.model_ids {
+            write!(f, "{separator}{id:04x}")?;
+            separator = ",";
+        }
+        write!(
+            f,
+            "] ext={:02x} serial={} unit_id=",
+            model.extended_model_id,
+            model.serial_number.as_deref().unwrap_or("—")
+        )?;
+        for byte in model.unit_id {
+            write!(f, "{byte:02x}")?;
+        }
+        write!(f, " transports=")?;
+
+        separator = "";
+        for (enabled, name) in [
+            (model.transports.usb, "usb"),
+            (model.transports.equad, "equad"),
+            (model.transports.btle, "btle"),
+            (model.transports.bluetooth, "bt"),
+        ] {
+            if enabled {
+                write!(f, "{separator}{name}")?;
+                separator = "+";
+            }
+        }
+        if separator.is_empty() {
+            write!(f, "—")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// The CLI historically rendered these enums by lowercasing their `Debug`
+/// names. Keep that exact spelling without allocating an intermediate string.
+struct LowercaseDebug<T>(T);
+
+impl<T: fmt::Debug> fmt::Display for LowercaseDebug<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(LowercaseWriter(f), "{:?}", self.0)
+    }
+}
+
+struct LowercaseWriter<'a, 'b>(&'a mut fmt::Formatter<'b>);
+
+impl fmt::Write for LowercaseWriter<'_, '_> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        for character in value.chars().flat_map(char::to_lowercase) {
+            self.0.write_char(character)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod format_tests {
     use openlogi_core::device::{BatteryLevel, BatteryStatus, DeviceKind, DeviceTransports};
 
+    use super::{
+        BatteryDisplay, CameraCapabilitiesDisplay, DeviceModelDisplay, PairedDevice,
+        PairedDeviceDisplay,
+    };
     use super::{BatteryInfo, DeviceModelInfo};
-    use super::{PairedDevice, format_battery, format_device, format_model};
 
     fn base_device() -> PairedDevice {
         PairedDevice {
@@ -181,7 +247,7 @@ mod format_tests {
     #[test]
     fn online_device_uses_filled_dot_and_reports_fields() {
         let d = base_device();
-        let out = format_device(&d);
+        let out = PairedDeviceDisplay(&d).to_string();
         assert_eq!(out, "slot 1 ● MX Master 3S (mouse, wpid=4082, battery=—)");
     }
 
@@ -189,7 +255,7 @@ mod format_tests {
     fn offline_device_uses_hollow_dot() {
         let mut d = base_device();
         d.online = false;
-        let out = format_device(&d);
+        let out = PairedDeviceDisplay(&d).to_string();
         assert!(out.starts_with("slot 1 ○ "));
     }
 
@@ -198,7 +264,7 @@ mod format_tests {
         let mut d = base_device();
         d.codename = None;
         d.wpid = None;
-        let out = format_device(&d);
+        let out = PairedDeviceDisplay(&d).to_string();
         assert_eq!(out, "slot 1 ● Unknown device (mouse, wpid=?, battery=—)");
     }
 
@@ -210,7 +276,7 @@ mod format_tests {
             level: BatteryLevel::Low,
             status: BatteryStatus::Discharging,
         });
-        let out = format_device(&d);
+        let out = PairedDeviceDisplay(&d).to_string();
         assert!(out.contains("battery=42% low (discharging)"));
     }
 
@@ -223,7 +289,38 @@ mod format_tests {
             level: BatteryLevel::Critical,
             status: BatteryStatus::ChargingSlow,
         };
-        assert_eq!(format_battery(&b), "battery=10% critical (chargingslow)");
+        assert_eq!(
+            BatteryDisplay(&b).to_string(),
+            "battery=10% critical (chargingslow)"
+        );
+    }
+
+    #[test]
+    fn camera_capabilities_include_resolution_and_optional_fps() {
+        assert_eq!(
+            CameraCapabilitiesDisplay {
+                resolution: Some((1920, 1080)),
+                fps: Some(60),
+            }
+            .to_string(),
+            ", up to 1920x1080@60"
+        );
+        assert_eq!(
+            CameraCapabilitiesDisplay {
+                resolution: Some((1920, 1080)),
+                fps: None,
+            }
+            .to_string(),
+            ", up to 1920x1080"
+        );
+        assert_eq!(
+            CameraCapabilitiesDisplay {
+                resolution: None,
+                fps: Some(60),
+            }
+            .to_string(),
+            ""
+        );
     }
 
     fn base_model() -> DeviceModelInfo {
@@ -240,7 +337,7 @@ mod format_tests {
     #[test]
     fn model_with_no_transports_shows_placeholder_and_missing_serial() {
         let m = base_model();
-        let out = format_model(&m);
+        let out = DeviceModelDisplay(&m).to_string();
         assert_eq!(
             out,
             "     model_ids=[b042,0000,0000] ext=02 serial=— unit_id=00010203 transports=—"
@@ -257,7 +354,7 @@ mod format_tests {
             bluetooth: true,
         };
         m.serial_number = Some("SN123".to_string());
-        let out = format_model(&m);
+        let out = DeviceModelDisplay(&m).to_string();
         assert!(out.contains("transports=usb+btle+bt"));
         assert!(out.contains("serial=SN123"));
     }

--- a/crates/openlogi-core/src/config/key_trigger.rs
+++ b/crates/openlogi-core/src/config/key_trigger.rs
@@ -55,22 +55,24 @@ pub struct KeyTrigger {
 
 impl std::fmt::Display for KeyTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut parts: Vec<&str> = Vec::new();
-        let m = &self.modifiers;
-        if m.shift {
-            parts.push("shift");
+        let modifiers = &self.modifiers;
+        let mut separator = "";
+        for (enabled, name) in [
+            (modifiers.shift, "shift"),
+            (modifiers.control, "control"),
+            (modifiers.option, "option"),
+            (modifiers.command, "command"),
+        ] {
+            if enabled {
+                write!(f, "{separator}{name}")?;
+                separator = "+";
+            }
         }
-        if m.control {
-            parts.push("control");
-        }
-        if m.option {
-            parts.push("option");
-        }
-        if m.command {
-            parts.push("command");
-        }
-        parts.push(keycode_to_name(self.keycode).ok_or(std::fmt::Error)?);
-        write!(f, "{}", parts.join("+"))
+        write!(
+            f,
+            "{separator}{}",
+            keycode_to_name(self.keycode).ok_or(std::fmt::Error)?
+        )
     }
 }
 

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -533,7 +533,7 @@ async fn read_loop(
             len,
             matched,
             pending_count,
-            payload = format!("{:02x?}", &buf[..len.min(16)]),
+            payload = format_args!("{:02x?}", &buf[..len.min(16)]),
             "raw report received"
         );
 


### PR DESCRIPTION
## Summary

Follow up on #758 by scanning the repository for the same allocation pattern: formatting an owned `String` only to pass it immediately to `println!`, tracing, or another `Display` context.

The refactor is intentionally limited to display-only call sites. It leaves owned formatting in place where the string is part of UI state, clipboard content, serialization/API data, error context, paths, rendered files, caches, or map keys.

## Changes

- **CLI:** stream device inventory, camera capabilities, control capabilities, and DPI summaries through private `Display` adapters; avoid cloning the feature codename fallback
- **core:** write `KeyTrigger` modifiers directly to its formatter instead of collecting and joining a temporary vector
- **hidpp:** pass raw report payloads to tracing with `format_args!` instead of allocating with `format!`
- **agent:** stream `systemctl` arguments in debug logs instead of joining them into an owned string
- Preserve the existing output text and extend focused formatter coverage

## Testing

- `cargo test -p openlogi-cli -p openlogi-core -p openlogi-hidpp -p openlogi-agent`
- `cargo clippy -p openlogi-cli -p openlogi-core -p openlogi-hidpp -p openlogi-agent --all-targets -- -D warnings`
- `cargo xtask ci`
- Not runtime-tested on hardware; these changes only affect text rendering and diagnostics/log output
