### PR TITLE
fix(agent): reuse and release mouse capture channels

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -27,7 +27,9 @@ use std::time::{Duration, Instant};
 use openlogi_core::binding::{Action, ButtonId, default_binding};
 use openlogi_core::config::ThumbwheelSensitivity;
 use openlogi_hid::session::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
-use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
+use openlogi_hid::{
+    CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute, run_capture_session_with_registry,
+};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
@@ -55,6 +57,7 @@ pub fn spawn(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
     dispatcher: ActionDispatcher,
 ) {
     thread::spawn(move || {
@@ -72,6 +75,7 @@ pub fn spawn(
             capture_plans,
             capture_channel,
             receiver_access,
+            registry,
             dispatcher,
         ));
     });
@@ -153,6 +157,7 @@ async fn manage(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
     dispatcher: ActionDispatcher,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<(String, CapturedInput)>();
@@ -258,6 +263,7 @@ async fn manage(
                         &tx,
                         &done_tx,
                         &capture_channel,
+                        &registry,
                     );
                     sessions.insert(key, session);
                 }
@@ -297,6 +303,7 @@ fn spawn_session(
     inputs: &mpsc::UnboundedSender<(String, CapturedInput)>,
     done: &mpsc::UnboundedSender<(String, u64)>,
     capture_channel: &CaptureChannel,
+    registry: &ChannelRegistry,
 ) -> RunningSession {
     let (stop_tx, stop_rx) = oneshot::channel();
     // Tag this session's inputs with its device key so dispatch resolves them
@@ -313,16 +320,16 @@ fn spawn_session(
     let session_route = route.clone();
     let session_spec = spec.clone();
     let slot = Arc::clone(capture_channel);
+    let session_registry = registry.clone();
     tokio::spawn(async move {
         let _lease = lease;
-        let backend = openlogi_hid::host::backend();
-        if let Err(e) = run_capture_session(
-            &*backend,
+        if let Err(e) = run_capture_session_with_registry(
             session_route,
             session_spec,
             session_tx,
             stop_rx,
             slot,
+            &session_registry,
         )
         .await
         {

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -148,6 +148,7 @@ fn spawn_hidpp_watchers(shared: &SharedRuntime, dispatcher: ActionDispatcher) {
         shared.capture_plans.clone(),
         shared.capture_channel.clone(),
         shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
         dispatcher.clone(),
     );
     watchers::host_switch::spawn(

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -49,7 +49,7 @@ pub use pairing::{
 };
 pub use session::gesture::{
     CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
-    run_capture_session_with_stop_reason,
+    run_capture_session_with_registry, run_capture_session_with_stop_reason,
 };
 pub use session::host_switch::{
     HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -26,9 +26,9 @@ use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
-use crate::SharedChannel;
 use crate::backend::{BackendError, HidBackend};
 use crate::channel::route::{DeviceRoute, open_route_channel};
+use crate::{ChannelRegistry, SharedChannel};
 
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::thumbwheel::{self, Thumbwheel};
@@ -184,13 +184,45 @@ pub async fn run_capture_session(
     let chan = open_route_channel(backend, &route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
+    let shared = SharedChannel::new(chan, route.clone());
+    run_capture_session_on(route, shared, spec, sink, shutdown, channel_slot).await
+}
+
+/// Run control capture on the exact channel currently published by `registry`.
+///
+/// A registry miss returns [`GestureError::DeviceNotFound`] without falling
+/// back to route enumeration/opening; the agent watcher retries after a later
+/// inventory publication.
+pub async fn run_capture_session_with_registry(
+    route: DeviceRoute,
+    spec: CaptureSpec,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+    registry: &ChannelRegistry,
+) -> Result<(), GestureError> {
+    let shared = registry
+        .lookup(&route)
+        .ok_or(GestureError::DeviceNotFound)?;
+    run_capture_session_on(route, shared, spec, sink, shutdown, channel_slot).await
+}
+
+async fn run_capture_session_on(
+    route: DeviceRoute,
+    shared: SharedChannel,
+    spec: CaptureSpec,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+) -> Result<(), GestureError> {
+    let chan = Arc::clone(shared.channel());
     let device_index = route.device_index();
     let armed = arm_controls(&chan, device_index, &spec).await?;
 
     // Publish this device's open channel so DPI/SmartShift writes reuse it
     // instead of opening their own. Cleared on the way out.
     if let Ok(mut slot) = channel_slot.write() {
-        *slot = Some(SharedChannel::new(Arc::clone(&chan), route.clone()));
+        *slot = Some(shared);
     }
 
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -219,6 +219,17 @@ async fn run_capture_session_on(
     let device_index = route.device_index();
     let armed = arm_controls(&chan, device_index, &spec).await?;
 
+    // A plan can resolve to no actual controls (the DEX is one example). Keep
+    // the manager session alive so it does not respawn in a loop, but release
+    // every channel reference immediately. The inventory enumerator must be
+    // able to retire and reopen a receiver whose delivery stops; an idle
+    // capture pin would otherwise leave the route unpublished indefinitely.
+    if armed.is_empty() {
+        drop((armed, shared, chan));
+        let _ = shutdown.await;
+        return Ok(());
+    }
+
     // Publish this device's open channel so DPI/SmartShift writes reuse it
     // instead of opening their own. Cleared on the way out.
     if let Ok(mut slot) = channel_slot.write() {
@@ -393,6 +404,13 @@ struct ArmedCid {
 }
 
 impl ArmedControls {
+    fn is_empty(&self) -> bool {
+        self.gesture_cids.is_empty()
+            && self.dpi_cids.is_empty()
+            && self.button_cids.is_empty()
+            && self.thumb.is_none()
+    }
+
     /// Restore every diverted control. Failures are logged, not propagated.
     async fn disarm(&self) {
         if let Some((rc, _)) = self.reprog.as_ref() {
@@ -429,11 +447,7 @@ async fn arm_controls(
         armed.disarm().await;
         return Err(error);
     }
-    if armed.gesture_cids.is_empty()
-        && armed.dpi_cids.is_empty()
-        && armed.button_cids.is_empty()
-        && armed.thumb.is_none()
-    {
+    if armed.is_empty() {
         debug!(slot, "no capturable controls — idle session");
     }
     Ok(armed)

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -7,6 +7,15 @@ const BOTH: &[u16] = &[
     reprog_controls::HAPTIC_PANEL_CID,
 ];
 
+#[test]
+fn empty_capture_state_does_not_pin_an_idle_channel() {
+    let mut armed = ArmedControls::default();
+    assert!(armed.is_empty());
+
+    armed.dpi_cids.push(reprog_controls::DPI_MODE_SHIFT_CIDS[0]);
+    assert!(!armed.is_empty());
+}
+
 fn reporting(
     diverted: bool,
     remap: Option<reprog_controls::ControlId>,


### PR DESCRIPTION
## Summary

Mouse capture can open another HID++ connection even when inventory already owns a working one. An empty capture state can also keep that channel alive after capture stops.

Reuse the inventory channel for capture and drop the stored handle when the capture session becomes idle.

## Changes

- Pass the current inventory channel into mouse capture startup.
- Fall back cleanly when that channel is no longer current.
- Release the channel once the capture state is empty.

## Testing

- `cargo test -p openlogi-device -p openlogi-agent-core -p openlogi-agent`
- Covered channel reuse, stale-channel fallback, and idle release.
