### PR TITLE
build(macos): name the helper bundles after their display names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,16 +231,16 @@ jobs:
             [ -f "$1/Contents/Resources/AppIcon.icns" ]
           }
           check "$app" "org.openlogi.openlogi" "OpenLogi"
-          check "$app/Contents/Library/LoginItems/OpenLogiAgent.app" "org.openlogi.agent" "OpenLogi Agent"
-          check "$app/Contents/Library/LoginItems/OpenLogiOverlay.app" "org.openlogi.overlay" "OpenLogi Overlay"
+          check "$app/Contents/Library/LoginItems/OpenLogi Agent.app" "org.openlogi.agent" "OpenLogi Agent"
+          check "$app/Contents/Library/LoginItems/OpenLogi Overlay.app" "org.openlogi.overlay" "OpenLogi Overlay"
 
       - name: Verify signed app bundle
         if: ${{ inputs.sign }}
         run: |
           set -euo pipefail
           app="target/release/bundle/osx/OpenLogi.app"
-          helper="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
-          overlay="$app/Contents/Library/LoginItems/OpenLogiOverlay.app"
+          helper="$app/Contents/Library/LoginItems/OpenLogi Agent.app"
+          overlay="$app/Contents/Library/LoginItems/OpenLogi Overlay.app"
           cli="$app/Contents/MacOS/openlogi"
           codesign --verify --strict --verbose=2 "$app"
           [ -d "$helper" ] && codesign --verify --strict --verbose=2 "$helper"

--- a/crates/openlogi-agent/src/launch_agent.rs
+++ b/crates/openlogi-agent/src/launch_agent.rs
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn rendered_plist_targets_the_agent_and_keeps_alive() {
         let body = render_plist(
-            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
         )
         .expect("render plist");
         assert!(body.contains(LABEL));

--- a/crates/openlogi-agent/src/overlay.rs
+++ b/crates/openlogi-agent/src/overlay.rs
@@ -132,6 +132,8 @@ fn overlay_binary_path() -> Option<PathBuf> {
     }) {
         for relative in [
             "Contents/Library/LoginItems/OpenLogi Overlay Dev.app/Contents/MacOS/openlogi-overlay",
+            "Contents/Library/LoginItems/OpenLogi Overlay.app/Contents/MacOS/openlogi-overlay",
+            // Bundles built before the helpers were renamed to their display names.
             "Contents/Library/LoginItems/OpenLogiOverlay.app/Contents/MacOS/openlogi-overlay",
         ] {
             let candidate = app.join(relative);
@@ -171,10 +173,10 @@ mod tests {
         let outer = Path::new("/Applications/OpenLogi.app");
         assert_eq!(
             outer.join(
-                "Contents/Library/LoginItems/OpenLogiOverlay.app/Contents/MacOS/openlogi-overlay"
+                "Contents/Library/LoginItems/OpenLogi Overlay.app/Contents/MacOS/openlogi-overlay"
             ),
             Path::new(
-                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiOverlay.app/Contents/MacOS/openlogi-overlay"
+                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Overlay.app/Contents/MacOS/openlogi-overlay"
             )
         );
     }

--- a/crates/openlogi-agent/src/self_restart.rs
+++ b/crates/openlogi-agent/src/self_restart.rs
@@ -260,10 +260,10 @@ mod tests {
         use std::path::Path;
 
         let binary = Path::new(
-            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
         );
         let bundle =
-            Path::new("/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app");
+            Path::new("/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app");
         assert_eq!(helper_bundle(binary), Some(bundle));
         assert_eq!(helper_bundle(Path::new("/tmp/openlogi-agent")), None);
     }

--- a/crates/openlogi-desktop/bundle/agent-release/Info.plist
+++ b/crates/openlogi-desktop/bundle/agent-release/Info.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
 <!--
   Release Info.plist for the nested login-item helper, assembled by `xtask` into
-  OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app.
+  OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app.
 
   LSUIElement=true makes the agent an Accessory app: a menu-bar status item with
   no Dock icon (the agent also sets NSApplicationActivationPolicy::Accessory at

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -352,7 +352,7 @@ fn helper_bundle(path: &std::path::Path) -> Option<&std::path::Path> {
 
 /// Resolve the agent executable relative to the running GUI: a sibling in the
 /// cargo target dir (dev, and the flat Windows install layout), else the
-/// embedded `OpenLogiAgent.app` login-item helper (packaged macOS build).
+/// embedded `OpenLogi Agent.app` login-item helper (packaged macOS build).
 fn agent_binary_path() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let dir = exe.parent()?;
@@ -365,9 +365,11 @@ fn agent_binary_path() -> Option<PathBuf> {
         return Some(sibling);
     }
     // Packaged: …/OpenLogi.app/Contents/MacOS/openlogi-desktop → the helper at
-    // …/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent
-    // Dev uses a spaced bundle path so macOS privacy panes never fall back to
-    // displaying the old path-derived `OpenLogiAgent` name when metadata is stale.
+    // …/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent
+    // Every family names its directory after the display name, so the privacy
+    // panes' filename fallback (used when bundle metadata is stale) shows the
+    // real name. The last entry keeps finding helpers in bundles built before
+    // the rename.
     #[cfg(target_os = "macos")]
     {
         let contents = dir.parent()?;
@@ -662,21 +664,21 @@ mod tests {
     #[test]
     fn helper_bundle_resolves_only_the_packaged_layout() {
         let packaged = Path::new(
-            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent",
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
         );
         assert_eq!(
             helper_bundle(packaged),
             Some(Path::new(
-                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app"
+                "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app"
             ))
         );
         let dev = Path::new(
-            "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
+            "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent Dev.app/Contents/MacOS/openlogi-agent",
         );
         assert_eq!(
             helper_bundle(dev),
             Some(Path::new(
-                "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app"
+                "/Users/me/OpenLogi/target/dev/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent Dev.app"
             ))
         );
         assert_eq!(

--- a/xtask/src/commands/macos/bundle/identity.rs
+++ b/xtask/src/commands/macos/bundle/identity.rs
@@ -59,24 +59,26 @@ pub(crate) enum Component {
 impl Component {
     /// Where this component lives inside the app bundle; `None` is the app itself.
     ///
-    /// The dev family spells "Dev" in the *directory* name as well as in
-    /// `CFBundleDisplayName`, because macOS privacy panes fall back to a
-    /// bundle's filename whenever its metadata is stale — a dev helper in a
-    /// directory named like the shipped one renders as a second row nobody can
-    /// tell from the real thing. The shipped spellings are frozen: the GUI's
-    /// `agent_binary_path` and the agent's `overlay_binary_path` look for both
-    /// families by name at runtime.
+    /// Each directory is named exactly like its `CFBundleDisplayName`, because
+    /// macOS privacy panes fall back to a bundle's filename whenever its
+    /// metadata is stale — a spelling that differs from the display name (or a
+    /// dev helper named like the shipped one) renders as a row nobody can
+    /// trust. The spellings are load-bearing: the GUI's `agent_binary_path`
+    /// and the agent's `overlay_binary_path` look the helpers up by name at
+    /// runtime, keeping the old no-space names (`OpenLogiAgent.app`,
+    /// `OpenLogiOverlay.app`) as fallbacks for bundles built before the
+    /// rename.
     pub(crate) fn nested_bundle(self, channel: Channel) -> Option<&'static str> {
         match (self, channel) {
             (Self::App, _) => None,
             (Self::Agent, Channel::Production) => {
-                Some("Contents/Library/LoginItems/OpenLogiAgent.app")
+                Some("Contents/Library/LoginItems/OpenLogi Agent.app")
             }
             (Self::Agent, Channel::Dev) => {
                 Some("Contents/Library/LoginItems/OpenLogi Agent Dev.app")
             }
             (Self::Overlay, Channel::Production) => {
-                Some("Contents/Library/LoginItems/OpenLogiOverlay.app")
+                Some("Contents/Library/LoginItems/OpenLogi Overlay.app")
             }
             (Self::Overlay, Channel::Dev) => {
                 Some("Contents/Library/LoginItems/OpenLogi Overlay Dev.app")


### PR DESCRIPTION
## Summary

Rename the production login-item helpers from `OpenLogiAgent.app` / `OpenLogiOverlay.app` to `OpenLogi Agent.app` / `OpenLogi Overlay.app`, so every family's directory name matches its `CFBundleDisplayName` — the dev family already works this way (`OpenLogi Agent Dev.app`). macOS privacy panes fall back to a bundle's *filename* whenever its metadata cache is stale; today that fallback renders `OpenLogiAgent`, which is not the "OpenLogi Agent" row users are told to look for. After the rename even the fallback shows the real name.

Existing permission grants survive the rename: TCC keys on (service, bundle identifier, designated requirement), and both stay unchanged (`org.openlogi.agent`, Developer ID identifier + team anchor). This is the inverse of the 0.6.24–0.6.26 incident, where the identifiers changed under an unchanged path and every grant died.

The GUI→agent lookup already tolerated the spaced spelling (its candidate list carries all three); this PR adds the same tolerance to the agent→overlay lookup and keeps the old no-space names as fallbacks for bundles built before the rename. One known transition seam: `~/Library/LaunchAgents/org.openlogi.agent.plist` on an existing install points at the old helper path, so the login autostart fails once after updating, until the GUI is next opened (it spawns the agent, which rewrites the plist in `reconcile`). The regular updater flow relaunches the app immediately after updating, so most users never hit it.

## Changes

- `xtask`: `Component::nested_bundle` names the production helper directories after their display names; the doc comment now explains why the spellings are load-bearing and which old names remain as lookup fallbacks.
- `agent`: `overlay_binary_path` gains the spaced production candidate and keeps the pre-rename name as a fallback; test fixtures updated.
- `gui`: comments around `agent_binary_path` updated (its candidate list already knew all three spellings); the `helper_bundle` dev fixture now uses the real dev directory name (`OpenLogi Agent Dev.app`) instead of a spelling that never shipped.
- `ci`: `build.yml` bundle-identity and signed-bundle checks target the new paths.

## Testing

- `cargo test -p openlogi-agent -p xtask` — green.
- Full local gate on the final tree (`cargo fmt --all -- --check`; `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`; rustdoc for the non-GUI crates with `-D warnings`) — green.
- All Rust edits are string literals inside existing `#[cfg(target_os = "macos")]` blocks or macOS-gated test modules; hand-audited that no non-macOS code path changed.
- This PR's CI builds the unsigned installers, so the renamed layout runs through `Verify production bundle identities` here, not just at release time.
- Not runtime-tested on hardware. The one check that needs a real machine: install this build over an existing granted install and confirm the Input Monitoring / Accessibility rows keep working without re-granting (identifiers and signatures are unchanged, so they should).

Follow-up once this and #813 both land: the macOS permissions skill hardcodes the old helper path; its default should prefer the spaced name and fall back to the old one for pre-rename installs.
