### PR TITLE
perf(dpi): avoid repeated capability handshakes

### DIFF
--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -24,6 +24,7 @@ use std::collections::VecDeque;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use openlogi_core::config::Lighting;
@@ -189,6 +190,11 @@ async fn observe_loop(
     let mut seen: Generation = 0;
     let mut inflight: Option<ObserveFuture> = None;
     let mut dpi_write: Option<DpiWriteFuture> = None;
+    // Every live connection generation owns a distinct token. A DPI future
+    // keeps the token of the client it was started on, so a late completion
+    // from a retired client cannot tear down its replacement or discard work
+    // queued for that replacement.
+    let mut client_generation = Arc::new(());
     let mut queued_dpi = PendingDpiWrites::default();
     let mut retry = ticker(RECONNECT_DELAY);
     loop {
@@ -221,7 +227,7 @@ async fn observe_loop(
             // The connection dropped (agent self-exec on update, or a crash).
             // Reconnecting re-reads the whole state, so nothing is lost.
             Woken::Observed(Err(())) => {
-                client = None;
+                invalidate_client(&mut client, &mut client_generation);
                 seen = 0;
                 connected_since = None;
                 dpi_write = pending_dpi_write;
@@ -236,21 +242,17 @@ async fn observe_loop(
                 inflight = pending;
                 dpi_write = pending_dpi_write;
                 if handle(&mut client, update_tx, cmd).await.is_err() {
-                    client = None;
+                    invalidate_client(&mut client, &mut client_generation);
                     seen = 0;
                     connected_since = None;
                 }
             }
-            Woken::DpiWritten(result) => {
+            Woken::DpiWritten(completion) => {
                 inflight = pending;
-                if result.is_err() {
-                    client = None;
+                if complete_dpi_write(&client_generation, &mut queued_dpi, &completion) {
+                    invalidate_client(&mut client, &mut client_generation);
                     seen = 0;
                     connected_since = None;
-                    // Match the existing fire-and-forget semantics: a transport
-                    // failure drops writes that never reached the agent rather
-                    // than replaying stale pointer speeds after reconnect.
-                    queued_dpi.clear();
                 }
             }
             Woken::Reconnect => {
@@ -265,7 +267,7 @@ async fn observe_loop(
             }
         }
         if dpi_write.is_none() {
-            match start_next_dpi_write(&mut client, &mut queued_dpi).await {
+            match start_next_dpi_write(&mut client, &client_generation, &mut queued_dpi).await {
                 Ok(next) => dpi_write = next,
                 Err(ConnectFailure::Unreachable) => {}
                 Err(ConnectFailure::NewerAgent) => {
@@ -295,7 +297,7 @@ enum Woken {
     /// A device command, or `None` once the GUI drops the sender.
     Command(Option<Command>),
     /// The one DPI write allowed in flight at a time completed.
-    DpiWritten(Result<(), ()>),
+    DpiWritten(DpiWriteCompletion),
     /// Time to try connecting again.
     Reconnect,
 }
@@ -308,7 +310,12 @@ type ObserveFuture = Pin<Box<dyn Future<Output = Result<Observation, ()>> + Send
 /// An in-flight DPI write. Keeping it outside [`handle`] lets the command loop
 /// continue receiving newer slider values while the receiver acknowledges the
 /// current one.
-type DpiWriteFuture = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
+type DpiWriteFuture = Pin<Box<dyn Future<Output = DpiWriteCompletion> + Send>>;
+
+struct DpiWriteCompletion {
+    connection: Arc<()>,
+    result: Result<(), ()>,
+}
 
 #[derive(Default)]
 struct PendingDpiWrites(VecDeque<(DeviceRoute, Dpi)>);
@@ -346,25 +353,65 @@ fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
     })
 }
 
-fn write_dpi(client: &AgentClient, route: DeviceRoute, dpi: Dpi) -> DpiWriteFuture {
+fn write_dpi(
+    client: &AgentClient,
+    connection: Arc<()>,
+    route: DeviceRoute,
+    dpi: Dpi,
+) -> DpiWriteFuture {
     let client = client.clone();
-    Box::pin(async move { log_apply(client.set_dpi(context::current(), route, dpi).await) })
+    Box::pin(async move {
+        let result = log_apply(client.set_dpi(context::current(), route, dpi).await);
+        DpiWriteCompletion { connection, result }
+    })
 }
 
 async fn start_next_dpi_write(
     client: &mut Option<AgentClient>,
+    connection: &Arc<()>,
     queued: &mut PendingDpiWrites,
 ) -> Result<Option<DpiWriteFuture>, ConnectFailure> {
     let Some((route, dpi)) = queued.pop() else {
         return Ok(None);
     };
     match ensure(client).await {
-        Ok(client) => Ok(Some(write_dpi(client, route, dpi))),
+        Ok(client) => Ok(Some(write_dpi(client, Arc::clone(connection), route, dpi))),
         Err(error) => {
             queued.clear();
             Err(error)
         }
     }
+}
+
+/// Retire the current IPC client and advance the generation even when a clone
+/// remains alive inside an in-flight request.
+fn invalidate_client(client: &mut Option<AgentClient>, generation: &mut Arc<()>) {
+    *client = None;
+    *generation = Arc::new(());
+}
+
+/// Apply a DPI completion only when it belongs to the current client.
+///
+/// Returns whether the current connection failed and must be retired. A stale
+/// failure is ignored: another failure path already retired that client, and
+/// clearing here would destroy writes accepted for its healthy replacement.
+fn complete_dpi_write(
+    current_connection: &Arc<()>,
+    queued: &mut PendingDpiWrites,
+    completion: &DpiWriteCompletion,
+) -> bool {
+    if !Arc::ptr_eq(current_connection, &completion.connection) {
+        debug!("stale DPI write completion ignored after IPC reconnect");
+        return false;
+    }
+    if completion.result.is_ok() {
+        return false;
+    }
+    // Match the existing fire-and-forget semantics for the *current*
+    // connection: do not replay pointer speeds that may have reached the agent
+    // before the transport failed to acknowledge them.
+    queued.clear();
+    true
 }
 
 fn notify_outdated(update_tx: &mpsc::UnboundedSender<GuiUpdate>, notified: &mut bool) {
@@ -787,6 +834,53 @@ mod tests {
 
         assert_eq!(pending.pop(), Some((first, Dpi::new(2_400))));
         assert_eq!(pending.pop(), Some((second, Dpi::new(3_200))));
+        assert_eq!(pending.pop(), None);
+    }
+
+    #[test]
+    fn stale_dpi_failure_keeps_the_new_client_and_its_queue() {
+        let stale_connection = Arc::new(());
+        let current_connection = Arc::new(());
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09b,
+        };
+        let mut pending = PendingDpiWrites::default();
+        pending.push(route.clone(), Dpi::new(1_600));
+
+        let retire_current = complete_dpi_write(
+            &current_connection,
+            &mut pending,
+            &DpiWriteCompletion {
+                connection: stale_connection,
+                result: Err(()),
+            },
+        );
+
+        assert!(!retire_current);
+        assert_eq!(pending.pop(), Some((route, Dpi::new(1_600))));
+    }
+
+    #[test]
+    fn current_dpi_failure_retires_the_client_and_drops_ambiguous_writes() {
+        let current_connection = Arc::new(());
+        let route = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09b,
+        };
+        let mut pending = PendingDpiWrites::default();
+        pending.push(route, Dpi::new(1_600));
+
+        let retire_current = complete_dpi_write(
+            &current_connection,
+            &mut pending,
+            &DpiWriteCompletion {
+                connection: Arc::clone(&current_connection),
+                result: Err(()),
+            },
+        );
+
+        assert!(retire_current);
         assert_eq!(pending.pop(), None);
     }
 

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -20,6 +20,7 @@
 //! forever. A dead agent is noticed the moment the socket closes; a *hung* one
 //! is noticed when its hold window passes without an answer.
 
+use std::collections::VecDeque;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -187,13 +188,17 @@ async fn observe_loop(
     // every disconnect: the replacement agent numbers its own generations.
     let mut seen: Generation = 0;
     let mut inflight: Option<ObserveFuture> = None;
+    let mut dpi_write: Option<DpiWriteFuture> = None;
+    let mut queued_dpi = PendingDpiWrites::default();
     let mut retry = ticker(RECONNECT_DELAY);
     loop {
         // Taken for the duration of the select so the completed arm can consume
         // it while the others hand it back untouched.
         let mut pending = inflight.take();
+        let mut pending_dpi_write = dpi_write.take();
         let woken = tokio::select! {
             observed = maybe(pending.as_mut()) => Woken::Observed(observed),
+            result = maybe(pending_dpi_write.as_mut()) => Woken::DpiWritten(result),
             cmd = cmd_rx.recv() => Woken::Command(cmd),
             _ = retry.tick(), if pending.is_none() => Woken::Reconnect,
         };
@@ -211,6 +216,7 @@ async fn observe_loop(
                 if let Some(client) = client.as_ref() {
                     inflight = Some(observe(client, seen));
                 }
+                dpi_write = pending_dpi_write;
             }
             // The connection dropped (agent self-exec on update, or a crash).
             // Reconnecting re-reads the whole state, so nothing is lost.
@@ -218,26 +224,54 @@ async fn observe_loop(
                 client = None;
                 seen = 0;
                 connected_since = None;
+                dpi_write = pending_dpi_write;
             }
             Woken::Command(None) => break, // GUI dropped the sender → shut down
+            Woken::Command(Some(Command::SetDpi(route, dpi))) => {
+                inflight = pending;
+                dpi_write = pending_dpi_write;
+                queued_dpi.push(route, dpi);
+            }
             Woken::Command(Some(cmd)) => {
                 inflight = pending;
+                dpi_write = pending_dpi_write;
                 if handle(&mut client, update_tx, cmd).await.is_err() {
                     client = None;
                     seen = 0;
                     connected_since = None;
                 }
             }
-            Woken::Reconnect => match ensure(&mut client).await {
-                Ok(client) => inflight = Some(observe(client, seen)),
-                Err(ConnectFailure::Unreachable) => {}
-                Err(ConnectFailure::NewerAgent) => {
-                    if !notified_outdated {
-                        notified_outdated = true;
-                        let _ = update_tx.send(GuiUpdate::OutdatedGui);
+            Woken::DpiWritten(result) => {
+                inflight = pending;
+                if result.is_err() {
+                    client = None;
+                    seen = 0;
+                    connected_since = None;
+                    // Match the existing fire-and-forget semantics: a transport
+                    // failure drops writes that never reached the agent rather
+                    // than replaying stale pointer speeds after reconnect.
+                    queued_dpi.clear();
+                }
+            }
+            Woken::Reconnect => {
+                dpi_write = pending_dpi_write;
+                match ensure(&mut client).await {
+                    Ok(client) => inflight = Some(observe(client, seen)),
+                    Err(ConnectFailure::Unreachable) => {}
+                    Err(ConnectFailure::NewerAgent) => {
+                        notify_outdated(update_tx, &mut notified_outdated);
                     }
                 }
-            },
+            }
+        }
+        if dpi_write.is_none() {
+            match start_next_dpi_write(&mut client, &mut queued_dpi).await {
+                Ok(next) => dpi_write = next,
+                Err(ConnectFailure::Unreachable) => {}
+                Err(ConnectFailure::NewerAgent) => {
+                    notify_outdated(update_tx, &mut notified_outdated);
+                }
+            }
         }
         if client.is_none() {
             let down_since = connected_since.unwrap_or(started);
@@ -260,6 +294,8 @@ enum Woken {
     Observed(Result<Observation, ()>),
     /// A device command, or `None` once the GUI drops the sender.
     Command(Option<Command>),
+    /// The one DPI write allowed in flight at a time completed.
+    DpiWritten(Result<(), ()>),
     /// Time to try connecting again.
     Reconnect,
 }
@@ -268,6 +304,35 @@ enum Woken {
 /// owns a clone of the client so the loop can still replace its own `client`
 /// while the poll is outstanding.
 type ObserveFuture = Pin<Box<dyn Future<Output = Result<Observation, ()>> + Send>>;
+
+/// An in-flight DPI write. Keeping it outside [`handle`] lets the command loop
+/// continue receiving newer slider values while the receiver acknowledges the
+/// current one.
+type DpiWriteFuture = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
+
+#[derive(Default)]
+struct PendingDpiWrites(VecDeque<(DeviceRoute, Dpi)>);
+
+impl PendingDpiWrites {
+    /// Keep only the newest not-yet-started value for each device. Different
+    /// devices retain FIFO order so switching the carousel cannot discard a
+    /// pending write for the device the user just left.
+    fn push(&mut self, route: DeviceRoute, dpi: Dpi) {
+        if let Some((_, pending)) = self.0.iter_mut().find(|(candidate, _)| *candidate == route) {
+            *pending = dpi;
+        } else {
+            self.0.push_back((route, dpi));
+        }
+    }
+
+    fn pop(&mut self) -> Option<(DeviceRoute, Dpi)> {
+        self.0.pop_front()
+    }
+
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
 
 /// Ask for the next state newer than `seen`.
 fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
@@ -279,6 +344,34 @@ fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
             debug!(%error, "observe failed — reconnecting");
         })
     })
+}
+
+fn write_dpi(client: &AgentClient, route: DeviceRoute, dpi: Dpi) -> DpiWriteFuture {
+    let client = client.clone();
+    Box::pin(async move { log_apply(client.set_dpi(context::current(), route, dpi).await) })
+}
+
+async fn start_next_dpi_write(
+    client: &mut Option<AgentClient>,
+    queued: &mut PendingDpiWrites,
+) -> Result<Option<DpiWriteFuture>, ConnectFailure> {
+    let Some((route, dpi)) = queued.pop() else {
+        return Ok(None);
+    };
+    match ensure(client).await {
+        Ok(client) => Ok(Some(write_dpi(client, route, dpi))),
+        Err(error) => {
+            queued.clear();
+            Err(error)
+        }
+    }
+}
+
+fn notify_outdated(update_tx: &mpsc::UnboundedSender<GuiUpdate>, notified: &mut bool) {
+    if !*notified {
+        *notified = true;
+        let _ = update_tx.send(GuiUpdate::OutdatedGui);
+    }
 }
 
 /// Await a future that may not exist, never resolving when there is none. The
@@ -673,6 +766,28 @@ mod tests {
             panic!("a reload that never reached the agent must be reported as failed");
         };
         assert!(!error.message.is_empty(), "the notice needs a reason");
+    }
+
+    #[test]
+    fn rapid_dpi_writes_keep_only_the_newest_value_per_device() {
+        let first = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09b,
+        };
+        let second = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc09c,
+        };
+        let mut pending = PendingDpiWrites::default();
+
+        pending.push(first.clone(), Dpi::new(800));
+        pending.push(first.clone(), Dpi::new(1_600));
+        pending.push(second.clone(), Dpi::new(3_200));
+        pending.push(first.clone(), Dpi::new(2_400));
+
+        assert_eq!(pending.pop(), Some((first, Dpi::new(2_400))));
+        assert_eq!(pending.pop(), Some((second, Dpi::new(3_200))));
+        assert_eq!(pending.pop(), None);
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/openlogi-desktop/src/state/dpi.rs
+++ b/crates/openlogi-desktop/src/state/dpi.rs
@@ -118,7 +118,7 @@ impl AppState {
         let route = record.route.clone();
         if let Some(persistent_key) = persistent_key {
             self.config.set_dpi(&persistent_key, dpi);
-            if !self.persist_and_reload("DPI") {
+            if !self.persist_config("DPI") {
                 return;
             }
         } else {
@@ -130,6 +130,10 @@ impl AppState {
         if let Some(route) = route {
             self.send_ipc(crate::services::ipc::Command::SetDpi(route, dpi));
         }
+        // Apply-now is deliberately queued before the config reload. The IPC
+        // client can coalesce rapid slider releases while this reload runs, so
+        // the mouse no longer waits behind older config work before changing.
+        self.send_ipc(crate::services::ipc::Command::ReloadConfig);
     }
 }
 

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -97,6 +97,33 @@ fn direct_inventory(unit_id: [u8; 4]) -> DeviceInventory {
     }
 }
 
+#[test]
+fn dpi_apply_is_queued_before_the_config_reload() {
+    let inventory = direct_inventory([1, 2, 3, 4]);
+    let (commands, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::default(),
+        &[inventory],
+        &[],
+        &AssetResolver::new(),
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    state.commit_dpi(Dpi::new(2_400));
+
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(crate::services::ipc::Command::SetDpi(_, dpi)) if dpi == Dpi::new(2_400)
+    ));
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(crate::services::ipc::Command::ReloadConfig)
+    ));
+    assert!(receiver.try_recv().is_err());
+}
+
 fn superseded_litra_light() -> StandaloneDevice {
     StandaloneDevice {
         address: RawDeviceAddress {

--- a/crates/openlogi-device/src/channel.rs
+++ b/crates/openlogi-device/src/channel.rs
@@ -23,6 +23,17 @@ pub(crate) mod scripted;
 pub use pool::ChannelPool;
 pub use registry::ChannelRegistry;
 
+/// Stable identity used to keep immutable metadata attached to one physical
+/// device rather than merely to its receiver slot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DeviceCacheIdentity {
+    Direct,
+    Physical {
+        unit_id: Option<[u8; 4]>,
+        serial_number: Option<String>,
+    },
+}
+
 /// An open HID++ channel to a device, shared so route-addressed reads and writes
 /// can reuse an inventory- or capture-owned connection instead of
 /// re-enumerating and opening a fresh channel each time (which costs ~100ms+).
@@ -33,13 +44,39 @@ pub use registry::ChannelRegistry;
 pub struct SharedChannel {
     channel: Arc<HidppChannel>,
     route: DeviceRoute,
+    cache_identity: Option<DeviceCacheIdentity>,
 }
 
 impl SharedChannel {
     /// Wrap an open channel that reaches `route`.
+    ///
+    /// Standalone direct channels are device-specific and may cache immutable
+    /// metadata. Receiver routes need inventory's physical identity, so they
+    /// deliberately remain uncached when built outside the registry.
     #[must_use]
     pub(crate) fn new(channel: Arc<HidppChannel>, route: DeviceRoute) -> Self {
-        Self { channel, route }
+        let cache_identity =
+            matches!(route, DeviceRoute::Direct { .. }).then_some(DeviceCacheIdentity::Direct);
+        Self {
+            channel,
+            route,
+            cache_identity,
+        }
+    }
+
+    /// Wrap a registry-owned channel with the identity of the physical device
+    /// currently occupying this route.
+    #[must_use]
+    pub(crate) fn with_cache_identity(
+        channel: Arc<HidppChannel>,
+        route: DeviceRoute,
+        cache_identity: Option<DeviceCacheIdentity>,
+    ) -> Self {
+        Self {
+            channel,
+            route,
+            cache_identity,
+        }
     }
 
     /// Whether this channel reaches `route` — so the write path only reuses it
@@ -55,5 +92,13 @@ impl SharedChannel {
 
     pub(crate) fn device_index(&self) -> u8 {
         self.route.device_index()
+    }
+
+    pub(crate) fn cache_identity(&self) -> Option<&DeviceCacheIdentity> {
+        self.cache_identity.as_ref()
+    }
+
+    pub(crate) fn cache_identity_matches(&self, current: Option<&DeviceCacheIdentity>) -> bool {
+        self.cache_identity() == current
     }
 }

--- a/crates/openlogi-device/src/channel/registry.rs
+++ b/crates/openlogi-device/src/channel/registry.rs
@@ -6,7 +6,9 @@ use std::sync::{Arc, PoisonError, RwLock};
 
 use crate::backend::NodeId;
 use hidpp::channel::HidppChannel;
+use openlogi_core::device::PairedDevice;
 
+use crate::channel::DeviceCacheIdentity;
 use crate::{DeviceRoute, SharedChannel};
 
 struct Publication<Node, Channel> {
@@ -154,6 +156,69 @@ impl<Node: Eq, Channel> Registry<Node, Channel> {
     }
 }
 
+/// One route discovered during inventory, plus enough identity to decide
+/// whether immutable feature metadata can safely survive the next refresh.
+#[derive(Clone, Debug)]
+pub(crate) struct PublishedRoute {
+    route: DeviceRoute,
+    identity: Option<DeviceCacheIdentity>,
+}
+
+impl PublishedRoute {
+    pub(crate) fn for_device(
+        route: DeviceRoute,
+        paired: &PairedDevice,
+        identity_is_current: bool,
+    ) -> Self {
+        let identity = if identity_is_current {
+            match route {
+                DeviceRoute::Direct { .. } => Some(DeviceCacheIdentity::Direct),
+                DeviceRoute::Bolt { .. } | DeviceRoute::Unifying { .. } => {
+                    paired.model_info.as_ref().and_then(|model| {
+                        let unit_id = (model.unit_id != [0; 4]).then_some(model.unit_id);
+                        let serial_number = model
+                            .serial_number
+                            .as_deref()
+                            .filter(|serial| !serial.is_empty())
+                            .map(str::to_owned);
+                        (unit_id.is_some() || serial_number.is_some()).then_some(
+                            DeviceCacheIdentity::Physical {
+                                unit_id,
+                                serial_number,
+                            },
+                        )
+                    })
+                }
+                DeviceRoute::RawHid { .. } => None,
+            }
+        } else {
+            None
+        };
+        Self { route, identity }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn route(&self) -> &DeviceRoute {
+        &self.route
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_cache_identity(&self) -> bool {
+        self.identity.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cache_identity(&self) -> Option<&DeviceCacheIdentity> {
+        self.identity.as_ref()
+    }
+}
+
+#[derive(Clone)]
+struct RegisteredChannel {
+    channel: Arc<HidppChannel>,
+    routes: Vec<PublishedRoute>,
+}
+
 /// Channels already opened and owned by the persistent inventory enumerator.
 ///
 /// Publications are keyed by OS HID node internally and selected by exact
@@ -161,7 +226,7 @@ impl<Node: Eq, Channel> Registry<Node, Channel> {
 /// oldest live node wins until it is removed.
 #[derive(Clone, Default)]
 pub struct ChannelRegistry {
-    inner: Registry<NodeId, Arc<HidppChannel>>,
+    inner: Registry<NodeId, RegisteredChannel>,
 }
 
 impl ChannelRegistry {
@@ -170,10 +235,16 @@ impl ChannelRegistry {
     pub(crate) fn replace_node(
         &self,
         node: NodeId,
-        routes: impl IntoIterator<Item = DeviceRoute>,
+        routes: impl IntoIterator<Item = PublishedRoute>,
         channel: Arc<HidppChannel>,
     ) {
-        self.inner.replace_node(node, routes, channel);
+        let routes = routes.into_iter().collect::<Vec<_>>();
+        let plain_routes = routes
+            .iter()
+            .map(|published| published.route.clone())
+            .collect::<Vec<_>>();
+        self.inner
+            .replace_node(node, plain_routes, RegisteredChannel { channel, routes });
     }
 
     /// Remove every route and channel reference owned by `node`.
@@ -189,17 +260,29 @@ impl ChannelRegistry {
     /// Clone the current exact-route winner.
     #[must_use]
     pub fn lookup(&self, route: &DeviceRoute) -> Option<SharedChannel> {
-        self.inner
-            .lookup(route)
-            .map(|channel| SharedChannel::new(channel, route.clone()))
+        self.inner.lookup(route).map(|registered| {
+            let cache_identity = registered
+                .routes
+                .iter()
+                .find(|published| published.route == *route)
+                .and_then(|published| published.identity.clone());
+            SharedChannel::with_cache_identity(registered.channel, route.clone(), cache_identity)
+        })
     }
 
-    /// Whether `shared` is still the winning publication for its exact route
-    /// and points to the same underlying connection.
+    /// Whether `shared` is still the winning publication for its exact route,
+    /// connection, and physical-device identity.
     #[must_use]
     pub fn is_current(&self, shared: &SharedChannel) -> bool {
-        self.inner.any_current(|route, channel| {
-            shared.matches(route) && Arc::ptr_eq(channel, shared.channel())
+        self.inner.any_current(|route, registered| {
+            let cache_identity = registered
+                .routes
+                .iter()
+                .find(|published| published.route == *route)
+                .and_then(|published| published.identity.as_ref());
+            shared.matches(route)
+                && Arc::ptr_eq(&registered.channel, shared.channel())
+                && shared.cache_identity_matches(cache_identity)
         })
     }
 }

--- a/crates/openlogi-device/src/channel/registry.rs
+++ b/crates/openlogi-device/src/channel/registry.rs
@@ -173,23 +173,27 @@ impl PublishedRoute {
         let identity = if identity_is_current {
             match route {
                 DeviceRoute::Direct { .. } => Some(DeviceCacheIdentity::Direct),
-                DeviceRoute::Bolt { .. } | DeviceRoute::Unifying { .. } => {
-                    paired.model_info.as_ref().and_then(|model| {
-                        let unit_id = (model.unit_id != [0; 4]).then_some(model.unit_id);
-                        let serial_number = model
-                            .serial_number
-                            .as_deref()
-                            .filter(|serial| !serial.is_empty())
-                            .map(str::to_owned);
-                        (unit_id.is_some() || serial_number.is_some()).then_some(
-                            DeviceCacheIdentity::Physical {
-                                unit_id,
-                                serial_number,
-                            },
-                        )
-                    })
-                }
-                DeviceRoute::RawHid { .. } => None,
+                DeviceRoute::Bolt { .. } => paired.model_info.as_ref().and_then(|model| {
+                    let unit_id = (model.unit_id != [0; 4]).then_some(model.unit_id);
+                    let serial_number = model
+                        .serial_number
+                        .as_deref()
+                        .filter(|serial| !serial.is_empty())
+                        .map(str::to_owned);
+                    (unit_id.is_some() || serial_number.is_some()).then_some(
+                        DeviceCacheIdentity::Physical {
+                            unit_id,
+                            serial_number,
+                        },
+                    )
+                }),
+                // Unifying arrival events identify only receiver + slot +
+                // model-level WPID. Its inventory probe cache is slot-keyed,
+                // so model_info may still describe the former occupant just
+                // after re-pairing. Without a live per-unit discriminator, a
+                // same-model replacement cannot be told apart safely. Raw HID
+                // routes do not carry HID++ feature metadata at all.
+                DeviceRoute::Unifying { .. } | DeviceRoute::RawHid { .. } => None,
             }
         } else {
             None

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -16,6 +16,7 @@ use tracing::{debug, warn};
 
 use crate::ChannelRegistry;
 use crate::backend::{BackendError, HidBackend, NodeId, NodeInfo};
+use crate::channel::registry::PublishedRoute;
 use crate::channel::route::{DeviceRoute, is_receiver_pid};
 use ledger::NodeLedger;
 
@@ -246,14 +247,17 @@ impl<Node: Eq + Hash + Clone, Channel> ChannelCache<Node, Channel> {
     }
 }
 
-fn routes_for_inventories(inventories: &[DeviceInventory]) -> Vec<DeviceRoute> {
+fn routes_for_inventories(
+    inventories: &[DeviceInventory],
+    identities_are_current: bool,
+) -> Vec<PublishedRoute> {
     inventories
         .iter()
         .flat_map(|inventory| {
-            inventory
-                .paired
-                .iter()
-                .filter_map(|paired| DeviceRoute::device_route_for(inventory, paired.slot))
+            inventory.paired.iter().filter_map(|paired| {
+                DeviceRoute::device_route_for(inventory, paired.slot)
+                    .map(|route| PublishedRoute::for_device(route, paired, identities_are_current))
+            })
         })
         .collect()
 }
@@ -636,6 +640,7 @@ impl Enumerator {
             all_complete &= probe.complete;
             all_healthy &= probe.healthy;
             outcomes.extend(probe.outcomes);
+            let identities_are_current = probe.healthy;
             let settled = self.ledger.settle(&node, probe.healthy, probe.inventory);
             // Every node waits for the ledger's consecutive-failure threshold,
             // receivers included. One full-budget timeout is not evidence of
@@ -664,7 +669,10 @@ impl Enumerator {
                     .inventory
                     .as_ref()
                     .map_or_else(Vec::new, |inventory| {
-                        routes_for_inventories(std::slice::from_ref(inventory))
+                        routes_for_inventories(
+                            std::slice::from_ref(inventory),
+                            identities_are_current,
+                        )
                     });
                 if routes.is_empty() {
                     registry.remove_node(&node);

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -173,6 +173,13 @@ fn with_unit_id(mut inventories: Vec<DeviceInventory>, unit_id: [u8; 4]) -> Vec<
     inventories
 }
 
+fn bolt_inventory(unit_id: [u8; 4]) -> Vec<DeviceInventory> {
+    let mut inventories = with_unit_id(inventory(&[1]), unit_id);
+    inventories[0].receiver.name = "Bolt Receiver".into();
+    inventories[0].receiver.product_id = 0xc548;
+    inventories
+}
+
 #[test]
 fn settled_inventories_publish_exact_receiver_routes() {
     let routes = |inventories: &[DeviceInventory]| {
@@ -206,8 +213,8 @@ fn settled_inventories_publish_exact_receiver_routes() {
 }
 
 #[test]
-fn replayed_inventory_does_not_reuse_a_physical_device_cache_scope() {
-    let replayed = routes_for_inventories(&with_unit_id(inventory(&[1]), [1, 2, 3, 4]), false);
+fn replayed_inventory_does_not_reuse_a_physical_device_cache_identity() {
+    let replayed = routes_for_inventories(&bolt_inventory([1, 2, 3, 4]), false);
 
     assert_eq!(
         replayed.len(),
@@ -222,11 +229,28 @@ fn replayed_inventory_does_not_reuse_a_physical_device_cache_scope() {
 
 #[test]
 fn physical_identity_changes_when_a_receiver_slot_is_repaired() {
-    let first = routes_for_inventories(&with_unit_id(inventory(&[1]), [1, 2, 3, 4]), true);
-    let replacement = routes_for_inventories(&with_unit_id(inventory(&[1]), [5, 6, 7, 8]), true);
+    let first = routes_for_inventories(&bolt_inventory([1, 2, 3, 4]), true);
+    let replacement = routes_for_inventories(&bolt_inventory([5, 6, 7, 8]), true);
 
     assert!(first[0].has_cache_identity());
     assert_ne!(first[0].cache_identity(), replacement[0].cache_identity());
+}
+
+#[test]
+fn unifying_slot_identity_is_never_used_for_dpi_caching() {
+    let published = routes_for_inventories(&with_unit_id(inventory(&[1]), [1, 2, 3, 4]), true);
+
+    assert_eq!(
+        published[0].route(),
+        &DeviceRoute::Unifying {
+            receiver_uid: "receiver-1".into(),
+            slot: 1,
+        }
+    );
+    assert!(
+        !published[0].has_cache_identity(),
+        "slot-keyed Unifying model info can belong to the former occupant"
+    );
 }
 
 #[test]

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -158,10 +158,31 @@ fn inventory(slots: &[u8]) -> Vec<DeviceInventory> {
     }]
 }
 
+fn with_unit_id(mut inventories: Vec<DeviceInventory>, unit_id: [u8; 4]) -> Vec<DeviceInventory> {
+    inventories[0].paired[0].model_info = Some(DeviceModelInfo {
+        entity_count: 1,
+        serial_number: None,
+        unit_id,
+        transports: DeviceTransports {
+            equad: true,
+            ..DeviceTransports::default()
+        },
+        model_ids: [0xb001, 0, 0],
+        extended_model_id: 0,
+    });
+    inventories
+}
+
 #[test]
 fn settled_inventories_publish_exact_receiver_routes() {
+    let routes = |inventories: &[DeviceInventory]| {
+        routes_for_inventories(inventories, true)
+            .into_iter()
+            .map(|published| published.route().clone())
+            .collect::<Vec<_>>()
+    };
     assert_eq!(
-        routes_for_inventories(&inventory(&[1, 4])),
+        routes(&inventory(&[1, 4])),
         vec![
             DeviceRoute::Unifying {
                 receiver_uid: "receiver-1".into(),
@@ -175,13 +196,37 @@ fn settled_inventories_publish_exact_receiver_routes() {
     );
 
     assert_eq!(
-        routes_for_inventories(&inventory(&[4])),
+        routes(&inventory(&[4])),
         vec![DeviceRoute::Unifying {
             receiver_uid: "receiver-1".into(),
             slot: 4,
         }],
         "a vanished slot must not survive the next atomic node replacement"
     );
+}
+
+#[test]
+fn replayed_inventory_does_not_reuse_a_physical_device_cache_scope() {
+    let replayed = routes_for_inventories(&with_unit_id(inventory(&[1]), [1, 2, 3, 4]), false);
+
+    assert_eq!(
+        replayed.len(),
+        1,
+        "the device remains visible during replay"
+    );
+    assert!(
+        !replayed[0].has_cache_identity(),
+        "an unverified snapshot must not lend stale feature metadata to a replacement device"
+    );
+}
+
+#[test]
+fn physical_identity_changes_when_a_receiver_slot_is_repaired() {
+    let first = routes_for_inventories(&with_unit_id(inventory(&[1]), [1, 2, 3, 4]), true);
+    let replacement = routes_for_inventories(&with_unit_id(inventory(&[1]), [5, 6, 7, 8]), true);
+
+    assert!(first[0].has_cache_identity());
+    assert_ne!(first[0].cache_identity(), replacement[0].cache_identity());
 }
 
 #[test]
@@ -206,7 +251,10 @@ fn settled_direct_inventory_publishes_one_direct_route() {
     }];
 
     assert_eq!(
-        routes_for_inventories(&direct),
+        routes_for_inventories(&direct, true)
+            .into_iter()
+            .map(|published| published.route().clone())
+            .collect::<Vec<_>>(),
         vec![DeviceRoute::Direct {
             vendor_id: 0x046d,
             product_id: 0xb35b,

--- a/crates/openlogi-device/src/write/dpi.rs
+++ b/crates/openlogi-device/src/write/dpi.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use hidpp::{
     device::Device,
@@ -26,6 +26,16 @@ pub use openlogi_core::hid::dpi::{Dpi, DpiCapabilities, DpiInfo};
 /// per device, and every Logitech pointing device reports its pointer sensor
 /// first.
 const SENSOR: u8 = 0;
+
+/// Brief pause before retrying a valid DPI write that the firmware rejected as
+/// transiently busy/internal. The PRO X SUPERLIGHT 2 DEX has been observed to
+/// return either response while processing closely spaced host writes, then
+/// accept the identical request immediately afterward.
+const TRANSIENT_WRITE_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+/// One initial write plus this many retries keeps the live control responsive
+/// without turning a genuinely wedged device into a long-running IPC call.
+const TRANSIENT_WRITE_RETRIES: u8 = 2;
 
 /// Whichever DPI feature a device actually exposes.
 ///
@@ -121,21 +131,31 @@ impl DpiFeature {
                 // not asked to change. Writing a bare `lod` would silently
                 // retune the sensor's lift-off height.
                 let current = feature.get_sensor_dpi_parameters(SENSOR).await?;
-                feature
-                    .set_sensor_dpi_parameters(
-                        SENSOR,
-                        SetDpiParameters {
-                            dpi_x: dpi,
-                            // The spec has the host send 0 for dpiY when the
-                            // sensor has no independent Y axis, and reports 0
-                            // on read in exactly that case. When it does have
-                            // one, keep the axes locked together — the UI
-                            // exposes a single DPI.
-                            dpi_y: if current.dpi_y == 0 { 0 } else { dpi },
-                            lod: current.lod,
-                        },
-                    )
-                    .await
+                let params = SetDpiParameters {
+                    dpi_x: dpi,
+                    // The spec has the host send 0 for dpiY when the sensor
+                    // has no independent Y axis, and reports 0 on read in
+                    // exactly that case. When it does have one, keep the axes
+                    // locked together — the UI exposes a single DPI.
+                    dpi_y: if current.dpi_y == 0 { 0 } else { dpi },
+                    lod: current.lod,
+                };
+                let mut retries = 0;
+                loop {
+                    let result = feature.set_sensor_dpi_parameters(SENSOR, params).await;
+                    let transient = matches!(
+                        &result,
+                        Err(Hidpp20Error::Feature(
+                            ErrorType::Busy | ErrorType::LogitechInternal
+                        ))
+                    );
+                    if !transient || retries >= TRANSIENT_WRITE_RETRIES {
+                        break result;
+                    }
+                    retries += 1;
+                    debug!(retries, %dpi, "retrying transient extended-DPI write");
+                    tokio::time::sleep(TRANSIENT_WRITE_RETRY_DELAY).await;
+                }
             }
         }
     }

--- a/crates/openlogi-device/src/write/dpi.rs
+++ b/crates/openlogi-device/src/write/dpi.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, LazyLock, Mutex, PoisonError, Weak},
+    time::Duration,
+};
 
 use hidpp::{
     device::Device,
@@ -46,12 +49,36 @@ const TRANSIENT_WRITE_RETRIES: u8 = 2;
 /// `0x2202`-only mouse gets a panel that cannot read or write anything.
 enum DpiFeature {
     /// `0x2201` — one DPI per sensor, described as a flat list of values.
-    Adjustable(Arc<AdjustableDpiFeature>),
+    Adjustable {
+        feature: Arc<AdjustableDpiFeature>,
+        index: u8,
+    },
 
     /// `0x2202` — independent X/Y DPI plus lift-off distance, described as a
     /// mix of fixed values and stepped ranges.
-    Extended(Arc<ExtendedDpiFeature>),
+    Extended {
+        feature: Arc<ExtendedDpiFeature>,
+        index: u8,
+    },
 }
+
+#[derive(Clone, Copy)]
+enum DpiFeatureAddress {
+    Adjustable(u8),
+    Extended(u8),
+}
+
+struct DpiCacheEntry {
+    channel: Weak<hidpp::channel::HidppChannel>,
+    device_index: u8,
+    feature: DpiFeatureAddress,
+    capabilities: Option<DpiCapabilities>,
+}
+
+/// DPI feature addresses and ranges are immutable for one open HID++ channel.
+/// Keep them beside a weak channel reference so repeated UI reads and startup
+/// re-applies skip the root handshake without pinning a retired receiver.
+static DPI_CACHE: LazyLock<Mutex<Vec<DpiCacheEntry>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
 impl DpiFeature {
     /// Opens whichever DPI feature `device` exposes, preferring `0x2201`.
@@ -62,10 +89,16 @@ impl DpiFeature {
     /// exactly as it did before.
     async fn open(device: &mut Device) -> Result<Self, WriteError> {
         if let Some(index) = feature_index(device, AdjustableDpiFeature::ID).await? {
-            return Ok(Self::Adjustable(device.add_feature(index)));
+            return Ok(Self::Adjustable {
+                feature: device.add_feature(index),
+                index,
+            });
         }
         if let Some(index) = feature_index(device, ExtendedDpiFeature::ID).await? {
-            return Ok(Self::Extended(device.add_feature(index)));
+            return Ok(Self::Extended {
+                feature: device.add_feature(index),
+                index,
+            });
         }
         // Neither ID is present. Name the canonical one in the error: a caller
         // reading "0x2201 unsupported" is being told this device has no DPI
@@ -78,24 +111,31 @@ impl DpiFeature {
     /// The HID++ feature ID being driven, for error reporting.
     const fn id(&self) -> u16 {
         match self {
-            Self::Adjustable(_) => AdjustableDpiFeature::ID,
-            Self::Extended(_) => ExtendedDpiFeature::ID,
+            Self::Adjustable { .. } => AdjustableDpiFeature::ID,
+            Self::Extended { .. } => ExtendedDpiFeature::ID,
+        }
+    }
+
+    const fn address(&self) -> DpiFeatureAddress {
+        match self {
+            Self::Adjustable { index, .. } => DpiFeatureAddress::Adjustable(*index),
+            Self::Extended { index, .. } => DpiFeatureAddress::Extended(*index),
         }
     }
 
     /// The number of motion sensors the device reports.
     async fn sensor_count(&self) -> Result<u8, Hidpp20Error> {
         match self {
-            Self::Adjustable(feature) => feature.get_sensor_count().await,
-            Self::Extended(feature) => feature.get_sensor_count().await,
+            Self::Adjustable { feature, .. } => feature.get_sensor_count().await,
+            Self::Extended { feature, .. } => feature.get_sensor_count().await,
         }
     }
 
     /// The DPI currently configured on [`SENSOR`].
     async fn current_dpi(&self) -> Result<Dpi, Hidpp20Error> {
         match self {
-            Self::Adjustable(feature) => feature.get_sensor_dpi(SENSOR).await.map(Dpi::from),
-            Self::Extended(feature) => Ok(feature
+            Self::Adjustable { feature, .. } => feature.get_sensor_dpi(SENSOR).await.map(Dpi::from),
+            Self::Extended { feature, .. } => Ok(feature
                 .get_sensor_dpi_parameters(SENSOR)
                 .await?
                 .dpi_x
@@ -106,8 +146,8 @@ impl DpiFeature {
     /// Every DPI value [`SENSOR`] accepts, as a flat list.
     async fn supported_dpi(&self) -> Result<Vec<u16>, Hidpp20Error> {
         match self {
-            Self::Adjustable(feature) => feature.get_sensor_dpi_list(SENSOR).await,
-            Self::Extended(feature) => {
+            Self::Adjustable { feature, .. } => feature.get_sensor_dpi_list(SENSOR).await,
+            Self::Extended { feature, .. } => {
                 // `getSensorDpiList` (function 3) only answers on sensors that
                 // support profiles; the range description is the one every
                 // 0x2202 sensor reports. X is the axis the UI drives.
@@ -120,17 +160,26 @@ impl DpiFeature {
     }
 
     /// Sets [`SENSOR`]'s DPI.
-    async fn set_dpi(&self, dpi: Dpi) -> Result<(), Hidpp20Error> {
+    async fn set_dpi(&self, dpi: Dpi) -> Result<bool, Hidpp20Error> {
         let dpi = dpi.into();
         match self {
-            Self::Adjustable(feature) => feature.set_sensor_dpi(SENSOR, dpi).await,
-            Self::Extended(feature) => {
+            Self::Adjustable { feature, .. } => {
+                if feature.get_sensor_dpi(SENSOR).await? == dpi {
+                    return Ok(false);
+                }
+                feature.set_sensor_dpi(SENSOR, dpi).await?;
+                Ok(true)
+            }
+            Self::Extended { feature, .. } => {
                 // `setSensorDpiParameters` writes DPI X, DPI Y and lift-off
                 // distance in one packet with no "leave unchanged" encoding, so
                 // read the current parameters first and put back what we are
                 // not asked to change. Writing a bare `lod` would silently
                 // retune the sensor's lift-off height.
                 let current = feature.get_sensor_dpi_parameters(SENSOR).await?;
+                if current.dpi_x == dpi && (current.dpi_y == 0 || current.dpi_y == dpi) {
+                    return Ok(false);
+                }
                 let params = SetDpiParameters {
                     dpi_x: dpi,
                     // The spec has the host send 0 for dpiY when the sensor
@@ -150,7 +199,8 @@ impl DpiFeature {
                         ))
                     );
                     if !transient || retries >= TRANSIENT_WRITE_RETRIES {
-                        break result;
+                        result?;
+                        return Ok(true);
                     }
                     retries += 1;
                     debug!(retries, %dpi, "retrying transient extended-DPI write");
@@ -159,6 +209,106 @@ impl DpiFeature {
             }
         }
     }
+}
+
+impl DpiFeatureAddress {
+    fn bind(self, channel: &Arc<hidpp::channel::HidppChannel>, device_index: u8) -> DpiFeature {
+        match self {
+            Self::Adjustable(index) => DpiFeature::Adjustable {
+                feature: Arc::new(AdjustableDpiFeature::new(
+                    Arc::clone(channel),
+                    device_index,
+                    index,
+                )),
+                index,
+            },
+            Self::Extended(index) => DpiFeature::Extended {
+                feature: Arc::new(ExtendedDpiFeature::new(
+                    Arc::clone(channel),
+                    device_index,
+                    index,
+                )),
+                index,
+            },
+        }
+    }
+}
+
+fn cached_dpi(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    device_index: u8,
+) -> Option<(DpiFeatureAddress, Option<DpiCapabilities>)> {
+    let mut cache = DPI_CACHE.lock().unwrap_or_else(PoisonError::into_inner);
+    cache.retain(|entry| entry.channel.strong_count() > 0);
+    cache
+        .iter()
+        .find(|entry| {
+            entry.device_index == device_index
+                && entry
+                    .channel
+                    .upgrade()
+                    .is_some_and(|cached| Arc::ptr_eq(&cached, channel))
+        })
+        .map(|entry| (entry.feature, entry.capabilities.clone()))
+}
+
+fn cache_dpi_feature(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    device_index: u8,
+    feature: DpiFeatureAddress,
+) {
+    let mut cache = DPI_CACHE.lock().unwrap_or_else(PoisonError::into_inner);
+    cache.retain(|entry| entry.channel.strong_count() > 0);
+    if let Some(entry) = cache.iter_mut().find(|entry| {
+        entry.device_index == device_index
+            && entry
+                .channel
+                .upgrade()
+                .is_some_and(|cached| Arc::ptr_eq(&cached, channel))
+    }) {
+        entry.feature = feature;
+        return;
+    }
+    cache.push(DpiCacheEntry {
+        channel: Arc::downgrade(channel),
+        device_index,
+        feature,
+        capabilities: None,
+    });
+}
+
+fn cache_dpi_capabilities(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    device_index: u8,
+    capabilities: DpiCapabilities,
+) {
+    let mut cache = DPI_CACHE.lock().unwrap_or_else(PoisonError::into_inner);
+    if let Some(entry) = cache.iter_mut().find(|entry| {
+        entry.device_index == device_index
+            && entry
+                .channel
+                .upgrade()
+                .is_some_and(|cached| Arc::ptr_eq(&cached, channel))
+    }) {
+        entry.capabilities = Some(capabilities);
+    }
+}
+
+async fn open_dpi_feature(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    device_index: u8,
+) -> Result<(DpiFeature, Option<DpiCapabilities>), WriteError> {
+    if let Some((address, capabilities)) = cached_dpi(channel, device_index) {
+        return Ok((address.bind(channel, device_index), capabilities));
+    }
+    let mut device = Device::new(Arc::clone(channel), device_index)
+        .await
+        .map_err(|_| WriteError::DeviceUnreachable {
+            index: device_index,
+        })?;
+    let feature = DpiFeature::open(&mut device).await?;
+    cache_dpi_feature(channel, device_index, feature.address());
+    Ok((feature, None))
 }
 
 /// Resolves `feature_hex` to its runtime index, or `None` when the device does
@@ -219,10 +369,7 @@ async fn get_dpi_on_channel(
     channel: &Arc<hidpp::channel::HidppChannel>,
     index: u8,
 ) -> Result<Dpi, WriteError> {
-    let mut device = Device::new(Arc::clone(channel), index)
-        .await
-        .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = DpiFeature::open(&mut device).await?;
+    let (feature, _) = open_dpi_feature(channel, index).await?;
     feature
         .current_dpi()
         .await
@@ -260,11 +407,18 @@ pub(super) async fn get_dpi_info_on_channel(
     channel: &Arc<hidpp::channel::HidppChannel>,
     index: u8,
 ) -> Result<DpiInfo, WriteError> {
-    let mut device = Device::new(Arc::clone(channel), index)
-        .await
-        .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = DpiFeature::open(&mut device).await?;
+    let (feature, cached_capabilities) = open_dpi_feature(channel, index).await?;
     let feature_hex = feature.id();
+    if let Some(capabilities) = cached_capabilities {
+        let current = feature
+            .current_dpi()
+            .await
+            .map_err(|e| classify_dpi_error(feature_hex, e))?;
+        return Ok(DpiInfo {
+            current,
+            capabilities,
+        });
+    }
     let sensor_count = feature
         .sensor_count()
         .await
@@ -282,9 +436,11 @@ pub(super) async fn get_dpi_info_on_channel(
         .supported_dpi()
         .await
         .map_err(|e| classify_dpi_error(feature_hex, e))?;
+    let capabilities = DpiCapabilities::new(values)?;
+    cache_dpi_capabilities(channel, index, capabilities.clone());
     Ok(DpiInfo {
         current,
-        capabilities: DpiCapabilities::new(values)?,
+        capabilities,
     })
 }
 
@@ -309,14 +465,15 @@ pub(super) async fn set_dpi_on_channel(
     index: u8,
     dpi: Dpi,
 ) -> Result<(), WriteError> {
-    let mut device = Device::new(Arc::clone(channel), index)
-        .await
-        .map_err(|_| WriteError::DeviceUnreachable { index })?;
-    let feature = DpiFeature::open(&mut device).await?;
-    feature
+    let (feature, _) = open_dpi_feature(channel, index).await?;
+    let wrote = feature
         .set_dpi(dpi)
         .await
         .map_err(|e| classify_hidpp_error(e, HidppOperation::WriteDpi, feature.id()))?;
+    if !wrote {
+        debug!(index, %dpi, "DPI already matches; write skipped");
+        return Ok(());
+    }
     // Read back to confirm the firmware accepted the value. A mismatch is a
     // silent failure mode that's otherwise invisible — devices in low-power
     // states or with unsupported DPI ranges can ACK the write yet keep the old

--- a/crates/openlogi-device/src/write/dpi.rs
+++ b/crates/openlogi-device/src/write/dpi.rs
@@ -16,6 +16,7 @@ use tracing::debug;
 
 use crate::SharedChannel;
 use crate::backend::HidBackend;
+use crate::channel::DeviceCacheIdentity;
 use crate::channel::route::DeviceRoute;
 
 use super::{HidppOperation, WriteError, classify_hidpp_error, with_route};
@@ -70,14 +71,16 @@ enum DpiFeatureAddress {
 
 struct DpiCacheEntry {
     channel: Weak<hidpp::channel::HidppChannel>,
+    identity: DeviceCacheIdentity,
     device_index: u8,
     feature: DpiFeatureAddress,
     capabilities: Option<DpiCapabilities>,
 }
 
-/// DPI feature addresses and ranges are immutable for one open HID++ channel.
-/// Keep them beside a weak channel reference so repeated UI reads and startup
-/// re-applies skip the root handshake without pinning a retired receiver.
+/// DPI feature addresses and ranges are immutable for one physical device.
+/// Keep them beside a weak channel and physical identity so repeated UI
+/// reads skip the root handshake without pinning a retired receiver or letting
+/// a newly paired mouse inherit the former occupant's metadata.
 static DPI_CACHE: LazyLock<Mutex<Vec<DpiCacheEntry>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 
 impl DpiFeature {
@@ -236,14 +239,17 @@ impl DpiFeatureAddress {
 
 fn cached_dpi(
     channel: &Arc<hidpp::channel::HidppChannel>,
+    identity: Option<&DeviceCacheIdentity>,
     device_index: u8,
 ) -> Option<(DpiFeatureAddress, Option<DpiCapabilities>)> {
+    let identity = identity?;
     let mut cache = DPI_CACHE.lock().unwrap_or_else(PoisonError::into_inner);
     cache.retain(|entry| entry.channel.strong_count() > 0);
     cache
         .iter()
         .find(|entry| {
             entry.device_index == device_index
+                && entry.identity == *identity
                 && entry
                     .channel
                     .upgrade()
@@ -254,13 +260,18 @@ fn cached_dpi(
 
 fn cache_dpi_feature(
     channel: &Arc<hidpp::channel::HidppChannel>,
+    identity: Option<&DeviceCacheIdentity>,
     device_index: u8,
     feature: DpiFeatureAddress,
 ) {
+    let Some(identity) = identity else {
+        return;
+    };
     let mut cache = DPI_CACHE.lock().unwrap_or_else(PoisonError::into_inner);
     cache.retain(|entry| entry.channel.strong_count() > 0);
     if let Some(entry) = cache.iter_mut().find(|entry| {
         entry.device_index == device_index
+            && entry.identity == *identity
             && entry
                 .channel
                 .upgrade()
@@ -271,6 +282,7 @@ fn cache_dpi_feature(
     }
     cache.push(DpiCacheEntry {
         channel: Arc::downgrade(channel),
+        identity: identity.clone(),
         device_index,
         feature,
         capabilities: None,
@@ -279,12 +291,17 @@ fn cache_dpi_feature(
 
 fn cache_dpi_capabilities(
     channel: &Arc<hidpp::channel::HidppChannel>,
+    identity: Option<&DeviceCacheIdentity>,
     device_index: u8,
     capabilities: DpiCapabilities,
 ) {
+    let Some(identity) = identity else {
+        return;
+    };
     let mut cache = DPI_CACHE.lock().unwrap_or_else(PoisonError::into_inner);
     if let Some(entry) = cache.iter_mut().find(|entry| {
         entry.device_index == device_index
+            && entry.identity == *identity
             && entry
                 .channel
                 .upgrade()
@@ -296,9 +313,10 @@ fn cache_dpi_capabilities(
 
 async fn open_dpi_feature(
     channel: &Arc<hidpp::channel::HidppChannel>,
+    identity: Option<&DeviceCacheIdentity>,
     device_index: u8,
 ) -> Result<(DpiFeature, Option<DpiCapabilities>), WriteError> {
-    if let Some((address, capabilities)) = cached_dpi(channel, device_index) {
+    if let Some((address, capabilities)) = cached_dpi(channel, identity, device_index) {
         return Ok((address.bind(channel, device_index), capabilities));
     }
     let mut device = Device::new(Arc::clone(channel), device_index)
@@ -307,7 +325,7 @@ async fn open_dpi_feature(
             index: device_index,
         })?;
     let feature = DpiFeature::open(&mut device).await?;
-    cache_dpi_feature(channel, device_index, feature.address());
+    cache_dpi_feature(channel, identity, device_index, feature.address());
     Ok((feature, None))
 }
 
@@ -369,7 +387,7 @@ async fn get_dpi_on_channel(
     channel: &Arc<hidpp::channel::HidppChannel>,
     index: u8,
 ) -> Result<Dpi, WriteError> {
-    let (feature, _) = open_dpi_feature(channel, index).await?;
+    let (feature, _) = open_dpi_feature(channel, None, index).await?;
     feature
         .current_dpi()
         .await
@@ -407,7 +425,15 @@ pub(super) async fn get_dpi_info_on_channel(
     channel: &Arc<hidpp::channel::HidppChannel>,
     index: u8,
 ) -> Result<DpiInfo, WriteError> {
-    let (feature, cached_capabilities) = open_dpi_feature(channel, index).await?;
+    get_dpi_info_on_identified_channel(channel, None, index).await
+}
+
+async fn get_dpi_info_on_identified_channel(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    identity: Option<&DeviceCacheIdentity>,
+    index: u8,
+) -> Result<DpiInfo, WriteError> {
+    let (feature, cached_capabilities) = open_dpi_feature(channel, identity, index).await?;
     let feature_hex = feature.id();
     if let Some(capabilities) = cached_capabilities {
         let current = feature
@@ -437,7 +463,7 @@ pub(super) async fn get_dpi_info_on_channel(
         .await
         .map_err(|e| classify_dpi_error(feature_hex, e))?;
     let capabilities = DpiCapabilities::new(values)?;
-    cache_dpi_capabilities(channel, index, capabilities.clone());
+    cache_dpi_capabilities(channel, identity, index, capabilities.clone());
     Ok(DpiInfo {
         current,
         capabilities,
@@ -465,7 +491,16 @@ pub(super) async fn set_dpi_on_channel(
     index: u8,
     dpi: Dpi,
 ) -> Result<(), WriteError> {
-    let (feature, _) = open_dpi_feature(channel, index).await?;
+    set_dpi_on_identified_channel(channel, None, index, dpi).await
+}
+
+async fn set_dpi_on_identified_channel(
+    channel: &Arc<hidpp::channel::HidppChannel>,
+    identity: Option<&DeviceCacheIdentity>,
+    index: u8,
+    dpi: Dpi,
+) -> Result<(), WriteError> {
+    let (feature, _) = open_dpi_feature(channel, identity, index).await?;
     let wrote = feature
         .set_dpi(dpi)
         .await
@@ -500,10 +535,21 @@ pub(super) async fn set_dpi_on_channel(
 /// Write DPI on an already-open [`SharedChannel`] — the fast path that skips
 /// enumeration and channel setup.
 pub async fn set_dpi_on(shared: &SharedChannel, dpi: Dpi) -> Result<(), WriteError> {
-    set_dpi_on_channel(shared.channel(), shared.device_index(), dpi).await
+    set_dpi_on_identified_channel(
+        shared.channel(),
+        shared.cache_identity(),
+        shared.device_index(),
+        dpi,
+    )
+    .await
 }
 
 /// Read current DPI and supported values on an already-open [`SharedChannel`].
 pub async fn get_dpi_info_on(shared: &SharedChannel) -> Result<DpiInfo, WriteError> {
-    get_dpi_info_on_channel(shared.channel(), shared.device_index()).await
+    get_dpi_info_on_identified_channel(
+        shared.channel(),
+        shared.cache_identity(),
+        shared.device_index(),
+    )
+    .await
 }

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -5,6 +5,7 @@ use hidpp::feature::smartshift::WheelMode;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::SharedChannel;
+use crate::channel::DeviceCacheIdentity;
 use crate::channel::scripted::{ScriptedRawHidChannel, feature_error, scripted_channel};
 use crate::write::diagnostics::dump_firmware_entities_on_channel;
 use crate::write::dpi::expand_dpi_ranges;
@@ -366,6 +367,64 @@ async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Resul
     // Lift-off distance is read back and rewritten unchanged — the packet has
     // no "leave alone" encoding, so writing a bare 0 would retune the sensor.
     assert_eq!(write[9], u8::from(Lod::Medium));
+    Ok(())
+}
+
+#[tokio::test]
+async fn replacing_a_mouse_in_one_receiver_slot_reprobes_dpi_capabilities() -> Result<(), WriteError>
+{
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(extended_dpi_scripted_response);
+    let channel = scripted_channel(raw).await;
+    let route = DeviceRoute::Bolt {
+        receiver_uid: "AABB".into(),
+        slot: 2,
+    };
+    let first_identity = DeviceCacheIdentity::Physical {
+        unit_id: Some([1, 2, 3, 4]),
+        serial_number: None,
+    };
+    let first_mouse = SharedChannel::with_cache_identity(
+        Arc::clone(&channel),
+        route.clone(),
+        Some(first_identity.clone()),
+    );
+    get_dpi_info_on(&first_mouse).await?;
+
+    let reports_before_refresh = handle.written_reports().len();
+    let refreshed_handle = SharedChannel::with_cache_identity(
+        Arc::clone(&channel),
+        route.clone(),
+        Some(first_identity),
+    );
+    get_dpi_info_on(&refreshed_handle).await?;
+    assert_eq!(
+        handle.written_reports().len() - reports_before_refresh,
+        1,
+        "a normal inventory refresh for the same mouse should keep the fast path"
+    );
+
+    let reports_before_replacement = handle.written_reports().len();
+    let replacement = SharedChannel::with_cache_identity(
+        channel,
+        route,
+        Some(DeviceCacheIdentity::Physical {
+            unit_id: Some([5, 6, 7, 8]),
+            serial_number: None,
+        }),
+    );
+    get_dpi_info_on(&replacement).await?;
+    let replacement_reports = &handle.written_reports()[reports_before_replacement..];
+
+    assert!(
+        replacement_reports
+            .iter()
+            .any(|report| report[2] == 0x00 && report[3] >> 4 == 0x00),
+        "a replacement device must resolve its DPI feature instead of inheriting the old index"
+    );
+    assert!(
+        replacement_reports.len() > 1,
+        "a replacement device must reload its range instead of reading only current DPI"
+    );
     Ok(())
 }
 

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use hidpp::feature::extended_dpi::{DpiRange, Lod};
 use hidpp::feature::per_key_lighting::FramePersistence;
 use hidpp::feature::smartshift::WheelMode;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::SharedChannel;
 use crate::channel::scripted::{ScriptedRawHidChannel, feature_error, scripted_channel};
@@ -357,6 +358,62 @@ async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Resul
     Ok(())
 }
 
+#[tokio::test]
+async fn extended_dpi_retries_a_transient_firmware_rejection() -> Result<(), WriteError> {
+    EXTENDED_DPI_TRANSIENT_WRITES.store(0, Ordering::SeqCst);
+    let (raw, handle) =
+        ScriptedRawHidChannel::with_responder(extended_dpi_transient_write_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    set_dpi_on(&shared, Dpi::new(1200)).await?;
+
+    let write_count = handle
+        .written_reports()
+        .iter()
+        .filter(|report| report.len() == 20 && report[2] == 0x05 && report[3] >> 4 == 0x06)
+        .count();
+    assert_eq!(write_count, 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn extended_dpi_stops_after_the_bounded_transient_retries() {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(extended_dpi_rejected_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    let error = set_dpi_on(&shared, Dpi::new(1200))
+        .await
+        .expect_err("a persistently rejected write must still fail");
+    assert!(matches!(
+        error,
+        WriteError::HidppFeature {
+            operation: HidppOperation::WriteDpi,
+            kind: HidppFeatureErrorKind::LogitechInternal,
+            ..
+        }
+    ));
+    let write_count = handle
+        .written_reports()
+        .iter()
+        .filter(|report| report.len() == 20 && report[2] == 0x05 && report[3] >> 4 == 0x06)
+        .count();
+    assert_eq!(write_count, 3);
+}
+
 #[test]
 fn zone_presence_bits_decode_lsb_first_from_the_page_base() {
     let mut bitfield = [0u8; 14];
@@ -552,6 +609,23 @@ fn extended_dpi_scripted_response(request: &[u8]) -> Option<Vec<u8>> {
     let payload_len = response.len() - 4;
     response[4..].copy_from_slice(&payload[..payload_len]);
     Some(response)
+}
+
+static EXTENDED_DPI_TRANSIENT_WRITES: AtomicUsize = AtomicUsize::new(0);
+
+fn extended_dpi_transient_write_response(request: &[u8]) -> Option<Vec<u8>> {
+    let is_set = request.len() == 20 && request[2] == 0x05 && request[3] >> 4 == 0x06;
+    if is_set && EXTENDED_DPI_TRANSIENT_WRITES.fetch_add(1, Ordering::SeqCst) == 0 {
+        return Some(feature_error(request, 0x05));
+    }
+    extended_dpi_scripted_response(request)
+}
+
+fn extended_dpi_rejected_response(request: &[u8]) -> Option<Vec<u8>> {
+    let is_set = request.len() == 20 && request[2] == 0x05 && request[3] >> 4 == 0x06;
+    is_set
+        .then(|| feature_error(request, 0x05))
+        .or_else(|| extended_dpi_scripted_response(request))
 }
 
 /// A keyboard that exposes `0x8081 PerKeyLighting2` and neither `0x8070`

--- a/crates/openlogi-device/src/write/tests.rs
+++ b/crates/openlogi-device/src/write/tests.rs
@@ -340,6 +340,17 @@ async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Resul
         ]
     );
 
+    // The feature address and immutable range belong to this open channel.
+    // A second panel load should read only the volatile current DPI instead of
+    // repeating the root handshake, feature lookups, sensor count and range.
+    let reports_before_cached_read = handle.written_reports().len();
+    let cached = get_dpi_info_on(&shared).await?;
+    assert_eq!(cached, dpi);
+    let cached_read_reports = &handle.written_reports()[reports_before_cached_read..];
+    assert_eq!(cached_read_reports.len(), 1);
+    assert_eq!(cached_read_reports[0][2], 0x05);
+    assert_eq!(cached_read_reports[0][3] >> 4, 0x05);
+
     set_dpi_on(&shared, Dpi::new(1200)).await?;
 
     // setSensorDpiParameters is a long request on function 6 of feature index
@@ -355,6 +366,29 @@ async fn dpi_reads_and_writes_work_on_a_device_with_only_extended_dpi() -> Resul
     // Lift-off distance is read back and rewritten unchanged — the packet has
     // no "leave alone" encoding, so writing a bare 0 would retune the sensor.
     assert_eq!(write[9], u8::from(Lod::Medium));
+    Ok(())
+}
+
+#[tokio::test]
+async fn matching_extended_dpi_skips_the_firmware_write() -> Result<(), WriteError> {
+    let (raw, handle) = ScriptedRawHidChannel::with_responder(extended_dpi_scripted_response);
+    let channel = scripted_channel(raw).await;
+    let shared = SharedChannel::new(
+        channel,
+        DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb35b,
+        },
+    );
+
+    set_dpi_on(&shared, Dpi::new(800)).await?;
+
+    assert!(
+        handle
+            .written_reports()
+            .iter()
+            .all(|report| report.len() != 20 || report[2] != 0x05 || report[3] >> 4 != 0x06)
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Opening the pointer panel repeatedly asks the device for the DPI feature address, sensor count, current value, and full supported range. Startup reapply can repeat much of the same work.

Cache the feature address and immutable capabilities when the open HID++ channel can be tied to a trustworthy physical-device identity. Later panel reads request only the current DPI, and a startup write is skipped when the mouse already has the saved value.

## Changes

- Key cached metadata by the open channel, route, and physical unit/serial identity for Bolt/Lightspeed devices.
- Keep direct-device caching scoped to the device-specific open channel.
- Bypass DPI metadata caching for Unifying slots because their inventory cache is slot-keyed and the arrival protocol has no per-unit discriminator.
- Disable receiver-side caching when current physical identity is unavailable or inventory is being replayed after a failed probe.
- Fetch supported values again after a receiver slot is re-paired or the channel reconnects.
- Keep only a weak channel reference so retired receivers are not kept alive.
- Skip the firmware write when the current DPI already matches.

## Testing

- `cargo test -p openlogi-device -p openlogi-desktop -p openlogi-agent-core -p openlogi-agent`
- `cargo clippy -p openlogi-device -p openlogi-desktop -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- Verified a stable identified device refresh sends only the current-DPI request.
- Verified a replacement in the same Bolt/Lightspeed receiver slot performs a full feature and range probe.
- Verified stale or unidentified receiver inventory cannot reuse cached metadata.
- Verified Unifying slot identity never authorizes DPI caching, even when slot-cached model info is present.
- Verified a matching value sends no firmware write.

## Dependency

This is stacked on #851 because both changes touch the extended-DPI write path. The extra commits will drop out of this diff when that PR lands.