### PR TITLE
fix(gui): embed the Sleep action's moon glyph

### DIFF
--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -680,3 +680,42 @@ pub(crate) fn scroll_list(id: &'static str, rows: Vec<AnyElement>) -> impl IntoE
         .overflow_y_scroll()
         .children(rows)
 }
+
+#[cfg(test)]
+mod tests {
+    use gpui::AssetSource as _;
+    use openlogi_core::binding::ApplicationTarget;
+    use openlogi_ui::action_icons::ActionIcons;
+
+    use super::*;
+
+    /// [`action_icon_path`] is exhaustive over [`Action`], so the compiler
+    /// catches a missing arm — but nothing checks that the path an arm names is
+    /// actually embedded, and an unembedded path renders as a blank slot with
+    /// no error anywhere. [`Action::catalog`] misses the variants below:
+    /// `ShowActionsRing` is `not_pickable` yet still drawn wherever it is
+    /// already bound, and the parameterised arms hold the only references to
+    /// the keyboard and terminal glyphs.
+    #[test]
+    fn every_reachable_action_icon_is_embedded() {
+        let uncatalogued = [
+            Action::ShowActionsRing,
+            Action::SetDpiPreset(0),
+            Action::CustomShortcut("Ctrl+A".parse().expect("Ctrl+A is a valid combo")),
+            Action::TypeText(String::new()),
+            Action::RunShellCommand(String::new()),
+            Action::RunAppleScript(String::new()),
+            Action::Workflow(Vec::new()),
+            Action::OpenApplication(
+                ApplicationTarget::new("/usr/bin/true", "true").expect("non-empty path"),
+            ),
+        ];
+        for action in Action::catalog().into_iter().chain(uncatalogued) {
+            let path = action_icon_path(&action);
+            assert!(
+                matches!(ActionIcons.load(path), Ok(Some(_))),
+                "{path}, bound to {action:?}, is not embedded"
+            );
+        }
+    }
+}

--- a/crates/openlogi-ui/src/action_icons.rs
+++ b/crates/openlogi-ui/src/action_icons.rs
@@ -54,6 +54,7 @@ const ACTION_ICONS: &[(&str, &[u8])] = &[
     ("action-icons/list-checks.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/list-checks.svg"))),
     ("action-icons/lock.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/lock.svg"))),
     ("action-icons/monitor.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/monitor.svg"))),
+    ("action-icons/moon.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/moon.svg"))),
     ("action-icons/mouse-pointer-click.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse-pointer-click.svg"))),
     ("action-icons/mouse.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse.svg"))),
     ("action-icons/move.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/move.svg"))),
@@ -108,6 +109,9 @@ impl AssetSource for ActionIcons {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::Path;
+
     use openlogi_core::binding::ActionRingIcon;
 
     use super::*;
@@ -119,6 +123,28 @@ mod tests {
             assert!(
                 matches!(loaded, Ok(Some(_))),
                 "missing embedded asset for {icon:?}"
+            );
+        }
+    }
+
+    /// A glyph dropped into `action-icons/` but left out of [`ACTION_ICONS`]
+    /// resolves to no bytes, which GPUI draws as an empty slot rather than
+    /// reporting — the failure has no error path to catch it at runtime. The
+    /// button picker's `moon.svg` shipped that way from the day it was added.
+    #[test]
+    fn every_bundled_glyph_is_embedded() {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("action-icons");
+        let entries = fs::read_dir(&dir).expect("action-icons/ is readable");
+        for entry in entries {
+            let name = entry.expect("readable directory entry").file_name();
+            let name = name.to_string_lossy();
+            if !name.ends_with(".svg") {
+                continue;
+            }
+            let path = format!("action-icons/{name}");
+            assert!(
+                matches!(ActionIcons.load(&path), Ok(Some(_))),
+                "{path} is on disk but missing from ACTION_ICONS"
             );
         }
     }


### PR DESCRIPTION
## Summary

The "Sleep" action rendered with a blank icon in the button picker. `action_icon_path` has mapped `Action::Sleep` to `action-icons/moon.svg` since #395 landed the file and the arm together, but the glyph was never added to `ACTION_ICONS`. `ActionIcons::load` answers `Ok(None)` for an unlisted path, so the row drew an empty slot — there is no error path for this, at runtime or at compile time.

`moon.svg` was the only referenced-but-unembedded path in the tree, and nothing is embedded-but-orphaned, so this is the whole of the bug.

## Changes

**`openlogi-ui`**
- Register `moon.svg` in `ACTION_ICONS`, positioned after `monitor.svg`.
- `every_bundled_glyph_is_embedded`: walks `action-icons/` and asserts each `.svg` resolves through the asset source. Catches a glyph added to the directory but left out of the table — this bug's exact shape. Lives here rather than in the GUI crate so it also runs in the Linux test lane.

**`openlogi-desktop`**
- `every_reachable_action_icon_is_embedded`: asserts every path `action_icon_path` can return is embedded, guarding the opposite direction — an arm naming a glyph nobody shipped. `Action::catalog()` omits `ShowActionsRing` (`not_pickable`, but still drawn wherever it is already bound) and the parameterised variants, which hold the only references to `keyboard.svg` and `terminal.svg`; those are listed explicitly so all 51 `Action` variants are reached.

## Testing

Local gate, green on the final tree:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace                                  # 1059 tests, 0 failed
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo xtask ci
```

`cargo xtask ci` reports 8 passed, 0 failed, 1 skipped. **`tests (macos)` did not run** — this is a Linux host, so that job is unverified here; CI covers it.

The rustdoc job excludes both crates touched here, so I ran rustdoc on them directly as well: `openlogi-ui` is clean; `openlogi-desktop` reports 12 unresolved intra-doc links that are all pre-existing on master and unrelated to this change.

The guard is proven rather than assumed — deleting the table entry fails the new test on the real path:

```
action-icons/moon.svg is on disk but missing from ACTION_ICONS
test result: FAILED. 1 passed; 1 failed
```

Runtime-tested on hardware: MX Master 3S over Bluetooth-direct on Fedora 44 (Wayland, GNOME). The moon glyph renders on the Sleep row and matches its neighbours in the System section.

Fixes #770.

Before fix:
<img width="2200" height="1500" alt="Before" src="https://github.com/user-attachments/assets/3e58b589-89f0-4144-a910-69cf69c9bcd5" />

After fix:
<img width="2200" height="1500" alt="After" src="https://github.com/user-attachments/assets/09037dc1-5780-41e8-8624-23d2bca122ac" />
