### PR TITLE
fix(agent): shut down when the app is uninstalled

### DIFF
--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
     // Watch our own executable and restart as the new image when an app update
     // replaces it — see `self_restart`. Only the lock-holding (real) agent
     // watches, so a losing duplicate can't restart anything.
-    self_restart::spawn();
+    let uninstalled = self_restart::spawn();
     overlay::spawn();
 
     let config = Config::load_or_default().unwrap_or_else(|e| {
@@ -115,7 +115,7 @@ fn main() {
         let core_resume_pending = Arc::clone(&resume_pending);
         if let Err(e) = std::thread::Builder::new()
             .name("openlogi-agent-core".into())
-            .spawn(move || runtime.block_on(run(config, core_resume_pending)))
+            .spawn(move || runtime.block_on(run(config, core_resume_pending, uninstalled)))
         {
             warn!(error = %e, "could not spawn the agent core thread; exiting");
             return;
@@ -134,10 +134,10 @@ fn main() {
             // when the flag is set.
             let resume_pending = Arc::new(AtomicBool::new(false));
             resume_windows::register(Arc::clone(&resume_pending));
-            runtime.block_on(run(config, resume_pending));
+            runtime.block_on(run(config, resume_pending, uninstalled));
         }
         #[cfg(not(target_os = "windows"))]
-        runtime.block_on(run(config));
+        runtime.block_on(run(config, uninstalled));
     }
 }
 
@@ -286,11 +286,12 @@ fn shutdown_signals() -> (Option<()>, Option<()>) {
 /// Release the input hook, then end the process.
 ///
 /// Dropping the hook detaches the macOS event tap; a signal's default
-/// disposition would have killed the process with the tap still armed. The
-/// agent's run loop is not the process — macOS keeps the AppKit tray loop on
-/// the main thread — so the exit has to be explicit.
-fn release_hook_and_exit(hook: Option<Hook>) -> ! {
-    info!("shutdown signal — releasing the input hook and exiting");
+/// disposition would have killed the process with the tap still armed, and so
+/// would any other way of leaving that skips destructors. The agent's run loop
+/// is not the process — macOS keeps the AppKit tray loop on the main thread —
+/// so the exit has to be explicit.
+fn release_hook_and_exit(hook: Option<Hook>, reason: &str) -> ! {
+    info!(reason, "releasing the input hook and exiting");
     drop(hook);
     #[expect(
         clippy::exit,
@@ -373,6 +374,7 @@ async fn apply_inventory_event(
 async fn run(
     config: Config,
     #[cfg(any(target_os = "macos", target_os = "windows"))] resume_pending: Arc<AtomicBool>,
+    mut uninstalled: tokio::sync::mpsc::UnboundedReceiver<()>,
 ) {
     // Reconcile the agent's launch-at-login autostart and clear the legacy GUI
     // LaunchAgent, before `config` moves into the orchestrator.
@@ -498,7 +500,14 @@ async fn run(
                 // or never installed because capture is off.
                 observable.set_hook_installed(hook.is_some());
             }
-            () = shutdown_signal(&mut sigterm, &mut sigint) => release_hook_and_exit(hook.take()),
+            () = shutdown_signal(&mut sigterm, &mut sigint) => {
+                release_hook_and_exit(hook.take(), "shutdown signal")
+            }
+            // The app was removed while we kept running from its bundle. Leave
+            // through the same door, so the event tap goes with us (#807).
+            Some(()) = uninstalled.recv() => {
+                release_hook_and_exit(hook.take(), "the app was uninstalled")
+            }
             else => break,
         }
     }

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -118,13 +118,18 @@ impl Watch {
     ///
     /// Absence is the ambiguous observation — mid-replace the old inode is
     /// unlinked before the new file lands — so it only becomes a verdict after
-    /// [`MISSING_TICKS_UNTIL_GONE`] ticks of it. A [`Sighting::Unknown`] tick
-    /// carries no information at all and so changes nothing: a stat that fails
-    /// for a reason other than absence must never condemn a live install.
+    /// [`MISSING_TICKS_UNTIL_GONE`] *consecutive* ticks of it. A
+    /// [`Sighting::Unknown`] tick breaks that run rather than extending it: it
+    /// could not establish that the file was missing, and in a real uninstall
+    /// the following ticks are absent anyway, so starting the count over costs
+    /// one tick and removes a way to shut down a live install.
     fn tick(&mut self, baseline: Fingerprint, now: Sighting) -> Tick {
         let now = match now {
             Sighting::Seen(now) => now,
-            Sighting::Unknown => return Tick::Watch,
+            Sighting::Unknown => {
+                self.missing = 0;
+                return Tick::Watch;
+            }
             Sighting::Absent => {
                 self.pending = None;
                 self.missing += 1;
@@ -423,11 +428,18 @@ mod tests {
         for _ in 0..MISSING_TICKS_UNTIL_GONE * 3 {
             assert_eq!(watch.tick(baseline, Sighting::Unknown), Tick::Watch);
         }
-        // And it does not erase what absence had already established.
+        // And it breaks a run of absences rather than extending it: the run
+        // has to be consecutive, or a stat that never answers could add up to
+        // a shutdown one uncertain tick at a time.
         for _ in 1..MISSING_TICKS_UNTIL_GONE {
             assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
         }
         assert_eq!(watch.tick(baseline, Sighting::Unknown), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
+        // Absent from a clean start still condemns.
+        for _ in 2..MISSING_TICKS_UNTIL_GONE {
+            assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
+        }
         assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Uninstalled);
     }
 

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -1,4 +1,5 @@
-//! Restart the agent when its on-disk executable is replaced.
+//! Restart the agent when its on-disk executable is replaced — and stop it when
+//! that executable goes away for good.
 //!
 //! An app update (Homebrew cask, the in-app updater, a dev rebuild) swaps the
 //! bundle on disk while the old agent keeps running. launchd only restarts the
@@ -12,6 +13,15 @@
 //! status item, and the new AppKit process must start from the normal process
 //! main thread or the menu-bar item can render as an empty slot.
 //!
+//! The same stat answers the uninstall question. Dragging the app to the Trash
+//! does not stop the agent: it keeps running from the trashed bundle with its
+//! macOS event tap armed, which is the worst possible moment to hold one — the
+//! user is about to revoke the permissions it depends on (#674, #807). Absence
+//! is ambiguous for one tick (every replace unlinks before it writes), so it
+//! only means "uninstalled" once it has held for [`MISSING_TICKS_UNTIL_GONE`]
+//! ticks, and then the agent shuts down through its normal path, which drops
+//! the hook and detaches the tap.
+//!
 //! Limitation: the path is resolved once via `current_exe`, which returns the
 //! fully-resolved target (`/proc/self/exe` on Linux). Installs that update by
 //! flipping a symlink to a new immutable payload (Nix profiles) never change
@@ -21,6 +31,7 @@
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
+use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 /// How often to stat the executable: one `metadata` call per tick — noise next
@@ -37,67 +48,143 @@ fn fingerprint(path: &Path) -> Option<Fingerprint> {
     Some((meta.len(), meta.modified().ok()?))
 }
 
-/// One watch tick: what the new fingerprint means, given what the last tick saw.
-///
-/// A change must hold still for two consecutive ticks before it triggers a
-/// restart: a non-atomic replacement (`cp`, the linker rewriting the file in
-/// place) is observable mid-write, and exec'ing a half-written image would kill
-/// the agent instead of updating it. `pending` carries the candidate between
-/// ticks.
-fn assess(
-    baseline: Fingerprint,
+/// How many consecutive ticks with nothing at our path mean the app is gone
+/// rather than being replaced. At [`PERIOD`] that is 30 s of absence — far
+/// longer than the unlink/write window of any install path, and short enough
+/// that an uninstall does not leave an armed event tap behind for long.
+const MISSING_TICKS_UNTIL_GONE: u32 = 3;
+
+/// What one watch tick concluded.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Tick {
+    /// Nothing has settled; keep watching.
+    Watch,
+    /// The file at our path settled on new content — restart as it.
+    Restart,
+    /// Our executable has been gone long enough to mean uninstalled.
+    Uninstalled,
+}
+
+/// What the watcher carries between ticks.
+#[derive(Debug)]
+struct Watch {
+    /// A changed fingerprint waiting to be confirmed by the next tick.
     pending: Option<Fingerprint>,
-    now: Option<Fingerprint>,
-) -> (Option<Fingerprint>, bool) {
-    match now {
-        // A vanished file is *not* a change: mid-replace the old inode is
-        // unlinked before the new file lands, so wait for a readable
-        // replacement before even arming.
-        None => (None, false),
-        Some(now) if now == baseline => (None, false),
-        // Same non-baseline fingerprint twice in a row — the write has settled.
-        Some(now) if pending == Some(now) => (Some(now), true),
-        // First sighting (or still churning): arm and re-check next tick.
-        Some(now) => (Some(now), false),
+    /// Consecutive ticks that found nothing at our path.
+    missing: u32,
+    /// Whether a sustained absence may be read as an uninstall at all. False
+    /// for a translocated bundle, whose mount can go away on its own.
+    condemn_on_absence: bool,
+}
+
+impl Watch {
+    fn new(condemn_on_absence: bool) -> Self {
+        Self {
+            pending: None,
+            missing: 0,
+            condemn_on_absence,
+        }
     }
+
+    /// Fold one observation into the watch state.
+    ///
+    /// A change must hold still for two consecutive ticks before it triggers a
+    /// restart: a non-atomic replacement (`cp`, the linker rewriting the file in
+    /// place) is observable mid-write, and exec'ing a half-written image would
+    /// kill the agent instead of updating it.
+    ///
+    /// Absence is the ambiguous observation — mid-replace the old inode is
+    /// unlinked before the new file lands — so it only becomes a verdict after
+    /// [`MISSING_TICKS_UNTIL_GONE`] ticks of it.
+    fn tick(&mut self, baseline: Fingerprint, now: Option<Fingerprint>) -> Tick {
+        let Some(now) = now else {
+            self.pending = None;
+            self.missing += 1;
+            return if self.condemn_on_absence && self.missing >= MISSING_TICKS_UNTIL_GONE {
+                Tick::Uninstalled
+            } else {
+                Tick::Watch
+            };
+        };
+        self.missing = 0;
+        if now == baseline {
+            self.pending = None;
+            return Tick::Watch;
+        }
+        // The same non-baseline fingerprint twice in a row means the write has
+        // settled; the first sighting only arms.
+        let settled = self.pending == Some(now);
+        self.pending = Some(now);
+        if settled { Tick::Restart } else { Tick::Watch }
+    }
+}
+
+/// Whether `path` sits inside a macOS App Translocation mount — the randomized,
+/// read-only copy the system runs a quarantined bundle from. That path can
+/// vanish for reasons that have nothing to do with an uninstall, so the
+/// gone-for-good verdict stays off there. No such path exists off macOS.
+fn is_translocated(path: &Path) -> bool {
+    path.components()
+        .any(|component| component.as_os_str() == "AppTranslocation")
 }
 
 /// Spawn the watcher thread. The executable path and its baseline fingerprint
 /// are resolved once, up front; if either fails the watch is disabled (logged)
 /// rather than guessing at a path.
-pub fn spawn() {
+///
+/// The returned receiver fires once, when the executable has been gone long
+/// enough to mean the app was uninstalled. The agent core shuts down on it —
+/// that path, and not a bare `process::exit`, is what drops the hook and
+/// detaches the macOS event tap. A disabled watch simply drops the sender, so
+/// the receiver never fires.
+pub fn spawn() -> mpsc::UnboundedReceiver<()> {
+    let (uninstalled_tx, uninstalled_rx) = mpsc::unbounded_channel();
     let Ok(path) = std::env::current_exe() else {
         warn!("could not resolve own executable — binary-update watch disabled");
-        return;
+        return uninstalled_rx;
     };
     let Some(baseline) = fingerprint(&path) else {
         warn!(
             path = %path.display(),
             "could not stat own executable — binary-update watch disabled"
         );
-        return;
+        return uninstalled_rx;
     };
+    // A translocated bundle already lives on a randomized, ephemeral mount, so
+    // its path disappearing says nothing about whether the app is installed.
+    let mut watch = Watch::new(!is_translocated(&path));
     let spawn_result = std::thread::Builder::new()
         .name("openlogi-binary-watch".into())
         .spawn(move || {
-            let mut pending: Option<Fingerprint> = None;
             loop {
                 std::thread::sleep(PERIOD);
-                let restart_now;
-                (pending, restart_now) = assess(baseline, pending, fingerprint(&path));
-                if restart_now {
-                    restart(&path);
-                    // Only reached when the exec failed (a broken or still-
-                    // churning file). Disarm so the retry needs a fresh
-                    // two-tick settle — staying alive on the old image beats
-                    // dying in setups with no respawner.
-                    pending = None;
+                match watch.tick(baseline, fingerprint(&path)) {
+                    Tick::Watch => {}
+                    Tick::Restart => {
+                        restart(&path);
+                        // Only reached when the exec failed (a broken or still-
+                        // churning file). Disarm so the retry needs a fresh
+                        // two-tick settle — staying alive on the old image beats
+                        // dying in setups with no respawner.
+                        watch.pending = None;
+                    }
+                    Tick::Uninstalled => {
+                        info!(
+                            path = %path.display(),
+                            "own executable is gone — the app was removed; shutting down"
+                        );
+                        // A closed receiver means the core is already going
+                        // down; either way this watcher is finished.
+                        let _ = uninstalled_tx.send(());
+                        return;
+                    }
                 }
             }
         });
     if let Err(e) = spawn_result {
         warn!(error = %e, "could not spawn the binary-update watch thread");
     }
+    uninstalled_rx
 }
 
 /// Restart this process as the new binary at `path`.
@@ -214,7 +301,7 @@ fn restart(path: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Fingerprint, assess};
+    use super::{Fingerprint, MISSING_TICKS_UNTIL_GONE, Tick, Watch, is_translocated};
     use std::time::{Duration, SystemTime};
 
     fn fp(len: u64, secs: u64) -> Fingerprint {
@@ -225,32 +312,94 @@ mod tests {
     fn restarts_only_after_a_change_settles() {
         let baseline = fp(100, 1);
         let new = fp(200, 2);
+        let mut watch = Watch::new(true);
         // First differing sighting arms but does not restart…
-        assert_eq!(assess(baseline, None, Some(new)), (Some(new), false));
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
         // …the same fingerprint on the next tick restarts.
-        assert_eq!(assess(baseline, Some(new), Some(new)), (Some(new), true));
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Restart);
     }
 
     #[test]
     fn churning_writes_keep_rearming() {
         let baseline = fp(100, 1);
-        let half = fp(150, 2);
-        let full = fp(200, 3);
+        let mut watch = Watch::new(true);
         // A still-growing file never matches its previous sighting.
-        assert_eq!(
-            assess(baseline, Some(half), Some(full)),
-            (Some(full), false)
-        );
+        assert_eq!(watch.tick(baseline, Some(fp(150, 2))), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Some(fp(200, 3))), Tick::Watch);
     }
 
     #[test]
-    fn vanished_and_reverted_files_disarm() {
+    fn a_reverted_file_disarms() {
+        let baseline = fp(100, 1);
+        let mut watch = Watch::new(true);
+        assert_eq!(watch.tick(baseline, Some(fp(200, 2))), Tick::Watch);
+        // Back at the baseline (e.g. a rollback): disarm, so a later sighting
+        // of the same candidate has to settle again.
+        assert_eq!(watch.tick(baseline, Some(baseline)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Some(fp(200, 2))), Tick::Watch);
+    }
+
+    #[test]
+    fn a_brief_absence_is_a_replacement_not_an_uninstall() {
         let baseline = fp(100, 1);
         let new = fp(200, 2);
-        // Mid-replace ENOENT: not a change, and any armed candidate is dropped.
-        assert_eq!(assess(baseline, Some(new), None), (None, false));
-        // Back at the baseline (e.g. a rollback): disarm too.
-        assert_eq!(assess(baseline, Some(new), Some(baseline)), (None, false));
+        let mut watch = Watch::new(true);
+        // The unlink half of a replace, for every tick but the last one that
+        // would condemn it…
+        for _ in 1..MISSING_TICKS_UNTIL_GONE {
+            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+        }
+        // …then the new file lands and settles: a restart, and the absence
+        // count is forgotten.
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Restart);
+        for _ in 1..MISSING_TICKS_UNTIL_GONE {
+            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+        }
+    }
+
+    #[test]
+    fn a_sustained_absence_is_an_uninstall() {
+        let baseline = fp(100, 1);
+        let mut watch = Watch::new(true);
+        for _ in 1..MISSING_TICKS_UNTIL_GONE {
+            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+        }
+        assert_eq!(watch.tick(baseline, None), Tick::Uninstalled);
+    }
+
+    #[test]
+    fn an_armed_candidate_does_not_survive_the_file_going_away() {
+        let baseline = fp(100, 1);
+        let new = fp(200, 2);
+        let mut watch = Watch::new(true);
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, None), Tick::Watch);
+        // The candidate has to settle again rather than restarting off a
+        // sighting from before the gap.
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Some(new)), Tick::Restart);
+    }
+
+    #[test]
+    fn a_translocated_bundle_is_never_condemned() {
+        let baseline = fp(100, 1);
+        let mut watch = Watch::new(false);
+        for _ in 0..MISSING_TICKS_UNTIL_GONE * 3 {
+            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+        }
+    }
+
+    #[test]
+    fn translocated_paths_are_recognised() {
+        use std::path::Path;
+
+        assert!(is_translocated(Path::new(
+            "/private/var/folders/ab/xy/T/AppTranslocation/1E5A/d/OpenLogi.app/Contents/MacOS/openlogi-agent"
+        )));
+        assert!(!is_translocated(Path::new(
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent"
+        )));
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -43,9 +43,32 @@ const PERIOD: Duration = Duration::from_secs(10);
 /// buy nothing.
 type Fingerprint = (u64, SystemTime);
 
-fn fingerprint(path: &Path) -> Option<Fingerprint> {
-    let meta = std::fs::metadata(path).ok()?;
-    Some((meta.len(), meta.modified().ok()?))
+/// What one stat of our own path saw.
+///
+/// Absence and failure are different answers, and only one of them may condemn
+/// the agent: a stat that fails for any other reason — a permission change on a
+/// parent directory, an I/O error, a filesystem that cannot report a
+/// modification time — says nothing about whether the app is still installed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Sighting {
+    /// The file is there, with this fingerprint.
+    Seen(Fingerprint),
+    /// The path confirmably does not exist.
+    Absent,
+    /// The stat did not answer the question.
+    Unknown,
+}
+
+fn sight(path: &Path) -> Sighting {
+    let meta = match std::fs::metadata(path) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Sighting::Absent,
+        Err(_) => return Sighting::Unknown,
+    };
+    match meta.modified() {
+        Ok(modified) => Sighting::Seen((meta.len(), modified)),
+        Err(_) => Sighting::Unknown,
+    }
 }
 
 /// How many consecutive ticks with nothing at our path mean the app is gone
@@ -95,16 +118,22 @@ impl Watch {
     ///
     /// Absence is the ambiguous observation — mid-replace the old inode is
     /// unlinked before the new file lands — so it only becomes a verdict after
-    /// [`MISSING_TICKS_UNTIL_GONE`] ticks of it.
-    fn tick(&mut self, baseline: Fingerprint, now: Option<Fingerprint>) -> Tick {
-        let Some(now) = now else {
-            self.pending = None;
-            self.missing += 1;
-            return if self.condemn_on_absence && self.missing >= MISSING_TICKS_UNTIL_GONE {
-                Tick::Uninstalled
-            } else {
-                Tick::Watch
-            };
+    /// [`MISSING_TICKS_UNTIL_GONE`] ticks of it. A [`Sighting::Unknown`] tick
+    /// carries no information at all and so changes nothing: a stat that fails
+    /// for a reason other than absence must never condemn a live install.
+    fn tick(&mut self, baseline: Fingerprint, now: Sighting) -> Tick {
+        let now = match now {
+            Sighting::Seen(now) => now,
+            Sighting::Unknown => return Tick::Watch,
+            Sighting::Absent => {
+                self.pending = None;
+                self.missing += 1;
+                return if self.condemn_on_absence && self.missing >= MISSING_TICKS_UNTIL_GONE {
+                    Tick::Uninstalled
+                } else {
+                    Tick::Watch
+                };
+            }
         };
         self.missing = 0;
         if now == baseline {
@@ -143,7 +172,7 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
         warn!("could not resolve own executable — binary-update watch disabled");
         return uninstalled_rx;
     };
-    let Some(baseline) = fingerprint(&path) else {
+    let Sighting::Seen(baseline) = sight(&path) else {
         warn!(
             path = %path.display(),
             "could not stat own executable — binary-update watch disabled"
@@ -158,7 +187,7 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
         .spawn(move || {
             loop {
                 std::thread::sleep(PERIOD);
-                match watch.tick(baseline, fingerprint(&path)) {
+                match watch.tick(baseline, sight(&path)) {
                     Tick::Watch => {}
                     Tick::Restart => {
                         restart(&path);
@@ -301,11 +330,15 @@ fn restart(path: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Fingerprint, MISSING_TICKS_UNTIL_GONE, Tick, Watch, is_translocated};
+    use super::{Fingerprint, MISSING_TICKS_UNTIL_GONE, Sighting, Tick, Watch, is_translocated};
     use std::time::{Duration, SystemTime};
 
     fn fp(len: u64, secs: u64) -> Fingerprint {
         (len, SystemTime::UNIX_EPOCH + Duration::from_secs(secs))
+    }
+
+    fn seen(len: u64, secs: u64) -> Sighting {
+        Sighting::Seen(fp(len, secs))
     }
 
     #[test]
@@ -314,9 +347,9 @@ mod tests {
         let new = fp(200, 2);
         let mut watch = Watch::new(true);
         // First differing sighting arms but does not restart…
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Watch);
         // …the same fingerprint on the next tick restarts.
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Restart);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Restart);
     }
 
     #[test]
@@ -324,19 +357,19 @@ mod tests {
         let baseline = fp(100, 1);
         let mut watch = Watch::new(true);
         // A still-growing file never matches its previous sighting.
-        assert_eq!(watch.tick(baseline, Some(fp(150, 2))), Tick::Watch);
-        assert_eq!(watch.tick(baseline, Some(fp(200, 3))), Tick::Watch);
+        assert_eq!(watch.tick(baseline, seen(150, 2)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, seen(200, 3)), Tick::Watch);
     }
 
     #[test]
     fn a_reverted_file_disarms() {
         let baseline = fp(100, 1);
         let mut watch = Watch::new(true);
-        assert_eq!(watch.tick(baseline, Some(fp(200, 2))), Tick::Watch);
+        assert_eq!(watch.tick(baseline, seen(200, 2)), Tick::Watch);
         // Back at the baseline (e.g. a rollback): disarm, so a later sighting
         // of the same candidate has to settle again.
-        assert_eq!(watch.tick(baseline, Some(baseline)), Tick::Watch);
-        assert_eq!(watch.tick(baseline, Some(fp(200, 2))), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(baseline)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, seen(200, 2)), Tick::Watch);
     }
 
     #[test]
@@ -347,14 +380,14 @@ mod tests {
         // The unlink half of a replace, for every tick but the last one that
         // would condemn it…
         for _ in 1..MISSING_TICKS_UNTIL_GONE {
-            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+            assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
         }
         // …then the new file lands and settles: a restart, and the absence
         // count is forgotten.
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Restart);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Restart);
         for _ in 1..MISSING_TICKS_UNTIL_GONE {
-            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+            assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
         }
     }
 
@@ -363,9 +396,9 @@ mod tests {
         let baseline = fp(100, 1);
         let mut watch = Watch::new(true);
         for _ in 1..MISSING_TICKS_UNTIL_GONE {
-            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+            assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
         }
-        assert_eq!(watch.tick(baseline, None), Tick::Uninstalled);
+        assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Uninstalled);
     }
 
     #[test]
@@ -373,12 +406,29 @@ mod tests {
         let baseline = fp(100, 1);
         let new = fp(200, 2);
         let mut watch = Watch::new(true);
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
-        assert_eq!(watch.tick(baseline, None), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
         // The candidate has to settle again rather than restarting off a
         // sighting from before the gap.
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Watch);
-        assert_eq!(watch.tick(baseline, Some(new)), Tick::Restart);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Seen(new)), Tick::Restart);
+    }
+
+    #[test]
+    fn a_stat_that_fails_for_any_other_reason_never_condemns() {
+        let baseline = fp(100, 1);
+        let mut watch = Watch::new(true);
+        // Not absence: a permission change on a parent, an I/O error, a
+        // filesystem with no mtime. However long it lasts, the agent stays.
+        for _ in 0..MISSING_TICKS_UNTIL_GONE * 3 {
+            assert_eq!(watch.tick(baseline, Sighting::Unknown), Tick::Watch);
+        }
+        // And it does not erase what absence had already established.
+        for _ in 1..MISSING_TICKS_UNTIL_GONE {
+            assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
+        }
+        assert_eq!(watch.tick(baseline, Sighting::Unknown), Tick::Watch);
+        assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Uninstalled);
     }
 
     #[test]
@@ -386,7 +436,7 @@ mod tests {
         let baseline = fp(100, 1);
         let mut watch = Watch::new(false);
         for _ in 0..MISSING_TICKS_UNTIL_GONE * 3 {
-            assert_eq!(watch.tick(baseline, None), Tick::Watch);
+            assert_eq!(watch.tick(baseline, Sighting::Absent), Tick::Watch);
         }
     }
 


### PR DESCRIPTION
## Summary

Dragging OpenLogi.app to the Trash did not stop the agent. It kept running from the trashed bundle, kept serving IPC, and — the part that matters — kept its macOS event tap armed. That is the worst possible moment to hold an active HID-level tap: the user is done with the app and is about to remove the very permissions the tap depends on. It is exactly how #674 froze a machine.

The binary watcher in `self_restart.rs` was already stat'ing our own executable every 10 s, and already treating a vanished file as ambiguous, with this comment:

> A vanished file is *not* a change: mid-replace the old inode is unlinked before the new file lands, so wait for a readable replacement before even arming.

That ambiguity is real, and it is the whole problem: absence means "being replaced" for a moment and "uninstalled" forever after. So absence now gets a verdict of its own — three consecutive ticks with nothing at our path (30 s) — and the agent leaves through the same door SIGTERM uses, which drops the hook and detaches the tap.

## Changes

**`openlogi-agent/src/self_restart.rs`**
- `assess()`'s `(Option<Fingerprint>, bool)` return could not carry a third outcome, so the between-tick state is now a `Watch` with a named `Tick` result (`Watch` / `Restart` / `Uninstalled`). Same settle-over-two-ticks rule for updates, plus a counter for consecutive absences.
- A translocated bundle is exempt: it runs from a randomized, ephemeral mount whose path can disappear on its own, so `Watch::new(!is_translocated(path))` never lets absence become a verdict there. Without this, an agent started from a quarantined copy would eventually shut itself down for no reason.
- `spawn()` returns an `UnboundedReceiver<()>` that fires once on that verdict. A watch that could not start (no `current_exe`, no stat) just drops the sender, so the receiver never fires.

**`openlogi-agent/src/main.rs`**
- The core selects on that receiver and calls the existing shutdown path. `release_hook_and_exit` now takes a reason so the two callers log why they are leaving.

Deliberately **not** in scope, and still open on #807: whether the agent should also remove its own LaunchAgent plist on the way out, which is what would make the uninstall complete. Leaving it means launchd keeps a plist pointing at a binary that is gone; removing it would also fire when a user merely *moves* the app. That is a product decision, not a bug fix.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo xtask ci
```

Seven unit tests cover the state machine: a change still has to settle over two ticks, a churning write keeps re-arming, a revert disarms, a brief absence is a replacement rather than an uninstall, a sustained one is an uninstall, an armed candidate does not survive a gap, and a translocated bundle is never condemned.

The premise underneath was checked against the OS rather than assumed. A small program that resolves `current_exe()` once and then stats that path in a loop was moved aside while running: it keeps executing, its captured path reports `NotFound` for as long as it is gone, and it reads normally again once the file is moved back — which is the case the hysteresis exists to not condemn.

**Not runtime-tested against a real install.** Verifying the whole path means running a production agent and trashing its bundle, which would install a second event tap on the machine doing the testing; that is the maintainer's call. `tests (linux)` was not run locally either (this host is macOS) — CI is the gate for it.

Fixes #807
