### PR TITLE
fix(hook): fall back to a recent device attribution on macOS

### DIFF
--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -281,8 +281,70 @@ fn button_number_to_id(n: i64) -> Option<ButtonId> {
 }
 
 /// Best-effort device identity for a button event's HID sender.
+/// How long a remembered attribution stays usable for an unattributed event.
+const ATTRIBUTION_TTL: Duration = Duration::from_secs(2);
+/// How stale the remembered attribution must be before a pointer move refreshes
+/// it. Moves arrive at pointer rates; refreshing on every one would run two
+/// CoreGraphics/IOKit calls per event on the tap callback's hot path.
+const ATTRIBUTION_REFRESH: Duration = Duration::from_millis(200);
+
+thread_local! {
+    /// Last successful device attribution, with when it was taken.
+    ///
+    /// Some devices produce `CGEvent`s with no backing `IOHIDEvent` for a
+    /// subset of their event types: a Bluetooth-direct MX Anywhere 3 attributes
+    /// its Left/Right clicks and pointer moves normally, but every
+    /// `OtherMouseDown`/`OtherMouseUp` (middle, back, forward) arrives with
+    /// `CGEventCopyIOHIDEvent` returning null. Those events would otherwise be
+    /// unattributable, and the remap policy fails closed on macOS — so the
+    /// middle button silently does nothing.
+    static LAST_ATTRIBUTION: RefCell<Option<(crate::EventDevice, std::time::Instant)>> =
+        const { RefCell::new(None) };
+}
+
+/// Record a successful attribution for later unattributed events.
+fn remember_attribution(device: &crate::EventDevice) {
+    LAST_ATTRIBUTION.with_borrow_mut(|slot| {
+        *slot = Some((device.clone(), std::time::Instant::now()));
+    });
+}
+
+/// The last attribution, if it is recent enough to still describe the device
+/// the user's hand is on.
+fn recent_attribution() -> Option<crate::EventDevice> {
+    LAST_ATTRIBUTION.with_borrow(|slot| {
+        slot.as_ref()
+            .and_then(|(device, at)| (at.elapsed() < ATTRIBUTION_TTL).then(|| device.clone()))
+    })
+}
+
+/// Whether a pointer move should spend a lookup refreshing the attribution.
+fn attribution_needs_refresh() -> bool {
+    LAST_ATTRIBUTION.with_borrow(|slot| {
+        slot.as_ref()
+            .is_none_or(|(_, at)| at.elapsed() >= ATTRIBUTION_REFRESH)
+    })
+}
+
+/// Refresh the remembered attribution from an event that has a HID backing.
+/// Called from the pointer-move path so the fallback stays warm even when the
+/// user has not clicked an attributable button recently.
+fn refresh_attribution(event: &CGEvent) {
+    if attribution_needs_refresh()
+        && let Some(device) = event_sender_id(event).map(|id| sender_device_info(id).event_device)
+    {
+        remember_attribution(&device);
+    }
+}
+
 fn button_source(event: &CGEvent) -> Option<crate::EventDevice> {
-    event_sender_id(event).map(|id| sender_device_info(id).event_device)
+    if let Some(device) = event_sender_id(event).map(|id| sender_device_info(id).event_device) {
+        remember_attribution(&device);
+        return Some(device);
+    }
+    // No backing IOHIDEvent. Fall back to the device the tap most recently
+    // attributed, rather than dropping the event as unattributable.
+    recent_attribution()
 }
 
 /// Map the macOS modifier flags on a `CGEvent` to our [`KeyModifiers`].
@@ -412,6 +474,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
         | CGEventType::LeftMouseDragged
         | CGEventType::RightMouseDragged
         | CGEventType::OtherMouseDragged => {
+            refresh_attribution(event);
             let dx = event.get_integer_value_field(EventField::MOUSE_EVENT_DELTA_X);
             let dy = event.get_integer_value_field(EventField::MOUSE_EVENT_DELTA_Y);
             #[expect(
@@ -1035,5 +1098,33 @@ mod tests {
             ),
             CallbackResult::Keep
         ));
+    }
+
+    /// An unattributed event falls back to a recent attribution, so a device
+    /// whose CGEvents carry no backing IOHIDEvent for some event types is not
+    /// dropped by the fail-closed remap policy.
+    #[test]
+    fn recent_attribution_backs_an_unattributed_event() {
+        let mouse = crate::EventDevice {
+            vendor_id: Some(crate::LOGITECH_VENDOR_ID),
+            product_id: Some(0xb025),
+            product_name: Some("MX Anywhere 3".into()),
+        };
+        LAST_ATTRIBUTION.with_borrow_mut(|slot| *slot = None);
+        assert_eq!(recent_attribution(), None);
+
+        remember_attribution(&mouse);
+        assert_eq!(recent_attribution(), Some(mouse.clone()));
+        assert!(!attribution_needs_refresh());
+
+        // Aged past the TTL, the fallback stops describing the user's hand.
+        LAST_ATTRIBUTION.with_borrow_mut(|slot| {
+            let stale = std::time::Instant::now()
+                .checked_sub(ATTRIBUTION_TTL + Duration::from_secs(1))
+                .expect("clock must support the test offset");
+            *slot = Some((mouse.clone(), stale));
+        });
+        assert_eq!(recent_attribution(), None);
+        assert!(attribution_needs_refresh());
     }
 }


### PR DESCRIPTION
## Problem

On macOS, some devices produce `CGEvent`s with **no backing `IOHIDEvent`** for a subset of their event types.

On a Bluetooth-direct MX Anywhere 3 (`046d:b025`, BLE, no receiver), left/right clicks and pointer moves are attributed normally, but **every `OtherMouseDown` / `OtherMouseUp` arrives with `CGEventCopyIOHIDEvent` returning null**. `event_sender_id` returns `None`, so `button_source` yields `None`, and `source_is_remappable` fails closed on macOS by design:

```rust
None => !cfg!(target_os = "macos")   // false on macOS
```

`handle_button` then returns `PassThrough` for both press and release.

## Symptom

Gesture mode on Middle / Back / Forward **silently does nothing** on such a device, while a plain single binding on the *same button* works fine.

That asymmetry is the confusing part, and it follows directly from `capture_plan.rs`: a button in gesture mode is deliberately excluded from the HID++ divert so the hook can see it, whereas a plain binding is delivered by the divert and never touches the hook. So the plain path works and the gesture path is dead, on one and the same button.

From the terminal, the mouse looks entirely healthy — `openlogi diag controls` reports `0x0052` as `divertable, raw-xy`, and the agent logs `accessibility granted`, `OS input hook installed` and `control capture active`.

## Evidence

Instrumenting `handle_button` on 0.7.4, pressing left click and then middle click on the same mouse, seconds apart:

```
id=LeftClick   pressed=true device=Some(EventDevice { vendor_id: Some(1133),
                 product_id: Some(45093), product_name: Some("MX Anywhere 3") })
                 os_hook_button=false remappable=true

id=MiddleClick pressed=true device=None os_hook_button=true remappable=false
```

22 middle-click events in that session, every one `device=None` and rejected. `Settings → Diagnostics` reported no other app intercepting mouse input, and Accessibility was granted throughout.

## Fix

Remember the last successful attribution and reuse it for an event that arrives unattributed, refreshed from the pointer-move path (throttled to 200 ms so the tap callback's hot path stays cheap) and expiring after 2 s so it always describes the device currently in use.

The trackpad and vendor checks in `source_is_remappable` are untouched — the fail-closed policy still applies in full to whatever device the fallback names. The change only affects events that would otherwise have been dropped as unattributable.

## Verification

With the fix applied, all four directions and the click dispatch on the previously dead button:

```
gesture swipe → button=Middle Click dir=Right action=Previous Desktop
gesture swipe → button=Middle Click dir=Left  action=Next Desktop
gesture swipe → button=Middle Click dir=Up    action=Mission Control
gesture swipe → button=Middle Click dir=Down  action=Show Desktop
gesture click → button=Middle Click           action=App Exposé
```

`cargo fmt --all -- --check`, `cargo clippy -p openlogi-hook --all-targets -- -D warnings` and `cargo test -p openlogi-hook` all pass. Adds one unit test covering the fallback and its TTL expiry.

Tested on macOS 27 (arm64) with an MX Anywhere 3 over Bluetooth LE. I don't have a receiver-attached device to hand, so I can't confirm whether the same null-attribution behaviour occurs over Bolt/Unifying — on this hardware the receiver path isn't involved.

Related to #920