### PR TITLE
docs(agents): refresh the permissions skill for the landed fixes

### DIFF
--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -18,7 +18,8 @@ list). Classify before doing anything else. The discriminator is one log line:
 | Agent log | Layer | TCC? |
 |---|---|---|
 | `HID++ candidate interfaces count=0` | enumeration | **No.** The device's HID++ collection never matched — unsupported device, or not connected. |
-| `failed to open HID++ channel — retrying next tick error=Message("Failed to open device")` | open | **Yes, usually.** `IOHIDDeviceOpen` was denied. Same string also covers exclusive access and a device that vanished — see §5. |
+| `failed to open HID++ channel … Failed to open device: Input Monitoring is NOT granted to this process…` | open | **Yes.** The message classifies itself — grant Input Monitoring to the identity named in §2. |
+| `… Failed to open device: Input Monitoring is granted to this process — another app may hold the device exclusively, or macOS is serving a stale permission session (log out and back in)` | open | **The grant is fine.** Quit the other app (usually Logi Options+), or log out and back in. See §5. |
 | `opened HID++ channel` … then `Device::new failed` / `enumerate_features failed` with `Channel(Timeout)` or `report writer callback error: 0xE00002D6` | probe | **No.** The open succeeded, so permissions are fine. This is the async-hid macOS write bug (upstream `sidit77/async-hid#45`). |
 
 All of these lines are `debug`-level except the open failure, which is a
@@ -39,15 +40,18 @@ permissions.
 
 | Identity | Binary | Needs |
 |---|---|---|
-| `org.openlogi.agent` | `…/Contents/Library/LoginItems/OpenLogiAgent.app` | **Input Monitoring** (opens HID) and **Accessibility** (owns the event tap) |
+| `org.openlogi.agent` | `…/Contents/Library/LoginItems/OpenLogi Agent.app` | **Input Monitoring** (opens HID) and **Accessibility** (owns the event tap) |
 | `org.openlogi.openlogi` | `…/Contents/MacOS/openlogi-desktop` | Camera only. It is a pure IPC client and needs neither of the above. |
 | `openlogi` | `…/Contents/MacOS/openlogi` (embedded CLI) | Input Monitoring, because it opens HID directly today |
 | `org.openlogi.overlay` | `…/LoginItems/OpenLogiOverlay.app` | Nothing |
 
 Two consequences that drive most reports:
 
-- The identity the user must grant is **OpenLogiAgent**, which lives inside the
-  app bundle. The System Settings `+` picker will not browse into a bundle, so
+- The identity the user must grant is **OpenLogi Agent**, which lives inside the
+  app bundle. Bundles built before the rename spell that directory
+  `OpenLogiAgent.app`; both are the same identity (`org.openlogi.agent`), and
+  the grant survived the rename because TCC keys on the identifier, not the
+  path. The System Settings `+` picker will not browse into a bundle, so
   they have to use Go-to-Folder. Say this explicitly; do not tell someone to
   "grant OpenLogi permission".
 - A grant to the GUI does nothing for the agent, and vice versa. There is no
@@ -62,14 +66,19 @@ Two consequences that drive most reports:
 Run `scripts/diagnose.sh` from this skill, or the same steps by hand. It is
 read-only and safe to hand to a reporter.
 
-The one step it cannot do for them: **the agent's log has nowhere to go.** The
-generated LaunchAgent plist sets no `StandardOutPath`/`StandardErrorPath` and
-there is no file logger, so launchd discards everything. Until that changes, the
-only way to see the agent's own log is to stop it and run it in the foreground:
+**Ask for the agent's log file first.** launchd discards the agent's stderr,
+so the agent also writes a daily-rotated file (7 kept) a reporter can attach:
+
+```sh
+ls ~/.local/state/openlogi/
+```
+
+It carries panics too. Only when that file is missing or predates the failure
+is a foreground run worth its cost:
 
 ```sh
 OPENLOGI_LOG=debug \
-  /Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogiAgent.app/Contents/MacOS/openlogi-agent
+  "/Applications/OpenLogi.app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent"
 ```
 
 Note what that costs: run from a terminal, the agent's responsible process
@@ -86,8 +95,8 @@ Access.
 
 macOS attributes a TCC request to the *responsible* process, which for a plain
 child process is the parent. An agent spawned directly by the GUI therefore asks
-with the **GUI's** identity, and the user's grant to `OpenLogiAgent` appears to
-do nothing.
+with the **GUI's** identity, and the user's grant to `OpenLogi Agent` appears
+to do nothing.
 
 Two ways to break the chain, both already in the tree
 (`openlogi-desktop/src/services/ipc.rs`):
@@ -116,10 +125,10 @@ every grant on that machine is being ignored.
   after a grant or revoke the calling process keeps seeing the old answer until
   it restarts. That is why the agent calls
   `binary_watch::relaunch_after_input_monitoring_grant()`.
-- `IOHIDDeviceOpen` — **denial is silent**. There is no TCC-specific error; the
-  failure is indistinguishable from exclusive access or a disconnect. Never
-  report `Failed to open device` to a user as-is; check
-  `openlogi_hid::permissions::has_access()` and say which one it was.
+- `IOHIDDeviceOpen` — **denial is silent**. There is no TCC-specific error, so
+  the transport pairs every open failure with
+  `openlogi_hid::permissions::has_access()` and says which case it is (§1).
+  Keep it that way: a bare `Failed to open device` is not reportable.
 
 ## 6. Invariants — do not break these
 
@@ -142,14 +151,11 @@ every grant on that machine is being ignored.
 
 ## 7. Known-broken right now
 
-Check these before filing a new diagnosis. This list is a snapshot — confirm
-each is still open (`gh issue view 606`, `gh pr view 760`) before citing it:
-
-- The Settings → Input Monitoring row queries the **GUI's** grant, not the
-  agent's (#606, PR #760 open). It can read "Granted" while the agent has
-  nothing. The Accessibility row above it is already correct — it goes over IPC.
-- The agent's launchd log has no destination (§3). Open.
-- `disclaim`'s spawn result is discarded in `ipc.rs` (`.map(|_| ())`).
+Nothing in the launch, permission-reporting, or diagnosis path is known
+broken right now: the Settings row reads the agent's own grant over IPC
+(#606), the agent writes a log file (§3), open failures classify themselves
+(§1), and the `open -g -n` handoff checks its exit status. This is a
+snapshot — re-check the tracker before telling anyone a gap is still open.
 
 ## 8. What this cannot fix
 

--- a/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
+++ b/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
@@ -5,7 +5,18 @@
 set -uo pipefail
 
 app=${OPENLOGI_APP:-/Applications/OpenLogi.app}
-agent="$app/Contents/Library/LoginItems/OpenLogiAgent.app"
+# The helper is named after its display name; bundles built before that rename
+# spell it without the space. Same identity (org.openlogi.agent) either way.
+helper_bundle() {
+  for name in "OpenLogi Agent.app" "OpenLogiAgent.app"; do
+    [ -d "$1/Contents/Library/LoginItems/$name" ] && {
+      printf '%s\n' "$1/Contents/Library/LoginItems/$name"
+      return
+    }
+  done
+  printf '%s\n' "$1/Contents/Library/LoginItems/OpenLogi Agent.app"
+}
+agent=$(helper_bundle "$app")
 
 say() { printf '\n== %s\n' "$1"; }
 
@@ -82,9 +93,20 @@ done
 say "5. Designated requirement recorded against the agent's grant"
 [ -d "$agent" ] && codesign -d --requirements - "$agent" 2>&1 | grep '^designated' | sed 's/^/   /'
 
-say "6. Next step: the agent's own log"
+say "6. The agent's own log"
+# Names are agent.<ISO date>.log, so the lexically last one is the newest.
+logs=("$HOME"/.local/state/openlogi/agent.*.log)
+latest_log=${logs[${#logs[@]} - 1]}
+if [ -f "$latest_log" ]; then
+  echo "   $latest_log"
+  echo "   attach this file — it holds the classified open errors and any panic"
+else
+  echo "   none under ~/.local/state/openlogi (agent predates the log file, or never ran)"
+fi
 cat <<TXT
-   launchd discards the agent's output, so run it in the foreground:
+
+   launchd discards the agent's stderr, so if the file above is missing or
+   predates the failure, reproduce it in the foreground:
 
      OPENLOGI_LOG=debug "$agent/Contents/MacOS/openlogi-agent"
 
@@ -93,11 +115,14 @@ cat <<TXT
    copy launchd runs, and a denial here may only mean the terminal has no
    grant.
 
-   Then classify the first failure you see:
+   Then classify the first failure you see. The open error names its own
+   cause; the identity it speaks about is the one in the caveat above:
      "HID++ candidate interfaces count=0"      -> device not matched; not a permission problem
-     "failed to open HID++ channel ... Failed to open device"
-                                               -> open denied (or exclusive access) — for the
-                                                  identity named in the caveat above
+     "Failed to open device: Input Monitoring is NOT granted ..."
+                                               -> grant it to OpenLogi Agent
+     "Failed to open device: Input Monitoring is granted ..."
+                                               -> another app holds the device (quit Logi
+                                                  Options+), or log out and back in
      "opened HID++ channel" then a probe error -> the async-hid write bug is present; this
                                                   run's permission was fine, but the launchd
                                                   copy's grant is still unproven


### PR DESCRIPTION
## Summary

The macOS permissions skill described the world before #760, #814, #817 and #820 all landed. Left as-is it would actively mislead: it sends reporters to a log that (it says) has nowhere to go, spells the helper bundle `OpenLogiAgent.app`, tells the reader a bare `Failed to open device` needs manual interpretation, and lists already-fixed gaps as open.

Two of these are more than staleness. The skill's whole first section is a discriminator keyed on log strings, and the transport now emits *different* strings that classify themselves — a triage run against the old table would stall on a line that no longer exists. And the helper path is what a reporter is told to type into Go-to-Folder.

## Changes

- `§1`: the open-failure row splits into the two messages the transport now emits (grant missing → grant it; grant present → exclusive open or stale session).
- `§2`: helper is `OpenLogi Agent.app`, with a note that pre-rename bundles carry the old spelling under the same identity and that the grant survived the rename because TCC keys on the identifier.
- `§3`: ask for `~/.local/state/openlogi/agent.<date>.log` first; the foreground run is now the fallback it has become, caveat intact.
- `§5`: state that the transport already pairs open failures with the grant check, instead of prescribing it.
- `§7`: the known-broken list is replaced by the state it actually has (nothing outstanding in that path), still marked as a snapshot to re-verify.
- `scripts/diagnose.sh`: resolves either helper spelling, prints the log-file path when one exists, and its classification hints match the new messages. Also drops an `ls | head` in favour of a glob (SC2012); the ISO-dated names sort lexically.

## Testing

- Ran `diagnose.sh` against this machine's installed app: it resolves the renamed `OpenLogi Agent.app`, prints all three identities with `org.openlogi.agent` intact, verifies signatures, and finds the live log file.
- `cargo xtask ci shell` (shellcheck + shfmt) — PASS.
- Docs-only otherwise; no Rust touched.

## Side finding, filed separately

Reading that live log turned up an unrelated live bug: the agent has been emitting `role held by a tenant that never identified itself` twice a second for over an hour. `Event::SupersededAnonymously` warns but never evicts, so an unidentifiable overlay tenant wedges the role permanently — the Actions Ring stays dead and the log grows ~19 MB/day. Details in #842.