### PR TITLE
fix(nix): provide git to the sandboxed test phase

### DIFF
--- a/packaging/linux/package.nix
+++ b/packaging/linux/package.nix
@@ -28,6 +28,7 @@
   rustPlatform,
   fetchgit,
   src,
+  git,
   pkg-config,
   patchelf,
   versionCheckHook,
@@ -140,6 +141,11 @@ rustPlatform.buildRustPackage {
     patchelf
     rustPlatform.bindgenHook # `media` (a gpui dep) runs bindgen — needs libclang
   ];
+
+  # The xtask release tests exercise version-bump checkout against throwaway
+  # repositories they `git init` themselves, so the sandboxed `cargo test`
+  # needs a git binary even though the build does not.
+  nativeCheckInputs = [ git ];
 
   # Only libraries whose *-sys crates appear in Cargo.lock. TLS is rustls and
   # evdev/hidraw are opened directly. Runtime-selected graphics libraries also


### PR DESCRIPTION
## Summary

Nix CI on #822 failed in `cargo test` with four `checkout_version_bump` tests panicking on `command not found: git` — the xtask release tests introduced with the version-bump checkout work `git init` throwaway repositories, and the nix sandbox provides no git binary. This is latent master breakage, not something #822 touches: Nix CI has not run against master since those tests landed, so the first PR whose run met them went red.

## Changes

- `nix`: add `git` to `nativeCheckInputs` in `packaging/linux/package.nix` (test phase only; the build itself does not need it).

## Testing

- `nix eval .#packages.x86_64-linux.default.drvPath` — evaluates clean with the new argument.
- The real check is this PR's own Nix CI run (the failing legs are Linux-only and this host cannot build them); the `nix fmt` job likewise runs on CI, as the flake defines no darwin formatter.
- After this merges, re-running Nix CI on #822 (or rebasing it) should turn that PR green.