### PR TITLE
feat(hid): recognise Lightspeed receiver 046d:c54d (PRO X SUPERLIGHT 2 DEX)

### DIFF
--- a/crates/openlogi-core/src/hid/route.rs
+++ b/crates/openlogi-core/src/hid/route.rs
@@ -94,11 +94,12 @@ pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532, 0xc537];
 /// G502 LIGHTSPEED and the G Pro Wireless — its USB product string is
 /// literally `LIGHTSPEED Receiver`; `0xc53f` is the nano receiver of wireless
 /// mice such as the G305; `0xc547` ships with newer G-series devices such as
-/// the G915 keyboard and the G502 X LIGHTSPEED.
+/// the G915 keyboard and the G502 X LIGHTSPEED; `0xc54d` ships with the
+/// PRO X SUPERLIGHT 2 DEX.
 /// They speak the same HID++ 1.0 receiver register protocol as Unifying, so
 /// they are enumerated, routed, and paired through the Unifying code path;
 /// only the user-facing receiver name (see [`receiver_display_name`]) differs.
-pub const LIGHTSPEED_PIDS: &[u16] = &[0xc539, 0xc53f, 0xc547];
+pub const LIGHTSPEED_PIDS: &[u16] = &[0xc539, 0xc53f, 0xc547, 0xc54d];
 
 /// Whether `product_id` is a receiver that speaks the Unifying HID++ 1.0
 /// register protocol — a Unifying receiver proper, or a protocol-compatible
@@ -292,6 +293,7 @@ mod tests {
         assert_eq!(receiver_display_name(0xc539), "Lightspeed Receiver");
         assert_eq!(receiver_display_name(0xc53f), "Lightspeed Receiver");
         assert_eq!(receiver_display_name(0xc547), "Lightspeed Receiver");
+        assert_eq!(receiver_display_name(0xc54d), "Lightspeed Receiver");
         assert_eq!(receiver_display_name(0xc52b), "Unifying Receiver");
         assert_eq!(receiver_display_name(0xc532), "Unifying Receiver");
     }

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -26,12 +26,14 @@ use crate::{
 /// `046d:c539` is the Lightspeed gaming receiver; `046d:c53f` is the Lightspeed
 /// nano receiver (bundled with G-series wireless mice such as the G305);
 /// `046d:c547` is the Lightspeed receiver bundled with newer G-series devices
-/// such as the G915 keyboard and the G502 X LIGHTSPEED. All answer the same
+/// such as the G915 keyboard and the G502 X LIGHTSPEED; `046d:c54d` ships with
+/// the PRO X SUPERLIGHT 2 DEX. All answer the same
 /// HID++ 1.0 registers (pairing count, connection state, pairing information)
 /// as Unifying receivers. Callers that surface a user-facing receiver name
 /// label Lightspeed PIDs separately (see `openlogi-hid`).
 /// `0xc53f` was verified against a G305 (paired device wpid `0x4074`);
-/// `0xc547` against a G915 (paired device wpid `0x407c`).
+/// `0xc547` against a G915 (paired device wpid `0x407c`); `0xc54d` against a
+/// PRO X SUPERLIGHT 2 DEX.
 pub const VPID_PAIRS: &[(u16, u16)] = &[
     (0x046d, 0xc52b),
     (0x046d, 0xc532),
@@ -39,6 +41,7 @@ pub const VPID_PAIRS: &[(u16, u16)] = &[
     (0x046d, 0xc539),
     (0x046d, 0xc53f),
     (0x046d, 0xc547),
+    (0x046d, 0xc54d),
 ];
 
 /// All known registers of the Unifying receiver.


### PR DESCRIPTION
## Summary

Recognises the `046d:c54d` Lightspeed receiver shipped with the Logitech PRO X SUPERLIGHT 2 DEX.

Before this change, `receiver::detect()` did not recognise the receiver, so its paired mouse never reached inventory and was absent from both `openlogi list` and the GUI. The receiver answers the same HID++ 1.0 enumeration registers as the existing Lightspeed receivers, so it uses the established Unifying-compatible route.

## Changes

- Add `0xc54d` to the shared Lightspeed receiver PID table.
- Add `046d:c54d` to HID++ receiver detection.
- Cover the receiver display name with the existing regression test.

No routing or pairing logic changes are needed. The shared Lightspeed tables already drive route selection, Linux receiver-child filtering, pairing-family classification, and the user-facing receiver name.

## Hardware verification

Tested on macOS 26.6 with:

- Receiver: `046d:c54d`
- Device: PRO X SUPERLIGHT 2 DEX
- Paired-device WPID: `0x40b8`

Before the patch, OpenLogi v0.7.4 did not list the receiver or mouse. With the patch, the receiver enumerates its slot, the device is persisted in configuration, and the GUI shows the mouse with its battery state and catalog artwork. `openlogi diag features` completed with 33 feature entries.

Pairing and unpairing were not exercised because that would change the receiver's working pairing state. Device-specific feature work beyond discovery is out of scope.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Refs #512
