### PR TITLE
feat(gui): bind a custom shortcut from the button picker

### DIFF
--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -59,7 +59,7 @@ impl Render for ActionRingPanel {
         );
         let shortcut_input = editor_input(
             &mut self.shortcut_input,
-            tr!("Shortcut, e.g. Cmd+Shift+P"),
+            tr!("e.g. Cmd+Shift+P"),
             window,
             cx,
         );

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -29,9 +29,17 @@ use gpui::{
     ParentElement, Role, StatefulInteractiveElement as _, Styled, Window, div,
     prelude::FluentBuilder as _, px, rgb, svg,
 };
-use gpui_component::{Icon, IconName, h_flex, popover::PopoverState, v_flex};
+use gpui_component::{
+    Disableable as _, Icon, IconName, Sizable as _,
+    button::Button,
+    h_flex,
+    input::{Input, InputState},
+    popover::PopoverState,
+    v_flex,
+};
 use openlogi_core::binding::{
-    Action, ButtonId, Category, GestureDirection, default_binding, default_gesture_binding,
+    Action, ButtonId, Category, GestureDirection, KeyCombo, default_binding,
+    default_gesture_binding,
 };
 
 use super::thumbwheel::ThumbwheelPreset;
@@ -45,6 +53,11 @@ use crate::ui::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography a
 /// gpui-component's own `PopupMenu` floor (`min_w(rems(8.))`).
 pub(crate) const POPOVER_W: f32 = 128.;
 
+/// Floor width for the "Custom shortcut" field. Without it the field is free to
+/// shrink under its own placeholder whenever the popover title is the widest
+/// thing in the card, which is most buttons.
+const SHORTCUT_FIELD_W: f32 = 168.;
+
 /// Cap the scrollable action list height. The catalog has 29+ entries across
 /// half a dozen categories; without a cap the list overflows the window.
 pub(crate) const POPOVER_LIST_MAX_H: f32 = 360.;
@@ -57,6 +70,7 @@ pub(crate) const POPOVER_LIST_MAX_H: f32 = 360.;
 pub fn action_picker<T: 'static>(
     btn: ButtonId,
     observer: &Entity<T>,
+    shortcut_input: &Entity<InputState>,
     cx: &mut Context<PopoverState>,
 ) -> AnyElement {
     let current = cx
@@ -93,10 +107,18 @@ pub fn action_picker<T: 'static>(
             card.child(gesture_mode_row(btn, &observer, &popover, pal))
                 .child(divider(pal))
         })
-        .child(scroll_list(
-            "picker-scroll",
-            action_rows("action-item", current.as_ref(), &on_pick, pal),
-        ))
+        .child(scroll_list("picker-scroll", {
+            let mut rows = shortcut_rows(
+                "picker-add-shortcut",
+                current.as_ref(),
+                &on_pick,
+                shortcut_input,
+                pal,
+                cx,
+            );
+            rows.extend(action_rows("action-item", current.as_ref(), &on_pick, pal));
+            rows
+        }))
         .into_any_element()
 }
 
@@ -238,6 +260,7 @@ const GESTURE_CELL_W: f32 = 104.;
 pub fn gesture_overview(
     btn: ButtonId,
     view: &Entity<MouseModelView>,
+    shortcut_input: &Entity<InputState>,
     cx: &mut Context<PopoverState>,
 ) -> AnyElement {
     let pal = theme::palette(cx);
@@ -248,7 +271,7 @@ pub fn gesture_overview(
         .child(plus_card(btn, view, active, pal, cx))
         // The flyout card only appears once a direction is activated.
         .when_some(active, |row, dir| {
-            row.child(flyout_card(btn, dir, view, pal, cx))
+            row.child(flyout_card(btn, dir, view, shortcut_input, pal, cx))
         })
         .into_any_element()
 }
@@ -442,6 +465,7 @@ fn flyout_card(
     btn: ButtonId,
     dir: GestureDirection,
     view: &Entity<MouseModelView>,
+    shortcut_input: &Entity<InputState>,
     pal: Palette,
     cx: &mut Context<PopoverState>,
 ) -> AnyElement {
@@ -466,10 +490,18 @@ fn flyout_card(
         .min_w(px(POPOVER_W))
         .child(title(format!("{}  {}", dir.glyph(), tr!(dir.label())), pal))
         .child(divider(pal))
-        .child(scroll_list(
-            "gesture-dir-scroll",
-            action_rows("gesture-action", Some(&current), &on_pick, pal),
-        ))
+        .child(scroll_list("gesture-dir-scroll", {
+            let mut rows = shortcut_rows(
+                "gesture-add-shortcut",
+                Some(&current),
+                &on_pick,
+                shortcut_input,
+                pal,
+                cx,
+            );
+            rows.extend(action_rows("gesture-action", Some(&current), &on_pick, pal));
+            rows
+        }))
         .into_any_element()
 }
 
@@ -611,6 +643,93 @@ pub(crate) fn action_rows(
         }
     }
     children
+}
+
+/// The "Custom shortcut" rows: the chord already bound (if any), a text field,
+/// and an Add button that commits it through `on_pick`.
+///
+/// [`Action::CustomShortcut`] is deliberately absent from [`Action::catalog`],
+/// so this is the only way to reach it from a picker. Mirrors the Actions Ring
+/// editor's field of the same name and shares its placeholder string, but keeps
+/// Add disabled until the text parses as a [`KeyCombo`] — an unparseable chord
+/// would otherwise commit nothing with no visible reason why.
+fn shortcut_rows(
+    id_prefix: &'static str,
+    current: Option<&Action>,
+    on_pick: &PickFn,
+    input: &Entity<InputState>,
+    pal: Palette,
+    cx: &App,
+) -> Vec<AnyElement> {
+    let can_add = input.read(cx).value().parse::<KeyCombo>().is_ok();
+    let submit = input.clone();
+    let on_pick = on_pick.clone();
+
+    let mut rows = vec![popover_section(tr!("Custom shortcut"), pal)];
+    // The bound chord has no catalog row to check, so state it here instead —
+    // without this the picker looks unbound whenever a shortcut is in use.
+    if let Some(bound @ Action::CustomShortcut(combo)) = current {
+        rows.push(
+            h_flex()
+                .w_full()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .pb_1()
+                .text_body()
+                .text_color(pal.text_primary)
+                .child(
+                    svg()
+                        .path(action_icon_path(bound))
+                        .size_4()
+                        .flex_none()
+                        .text_color(pal.text_muted),
+                )
+                .child(div().flex_1().min_w_0().child(combo.rendered_label()))
+                .child(
+                    Icon::new(IconName::Check)
+                        .size_3()
+                        .text_color(rgb(ACCENT_BLUE)),
+                )
+                .into_any_element(),
+        );
+    }
+    rows.push(
+        h_flex()
+            .w_full()
+            .items_center()
+            .gap_2()
+            .px_2()
+            .pb_1()
+            .child(
+                // `cleanable` is deliberately off: the field already clears
+                // itself on commit and whenever a popover opens, and its glyph
+                // ate enough of the row to truncate the placeholder. The floor
+                // keeps the hint readable when the title is the widest thing in
+                // the card.
+                div()
+                    .flex_1()
+                    .min_w(px(SHORTCUT_FIELD_W))
+                    .child(Input::new(input).small()),
+            )
+            .child(
+                Button::new(id_prefix)
+                    .compact()
+                    .label(tr!("Add"))
+                    .disabled(!can_add)
+                    .on_click(move |_event, window, cx| {
+                        if let Ok(combo) = submit.read(cx).value().parse::<KeyCombo>() {
+                            (on_pick)(Action::CustomShortcut(combo), window, cx);
+                            // The gesture flyout's `on_pick` deliberately stays
+                            // open, so the committed chord would sit in the
+                            // field while the row above already shows it bound.
+                            submit.update(cx, |state, cx| state.set_value("", window, cx));
+                        }
+                    }),
+            )
+            .into_any_element(),
+    );
+    rows
 }
 
 /// A clickable, full-width menu row: `text-sm`, children spread left/right.

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -447,10 +447,10 @@ fn direction_cell(
         // Click opens this direction's flyout; clicking the active cell again
         // closes it. (Hover-to-open was too easy to mis-trigger while moving the
         // cursor across the plus.)
-        .on_click(move |_event, _window, cx| {
+        .on_click(move |_event, window, cx| {
             view.update(cx, |v, vcx| {
                 let next = (v.gesture_selected_dir() != Some(dir)).then_some(dir);
-                v.set_gesture_selected_dir(next);
+                v.set_gesture_selected_dir(next, window, vcx);
                 vcx.notify();
             });
         })

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
 use gpui::{
-    Anchor, AnyElement, App, Context, ElementId, Entity, Hsla, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, RenderOnce, Role, StatefulInteractiveElement as _, Styled,
-    Subscription, Window, canvas, div, hsla, img, prelude::FluentBuilder as _, px, rgb, svg,
+    Anchor, AnyElement, App, AppContext as _, Context, ElementId, Entity, Hsla, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, RenderOnce, Role,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, img,
+    prelude::FluentBuilder as _, px, rgb, svg,
 };
-use gpui_component::{Icon, IconName, Selectable, h_flex, popover::Popover, v_flex};
+use gpui_component::{
+    Icon, IconName, Selectable, h_flex, input::InputState, popover::Popover, v_flex,
+};
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 
 use super::geometry::{
@@ -60,6 +63,11 @@ pub struct MouseModelView {
     /// state, so the popover's `on_open_change` — which runs outside paint — can
     /// reset it without tripping gpui's render-only guard.
     gesture_active_dir: Option<GestureDirection>,
+    /// Lazily-created text field backing the "Custom shortcut" row every
+    /// binding popover shows. One field for the whole view: only one popover is
+    /// open at a time, and it must outlive each popover's render closure —
+    /// re-creating it per render would clear whatever the user had typed.
+    shortcut_input: Option<Entity<InputState>>,
     _state_obs: Subscription,
 }
 
@@ -72,6 +80,7 @@ impl MouseModelView {
             hovered: None,
             open_binding_popover: None,
             gesture_active_dir: None,
+            shortcut_input: None,
             _state_obs: state_obs,
         }
     }
@@ -87,11 +96,24 @@ impl MouseModelView {
         self.gesture_active_dir = dir;
     }
 
-    fn set_binding_popover_open(&mut self, popover: BindingPopover, open: bool) {
+    fn set_binding_popover_open(
+        &mut self,
+        popover: BindingPopover,
+        open: bool,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
         if open {
             self.open_binding_popover = Some(popover);
         } else if self.open_binding_popover == Some(popover) {
             self.open_binding_popover = None;
+        }
+        // One shortcut field serves every binding popover, so without this a
+        // chord typed for one button — committed or not — would still be
+        // sitting there when the next button's picker opens. Safe here because
+        // `on_open_change` runs outside paint (see `gesture_active_dir`).
+        if let Some(input) = &self.shortcut_input {
+            input.update(cx, |state, cx| state.set_value("", window, cx));
         }
     }
 }
@@ -149,6 +171,13 @@ impl Render for MouseModelView {
         let canvas_h = mouse_h;
         let mouse_left = gutter;
 
+        let shortcut_input = self
+            .shortcut_input
+            .get_or_insert_with(|| {
+                cx.new(|cx| InputState::new(window, cx).placeholder(tr!("e.g. Cmd+Shift+P")))
+            })
+            .clone();
+
         let highlight = self.hovered.or(active);
         let view = cx.entity();
         let hovered = self.hovered;
@@ -168,6 +197,7 @@ impl Render for MouseModelView {
             &gesture_buttons,
             self.open_binding_popover,
             &view,
+            &shortcut_input,
         );
         let canvas = div()
             .relative()
@@ -192,6 +222,7 @@ impl Render for MouseModelView {
                         .filter(|button| gesture_buttons.contains(button)),
                     self.open_binding_popover == Some(BindingPopover::Label(label.id)),
                     &view,
+                    &shortcut_input,
                 )
             }))
             .child(hotspots_layer);
@@ -318,6 +349,7 @@ fn hotspots_layer(
     gesture_buttons: &[ButtonId],
     open_popover: Option<BindingPopover>,
     view: &Entity<MouseModelView>,
+    shortcut_input: &Entity<InputState>,
 ) -> impl IntoElement {
     div()
         .absolute()
@@ -337,6 +369,7 @@ fn hotspots_layer(
                     .filter(|button| gesture_buttons.contains(button)),
                 open_popover == Some(BindingPopover::Hotspot(hotspot.id)),
                 view,
+                shortcut_input,
             )
         }))
 }
@@ -347,6 +380,11 @@ fn hotspots_layer(
 /// stays on so an outside click dismisses and re-clicking the trigger toggles.
 /// Closing resets the activated direction (scratch state on the view) so the
 /// next open starts on the plus.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "popover placement + trigger state + the shared shortcut field; \
+bundling would just hide the dependency"
+)]
 fn gesture_overview_popover<Tr>(
     popover_id: impl Into<ElementId>,
     anchor: Anchor,
@@ -355,6 +393,7 @@ fn gesture_overview_popover<Tr>(
     binding_popover: BindingPopover,
     open: bool,
     view: Entity<MouseModelView>,
+    shortcut_input: Entity<InputState>,
 ) -> impl IntoElement
 where
     Tr: Selectable + IntoElement + 'static,
@@ -366,16 +405,16 @@ where
         .anchor(anchor)
         .trigger(trigger)
         .open(open)
-        .on_open_change(move |open, _window, cx| {
+        .on_open_change(move |open, window, cx| {
             view_state.update(cx, |v, vcx| {
-                v.set_binding_popover_open(binding_popover, *open);
+                v.set_binding_popover_open(binding_popover, *open, window, vcx);
                 if !*open {
                     v.set_gesture_selected_dir(None);
                 }
                 vcx.notify();
             });
         })
-        .content(move |_state, _window, cx| gesture_overview(btn, &view, cx))
+        .content(move |_state, _window, cx| gesture_overview(btn, &view, &shortcut_input, cx))
 }
 
 /// Position the popover wrapper at the label's slot in the side gutter and
@@ -401,6 +440,7 @@ fn label_popover(
     gesture_button: Option<ButtonId>,
     open: bool,
     view: &Entity<MouseModelView>,
+    shortcut_input: &Entity<InputState>,
 ) -> AnyElement {
     let x = match label.side {
         Side::Left => mouse_left - SIDE_GAP - SIDE_W,
@@ -425,11 +465,13 @@ fn label_popover(
             binding_popover,
             open,
             view.clone(),
+            shortcut_input.clone(),
         )
         .into_any_element()
     } else {
         let view_state = view.clone();
         let view_content = view.clone();
+        let shortcut_input = shortcut_input.clone();
         Popover::new(("label-popover", idx))
             // `action_picker` draws its own `menu_card` surface, matching the
             // gesture menu — so suppress the framework popover surface.
@@ -438,14 +480,16 @@ fn label_popover(
             .mouse_button(MouseButton::Left)
             .trigger(trigger)
             .open(open)
-            .on_open_change(move |open, _window, cx| {
+            .on_open_change(move |open, window, cx| {
                 view_state.update(cx, |v, vcx| {
-                    v.set_binding_popover_open(binding_popover, *open);
+                    v.set_binding_popover_open(binding_popover, *open, window, vcx);
                     vcx.notify();
                 });
             })
             .content(move |_state, _window, cx| match label.id {
-                MouseControlId::Button(button) => action_picker(button, &view_content, cx),
+                MouseControlId::Button(button) => {
+                    action_picker(button, &view_content, &shortcut_input, cx)
+                }
                 MouseControlId::ThumbwheelRotation => thumbwheel_picker(&view, cx),
             })
             .into_any_element()
@@ -708,6 +752,11 @@ fn silhouette(w: f32, h: f32, pal: Palette) -> impl IntoElement {
         )
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "hotspot position + hover/active/gesture state + the shared shortcut \
+field; bundling would just hide the dependency"
+)]
 fn hotspot_popover(
     idx: usize,
     hotspot: Hotspot,
@@ -718,6 +767,7 @@ fn hotspot_popover(
     gesture_button: Option<ButtonId>,
     open: bool,
     view: &Entity<MouseModelView>,
+    shortcut_input: &Entity<InputState>,
 ) -> AnyElement {
     let view = view.clone();
     let binding_popover = BindingPopover::Hotspot(hotspot.id);
@@ -740,11 +790,13 @@ fn hotspot_popover(
             binding_popover,
             open,
             view.clone(),
+            shortcut_input.clone(),
         )
         .into_any_element()
     } else {
         let view_state = view.clone();
         let view_content = view.clone();
+        let shortcut_input = shortcut_input.clone();
         Popover::new(("hotspot-popover", idx))
             // `action_picker` draws its own `menu_card` surface, matching the
             // gesture menu — so suppress the framework popover surface.
@@ -753,14 +805,16 @@ fn hotspot_popover(
             .mouse_button(MouseButton::Left)
             .trigger(trigger)
             .open(open)
-            .on_open_change(move |open, _window, cx| {
+            .on_open_change(move |open, window, cx| {
                 view_state.update(cx, |v, vcx| {
-                    v.set_binding_popover_open(binding_popover, *open);
+                    v.set_binding_popover_open(binding_popover, *open, window, vcx);
                     vcx.notify();
                 });
             })
             .content(move |_state, _window, cx| match hotspot.id {
-                MouseControlId::Button(button) => action_picker(button, &view_content, cx),
+                MouseControlId::Button(button) => {
+                    action_picker(button, &view_content, &shortcut_input, cx)
+                }
                 MouseControlId::ThumbwheelRotation => thumbwheel_picker(&view, cx),
             })
             .into_any_element()

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -92,8 +92,19 @@ impl MouseModelView {
 
     /// Set (or clear, with `None`) the activated gesture direction. Callers must
     /// `cx.notify()` to re-render.
-    pub(crate) fn set_gesture_selected_dir(&mut self, dir: Option<GestureDirection>) {
+    ///
+    /// Switching direction keeps the same popover open, so this — not
+    /// [`Self::set_binding_popover_open`] — is where the shortcut field has to
+    /// be reset: the flyout is rebuilt with `on_pick` aimed at the new
+    /// direction, and retained text would commit there instead.
+    pub(crate) fn set_gesture_selected_dir(
+        &mut self,
+        dir: Option<GestureDirection>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
         self.gesture_active_dir = dir;
+        self.clear_shortcut_input(window, cx);
     }
 
     fn set_binding_popover_open(
@@ -108,10 +119,17 @@ impl MouseModelView {
         } else if self.open_binding_popover == Some(popover) {
             self.open_binding_popover = None;
         }
-        // One shortcut field serves every binding popover, so without this a
-        // chord typed for one button — committed or not — would still be
-        // sitting there when the next button's picker opens. Safe here because
-        // `on_open_change` runs outside paint (see `gesture_active_dir`).
+        self.clear_shortcut_input(window, cx);
+    }
+
+    /// Empty the shared shortcut field.
+    ///
+    /// One field serves every binding popover and every gesture direction, so
+    /// without this a chord typed against one target — committed or not —
+    /// would still be sitting there, ready to commit, once the user moves to
+    /// the next. Safe from these callers because all of them run outside paint
+    /// (see [`Self::gesture_active_dir`]).
+    fn clear_shortcut_input(&self, window: &mut Window, cx: &mut App) {
         if let Some(input) = &self.shortcut_input {
             input.update(cx, |state, cx| state.set_value("", window, cx));
         }
@@ -409,7 +427,7 @@ where
             view_state.update(cx, |v, vcx| {
                 v.set_binding_popover_open(binding_popover, *open, window, vcx);
                 if !*open {
-                    v.set_gesture_selected_dir(None);
+                    v.set_gesture_selected_dir(None, window, vcx);
                 }
                 vcx.notify();
             });

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Farvepalet"
 "Book": "Bog"
 "Custom shortcut": "Brugerdefineret genvej"
-"Shortcut, e.g. Cmd+Shift+P": "Genvej, f.eks. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "f.eks. Cmd+Shift+P"
 "Application, folder path, or URL": "Program, mappesti eller URL"
 "Open application or folder": "Åbn program eller mappe"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Farbpalette"
 "Book": "Buch"
 "Custom shortcut": "Benutzerdefinierter Kurzbefehl"
-"Shortcut, e.g. Cmd+Shift+P": "Tastenkürzel, z. B. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "z. B. Cmd+Shift+P"
 "Application, folder path, or URL": "Anwendung, Ordnerpfad oder URL"
 "Open application or folder": "Anwendung oder Ordner öffnen"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Παλέτα"
 "Book": "Βιβλίο"
 "Custom shortcut": "Προσαρμοσμένη συντόμευση"
-"Shortcut, e.g. Cmd+Shift+P": "Συντόμευση, π.χ. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "π.χ. Cmd+Shift+P"
 "Application, folder path, or URL": "Εφαρμογή, διαδρομή φακέλου ή URL"
 "Open application or folder": "Άνοιγμα εφαρμογής ή φακέλου"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Palette"
 "Book": "Book"
 "Custom shortcut": "Custom shortcut"
-"Shortcut, e.g. Cmd+Shift+P": "Shortcut, e.g. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "e.g. Cmd+Shift+P"
 "Application, folder path, or URL": "Application, folder path, or URL"
 "Open application or folder": "Open application or folder"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Libro"
 "Custom shortcut": "Atajo personalizado"
-"Shortcut, e.g. Cmd+Shift+P": "Atajo, p. ej. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "p. ej. Cmd+Shift+P"
 "Application, folder path, or URL": "Aplicación, ruta de carpeta o URL"
 "Open application or folder": "Abrir aplicación o carpeta"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Väripaletti"
 "Book": "Kirja"
 "Custom shortcut": "Mukautettu pikanäppäin"
-"Shortcut, e.g. Cmd+Shift+P": "Pikanäppäin, esim. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "esim. Cmd+Shift+P"
 "Application, folder path, or URL": "Sovellus, kansiopolku tai URL"
 "Open application or folder": "Avaa sovellus tai kansio"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Palette"
 "Book": "Livre"
 "Custom shortcut": "Raccourci personnalisé"
-"Shortcut, e.g. Cmd+Shift+P": "Raccourci, p. ex. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "p. ex. Cmd+Shift+P"
 "Application, folder path, or URL": "Application, chemin de dossier ou URL"
 "Open application or folder": "Ouvrir une application ou un dossier"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Tavolozza"
 "Book": "Libro"
 "Custom shortcut": "Scorciatoia personalizzata"
-"Shortcut, e.g. Cmd+Shift+P": "Scorciatoia, ad es. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "ad es. Cmd+Shift+P"
 "Application, folder path, or URL": "Applicazione, percorso cartella o URL"
 "Open application or folder": "Apri applicazione o cartella"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "パレット"
 "Book": "本"
 "Custom shortcut": "カスタムショートカット"
-"Shortcut, e.g. Cmd+Shift+P": "ショートカット（例: Cmd+Shift+P）"
+"e.g. Cmd+Shift+P": "例: Cmd+Shift+P"
 "Application, folder path, or URL": "アプリ、フォルダのパス、またはURL"
 "Open application or folder": "アプリまたはフォルダを開く"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "팔레트"
 "Book": "책"
 "Custom shortcut": "사용자 지정 단축키"
-"Shortcut, e.g. Cmd+Shift+P": "단축키(예: Cmd+Shift+P)"
+"e.g. Cmd+Shift+P": "예: Cmd+Shift+P"
 "Application, folder path, or URL": "앱, 폴더 경로 또는 URL"
 "Open application or folder": "앱 또는 폴더 열기"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Palett"
 "Book": "Bok"
 "Custom shortcut": "Egendefinert snarvei"
-"Shortcut, e.g. Cmd+Shift+P": "Snarvei, f.eks. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "f.eks. Cmd+Shift+P"
 "Application, folder path, or URL": "Program, mappebane eller URL"
 "Open application or folder": "Åpne program eller mappe"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Palet"
 "Book": "Boek"
 "Custom shortcut": "Aangepaste sneltoets"
-"Shortcut, e.g. Cmd+Shift+P": "Sneltoets, bijv. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "bijv. Cmd+Shift+P"
 "Application, folder path, or URL": "Toepassing, mappad of URL"
 "Open application or folder": "Toepassing of map openen"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Książka"
 "Custom shortcut": "Własny skrót"
-"Shortcut, e.g. Cmd+Shift+P": "Skrót, np. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "np. Cmd+Shift+P"
 "Application, folder path, or URL": "Aplikacja, ścieżka folderu lub URL"
 "Open application or folder": "Otwórz aplikację lub folder"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Livro"
 "Custom shortcut": "Atalho personalizado"
-"Shortcut, e.g. Cmd+Shift+P": "Atalho, por exemplo, Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "ex.: Cmd+Shift+P"
 "Application, folder path, or URL": "Aplicativo, caminho de pasta ou URL"
 "Open application or folder": "Abrir aplicativo ou pasta"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Paleta"
 "Book": "Livro"
 "Custom shortcut": "Atalho personalizado"
-"Shortcut, e.g. Cmd+Shift+P": "Atalho, por exemplo, Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "ex.: Cmd+Shift+P"
 "Application, folder path, or URL": "Aplicação, caminho de pasta ou URL"
 "Open application or folder": "Abrir aplicação ou pasta"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Палитра"
 "Book": "Книга"
 "Custom shortcut": "Пользовательское сочетание клавиш"
-"Shortcut, e.g. Cmd+Shift+P": "Сочетание, например Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "напр. Cmd+Shift+P"
 "Application, folder path, or URL": "Приложение, путь к папке или URL"
 "Open application or folder": "Открыть приложение или папку"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Palett"
 "Book": "Bok"
 "Custom shortcut": "Anpassat kortkommando"
-"Shortcut, e.g. Cmd+Shift+P": "Kortkommando, t.ex. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "t.ex. Cmd+Shift+P"
 "Application, folder path, or URL": "Program, mappsökväg eller URL"
 "Open application or folder": "Öppna program eller mapp"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "Палітра"
 "Book": "Книга"
 "Custom shortcut": "Власне сполучення клавіш"
-"Shortcut, e.g. Cmd+Shift+P": "Сполучення клавіш, напр. Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "напр. Cmd+Shift+P"
 "Application, folder path, or URL": "Програма, шлях до папки або URL"
 "Open application or folder": "Відкрити програму або папку"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "调色板"
 "Book": "书籍"
 "Custom shortcut": "自定义快捷键"
-"Shortcut, e.g. Cmd+Shift+P": "快捷键，例如 Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "例如 Cmd+Shift+P"
 "Application, folder path, or URL": "应用、文件夹路径或 URL"
 "Open application or folder": "打开应用或文件夹"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "調色盤"
 "Book": "書籍"
 "Custom shortcut": "自訂快速鍵"
-"Shortcut, e.g. Cmd+Shift+P": "快速鍵，例如 Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "例如 Cmd+Shift+P"
 "Application, folder path, or URL": "應用程式、資料夾路徑或 URL"
 "Open application or folder": "開啟應用程式或資料夾"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -394,6 +394,6 @@ _version: 1
 "Palette": "調色盤"
 "Book": "書籍"
 "Custom shortcut": "自訂快速鍵"
-"Shortcut, e.g. Cmd+Shift+P": "快速鍵，例如 Cmd+Shift+P"
+"e.g. Cmd+Shift+P": "例如 Cmd+Shift+P"
 "Application, folder path, or URL": "應用程式、資料夾路徑或 URL"
 "Open application or folder": "開啟應用程式或資料夾"


### PR DESCRIPTION
## Summary

`Action::CustomShortcut` is deliberately excluded from `Action::catalog`, so the
mouse button picker had no way to reach it — binding a chord to a button meant
hand-editing `config.toml`. The Actions Ring editor already had the field, so
this adds the same one to each button's popover and to a gesture button's
per-direction flyout.

Two deliberate differences from the ring's editor:

- **Add stays disabled until the text parses** as a `KeyCombo`. The ring's
  `if let Ok(..)` commits nothing and says nothing when the chord is malformed,
  which is the shape of the confusion in #518.
- **`cleanable` is off.** Its glyph took enough of the row to truncate the
  placeholder, and the field now clears itself anyway.

## Changes

- **openlogi-desktop**
  - `features/mouse/picker.rs`: new `shortcut_rows` helper — the chord already
    bound (if any), the text field, and an Add button committing through the
    existing `PickFn`. Prepended to the action list in both `action_picker` and
    the gesture `flyout_card`. The bound chord has no catalog row to check, so
    the section states it explicitly; without that the picker looks unbound
    whenever a shortcut is in use.
  - `features/mouse/view.rs`: `MouseModelView` owns one lazily-created
    `InputState`, threaded to both popovers. One field for the view, not one per
    popover — only one is open at a time, and a per-render entity would clear
    the field on every repaint. It resets on commit and on every popover
    open/close, so a chord typed for one button does not follow the user to the
    next. Reset lives in `set_binding_popover_open`, which runs outside paint
    for the same reason `gesture_active_dir` does.
  - `features/action_ring.rs`: moved to the shortened placeholder key.
- **openlogi-ui**: `"Shortcut, e.g. Cmd+Shift+P"` → `"e.g. Cmd+Shift+P"` in all
  21 catalogs, same position, real translations rather than English fill-in. The
  longer string did not fit the popover, and both call sites move together so
  the catalogs carry one placeholder instead of two near-identical ones.

No wire types changed — `Action::CustomShortcut` already round-trips through
config and IPC — so `PROTOCOL_VERSION` is untouched.

## Testing

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo test -p openlogi-ui locale
cargo test -p openlogi-desktop i18n
cargo xtask ci   # 8 passed, 1 skipped
```

All run on Linux with `RUSTFLAGS="-D warnings"`. `cargo xtask ci`'s skipped job
is `tests (macos)` — not reproducible on this host, so **not** claimed green.

Exercised in a dev GUI build against `openlogi-agent-mock` on Fedora 44 /
Wayland: entering a chord on a button and on a gesture direction, Add disabled
until the text parses, the field clearing on commit and when switching buttons,
and the bound chord showing in the section. **Not runtime-tested on hardware** —
this is GUI-side only, and whether the agent then fires the chord is the
injector path, which this PR does not touch. Worth noting #514 reports the agent
ignoring a `CustomShortcut` on a button; if that is still live it is a separate
agent-side bug, not something this change would fix.


<img width="2200" height="1500" alt="gui-custom-shorcut-buttons" src="https://github.com/user-attachments/assets/0edc16c4-69cf-4203-ae2a-51c4c1e9ba98" />

Fixes #573