### PR TITLE
refactor(device): take a wasm-portable timer instead of tokio::time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,10 @@ name = "futures-timer"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -2724,6 +2728,18 @@ dependencies = [
  "bitflags 1.3.2",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5539,6 +5555,7 @@ version = "0.7.10"
 dependencies = [
  "futures-concurrency",
  "futures-lite",
+ "futures-timer",
  "openlogi-core",
  "openlogi-device-registry",
  "openlogi-hidpp",
@@ -7181,6 +7198,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/crates/openlogi-device/Cargo.toml
+++ b/crates/openlogi-device/Cargo.toml
@@ -20,6 +20,9 @@ openlogi-core = { version = "0.7.10", path = "../openlogi-core", default-feature
 openlogi-device-registry = { workspace = true }
 futures-lite = { workspace = true }
 futures-concurrency = "7"
+# The one timer for both targets — see `src/time.rs`. Already in the graph via
+# `openlogi-hidpp`, the other crate on the portable list.
+futures-timer = "3.0.4"
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -30,3 +33,10 @@ tempfile = "3"
 
 [lints]
 workspace = true
+
+# `futures-timer` only reaches for the browser's timer under this feature;
+# without it a wasm build silently gets the thread-backed native path, which is
+# the runtime panic this crate is trying not to have. Scoped to the wasm target
+# so native builds pull neither `gloo-timers` nor `send_wrapper`.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+futures-timer = { version = "3.0.4", features = ["wasm-bindgen"] }

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -7,11 +7,11 @@ use std::{
     time::Duration,
 };
 
+use crate::time::timeout;
 use futures_concurrency::future::Join as _;
 use hidpp::channel::HidppChannel;
 use openlogi_core::device::DeviceInventory;
 use thiserror::Error;
-use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use crate::ChannelRegistry;
@@ -337,7 +337,7 @@ pub async fn enumerate(
         // partial live result) is cleared so it can't count as one of the two
         // "stable" reads and short-circuit a later healthy-but-short pass.
         previous_inventories = if all_healthy { Some(inventories) } else { None };
-        tokio::time::sleep(ONESHOT_RETRY_DELAY).await;
+        crate::time::sleep(ONESHOT_RETRY_DELAY).await;
         attempt += 1;
     }
 }

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
+use crate::time::timeout;
 use futures_concurrency::future::Join as _;
 use hidpp::{
     channel::HidppChannel,
@@ -15,7 +16,6 @@ use hidpp::{
     },
 };
 use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
-use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use super::mappings::{map_kind, map_unifying_kind, resolve_device_kind};

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -25,6 +25,7 @@ pub mod pairing;
 pub mod reprog_controls;
 pub mod session;
 pub mod thumbwheel;
+pub mod time;
 pub mod write;
 
 pub use backend::{

--- a/crates/openlogi-device/src/pairing.rs
+++ b/crates/openlogi-device/src/pairing.rs
@@ -310,7 +310,7 @@ async fn drive(
     let mut partial: HashMap<u16, PartialDevice> = HashMap::new();
     // Auth byte of the device the user chose to pair, for passkey rendering.
     let mut pairing_auth: Option<u8> = None;
-    let deadline = tokio::time::sleep(SESSION_TIMEOUT);
+    let deadline = crate::time::sleep(SESSION_TIMEOUT);
     tokio::pin!(deadline);
 
     loop {

--- a/crates/openlogi-device/src/pairing/tests.rs
+++ b/crates/openlogi-device/src/pairing/tests.rs
@@ -85,7 +85,7 @@ async fn malformed_passkey_after_pair_cancels_bolt_pairing() {
         reports
     };
 
-    let result = tokio::time::timeout(Duration::from_secs(2), async {
+    let result = crate::time::timeout(Duration::from_secs(2), async {
         tokio::join!(
             run_session(
                 &channel,

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -275,7 +275,7 @@ pub async fn run_capture_session(
     let channel_dead = loop {
         tokio::select! {
             _ = &mut shutdown => break false,
-            () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
+            () = crate::time::sleep(LIVENESS_PING_INTERVAL) => {
                 match root.ping(0x5a).await {
                     Err(v20::Hidpp20Error::Channel(
                         hidpp::channel::ChannelError::Timeout

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -19,12 +19,10 @@ use hidpp::{
     protocol::v20,
 };
 use thiserror::Error;
-use tokio::{
-    sync::{mpsc, oneshot},
-    time::timeout,
-};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info};
 
+use crate::time::timeout;
 use crate::{
     ChannelPool, DeviceRoute,
     backend::BackendError,

--- a/crates/openlogi-device/src/session/keyboard.rs
+++ b/crates/openlogi-device/src/session/keyboard.rs
@@ -263,7 +263,7 @@ async fn arm_keys(
 async fn rearm_keys(rc: &ReprogControlsV4, diverted: &BTreeMap<u16, ButtonId>) {
     // A settling pause: the broadcast arrives the instant the link is back,
     // occasionally before the device accepts feature writes again.
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    crate::time::sleep(std::time::Duration::from_millis(200)).await;
     for &cid in diverted.keys() {
         if let Err(e) = rc.set_cid_reporting(cid, true, false).await {
             warn!(

--- a/crates/openlogi-device/src/time.rs
+++ b/crates/openlogi-device/src/time.rs
@@ -1,0 +1,79 @@
+//! The crate's one timer story, for native and wasm alike.
+//!
+//! `openlogi-device` exists to be host-free: the WebHID backend is meant to
+//! drive it from a browser, which is why CI's `wasm (portable crates)` job
+//! holds this crate to `wasm32-unknown-unknown`. `tokio::time` passed that job
+//! and would still have been wrong — it *compiles* for wasm and panics the
+//! first time a timer is polled, and a `cargo check` cannot see that.
+//!
+//! `futures-timer` is the timer both targets share. It was already in the
+//! dependency graph — `openlogi-hidpp`, the other crate on the portable list,
+//! times its own reads with it — so the global timer thread it costs on native
+//! is paid whether or not this crate joins, and nothing here has to know which
+//! target it is on.
+//!
+//! [`timeout`] is written once on top of [`sleep`] because `futures-timer`
+//! ships no timeout combinator. That is the whole reason this module exists
+//! rather than each call site reaching for `Delay` itself.
+
+use std::future::Future;
+use std::time::Duration;
+
+use futures_timer::Delay;
+
+/// The error [`timeout`] returns when its budget ran out first.
+///
+/// Deliberately carries nothing: every caller in this crate treats a timeout
+/// as one opaque outcome, and a payload would only invite matching on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("the operation did not finish within its budget")]
+pub struct Elapsed;
+
+/// Complete after `duration`.
+#[must_use]
+pub fn sleep(duration: Duration) -> Delay {
+    Delay::new(duration)
+}
+
+/// Run `future` with a time budget, yielding [`Elapsed`] if it runs out.
+///
+/// The future is polled before the timer on every wake, so one that is already
+/// ready wins a zero-length budget rather than racing it — the behaviour
+/// `tokio::time::timeout` documents, and what the probe paths here rely on
+/// when a cached answer resolves immediately.
+pub async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, Elapsed>
+where
+    F: Future,
+{
+    futures_lite::future::or(async move { Ok(future.await) }, async move {
+        sleep(duration).await;
+        Err(Elapsed)
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_future_that_finishes_in_budget_yields_its_output() {
+        let out = timeout(Duration::from_secs(30), async { 7 }).await;
+        assert_eq!(out, Ok(7));
+    }
+
+    /// The left side is polled first, so an already-ready future beats even a
+    /// zero budget. The probe paths depend on this: a cached answer resolves
+    /// without ever suspending, and must not be reported as timed out.
+    #[tokio::test]
+    async fn an_already_ready_future_wins_a_zero_budget() {
+        let out = timeout(Duration::ZERO, async { "cached" }).await;
+        assert_eq!(out, Ok("cached"));
+    }
+
+    #[tokio::test]
+    async fn a_future_that_never_finishes_elapses() {
+        let out = timeout(Duration::from_millis(1), std::future::pending::<()>()).await;
+        assert_eq!(out, Err(Elapsed));
+    }
+}

--- a/crates/openlogi-device/src/write/lighting.rs
+++ b/crates/openlogi-device/src/write/lighting.rs
@@ -218,7 +218,7 @@ async fn set_color_effects(
             .set_zone_effect(zone, EFFECT_FIXED, params, Persistence::Volatile)
             .await
             .map_err(classify_lighting_error)?;
-        tokio::time::sleep(FRAME_GAP).await;
+        crate::time::sleep(FRAME_GAP).await;
     }
     debug!(
         index,

--- a/crates/openlogi-device/src/write/litra.rs
+++ b/crates/openlogi-device/src/write/litra.rs
@@ -191,7 +191,7 @@ pub async fn apply(
     let Some(mut writer) = open_route_writer(backend, route).await? else {
         return Err(WriteError::DeviceNotFound);
     };
-    tokio::time::timeout(RAW_WRITE_TIMEOUT, writer.write_output_report(&report))
+    crate::time::timeout(RAW_WRITE_TIMEOUT, writer.write_output_report(&report))
         .await
         .map_err(|_| WriteError::RequestTimedOut {
             operation: super::HidppOperation::Light,

--- a/crates/openlogi-device/src/write/smartshift.rs
+++ b/crates/openlogi-device/src/write/smartshift.rs
@@ -329,7 +329,7 @@ pub(super) async fn toggle_smartshift_on_channel(
                 error = ?err,
                 "SmartShift toggle hit a transient error; retrying once"
             );
-            tokio::time::sleep(TRANSIENT_RETRY_DELAY).await;
+            crate::time::sleep(TRANSIENT_RETRY_DELAY).await;
             toggle_once(&mut device, index).await
         }
         Err(err) => Err(err),
@@ -409,7 +409,7 @@ pub(super) async fn set_smartshift_on_channel(
                 error = ?err,
                 "SmartShift write hit a transient error; retrying once"
             );
-            tokio::time::sleep(TRANSIENT_RETRY_DELAY).await;
+            crate::time::sleep(TRANSIENT_RETRY_DELAY).await;
             // Re-open: the first attempt may have bound the wrong feature index
             // after a mis-delivered root.get_feature response.
             let smartshift = SmartShift::open(&mut device).await?;


### PR DESCRIPTION
## Summary

`openlogi-device` timed its inventory probes, writes and pairing session with
`tokio::time`, which compiles for `wasm32-unknown-unknown` and panics the first
time a timer is polled. The `wasm (portable crates)` job is a `cargo check`, so
the crate sat on the portable list carrying a timer that cannot run there.

Fixes #826

## The choice

The issue frames it as `futures-timer` — which costs a global timer thread on
native — against a cfg-split shim. The tie-breaker is that `futures-timer` is
already in the graph: `openlogi-hidpp`, the other crate on the portable list,
times its own reads with it, so every native build that links `openlogi-device`
pays for that thread whether or not this crate joins. Taking it costs nothing
new and removes the cfg entirely.

So the split lives in the manifest, not the code. `src/time.rs` exposes `sleep`
and `timeout`; no call site learns which target it is on, which is the
constraint the issue sets.

## Changes

**`openlogi-device/src/time.rs`** (new)
- `sleep` wraps `futures_timer::Delay`.
- `timeout` is written once on top of it, because futures-timer ships no
  timeout combinator — that is the reason this module exists rather than each
  call site reaching for `Delay`. The future is polled ahead of the timer, so
  one that is already ready still wins a zero-length budget, matching what
  `tokio::time::timeout` documents and what the probe paths rely on when a
  cached answer resolves without suspending.
- `Elapsed` is a unit error: every caller in this crate already treated a
  timeout as one opaque outcome (`Err(_)`, `.is_err()`, `.ok()`).

**Call sites** — eleven, across `inventory`, `inventory::probe`,
`session::{gesture, host_switch, keyboard}`, `write::{lighting, litra,
smartshift}` and `pairing`, plus one test harness guard. `grep tokio::time`
over the crate now returns only two doc references in the new module.
`tokio::sync` is untouched; it works on wasm.

**`Cargo.toml`**
- `futures-timer = "3.0.4"`, matching the version `openlogi-hidpp` pins.
- The `wasm-bindgen` feature enabled for the wasm target only. Without it
  futures-timer hands a wasm build its *native*, thread-backed path — the same
  runtime failure this change is removing, in a different crate. Scoping it to
  the target keeps `gloo-timers` and `send_wrapper` out of native builds, and
  since Cargo unifies features it also gives `openlogi-hidpp`'s timers the
  browser path on wasm.

## Testing

Linux, x86_64, Rust 1.98.0:

```
cargo xtask ci wasm          # the job this is about — passes
cargo test -p openlogi-device
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings   # RUSTFLAGS=-D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
```

All green; 173 tests in `openlogi-device`.

The feature scoping was checked directly rather than assumed:

```
$ cargo tree -p openlogi-device --target wasm32-unknown-unknown | grep -cE 'gloo-timers|send_wrapper'
2
$ cargo tree -p openlogi-device | grep -cE 'gloo-timers|send_wrapper'
0
```

`src/time.rs` carries three tests: budget met, already-ready future against a
zero budget, and a pending future elapsing.

**What this does not prove.** The panic it removes is a *runtime* one on wasm,
and there is no wasm runtime here — `cargo check` is as far as CI or this host
goes, which is the gap the issue itself names. What is verified is that the
crate no longer references `tokio::time`, that the browser timer is the one
selected for wasm builds, and that native behaviour is unchanged by the test
suite. Real confirmation belongs with whatever first drives this crate from a
browser (#825).

**Not run on this host:** `tests (macos)`, `cargo-deny`, macOS clippy.
No hardware verification applies — no device code changed, only the timers
around it.
