### PR TITLE
chore: cut manifest comments that describe instead of constrain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,12 @@ description = "Lightweight, local-first alternative to Logitech Options+ for HID
 [workspace.dependencies]
 hidpp = { package = "openlogi-hidpp", path = "crates/openlogi-hidpp", version = "0.7.4" }
 async-hid = "0.5.2"
-# Cross-platform local IPC for the agent <-> GUI tarpc transport: a Unix-domain
-# socket on Unix, a named pipe on Windows. The `tokio` feature gives the async
-# Stream/Listener used by serde_transport.
 interprocess = { version = "2", features = ["tokio"] }
 # The agent <-> GUI RPC layer itself, over the `interprocess` transport above.
 # 0.38 is a hard floor: earlier releases hard-depend on opentelemetry 0.30 (not
 # feature-gated — google/tarpc#564), which drags the vulnerable
 # opentelemetry_sdk 0.30 into the graph (GHSA-w9wp-h8wv-79jx).
 tarpc = { version = "0.38", features = ["serde1", "serde-transport", "serde-transport-bincode", "tokio1"] }
-# Windows FFI for the leaf input/HID paths (WH_MOUSE_LL hook, SendInput action
-# synthesis, native HID writes). Features are selected per crate.
 windows-sys = "0.61"
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "sync", "time"] }
 futures-lite = "2"
@@ -75,12 +70,8 @@ core-foundation = { version = "0.10", default-features = false, features = ["lin
 opener = "0.8.5"
 shellexpand = "3.1.2"
 evdev = "0.13"
-# macOS ObjC / C FFI (see platform/CLAUDE.md): objc2 gives leak-proof Retained<T>
-# bindings, and the framework crates give typed bindings for the C APIs (privacy
-# permissions included) instead of hand-written `#[link] extern "C"` blocks.
-# Feature lists are selected per crate — these crates are huge, so every entry is
-# `default-features = false`. The version stays unified so a resolve can't move
-# gpui's Cargo.lock pin out from under the GUI.
+# Kept on one version across the workspace (block2 included) so a resolve can't
+# move gpui's Cargo.lock pin out from under the GUI.
 objc2 = "0.6.4"
 objc2-app-kit = "0.3.2"
 objc2-foundation = "0.3.2"
@@ -88,8 +79,6 @@ objc2-core-foundation = { version = "0.3.2", default-features = false }
 objc2-application-services = { version = "0.3.2", default-features = false }
 objc2-core-graphics = { version = "0.3.2", default-features = false }
 objc2-io-kit = { version = "0.3.2", default-features = false }
-# The block ABI crate objc2's generated bindings use for handler arguments;
-# same unified-version rationale as the objc2 crates above.
 block2 = "0.6.2"
 
 # gpui / gpui_platform track zed's default branch, matching how gpui-component

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -37,25 +37,17 @@ sysinfo = { version = "0.38.4", default-features = false, features = ["system"] 
 opener = { workspace = true }
 succession = { version = "0.1", features = ["supervision", "eviction"] }
 
-# Windows exe resources (app icon + VERSIONINFO) — see build.rs. The exact
-# version already in Cargo.lock as gpui's own build-dependency, so the resolve
-# adds an edge, not a crate, and the pinned gpui rev cannot move.
+# Held at the version Cargo.lock already has for gpui's own build-dependency;
+# bumping it independently would move the pinned gpui rev.
 [build-dependencies]
 embed-resource = "3.0.9"
 
-# Menu-bar status item (NSStatusItem) — the agent hosts the tray now. objc2
-# gives Retained<T>-owned AppKit bindings (no #99-style leaks); versions match
-# the GUI's so the resolve doesn't move the gpui Cargo.lock pin.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSStatusBar", "NSStatusItem", "NSStatusBarButton", "NSButton", "NSControl", "NSResponder", "NSView", "NSMenu", "NSMenuItem", "NSImage", "NSApplication", "NSRunningApplication", "NSWorkspace"] }
 objc2-foundation = { workspace = true, features = ["NSString", "NSData", "NSArray", "NSNotification"] }
 plist = "1.10.0"
 
-# Autostart via the HKCU Run key (launch_agent.rs); winreg also answers the
-# taskbar light/dark theme read for the tray glyph (tray_windows.rs). The
-# notification-area icon and the suspend/resume listener (resume_windows.rs)
-# are raw win32 via the workspace windows-sys.
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.55"
 windows-sys = { workspace = true, features = [

--- a/crates/openlogi-camera/Cargo.toml
+++ b/crates/openlogi-camera/Cargo.toml
@@ -15,17 +15,6 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
-# AVFoundation (AVCaptureDevice enumeration + AVCaptureSession capture) on the
-# same objc2 toolchain as the rest of the workspace's ObjC FFI (GUI menu bar /
-# permissions, the hook's NSWorkspace read): leak-proof `Retained<T>` ownership,
-# `define_class!` for the frame delegate (matching the agent tray target), and
-# `block2` for the `requestAccess…` completion block.
-#
-# The UVC control path is IOKit rather than AVFoundation, and gets the same
-# treatment from the objc2 bindings: `CFRetained` for CoreFoundation values,
-# `IOServiceGetMatchingServices` taking the matching dictionary *by value*
-# (it consumes a reference), and the real `IOUSBDeviceInterface182` vtable —
-# so nothing here declares its own `extern "C"` block.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { workspace = true }
 block2 = { workspace = true }
@@ -45,7 +34,6 @@ objc2-io-kit = { workspace = true, features = [
     "USB",
 ] }
 
-# DirectShow enumeration + IAMVideoProcAmp / IAMCameraControl UVC controls.
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61", features = [
     "Win32_Foundation",
@@ -57,16 +45,12 @@ windows = { version = "0.61", features = [
     "Win32_System_Ole",
 ] }
 
-# V4L2 enumeration, UVC controls and mmap capture. `v4l` wraps every ioctl in a
-# safe API, so the Linux backend needs no `unsafe` of its own. MJPEG frames are
-# decoded by `zune-jpeg`, which already ships in the tree (via `image`) and can
-# emit BGRA directly — gpui's texture order, so the preview needs no swap.
+# `zune-jpeg` decodes MJPEG straight to BGRA — gpui's texture order, so the
+# preview needs no swap — and already ships in the tree via `image`.
 [target.'cfg(target_os = "linux")'.dependencies]
 v4l = "0.14"
 zune-jpeg = "0.5"
 zune-core = "0.5"
 
-# unsafe_code stays denied (from [workspace.lints]); the AVFoundation modules opt
-# in locally with #[expect(unsafe_code)].
 [lints]
 workspace = true

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -12,14 +12,9 @@ categories = ["hardware-support", "config"]
 
 [features]
 default = ["fs"]
-# Reading and writing the user's config file, and the paths it lives at.
-#
-# Everything else here is data: the device model, the action catalogue, the
-# binding types, the TOML *shapes* of the config. Those describe a device and a
-# user's choices and need no host at all, which is what lets them be checked
-# against `wasm32-unknown-unknown` (see xtask's `WASM_PORTABLE_CRATES`). This
-# feature is the line between the two, and it is on by default so every
-# consumer in this workspace is unaffected.
+# The line between the host-touching config I/O and everything else here, which
+# is pure data and stays checkable against `wasm32-unknown-unknown` (see xtask's
+# `WASM_PORTABLE_CRATES`). On by default, so no consumer here is affected.
 fs = ["dep:atomic-write-file", "dep:etcetera", "dep:toml_edit"]
 
 [dependencies]

--- a/crates/openlogi-desktop/Cargo.toml
+++ b/crates/openlogi-desktop/Cargo.toml
@@ -41,8 +41,7 @@ rust-i18n = "4"
 # *negotiation* lives in openlogi-ui.
 sys-locale = "0.3.2"
 gpui-updater = { git = "https://github.com/AprilNEA/gpui-updater", tag = "v0.0.7", features = ["gpui"] }
-# Spawn the agent under its own macOS TCC identity (see ipc_client::spawn_agent).
-# Cross-platform: a no-op pass-through to std::process::Command off macOS.
+# Spawns the agent under its own macOS TCC identity (see ipc_client::spawn_agent).
 disclaim = "0.1"
 url = "2.5.8"
 walkdir = "2.5.0"
@@ -50,23 +49,17 @@ backon.workspace = true
 opener = { workspace = true }
 derive_more = { version = "2.1.1", default-features = false, features = ["display", "from"] }
 
-# Windows exe resources (app icon + VERSIONINFO) — see build.rs. The exact
-# version already in Cargo.lock as gpui's own build-dependency, so the resolve
-# adds an edge, not a crate, and the pinned gpui rev cannot move.
+# Held at the version Cargo.lock already has for gpui's own build-dependency;
+# bumping it independently would move the pinned gpui rev.
 [build-dependencies]
 embed-resource = "3.0.9"
 
-# Native window chrome + host OS version (platform/os.rs): NSAppearance /
-# NSApplication pin the titlebar to the in-app light/dark preference, and
-# NSProcessInfo supplies the diagnostics report's OS string. The menu-bar status
-# item lives in the agent, not here.
+# Window chrome and the host OS string only — the menu-bar status item lives in
+# the agent, not here.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { workspace = true, features = ["NSApplication", "NSAppearance"] }
 objc2-foundation = { workspace = true, features = ["NSProcessInfo"] }
 
-# unsafe_code stays denied (from [workspace.lints]); platform/os.rs opts in
-# locally with #[expect(unsafe_code)] to read AppKit's `NSAppearanceName`
-# statics.
 [lints]
 workspace = true
 

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -35,14 +35,9 @@ core-foundation = { workspace = true }
 foreign-types-shared = "0.3"
 objc2 = { workspace = true }
 objc2-app-kit = { workspace = true, features = ["NSWorkspace", "NSRunningApplication"] }
-# Accessibility-trust query + prompt (`AXIsProcessTrusted[WithOptions]`) and the
-# `kAXTrustedCheckOptionPrompt` dictionary it takes — typed, so no hand-written
-# ApplicationServices `extern` block.
 objc2-application-services = { workspace = true, features = ["std", "HIServices", "AXUIElement"] }
 objc2-core-foundation = { workspace = true, features = ["std", "CFDictionary", "CFNumber"] }
 
-# WH_MOUSE_LL low-level mouse hook + foreground-process path (GetForegroundWindow
-# / QueryFullProcessImageNameW).
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
@@ -51,7 +46,5 @@ windows-sys = { workspace = true, features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
-# unsafe_code is denied workspace-wide; the three platform modules are wall-to-wall
-# OS FFI, so each opts out at its own module root instead of the whole crate.
 [lints]
 workspace = true

--- a/crates/openlogi-inject/Cargo.toml
+++ b/crates/openlogi-inject/Cargo.toml
@@ -41,6 +41,5 @@ objc2-app-kit = { workspace = true, features = [
 objc2-core-graphics = { workspace = true, features = ["CGEvent"] }
 objc2-foundation = { workspace = true }
 
-# SendInput-based action synthesis (execute_windows).
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_UI_Input_KeyboardAndMouse"] }

--- a/crates/openlogi-overlay/Cargo.toml
+++ b/crates/openlogi-overlay/Cargo.toml
@@ -29,14 +29,11 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-# Windows exe resources (app icon + VERSIONINFO) — see build.rs. Pinned to the
-# version already in Cargo.lock as gpui's own build-dependency, so the resolve
-# adds an edge, not a crate, and the pinned gpui rev cannot move.
+# Held at the version Cargo.lock already has for gpui's own build-dependency;
+# bumping it independently would move the pinned gpui rev.
 [build-dependencies]
 embed-resource = "3.0.9"
 
-# Native window policy for the ring panel — see src/platform.rs, and
-# crates/openlogi-desktop/src/platform/AGENTS.md for the rules this code follows.
 [target.'cfg(target_os = "macos")'.dependencies]
 # CGGetActiveDisplayList/CGDisplayBounds: placing the ring on the cursor's
 # display needs global display bounds, which GPUI's display API doesn't expose

--- a/crates/openlogi-permissions/Cargo.toml
+++ b/crates/openlogi-permissions/Cargo.toml
@@ -14,9 +14,7 @@ publish = false
 # whoever owns the resource raises its prompt (see the crate docs).
 [target.'cfg(target_os = "macos")'.dependencies]
 openlogi-camera = { path = "../openlogi-camera" }
-# `+[CBManager authorization]` by class lookup; see the `macos` module.
 objc2 = { workspace = true }
-# Input-Monitoring status (`IOHIDCheckAccess`) with typed request/access enums.
 objc2-io-kit = { workspace = true, features = ["std", "hidsystem"] }
 opener = { workspace = true }
 tracing = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -24,8 +24,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2_hasher = { version = "0.3.2", features = ["sync"] }
 strum = { version = "0.27", features = ["derive"] }
-# Matching the agent's feature set: only process enumeration, so the dev
-# bundler can stop the leftovers an earlier `cargo run` detached.
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 tempfile = "3.27.0"
 time = { version = "0.3", features = ["formatting"] }


### PR DESCRIPTION
## Summary

`.claude/rules/rust.md` already sets the bar — **"Comments state non-obvious constraints only"** — and a pile of manifest comments were not clearing it. They named what a dependency is, argued for a decision already recorded in `.claude/rules/objc-ffi.md`, or restated the line directly beneath them.

This removes those, and rewrites the few that had a real constraint buried in prose down to that constraint. Every removed line is a comment and every added line is a comment — no dependency, feature, version, or lint moved.

## Changes

**workspace `Cargo.toml`** — dropped the `interprocess` and `windows-sys` blurbs, both of which restate the crate's own README. Collapsed the six-line objc2 essay to the one sentence that constrains a future edit (one version across the workspace, or a resolve moves gpui's `Cargo.lock` pin) and folded `block2`'s "same rationale as above" into it.

**openlogi-camera** — dropped the eleven-line AVFoundation/IOKit essay; its content is `.claude/rules/objc-ffi.md`'s job, and nothing in this manifest can violate it. Dropped the "this section is DirectShow" header. Kept the one Linux fact that explains a choice: `zune-jpeg` decodes MJPEG straight to BGRA, gpui's texture order.

**openlogi-agent, openlogi-desktop, openlogi-overlay** — the same three-line `winresource` paragraph was copied into all three; each is now the two lines that state the rule (don't bump it independently, it moves the pinned gpui rev). Also dropped the `NSStatusItem` and `winreg` dependency descriptions, and trimmed the desktop macOS block to the part that is a rule: the menu-bar status item lives in the agent, not there.

**openlogi-hook, openlogi-inject, openlogi-permissions, xtask** — dropped section headers that name the API listed on the next line.

**openlogi-core** — the `fs` feature keeps its wasm-portability rationale, in three lines instead of eight.

**three crates** — the near-identical `[lints]` note ("unsafe_code stays denied; module X opts in locally") is gone from openlogi-camera, openlogi-desktop and openlogi-hook. The source says it at each opt-in site, and the workspace lint table is the authority.

Kept, because they do constrain a future edit: the tarpc 0.38 GHSA floor, the gpui no-rev and gpui-component-assets same-rev pins, `default-members`, the MSRV policy, `openlogi-device`'s wasm rule, `openlogi-ui`'s gpui-only rule, `openlogi-hidpp`'s fork provenance and its "not in upstream hidpp" markers, and `openlogi-hid`'s windows-sys feature-gating notes.

## Testing

```
cargo fmt --all -- --check                                                    # pass
RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings # pass
RUSTFLAGS="-D warnings" cargo test --workspace                                # pass
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps \
  --document-private-items --exclude openlogi-ui --exclude openlogi-desktop \
  --exclude openlogi-overlay --exclude openlogi-agent                         # pass
cargo metadata --format-version 1                                             # pass
```

The diff was also checked mechanically: `git diff -U0` has zero removed and zero added lines that are not comment lines.

Host is macOS/arm64, so the Linux clippy, Linux tests, and Windows clippy jobs were **not** run locally — CI covers them. No hardware verification applies; this changes no code.
