### PR TITLE
fix(hid): improve Unifying receiver discovery reliability

### DIFF
--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -93,6 +93,15 @@ const RECEIVER_PROBE_BUDGET: Duration = Duration::from_secs(13);
 /// just lacks capabilities / battery until the next tick.
 const UNIFYING_SLOT_PROBE: Duration = Duration::from_millis(3500);
 
+/// Per-slot budget when a Unifying device already has a fresh immutable probe.
+///
+/// This path normally performs just one battery read. Some Lightspeed devices
+/// occasionally omit that reply even though their receiver has just emitted a
+/// live device-arrival event. Do not let that optional refresh consume the
+/// full first-sight feature-walk budget or delay publication of a known-online
+/// mouse on every watcher tick.
+const UNIFYING_CACHED_SLOT_PROBE: Duration = Duration::from_millis(750);
+
 /// Per-slot budget for the HID++ 2.0 feature walk on a Bolt paired device.
 ///
 /// Bounds a single device that stops answering its feature-walk reads (seen on

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -170,9 +170,20 @@ async fn probe_unifying_receiver(
     cache: &HashMap<CacheKey, Cached>,
     tick: u64,
 ) -> NodeProbe {
+    // Pairing count is the health gate for this path: without it the result is
+    // settled as a failed probe regardless of any later arrival events. Check
+    // it first and stop immediately on failure instead of spending two more
+    // request timeouts enabling notifications and triggering arrivals on a
+    // channel that has already stopped delivering receiver replies.
+    let pairing_count = match unifying.count_pairings().await {
+        Ok(count) => count,
+        Err(error) => {
+            debug!(?error, "receiver pairing-count read failed");
+            return NodeProbe::failed();
+        }
+    };
+    debug!(pairing_count, "receiver reports pairing count");
     let unique_id = unifying.get_unique_id().await.ok();
-    let pairing_count = unifying.count_pairings().await.ok();
-    debug!(?pairing_count, "receiver reports pairing count");
 
     // Trigger device-arrival events and collect one event per online device.
     // Each event carries the slot index, kind, wpid, and online flag — enough
@@ -229,11 +240,9 @@ async fn probe_unifying_receiver(
 
     let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().flatten().unzip();
 
-    if let Some(count) = pairing_count
-        && paired.len() != usize::from(count)
-    {
+    if paired.len() != usize::from(pairing_count) {
         debug!(
-            expected = count,
+            expected = pairing_count,
             found = paired.len(),
             "online devices differ from pairing count; offline devices not yet surfaced for Unifying"
         );
@@ -249,8 +258,8 @@ async fn probe_unifying_receiver(
     // devices may appear after a late arrival drain. Report that separately as
     // `complete = false`; the unchanged-inventory fallback stops expected
     // offline Unifying shortfalls after they stabilize.
-    let healthy = pairing_count.is_some();
-    let complete = pairing_count.is_some_and(|count| paired.len() == usize::from(count));
+    let healthy = true;
+    let complete = paired.len() == usize::from(pairing_count);
 
     NodeProbe {
         inventory: Some(DeviceInventory {

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -186,14 +186,14 @@ async fn probe_unifying_receiver(
     debug!(pairing_count, "receiver reports pairing count");
     let unique_id = unifying.get_unique_id().await.ok();
 
-    // Trigger device-arrival events and collect one event per online device.
-    // Each event carries the slot index, kind, wpid, and online flag — enough
-    // to build a PairedDevice entry for every currently-connected device.
+    // Trigger device-arrival events and collect one event per paired slot.
+    // Each event carries the slot index, kind, wpid, and a link-status bit —
+    // enough to build a PairedDevice entry, online or not.
     //
     // Note: the Unifying `0xB5/0x5N` pairing-info register uses a different
-    // sub-register base than Bolt, so we don't yet poll offline paired slots.
-    // Online devices are covered by the arrival drain; offline device support
-    // requires resolving the correct sub-register format.
+    // sub-register base than Bolt, so paired slots are not polled directly.
+    // A slot whose re-broadcast goes missing this tick cannot be backfilled
+    // until that register format is resolved.
     //
     // The drain is therefore the *only* device source on this path, so a
     // failed arrival trigger is "couldn't check", not "no devices online":
@@ -245,11 +245,13 @@ async fn probe_unifying_receiver(
         debug!(
             expected = pairing_count,
             found = paired.len(),
-            "online devices differ from pairing count; offline devices not yet surfaced for Unifying"
+            "arrival drain reported fewer slots than the pairing count"
         );
     }
-    // Unlike Bolt, a count/list shortfall is *expected* here (offline paired
-    // devices aren't enumerable yet), so ledger health can't ride on it. The
+    // Unlike Bolt, a count/list shortfall is tolerated here: not every
+    // firmware re-broadcasts all paired slots (offline slots in particular can
+    // go missing), and there is no register poll to backfill them, so ledger
+    // health can't ride on it. The
     // ledger health signal is the pairing-count register answering at all: that
     // proves the receiver round-trip worked this cycle, while `None` (e.g. a
     // parked channel) is "couldn't fully check" — the ledger then replays the
@@ -580,8 +582,13 @@ async fn drain_device_arrival_unifying(
     // wireless notifications are on. Fall back to enabling that flag when the
     // direct trigger produced no device, then retry once on the same listener.
     if let Err(error) = unifying.set_wireless_notifications(true).await {
+        // A register write the receiver stopped ACK'ing is "couldn't check",
+        // exactly like a failed trigger: settle it as a failed probe so the
+        // ledger replays the last snapshot, instead of publishing an
+        // authoritative empty inventory that overwrites the node's last-good
+        // device list.
         debug!(?error, "enable wireless notifications failed");
-        return Some(Vec::new());
+        return None;
     }
     if let Err(error) = unifying.trigger_device_arrival().await {
         debug!(?error, "arrival retry after enabling notifications failed");
@@ -605,7 +612,7 @@ async fn drain_device_arrival_unifying(
 /// working `get_device_pairing_information` call; we derive a stable cache key
 /// from the receiver UID + slot so the feature-table walk is amortised at ~30s
 /// and two receivers sharing a slot number don't collide in the cache.
-async fn probe_unifying_slot(
+pub(super) async fn probe_unifying_slot(
     channel: &Arc<HidppChannel>,
     event: &UnifyingDeviceConnection,
     receiver_uid: &str,
@@ -622,14 +629,17 @@ async fn probe_unifying_slot(
     let cached = cache.get(&id);
     let register_kind = map_unifying_kind(event.kind);
 
-    // A 0x41 event is itself the receiver's answer to TriggerDeviceArrival and
-    // is emitted for online devices. Keep the optional feature/battery refresh
-    // bounded, but don't turn a device that just announced itself offline when
-    // that follow-up read is the one reply the firmware happens to omit.
+    // The 0x41 re-broadcast is the receiver's own slot report and its
+    // link-status bit is the liveness authority (Solaar's trigger scan trusts
+    // the same bit). The feature/battery refresh below is optional metadata:
+    // keep it bounded, never let its one lost reply turn a device that just
+    // announced itself into "offline" — and don't probe an offline slot at
+    // all, which would burn the budget on a link the receiver just reported
+    // as not established.
     let probe_budget = unifying_probe_budget(cached, tick);
     let probe_result = timeout(
         probe_budget,
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, true, tick),
+        probe_or_reuse(channel, slot, Some(id.clone()), cached, event.online, tick),
     )
     .await;
     let (probe, outcome) = if let Ok(result) = probe_result {

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -198,7 +198,7 @@ async fn probe_unifying_receiver(
     // The drain is therefore the *only* device source on this path, so a
     // failed arrival trigger is "couldn't check", not "no devices online":
     // settle it as a failed probe and let the ledger replay the last snapshot.
-    let Some(connections) = drain_device_arrival_unifying(&unifying).await else {
+    let Some(connections) = drain_device_arrival_unifying(&unifying, pairing_count).await else {
         return NodeProbe::failed();
     };
     debug!(events = connections.len(), "drained device-arrival events");
@@ -556,6 +556,7 @@ async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> 
 /// empty receiver.
 async fn drain_device_arrival_unifying(
     unifying: &UnifyingReceiver,
+    pairing_count: u8,
 ) -> Option<Vec<UnifyingDeviceConnection>> {
     let rx = unifying.listen();
     // Newer Lightspeed receivers can already have notifications enabled (or
@@ -575,7 +576,10 @@ async fn drain_device_arrival_unifying(
             Ok(Err(_)) | Err(_) => break,
         }
     }
-    if !out.is_empty() {
+    // A receiver with no pairings legitimately emits nothing: don't pay a
+    // notification-register round trip and a second drain window for it on
+    // every watcher tick.
+    if !out.is_empty() || pairing_count == 0 {
         return Some(out);
     }
 

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -549,7 +549,8 @@ async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> 
     out
 }
 
-/// `None` when the arrival trigger itself failed: unlike Bolt (whose paired
+/// `None` when the receiver could not be asked: the arrival trigger failed,
+/// or the notification-flag fallback write did. Unlike Bolt (whose paired
 /// list comes from the slot registers), the drain is the only Unifying device
 /// source, so the caller must treat that as a failed probe rather than an
 /// empty receiver.

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, sync::Arc};
 use futures_concurrency::future::Join as _;
 use hidpp::{
     channel::HidppChannel,
-    device::Device,
     receiver::{
         self, Receiver,
         bolt::{
@@ -23,9 +22,11 @@ use super::mappings::{map_kind, map_unifying_kind, resolve_device_kind};
 use crate::backend::NodeInfo;
 use crate::channel::route::DIRECT_DEVICE_INDEX;
 
-use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
+use super::cache::{CacheKey, CacheOutcome, Cached, is_stale, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
-use super::{ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_SLOT_PROBE};
+use super::{
+    ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
+};
 
 /// One probed node's contribution this tick: its inventory (if any), whether
 /// the node actually answered — the ledger replays the last snapshot when it
@@ -553,27 +554,47 @@ async fn drain_device_arrival(bolt: &BoltReceiver) -> Vec<BoltDeviceConnection> 
 async fn drain_device_arrival_unifying(
     unifying: &UnifyingReceiver,
 ) -> Option<Vec<UnifyingDeviceConnection>> {
-    // The receiver only re-broadcasts 0x41 arrival events while wireless
-    // notifications are on; without this the trigger below is ACK'd but emits
-    // nothing, so a paired online device never surfaces.
-    if let Err(e) = unifying.set_wireless_notifications(true).await {
-        debug!(error = ?e, "enable wireless notifications failed");
-    }
     let rx = unifying.listen();
+    // Newer Lightspeed receivers can already have notifications enabled (or
+    // emit the requested arrival event without changing the legacy Unifying
+    // flag). Ask first: c54d has been observed to answer this trigger while
+    // occasionally withholding the ACK for the notification-register setup,
+    // which otherwise stalls discovery before it reaches the useful request.
     if let Err(e) = unifying.trigger_device_arrival().await {
         debug!(error = ?e, "trigger_device_arrival failed; receiver may report no devices");
         return None;
     }
-
     let mut out = Vec::new();
     loop {
         match timeout(ARRIVAL_DRAIN, rx.recv()).await {
-            Ok(Ok(UnifyingEvent::DeviceConnection(c))) => out.push(c),
+            Ok(Ok(UnifyingEvent::DeviceConnection(connection))) => out.push(connection),
             Ok(Ok(_)) => {}
             Ok(Err(_)) | Err(_) => break,
         }
     }
-    Some(out)
+    if !out.is_empty() {
+        return Some(out);
+    }
+
+    // Classic Unifying receivers only re-broadcast 0x41 arrival events while
+    // wireless notifications are on. Fall back to enabling that flag when the
+    // direct trigger produced no device, then retry once on the same listener.
+    if let Err(error) = unifying.set_wireless_notifications(true).await {
+        debug!(?error, "enable wireless notifications failed");
+        return Some(Vec::new());
+    }
+    if let Err(error) = unifying.trigger_device_arrival().await {
+        debug!(?error, "arrival retry after enabling notifications failed");
+        return None;
+    }
+    out.clear();
+    loop {
+        match timeout(ARRIVAL_DRAIN, rx.recv()).await {
+            Ok(Ok(UnifyingEvent::DeviceConnection(connection))) => out.push(connection),
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(_) => return Some(out),
+        }
+    }
 }
 
 /// Probe a Unifying slot from a live device-connection event.
@@ -592,16 +613,6 @@ async fn probe_unifying_slot(
     tick: u64,
 ) -> Option<(PairedDevice, CacheOutcome)> {
     let slot = event.index;
-    let codename = read_codename_unifying(channel, slot).await;
-    debug!(
-        slot,
-        online = event.online,
-        wpid = format_args!("{:04x}", event.wpid),
-        kind = ?event.kind,
-        codename = ?codename,
-        "unifying paired slot"
-    );
-
     // Cache key: full receiver serial + slot so two Unifying receivers with
     // a device on the same slot number never share a cache entry.
     let id = CacheKey::UnifyingSlot {
@@ -611,53 +622,65 @@ async fn probe_unifying_slot(
     let cached = cache.get(&id);
     let register_kind = map_unifying_kind(event.kind);
 
-    // `trigger_device_arrival` re-broadcasts a 0x41 for *every* paired slot,
-    // online or not, and the crate's `event.online` reads the wrong notification
-    // byte (payload[1] bit6, always set here — wire-verified `04 62 69 40`), so
-    // neither tells us if the device is actually reachable on this receiver.
-    // A cache hit must therefore still do one live round-trip: otherwise cached
-    // capabilities keep an absent device "online" forever and its reconnect is
-    // invisible to the agent's volatile-state re-apply/capture re-arm path.
+    // A 0x41 event is itself the receiver's answer to TriggerDeviceArrival and
+    // is emitted for online devices. Keep the optional feature/battery refresh
+    // bounded, but don't turn a device that just announced itself offline when
+    // that follow-up read is the one reply the firmware happens to omit.
+    let probe_budget = unifying_probe_budget(cached, tick);
     let probe_result = timeout(
-        UNIFYING_SLOT_PROBE,
-        probe_unifying_features(channel, slot, &id, cached, tick),
+        probe_budget,
+        probe_or_reuse(channel, slot, Some(id.clone()), cached, true, tick),
     )
     .await;
-    let (probe, outcome, online) = if let Ok(r) = probe_result {
-        r
+    let (probe, outcome) = if let Ok(result) = probe_result {
+        result
     } else {
-        debug!(slot, budget = ?UNIFYING_SLOT_PROBE,
+        debug!(slot, budget = ?probe_budget,
             "Unifying slot probe timed out; using cached data if available");
-        let probe = cached.map_or_else(ProbedFeatures::default, |c| c.probe.clone());
-        (probe, CacheOutcome::Seen(id), false)
+        let probe = cached.map_or_else(ProbedFeatures::default, |entry| entry.probe.clone());
+        (probe, CacheOutcome::Seen(id))
     };
 
-    let device = assemble_unifying_device(slot, codename, event.wpid, register_kind, probe, online);
+    // HID++ 2.0's marketing name is the same identity we need for display and
+    // avoids another receiver-register round trip. Keep the legacy codename
+    // read only for a completed feature walk that did not expose a name; never
+    // put it in front of the feature probe, where one missing receiver ACK can
+    // otherwise starve a healthy Lightspeed mouse forever.
+    let codename = if let Some(name) = probe.marketing_name.clone() {
+        Some(name)
+    } else if probe.capabilities.is_some() {
+        read_codename_unifying(channel, slot).await
+    } else {
+        None
+    };
+    debug!(
+        slot,
+        online = event.online,
+        wpid = format_args!("{:04x}", event.wpid),
+        kind = ?event.kind,
+        codename = ?codename,
+        "unifying paired slot"
+    );
+
+    let device = assemble_unifying_device(
+        slot,
+        codename,
+        event.wpid,
+        register_kind,
+        probe,
+        event.online,
+    );
     Some((device, outcome))
 }
 
-/// Return cached immutable features together with a fresh reachability result.
-///
-/// A successful full probe ([`CacheOutcome::Fresh`]) confirms liveness on a
-/// cache miss/stale entry. A fresh cached entry normally refreshes its battery,
-/// whose successful response ([`CacheOutcome::Update`]) is the liveness check.
-/// A failed battery refresh, or a device without that feature, gets a root ping
-/// before being treated as offline.
-pub(super) async fn probe_unifying_features(
-    channel: &Arc<HidppChannel>,
-    slot: u8,
-    id: &CacheKey,
-    cached: Option<&Cached>,
-    tick: u64,
-) -> (ProbedFeatures, CacheOutcome, bool) {
-    let (probe, outcome) =
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, true, tick).await;
-    let online = if matches!(outcome, CacheOutcome::Fresh(..) | CacheOutcome::Update(..)) {
-        true
+/// A fresh cache hit needs only an optional battery refresh; first-sight and
+/// stale entries retain the larger budget needed for a complete feature walk.
+pub(super) fn unifying_probe_budget(cached: Option<&Cached>, tick: u64) -> std::time::Duration {
+    if cached.is_some_and(|entry| !is_stale(entry, tick)) {
+        UNIFYING_CACHED_SLOT_PROBE
     } else {
-        Device::new(Arc::clone(channel), slot).await.is_ok()
-    };
-    (probe, outcome, online)
+        UNIFYING_SLOT_PROBE
+    }
 }
 
 pub(super) fn assemble_unifying_device(

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -12,11 +12,12 @@ use super::cache::{
 };
 use super::features::ProbedFeatures;
 use super::probe::{
-    NodeProbe, assemble_bolt_probe, parse_codename_unifying, preferred_direct_codename,
+    NodeProbe, assemble_bolt_probe, assemble_unifying_device, parse_codename_unifying,
+    preferred_direct_codename, unifying_probe_budget,
 };
 use super::{
-    ChannelCache, Enumerator, ONESHOT_ATTEMPTS, one_shot_should_stop, retained_nodes,
-    routes_for_inventories, settle_unhealthy_node,
+    ChannelCache, Enumerator, ONESHOT_ATTEMPTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
+    one_shot_should_stop, retained_nodes, routes_for_inventories, settle_unhealthy_node,
 };
 use crate::channel::scripted::{ScriptedBackend, ScriptedNode, scripted_node_info};
 use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
@@ -131,6 +132,40 @@ fn cached_probe_is_reused_until_refresh_ticks() {
         is_stale(&cached, 10 + REFRESH_TICKS),
         "at the window the probe is refreshed"
     );
+}
+
+#[test]
+fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
+    let cached = cache_entry(10);
+    assert_eq!(
+        unifying_probe_budget(Some(&cached), 10),
+        UNIFYING_CACHED_SLOT_PROBE
+    );
+    assert_eq!(
+        unifying_probe_budget(Some(&cached), 10 + REFRESH_TICKS),
+        UNIFYING_SLOT_PROBE,
+        "stale entries still get enough time for a full feature walk"
+    );
+    assert_eq!(
+        unifying_probe_budget(None, 10),
+        UNIFYING_SLOT_PROBE,
+        "first sight still gets the full feature-walk budget"
+    );
+}
+
+#[test]
+fn unifying_arrival_liveness_survives_missing_feature_data() {
+    let device = assemble_unifying_device(
+        1,
+        None,
+        0x40b8,
+        DeviceKind::Mouse,
+        ProbedFeatures::default(),
+        true,
+    );
+    assert!(device.online);
+    assert_eq!(device.wpid, Some(0x40b8));
+    assert_eq!(device.kind, DeviceKind::Mouse);
 }
 
 fn inventory(slots: &[u8]) -> Vec<DeviceInventory> {

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -1,6 +1,8 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use hidpp::protocol::v10::{Message, MessageHeader};
+use hidpp::receiver::unifying::{Event as UnifyingEvent, decode_notification};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice,
     ReceiverInfo,
@@ -13,13 +15,15 @@ use super::cache::{
 use super::features::ProbedFeatures;
 use super::probe::{
     NodeProbe, assemble_bolt_probe, assemble_unifying_device, parse_codename_unifying,
-    preferred_direct_codename, unifying_probe_budget,
+    preferred_direct_codename, probe_unifying_slot, unifying_probe_budget,
 };
 use super::{
     ChannelCache, Enumerator, ONESHOT_ATTEMPTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
     one_shot_should_stop, retained_nodes, routes_for_inventories, settle_unhealthy_node,
 };
-use crate::channel::scripted::{ScriptedBackend, ScriptedNode, scripted_node_info};
+use crate::channel::scripted::{
+    ScriptedBackend, ScriptedNode, ScriptedRawHidChannel, scripted_channel, scripted_node_info,
+};
 use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
 
 fn cache_entry(probed_tick: u64) -> Cached {
@@ -150,6 +154,41 @@ fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
         unifying_probe_budget(None, 10),
         UNIFYING_SLOT_PROBE,
         "first sight still gets the full feature-walk budget"
+    );
+}
+
+#[tokio::test]
+async fn offline_arrival_rebroadcasts_surface_without_probing_the_device() {
+    // The exact wire bytes once misread as proof that the online bit is
+    // stuck: `04 62 69 40` is an encrypted MX Master 2S (wpid 0x4069) slot
+    // re-broadcast with bit 6 *set* — link not established, device offline.
+    let message = Message::Short(
+        MessageHeader {
+            device_index: 1,
+            sub_id: 0x41,
+        },
+        [0x04, 0x62, 0x69, 0x40],
+    );
+    let Some(UnifyingEvent::DeviceConnection(event)) = decode_notification(&message) else {
+        panic!("expected a device-connection event");
+    };
+    assert!(!event.online, "bit 6 set must decode as offline");
+
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(|_| None);
+    let channel = scripted_channel(raw).await;
+    let writes_before = handle.written_reports().len();
+
+    let cache = HashMap::new();
+    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache, 0)
+        .await
+        .expect("an offline slot still surfaces from its re-broadcast");
+
+    assert!(!device.online);
+    assert_eq!(device.wpid, Some(0x4069));
+    assert_eq!(
+        handle.written_reports().len(),
+        writes_before,
+        "an offline slot must not be probed for features, battery, or codename"
     );
 }
 

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -146,7 +146,6 @@ impl Receiver {
     pub async fn set_wireless_notifications(&self, enabled: bool) -> Result<(), ReceiverError> {
         // Notification flags are a 3-byte big-endian word; the receiver-reporting
         // bits live in byte 1 (WIRELESS = 0x000100, SOFTWARE_PRESENT = 0x000800).
-        const WIRELESS: u8 = 0x01;
         let mut flags = self
             .chan
             .read_register(
@@ -155,10 +154,12 @@ impl Receiver {
                 [0; 3],
             )
             .await?;
-        if enabled {
-            flags[1] |= WIRELESS;
-        } else {
-            flags[1] &= !WIRELESS;
+        // This flag persists in receiver RAM. Avoid issuing an identical
+        // register write on every inventory tick: Lightspeed receiver c54d
+        // has been observed to occasionally omit the ACK for that no-op,
+        // parking the otherwise healthy shared channel until timeout.
+        if !update_wireless_notification_flag(&mut flags, enabled) {
+            return Ok(());
         }
         self.chan
             .write_register(RECEIVER_DEVICE_INDEX, Register::Notifications.into(), flags)
@@ -233,6 +234,20 @@ impl Receiver {
     pub async fn get_unique_id(&self) -> Result<String, ReceiverError> {
         self.get_receiver_info().await.map(|i| i.serial_number)
     }
+}
+
+/// Update the wireless-notification bit and report whether a register write is
+/// needed. Kept separate so the preservation of unrelated flags is testable
+/// without a receiver transport.
+fn update_wireless_notification_flag(flags: &mut [u8; 3], enabled: bool) -> bool {
+    const WIRELESS: u8 = 0x01;
+    let previous = *flags;
+    if enabled {
+        flags[1] |= WIRELESS;
+    } else {
+        flags[1] &= !WIRELESS;
+    }
+    *flags != previous
 }
 
 /// The sub-id of the only notification this receiver emits: a paired device
@@ -354,7 +369,9 @@ pub enum Event {
 
 #[cfg(test)]
 mod tests {
-    use super::{DeviceConnection, DeviceKind, Event, decode_notification};
+    use super::{
+        DeviceConnection, DeviceKind, Event, decode_notification, update_wireless_notification_flag,
+    };
     use crate::protocol::v10::{Message, MessageHeader};
 
     /// Builds the long notification the receiver broadcasts, with `payload`
@@ -367,6 +384,18 @@ mod tests {
             },
             payload,
         )
+    }
+
+    #[test]
+    fn wireless_notification_flag_only_writes_on_a_real_change() {
+        let mut disabled = [0x00, 0x08, 0x55];
+        assert!(update_wireless_notification_flag(&mut disabled, true));
+        assert_eq!(disabled, [0x00, 0x09, 0x55]);
+        assert!(!update_wireless_notification_flag(&mut disabled, true));
+
+        assert!(update_wireless_notification_flag(&mut disabled, false));
+        assert_eq!(disabled, [0x00, 0x08, 0x55]);
+        assert!(!update_wireless_notification_flag(&mut disabled, false));
     }
 
     #[test]

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -168,8 +168,10 @@ impl Receiver {
         Ok(())
     }
 
-    /// Triggers device-arrival notifications for all currently connected
-    /// devices. Used to enumerate online devices at startup.
+    /// Triggers device-arrival notifications for every paired slot, online or
+    /// not — the notification's link-status bit distinguishes (Solaar uses the
+    /// same trigger as its "scan all devices" pass). Used to enumerate paired
+    /// devices at startup.
     pub async fn trigger_device_arrival(&self) -> Result<(), ReceiverError> {
         self.chan
             .write_register(
@@ -250,16 +252,18 @@ fn update_wireless_notification_flag(flags: &mut [u8; 3], enabled: bool) -> bool
     *flags != previous
 }
 
-/// The sub-id of the only notification this receiver emits: a paired device
-/// came online.
+/// The sub-id of the only notification this receiver emits: a paired slot's
+/// connection status changed, or was re-reported by
+/// [`Receiver::trigger_device_arrival`].
 const DEVICE_CONNECTION_SUB_ID: u8 = 0x41;
 
 /// Decodes an unsolicited receiver message into the event it carries, or
 /// `None` for a report this crate does not model.
 ///
-/// Kept separate from the message listener in [`Receiver::new`] so the wire
-/// layout is reachable from tests without a HID channel behind it.
-fn decode_notification(msg: &v10::Message) -> Option<Event> {
+/// Public so consumers can decode captured reports and fabricate events from
+/// wire bytes in their own tests without a HID channel behind them.
+#[must_use]
+pub fn decode_notification(msg: &v10::Message) -> Option<Event> {
     let header = msg.header();
     if header.sub_id != DEVICE_CONNECTION_SUB_ID {
         return None;
@@ -340,7 +344,8 @@ pub enum DeviceKind {
 }
 
 /// Represents a device-connection event fired by the receiver when a paired
-/// device comes online (or in response to [`Receiver::trigger_device_arrival`]).
+/// device's link status changes, or re-broadcast for a paired slot in
+/// response to [`Receiver::trigger_device_arrival`].
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
@@ -351,7 +356,9 @@ pub struct DeviceConnection {
     pub kind: DeviceKind,
     /// Whether the link is encrypted.
     pub encrypted: bool,
-    /// Whether the device is currently online.
+    /// Whether the device's link is currently established (payload bit 6
+    /// clear). Trigger-driven re-broadcasts report offline paired slots with
+    /// `false`, so a `0x41` alone is a slot report, not proof of liveness.
     pub online: bool,
     /// Wireless product ID of the device.
     pub wpid: u16,
@@ -362,8 +369,10 @@ pub struct DeviceConnection {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
 pub enum Event {
-    /// Fired whenever a paired device connects or reconnects, and for all
-    /// online devices in response to [`Receiver::trigger_device_arrival`].
+    /// Fired whenever a paired device connects or reconnects, and for *every*
+    /// paired slot — offline ones included — in response to
+    /// [`Receiver::trigger_device_arrival`], with
+    /// [`DeviceConnection::online`] carrying the link status.
     DeviceConnection(DeviceConnection),
 }
 


### PR DESCRIPTION
## Summary

An unresponsive receiver can hold an inventory scan until several lower-level timeouts expire. A live Unifying arrival event can also be discarded when optional feature reads are incomplete, making a connected device appear offline.

Put a bounded deadline around receiver probes and preserve the liveness reported by a valid arrival event while optional details are filled in later.

## Changes

- Fail a receiver probe within the inventory budget.
- Retire a repeatedly unresponsive channel before reopening it.
- Keep live arrival state even when feature metadata is incomplete.
- Continue to reject malformed or unrelated receiver events.

## Testing

- `cargo test -p openlogi-device`
- Covered probe deadlines, retirement, cache fallback, and incomplete arrival data.


Refs #293.
