### PR TITLE
docs(linux): fix the Debian install command and the bug form's platform note

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,7 +50,7 @@ body:
     id: os
     attributes:
       label: Operating system
-      description: macOS is the only supported platform today; Linux and Windows are still stubs.
+      description: macOS and Linux are first-class; Windows is a younger but shipping port.
       options:
         - macOS
         - Linux

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Download the package for your distribution from the
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -232,7 +232,7 @@ derived from the host (override with `PKG_ARCH`):
 
 ```sh
 cargo run -p xtask -- linux package
-# → target/release/openlogi_*.deb / .rpm / .pkg.tar.zst
+# → target/release/*.deb / *.rpm / *.pkg.tar.zst
 ```
 
 The package contents (binaries, udev rules, systemd user unit, desktop entry,

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -106,7 +106,7 @@ Lade das `.deb` oder `.rpm` vom [neuesten Release](https://github.com/AprilNEA/O
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -106,7 +106,7 @@ Téléchargez le `.deb` ou le `.rpm` depuis la [dernière release](https://githu
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -106,7 +106,7 @@ brew install --cask aprilnea/tap/openlogi@latest
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -106,7 +106,7 @@ brew install --cask aprilnea/tap/openlogi@latest
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -106,7 +106,7 @@ brew install --cask aprilnea/tap/openlogi@latest
 
 ```sh
 # Debian / Ubuntu
-sudo dpkg -i openlogi_*.deb
+sudo dpkg -i openlogi-*.deb
 
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm


### PR DESCRIPTION
## Summary

Two of the three papercuts reported in #763.

**The Debian install command matches no file.** The README tells users to run `sudo dpkg -i openlogi_*.deb`, but release assets are renamed to `openlogi-v<version>-linux-<arch>.deb` on the way out of CI. The underscore glob expands to nothing and dpkg fails before it ever reads a package:

```
dpkg: error: cannot access archive 'openlogi_*.deb': No such file or directory
```

Checked against the real v0.7.4 asset names:

```
openlogi-*.deb  ->  openlogi-v0.7.4-linux-amd64.deb  openlogi-v0.7.4-linux-arm64.deb
openlogi_*.deb  ->  NO MATCH
```

The neighbouring rpm and pacman lines already used `openlogi-*` and were correct, so only the deb line changes.

**The bug form's platform note was stale.** The Operating system field still described macOS as the only supported platform with Linux and Windows as stubs, which the reporter noticed while filing a Linux bug against a shipping Linux package.

## Changes

- `README.md` and the five translated READMEs (`de`, `fr`, `ja`, `ko`, `zh-CN`): `openlogi_*.deb` → `openlogi-*.deb`.
- `docs/DEVELOPMENT.md`: the packaging note claimed local nfpm output is `openlogi_*.deb / .rpm / .pkg.tar.zst`. Only the deb carries the underscore; the other two do not. Replaced with `*.deb / *.rpm / *.pkg.tar.zst` rather than restating a naming convention nfpm owns.
- `.github/ISSUE_TEMPLATE/bug_report.yml`: platform note now matches AGENTS.md — macOS and Linux first-class, Windows a younger but shipping port.

## Testing

Docs and template only — no Rust or shell files in the diff.

```
cargo fmt --all -- --check
cargo xtask ci     # 8 passed, 0 failed, 1 skipped
```

`tests (macos)` **did not run** — Linux host, so that job is unverified here; CI covers it.

The corrected globs were checked against the actual v0.7.4 release asset names (result above, old glob matching nothing). The DEVELOPMENT.md naming was checked by running nfpm rather than assumed, since the underscore is genuinely correct there for the deb:

```
openlogi_0.7.4_amd64.deb
openlogi-0.7.4-1.x86_64.rpm
openlogi-0.7.4-1-x86_64.pkg.tar.zst
```

`bug_report.yml` re-parsed as YAML with the dropdown options intact.

## Not covered here

**The third item in #763 — the systemd user unit — is not addressed by this PR.** The GUI's autostart toggle writes `~/.config/systemd/user/openlogi-agent.service`, which outranks the packaged unit in `/usr/lib/systemd/user` per systemd's unit load path, so once a user flips the toggle their private copy wins and package upgrades never update it. That needs a behaviour decision, not a docs edit, so it deserves its own PR. Keeping the issue open on that account — hence `Refs`, not `Fixes`.

**openlogi.org carries the same broken command** and is outside this repo. It is currently at https://openlogi.org/docs/installation (the `/docs/getting-started/installation#linux` URL cited in the issue now 404s). Worth noting that the site's own Linux download button redirects to `openlogi-v0.7.4-linux-amd64.deb`, so the page hands the user a dash-named file and then tells them to install an underscore-named one.

Refs #763.