### PR TITLE
feat(ipc): surface HID open failures in agent status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,8 +5183,10 @@ dependencies = [
  "succession",
  "sysinfo 0.38.4",
  "tarpc",
+ "tempfile",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "windows-sys 0.61.2",
  "winreg",
@@ -7526,6 +7537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8093,6 +8110,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -112,7 +112,8 @@ impl ObservableState {
     }
 
     /// Publish where enumeration stands together with the device set it
-    /// produced, so the two can never be read from different generations.
+    /// produced — and whether that tick failed to open HID++ nodes — so none
+    /// of the three can be read from different generations.
     ///
     /// The inventory watcher re-enumerates on a timer, so most calls carry the
     /// same devices as the last one; those notify nobody.
@@ -121,17 +122,20 @@ impl ObservableState {
         health: InventoryHealth,
         inventories: &[DeviceInventory],
         standalone: &[StandaloneDevice],
+        hid_open_failures: bool,
     ) {
         self.update(|snapshot| {
             if snapshot.status.inventory == health
                 && snapshot.inventory == inventories
                 && snapshot.standalone == standalone
+                && snapshot.status.hid_open_failures == hid_open_failures
             {
                 return false;
             }
             snapshot.status.inventory = health;
             snapshot.inventory = inventories.to_vec();
             snapshot.standalone = standalone.to_vec();
+            snapshot.status.hid_open_failures = hid_open_failures;
             true
         });
     }
@@ -178,21 +182,6 @@ impl ObservableState {
                 return false;
             }
             snapshot.status.input_monitoring_granted = granted;
-            true
-        });
-    }
-
-    /// Publish whether the last enumeration tick failed to open HID++
-    /// nodes, as reported by
-    /// [`watchers::inventory`](crate::watchers::inventory) — with the grant
-    /// state this is what separates "grant Input Monitoring" from "the grant
-    /// exists but another app or a stale permission session is in the way".
-    pub fn set_hid_open_failures(&self, failing: bool) {
-        self.update(|snapshot| {
-            if snapshot.status.hid_open_failures == failing {
-                return false;
-            }
-            snapshot.status.hid_open_failures = failing;
             true
         });
     }
@@ -282,12 +271,12 @@ mod tests {
         let state = state();
         let mut rx = state.subscribe();
 
-        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[], false);
         assert!(rx.has_changed().unwrap(), "the first enumeration is news");
         rx.mark_unchanged();
 
         // What the inventory watcher does every couple of seconds on a steady desk.
-        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[], false);
         assert!(
             !rx.has_changed().unwrap(),
             "an identical enumeration must not wake a reader"
@@ -298,10 +287,10 @@ mod tests {
     fn a_device_waking_inside_an_otherwise_identical_set_is_news() {
         let state = state();
         let mut rx = state.subscribe();
-        state.set_inventory(InventoryHealth::Ready, &[inventory(false)], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[inventory(false)], &[], false);
         rx.mark_unchanged();
 
-        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[], false);
         assert!(rx.has_changed().unwrap());
     }
 
@@ -312,7 +301,7 @@ mod tests {
 
         // "Checked, no devices" differs from "not checked yet" only in health —
         // the distinction the GUI's empty state reads.
-        state.set_inventory(InventoryHealth::Ready, &[], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[], &[], false);
         assert!(rx.has_changed().unwrap());
         let snapshot = state.snapshot();
         assert_eq!(snapshot.status.inventory, InventoryHealth::Ready);
@@ -322,7 +311,7 @@ mod tests {
     #[test]
     fn a_hook_write_leaves_the_device_facts_alone() {
         let state = state();
-        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[], false);
 
         state.set_hook_installed(true);
         state.set_accessibility_granted(true);
@@ -348,7 +337,7 @@ mod tests {
     #[tokio::test]
     async fn a_stale_generation_gets_the_current_state_at_once() {
         let state = state();
-        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[]);
+        state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[], false);
 
         let observed = state.observe(1).await;
         assert_eq!(observed.generation, 2);

--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -51,6 +51,7 @@ impl ObservableState {
                     protocol_version: PROTOCOL_VERSION,
                     agent_version,
                     input_monitoring_granted: openlogi_hid::permissions::has_access(),
+                    hid_open_failures: false,
                 },
                 inventory: Vec::new(),
                 standalone: Vec::new(),
@@ -177,6 +178,21 @@ impl ObservableState {
                 return false;
             }
             snapshot.status.input_monitoring_granted = granted;
+            true
+        });
+    }
+
+    /// Publish whether the last enumeration tick failed to open HID++
+    /// nodes, as reported by
+    /// [`watchers::inventory`](crate::watchers::inventory) — with the grant
+    /// state this is what separates "grant Input Monitoring" from "the grant
+    /// exists but another app or a stale permission session is in the way".
+    pub fn set_hid_open_failures(&self, failing: bool) {
+        self.update(|snapshot| {
+            if snapshot.status.hid_open_failures == failing {
+                return false;
+            }
+            snapshot.status.hid_open_failures = failing;
             true
         });
     }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -145,6 +145,10 @@ pub struct Orchestrator {
     /// set/route/online state looks identical across the sleep gap, so the
     /// next refresh re-applies volatile settings to every online device.
     reapply_all_next_refresh: bool,
+    /// Whether the last enumeration tick failed to open HID++ nodes; published
+    /// atomically with the inventory so no observation pairs a fresh device
+    /// set with a stale flag.
+    hid_open_failures: bool,
     /// Config keys of devices first sighted (or wake-flagged) recently, with
     /// remaining confirming re-apply budget: the first write can race the
     /// device's own boot or reconnect and be lost.
@@ -206,6 +210,7 @@ impl Orchestrator {
             current_app: None,
             inventory: InventoryState::Pending,
             reapply_all_next_refresh: false,
+            hid_open_failures: false,
             reapply_followup: HashMap::new(),
             camera_active: None,
             manual_light_overrides: BTreeMap::new(),
@@ -402,10 +407,12 @@ impl Orchestrator {
         &mut self,
         inventories: &[DeviceInventory],
         standalone: &[StandaloneDevice],
+        hid_open_failures: bool,
     ) {
         // Even an empty snapshot is a *completed* enumeration — the watcher
         // skips failed ticks — so the device set is now known either way (and
         // a recovered backend upgrades `Unavailable` back to live data).
+        self.hid_open_failures = hid_open_failures;
         self.inventory = InventoryState::Ready {
             inventories: inventories.to_vec(),
             standalone: standalone.to_vec(),
@@ -675,20 +682,19 @@ impl Orchestrator {
             InventoryState::Ready {
                 inventories,
                 standalone,
-            } => self
-                .observable
-                .set_inventory(health, inventories, standalone),
+            } => {
+                self.observable.set_inventory(
+                    health,
+                    inventories,
+                    standalone,
+                    self.hid_open_failures,
+                );
+            }
             InventoryState::Pending | InventoryState::Unavailable => {
-                self.observable.set_inventory(health, &[], &[]);
+                self.observable
+                    .set_inventory(health, &[], &[], self.hid_open_failures);
             }
         }
-    }
-
-    /// Record whether the last enumeration tick failed to open HID++ nodes.
-    /// Straight onto the observable status: no orchestration depends on it,
-    /// it exists for the GUI's permission diagnostics.
-    pub fn set_hid_open_failures(&self, failing: bool) {
-        self.observable.set_hid_open_failures(failing);
     }
 
     /// Record that enumeration has never worked and has stopped being treated

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -684,6 +684,13 @@ impl Orchestrator {
         }
     }
 
+    /// Record whether the last enumeration tick failed to open HID++ nodes.
+    /// Straight onto the observable status: no orchestration depends on it,
+    /// it exists for the GUI's permission diagnostics.
+    pub fn set_hid_open_failures(&self, failing: bool) {
+        self.observable.set_hid_open_failures(failing);
+    }
+
     /// Record that enumeration has never worked and has stopped being treated
     /// as "still starting" (persistent initial failure, or the watcher died).
     /// Downgrades only the pending state: once a snapshot exists the

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -218,6 +218,7 @@ fn runtime_selection_tracks_online_transition_without_device_set_change() {
             direct_inventory_state(0xb034, None, [2, 0, 0, 0], false),
         ],
         &[],
+        false,
     );
     assert_eq!(orchestrator.current_key(), Some(saved_key));
 
@@ -227,6 +228,7 @@ fn runtime_selection_tracks_online_transition_without_device_set_change() {
             direct_inventory_state(0xb034, None, [2, 0, 0, 0], true),
         ],
         &[],
+        false,
     );
     assert_eq!(orchestrator.current_key(), Some(other_key));
 }
@@ -518,7 +520,7 @@ fn plan_reapply_skips_a_followup_that_went_offline() {
 fn empty_refresh_marks_inventory_ready() {
     let mut orch = orchestrator(Config::default());
     assert_eq!(orch.inventory_health(), InventoryHealth::Scanning);
-    orch.refresh_inventory(&[], &[]);
+    orch.refresh_inventory(&[], &[], false);
     assert_eq!(orch.inventory_health(), InventoryHealth::Ready);
 }
 
@@ -531,7 +533,7 @@ fn unavailable_only_downgrades_a_pending_inventory() {
     let mut orch = orchestrator(Config::default());
     orch.mark_inventory_unavailable();
     assert_eq!(orch.inventory_health(), InventoryHealth::Unavailable);
-    orch.refresh_inventory(&[], &[]);
+    orch.refresh_inventory(&[], &[], false);
     assert_eq!(orch.inventory_health(), InventoryHealth::Ready);
     orch.mark_inventory_unavailable();
     assert_eq!(orch.inventory_health(), InventoryHealth::Ready);
@@ -553,7 +555,11 @@ fn every_inventory_mutator_republishes_what_the_ipc_server_answers() {
         InventoryHealth::Unavailable
     );
 
-    orch.refresh_inventory(&[direct_inventory(Some("serial-1"), [1, 2, 3, 4])], &[]);
+    orch.refresh_inventory(
+        &[direct_inventory(Some("serial-1"), [1, 2, 3, 4])],
+        &[],
+        false,
+    );
     let published = observable.snapshot();
     assert_eq!(published.status.inventory, InventoryHealth::Ready);
     assert_eq!(published.inventory, orch.inventory());

--- a/crates/openlogi-agent-core/src/watchers/inventory.rs
+++ b/crates/openlogi-agent-core/src/watchers/inventory.rs
@@ -54,6 +54,10 @@ pub enum InventoryEvent {
         inventories: Vec<DeviceInventory>,
         /// Recognized standalone raw-HID devices.
         standalone: Vec<StandaloneDevice>,
+        /// Whether this tick failed to open at least one HID++ node — on
+        /// macOS the observable signature of a missing or stale Input
+        /// Monitoring grant (the open denial itself is silent).
+        hid_open_failures: bool,
     },
     /// Enumeration has never succeeded and won't be treated as "still
     /// starting" any longer; without this the GUI would show its scanning
@@ -156,6 +160,7 @@ impl WatchState {
         &mut self,
         inventories: Vec<DeviceInventory>,
         standalone: Result<Vec<StandaloneDevice>, openlogi_hid::InventoryError>,
+        hid_open_failures: bool,
     ) -> InventoryEvent {
         self.succeeded = true;
         let standalone = match standalone {
@@ -171,6 +176,7 @@ impl WatchState {
         InventoryEvent::Snapshot {
             inventories,
             standalone,
+            hid_open_failures,
         }
     }
 
@@ -192,7 +198,9 @@ impl WatchState {
         result: Result<(Vec<DeviceInventory>, Vec<StandaloneDevice>), openlogi_hid::InventoryError>,
     ) -> Option<InventoryEvent> {
         match result {
-            Ok((inventories, standalone)) => Some(self.classify_parts(inventories, Ok(standalone))),
+            Ok((inventories, standalone)) => {
+                Some(self.classify_parts(inventories, Ok(standalone), false))
+            }
             Err(e) => {
                 warn!(error = ?e, "enumerate failed during watch tick — keeping last snapshot");
                 if self.succeeded {
@@ -286,7 +294,8 @@ fn spawn_inner(
                 let event = match rt.block_on(enumerator.enumerate()) {
                     Ok(inventories) => {
                         let standalone = rt.block_on(openlogi_hid::enumerate_standalone());
-                        Some(state.classify_parts(inventories, standalone))
+                        let open_failures = enumerator.open_failures_last_tick();
+                        Some(state.classify_parts(inventories, standalone, open_failures))
                     }
                     Err(error) => state.classify(Err(error)),
                 };
@@ -363,7 +372,7 @@ mod tests {
         // the resilience must not swallow a real empty.
         assert_matches!(
             state.classify(Ok((vec![], vec![]))),
-            Some(InventoryEvent::Snapshot { inventories, standalone }) if inventories.is_empty() && standalone.is_empty()
+            Some(InventoryEvent::Snapshot { inventories, standalone, .. }) if inventories.is_empty() && standalone.is_empty()
         );
         assert!(state.succeeded);
     }
@@ -388,8 +397,8 @@ mod tests {
         let _ = state.classify(Ok((vec![], vec![raw_light("serial:glow-1")])));
 
         assert_matches!(
-            state.classify_parts(vec![], Err(enumerate_failed())),
-            InventoryEvent::Snapshot { inventories, standalone }
+            state.classify_parts(vec![], Err(enumerate_failed()), false),
+            InventoryEvent::Snapshot { inventories, standalone, .. }
                 if inventories.is_empty()
                     && standalone.len() == 1
                     && standalone[0].online

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -36,6 +36,7 @@ tracing-subscriber = { workspace = true }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 opener = { workspace = true }
 succession = { version = "0.1", features = ["supervision", "eviction"] }
+tracing-appender = "0.2.5"
 
 # Held at the version Cargo.lock already has for gpui's own build-dependency;
 # bumping it independently would move the pinned gpui rev.
@@ -61,3 +62,6 @@ windows-sys = { workspace = true, features = [
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -627,6 +627,7 @@ fn agent_status() -> AgentStatus {
         // version, so a mock session can't be mistaken for a live one.
         agent_version: concat!(env!("CARGO_PKG_VERSION"), "-mock").to_string(),
         input_monitoring_granted: true,
+        hid_open_failures: false,
     }
 }
 

--- a/crates/openlogi-agent/src/logging.rs
+++ b/crates/openlogi-agent/src/logging.rs
@@ -1,0 +1,100 @@
+//! Agent tracing setup: stderr for foreground runs, a rotating file under the
+//! XDG state directory for launchd runs (which discard stderr), and a panic
+//! hook so crashes land in the same file.
+
+use std::io;
+use std::path::Path;
+
+use tracing::warn;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+
+/// Rotated log files kept before the oldest is deleted.
+const MAX_LOG_FILES: usize = 7;
+
+/// Install the agent's tracing subscriber and panic hook.
+///
+/// Always logs to stderr (visible in a foreground run), and additionally to a
+/// daily-rotated `agent.<date>.log` under [`openlogi_core::paths::state_dir`]
+/// — launchd gives the agent's stderr no destination, so without the file a
+/// launchd-run agent cannot be diagnosed at all (#336). If the file cannot be
+/// opened the agent falls back to stderr only and says so.
+pub(crate) fn init() {
+    let filter = EnvFilter::try_from_env("OPENLOGI_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+    let (file_layer, file_error) = match file_appender() {
+        Ok(appender) => (
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(appender),
+            ),
+            None,
+        ),
+        Err(e) => (None, Some(e)),
+    };
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(file_layer)
+        .init();
+    if let Some(e) = file_error {
+        warn!(error = %e, "agent log file unavailable — logging to stderr only");
+    }
+    route_panics_to_tracing();
+}
+
+/// A daily-rotated appender in the app state directory, capped at
+/// [`MAX_LOG_FILES`] files.
+fn file_appender() -> io::Result<RollingFileAppender> {
+    let dir = openlogi_core::paths::state_dir().map_err(io::Error::other)?;
+    std::fs::create_dir_all(&dir)?;
+    build_appender(&dir)
+}
+
+fn build_appender(dir: &Path) -> io::Result<RollingFileAppender> {
+    RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix("agent")
+        .filename_suffix("log")
+        .max_log_files(MAX_LOG_FILES)
+        .build(dir)
+        .map_err(io::Error::other)
+}
+
+/// Panics print to stderr, which launchd discards; mirror them into tracing
+/// so the log file records why the agent died.
+fn route_panics_to_tracing() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        tracing::error!("agent panicked: {info}");
+        default_hook(info);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use super::*;
+
+    #[test]
+    fn appender_writes_into_the_given_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut appender = build_appender(dir.path()).expect("build appender");
+        appender.write_all(b"probe line\n").expect("write");
+        appender.flush().expect("flush");
+        let files: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            files
+                .iter()
+                .any(|name| name.starts_with("agent") && name.ends_with("log")),
+            "no agent log file created: {files:?}"
+        );
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -16,6 +16,7 @@
 )]
 
 mod launch_agent;
+mod logging;
 mod overlay;
 mod pairing;
 #[cfg(target_os = "windows")]
@@ -47,12 +48,11 @@ use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
-use tracing_subscriber::EnvFilter;
 
 use crate::server::AgentServer;
 
 fn main() {
-    init_tracing();
+    logging::init();
 
     // Single-instance guard: the agent owns all device I/O, the CGEventTap, and
     // the IPC socket, so a second agent must never start — launchd's KeepAlive
@@ -515,13 +515,4 @@ async fn run(
             else => break,
         }
     }
-}
-
-fn init_tracing() {
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(
-            EnvFilter::try_from_env("OPENLOGI_LOG").unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
 }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -347,6 +347,7 @@ async fn apply_inventory_event(
         watchers::inventory::InventoryEvent::Snapshot {
             inventories,
             standalone,
+            hid_open_failures,
         } => {
             let mut orchestrator = orchestrator.lock().await;
             // The portable watcher catches long sleeps from a polling gap.
@@ -359,6 +360,7 @@ async fn apply_inventory_event(
                 orchestrator.reapply_volatile_on_next_refresh();
             }
             orchestrator.refresh_inventory(&inventories, &standalone);
+            orchestrator.set_hid_open_failures(hid_open_failures);
         }
         watchers::inventory::InventoryEvent::Unavailable => {
             orchestrator.lock().await.mark_inventory_unavailable();

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -359,8 +359,7 @@ async fn apply_inventory_event(
                 info!("native resume notification — replaying volatile settings");
                 orchestrator.reapply_volatile_on_next_refresh();
             }
-            orchestrator.refresh_inventory(&inventories, &standalone);
-            orchestrator.set_hid_open_failures(hid_open_failures);
+            orchestrator.refresh_inventory(&inventories, &standalone, hid_open_failures);
         }
         watchers::inventory::InventoryEvent::Unavailable => {
             orchestrator.lock().await.mark_inventory_unavailable();

--- a/crates/openlogi-core/src/paths.rs
+++ b/crates/openlogi-core/src/paths.rs
@@ -7,6 +7,7 @@
 //! |--------|---------------------|-------------------------------|
 //! | config | `$XDG_CONFIG_HOME`  | `~/.config/openlogi`          |
 //! | data   | `$XDG_DATA_HOME`    | `~/.local/share/openlogi`     |
+//! | state  | `$XDG_STATE_HOME`   | `~/.local/state/openlogi`     |
 //!
 //! On Windows `$HOME` falls back to `%USERPROFILE%`, so paths resolve to
 //! `%USERPROFILE%\.config\openlogi` etc.
@@ -142,6 +143,18 @@ pub fn config_path() -> Result<PathBuf, PathsError> {
 /// Local macOS dev builds use `openlogi-dev` instead.
 pub fn data_dir() -> Result<PathBuf, PathsError> {
     Ok(xdg()?.data_dir().join(app_dir()))
+}
+
+/// Directory for logs and other rebuildable process state — the agent's
+/// rotated log files live here.
+///
+/// `$XDG_STATE_HOME/openlogi`, default `~/.local/state/openlogi`.
+/// Local macOS dev builds use `openlogi-dev` instead.
+pub fn state_dir() -> Result<PathBuf, PathsError> {
+    let xdg = xdg()?;
+    Ok(xdg
+        .state_dir()
+        .map_or_else(|| xdg.data_dir().join(app_dir()), |dir| dir.join(app_dir())))
 }
 
 /// Directory for runtime sockets — the background agent's IPC endpoint.

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -46,18 +46,7 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
                 },
                 pal,
             ))
-            .item(permission_item(
-                "perm-input-monitoring",
-                tr!("Input Monitoring"),
-                tr!("Needed to read HID++ data, including Bluetooth-direct mice."),
-                Permission::InputMonitoring,
-                |cx| match cx.try_global::<AppState>().and_then(AppState::agent_status) {
-                    Some(status) if status.input_monitoring_granted => PermissionStatus::Granted,
-                    Some(_) => PermissionStatus::Denied,
-                    None => PermissionStatus::Unknown,
-                },
-                pal,
-            ))
+            .item(input_monitoring_item(pal))
             .item(permission_item(
                 "perm-bluetooth",
                 tr!("Bluetooth"),
@@ -121,6 +110,46 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
     }));
 
     page
+}
+
+#[cfg(target_os = "macos")]
+fn input_monitoring_item(pal: Palette) -> SettingItem {
+    SettingItem::new(
+                tr!("Input Monitoring"),
+                SettingField::render(move |_, _, cx| {
+                    let status = cx.try_global::<AppState>().and_then(AppState::agent_status);
+                    // Granted-but-still-failing is the one state the badge
+                    // alone cannot express: the grant exists, yet every
+                    // open is refused — an exclusive open elsewhere, or a
+                    // TCC session only a re-login refreshes (#704).
+                    let stalled = status
+                        .as_ref()
+                        .is_some_and(|s| s.input_monitoring_granted && s.hid_open_failures);
+                    let badge = match status {
+                        Some(s) if s.input_monitoring_granted => PermissionStatus::Granted,
+                        Some(_) => PermissionStatus::Denied,
+                        None => PermissionStatus::Unknown,
+                    };
+                    let field = gpui_component::v_flex().gap_1().child(permission_field(
+                        "perm-input-monitoring",
+                        badge,
+                        Permission::InputMonitoring,
+                        pal,
+                    ));
+                    if stalled {
+                        field.child(div().text_caption().text_color(pal.text_muted).child(
+                            tr!(
+                                "Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in."
+                            ),
+                        ))
+                    } else {
+                        field
+                    }
+                }),
+            )
+            .description(tr!(
+                "Needed to read HID++ data, including Bluetooth-direct mice."
+            ))
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -153,6 +153,8 @@ pub struct Enumerator {
     /// Whether the persistable cache content changed since the last save —
     /// fresh full probes and evictions, not per-tick battery refreshes.
     cache_dirty: bool,
+    /// Whether the most recent tick failed to open at least one HID++ node.
+    open_failures_last_tick: bool,
 }
 
 /// An open channel to a receiver / direct-device HID node, held across
@@ -401,6 +403,18 @@ fn append_live_cached_channels(
 }
 
 impl Enumerator {
+    /// Whether the most recent [`enumerate`](Self::enumerate) tick failed to
+    /// open at least one HID++ node. `false` before the first tick.
+    ///
+    /// On macOS a run of ticks with this set is the observable signature of a
+    /// denied Input Monitoring grant or a stale permission session — paired
+    /// with the grant state it separates "grant it" from "log out", which the
+    /// bare open error cannot (the denial is silent).
+    #[must_use]
+    pub fn open_failures_last_tick(&self) -> bool {
+        self.open_failures_last_tick
+    }
+
     /// An enumerator that walks `backend` — this host's HID stack, a scripted
     /// device tree in tests, or another host's.
     #[must_use]
@@ -415,6 +429,7 @@ impl Enumerator {
             tick: 0,
             store: None,
             cache_dirty: false,
+            open_failures_last_tick: false,
         }
     }
 
@@ -565,6 +580,7 @@ impl Enumerator {
             open_failures,
             retiring: retiring_nodes,
         } = self.prepare_nodes(&*backend, candidates).await;
+        self.open_failures_last_tick = !open_failures.is_empty();
 
         // Probe each open channel concurrently, sharing `&cache` read-only;
         // updates are collected and applied afterwards (no `RefCell`).

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -48,6 +48,30 @@ fn backend_error(error: async_hid::HidError) -> BackendError {
     }
 }
 
+/// Classify a failed device open. On macOS `IOHIDDeviceOpen` denies silently —
+/// the error is indistinguishable from exclusive access — so fold the Input
+/// Monitoring state into the message: it is the difference between "grant the
+/// permission" and "close the other app, or log out and back in".
+#[cfg(not(target_os = "windows"))]
+fn open_error(error: async_hid::HidError) -> BackendError {
+    match backend_error(error) {
+        #[cfg(target_os = "macos")]
+        BackendError::Backend(message) => {
+            let hint = if crate::permissions::has_access() {
+                "Input Monitoring is granted to this process — another app may \
+                 hold the device exclusively, or macOS is serving a stale \
+                 permission session (log out and back in)"
+            } else {
+                "Input Monitoring is NOT granted to this process; grant it to \
+                 OpenLogi Agent under System Settings → Privacy & Security → \
+                 Input Monitoring"
+            };
+            BackendError::Backend(format!("{message}: {hint}"))
+        }
+        other => other,
+    }
+}
+
 /// `DeviceId` is an opaque OS handle (a hidraw path, a Windows device path, an
 /// IOKit entry), so [`NodeId`] carries its `Debug` rendering verbatim.
 ///
@@ -370,7 +394,7 @@ pub(crate) async fn open_hidpp_channel(
 
     #[cfg(not(target_os = "windows"))]
     {
-        let (reader, writer) = dev.open().await.map_err(backend_error)?;
+        let (reader, writer) = dev.open().await.map_err(open_error)?;
         // BLE-direct devices expose only the long HID++ report; flag the channel so
         // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
         let long_only = is_long_only_collection(info.usage_page, info.usage_id);

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -54,7 +54,8 @@ pub use succession::Identity;
 /// v23: SmartShift writes carry one typed [`SmartShiftStatus`] value.
 /// v24: `StandaloneDevice::registry_model_id` is always encoded (bincode fix).
 /// v25: `AgentStatus::input_monitoring_granted` appended.
-pub const PROTOCOL_VERSION: u32 = 25;
+/// v26: `AgentStatus::hid_open_failures` appended.
+pub const PROTOCOL_VERSION: u32 = 26;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -107,6 +108,10 @@ pub struct AgentStatus {
     pub agent_version: String,
     /// Whether the agent process holds Input Monitoring (HID) access.
     pub input_monitoring_granted: bool,
+    /// Whether the last enumeration tick failed to open at least one HID++
+    /// node. Paired with [`Self::input_monitoring_granted`] it distinguishes
+    /// a missing grant from an exclusive open or a stale permission session.
+    pub hid_open_failures: bool,
 }
 
 /// Status and inventory as one poll result. Kept together so the GUI never

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -100,7 +100,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 25);
+    assert_eq!(PROTOCOL_VERSION, 26);
 }
 
 #[test]
@@ -271,8 +271,9 @@ fn agent_status() {
         protocol_version: 7,
         agent_version: "0.6.6".into(),
         input_monitoring_granted: true,
+        hid_open_failures: false,
     };
-    assert_wire(&status, "010001010705302e362e3601");
+    assert_wire(&status, "010001010705302e362e360100");
 
     assert_wire(&InventoryHealth::Scanning, "00");
     assert_wire(&InventoryHealth::Ready, "01");
@@ -290,20 +291,21 @@ fn agent_snapshot() {
             protocol_version: 7,
             agent_version: "0.6.6".into(),
             input_monitoring_granted: true,
+            hid_open_failures: false,
         },
         inventory: Vec::new(),
         standalone: Vec::new(),
         camera_active: false,
         pairing: None,
     };
-    assert_wire(&snapshot, "010001010705302e362e360100000000");
+    assert_wire(&snapshot, "010001010705302e362e36010000000000");
 
     // The observation is the snapshot with its generation in front.
     let observed = Observation {
         generation: 3,
         snapshot,
     };
-    assert_wire(&observed, "03010001010705302e362e360100000000");
+    assert_wire(&observed, "03010001010705302e362e36010000000000");
 }
 
 /// The pairing session is state, so its phases are wire format like any enum.

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Giv adgang"
 "Needed for gesture and button remapping (event tap).": "Nødvendig for gestus- og knapremapping (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Nødvendig for at læse HID++-data, inklusive Bluetooth-direkte mus."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Tilladt, men enhederne kan stadig ikke åbnes — en anden app holder dem muligvis eksklusivt, eller macOS kræver, at du logger ud og ind igen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Tillader OpenLogi at bruge CoreBluetooth (ikke nødvendigt for HID-adgang)."
 "Scanning for devices…": "Søger efter enheder…"
 "Connecting to the background service…": "Opretter forbindelse til baggrundstjenesten…"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Erlauben"
 "Needed for gesture and button remapping (event tap).": "Erforderlich für Gesten- und Tastenneubelegung (Event-Tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Erforderlich zum Lesen von HID++-Daten, einschließlich Bluetooth-Direktmäusen."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Erteilt, aber Geräte lassen sich weiterhin nicht öffnen — eine andere App hält sie möglicherweise exklusiv, oder macOS erfordert ein Ab- und erneutes Anmelden."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Erlaubt OpenLogi die Nutzung von CoreBluetooth (für HID-Zugriff nicht erforderlich)."
 "Scanning for devices…": "Suche nach Geräten…"
 "Connecting to the background service…": "Verbindung zum Hintergrunddienst wird hergestellt…"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Παραχώρηση"
 "Needed for gesture and button remapping (event tap).": "Απαιτείται για την αντιστοίχιση χειρονομιών και κουμπιών (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Απαιτείται για την ανάγνωση δεδομένων HID++, συμπεριλαμβανομένων ποντικιών απευθείας μέσω Bluetooth."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Έχει χορηγηθεί, αλλά οι συσκευές εξακολουθούν να μην ανοίγουν — μια άλλη εφαρμογή ίσως τις δεσμεύει αποκλειστικά, ή το macOS χρειάζεται αποσύνδεση και επανασύνδεση."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Επιτρέπει στο OpenLogi να χρησιμοποιεί το CoreBluetooth (δεν απαιτείται για πρόσβαση HID)."
 "Scanning for devices…": "Αναζήτηση συσκευών…"
 "Connecting to the background service…": "Σύνδεση με την υπηρεσία παρασκηνίου…"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Grant"
 "Needed for gesture and button remapping (event tap).": "Needed for gesture and button remapping (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Needed to read HID++ data, including Bluetooth-direct mice."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Allows OpenLogi to use CoreBluetooth (not required for HID access)."
 "Scanning for devices…": "Scanning for devices…"
 "Connecting to the background service…": "Connecting to the background service…"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Conceder"
 "Needed for gesture and button remapping (event tap).": "Necesario para reasignar gestos y botones (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necesario para leer datos HID++, incluidos los ratones Bluetooth directos."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Concedido, pero los dispositivos siguen sin abrirse — otra aplicación puede estar reteniéndolos en exclusiva, o macOS necesita cerrar sesión y volver a iniciarla."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permite que OpenLogi use CoreBluetooth (no es necesario para el acceso HID)."
 "Scanning for devices…": "Buscando dispositivos…"
 "Connecting to the background service…": "Conectando con el servicio en segundo plano…"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Myönnä"
 "Needed for gesture and button remapping (event tap).": "Tarvitaan eleiden ja painikkeiden uudelleenmääritykseen (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Tarvitaan HID++-tietojen lukemiseen, mukaan lukien suoraan Bluetoothiin liitetyt hiiret."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Myönnetty, mutta laitteiden avaaminen epäonnistuu yhä — toinen sovellus saattaa pitää niitä yksinoikeudella, tai macOS vaatii ulos- ja sisäänkirjautumisen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Sallii OpenLogin käyttää CoreBluetoothia (ei vaadita HID-käyttöön)."
 "Scanning for devices…": "Etsitään laitteita…"
 "Connecting to the background service…": "Yhdistetään taustapalveluun…"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Autoriser"
 "Needed for gesture and button remapping (event tap).": "Requis pour la réaffectation des gestes et des boutons (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Requis pour lire les données HID++, y compris les souris Bluetooth directes."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Accordé, mais les appareils ne s'ouvrent toujours pas — une autre application les détient peut-être en exclusivité, ou macOS nécessite une déconnexion puis une reconnexion."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permet à OpenLogi d'utiliser CoreBluetooth (non requis pour l'accès HID)."
 "Scanning for devices…": "Recherche d'appareils…"
 "Connecting to the background service…": "Connexion au service d'arrière-plan…"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Concedi"
 "Needed for gesture and button remapping (event tap).": "Necessario per la rimappatura di gesture e pulsanti (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necessario per leggere i dati HID++, inclusi i mouse con connessione diretta Bluetooth."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Concesso, ma i dispositivi continuano a non aprirsi — un'altra app potrebbe trattenerli in esclusiva, oppure macOS richiede la disconnessione e un nuovo accesso."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Consente a OpenLogi di utilizzare CoreBluetooth (non richiesto per l'accesso HID)."
 "Scanning for devices…": "Scansione dispositivi in corso…"
 "Connecting to the background service…": "Connessione al servizio in background…"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "許可する"
 "Needed for gesture and button remapping (event tap).": "ジェスチャーとボタンの再割り当てに必要です（イベントタップ）。"
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Bluetooth 直結マウスを含む HID++ データの読み取りに必要です。"
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "許可されていますが、デバイスを開けません — 別のアプリが占有しているか、macOS のログアウトと再ログインが必要です。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "OpenLogi が CoreBluetooth を使用できるようにします（HID アクセスには不要）。"
 "Scanning for devices…": "デバイスを検索中…"
 "Connecting to the background service…": "バックグラウンドサービスに接続中…"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "허용"
 "Needed for gesture and button remapping (event tap).": "제스처 및 버튼 재매핑에 필요합니다(이벤트 탭)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "블루투스 직접 연결 마우스를 포함한 HID++ 데이터를 읽는 데 필요합니다."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "허용되었지만 장치를 여전히 열 수 없습니다 — 다른 앱이 독점하고 있거나 macOS에서 로그아웃 후 다시 로그인해야 합니다."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "OpenLogi가 CoreBluetooth를 사용할 수 있도록 허용합니다(HID 접근에는 필요하지 않음)."
 "Scanning for devices…": "기기 검색 중…"
 "Connecting to the background service…": "백그라운드 서비스에 연결하는 중…"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Gi tilgang"
 "Needed for gesture and button remapping (event tap).": "Kreves for ommapping av bevegelser og knapper (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Kreves for å lese HID++-data, inkludert Bluetooth-direkte mus."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Innvilget, men enhetene kan fortsatt ikke åpnes — en annen app holder dem kanskje eksklusivt, eller macOS krever at du logger ut og inn igjen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Lar OpenLogi bruke CoreBluetooth (ikke nødvendig for HID-tilgang)."
 "Scanning for devices…": "Søker etter enheter…"
 "Connecting to the background service…": "Kobler til bakgrunnstjenesten…"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Toestaan"
 "Needed for gesture and button remapping (event tap).": "Vereist voor het opnieuw toewijzen van gebaren en knoppen (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Vereist om HID++-gegevens te lezen, inclusief Bluetooth-directe muizen."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Toegestaan, maar apparaten kunnen nog steeds niet worden geopend — een andere app houdt ze mogelijk exclusief vast, of macOS vereist uit- en opnieuw inloggen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Staat OpenLogi toe CoreBluetooth te gebruiken (niet vereist voor HID-toegang)."
 "Scanning for devices…": "Apparaten zoeken…"
 "Connecting to the background service…": "Verbinden met de achtergrondservice…"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Przyznaj"
 "Needed for gesture and button remapping (event tap).": "Wymagane do zmiany przypisań gestów i przycisków (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Wymagane do odczytu danych HID++, w tym myszy podłączonych bezpośrednio przez Bluetooth."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Przyznano, ale urządzenia nadal nie dają się otworzyć — inna aplikacja może je zajmować na wyłączność albo macOS wymaga wylogowania i ponownego zalogowania."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Pozwala aplikacji OpenLogi używać CoreBluetooth (niewymagane do dostępu HID)."
 "Scanning for devices…": "Wyszukiwanie urządzeń…"
 "Connecting to the background service…": "Łączenie z usługą działającą w tle…"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Conceder"
 "Needed for gesture and button remapping (event tap).": "Necessário para remapear gestos e botões (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necessário para ler dados HID++, incluindo mouses Bluetooth diretos."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Concedido, mas os dispositivos ainda não abrem — outro aplicativo pode estar segurando-os com exclusividade, ou o macOS precisa de logout e login novamente."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permite que o OpenLogi use o CoreBluetooth (não necessário para acesso HID)."
 "Scanning for devices…": "Procurando dispositivos…"
 "Connecting to the background service…": "Conectando ao serviço em segundo plano…"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Conceder"
 "Needed for gesture and button remapping (event tap).": "Necessário para remapear gestos e botões (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Necessário para ler dados HID++, incluindo ratos Bluetooth diretos."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Concedido, mas os dispositivos continuam sem abrir — outra aplicação pode estar a retê-los em exclusivo, ou o macOS precisa de terminar sessão e iniciar sessão novamente."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Permite que o OpenLogi use o CoreBluetooth (não necessário para acesso HID)."
 "Scanning for devices…": "A procurar dispositivos…"
 "Connecting to the background service…": "A ligar ao serviço em segundo plano…"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Разрешить"
 "Needed for gesture and button remapping (event tap).": "Требуется для переназначения жестов и кнопок (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Требуется для чтения данных HID++, включая мыши с прямым Bluetooth-подключением."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Доступ предоставлен, но устройства по-прежнему не открываются — другое приложение может удерживать их монопольно, либо macOS требует выйти из системы и войти снова."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Позволяет OpenLogi использовать CoreBluetooth (не требуется для доступа к HID)."
 "Scanning for devices…": "Сканирование устройств…"
 "Connecting to the background service…": "Подключение к фоновой службе…"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Bevilja"
 "Needed for gesture and button remapping (event tap).": "Krävs för ommappning av gester och knappar (event tap)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Krävs för att läsa HID++-data, inklusive Bluetooth-direktanslutna möss."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Beviljat, men enheterna kan fortfarande inte öppnas — en annan app kanske håller dem exklusivt, eller så kräver macOS ut- och inloggning igen."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Tillåter OpenLogi att använda CoreBluetooth (krävs inte för HID-åtkomst)."
 "Scanning for devices…": "Söker efter enheter…"
 "Connecting to the background service…": "Ansluter till bakgrundstjänsten…"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "Надати"
 "Needed for gesture and button remapping (event tap).": "Потрібен для перепризначення жестів і кнопок (перехоплення подій)."
 "Needed to read HID++ data, including Bluetooth-direct mice.": "Потрібен для читання даних HID++, зокрема мишей, підключених напряму через Bluetooth."
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "Надано, але пристрої досі не відкриваються — інший застосунок може утримувати їх монопольно, або macOS потребує виходу та повторного входу."
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "Дозволяє OpenLogi використовувати CoreBluetooth (для доступу до HID не потрібен)."
 "Scanning for devices…": "Сканування пристроїв…"
 "Connecting to the background service…": "Підключення до фонової служби…"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "授权"
 "Needed for gesture and button remapping (event tap).": "手势与按键重映射所需（事件捕获）。"
 "Needed to read HID++ data, including Bluetooth-direct mice.": "读取 HID++ 数据所需，包括蓝牙直连鼠标。"
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "已授权，但设备仍然打不开 —— 可能有其他应用独占设备，或需要退出登录 macOS 后重新登录。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "允许 OpenLogi 使用 CoreBluetooth（HID 访问不需要）。"
 "Scanning for devices…": "正在扫描设备…"
 "Connecting to the background service…": "正在连接后台服务…"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "授權"
 "Needed for gesture and button remapping (event tap).": "手勢與按鍵重新對應所需（事件攔截）。"
 "Needed to read HID++ data, including Bluetooth-direct mice.": "讀取 HID++ 數據所需，包括藍牙直連滑鼠。"
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "已授權，但裝置仍然無法開啟 —— 可能有其他應用程式獨佔裝置，或需要登出 macOS 後重新登入。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。"
 "Scanning for devices…": "正在掃描裝置…"
 "Connecting to the background service…": "正在連接背景服務…"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -258,6 +258,7 @@ _version: 1
 "Grant": "授權"
 "Needed for gesture and button remapping (event tap).": "手勢與按鍵重新對應需要此權限（事件監聽）。"
 "Needed to read HID++ data, including Bluetooth-direct mice.": "需要此權限才能讀取 HID++ 資料，包括藍牙直連滑鼠。"
+"Granted, but devices still fail to open — another app may hold them exclusively, or macOS needs a log out and back in.": "已授權，但裝置仍然無法開啟 —— 可能有其他應用程式獨佔裝置，或需要登出 macOS 後重新登入。"
 "Allows OpenLogi to use CoreBluetooth (not required for HID access).": "允許 OpenLogi 使用 CoreBluetooth（HID 存取不需要）。"
 "Scanning for devices…": "正在掃描裝置…"
 "Connecting to the background service…": "正在連線背景服務…"


### PR DESCRIPTION
**Stacked on #817** — merge that first; this PR's base is its branch.

## Summary

The agent has always known when HID++ nodes refuse to open — the inventory tick collects the failures for its ledger — but the fact died there, so the GUI could not tell "grant Input Monitoring" apart from "the grant exists and something else is wrong". Protocol v26 appends `AgentStatus::hid_open_failures`, fed from the enumerator's last tick through the inventory watcher and orchestrator.

Settings → Input Monitoring pairs it with the grant: the granted-but-still-failing case now shows a hint naming the two causes — an exclusive open by another app, or a stale TCC session that only a re-login refreshes. That is exactly the state reported in #704, where all three identities were granted, agent restarts changed nothing, and a full logout fixed it.

## Changes

- `device`: `Enumerator::open_failures_last_tick()` — records whether the tick's `prepare_nodes` failed to open any node.
- `agent`: `InventoryEvent::Snapshot` carries the flag; `apply_inventory_event` forwards it via a new `Orchestrator::set_hid_open_failures` passthrough (no orchestration depends on it, so `refresh_inventory`'s contract is untouched).
- `ipc`: `PROTOCOL_VERSION` 26; `AgentStatus::hid_open_failures` appended (append-only, goldens regenerated); mock agent updated.
- `gui`: the Input Monitoring row becomes `input_monitoring_item` with a conditional caption for the granted-but-failing state, following the Linux row's badge-plus-hint pattern; the hint string is added to all 21 locale catalogs at the same position.

## Testing

- `cargo test -p openlogi-ipc --test wire_format` — 13 passed against hand-computed goldens (append = one trailing byte).
- `cargo test -p openlogi-agent-core` (102) and `-p openlogi-device` (170) — green.
- `cargo test -p openlogi-ui locale` and `cargo test -p openlogi-desktop i18n` — catalog parity and end-to-end key resolution green.
- Full local gate on the final tree (fmt, clippy workspace `--all-targets -D warnings` with `RUSTFLAGS`, workspace tests, rustdoc non-GUI) — green.
- Not runtime-tested on hardware. To verify: with Input Monitoring granted, hold a device open exclusively (or revoke and re-grant without relaunching) and watch the Settings row grow the hint while the log shows the classified open errors from #817.

Closes #54 (the Input Monitoring half; the Bluetooth row already exists and CoreBluetooth is not required for HID access).