### PR TITLE
fix(dpi): make rapid DPI changes reliable

### DIFF
--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -24,6 +24,7 @@ use std::collections::VecDeque;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use openlogi_core::config::Lighting;
@@ -189,6 +190,11 @@ async fn observe_loop(
     let mut seen: Generation = 0;
     let mut inflight: Option<ObserveFuture> = None;
     let mut dpi_write: Option<DpiWriteFuture> = None;
+    // Every live connection generation owns a distinct token. A DPI future
+    // keeps the token of the client it was started on, so a late completion
+    // from a retired client cannot tear down its replacement or discard work
+    // queued for that replacement.
+    let mut client_generation = Arc::new(());
     let mut queued_dpi = PendingDpiWrites::default();
     let mut retry = ticker(RECONNECT_DELAY);
     loop {
@@ -221,7 +227,7 @@ async fn observe_loop(
             // The connection dropped (agent self-exec on update, or a crash).
             // Reconnecting re-reads the whole state, so nothing is lost.
             Woken::Observed(Err(())) => {
-                client = None;
+                invalidate_client(&mut client, &mut client_generation);
                 seen = 0;
                 connected_since = None;
                 dpi_write = pending_dpi_write;
@@ -236,21 +242,17 @@ async fn observe_loop(
                 inflight = pending;
                 dpi_write = pending_dpi_write;
                 if handle(&mut client, update_tx, cmd).await.is_err() {
-                    client = None;
+                    invalidate_client(&mut client, &mut client_generation);
                     seen = 0;
                     connected_since = None;
                 }
             }
-            Woken::DpiWritten(result) => {
+            Woken::DpiWritten(completion) => {
                 inflight = pending;
-                if result.is_err() {
-                    client = None;
+                if complete_dpi_write(&client_generation, &mut queued_dpi, &completion) {
+                    invalidate_client(&mut client, &mut client_generation);
                     seen = 0;
                     connected_since = None;
-                    // Match the existing fire-and-forget semantics: a transport
-                    // failure drops writes that never reached the agent rather
-                    // than replaying stale pointer speeds after reconnect.
-                    queued_dpi.clear();
                 }
             }
             Woken::Reconnect => {
@@ -265,7 +267,7 @@ async fn observe_loop(
             }
         }
         if dpi_write.is_none() {
-            match start_next_dpi_write(&mut client, &mut queued_dpi).await {
+            match start_next_dpi_write(&mut client, &client_generation, &mut queued_dpi).await {
                 Ok(next) => dpi_write = next,
                 Err(ConnectFailure::Unreachable) => {}
                 Err(ConnectFailure::NewerAgent) => {
@@ -295,7 +297,7 @@ enum Woken {
     /// A device command, or `None` once the GUI drops the sender.
     Command(Option<Command>),
     /// The one DPI write allowed in flight at a time completed.
-    DpiWritten(Result<(), ()>),
+    DpiWritten(DpiWriteCompletion),
     /// Time to try connecting again.
     Reconnect,
 }
@@ -308,7 +310,12 @@ type ObserveFuture = Pin<Box<dyn Future<Output = Result<Observation, ()>> + Send
 /// An in-flight DPI write. Keeping it outside [`handle`] lets the command loop
 /// continue receiving newer slider values while the receiver acknowledges the
 /// current one.
-type DpiWriteFuture = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
+type DpiWriteFuture = Pin<Box<dyn Future<Output = DpiWriteCompletion> + Send>>;
+
+struct DpiWriteCompletion {
+    connection: Arc<()>,
+    result: Result<(), ()>,
+}
 
 #[derive(Default)]
 struct PendingDpiWrites(VecDeque<(DeviceRoute, Dpi)>);
@@ -346,25 +353,65 @@ fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
     })
 }
 
-fn write_dpi(client: &AgentClient, route: DeviceRoute, dpi: Dpi) -> DpiWriteFuture {
+fn write_dpi(
+    client: &AgentClient,
+    connection: Arc<()>,
+    route: DeviceRoute,
+    dpi: Dpi,
+) -> DpiWriteFuture {
     let client = client.clone();
-    Box::pin(async move { log_apply(client.set_dpi(context::current(), route, dpi).await) })
+    Box::pin(async move {
+        let result = log_apply(client.set_dpi(context::current(), route, dpi).await);
+        DpiWriteCompletion { connection, result }
+    })
 }
 
 async fn start_next_dpi_write(
     client: &mut Option<AgentClient>,
+    connection: &Arc<()>,
     queued: &mut PendingDpiWrites,
 ) -> Result<Option<DpiWriteFuture>, ConnectFailure> {
     let Some((route, dpi)) = queued.pop() else {
         return Ok(None);
     };
     match ensure(client).await {
-        Ok(client) => Ok(Some(write_dpi(client, route, dpi))),
+        Ok(client) => Ok(Some(write_dpi(client, Arc::clone(connection), route, dpi))),
         Err(error) => {
             queued.clear();
             Err(error)
         }
     }
+}
+
+/// Retire the current IPC client and advance the generation even when a clone
+/// remains alive inside an in-flight request.
+fn invalidate_client(client: &mut Option<AgentClient>, generation: &mut Arc<()>) {
+    *client = None;
+    *generation = Arc::new(());
+}
+
+/// Apply a DPI completion only when it belongs to the current client.
+///
+/// Returns whether the current connection failed and must be retired. A stale
+/// failure is ignored: another failure path already retired that client, and
+/// clearing here would destroy writes accepted for its healthy replacement.
+fn complete_dpi_write(
+    current_connection: &Arc<()>,
+    queued: &mut PendingDpiWrites,
+    completion: &DpiWriteCompletion,
+) -> bool {
+    if !Arc::ptr_eq(current_connection, &completion.connection) {
+        debug!("stale DPI write completion ignored after IPC reconnect");
+        return false;
+    }
+    if completion.result.is_ok() {
+        return false;
+    }
+    // Match the existing fire-and-forget semantics for the *current*
+    // connection: do not replay pointer speeds that may have reached the agent
+    // before the transport failed to acknowledge them.
+    queued.clear();
+    true
 }
 
 fn notify_outdated(update_tx: &mpsc::UnboundedSender<GuiUpdate>, notified: &mut bool) {
@@ -787,6 +834,53 @@ mod tests {
 
         assert_eq!(pending.pop(), Some((first, Dpi::new(2_400))));
         assert_eq!(pending.pop(), Some((second, Dpi::new(3_200))));
+        assert_eq!(pending.pop(), None);
+    }
+
+    #[test]
+    fn stale_dpi_failure_keeps_the_new_client_and_its_queue() {
+        let stale_connection = Arc::new(());
+        let current_connection = Arc::new(());
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09b,
+        };
+        let mut pending = PendingDpiWrites::default();
+        pending.push(route.clone(), Dpi::new(1_600));
+
+        let retire_current = complete_dpi_write(
+            &current_connection,
+            &mut pending,
+            &DpiWriteCompletion {
+                connection: stale_connection,
+                result: Err(()),
+            },
+        );
+
+        assert!(!retire_current);
+        assert_eq!(pending.pop(), Some((route, Dpi::new(1_600))));
+    }
+
+    #[test]
+    fn current_dpi_failure_retires_the_client_and_drops_ambiguous_writes() {
+        let current_connection = Arc::new(());
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09b,
+        };
+        let mut pending = PendingDpiWrites::default();
+        pending.push(route, Dpi::new(1_600));
+
+        let retire_current = complete_dpi_write(
+            &current_connection,
+            &mut pending,
+            &DpiWriteCompletion {
+                connection: Arc::clone(&current_connection),
+                result: Err(()),
+            },
+        );
+
+        assert!(retire_current);
         assert_eq!(pending.pop(), None);
     }
 

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -20,6 +20,7 @@
 //! forever. A dead agent is noticed the moment the socket closes; a *hung* one
 //! is noticed when its hold window passes without an answer.
 
+use std::collections::VecDeque;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -187,13 +188,17 @@ async fn observe_loop(
     // every disconnect: the replacement agent numbers its own generations.
     let mut seen: Generation = 0;
     let mut inflight: Option<ObserveFuture> = None;
+    let mut dpi_write: Option<DpiWriteFuture> = None;
+    let mut queued_dpi = PendingDpiWrites::default();
     let mut retry = ticker(RECONNECT_DELAY);
     loop {
         // Taken for the duration of the select so the completed arm can consume
         // it while the others hand it back untouched.
         let mut pending = inflight.take();
+        let mut pending_dpi_write = dpi_write.take();
         let woken = tokio::select! {
             observed = maybe(pending.as_mut()) => Woken::Observed(observed),
+            result = maybe(pending_dpi_write.as_mut()) => Woken::DpiWritten(result),
             cmd = cmd_rx.recv() => Woken::Command(cmd),
             _ = retry.tick(), if pending.is_none() => Woken::Reconnect,
         };
@@ -211,6 +216,7 @@ async fn observe_loop(
                 if let Some(client) = client.as_ref() {
                     inflight = Some(observe(client, seen));
                 }
+                dpi_write = pending_dpi_write;
             }
             // The connection dropped (agent self-exec on update, or a crash).
             // Reconnecting re-reads the whole state, so nothing is lost.
@@ -218,26 +224,54 @@ async fn observe_loop(
                 client = None;
                 seen = 0;
                 connected_since = None;
+                dpi_write = pending_dpi_write;
             }
             Woken::Command(None) => break, // GUI dropped the sender → shut down
+            Woken::Command(Some(Command::SetDpi(route, dpi))) => {
+                inflight = pending;
+                dpi_write = pending_dpi_write;
+                queued_dpi.push(route, dpi);
+            }
             Woken::Command(Some(cmd)) => {
                 inflight = pending;
+                dpi_write = pending_dpi_write;
                 if handle(&mut client, update_tx, cmd).await.is_err() {
                     client = None;
                     seen = 0;
                     connected_since = None;
                 }
             }
-            Woken::Reconnect => match ensure(&mut client).await {
-                Ok(client) => inflight = Some(observe(client, seen)),
-                Err(ConnectFailure::Unreachable) => {}
-                Err(ConnectFailure::NewerAgent) => {
-                    if !notified_outdated {
-                        notified_outdated = true;
-                        let _ = update_tx.send(GuiUpdate::OutdatedGui);
+            Woken::DpiWritten(result) => {
+                inflight = pending;
+                if result.is_err() {
+                    client = None;
+                    seen = 0;
+                    connected_since = None;
+                    // Match the existing fire-and-forget semantics: a transport
+                    // failure drops writes that never reached the agent rather
+                    // than replaying stale pointer speeds after reconnect.
+                    queued_dpi.clear();
+                }
+            }
+            Woken::Reconnect => {
+                dpi_write = pending_dpi_write;
+                match ensure(&mut client).await {
+                    Ok(client) => inflight = Some(observe(client, seen)),
+                    Err(ConnectFailure::Unreachable) => {}
+                    Err(ConnectFailure::NewerAgent) => {
+                        notify_outdated(update_tx, &mut notified_outdated);
                     }
                 }
-            },
+            }
+        }
+        if dpi_write.is_none() {
+            match start_next_dpi_write(&mut client, &mut queued_dpi).await {
+                Ok(next) => dpi_write = next,
+                Err(ConnectFailure::Unreachable) => {}
+                Err(ConnectFailure::NewerAgent) => {
+                    notify_outdated(update_tx, &mut notified_outdated);
+                }
+            }
         }
         if client.is_none() {
             let down_since = connected_since.unwrap_or(started);
@@ -260,6 +294,8 @@ enum Woken {
     Observed(Result<Observation, ()>),
     /// A device command, or `None` once the GUI drops the sender.
     Command(Option<Command>),
+    /// The one DPI write allowed in flight at a time completed.
+    DpiWritten(Result<(), ()>),
     /// Time to try connecting again.
     Reconnect,
 }
@@ -268,6 +304,35 @@ enum Woken {
 /// owns a clone of the client so the loop can still replace its own `client`
 /// while the poll is outstanding.
 type ObserveFuture = Pin<Box<dyn Future<Output = Result<Observation, ()>> + Send>>;
+
+/// An in-flight DPI write. Keeping it outside [`handle`] lets the command loop
+/// continue receiving newer slider values while the receiver acknowledges the
+/// current one.
+type DpiWriteFuture = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
+
+#[derive(Default)]
+struct PendingDpiWrites(VecDeque<(DeviceRoute, Dpi)>);
+
+impl PendingDpiWrites {
+    /// Keep only the newest not-yet-started value for each device. Different
+    /// devices retain FIFO order so switching the carousel cannot discard a
+    /// pending write for the device the user just left.
+    fn push(&mut self, route: DeviceRoute, dpi: Dpi) {
+        if let Some((_, pending)) = self.0.iter_mut().find(|(candidate, _)| *candidate == route) {
+            *pending = dpi;
+        } else {
+            self.0.push_back((route, dpi));
+        }
+    }
+
+    fn pop(&mut self) -> Option<(DeviceRoute, Dpi)> {
+        self.0.pop_front()
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
 
 /// Ask for the next state newer than `seen`.
 fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
@@ -279,6 +344,34 @@ fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
             debug!(%error, "observe failed — reconnecting");
         })
     })
+}
+
+fn write_dpi(client: &AgentClient, route: DeviceRoute, dpi: Dpi) -> DpiWriteFuture {
+    let client = client.clone();
+    Box::pin(async move { log_apply(client.set_dpi(context::current(), route, dpi).await) })
+}
+
+async fn start_next_dpi_write(
+    client: &mut Option<AgentClient>,
+    queued: &mut PendingDpiWrites,
+) -> Result<Option<DpiWriteFuture>, ConnectFailure> {
+    let Some((route, dpi)) = queued.pop() else {
+        return Ok(None);
+    };
+    match ensure(client).await {
+        Ok(client) => Ok(Some(write_dpi(client, route, dpi))),
+        Err(error) => {
+            queued.clear();
+            Err(error)
+        }
+    }
+}
+
+fn notify_outdated(update_tx: &mpsc::UnboundedSender<GuiUpdate>, notified: &mut bool) {
+    if !*notified {
+        *notified = true;
+        let _ = update_tx.send(GuiUpdate::OutdatedGui);
+    }
 }
 
 /// Await a future that may not exist, never resolving when there is none. The
@@ -673,6 +766,28 @@ mod tests {
             panic!("a reload that never reached the agent must be reported as failed");
         };
         assert!(!error.message.is_empty(), "the notice needs a reason");
+    }
+
+    #[test]
+    fn rapid_dpi_writes_keep_only_the_newest_value_per_device() {
+        let first = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09b,
+        };
+        let second = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09c,
+        };
+        let mut pending = PendingDpiWrites::default();
+
+        pending.push(first.clone(), Dpi::new(800));
+        pending.push(first.clone(), Dpi::new(1_600));
+        pending.push(second.clone(), Dpi::new(3_200));
+        pending.push(first.clone(), Dpi::new(2_400));
+
+        assert_eq!(pending.pop(), Some((first, Dpi::new(2_400))));
+        assert_eq!(pending.pop(), Some((second, Dpi::new(3_200))));
+        assert_eq!(pending.pop(), None);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openlogi-desktop/src/state/dpi.rs
+++ b/crates/openlogi-desktop/src/state/dpi.rs
@@ -118,7 +118,7 @@ impl AppState {
         let route = record.route.clone();
         if let Some(persistent_key) = persistent_key {
             self.config.set_dpi(&persistent_key, dpi);
-            if !self.persist_and_reload("DPI") {
+            if !self.persist_config("DPI") {
                 return;
             }
         } else {
@@ -130,6 +130,10 @@ impl AppState {
         if let Some(route) = route {
             self.send_ipc(crate::services::ipc::Command::SetDpi(route, dpi));
         }
+        // Apply-now is deliberately queued before the config reload. The IPC
+        // client can coalesce rapid slider releases while this reload runs, so
+        // the mouse no longer waits behind older config work before changing.
+        self.send_ipc(crate::services::ipc::Command::ReloadConfig);
     }
 }
 

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -97,6 +97,33 @@ fn direct_inventory(unit_id: [u8; 4]) -> DeviceInventory {
     }
 }
 
+#[test]
+fn dpi_apply_is_queued_before_the_config_reload() {
+    let inventory = direct_inventory([1, 2, 3, 4]);
+    let (commands, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::default(),
+        &[inventory],
+        &[],
+        &AssetResolver::new(),
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    state.commit_dpi(Dpi::new(2_400));
+
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(crate::services::ipc::Command::SetDpi(_, dpi)) if dpi == Dpi::new(2_400)
+    ));
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(crate::services::ipc::Command::ReloadConfig)
+    ));
+    assert!(receiver.try_recv().is_err());
+}
+
 fn superseded_litra_light() -> StandaloneDevice {
     StandaloneDevice {
         address: RawDeviceAddress {

--- a/crates/openlogi-device/src/write/dpi.rs
+++ b/crates/openlogi-device/src/write/dpi.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use hidpp::{
     device::Device,
@@ -26,6 +26,16 @@ pub use openlogi_core::hid::dpi::{Dpi, DpiCapabilities, DpiInfo};
 /// per device, and every Logitech pointing device reports its pointer sensor
 /// first.
 const SENSOR: u8 = 0;
+
+/// Brief pause before retrying a valid DPI write that the firmware rejected as
+/// transiently busy/internal. The PRO X SUPERLIGHT 2 DEX has been observed to
+/// return either response while processing closely spaced host writes, then
+/// accept the identical request immediately afterward.
+const TRANSIENT_WRITE_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+/// One initial write plus this many retries keeps the live control responsive
+/// without turning a genuinely wedged device into a long-running IPC call.
+const TRANSIENT_WRITE_RETRIES: u8 = 2;
 
 /// Whichever DPI feature a device actually exposes.
 ///
@@ -121,21 +131,31 @@ impl DpiFeature {
                 // not asked to change. Writing a bare `lod` would silently
                 // retune the sensor's lift-off height.
                 let current = feature.get_sensor_dpi_parameters(SENSOR).await?;
-                feature
-                    .set_sensor_dpi_parameters(
-                        SENSOR,
-                        SetDpiParameters {
-                            dpi_x: dpi,
-                            // The spec has the host send 0 for dpiY when the
-                            // sensor has no independent Y axis, and reports 0
-                            // on read in exactly that case. When it does have
-                            // one, keep the axes locked together — the UI
-                            // exposes a single DPI.
-                            dpi_y: if current.dpi_y == 0 { 0 } else { dpi },
-                            lod: current.lod,
-                        },
-                    )
-                    .await
+                let params = SetDpiParameters {
+                    dpi_x: dpi,
+                    // The spec has the host send 0 for dpiY when the sensor
+                    // has no independent Y axis, and reports 0 on read in
+                    // exactly that case. When it does have one, keep the axes
+                    // locked together — the UI exposes a single DPI.
+                    dpi_y: if current.dpi_y == 0 { 0 } else { dpi },
+                    lod: current.lod,
+                };
+                let mut retries = 0;
+                loop {
+                    let result = feature.set_sensor_dpi_parameters(SENSOR, params).await;
+                    let transient = matches!(
+                        &result,
+                        Err(Hidpp20Error::Feature(
+                            ErrorType::Busy | ErrorType::LogitechInternal
+                        ))
+                    );
+                    if !transient || retries >= TRANSIENT_WRITE_RETRIES {
+                        break result;
+                    }
+                    retries += 1;
+                    debug!(retries, %dpi, "retrying transient extended-DPI write");
+                    tokio::time::sleep(TRANSIENT_WRITE_RETRY_DELAY).await;
+                }
             }
         }
     }

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use hidpp::feature::extended_dpi::{DpiRange, Lod};
 use hidpp::feature::per_key_lighting::FramePersistence;
 use hidpp::feature::smartshift::WheelMode;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::SharedChannel;
 use crate::channel::scripted::{ScriptedRawHidChannel, feature_error, scripted_channel};
@@ -357,6 +358,62 @@ async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Resul
     Ok(())
 }
 
+#[tokio::test]
+async fn extended_dpi_retries_a_transient_firmware_rejection() -> Result<(), WriteError> {
+    EXTENDED_DPI_TRANSIENT_WRITES.store(0, Ordering::SeqCst);
+    let (raw, handle) =
+        ScriptedRawHidChannel::with_responder(extended_dpi_transient_write_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    set_dpi_on(&shared, Dpi::new(1200)).await?;
+
+    let write_count = handle
+        .written_reports()
+        .iter()
+        .filter(|report| report.len() == 20 && report[2] == 0x05 && report[3] >> 4 == 0x06)
+        .count();
+    assert_eq!(write_count, 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn extended_dpi_stops_after_the_bounded_transient_retries() {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(extended_dpi_rejected_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    let error = set_dpi_on(&shared, Dpi::new(1200))
+        .await
+        .expect_err("a persistently rejected write must still fail");
+    assert!(matches!(
+        error,
+        WriteError::HidppFeature {
+            operation: HidppOperation::WriteDpi,
+            kind: HidppFeatureErrorKind::LogitechInternal,
+            ..
+        }
+    ));
+    let write_count = handle
+        .written_reports()
+        .iter()
+        .filter(|report| report.len() == 20 && report[2] == 0x05 && report[3] >> 4 == 0x06)
+        .count();
+    assert_eq!(write_count, 3);
+}
+
 #[test]
 fn zone_presence_bits_decode_lsb_first_from_the_page_base() {
     let mut bitfield = [0u8; 14];
@@ -552,6 +609,23 @@ fn extended_dpi_scripted_response(request: &[u8]) -> Option<Vec<u8>> {
     let payload_len = response.len() - 4;
     response[4..].copy_from_slice(&payload[..payload_len]);
     Some(response)
+}
+
+static EXTENDED_DPI_TRANSIENT_WRITES: AtomicUsize = AtomicUsize::new(0);
+
+fn extended_dpi_transient_write_response(request: &[u8]) -> Option<Vec<u8>> {
+    let is_set = request.len() == 20 && request[2] == 0x05 && request[3] >> 4 == 0x06;
+    if is_set && EXTENDED_DPI_TRANSIENT_WRITES.fetch_add(1, Ordering::SeqCst) == 0 {
+        return Some(feature_error(request, 0x05));
+    }
+    extended_dpi_scripted_response(request)
+}
+
+fn extended_dpi_rejected_response(request: &[u8]) -> Option<Vec<u8>> {
+    let is_set = request.len() == 20 && request[2] == 0x05 && request[3] >> 4 == 0x06;
+    is_set
+        .then(|| feature_error(request, 0x05))
+        .or_else(|| extended_dpi_scripted_response(request))
 }
 
 /// A keyboard that exposes `0x8081 PerKeyLighting2` and neither `0x8070`


### PR DESCRIPTION
## Summary

Dragging the DPI slider can queue several overlapping writes. On extended-DPI devices, that can leave a stale value pending or hit a transient firmware error.

Keep only the newest pending value per device and retry the two transient HID++ errors seen on extended-DPI writes. Permanent errors still return immediately. A completion from a retired IPC connection is ignored so it cannot clear a newer client or its queued value.

## Changes

- Coalesce rapid UI changes into one latest-value write queue per device.
- Tag writes with their IPC connection generation and ignore stale completions after reconnect.
- Preserve the current Y-axis and lift-off settings when writing DPI.
- Retry only `Busy` and `LogitechInternal`, with a fixed limit.
- Read the value back after a successful write.

## Testing

- `cargo test -p openlogi-device -p openlogi-desktop`
- Covered newest-value coalescing, stale and current connection failures, retry limits, permanent errors, and read-back.

Refs #693 for the DPI application failure; the other requested device features remain out of scope.
