### PR TITLE
fix(linux): keep the generated systemd unit out of the user's tier

### DIFF
--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -24,13 +24,26 @@
 //!
 //! ## Linux
 //!
-//! A systemd **user** unit at
-//! `$XDG_CONFIG_HOME/systemd/user/openlogi-agent.service` (default
-//! `~/.config/systemd/user/openlogi-agent.service`) is written/removed, then
-//! `systemctl --user daemon-reload` and `enable`/`disable` are called.
+//! When a packaged unit already launches this exact binary — installed by a
+//! distribution package, `install.sh`, or an administrator — it is simply
+//! enabled. Generating a second copy would duplicate its directives one tier
+//! higher, shadowing later changes to it and outliving its removal, since no
+//! package script can clean a home directory.
+//!
+//! Otherwise a systemd **user** unit at
+//! `$XDG_DATA_HOME/systemd/user/openlogi-agent.service` (default
+//! `~/.local/share/systemd/user/openlogi-agent.service`) is written/removed,
+//! then `systemctl --user daemon-reload` and `enable`/`disable` are called.
+//! That is the tier systemd reserves for units installed *on* a user's behalf;
+//! `$XDG_CONFIG_HOME/systemd/user` outranks it and belongs to the user, so a
+//! unit they author by hand always wins over this generated one.
 //! `Restart=on-failure` mirrors the macOS `KeepAlive=SuccessfulExit:false`
 //! semantics. A clean `exit(0)` leaves the unit enabled but stopped until the
 //! next session login.
+//!
+//! Earlier versions wrote into `$XDG_CONFIG_HOME/systemd/user` directly; such a
+//! file is removed on reconcile, but only when it round-trips through the
+//! renderer and is therefore provably one of ours.
 
 use tracing::debug;
 
@@ -38,6 +51,8 @@ use tracing::debug;
 use std::fmt;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::io;
+#[cfg(target_os = "linux")]
+use std::path::Path;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::path::PathBuf;
 #[cfg(target_os = "windows")]
@@ -214,10 +229,40 @@ fn reconcile_windows(enabled: bool) -> std::io::Result<()> {
 #[cfg(target_os = "linux")]
 const UNIT_NAME: &str = "openlogi-agent.service";
 
+/// Unit directories outside the two user-writable tiers, in systemd's own
+/// precedence order (`systemd.unit(5)`, "Load path when running in user mode").
+///
+/// Probed to answer one question: has something outside this app's control —
+/// a distribution package, `install.sh`, or an administrator — already
+/// installed this unit? The user tiers are deliberately absent: a file there
+/// is either ours or the user's, never a package's.
+#[cfg(target_os = "linux")]
+const SYSTEM_UNIT_DIRS: &[&str] = &[
+    "/etc/systemd/user",
+    "/usr/local/share/systemd/user",
+    "/usr/share/systemd/user",
+    "/usr/local/lib/systemd/user",
+    "/usr/lib/systemd/user",
+];
+
 #[cfg(target_os = "linux")]
 fn reconcile_linux(enabled: bool) -> io::Result<()> {
-    let path = unit_path()?;
     let exe = std::env::current_exe()?;
+    migrate_legacy_unit();
+
+    // A packaged unit that already launches this exact binary makes a generated
+    // copy pure redundancy — identical directives, one tier higher. Writing one
+    // would shadow the package (later changes to the packaged unit would never
+    // reach this user) and outlive it (uninstall cannot reach a home
+    // directory). Enable the packaged unit instead and write nothing.
+    if enabled && let Some(packaged) = packaged_unit_for(&exe) {
+        remove_generated_unit()?;
+        info!(path = %packaged.display(), "enabling the packaged systemd user unit");
+        run_systemctl(&["enable", UNIT_NAME]);
+        return Ok(());
+    }
+
+    let path = generated_unit_path()?;
     let desired = enabled.then(|| render_unit(&exe.to_string_lossy()));
 
     let current = std::fs::read_to_string(&path).ok();
@@ -243,18 +288,162 @@ fn reconcile_linux(enabled: bool) -> io::Result<()> {
             run_systemctl(&["daemon-reload"]);
             info!(path = %path.display(), "systemd user unit removed");
         }
-        (None, None) => debug!("systemd user unit already absent"),
+        (None, None) => {
+            debug!("systemd user unit already absent");
+            // The packaged unit, if any, may still be enabled from an earlier
+            // run; disabling is cheap and idempotent when it is not.
+            run_systemctl(&["disable", UNIT_NAME]);
+        }
     }
     Ok(())
 }
 
-/// Path to the per-user systemd unit:
-/// `$XDG_CONFIG_HOME/systemd/user/openlogi-agent.service`
-/// (default `~/.config/systemd/user/openlogi-agent.service`).
+/// Path to the generated unit:
+/// `$XDG_DATA_HOME/systemd/user/openlogi-agent.service`
+/// (default `~/.local/share/systemd/user/openlogi-agent.service`).
+///
+/// The *data* tier, not `$XDG_CONFIG_HOME`: systemd ranks it below the user's
+/// own config directory, so a unit the user writes by hand always wins over
+/// this generated one. `$XDG_CONFIG_HOME/systemd/user` belongs to them.
 #[cfg(target_os = "linux")]
-fn unit_path() -> io::Result<PathBuf> {
+fn generated_unit_path() -> io::Result<PathBuf> {
+    let data_home = openlogi_core::paths::xdg_data_home().map_err(io::Error::other)?;
+    Ok(data_home.join("systemd").join("user").join(UNIT_NAME))
+}
+
+/// The location earlier versions wrote to, inside the user's own config tier.
+/// Read only, to clean up after them — never written.
+#[cfg(target_os = "linux")]
+fn legacy_unit_path() -> io::Result<PathBuf> {
     let config_home = openlogi_core::paths::xdg_config_home().map_err(io::Error::other)?;
     Ok(config_home.join("systemd").join("user").join(UNIT_NAME))
+}
+
+/// Remove the unit earlier versions wrote into `$XDG_CONFIG_HOME/systemd/user`.
+///
+/// That path outranks every other tier, so leaving it behind would shadow both
+/// the generated unit and any packaged one indefinitely — including a stale
+/// `ExecStart` pointing at a binary that no longer exists.
+///
+/// Only a file this app generated is removed, and provenance is exact rather
+/// than heuristic. One template has ever shipped, parameterised solely by
+/// `ExecStart`, so splicing a file's own `ExecStart` line back into that
+/// template reproduces the file byte for byte if and only if we rendered it.
+/// Anything carrying another directive is the user's: it is left in place and
+/// keeps winning, which is the right outcome for a unit they chose to author.
+#[cfg(target_os = "linux")]
+fn migrate_legacy_unit() {
+    let Ok(path) = legacy_unit_path() else {
+        return;
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    if !is_generated_unit(&contents) {
+        warn!(
+            path = %path.display(),
+            "leaving a hand-edited systemd user unit in place; it takes precedence over OpenLogi's own",
+        );
+        return;
+    }
+    match std::fs::remove_file(&path) {
+        Ok(()) => {
+            info!(path = %path.display(), "removed the generated systemd user unit from the user's config tier");
+            // The enable symlink still points at the file just deleted; the
+            // reload plus the enable that follows re-point it at the new unit.
+            run_systemctl(&["daemon-reload"]);
+        }
+        Err(e) => {
+            warn!(error = %e, path = %path.display(), "could not remove the legacy systemd user unit");
+        }
+    }
+}
+
+/// Whether `contents` is a unit this app rendered, for *any* executable path.
+#[cfg(target_os = "linux")]
+fn is_generated_unit(contents: &str) -> bool {
+    exec_start_value(contents).is_some_and(|value| render_unit_with_exec(value) == contents)
+}
+
+/// The verbatim, still-escaped value of the file's single `ExecStart=` line.
+///
+/// `None` when there is no such line, or more than one — neither shape is
+/// something [`render_unit`] can produce.
+#[cfg(target_os = "linux")]
+fn exec_start_value(contents: &str) -> Option<&str> {
+    let mut values = contents
+        .lines()
+        .filter_map(|line| line.strip_prefix("ExecStart="));
+    let value = values.next()?;
+    values.next().is_none().then_some(value)
+}
+
+/// The first system-tier unit whose `ExecStart` launches `exe`, if any.
+///
+/// A unit that launches some *other* binary is not a match: the generated unit
+/// is what makes autostart work for a build the packaged unit cannot describe,
+/// so in that case the normal write path must still run.
+#[cfg(target_os = "linux")]
+fn packaged_unit_for(exe: &Path) -> Option<PathBuf> {
+    SYSTEM_UNIT_DIRS
+        .iter()
+        .map(|dir| Path::new(dir).join(UNIT_NAME))
+        .find(|path| {
+            std::fs::read_to_string(path)
+                .ok()
+                .and_then(|contents| exec_start_value(&contents).map(unescape_systemd_exec))
+                .is_some_and(|packaged| same_executable(Path::new(&packaged), exe))
+        })
+}
+
+/// Recover the executable path from a rendered `ExecStart` value.
+///
+/// Inverts [`escape_systemd_exec`] and drops any arguments. Units using
+/// systemd's `ExecStart` prefix characters (`-`, `@`, `+`, `!`) are not
+/// unwrapped: they are nothing this app writes, and failing to match one
+/// simply falls back to generating a unit, which is the safe direction.
+#[cfg(target_os = "linux")]
+fn unescape_systemd_exec(value: &str) -> String {
+    let program = match value.strip_prefix('"') {
+        Some(rest) => rest.split_once('"').map_or_else(
+            || rest.to_string(),
+            |(inner, _)| inner.replace("\\\"", "\""),
+        ),
+        None => value
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_string(),
+    };
+    program.replace("%%", "%").replace("$$", "$")
+}
+
+/// Whether two paths name the same executable.
+///
+/// Resolved through symlinks when both exist, so a merged-`/usr` layout or an
+/// `install.sh --prefix` that points one at the other still compares equal.
+/// Falls back to a literal comparison when either side cannot be resolved.
+#[cfg(target_os = "linux")]
+fn same_executable(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+/// Delete the generated unit if present. Absent is success, not an error.
+#[cfg(target_os = "linux")]
+fn remove_generated_unit() -> io::Result<()> {
+    let path = generated_unit_path()?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => {
+            info!(path = %path.display(), "removed the redundant generated systemd user unit");
+            run_systemctl(&["daemon-reload"]);
+            Ok(())
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 /// Render the systemd user unit for the given executable path.
@@ -264,7 +453,17 @@ fn unit_path() -> io::Result<PathBuf> {
 /// the tray's Quit) stays stopped until the next login.
 #[cfg(target_os = "linux")]
 fn render_unit(exe: &str) -> String {
-    let exec_start = escape_systemd_exec(exe);
+    render_unit_with_exec(&escape_systemd_exec(exe))
+}
+
+/// Render the unit around an `ExecStart` value that is **already escaped**.
+///
+/// Split out so [`is_generated_unit`] can splice a file's own `ExecStart` line
+/// back in verbatim: running [`escape_systemd_exec`] over an already-escaped
+/// value would double `%%` into `%%%%`, and a unit this app wrote would fail to
+/// match itself.
+#[cfg(target_os = "linux")]
+fn render_unit_with_exec(exec_start: &str) -> String {
     format!(
         "[Unit]\n\
         Description=OpenLogi background agent (Logitech HID++ device control)\n\
@@ -336,122 +535,8 @@ impl fmt::Display for SystemctlArgsDisplay<'_, '_> {
 
 #[cfg(test)]
 #[cfg(target_os = "macos")]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rendered_plist_targets_the_agent_and_keeps_alive() {
-        let body = render_plist(
-            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
-        )
-        .expect("render plist");
-        assert!(body.contains(LABEL));
-        assert!(body.contains("openlogi-agent"));
-        assert!(body.contains("RunAtLoad"));
-        // KeepAlive uses SuccessfulExit:false so a crash respawns but the tray's
-        // Quit (a clean exit(0)) is NOT relaunched; no --minimized (always headless).
-        let parsed = plist::Value::from_reader_xml(body.as_bytes()).expect("parse plist");
-        let keep_alive = parsed
-            .as_dictionary()
-            .and_then(|root| root.get("KeepAlive"))
-            .and_then(plist::Value::as_dictionary)
-            .expect("KeepAlive dictionary");
-        assert_eq!(
-            keep_alive
-                .get("SuccessfulExit")
-                .and_then(plist::Value::as_boolean),
-            Some(false)
-        );
-        assert!(!body.contains("--minimized"));
-    }
-
-    #[test]
-    fn render_plist_serializes_xml_metacharacters_in_the_path() {
-        // A home/app path with XML metacharacters (all legal APFS filename chars)
-        // must not produce a malformed plist launchd would reject.
-        let path = "/Users/R&D/Apps/<OpenLogi>/openlogi-agent";
-        let body = render_plist(path).expect("render plist");
-        let parsed = plist::Value::from_reader_xml(body.as_bytes()).expect("parse plist");
-        let args = parsed
-            .as_dictionary()
-            .and_then(|root| root.get("ProgramArguments"))
-            .and_then(plist::Value::as_array)
-            .expect("ProgramArguments array");
-        assert_eq!(args.first().and_then(plist::Value::as_string), Some(path));
-    }
-}
+mod macos_tests;
 
 #[cfg(test)]
 #[cfg(target_os = "linux")]
-mod linux_tests {
-    use super::*;
-
-    #[test]
-    fn rendered_unit_targets_agent_and_restarts_on_failure() {
-        let body = render_unit("/usr/bin/openlogi-agent");
-        assert!(body.contains("ExecStart=/usr/bin/openlogi-agent"));
-        assert!(body.contains("Restart=on-failure"));
-        assert!(body.contains("WantedBy=graphical-session.target"));
-        assert!(!body.contains("--minimized"));
-    }
-
-    #[test]
-    fn rendered_unit_is_valid_ini_with_all_three_sections() {
-        let body = render_unit("/usr/bin/openlogi-agent");
-        assert!(body.contains("[Unit]"));
-        assert!(body.contains("[Service]"));
-        assert!(body.contains("[Install]"));
-    }
-
-    #[test]
-    fn escape_systemd_exec_doubles_percent() {
-        assert_eq!(
-            escape_systemd_exec("/home/user%20/bin/openlogi-agent"),
-            "/home/user%%20/bin/openlogi-agent"
-        );
-    }
-
-    #[test]
-    fn escape_systemd_exec_quotes_path_with_spaces() {
-        let result = escape_systemd_exec("/home/my user/bin/openlogi-agent");
-        assert_eq!(result, "\"/home/my user/bin/openlogi-agent\"");
-    }
-
-    #[test]
-    fn escape_systemd_exec_quotes_and_doubles_percent_with_spaces() {
-        let result = escape_systemd_exec("/home/my%20 user/openlogi-agent");
-        assert_eq!(result, "\"/home/my%%20 user/openlogi-agent\"");
-    }
-
-    #[test]
-    fn escape_systemd_exec_doubles_dollar() {
-        assert_eq!(
-            escape_systemd_exec("/opt/release$1/bin/openlogi-agent"),
-            "/opt/release$$1/bin/openlogi-agent"
-        );
-    }
-
-    #[test]
-    fn escape_systemd_exec_plain_path_unchanged() {
-        let path = "/usr/local/bin/openlogi-agent";
-        assert_eq!(escape_systemd_exec(path), path);
-    }
-
-    #[test]
-    fn systemctl_arguments_render_as_a_command_suffix() {
-        assert_eq!(
-            SystemctlArgsDisplay(&["enable", UNIT_NAME]).to_string(),
-            "enable openlogi-agent.service"
-        );
-    }
-
-    #[test]
-    fn unit_path_uses_home_fallback() {
-        // When XDG_CONFIG_HOME is unset (or relative), falls back to $HOME/.config.
-        // We can't mutate global env safely in a parallel test suite, so we test
-        // the logic indirectly: unit_path() must end in the UNIT_NAME component.
-        let path = unit_path().expect("unit_path should resolve with a valid HOME");
-        assert!(path.ends_with(UNIT_NAME));
-        assert!(path.to_string_lossy().contains("systemd/user"));
-    }
-}
+mod linux_tests;

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -337,20 +337,43 @@ fn enablement_marker_path() -> io::Result<PathBuf> {
 
 /// Enable the unit and record that this app is the one that did.
 ///
-/// The marker is written only once `systemctl` reports success. Recording an
-/// enablement that never happened — no session bus, unit not found — would let
-/// a later reconcile disable something this app never turned on.
+/// The claim is recorded *before* enabling. An enablement this app cannot
+/// record is one a later reconcile could never withdraw, leaving autostart
+/// running while the setting reads off — so if the marker cannot be written,
+/// autostart is left alone rather than turned on untrackably. If `systemctl`
+/// then fails, the claim is dropped again: recording an enablement that never
+/// happened would let a later reconcile disable something this app never
+/// turned on.
 ///
 /// Claiming an enablement the user made by hand is deliberate: reaching the
 /// toggle at all is an explicit request for this app to manage autostart, and
 /// the setting has to mean what it says when it is switched back off.
 #[cfg(target_os = "linux")]
 fn enable_unit() {
-    if !run_systemctl(&["enable", UNIT_NAME]) {
+    if let Err(e) = record_enablement() {
+        warn!(
+            error = %e,
+            "could not record the autostart enablement; leaving autostart unchanged",
+        );
         return;
     }
-    if let Err(e) = record_enablement() {
-        warn!(error = %e, "could not record the autostart enablement");
+    if !run_systemctl(&["enable", UNIT_NAME]) {
+        clear_enablement_marker();
+    }
+}
+
+/// Drop this app's claim on the enablement. Absent is success.
+#[cfg(target_os = "linux")]
+fn clear_enablement_marker() {
+    let Ok(marker) = enablement_marker_path() else {
+        return;
+    };
+    match std::fs::remove_file(&marker) {
+        Ok(()) => debug!(path = %marker.display(), "cleared the autostart marker"),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => {
+            warn!(error = %e, path = %marker.display(), "could not clear the autostart marker");
+        }
     }
 }
 
@@ -386,9 +409,7 @@ fn disable_unit_if_ours() {
         // an enablement this app is still responsible for.
         return;
     }
-    if let Err(e) = std::fs::remove_file(&marker) {
-        warn!(error = %e, path = %marker.display(), "could not clear the autostart marker");
-    }
+    clear_enablement_marker();
 }
 
 /// Path to the generated unit:

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -290,9 +290,18 @@ fn reconcile_linux(enabled: bool) -> io::Result<()> {
         }
         (None, None) => {
             debug!("systemd user unit already absent");
-            // The packaged unit, if any, may still be enabled from an earlier
-            // run; disabling is cheap and idempotent when it is not.
-            run_systemctl(&["disable", UNIT_NAME]);
+            // Nothing of ours is on disk, so `disable` would act on whatever
+            // else claims this unit name. Withdraw only an enablement this app
+            // could have made: a packaged unit for this binary, and only while
+            // the user has not authored their own.
+            //
+            // Deliberately asymmetric with the enable path above, which does
+            // run against a hand-authored unit — enabling is what the user just
+            // asked for, whereas the enablement being withdrawn here may be one
+            // they made outside OpenLogi and never asked it to touch.
+            if packaged_unit_for(&exe).is_some() && !user_authored_unit_present() {
+                run_systemctl(&["disable", UNIT_NAME]);
+            }
         }
     }
     Ok(())
@@ -357,6 +366,18 @@ fn migrate_legacy_unit() {
             warn!(error = %e, path = %path.display(), "could not remove the legacy systemd user unit");
         }
     }
+}
+
+/// Whether the user's own config tier holds a unit this app did not render.
+///
+/// Such a file outranks everything else, so the service name belongs to them:
+/// its enablement is theirs to withdraw, not this app's.
+#[cfg(target_os = "linux")]
+fn user_authored_unit_present() -> bool {
+    legacy_unit_path()
+        .ok()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .is_some_and(|contents| !is_generated_unit(&contents))
 }
 
 /// Whether `contents` is a unit this app rendered, for *any* executable path.

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -336,9 +336,19 @@ fn enablement_marker_path() -> io::Result<PathBuf> {
 }
 
 /// Enable the unit and record that this app is the one that did.
+///
+/// The marker is written only once `systemctl` reports success. Recording an
+/// enablement that never happened — no session bus, unit not found — would let
+/// a later reconcile disable something this app never turned on.
+///
+/// Claiming an enablement the user made by hand is deliberate: reaching the
+/// toggle at all is an explicit request for this app to manage autostart, and
+/// the setting has to mean what it says when it is switched back off.
 #[cfg(target_os = "linux")]
 fn enable_unit() {
-    run_systemctl(&["enable", UNIT_NAME]);
+    if !run_systemctl(&["enable", UNIT_NAME]) {
+        return;
+    }
     if let Err(e) = record_enablement() {
         warn!(error = %e, "could not record the autostart enablement");
     }
@@ -371,7 +381,11 @@ fn disable_unit_if_ours() {
         debug!("autostart enablement was not made by OpenLogi; leaving it alone");
         return;
     }
-    run_systemctl(&["disable", UNIT_NAME]);
+    if !run_systemctl(&["disable", UNIT_NAME]) {
+        // Keep the marker so the next reconcile retries rather than stranding
+        // an enablement this app is still responsible for.
+        return;
+    }
     if let Err(e) = std::fs::remove_file(&marker) {
         warn!(error = %e, path = %marker.display(), "could not clear the autostart marker");
     }
@@ -585,12 +599,15 @@ fn escape_systemd_exec(s: &str) -> String {
 /// the unit file write is the authoritative record; enable/disable is
 /// best-effort (e.g. the session D-Bus may be unavailable in some environments).
 #[cfg(target_os = "linux")]
-fn run_systemctl(args: &[&str]) {
+fn run_systemctl(args: &[&str]) -> bool {
     let label = SystemctlArgsDisplay(args);
     let mut cmd = std::process::Command::new("systemctl");
     cmd.arg("--user").args(args);
     match cmd.output() {
-        Ok(out) if out.status.success() => debug!("systemctl --user {label} succeeded"),
+        Ok(out) if out.status.success() => {
+            debug!("systemctl --user {label} succeeded");
+            true
+        }
         Ok(out) => {
             let stderr = String::from_utf8_lossy(&out.stderr);
             warn!(
@@ -598,8 +615,12 @@ fn run_systemctl(args: &[&str]) {
                 out.status,
                 stderr.trim()
             );
+            false
         }
-        Err(e) => warn!("systemctl --user {label} failed to spawn: {e}"),
+        Err(e) => {
+            warn!("systemctl --user {label} failed to spawn: {e}");
+            false
+        }
     }
 }
 

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -41,9 +41,18 @@
 //! semantics. A clean `exit(0)` leaves the unit enabled but stopped until the
 //! next session login.
 //!
-//! Earlier versions wrote into `$XDG_CONFIG_HOME/systemd/user` directly; such a
-//! file is removed on reconcile, but only when it round-trips through the
-//! renderer and is therefore provably one of ours.
+//! Neither user-writable tier is exclusively this app's, so nothing is written
+//! over or deleted unless it round-trips through the renderer and is therefore
+//! provably one of ours — including the file earlier versions wrote into
+//! `$XDG_CONFIG_HOME/systemd/user`, which is cleaned up on reconcile. A unit
+//! anything else installed under the same name is left alone, and the setting
+//! is honoured through enablement alone.
+//!
+//! Enablement is tracked separately, because `systemctl --user enable` records
+//! only that a unit is enabled, never who asked. Without that record,
+//! reconciling a disabled setting would withdraw the enablement made by the
+//! documented `systemctl --user enable --now` install step. A marker beside the
+//! config notes an enablement this app made; `disable` runs only against one.
 
 use tracing::debug;
 
@@ -250,6 +259,28 @@ fn reconcile_linux(enabled: bool) -> io::Result<()> {
     let exe = std::env::current_exe()?;
     migrate_legacy_unit();
 
+    let path = generated_unit_path()?;
+    let current = std::fs::read_to_string(&path).ok();
+
+    // A unit at a user-writable tier that this app did not render belongs to
+    // whoever wrote it — another installer, or the user. Never overwrite it and
+    // never delete it; the toggle is honoured through enablement alone.
+    if current
+        .as_deref()
+        .is_some_and(|have| !is_generated_unit(have))
+    {
+        warn!(
+            path = %path.display(),
+            "leaving a systemd user unit this app did not write in place",
+        );
+        if enabled {
+            enable_unit();
+        } else {
+            disable_unit_if_ours();
+        }
+        return Ok(());
+    }
+
     // A packaged unit that already launches this exact binary makes a generated
     // copy pure redundancy — identical directives, one tier higher. Writing one
     // would shadow the package (later changes to the packaged unit would never
@@ -258,20 +289,17 @@ fn reconcile_linux(enabled: bool) -> io::Result<()> {
     if enabled && let Some(packaged) = packaged_unit_for(&exe) {
         remove_generated_unit()?;
         info!(path = %packaged.display(), "enabling the packaged systemd user unit");
-        run_systemctl(&["enable", UNIT_NAME]);
+        enable_unit();
         return Ok(());
     }
 
-    let path = generated_unit_path()?;
     let desired = enabled.then(|| render_unit(&exe.to_string_lossy()));
-
-    let current = std::fs::read_to_string(&path).ok();
     match (desired.as_deref(), current.as_deref()) {
         (Some(want), Some(have)) if want == have => {
             debug!(path = %path.display(), "systemd user unit already current");
             // Re-enable unconditionally: the unit file is current but the user
             // may have manually disabled the service since the last reconcile.
-            run_systemctl(&["enable", UNIT_NAME]);
+            enable_unit();
         }
         (Some(want), _) => {
             if let Some(parent) = path.parent() {
@@ -280,31 +308,73 @@ fn reconcile_linux(enabled: bool) -> io::Result<()> {
             std::fs::write(&path, want)?;
             info!(path = %path.display(), "systemd user unit written");
             run_systemctl(&["daemon-reload"]);
-            run_systemctl(&["enable", UNIT_NAME]);
+            enable_unit();
         }
         (None, Some(_)) => {
-            run_systemctl(&["disable", UNIT_NAME]);
-            std::fs::remove_file(&path)?;
-            run_systemctl(&["daemon-reload"]);
-            info!(path = %path.display(), "systemd user unit removed");
+            disable_unit_if_ours();
+            remove_generated_unit()?;
         }
         (None, None) => {
             debug!("systemd user unit already absent");
-            // Nothing of ours is on disk, so `disable` would act on whatever
-            // else claims this unit name. Withdraw only an enablement this app
-            // could have made: a packaged unit for this binary, and only while
-            // the user has not authored their own.
-            //
-            // Deliberately asymmetric with the enable path above, which does
-            // run against a hand-authored unit — enabling is what the user just
-            // asked for, whereas the enablement being withdrawn here may be one
-            // they made outside OpenLogi and never asked it to touch.
-            if packaged_unit_for(&exe).is_some() && !user_authored_unit_present() {
-                run_systemctl(&["disable", UNIT_NAME]);
-            }
+            disable_unit_if_ours();
         }
     }
     Ok(())
+}
+
+/// Path to the marker recording that *this app* enabled the unit.
+///
+/// `systemctl --user enable` writes a symlink that carries no record of who
+/// asked for it, and the unit name is shared with whatever a package or the
+/// user installs. Without this, reconciling a disabled setting would withdraw
+/// an enablement made by the documented `systemctl --user enable --now`
+/// install step, silently turning off autostart the user asked for.
+#[cfg(target_os = "linux")]
+fn enablement_marker_path() -> io::Result<PathBuf> {
+    let data_dir = openlogi_core::paths::data_dir().map_err(io::Error::other)?;
+    Ok(data_dir.join("autostart.enabled"))
+}
+
+/// Enable the unit and record that this app is the one that did.
+#[cfg(target_os = "linux")]
+fn enable_unit() {
+    run_systemctl(&["enable", UNIT_NAME]);
+    if let Err(e) = record_enablement() {
+        warn!(error = %e, "could not record the autostart enablement");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn record_enablement() -> io::Result<()> {
+    let path = enablement_marker_path()?;
+    if path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, b"")
+}
+
+/// Withdraw the enablement only when this app recorded making it.
+///
+/// A missing marker means the enablement came from somewhere else — the
+/// install instructions, another tool, the user — and is not ours to remove.
+/// Losing the marker therefore fails safe: autostart keeps working, and the
+/// user can still turn it off the way they turned it on.
+#[cfg(target_os = "linux")]
+fn disable_unit_if_ours() {
+    let Ok(marker) = enablement_marker_path() else {
+        return;
+    };
+    if !marker.exists() {
+        debug!("autostart enablement was not made by OpenLogi; leaving it alone");
+        return;
+    }
+    run_systemctl(&["disable", UNIT_NAME]);
+    if let Err(e) = std::fs::remove_file(&marker) {
+        warn!(error = %e, path = %marker.display(), "could not clear the autostart marker");
+    }
 }
 
 /// Path to the generated unit:
@@ -366,18 +436,6 @@ fn migrate_legacy_unit() {
             warn!(error = %e, path = %path.display(), "could not remove the legacy systemd user unit");
         }
     }
-}
-
-/// Whether the user's own config tier holds a unit this app did not render.
-///
-/// Such a file outranks everything else, so the service name belongs to them:
-/// its enablement is theirs to withdraw, not this app's.
-#[cfg(target_os = "linux")]
-fn user_authored_unit_present() -> bool {
-    legacy_unit_path()
-        .ok()
-        .and_then(|path| std::fs::read_to_string(path).ok())
-        .is_some_and(|contents| !is_generated_unit(&contents))
 }
 
 /// Whether `contents` is a unit this app rendered, for *any* executable path.
@@ -452,19 +510,27 @@ fn same_executable(a: &Path, b: &Path) -> bool {
     }
 }
 
-/// Delete the generated unit if present. Absent is success, not an error.
+/// Delete the generated unit if present, and only if this app rendered it.
+///
+/// The data tier is where OpenLogi writes, but it is not exclusively its own —
+/// another tool can install a unit under the same name. Absent is success.
 #[cfg(target_os = "linux")]
 fn remove_generated_unit() -> io::Result<()> {
     let path = generated_unit_path()?;
-    match std::fs::remove_file(&path) {
-        Ok(()) => {
-            info!(path = %path.display(), "removed the redundant generated systemd user unit");
-            run_systemctl(&["daemon-reload"]);
-            Ok(())
-        }
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e),
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Ok(());
+    };
+    if !is_generated_unit(&contents) {
+        warn!(
+            path = %path.display(),
+            "leaving a systemd user unit this app did not write in place",
+        );
+        return Ok(());
     }
+    std::fs::remove_file(&path)?;
+    info!(path = %path.display(), "removed the generated systemd user unit");
+    run_systemctl(&["daemon-reload"]);
+    Ok(())
 }
 
 /// Render the systemd user unit for the given executable path.

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -238,21 +238,102 @@ fn reconcile_windows(enabled: bool) -> std::io::Result<()> {
 #[cfg(target_os = "linux")]
 const UNIT_NAME: &str = "openlogi-agent.service";
 
-/// Unit directories outside the two user-writable tiers, in systemd's own
-/// precedence order (`systemd.unit(5)`, "Load path when running in user mode").
+/// Unit directories to fall back on when systemd cannot be asked for the real
+/// load path, highest precedence first.
 ///
-/// Probed to answer one question: has something outside this app's control —
-/// a distribution package, `install.sh`, or an administrator — already
-/// installed this unit? The user tiers are deliberately absent: a file there
-/// is either ours or the user's, never a package's.
+/// Mirrors the user-mode load path in `systemd.unit(5)` rather than a fixed set
+/// of absolute paths: `$XDG_CONFIG_DIRS`, `$XDG_RUNTIME_DIR`, and
+/// `$XDG_DATA_DIRS` all contribute directories that differ per session, and a
+/// unit in the runtime tier outranks the one this app generates. The two tiers
+/// this app writes to are omitted here and filtered again by [`user_unit_dirs`].
 #[cfg(target_os = "linux")]
-const SYSTEM_UNIT_DIRS: &[&str] = &[
-    "/etc/systemd/user",
-    "/usr/local/share/systemd/user",
-    "/usr/share/systemd/user",
-    "/usr/local/lib/systemd/user",
-    "/usr/lib/systemd/user",
-];
+fn fallback_unit_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    push_xdg_dirs(&mut dirs, "XDG_CONFIG_DIRS", "/etc/xdg");
+    dirs.push(PathBuf::from("/etc/systemd/user"));
+    if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
+        dirs.push(Path::new(&runtime).join("systemd").join("user"));
+    }
+    dirs.push(PathBuf::from("/run/systemd/user"));
+    push_xdg_dirs(&mut dirs, "XDG_DATA_DIRS", "/usr/local/share:/usr/share");
+    dirs.push(PathBuf::from("/usr/local/lib/systemd/user"));
+    dirs.push(PathBuf::from("/usr/lib/systemd/user"));
+    dirs
+}
+
+/// Append `systemd/user` under each entry of a colon-separated XDG base list,
+/// falling back to `default` when the variable is unset or empty.
+#[cfg(target_os = "linux")]
+fn push_xdg_dirs(dirs: &mut Vec<PathBuf>, var: &str, default: &str) {
+    let value = std::env::var(var).unwrap_or_default();
+    let list = if value.trim().is_empty() {
+        default
+    } else {
+        &value
+    };
+    dirs.extend(
+        list.split(':')
+            .map(str::trim)
+            .filter(|base| base.starts_with('/'))
+            .map(|base| Path::new(base).join("systemd").join("user")),
+    );
+}
+
+/// The user unit load path, highest precedence first, minus the two tiers this
+/// app writes to.
+///
+/// Asked of systemd rather than assumed. The real path is environment
+/// dependent — `$XDG_CONFIG_DIRS`, `/run`, custom `$XDG_DATA_DIRS`, and the
+/// Flatpak export directories all appear in it — so enumerating it by hand
+/// would answer for a machine nobody is running. What remains after the filter
+/// is every directory a unit could arrive in from somewhere other than here.
+#[cfg(target_os = "linux")]
+fn user_unit_dirs() -> Vec<PathBuf> {
+    let ours: Vec<PathBuf> = [generated_unit_path(), legacy_unit_path()]
+        .into_iter()
+        .filter_map(|path| {
+            path.ok()
+                .and_then(|path| path.parent().map(Path::to_path_buf))
+        })
+        .collect();
+    let dirs = systemd_unit_paths().unwrap_or_else(fallback_unit_dirs);
+    exclude_dirs(dirs, &ours)
+}
+
+/// The load path as `systemd-analyze` reports it, or `None` when it cannot be
+/// run — not installed, or no session bus to query.
+#[cfg(target_os = "linux")]
+fn systemd_unit_paths() -> Option<Vec<PathBuf>> {
+    let output = std::process::Command::new("systemd-analyze")
+        .args(["--user", "unit-paths"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8(output.stdout).ok()?;
+    let dirs = parse_unit_paths(&listing);
+    (!dirs.is_empty()).then_some(dirs)
+}
+
+/// One directory per non-empty line, order preserved.
+#[cfg(target_os = "linux")]
+fn parse_unit_paths(listing: &str) -> Vec<PathBuf> {
+    listing
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// Drop `exclude` from `dirs`, preserving precedence order.
+#[cfg(target_os = "linux")]
+fn exclude_dirs(dirs: Vec<PathBuf>, exclude: &[PathBuf]) -> Vec<PathBuf> {
+    dirs.into_iter()
+        .filter(|dir| !exclude.contains(dir))
+        .collect()
+}
 
 #[cfg(target_os = "linux")]
 fn reconcile_linux(enabled: bool) -> io::Result<()> {
@@ -350,25 +431,40 @@ fn enablement_marker_path() -> io::Result<PathBuf> {
 /// the setting has to mean what it says when it is switched back off.
 #[cfg(target_os = "linux")]
 fn enable_unit() {
-    if let Err(e) = record_enablement() {
-        warn!(
-            error = %e,
-            "could not record the autostart enablement; leaving autostart unchanged",
-        );
+    let Ok(marker) = enablement_marker_path() else {
         return;
-    }
-    if !run_systemctl(&["enable", UNIT_NAME]) {
-        clear_enablement_marker();
+    };
+    enable_unit_with(&marker, || run_systemctl(&["enable", UNIT_NAME]));
+}
+
+/// The ordering and rollback rules of [`enable_unit`], over an injectable
+/// marker path and enable step so the state transitions can be tested.
+///
+/// A claim that already existed is left alone when `enable` fails: the failure
+/// may be transient (no session bus yet at login), and dropping a claim made by
+/// an earlier reconcile would leave an enablement this app owns with nothing
+/// able to withdraw it. Only a claim *this* call created is rolled back.
+#[cfg(target_os = "linux")]
+fn enable_unit_with(marker: &Path, enable: impl FnOnce() -> bool) {
+    let claimed_now = match record_enablement_at(marker) {
+        Ok(claimed_now) => claimed_now,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "could not record the autostart enablement; leaving autostart unchanged",
+            );
+            return;
+        }
+    };
+    if !enable() && claimed_now {
+        clear_marker_at(marker);
     }
 }
 
 /// Drop this app's claim on the enablement. Absent is success.
 #[cfg(target_os = "linux")]
-fn clear_enablement_marker() {
-    let Ok(marker) = enablement_marker_path() else {
-        return;
-    };
-    match std::fs::remove_file(&marker) {
+fn clear_marker_at(marker: &Path) {
+    match std::fs::remove_file(marker) {
         Ok(()) => debug!(path = %marker.display(), "cleared the autostart marker"),
         Err(e) if e.kind() == io::ErrorKind::NotFound => {}
         Err(e) => {
@@ -378,15 +474,18 @@ fn clear_enablement_marker() {
 }
 
 #[cfg(target_os = "linux")]
-fn record_enablement() -> io::Result<()> {
-    let path = enablement_marker_path()?;
+/// Record this app's claim on the enablement, reporting whether the claim was
+/// created by this call rather than already held from an earlier reconcile.
+#[cfg(target_os = "linux")]
+fn record_enablement_at(path: &Path) -> io::Result<bool> {
     if path.exists() {
-        return Ok(());
+        return Ok(false);
     }
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&path, b"")
+    std::fs::write(path, b"")?;
+    Ok(true)
 }
 
 /// Withdraw the enablement only when this app recorded making it.
@@ -409,7 +508,7 @@ fn disable_unit_if_ours() {
         // an enablement this app is still responsible for.
         return;
     }
-    clear_enablement_marker();
+    clear_marker_at(&marker);
 }
 
 /// Path to the generated unit:
@@ -499,15 +598,25 @@ fn exec_start_value(contents: &str) -> Option<&str> {
 /// so in that case the normal write path must still run.
 #[cfg(target_os = "linux")]
 fn packaged_unit_for(exe: &Path) -> Option<PathBuf> {
-    SYSTEM_UNIT_DIRS
+    packaged_unit_in(&user_unit_dirs(), exe)
+}
+
+/// [`packaged_unit_for`] over an injectable set of directories, listed highest
+/// precedence first.
+///
+/// Only the *effective* unit is considered — the first one that exists. A lower
+/// entry is never matched past a higher one that names a different executable,
+/// because systemd would resolve the name to that higher unit: enabling on the
+/// strength of a shadowed entry would start a binary this app never verified.
+#[cfg(target_os = "linux")]
+fn packaged_unit_in(dirs: &[PathBuf], exe: &Path) -> Option<PathBuf> {
+    let effective = dirs
         .iter()
-        .map(|dir| Path::new(dir).join(UNIT_NAME))
-        .find(|path| {
-            std::fs::read_to_string(path)
-                .ok()
-                .and_then(|contents| exec_start_value(&contents).map(unescape_systemd_exec))
-                .is_some_and(|packaged| same_executable(Path::new(&packaged), exe))
-        })
+        .map(|dir| dir.join(UNIT_NAME))
+        .find(|path| path.is_file())?;
+    let contents = std::fs::read_to_string(&effective).ok()?;
+    let packaged = exec_start_value(&contents).map(unescape_systemd_exec)?;
+    same_executable(Path::new(&packaged), exe).then_some(effective)
 }
 
 /// Recover the executable path from a rendered `ExecStart` value.

--- a/crates/openlogi-agent/src/launch_agent/linux_tests.rs
+++ b/crates/openlogi-agent/src/launch_agent/linux_tests.rs
@@ -237,11 +237,11 @@ fn packaged_probe_ignores_a_unit_for_another_binary() {
     ));
 }
 
-/// A unit the user wrote themselves means the service name is theirs: reconcile
-/// must not withdraw an enablement it never made. Guards the predicate that
-/// gates `disable` when nothing of ours is on disk.
+/// A unit this app did not render is never overwritten or deleted, at either
+/// user-writable tier. The same round-trip check gates the config-tier
+/// migration, the data-tier delete, and the decision to leave a file alone.
 #[test]
-fn a_hand_authored_unit_is_recognised_as_the_users() {
+fn a_unit_this_app_did_not_render_is_not_ours() {
     let ours = render_unit("/usr/bin/openlogi-agent");
     assert!(
         is_generated_unit(&ours),
@@ -254,6 +254,25 @@ fn a_hand_authored_unit_is_recognised_as_the_users() {
     );
     assert!(
         !is_generated_unit(&theirs),
-        "an edited unit is the user's, so its enablement is theirs to withdraw"
+        "an edited unit belongs to whoever wrote it"
     );
+}
+
+/// The marker is what distinguishes an enablement this app made from one the
+/// documented `systemctl --user enable --now` step made. It lives beside the
+/// config, not among the units, so it cannot collide with a unit file.
+#[test]
+fn the_enablement_marker_sits_outside_the_unit_directories() {
+    let marker = enablement_marker_path().expect("marker path resolves");
+    let generated = generated_unit_path().expect("generated path resolves");
+    let legacy = legacy_unit_path().expect("legacy path resolves");
+
+    assert_ne!(marker, generated);
+    assert_ne!(marker, legacy);
+    assert_ne!(
+        marker.parent(),
+        generated.parent(),
+        "the marker must not share a directory with the generated unit"
+    );
+    assert!(!marker.to_string_lossy().contains("systemd/user"));
 }

--- a/crates/openlogi-agent/src/launch_agent/linux_tests.rs
+++ b/crates/openlogi-agent/src/launch_agent/linux_tests.rs
@@ -236,3 +236,24 @@ fn packaged_probe_ignores_a_unit_for_another_binary() {
         Path::new("/usr/bin/openlogi-agent")
     ));
 }
+
+/// A unit the user wrote themselves means the service name is theirs: reconcile
+/// must not withdraw an enablement it never made. Guards the predicate that
+/// gates `disable` when nothing of ours is on disk.
+#[test]
+fn a_hand_authored_unit_is_recognised_as_the_users() {
+    let ours = render_unit("/usr/bin/openlogi-agent");
+    assert!(
+        is_generated_unit(&ours),
+        "our own rendering is not the user's"
+    );
+
+    let theirs = ours.replace(
+        "Restart=on-failure",
+        "Environment=RUST_LOG=debug\nRestart=on-failure",
+    );
+    assert!(
+        !is_generated_unit(&theirs),
+        "an edited unit is the user's, so its enablement is theirs to withdraw"
+    );
+}

--- a/crates/openlogi-agent/src/launch_agent/linux_tests.rs
+++ b/crates/openlogi-agent/src/launch_agent/linux_tests.rs
@@ -1,0 +1,238 @@
+//! Unit tests for the Linux systemd user-unit reconcile.
+
+use super::*;
+
+#[test]
+fn rendered_unit_targets_agent_and_restarts_on_failure() {
+    let body = render_unit("/usr/bin/openlogi-agent");
+    assert!(body.contains("ExecStart=/usr/bin/openlogi-agent"));
+    assert!(body.contains("Restart=on-failure"));
+    assert!(body.contains("WantedBy=graphical-session.target"));
+    assert!(!body.contains("--minimized"));
+}
+
+#[test]
+fn rendered_unit_is_valid_ini_with_all_three_sections() {
+    let body = render_unit("/usr/bin/openlogi-agent");
+    assert!(body.contains("[Unit]"));
+    assert!(body.contains("[Service]"));
+    assert!(body.contains("[Install]"));
+}
+
+#[test]
+fn escape_systemd_exec_doubles_percent() {
+    assert_eq!(
+        escape_systemd_exec("/home/user%20/bin/openlogi-agent"),
+        "/home/user%%20/bin/openlogi-agent"
+    );
+}
+
+#[test]
+fn escape_systemd_exec_quotes_path_with_spaces() {
+    let result = escape_systemd_exec("/home/my user/bin/openlogi-agent");
+    assert_eq!(result, "\"/home/my user/bin/openlogi-agent\"");
+}
+
+#[test]
+fn escape_systemd_exec_quotes_and_doubles_percent_with_spaces() {
+    let result = escape_systemd_exec("/home/my%20 user/openlogi-agent");
+    assert_eq!(result, "\"/home/my%%20 user/openlogi-agent\"");
+}
+
+#[test]
+fn escape_systemd_exec_doubles_dollar() {
+    assert_eq!(
+        escape_systemd_exec("/opt/release$1/bin/openlogi-agent"),
+        "/opt/release$$1/bin/openlogi-agent"
+    );
+}
+
+#[test]
+fn escape_systemd_exec_plain_path_unchanged() {
+    let path = "/usr/local/bin/openlogi-agent";
+    assert_eq!(escape_systemd_exec(path), path);
+}
+
+#[test]
+fn systemctl_arguments_render_as_a_command_suffix() {
+    assert_eq!(
+        SystemctlArgsDisplay(&["enable", UNIT_NAME]).to_string(),
+        "enable openlogi-agent.service"
+    );
+}
+
+#[test]
+fn unit_path_uses_home_fallback() {
+    // When XDG_CONFIG_HOME is unset (or relative), falls back to $HOME/.config.
+    // We can't mutate global env safely in a parallel test suite, so we test
+    // the logic indirectly: the path must end in the UNIT_NAME component.
+    let path = generated_unit_path().expect("generated_unit_path resolves with a valid HOME");
+    assert!(path.ends_with(UNIT_NAME));
+    assert!(path.to_string_lossy().contains("systemd/user"));
+}
+
+/// The generated unit must sit in the data tier, which systemd ranks below
+/// the user's own config directory. Writing to the config tier is the bug
+/// this addresses: it outranks everything and cannot be overridden.
+#[test]
+fn generated_unit_lives_below_the_user_config_tier() {
+    let generated = generated_unit_path().expect("generated path resolves");
+    let legacy = legacy_unit_path().expect("legacy path resolves");
+    let config_home = openlogi_core::paths::xdg_config_home().expect("config home resolves");
+
+    assert!(
+        !generated.starts_with(&config_home),
+        "{}",
+        generated.display()
+    );
+    assert!(legacy.starts_with(&config_home), "{}", legacy.display());
+    assert_ne!(generated, legacy);
+}
+
+#[test]
+fn a_rendered_unit_is_recognised_as_ours_for_any_executable() {
+    for exe in [
+        "/usr/bin/openlogi-agent",
+        "/usr/local/bin/openlogi-agent",
+        "/home/dev/OpenLogi/target/debug/openlogi-agent",
+    ] {
+        assert!(
+            is_generated_unit(&render_unit(exe)),
+            "{exe} should round-trip"
+        );
+    }
+}
+
+/// The escaped forms are the reason [`render_unit_with_exec`] exists: a
+/// naive check that re-escapes the parsed value turns `%%` into `%%%%` and
+/// fails to recognise a unit this app wrote.
+#[test]
+fn a_rendered_unit_is_recognised_as_ours_when_the_path_needs_escaping() {
+    for exe in [
+        "/opt/100%/bin/openlogi-agent",
+        "/opt/release$1/bin/openlogi-agent",
+        "/home/a b/openlogi-agent",
+    ] {
+        assert!(
+            is_generated_unit(&render_unit(exe)),
+            "{exe} should round-trip"
+        );
+    }
+}
+
+#[test]
+fn a_hand_edited_unit_is_not_ours() {
+    let base = render_unit("/usr/bin/openlogi-agent");
+
+    let with_extra = base.replace(
+        "Restart=on-failure",
+        "Environment=RUST_LOG=debug\nRestart=on-failure",
+    );
+    assert!(
+        !is_generated_unit(&with_extra),
+        "an added directive is theirs"
+    );
+
+    let changed = base.replace("RestartSec=5", "RestartSec=1");
+    assert!(!is_generated_unit(&changed), "a changed value is theirs");
+
+    let removed = base.replace("After=graphical-session.target\n", "");
+    assert!(
+        !is_generated_unit(&removed),
+        "a dropped directive is theirs"
+    );
+
+    assert!(!is_generated_unit(""), "an empty file has no ExecStart");
+    assert!(
+        !is_generated_unit("[Service]\nExecStart=/bin/true\n"),
+        "an unrelated unit is theirs"
+    );
+}
+
+/// Two `ExecStart` lines is not a shape the renderer can emit, so such a
+/// file is the user's however much of it looks familiar.
+#[test]
+fn a_unit_with_two_exec_starts_is_not_ours() {
+    let doubled = render_unit("/usr/bin/openlogi-agent").replace(
+        "Restart=on-failure",
+        "ExecStart=/bin/true\nRestart=on-failure",
+    );
+    assert_eq!(exec_start_value(&doubled), None);
+    assert!(!is_generated_unit(&doubled));
+}
+
+#[test]
+fn exec_start_value_is_returned_still_escaped() {
+    let unit = render_unit("/opt/100%/bin/openlogi-agent");
+    assert_eq!(
+        exec_start_value(&unit),
+        Some("/opt/100%%/bin/openlogi-agent")
+    );
+}
+
+#[test]
+fn unescaping_inverts_the_escaping() {
+    for exe in [
+        "/usr/bin/openlogi-agent",
+        "/opt/100%/bin/openlogi-agent",
+        "/opt/release$1/bin/openlogi-agent",
+        "/home/a b/openlogi-agent",
+        "/home/quote\"odd/openlogi-agent",
+    ] {
+        assert_eq!(unescape_systemd_exec(&escape_systemd_exec(exe)), exe);
+    }
+}
+
+/// A packaged unit may carry arguments; only the program is compared.
+#[test]
+fn unescaping_drops_arguments() {
+    assert_eq!(
+        unescape_systemd_exec("/usr/bin/openlogi-agent --verbose"),
+        "/usr/bin/openlogi-agent"
+    );
+    assert_eq!(
+        unescape_systemd_exec("\"/home/a b/openlogi-agent\" --verbose"),
+        "/home/a b/openlogi-agent"
+    );
+}
+
+#[test]
+fn same_executable_compares_missing_paths_literally() {
+    assert!(same_executable(
+        Path::new("/nonexistent/openlogi-agent"),
+        Path::new("/nonexistent/openlogi-agent")
+    ));
+    assert!(!same_executable(
+        Path::new("/nonexistent/a"),
+        Path::new("/nonexistent/b")
+    ));
+}
+
+/// `/usr/bin` is a symlink into `/usr` on merged-`/usr` systems, so the
+/// comparison has to resolve both sides rather than match strings.
+#[test]
+fn same_executable_resolves_symlinks() {
+    let dir = std::env::temp_dir().join(format!("openlogi-unit-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("temp dir");
+    let target = dir.join("openlogi-agent");
+    std::fs::write(&target, b"#!/bin/sh\n").expect("write target");
+    let link = dir.join("linked-agent");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    assert!(same_executable(&link, &target));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The packaged-unit probe must not match a unit describing some other
+/// binary — that is exactly when a generated unit is still needed.
+#[test]
+fn packaged_probe_ignores_a_unit_for_another_binary() {
+    let unit = render_unit("/usr/bin/some-other-agent");
+    let parsed = exec_start_value(&unit).map(unescape_systemd_exec);
+    assert_eq!(parsed.as_deref(), Some("/usr/bin/some-other-agent"));
+    assert!(!same_executable(
+        Path::new("/usr/bin/some-other-agent"),
+        Path::new("/usr/bin/openlogi-agent")
+    ));
+}

--- a/crates/openlogi-agent/src/launch_agent/linux_tests.rs
+++ b/crates/openlogi-agent/src/launch_agent/linux_tests.rs
@@ -276,3 +276,259 @@ fn the_enablement_marker_sits_outside_the_unit_directories() {
     );
     assert!(!marker.to_string_lossy().contains("systemd/user"));
 }
+
+/// Scratch directory for tests that need real files. Removed on drop so a
+/// failing assertion cannot leave state behind for the next run.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let dir = std::env::temp_dir().join(format!(
+            "openlogi-launch-agent-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        Self(dir)
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// A claim held from an earlier reconcile must survive a transient enable
+/// failure — no session bus yet at login, say. Dropping it would leave an
+/// enablement this app owns with nothing able to withdraw it, so `Launch at
+/// login: off` would never turn autostart back off.
+#[test]
+fn a_held_claim_survives_a_failed_re_enable() {
+    let dir = TempDir::new("held-claim");
+    let marker = dir.path("autostart.enabled");
+    std::fs::write(&marker, b"").expect("pre-existing claim");
+
+    enable_unit_with(&marker, || false);
+
+    assert!(
+        marker.exists(),
+        "a claim from an earlier reconcile must not be dropped by a failed enable"
+    );
+}
+
+/// A claim created by this call is rolled back when the enable fails, so no
+/// marker outlives an enablement that never happened.
+#[test]
+fn a_claim_made_now_is_rolled_back_when_enable_fails() {
+    let dir = TempDir::new("fresh-claim");
+    let marker = dir.path("autostart.enabled");
+
+    enable_unit_with(&marker, || false);
+
+    assert!(
+        !marker.exists(),
+        "a claim this call created must not outlive a failed enable"
+    );
+}
+
+#[test]
+fn a_claim_is_kept_when_enable_succeeds() {
+    let dir = TempDir::new("ok-claim");
+    let marker = dir.path("autostart.enabled");
+
+    enable_unit_with(&marker, || true);
+    assert!(marker.exists(), "a successful enable is recorded");
+
+    // A second reconcile finds the claim already held and keeps it.
+    enable_unit_with(&marker, || true);
+    assert!(marker.exists());
+}
+
+#[test]
+fn recording_reports_whether_the_claim_is_new() {
+    let dir = TempDir::new("record");
+    let marker = dir.path("nested/autostart.enabled");
+
+    assert!(
+        record_enablement_at(&marker).expect("first claim"),
+        "the first call creates the claim"
+    );
+    assert!(
+        !record_enablement_at(&marker).expect("second claim"),
+        "a claim already held is not created again"
+    );
+}
+
+/// systemd resolves a unit name to the highest-precedence file that exists, so
+/// a lower entry must never be matched past a higher one naming a different
+/// executable — enabling on the strength of a shadowed entry would start a
+/// binary this app never verified.
+#[test]
+fn only_the_effective_system_unit_is_considered() {
+    let dir = TempDir::new("precedence");
+    let high = dir.path("high");
+    let low = dir.path("low");
+    std::fs::create_dir_all(&high).expect("high dir");
+    std::fs::create_dir_all(&low).expect("low dir");
+
+    let ours = std::env::current_exe().expect("current exe");
+    std::fs::write(low.join(UNIT_NAME), render_unit(&ours.to_string_lossy())).expect("low unit");
+
+    let dirs = [high.clone(), low.clone()];
+
+    // Only the lower entry exists: it is the effective unit, and it matches.
+    assert_eq!(
+        packaged_unit_in(&dirs, &ours).as_deref(),
+        Some(low.join(UNIT_NAME).as_path()),
+        "the sole existing unit is the effective one"
+    );
+
+    // A higher-precedence unit for a different binary now shadows it.
+    std::fs::write(
+        high.join(UNIT_NAME),
+        render_unit("/usr/bin/some-other-agent"),
+    )
+    .expect("high unit");
+    assert_eq!(
+        packaged_unit_in(&dirs, &ours),
+        None,
+        "a shadowed match must not be reported"
+    );
+
+    // The effective unit naming this binary is reported, shadowing or not.
+    std::fs::write(high.join(UNIT_NAME), render_unit(&ours.to_string_lossy()))
+        .expect("high unit rewritten");
+    assert_eq!(
+        packaged_unit_in(&dirs, &ours).as_deref(),
+        Some(high.join(UNIT_NAME).as_path()),
+        "the highest-precedence unit is the one reported"
+    );
+}
+
+/// The load path is environment dependent, so it is read from systemd rather
+/// than assumed. Parsing keeps precedence order and ignores blank padding.
+#[test]
+fn the_reported_load_path_is_parsed_in_order() {
+    let listing = "\
+/home/u/.config/systemd/user.control
+/home/u/.config/systemd/user
+
+/etc/systemd/user
+   /usr/lib/systemd/user   
+";
+    assert_eq!(
+        parse_unit_paths(listing),
+        vec![
+            PathBuf::from("/home/u/.config/systemd/user.control"),
+            PathBuf::from("/home/u/.config/systemd/user"),
+            PathBuf::from("/etc/systemd/user"),
+            PathBuf::from("/usr/lib/systemd/user"),
+        ]
+    );
+    assert!(parse_unit_paths("").is_empty());
+}
+
+/// The two tiers this app writes to are removed, so the probe only ever sees
+/// directories a unit could arrive in from somewhere else. Order survives.
+#[test]
+fn our_own_tiers_are_excluded_from_the_load_path() {
+    let dirs = vec![
+        PathBuf::from("/home/u/.config/systemd/user"),
+        PathBuf::from("/etc/systemd/user"),
+        PathBuf::from("/home/u/.local/share/systemd/user"),
+        PathBuf::from("/home/u/.local/share/flatpak/exports/share/systemd/user"),
+        PathBuf::from("/usr/lib/systemd/user"),
+    ];
+    let ours = [
+        PathBuf::from("/home/u/.config/systemd/user"),
+        PathBuf::from("/home/u/.local/share/systemd/user"),
+    ];
+
+    assert_eq!(
+        exclude_dirs(dirs, &ours),
+        vec![
+            PathBuf::from("/etc/systemd/user"),
+            PathBuf::from("/home/u/.local/share/flatpak/exports/share/systemd/user"),
+            PathBuf::from("/usr/lib/systemd/user"),
+        ],
+        "a tier this app writes to is never treated as somebody else's"
+    );
+}
+
+/// The resolved path must keep the tiers the old static list omitted — the
+/// runtime directory, the session's exports — and must not contain ours.
+#[test]
+fn the_resolved_load_path_excludes_our_tiers() {
+    let dirs = user_unit_dirs();
+    assert!(!dirs.is_empty(), "the fallback alone is non-empty");
+
+    let generated = generated_unit_path().expect("generated path");
+    let legacy = legacy_unit_path().expect("legacy path");
+    for ours in [generated.parent(), legacy.parent()].into_iter().flatten() {
+        assert!(
+            !dirs.iter().any(|dir| dir == ours),
+            "{} must not be probed as a packaged tier",
+            ours.display()
+        );
+    }
+}
+
+/// The fallback stands in when systemd cannot be asked, so it has to mirror the
+/// documented load path — including the tiers a fixed list of absolute paths
+/// misses. The runtime tier matters most: a unit there outranks the one this
+/// app generates.
+#[test]
+fn the_fallback_covers_the_xdg_derived_tiers() {
+    let dirs = fallback_unit_dirs();
+    let has = |needle: &str| dirs.iter().any(|dir| dir == Path::new(needle));
+
+    assert!(has("/etc/systemd/user"), "{dirs:?}");
+    assert!(has("/run/systemd/user"), "{dirs:?}");
+    assert!(has("/usr/lib/systemd/user"), "{dirs:?}");
+    assert!(has("/usr/local/lib/systemd/user"), "{dirs:?}");
+
+    // $XDG_DATA_DIRS defaults, appended with systemd/user.
+    assert!(
+        has("/usr/share/systemd/user") || std::env::var_os("XDG_DATA_DIRS").is_some(),
+        "the data-dirs default must be expanded: {dirs:?}"
+    );
+
+    // The runtime tier is present whenever the session exports one.
+    if std::env::var_os("XDG_RUNTIME_DIR").is_some() {
+        assert!(
+            dirs.iter()
+                .any(|dir| dir.ends_with("systemd/user") && dir.starts_with("/run")),
+            "the runtime tier outranks the generated unit and must be probed: {dirs:?}"
+        );
+    }
+}
+
+/// Colon-separated XDG base lists expand to one unit directory each, in order,
+/// and relative entries are ignored the way systemd ignores them.
+#[test]
+fn xdg_base_lists_expand_in_order() {
+    let mut dirs = Vec::new();
+    push_xdg_dirs(&mut dirs, "OPENLOGI_TEST_UNSET_VAR", "/one:/two");
+    assert_eq!(
+        dirs,
+        vec![
+            PathBuf::from("/one/systemd/user"),
+            PathBuf::from("/two/systemd/user"),
+        ],
+        "an unset variable falls back to the default list"
+    );
+
+    let mut dirs = Vec::new();
+    push_xdg_dirs(&mut dirs, "PATH", "/unused");
+    assert!(
+        dirs.iter()
+            .all(|dir| dir.is_absolute() && dir.ends_with("systemd/user")),
+        "every expanded entry is an absolute unit directory: {dirs:?}"
+    );
+}

--- a/crates/openlogi-agent/src/launch_agent/macos_tests.rs
+++ b/crates/openlogi-agent/src/launch_agent/macos_tests.rs
@@ -1,0 +1,44 @@
+//! Unit tests for the macOS `LaunchAgent` plist reconcile.
+
+use super::*;
+
+#[test]
+fn rendered_plist_targets_the_agent_and_keeps_alive() {
+    let body = render_plist(
+        "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
+    )
+    .expect("render plist");
+    assert!(body.contains(LABEL));
+    assert!(body.contains("openlogi-agent"));
+    assert!(body.contains("RunAtLoad"));
+    // KeepAlive uses SuccessfulExit:false so a crash respawns but the tray's
+    // Quit (a clean exit(0)) is NOT relaunched; no --minimized (always headless).
+    let parsed = plist::Value::from_reader_xml(body.as_bytes()).expect("parse plist");
+    let keep_alive = parsed
+        .as_dictionary()
+        .and_then(|root| root.get("KeepAlive"))
+        .and_then(plist::Value::as_dictionary)
+        .expect("KeepAlive dictionary");
+    assert_eq!(
+        keep_alive
+            .get("SuccessfulExit")
+            .and_then(plist::Value::as_boolean),
+        Some(false)
+    );
+    assert!(!body.contains("--minimized"));
+}
+
+#[test]
+fn render_plist_serializes_xml_metacharacters_in_the_path() {
+    // A home/app path with XML metacharacters (all legal APFS filename chars)
+    // must not produce a malformed plist launchd would reject.
+    let path = "/Users/R&D/Apps/<OpenLogi>/openlogi-agent";
+    let body = render_plist(path).expect("render plist");
+    let parsed = plist::Value::from_reader_xml(body.as_bytes()).expect("parse plist");
+    let args = parsed
+        .as_dictionary()
+        .and_then(|root| root.get("ProgramArguments"))
+        .and_then(plist::Value::as_array)
+        .expect("ProgramArguments array");
+    assert_eq!(args.first().and_then(plist::Value::as_string), Some(path));
+}

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -116,10 +116,22 @@ pub fn home_dir() -> Result<PathBuf, PathsError> {
 /// The raw XDG config home directory (without the `openlogi` subdirectory).
 ///
 /// Honours an absolute `$XDG_CONFIG_HOME`; falls back to `~/.config`.
-/// Useful when placing files that belong to other apps under the same base
-/// (e.g. systemd user units at `$XDG_CONFIG_HOME/systemd/user/`).
+/// Useful when reading files that belong to another app's namespace under the
+/// same base. This tier is the user's own: generated files belong under
+/// [`xdg_data_home`] instead, which systemd and friends rank below it.
 pub fn xdg_config_home() -> Result<PathBuf, PathsError> {
     Ok(xdg()?.config_dir())
+}
+
+/// The raw XDG data home directory (without the `openlogi` subdirectory).
+///
+/// Honours an absolute `$XDG_DATA_HOME`; falls back to `~/.local/share`.
+/// The counterpart to [`xdg_config_home`] for files that belong to another
+/// app's namespace under the same base — generated systemd user units at
+/// `$XDG_DATA_HOME/systemd/user/`, which is the tier systemd reserves for
+/// units installed on the user's behalf rather than authored by them.
+pub fn xdg_data_home() -> Result<PathBuf, PathsError> {
+    Ok(xdg()?.data_dir())
 }
 
 /// Directory holding the user's `config.toml`.

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -173,6 +173,10 @@ ranks it above both locations, so a unit you write there overrides whatever
 OpenLogi does. Use `systemctl --user edit openlogi-agent.service` for a drop-in
 that survives package upgrades.
 
+OpenLogi never overwrites or deletes a unit it did not generate, at either
+location, and it only turns off an autostart it turned on. Enabling the service
+yourself with the command above keeps working regardless of the GUI toggle.
+
 ## Verify the installation
 
 ```sh

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -162,9 +162,16 @@ show connected devices. Enable it for your user session:
 systemctl --user enable --now openlogi-agent.service
 ```
 
-Alternatively, toggle **Settings → General → Launch at login** in the GUI — it
-writes the unit to `~/.config/systemd/user/openlogi-agent.service`
-automatically.
+Alternatively, toggle **Settings → General → Launch at login** in the GUI. When
+a packaged unit is already installed it simply enables that one. Otherwise — a
+build from source, or an install under a custom prefix — it generates a unit at
+`~/.local/share/systemd/user/openlogi-agent.service` pointing at the running
+binary.
+
+Either way `~/.config/systemd/user/openlogi-agent.service` stays yours: systemd
+ranks it above both locations, so a unit you write there overrides whatever
+OpenLogi does. Use `systemctl --user edit openlogi-agent.service` for a drop-in
+that survives package upgrades.
 
 ## Verify the installation
 

--- a/packaging/linux/systemd/openlogi-agent.service
+++ b/packaging/linux/systemd/openlogi-agent.service
@@ -2,9 +2,10 @@
 #
 # Packages use /usr/bin directly. install.sh rewrites ExecStart when installing
 # under a custom PREFIX (default: /usr/local).
-# The agent's launch_at_login setting writes its own copy to
-# $XDG_CONFIG_HOME/systemd/user/ using the current binary path — both coexist,
-# enabling either works.
+# The agent's launch_at_login setting enables this unit as-is when it launches
+# the same binary. It only generates its own copy — under $XDG_DATA_HOME, never
+# the user's $XDG_CONFIG_HOME — when this unit names a different executable, as
+# for a build from source.
 #
 # Enable for the current user:
 #   systemctl --user enable --now openlogi-agent.service


### PR DESCRIPTION
## Summary

The third item in #763, and the only behavioural one: `launch_at_login` wrote its unit to `$XDG_CONFIG_HOME/systemd/user` — the highest-precedence tier in systemd's user load path, and the one reserved for units the user writes themselves.

```
~/.config/systemd/user        ← the user's own tier   (what we wrote into)
/etc/systemd/user             ← sysadmin
~/.local/share/systemd/user   ← installed on the user's behalf
/usr/lib/systemd/user         ← packages              (where OpenLogi ships its unit)
```

Three consequences followed.

**A hand-edited unit could not survive.** `reconcile` runs on every agent start and every config reload, rewriting the file whenever its content differed. An added `Environment=`, a changed `RestartSec`, a `WantedBy=default.target` — reverted within one restart, with no message. Nothing marked the file as generated, so a deliberate edit and a stale artifact were indistinguishable.

**A packaged unit was shadowed permanently.** For a package install the generated copy is byte-identical to `/usr/lib/systemd/user/openlogi-agent.service` — same directives, same `ExecStart`. It added no capability, only precedence. Later changes to the packaged unit would never reach anyone who used the toggle, and `uninstall.sh` cannot remove the copy, because no package script can reach a home directory.

**`ExecStart` tracked whichever binary started last.** Running a build from source once pinned autostart to a path inside the build tree; a later `cargo clean` left a unit that fails at every login while the installed binary sits unused.

## Changes

**`openlogi-agent`** — `launch_agent.rs`

- A packaged unit that already launches this binary is enabled as-is; nothing is generated. Ownership stays with the package manager, and removing the package removes the unit. The probe walks the system tiers in systemd's own precedence order and compares `ExecStart` against the running executable, resolved through symlinks.
- Otherwise the unit is generated under `$XDG_DATA_HOME/systemd/user` — the tier systemd reserves for units installed on a user's behalf. It still outranks the packaged unit, but sits below the user's own, so a hand-written unit wins with no provenance check needed.
- A unit left in the config tier by earlier versions is removed, but only when provably ours. One template has ever shipped, parameterised solely by `ExecStart`, so splicing a file's own `ExecStart` line back into that template reproduces it byte for byte if and only if we rendered it. Anything carrying another directive is the user's: left in place, still winning.
- `render_unit` is split from `render_unit_with_exec` so that check can splice a line in verbatim. Re-running the escaper over an already-escaped value would double `%%` into `%%%%` and stop a unit we wrote from matching itself.

**`openlogi-core`** — `xdg_data_home()`, the counterpart to the existing `xdg_config_home()`.

**Docs** — `INSTALL-linux.md` describes both paths and states that `~/.config/systemd/user` stays the user's, pointing at `systemctl --user edit` for a drop-in that survives upgrades. The packaged unit's header comment no longer advertises the two copies as coexisting.

The test modules move to sibling files under `launch_agent/`; those lines are relocated unchanged, and the split keeps the module near the workspace's file-size guideline.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo test -p openlogi-ipc --test wire_format
cargo xtask ci      # 8 passed, 0 failed, 1 skipped
```

`tests (macos)` **did not run** — this is a Linux host. The diff is cfg-gated, so that is worth stating plainly: Linux is covered natively (both host and target of every new function) and the Windows proxy passed, but macOS is unverified here. Every new function is `#[cfg(target_os = "linux")]` and no macOS path changed. rustdoc was also run directly against `openlogi-agent`, which CI's rustdoc job excludes.

12 new unit tests cover the provenance check: a rendered unit is recognised for any executable path, including ones needing `%`, `$`, space and quote escaping; an added, changed, or dropped directive is not ours; two `ExecStart` lines is not a shape the renderer can emit; escaping round-trips; symlinked paths compare equal.

Runtime-verified against the built agent with the XDG bases redirected to a scratch tree, on Fedora 44 / systemd 259:

| Setup | Result |
|---|---|
| packaged unit naming this binary | nothing generated, packaged unit enabled |
| the same, plus a redundant generated unit | redundant file removed, packaged unit enabled |
| packaged unit naming a *different* binary | unit generated for the running path |
| stale unit in the config tier, naming an old checkout | removed, unit generated |
| hand-edited unit in the config tier (`Environment=RUST_LOG=debug`) | byte-identical afterwards, warned, left winning |

The packaged cases were exercised by placing a unit at `/usr/lib/systemd/user/openlogi-agent.service`; the load-path precedence was confirmed with `systemd-analyze --user unit-paths` and `systemctl --user show -p FragmentPath`.

## Notes

The template has never changed since Linux autostart shipped in v0.6.8 — byte-identical across every commit that touched it — so the provenance check needs no template history. The one intermediate rendering that differed (`$` escaping) existed for 71 minutes on the #172 branch and never shipped.

One gap remains, unchanged by this PR: `uninstall.sh` cannot clean a home directory, so a config-tier unit from an older install survives if a user upgrades and uninstalls without ever launching the agent. Package scripts have never been able to reach `$HOME`.

Fixes #763.