### PR TITLE
fix(gui): check the open helper's exit status when launching the agent

### DIFF
--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -331,12 +331,23 @@ fn launch_agent(path: &std::path::Path) -> std::io::Result<()> {
     // check to the parent GUI and the grant flips with the launch path (#192).
     #[cfg(target_os = "macos")]
     if let Some(bundle) = helper_bundle(path) {
-        return std::process::Command::new("/usr/bin/open")
+        let mut child = std::process::Command::new("/usr/bin/open")
             .arg("-g")
             .arg("-n")
             .arg(bundle)
-            .spawn()
-            .map(|_| ());
+            .spawn()?;
+        // `open` exits as soon as it hands the bundle to LaunchServices, and
+        // its exit status is the only signal that the handoff failed (damaged
+        // bundle, LaunchServices refusal) — a successful spawn alone proves
+        // nothing. Reap it off-thread and log the failure the spawn hides.
+        std::thread::spawn(move || match child.wait() {
+            Ok(status) if !status.success() => {
+                warn!(%status, "`open` could not launch the agent bundle");
+            }
+            Err(e) => warn!(error = %e, "could not reap the `open` helper"),
+            Ok(_) => {}
+        });
+        return Ok(());
     }
     // Any other layout (bare dev binary, Windows, Linux): exec the binary
     // directly while disclaiming the GUI's TCC responsibility (#214).

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -318,8 +318,12 @@ fn spawn_agent() {
     // The packaged helper goes through LaunchServices so it is its own TCC
     // responsible process; everything else is a `disclaim` exec (a no-op
     // pass-through to `std::process::Command` off macOS).
+    // "started", not "launched": on the packaged path success here only means
+    // `open` was handed the bundle — the waiter inside `launch_agent` reports
+    // the definitive outcome, so a LaunchServices rejection is not preceded by
+    // a success claim it then contradicts.
     match launch_agent(&path) {
-        Ok(()) => info!(path = %path.display(), "agent not running — launched it"),
+        Ok(()) => info!(path = %path.display(), "agent not running — launch started"),
         Err(e) => warn!(error = %e, path = %path.display(), "could not launch the agent"),
     }
 }


### PR DESCRIPTION
## Summary

Launching the packaged agent goes through `/usr/bin/open -g -n <bundle>`, and the GUI treated a successful *spawn of open* as a successful *launch of the agent*. `open` exits as soon as it hands the bundle to LaunchServices, and its exit status is the only signal that the handoff failed (damaged bundle, LaunchServices refusal) — that failure was invisible and the GUI logged "agent not running — launched it" regardless.

Reap the `open` child on a background thread and log a warning on non-zero exit. The `disclaim` path needs no change: its spawn result was already checked and logged by the caller (the `.map(|_| ())` there discards the child handle, not the error).

## Changes

- `gui`: `launch_agent` keeps the `open` child, waits for it off-thread, and warns with the exit status when the LaunchServices handoff fails.

## Testing

- Full local gate on the final tree (fmt check; `RUSTFLAGS=-D warnings` clippy workspace `--all-targets`; workspace tests; rustdoc non-GUI) — green.
- The change is inside the existing `#[cfg(target_os = "macos")]` block; no other platform's code path changed.
- Not runtime-tested on hardware. To verify: rename the helper bundle inside a packaged app and confirm the GUI now logs the non-zero `open` exit instead of claiming a launch.