### PR TITLE
fix: show Windows MSI completion and failure state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,10 +635,12 @@ jobs:
         # Pinned exactly: a WiX point release can silently change the produced
         # MSI (validation, cab layout), and nothing in CI installs the MSI, so
         # drift would only surface on end-user machines. Bump deliberately.
-        # The Util extension (util:CloseApplication in OpenLogi.wxs) is pinned
-        # to the same version — WiX extensions release in lockstep with wix.
+        # The UI extension (the progress-only dialog flow) and Util extension
+        # (util:CloseApplication in OpenLogi.wxs) are pinned to the same version
+        # — WiX extensions release in lockstep with wix.
         run: |
           dotnet tool install --global wix --version 6.0.2
+          wix extension add --global WixToolset.UI.wixext/6.0.2
           wix extension add --global WixToolset.Util.wixext/6.0.2
 
       - name: Build the MSI
@@ -667,6 +669,7 @@ jobs:
           }
           New-Item -ItemType Directory -Force -Path out | Out-Null
           wix build packaging\windows\OpenLogi.wxs `
+            -ext WixToolset.UI.wixext `
             -ext WixToolset.Util.wixext `
             -arch ${{ matrix.msi_platform }} `
             -d Version=$version `

--- a/packaging/windows/OpenLogi.wxs
+++ b/packaging/windows/OpenLogi.wxs
@@ -18,8 +18,9 @@
                     entry); defaults to the committed design/icon/openlogi.ico
                     below, so the release workflow needs no extra define
 
-  - Requires WixToolset.Util.wixext (util:CloseApplication below); the
-    windows-msi job installs it pinned to the same version as wix itself.
+  - Requires WixToolset.UI.wixext (the progress-only dialog flow) and
+    WixToolset.Util.wixext (util:CloseApplication below); the windows-msi job
+    installs both pinned to the same version as wix itself.
 -->
 
 <!--
@@ -40,6 +41,7 @@
 <?endif?>
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
   <Package Name="OpenLogi"
            Manufacturer="AprilNEA"
@@ -51,6 +53,34 @@
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of OpenLogi is already installed." />
     <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+
+    <!--
+      Start interactive installs immediately, but keep the standard progress
+      and terminal dialogs so closing the OpenLogi processes below cannot make
+      a successful, cancelled, or failed install look like it simply vanished.
+      Windows Installer suppresses this authored UI at the /qn UI level, so
+      staged updates remain non-interactive.
+    -->
+    <UI>
+      <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+      <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
+      <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
+      <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+
+      <DialogRef Id="ErrorDlg" />
+      <DialogRef Id="FatalError" />
+      <DialogRef Id="FilesInUse" />
+      <DialogRef Id="MsiRMFilesInUse" />
+      <DialogRef Id="ProgressDlg" />
+      <DialogRef Id="UserExit" />
+      <Publish Dialog="ExitDialog"
+               Control="Finish"
+               Event="EndDialog"
+               Value="Return"
+               Order="999" />
+
+      <ui:WixUI Id="WixUI_Common" />
+    </UI>
 
     <StandardDirectory Id="LocalAppDataFolder">
       <Directory Id="ProgramsFolder" Name="Programs">


### PR DESCRIPTION
Windows 11 users report that launching the release MSI shows only the transient “Please wait while Windows configures OpenLogi” window and then disappears, which looks like an aborted installation. The same behavior is reported for 0.7.1 and 0.7.3, with the external progress window disappearing at different points; a running portable OpenLogi process is also closed during the operation. The current WiX package intentionally closes running OpenLogi processes but authors no MSI dialog set that can distinguish successful completion from cancellation or failure. The package therefore needs an explicit interactive completion/error flow without changing its per-user scope or silent-update contract.

## Summary

Wire the WiX UI extension into the Windows MSI build at the same pinned 6.0.2 version as the core toolset and Util extension, then reference it explicitly in both architecture build legs. In `OpenLogi.wxs`, enable the built-in progress-only UI flow so an interactive launch retains the existing no-configuration install path while presenting progress, fatal-error, cancellation, and successful-completion dialogs. Keep the existing `util:CloseApplication` actions and their GUI/agent/overlay semantics intact; the portable GUI closing during installation remains expected, but the installer must then make the outcome explicit.

## Testing

- On a clean Windows 11 user profile, double-click each x86_64 and arm64 MSI: the package displays authored progress and a success completion dialog, installs under the per-user location, and leaves a working Start Menu shortcut.
- Start the portable GUI and agent before an interactive install: the existing close actions stop the running processes, installation continues, and the completion dialog remains visible rather than disappearing with the application.
- Trigger an installation failure or user cancellation: the interactive flow reports failure/cancellation and does not present the success state.
- Run a silent install or staged update with `/qn`: no UI is shown, process-closing behavior still works, and `msiexec` returns a deterministic success or failure code without waiting for dialog input.
- Build both Windows architecture matrix legs: WiX resolves the UI and Util extensions at the same pinned version and produces the signed MSI artifacts without authoring or extension-resolution errors.

Fixes #666

AI was used for assistance.
