### PR TITLE
fix(linux): give the Actions Ring overlay the GPUI runtime RUNPATH

### DIFF
--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -70,6 +70,20 @@ let
   # materialising the filtered build source first.
   version = (builtins.fromTOML (builtins.readFile (src + "/Cargo.toml"))).workspace.package.version;
 
+  # The packaged binaries, defined once: install, fixup, and the install check
+  # all iterate these lists, so adding a binary in one place cannot leave it
+  # unpatched or unchecked. GPUI binaries are the ones that need the runtime
+  # graphics backends on their RUNPATH.
+  gpuiBinaries = [
+    "openlogi-desktop"
+    "openlogi-overlay"
+  ];
+  binaries = [
+    "openlogi"
+    "openlogi-agent"
+  ]
+  ++ gpuiBinaries;
+
   # GPUI discovers these graphics backends at runtime instead of linking them,
   # so normal fixup cannot infer their store paths. Add only those paths to the
   # RUNPATH of every GPUI binary; linked xkbcommon/xcb/font libraries are fixed
@@ -186,7 +200,7 @@ rustPlatform.buildRustPackage {
     runHook preInstall
 
     releaseDir=target/${stdenv.hostPlatform.rust.rustcTarget}/release
-    for binary in openlogi openlogi-agent openlogi-desktop openlogi-overlay; do
+    for binary in ${toString binaries}; do
       install -Dm755 "$releaseDir/$binary" "$out/bin/$binary"
     done
 
@@ -221,7 +235,7 @@ rustPlatform.buildRustPackage {
   # only the desktop app left the overlay panicking on `NoWaylandLib` at
   # startup, which the agent's supervisor turned into a restart loop.
   postFixup = ''
-    for binary in openlogi-desktop openlogi-overlay; do
+    for binary in ${toString gpuiBinaries}; do
       patchelf --add-rpath "${runtimeLibs}" "$out/bin/$binary"
     done
   '';
@@ -229,7 +243,7 @@ rustPlatform.buildRustPackage {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   preInstallCheck = ''
-    for binary in openlogi openlogi-agent openlogi-desktop openlogi-overlay; do
+    for binary in ${toString binaries}; do
       test -x "$out/bin/$binary"
     done
     test ! -e "$out/bin/openlogi-agent-mock"
@@ -248,7 +262,7 @@ rustPlatform.buildRustPackage {
     # restarts the overlay indefinitely, so an unpatched overlay degrades into
     # a restart loop rather than into a visible failure. Assert the RUNPATH of
     # every GPUI binary instead of trusting postFixup to have listed them all.
-    for binary in openlogi-desktop openlogi-overlay; do
+    for binary in ${toString gpuiBinaries}; do
       rpath=$(patchelf --print-rpath "$out/bin/$binary")
       for entry in $(echo "${runtimeLibs}" | tr ':' ' '); do
         case ":$rpath:" in

--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -72,7 +72,8 @@ let
 
   # GPUI discovers these graphics backends at runtime instead of linking them,
   # so normal fixup cannot infer their store paths. Add only those paths to the
-  # GUI's RUNPATH; linked xkbcommon/xcb/font libraries are fixed up normally.
+  # RUNPATH of every GPUI binary; linked xkbcommon/xcb/font libraries are fixed
+  # up normally.
   runtimeLibs = lib.makeLibraryPath [
     libGL
     wayland
@@ -215,8 +216,14 @@ rustPlatform.buildRustPackage {
     runHook postInstall
   '';
 
+  # The desktop app and the Actions Ring overlay are siblings: both are GPUI
+  # processes, so both need the runtime backends on their RUNPATH. Patching
+  # only the desktop app left the overlay panicking on `NoWaylandLib` at
+  # startup, which the agent's supervisor turned into a restart loop.
   postFixup = ''
-    patchelf --add-rpath "${runtimeLibs}" "$out/bin/openlogi-desktop"
+    for binary in openlogi-desktop openlogi-overlay; do
+      patchelf --add-rpath "${runtimeLibs}" "$out/bin/$binary"
+    done
   '';
 
   doInstallCheck = true;

--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -234,6 +234,25 @@ rustPlatform.buildRustPackage {
     grep -Fqx \
       "ExecStart=$out/bin/openlogi-agent" \
       "$out/share/systemd/user/openlogi-agent.service"
+
+    # GPUI dlopens its graphics backends, so a missing RUNPATH entry is not a
+    # link error the build can catch: the process panics with `NoWaylandLib`
+    # the instant it starts. Two GPUI processes ship here, and the agent
+    # restarts the overlay indefinitely, so an unpatched overlay degrades into
+    # a restart loop rather than into a visible failure. Assert the RUNPATH of
+    # every GPUI binary instead of trusting postFixup to have listed them all.
+    for binary in openlogi-desktop openlogi-overlay; do
+      rpath=$(patchelf --print-rpath "$out/bin/$binary")
+      for entry in $(echo "${runtimeLibs}" | tr ':' ' '); do
+        case ":$rpath:" in
+          *":$entry:"*) ;;
+          *)
+            echo "$binary lacks $entry in its RUNPATH ($rpath)" >&2
+            exit 1
+            ;;
+        esac
+      done
+    done
   '';
 
   meta = {


### PR DESCRIPTION
## Summary

The Nix package ships two GPUI processes but patches only one. `postFixup` added
the runtime library RUNPATH (`libGL`, `wayland`, `vulkan-loader`) to
`openlogi-desktop`, leaving `openlogi-overlay` without it. GPUI dlopens those
libraries, so the overlay panics at startup, long before it reaches the
compositor:

```
thread 'main' panicked at gpui_linux-0.1.0/src/linux/wayland/client.rs:569:49:
called `Result::unwrap()` on an `Err` value: NoWaylandLib
```

The agent supervises the overlay, so the panic is not a one-off failure: the
helper is restarted on every backoff tick, forever. On a NixOS install the
only visible symptoms are journal noise and wasted CPU — the Actions Ring
itself simply never appears.

Nothing in the package's own checks could catch this, because a missing dlopen
path is neither a link error nor a test failure; the binary installs perfectly
and only fails when it runs.

## Changes

- `packaging/linux/package.nix`
  - `postFixup` now loops over both GPUI binaries (`openlogi-desktop`,
    `openlogi-overlay`) instead of naming the desktop app alone.
  - `preInstallCheck` asserts that every GPUI binary carries every entry of
    `runtimeLibs` in its RUNPATH, so the next GPUI process added to the bundle
    cannot silently ship without it.

## Testing

```sh
nix build .#openlogi                     # green, installCheck included
patchelf --print-rpath result/bin/openlogi-overlay   # contains wayland / vulkan-loader / libGL
nix run nixpkgs#nixfmt -- --check packaging/linux/package.nix
```

The RED commit's assertion was confirmed to fail against a build without the
`postFixup` change (that is what it pins). No Rust code changed, so the Rust
gate is untouched by this diff.

Runtime-verified on NixOS (Wayland): the overlay starts and the restart loop
in `journalctl --user -u openlogi-agent` stops.
