### PR TITLE
refactor(hook): give the platform backends a trait

### DIFF
--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -315,6 +315,82 @@ pub enum HookError {
     WindowsHook(String),
 }
 
+/// Everything one operating system has to provide for [`Hook`] to work.
+///
+/// Exactly one backend is compiled in — see the `Backend` alias below — so this
+/// is a compile-time contract, not runtime polymorphism. It earns its place by
+/// keeping the crate's per-OS `cfg` down to that single site, and by making the
+/// platform surface a list the compiler checks instead of a naming convention.
+/// Everything only some platforms can answer carries its do-nothing default
+/// here, so a backend implements exactly what it has.
+trait HookBackend {
+    /// Whatever the platform holds on to while the hook runs; handed back to
+    /// [`Self::stop`] to tear it down.
+    type Running;
+
+    /// Install the hook. [`Hook::start`] documents the contract owed to callers.
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<Self::Running, HookError>;
+
+    /// Stop the hook and join its threads.
+    fn stop(running: Self::Running);
+
+    /// See [`Hook::has_accessibility`]. Platforms that gate the hook below the
+    /// privacy layer answer `true`.
+    fn has_accessibility() -> bool {
+        true
+    }
+
+    /// See [`Hook::prompt_accessibility`]. Nothing to prompt for by default.
+    fn prompt_accessibility() {}
+
+    /// See [`Hook::list_event_taps`]. Empty where the OS keeps no tap registry.
+    fn list_event_taps() -> Vec<EventTapInfo> {
+        Vec::new()
+    }
+
+    /// See [`crate::frontmost_bundle_id`].
+    fn frontmost_app() -> Option<String> {
+        None
+    }
+
+    /// See [`crate::cursor_position`].
+    fn cursor_position() -> Option<CursorPosition> {
+        None
+    }
+}
+
+/// The backend for a platform with no hook: every default, and a
+/// [`HookBackend::start`] that can only fail. Compiled only where it is the
+/// one selected below, so it never sits unused in a real build.
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+struct Unsupported;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+impl HookBackend for Unsupported {
+    /// Uninhabited, so [`Hook`] can never hold a running hook here.
+    type Running = std::convert::Infallible;
+
+    fn start(
+        _cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<Self::Running, HookError> {
+        Err(HookError::Unsupported)
+    }
+
+    fn stop(running: Self::Running) {
+        match running {}
+    }
+}
+
+// The backend this build talks to — the crate's one platform switch.
+cfg_select! {
+    target_os = "macos" => { type Backend = macos::Backend; }
+    target_os = "linux" => { type Backend = linux::Backend; }
+    target_os = "windows" => { type Backend = windows::Backend; }
+    _ => { type Backend = Unsupported; }
+}
+
 /// A running OS-level mouse hook. Call [`Hook::stop`] to tear down.
 ///
 /// On macOS a dedicated thread runs a `CFRunLoop` draining a `CGEventTap`.
@@ -324,16 +400,7 @@ pub enum HookError {
 /// Call `stop` (or let the value drop) to shut down all threads and release
 /// grabbed devices.
 pub struct Hook {
-    #[cfg(target_os = "macos")]
-    inner: Option<macos::HookInner>,
-    #[cfg(target_os = "linux")]
-    inner: Option<linux::HookInner>,
-    #[cfg(target_os = "windows")]
-    inner: Option<windows::HookInner>,
-    /// Makes `Hook` uninhabited on unsupported targets so [`Hook::start`] can
-    /// only ever return `Err` there and the type can never be constructed.
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    never: std::convert::Infallible,
+    inner: Option<<Backend as HookBackend>::Running>,
 }
 
 impl Drop for Hook {
@@ -358,21 +425,7 @@ impl Hook {
     pub fn start(
         cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
     ) -> Result<Self, HookError> {
-        cfg_select! {
-            target_os = "macos" => {
-                macos::start(cb).map(|inner| Self { inner: Some(inner) })
-            }
-            target_os = "linux" => {
-                linux::start(cb).map(|inner| Self { inner: Some(inner) })
-            }
-            target_os = "windows" => {
-                windows::start(cb).map(|inner| Self { inner: Some(inner) })
-            }
-            _ => {
-                let _ = cb;
-                Err(HookError::Unsupported)
-            }
-        }
+        Backend::start(cb).map(|inner| Self { inner: Some(inner) })
     }
 
     /// Stop the hook and release OS resources.
@@ -388,25 +441,8 @@ impl Hook {
     /// first call takes `inner`, so the `Drop` after an explicit [`Self::stop`]
     /// is a no-op.
     fn shutdown(&mut self) {
-        cfg_select! {
-            target_os = "macos" => {
-                if let Some(inner) = self.inner.take() {
-                    macos::stop(inner);
-                }
-            }
-            target_os = "linux" => {
-                if let Some(inner) = self.inner.take() {
-                    linux::stop(inner);
-                }
-            }
-            target_os = "windows" => {
-                if let Some(inner) = self.inner.take() {
-                    windows::stop(inner);
-                }
-            }
-            _ => {
-                // Unreachable: `never: Infallible` makes `Hook` uninhabited here.
-            }
+        if let Some(inner) = self.inner.take() {
+            Backend::stop(inner);
         }
     }
 
@@ -424,10 +460,7 @@ impl Hook {
     /// Windows low-level hook needs no separate privacy grant).
     #[must_use]
     pub fn has_accessibility() -> bool {
-        cfg_select! {
-            target_os = "macos" => { macos::has_accessibility() }
-            _ => { true }
-        }
+        Backend::has_accessibility()
     }
 
     /// Show the macOS Accessibility permission dialog and register this
@@ -440,10 +473,7 @@ impl Hook {
     /// its side effect; the resulting trust state is observed separately via
     /// [`Self::has_accessibility`]. No-op on non-macOS.
     pub fn prompt_accessibility() {
-        cfg_select! {
-            target_os = "macos" => { macos::prompt_accessibility(); }
-            _ => {}
-        }
+        Backend::prompt_accessibility();
     }
 
     /// Enumerate every event tap currently installed in this login session.
@@ -458,10 +488,7 @@ impl Hook {
     /// global tap registry.
     #[must_use]
     pub fn list_event_taps() -> Vec<EventTapInfo> {
-        cfg_select! {
-            target_os = "macos" => { macos::list_event_taps() }
-            _ => { Vec::new() }
-        }
+        Backend::list_event_taps()
     }
 }
 
@@ -479,12 +506,7 @@ impl Hook {
 /// `openlogi-desktop::app_watcher`.
 #[must_use]
 pub fn frontmost_bundle_id() -> Option<String> {
-    cfg_select! {
-        target_os = "macos" => { macos::frontmost_bundle_id() }
-        target_os = "linux" => { linux::frontmost_bundle_id() }
-        target_os = "windows" => { windows::frontmost_process_path() }
-        _ => { None }
-    }
+    Backend::frontmost_app()
 }
 
 /// Return the current global cursor position without installing an input hook.
@@ -493,12 +515,7 @@ pub fn frontmost_bundle_id() -> Option<String> {
 /// compositor deliberately does not expose global pointer coordinates.
 #[must_use]
 pub fn cursor_position() -> Option<CursorPosition> {
-    cfg_select! {
-        target_os = "macos" => { macos::cursor_position() }
-        target_os = "linux" => { linux::cursor_position() }
-        target_os = "windows" => { windows::cursor_position() }
-        _ => { None }
-    }
+    Backend::cursor_position()
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -280,6 +280,10 @@ impl EventTapInfo {
 }
 
 /// Errors that [`Hook::start`] and related functions can produce.
+///
+/// The same shape on every target: a platform-conditional enum would compile on
+/// the maintainer's macOS and break an exhaustive `match` on Linux, and one
+/// unreachable variant costs nothing.
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
     /// This platform has no hook implementation (neither macOS, Linux, nor
@@ -299,7 +303,6 @@ pub enum HookError {
     /// No mouse device was found under `/dev/input`. Either no pointing device
     /// is connected, or the process lacks read permission on the device nodes
     /// (add the user to the `input` group, or add a `udev` rule).
-    #[cfg(target_os = "linux")]
     #[error(
         "no mouse device found under /dev/input; \
          ensure a pointing device is connected and the process has read permission \
@@ -307,7 +310,6 @@ pub enum HookError {
     )]
     NoDeviceFound,
     /// A Linux-specific I/O error occurred while setting up or running the hook.
-    #[cfg(target_os = "linux")]
     #[error("Linux input error: {0}")]
     Linux(#[source] std::io::Error),
     /// `SetWindowsHookExW` failed, or the hook thread could not be started.

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -42,8 +42,8 @@ use x11rb::protocol::xproto::{Atom, AtomEnum, ConnectionExt as _, Window};
 use x11rb::rust_connection::RustConnection;
 
 use crate::{
-    ButtonId, CursorPosition, EventDisposition, HookError, HookEvent, LOGITECH_VENDOR_ID,
-    MouseEvent,
+    ButtonId, CursorPosition, EventDisposition, HookBackend, HookError, HookEvent,
+    LOGITECH_VENDOR_ID, MouseEvent,
 };
 
 /// Prefix carried by every uinput device OpenLogi creates — the hook's
@@ -67,50 +67,79 @@ pub(crate) struct HookInner {
     threads: Vec<thread::JoinHandle<()>>,
 }
 
-pub(crate) fn start(
-    cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
-) -> Result<HookInner, HookError> {
-    let devices = find_mouse_devices();
-    if devices.is_empty() {
-        return Err(HookError::NoDeviceFound);
-    }
+/// The Linux backend: one `evdev` reader thread per mouse, re-injecting
+/// pass-through events through a `uinput` device.
+pub(crate) struct Backend;
 
-    let stop = Arc::new(AtomicBool::new(false));
-    let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
-    let mut threads: Vec<thread::JoinHandle<()>> = Vec::with_capacity(devices.len());
-    let mut stop_pipes: Vec<OwnedFd> = Vec::with_capacity(devices.len());
+impl HookBackend for Backend {
+    type Running = HookInner;
 
-    let result = (|| -> io::Result<()> {
-        for (path, device) in devices {
-            let virtual_device = build_virtual_device(&device)?;
-            let (rx, tx) = create_pipe()?;
-            let stop_clone = Arc::clone(&stop);
-            let cb_clone = Arc::clone(&cb);
-            let handle = thread::Builder::new()
-                .name(format!("openlogi-hook:{}", path.display()))
-                .spawn(move || {
-                    device_thread(path, device, virtual_device, cb_clone, stop_clone, rx);
-                })?;
-            threads.push(handle);
-            stop_pipes.push(tx);
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<HookInner, HookError> {
+        let devices = find_mouse_devices();
+        if devices.is_empty() {
+            return Err(HookError::NoDeviceFound);
         }
-        Ok(())
-    })();
 
-    if let Err(e) = result {
-        shutdown(&stop, &stop_pipes, threads);
-        return Err(HookError::Linux(e));
+        let stop = Arc::new(AtomicBool::new(false));
+        let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
+        let mut threads: Vec<thread::JoinHandle<()>> = Vec::with_capacity(devices.len());
+        let mut stop_pipes: Vec<OwnedFd> = Vec::with_capacity(devices.len());
+
+        let result = (|| -> io::Result<()> {
+            for (path, device) in devices {
+                let virtual_device = build_virtual_device(&device)?;
+                let (rx, tx) = create_pipe()?;
+                let stop_clone = Arc::clone(&stop);
+                let cb_clone = Arc::clone(&cb);
+                let handle = thread::Builder::new()
+                    .name(format!("openlogi-hook:{}", path.display()))
+                    .spawn(move || {
+                        device_thread(path, device, virtual_device, cb_clone, stop_clone, rx);
+                    })?;
+                threads.push(handle);
+                stop_pipes.push(tx);
+            }
+            Ok(())
+        })();
+
+        if let Err(e) = result {
+            shutdown(&stop, &stop_pipes, threads);
+            return Err(HookError::Linux(e));
+        }
+
+        Ok(HookInner {
+            stop,
+            stop_pipes,
+            threads,
+        })
     }
 
-    Ok(HookInner {
-        stop,
-        stop_pipes,
-        threads,
-    })
-}
+    fn stop(inner: HookInner) {
+        shutdown(&inner.stop, &inner.stop_pipes, inner.threads);
+    }
 
-pub(crate) fn stop(inner: HookInner) {
-    shutdown(&inner.stop, &inner.stop_pipes, inner.threads);
+    /// Return an opaque identifier of the currently frontmost application, or
+    /// `None` when unavailable. Dispatches to the backend chosen at startup.
+    ///
+    /// On an X11 session this is the `WM_CLASS` class component (e.g. "Firefox").
+    /// On a Wayland session the wlr-foreign-toplevel or gnome-shell backend is used
+    /// when available; XWayland windows fall back to the X11 backend.
+    fn frontmost_app() -> Option<String> {
+        FRONTMOST_SOURCE.frontmost_bundle_id()
+    }
+
+    /// Read the global cursor position through X11 when an X server is available.
+    /// Native Wayland intentionally has no equivalent global-coordinate API.
+    fn cursor_position() -> Option<CursorPosition> {
+        let source = X11Source::connect()?;
+        let reply = source.conn.query_pointer(source.root).ok()?.reply().ok()?;
+        Some(CursorPosition {
+            x: f64::from(reply.root_x),
+            y: f64::from(reply.root_y),
+        })
+    }
 }
 
 fn shutdown(stop: &AtomicBool, pipes: &[OwnedFd], threads: Vec<thread::JoinHandle<()>>) {
@@ -705,27 +734,6 @@ fn detect_frontmost_source() -> Box<dyn FrontmostSource> {
 
 static FRONTMOST_SOURCE: LazyLock<Box<dyn FrontmostSource>> =
     LazyLock::new(detect_frontmost_source);
-
-/// Return an opaque identifier of the currently frontmost application, or
-/// `None` when unavailable. Dispatches to the backend chosen at startup.
-///
-/// On an X11 session this is the `WM_CLASS` class component (e.g. "Firefox").
-/// On a Wayland session the wlr-foreign-toplevel or gnome-shell backend is used
-/// when available; XWayland windows fall back to the X11 backend.
-pub(crate) fn frontmost_bundle_id() -> Option<String> {
-    FRONTMOST_SOURCE.frontmost_bundle_id()
-}
-
-/// Read the global cursor position through X11 when an X server is available.
-/// Native Wayland intentionally has no equivalent global-coordinate API.
-pub(crate) fn cursor_position() -> Option<CursorPosition> {
-    let source = X11Source::connect()?;
-    let reply = source.conn.query_pointer(source.root).ok()?.reply().ok()?;
-    Some(CursorPosition {
-        x: f64::from(reply.root_x),
-        y: f64::from(reply.root_y),
-    })
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -30,8 +30,8 @@ use objc2_application_services::{AXIsProcessTrusted, AXIsProcessTrustedWithOptio
 use tracing::{debug, error, warn};
 
 use crate::{
-    ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, HookError, HookEvent,
-    KeyEvent, KeyModifiers, MouseEvent, TapLocation,
+    ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, HookBackend, HookError,
+    HookEvent, KeyEvent, KeyModifiers, MouseEvent, TapLocation,
 };
 use watchdog::{
     LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, RearmBudget,
@@ -215,23 +215,6 @@ fn sender_device_info(sender_id: u64) -> SenderDeviceInfo {
     })
 }
 
-/// Check whether this process can still install the hook's event tap.
-///
-/// `AXIsProcessTrusted()` alone is not that answer: it keeps returning `true`
-/// after the user *deletes* the app's row from System Settings → Privacy &
-/// Security → Accessibility, so a hook that believes it would never learn it
-/// had been revoked, would keep re-arming a tap macOS no longer lets it
-/// service, and would wedge clicks machine-wide until reboot (#674). Only
-/// creating a filtering tap tracks the live grant, so both are consulted: the
-/// trust read short-circuits the probe for a process that was never granted,
-/// which keeps a denied agent from asking `WindowServer` twice a second.
-pub(crate) fn has_accessibility() -> bool {
-    // SAFETY: takes no arguments and only reads the current trust state — the
-    // non-prompting counterpart of `AXIsProcessTrustedWithOptions`.
-    let trusted = unsafe { AXIsProcessTrusted() };
-    trusted && can_filter_events()
-}
-
 /// Can this process create an *active* (event-filtering) tap right now?
 ///
 /// The probe mirrors the real tap's location, placement and options — that is
@@ -247,59 +230,6 @@ fn can_filter_events() -> bool {
         |_proxy: CGEventTapProxy, _etype: CGEventType, _event: &CGEvent| CallbackResult::Keep,
     )
     .is_ok()
-}
-
-/// Raise the Accessibility prompt + register the process. See
-/// [`super::Hook::prompt_accessibility`].
-///
-/// The `kAXTrustedCheckOptionPrompt = true` option is what makes macOS surface
-/// the dialog and list the process in System Settings; without it this is just
-/// [`has_accessibility`].
-pub(crate) fn prompt_accessibility() {
-    use objc2_application_services::kAXTrustedCheckOptionPrompt;
-    use objc2_core_foundation::{CFDictionary, kCFBooleanTrue};
-
-    // SAFETY: both are framework-provided constants, live for the process
-    // lifetime; reading them copies a `&'static` reference.
-    let (key, value) = unsafe { (kAXTrustedCheckOptionPrompt, kCFBooleanTrue) };
-    let Some(value) = value else { return };
-    let options = CFDictionary::from_slices(&[key], &[value]);
-    // SAFETY: the dictionary holds exactly the documented key/value types
-    // (`kAXTrustedCheckOptionPrompt` → `CFBoolean`). The returned trust state is
-    // observed separately via the watcher, so it is deliberately dropped here.
-    let _trusted = unsafe { AXIsProcessTrustedWithOptions(Some(options.as_opaque())) };
-}
-
-/// Read the frontmost application's bundle identifier via `NSWorkspace`.
-/// Returns `None` when no app is frontmost or the identifier is missing.
-///
-/// `NSWorkspace` is `AnyThread`, so this is sound on the watcher thread. The
-/// reads return owned `Retained` values (no leak by construction), but the
-/// framework still autoreleases internal temporaries and `to_str` borrows its
-/// UTF-8 view from the pool — so an explicit `autoreleasepool` is required off
-/// the main thread, where no run loop drains one. (Without it the old raw path
-/// leaked the workspace/app/bundle-id objects: hundreds of MB across a workday.)
-pub(crate) fn cursor_position() -> Option<CursorPosition> {
-    let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
-    let point = CGEvent::new(source).ok()?.location();
-    Some(CursorPosition {
-        x: point.x,
-        y: point.y,
-    })
-}
-
-pub(crate) fn frontmost_bundle_id() -> Option<String> {
-    use objc2::rc::autoreleasepool;
-    use objc2_app_kit::NSWorkspace;
-
-    autoreleasepool(|pool| {
-        let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
-        let bundle_id = app.bundleIdentifier()?;
-        // SAFETY: `to_str` yields a UTF-8 view valid for `pool`'s lifetime; we
-        // copy it into an owned `String` before the pool (and `bundle_id`) drop,
-        // so the borrow never escapes.
-        Some(unsafe { bundle_id.to_str(pool) }.to_owned())
-    })
 }
 
 /// Translate a raw OS button number to a [`ButtonId`].
@@ -522,70 +452,211 @@ fn usable_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
     event.get_integer_value_field(axis.line) as f64
 }
 
-/// Create the event tap and run loop on a dedicated thread.
-pub(crate) fn start(
-    cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
-) -> Result<HookInner, HookError> {
-    if !has_accessibility() {
-        return Err(HookError::AccessibilityDenied);
-    }
-
-    // Wrap in Arc so the closure handed to CGEventTap::new captures it by
-    // clone rather than by move — avoids a second Box allocation.
-    let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
-
-    let signals = Arc::new(WatchdogSignals::default());
-    let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
-    let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
-
-    let thread = {
-        let thread_signals = Arc::clone(&signals);
-        match thread::Builder::new()
-            .name("openlogi-hook".into())
-            .spawn(move || thread_main(cb, rl_tx, thread_signals))
-        {
-            Ok(thread) => thread,
-            Err(error) => {
-                signals.set_phase(TapPhase::ThreadExited);
-                lifecycle_watchdog.thread().unpark();
-                let _ = lifecycle_watchdog.join();
-                return Err(HookError::MacOsTap(error.to_string()));
-            }
-        }
-    };
-
-    // Block until the background thread confirms the run loop is live, or
-    // reports failure by dropping its sender.
-    let Ok(run_loop) = rl_rx.recv() else {
-        let error = HookError::MacOsTap(
-            "background thread exited before the run loop started; \
-             CGEventTapCreate likely returned null"
-                .into(),
-        );
-        if let Err(panic) = thread.join() {
-            error!(?panic, "hook thread panicked during startup");
-        }
-        lifecycle_watchdog.thread().unpark();
-        if let Err(panic) = lifecycle_watchdog.join() {
-            error!(?panic, "hook lifecycle watchdog panicked during startup");
-        }
-        return Err(error);
-    };
-
-    Ok(HookInner {
-        thread,
-        lifecycle_watchdog,
-        run_loop,
-        signals,
-    })
-}
-
 const CALLBACK_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(20);
 const LIFECYCLE_WATCHDOG_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const FREEZE_HAZARD_EXIT_CODE: i32 = 78;
 
 /// Event types the HID tap observes. Pointer *Dragged variants are required
 /// because a held button makes the OS emit those instead of `MouseMoved`.
+/// The macOS backend: a `CGEventTap` serviced by a private run-loop thread.
+pub(crate) struct Backend;
+
+impl HookBackend for Backend {
+    type Running = HookInner;
+
+    /// Create the event tap and run loop on a dedicated thread.
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<HookInner, HookError> {
+        if !Self::has_accessibility() {
+            return Err(HookError::AccessibilityDenied);
+        }
+
+        // Wrap in Arc so the closure handed to CGEventTap::new captures it by
+        // clone rather than by move — avoids a second Box allocation.
+        let cb: Arc<dyn Fn(HookEvent) -> EventDisposition + Send + Sync> = Arc::new(cb);
+
+        let signals = Arc::new(WatchdogSignals::default());
+        let lifecycle_watchdog = spawn_lifecycle_watchdog(Arc::clone(&signals))?;
+        let (rl_tx, rl_rx) = mpsc::channel::<CFRunLoop>();
+
+        let thread = {
+            let thread_signals = Arc::clone(&signals);
+            match thread::Builder::new()
+                .name("openlogi-hook".into())
+                .spawn(move || thread_main(cb, rl_tx, thread_signals))
+            {
+                Ok(thread) => thread,
+                Err(error) => {
+                    signals.set_phase(TapPhase::ThreadExited);
+                    lifecycle_watchdog.thread().unpark();
+                    let _ = lifecycle_watchdog.join();
+                    return Err(HookError::MacOsTap(error.to_string()));
+                }
+            }
+        };
+
+        // Block until the background thread confirms the run loop is live, or
+        // reports failure by dropping its sender.
+        let Ok(run_loop) = rl_rx.recv() else {
+            let error = HookError::MacOsTap(
+                "background thread exited before the run loop started; \
+                 CGEventTapCreate likely returned null"
+                    .into(),
+            );
+            if let Err(panic) = thread.join() {
+                error!(?panic, "hook thread panicked during startup");
+            }
+            lifecycle_watchdog.thread().unpark();
+            if let Err(panic) = lifecycle_watchdog.join() {
+                error!(?panic, "hook lifecycle watchdog panicked during startup");
+            }
+            return Err(error);
+        };
+
+        Ok(HookInner {
+            thread,
+            lifecycle_watchdog,
+            run_loop,
+            signals,
+        })
+    }
+
+    /// Signal the run loop to stop and join the background thread.
+    fn stop(inner: HookInner) {
+        // Latch stop before waking either thread. The lifecycle watchdog stays
+        // armed across the blocking join and accepts only `ThreadExited` as proof
+        // that explicit shutdown completed.
+        inner.signals.request_stop();
+        inner.lifecycle_watchdog.thread().unpark();
+        inner.run_loop.stop();
+        if let Err(e) = inner.thread.join() {
+            error!("hook thread panicked on shutdown: {e:?}");
+        }
+        inner.lifecycle_watchdog.thread().unpark();
+        if let Err(e) = inner.lifecycle_watchdog.join() {
+            error!("hook lifecycle watchdog panicked on shutdown: {e:?}");
+        }
+    }
+
+    /// Check whether this process can still install the hook's event tap.
+    ///
+    /// `AXIsProcessTrusted()` alone is not that answer: it keeps returning `true`
+    /// after the user *deletes* the app's row from System Settings → Privacy &
+    /// Security → Accessibility, so a hook that believes it would never learn it
+    /// had been revoked, would keep re-arming a tap macOS no longer lets it
+    /// service, and would wedge clicks machine-wide until reboot (#674). Only
+    /// creating a filtering tap tracks the live grant, so both are consulted: the
+    /// trust read short-circuits the probe for a process that was never granted,
+    /// which keeps a denied agent from asking `WindowServer` twice a second.
+    fn has_accessibility() -> bool {
+        // SAFETY: takes no arguments and only reads the current trust state — the
+        // non-prompting counterpart of `AXIsProcessTrustedWithOptions`.
+        let trusted = unsafe { AXIsProcessTrusted() };
+        trusted && can_filter_events()
+    }
+
+    /// Raise the Accessibility prompt + register the process. See
+    /// [`super::Hook::prompt_accessibility`].
+    ///
+    /// The `kAXTrustedCheckOptionPrompt = true` option is what makes macOS surface
+    /// the dialog and list the process in System Settings; without it this is just
+    /// [`Self::has_accessibility`].
+    fn prompt_accessibility() {
+        use objc2_application_services::kAXTrustedCheckOptionPrompt;
+        use objc2_core_foundation::{CFDictionary, kCFBooleanTrue};
+
+        // SAFETY: both are framework-provided constants, live for the process
+        // lifetime; reading them copies a `&'static` reference.
+        let (key, value) = unsafe { (kAXTrustedCheckOptionPrompt, kCFBooleanTrue) };
+        let Some(value) = value else { return };
+        let options = CFDictionary::from_slices(&[key], &[value]);
+        // SAFETY: the dictionary holds exactly the documented key/value types
+        // (`kAXTrustedCheckOptionPrompt` → `CFBoolean`). The returned trust state is
+        // observed separately via the watcher, so it is deliberately dropped here.
+        let _trusted = unsafe { AXIsProcessTrustedWithOptions(Some(options.as_opaque())) };
+    }
+
+    /// See [`super::Hook::list_event_taps`].
+    fn list_event_taps() -> Vec<EventTapInfo> {
+        let mut count: u32 = 0;
+        // SAFETY: a null `tap_list` with `max == 0` is the documented count-probe
+        // form; it only writes `count`.
+        let err = unsafe { CGGetEventTapList(0, std::ptr::null_mut(), &raw mut count) };
+        if err != 0 || count == 0 {
+            return Vec::new();
+        }
+
+        // SAFETY: `CGEventTapInformation` is a plain `repr(C)` POD; an all-zero bit
+        // pattern is a valid instance (`enabled = false`, all numeric fields 0).
+        // `CGGetEventTapList` overwrites each slot it fills.
+        let mut taps: Vec<CGEventTapInformation> =
+            vec![unsafe { std::mem::zeroed() }; count as usize];
+        // SAFETY: `taps` holds exactly `count` initialised, correctly aligned slots
+        // and stays alive for the call, and that same `count` is the maximum passed
+        // in, so the C side cannot write past the allocation; the out-parameter
+        // points at a live local it may only overwrite.
+        let err = unsafe { CGGetEventTapList(count, taps.as_mut_ptr(), &raw mut count) };
+        if err != 0 {
+            return Vec::new();
+        }
+        // The second call may report fewer taps than the probe; never read past it.
+        taps.truncate(count as usize);
+
+        taps.into_iter()
+            .map(|t| EventTapInfo {
+                tap_id: t.event_tap_id,
+                location: match t.tap_point {
+                    0 => TapLocation::Hid,
+                    1 => TapLocation::Session,
+                    2 => TapLocation::AnnotatedSession,
+                    other => TapLocation::Other(other),
+                },
+                // kCGEventTapOptionDefault == 0 (active); kCGEventTapOptionListenOnly == 1.
+                active: t.options == 0,
+                enabled: t.enabled,
+                owner_pid: t.tapping_process,
+                owner_name: process_name(t.tapping_process),
+                target_pid: (t.process_being_tapped != 0).then_some(t.process_being_tapped),
+            })
+            .collect()
+    }
+
+    /// Read the frontmost application's bundle identifier via `NSWorkspace`.
+    /// Returns `None` when no app is frontmost or the identifier is missing.
+    ///
+    /// `NSWorkspace` is `AnyThread`, so this is sound on the watcher thread. The
+    /// reads return owned `Retained` values (no leak by construction), but the
+    /// framework still autoreleases internal temporaries and `to_str` borrows its
+    /// UTF-8 view from the pool — so an explicit `autoreleasepool` is required off
+    /// the main thread, where no run loop drains one. (Without it the old raw path
+    /// leaked the workspace/app/bundle-id objects: hundreds of MB across a workday.)
+    fn frontmost_app() -> Option<String> {
+        use objc2::rc::autoreleasepool;
+        use objc2_app_kit::NSWorkspace;
+
+        autoreleasepool(|pool| {
+            let app = NSWorkspace::sharedWorkspace().frontmostApplication()?;
+            let bundle_id = app.bundleIdentifier()?;
+            // SAFETY: `to_str` yields a UTF-8 view valid for `pool`'s lifetime; we
+            // copy it into an owned `String` before the pool (and `bundle_id`) drop,
+            // so the borrow never escapes.
+            Some(unsafe { bundle_id.to_str(pool) }.to_owned())
+        })
+    }
+
+    /// Read the global cursor position from a HID-state event source, which
+    /// needs no tap and no permission.
+    fn cursor_position() -> Option<CursorPosition> {
+        let source = CGEventSource::new(CGEventSourceStateID::HIDSystemState).ok()?;
+        let point = CGEvent::new(source).ok()?.location();
+        Some(CursorPosition {
+            x: point.x,
+            y: point.y,
+        })
+    }
+}
+
 fn hooked_event_types() -> Vec<CGEventType> {
     vec![
         CGEventType::LeftMouseDown,
@@ -813,7 +884,7 @@ fn service_tap(tap: &SharedTap, signals: &WatchdogSignals, tap_disabled: &Atomic
             CFRunLoopRunResult::TimedOut | CFRunLoopRunResult::HandledSource => {}
         }
         signals.mark_tap_progress();
-        if !has_accessibility() {
+        if !Backend::has_accessibility() {
             warn!(
                 "Accessibility revoked while the event tap was live — \
                  disabling the tap to avoid wedging system input"
@@ -1104,50 +1175,6 @@ unsafe extern "C" {
     fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, buffersize: u32) -> i32;
 }
 
-/// See [`super::Hook::list_event_taps`].
-pub(crate) fn list_event_taps() -> Vec<EventTapInfo> {
-    let mut count: u32 = 0;
-    // SAFETY: a null `tap_list` with `max == 0` is the documented count-probe
-    // form; it only writes `count`.
-    let err = unsafe { CGGetEventTapList(0, std::ptr::null_mut(), &raw mut count) };
-    if err != 0 || count == 0 {
-        return Vec::new();
-    }
-
-    // SAFETY: `CGEventTapInformation` is a plain `repr(C)` POD; an all-zero bit
-    // pattern is a valid instance (`enabled = false`, all numeric fields 0).
-    // `CGGetEventTapList` overwrites each slot it fills.
-    let mut taps: Vec<CGEventTapInformation> = vec![unsafe { std::mem::zeroed() }; count as usize];
-    // SAFETY: `taps` holds exactly `count` initialised, correctly aligned slots
-    // and stays alive for the call, and that same `count` is the maximum passed
-    // in, so the C side cannot write past the allocation; the out-parameter
-    // points at a live local it may only overwrite.
-    let err = unsafe { CGGetEventTapList(count, taps.as_mut_ptr(), &raw mut count) };
-    if err != 0 {
-        return Vec::new();
-    }
-    // The second call may report fewer taps than the probe; never read past it.
-    taps.truncate(count as usize);
-
-    taps.into_iter()
-        .map(|t| EventTapInfo {
-            tap_id: t.event_tap_id,
-            location: match t.tap_point {
-                0 => TapLocation::Hid,
-                1 => TapLocation::Session,
-                2 => TapLocation::AnnotatedSession,
-                other => TapLocation::Other(other),
-            },
-            // kCGEventTapOptionDefault == 0 (active); kCGEventTapOptionListenOnly == 1.
-            active: t.options == 0,
-            enabled: t.enabled,
-            owner_pid: t.tapping_process,
-            owner_name: process_name(t.tapping_process),
-            target_pid: (t.process_being_tapped != 0).then_some(t.process_being_tapped),
-        })
-        .collect()
-}
-
 /// Best-effort PID → executable file name via libproc.
 fn process_name(pid: i32) -> Option<String> {
     // PROC_PIDPATHINFO_MAXSIZE is 4 * MAXPATHLEN (4 * 1024).
@@ -1167,23 +1194,6 @@ fn process_name(pid: i32) -> Option<String> {
     buf.truncate(len.unsigned_abs() as usize);
     let path = String::from_utf8_lossy(&buf);
     Some(path.rsplit('/').next().unwrap_or(&path).to_string())
-}
-
-/// Signal the run loop to stop and join the background thread.
-pub(crate) fn stop(inner: HookInner) {
-    // Latch stop before waking either thread. The lifecycle watchdog stays
-    // armed across the blocking join and accepts only `ThreadExited` as proof
-    // that explicit shutdown completed.
-    inner.signals.request_stop();
-    inner.lifecycle_watchdog.thread().unpark();
-    inner.run_loop.stop();
-    if let Err(e) = inner.thread.join() {
-        error!("hook thread panicked on shutdown: {e:?}");
-    }
-    inner.lifecycle_watchdog.thread().unpark();
-    if let Err(e) = inner.lifecycle_watchdog.join() {
-        error!("hook lifecycle watchdog panicked on shutdown: {e:?}");
-    }
 }
 
 #[cfg(test)]

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -28,8 +28,8 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 };
 
 use crate::{
-    ButtonId, CursorPosition, EventDisposition, HookError, HookEvent, KeyEvent, KeyModifiers,
-    MouseEvent,
+    ButtonId, CursorPosition, EventDisposition, HookBackend, HookError, HookEvent, KeyEvent,
+    KeyModifiers, MouseEvent,
 };
 
 const WHEEL_DELTA: f32 = 120.0;
@@ -55,46 +55,113 @@ pub(crate) struct HookInner {
     join: Option<thread::JoinHandle<()>>,
 }
 
-pub(crate) fn start(
-    cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
-) -> Result<HookInner, HookError> {
-    let callback: HookCallback = Arc::new(cb);
-    let (ready_tx, ready_rx) = mpsc::channel();
-    let join = thread::Builder::new()
-        .name("openlogi-windows-hook".into())
-        .spawn(move || hook_thread(callback, ready_tx))
-        .map_err(|e| HookError::WindowsHook(format!("could not spawn hook thread: {e}")))?;
+/// The Windows backend: `WH_MOUSE_LL` / `WH_KEYBOARD_LL` hooks on a thread
+/// with its own message pump.
+pub(crate) struct Backend;
 
-    match ready_rx
-        .recv()
-        .map_err(|e| HookError::WindowsHook(format!("hook thread exited before setup: {e}")))?
-    {
-        Ok(thread_id) => Ok(HookInner {
-            thread_id,
-            join: Some(join),
-        }),
-        Err(e) => {
-            let _ = join.join();
-            Err(e)
+impl HookBackend for Backend {
+    type Running = HookInner;
+
+    fn start(
+        cb: impl Fn(HookEvent) -> EventDisposition + Send + Sync + 'static,
+    ) -> Result<HookInner, HookError> {
+        let callback: HookCallback = Arc::new(cb);
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let join = thread::Builder::new()
+            .name("openlogi-windows-hook".into())
+            .spawn(move || hook_thread(callback, ready_tx))
+            .map_err(|e| HookError::WindowsHook(format!("could not spawn hook thread: {e}")))?;
+
+        match ready_rx
+            .recv()
+            .map_err(|e| HookError::WindowsHook(format!("hook thread exited before setup: {e}")))?
+        {
+            Ok(thread_id) => Ok(HookInner {
+                thread_id,
+                join: Some(join),
+            }),
+            Err(e) => {
+                let _ = join.join();
+                Err(e)
+            }
         }
     }
-}
 
-pub(crate) fn stop(mut inner: HookInner) {
-    // SAFETY: PostThreadMessageW takes the target thread id and the message by
-    // value (no pointers); `thread_id` was returned by the hook thread's own
-    // GetCurrentThreadId, so it names a real thread with a message queue.
-    let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
-    if posted == 0 {
-        // SAFETY: GetLastError reads the calling thread's last-error code and
-        // has no preconditions.
-        let err = unsafe { GetLastError() };
-        tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
+    fn stop(mut inner: HookInner) {
+        // SAFETY: PostThreadMessageW takes the target thread id and the message by
+        // value (no pointers); `thread_id` was returned by the hook thread's own
+        // GetCurrentThreadId, so it names a real thread with a message queue.
+        let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
+        if posted == 0 {
+            // SAFETY: GetLastError reads the calling thread's last-error code and
+            // has no preconditions.
+            let err = unsafe { GetLastError() };
+            tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
+        }
+        if let Some(join) = inner.join.take()
+            && let Err(e) = join.join()
+        {
+            tracing::warn!(?e, "Windows hook thread panicked while stopping");
+        }
     }
-    if let Some(join) = inner.join.take()
-        && let Err(e) = join.join()
-    {
-        tracing::warn!(?e, "Windows hook thread panicked while stopping");
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "the path buffer is a fixed 32768 u16s"
+    )]
+    fn frontmost_app() -> Option<String> {
+        // SAFETY: GetForegroundWindow takes no arguments and returns a window handle
+        // or null; no preconditions.
+        let hwnd = unsafe { GetForegroundWindow() };
+        if hwnd.is_null() {
+            return None;
+        }
+
+        let mut pid = 0;
+        // SAFETY: `hwnd` is the non-null handle just returned; `&raw mut pid` is a
+        // valid out-pointer the call writes the owning process id into.
+        unsafe {
+            GetWindowThreadProcessId(hwnd, &raw mut pid);
+        }
+        if pid == 0 {
+            return None;
+        }
+
+        // SAFETY: OpenProcess takes the access mask and pid by value and returns a
+        // handle or null (checked); on success we own the handle and close it below.
+        let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if process.is_null() {
+            return None;
+        }
+
+        let mut buf = vec![0u16; 32_768];
+        let mut len = buf.len() as u32;
+        // SAFETY: `process` is the valid handle from OpenProcess; `buf` is a live
+        // 32768-u16 buffer and `len` holds its length, so the call writes at most
+        // `len` code units and updates `len` with the count written.
+        let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &raw mut len) };
+        // SAFETY: `process` is the handle from OpenProcess, owned here and closed
+        // exactly once now that the query has returned.
+        unsafe {
+            CloseHandle(process);
+        }
+        if ok == 0 || len == 0 {
+            return None;
+        }
+
+        Some(String::from_utf16_lossy(&buf[..len as usize]).to_lowercase())
+    }
+
+    fn cursor_position() -> Option<CursorPosition> {
+        let mut point = POINT { x: 0, y: 0 };
+        // SAFETY: `point` is a valid writable POINT for the duration of the call.
+        if unsafe { GetCursorPos(&raw mut point) } == 0 {
+            return None;
+        }
+        Some(CursorPosition {
+            x: f64::from(point.x),
+            y: f64::from(point.y),
+        })
     }
 }
 
@@ -482,65 +549,6 @@ fn high_word(value: u32) -> u16 {
 
 fn signed_high_word(value: u32) -> i16 {
     high_word(value).cast_signed()
-}
-
-pub(crate) fn cursor_position() -> Option<CursorPosition> {
-    let mut point = POINT { x: 0, y: 0 };
-    // SAFETY: `point` is a valid writable POINT for the duration of the call.
-    if unsafe { GetCursorPos(&raw mut point) } == 0 {
-        return None;
-    }
-    Some(CursorPosition {
-        x: f64::from(point.x),
-        y: f64::from(point.y),
-    })
-}
-
-#[expect(
-    clippy::cast_possible_truncation,
-    reason = "the path buffer is a fixed 32768 u16s"
-)]
-pub(crate) fn frontmost_process_path() -> Option<String> {
-    // SAFETY: GetForegroundWindow takes no arguments and returns a window handle
-    // or null; no preconditions.
-    let hwnd = unsafe { GetForegroundWindow() };
-    if hwnd.is_null() {
-        return None;
-    }
-
-    let mut pid = 0;
-    // SAFETY: `hwnd` is the non-null handle just returned; `&raw mut pid` is a
-    // valid out-pointer the call writes the owning process id into.
-    unsafe {
-        GetWindowThreadProcessId(hwnd, &raw mut pid);
-    }
-    if pid == 0 {
-        return None;
-    }
-
-    // SAFETY: OpenProcess takes the access mask and pid by value and returns a
-    // handle or null (checked); on success we own the handle and close it below.
-    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
-    if process.is_null() {
-        return None;
-    }
-
-    let mut buf = vec![0u16; 32_768];
-    let mut len = buf.len() as u32;
-    // SAFETY: `process` is the valid handle from OpenProcess; `buf` is a live
-    // 32768-u16 buffer and `len` holds its length, so the call writes at most
-    // `len` code units and updates `len` with the count written.
-    let ok = unsafe { QueryFullProcessImageNameW(process, 0, buf.as_mut_ptr(), &raw mut len) };
-    // SAFETY: `process` is the handle from OpenProcess, owned here and closed
-    // exactly once now that the query has returned.
-    unsafe {
-        CloseHandle(process);
-    }
-    if ok == 0 || len == 0 {
-        return None;
-    }
-
-    Some(String::from_utf16_lossy(&buf[..len as usize]).to_lowercase())
 }
 
 fn last_error(context: &str) -> HookError {


### PR DESCRIPTION
## Summary

Stacked on #801 — review that one first; this branch's base is `fix/hook-revocation-probe` and will retarget to `master` when it merges.

`lib.rs` reached the per-OS modules through **seven `cfg_select!` blocks** plus four cfg-gated `Hook` fields, and `c99c80a3` ("dispatch platform backends with cfg_select") already named what was left over:

> The struct-shape sites (Hook fields, cfg-gated modules, HookError variants) were considered and left as `#[cfg]`: cfg_select cannot express per-arm fields or attributes.

An associated type expresses exactly that. Each platform module now carries a `Backend` implementing a private `HookBackend` trait; `Hook` holds `Option<<Backend as HookBackend>::Running>`, and the whole platform switch collapses to one `type Backend` alias. Platform-cfg sites in `lib.rs`: **17 → 6**.

This is not runtime polymorphism — exactly one backend is ever compiled in. It pays for itself by (a) collapsing the cfg sites, (b) turning the platform surface into a list the compiler checks instead of a naming convention, and (c) letting the platform-optional calls carry do-nothing defaults on the trait, so the never-hooked platform is one small impl instead of five scattered fallback arms.

The Linux side already uses a trait where there genuinely is runtime polymorphism (`FrontmostSource` over X11 / wlr-foreign-toplevel / gnome-shell / null) and is untouched. The macOS tap state machine is untouched too: single implementation, load-bearing invariants, and its pure logic is already extracted into `watchdog.rs` — a trait there would be ceremony.

## Changes

**`openlogi-hook/src/lib.rs`**
- New private `trait HookBackend`: associated `Running` type, `start`/`stop`, and `has_accessibility` / `prompt_accessibility` / `list_event_taps` / `frontmost_app` / `cursor_position` with defaults for platforms that have no such concept.
- `Unsupported` backend (cfg-gated to the targets that select it) replaces the `_ =>` arms and the `never: Infallible` field trick.
- One `cfg_select!` picks the alias; the seven dispatch bodies become one-liners.
- `HookError` no longer changes shape per target: the two Linux variants lose their `#[cfg]`. A platform-conditional enum is the kind of thing that compiles on macOS and breaks an exhaustive `match` on Linux, which the macOS-green local gate cannot see.

**`openlogi-hook/src/{macos,linux,windows}.rs`** — each gains `pub(crate) struct Backend` and an `impl HookBackend`; the function bodies moved verbatim.

Two fixes fall out of the move:
- macOS's frontmost read and cursor read had **swapped doc comments** since some earlier reorder — the `NSWorkspace`/autoreleasepool explanation was sitting on `cursor_position`.
- Windows' `frontmost_process_path` now answers to the same name as the other two backends (`frontmost_app`), instead of being reconciled by hand in `lib.rs`.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo xtask ci
```

The rustdoc gate earned its keep here: moving `has_accessibility` onto the trait broke an intra-doc link in `prompt_accessibility` that neither the compiler nor clippy sees.

**`tests (linux)` was not run** (this host is macOS), and — more importantly for this PR — **the Linux backend cannot be compiled locally at all**: the devenv toolchain has no `x86_64-unknown-linux-gnu` std, so `cargo clippy --target` fails on `unicode-ident`. The Linux impl was hand-audited against master (bodies moved verbatim, no internal callers of the moved functions, `FRONTMOST_SOURCE.frontmost_bundle_id()` is the `FrontmostSource` method and is unaffected) and CI's `clippy`/`tests (linux)`/`nix build` jobs are the real gate for it. The Windows backend *is* covered locally by `cargo xtask ci clippy-windows` (the ring-free windows-gnu cross lint), which passes.

No behaviour change intended: this is a move plus a dispatch rewrite.
