### PR TITLE
fix(overlay,agent): stop the anonymous overlay tenant from wedging the Actions Ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7404,9 +7404,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "succession"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494a7cfcb4902761096db71e5e02c48f3e8c5060e563ff3113c306f86a0277ca"
+checksum = "ebea0f5590b6dde1056c1ba7e6045d5abce2f69da6a3f438d05b91d246d5bd53"
 dependencies = [
  "serde",
  "sysinfo 0.38.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7404,9 +7404,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "succession"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df31a32bd0059852bec1a32bebadaa29ea6688c07795f56c7d030fc73d76da7"
+checksum = "494a7cfcb4902761096db71e5e02c48f3e8c5060e563ff3113c306f86a0277ca"
 dependencies = [
  "serde",
  "sysinfo 0.38.4",

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 opener = { workspace = true }
-succession = { version = "0.1", features = ["supervision", "eviction"] }
+succession = { version = "0.2", features = ["supervision", "eviction"] }
 tracing-appender = "0.2.5"
 
 # Held at the version Cargo.lock already has for gpui's own build-dependency;

--- a/crates/openlogi-agent/src/overlay.rs
+++ b/crates/openlogi-agent/src/overlay.rs
@@ -11,11 +11,11 @@
 //! the child in the environment, so a helper started by a previous agent is
 //! recognizable on sight rather than after a timeout.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use openlogi_ipc::RUN_ENV;
-use succession::eviction::{self, Policy};
+use succession::eviction::{self, AnonymousOutcome, Policy};
 use succession::supervision::{Event, Supervisor};
 use succession::{Role, Run};
 use tracing::{info, warn};
@@ -32,6 +32,9 @@ pub fn spawn() {
     };
     let mine = Run::mint();
     let mut supervisor = Supervisor::new(Role::new(directory, "overlay"), mine);
+    // The image an unidentified tenant is recognized by, kept beside the
+    // spawn closure that owns the original.
+    let helper = binary.clone();
     let result = std::thread::Builder::new()
         .name("openlogi-overlay-supervisor".into())
         .spawn(move || {
@@ -40,8 +43,15 @@ pub fn spawn() {
                     .env(RUN_ENV, mine.get().to_string())
                     .spawn()
             };
+            // The anonymous verdict repeats every poll for as long as the
+            // tenant lives, and answering it walks the process table. Answer
+            // once per spell of anonymity and stay quiet until the role
+            // changes hands.
+            let mut pressed_anonymous = false;
             loop {
-                if let Err(error) = supervisor.tick(&mut spawn, &mut |event| report(&event)) {
+                if let Err(error) = supervisor.tick(&mut spawn, &mut |event| {
+                    report(&event, &helper, &mut pressed_anonymous);
+                }) {
                     // A role that cannot be probed is treated as free by the
                     // next tick; refusing to look again would wait forever.
                     warn!(%error, "could not read the Actions Ring overlay role");
@@ -88,13 +98,19 @@ pub fn evict_on_quit() {
     info!(?outcome, "asked the overlay to leave before exiting");
 }
 
-/// Log what the supervisor did, and evict a tenant from a finished run.
+/// Log what the supervisor did, and evict a tenant this agent has superseded.
 ///
 /// Eviction is the migration path: an overlay that predates the claim record
 /// cannot recognize this agent as a different run, so it never yields on its
-/// own. Signalling is refused unless the live process still matches the record
-/// (see [`succession::Tenant::compare`]) — a pid alone never justifies it.
-fn report(event: &Event<'_>) {
+/// own. Which of the two evictions applies depends on what the tenant said
+/// about itself, and neither takes a pid on faith — a record is checked
+/// against the live process ([`succession::Tenant::compare`]), and a tenant
+/// with no record at all is only ever recognized by the image we start the
+/// overlay from.
+fn report(event: &Event<'_>, helper: &Path, pressed_anonymous: &mut bool) {
+    if !matches!(event, Event::SupersededAnonymously) {
+        *pressed_anonymous = false;
+    }
     match *event {
         Event::Superseded(record) => {
             info!("{event}");
@@ -108,8 +124,30 @@ fn report(event: &Event<'_>) {
                 outcome => info!(?outcome, "asked the superseded overlay to leave"),
             }
         }
+        // A tenant holding the role with no readable claim record: an overlay
+        // from an install that predates the record, or one whose publish
+        // failed. Nothing identifies it, so `succession` falls back on the
+        // image we start the overlay from and refuses unless exactly one
+        // process matches — otherwise the role stays wedged for as long as
+        // that process lives and the Actions Ring never comes up (#842).
         Event::SupersededAnonymously => {
+            if std::mem::replace(pressed_anonymous, true) {
+                tracing::debug!("{event}");
+                return;
+            }
             warn!("{event}");
+            match eviction::evict_anonymous(helper, &Policy::default()) {
+                AnonymousOutcome::NoCandidate => warn!(
+                    helper = %helper.display(),
+                    "nothing is running our overlay binary — the role is held by something else"
+                ),
+                AnonymousOutcome::Ambiguous { running } => warn!(
+                    running,
+                    "several overlay processes are running — left them alone rather than \
+                     guess which one holds the role"
+                ),
+                outcome => info!(?outcome, "asked the unidentified overlay to leave"),
+            }
         }
         Event::Occupied(_) => tracing::debug!("{event}"),
         _ => info!("{event}"),

--- a/crates/openlogi-ipc/Cargo.toml
+++ b/crates/openlogi-ipc/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tarpc = { workspace = true }
 interprocess = { workspace = true }
-succession = { version = "0.1", features = ["serde"] }
+succession = { version = "0.2", features = ["serde"] }
 
 [lints]
 workspace = true

--- a/crates/openlogi-overlay/Cargo.toml
+++ b/crates/openlogi-overlay/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = { workspace = true }
 gpui = { workspace = true }
 gpui_platform = { workspace = true }
 rust-i18n = "4"
-succession = "0.1"
+succession = "0.2"
 tarpc = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/openlogi-overlay/src/session.rs
+++ b/crates/openlogi-overlay/src/session.rs
@@ -106,17 +106,17 @@ pub(crate) fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
 
 pub(crate) fn claim_the_role() -> Result<Tenancy> {
     let directory = openlogi_core::paths::config_dir().context("resolving the config directory")?;
-    let tenancy = Role::new(directory, "overlay")
-        .claim()
-        .context("Actions Ring overlay single-instance check")?;
     let serving = spawned_by().unwrap_or_else(Run::mint);
-    if let Err(error) = tenancy.publish(&Record::new(
-        Identity::new(serving, Compat::from(PROTOCOL_VERSION)),
-        Tenant::current(),
-    )) {
-        warn!(%error, "could not publish the overlay claim record");
-    }
-    Ok(tenancy)
+    // Identity comes with the claim: an overlay the agent cannot recognize
+    // holds the role while being unevictable by the ordinary path, so failing
+    // here and letting the supervisor start a replacement beats running as
+    // one (#842).
+    Role::new(directory, "overlay")
+        .claim(&Record::new(
+            Identity::new(serving, Compat::from(PROTOCOL_VERSION)),
+            Tenant::current(),
+        ))
+        .context("Actions Ring overlay single-instance check")
 }
 
 /// The agent run this overlay serves.


### PR DESCRIPTION
## Summary

An overlay holding the role lock with no readable claim record wedged the Actions Ring permanently, and the agent spun on it at 2 Hz for as long as that process lived — 9,145 identical warnings in 76 minutes on the machine this was found on, still going when I looked. The Ring was dead the whole time. Only visible at all because the agent now writes a log file (#817).

This fixes both directions: remove the tenants that exist, and stop making new ones.

## Removing them

The supervisor's answer to `Verdict::EvictAnonymous` was a warning and nothing else. It could not do better — `eviction::evict` verifies a pid against a `Record`, and an anonymous tenant by definition has none — so the role could never free itself.

succession 0.1.1 (AprilNEA/succession#1) adds `evict_anonymous`, which recognizes the tenant by the image we start the overlay from. That is what makes signalling defensible: every process behind that path is our own helper. It refuses unless the choice is forced — no match means the holder is something else, several matches mean a bystander would be the one to die.

The agent answers **once per spell of anonymity**. The verdict repeats every 500 ms poll and each answer walks the whole process table, so retrying per tick would trade a wedge for a hot loop. The flag resets as soon as the role changes hands.

## Not making them

The overlay used to warn and keep the role when it could not write its claim record — which manufactures exactly the tenant above: it serves the Ring now and wedges the next agent run later, invisibly and for someone else.

succession 0.2.0 (AprilNEA/succession#2) folds publishing into `Role::claim`, so identity arrives with the role or the role comes straight back. The overlay takes that answer and exits; its supervisor starts a replacement that can probably identify itself, and a persistent write failure surfaces as `Restart` back-off (2 s doubling to 60 s) rather than silent damage. Holding a role you cannot be evicted from is worse than not holding it.

## Changes

- `agent`: `report()` answers `SupersededAnonymously` with `evict_anonymous`, logging its two refusals distinctly, once per spell.
- `agent`: `report()`'s doc claimed eviction already covered "an overlay that predates the claim record". That was precisely the branch that did not evict; it now says what each of the two paths verifies.
- `overlay`: `claim_the_role` publishes through `claim` and propagates the failure instead of warning past it.
- `deps`: succession 0.1 → 0.2 across the three crates that use it. `Cargo.lock` moved with `--precise`, so it carries those two lines and nothing else.

## Testing

- Full local gate on the final tree (fmt, clippy workspace `--all-targets -D warnings` with `RUSTFLAGS`, workspace tests, rustdoc non-GUI) — green.
- The eviction API was validated against this consumer before succession 0.1.1 was published, through a temporary `[patch.crates-io]`, so the published shape is one that fits.
- The guards live in succession with their own tests: the sibling and empty cases, a walk of the real process table proving the caller is never its own candidate, and — for the claim change — a forced write failure asserting both that the claim reports `Unpublishable` and that the role reads `Free` afterwards, so the lock is released rather than leaked.
- Not yet exercised against a live wedge. The machine this was found on still has one (a stale overlay from a pre-rename install), so installing a build with this change is the end-to-end check — worth doing before merge if you want the eviction path proven rather than argued.

Fixes #842.