### PR TITLE
fix(hook): stop trusting AXIsProcessTrusted as a revocation signal

### DIFF
--- a/.claude/rules/hook.md
+++ b/.claude/rules/hook.md
@@ -12,6 +12,19 @@ paths:
   The `NSWorkspace` read and the Accessibility-trust check/prompt are the parts that
   did move to the objc2 framework crates — see `.claude/rules/objc-ffi.md` for the rule that
   every TCC call uses a typed binding rather than a hand-written `extern` block.
+- `AXIsProcessTrusted()` is **not** a revocation signal: it keeps returning `true`
+  after the user deletes the app's row from System Settings, which is how #674 froze
+  clicks machine-wide. `has_accessibility` pairs it with a throwaway filtering tap
+  (`CGEventTapCreate` → NULL when the grant is gone); keep both, in that order — the
+  trust read is the cheap short-circuit, the probe is the truth. Never probe with
+  `ListenOnly`: that asks about Input Monitoring, a different grant.
+- Re-arm the tap only after the OS actually disabled it (`TapDisabledBy*`), and only
+  within `RearmBudget`. Re-enabling on a timer is what turns a tap we may no longer
+  service into a permanent gate on the HID stream.
+- No exit path may leave an armed tap behind. `process::exit` runs no destructors, so
+  `ARMED_TAP` is detached from an `atexit` handler (covers the tray's Quit, the
+  post-update self-restart, both watchdogs) and the agent handles SIGTERM/SIGINT
+  rather than dying with the tap installed.
 - The tap callback must never block and never panic: use `try_read`/`try_lock` only,
   queue bound actions off-thread, wrap the user callback in `catch_unwind`, and keep
   the stuck-callback watchdog that force-exits the agent if the budget is exceeded.

--- a/.claude/rules/hook.md
+++ b/.claude/rules/hook.md
@@ -18,9 +18,11 @@ paths:
   (`CGEventTapCreate` → NULL when the grant is gone); keep both, in that order — the
   trust read is the cheap short-circuit, the probe is the truth. Never probe with
   `ListenOnly`: that asks about Input Monitoring, a different grant.
-- Re-arm the tap only after the OS actually disabled it (`TapDisabledBy*`), and only
-  within `RearmBudget`. Re-enabling on a timer is what turns a tap we may no longer
-  service into a permanent gate on the HID stream.
+- Re-enabling the tap each slice is idempotent and recovers a disable the OS never
+  reported — but an OS-initiated disable (`TapDisabledBy*`) is answered on
+  `RearmBudget`, so a tap the system keeps disabling is let go instead of fought
+  over. Fighting it is what turns a tap we may no longer service into a permanent
+  gate on the HID stream.
 - No exit path may leave an armed tap behind. `process::exit` runs no destructors, so
   `ARMED_TAP` is detached from an `atexit` handler (covers the tray's Quit, the
   post-update self-restart, both watchdogs) and the agent handles SIGTERM/SIGINT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7884,6 +7884,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -29,7 +29,7 @@ openlogi-hook = { path = "../openlogi-hook" }
 openlogi-ipc = { path = "../openlogi-ipc" }
 tarpc = { workspace = true }
 interprocess = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "signal"] }
 futures = "0.3"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -227,6 +227,78 @@ async fn begin_action_ring(
     }
 }
 
+/// A future that fires when `signal` does, or never when the handler could not
+/// be installed.
+#[cfg(unix)]
+async fn fires(signal: &mut Option<tokio::signal::unix::Signal>) {
+    match signal {
+        Some(signal) => {
+            signal.recv().await;
+        }
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Resolves on the first signal that means *stop now*: `SIGTERM` from launchd
+/// (logout, `bootout`) or from an incoming agent's takeover, `SIGINT` from a
+/// dev-run Ctrl-C. Both default to killing the process where it stands, which
+/// on macOS would strand an armed HID event tap in the system's tap chain.
+#[cfg(unix)]
+async fn shutdown_signal(
+    sigterm: &mut Option<tokio::signal::unix::Signal>,
+    sigint: &mut Option<tokio::signal::unix::Signal>,
+) {
+    tokio::select! {
+        () = fires(sigterm) => {}
+        () = fires(sigint) => {}
+    }
+}
+
+/// No signal to wait for off unix; the arm simply never fires.
+#[cfg(not(unix))]
+async fn shutdown_signal(_sigterm: &mut Option<()>, _sigint: &mut Option<()>) {
+    std::future::pending::<()>().await;
+}
+
+/// Install the shutdown-signal handlers, `(SIGTERM, SIGINT)`. A handler that
+/// cannot be installed is `None`, which simply never fires.
+#[cfg(unix)]
+fn shutdown_signals() -> (
+    Option<tokio::signal::unix::Signal>,
+    Option<tokio::signal::unix::Signal>,
+) {
+    fn listen(kind: tokio::signal::unix::SignalKind) -> Option<tokio::signal::unix::Signal> {
+        tokio::signal::unix::signal(kind)
+            .inspect_err(|error| warn!(%error, ?kind, "could not install signal handler"))
+            .ok()
+    }
+    (
+        listen(tokio::signal::unix::SignalKind::terminate()),
+        listen(tokio::signal::unix::SignalKind::interrupt()),
+    )
+}
+
+#[cfg(not(unix))]
+fn shutdown_signals() -> (Option<()>, Option<()>) {
+    (None, None)
+}
+
+/// Release the input hook, then end the process.
+///
+/// Dropping the hook detaches the macOS event tap; a signal's default
+/// disposition would have killed the process with the tap still armed. The
+/// agent's run loop is not the process — macOS keeps the AppKit tray loop on
+/// the main thread — so the exit has to be explicit.
+fn release_hook_and_exit(hook: Option<Hook>) -> ! {
+    info!("shutdown signal — releasing the input hook and exiting");
+    drop(hook);
+    #[expect(
+        clippy::exit,
+        reason = "a signalled shutdown must end the process, and the loop that observed it runs off the main thread"
+    )]
+    std::process::exit(0)
+}
+
 /// Prompt for Accessibility when the enabled mouse hook needs it.
 fn prompt_missing_accessibility(capture_mouse_events: bool) {
     // With the hook disabled the agent needs no Accessibility at all, so the
@@ -260,6 +332,40 @@ async fn request_input_monitoring() {
             Err(e) => {
                 warn!(error = %e, "Input Monitoring permission request task failed");
             }
+        }
+    }
+}
+
+/// Fold one inventory-watcher event into the orchestrator.
+async fn apply_inventory_event(
+    event: watchers::inventory::InventoryEvent,
+    orchestrator: &Mutex<Orchestrator>,
+    #[cfg(any(target_os = "macos", target_os = "windows"))] resume_pending: &AtomicBool,
+) {
+    match event {
+        watchers::inventory::InventoryEvent::Snapshot {
+            inventories,
+            standalone,
+        } => {
+            let mut orchestrator = orchestrator.lock().await;
+            // The portable watcher catches long sleeps from a polling gap.
+            // Native notifications (macOS workspace wakes, Windows
+            // suspend/resume) also cover the sleeps that gap misses; consume
+            // the coalesced signal at the exact point that can replay it.
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
+            if resume_pending.swap(false, Ordering::Relaxed) {
+                info!("native resume notification — replaying volatile settings");
+                orchestrator.reapply_volatile_on_next_refresh();
+            }
+            orchestrator.refresh_inventory(&inventories, &standalone);
+        }
+        watchers::inventory::InventoryEvent::Unavailable => {
+            orchestrator.lock().await.mark_inventory_unavailable();
+        }
+        // Devices likely power-cycled during the sleep; the next snapshot
+        // re-applies their volatile settings (#189).
+        watchers::inventory::InventoryEvent::SystemWake => {
+            orchestrator.lock().await.reapply_volatile_on_next_refresh();
         }
     }
 }
@@ -318,6 +424,8 @@ async fn run(
     let mut app_rx = watchers::foreground_app::spawn(Duration::from_secs(1));
     let mut accessibility_rx = watchers::accessibility::spawn(Duration::from_millis(1200));
 
+    let (mut sigterm, mut sigint) = shutdown_signals();
+
     // IPC server: the GUI connects here for device state + "apply now" commands.
     // The endpoint (Unix socket / Windows named pipe) is resolved inside
     // `transport::bind`, called by `server::run`.
@@ -345,36 +453,20 @@ async fn run(
     let mut camera_open = true;
     loop {
         tokio::select! {
-            event = inventory_rx.recv(), if inventory_open => match event {
-                Some(watchers::inventory::InventoryEvent::Snapshot { inventories, standalone }) => {
-                    let mut orchestrator = orchestrator.lock().await;
-                    // The portable watcher catches long sleeps from a polling
-                    // gap. Native notifications (macOS workspace wakes,
-                    // Windows suspend/resume) also cover the sleeps that gap
-                    // misses; consume the coalesced signal at the exact point
-                    // that can replay it.
+            event = inventory_rx.recv(), if inventory_open => if let Some(event) = event {
+                apply_inventory_event(
+                    event,
+                    &orchestrator,
                     #[cfg(any(target_os = "macos", target_os = "windows"))]
-                    if resume_pending.swap(false, Ordering::Relaxed) {
-                        info!("native resume notification — replaying volatile settings");
-                        orchestrator.reapply_volatile_on_next_refresh();
-                    }
-                    orchestrator.refresh_inventory(&inventories, &standalone);
-                }
-                Some(watchers::inventory::InventoryEvent::Unavailable) => {
-                    orchestrator.lock().await.mark_inventory_unavailable();
-                }
-                Some(watchers::inventory::InventoryEvent::SystemWake) => {
-                    // Devices likely power-cycled during the sleep; the next
-                    // snapshot re-applies their volatile settings (#189).
-                    orchestrator.lock().await.reapply_volatile_on_next_refresh();
-                }
+                    &resume_pending,
+                )
+                .await;
+            } else {
                 // Watcher thread death (e.g. a panic inside the HID backend's
                 // enumerate) — without a snapshot the GUI would scan forever.
-                None => {
-                    warn!("inventory watcher channel closed — marking enumeration unavailable");
-                    orchestrator.lock().await.mark_inventory_unavailable();
-                    inventory_open = false;
-                }
+                warn!("inventory watcher channel closed — marking enumeration unavailable");
+                orchestrator.lock().await.mark_inventory_unavailable();
+                inventory_open = false;
             },
             event = camera_rx.recv(), if camera_open => if let Some(active) = event {
                 orchestrator.lock().await.set_camera_active(active);
@@ -406,6 +498,7 @@ async fn run(
                 // or never installed because capture is off.
                 observable.set_hook_installed(hook.is_some());
             }
+            () = shutdown_signal(&mut sigterm, &mut sigint) => release_hook_and_exit(hook.take()),
             else => break,
         }
     }

--- a/crates/openlogi-agent/src/takeover.rs
+++ b/crates/openlogi-agent/src/takeover.rs
@@ -17,10 +17,12 @@
 //! same version or newer means *we* are the duplicate (or the stale one),
 //! and we exit as before.
 //!
-//! SIGTERM, not a polite RPC: past protocols have no quit method. If the old
-//! agent ran under launchd, dying by signal is a non-successful exit, so
-//! launchd respawns it — from the bundle path, i.e. as the *new* binary —
-//! and whichever copy loses the ensuing lock race exits cleanly. Either way
+//! SIGTERM, not a polite RPC: past protocols have no quit method. A holder
+//! too old to handle the signal dies by it, which under launchd is a
+//! non-successful exit, so launchd respawns it — from the bundle path, i.e.
+//! as the *new* binary — and whichever copy loses the ensuing lock race exits
+//! cleanly. A holder new enough to handle SIGTERM releases its event tap and
+//! exits 0, which launchd leaves alone, so the lock falls to us. Either way
 //! exactly one up-to-date agent survives.
 
 #[cfg(unix)]

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -280,6 +280,10 @@ impl EventTapInfo {
 }
 
 /// Errors that [`Hook::start`] and related functions can produce.
+///
+/// The same shape on every target: a platform-conditional enum would compile on
+/// the maintainer's macOS and break an exhaustive `match` on Linux, and one
+/// unreachable variant costs nothing.
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
     /// This platform has no hook implementation (neither macOS, Linux, nor
@@ -299,7 +303,6 @@ pub enum HookError {
     /// No mouse device was found under `/dev/input`. Either no pointing device
     /// is connected, or the process lacks read permission on the device nodes
     /// (add the user to the `input` group, or add a `udev` rule).
-    #[cfg(target_os = "linux")]
     #[error(
         "no mouse device found under /dev/input; \
          ensure a pointing device is connected and the process has read permission \
@@ -307,12 +310,87 @@ pub enum HookError {
     )]
     NoDeviceFound,
     /// A Linux-specific I/O error occurred while setting up or running the hook.
-    #[cfg(target_os = "linux")]
     #[error("Linux input error: {0}")]
     Linux(#[source] std::io::Error),
     /// `SetWindowsHookExW` failed, or the hook thread could not be started.
     #[error("Windows mouse hook setup failed: {0}")]
     WindowsHook(String),
+}
+
+/// Everything one operating system has to provide for [`Hook`] to work.
+///
+/// Exactly one backend is compiled in — see the `Backend` alias below — so this
+/// is a compile-time contract, not runtime polymorphism. It earns its place by
+/// keeping the crate's per-OS `cfg` down to that single site, and by making the
+/// platform surface a list the compiler checks instead of a naming convention.
+/// Everything only some platforms can answer carries its do-nothing default
+/// here, so a backend implements exactly what it has.
+trait HookBackend {
+    /// Whatever the platform holds on to while the hook runs; handed back to
+    /// [`Self::stop`] to tear it down.
+    type Running;
+
+    /// Install the hook. [`Hook::start`] documents the contract owed to callers.
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<Self::Running, HookError>;
+
+    /// Stop the hook and join its threads.
+    fn stop(running: Self::Running);
+
+    /// See [`Hook::has_accessibility`]. Platforms that gate the hook below the
+    /// privacy layer answer `true`.
+    fn has_accessibility() -> bool {
+        true
+    }
+
+    /// See [`Hook::prompt_accessibility`]. Nothing to prompt for by default.
+    fn prompt_accessibility() {}
+
+    /// See [`Hook::list_event_taps`]. Empty where the OS keeps no tap registry.
+    fn list_event_taps() -> Vec<EventTapInfo> {
+        Vec::new()
+    }
+
+    /// See [`crate::frontmost_bundle_id`].
+    fn frontmost_app() -> Option<String> {
+        None
+    }
+
+    /// See [`crate::cursor_position`].
+    fn cursor_position() -> Option<CursorPosition> {
+        None
+    }
+}
+
+/// The backend for a platform with no hook: every default, and a
+/// [`HookBackend::start`] that can only fail. Compiled only where it is the
+/// one selected below, so it never sits unused in a real build.
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+struct Unsupported;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+impl HookBackend for Unsupported {
+    /// Uninhabited, so [`Hook`] can never hold a running hook here.
+    type Running = std::convert::Infallible;
+
+    fn start(
+        _cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<Self::Running, HookError> {
+        Err(HookError::Unsupported)
+    }
+
+    fn stop(running: Self::Running) {
+        match running {}
+    }
+}
+
+// The backend this build talks to — the crate's one platform switch.
+cfg_select! {
+    target_os = "macos" => { type Backend = macos::Backend; }
+    target_os = "linux" => { type Backend = linux::Backend; }
+    target_os = "windows" => { type Backend = windows::Backend; }
+    _ => { type Backend = Unsupported; }
 }
 
 /// A running OS-level mouse hook. Call [`Hook::stop`] to tear down.
@@ -324,16 +402,7 @@ pub enum HookError {
 /// Call `stop` (or let the value drop) to shut down all threads and release
 /// grabbed devices.
 pub struct Hook {
-    #[cfg(target_os = "macos")]
-    inner: Option<macos::HookInner>,
-    #[cfg(target_os = "linux")]
-    inner: Option<linux::HookInner>,
-    #[cfg(target_os = "windows")]
-    inner: Option<windows::HookInner>,
-    /// Makes `Hook` uninhabited on unsupported targets so [`Hook::start`] can
-    /// only ever return `Err` there and the type can never be constructed.
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    never: std::convert::Infallible,
+    inner: Option<<Backend as HookBackend>::Running>,
 }
 
 impl Drop for Hook {
@@ -358,21 +427,7 @@ impl Hook {
     pub fn start(
         cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
     ) -> Result<Self, HookError> {
-        cfg_select! {
-            target_os = "macos" => {
-                macos::start(cb).map(|inner| Self { inner: Some(inner) })
-            }
-            target_os = "linux" => {
-                linux::start(cb).map(|inner| Self { inner: Some(inner) })
-            }
-            target_os = "windows" => {
-                windows::start(cb).map(|inner| Self { inner: Some(inner) })
-            }
-            _ => {
-                let _ = cb;
-                Err(HookError::Unsupported)
-            }
-        }
+        Backend::start(cb).map(|inner| Self { inner: Some(inner) })
     }
 
     /// Stop the hook and release OS resources.
@@ -388,25 +443,8 @@ impl Hook {
     /// first call takes `inner`, so the `Drop` after an explicit [`Self::stop`]
     /// is a no-op.
     fn shutdown(&mut self) {
-        cfg_select! {
-            target_os = "macos" => {
-                if let Some(inner) = self.inner.take() {
-                    macos::stop(inner);
-                }
-            }
-            target_os = "linux" => {
-                if let Some(inner) = self.inner.take() {
-                    linux::stop(inner);
-                }
-            }
-            target_os = "windows" => {
-                if let Some(inner) = self.inner.take() {
-                    windows::stop(inner);
-                }
-            }
-            _ => {
-                // Unreachable: `never: Infallible` makes `Hook` uninhabited here.
-            }
+        if let Some(inner) = self.inner.take() {
+            Backend::stop(inner);
         }
     }
 
@@ -424,10 +462,7 @@ impl Hook {
     /// Windows low-level hook needs no separate privacy grant).
     #[must_use]
     pub fn has_accessibility() -> bool {
-        cfg_select! {
-            target_os = "macos" => { macos::has_accessibility() }
-            _ => { true }
-        }
+        Backend::has_accessibility()
     }
 
     /// Show the macOS Accessibility permission dialog and register this
@@ -440,10 +475,7 @@ impl Hook {
     /// its side effect; the resulting trust state is observed separately via
     /// [`Self::has_accessibility`]. No-op on non-macOS.
     pub fn prompt_accessibility() {
-        cfg_select! {
-            target_os = "macos" => { macos::prompt_accessibility(); }
-            _ => {}
-        }
+        Backend::prompt_accessibility();
     }
 
     /// Enumerate every event tap currently installed in this login session.
@@ -458,10 +490,7 @@ impl Hook {
     /// global tap registry.
     #[must_use]
     pub fn list_event_taps() -> Vec<EventTapInfo> {
-        cfg_select! {
-            target_os = "macos" => { macos::list_event_taps() }
-            _ => { Vec::new() }
-        }
+        Backend::list_event_taps()
     }
 }
 
@@ -479,12 +508,7 @@ impl Hook {
 /// `openlogi-desktop::app_watcher`.
 #[must_use]
 pub fn frontmost_bundle_id() -> Option<String> {
-    cfg_select! {
-        target_os = "macos" => { macos::frontmost_bundle_id() }
-        target_os = "linux" => { linux::frontmost_bundle_id() }
-        target_os = "windows" => { windows::frontmost_process_path() }
-        _ => { None }
-    }
+    Backend::frontmost_app()
 }
 
 /// Return the current global cursor position without installing an input hook.
@@ -493,12 +517,7 @@ pub fn frontmost_bundle_id() -> Option<String> {
 /// compositor deliberately does not expose global pointer coordinates.
 #[must_use]
 pub fn cursor_position() -> Option<CursorPosition> {
-    cfg_select! {
-        target_os = "macos" => { macos::cursor_position() }
-        target_os = "linux" => { linux::cursor_position() }
-        target_os = "windows" => { windows::cursor_position() }
-        _ => { None }
-    }
+    Backend::cursor_position()
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -413,7 +413,12 @@ impl Hook {
     /// Returns `true` when the process has the permissions required to install
     /// the hook.
     ///
-    /// On macOS, checks the Accessibility entitlement. On Linux and Windows
+    /// On macOS this is a live capability check, not just a read of the
+    /// Accessibility trust flag: that flag keeps reporting `true` after the
+    /// user deletes the app's row from System Settings, so it is paired with a
+    /// throwaway event tap that only succeeds while the grant really stands.
+    /// Poll it for as long as a hook is installed — an active tap that outlives
+    /// its permission wedges system input until reboot. On Linux and Windows
     /// this always returns `true`; those platforms enforce permissions at a
     /// lower layer (device-node ownership / group membership on Linux; the
     /// Windows low-level hook needs no separate privacy grant).

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -42,8 +42,8 @@ use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
 use x11rb::rust_connection::RustConnection;
 
 use crate::{
-    ButtonId, CursorPosition, EventDisposition, HookError, HookEvent, LOGITECH_VENDOR_ID,
-    MouseEvent,
+    ButtonId, CursorPosition, EventDisposition, HookBackend, HookError, HookEvent,
+    LOGITECH_VENDOR_ID, MouseEvent,
 };
 
 /// Prefix carried by every uinput device OpenLogi creates — the hook's
@@ -67,50 +67,79 @@ pub(crate) struct HookInner {
     threads: Vec<thread::JoinHandle<()>>,
 }
 
-pub(crate) fn start(
-    cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
-) -> Result<HookInner, HookError> {
-    let devices = find_mouse_devices();
-    if devices.is_empty() {
-        return Err(HookError::NoDeviceFound);
-    }
+/// The Linux backend: one `evdev` reader thread per mouse, re-injecting
+/// pass-through events through a `uinput` device.
+pub(crate) struct Backend;
 
-    let stop = Arc::new(AtomicBool::new(false));
-    let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
-    let mut threads: Vec<thread::JoinHandle<()>> = Vec::with_capacity(devices.len());
-    let mut stop_pipes: Vec<OwnedFd> = Vec::with_capacity(devices.len());
+impl HookBackend for Backend {
+    type Running = HookInner;
 
-    let result = (|| -> io::Result<()> {
-        for (path, device) in devices {
-            let virtual_device = build_virtual_device(&device)?;
-            let (rx, tx) = create_pipe()?;
-            let stop_clone = Arc::clone(&stop);
-            let cb_clone = Arc::clone(&cb);
-            let handle = thread::Builder::new()
-                .name(format!("openlogi-hook:{}", path.display()))
-                .spawn(move || {
-                    device_thread(path, device, virtual_device, cb_clone, stop_clone, rx);
-                })?;
-            threads.push(handle);
-            stop_pipes.push(tx);
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<HookInner, HookError> {
+        let devices = find_mouse_devices();
+        if devices.is_empty() {
+            return Err(HookError::NoDeviceFound);
         }
-        Ok(())
-    })();
 
-    if let Err(e) = result {
-        shutdown(&stop, &stop_pipes, threads);
-        return Err(HookError::Linux(e));
+        let stop = Arc::new(AtomicBool::new(false));
+        let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
+        let mut threads: Vec<thread::JoinHandle<()>> = Vec::with_capacity(devices.len());
+        let mut stop_pipes: Vec<OwnedFd> = Vec::with_capacity(devices.len());
+
+        let result = (|| -> io::Result<()> {
+            for (path, device) in devices {
+                let virtual_device = build_virtual_device(&device)?;
+                let (rx, tx) = create_pipe()?;
+                let stop_clone = Arc::clone(&stop);
+                let cb_clone = Arc::clone(&cb);
+                let handle = thread::Builder::new()
+                    .name(format!("openlogi-hook:{}", path.display()))
+                    .spawn(move || {
+                        device_thread(path, device, virtual_device, cb_clone, stop_clone, rx);
+                    })?;
+                threads.push(handle);
+                stop_pipes.push(tx);
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            shutdown(&stop, &stop_pipes, threads);
+            return Err(HookError::Linux(e));
+        }
+
+        Ok(HookInner {
+            stop,
+            stop_pipes,
+            threads,
+        })
     }
 
-    Ok(HookInner {
-        stop,
-        stop_pipes,
-        threads,
-    })
-}
+    fn stop(inner: HookInner) {
+        shutdown(&inner.stop, &inner.stop_pipes, inner.threads);
+    }
 
-pub(crate) fn stop(inner: HookInner) {
-    shutdown(&inner.stop, &inner.stop_pipes, inner.threads);
+    /// Return an opaque identifier of the currently frontmost application, or
+    /// `None` when unavailable. Dispatches to the backend chosen at startup.
+    ///
+    /// On an X11 session this is the `WM_CLASS` class component (e.g. "Firefox").
+    /// On a Wayland session the wlr-foreign-toplevel or gnome-shell backend is used
+    /// when available; XWayland windows fall back to the X11 backend.
+    fn frontmost_app() -> Option<String> {
+        FRONTMOST_SOURCE.frontmost_bundle_id()
+    }
+
+    /// Read the global cursor position through X11 when an X server is available.
+    /// Native Wayland intentionally has no equivalent global-coordinate API.
+    fn cursor_position() -> Option<CursorPosition> {
+        let source = X11Source::connect()?;
+        let reply = source.conn.query_pointer(source.root).ok()?.reply().ok()?;
+        Some(CursorPosition {
+            x: f64::from(reply.root_x),
+            y: f64::from(reply.root_y),
+        })
+    }
 }
 
 fn shutdown(stop: &AtomicBool, pipes: &[OwnedFd], threads: Vec<thread::JoinHandle<()>>) {
@@ -705,27 +734,6 @@ fn detect_frontmost_source() -> Box<dyn FrontmostSource> {
 
 static FRONTMOST_SOURCE: LazyLock<Box<dyn FrontmostSource>> =
     LazyLock::new(detect_frontmost_source);
-
-/// Return an opaque identifier of the currently frontmost application, or
-/// `None` when unavailable. Dispatches to the backend chosen at startup.
-///
-/// On an X11 session this is the `WM_CLASS` class component (e.g. "Firefox").
-/// On a Wayland session the wlr-foreign-toplevel or gnome-shell backend is used
-/// when available; XWayland windows fall back to the X11 backend.
-pub(crate) fn frontmost_bundle_id() -> Option<String> {
-    FRONTMOST_SOURCE.frontmost_bundle_id()
-}
-
-/// Read the global cursor position through X11 when an X server is available.
-/// Native Wayland intentionally has no equivalent global-coordinate API.
-pub(crate) fn cursor_position() -> Option<CursorPosition> {
-    let source = X11Source::connect()?;
-    let reply = source.conn.query_pointer(source.root).ok()?.reply().ok()?;
-    Some(CursorPosition {
-        x: f64::from(reply.root_x),
-        y: f64::from(reply.root_y),
-    })
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -30,8 +30,8 @@ use objc2_application_services::{AXIsProcessTrusted, AXIsProcessTrustedWithOptio
 use tracing::{debug, error, warn};
 
 use crate::{
-    ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, HookError, HookEvent,
-    KeyEvent, KeyModifiers, MouseEvent, TapLocation,
+    ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, HookBackend, HookError,
+    HookEvent, KeyEvent, KeyModifiers, MouseEvent, TapLocation,
 };
 use watchdog::{
     LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, RearmBudget,
@@ -215,23 +215,6 @@ fn sender_device_info(sender_id: u64) -> SenderDeviceInfo {
     })
 }
 
-/// Check whether this process can still install the hook's event tap.
-///
-/// `AXIsProcessTrusted()` alone is not that answer: it keeps returning `true`
-/// after the user *deletes* the app's row from System Settings → Privacy &
-/// Security → Accessibility, so a hook that believes it would never learn it
-/// had been revoked, would keep re-arming a tap macOS no longer lets it
-/// service, and would wedge clicks machine-wide until reboot (#674). Only
-/// creating a filtering tap tracks the live grant, so both are consulted: the
-/// trust read short-circuits the probe for a process that was never granted,
-/// which keeps a denied agent from asking `WindowServer` twice a second.
-pub(crate) fn has_accessibility() -> bool {
-    // SAFETY: takes no arguments and only reads the current trust state — the
-    // non-prompting counterpart of `AXIsProcessTrustedWithOptions`.
-    let trusted = unsafe { AXIsProcessTrusted() };
-    trusted && can_filter_events()
-}
-
 /// Can this process create an *active* (event-filtering) tap right now?
 ///
 /// The probe mirrors the real tap's location, placement and options — that is
@@ -247,59 +230,6 @@ fn can_filter_events() -> bool {
         |_proxy: CGEventTapProxy, _etype: CGEventType, _event: &CGEvent| CallbackResult::Keep,
     )
     .is_ok()
-}
-
-/// Raise the Accessibility prompt + register the process. See
-/// [`super::Hook::prompt_accessibility`].
-///
-/// The `kAXTrustedCheckOptionPrompt = true` option is what makes macOS surface
-/// the dialog and list the process in System Settings; without it this is just
-/// [`has_accessibility`].
-pub(crate) fn prompt_accessibility() {
-    use objc2_application_services::kAXTrustedCheckOptionPrompt;
-    use objc2_core_foundation::{CFDictionary, kCFBooleanTrue};
-
-    // SAFETY: both are framework-provided constants, live for the process
-    // lifetime; reading them copies a `&'static` reference.
-    let (key, value) = unsafe { (kAXTrustedCheckOptionPrompt, kCFBooleanTrue) };
-    let Some(value) = value else { return };
-    let options = CFDictionary::from_slices(&[key], &[value]);
-    // SAFETY: the dictionary holds exactly the documented key/value types
-    // (`kAXTrustedCheckOptionPrompt` → `CFBoolean`). The returned trust state is
-    // observed separately via the watcher, so it is deliberately dropped here.
-    let _trusted = unsafe { AXIsProcessTrustedWithOptions(Some(options.as_opaque())) };
-}
-
-/// Read the frontmost application's bundle identifier via `NSWorkspace`.
-/// Returns `None` when no app is frontmost or the identifier is missing.
-///
-/// `NSWorkspace` is `AnyThread`, so this is sound on the watcher thread. The
-/// reads return owned `Retained` values (no leak by construction), but the
-/// framework still autoreleases internal temporaries and `to_str` borrows its
-/// UTF-8 view from the pool — so an explicit `autoreleasepool` is required off
-/// the main thread, where no run loop drains one. (Without it the old raw path
-/// leaked the workspace/app/bundle-id objects: hundreds of MB across a workday.)
-pub(crate) fn cursor_position() -> Option<CursorPosition> {
-    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
-    let point = CGEvent::new(source).ok()?.location();
-    Some(CursorPosition {
-        x: point.x,
-        y: point.y,
-    })
-}
-
-pub(crate) fn frontmost_bundle_id() -> Option<String> {
-    use objc2::rc::autoreleasepool;
-    use objc2_app_kit::NSWorkspace;
-
-    autoreleasepool(|pool| {
-        let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
-        let bundle_id = app.bundleIdentifier()?;
-        // SAFETY: `to_str` yields a UTF-8 view valid for `pool`'s lifetime; we
-        // copy it into an owned `String` before the pool (and `bundle_id`) drop,
-        // so the borrow never escapes.
-        Some(unsafe { bundle_id.to_str(pool) }.to_owned())
-    })
 }
 
 /// Translate a raw OS button number to a [`ButtonId`].
@@ -522,70 +452,211 @@ fn usable_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
     event.get_integer_value_field(axis.line) as f64
 }
 
-/// Create the event tap and run loop on a dedicated thread.
-pub(crate) fn start(
-    cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
-) -> Result<HookInner, HookError> {
-    if !has_accessibility() {
-        return Err(HookError::AccessibilityDenied);
-    }
-
-    // Wrap in Arc so the closure handed to CGEventTap::new captures it by
-    // clone rather than by move — avoids a second Box allocation.
-    let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
-
-    let signals = Arc::new(WatchdogSignals::default());
-    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
-    let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
-
-    let thread = {
-        let thread_signals = Arc::clone(&signals);
-        match thread::Builder::new()
-            .name("openlogi-hook".into())
-            .spawn(move || thread_main(cb, rl_tx, thread_signals))
-        {
-            Ok(thread) => thread,
-            Err(error) => {
-                signals.set_phase(TapPhase::ThreadExited);
-                lifecycle_watchdog.thread().unpark();
-                let _ = lifecycle_watchdog.join();
-                return Err(HookError::MacOsTap(error.to_string()));
-            }
-        }
-    };
-
-    // Block until the background thread confirms the run loop is live, or
-    // reports failure by dropping its sender.
-    let Ok(run_loop) = rl_rx.recv() else {
-        let error = HookError::MacOsTap(
-            "background thread exited before the run loop started; \
-             CGEventTapCreate likely returned null"
-                .into(),
-        );
-        if let Err(panic) = thread.join() {
-            error!(?panic, "hook thread panicked during startup");
-        }
-        lifecycle_watchdog.thread().unpark();
-        if let Err(panic) = lifecycle_watchdog.join() {
-            error!(?panic, "hook lifecycle watchdog panicked during startup");
-        }
-        return Err(error);
-    };
-
-    Ok(HookInner {
-        thread,
-        lifecycle_watchdog,
-        run_loop,
-        signals,
-    })
-}
-
 const CALLBACK_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const LIFECYCLE_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const FREEZE_HAZARD_EXIT_CODE: i32 = 78;
 
 /// Event types the HID tap observes. Pointer *Dragged variants are required
 /// because a held button makes the OS emit those instead of `MouseMoved`.
+/// The macOS backend: a `CGEventTap` serviced by a private run-loop thread.
+pub(crate) struct Backend;
+
+impl HookBackend for Backend {
+    type Running = HookInner;
+
+    /// Create the event tap and run loop on a dedicated thread.
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<HookInner, HookError> {
+        if !Self::has_accessibility() {
+            return Err(HookError::AccessibilityDenied);
+        }
+
+        // Wrap in Arc so the closure handed to CGEventTap::new captures it by
+        // clone rather than by move — avoids a second Box allocation.
+        let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
+
+        let signals = Arc::new(WatchdogSignals::default());
+        let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
+        let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
+
+        let thread = {
+            let thread_signals = Arc::clone(&signals);
+            match thread::Builder::new()
+                .name("openlogi-hook".into())
+                .spawn(move || thread_main(cb, rl_tx, thread_signals))
+            {
+                Ok(thread) => thread,
+                Err(error) => {
+                    signals.set_phase(TapPhase::ThreadExited);
+                    lifecycle_watchdog.thread().unpark();
+                    let _ = lifecycle_watchdog.join();
+                    return Err(HookError::MacOsTap(error.to_string()));
+                }
+            }
+        };
+
+        // Block until the background thread confirms the run loop is live, or
+        // reports failure by dropping its sender.
+        let Ok(run_loop) = rl_rx.recv() else {
+            let error = HookError::MacOsTap(
+                "background thread exited before the run loop started; \
+                 CGEventTapCreate likely returned null"
+                    .into(),
+            );
+            if let Err(panic) = thread.join() {
+                error!(?panic, "hook thread panicked during startup");
+            }
+            lifecycle_watchdog.thread().unpark();
+            if let Err(panic) = lifecycle_watchdog.join() {
+                error!(?panic, "hook lifecycle watchdog panicked during startup");
+            }
+            return Err(error);
+        };
+
+        Ok(HookInner {
+            thread,
+            lifecycle_watchdog,
+            run_loop,
+            signals,
+        })
+    }
+
+    /// Signal the run loop to stop and join the background thread.
+    fn stop(inner: HookInner) {
+        // Latch stop before waking either thread. The lifecycle watchdog stays
+        // armed across the blocking join and accepts only `ThreadExited` as proof
+        // that explicit shutdown completed.
+        inner.signals.request_stop();
+        inner.lifecycle_watchdog.thread().unpark();
+        inner.run_loop.stop();
+        if let Err(e) = inner.thread.join() {
+            error!("hook thread panicked on shutdown: {e:?}");
+        }
+        inner.lifecycle_watchdog.thread().unpark();
+        if let Err(e) = inner.lifecycle_watchdog.join() {
+            error!("hook lifecycle watchdog panicked on shutdown: {e:?}");
+        }
+    }
+
+    /// Check whether this process can still install the hook's event tap.
+    ///
+    /// `AXIsProcessTrusted()` alone is not that answer: it keeps returning `true`
+    /// after the user *deletes* the app's row from System Settings → Privacy &
+    /// Security → Accessibility, so a hook that believes it would never learn it
+    /// had been revoked, would keep re-arming a tap macOS no longer lets it
+    /// service, and would wedge clicks machine-wide until reboot (#674). Only
+    /// creating a filtering tap tracks the live grant, so both are consulted: the
+    /// trust read short-circuits the probe for a process that was never granted,
+    /// which keeps a denied agent from asking `WindowServer` twice a second.
+    fn has_accessibility() -> bool {
+        // SAFETY: takes no arguments and only reads the current trust state — the
+        // non-prompting counterpart of `AXIsProcessTrustedWithOptions`.
+        let trusted = unsafe { AXIsProcessTrusted() };
+        trusted && can_filter_events()
+    }
+
+    /// Raise the Accessibility prompt + register the process. See
+    /// [`super::Hook::prompt_accessibility`].
+    ///
+    /// The `kAXTrustedCheckOptionPrompt = true` option is what makes macOS surface
+    /// the dialog and list the process in System Settings; without it this is just
+    /// [`Self::has_accessibility`].
+    fn prompt_accessibility() {
+        use objc2_application_services::kAXTrustedCheckOptionPrompt;
+        use objc2_core_foundation::{CFDictionary, kCFBooleanTrue};
+
+        // SAFETY: both are framework-provided constants, live for the process
+        // lifetime; reading them copies a `&'static` reference.
+        let (key, value) = unsafe { (kAXTrustedCheckOptionPrompt, kCFBooleanTrue) };
+        let Some(value) = value else { return };
+        let options = CFDictionary::from_slices(&[key], &[value]);
+        // SAFETY: the dictionary holds exactly the documented key/value types
+        // (`kAXTrustedCheckOptionPrompt` → `CFBoolean`). The returned trust state is
+        // observed separately via the watcher, so it is deliberately dropped here.
+        let _trusted = unsafe { AXIsProcessTrustedWithOptions(Some(options.as_opaque())) };
+    }
+
+    /// See [`super::Hook::list_event_taps`].
+    fn list_event_taps() -> Vec<EventTapInfo> {
+        let mut count: u32 = 0;
+        // SAFETY: a null `tap_list` with `max == 0` is the documented count-probe
+        // form; it only writes `count`.
+        let err = unsafe { CGGetEventTapList(0, std::ptr::null_mut(), &raw mut count) };
+        if err != 0 || count == 0 {
+            return Vec::new();
+        }
+
+        // SAFETY: `CGEventTapInformation` is a plain `repr(C)` POD; an all-zero bit
+        // pattern is a valid instance (`enabled = false`, all numeric fields 0).
+        // `CGGetEventTapList` overwrites each slot it fills.
+        let mut taps: Vec<CGEventTapInformation> =
+            vec![unsafe { std::mem::zeroed() }; count as usize];
+        // SAFETY: `taps` holds exactly `count` initialised, correctly aligned slots
+        // and stays alive for the call, and that same `count` is the maximum passed
+        // in, so the C side cannot write past the allocation; the out-parameter
+        // points at a live local it may only overwrite.
+        let err = unsafe { CGGetEventTapList(count, taps.as_mut_ptr(), &raw mut count) };
+        if err != 0 {
+            return Vec::new();
+        }
+        // The second call may report fewer taps than the probe; never read past it.
+        taps.truncate(count as usize);
+
+        taps.into_iter()
+            .map(|t| EventTapInfo {
+                tap_id: t.event_tap_id,
+                location: match t.tap_point {
+                    0 => TapLocation::Hid,
+                    1 => TapLocation::Session,
+                    2 => TapLocation::AnnotatedSession,
+                    other => TapLocation::Other(other),
+                },
+                // kCGEventTapOptionDefault == 0 (active); kCGEventTapOptionListenOnly == 1.
+                active: t.options == 0,
+                enabled: t.enabled,
+                owner_pid: t.tapping_process,
+                owner_name: process_name(t.tapping_process),
+                target_pid: (t.process_being_tapped != 0).then_some(t.process_being_tapped),
+            })
+            .collect()
+    }
+
+    /// Read the frontmost application's bundle identifier via `NSWorkspace`.
+    /// Returns `None` when no app is frontmost or the identifier is missing.
+    ///
+    /// `NSWorkspace` is `AnyThread`, so this is sound on the watcher thread. The
+    /// reads return owned `Retained` values (no leak by construction), but the
+    /// framework still autoreleases internal temporaries and `to_str` borrows its
+    /// UTF-8 view from the pool — so an explicit `autoreleasepool` is required off
+    /// the main thread, where no run loop drains one. (Without it the old raw path
+    /// leaked the workspace/app/bundle-id objects: hundreds of MB across a workday.)
+    fn frontmost_app() -> Option<String> {
+        use objc2::rc::autoreleasepool;
+        use objc2_app_kit::NSWorkspace;
+
+        autoreleasepool(|pool| {
+            let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
+            let bundle_id = app.bundleIdentifier()?;
+            // SAFETY: `to_str` yields a UTF-8 view valid for `pool`'s lifetime; we
+            // copy it into an owned `String` before the pool (and `bundle_id`) drop,
+            // so the borrow never escapes.
+            Some(unsafe { bundle_id.to_str(pool) }.to_owned())
+        })
+    }
+
+    /// Read the global cursor position from a HID-state event source, which
+    /// needs no tap and no permission.
+    fn cursor_position() -> Option<CursorPosition> {
+        let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
+        let point = CGEvent::new(source).ok()?.location();
+        Some(CursorPosition {
+            x: point.x,
+            y: point.y,
+        })
+    }
+}
+
 fn hooked_event_types() -> Vec<CGEventType> {
     vec![
         CGEventType::LeftMouseDown,
@@ -813,7 +884,7 @@ fn service_tap(tap: &SharedTap, signals: &WatchdogSignals, tap_disabled: &Atomic
             CFRunLoopRunResult::TimedOut | CFRunLoopRunResult::HandledSource => {}
         }
         signals.mark_tap_progress();
-        if !has_accessibility() {
+        if !Backend::has_accessibility() {
             warn!(
                 "Accessibility revoked while the event tap was live — \
                  disabling the tap to avoid wedging system input"
@@ -1104,50 +1175,6 @@ unsafe extern "C" {
     fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, buffersize: u32) -> i32;
 }
 
-/// See [`super::Hook::list_event_taps`].
-pub(crate) fn list_event_taps() -> Vec<EventTapInfo> {
-    let mut count: u32 = 0;
-    // SAFETY: a null `tap_list` with `max == 0` is the documented count-probe
-    // form; it only writes `count`.
-    let err = unsafe { CGGetEventTapList(0, std::ptr::null_mut(), &raw mut count) };
-    if err != 0 || count == 0 {
-        return Vec::new();
-    }
-
-    // SAFETY: `CGEventTapInformation` is a plain `repr(C)` POD; an all-zero bit
-    // pattern is a valid instance (`enabled = false`, all numeric fields 0).
-    // `CGGetEventTapList` overwrites each slot it fills.
-    let mut taps: Vec<CGEventTapInformation> = vec![unsafe { std::mem::zeroed() }; count as usize];
-    // SAFETY: `taps` holds exactly `count` initialised, correctly aligned slots
-    // and stays alive for the call, and that same `count` is the maximum passed
-    // in, so the C side cannot write past the allocation; the out-parameter
-    // points at a live local it may only overwrite.
-    let err = unsafe { CGGetEventTapList(count, taps.as_mut_ptr(), &raw mut count) };
-    if err != 0 {
-        return Vec::new();
-    }
-    // The second call may report fewer taps than the probe; never read past it.
-    taps.truncate(count as usize);
-
-    taps.into_iter()
-        .map(|t| EventTapInfo {
-            tap_id: t.event_tap_id,
-            location: match t.tap_point {
-                0 => TapLocation::Hid,
-                1 => TapLocation::Session,
-                2 => TapLocation::AnnotatedSession,
-                other => TapLocation::Other(other),
-            },
-            // kCGEventTapOptionDefault == 0 (active); kCGEventTapOptionListenOnly == 1.
-            active: t.options == 0,
-            enabled: t.enabled,
-            owner_pid: t.tapping_process,
-            owner_name: process_name(t.tapping_process),
-            target_pid: (t.process_being_tapped != 0).then_some(t.process_being_tapped),
-        })
-        .collect()
-}
-
 /// Best-effort PID → executable file name via libproc.
 fn process_name(pid: i32) -> Option<String> {
     // PROC_PIDPATHINFO_MAXSIZE is 4 * MAXPATHLEN (4 * 1024).
@@ -1167,23 +1194,6 @@ fn process_name(pid: i32) -> Option<String> {
     buf.truncate(len.unsigned_abs() as usize);
     let path = String::from_utf8_lossy(&buf);
     Some(path.rsplit('/').next().unwrap_or(&path).to_string())
-}
-
-/// Signal the run loop to stop and join the background thread.
-pub(crate) fn stop(inner: HookInner) {
-    // Latch stop before waking either thread. The lifecycle watchdog stays
-    // armed across the blocking join and accepts only `ThreadExited` as proof
-    // that explicit shutdown completed.
-    inner.signals.request_stop();
-    inner.lifecycle_watchdog.thread().unpark();
-    inner.run_loop.stop();
-    if let Err(e) = inner.thread.join() {
-        error!("hook thread panicked on shutdown: {e:?}");
-    }
-    inner.lifecycle_watchdog.thread().unpark();
-    if let Err(e) = inner.lifecycle_watchdog.join() {
-        error!("hook lifecycle watchdog panicked on shutdown: {e:?}");
-    }
 }
 
 #[cfg(test)]

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -57,6 +57,12 @@ pub(crate) struct HookInner {
 // threads; only CFRunLoopRun must be called on the owning thread.
 unsafe impl Send for HookInner {}
 
+unsafe extern "C" {
+    /// Register a handler the C runtime runs from `exit()` — which is what
+    /// `std::process::exit` calls, destructors skipped.
+    fn atexit(handler: extern "C" fn()) -> std::ffi::c_int;
+}
+
 /// Opaque `IOHIDEventRef` — the HID event backing a `CGEvent`.
 type IOHIDEventRef = *mut std::ffi::c_void;
 
@@ -529,15 +535,14 @@ pub(crate) fn start(
     let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
 
     let signals = Arc::new(WatchdogSignals::default());
-    let armed = Arc::new(ArmedTap::default());
-    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals), Arc::clone(&armed))?;
+    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
     let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
 
     let thread = {
         let thread_signals = Arc::clone(&signals);
         match thread::Builder::new()
             .name("openlogi-hook".into())
-            .spawn(move || thread_main(cb, rl_tx, thread_signals, armed))
+            .spawn(move || thread_main(cb, rl_tx, thread_signals))
         {
             Ok(thread) => thread,
             Err(error) => {
@@ -636,7 +641,6 @@ fn run_tap_callback(
 /// the agent so macOS tears the tap down and system input recovers.
 fn spawn_callback_watchdog(
     signals: Arc<WatchdogSignals>,
-    armed: Arc<ArmedTap>,
     in_callback: Arc<AtomicBool>,
     entered_at_ms: Arc<AtomicU64>,
 ) -> std::io::Result<()> {
@@ -677,7 +681,7 @@ fn spawn_callback_watchdog(
                 // Detaching cannot unblock an in-flight callback, so the
                 // process still has to go — but it goes with the tap already
                 // out of the chain rather than stranded there.
-                armed.detach();
+                ARMED_TAP.detach();
                 #[expect(
                     clippy::exit,
                     reason = "this watchdog thread has no caller to return to and the stuck callback owns the active HID tap, which serialises every pointer event machine-wide; only process death makes macOS tear the tap down"
@@ -700,7 +704,6 @@ fn spawn_callback_watchdog(
 /// after that thread has exited.
 fn spawn_lifecycle_watchdog(
     signals: Arc<WatchdogSignals>,
-    armed: Arc<ArmedTap>,
 ) -> Result<thread::JoinHandle<()>, HookError> {
     thread::Builder::new()
         .name("openlogi-hook-lifecycle-watchdog".into())
@@ -748,7 +751,7 @@ fn spawn_lifecycle_watchdog(
                             "HID CGEventTap lifecycle did not make progress before deadline — \
                              exiting agent to restore system input"
                         );
-                        armed.detach();
+                        ARMED_TAP.detach();
                         #[expect(
                             clippy::exit,
                             reason = "the tap thread is wedged (TCC revocation can stall it inside CoreGraphics), so no unwinding path can reach it from this watchdog thread; a live HID tap left behind freezes all input until the process dies"
@@ -767,12 +770,12 @@ fn spawn_lifecycle_watchdog(
 /// leaving it armed there would gate the HID stream with no run loop behind it.
 /// The ordinary teardown detaches explicitly, in order, before it publishes
 /// [`TapPhase::TapStopped`]; this only catches the paths that never get there.
-struct ArmGuard(Arc<ArmedTap>);
+struct ArmGuard;
 
 impl Drop for ArmGuard {
     fn drop(&mut self) {
-        self.0.detach();
-        self.0.disarm();
+        ARMED_TAP.detach();
+        ARMED_TAP.disarm();
     }
 }
 
@@ -846,7 +849,6 @@ fn thread_main(
     cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync>,
     rl_tx: mpsc::Sender<CFRunLoop>,
     signals: Arc<WatchdogSignals>,
-    armed: Arc<ArmedTap>,
 ) {
     // Declared first so it drops last, after the tap, callback, source, and run
     // loop locals have unwound. The lifecycle watchdog treats this notification
@@ -900,8 +902,8 @@ fn thread_main(
     // installed the tap, so from here on every exit path must be able to
     // detach it — including the watchdogs' `process::exit`.
     let tap = Arc::new(SharedTap(tap));
-    armed.arm(&tap);
-    let _disarm = ArmGuard(Arc::clone(&armed));
+    ARMED_TAP.arm(&tap);
+    let _disarm = ArmGuard;
     signals.mark_tap_progress();
 
     let Ok(loop_source) = tap.0.mach_port().create_runloop_source(0) else {
@@ -920,7 +922,6 @@ fn thread_main(
     signals.mark_tap_progress();
     if let Err(error) = spawn_callback_watchdog(
         Arc::clone(&signals),
-        Arc::clone(&armed),
         Arc::clone(&in_callback),
         Arc::clone(&entered_at_ms),
     ) {
@@ -935,7 +936,7 @@ fn thread_main(
     if rl_tx.send(run_loop.clone()).is_err() {
         debug!("hook parent dropped before run loop was ready; stopping");
         tap.detach();
-        armed.disarm();
+        ARMED_TAP.disarm();
         // SAFETY: framework-provided static CFStringRef, 'static.
         run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
         drop(loop_source);
@@ -950,7 +951,7 @@ fn thread_main(
     // so input recovers immediately rather than whenever CF happens to
     // release the port.
     tap.detach();
-    armed.disarm();
+    ARMED_TAP.disarm();
     // SAFETY: framework-provided static CFStringRef, 'static.
     run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
     drop(loop_source);
@@ -1010,16 +1011,37 @@ impl SharedTap {
     }
 }
 
-/// The armed tap, published so the watchdog threads can reach it.
+/// The tap this process has armed, if any.
 ///
-/// Holding an `Arc` rather than a raw port keeps the tap alive for as long as a
-/// watchdog is touching it, so an emergency detach can never race the tap
+/// A process-wide slot because the paths that must reach it hold no handle:
+/// the watchdog threads, and `atexit`. The agent runs exactly one hook (it is
+/// single-instance, and the tap is a process-wide resource either way), so one
+/// slot is the whole story.
+///
+/// Holding an `Arc` rather than a raw port keeps the tap alive for as long as
+/// anything is touching it, so an emergency detach can never race the tap
 /// thread's teardown into a released port.
-#[derive(Default)]
+static ARMED_TAP: ArmedTap = ArmedTap(std::sync::Mutex::new(None));
+
+/// Detach on the way out of a `process::exit`, which runs C `atexit` handlers
+/// but no Rust destructors. The tray's Quit, the post-update self-restart and
+/// both watchdogs all leave that way, and a tap that dies with its process
+/// without being invalidated can stay registered in the system's tap chain.
+extern "C" fn detach_armed_tap_at_exit() {
+    ARMED_TAP.detach();
+}
+
 struct ArmedTap(std::sync::Mutex<Option<Arc<SharedTap>>>);
 
 impl ArmedTap {
     fn arm(&self, tap: &Arc<SharedTap>) {
+        static REGISTER_ATEXIT: std::sync::Once = std::sync::Once::new();
+        REGISTER_ATEXIT.call_once(|| {
+            // SAFETY: `atexit` stores the handler for the process to run at
+            // exit; ours only locks a static mutex and makes CoreFoundation
+            // calls that are safe from any thread.
+            unsafe { atexit(detach_armed_tap_at_exit) };
+        });
         *self.lock() = Some(Arc::clone(tap));
     }
 

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -34,8 +34,8 @@ use crate::{
     KeyEvent, KeyModifiers, MouseEvent, TapLocation,
 };
 use watchdog::{
-    LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, TapPhase,
-    WatchdogSignals, stuck_callback,
+    LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, RearmBudget,
+    TapPhase, WatchdogSignals, stuck_callback,
 };
 
 /// Everything `Hook` needs to control the background thread.
@@ -76,6 +76,10 @@ unsafe extern "C" {
 #[link(name = "CoreFoundation", kind = "framework")]
 unsafe extern "C" {
     fn CFRelease(cf: *const std::ffi::c_void);
+    /// Unregister a `CFMachPort` — for a tap port, this is what removes the tap
+    /// from the event chain. `CGEventTap`'s `Drop` calls it, so only the paths
+    /// that end in `process::exit` (which runs no destructors) need it by hand.
+    fn CFMachPortInvalidate(port: core_foundation::mach_port::CFMachPortRef);
 }
 
 /// The registry id of the device that produced `event`, via its backing
@@ -205,11 +209,38 @@ fn sender_device_info(sender_id: u64) -> SenderDeviceInfo {
     })
 }
 
-/// Check whether this process has been granted Accessibility access.
+/// Check whether this process can still install the hook's event tap.
+///
+/// `AXIsProcessTrusted()` alone is not that answer: it keeps returning `true`
+/// after the user *deletes* the app's row from System Settings → Privacy &
+/// Security → Accessibility, so a hook that believes it would never learn it
+/// had been revoked, would keep re-arming a tap macOS no longer lets it
+/// service, and would wedge clicks machine-wide until reboot (#674). Only
+/// creating a filtering tap tracks the live grant, so both are consulted: the
+/// trust read short-circuits the probe for a process that was never granted,
+/// which keeps a denied agent from asking `WindowServer` twice a second.
 pub(crate) fn has_accessibility() -> bool {
     // SAFETY: takes no arguments and only reads the current trust state — the
     // non-prompting counterpart of `AXIsProcessTrustedWithOptions`.
-    unsafe { AXIsProcessTrusted() }
+    let trusted = unsafe { AXIsProcessTrusted() };
+    trusted && can_filter_events()
+}
+
+/// Can this process create an *active* (event-filtering) tap right now?
+///
+/// The probe mirrors the real tap's location, placement and options — that is
+/// the capability being tested — but subscribes to `kCGEventNull`, an event
+/// type nothing ever posts, so it cannot gate a single real event during the
+/// microseconds it exists. Dropping it invalidates the port.
+fn can_filter_events() -> bool {
+    CGEventTap::new(
+        CGEventTapLocation::HID,
+        CGEventTapPlacement::HeadInsertEventTap,
+        CGEventTapOptions::Default,
+        vec![CGEventType::Null],
+        |_proxy: CGEventTapProxy, _etype: CGEventType, _event: &CGEvent| CallbackResult::Keep,
+    )
+    .is_ok()
 }
 
 /// Raise the Accessibility prompt + register the process. See
@@ -498,14 +529,15 @@ pub(crate) fn start(
     let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
 
     let signals = Arc::new(WatchdogSignals::default());
-    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
+    let armed = Arc::new(ArmedTap::default());
+    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals), Arc::clone(&armed))?;
     let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
 
     let thread = {
         let thread_signals = Arc::clone(&signals);
         match thread::Builder::new()
             .name("openlogi-hook".into())
-            .spawn(move || thread_main(cb, rl_tx, thread_signals))
+            .spawn(move || thread_main(cb, rl_tx, thread_signals, armed))
         {
             Ok(thread) => thread,
             Err(error) => {
@@ -604,6 +636,7 @@ fn run_tap_callback(
 /// the agent so macOS tears the tap down and system input recovers.
 fn spawn_callback_watchdog(
     signals: Arc<WatchdogSignals>,
+    armed: Arc<ArmedTap>,
     in_callback: Arc<AtomicBool>,
     entered_at_ms: Arc<AtomicU64>,
 ) -> std::io::Result<()> {
@@ -641,8 +674,10 @@ fn spawn_callback_watchdog(
                     "OS mouse-hook callback stuck past budget — exiting agent to \
                      restore system input (HID CGEventTap freeze hazard)"
                 );
-                // Hard exit: disable_tap alone cannot unblock an in-flight
-                // callback, and a live active HID tap freezes all pointer I/O.
+                // Detaching cannot unblock an in-flight callback, so the
+                // process still has to go — but it goes with the tap already
+                // out of the chain rather than stranded there.
+                armed.detach();
                 #[expect(
                     clippy::exit,
                     reason = "this watchdog thread has no caller to return to and the stuck callback owns the active HID tap, which serialises every pointer event machine-wide; only process death makes macOS tear the tap down"
@@ -665,6 +700,7 @@ fn spawn_callback_watchdog(
 /// after that thread has exited.
 fn spawn_lifecycle_watchdog(
     signals: Arc<WatchdogSignals>,
+    armed: Arc<ArmedTap>,
 ) -> Result<thread::JoinHandle<()>, HookError> {
     thread::Builder::new()
         .name("openlogi-hook-lifecycle-watchdog".into())
@@ -712,6 +748,7 @@ fn spawn_lifecycle_watchdog(
                             "HID CGEventTap lifecycle did not make progress before deadline — \
                              exiting agent to restore system input"
                         );
+                        armed.detach();
                         #[expect(
                             clippy::exit,
                             reason = "the tap thread is wedged (TCC revocation can stall it inside CoreGraphics), so no unwinding path can reach it from this watchdog thread; a live HID tap left behind freezes all input until the process dies"
@@ -724,99 +761,29 @@ fn spawn_lifecycle_watchdog(
         .map_err(|error| HookError::MacOsTap(format!("could not spawn tap watchdog: {error}")))
 }
 
-/// Body of the background hook thread.
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "rl_tx must be owned: dropping it signals the parent's recv() to return Err on failure paths"
-)]
-fn thread_main(
-    cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync>,
-    rl_tx: mpsc::Sender<CFRunLoop>,
-    signals: Arc<WatchdogSignals>,
-) {
-    // Declared first so it drops last, after the tap, callback, source, and run
-    // loop locals have unwound. The lifecycle watchdog treats this notification
-    // as proof that an explicit stop has completed, not merely been requested.
-    let _thread_exit = signals.thread_exit_guard();
+/// Detaches whatever tap is still armed when the tap thread unwinds.
+///
+/// Setup can fail after `CGEventTapCreate` has already installed the tap, and
+/// leaving it armed there would gate the HID stream with no run loop behind it.
+/// The ordinary teardown detaches explicitly, in order, before it publishes
+/// [`TapPhase::TapStopped`]; this only catches the paths that never get there.
+struct ArmGuard(Arc<ArmedTap>);
 
-    // A successful CGEventTapCreate may install the HID tap before returning,
-    // so lifecycle monitoring must be armed before entering CoreGraphics.
-    signals.mark_tap_progress();
-    signals.set_phase(TapPhase::Arming);
-
-    let in_callback = Arc::new(AtomicBool::new(false));
-    let entered_at_ms = Arc::new(AtomicU64::new(0));
-
-    let tap_result = {
-        let callback_signals = Arc::clone(&signals);
-        let in_callback = Arc::clone(&in_callback);
-        let entered_at_ms = Arc::clone(&entered_at_ms);
-        CGEventTap::new(
-            CGEventTapLocation::HID,
-            CGEventTapPlacement::HeadInsertEventTap,
-            CGEventTapOptions::Default,
-            hooked_event_types(),
-            move |_proxy: CGEventTapProxy, etype: CGEventType, event: &CGEvent| {
-                entered_at_ms.store(callback_signals.now_millis(), Ordering::Relaxed);
-                in_callback.store(true, Ordering::Release);
-                let disposition = run_tap_callback(cb.as_ref(), etype, event);
-                in_callback.store(false, Ordering::Release);
-                disposition
-            },
-        )
-    };
-
-    let Ok(tap) = tap_result else {
-        error!("CGEventTapCreate returned null — Accessibility may have been revoked");
-        // Dropping rl_tx causes rl_rx.recv() on the parent to return Err,
-        // which we surface as MacOsTap.
-        return;
-    };
-    signals.mark_tap_progress();
-
-    let Ok(loop_source) = tap.mach_port().create_runloop_source(0) else {
-        error!("CFRunLoopSourceCreate failed for event tap");
-        return;
-    };
-    signals.mark_tap_progress();
-
-    let run_loop = CFRunLoop::get_current();
-
-    // SAFETY: kCFRunLoopCommonModes is a static CF string constant that
-    // lives for the duration of the process.
-    unsafe {
-        run_loop.add_source(&loop_source, kCFRunLoopCommonModes);
+impl Drop for ArmGuard {
+    fn drop(&mut self) {
+        self.0.detach();
+        self.0.disarm();
     }
-    signals.mark_tap_progress();
-    if let Err(error) = spawn_callback_watchdog(
-        Arc::clone(&signals),
-        Arc::clone(&in_callback),
-        Arc::clone(&entered_at_ms),
-    ) {
-        error!(%error, "could not spawn callback watchdog — refusing to arm HID tap");
-        return;
-    }
-    signals.mark_tap_progress();
-    tap.enable();
-    signals.mark_tap_progress();
-    signals.set_phase(TapPhase::Armed);
+}
 
-    if rl_tx.send(run_loop.clone()).is_err() {
-        debug!("hook parent dropped before run loop was ready; stopping");
-        disable_tap(&tap);
-        // SAFETY: framework-provided static CFStringRef, 'static.
-        run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
-        drop(loop_source);
-        drop(tap);
-        signals.set_phase(TapPhase::TapStopped);
-        return;
-    }
-
+/// Service the tap until it has to be released: an explicit stop, a stopped run
+/// loop, a revoked permission, or a tap the OS will not keep enabled.
+fn service_tap(tap: &SharedTap, signals: &WatchdogSignals, tap_disabled: &AtomicBool) {
     // Service the tap in short slices instead of an unbounded
-    // `run_current()`. Between slices we re-check Accessibility: an active
-    // tap at the HID location that outlives its permission wedges the
-    // *entire* system input stream — mouse and keyboard alike — until
-    // reboot. If the user revokes access while we're live, tear the tap
+    // `run_current()`. Between slices we re-check that we may still filter
+    // events: an active tap at the HID location that outlives its permission
+    // wedges the *entire* system input stream — mouse and keyboard alike —
+    // until reboot. If the user revokes access while we're live, tear the tap
     // down right here, on the tap's own thread, so input is restored even
     // when the UI thread is already stuck.
     //
@@ -827,6 +794,7 @@ fn thread_main(
     // checked at the top of every slice, is the reliable signal: in
     // that race the thread notices one 500 ms slice later instead of joining
     // forever.
+    let mut rearm = RearmBudget::default();
     loop {
         if signals.stop_requested() {
             break;
@@ -849,17 +817,140 @@ fn thread_main(
             );
             break;
         }
-        // Recover from an OS-initiated disable (TapDisabledByTimeout/UserInput):
-        // re-enabling is idempotent while the tap is already live, so this brings
-        // a disabled tap back within one slice instead of the hook going
-        // permanently deaf. Only reached while Accessibility is still granted.
+        // Recover from an OS-initiated disable (TapDisabledByTimeout/UserInput),
+        // and *only* from that: re-enabling a tap the OS did not disable is a
+        // no-op at best, and once the permission check is the thing that is
+        // lying it is what turns a dead tap into a permanent gate on the HID
+        // stream. Re-arming is also budgeted, so a tap the system keeps
+        // disabling is eventually given up instead of fought over.
+        if !tap_disabled.swap(false, Ordering::AcqRel) {
+            continue;
+        }
+        if !rearm.allow(signals.now()) {
+            error!(
+                "the OS keeps disabling the HID tap — releasing it instead of \
+                 re-arming a tap nothing is servicing"
+            );
+            break;
+        }
         tap.enable();
     }
+}
+
+/// Body of the background hook thread.
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "rl_tx must be owned: dropping it signals the parent's recv() to return Err on failure paths"
+)]
+fn thread_main(
+    cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync>,
+    rl_tx: mpsc::Sender<CFRunLoop>,
+    signals: Arc<WatchdogSignals>,
+    armed: Arc<ArmedTap>,
+) {
+    // Declared first so it drops last, after the tap, callback, source, and run
+    // loop locals have unwound. The lifecycle watchdog treats this notification
+    // as proof that an explicit stop has completed, not merely been requested.
+    let _thread_exit = signals.thread_exit_guard();
+
+    // A successful CGEventTapCreate may install the HID tap before returning,
+    // so lifecycle monitoring must be armed before entering CoreGraphics.
+    signals.mark_tap_progress();
+    signals.set_phase(TapPhase::Arming);
+
+    let in_callback = Arc::new(AtomicBool::new(false));
+    let entered_at_ms = Arc::new(AtomicU64::new(0));
+    // Latched by the callback when the OS disables the tap, consumed by the
+    // run-loop slice that decides whether to re-arm it.
+    let tap_disabled = Arc::new(AtomicBool::new(false));
+
+    let tap_result = {
+        let callback_signals = Arc::clone(&signals);
+        let in_callback = Arc::clone(&in_callback);
+        let entered_at_ms = Arc::clone(&entered_at_ms);
+        let tap_disabled = Arc::clone(&tap_disabled);
+        CGEventTap::new(
+            CGEventTapLocation::HID,
+            CGEventTapPlacement::HeadInsertEventTap,
+            CGEventTapOptions::Default,
+            hooked_event_types(),
+            move |_proxy: CGEventTapProxy, etype: CGEventType, event: &CGEvent| {
+                if matches!(
+                    etype,
+                    CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
+                ) {
+                    tap_disabled.store(true, Ordering::Release);
+                }
+                entered_at_ms.store(callback_signals.now_millis(), Ordering::Relaxed);
+                in_callback.store(true, Ordering::Release);
+                let disposition = run_tap_callback(cb.as_ref(), etype, event);
+                in_callback.store(false, Ordering::Release);
+                disposition
+            },
+        )
+    };
+
+    let Ok(tap) = tap_result else {
+        error!("CGEventTapCreate returned null — Accessibility may have been revoked");
+        // Dropping rl_tx causes rl_rx.recv() on the parent to return Err,
+        // which we surface as MacOsTap.
+        return;
+    };
+    // Published before anything can fail: `CGEventTapCreate` may already have
+    // installed the tap, so from here on every exit path must be able to
+    // detach it — including the watchdogs' `process::exit`.
+    let tap = Arc::new(SharedTap(tap));
+    armed.arm(&tap);
+    let _disarm = ArmGuard(Arc::clone(&armed));
+    signals.mark_tap_progress();
+
+    let Ok(loop_source) = tap.0.mach_port().create_runloop_source(0) else {
+        error!("CFRunLoopSourceCreate failed for event tap");
+        return;
+    };
+    signals.mark_tap_progress();
+
+    let run_loop = CFRunLoop::get_current();
+
+    // SAFETY: kCFRunLoopCommonModes is a static CF string constant that
+    // lives for the duration of the process.
+    unsafe {
+        run_loop.add_source(&loop_source, kCFRunLoopCommonModes);
+    }
+    signals.mark_tap_progress();
+    if let Err(error) = spawn_callback_watchdog(
+        Arc::clone(&signals),
+        Arc::clone(&armed),
+        Arc::clone(&in_callback),
+        Arc::clone(&entered_at_ms),
+    ) {
+        error!(%error, "could not spawn callback watchdog — refusing to arm HID tap");
+        return;
+    }
+    signals.mark_tap_progress();
+    tap.enable();
+    signals.mark_tap_progress();
+    signals.set_phase(TapPhase::Armed);
+
+    if rl_tx.send(run_loop.clone()).is_err() {
+        debug!("hook parent dropped before run loop was ready; stopping");
+        tap.detach();
+        armed.disarm();
+        // SAFETY: framework-provided static CFStringRef, 'static.
+        run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
+        drop(loop_source);
+        drop(tap);
+        signals.set_phase(TapPhase::TapStopped);
+        return;
+    }
+
+    service_tap(&tap, &signals, &tap_disabled);
 
     // Detach the tap from the event stream synchronously before unwinding,
     // so input recovers immediately rather than whenever CF happens to
     // release the port.
-    disable_tap(&tap);
+    tap.detach();
+    armed.disarm();
     // SAFETY: framework-provided static CFStringRef, 'static.
     run_loop.remove_source(&loop_source, unsafe { kCFRunLoopCommonModes });
     drop(loop_source);
@@ -871,20 +962,87 @@ fn duration_millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
-/// Disable an active event tap now. core-graphics only exposes the enable
-/// side of `CGEventTapEnable`, so we bind the disable side ourselves.
-fn disable_tap(tap: &CGEventTap) {
-    use core_foundation::base::TCFType as _;
+/// The tap, shareable with the watchdog threads.
+///
+/// A watchdog that force-exits the agent has to be able to detach the tap
+/// first: `process::exit` runs no destructors, and a tap that dies with its
+/// process without being invalidated can be left behind in the system's tap
+/// chain, where it gates events nothing will ever answer for.
+struct SharedTap(CGEventTap<'static>);
 
-    #[link(name = "CoreGraphics", kind = "framework")]
-    unsafe extern "C" {
-        fn CGEventTapEnable(tap: core_foundation::mach_port::CFMachPortRef, enable: bool);
+// SAFETY: a `CGEventTap` is a `CFMachPort` plus the boxed callback, which
+// `CGEventTap::new` already requires to be `Send + 'static` (type erasure is
+// what loses that bound). CoreFoundation objects may be retained, released and
+// invalidated from any thread, and `CGEventTapEnable` is likewise thread-safe.
+// The callback itself is only ever invoked by the run loop servicing the tap,
+// which never leaves the thread that created it.
+unsafe impl Send for SharedTap {}
+// SAFETY: as above — every method reachable through a shared reference is a
+// thread-safe CoreFoundation or CoreGraphics call on the port.
+unsafe impl Sync for SharedTap {}
+
+impl SharedTap {
+    /// Detach the tap from the event stream now, and unregister it.
+    ///
+    /// Disabling stops it gating events immediately rather than whenever
+    /// CoreFoundation happens to release the port; invalidating unregisters it
+    /// so an exit that skips `Drop` cannot strand it. Both are idempotent.
+    fn detach(&self) {
+        use core_foundation::base::TCFType as _;
+
+        // core-graphics only exposes the enable side of `CGEventTapEnable`.
+        #[link(name = "CoreGraphics", kind = "framework")]
+        unsafe extern "C" {
+            fn CGEventTapEnable(tap: core_foundation::mach_port::CFMachPortRef, enable: bool);
+        }
+
+        let port = self.0.mach_port().as_concrete_TypeRef();
+        // SAFETY: `port` is a live `CFMachPort` owned by `self.0` for the
+        // duration of both calls.
+        unsafe {
+            CGEventTapEnable(port, false);
+            CFMachPortInvalidate(port);
+        }
     }
 
-    // SAFETY: `tap.mach_port()` is a live `CFMachPort` for the duration of
-    // the call; `CGEventTapEnable(.., false)` is idempotent and merely
-    // detaches the tap from the system event stream.
-    unsafe { CGEventTapEnable(tap.mach_port().as_concrete_TypeRef(), false) };
+    fn enable(&self) {
+        self.0.enable();
+    }
+}
+
+/// The armed tap, published so the watchdog threads can reach it.
+///
+/// Holding an `Arc` rather than a raw port keeps the tap alive for as long as a
+/// watchdog is touching it, so an emergency detach can never race the tap
+/// thread's teardown into a released port.
+#[derive(Default)]
+struct ArmedTap(std::sync::Mutex<Option<Arc<SharedTap>>>);
+
+impl ArmedTap {
+    fn arm(&self, tap: &Arc<SharedTap>) {
+        *self.lock() = Some(Arc::clone(tap));
+    }
+
+    fn disarm(&self) {
+        *self.lock() = None;
+    }
+
+    /// Detach the armed tap, if any. For watchdog threads on their way to
+    /// `process::exit`.
+    fn detach(&self) {
+        let tap = self.lock().clone();
+        if let Some(tap) = tap {
+            tap.detach();
+        }
+    }
+
+    /// A poisoned lock still holds a perfectly good tap handle, and this is the
+    /// path that keeps input alive — never panic on it.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<Arc<SharedTap>>> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 }
 
 /// Mirror of CoreGraphics' `CGEventTapInformation`. `#[repr(C)]` reproduces the

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -820,22 +820,21 @@ fn service_tap(tap: &SharedTap, signals: &WatchdogSignals, tap_disabled: &Atomic
             );
             break;
         }
-        // Recover from an OS-initiated disable (TapDisabledByTimeout/UserInput),
-        // and *only* from that: re-enabling a tap the OS did not disable is a
-        // no-op at best, and once the permission check is the thing that is
-        // lying it is what turns a dead tap into a permanent gate on the HID
-        // stream. Re-arming is also budgeted, so a tap the system keeps
-        // disabling is eventually given up instead of fought over.
-        if !tap_disabled.swap(false, Ordering::AcqRel) {
-            continue;
-        }
-        if !rearm.allow(signals.now()) {
+        // An OS-initiated disable (TapDisabledByTimeout/UserInput) is answered
+        // on a budget: a tap the system disables slice after slice is one we
+        // are no longer servicing, and re-arming it just holds the HID stream
+        // hostage — which is what turned the revoked grant in #674 into a
+        // machine-wide freeze.
+        if tap_disabled.swap(false, Ordering::AcqRel) && !rearm.allow(signals.now()) {
             error!(
                 "the OS keeps disabling the HID tap — releasing it instead of \
                  re-arming a tap nothing is servicing"
             );
             break;
         }
+        // Enabling is idempotent while the tap is already live, so this both
+        // answers the notification above and recovers a tap that was disabled
+        // without one. Only reached while the grant still stands.
         tap.enable();
     }
 }

--- a/crates/openlogi-hook/src/macos/watchdog.rs
+++ b/crates/openlogi-hook/src/macos/watchdog.rs
@@ -6,6 +6,13 @@ use std::time::{Duration, Instant};
 
 pub(super) const CALLBACK_STUCK_BUDGET: Duration = Duration::from_millis(200);
 pub(super) const TAP_SHUTDOWN_BUDGET: Duration = Duration::from_millis(1_500);
+/// How many re-arms the hook grants inside [`REARM_WINDOW`] before it gives
+/// the tap up.
+pub(super) const REARM_LIMIT: u32 = 10;
+/// The rolling window [`REARM_LIMIT`] applies to. Re-arming happens at most
+/// once per run-loop slice, so a spent budget means the OS has been disabling
+/// the tap for seconds on end.
+pub(super) const REARM_WINDOW: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
@@ -173,6 +180,33 @@ impl LifecycleWatchdog {
     }
 }
 
+/// Bounded re-arming of a tap the OS has disabled.
+///
+/// `TapDisabledByUserInput` fires during ordinary heavy input and self-heals,
+/// so a burst has to be re-armed or the hook goes deaf. A tap the OS disables
+/// again slice after slice is a different animal: nothing is servicing it, and
+/// re-enabling it keeps an active HID tap gating events it will never answer
+/// for. Give the burst room, then stop fighting and let the tap go.
+#[derive(Debug, Default)]
+pub(super) struct RearmBudget {
+    window_start: Option<Duration>,
+    used: u32,
+}
+
+impl RearmBudget {
+    /// Charge a re-arm at `now`; `false` once this window's budget is spent.
+    pub fn allow(&mut self, now: Duration) -> bool {
+        match self.window_start {
+            Some(start) if now.saturating_sub(start) < REARM_WINDOW => self.used += 1,
+            _ => {
+                self.window_start = Some(now);
+                self.used = 1;
+            }
+        }
+        self.used <= REARM_LIMIT
+    }
+}
+
 pub(super) fn stuck_callback(now_ms: u64, entered_at_ms: u64) -> Option<Duration> {
     let elapsed = Duration::from_millis(now_ms.saturating_sub(entered_at_ms));
     (elapsed >= CALLBACK_STUCK_BUDGET).then_some(elapsed)
@@ -323,6 +357,34 @@ mod tests {
             ),
             LifecycleDecision::Complete
         );
+    }
+
+    #[test]
+    fn a_burst_of_re_arms_is_allowed_and_then_bounded() {
+        let mut budget = RearmBudget::default();
+        for i in 0..REARM_LIMIT {
+            assert!(
+                budget.allow(Duration::from_millis(u64::from(i) * 500)),
+                "re-arm {i} is within the budget"
+            );
+        }
+        assert!(!budget.allow(Duration::from_millis(u64::from(REARM_LIMIT) * 500)));
+    }
+
+    #[test]
+    fn a_new_window_restores_the_budget() {
+        let mut budget = RearmBudget::default();
+        for _ in 0..=REARM_LIMIT {
+            let _ = budget.allow(Duration::ZERO);
+        }
+        assert!(!budget.allow(Duration::ZERO));
+        // A re-arm past the window opens a fresh one, anchored at that re-arm
+        // rather than at the first one ever charged.
+        for _ in 0..REARM_LIMIT {
+            assert!(budget.allow(REARM_WINDOW));
+        }
+        let just_inside = REARM_WINDOW + REARM_WINDOW.saturating_sub(Duration::from_millis(1));
+        assert!(!budget.allow(just_inside));
     }
 
     #[test]

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -28,8 +28,8 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::{
-    ButtonId, CursorPosition, EventDisposition, HookError, HookEvent, KeyEvent, KeyModifiers,
-    MouseEvent,
+    ButtonId, CursorPosition, EventDisposition, HookBackend, HookError, HookEvent, KeyEvent,
+    KeyModifiers, MouseEvent,
 };
 
 const WHEEL_DELTA: f32 = 120.0;
@@ -55,46 +55,113 @@ pub(crate) struct HookInner {
     join: Option<thread::JoinHandle<()>>,
 }
 
-pub(crate) fn start(
-    cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
-) -> Result<HookInner, HookError> {
-    let callback: HookCallback = Arc::new(cb);
-    let (ready_tx, ready_rx) = mpsc::channel();
-    let join = thread::Builder::new()
-        .name("openlogi-windows-hook".into())
-        .spawn(move || hook_thread(callback, ready_tx))
-        .map_err(|e| HookError::WindowsHook(format!("could not spawn hook thread: {e}")))?;
+/// The Windows backend: `WH_MOUSE_LL` / `WH_KEYBOARD_LL` hooks on a thread
+/// with its own message pump.
+pub(crate) struct Backend;
 
-    match ready_rx
-        .recv()
-        .map_err(|e| HookError::WindowsHook(format!("hook thread exited before setup: {e}")))?
-    {
-        Ok(thread_id) => Ok(HookInner {
-            thread_id,
-            join: Some(join),
-        }),
-        Err(e) => {
-            let _ = join.join();
-            Err(e)
+impl HookBackend for Backend {
+    type Running = HookInner;
+
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<HookInner, HookError> {
+        let callback: HookCallback = Arc::new(cb);
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let join = thread::Builder::new()
+            .name("openlogi-windows-hook".into())
+            .spawn(move || hook_thread(callback, ready_tx))
+            .map_err(|e| HookError::WindowsHook(format!("could not spawn hook thread: {e}")))?;
+
+        match ready_rx
+            .recv()
+            .map_err(|e| HookError::WindowsHook(format!("hook thread exited before setup: {e}")))?
+        {
+            Ok(thread_id) => Ok(HookInner {
+                thread_id,
+                join: Some(join),
+            }),
+            Err(e) => {
+                let _ = join.join();
+                Err(e)
+            }
         }
     }
-}
 
-pub(crate) fn stop(mut inner: HookInner) {
-    // SAFETY: PostThreadMessageW takes the target thread id and the message by
-    // value (no pointers); `thread_id` was returned by the hook thread's own
-    // GetCurrentThreadId, so it names a real thread with a message queue.
-    let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
-    if posted == 0 {
-        // SAFETY: GetLastError reads the calling thread's last-error code and
-        // has no preconditions.
-        let err = unsafe { GetLastError() };
-        tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
+    fn stop(mut inner: HookInner) {
+        // SAFETY: PostThreadMessageW takes the target thread id and the message by
+        // value (no pointers); `thread_id` was returned by the hook thread's own
+        // GetCurrentThreadId, so it names a real thread with a message queue.
+        let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
+        if posted == 0 {
+            // SAFETY: GetLastError reads the calling thread's last-error code and
+            // has no preconditions.
+            let err = unsafe { GetLastError() };
+            tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
+        }
+        if let Some(join) = inner.join.take()
+            && let Err(e) = join.join()
+        {
+            tracing::warn!(?e, "Windows hook thread panicked while stopping");
+        }
     }
-    if let Some(join) = inner.join.take()
-        && let Err(e) = join.join()
-    {
-        tracing::warn!(?e, "Windows hook thread panicked while stopping");
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the path buffer is a fixed 32768 u16s"
+    )]
+    fn frontmost_app() -> Option<String> {
+        // SAFETY: GetForegroundWindow takes no arguments and returns a window handle
+        // or null; no preconditions.
+        let hwnd = unsafe { GetForegroundWindow() };
+        if hwnd.is_null() {
+            return None;
+        }
+
+        let mut pid = 0;
+        // SAFETY: `hwnd` is the non-null handle just returned; `&raw mut pid` is a
+        // valid out-pointer the call writes the owning process id into.
+        unsafe {
+            GetWindowThreadProcessId(hwnd, &raw mut pid);
+        }
+        if pid == 0 {
+            return None;
+        }
+
+        // SAFETY: OpenProcess takes the access mask and pid by value and returns a
+        // handle or null (checked); on success we own the handle and close it below.
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process.is_null() {
+            return None;
+        }
+
+        let mut buf = vec![0u16; 32_768];
+        let mut len = buf.len() as u32;
+        // SAFETY: `process` is the valid handle from OpenProcess; `buf` is a live
+        // 32768-u16 buffer and `len` holds its length, so the call writes at most
+        // `len` code units and updates `len` with the count written.
+        let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &raw mut len) };
+        // SAFETY: `process` is the handle from OpenProcess, owned here and closed
+        // exactly once now that the query has returned.
+        unsafe {
+            CloseHandle(process);
+        }
+        if ok == 0 || len == 0 {
+            return None;
+        }
+
+        Some(String::from_utf16_lossy(&buf[..len as usize]).to_lowercase())
+    }
+
+    fn cursor_position() -> Option<CursorPosition> {
+        let mut point = POINT { x: 0, y: 0 };
+        // SAFETY: `point` is a valid writable POINT for the duration of the call.
+        if unsafe { GetCursorPos(&raw mut point) } == 0 {
+            return None;
+        }
+        Some(CursorPosition {
+            x: f64::from(point.x),
+            y: f64::from(point.y),
+        })
     }
 }
 
@@ -482,65 +549,6 @@ fn high_word(value: u32) -> u16 {
 
 fn signed_high_word(value: u32) -> i16 {
     high_word(value).cast_signed()
-}
-
-pub(crate) fn cursor_position() -> Option<CursorPosition> {
-    let mut point = POINT { x: 0, y: 0 };
-    // SAFETY: `point` is a valid writable POINT for the duration of the call.
-    if unsafe { GetCursorPos(&raw mut point) } == 0 {
-        return None;
-    }
-    Some(CursorPosition {
-        x: f64::from(point.x),
-        y: f64::from(point.y),
-    })
-}
-
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "the path buffer is a fixed 32768 u16s"
-)]
-pub(crate) fn frontmost_process_path() -> Option<String> {
-    // SAFETY: GetForegroundWindow takes no arguments and returns a window handle
-    // or null; no preconditions.
-    let hwnd = unsafe { GetForegroundWindow() };
-    if hwnd.is_null() {
-        return None;
-    }
-
-    let mut pid = 0;
-    // SAFETY: `hwnd` is the non-null handle just returned; `&raw mut pid` is a
-    // valid out-pointer the call writes the owning process id into.
-    unsafe {
-        GetWindowThreadProcessId(hwnd, &raw mut pid);
-    }
-    if pid == 0 {
-        return None;
-    }
-
-    // SAFETY: OpenProcess takes the access mask and pid by value and returns a
-    // handle or null (checked); on success we own the handle and close it below.
-    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    if process.is_null() {
-        return None;
-    }
-
-    let mut buf = vec![0u16; 32_768];
-    let mut len = buf.len() as u32;
-    // SAFETY: `process` is the valid handle from OpenProcess; `buf` is a live
-    // 32768-u16 buffer and `len` holds its length, so the call writes at most
-    // `len` code units and updates `len` with the count written.
-    let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &raw mut len) };
-    // SAFETY: `process` is the handle from OpenProcess, owned here and closed
-    // exactly once now that the query has returned.
-    unsafe {
-        CloseHandle(process);
-    }
-    if ok == 0 || len == 0 {
-        return None;
-    }
-
-    Some(String::from_utf16_lossy(&buf[..len as usize]).to_lowercase())
 }
 
 fn last_error(context: &str) -> HookError {


### PR DESCRIPTION
## Summary

Deleting OpenLogi's row from System Settings → Privacy & Security → Accessibility froze the machine's input until reboot: pointer motion still worked, clicks and modifier combinations did not. The hook already had a revocation teardown path — it just never ran. `AXIsProcessTrusted()` keeps returning `true` after the row is *deleted* (as opposed to toggled off), so the tap thread went on believing it had permission and went on re-arming, twice a second, an active HID tap that macOS would no longer let it service. An active tap in that state gates the events it subscribes to with nobody left to answer for them, which is exactly the reported fingerprint.

Two Apple Developer Forums threads describe the same failure and land on the same workaround — the trust flag is not a revocation signal, and the only thing that tracks the live grant is trying to create a filtering tap and checking for NULL: [thread 735204](https://developer.apple.com/forums/thread/735204) ("left and right mouse clicks become permanently blocked ... unless the system is restarted", plus "AXIsProcessTrusted() ... returns `true` even after accessibility access is revoked") and [thread 744440](https://developer.apple.com/forums/thread/744440), where Apple DTS confirms there is no formal API for this and files FB13533901.

The probe is not a no-op, verified on this machine: from a trusted terminal `AXIsProcessTrusted()` is 1 and the probe tap is created; from a launchd-spawned process with its own TCC identity `AXIsProcessTrusted()` is 0 and `CGEventTapCreate(kCGHIDEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, CGEventMaskBit(kCGEventNull))` returns NULL 40 times out of 40. One `Hook::has_accessibility()` costs ~120 µs, and 50 probe processes produced zero lines in `log show`, granted or denied.

#803 has been merged into this branch, so this PR now carries the `HookBackend` refactor as well — see the "From #803" section below. Every commit here is a focused conventional commit, so rebase-merge is available if you would rather not squash a fix and a refactor into one.

## Changes

**`openlogi-hook`**

- `has_accessibility()` now pairs the trust read with a throwaway filtering tap that mirrors the real one's location, placement and options but subscribes to `kCGEventNull` — an event type nothing ever posts — so it cannot gate a real event during the microseconds it exists. The trust read stays as the cheap short-circuit, so a never-granted process does not ask WindowServer twice a second; the probe is the truth.
- The per-slice re-enable stays (it is idempotent, and it recovers a tap the OS disabled without reporting it), but an OS-initiated disable (`TapDisabledByTimeout` / `ByUserInput`) is now answered on a budget: 10 re-arms per rolling 10 s, after which the hook lets the tap go instead of fighting the system for the HID stream. That is a second line of defence that holds even if the permission check is the thing that is lying.
- The armed tap is shared with the two watchdog threads and detached — `CGEventTapEnable(false)` *and* `CFMachPortInvalidate` — before they force-exit, and from an `atexit` handler that covers every other `process::exit` in the agent (the tray's Quit, the post-update self-restart). `process::exit` runs no destructors, and a tap that dies with its process without being invalidated can be left registered in the system's tap chain.
- `service_tap` is split out of `thread_main`; no behaviour change beyond the above.

**`openlogi-agent`**

- SIGTERM and SIGINT are handled instead of killing the process where it stands: drop the hook (which detaches the tap synchronously), then exit. The takeover path sends exactly this signal to a stale agent, and a dev-run Ctrl-C is the same story. The exit has to be explicit because the agent's run loop is not the process — macOS keeps the AppKit tray loop on the main thread.
- `apply_inventory_event` is split out of `run` to stay inside the line budget; the arm's behaviour, including the resume-flag/lock ordering, is unchanged.
- `takeover.rs`'s module doc now covers both outcomes: a holder too old to handle SIGTERM still dies by signal and is respawned by launchd from the bundle path, a holder new enough exits 0 and leaves the lock to us.

**`.claude/rules/hook.md`** — records the three invariants above so the next refactor does not undo them.

**From #803 — `openlogi-hook` platform dispatch**

- `lib.rs` reached the per-OS modules through seven `cfg_select!` blocks plus four cfg-gated `Hook` fields. A private `trait HookBackend` with an associated `Running` type replaces them: each platform module carries a `Backend`, and the platform switch collapses to one `type Backend` alias. Platform-cfg sites in `lib.rs`: 17 → 6.
- Platform-optional calls (Accessibility, the tap list, the frontmost read, the cursor) are trait methods with do-nothing defaults, so the never-hooked platform is one small impl instead of five fallback arms.
- `HookError` no longer changes shape per target: the two Linux variants lose their `#[cfg]`, so an exhaustive `match` cannot compile on macOS and break on Linux.
- Two fixes fell out of the move: macOS's frontmost and cursor reads had swapped doc comments, and Windows' `frontmost_process_path` now answers to the same name as the other backends.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test --workspace                                   # 35 suites green
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo xtask ci
```

`cargo xtask ci`: rustfmt, shell, clippy, MSRV (macos, rustc 1.98), rustdoc, tests (macos, aarch64), cargo-deny, clippy (windows) proxy and wasm (portable crates) all pass. **`tests (linux)` was not run** — this host is macOS; CI is the gate for it.

Empirical checks beyond the gate: the trusted-vs-launchd probe comparison above, `Hook::has_accessibility()` returning `true` on a granted machine across repeated calls (a probe that always failed would silently disable everyone's hook), and `log show` staying quiet under repeated probing.

**Not runtime-tested on hardware.** Reproducing the reported freeze means actually deleting the TCC row on a machine running the agent, which is the maintainer's call — the fix is verified by the permission probe's behaviour, not by observing the freeze disappear. To test it: run the agent with the hook installed, delete OpenLogiAgent.app's row from System Settings → Privacy & Security → Accessibility, and watch for `Accessibility revoked while the event tap was live` in the agent log within ~500 ms, with clicks still working.

The gate above was run on the tree this branch now has (the #803 squash is byte-identical to the branch it was tested on), and CI is green on both heads, including `tests (linux)` and `clippy` on Linux — which matters for the refactor, since the Linux backend cannot be compiled on this host at all.

Not addressed here, worth a follow-up issue: the agent keeps running (and keeps its tap armed) after the app bundle is dragged to the Trash, which is how the reporter got into this state in the first place.

Fixes #674

