### PR TITLE
refactor(agent): split the binary watcher from how it relaunches

### DIFF
--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -115,7 +115,7 @@ every grant on that machine is being ignored.
   answers, so it must not run on the async runtime. It is also not real-time:
   after a grant or revoke the calling process keeps seeing the old answer until
   it restarts. That is why the agent calls
-  `self_restart::relaunch_after_input_monitoring_grant()`.
+  `binary_watch::relaunch_after_input_monitoring_grant()`.
 - `IOHIDDeviceOpen` — **denial is silent**. There is no TCC-specific error; the
   failure is indistinguishable from exclusive access or a disconnect. Never
   report `Failed to open device` to a user as-is; check

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 # auxiliary-window registry (Settings, Add Device), not Win32 code.
 #
 # Windows-only branches living in multi-platform files (openlogi-agent's
-# main.rs / launch_agent.rs / self_restart.rs / takeover.rs, hid/transport.rs,
+# main.rs / launch_agent.rs / binary_watch/ / takeover.rs, hid/transport.rs,
 # hook/lib.rs, …) stay with the maintainer: CODEOWNERS scopes by path, so it
 # cannot hand out ownership of a single `#[cfg(windows)]` branch.
 #

--- a/crates/openlogi-agent/src/binary_watch.rs
+++ b/crates/openlogi-agent/src/binary_watch.rs
@@ -8,10 +8,8 @@
 //! IPC protocol on a version bump, sitting on its connecting screen with no way
 //! forward. Watching our own executable and replacing the process image once it
 //! changes keeps "the running agent is the installed binary" true within a few
-//! ticks, with no launchd or GUI involvement. On macOS restarts use a short
-//! delayed relaunch rather than an in-thread `exec`: the agent owns an AppKit
-//! status item, and the new AppKit process must start from the normal process
-//! main thread or the menu-bar item can render as an empty slot.
+//! ticks, with no launchd or GUI involvement. How a restart is actually carried
+//! out differs per OS and lives in [`relaunch`].
 //!
 //! The same stat answers the uninstall question. Dragging the app to the Trash
 //! does not stop the agent: it keeps running from the trashed bundle with its
@@ -33,6 +31,11 @@ use std::time::{Duration, SystemTime};
 
 use tokio::sync::mpsc;
 use tracing::{info, warn};
+
+mod relaunch;
+
+#[cfg(target_os = "macos")]
+pub use relaunch::relaunch_after_input_monitoring_grant;
 
 /// How often to stat the executable: one `metadata` call per tick — noise next
 /// to the 2 s HID enumerate — while keeping the update-to-restart window short.
@@ -195,7 +198,7 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
                 match watch.tick(baseline, sight(&path)) {
                     Tick::Watch => {}
                     Tick::Restart => {
-                        restart(&path);
+                        relaunch::restart(&path);
                         // Only reached when the exec failed (a broken or still-
                         // churning file). Disarm so the retry needs a fresh
                         // two-tick settle — staying alive on the old image beats
@@ -219,118 +222,6 @@ pub fn spawn() -> mpsc::UnboundedReceiver<()> {
         warn!(error = %e, "could not spawn the binary-update watch thread");
     }
     uninstalled_rx
-}
-
-/// Restart this process as the new binary at `path`.
-///
-/// The singleton file lock and the IPC socket close with the old image and are
-/// re-acquired by the new one; the listener unlinks the stale socket file on
-/// bind. If scheduling the restart fails the process is still intact, so return
-/// and let the watch loop retry once the file settles again.
-#[cfg(all(unix, not(target_os = "macos")))]
-fn restart(path: &Path) {
-    use std::os::unix::process::CommandExt as _;
-    info!(
-        path = %path.display(),
-        "executable changed on disk — restarting as the new binary"
-    );
-    // Forward our argv (none today) so a future flag survives the restart.
-    let err = std::process::Command::new(path)
-        .args(std::env::args_os().skip(1))
-        .exec();
-    warn!(error = %err, "exec of the updated agent failed — keeping the current image and retrying");
-}
-
-/// macOS cannot safely `exec` the replacement from this watcher thread: after
-/// `exec`, the new program continues on the calling thread, while AppKit expects
-/// the status item to be created from the process main thread. Relaunch the
-/// packaged helper through LaunchServices (preserving its TCC identity), or a
-/// bare dev binary directly, after this process has had time to exit and release
-/// the singleton lock.
-#[cfg(target_os = "macos")]
-fn restart(path: &Path) {
-    info!(
-        path = %path.display(),
-        "executable changed on disk — relaunching as the new macOS agent"
-    );
-    if let Err(e) = schedule_macos_relaunch_and_exit(path) {
-        warn!(error = %e, "could not schedule updated agent relaunch — keeping the current image and retrying");
-    }
-}
-
-/// Relaunch the macOS agent after Input Monitoring is granted.
-///
-/// macOS does not apply a new Input Monitoring grant to the running process.
-/// The successor starts only after this process exits and releases its
-/// singleton lock and IPC socket. If the relaunch cannot be scheduled, the
-/// current process stays alive so the user can restart it manually.
-#[cfg(target_os = "macos")]
-pub fn relaunch_after_input_monitoring_grant() {
-    let path = match std::env::current_exe() {
-        Ok(path) => path,
-        Err(e) => {
-            warn!(error = %e, "could not resolve own executable after Input Monitoring was granted — restart the agent manually");
-            return;
-        }
-    };
-    info!("Input Monitoring granted — relaunching the macOS agent");
-    if let Err(e) = schedule_macos_relaunch_and_exit(&path) {
-        warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn schedule_macos_relaunch(path: &Path) -> std::io::Result<()> {
-    let mut command = std::process::Command::new("/bin/sh");
-    if let Some(bundle) = helper_bundle(path) {
-        command
-            .arg("-c")
-            .arg("sleep 0.5; exec /usr/bin/open -g -n \"$1\"")
-            .arg("openlogi-relaunch")
-            .arg(bundle);
-    } else {
-        command
-            .arg("-c")
-            .arg("path=$1; shift; sleep 0.5; exec \"$path\" \"$@\"")
-            .arg("openlogi-relaunch")
-            .arg(path)
-            .args(std::env::args_os().skip(1));
-    }
-    command.spawn().map(|_| ())
-}
-
-#[cfg(target_os = "macos")]
-fn schedule_macos_relaunch_and_exit(path: &Path) -> std::io::Result<()> {
-    schedule_macos_relaunch(path)?;
-    #[expect(
-        clippy::exit,
-        reason = "the delayed successor is already scheduled and waits for this process to release the singleton lock and IPC socket"
-    )]
-    std::process::exit(0)
-}
-
-/// The `.app` root of a packaged helper binary, `None` for a bare dev binary.
-#[cfg(target_os = "macos")]
-fn helper_bundle(path: &Path) -> Option<&Path> {
-    let bundle = path.ancestors().nth(3)?;
-    (bundle.extension()? == "app").then_some(bundle)
-}
-
-/// Windows has no `exec`: exit cleanly and let the GUI's socket-down spawn
-/// retry (or the next login's autostart) start the replaced binary. A
-/// spawn-before-exit handover would lose the race against the singleton lock
-/// this process still holds.
-#[cfg(windows)]
-fn restart(path: &Path) {
-    info!(
-        path = %path.display(),
-        "executable changed on disk — exiting so the new binary can start"
-    );
-    #[expect(
-        clippy::exit,
-        reason = "windows has no `exec`, and this watcher thread cannot return a status to `main`, which is blocked on the agent core; releasing the singleton lock by exiting is what lets the replaced binary start"
-    )]
-    std::process::exit(0);
 }
 
 #[cfg(test)]
@@ -462,20 +353,5 @@ mod tests {
         assert!(!is_translocated(Path::new(
             "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent"
         )));
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn macos_helper_bundle_is_detected_from_packaged_binary_path() {
-        use super::helper_bundle;
-        use std::path::Path;
-
-        let binary = Path::new(
-            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
-        );
-        let bundle =
-            Path::new("/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app");
-        assert_eq!(helper_bundle(binary), Some(bundle));
-        assert_eq!(helper_bundle(Path::new("/tmp/openlogi-agent")), None);
     }
 }

--- a/crates/openlogi-agent/src/binary_watch/relaunch.rs
+++ b/crates/openlogi-agent/src/binary_watch/relaunch.rs
@@ -1,0 +1,158 @@
+//! How a restart is actually carried out, per OS.
+//!
+//! [`super`] decides *that* the agent should become the binary now on disk;
+//! this module knows what that costs on each platform, and the three answers
+//! have nothing in common:
+//!
+//! - **Linux and the other unixes** `exec` the new image in place, which keeps
+//!   the pid, the singleton lock, and the IPC socket.
+//! - **macOS** cannot: after `exec` the new program continues on the calling
+//!   thread, while AppKit insists the status item be created from the process
+//!   main thread. So it schedules a detached successor and exits, and the
+//!   successor waits for this process to release the singleton lock. Going
+//!   through LaunchServices (`open`) rather than spawning the binary directly
+//!   is what preserves the helper's TCC identity — see
+//!   `.claude/rules/objc-ffi.md` and the permissions skill.
+//! - **Windows** has no `exec` at all: it exits and lets the GUI's socket-down
+//!   spawn (or the next login) start the replacement.
+//!
+//! The macOS path also serves the Input Monitoring grant, which needs the same
+//! "leave and come back" move for an unrelated reason.
+
+use std::path::Path;
+
+use tracing::info;
+// Only the unix relaunches can fail in a way worth reporting; Windows just
+// exits.
+#[cfg(unix)]
+use tracing::warn;
+
+/// Restart this process as the new binary at `path`.
+///
+/// The singleton file lock and the IPC socket close with the old image and are
+/// re-acquired by the new one; the listener unlinks the stale socket file on
+/// bind. If scheduling the restart fails the process is still intact, so return
+/// and let the watch loop retry once the file settles again.
+#[cfg(all(unix, not(target_os = "macos")))]
+pub(super) fn restart(path: &Path) {
+    use std::os::unix::process::CommandExt as _;
+    info!(
+        path = %path.display(),
+        "executable changed on disk — restarting as the new binary"
+    );
+    // Forward our argv (none today) so a future flag survives the restart.
+    let err = std::process::Command::new(path)
+        .args(std::env::args_os().skip(1))
+        .exec();
+    warn!(error = %err, "exec of the updated agent failed — keeping the current image and retrying");
+}
+
+/// macOS cannot safely `exec` the replacement from this watcher thread: after
+/// `exec`, the new program continues on the calling thread, while AppKit expects
+/// the status item to be created from the process main thread. Relaunch the
+/// packaged helper through LaunchServices (preserving its TCC identity), or a
+/// bare dev binary directly, after this process has had time to exit and release
+/// the singleton lock.
+#[cfg(target_os = "macos")]
+pub(super) fn restart(path: &Path) {
+    info!(
+        path = %path.display(),
+        "executable changed on disk — relaunching as the new macOS agent"
+    );
+    if let Err(e) = schedule_macos_relaunch_and_exit(path) {
+        warn!(error = %e, "could not schedule updated agent relaunch — keeping the current image and retrying");
+    }
+}
+
+/// Relaunch the macOS agent after Input Monitoring is granted.
+///
+/// macOS does not apply a new Input Monitoring grant to the running process.
+/// The successor starts only after this process exits and releases its
+/// singleton lock and IPC socket. If the relaunch cannot be scheduled, the
+/// current process stays alive so the user can restart it manually.
+#[cfg(target_os = "macos")]
+pub fn relaunch_after_input_monitoring_grant() {
+    let path = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(e) => {
+            warn!(error = %e, "could not resolve own executable after Input Monitoring was granted — restart the agent manually");
+            return;
+        }
+    };
+    info!("Input Monitoring granted — relaunching the macOS agent");
+    if let Err(e) = schedule_macos_relaunch_and_exit(&path) {
+        warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn schedule_macos_relaunch(path: &Path) -> std::io::Result<()> {
+    let mut command = std::process::Command::new("/bin/sh");
+    if let Some(bundle) = helper_bundle(path) {
+        command
+            .arg("-c")
+            .arg("sleep 0.5; exec /usr/bin/open -g -n \"$1\"")
+            .arg("openlogi-relaunch")
+            .arg(bundle);
+    } else {
+        command
+            .arg("-c")
+            .arg("path=$1; shift; sleep 0.5; exec \"$path\" \"$@\"")
+            .arg("openlogi-relaunch")
+            .arg(path)
+            .args(std::env::args_os().skip(1));
+    }
+    command.spawn().map(|_| ())
+}
+
+#[cfg(target_os = "macos")]
+fn schedule_macos_relaunch_and_exit(path: &Path) -> std::io::Result<()> {
+    schedule_macos_relaunch(path)?;
+    #[expect(
+        clippy::exit,
+        reason = "the delayed successor is already scheduled and waits for this process to release the singleton lock and IPC socket"
+    )]
+    std::process::exit(0)
+}
+
+/// The `.app` root of a packaged helper binary, `None` for a bare dev binary.
+#[cfg(target_os = "macos")]
+fn helper_bundle(path: &Path) -> Option<&Path> {
+    let bundle = path.ancestors().nth(3)?;
+    (bundle.extension()? == "app").then_some(bundle)
+}
+
+/// Windows has no `exec`: exit cleanly and let the GUI's socket-down spawn
+/// retry (or the next login's autostart) start the replaced binary. A
+/// spawn-before-exit handover would lose the race against the singleton lock
+/// this process still holds.
+#[cfg(windows)]
+pub(super) fn restart(path: &Path) {
+    info!(
+        path = %path.display(),
+        "executable changed on disk — exiting so the new binary can start"
+    );
+    #[expect(
+        clippy::exit,
+        reason = "windows has no `exec`, and this watcher thread cannot return a status to `main`, which is blocked on the agent core; releasing the singleton lock by exiting is what lets the replaced binary start"
+    )]
+    std::process::exit(0);
+}
+
+#[cfg(target_os = "macos")]
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn macos_helper_bundle_is_detected_from_packaged_binary_path() {
+        use super::helper_bundle;
+        use std::path::Path;
+
+        let binary = Path::new(
+            "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent",
+        );
+        let bundle =
+            Path::new("/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app");
+        assert_eq!(helper_bundle(binary), Some(bundle));
+        assert_eq!(helper_bundle(Path::new("/tmp/openlogi-agent")), None);
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -15,12 +15,12 @@
     windows_subsystem = "windows"
 )]
 
+mod binary_watch;
 mod launch_agent;
 mod overlay;
 mod pairing;
 #[cfg(target_os = "windows")]
 mod resume_windows;
-mod self_restart;
 mod server;
 #[cfg(target_os = "macos")]
 mod status_item;
@@ -81,9 +81,9 @@ fn main() {
     };
 
     // Watch our own executable and restart as the new image when an app update
-    // replaces it — see `self_restart`. Only the lock-holding (real) agent
+    // replaces it — see `binary_watch`. Only the lock-holding (real) agent
     // watches, so a losing duplicate can't restart anything.
-    let uninstalled = self_restart::spawn();
+    let uninstalled = binary_watch::spawn();
     overlay::spawn();
 
     let config = Config::load_or_default().unwrap_or_else(|e| {
@@ -328,7 +328,7 @@ async fn request_input_monitoring() {
         })
         .await;
         match access_after_prompt {
-            Ok(true) => self_restart::relaunch_after_input_monitoring_grant(),
+            Ok(true) => binary_watch::relaunch_after_input_monitoring_grant(),
             Ok(false) => {}
             Err(e) => {
                 warn!(error = %e, "Input Monitoring permission request task failed");

--- a/crates/openlogi-agent/src/takeover.rs
+++ b/crates/openlogi-agent/src/takeover.rs
@@ -1,6 +1,6 @@
 //! Replace a running agent that speaks an older IPC protocol.
 //!
-//! The self-restart watcher (see [`crate::self_restart`]) keeps a *future*
+//! The binary watcher (see [`crate::binary_watch`]) keeps a *future*
 //! stale agent from outliving an update — but the watcher only exists in
 //! binaries that ship it, so the first protocol bump still strands every
 //! user whose pre-watcher agent is running: it never exits, launchd only
@@ -144,7 +144,7 @@ fn replace_stale() -> Option<InstanceGuard> {
 
 /// No Windows release has ever shipped (or auto-started) the agent, so there
 /// is no pre-watcher population to migrate; from the first shipped build
-/// onward, `self_restart` exits on update and the GUI's spawn retry starts
+/// onward, `binary_watch` exits on update and the GUI's spawn retry starts
 /// the new binary.
 #[cfg(windows)]
 fn replace_stale() -> Option<InstanceGuard> {


### PR DESCRIPTION
## Summary

`self_restart.rs` had grown into three jobs in one file, which is why reading it felt like reading a procedure rather than a design:

1. decide whether the installed binary changed or went away (a pure state machine, with tests),
2. carry that out on three operating systems that agree on nothing,
3. relaunch after an Input Monitoring grant, which is a different trigger entirely.

Nothing here changes behaviour. The decision layer keeps the module; the per-OS mechanics move to a child.

## Changes

- `self_restart.rs` → `binary_watch.rs`. The old name stopped being true when the watcher learned to *stop* the agent on uninstall (#807), not just restart it.
- New `binary_watch/relaunch.rs` holds the three `restart()` implementations, the macOS scheduling helpers, and `relaunch_after_input_monitoring_grant` (re-exported, so the call site is unchanged). Its module doc gets to state the thing that was previously spread across three comment blocks: unix `exec`s in place, macOS *cannot* — after `exec` the new program continues on the calling thread while AppKit wants the status item created from the main thread — so it schedules a detached successor through LaunchServices (which is what preserves the helper's TCC identity) and exits, and Windows has no `exec` at all.
- The macOS `helper_bundle` test travels with the code it covers.
- References to the old module name in `takeover.rs`, `main.rs` and the macOS-permissions skill are updated.

357 + 154 lines, from 481 in one file; both halves now have one subject.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items ...
cargo xtask ci
```

`cargo xtask ci`: 9 pass, `tests (linux)` not run (this host is macOS).

The Windows cross-lint caught the one real mistake in the move: `warn!` is unused on Windows, where the relaunch is nothing but an exit, so the import is now `#[cfg(unix)]`.
