### PR TITLE
docs(agents): add a macOS permissions task skill

### DIFF
--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -21,6 +21,11 @@ list). Classify before doing anything else. The discriminator is one log line:
 | `failed to open HID++ channel — retrying next tick error=Message("Failed to open device")` | open | **Yes, usually.** `IOHIDDeviceOpen` was denied. Same string also covers exclusive access and a device that vanished — see §5. |
 | `opened HID++ channel` … then `Device::new failed` / `enumerate_features failed` with `Channel(Timeout)` or `report writer callback error: 0xE00002D6` | probe | **No.** The open succeeded, so permissions are fine. This is the async-hid macOS write bug (upstream `sidit77/async-hid#45`). |
 
+All of these lines are `debug`-level except the open failure, which is a
+`warn`. A log captured without `OPENLOGI_LOG=debug` can only ever show the
+middle row — in such a log, the absence of the other lines is not evidence
+of anything.
+
 `openlogi list` showing the device while the GUI does not is **not** evidence
 either way: the CLI is a separate code-signing identity running its own HID
 stack, so it can succeed where the agent fails, for either reason.
@@ -69,7 +74,9 @@ OPENLOGI_LOG=debug \
 
 Note what that costs: run from a terminal, the agent's responsible process
 becomes the terminal (§4), so the run you are observing is not the run that
-failed. Compare identities before concluding anything from it.
+failed. Compare identities before concluding anything from it — in
+particular, a successful open under the terminal's grant does not clear the
+copy launchd runs.
 
 Reading the TCC database directly is not an option for a normal user — it is
 itself TCC-protected and returns `authorization denied` without Full Disk
@@ -135,7 +142,8 @@ every grant on that machine is being ignored.
 
 ## 7. Known-broken right now
 
-Check these before filing a new diagnosis:
+Check these before filing a new diagnosis. This list is a snapshot — confirm
+each is still open (`gh issue view 606`, `gh pr view 760`) before citing it:
 
 - The Settings → Input Monitoring row queries the **GUI's** grant, not the
   agent's (#606, PR #760 open). It can read "Granted" while the agent has

--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openlogi-macos-permissions
+description: Decide whether a macOS problem is a privacy-permission (TCC) problem, and act on it correctly. Use when triaging a report that no devices appear / the GUI is empty while `openlogi list` works / "Failed to open device" / "Pairing failed" on macOS; when a user asks which permission OpenLogi needs or why they were never prompted; when reasoning about Input Monitoring, Accessibility, kTCCServiceListenEvent, kTCCServiceAccessibility, code-signing identity, responsible process, or bundle identifiers; and before changing anything under openlogi-permissions, openlogi-hid/permissions.rs, the agent's launch/self-restart path, the GUI's settings permission rows, or the macOS bundling and signing code in xtask.
+---
+
+# macOS permissions (TCC) in OpenLogi
+
+One sentence to keep: **TCC does not authorize processes, it authorizes
+identities.** Almost every "permission bug" here is an identity bug — the user
+ticked a box, but not for the identity that actually opens the device.
+
+## 1. First decide whether it is TCC at all
+
+Three unrelated failures reach the user as the same symptom (an empty device
+list). Classify before doing anything else. The discriminator is one log line:
+**did the channel open?**
+
+| Agent log | Layer | TCC? |
+|---|---|---|
+| `HID++ candidate interfaces count=0` | enumeration | **No.** The device's HID++ collection never matched — unsupported device, or not connected. |
+| `failed to open HID++ channel — retrying next tick error=Message("Failed to open device")` | open | **Yes, usually.** `IOHIDDeviceOpen` was denied. Same string also covers exclusive access and a device that vanished — see §5. |
+| `opened HID++ channel` … then `Device::new failed` / `enumerate_features failed` with `Channel(Timeout)` or `report writer callback error: 0xE00002D6` | probe | **No.** The open succeeded, so permissions are fine. This is the async-hid macOS write bug (upstream `sidit77/async-hid#45`). |
+
+`openlogi list` showing the device while the GUI does not is **not** evidence
+either way: the CLI is a separate code-signing identity running its own HID
+stack, so it can succeed where the agent fails, for either reason.
+
+If there is no log at all, go to §3 — getting a log is the whole job.
+
+## 2. The identity map
+
+One install ships four TCC identities. Only one of them may hold device
+permissions.
+
+| Identity | Binary | Needs |
+|---|---|---|
+| `org.openlogi.agent` | `…/Contents/Library/LoginItems/OpenLogiAgent.app` | **Input Monitoring** (opens HID) and **Accessibility** (owns the event tap) |
+| `org.openlogi.openlogi` | `…/Contents/MacOS/openlogi-desktop` | Camera only. It is a pure IPC client and needs neither of the above. |
+| `openlogi` | `…/Contents/MacOS/openlogi` (embedded CLI) | Input Monitoring, because it opens HID directly today |
+| `org.openlogi.overlay` | `…/LoginItems/OpenLogiOverlay.app` | Nothing |
+
+Two consequences that drive most reports:
+
+- The identity the user must grant is **OpenLogiAgent**, which lives inside the
+  app bundle. The System Settings `+` picker will not browse into a bundle, so
+  they have to use Go-to-Folder. Say this explicitly; do not tell someone to
+  "grant OpenLogi permission".
+- A grant to the GUI does nothing for the agent, and vice versa. There is no
+  bundle-wide grant.
+- **Every copy is its own identity.** A dev build (`org.openlogi.agent-dev`), a
+  second install, or a bundle still sitting in `~/Downloads` each get their own
+  row. Confirm which binary is actually running before trusting any grant — the
+  diagnose script warns when the running agent is not the one being inspected.
+
+## 3. Diagnose
+
+Run `scripts/diagnose.sh` from this skill, or the same steps by hand. It is
+read-only and safe to hand to a reporter.
+
+The one step it cannot do for them: **the agent's log has nowhere to go.** The
+generated LaunchAgent plist sets no `StandardOutPath`/`StandardErrorPath` and
+there is no file logger, so launchd discards everything. Until that changes, the
+only way to see the agent's own log is to stop it and run it in the foreground:
+
+```sh
+OPENLOGI_LOG=debug \
+  /Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent
+```
+
+Note what that costs: run from a terminal, the agent's responsible process
+becomes the terminal (§4), so the run you are observing is not the run that
+failed. Compare identities before concluding anything from it.
+
+Reading the TCC database directly is not an option for a normal user — it is
+itself TCC-protected and returns `authorization denied` without Full Disk
+Access.
+
+## 4. Responsible process
+
+macOS attributes a TCC request to the *responsible* process, which for a plain
+child process is the parent. An agent spawned directly by the GUI therefore asks
+with the **GUI's** identity, and the user's grant to `OpenLogiAgent` appears to
+do nothing.
+
+Two ways to break the chain, both already in the tree
+(`openlogi-desktop/src/services/ipc.rs`):
+
+- packaged helper → `/usr/bin/open -g -n <bundle>` (LaunchServices parents it
+  under launchd, so it is its own responsible process)
+- bare dev binary → `disclaim::Command` (wraps
+  `responsibility_spawnattrs_setdisclaim`)
+
+Never spawn a helper with plain `std::process::Command` on macOS. Check with:
+
+```sh
+sudo launchctl procinfo $(pgrep -x openlogi-agent) | grep -i responsible
+```
+
+It must name the agent itself. `OpenLogi.app` or `Terminal.app` there means
+every grant on that machine is being ignored.
+
+## 5. What the APIs actually do
+
+- `IOHIDCheckAccess` — queries only. **Never prompts, and never registers the
+  app in System Settings**, so an app that only ever calls this cannot be
+  granted: the user has no row to tick.
+- `IOHIDRequestAccess` — prompts. **Blocks the calling thread** until the user
+  answers, so it must not run on the async runtime. It is also not real-time:
+  after a grant or revoke the calling process keeps seeing the old answer until
+  it restarts. That is why the agent calls
+  `self_restart::relaunch_after_input_monitoring_grant()`.
+- `IOHIDDeviceOpen` — **denial is silent**. There is no TCC-specific error; the
+  failure is indistinguishable from exclusive access or a disconnect. Never
+  report `Failed to open device` to a user as-is; check
+  `openlogi_hid::permissions::has_access()` and say which one it was.
+
+## 6. Invariants — do not break these
+
+1. **Only the agent holds device permissions.** Any UI that reports permission
+   state must read it from the agent over IPC, never by querying its own
+   process. The GUI never opens a HID device, so its own grant means nothing.
+2. **Every helper launch establishes its own responsible process** (§4), and the
+   spawn result is checked — a silently failed `disclaim` leaves the agent
+   running under the GUI's identity, which is invisible until a user reports it.
+3. **Bundle identifiers are the TCC primary key.** Changing one voids every
+   existing user grant. Releases 0.6.24–0.6.26 shipped `.dev` identifiers and
+   did exactly that. The `Verify production bundle identities` step in
+   `.github/workflows/build.yml` is load-bearing; do not weaken it.
+4. **Sign inside-out.** The helper needs its own stable designated requirement
+   so its grant survives updates; `--deep` cannot give it one. See
+   `xtask/src/commands/macos/bundle/signing.rs`.
+5. **Prompt from the process that needs the permission**, not from whichever
+   process happens to be running. A TCC grant is scoped to the identity that
+   asked.
+
+## 7. Known-broken right now
+
+Check these before filing a new diagnosis:
+
+- The Settings → Input Monitoring row queries the **GUI's** grant, not the
+  agent's (#606, PR #760 open). It can read "Granted" while the agent has
+  nothing. The Accessibility row above it is already correct — it goes over IPC.
+- The agent's launchd log has no destination (§3). Open.
+- `disclaim`'s spawn result is discarded in `ipc.rs` (`.map(|_| ())`).
+
+## 8. What this cannot fix
+
+Say so plainly rather than promising a fix:
+
+- Apple's `+` picker not browsing into bundles.
+- `IOHIDDeviceOpen`'s silent denial — we can only infer it by checking access
+  separately.
+- A stale `tccd` decision that needs a full logout, or an MDM policy.
+- Ad-hoc-signed local builds: their designated requirement is cdhash-based, so
+  the grant goes stale on **every** rebuild. Use an Apple Development identity
+  for dev bundles.

--- a/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
+++ b/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Read-only macOS permission diagnosis for OpenLogi. Safe to hand to a reporter:
-# it changes nothing. `sudo` is used for one optional step and skipped without it.
+# it changes nothing. One step needs root; without it the script prints the
+# command to run instead.
 set -uo pipefail
 
 app=${OPENLOGI_APP:-/Applications/OpenLogi.app}
@@ -9,17 +10,18 @@ agent="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
 say() { printf '\n== %s\n' "$1"; }
 
 say "1. Is the agent running, and which binary is it?"
-running=$(pgrep -fl openlogi-agent | head -1 | cut -d' ' -f2-)
-if [ -z "$running" ]; then
+pid=$(pgrep -x openlogi-agent | head -1)
+if [ -z "${pid:-}" ]; then
   echo "   no openlogi-agent process — the GUI cannot show devices without it"
 else
+  running=$(ps -o comm= -p "$pid")
   echo "   $running"
   # The identity that matters is the one actually running. A dev bundle, a
   # second copy, or a build in ~/Downloads is a different identity from the
   # installed app, and a grant to one says nothing about the other.
   case "$running" in
     "$app"/*) ;;
-    *)
+    *.app/Contents/*)
       # `%%` strips at the first ".app/Contents/" -> the outer app bundle;
       # `%` strips at the last one -> the helper bundle it is nested in.
       app=${running%%.app/Contents/*}.app
@@ -28,11 +30,16 @@ else
       echo "            grants given to one copy do not apply to another"
       echo "   inspecting the running copy instead: $app"
       ;;
+    *)
+      echo "   WARNING: running as a bare binary, not from an app bundle."
+      echo "            Its ad-hoc identity changes on every rebuild, and TCC"
+      echo "            attributes it to the terminal that launched it."
+      echo "   inspecting the installed app below for reference: $app"
+      ;;
   esac
 fi
 
 say "2. Responsible process (must be the agent itself, not the GUI or a terminal)"
-pid=$(pgrep -x openlogi-agent | head -1)
 if [ -z "${pid:-}" ]; then
   echo "   skipped: agent not running"
 elif [ "$(id -u)" -eq 0 ]; then
@@ -42,6 +49,8 @@ else
 fi
 
 say "3. Identities — TCC keys on these, not on the app you see in Finder"
+# The overlay is omitted on purpose: it is the one identity that holds no TCC
+# grants, so there is nothing to compare.
 for target in "$app" "$agent" "$app/Contents/MacOS/openlogi"; do
   [ -e "$target" ] || {
     echo "   missing: $target"
@@ -71,9 +80,17 @@ cat <<TXT
 
      OPENLOGI_LOG=debug "$agent/Contents/MacOS/openlogi-agent"
 
+   Caveat: run from a terminal, macOS judges the TERMINAL's Input Monitoring
+   permission, not the agent's. A successful open here says nothing about the
+   copy launchd runs, and a denial here may only mean the terminal has no
+   grant.
+
    Then classify the first failure you see:
-     "HID++ candidate interfaces count=0"      -> device not matched, not a permission problem
+     "HID++ candidate interfaces count=0"      -> device not matched; not a permission problem
      "failed to open HID++ channel ... Failed to open device"
-                                               -> Input Monitoring for OpenLogiAgent (or exclusive access)
-     "opened HID++ channel" then a probe error -> permissions are fine; async-hid write bug
+                                               -> open denied (or exclusive access) — for the
+                                                  identity named in the caveat above
+     "opened HID++ channel" then a probe error -> the async-hid write bug is present; this
+                                                  run's permission was fine, but the launchd
+                                                  copy's grant is still unproven
 TXT

--- a/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
+++ b/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
@@ -14,6 +14,14 @@ pid=$(pgrep -x openlogi-agent | head -1)
 if [ -z "${pid:-}" ]; then
   echo "   no openlogi-agent process — the GUI cannot show devices without it"
 else
+  count=$(pgrep -x openlogi-agent | wc -l | tr -d ' ')
+  if [ "$count" -gt 1 ]; then
+    echo "   WARNING: $count agent processes are running — each is its own TCC identity:"
+    pgrep -x openlogi-agent | while read -r p; do
+      echo "      pid $p: $(ps -o comm= -p "$p")"
+    done
+    echo "   the rest of this report inspects pid $pid only; quit the others first"
+  fi
   running=$(ps -o comm= -p "$pid")
   echo "   $running"
   # The identity that matters is the one actually running. A dev bundle, a

--- a/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
+++ b/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Read-only macOS permission diagnosis for OpenLogi. Safe to hand to a reporter:
+# it changes nothing. `sudo` is used for one optional step and skipped without it.
+set -uo pipefail
+
+app=${OPENLOGI_APP:-/Applications/OpenLogi.app}
+agent="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
+
+say() { printf '\n== %s\n' "$1"; }
+
+say "1. Is the agent running, and which binary is it?"
+running=$(pgrep -fl openlogi-agent | head -1 | cut -d' ' -f2-)
+if [ -z "$running" ]; then
+  echo "   no openlogi-agent process — the GUI cannot show devices without it"
+else
+  echo "   $running"
+  # The identity that matters is the one actually running. A dev bundle, a
+  # second copy, or a build in ~/Downloads is a different identity from the
+  # installed app, and a grant to one says nothing about the other.
+  case "$running" in
+    "$app"/*) ;;
+    *)
+      # `%%` strips at the first ".app/Contents/" -> the outer app bundle;
+      # `%` strips at the last one -> the helper bundle it is nested in.
+      app=${running%%.app/Contents/*}.app
+      agent=${running%.app/Contents/*}.app
+      echo "   WARNING: this is not the installed app"
+      echo "            grants given to one copy do not apply to another"
+      echo "   inspecting the running copy instead: $app"
+      ;;
+  esac
+fi
+
+say "2. Responsible process (must be the agent itself, not the GUI or a terminal)"
+pid=$(pgrep -x openlogi-agent | head -1)
+if [ -z "${pid:-}" ]; then
+  echo "   skipped: agent not running"
+elif [ "$(id -u)" -eq 0 ]; then
+  launchctl procinfo "$pid" | grep -i responsible || echo "   (no responsible line)"
+else
+  echo "   needs root; run: sudo launchctl procinfo $pid | grep -i responsible"
+fi
+
+say "3. Identities — TCC keys on these, not on the app you see in Finder"
+for target in "$app" "$agent" "$app/Contents/MacOS/openlogi"; do
+  [ -e "$target" ] || {
+    echo "   missing: $target"
+    continue
+  }
+  printf '   %s\n' "$target"
+  codesign -d --verbose=2 "$target" 2>&1 | grep -E '^Identifier=|^TeamIdentifier=|flags=' | sed 's/^/      /'
+done
+
+say "4. Signature integrity (a broken signature fails the TCC requirement match)"
+for target in "$app" "$agent"; do
+  [ -d "$target" ] || continue
+  if out=$(codesign --verify --strict "$target" 2>&1); then
+    echo "   OK: $target"
+  else
+    echo "   FAILED: $target"
+    printf '      %s\n' "$out"
+  fi
+done
+
+say "5. Designated requirement recorded against the agent's grant"
+[ -d "$agent" ] && codesign -d --requirements - "$agent" 2>&1 | grep '^designated' | sed 's/^/   /'
+
+say "6. Next step: the agent's own log"
+cat <<TXT
+   launchd discards the agent's output, so run it in the foreground:
+
+     OPENLOGI_LOG=debug "$agent/Contents/MacOS/openlogi-agent"
+
+   Then classify the first failure you see:
+     "HID++ candidate interfaces count=0"      -> device not matched, not a permission problem
+     "failed to open HID++ channel ... Failed to open device"
+                                               -> Input Monitoring for OpenLogiAgent (or exclusive access)
+     "opened HID++ channel" then a probe error -> permissions are fine; async-hid write bug
+TXT

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ devenv.local.yaml
 # The path-scoped agent rules in .claude/rules/ are project config and stay tracked.
 /.claude/*
 !/.claude/rules/
+# Project skills are named explicitly and tracked; everything else under
+# .claude/skills/ is the per-developer symlink farm into .agents/skills/.
+!/.claude/skills/
+/.claude/skills/*
+!/.claude/skills/openlogi-macos-permissions/
 
 # Node dependencies for the JS helper scripts under .github/scripts/.
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,3 +264,17 @@ before editing that area.
 | `crates/openlogi-hook/**` (event taps) | `.claude/rules/hook.md` |
 | `xtask/**`, `packaging/**`, `.github/scripts/**` | `.claude/rules/xtask.md` (+ `xtask/README.md`) |
 | macOS native FFI wherever it lives — `openlogi-{agent,camera,hook,inject,overlay,permissions}` + `openlogi-desktop/src/platform/**` | `.claude/rules/objc-ffi.md` |
+
+## Task skills — invoke when the task matches, not when a path matches
+
+The rules above load from the file you are editing. Some work has no file to key
+on: triaging a user report, or deciding what a symptom means. That lives in
+`.claude/skills/`, which Claude Code offers by task description; other agents
+should read the `SKILL.md` when the task matches.
+
+| Task | Skill |
+|---|---|
+| a macOS report of no devices / "Failed to open device" / which permission to grant, and any change to the permission, helper-launch, or bundle-signing code | `.claude/skills/openlogi-macos-permissions/SKILL.md` |
+
+Everything else under `.claude/skills/` is a per-developer symlink into
+`.agents/skills/` and is not part of the project — see `.gitignore`.


### PR DESCRIPTION
## Summary

The path-scoped rules in `.claude/rules/` load from the file being edited. Triaging a permissions report has no file to key on — you are reading an issue, not a crate — so the knowledge that answers "is this a permission problem at all" was never reachable at the moment it was needed.

That question has been answered wrong repeatedly. #336, #704, #707 and #87 fail at `IOHIDDeviceOpen` and are TCC. #520, #780, #781 and #798 open the channel fine and fail in the feature walk, and are the async-hid macOS write bug. All eight reach the user as the same symptom: an empty device list.

This adds a task skill that leads with the discriminator — did `opened HID++ channel` appear in the agent log? — and carries the rest of what this area needs: the identity map (one install ships four code-signing identities, and only the agent may hold Input Monitoring), the responsible-process rules the helper launch already implements, what `IOHIDCheckAccess` / `IOHIDRequestAccess` / `IOHIDDeviceOpen` actually do, the invariants a change here must not break, and an explicit list of what TCC will never let us fix.

## Changes

**`.claude/skills/openlogi-macos-permissions/SKILL.md`** — the skill. Sections in decision order: classify first, then identities, diagnose, responsible process, API semantics, invariants, what is known-broken today (#606, the missing agent log destination, the discarded `disclaim` result), and what is out of our hands.

**`.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh`** — read-only, safe to hand to a reporter. It resolves the *running* agent instead of assuming `/Applications`: a dev bundle is its own TCC identity (`org.openlogi.agent-dev`), so a grant to the installed copy says nothing about it. That check fires on the maintainer's own machine today, which is how it got written.

**`.gitignore`** — a named carve-out so project skills are versioned while the per-developer symlinks under `.claude/skills/` into `.agents/skills/` stay ignored, matching the existing `!/.claude/rules/` line.

**`AGENTS.md`** — a "Task skills" section next to the rules table, so agents that do not read skills by description still find it.

## Testing

```
cargo xtask ci shell     # shellcheck + shfmt over every tracked script, incl. the new one — pass
```

The script was run on this machine and its output checked step by step; it is read-only (no `tccutil`, no writes) and every command it prints for the user to run is quoted for paths containing spaces.

No Rust changed, so the compile gate does not apply. Not runtime-tested on hardware — nothing here runs in the product.
