### PR TITLE
feat(camera): add anti-flicker and low-light controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Things OpenLogi does that Options+ won't:
 
 - Any Logitech UVC webcam (Brio, StreamCam, the C920 series, …), plug and play
 - Live preview that opens the camera only while you watch — leaving it releases the camera entirely and the LED goes off
-- Image controls written straight to the UVC hardware — zoom, focus, exposure, brightness, contrast, saturation, sharpness, white balance, tint, with auto-mode toggles for focus / exposure / white balance — so changes apply in Meet / Zoom / OBS and every other app using the camera
+- Image controls written straight to the UVC hardware — zoom, focus, exposure, brightness, contrast, saturation, sharpness, white balance, tint, anti-flicker, and low-light compensation, with auto-mode toggles for focus / exposure / white balance — so changes apply in Meet / Zoom / OBS and every other app using the camera
 - One-click profiles: built-in Default / Streaming / Video call plus custom snapshots; settings persist per camera and are written back to the hardware on the next view
 
 ¹ Media key actions use D-Bus MPRIS on Linux; a handful of macOS-specific actions have no universal Linux equivalent and are no-ops. Windows maps platform actions to native equivalents where available.

--- a/crates/openlogi-camera/src/controls.rs
+++ b/crates/openlogi-camera/src/controls.rs
@@ -111,6 +111,45 @@ pub struct ControlRange {
     pub max: i32,
     pub default: i32,
     pub current: i32,
+    /// Bit `n` is set when discrete value `n` is supported. `None` means every
+    /// value in the range is available.
+    pub value_mask: Option<u32>,
+}
+
+impl ControlRange {
+    /// Whether the device reports `value` as supported.
+    #[must_use]
+    pub fn supports(self, value: i32) -> bool {
+        if !(self.min..=self.max).contains(&value) {
+            return false;
+        }
+        self.value_mask.is_none_or(|mask| {
+            u32::try_from(value)
+                .ok()
+                .filter(|value| *value < u32::BITS)
+                .is_some_and(|value| mask & (1 << value) != 0)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ControlRange;
+
+    #[test]
+    fn discrete_range_rejects_missing_values() {
+        let range = ControlRange {
+            min: 0,
+            max: 3,
+            default: 1,
+            current: 1,
+            value_mask: Some((1 << 1) | (1 << 3)),
+        };
+
+        assert!(range.supports(1));
+        assert!(!range.supports(2));
+        assert!(range.supports(3));
+    }
 }
 
 /// Why a UVC control operation failed.

--- a/crates/openlogi-camera/src/controls.rs
+++ b/crates/openlogi-camera/src/controls.rs
@@ -9,6 +9,8 @@ pub enum CameraControl {
     Zoom,
     Focus,
     Exposure,
+    PowerLineFrequency,
+    LowLightCompensation,
     Brightness,
     Contrast,
     Saturation,
@@ -19,10 +21,12 @@ pub enum CameraControl {
 
 impl CameraControl {
     /// Every control, in the order the UI lists them (lens first, then image).
-    pub const ALL: [Self; 9] = [
+    pub const ALL: [Self; 11] = [
         Self::Zoom,
         Self::Focus,
         Self::Exposure,
+        Self::PowerLineFrequency,
+        Self::LowLightCompensation,
         Self::Brightness,
         Self::Contrast,
         Self::Saturation,
@@ -38,6 +42,8 @@ impl CameraControl {
             Self::Zoom => "zoom",
             Self::Focus => "focus",
             Self::Exposure => "exposure",
+            Self::PowerLineFrequency => "power_line_frequency",
+            Self::LowLightCompensation => "low_light_compensation",
             Self::Brightness => "brightness",
             Self::Contrast => "contrast",
             Self::Saturation => "saturation",

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -44,6 +44,8 @@ pub use crate::controls::{
 /// them into the one combination each control actually uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Payload {
+    /// 1-byte unsigned (menu/enum controls).
+    U8,
     /// 2-byte unsigned (most controls).
     U16,
     /// 2-byte signed (brightness, hue).
@@ -56,6 +58,7 @@ impl Payload {
     /// Size in bytes on the wire.
     const fn len(self) -> usize {
         match self {
+            Self::U8 => 1,
             Self::U16 | Self::I16 => 2,
             Self::U32 => 4,
         }
@@ -74,12 +77,14 @@ impl CameraControl {
     /// UVC entity, control selector (Camera Terminal §A.9.4, Processing Unit
     /// §A.9.5), and wire payload type for this control.
     const fn spec(self) -> ControlSpec {
-        use Payload::{I16, U16, U32};
+        use Payload::{I16, U8, U16, U32};
         use Unit::{CameraTerminal, Processing};
         let (unit, selector, payload) = match self {
             Self::Zoom => (CameraTerminal, 0x0B, U16), // CT_ZOOM_ABSOLUTE_CONTROL
             Self::Focus => (CameraTerminal, 0x06, U16), // CT_FOCUS_ABSOLUTE_CONTROL
             Self::Exposure => (CameraTerminal, 0x04, U32), // CT_EXPOSURE_TIME_ABSOLUTE_CONTROL
+            Self::PowerLineFrequency => (Processing, 0x05, U8), // PU_POWER_LINE_FREQUENCY_CONTROL
+            Self::LowLightCompensation => (CameraTerminal, 0x03, U8), // CT_AE_PRIORITY_CONTROL
             Self::Brightness => (Processing, 0x02, I16), // PU_BRIGHTNESS_CONTROL
             Self::Contrast => (Processing, 0x03, U16), // PU_CONTRAST_CONTROL
             Self::Saturation => (Processing, 0x07, U16), // PU_SATURATION_CONTROL
@@ -160,16 +165,7 @@ pub fn control_range(
 ) -> Result<ControlRange, ControlError> {
     let _quiesce = quiesce();
     let dev = UsbDevice::open_for(unique_id)?;
-    let min = dev.get(control, UVC_GET_MIN)?;
-    let max = dev.get(control, UVC_GET_MAX)?;
-    let default = dev.get(control, UVC_GET_DEF)?;
-    let current = dev.get(control, UVC_GET_CUR).unwrap_or(default);
-    Ok(ControlRange {
-        min,
-        max,
-        default,
-        current,
-    })
+    dev.range(control)
 }
 
 /// Read every supported control in a single device-open (controls the camera
@@ -192,21 +188,8 @@ pub fn read_camera_state(unique_id: &str) -> Result<CameraState, ControlError> {
     let dev = UsbDevice::open_for(unique_id)?;
     let mut state = CameraState::default();
     for control in CameraControl::ALL {
-        if let (Ok(min), Ok(max), Ok(default)) = (
-            dev.get(control, UVC_GET_MIN),
-            dev.get(control, UVC_GET_MAX),
-            dev.get(control, UVC_GET_DEF),
-        ) {
-            let current = dev.get(control, UVC_GET_CUR).unwrap_or(default);
-            state.controls.push((
-                control,
-                ControlRange {
-                    min,
-                    max,
-                    default,
-                    current,
-                },
-            ));
+        if let Ok(range) = dev.range(control) {
+            state.controls.push((control, range));
         }
     }
     for toggle in AutoToggle::ALL {
@@ -423,6 +406,30 @@ impl UsbDevice {
         }
     }
 
+    /// Read one control's complete range. Boolean AE priority controls need
+    /// synthetic bounds because UVC cameras commonly implement only GET_CUR.
+    fn range(&self, control: CameraControl) -> Result<ControlRange, ControlError> {
+        if control == CameraControl::LowLightCompensation {
+            let current = self.get(control, UVC_GET_CUR)?;
+            return Ok(ControlRange {
+                min: 0,
+                max: 1,
+                default: self.get(control, UVC_GET_DEF).unwrap_or(0),
+                current,
+            });
+        }
+        let min = self.get(control, UVC_GET_MIN)?;
+        let max = self.get(control, UVC_GET_MAX)?;
+        let default = self.get(control, UVC_GET_DEF)?;
+        let current = self.get(control, UVC_GET_CUR).unwrap_or(default);
+        Ok(ControlRange {
+            min,
+            max,
+            default,
+            current,
+        })
+    }
+
     /// Issue a UVC GET request (`req` = GET_MIN/MAX/DEF/CUR), returning the
     /// control-sized little-endian value, sign-extended per the control.
     fn get(&self, control: CameraControl, req: u8) -> Result<i32, ControlError> {
@@ -435,6 +442,7 @@ impl UsbDevice {
         let mut buf = [0u8; 4];
         self.transfer(RT_GET, req, selector, entity, &mut buf[..payload.len()])?;
         Ok(match payload {
+            Payload::U8 => i32::from(buf[0]),
             Payload::U32 => i32::try_from(u32::from_le_bytes(buf)).unwrap_or(i32::MAX),
             Payload::I16 => i32::from(i16::from_le_bytes([buf[0], buf[1]])),
             Payload::U16 => i32::from(u16::from_le_bytes([buf[0], buf[1]])),
@@ -625,7 +633,22 @@ fn scan_descriptors(blob: &[u8]) -> Option<VcTopology> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ITT_CAMERA, VcTopology, location_hint, scan_descriptors};
+    use super::{
+        CameraControl, ITT_CAMERA, Payload, Unit, VcTopology, location_hint, scan_descriptors,
+    };
+
+    #[test]
+    fn flicker_and_low_light_use_standard_uvc_controls() {
+        let flicker = CameraControl::PowerLineFrequency.spec();
+        assert_eq!(flicker.unit, Unit::Processing);
+        assert_eq!(flicker.selector, 0x05);
+        assert_eq!(flicker.payload, Payload::U8);
+
+        let low_light = CameraControl::LowLightCompensation.spec();
+        assert_eq!(low_light.unit, Unit::CameraTerminal);
+        assert_eq!(low_light.selector, 0x03);
+        assert_eq!(low_light.payload, Payload::U8);
+    }
 
     /// AVFoundation prints the location id unpadded: a StreamCam on bus
     /// 0x01123000 yields a 15-digit id whose leading run is only 7 digits.

--- a/crates/openlogi-camera/src/uvc.rs
+++ b/crates/openlogi-camera/src/uvc.rs
@@ -407,15 +407,17 @@ impl UsbDevice {
     }
 
     /// Read one control's complete range. Boolean AE priority controls need
-    /// synthetic bounds because UVC cameras commonly implement only GET_CUR.
+    /// synthetic bounds because UVC cameras commonly implement only GET_CUR;
+    /// without GET_DEF, the live value is the only safe reset target.
     fn range(&self, control: CameraControl) -> Result<ControlRange, ControlError> {
         if control == CameraControl::LowLightCompensation {
             let current = self.get(control, UVC_GET_CUR)?;
             return Ok(ControlRange {
                 min: 0,
                 max: 1,
-                default: self.get(control, UVC_GET_DEF).unwrap_or(0),
+                default: self.get(control, UVC_GET_DEF).unwrap_or(current),
                 current,
+                value_mask: None,
             });
         }
         let min = self.get(control, UVC_GET_MIN)?;
@@ -427,6 +429,7 @@ impl UsbDevice {
             max,
             default,
             current,
+            value_mask: None,
         })
     }
 

--- a/crates/openlogi-camera/src/uvc_linux.rs
+++ b/crates/openlogi-camera/src/uvc_linux.rs
@@ -292,6 +292,11 @@ fn range_of(device: &Device, description: &Description) -> Option<ControlRange> 
         max: clamp_i32(description.maximum),
         default: clamp_i32(description.default),
         current: clamp_i32(current),
+        value_mask: description.items.as_ref().and_then(|items| {
+            items.iter().try_fold(0u32, |mask, (value, _)| {
+                (*value < u32::BITS).then_some(mask | (1u32 << *value))
+            })
+        }),
     })
 }
 

--- a/crates/openlogi-camera/src/uvc_linux.rs
+++ b/crates/openlogi-camera/src/uvc_linux.rs
@@ -27,12 +27,14 @@ const CID_BRIGHTNESS: u32 = 0x0098_0900;
 const CID_CONTRAST: u32 = 0x0098_0901;
 const CID_SATURATION: u32 = 0x0098_0902;
 const CID_AUTO_WHITE_BALANCE: u32 = 0x0098_090c;
+const CID_POWER_LINE_FREQUENCY: u32 = 0x0098_0918;
 const CID_WHITE_BALANCE_TEMPERATURE: u32 = 0x0098_091a;
 const CID_SHARPNESS: u32 = 0x0098_091b;
 
 /// `V4L2_CID_EXPOSURE_AUTO` — the Camera control class base.
 const CID_EXPOSURE_AUTO: u32 = 0x009a_0901;
 const CID_EXPOSURE_ABSOLUTE: u32 = 0x009a_0902;
+const CID_EXPOSURE_AUTO_PRIORITY: u32 = 0x009a_0903;
 const CID_FOCUS_ABSOLUTE: u32 = 0x009a_090a;
 const CID_FOCUS_AUTO: u32 = 0x009a_090c;
 const CID_ZOOM_ABSOLUTE: u32 = 0x009a_090d;
@@ -54,6 +56,8 @@ fn control_id(control: CameraControl) -> Option<u32> {
         CameraControl::Zoom => CID_ZOOM_ABSOLUTE,
         CameraControl::Focus => CID_FOCUS_ABSOLUTE,
         CameraControl::Exposure => CID_EXPOSURE_ABSOLUTE,
+        CameraControl::PowerLineFrequency => CID_POWER_LINE_FREQUENCY,
+        CameraControl::LowLightCompensation => CID_EXPOSURE_AUTO_PRIORITY,
         CameraControl::Brightness => CID_BRIGHTNESS,
         CameraControl::Contrast => CID_CONTRAST,
         CameraControl::Saturation => CID_SATURATION,

--- a/crates/openlogi-camera/src/uvc_windows.rs
+++ b/crates/openlogi-camera/src/uvc_windows.rs
@@ -46,6 +46,7 @@ const VPA_HUE: i32 = 2;
 const VPA_SATURATION: i32 = 3;
 const VPA_SHARPNESS: i32 = 4;
 const VPA_WHITE_BALANCE: i32 = 6;
+const VPA_BACKLIGHT_COMPENSATION: i32 = 8;
 const CC_ZOOM: i32 = 3;
 const CC_EXPOSURE: i32 = 4;
 const CC_FOCUS: i32 = 6;
@@ -58,6 +59,7 @@ const FLAG_MANUAL: i32 = 0x2;
 enum Prop {
     VideoProcAmp(i32),
     CameraControl(i32),
+    Unsupported,
 }
 
 impl CameraControl {
@@ -66,6 +68,8 @@ impl CameraControl {
             Self::Zoom => Prop::CameraControl(CC_ZOOM),
             Self::Focus => Prop::CameraControl(CC_FOCUS),
             Self::Exposure => Prop::CameraControl(CC_EXPOSURE),
+            Self::PowerLineFrequency => Prop::Unsupported,
+            Self::LowLightCompensation => Prop::VideoProcAmp(VPA_BACKLIGHT_COMPENSATION),
             Self::Brightness => Prop::VideoProcAmp(VPA_BRIGHTNESS),
             Self::Contrast => Prop::VideoProcAmp(VPA_CONTRAST),
             Self::Saturation => Prop::VideoProcAmp(VPA_SATURATION),
@@ -251,6 +255,7 @@ impl<'a> Device<'a> {
         // SAFETY: documented COM calls writing the five out-params.
         unsafe {
             match prop {
+                Prop::Unsupported => return Err(ControlError::Unsupported),
                 Prop::VideoProcAmp(id) => self
                     .proc_amp
                     .as_ref()
@@ -296,6 +301,7 @@ impl<'a> Device<'a> {
         // SAFETY: documented COM calls writing the two out-params.
         unsafe {
             match prop {
+                Prop::Unsupported => return Err(ControlError::Unsupported),
                 Prop::VideoProcAmp(id) => self
                     .proc_amp
                     .as_ref()
@@ -322,6 +328,7 @@ impl<'a> Device<'a> {
         // SAFETY: documented COM calls; the device validates the value.
         unsafe {
             match prop {
+                Prop::Unsupported => return Err(ControlError::Unsupported),
                 Prop::VideoProcAmp(id) => self
                     .proc_amp
                     .as_ref()

--- a/crates/openlogi-camera/src/uvc_windows.rs
+++ b/crates/openlogi-camera/src/uvc_windows.rs
@@ -46,7 +46,6 @@ const VPA_HUE: i32 = 2;
 const VPA_SATURATION: i32 = 3;
 const VPA_SHARPNESS: i32 = 4;
 const VPA_WHITE_BALANCE: i32 = 6;
-const VPA_BACKLIGHT_COMPENSATION: i32 = 8;
 const CC_ZOOM: i32 = 3;
 const CC_EXPOSURE: i32 = 4;
 const CC_FOCUS: i32 = 6;
@@ -68,8 +67,7 @@ impl CameraControl {
             Self::Zoom => Prop::CameraControl(CC_ZOOM),
             Self::Focus => Prop::CameraControl(CC_FOCUS),
             Self::Exposure => Prop::CameraControl(CC_EXPOSURE),
-            Self::PowerLineFrequency => Prop::Unsupported,
-            Self::LowLightCompensation => Prop::VideoProcAmp(VPA_BACKLIGHT_COMPENSATION),
+            Self::PowerLineFrequency | Self::LowLightCompensation => Prop::Unsupported,
             Self::Brightness => Prop::VideoProcAmp(VPA_BRIGHTNESS),
             Self::Contrast => Prop::VideoProcAmp(VPA_CONTRAST),
             Self::Saturation => Prop::VideoProcAmp(VPA_SATURATION),
@@ -290,6 +288,7 @@ impl<'a> Device<'a> {
                 max,
                 default,
                 current,
+                value_mask: None,
             },
             caps,
         ))

--- a/crates/openlogi-cli/src/cmd/camera.rs
+++ b/crates/openlogi-cli/src/cmd/camera.rs
@@ -25,7 +25,8 @@ pub enum CameraCmd {
     /// Set a control to a value (or an auto toggle to 0/1); persists on the
     /// device.
     Set {
-        /// zoom | focus | exposure | brightness | contrast | saturation |
+        /// zoom | focus | exposure | power_line_frequency |
+        /// low_light_compensation | brightness | contrast | saturation |
         /// sharpness | white_balance | tint, or focus_auto | exposure_auto |
         /// white_balance_auto
         control: String,

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -537,11 +537,20 @@ impl CameraControlsPanel {
                 ));
             }
             for slider in &self.sliders {
+                let fallback = if builtin.id != "default"
+                    && matches!(
+                        slider.control,
+                        CameraControl::PowerLineFrequency | CameraControl::LowLightCompensation
+                    ) {
+                    from_slider(slider.state.read(cx).value().start())
+                } else {
+                    slider.range.default
+                };
                 let target = builtin
                     .values
                     .iter()
                     .find(|(c, _)| *c == slider.control)
-                    .map_or(slider.range.default, |(_, pct)| {
+                    .map_or(fallback, |(_, pct)| {
                         let span = to_slider(slider.range.max - slider.range.min);
                         slider.range.min + from_slider(span * pct)
                     });
@@ -853,6 +862,18 @@ fn control_row(
     pal: Palette,
 ) -> AnyElement {
     let slider = &panel.sliders[ix];
+    if slider.control == CameraControl::PowerLineFrequency
+        && slider.range.min <= 1
+        && slider.range.max >= 2
+    {
+        return frequency_row(panel, ix, cx, pal);
+    }
+    if slider.control == CameraControl::LowLightCompensation
+        && slider.range.min == 0
+        && slider.range.max == 1
+    {
+        return binary_control_row(panel, ix, cx, pal);
+    }
     let value = from_slider(slider.state.read(cx).value().start());
     let auto_on = panel.auto_state_for(slider.control);
     let dimmed = auto_on == Some(true);
@@ -935,6 +956,128 @@ fn control_row(
     row.into_any_element()
 }
 
+fn frequency_row(
+    panel: &CameraControlsPanel,
+    ix: usize,
+    cx: &Context<CameraControlsPanel>,
+    pal: Palette,
+) -> AnyElement {
+    let slider = &panel.sliders[ix];
+    let current = from_slider(slider.state.read(cx).value().start());
+    let mut choices = h_flex().flex_1().justify_end().gap_1();
+    for (choice_ix, (value, label)) in [
+        (1, SharedString::from("50 Hz")),
+        (2, SharedString::from("60 Hz")),
+        (3, tr!("Auto")),
+    ]
+    .into_iter()
+    .filter(|(value, _)| *value >= slider.range.min && *value <= slider.range.max)
+    .enumerate()
+    {
+        let active = value == current;
+        let accent = rgb(ACCENT_BLUE);
+        choices = choices.child(
+            div()
+                .id(("camera-frequency", choice_ix))
+                .px_1p5()
+                .py_0p5()
+                .rounded_full()
+                .border_1()
+                .border_color(if active { accent.into() } else { pal.border })
+                .text_caption()
+                .text_color(if active {
+                    accent.into()
+                } else {
+                    pal.text_muted
+                })
+                .hover(|s| s.bg(pal.surface_hover))
+                .child(label)
+                .on_click(cx.listener(move |panel, _: &ClickEvent, window, cx| {
+                    let (Some(key), Some(uid)) = (panel.key.clone(), panel.uid.clone()) else {
+                        return;
+                    };
+                    panel.sliders[ix].state.clone().update(cx, |state, cx| {
+                        state.set_value(to_slider(value), window, cx);
+                    });
+                    panel.commit_release(CameraControl::PowerLineFrequency, &uid, &key, value, cx);
+                })),
+        );
+    }
+
+    h_flex()
+        .id(("camera-control-row", ix))
+        .w_full()
+        .gap_3()
+        .items_center()
+        .child(
+            div()
+                .w(px(96.))
+                .flex_shrink_0()
+                .truncate()
+                .text_body()
+                .text_color(pal.text_muted)
+                .child(slider.label.clone()),
+        )
+        .child(choices)
+        .into_any_element()
+}
+
+fn binary_control_row(
+    panel: &CameraControlsPanel,
+    ix: usize,
+    cx: &Context<CameraControlsPanel>,
+    pal: Palette,
+) -> AnyElement {
+    let slider = &panel.sliders[ix];
+    let on = from_slider(slider.state.read(cx).value().start()) != 0;
+    let accent = rgb(ACCENT_BLUE);
+    h_flex()
+        .id(("camera-control-row", ix))
+        .w_full()
+        .gap_3()
+        .items_center()
+        .child(
+            div()
+                .w(px(96.))
+                .flex_shrink_0()
+                .truncate()
+                .text_body()
+                .text_color(pal.text_muted)
+                .child(slider.label.clone()),
+        )
+        .child(div().flex_1())
+        .child(
+            div()
+                .id("camera-low-light")
+                .px_1p5()
+                .py_0p5()
+                .rounded_full()
+                .border_1()
+                .border_color(if on { accent.into() } else { pal.border })
+                .text_caption()
+                .text_color(if on { accent.into() } else { pal.text_muted })
+                .hover(|s| s.bg(pal.surface_hover))
+                .child(if on { tr!("On") } else { tr!("Off") })
+                .on_click(cx.listener(move |panel, _: &ClickEvent, window, cx| {
+                    let (Some(key), Some(uid)) = (panel.key.clone(), panel.uid.clone()) else {
+                        return;
+                    };
+                    let value = i32::from(!on);
+                    panel.sliders[ix].state.clone().update(cx, |state, cx| {
+                        state.set_value(to_slider(value), window, cx);
+                    });
+                    panel.commit_release(
+                        CameraControl::LowLightCompensation,
+                        &uid,
+                        &key,
+                        value,
+                        cx,
+                    );
+                })),
+        )
+        .into_any_element()
+}
+
 fn reset_button(pal: Palette, cx: &mut Context<CameraControlsPanel>) -> AnyElement {
     h_flex()
         .w_full()
@@ -972,6 +1115,8 @@ fn control_label(control: CameraControl) -> SharedString {
         CameraControl::Zoom => tr!("Zoom"),
         CameraControl::Focus => tr!("Focus"),
         CameraControl::Exposure => tr!("Exposure"),
+        CameraControl::PowerLineFrequency => tr!("Anti-flicker"),
+        CameraControl::LowLightCompensation => tr!("Low light compensation"),
         CameraControl::Brightness => tr!("Brightness"),
         CameraControl::Contrast => tr!("Contrast"),
         CameraControl::Saturation => tr!("Saturation"),

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -863,8 +863,9 @@ fn control_row(
 ) -> AnyElement {
     let slider = &panel.sliders[ix];
     if slider.control == CameraControl::PowerLineFrequency
-        && slider.range.min <= 1
-        && slider.range.max >= 2
+        && [1, 2, 3]
+            .into_iter()
+            .any(|value| slider.range.supports(value))
     {
         return frequency_row(panel, ix, cx, pal);
     }
@@ -971,7 +972,7 @@ fn frequency_row(
         (3, tr!("Auto")),
     ]
     .into_iter()
-    .filter(|(value, _)| *value >= slider.range.min && *value <= slider.range.max)
+    .filter(|(value, _)| slider.range.supports(*value))
     .enumerate()
     {
         let active = value == current;

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Dette kamera har ingen justerbare billedkontroller."
 "Focus": "Fokus"
 "Exposure": "Eksponering"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Hvidbalance"
 "Tint": "Farvetone"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Diese Kamera bietet keine einstellbaren Bildregler."
 "Focus": "Fokus"
 "Exposure": "Belichtung"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Weißabgleich"
 "Tint": "Farbton"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Αυτή η κάμερα δεν διαθέτει ρυθμιζόμενα στοιχεία ελέγχου εικόνας."
 "Focus": "Εστίαση"
 "Exposure": "Έκθεση"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Ισορροπία λευκού"
 "Tint": "Απόχρωση"
 "Auto": "Αυτόματο"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "This camera exposes no adjustable image controls."
 "Focus": "Focus"
 "Exposure": "Exposure"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "White balance"
 "Tint": "Tint"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Esta cámara no ofrece controles de imagen ajustables."
 "Focus": "Enfoque"
 "Exposure": "Exposición"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Balance de blancos"
 "Tint": "Matiz"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Tässä kamerassa ei ole säädettäviä kuva-asetuksia."
 "Focus": "Tarkennus"
 "Exposure": "Valotus"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Valkotasapaino"
 "Tint": "Sävy"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Cette caméra n'expose aucun réglage d'image ajustable."
 "Focus": "Mise au point"
 "Exposure": "Exposition"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Balance des blancs"
 "Tint": "Teinte"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Questa fotocamera non espone controlli immagine regolabili."
 "Focus": "Messa a fuoco"
 "Exposure": "Esposizione"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Bilanciamento del bianco"
 "Tint": "Tinta"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "このカメラには調整可能な画質コントロールがありません。"
 "Focus": "フォーカス"
 "Exposure": "露出"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "ホワイトバランス"
 "Tint": "色合い"
 "Auto": "自動"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "이 카메라에는 조정 가능한 이미지 컨트롤이 없습니다."
 "Focus": "초점"
 "Exposure": "노출"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "화이트 밸런스"
 "Tint": "틴트"
 "Auto": "자동"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Dette kameraet har ingen justerbare bildekontroller."
 "Focus": "Fokus"
 "Exposure": "Eksponering"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Hvitbalanse"
 "Tint": "Fargetone"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Deze camera heeft geen instelbare beeldregelaars."
 "Focus": "Focus"
 "Exposure": "Belichting"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Witbalans"
 "Tint": "Tint"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Ta kamera nie udostępnia regulowanych ustawień obrazu."
 "Focus": "Ostrość"
 "Exposure": "Ekspozycja"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Balans bieli"
 "Tint": "Odcień"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Esta câmera não oferece controles de imagem ajustáveis."
 "Focus": "Foco"
 "Exposure": "Exposição"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Balanço de branco"
 "Tint": "Matiz"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Esta câmara não oferece controlos de imagem ajustáveis."
 "Focus": "Focagem"
 "Exposure": "Exposição"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Equilíbrio de brancos"
 "Tint": "Tonalidade"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Эта камера не имеет регулируемых параметров изображения."
 "Focus": "Фокус"
 "Exposure": "Экспозиция"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Баланс белого"
 "Tint": "Оттенок"
 "Auto": "Авто"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Den här kameran har inga justerbara bildkontroller."
 "Focus": "Fokus"
 "Exposure": "Exponering"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Vitbalans"
 "Tint": "Färgton"
 "Auto": "Auto"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "Ця камера не надає регульованих елементів керування зображенням."
 "Focus": "Фокус"
 "Exposure": "Експозиція"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "Баланс білого"
 "Tint": "Відтінок"
 "Auto": "Авто"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "此摄像头没有可调节的图像控制项。"
 "Focus": "对焦"
 "Exposure": "曝光"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "白平衡"
 "Tint": "色调"
 "Auto": "自动"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "此攝影機沒有可調整的影像控制項。"
 "Focus": "對焦"
 "Exposure": "曝光"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "白平衡"
 "Tint": "色調"
 "Auto": "自動"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -349,6 +349,8 @@ _version: 1
 "This camera exposes no adjustable image controls.": "此攝影機沒有可調整的影像控制項。"
 "Focus": "對焦"
 "Exposure": "曝光"
+"Anti-flicker": "Anti-flicker"
+"Low light compensation": "Low light compensation"
 "White balance": "白平衡"
 "Tint": "色調"
 "Auto": "自動"


### PR DESCRIPTION
## Summary

Add standard UVC anti-flicker and low-light compensation controls for Logitech webcams.

## Changes

- **camera:** add power-line frequency and AE-priority controls to the shared camera vocabulary; implement macOS UVC, Linux V4L2, and Windows DirectShow mappings
- **gui:** render supported 50 Hz / 60 Hz / Auto choices and a low-light toggle, persist changes per camera, and preserve them across built-in profile switches
- **cli:** expose `power_line_frequency` and `low_light_compensation`
- **i18n/docs:** add catalog keys and document both controls

## Testing

- `export RUSTFLAGS="-D warnings"`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 6 passed; shell and Linux tests were not run on macOS, and the Windows proxy was initially skipped until its target was installed
- `cargo xtask ci clippy-windows` — passed
- Runtime-tested on a Logitech Brio 100 on macOS: 50/60 Hz writes change the live preview and selected state correctly; low-light compensation toggles correctly; Logi Tune was stopped during verification
- Not runtime-tested on Linux or Windows hardware
