### PR TITLE
refactor(hid): centralize device identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
       # picks up a filesystem, a randomness source or a thread stops compiling
       # here and nowhere else. The crate list lives in xtask
       # (`WASM_PORTABLE_CRATES`) and the drift test keeps the two in step.
-      - run: cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown
+      - run: cargo check -p openlogi-device-registry -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown
       # `openlogi-core` earns its place only with `fs` off: that feature is
       # the config file, and a config file needs a filesystem.
       - run: cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ sits beneath both.
 |---|---|
 | `crates/openlogi` | The CLI binary — thin wrapper over `openlogi-cli` |
 | `crates/openlogi-core` | Pure types: TOML config, device model, action catalog. No I/O, no async |
+| `crates/openlogi-device-registry` | Pure hardware identity registry: receiver protocols and standalone-device driver metadata |
 | `crates/openlogi-hidpp` | Vendored fork of the `hidpp` protocol crate (**lib name `hidpp`**, 0BSD) |
 | `crates/openlogi-device` | The HID++ device layer: enumeration, probing, writes, sessions, pairing. Knows no host — expressed against `HidBackend` |
 | `crates/openlogi-hid` | That layer wired to this host: `async-hid` transport, macOS Input Monitoring, the on-disk probe cache |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5313,6 +5313,7 @@ dependencies = [
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "openlogi-device-registry",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -5349,6 +5350,7 @@ dependencies = [
  "etcetera",
  "num_enum",
  "nutype",
+ "openlogi-device-registry",
  "plist",
  "serde",
  "strum",
@@ -5407,6 +5409,7 @@ dependencies = [
  "futures-concurrency",
  "futures-lite",
  "openlogi-core",
+ "openlogi-device-registry",
  "openlogi-hidpp",
  "serde",
  "tempfile",
@@ -5414,6 +5417,10 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "openlogi-device-registry"
+version = "0.7.10"
 
 [[package]]
 name = "openlogi-hid"
@@ -5450,6 +5457,7 @@ dependencies = [
  "hex",
  "hidreport",
  "num_enum",
+ "openlogi-device-registry",
  "openlogi-hidpp-derive",
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/openlogi",
     "crates/openlogi-core",
+    "crates/openlogi-device-registry",
     "crates/openlogi-inject",
     "crates/openlogi-hidpp",
     "crates/openlogi-hidpp-derive",
@@ -42,6 +43,7 @@ description = "Lightweight, local-first alternative to Logitech Options+ for HID
 
 [workspace.dependencies]
 hidpp = { package = "openlogi-hidpp", path = "crates/openlogi-hidpp", version = "0.7.10" }
+openlogi-device-registry = { path = "crates/openlogi-device-registry", version = "0.7.10" }
 async-hid = "0.5.3"
 interprocess = { version = "2", features = ["tokio"] }
 # The agent <-> GUI RPC layer itself, over the `interprocess` transport above.

--- a/crates/openlogi-agent-core/src/hardware/light.rs
+++ b/crates/openlogi-agent-core/src/hardware/light.rs
@@ -8,7 +8,8 @@ use std::thread;
 use openlogi_core::config::LightSettings;
 use openlogi_core::device::LightCapabilities;
 use openlogi_hid::{
-    DeviceRoute, HidppOperation, LightCommand, LitraModel, WriteError, commands_for_light_settings,
+    DeviceRoute, HidppOperation, LightCommand, WriteError, commands_for_light_settings,
+    litra_model_for_route,
 };
 use tracing::{debug, info, warn};
 
@@ -204,7 +205,7 @@ async fn apply_light_unlocked(
     route: &DeviceRoute,
     command: LightCommand,
 ) -> Result<(), WriteError> {
-    let Some(model) = LitraModel::from_route(route) else {
+    let Some(model) = litra_model_for_route(route) else {
         return Err(WriteError::LightUnsupported {
             control: "raw_hid_route".into(),
         });

--- a/crates/openlogi-camera/Cargo.toml
+++ b/crates/openlogi-camera/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["logitech", "uvc", "webcam", "camera", "v4l2"]
 categories = ["hardware-support"]
 
 [dependencies]
+openlogi-device-registry = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/openlogi-camera/src/lib.rs
+++ b/crates/openlogi-camera/src/lib.rs
@@ -179,7 +179,7 @@ pub use uvc::{
 
 /// Logitech's USB vendor id. Reported in decimal (`1133`) inside an
 /// `AVCaptureDevice` modelID, and in hex (`046d`) most everywhere else.
-pub const LOGITECH_VID: u16 = 0x046d;
+pub use openlogi_device_registry::LOGITECH_VENDOR_ID as LOGITECH_VID;
 
 /// Tri-state Camera permission, mirroring macOS `AVAuthorizationStatus`.
 ///

--- a/crates/openlogi-cli/src/cmd/light.rs
+++ b/crates/openlogi-cli/src/cmd/light.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result, anyhow};
 use clap::{Args, Subcommand};
 use openlogi_core::device::{LightValueUnit, StandaloneDevice};
-use openlogi_hid::{DeviceRoute, LightCommand, LitraModel};
+use openlogi_hid::{DeviceRoute, LightCommand, find_litra};
 
 #[derive(Debug, Subcommand)]
 pub enum LightCmd {
@@ -150,7 +150,14 @@ async fn set_temperature(args: TemperatureArgs) -> Result<()> {
 }
 
 async fn apply(device: &StandaloneDevice, command: LightCommand) -> Result<()> {
-    let model = LitraModel::from_product_id(device.address.product_id).ok_or_else(|| {
+    let model = find_litra(
+        device.address.vendor_id,
+        device.address.product_id,
+        device.address.usage_page,
+        device.address.usage_id,
+    )
+    .map(|descriptor| descriptor.model)
+    .ok_or_else(|| {
         anyhow!(
             "unsupported light product {:04x}",
             device.address.product_id

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -18,6 +18,7 @@ default = ["fs"]
 fs = ["dep:atomic-write-file", "dep:etcetera", "dep:toml_edit"]
 
 [dependencies]
+openlogi-device-registry = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/openlogi-core/src/hid.rs
+++ b/crates/openlogi-core/src/hid.rs
@@ -20,8 +20,9 @@ pub use error::{HidppFeatureErrorKind, HidppOperation, WriteError};
 pub use light::{LightCommand, commands_for_light_settings};
 pub use pairing::{Click, PairingError, PasskeyMethod, ReceiverSelector};
 pub use route::{
-    BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, LOGITECH_VENDOR_ID,
-    UNIFYING_PIDS, is_receiver_pid, receiver_display_name, speaks_unifying_protocol,
+    DIRECT_DEVICE_INDEX, DeviceRoute, LOGITECH_VENDOR_ID, RECEIVERS, ReceiverBrand,
+    ReceiverDescriptor, ReceiverProtocol, find_receiver, is_receiver_pid, receiver_display_name,
+    speaks_unifying_protocol,
 };
 pub use smartshift::{
     SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, TunableTorque,

--- a/crates/openlogi-core/src/hid/route.rs
+++ b/crates/openlogi-core/src/hid/route.rs
@@ -15,6 +15,10 @@
 
 use std::fmt;
 
+pub use openlogi_device_registry::LOGITECH_VENDOR_ID;
+pub use openlogi_device_registry::receiver::{
+    RECEIVERS, ReceiverBrand, ReceiverDescriptor, ReceiverProtocol, find_receiver,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::device::DeviceInventory;
@@ -22,11 +26,6 @@ use crate::device::DeviceInventory;
 /// HID++ device index that addresses a directly-attached device's own
 /// features (USB-cable or Bluetooth, no receiver indirection).
 pub const DIRECT_DEVICE_INDEX: u8 = 0xff;
-
-/// Logitech's USB/Bluetooth vendor ID. `u16` because that is the width of the
-/// field itself; readers whose API hands back a wider integer widen at the
-/// comparison.
-pub const LOGITECH_VENDOR_ID: u16 = 0x046d;
 
 /// How to reach a controllable HID++ device.
 ///
@@ -78,43 +77,21 @@ pub enum DeviceRoute {
     },
 }
 
-/// USB product IDs that identify Logi Bolt receivers.
-pub const BOLT_PIDS: &[u16] = &[0xc548];
-
-/// USB product IDs that identify Logi Unifying receivers. Used by callers that
-/// need to construct the correct [`DeviceRoute`] variant from a raw inventory.
-///
-/// `0xc537` is the Nano receiver bundled with the G602. It answers the same
-/// HID++ 1.0 enumeration and pairing-information registers as Unifying, so it
-/// routes as [`DeviceRoute::Unifying`].
-pub const UNIFYING_PIDS: &[u16] = &[0xc52b, 0xc532, 0xc537];
-
-/// USB product IDs that identify Logitech Lightspeed receivers — the
-/// receivers bundled with G-series wireless devices. `0xc539` ships with the
-/// G502 LIGHTSPEED and the G Pro Wireless — its USB product string is
-/// literally `LIGHTSPEED Receiver`; `0xc53f` is the nano receiver of wireless
-/// mice such as the G305; `0xc547` ships with newer G-series devices such as
-/// the G915 keyboard and the G502 X LIGHTSPEED; `0xc54d` ships with the
-/// PRO X SUPERLIGHT 2 DEX.
-/// They speak the same HID++ 1.0 receiver register protocol as Unifying, so
-/// they are enumerated, routed, and paired through the Unifying code path;
-/// only the user-facing receiver name (see [`receiver_display_name`]) differs.
-pub const LIGHTSPEED_PIDS: &[u16] = &[0xc539, 0xc53f, 0xc547, 0xc54d];
-
 /// Whether `product_id` is a receiver that speaks the Unifying HID++ 1.0
 /// register protocol — a Unifying receiver proper, or a protocol-compatible
-/// Lightspeed receiver. Such receivers are addressed with
+/// Nano or Lightspeed receiver. Such receivers are addressed with
 /// [`DeviceRoute::Unifying`].
 #[must_use]
 pub fn speaks_unifying_protocol(product_id: u16) -> bool {
-    UNIFYING_PIDS.contains(&product_id) || LIGHTSPEED_PIDS.contains(&product_id)
+    find_receiver(LOGITECH_VENDOR_ID, product_id)
+        .is_some_and(|receiver| receiver.protocol == ReceiverProtocol::Unifying)
 }
 
 /// Whether `product_id` is a known Logitech receiver dongle of any family
 /// (Bolt, Unifying, or Lightspeed).
 #[must_use]
 pub fn is_receiver_pid(product_id: u16) -> bool {
-    BOLT_PIDS.contains(&product_id) || speaks_unifying_protocol(product_id)
+    find_receiver(LOGITECH_VENDOR_ID, product_id).is_some()
 }
 
 /// Human-readable name for a receiver identified by `product_id`, used to label
@@ -122,7 +99,9 @@ pub fn is_receiver_pid(product_id: u16) -> bool {
 /// but are surfaced under their own name.
 #[must_use]
 pub fn receiver_display_name(product_id: u16) -> &'static str {
-    if LIGHTSPEED_PIDS.contains(&product_id) {
+    if find_receiver(LOGITECH_VENDOR_ID, product_id)
+        .is_some_and(|receiver| receiver.brand == ReceiverBrand::Lightspeed)
+    {
         "Lightspeed Receiver"
     } else {
         "Unifying Receiver"
@@ -170,10 +149,10 @@ impl DeviceRoute {
     /// Build the route that reaches a paired device from a receiver inventory.
     ///
     /// Picks [`DeviceRoute::Unifying`] or [`DeviceRoute::Bolt`] based on the
-    /// receiver's product ID via [`speaks_unifying_protocol`] (Unifying proper
-    /// plus protocol-compatible Lightspeed receivers). Any receiver that does
-    /// not speak the Unifying protocol — including future Bolt variants whose
-    /// PID isn't yet in `BOLT_PIDS` — defaults to [`DeviceRoute::Bolt`] so
+    /// receiver's identity in [`RECEIVERS`] (Unifying proper plus
+    /// protocol-compatible Nano and Lightspeed receivers). Any receiver that
+    /// does not speak the Unifying protocol — including future Bolt variants
+    /// whose PID is not yet registered — defaults to [`DeviceRoute::Bolt`] so
     /// writes keep working rather than silently dropping.
     /// [`DeviceRoute::Direct`] is used for directly-attached devices
     /// (slot == [`DIRECT_DEVICE_INDEX`] with no receiver UID). Returns `None`
@@ -189,11 +168,12 @@ impl DeviceRoute {
             }
             Some(uid) => {
                 // Default to Bolt for any receiver that does not speak the
-                // Unifying protocol. This covers both known Bolt PIDs
-                // (BOLT_PIDS) and any future Bolt-compatible receiver with a new
-                // PID — returning None would silently drop writes for such
-                // receivers.
-                if !BOLT_PIDS.contains(&inv.receiver.product_id) {
+                // Unifying protocol. This covers both known Bolt receivers and
+                // any future Bolt-compatible receiver with a new PID — returning
+                // None would silently drop writes for such receivers.
+                if find_receiver(LOGITECH_VENDOR_ID, inv.receiver.product_id)
+                    .is_none_or(|receiver| receiver.protocol != ReceiverProtocol::Bolt)
+                {
                     tracing::debug!(
                         pid = format_args!("{:04x}", inv.receiver.product_id),
                         "unknown receiver PID — routing as Bolt"
@@ -244,7 +224,7 @@ mod tests {
     use crate::device::{DeviceInventory, ReceiverInfo};
 
     use super::{
-        DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, UNIFYING_PIDS, receiver_display_name,
+        DIRECT_DEVICE_INDEX, DeviceRoute, RECEIVERS, ReceiverProtocol, receiver_display_name,
     };
 
     fn inv(product_id: u16, unique_id: Option<&str>) -> DeviceInventory {
@@ -260,27 +240,19 @@ mod tests {
     }
 
     #[test]
-    fn device_route_for_unifying_pids_create_unifying_route() {
-        for &pid in UNIFYING_PIDS {
-            let route = DeviceRoute::device_route_for(&inv(pid, Some("A1B2")), 2);
-            assert!(
-                matches!(route, Some(DeviceRoute::Unifying { ref receiver_uid, slot: 2 }) if receiver_uid == "A1B2"),
-                "pid {pid:#06x} should produce Unifying route"
-            );
-        }
-    }
-
-    #[test]
-    fn device_route_for_lightspeed_pids_create_unifying_route() {
-        // Lightspeed nano receivers (e.g. the G305's) speak the Unifying
-        // protocol, so writes must be routed through DeviceRoute::Unifying —
-        // not defaulted to Bolt, which would address the pairing slot wrong.
-        for &pid in LIGHTSPEED_PIDS {
-            let route = DeviceRoute::device_route_for(&inv(pid, Some("A1B2")), 2);
-            assert!(
-                matches!(route, Some(DeviceRoute::Unifying { ref receiver_uid, slot: 2 }) if receiver_uid == "A1B2"),
-                "lightspeed pid {pid:#06x} should produce a Unifying route"
-            );
+    fn device_route_for_known_receiver_follows_its_protocol() {
+        for receiver in RECEIVERS {
+            let route = DeviceRoute::device_route_for(&inv(receiver.product_id, Some("A1B2")), 2);
+            match receiver.protocol {
+                ReceiverProtocol::Bolt => assert_matches!(
+                    route,
+                    Some(DeviceRoute::Bolt { ref receiver_uid, slot: 2 }) if receiver_uid == "A1B2"
+                ),
+                ReceiverProtocol::Unifying => assert_matches!(
+                    route,
+                    Some(DeviceRoute::Unifying { ref receiver_uid, slot: 2 }) if receiver_uid == "A1B2"
+                ),
+            }
         }
     }
 
@@ -299,10 +271,8 @@ mod tests {
     }
 
     #[test]
-    fn device_route_for_bolt_pid_creates_bolt_route() {
-        // 0xC548 is Bolt; anything not in UNIFYING_PIDS defaults to Bolt so
-        // future Bolt variants with unknown PIDs still work.
-        let route = DeviceRoute::device_route_for(&inv(0xc548, Some("UID")), 1);
+    fn device_route_for_unknown_receiver_defaults_to_bolt() {
+        let route = DeviceRoute::device_route_for(&inv(0xc5ff, Some("UID")), 1);
         assert_matches!(
             route,
             Some(DeviceRoute::Bolt { ref receiver_uid, slot: 1 }) if receiver_uid == "UID"

--- a/crates/openlogi-device-registry/Cargo.toml
+++ b/crates/openlogi-device-registry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "openlogi-device-registry"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+description = "Pure hardware identity registry for OpenLogi devices and receivers."
+keywords = ["logitech", "hidpp", "device", "registry", "hid"]
+categories = ["hardware-support", "no-std"]
+
+[lints]
+workspace = true

--- a/crates/openlogi-device-registry/src/lib.rs
+++ b/crates/openlogi-device-registry/src/lib.rs
@@ -1,0 +1,18 @@
+//! Hardware identities shared across OpenLogi's protocol, device, and host
+//! layers.
+//!
+//! This crate records facts needed on both sides of dependency boundaries:
+//! exact USB/HID identities, marketed product families, protocol families,
+//! driver families, and asset-registry model IDs. Protocol encoding, host I/O,
+//! and runtime capabilities stay with their owning crates.
+
+#![no_std]
+#![deny(missing_docs)]
+#![deny(rustdoc::bare_urls)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub mod litra;
+pub mod receiver;
+
+/// Logitech's USB/Bluetooth vendor ID.
+pub const LOGITECH_VENDOR_ID: u16 = 0x046d;

--- a/crates/openlogi-device-registry/src/litra.rs
+++ b/crates/openlogi-device-registry/src/litra.rs
@@ -1,0 +1,136 @@
+//! Logitech Litra raw-HID identities.
+
+use crate::LOGITECH_VENDOR_ID;
+
+/// Stable driver-family identifier carried by standalone Litra inventory.
+pub const LITRA_DRIVER_ID: &str = "litra";
+/// Litra Glow product ID.
+pub const LITRA_GLOW_PRODUCT_ID: u16 = 0xc900;
+/// Litra Beam product ID.
+pub const LITRA_BEAM_PRODUCT_ID: u16 = 0xc901;
+/// Litra vendor usage page.
+pub const LITRA_USAGE_PAGE: u16 = 0xff43;
+/// Litra vendor usage ID.
+pub const LITRA_USAGE_ID: u16 = 0x0202;
+
+/// A supported Litra product model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LitraModel {
+    /// Logitech Litra Glow.
+    Glow,
+    /// Logitech Litra Beam.
+    Beam,
+}
+
+/// A known Litra raw-HID identity and its static product metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LitraDescriptor {
+    /// USB vendor ID.
+    pub vendor_id: u16,
+    /// USB product ID.
+    pub product_id: u16,
+    /// HID usage page of the writable vendor collection.
+    pub usage_page: u16,
+    /// HID usage ID of the writable vendor collection.
+    pub usage_id: u16,
+    /// Product model selected by this identity.
+    pub model: LitraModel,
+    /// Stable standalone-driver family identifier.
+    pub driver_id: &'static str,
+    /// Exact model identifier used by the OpenLogi asset registry.
+    pub registry_model_id: &'static str,
+}
+
+impl LitraDescriptor {
+    const fn logitech(product_id: u16, model: LitraModel, registry_model_id: &'static str) -> Self {
+        Self {
+            vendor_id: LOGITECH_VENDOR_ID,
+            product_id,
+            usage_page: LITRA_USAGE_PAGE,
+            usage_id: LITRA_USAGE_ID,
+            model,
+            driver_id: LITRA_DRIVER_ID,
+            registry_model_id,
+        }
+    }
+}
+
+/// All standalone Litra raw-HID identities supported by OpenLogi.
+pub const LITRA_DEVICES: &[LitraDescriptor] = &[
+    LitraDescriptor::logitech(LITRA_GLOW_PRODUCT_ID, LitraModel::Glow, "8c900"),
+    LitraDescriptor::logitech(LITRA_BEAM_PRODUCT_ID, LitraModel::Beam, "8c901"),
+];
+
+/// Finds a Litra descriptor by its complete writable raw-HID identity.
+#[must_use]
+pub fn find_litra(
+    vendor_id: u16,
+    product_id: u16,
+    usage_page: u16,
+    usage_id: u16,
+) -> Option<&'static LitraDescriptor> {
+    LITRA_DEVICES.iter().find(|device| {
+        device.vendor_id == vendor_id
+            && device.product_id == product_id
+            && device.usage_page == usage_page
+            && device.usage_id == usage_id
+    })
+}
+
+/// Whether an HID descriptor identifies a supported Litra interface.
+#[must_use]
+pub fn matches_litra(vendor_id: u16, product_id: u16, usage_page: u16, usage_id: u16) -> bool {
+    find_litra(vendor_id, product_id, usage_page, usage_id).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LITRA_DEVICES, LITRA_DRIVER_ID, LitraModel, find_litra};
+    use crate::LOGITECH_VENDOR_ID;
+
+    #[test]
+    fn litra_identities_are_unique() {
+        for (index, device) in LITRA_DEVICES.iter().enumerate() {
+            assert!(
+                LITRA_DEVICES[..index].iter().all(|other| {
+                    (
+                        other.vendor_id,
+                        other.product_id,
+                        other.usage_page,
+                        other.usage_id,
+                    ) != (
+                        device.vendor_id,
+                        device.product_id,
+                        device.usage_page,
+                        device.usage_id,
+                    )
+                }),
+                "duplicate Litra identity {:04x}:{:04x}/{:04x}:{:04x}",
+                device.vendor_id,
+                device.product_id,
+                device.usage_page,
+                device.usage_id
+            );
+        }
+    }
+
+    #[test]
+    fn complete_identity_selects_glow_metadata() {
+        let glow =
+            find_litra(LOGITECH_VENDOR_ID, 0xc900, 0xff43, 0x0202).expect("Litra Glow identity");
+
+        assert_eq!(glow.model, LitraModel::Glow);
+        assert_eq!(glow.driver_id, LITRA_DRIVER_ID);
+        assert_eq!(glow.registry_model_id, "8c900");
+        assert!(find_litra(LOGITECH_VENDOR_ID, 0xc900, 0xff43, 0x0203).is_none());
+    }
+
+    #[test]
+    fn complete_identity_selects_beam_metadata() {
+        let beam =
+            find_litra(LOGITECH_VENDOR_ID, 0xc901, 0xff43, 0x0202).expect("Litra Beam identity");
+
+        assert_eq!(beam.model, LitraModel::Beam);
+        assert_eq!(beam.registry_model_id, "8c901");
+    }
+}

--- a/crates/openlogi-device-registry/src/receiver.rs
+++ b/crates/openlogi-device-registry/src/receiver.rs
@@ -1,0 +1,129 @@
+//! Logitech receiver identities.
+
+use crate::LOGITECH_VENDOR_ID;
+
+/// Logitech receiver product family, independent of its wire protocol.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReceiverBrand {
+    /// Logi Bolt receiver.
+    Bolt,
+    /// Logitech Unifying receiver.
+    Unifying,
+    /// Logitech Nano receiver.
+    Nano,
+    /// Logitech Lightspeed receiver.
+    Lightspeed,
+}
+
+/// Receiver protocol implementation used to enumerate and address devices.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReceiverProtocol {
+    /// Logi Bolt receiver registers and pairing flow.
+    Bolt,
+    /// HID++ 1.0 Unifying-compatible receiver registers and pairing flow.
+    Unifying,
+}
+
+/// A known receiver's USB identity and the behavior OpenLogi assigns to it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReceiverDescriptor {
+    /// USB vendor ID.
+    pub vendor_id: u16,
+    /// USB product ID.
+    pub product_id: u16,
+    /// Receiver's marketed product family.
+    pub brand: ReceiverBrand,
+    /// Protocol implementation used for receiver operations.
+    pub protocol: ReceiverProtocol,
+}
+
+impl ReceiverDescriptor {
+    const fn logitech(product_id: u16, brand: ReceiverBrand, protocol: ReceiverProtocol) -> Self {
+        Self {
+            vendor_id: LOGITECH_VENDOR_ID,
+            product_id,
+            brand,
+            protocol,
+        }
+    }
+}
+
+/// All receiver identities supported by OpenLogi.
+///
+/// Each entry is a protocol claim and must be backed by hardware verification
+/// or an established reference implementation. Marketing families and protocol
+/// families are recorded separately: Nano and Lightspeed currently use
+/// [`ReceiverProtocol::Unifying`].
+pub const RECEIVERS: &[ReceiverDescriptor] = &[
+    ReceiverDescriptor::logitech(0xc52b, ReceiverBrand::Unifying, ReceiverProtocol::Unifying),
+    ReceiverDescriptor::logitech(0xc532, ReceiverBrand::Unifying, ReceiverProtocol::Unifying),
+    // Nano receiver bundled with the G602.
+    ReceiverDescriptor::logitech(0xc537, ReceiverBrand::Nano, ReceiverProtocol::Unifying),
+    // Lightspeed gaming receiver used by the G502, G Pro Wireless, G604, and
+    // other G-series devices.
+    ReceiverDescriptor::logitech(
+        0xc539,
+        ReceiverBrand::Lightspeed,
+        ReceiverProtocol::Unifying,
+    ),
+    // Lightspeed nano receiver, verified with a G305 (WPID 0x4074).
+    ReceiverDescriptor::logitech(
+        0xc53f,
+        ReceiverBrand::Lightspeed,
+        ReceiverProtocol::Unifying,
+    ),
+    // Lightspeed receiver, verified with a G915 (WPID 0x407c) and G502 X.
+    ReceiverDescriptor::logitech(
+        0xc547,
+        ReceiverBrand::Lightspeed,
+        ReceiverProtocol::Unifying,
+    ),
+    ReceiverDescriptor::logitech(0xc548, ReceiverBrand::Bolt, ReceiverProtocol::Bolt),
+    // Lightspeed receiver, verified with a PRO X SUPERLIGHT 2 DEX (WPID 0x40b8).
+    ReceiverDescriptor::logitech(
+        0xc54d,
+        ReceiverBrand::Lightspeed,
+        ReceiverProtocol::Unifying,
+    ),
+];
+
+/// Finds the descriptor for an exact USB vendor/product identity.
+#[must_use]
+pub fn find_receiver(vendor_id: u16, product_id: u16) -> Option<&'static ReceiverDescriptor> {
+    RECEIVERS
+        .iter()
+        .find(|receiver| receiver.vendor_id == vendor_id && receiver.product_id == product_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RECEIVERS, ReceiverBrand, ReceiverProtocol, find_receiver};
+    use crate::LOGITECH_VENDOR_ID;
+
+    #[test]
+    fn receiver_identities_are_unique() {
+        for (index, receiver) in RECEIVERS.iter().enumerate() {
+            assert!(
+                RECEIVERS[..index].iter().all(|other| {
+                    (other.vendor_id, other.product_id) != (receiver.vendor_id, receiver.product_id)
+                }),
+                "duplicate receiver identity {:04x}:{:04x}",
+                receiver.vendor_id,
+                receiver.product_id
+            );
+        }
+    }
+
+    #[test]
+    fn superlight_dex_receiver_is_lightspeed_over_unifying_protocol() {
+        let receiver = find_receiver(LOGITECH_VENDOR_ID, 0xc54d).expect("c54d receiver");
+
+        assert_eq!(receiver.brand, ReceiverBrand::Lightspeed);
+        assert_eq!(receiver.protocol, ReceiverProtocol::Unifying);
+    }
+
+    #[test]
+    fn lookup_requires_the_matching_vendor() {
+        assert!(find_receiver(0xffff, 0xc54d).is_none());
+    }
+}

--- a/crates/openlogi-device/Cargo.toml
+++ b/crates/openlogi-device/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["hardware-support"]
 [dependencies]
 hidpp = { workspace = true }
 openlogi-core = { version = "0.7.10", path = "../openlogi-core", default-features = false }
+openlogi-device-registry = { workspace = true }
 futures-lite = { workspace = true }
 futures-concurrency = "7"
 serde = { workspace = true }

--- a/crates/openlogi-device/src/channel/route.rs
+++ b/crates/openlogi-device/src/channel/route.rs
@@ -15,8 +15,9 @@ use hidpp::{
 };
 
 pub use openlogi_core::hid::route::{
-    BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, LOGITECH_VENDOR_ID,
-    UNIFYING_PIDS, is_receiver_pid, receiver_display_name, speaks_unifying_protocol,
+    DIRECT_DEVICE_INDEX, DeviceRoute, LOGITECH_VENDOR_ID, RECEIVERS, ReceiverBrand,
+    ReceiverDescriptor, ReceiverProtocol, find_receiver, is_receiver_pid, receiver_display_name,
+    speaks_unifying_protocol,
 };
 
 use tracing::warn;

--- a/crates/openlogi-device/src/inventory/standalone.rs
+++ b/crates/openlogi-device/src/inventory/standalone.rs
@@ -3,10 +3,11 @@
 use std::collections::{HashMap, HashSet};
 
 use openlogi_core::device::{DeviceKind, RawDeviceAddress, StandaloneDevice};
+use openlogi_device_registry::litra::find_litra;
 
 use super::InventoryError;
 use crate::backend::HidBackend;
-use crate::write::{LitraModel, matches_litra};
+use crate::write::litra_capabilities;
 
 /// Enumerate recognized standalone devices without probing them as HID++.
 ///
@@ -20,15 +21,12 @@ pub async fn enumerate_standalone(
     let devices: Vec<_> = devices
         .into_iter()
         .filter_map(|device| {
-            if !matches_litra(
+            let descriptor = find_litra(
                 device.vendor_id,
                 device.product_id,
                 device.usage_page,
                 device.usage_id,
-            ) {
-                return None;
-            }
-            let model = LitraModel::from_product_id(device.product_id)?;
+            )?;
             let identity = device.identity();
             Some(StandaloneDevice {
                 address: RawDeviceAddress {
@@ -45,9 +43,9 @@ pub async fn enumerate_standalone(
                 kind: DeviceKind::Light,
                 online: true,
                 capabilities: None,
-                light_capabilities: Some(model.capabilities()),
-                driver_id: model.driver_id().to_owned(),
-                registry_model_id: model.registry_model_id().map(str::to_owned),
+                light_capabilities: Some(litra_capabilities(descriptor.model)),
+                driver_id: descriptor.driver_id.to_owned(),
+                registry_model_id: Some(descriptor.registry_model_id.to_owned()),
             })
         })
         .collect();

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -32,8 +32,9 @@ pub use backend::{
 };
 pub use backlight::{BacklightMode, BacklightState, BacklightStatus};
 pub use channel::route::{
-    BOLT_PIDS, DIRECT_DEVICE_INDEX, DeviceRoute, LIGHTSPEED_PIDS, LOGITECH_VENDOR_ID,
-    UNIFYING_PIDS, receiver_display_name, speaks_unifying_protocol,
+    DIRECT_DEVICE_INDEX, DeviceRoute, LOGITECH_VENDOR_ID, RECEIVERS, ReceiverBrand,
+    ReceiverDescriptor, ReceiverProtocol, find_receiver, receiver_display_name,
+    speaks_unifying_protocol,
 };
 pub use channel::{ChannelPool, ChannelRegistry, SharedChannel};
 pub use inventory::hotplug::watch_hotplug;
@@ -60,14 +61,15 @@ pub use session::keyboard::{
 pub use write::{
     Dpi, DpiCapabilities, DpiInfo, FeatureEntry, FirmwareEntity, FirmwareEntityInfo,
     HapticWaveform, HidppFeatureErrorKind, HidppOperation, LITRA_BEAM_PRODUCT_ID,
-    LITRA_GLOW_PRODUCT_ID, LightCommand, LightingMethod, LitraModel, ReprogControlEntry,
-    ScrollReportingTarget, ScrollResolution, ScrollWheelMode, WriteError, apply_litra,
-    clear_haptic_feature_cache, commands_for_light_settings, dump_features, dump_firmware_entities,
-    dump_reprog_controls, encode_litra_command, ensure_haptics_armed_on, get_backlight, get_dpi,
-    get_dpi_info, get_dpi_info_on, get_scroll_wheel_mode, get_scroll_wheel_mode_on,
-    get_smartshift_status, get_smartshift_status_on, matches_litra, play_haptic, play_haptic_on,
-    read_battery_raw, set_backlight_enabled, set_dpi, set_dpi_on, set_fn_lock, set_fn_lock_on,
-    set_keyboard_color, set_keyboard_color_on, set_keyboard_color_with, set_keyboard_color_with_on,
+    LITRA_GLOW_PRODUCT_ID, LightCommand, LightingMethod, LitraDescriptor, LitraModel,
+    ReprogControlEntry, ScrollReportingTarget, ScrollResolution, ScrollWheelMode, WriteError,
+    apply_litra, clear_haptic_feature_cache, commands_for_light_settings, dump_features,
+    dump_firmware_entities, dump_reprog_controls, encode_litra_command, ensure_haptics_armed_on,
+    find_litra, get_backlight, get_dpi, get_dpi_info, get_dpi_info_on, get_scroll_wheel_mode,
+    get_scroll_wheel_mode_on, get_smartshift_status, get_smartshift_status_on,
+    litra_model_for_route, matches_litra, play_haptic, play_haptic_on, read_battery_raw,
+    set_backlight_enabled, set_dpi, set_dpi_on, set_fn_lock, set_fn_lock_on, set_keyboard_color,
+    set_keyboard_color_on, set_keyboard_color_with, set_keyboard_color_with_on,
     set_scroll_inversion, set_scroll_inversion_on, set_scroll_resolution, set_scroll_resolution_on,
     set_scroll_wheel_mode, set_scroll_wheel_mode_on, set_smartshift, set_smartshift_on,
     set_smartshift_sensitivity, toggle_smartshift, toggle_smartshift_on,

--- a/crates/openlogi-device/src/pairing.rs
+++ b/crates/openlogi-device/src/pairing.rs
@@ -78,13 +78,9 @@ impl From<ReceiverFamily> for PairingPhase {
 }
 
 fn family_for(product_id: u16) -> Option<ReceiverFamily> {
-    if crate::BOLT_PIDS.contains(&product_id) {
-        Some(ReceiverFamily::Bolt)
-    } else if crate::speaks_unifying_protocol(product_id) {
-        // Unifying proper plus protocol-compatible Lightspeed receivers.
-        Some(ReceiverFamily::Unifying)
-    } else {
-        None
+    match crate::find_receiver(crate::LOGITECH_VENDOR_ID, product_id)?.protocol {
+        crate::ReceiverProtocol::Bolt => Some(ReceiverFamily::Bolt),
+        crate::ReceiverProtocol::Unifying => Some(ReceiverFamily::Unifying),
     }
 }
 

--- a/crates/openlogi-device/src/pairing/tests.rs
+++ b/crates/openlogi-device/src/pairing/tests.rs
@@ -8,6 +8,18 @@ use hidpp::{
 };
 
 #[test]
+fn receiver_family_follows_the_shared_protocol_registry() {
+    for receiver in crate::RECEIVERS {
+        let expected = match receiver.protocol {
+            crate::ReceiverProtocol::Bolt => ReceiverFamily::Bolt,
+            crate::ReceiverProtocol::Unifying => ReceiverFamily::Unifying,
+        };
+        assert_eq!(family_for(receiver.product_id), Some(expected));
+    }
+    assert_eq!(family_for(0xc5ff), None);
+}
+
+#[test]
 fn passkey_clicks_are_msb_first_10_bits() {
     // 0b00_0000_0101 = 5 -> eight lefts then right, left, right.
     assert_eq!(

--- a/crates/openlogi-device/src/write.rs
+++ b/crates/openlogi-device/src/write.rs
@@ -50,9 +50,11 @@ pub use lighting::{
     LightingMethod, set_keyboard_color, set_keyboard_color_on, set_keyboard_color_with,
     set_keyboard_color_with_on,
 };
+pub(crate) use litra::litra_capabilities;
 pub use litra::{
-    LITRA_BEAM_PRODUCT_ID, LITRA_GLOW_PRODUCT_ID, LightCommand, LitraModel, apply as apply_litra,
-    encode_command as encode_litra_command, matches_litra,
+    LITRA_BEAM_PRODUCT_ID, LITRA_GLOW_PRODUCT_ID, LightCommand, LitraDescriptor, LitraModel,
+    apply as apply_litra, encode_command as encode_litra_command, find_litra,
+    litra_model_for_route, matches_litra,
 };
 pub use smartshift::{
     get_smartshift_status, get_smartshift_status_on, set_smartshift, set_smartshift_on,

--- a/crates/openlogi-device/src/write/litra.rs
+++ b/crates/openlogi-device/src/write/litra.rs
@@ -1,9 +1,9 @@
 //! Raw HID driver for Logitech Litra lights.
 //!
 //! Litra is deliberately implemented beside, not inside, the HID++ feature
-//! writers. The driver owns product matching, semantic-range conversion, and
-//! the fixed report encoding; the generic transport only owns enumeration and
-//! opening the selected raw HID node.
+//! writers. The shared device registry owns product matching; this driver owns
+//! semantic-range conversion and fixed report encoding, while the generic
+//! transport only owns enumeration and opening the selected raw HID node.
 
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
@@ -13,7 +13,6 @@ use openlogi_core::device::{LightCapabilities, LightValueRange, LightValueUnit};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::debug;
 
-use crate::LOGITECH_VENDOR_ID;
 use crate::backend::HidBackend;
 use crate::channel::route::{DeviceRoute, open_route_writer};
 
@@ -23,17 +22,10 @@ use super::WriteError;
 // `openlogi_core::hid::light`; re-exported here unchanged so this module's
 // own API surface doesn't churn.
 pub use openlogi_core::hid::light::LightCommand;
-
-/// Stable driver-family identifier carried by standalone inventory records.
-pub const LITRA_DRIVER_ID: &str = "litra";
-/// Litra Glow product ID.
-pub const LITRA_GLOW_PRODUCT_ID: u16 = 0xc900;
-/// Litra Beam product ID.
-pub const LITRA_BEAM_PRODUCT_ID: u16 = 0xc901;
-/// Litra vendor usage page.
-pub const LITRA_USAGE_PAGE: u16 = 0xff43;
-/// Litra Glow usage ID.
-pub const LITRA_USAGE_ID: u16 = 0x0202;
+pub use openlogi_device_registry::litra::{
+    LITRA_BEAM_PRODUCT_ID, LITRA_GLOW_PRODUCT_ID, LitraDescriptor, LitraModel, find_litra,
+    matches_litra,
+};
 
 const REPORT_LEN: usize = 20;
 const REPORT_ID: u8 = 0x11;
@@ -68,83 +60,33 @@ const GLOW_TEMPERATURE_RANGE: LightValueRange = validated_range(
     LightValueUnit::Kelvin,
 );
 
-/// A supported Litra product family variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LitraModel {
-    /// Logitech Litra Glow.
-    Glow,
-    /// Logitech Litra Beam.
-    Beam,
-}
-
-impl LitraModel {
-    /// Resolve a Litra model from its USB product ID.
-    #[must_use]
-    pub const fn from_product_id(product_id: u16) -> Option<Self> {
-        match product_id {
-            LITRA_GLOW_PRODUCT_ID => Some(Self::Glow),
-            LITRA_BEAM_PRODUCT_ID => Some(Self::Beam),
-            _ => None,
-        }
-    }
-
-    /// Resolve a model only when the complete raw-HID route matches a known
-    /// Litra interface. Product ID alone is insufficient protection against
-    /// writing a vendor report to an unrelated HID collection.
-    #[must_use]
-    pub fn from_route(route: &DeviceRoute) -> Option<Self> {
-        let DeviceRoute::RawHid {
-            vendor_id,
-            product_id,
-            usage_page,
-            usage_id,
-            ..
-        } = route
-        else {
-            return None;
-        };
-        matches_litra(*vendor_id, *product_id, *usage_page, *usage_id)
-            .then(|| Self::from_product_id(*product_id))
-            .flatten()
-    }
-
-    /// Stable driver-family identifier for this model.
-    #[must_use]
-    pub const fn driver_id(self) -> &'static str {
-        LITRA_DRIVER_ID
-    }
-
-    /// Exact model identifier used by the OpenLogi asset registry.
-    #[must_use]
-    pub const fn registry_model_id(self) -> Option<&'static str> {
-        match self {
-            Self::Glow => Some("8c900"),
-            Self::Beam => Some("8c901"),
-        }
-    }
-
-    /// Static capabilities exposed by the model.
-    #[must_use]
-    pub const fn capabilities(self) -> LightCapabilities {
-        match self {
-            Self::Glow | Self::Beam => LightCapabilities {
-                power: true,
-                brightness: Some(GLOW_BRIGHTNESS_RANGE),
-                temperature: Some(GLOW_TEMPERATURE_RANGE),
-                color: false,
-                zones: false,
-            },
-        }
-    }
-}
-
-/// Whether an HID descriptor identifies a supported Litra interface.
+/// Resolve a model only when the complete raw-HID route matches a registered
+/// Litra interface.
 #[must_use]
-pub fn matches_litra(vendor_id: u16, product_id: u16, usage_page: u16, usage_id: u16) -> bool {
-    vendor_id == LOGITECH_VENDOR_ID
-        && usage_page == LITRA_USAGE_PAGE
-        && usage_id == LITRA_USAGE_ID
-        && LitraModel::from_product_id(product_id).is_some()
+pub fn litra_model_for_route(route: &DeviceRoute) -> Option<LitraModel> {
+    let DeviceRoute::RawHid {
+        vendor_id,
+        product_id,
+        usage_page,
+        usage_id,
+        ..
+    } = route
+    else {
+        return None;
+    };
+    find_litra(*vendor_id, *product_id, *usage_page, *usage_id).map(|device| device.model)
+}
+
+pub(crate) const fn litra_capabilities(model: LitraModel) -> LightCapabilities {
+    match model {
+        LitraModel::Glow | LitraModel::Beam => LightCapabilities {
+            power: true,
+            brightness: Some(GLOW_BRIGHTNESS_RANGE),
+            temperature: Some(GLOW_TEMPERATURE_RANGE),
+            color: false,
+            zones: false,
+        },
+    }
 }
 
 /// Encode a semantic command into the exact fixed-width Litra report.
@@ -162,8 +104,7 @@ pub fn encode_command(
         }
         LightCommand::BrightnessPercent(percent) => {
             report[3] = COMMAND_BRIGHTNESS;
-            let range = model
-                .capabilities()
+            let range = litra_capabilities(model)
                 .brightness
                 .ok_or_else(|| unsupported("brightness"))?;
             let lumens = percent_to_native(percent, range)?;
@@ -171,8 +112,7 @@ pub fn encode_command(
         }
         LightCommand::TemperatureKelvin(kelvin) => {
             report[3] = COMMAND_TEMPERATURE;
-            let range = model
-                .capabilities()
+            let range = litra_capabilities(model)
                 .temperature
                 .ok_or_else(|| unsupported("temperature"))?;
             if !range.contains(kelvin) {
@@ -185,8 +125,7 @@ pub fn encode_command(
         }
         LightCommand::BrightnessNative(value) => {
             report[3] = COMMAND_BRIGHTNESS;
-            let range = model
-                .capabilities()
+            let range = litra_capabilities(model)
                 .brightness
                 .ok_or_else(|| unsupported("brightness"))?;
             if !range.contains(value) {
@@ -241,7 +180,7 @@ pub async fn apply(
     model: LitraModel,
     command: LightCommand,
 ) -> Result<(), WriteError> {
-    let Some(route_model) = LitraModel::from_route(route) else {
+    let Some(route_model) = litra_model_for_route(route) else {
         return Err(unsupported("raw_hid_route"));
     };
     if route_model != model {
@@ -266,8 +205,8 @@ mod tests {
     use std::assert_matches;
 
     use super::{
-        COMMAND_BRIGHTNESS, COMMAND_POWER, COMMAND_TEMPERATURE, LITRA_BEAM_PRODUCT_ID,
-        LightCommand, LitraModel, REPORT_ID, encode_command, matches_litra,
+        COMMAND_BRIGHTNESS, COMMAND_POWER, COMMAND_TEMPERATURE, LightCommand, LitraModel,
+        REPORT_ID, encode_command, litra_model_for_route,
     };
     use crate::{DeviceRoute, WriteError};
 
@@ -346,34 +285,6 @@ mod tests {
     }
 
     #[test]
-    fn matcher_requires_the_full_identity_tuple() {
-        assert!(matches_litra(0x046d, 0xc900, 0xff43, 0x0202));
-        assert!(!matches_litra(0x046d, 0xc900, 0xff43, 0x0203));
-        assert!(!matches_litra(0x046d, 0xc902, 0xff43, 0x0202));
-        assert!(!matches_litra(0x1234, 0xc900, 0xff43, 0x0202));
-    }
-
-    #[test]
-    fn glow_descriptor_exposes_driver_identity() {
-        assert_eq!(LitraModel::Glow.driver_id(), "litra");
-    }
-
-    #[test]
-    fn registry_model_ids_match_the_asset_registry() {
-        assert_eq!(LitraModel::Glow.registry_model_id(), Some("8c900"));
-        assert_eq!(LitraModel::Beam.registry_model_id(), Some("8c901"));
-    }
-
-    #[test]
-    fn beam_is_matched_by_its_complete_route_tuple() {
-        assert!(matches_litra(0x046d, 0xc901, 0xff43, 0x0202));
-        assert_eq!(
-            LitraModel::from_product_id(LITRA_BEAM_PRODUCT_ID),
-            Some(LitraModel::Beam)
-        );
-    }
-
-    #[test]
     fn model_resolution_requires_the_complete_raw_route_tuple() {
         let valid = DeviceRoute::RawHid {
             vendor_id: 0x046d,
@@ -390,10 +301,10 @@ mod tests {
             identity: "serial:test".into(),
         };
 
-        assert_eq!(LitraModel::from_route(&valid), Some(LitraModel::Glow));
-        assert_eq!(LitraModel::from_route(&wrong_usage), None);
+        assert_eq!(litra_model_for_route(&valid), Some(LitraModel::Glow));
+        assert_eq!(litra_model_for_route(&wrong_usage), None);
         assert_eq!(
-            LitraModel::from_route(&DeviceRoute::Direct {
+            litra_model_for_route(&DeviceRoute::Direct {
                 vendor_id: 0x046d,
                 product_id: 0xc900,
             }),

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -305,20 +305,16 @@ fn is_receiver_child_node(id: &async_hid::DeviceId) -> bool {
 /// can be unit-tested without filesystem access.
 #[cfg(any(target_os = "linux", test))]
 fn is_receiver_child_sysfs_path(path: &str) -> bool {
-    // Build parent-component markers from the canonical PID lists so adding a
-    // new receiver PID only needs to be done in one place (route.rs).
+    // Build parent-component markers from the canonical receiver registry so
+    // adding a new receiver identity only needs to be done in one place.
     // The kernel HID device name format is "BUS:VID:PID.IFACE" with uppercase hex.
-    crate::BOLT_PIDS
-        .iter()
-        .chain(crate::UNIFYING_PIDS.iter())
-        .chain(crate::LIGHTSPEED_PIDS.iter())
-        .any(|&pid| {
-            let marker = format!(":{LOGITECH_VENDOR_ID:04X}:{pid:04X}.");
-            // A parent component contains the marker followed by at least one
-            // more "/" — it is not the terminal component of the path.
-            path.find(&marker)
-                .is_some_and(|idx| path[idx + marker.len()..].contains('/'))
-        })
+    crate::RECEIVERS.iter().any(|receiver| {
+        let marker = format!(":{:04X}:{:04X}.", receiver.vendor_id, receiver.product_id);
+        // A parent component contains the marker followed by at least one
+        // more "/" — it is not the terminal component of the path.
+        path.find(&marker)
+            .is_some_and(|idx| path[idx + marker.len()..].contains('/'))
+    })
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -23,6 +23,7 @@ readme = "README.md"
 name = "hidpp"
 
 [dependencies]
+openlogi-device-registry = { workspace = true }
 thiserror = { workspace = true }
 hidreport = "0.5.0"
 futures = "0.3.31"

--- a/crates/openlogi-hidpp/src/receiver.rs
+++ b/crates/openlogi-hidpp/src/receiver.rs
@@ -8,12 +8,12 @@
 //! providing information and testing.
 //!
 //! Receivers can generally only be differentiated by their USB vendor and
-//! product IDs, so the [`detect`] function does nothing more than matching
-//! those values to the sets of known vendor and product ID pairs of the
-//! different receivers.
+//! product IDs, so [`detect`] dispatches through the shared
+//! `openlogi-device-registry`.
 
 use std::sync::Arc;
 
+use openlogi_device_registry::receiver::{ReceiverProtocol, find_receiver};
 use thiserror::Error;
 
 use crate::{channel::HidppChannel, protocol::v10::Hidpp10Error};
@@ -26,16 +26,10 @@ pub const RECEIVER_DEVICE_INDEX: u8 = 0xff;
 
 /// Tries to detect the receiver present on a HID++ channel.
 pub fn detect(chan: Arc<HidppChannel>) -> Option<Receiver> {
-    let vpid_pair = &(chan.vendor_id, chan.product_id);
-
-    if bolt::VPID_PAIRS.contains(vpid_pair) {
-        return bolt::Receiver::new(chan).ok().map(Receiver::Bolt);
+    match find_receiver(chan.vendor_id, chan.product_id)?.protocol {
+        ReceiverProtocol::Bolt => bolt::Receiver::new(chan).ok().map(Receiver::Bolt),
+        ReceiverProtocol::Unifying => unifying::Receiver::new(chan).ok().map(Receiver::Unifying),
     }
-
-    if unifying::VPID_PAIRS.contains(vpid_pair) {
-        return unifying::Receiver::new(chan).ok().map(Receiver::Unifying);
-    }
-    None
 }
 
 /// Represents a HID++ wireless receiver.

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use derive_builder::Builder;
 use futures::{FutureExt, pin_mut, select};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use openlogi_device_registry::receiver::{ReceiverProtocol, find_receiver};
 
 use super::{RECEIVER_DEVICE_INDEX, ReceiverError};
 use crate::{
@@ -26,9 +27,6 @@ use crate::{
 mod event;
 
 pub use event::{DeviceConnection, DeviceKind, Event, PairingError, PairingPasskeyPressType};
-
-/// All USB vendor & product ID pairs that are known to identify Bolt receivers.
-pub const VPID_PAIRS: &[(u16, u16)] = &[(0x046d, 0xc548)];
 
 /// All known registers of the Bolt receiver.
 ///
@@ -106,7 +104,9 @@ impl Receiver {
     /// match the ones of any known Bolt receiver, this function will return
     /// [`ReceiverError::UnknownReceiver`].
     pub fn new(chan: Arc<HidppChannel>) -> Result<Self, ReceiverError> {
-        if !VPID_PAIRS.contains(&(chan.vendor_id, chan.product_id)) {
+        if find_receiver(chan.vendor_id, chan.product_id)
+            .is_none_or(|receiver| receiver.protocol != ReceiverProtocol::Bolt)
+        {
             return Err(ReceiverError::UnknownReceiver);
         }
 

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -11,6 +11,7 @@
 use std::sync::Arc;
 
 use num_enum::{FromPrimitive, IntoPrimitive, TryFromPrimitive};
+use openlogi_device_registry::receiver::{ReceiverProtocol, find_receiver};
 
 use crate::{
     channel::{HidppChannel, MessageListenerGuard},
@@ -18,31 +19,6 @@ use crate::{
     protocol::v10,
     receiver::{RECEIVER_DEVICE_INDEX, ReceiverError},
 };
-
-/// All USB vendor & product ID pairs that are known to identify Unifying
-/// receivers.
-///
-/// `046d:c537` is the Nano receiver bundled with the G602;
-/// `046d:c539` is the Lightspeed gaming receiver; `046d:c53f` is the Lightspeed
-/// nano receiver (bundled with G-series wireless mice such as the G305);
-/// `046d:c547` is the Lightspeed receiver bundled with newer G-series devices
-/// such as the G915 keyboard and the G502 X LIGHTSPEED; `046d:c54d` ships with
-/// the PRO X SUPERLIGHT 2 DEX. All answer the same
-/// HID++ 1.0 registers (pairing count, connection state, pairing information)
-/// as Unifying receivers. Callers that surface a user-facing receiver name
-/// label Lightspeed PIDs separately (see `openlogi-hid`).
-/// `0xc53f` was verified against a G305 (paired device wpid `0x4074`);
-/// `0xc547` against a G915 (paired device wpid `0x407c`); `0xc54d` against a
-/// PRO X SUPERLIGHT 2 DEX.
-pub const VPID_PAIRS: &[(u16, u16)] = &[
-    (0x046d, 0xc52b),
-    (0x046d, 0xc532),
-    (0x046d, 0xc537),
-    (0x046d, 0xc539),
-    (0x046d, 0xc53f),
-    (0x046d, 0xc547),
-    (0x046d, 0xc54d),
-];
 
 /// All known registers of the Unifying receiver.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, TryFromPrimitive)]
@@ -105,7 +81,9 @@ impl Receiver {
     /// Returns [`ReceiverError::UnknownReceiver`] when the channel's VID/PID
     /// doesn't match any known Unifying receiver.
     pub fn new(chan: Arc<HidppChannel>) -> Result<Self, ReceiverError> {
-        if !VPID_PAIRS.contains(&(chan.vendor_id, chan.product_id)) {
+        if find_receiver(chan.vendor_id, chan.product_id)
+            .is_none_or(|receiver| receiver.protocol != ReceiverProtocol::Unifying)
+        {
             return Err(ReceiverError::UnknownReceiver);
         }
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -46,6 +46,10 @@ git_tag_name = "v{{ version }}"
 git_release_enable = false
 
 [[package]]
+name = "openlogi-device-registry"
+version_group = "openlogi"
+
+[[package]]
 name = "openlogi-core"
 version_group = "openlogi"
 

--- a/xtask/src/commands/ci/jobs/steps.rs
+++ b/xtask/src/commands/ci/jobs/steps.rs
@@ -46,7 +46,11 @@ const WINDOWS_LINT_CRATES: [&str; 8] = [
 /// `openlogi-core` qualifies only with its `fs` feature off — that feature is
 /// the config file, and a config file needs a filesystem. Hence
 /// `--no-default-features`, which is why this job checks it in its own pass.
-const WASM_PORTABLE_CRATES: [&str; 2] = ["openlogi-hidpp", "openlogi-device"];
+const WASM_PORTABLE_CRATES: [&str; 3] = [
+    "openlogi-device-registry",
+    "openlogi-hidpp",
+    "openlogi-device",
+];
 
 /// The crates that are portable once their host-facing feature is off.
 const WASM_PORTABLE_NO_DEFAULT_CRATES: [&str; 1] = ["openlogi-core"];


### PR DESCRIPTION
## Summary

Centralize OpenLogi's static hardware identity facts in `openlogi-device-registry` so receiver routing/protocol detection and standalone-device matching cannot drift between crates. This follows up on #811, where adding `046d:c54d` exposed multiple independently maintained receiver PID lists.

## Changes

- add the dependency-free, `no_std` `openlogi-device-registry` crate, split into `receiver` and `litra` domains
- record receiver USB identity, marketed family, and wire-protocol family separately, then derive HID++ detection, route selection, display naming, pairing, and Linux receiver-child filtering from that registry
- migrate Litra Glow/Beam raw-HID identity tuples plus driver and asset-model metadata into the registry
- keep Litra capabilities, value conversion, and HID report encoding in the device driver that owns that behavior
- share the Logitech vendor ID with camera discovery without introducing a camera PID table that the project does not currently have
- leave HID++ feature IDs with the protocol crate and the remotely fetched asset model catalog with `openlogi-assets`
- remove the old receiver PID constants and duplicated VID/PID tables; keep existing fallback and wire behavior unchanged
- include the registry crate in release-plz and Wasm portability checks

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 7 passed, 0 failed; shell, macOS tests, and cargo-deny skipped on this Linux orb
- not runtime-tested on hardware

Follow-up to #811.
