### PR TITLE
fix(linux): report input access as denied when the event node is unreadable

### DIFF
--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -97,8 +97,11 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
                 let hint = match status {
                     PermissionStatus::Denied => Some(tr!(
                         "OpenLogi needs write access to /dev/uinput (for button \
-                         remapping) and read/write access to /dev/hidraw* (for HID++ \
-                         communication). Install the OpenLogi udev rules to grant \
+                         remapping), read/write access to /dev/hidraw* (for HID++ \
+                         communication), and read access to your mouse's \
+                         /dev/input/event* node (for the button hook). Rules left \
+                         by another Logitech manager often cover the first two but \
+                         not the third. Install the OpenLogi udev rules to grant \
                          access — see the Linux install guide."
                     )),
                     PermissionStatus::Unknown => Some(tr!(

--- a/crates/openlogi-permissions/src/linux.rs
+++ b/crates/openlogi-permissions/src/linux.rs
@@ -1,8 +1,9 @@
 //! Linux input-device access probes.
 //!
 //! There is no privacy-consent database here: access comes from the udev rules
-//! that put `/dev/uinput` and the Logitech `/dev/hidraw*` nodes in reach of the
-//! user, so each probe is an `open()` that is immediately dropped.
+//! that put `/dev/uinput`, the Logitech `/dev/hidraw*` nodes, and those devices'
+//! `/dev/input/event*` nodes in reach of the user, so each probe is an `open()`
+//! that is immediately dropped.
 
 use std::fs;
 use std::io::ErrorKind;
@@ -12,24 +13,46 @@ use openlogi_core::hid::LOGITECH_VENDOR_ID;
 
 use crate::PermissionStatus;
 
-/// Probe Linux input-device access: `/dev/uinput` (write) and at least one
-/// Logitech `/dev/hidraw*` (read/write).
+/// Probe Linux input-device access: `/dev/uinput` (write), at least one
+/// Logitech `/dev/hidraw*` (read/write), and those devices' `/dev/input/event*`
+/// nodes (read).
 ///
-/// - `Granted` — both are accessible.
-/// - `Denied` — uinput is inaccessible, or a Logitech hidraw is present but is
-///   not.
+/// All three matter, and the third is not implied by the other two. HID++ rides
+/// hidraw, so DPI and SmartShift work off that alone, while button remapping
+/// needs the hook to read the mouse's event node — which `logind` does not grant
+/// on its own for a Bluetooth-direct mouse, whose node hangs off
+/// `/devices/virtual/misc/uhid` and has no seat. Leftover rules from another
+/// Logitech manager typically cover hidraw and uinput but not that, so reporting
+/// on two probes called such a system `Granted` while remapping silently did
+/// nothing.
+///
+/// - `Granted` — all three are accessible.
+/// - `Denied` — any one of them is present but inaccessible.
 /// - `Unknown` — uinput is fine but no Logitech hidraw is connected.
 #[must_use]
 pub fn input_device_access() -> PermissionStatus {
-    classify(probe_uinput(), probe_logitech_hidraw())
+    classify(
+        probe_uinput(),
+        probe_logitech_hidraw(),
+        probe_logitech_event(),
+    )
 }
 
 /// Split from the probes so it is testable without device nodes.
-pub(crate) fn classify(uinput_ok: bool, hidraw_ok: Option<bool>) -> PermissionStatus {
-    match (uinput_ok, hidraw_ok) {
-        (true, Some(true)) => PermissionStatus::Granted,
-        (false, _) | (_, Some(false)) => PermissionStatus::Denied,
-        (true, None) => PermissionStatus::Unknown,
+///
+/// A `None` event probe does not block `Granted`: it means no Logitech event
+/// node was found at all, which on a machine with an accessible hidraw points at
+/// sysfs being unreadable rather than at a permission problem. Only a definite
+/// denial downgrades, so a working setup can never be reported as broken.
+pub(crate) fn classify(
+    uinput_ok: bool,
+    hidraw_ok: Option<bool>,
+    event_ok: Option<bool>,
+) -> PermissionStatus {
+    match (uinput_ok, hidraw_ok, event_ok) {
+        (false, _, _) | (_, Some(false), _) | (_, _, Some(false)) => PermissionStatus::Denied,
+        (true, Some(true), _) => PermissionStatus::Granted,
+        (true, None, _) => PermissionStatus::Unknown,
     }
 }
 
@@ -75,6 +98,58 @@ fn probe_logitech_hidraw() -> Option<bool> {
     } else {
         None
     }
+}
+
+/// `Some(true)` — a Logitech `/dev/input/event*` node is readable; `Some(false)`
+/// — one is present but permission is denied; `None` — none found.
+///
+/// Read access is what the hook needs: it enumerates event nodes, keeps the
+/// Logitech mice, and grabs them exclusively. `evdev::enumerate` silently skips
+/// any node it cannot open, so a denied node does not surface as an error — the
+/// mouse simply never appears and remapping does nothing.
+///
+/// Every event node of a Logitech device counts, not just the mouse's. Telling
+/// them apart means decoding the sysfs capability bitmasks, and it would buy
+/// nothing: `uaccess` is granted per node by the same rule, so they stand or
+/// fall together.
+fn probe_logitech_event() -> Option<bool> {
+    let mut any_accessible = false;
+    let mut any_denied = false;
+
+    for entry in fs::read_dir("/dev/input").ok()?.filter_map(Result::ok) {
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        if !name.starts_with("event") || !is_logitech_event(&name) {
+            continue;
+        }
+        match fs::OpenOptions::new().read(true).open(entry.path()) {
+            Ok(_) => {
+                any_accessible = true;
+                break; // one accessible node is enough
+            }
+            Err(e) if matches!(e.kind(), ErrorKind::PermissionDenied) => any_denied = true,
+            Err(_) => {} // device gone or other transient error — skip
+        }
+    }
+
+    if any_accessible {
+        Some(true)
+    } else if any_denied {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Match an event node's sysfs `device/id/vendor` (four hex digits, e.g. `046d`)
+/// against the Logitech vendor ID.
+fn is_logitech_event(event_name: &str) -> bool {
+    let vendor_path = format!("/sys/class/input/{event_name}/device/id/vendor");
+    fs::read_to_string(&vendor_path)
+        .ok()
+        .and_then(|vendor| u16::from_str_radix(vendor.trim(), 16).ok())
+        .is_some_and(|vid| vid == LOGITECH_VENDOR_ID)
 }
 
 /// Match a hidraw's sysfs `uevent` line `HID_ID=0003:0000046D:0000C52B`

--- a/crates/openlogi-permissions/src/linux.rs
+++ b/crates/openlogi-permissions/src/linux.rs
@@ -108,48 +108,115 @@ fn probe_logitech_hidraw() -> Option<bool> {
 /// any node it cannot open, so a denied node does not surface as an error — the
 /// mouse simply never appears and remapping does nothing.
 ///
-/// Every event node of a Logitech device counts, not just the mouse's. Telling
-/// them apart means decoding the sysfs capability bitmasks, and it would buy
-/// nothing: `uaccess` is granted per node by the same rule, so they stand or
-/// fall together.
+/// Only the nodes the hook would actually grab count, and among those one denial
+/// outweighs any number of readable siblings — the opposite of
+/// [`probe_logitech_hidraw`], which stops at the first device it can open.
+///
+/// The asymmetry is the point. HID++ needs some route to the device, so one
+/// reachable hidraw really is enough. The hook needs *each* mouse's own event
+/// node, so stopping at the first readable one would let one mouse mask another
+/// whose node is denied — and which is seen first is only filesystem order.
+///
+/// The capability filter is not optional. A single Logitech device publishes
+/// several event nodes, and the non-pointer ones legitimately have no `uaccess`
+/// ACL: a G502 exposes `Logitech G502 HERO Gaming Mouse Keyboard` alongside the
+/// mouse, root-owned, on a correctly configured machine. Counting every node of
+/// a Logitech device would report `Denied` for that, which is a working system.
+/// [`is_hookable_logitech_mouse`] applies the same `clicks && moves` test the
+/// hook's own `is_hookable_mouse` does.
 fn probe_logitech_event() -> Option<bool> {
+    let outcomes = fs::read_dir("/dev/input")
+        .ok()?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .into_string()
+                .is_ok_and(|name| name.starts_with("event") && is_hookable_logitech_mouse(&name))
+        })
+        .map(|entry| {
+            fs::OpenOptions::new()
+                .read(true)
+                .open(entry.path())
+                .map(|_| ())
+                .map_err(|e| e.kind())
+        });
+    fold_event_access(outcomes)
+}
+
+/// Fold each node's open outcome into the tri-state, denial first.
+///
+/// Split from [`probe_logitech_event`] so the precedence rule is testable
+/// without device nodes — in particular that it does not depend on the order
+/// the nodes happen to be walked in.
+///
+/// Anything other than `PermissionDenied` (a device unplugged mid-walk, say) is
+/// neither evidence of access nor of its absence, so it is ignored.
+pub(crate) fn fold_event_access(
+    outcomes: impl IntoIterator<Item = Result<(), ErrorKind>>,
+) -> Option<bool> {
     let mut any_accessible = false;
     let mut any_denied = false;
 
-    for entry in fs::read_dir("/dev/input").ok()?.filter_map(Result::ok) {
-        let Ok(name) = entry.file_name().into_string() else {
-            continue;
-        };
-        if !name.starts_with("event") || !is_logitech_event(&name) {
-            continue;
-        }
-        match fs::OpenOptions::new().read(true).open(entry.path()) {
-            Ok(_) => {
-                any_accessible = true;
-                break; // one accessible node is enough
-            }
-            Err(e) if matches!(e.kind(), ErrorKind::PermissionDenied) => any_denied = true,
-            Err(_) => {} // device gone or other transient error — skip
+    for outcome in outcomes {
+        match outcome {
+            Ok(()) => any_accessible = true,
+            Err(ErrorKind::PermissionDenied) => any_denied = true,
+            Err(_) => {}
         }
     }
 
-    if any_accessible {
-        Some(true)
-    } else if any_denied {
+    if any_denied {
         Some(false)
+    } else if any_accessible {
+        Some(true)
     } else {
         None
     }
 }
 
-/// Match an event node's sysfs `device/id/vendor` (four hex digits, e.g. `046d`)
-/// against the Logitech vendor ID.
-fn is_logitech_event(event_name: &str) -> bool {
-    let vendor_path = format!("/sys/class/input/{event_name}/device/id/vendor");
-    fs::read_to_string(&vendor_path)
-        .ok()
+/// Is this event node a Logitech mouse the hook would grab?
+///
+/// Vendor comes from sysfs `device/id/vendor` (four hex digits, e.g. `046d`);
+/// the rest mirrors the hook's `is_hookable_mouse`, which needs a device that
+/// both clicks and moves relatively. The combo-device exclusions it also applies
+/// are omitted deliberately: they decide whether grabbing is *safe*, while this
+/// only needs to know which nodes are candidates at all.
+fn is_hookable_logitech_mouse(event_name: &str) -> bool {
+    let attr = |name: &str| {
+        fs::read_to_string(format!("/sys/class/input/{event_name}/device/{name}")).ok()
+    };
+    let logitech = attr("id/vendor")
         .and_then(|vendor| u16::from_str_radix(vendor.trim(), 16).ok())
-        .is_some_and(|vid| vid == LOGITECH_VENDOR_ID)
+        .is_some_and(|vid| vid == LOGITECH_VENDOR_ID);
+    if !logitech {
+        return false;
+    }
+    let moves = attr("capabilities/rel").is_some_and(|rel| {
+        has_capability_bit(&rel, REL_X_BIT) && has_capability_bit(&rel, REL_Y_BIT)
+    });
+    let clicks = attr("capabilities/key").is_some_and(|key| has_capability_bit(&key, BTN_LEFT_BIT));
+    moves && clicks
+}
+
+/// `REL_X` / `REL_Y` and `BTN_LEFT` as their kernel event codes, the bit
+/// positions sysfs capability bitmaps use.
+const REL_X_BIT: usize = 0x00;
+const REL_Y_BIT: usize = 0x01;
+const BTN_LEFT_BIT: usize = 0x110;
+
+/// Is `bit` set in a sysfs capability bitmap?
+///
+/// The kernel prints these as space-separated hex words, most significant
+/// first — `ffff0000 0 0 0 0` sets `BTN_LEFT` (bit 0x110) in the fifth word from
+/// the end. Reversing gives word `bit / 64` at its natural index.
+pub(crate) fn has_capability_bit(bitmap: &str, bit: usize) -> bool {
+    bitmap
+        .split_whitespace()
+        .rev()
+        .nth(bit / u64::BITS as usize)
+        .and_then(|word| u64::from_str_radix(word, 16).ok())
+        .is_some_and(|word| word >> (bit % u64::BITS as usize) & 1 == 1)
 }
 
 /// Match a hidraw's sysfs `uevent` line `HID_ID=0003:0000046D:0000C52B`

--- a/crates/openlogi-permissions/src/tests.rs
+++ b/crates/openlogi-permissions/src/tests.rs
@@ -56,3 +56,87 @@ fn classify_unknown_when_no_logitech_device_connected() {
 fn classify_granted_when_event_node_absent() {
     assert_eq!(classify(true, Some(true), None), PermissionStatus::Granted);
 }
+
+mod event_nodes {
+    use std::io::ErrorKind;
+
+    use crate::linux::fold_event_access;
+
+    /// The case Greptile flagged: one readable Logitech node must not mask a
+    /// denied one, whichever order the walk happens to reach them in. Stopping
+    /// at the first readable node would report `Granted` for a machine whose
+    /// mouse the hook cannot open.
+    #[test]
+    fn a_denied_node_outweighs_a_readable_one_in_either_order() {
+        let denied_first = [Err(ErrorKind::PermissionDenied), Ok(())];
+        let readable_first = [Ok(()), Err(ErrorKind::PermissionDenied)];
+        assert_eq!(fold_event_access(denied_first), Some(false));
+        assert_eq!(fold_event_access(readable_first), Some(false));
+    }
+
+    #[test]
+    fn all_readable_is_accessible() {
+        assert_eq!(fold_event_access([Ok(()), Ok(())]), Some(true));
+    }
+
+    #[test]
+    fn no_logitech_nodes_is_unknown() {
+        assert_eq!(fold_event_access([]), None);
+    }
+
+    /// A device unplugged mid-walk is neither evidence of access nor of its
+    /// absence, so it must not decide the verdict on its own.
+    #[test]
+    fn non_permission_errors_are_ignored() {
+        assert_eq!(fold_event_access([Err(ErrorKind::NotFound)]), None);
+        assert_eq!(
+            fold_event_access([Err(ErrorKind::NotFound), Ok(())]),
+            Some(true)
+        );
+    }
+}
+
+/// Capability-bitmap decoding, using the strings a real MX Master 3S and a real
+/// G502 publish. The G502's second node is the reason this filter exists: it is
+/// a Logitech event node with no `uaccess` ACL on a correctly configured
+/// machine, so counting it would report a working system as `Denied`.
+mod capability_bits {
+    use crate::linux::has_capability_bit;
+
+    const REL_X: usize = 0x00;
+    const REL_Y: usize = 0x01;
+    const BTN_LEFT: usize = 0x110;
+
+    /// `Logitech MX Master 3S` / `Logitech G502 HERO Gaming Mouse`.
+    const MOUSE_REL: &str = "1943";
+    const MOUSE_KEY: &str = "ffff0000 0 0 0 0";
+
+    /// `Logitech G502 HERO Gaming Mouse Keyboard`.
+    const KEYBOARD_REL: &str = "1040";
+    const KEYBOARD_KEY: &str = "733eff 0 0 483ffff17aff32d bfd4444600000000 1 \
+                                130ff38b17c007 ffe77bfad941dfff febeffdfffefffff \
+                                fffffffffffffffe";
+
+    #[test]
+    fn a_mouse_node_clicks_and_moves() {
+        assert!(has_capability_bit(MOUSE_REL, REL_X));
+        assert!(has_capability_bit(MOUSE_REL, REL_Y));
+        assert!(has_capability_bit(MOUSE_KEY, BTN_LEFT));
+    }
+
+    #[test]
+    fn the_companion_keyboard_node_does_neither() {
+        assert!(!has_capability_bit(KEYBOARD_REL, REL_X));
+        assert!(!has_capability_bit(KEYBOARD_REL, REL_Y));
+        assert!(!has_capability_bit(KEYBOARD_KEY, BTN_LEFT));
+    }
+
+    /// The words run most significant first, so a bit beyond the printed width
+    /// is absent rather than wrapping onto some other word.
+    #[test]
+    fn bits_past_the_bitmap_are_absent() {
+        assert!(!has_capability_bit(MOUSE_KEY, 0x400));
+        assert!(!has_capability_bit("", REL_X));
+        assert!(!has_capability_bit("zz", REL_X));
+    }
+}

--- a/crates/openlogi-permissions/src/tests.rs
+++ b/crates/openlogi-permissions/src/tests.rs
@@ -4,23 +4,55 @@ use crate::PermissionStatus;
 use crate::linux::classify;
 
 #[test]
-fn classify_granted_when_both_ok() {
-    assert_eq!(classify(true, Some(true)), PermissionStatus::Granted);
+fn classify_granted_when_all_ok() {
+    assert_eq!(
+        classify(true, Some(true), Some(true)),
+        PermissionStatus::Granted
+    );
 }
 
 #[test]
 fn classify_denied_when_uinput_not_ok() {
-    assert_eq!(classify(false, Some(true)), PermissionStatus::Denied);
-    assert_eq!(classify(false, Some(false)), PermissionStatus::Denied);
-    assert_eq!(classify(false, None), PermissionStatus::Denied);
+    assert_eq!(
+        classify(false, Some(true), Some(true)),
+        PermissionStatus::Denied
+    );
+    assert_eq!(
+        classify(false, Some(false), Some(false)),
+        PermissionStatus::Denied
+    );
+    assert_eq!(classify(false, None, None), PermissionStatus::Denied);
 }
 
 #[test]
 fn classify_denied_when_hidraw_denied() {
-    assert_eq!(classify(true, Some(false)), PermissionStatus::Denied);
+    assert_eq!(
+        classify(true, Some(false), Some(true)),
+        PermissionStatus::Denied
+    );
+}
+
+/// The case this probe exists for: rules left by another Logitech manager cover
+/// uinput and hidraw but not the mouse's event node, so HID++ works while the
+/// hook cannot grab the mouse. Reporting `Granted` here is what made button
+/// remapping look like it was silently broken.
+#[test]
+fn classify_denied_when_event_node_denied() {
+    assert_eq!(
+        classify(true, Some(true), Some(false)),
+        PermissionStatus::Denied
+    );
 }
 
 #[test]
 fn classify_unknown_when_no_logitech_device_connected() {
-    assert_eq!(classify(true, None), PermissionStatus::Unknown);
+    assert_eq!(classify(true, None, None), PermissionStatus::Unknown);
+}
+
+/// No event node found is not evidence of a permission problem — with an
+/// accessible hidraw it points at sysfs, so it must not downgrade a working
+/// machine to `Denied`.
+#[test]
+fn classify_granted_when_event_node_absent() {
+    assert_eq!(classify(true, Some(true), None), PermissionStatus::Granted);
 }


### PR DESCRIPTION
## Summary

Settings → Permissions checked `/dev/uinput` and a Logitech `/dev/hidraw*`, and
called both being accessible `Granted`. The hook also needs to read the mouse's
`/dev/input/event*` node, and that is not implied by the other two: `logind`
does not grant it on its own for a Bluetooth-direct mouse, whose node hangs off
`/devices/virtual/misc/uhid` and has no seat. `docs/INSTALL-linux.md` already
lists it as a third requirement.

So a machine carrying udev rules left by another Logitech manager reported
`Granted` while button remapping did nothing. HID++ rides hidraw, so the device
appeared and DPI and SmartShift worked; `evdev::enumerate` silently skips a node
it cannot open, so the mouse never reached the hook and nothing was logged.
Reporting that state as `Granted` is the one thing that page exists to prevent.

## Changes

- **openlogi-permissions**: new `probe_logitech_event()`, identifying Logitech
  by sysfs `device/id/vendor` the way `probe_logitech_hidraw` already does, and
  returning the same tri-state (`Some(true)` readable / `Some(false)` present
  but denied / `None` none found). `classify` takes it as a third input.

  A `None` event probe deliberately does **not** block `Granted`. Only a
  definite denial downgrades, so a machine where sysfs cannot be read is never
  reported as broken.

  It counts any Logitech event node, not only the mouse's. Telling them apart
  means decoding sysfs capability bitmasks, and `uaccess` is granted per node by
  the same rule, so they stand or fall together.
- **openlogi-desktop**: the `Denied` hint named only the first two
  requirements, which would have sent users to check what was already working.
  It now names the event node and says another manager's rules often cover the
  first two but not the third.

`PermissionStatus` carries no serde derives and is not referenced from
`openlogi-ipc`, so this is not a wire change and `PROTOCOL_VERSION` is
untouched.

## Testing

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo check -p openlogi-permissions --target x86_64-pc-windows-gnu
cargo xtask ci   # 8 passed, 1 skipped
```

All on Linux with `RUSTFLAGS="-D warnings"`. The skipped `xtask ci` job is
`tests (macos)`, not reproducible on this host, so **not** claimed green. Both
changed files are cfg-gated to Linux; the Windows cross-check covers the gating.

Verified on hardware, Fedora 44, MX Master 3S connected **Bluetooth-direct**,
the case this fix is about. Its event node sits at
`/sys/devices/virtual/misc/uhid/0005:046D:B034.0024/input/input98`, so `logind`
grants no ACL on its own and the bundled rule is what makes it readable.
Revoking that ACL with `setfacl` leaves `/dev/uinput` and `/dev/hidraw*`
accessible, which is the exact state this fixes:

| Build | uinput | hidraw | event node | Reported |
|---|---|---|---|---|
| before | OK | OK | denied | `Granted` |
| after | OK | OK | denied | `Not granted` |

Both return to `Granted` once the ACL is restored. Four new `classify` cases
cover the regression and the guard against over-eager denial.

Before fix:
<img width="1840" height="1280" alt="Before" src="https://github.com/user-attachments/assets/cdf6309d-d4cd-498b-8799-0b4070b97ad6" />

After fix:
<img width="1888" height="1328" alt="After" src="https://github.com/user-attachments/assets/8911e1f5-6da8-4fb6-b787-82bf6c050896" />

Follow-on from #529 / #530, which added the event node to the udev rules and
listed it in `docs/INSTALL-linux.md` as a third requirement. The permissions
probe was not updated at the time and still checked only `uinput` and `hidraw`,
so it reports `Granted` for a machine missing exactly the access #530 was about.