### PR TITLE
fix(agent): make macOS permission failures diagnosable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,8 +5183,10 @@ dependencies = [
  "succession",
  "sysinfo 0.38.4",
  "tarpc",
+ "tempfile",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "windows-sys 0.61.2",
  "winreg",
@@ -7526,6 +7537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8093,6 +8110,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -36,6 +36,7 @@ tracing-subscriber = { workspace = true }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 opener = { workspace = true }
 succession = { version = "0.1", features = ["supervision", "eviction"] }
+tracing-appender = "0.2.5"
 
 # Held at the version Cargo.lock already has for gpui's own build-dependency;
 # bumping it independently would move the pinned gpui rev.
@@ -61,3 +62,6 @@ windows-sys = { workspace = true, features = [
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/openlogi-agent/src/logging.rs
+++ b/crates/openlogi-agent/src/logging.rs
@@ -1,0 +1,100 @@
+//! Agent tracing setup: stderr for foreground runs, a rotating file under the
+//! XDG state directory for launchd runs (which discard stderr), and a panic
+//! hook so crashes land in the same file.
+
+use std::io;
+use std::path::Path;
+
+use tracing::warn;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+
+/// Rotated log files kept before the oldest is deleted.
+const MAX_LOG_FILES: usize = 7;
+
+/// Install the agent's tracing subscriber and panic hook.
+///
+/// Always logs to stderr (visible in a foreground run), and additionally to a
+/// daily-rotated `agent.<date>.log` under [`openlogi_core::paths::state_dir`]
+/// — launchd gives the agent's stderr no destination, so without the file a
+/// launchd-run agent cannot be diagnosed at all (#336). If the file cannot be
+/// opened the agent falls back to stderr only and says so.
+pub(crate) fn init() {
+    let filter = EnvFilter::try_from_env("OPENLOGI_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+    let (file_layer, file_error) = match file_appender() {
+        Ok(appender) => (
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(appender),
+            ),
+            None,
+        ),
+        Err(e) => (None, Some(e)),
+    };
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(file_layer)
+        .init();
+    if let Some(e) = file_error {
+        warn!(error = %e, "agent log file unavailable — logging to stderr only");
+    }
+    route_panics_to_tracing();
+}
+
+/// A daily-rotated appender in the app state directory, capped at
+/// [`MAX_LOG_FILES`] files.
+fn file_appender() -> io::Result<RollingFileAppender> {
+    let dir = openlogi_core::paths::state_dir().map_err(io::Error::other)?;
+    std::fs::create_dir_all(&dir)?;
+    build_appender(&dir)
+}
+
+fn build_appender(dir: &Path) -> io::Result<RollingFileAppender> {
+    RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("agent")
+        .filename_suffix("log")
+        .max_log_files(MAX_LOG_FILES)
+        .build(dir)
+        .map_err(io::Error::other)
+}
+
+/// Panics print to stderr, which launchd discards; mirror them into tracing
+/// so the log file records why the agent died.
+fn route_panics_to_tracing() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        tracing::error!("agent panicked: {info}");
+        default_hook(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use super::*;
+
+    #[test]
+    fn appender_writes_into_the_given_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut appender = build_appender(dir.path()).expect("build appender");
+        appender.write_all(b"probe line\n").expect("write");
+        appender.flush().expect("flush");
+        let files: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            files
+                .iter()
+                .any(|name| name.starts_with("agent") && name.ends_with("log")),
+            "no agent log file created: {files:?}"
+        );
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -16,6 +16,7 @@
 )]
 
 mod launch_agent;
+mod logging;
 mod overlay;
 mod pairing;
 #[cfg(target_os = "windows")]
@@ -47,12 +48,11 @@ use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
-use tracing_subscriber::EnvFilter;
 
 use crate::server::AgentServer;
 
 fn main() {
-    init_tracing();
+    logging::init();
 
     // Single-instance guard: the agent owns all device I/O, the CGEventTap, and
     // the IPC socket, so a second agent must never start — launchd's KeepAlive
@@ -515,13 +515,4 @@ async fn run(
             else => break,
         }
     }
-}
-
-fn init_tracing() {
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(
-            EnvFilter::try_from_env("OPENLOGI_LOG").unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
 }

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -7,6 +7,7 @@
 //! |--------|---------------------|-------------------------------|
 //! | config | `$XDG_CONFIG_HOME`  | `~/.config/openlogi`          |
 //! | data   | `$XDG_DATA_HOME`    | `~/.local/share/openlogi`     |
+//! | state  | `$XDG_STATE_HOME`   | `~/.local/state/openlogi`     |
 //!
 //! On Windows `$HOME` falls back to `%USERPROFILE%`, so paths resolve to
 //! `%USERPROFILE%\.config\openlogi` etc.
@@ -142,6 +143,18 @@ pub fn config_path() -> Result<PathBuf, PathsError> {
 /// Local macOS dev builds use `openlogi-dev` instead.
 pub fn data_dir() -> Result<PathBuf, PathsError> {
     Ok(xdg()?.data_dir().join(app_dir()))
+}
+
+/// Directory for logs and other rebuildable process state — the agent's
+/// rotated log files live here.
+///
+/// `$XDG_STATE_HOME/openlogi`, default `~/.local/state/openlogi`.
+/// Local macOS dev builds use `openlogi-dev` instead.
+pub fn state_dir() -> Result<PathBuf, PathsError> {
+    let xdg = xdg()?;
+    Ok(xdg
+        .state_dir()
+        .map_or_else(|| xdg.data_dir().join(app_dir()), |dir| dir.join(app_dir())))
 }
 
 /// Directory for runtime sockets — the background agent's IPC endpoint.

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -48,6 +48,30 @@ fn backend_error(error: async_hid::HidError) -> BackendError {
     }
 }
 
+/// Classify a failed device open. On macOS `IOHIDDeviceOpen` denies silently —
+/// the error is indistinguishable from exclusive access — so fold the Input
+/// Monitoring state into the message: it is the difference between "grant the
+/// permission" and "close the other app, or log out and back in".
+#[cfg(not(target_os = "windows"))]
+fn open_error(error: async_hid::HidError) -> BackendError {
+    match backend_error(error) {
+        #[cfg(target_os = "macos")]
+        BackendError::Backend(message) => {
+            let hint = if crate::permissions::has_access() {
+                "Input Monitoring is granted to this process — another app may \
+                 hold the device exclusively, or macOS is serving a stale \
+                 permission session (log out and back in)"
+            } else {
+                "Input Monitoring is NOT granted to this process; grant it to \
+                 OpenLogi Agent under System Settings → Privacy & Security → \
+                 Input Monitoring"
+            };
+            BackendError::Backend(format!("{message}: {hint}"))
+        }
+        other => other,
+    }
+}
+
 /// `DeviceId` is an opaque OS handle (a hidraw path, a Windows device path, an
 /// IOKit entry), so [`NodeId`] carries its `Debug` rendering verbatim.
 ///
@@ -370,7 +394,7 @@ pub(crate) async fn open_hidpp_channel(
 
     #[cfg(not(target_os = "windows"))]
     {
-        let (reader, writer) = dev.open().await.map_err(backend_error)?;
+        let (reader, writer) = dev.open().await.map_err(open_error)?;
         // BLE-direct devices expose only the long HID++ report; flag the channel so
         // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
         let long_only = is_long_only_collection(info.usage_page, info.usage_id);


### PR DESCRIPTION
## Summary

The macOS permission cluster (#336, #704, #707) has been undiagnosable for two reasons: a launchd-run agent's log goes nowhere (launchd discards stderr and the generated LaunchAgent plist sets no destination), and a denied `IOHIDDeviceOpen` produces the same bare `Failed to open device` as exclusive access or a stale permission session. This PR fixes both halves.

The agent now writes a daily-rotated log to the XDG state directory (`~/.local/state/openlogi/agent.<date>.log`, capped at 7 files), in addition to stderr for foreground runs, and installs a panic hook so crashes land in the same file. A failed HID open on macOS now says which case it is: Input Monitoring not granted (with the exact System Settings path and the OpenLogi Agent identity to grant), or granted-but-still-failing (exclusive access by another app, or a stale TCC session needing a log-out — the exact signature reported in #704, where a full logout fixed what agent restarts could not).

## Changes

- `core`: new `paths::state_dir()` (`$XDG_STATE_HOME/openlogi`, dev-profile aware, falling back to the data dir base when the strategy lacks a state home); doc table updated.
- `agent`: new `logging` module replaces `init_tracing` — a `registry` with the same `OPENLOGI_LOG` filter feeding a stderr layer plus a daily-rotated file layer (`tracing-appender`, `max_log_files(7)`), a stderr-only fallback that logs why the file is unavailable, and a panic hook that mirrors panics into tracing.
- `hid`: `open_error` wraps the transport's open failure with the Input Monitoring classification on macOS; gated off Windows, where opens go through the composite-channel path.

## Testing

- `cargo test -p openlogi-agent logging` — the appender writes into the given directory.
- Full local gate on the final tree (fmt check; clippy workspace `--all-targets -D warnings` with `RUSTFLAGS=-D warnings`; workspace tests; rustdoc non-GUI `-D warnings`) — green.
- windows-gnu cross-lint (`cargo-clippy` invoked directly, `RUSTFLAGS=-D warnings`, `--target x86_64-pc-windows-gnu`) of `openlogi-hid` and `openlogi-agent` — green; the new `open_error` is `cfg`'d off Windows precisely because that branch never calls it.
- Not runtime-tested on hardware. To verify on a real machine: run the packaged agent via launchd and confirm `~/.local/state/openlogi/agent.<date>.log` appears and receives the startup lines; revoke Input Monitoring and confirm the open failure now names the missing grant.

The macOS permissions skill (#813) pins the old bare `Failed to open device` string as a triage discriminator; once both land, the skill's classification table gets a follow-up documenting the new self-classified messages.

Fixes #336.
