### PR TITLE
docs: fix spelling errors

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -1048,7 +1048,7 @@ fn is_hidpp_device(device: &AgentDevice) -> bool {
 }
 
 /// Replace the value behind an `RwLock`, logging (not panicking) on poison so a
-/// background thread that paniced while holding the lock can't take the agent
+/// background thread that panicked while holding the lock can't take the agent
 /// down — it just keeps the stale value until the next successful rebuild.
 fn write_value<T>(lock: &RwLock<T>, value: T, name: &str) {
     match lock.write() {

--- a/crates/openlogi-hidpp/src/feature/reprog_controls/task_ids.rs
+++ b/crates/openlogi-hidpp/src/feature/reprog_controls/task_ids.rs
@@ -126,7 +126,7 @@ pub const TBD: TaskId = TaskId(0xB9);
 /// `Multiplatform Language Switch` (`0xBA`).
 pub const MULTIPLATFORM_LANGUAGE_SWITCH: TaskId = TaskId(0xBA);
 
-/// `SWCustomHighligt2` (`0xBB`).
+/// `SWCustomHighlight2` (`0xBB`).
 pub const SW_CUSTOM_HIGHLIGHT_2: TaskId = TaskId(0xBB);
 
 /// `FastForward` (`0xBC`).

--- a/crates/openlogi-hidpp/src/feature/thumbwheel.rs
+++ b/crates/openlogi-hidpp/src/feature/thumbwheel.rs
@@ -113,7 +113,7 @@ pub struct ThumbwheelInfo {
     /// [`ThumbwheelStatusUpdate::rotation`] value.
     pub default_direction: ThumbwheelDirection,
 
-    /// The capabilites of the thumbwheel.
+    /// The capabilities of the thumbwheel.
     pub capabilities: ThumbwheelCapabilities,
 }
 

--- a/crates/openlogi-hidpp/src/feature/unified_battery.rs
+++ b/crates/openlogi-hidpp/src/feature/unified_battery.rs
@@ -72,7 +72,7 @@ impl UnifiedBatteryFeature {
     }
 }
 
-/// Represents the capabilites of this feature and the battery itself.
+/// Represents the capabilities of this feature and the battery itself.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]

--- a/crates/openlogi-hidpp/src/lib.rs
+++ b/crates/openlogi-hidpp/src/lib.rs
@@ -70,7 +70,7 @@
 //!
 //! // HID++2.0 includes an arbitrary "software ID" in every message.
 //! // This ID is meant to differentiate messages of different
-//! // softwares, but it can also be used to ease the mapping of
+//! // software, but it can also be used to ease the mapping of
 //! // incoming messages to previously sent outgoing messages by
 //! // rotating it after every sent message.
 //! // By default, the software ID is `0x01` and will not rotate.

--- a/crates/openlogi-hidpp/src/protocol/v10.rs
+++ b/crates/openlogi-hidpp/src/protocol/v10.rs
@@ -326,7 +326,7 @@ pub enum ErrorType {
     /// The receiver indicates that too many devices are connected to it.
     TooManyDevices = 0x05,
 
-    /// The reciever indicates that something already exists. This error is not
+    /// The receiver indicates that something already exists. This error is not
     /// further documented, please let me know what it means.
     AlreadyExists = 0x06,
 


### PR DESCRIPTION
## Summary

Fix spelling errors in Rust comments and documentation.

## Changes

- **agent-core:** Fix a spelling error in a lock recovery comment.
- **hidpp:** Fix spelling errors in protocol and feature documentation.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=commit.gpgSign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=core.hooksPath GIT_CONFIG_VALUE_1=/dev/null RUSTFLAGS="-D warnings" cargo test --workspace` — 1082 passed, 2 ignored
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=commit.gpgSign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=core.hooksPath GIT_CONFIG_VALUE_1=/dev/null NIX_CONFIG="experimental-features = nix-command flakes" cargo xtask ci` — 7 passed, 0 failed, 3 skipped
- Shell checks were not run because `shellcheck` and `shfmt` are unavailable. This change has no shell files.
- macOS tests were not run on this Linux host.
- Windows Clippy was not run because the target is not installed.
- Not runtime-tested on hardware. This change does not alter runtime behavior.

Fixes #855