### PR TITLE
refactor(agent-core): give the polling watchers one loop

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/accessibility.rs
+++ b/crates/openlogi-agent-core/src/watchers/accessibility.rs
@@ -1,41 +1,27 @@
 //! Accessibility permission polling watcher.
 
-use std::thread;
 use std::time::Duration;
 
 use openlogi_hook::Hook;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+
+use super::poll::{self, Poll};
 
 /// Watch macOS Accessibility permission changes.
+///
+/// Poll it for as long as a hook is installed: an active event tap that
+/// outlives its grant wedges system input until reboot, so the agent has to
+/// learn about a revocation on its own (see `.claude/rules/hook.md`).
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<bool> {
-    let (tx, rx) = mpsc::unbounded_channel();
-
     if !cfg!(target_os = "macos") {
-        let _ = tx.send(true);
-        let _ = period;
-        return rx;
+        // Linux and Windows gate the hook below the privacy layer, so there is
+        // nothing here that can change.
+        return poll::constant(true);
     }
-
-    let spawn_result = thread::Builder::new()
-        .name("openlogi-accessibility-watcher".into())
-        .spawn(move || {
-            let mut last: Option<bool> = None;
-            loop {
-                let granted = Hook::has_accessibility();
-                if last != Some(granted) {
-                    debug!(granted, "accessibility trust changed");
-                    if tx.send(granted).is_err() {
-                        debug!("accessibility watcher receiver dropped — exiting");
-                        return;
-                    }
-                    last = Some(granted);
-                }
-                thread::sleep(period);
-            }
-        });
-    if let Err(e) = spawn_result {
-        warn!(error = %e, "could not spawn accessibility watcher — gate won't auto-dismiss");
+    Poll {
+        name: "openlogi-accessibility-watcher",
+        period,
+        degrades: "the permission gate won't auto-dismiss",
     }
-    rx
+    .on_change(Hook::has_accessibility)
 }

--- a/crates/openlogi-agent-core/src/watchers/foreground_app.rs
+++ b/crates/openlogi-agent-core/src/watchers/foreground_app.rs
@@ -1,10 +1,10 @@
 //! Foreground application polling watcher.
 
-use std::thread;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+
+use super::poll::{self, Poll};
 
 /// Channel item: `Some(bundle_id)` when an app is frontmost; `None` for
 /// "no foreground app" (rare on macOS — Finder is usually frontmost even
@@ -13,37 +13,18 @@ pub type ForegroundUpdate = Option<String>;
 
 /// Watch foreground application changes.
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<ForegroundUpdate> {
-    let (tx, rx) = mpsc::unbounded_channel();
     if !cfg!(any(
         target_os = "macos",
         target_os = "linux",
         target_os = "windows"
     )) {
-        drop(tx);
-        let _ = period;
-        return rx;
+        // No way to read the frontmost app, so per-app profiles never switch.
+        return poll::never();
     }
-    let spawn_result = thread::Builder::new()
-        .name("openlogi-app-watcher".into())
-        .spawn(move || {
-            let mut last: ForegroundUpdate = None;
-            let mut first_tick = true;
-            loop {
-                let current = openlogi_hook::frontmost_bundle_id();
-                if first_tick || current != last {
-                    debug!(?current, ?last, "frontmost app changed");
-                    if tx.send(current.clone()).is_err() {
-                        debug!("app watcher receiver dropped — exiting");
-                        return;
-                    }
-                    last = current;
-                    first_tick = false;
-                }
-                thread::sleep(period);
-            }
-        });
-    if let Err(e) = spawn_result {
-        warn!(error = %e, "could not spawn app watcher — per-app profiles disabled");
+    Poll {
+        name: "openlogi-app-watcher",
+        period,
+        degrades: "per-app profiles are disabled",
     }
-    rx
+    .on_change(openlogi_hook::frontmost_bundle_id)
 }

--- a/crates/openlogi-agent-core/src/watchers/input_monitoring.rs
+++ b/crates/openlogi-agent-core/src/watchers/input_monitoring.rs
@@ -1,40 +1,21 @@
 //! Input Monitoring permission polling watcher.
 
-use std::thread;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+
+use super::poll::{self, Poll};
 
 /// Watch macOS Input Monitoring permission changes.
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<bool> {
-    let (tx, rx) = mpsc::unbounded_channel();
-
     if !cfg!(target_os = "macos") {
-        let _ = tx.send(true);
-        let _ = period;
-        return rx;
+        // Only macOS gates HID access behind a privacy grant.
+        return poll::constant(true);
     }
-
-    let spawn_result = thread::Builder::new()
-        .name("openlogi-input-monitoring-watcher".into())
-        .spawn(move || {
-            let mut last: Option<bool> = None;
-            loop {
-                let granted = openlogi_hid::permissions::has_access();
-                if last != Some(granted) {
-                    debug!(granted, "input monitoring trust changed");
-                    if tx.send(granted).is_err() {
-                        debug!("input monitoring watcher receiver dropped — exiting");
-                        return;
-                    }
-                    last = Some(granted);
-                }
-                thread::sleep(period);
-            }
-        });
-    if let Err(e) = spawn_result {
-        warn!(error = %e, "could not spawn input monitoring watcher — status won't auto-refresh");
+    Poll {
+        name: "openlogi-input-monitoring-watcher",
+        period,
+        degrades: "the permission status won't auto-refresh",
     }
-    rx
+    .on_change(openlogi_hid::permissions::has_access)
 }

--- a/crates/openlogi-agent-core/src/watchers/mod.rs
+++ b/crates/openlogi-agent-core/src/watchers/mod.rs
@@ -11,3 +11,4 @@ pub mod input_monitoring;
 pub mod inventory;
 pub mod keyboard;
 pub mod pairing;
+mod poll;

--- a/crates/openlogi-agent-core/src/watchers/poll.rs
+++ b/crates/openlogi-agent-core/src/watchers/poll.rs
@@ -1,0 +1,148 @@
+//! The shape shared by the agent's polling watchers.
+//!
+//! Some of what the agent tracks has no notification worth using — a macOS
+//! privacy grant, the frontmost application — so it is read on a thread at a
+//! fixed cadence and reported when it changes. Writing that loop once means the
+//! three rules it has to get right are stated in one place, and tested:
+//!
+//! - the first sample is always reported (the consumer has nothing until it
+//!   arrives), and after that only changes are,
+//! - the thread ends when the consumer stops listening,
+//! - a thread that cannot start degrades the feature with a warning rather than
+//!   taking the agent down.
+//!
+//! Watchers with more to say than "the value changed" — the HID inventory, the
+//! gesture and pairing sessions — keep their own loops.
+
+use std::fmt::Debug;
+use std::thread;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+/// One polling watcher, described where it is started.
+#[derive(Clone, Copy, Debug)]
+pub struct Poll {
+    /// Thread name, and the tag this watcher's log lines carry.
+    pub name: &'static str,
+    /// How long to wait between samples.
+    pub period: Duration,
+    /// What stops working if the thread cannot start, for the warning that
+    /// says so — phrased to complete "could not spawn watcher — …".
+    pub degrades: &'static str,
+}
+
+impl Poll {
+    /// Report what `read` returns whenever it differs from the last value sent.
+    ///
+    /// `read` runs on the watcher's own thread and must not block for long: the
+    /// cadence is the sum of `period` and however long it takes.
+    pub fn on_change<T, F>(self, read: F) -> mpsc::UnboundedReceiver<T>
+    where
+        T: Clone + PartialEq + Debug + Send + 'static,
+        F: Fn() -> T + Send + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let spawned = thread::Builder::new()
+            .name(self.name.into())
+            .spawn(move || {
+                let mut last: Option<T> = None;
+                loop {
+                    let current = read();
+                    // `None` is "nothing reported yet", never a value, so the
+                    // first sample always goes out even when `T` itself is an
+                    // `Option` that starts at `None`.
+                    if last.as_ref() != Some(&current) {
+                        debug!(watcher = self.name, value = ?current, "changed");
+                        if tx.send(current.clone()).is_err() {
+                            debug!(watcher = self.name, "receiver dropped — exiting");
+                            return;
+                        }
+                        last = Some(current);
+                    }
+                    thread::sleep(self.period);
+                }
+            });
+        if let Err(error) = spawned {
+            warn!(
+                error = %error,
+                watcher = self.name,
+                "could not spawn watcher — {}",
+                self.degrades
+            );
+        }
+        rx
+    }
+}
+
+/// A watcher for a platform where the answer cannot change: `value` is
+/// reported once, and nothing follows it.
+pub fn constant<T>(value: T) -> mpsc::UnboundedReceiver<T> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    // The queued value outlives the sender, so the consumer still sees it.
+    let _ = tx.send(value);
+    rx
+}
+
+/// A watcher for a platform that has no such source: nothing is ever reported.
+pub fn never<T>() -> mpsc::UnboundedReceiver<T> {
+    mpsc::unbounded_channel().1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    /// Drain what the watcher reports until it goes quiet, bounded so a broken
+    /// watcher fails the test instead of hanging it.
+    fn drain<T>(rx: &mut mpsc::UnboundedReceiver<T>, want: usize) -> Vec<T> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut seen = Vec::new();
+        while seen.len() < want && Instant::now() < deadline {
+            match rx.try_recv() {
+                Ok(value) => seen.push(value),
+                Err(_) => thread::sleep(Duration::from_millis(1)),
+            }
+        }
+        seen
+    }
+
+    #[test]
+    fn the_first_sample_is_reported_and_then_only_changes() {
+        let samples = Mutex::new(vec![false, true, true, true, false].into_iter());
+        let mut rx = Poll {
+            name: "openlogi-test-watcher",
+            period: Duration::from_millis(1),
+            degrades: "the test learns nothing",
+        }
+        .on_change(move || {
+            samples
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .next()
+                // Hold the last sample once the script runs out, so the
+                // watcher has nothing new to report rather than exiting.
+                .unwrap_or(false)
+        });
+
+        // `false` opens the stream even though it equals `T::default()`, then
+        // only the two transitions follow.
+        assert_eq!(drain(&mut rx, 3), vec![false, true, false]);
+    }
+
+    #[test]
+    fn a_constant_watcher_reports_once() {
+        let mut rx = constant(true);
+        assert_eq!(drain(&mut rx, 1), vec![true]);
+        rx.try_recv().unwrap_err();
+    }
+
+    #[test]
+    fn a_never_watcher_reports_nothing() {
+        let mut rx = never::<bool>();
+        rx.try_recv().unwrap_err();
+    }
+}


### PR DESCRIPTION
## Summary

`watchers/accessibility.rs`, `watchers/input_monitoring.rs` and `watchers/foreground_app.rs` were the same 25-line procedure written three times: spawn a named thread, read a value, send it when it differs from the last one sent, exit when the receiver is gone, warn instead of panicking if the thread cannot start. What actually differed was the read function, the thread name, and the wording of two log lines.

The two permission watchers were near character-for-character copies of each other. That is why this corner reads like a pile of scripts rather than a design.

## Changes

- New `watchers/poll.rs`: a `Poll { name, period, degrades }` describing one watcher, with `on_change(read)` running the loop, plus `constant(value)` and `never()` for the platforms where a watcher has nothing to do. The rules it has to get right — first sample always reported, then only changes; end the thread when the consumer stops listening; degrade with a warning rather than taking the agent down — are now stated once, in one place, with tests they did not have before.
- The three watchers become declarations:

```rust
pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<bool> {
    if !cfg!(target_os = "macos") {
        return poll::constant(true);
    }
    Poll {
        name: "openlogi-accessibility-watcher",
        period,
        degrades: "the permission gate won't auto-dismiss",
    }
    .on_change(Hook::has_accessibility)
}
```

- The awkward bit in the old copies goes with them. `foreground_app` carried a `first_tick` flag because its value type is itself an `Option`, so "nothing reported yet" and "no frontmost app" were the same value and the change check would have swallowed the first sample. Tracking the previous sample as `Option<T>` says that properly, and all three watchers report their first sample exactly as before.

Watchers with more to report than "the value changed" — `inventory`, `camera`, `gesture`, `host_switch`, `keyboard`, `pairing` — keep their own loops. This is not a framework.

Not a line-count win, and not meant as one: the three watchers drop from 130 lines to 78, and the loop they shared is ~55 lines in one place, plus tests.

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items ...
cargo xtask ci
```

`cargo xtask ci`: 9 pass, `tests (linux)` not run (this host is macOS).

Three new tests cover the shared loop: the first sample is reported even when it equals the type's default, only changes follow it, and the constant/never watchers behave as their names claim. Behaviour is otherwise unchanged — same cadence, same channel types, same platform fallbacks (a single `true` for the permission watchers off macOS, a closed channel for the frontmost reader). The one visible difference is in the logs: changes now carry a `watcher` tag and the previous value is no longer logged alongside the new one.
