### PR TITLE
fix(ci): build both macOS legs with an Icon Composer-capable Xcode

### DIFF
--- a/.claude/rules/xtask.md
+++ b/.claude/rules/xtask.md
@@ -21,7 +21,11 @@ paths:
   macOS 13–25 draw, and what every helper bundle ships) and `Assets.car` (what
   macOS 26 composes the layered icon from — the app carries it, the helpers do
   not). `actool` names its outputs after the document, so the compile stages a
-  copy called `AppIcon.icon`; it ships with Xcode, not the command line tools.
+  copy called `AppIcon.icon`; it ships with Xcode (not the command line tools)
+  and has to be **Xcode 26 or newer**, since that is where Icon Composer
+  documents arrived. `OPENLOGI_DEVELOPER_DIR` picks which Xcode every macOS
+  build command runs under — `build.yml` sets it per leg, because the Intel
+  runner image still defaults to Xcode 16.
   `design/icon/openlogi.png` stays the master for Linux packaging and the GUI's
   embedded logo, and `openlogi.ico` for the Windows executables. The icon set
   itself lives in `xtask/src/icon.rs` (`AppIcon` plus the `IconPipeline` trait a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,8 +142,11 @@ jobs:
       # built by two different toolchains depending on which leg produced it.
       - name: Select the Xcode both legs build with
         run: |
-          xcode=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
-          if [ -z "$xcode" ]; then
+          # An unmatched glob stays literal, which `-d` then rejects — where
+          # `ls` would have failed the step under the shell's `-e -o pipefail`
+          # before this check could say what is actually wrong.
+          xcode=$(printf '%s\n' /Applications/Xcode_26*.app | sort -V | tail -1)
+          if [ ! -d "$xcode" ]; then
             echo "No Xcode 26 on this runner; the app icon cannot be compiled." >&2
             exit 1
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,21 @@ jobs:
       - name: Verify runner architecture
         run: test "$(uname -m)" = "${{ matrix.arch }}"
 
+      # The two macOS legs run on different images, and their default Xcode is
+      # whatever `/Applications/Xcode.app` happens to point at — 26.x on the
+      # arm64 image, 16.4 on the Intel one. Compiling the app icon needs an
+      # Icon Composer-capable actool (Xcode 26+), and a bundle should not be
+      # built by two different toolchains depending on which leg produced it.
+      - name: Select the Xcode both legs build with
+        run: |
+          xcode=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$xcode" ]; then
+            echo "No Xcode 26 on this runner; the app icon cannot be compiled." >&2
+            exit 1
+          fi
+          echo "OPENLOGI_DEVELOPER_DIR=$xcode/Contents/Developer" >> "$GITHUB_ENV"
+          echo "Building with $xcode"
+
       - name: Load release secrets from 1Password
         id: load_secrets
         if: ${{ inputs.sign }}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,8 +6,11 @@ build instructions, see the [README](../README.md).
 ## Toolchain
 
 - Stable Rust (Edition 2024, MSRV 1.98 — the floor tracks current stable)
-- macOS: Xcode 16+ with the optional **Metal Toolchain** component (required by
-  GPUI's `gpui_macos` build script to compile shaders)
+- macOS: Xcode 26+ with the optional **Metal Toolchain** component. The Metal
+  Toolchain is what GPUI's `gpui_macos` build script compiles shaders with; the
+  version floor is `actool`, which packaging uses to compile the app icon from
+  its Icon Composer document. `OPENLOGI_DEVELOPER_DIR` overrides which Xcode is
+  used when several are installed.
 - Linux: system libraries — on Debian/Ubuntu:
   `sudo apt-get install libudev-dev gcc g++ clang libfontconfig-dev libwayland-dev libxkbcommon-x11-dev libx11-xcb-dev libssl-dev libzstd-dev pkg-config`
 - `create-dmg` for packaging (`brew install create-dmg`); `cargo-bundle` is
@@ -22,7 +25,7 @@ Nix/devenv is optional. A normal Rust toolchain is enough.
 ```sh
 # rustup installs the stable toolchain pinned in rust-toolchain.toml
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-# macOS: full Xcode 16+ with the Metal Toolchain (not only Command Line Tools)
+# macOS: full Xcode 26+ with the Metal Toolchain (not only Command Line Tools)
 # Linux: see system libraries under Toolchain above
 # optional helpers: brew install cmake create-dmg sccache
 git clone https://github.com/AprilNEA/OpenLogi

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -15,6 +15,7 @@ use crate::icon::IconPipeline as _;
 use crate::icon::macos::AppBundle;
 use crate::support::fs::{command_exists, ensure_dir, repo_root};
 use crate::support::info_plist;
+use crate::support::xcode;
 use identity::{Channel, Component};
 
 // The rest of the macOS domain reaches these through `bundle::`, which is the
@@ -38,7 +39,7 @@ fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()>
     let root = repo_root()?;
     let sh = Shell::new()?;
     let _repo = sh.push_dir(&root);
-    let xcode_env = xcode_env()?;
+    let xcode_env = xcode::env()?;
 
     println!("==> app icon");
     AppBundle.compile()?;
@@ -112,17 +113,4 @@ fn remove_cargo_bundle_dmg(root: &Path) -> Result<()> {
         );
     }
     Ok(())
-}
-
-pub(super) fn xcode_env() -> Result<Vec<(String, String)>> {
-    let sh = Shell::new()?;
-    let developer_dir = env::var("OPENLOGI_DEVELOPER_DIR")
-        .unwrap_or_else(|_| "/Applications/Xcode.app/Contents/Developer".to_string());
-    let sdkroot = cmd!(sh, "/usr/bin/xcrun --sdk macosx --show-sdk-path")
-        .env("DEVELOPER_DIR", &developer_dir)
-        .read()?;
-    Ok(vec![
-        ("DEVELOPER_DIR".to_string(), developer_dir),
-        ("SDKROOT".to_string(), sdkroot.trim().to_string()),
-    ])
 }

--- a/xtask/src/icon/macos.rs
+++ b/xtask/src/icon/macos.rs
@@ -15,6 +15,7 @@ use xshell::{Shell, cmd};
 use super::{AppIcon, IconPipeline};
 use crate::support::fs::{ensure_dir, ensure_file, repo_root};
 use crate::support::info_plist::{read_plist_string, stamp_plist_strings};
+use crate::support::xcode;
 
 /// `OpenLogi.app`'s icons: the one it wears, and the alternates it can switch
 /// to at runtime.
@@ -236,6 +237,10 @@ fn compile_document(root: &Path, output_dir: &Path, icon: AppIcon) -> Result<()>
         .with_context(|| format!("could not create {}", compiled.display()))?;
     let partial_plist = work.path().join("icon.plist");
 
+    // Under the build's own Xcode, not whichever one the machine happens to
+    // have selected: a runner can carry several, and an Icon Composer document
+    // needs 26 or newer.
+    //
     // `actool` reports everything — errors included — as a plist on stdout and
     // nothing on stderr, so its output is only worth showing when it fails.
     let run = cmd!(
@@ -248,12 +253,14 @@ fn compile_document(root: &Path, output_dir: &Path, icon: AppIcon) -> Result<()>
          --app-icon {stem}
          --output-partial-info-plist {partial_plist}"
     )
+    .envs(xcode::env()?.iter().map(|(key, value)| (key, value)))
     .ignore_status()
     .output()
     .context("could not run actool (it ships with Xcode, not the command line tools)")?;
     if !run.status.success() {
         bail!(
-            "actool could not compile {}:\n{}",
+            "actool could not compile {}: an Icon Composer document needs Xcode 26 \
+             or newer, and OPENLOGI_DEVELOPER_DIR picks which Xcode is used.\n{}",
             source.display(),
             String::from_utf8_lossy(&run.stdout)
         );

--- a/xtask/src/support/mod.rs
+++ b/xtask/src/support/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod fs;
 pub(crate) mod info_plist;
 pub(crate) mod manifest;
+pub(crate) mod xcode;

--- a/xtask/src/support/xcode.rs
+++ b/xtask/src/support/xcode.rs
@@ -1,0 +1,30 @@
+//! Which Xcode the macOS build runs under.
+//!
+//! Every developer tool the bundle build shells out to — the cargo builds that
+//! link against the macOS SDK, and `actool` — has to be the same one, or a
+//! bundle is assembled from two toolchains. `OPENLOGI_DEVELOPER_DIR` picks it;
+//! without one, whatever `/Applications/Xcode.app` points at.
+//!
+//! That default is why this exists as a knob at all: a machine — a CI runner
+//! especially — can have several Xcodes installed with the symlink aimed at an
+//! old one. Compiling an Icon Composer document needs Xcode 26 or newer.
+
+use std::env;
+
+use anyhow::Result;
+use xshell::{Shell, cmd};
+
+/// The environment every macOS build command runs with: the chosen developer
+/// directory, and the SDK path that Xcode resolves to.
+pub(crate) fn env() -> Result<Vec<(String, String)>> {
+    let sh = Shell::new()?;
+    let developer_dir = env::var("OPENLOGI_DEVELOPER_DIR")
+        .unwrap_or_else(|_| "/Applications/Xcode.app/Contents/Developer".to_string());
+    let sdkroot = cmd!(sh, "/usr/bin/xcrun --sdk macosx --show-sdk-path")
+        .env("DEVELOPER_DIR", &developer_dir)
+        .read()?;
+    Ok(vec![
+        ("DEVELOPER_DIR".to_string(), developer_dir),
+        ("SDKROOT".to_string(), sdkroot.trim().to_string()),
+    ])
+}


### PR DESCRIPTION
## Summary

#812 made packaging compile the app icon with `actool` from an Icon Composer document. `actool` only understands those from Xcode 26 — that is where Icon Composer arrived — and the two macOS legs each take whatever `/Applications/Xcode.app` points at: 26.6 on the macos-26 image the arm64 leg runs on, **16.4** on the macos-15 image the Intel leg runs on.

So the Intel DMG would have failed at the first step of packaging. The release publishes per leg, so the failure would not have stopped the release — it would have shipped without an Intel DMG. Nothing caught it on #812 because PR installer builds are opt-in.

## Changes

- **build.yml**: the macOS job picks the newest installed Xcode 26 into `OPENLOGI_DEVELOPER_DIR`, and fails loudly when a runner has none — better red than a release quietly missing an artifact.
- **xtask**: `actool` was the one build command not running under the Xcode the rest of the bundle is built with; it now shares `xcode::env()` with them, which moves to `support/xcode.rs` since it is no longer the bundle module's alone. Its failure message names the version requirement and the variable that overrides it.
- **docs**: `DEVELOPMENT.md`'s macOS prerequisite moves to Xcode 26+, with the reason (the floor is `actool`, not the Metal Toolchain); `.claude/rules/xtask.md` records the same.

Worth naming as a side effect: the two DMGs were being built against different SDKs. They now share one.

## Testing

```
cargo fmt --all -- --check
cargo clippy -p xtask --all-targets -- -D warnings
cargo test -p xtask
RUSTDOCFLAGS="-D warnings" cargo doc -p xtask --no-deps --document-private-items
cargo run -p xtask -- macos icon      # recompiles on an edited document, skips an untouched one
```

An unsigned packaging build was dispatched on this branch — [run 32615468706](https://github.com/AprilNEA/OpenLogi/actions/runs/32615468706). All nine legs green. `macOS DMG (arm64)` built with `Xcode_26.6.0`, `macOS DMG (x86_64)` with `Xcode_26.3.0`, and the Intel log shows both documents compiling:

```
==> app icon
compiled openlogi from design/icon/openlogi.icon
compiled prism from design/icon/openlogi-prism.icon
```

On master today that leg fails there instead.

**Not runtime-tested**: the DMGs were not installed or launched. This run proves the build, not the artifact.
