### PR TITLE
fix(hid): park the Windows HID read on a permanently dead handle

### DIFF
--- a/crates/openlogi-hid/src/transport/windows.rs
+++ b/crates/openlogi-hid/src/transport/windows.rs
@@ -1,4 +1,6 @@
 #[cfg(target_os = "windows")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "windows")]
 use std::{error::Error, io};
 
 #[cfg(target_os = "windows")]
@@ -80,6 +82,11 @@ pub(super) struct WindowsHidppChannel {
     info: DeviceInfo,
     short: Option<HidEndpoint>,
     long: Option<HidEndpoint>,
+    /// Cleared the first time either endpoint reports a permanently dead
+    /// handle. Read by [`RawHidChannel::is_connected`], which is what lets
+    /// `inventory::ledger` evict this channel — the node-vanish path never
+    /// fires for a cabled device whose receiver keeps the HID node enumerated.
+    connected: AtomicBool,
 }
 
 #[cfg(target_os = "windows")]
@@ -130,8 +137,36 @@ impl WindowsHidppChannel {
             info: long_info,
             short,
             long,
+            connected: AtomicBool::new(true),
         })
     }
+
+    fn mark_disconnected(&self) {
+        if self.connected.swap(false, Ordering::AcqRel) {
+            debug!(name = %self.info.name, "HID channel disconnected");
+        }
+    }
+
+    /// Honour the permanent-failure half of the [`RawHidChannel::read_report`]
+    /// contract: an `Err` is retried by the `hidpp` read loop, so a condition
+    /// that will never clear has to park instead of surfacing — otherwise the
+    /// loop busy-spins a core until something evicts the channel. Sound because
+    /// the read loop always races this future against the channel's close
+    /// signal in a `select!`.
+    async fn park_disconnected<T>(&self) -> T {
+        self.mark_disconnected();
+        std::future::pending().await
+    }
+}
+
+/// Whether an already-boxed transport error means the handle is permanently
+/// dead. [`HidEndpoint::write_report`] boxes the `async_hid` error before the
+/// channel sees it, so that path can only recognise the variant by downcast.
+#[cfg(target_os = "windows")]
+fn is_permanent_disconnect(error: &(dyn Error + Send + Sync + 'static)) -> bool {
+    error
+        .downcast_ref::<async_hid::HidError>()
+        .is_some_and(|e| matches!(e, async_hid::HidError::Disconnected))
 }
 
 #[cfg(target_os = "windows")]
@@ -219,7 +254,13 @@ impl RawHidChannel for WindowsHidppChannel {
             )
         })?;
 
-        endpoint.write_report(src).await
+        let result = endpoint.write_report(src).await;
+        if let Err(e) = &result
+            && is_permanent_disconnect(e.as_ref())
+        {
+            self.mark_disconnected();
+        }
+        result
     }
 
     async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
@@ -236,23 +277,35 @@ impl RawHidChannel for WindowsHidppChannel {
                 // resumes it and retrieves the report. This relies on reusing the
                 // per-endpoint reader across calls; do not reopen readers per read.
                 tokio::select! {
-                    res = short_reader.read_input_report(&mut short_buf) => {
-                        copy_report(&short_buf, res?, buf)
-                    }
-                    res = long_reader.read_input_report(&mut long_buf) => {
-                        copy_report(&long_buf, res?, buf)
-                    }
+                    res = short_reader.read_input_report(&mut short_buf) => match res {
+                        Ok(len) => copy_report(&short_buf, len, buf),
+                        Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
+                        Err(e) => Err(e.into()),
+                    },
+                    res = long_reader.read_input_report(&mut long_buf) => match res {
+                        Ok(len) => copy_report(&long_buf, len, buf),
+                        Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
+                        Err(e) => Err(e.into()),
+                    },
                 }
             }
             (Some(endpoint), None) | (None, Some(endpoint)) => {
                 let mut reader = endpoint.reader.lock().await;
-                Ok(reader.read_input_report(buf).await?)
+                match reader.read_input_report(buf).await {
+                    Ok(len) => Ok(len),
+                    Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
+                    Err(e) => Err(e.into()),
+                }
             }
             (None, None) => Err(Box::new(io::Error::new(
                 io::ErrorKind::NotConnected,
                 "no Windows HID++ endpoints are open",
             ))),
         }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Acquire)
     }
 
     fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
@@ -302,5 +355,26 @@ mod tests {
             Some(ReportEndpoint::Long)
         );
         assert_eq!(endpoint_for_report_id(0x13), None);
+    }
+
+    /// `HidEndpoint::write_report` boxes the `async_hid` error before the
+    /// channel sees it, so the permanent-disconnect check on that path only
+    /// works through a downcast — a plain `matches!` silently never fires.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn a_boxed_disconnect_is_recognised_as_permanent() {
+        let disconnected: Box<dyn Error + Send + Sync> =
+            Box::new(async_hid::HidError::Disconnected);
+        assert!(is_permanent_disconnect(disconnected.as_ref()));
+
+        // `NotConnected` is the *open* failure, not a dead live handle: it is
+        // retryable, so it must keep flowing to the read loop as an error.
+        let not_connected: Box<dyn Error + Send + Sync> =
+            Box::new(async_hid::HidError::NotConnected);
+        assert!(!is_permanent_disconnect(not_connected.as_ref()));
+
+        let unrelated: Box<dyn Error + Send + Sync> =
+            Box::new(io::Error::other("write failed for some other reason"));
+        assert!(!is_permanent_disconnect(unrelated.as_ref()));
     }
 }

--- a/crates/openlogi-hid/src/transport/windows.rs
+++ b/crates/openlogi-hid/src/transport/windows.rs
@@ -60,6 +60,14 @@ impl HidEndpoint {
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
         let mut writer = self.writer.lock().await;
         if let Err(e) = writer.write_output_report(src).await {
+            // The native fallback works around async-hid write quirks on a
+            // *live* device; reopening a device that is gone can only fail, and
+            // its `NativeWriteError` would replace the typed `Disconnected`
+            // that `is_permanent_disconnect` needs to retire the channel.
+            if matches!(e, async_hid::HidError::Disconnected) {
+                return Err(Box::new(e));
+            }
+
             if let Some(native_writer) = &self.native_writer {
                 debug!(
                     error = %e,


### PR DESCRIPTION
## Summary

Unplugging the cable of a mouse that is also paired over its receiver left
`openlogi-agent` burning 100% of a CPU core forever. Replugging did not clear it,
and every unplug leaked another spinning thread.

`RawHidChannel::read_report` documents that an `Err` is *transient* — the `hidpp`
read loop logs it and retries — so an implementation must not surface a condition
that will never clear, and should park instead. `AsyncHidChannel` (the
`cfg(not(windows))` transport) honours that. `WindowsHidppChannel` never did: it
propagated `async_hid::HidError::Disconnected` straight into the retry loop,
which then spun at ~14,000 iterations per second.

The same impl also never overrode `is_connected`, so it reported the trait
default of `true` for the rest of the process's life. `inventory::ledger`
therefore never learned the channel was dead, `CHANNEL_EVICT_AFTER` never fired,
and the gesture watcher re-armed the vanished route once a second indefinitely.
Node-vanish eviction could not cover for it either — the receiver keeps the HID
node enumerated after the cable goes, which is exactly the case `ledger.rs`
calls out as needing `is_connected`.

macOS and Linux are unaffected; they compile the other implementation.

## Changes

**openlogi-hid** — `crates/openlogi-hid/src/channel/transport/windows.rs`

- `WindowsHidppChannel::read_report` parks on `HidError::Disconnected` in all
  three read paths — both `tokio::select!` arms and the single-endpoint arm —
  instead of returning an error the read loop retries.
- Track the state in a `connected: AtomicBool`, cleared by `mark_disconnected`,
  and report it through a new `is_connected` override so the inventory ledger
  can evict the channel.
- `write_report` marks the disconnect too. `HidEndpoint::write_report` boxes the
  `async_hid` error before the channel sees it, so that path recognises the
  variant by downcast; a plain `matches!` there would silently never fire, which
  is what the new unit test pins down.
- `HidEndpoint::write_report` no longer attempts the native Windows fallback on a
  `Disconnected` handle. That fallback works around async-hid output-report
  quirks on a *live* device; reopening a device that is gone can only fail, and
  the `NativeWriteError` it returned replaced the typed `Disconnected` the
  channel needs to retire itself (review finding, `c49ee67`).

## Testing

```
cargo fmt --all -- --check                                                      # pass
RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings    # pass
RUSTFLAGS="-D warnings" cargo test --workspace                                   # pass, except the pre-existing failure below
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
```

Two pre-existing failures on this host, both unrelated to this diff (which
touches one file in `openlogi-hid`):

- `xtask`'s `commands::ci::jobs::tests::ci_yml_runs_what_this_runner_runs` — also
  fails on `master` with the change reverted.
- the workspace rustdoc run stops on `openlogi-permissions`
  (`unresolved link to PermissionStatus::Unknown`, from `0f028a8`), the known
  Windows-only breakage. `cargo doc -p openlogi-hid --no-deps
  --document-private-items` under `RUSTDOCFLAGS="-D warnings"` is clean.

The Linux/macOS cross-lint from `.claude/rules/cross-platform.md` could not run
locally — only `x86_64-pc-windows-msvc` is installed on this host and devenv is
unavailable. Audited by hand against `master` instead: every item added here sits
inside a `#[cfg(target_os = "windows")]` block, the only ungated items in the file
are pre-existing and untouched, and the new names (`is_permanent_disconnect`,
`park_disconnected`, the `connected` field) collide with nothing.
`mark_disconnected` shares a name with `AsyncHidChannel`'s, on a different type in
the `cfg(not(windows))` impl. CI's `clippy`, `clippy (windows)`, `tests (linux)`,
`tests (macos)` and MSRV lanes are green, which is the actual confirmation.

**Verified on hardware** (Windows 11, G502 LIGHTSPEED on receiver `c539` plus USB
cable `c08d`), running each patched build through the exact repro — dongle
connected, cable added, cable removed — and sampling the agent for four minutes
afterwards:

| signal | before | `9e2c214` | `c49ee67` |
|---|---|---|---|
| peak agent CPU, any 5 s window | 100% of a core, indefinitely | 1.2% | 2.8%\* |
| samples flagged as spinning | every one | 0 | 0 |
| `read_report error` trace lines | 14,248 in 1.2 s | 0 | 0 |
| gesture `re-arming` warnings | 1 Hz, forever | 0 | 0 |
| `HID channel disconnected` | never logged | 1 | 2 |
| native-fallback attempts on the dead handle | 3 | 3 | 0 |
| `AllMethodsFailed` | 1 | 1 | 0 |

\* the 2.8% sample is at agent startup, before the cable cycle; every
post-disconnect window is at or below 0.06 s.

`HID channel disconnected` rising from one to two on `c49ee67` is the write path
marking the disconnect instead of losing it to `NativeWriteError`.

The device recovers rather than wedging: the probe fails transiently, the ledger
replays the last-known identity, and the receiver path re-enumerates the G502 on
slot 1 with `capture re-arm generation=2`.

Fixes #777
