### PR TITLE
fix(thumbwheel): stop the tap firing App Exposé, and scroll by the wheel's native amount

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -411,9 +411,12 @@ fn dispatch(
                 debug!(key, ?button, "HID++ button with no binding — ignored");
             }
         }
-        CapturedInput::Scroll(rotation) => {
+        CapturedInput::Scroll {
+            increments,
+            resolution,
+        } => {
             // Positive rotation is "up"; each direction has its own binding.
-            let up = rotation >= 0;
+            let up = increments >= 0;
             let button = if up {
                 ButtonId::ThumbwheelScrollUp
             } else {
@@ -427,8 +430,17 @@ fn dispatch(
             let sensitivity = plan.thumbwheel_sensitivity;
             let wheels = accumulators.entry(key.to_owned()).or_default();
             let dir = if up { &mut wheels.up } else { &mut wheels.down };
-            let magnitude = i32::from(rotation).abs();
-            match advance(dir, &action, magnitude, sensitivity, Instant::now()) {
+            let magnitude = i32::from(increments).abs();
+            match advance(
+                dir,
+                &action,
+                magnitude,
+                ScrollScale {
+                    native_per_increment: resolution.native_per_increment(),
+                    sensitivity,
+                },
+                Instant::now(),
+            ) {
                 WheelOutput::Idle => {}
                 WheelOutput::Scroll(lines) => {
                     openlogi_inject::post_horizontal_scroll(lines);
@@ -439,6 +451,27 @@ fn dispatch(
                 }
             }
         }
+    }
+}
+
+/// How far one rotation increment should scroll.
+#[derive(Debug, Clone, Copy)]
+struct ScrollScale {
+    /// Native scroll units one diverted increment is worth, from the wheel's
+    /// own `getThumbwheelInfo`. Diverting the wheel changes the unit it
+    /// reports in — an MX Master 4 goes from 20 ratchets per revolution to 120
+    /// increments — so without this the same physical motion scrolls six times
+    /// as far as it did natively, and the sensitivity slider's 1× is 1× of
+    /// nothing recognisable.
+    native_per_increment: f32,
+    /// The user's own multiplier, relative to that native amount.
+    sensitivity: ThumbwheelSensitivity,
+}
+
+impl ScrollScale {
+    /// Scroll units one increment contributes.
+    fn per_increment(self) -> f32 {
+        self.native_per_increment * self.sensitivity.scroll_multiplier()
     }
 }
 
@@ -455,16 +488,18 @@ fn advance(
     dir: &mut WheelDirection,
     action: &Action,
     magnitude: i32,
-    sensitivity: ThumbwheelSensitivity,
+    scale: ScrollScale,
     now: Instant,
 ) -> WheelOutput {
+    let sensitivity = scale.sensitivity;
     match action {
         // Suppressed: captured but produces nothing.
         Action::None => WheelOutput::Idle,
-        // Continuous, sensitivity-scaled horizontal scroll. Direction comes
-        // from the action; magnitude from the accumulated rotation.
+        // Continuous horizontal scroll, scaled from the wheel's diverted
+        // increments back to its native amount and then by the user's
+        // sensitivity. Direction comes from the action.
         Action::HorizontalScrollRight | Action::HorizontalScrollLeft => {
-            dir.scroll += magnitude as f32 * sensitivity.scroll_multiplier();
+            dir.scroll += magnitude as f32 * scale.per_increment();
             let lines = dir.scroll.trunc();
             if lines >= 1.0 {
                 dir.scroll -= lines;
@@ -512,6 +547,23 @@ fn advance(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openlogi_hid::thumbwheel::WheelResolution;
+
+    /// The resolutions traced off an MX Master 4 over Bolt: 20 ratchets per
+    /// revolution natively, 120 increments per revolution diverted.
+    const TRACED: WheelResolution = WheelResolution {
+        native_res: 20,
+        diverted_res: 120,
+    };
+
+    /// A wheel whose increments are already native scroll units — what the
+    /// scaling tests below vary, and what every other test here assumes.
+    fn unscaled(sensitivity: ThumbwheelSensitivity) -> ScrollScale {
+        ScrollScale {
+            native_per_increment: 1.0,
+            sensitivity,
+        }
+    }
 
     #[test]
     fn multiplier_is_unity_at_default_sensitivity() {
@@ -538,6 +590,54 @@ mod tests {
         );
     }
 
+    /// Diverting the wheel changes the unit it reports in. An MX Master 4
+    /// sends 120 increments per revolution where native scrolling produced 20
+    /// ratchets, so a revolution has to keep scrolling 20 units — not 120 —
+    /// with the sensitivity slider left alone.
+    #[test]
+    fn a_revolution_scrolls_its_native_amount_however_finely_the_wheel_reports() {
+        let scale = ScrollScale {
+            native_per_increment: TRACED.native_per_increment(),
+            sensitivity: ThumbwheelSensitivity::DEFAULT,
+        };
+        let mut dir = WheelDirection::default();
+        let now = Instant::now();
+        let mut lines = 0;
+        for _ in 0..120 {
+            if let WheelOutput::Scroll(n) =
+                advance(&mut dir, &Action::HorizontalScrollRight, 1, scale, now)
+            {
+                lines += n;
+            }
+        }
+        assert_eq!(lines, 20, "one revolution is 20 native scroll units");
+    }
+
+    /// The sensitivity slider stays a multiplier *of that native amount*.
+    #[test]
+    fn sensitivity_multiplies_the_native_amount() {
+        let scale = ScrollScale {
+            native_per_increment: TRACED.native_per_increment(),
+            sensitivity: ThumbwheelSensitivity::from_rounded(28.0), // 2x
+        };
+        let mut dir = WheelDirection::default();
+        let now = Instant::now();
+        let mut lines = 0;
+        for _ in 0..120 {
+            if let WheelOutput::Scroll(n) =
+                advance(&mut dir, &Action::HorizontalScrollRight, 1, scale, now)
+            {
+                lines += n;
+            }
+        }
+        assert_eq!(lines, 40, "2x sensitivity doubles the native 20");
+    }
+
+    #[test]
+    fn an_unreported_resolution_leaves_increments_unscaled() {
+        assert!((WheelResolution::UNKNOWN.native_per_increment() - 1.0).abs() < f32::EPSILON);
+    }
+
     #[test]
     fn scroll_accumulates_fractionally_at_sub_unity_sensitivity() {
         let mut dir = WheelDirection::default();
@@ -545,11 +645,23 @@ mod tests {
         // multiplier 0.5: two increments make one whole line.
         let half = ThumbwheelSensitivity::from_rounded(7.0);
         assert_eq!(
-            advance(&mut dir, &Action::HorizontalScrollRight, 1, half, now),
+            advance(
+                &mut dir,
+                &Action::HorizontalScrollRight,
+                1,
+                unscaled(half),
+                now
+            ),
             WheelOutput::Idle
         );
         assert_eq!(
-            advance(&mut dir, &Action::HorizontalScrollRight, 1, half, now),
+            advance(
+                &mut dir,
+                &Action::HorizontalScrollRight,
+                1,
+                unscaled(half),
+                now
+            ),
             WheelOutput::Scroll(1)
         );
     }
@@ -563,7 +675,7 @@ mod tests {
                 &mut dir,
                 &Action::HorizontalScrollLeft,
                 1,
-                ThumbwheelSensitivity::DEFAULT,
+                unscaled(ThumbwheelSensitivity::DEFAULT),
                 now
             ),
             WheelOutput::Scroll(-1)
@@ -578,17 +690,35 @@ mod tests {
         let now = Instant::now();
         let half = ThumbwheelSensitivity::from_rounded(7.0); // multiplier 0.5
         assert_eq!(
-            advance(&mut up, &Action::HorizontalScrollRight, 1, half, now),
+            advance(
+                &mut up,
+                &Action::HorizontalScrollRight,
+                1,
+                unscaled(half),
+                now
+            ),
             WheelOutput::Idle
         );
         // One tick the other way doesn't cancel `up`'s banked half-line…
         assert_eq!(
-            advance(&mut down, &Action::HorizontalScrollLeft, 1, half, now),
+            advance(
+                &mut down,
+                &Action::HorizontalScrollLeft,
+                1,
+                unscaled(half),
+                now
+            ),
             WheelOutput::Idle
         );
         // …so `up`'s next tick still completes its own line.
         assert_eq!(
-            advance(&mut up, &Action::HorizontalScrollRight, 1, half, now),
+            advance(
+                &mut up,
+                &Action::HorizontalScrollRight,
+                1,
+                unscaled(half),
+                now
+            ),
             WheelOutput::Scroll(1)
         );
     }
@@ -604,7 +734,7 @@ mod tests {
                     &mut dir,
                     &Action::VolumeUp,
                     1,
-                    ThumbwheelSensitivity::DEFAULT,
+                    unscaled(ThumbwheelSensitivity::DEFAULT),
                     now
                 ),
                 WheelOutput::Idle
@@ -615,7 +745,7 @@ mod tests {
                 &mut dir,
                 &Action::VolumeUp,
                 1,
-                ThumbwheelSensitivity::DEFAULT,
+                unscaled(ThumbwheelSensitivity::DEFAULT),
                 now
             ),
             WheelOutput::FireAction
@@ -627,7 +757,7 @@ mod tests {
                     &mut dir,
                     &Action::VolumeUp,
                     1,
-                    ThumbwheelSensitivity::DEFAULT,
+                    unscaled(ThumbwheelSensitivity::DEFAULT),
                     now
                 ),
                 WheelOutput::Idle
@@ -643,7 +773,7 @@ mod tests {
                 &mut dir,
                 &Action::None,
                 5,
-                ThumbwheelSensitivity::DEFAULT,
+                unscaled(ThumbwheelSensitivity::DEFAULT),
                 Instant::now()
             ),
             WheelOutput::Idle

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -48,16 +48,6 @@ const ACTION_DECAY: Duration = Duration::from_millis(300);
 /// deliberate flick triggers once instead of repeating across a fast spin.
 const ACTION_COOLDOWN: Duration = Duration::from_millis(200);
 
-/// How long a rotation report keeps the wheel's tap suppressed.
-///
-/// The wheel's touch sensor flags a tap on the finger that rolled it, and the
-/// flag can land in its own report a beat after the rotation stops — so a
-/// brisk flick otherwise fires the tap's action on top of the scroll. The
-/// capture session already drops the tap a *rolling* report carries
-/// (`openlogi-device`'s `thumbwheel_input`); this covers the trailing one.
-/// Deliberate taps are unaffected: they follow a still wheel.
-const TAP_ROLL_LOCKOUT: Duration = Duration::from_millis(300);
-
 /// Spawn the capture-manager thread. It owns a current-thread tokio runtime that
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
@@ -358,9 +348,6 @@ fn spawn_session(
 struct WheelAccumulators {
     up: WheelDirection,
     down: WheelDirection,
-    /// When this wheel last reported rotation, in either direction — the
-    /// clock behind [`TAP_ROLL_LOCKOUT`].
-    last_rotation: Option<Instant>,
 }
 
 /// Running state for one rotation direction.
@@ -417,17 +404,6 @@ fn dispatch(
             }
         }
         CapturedInput::ButtonPressed(button, _) => {
-            if button == ButtonId::Thumbwheel
-                && tap_is_roll_spillover(
-                    accumulators
-                        .get(key)
-                        .and_then(|wheels| wheels.last_rotation),
-                    Instant::now(),
-                )
-            {
-                debug!(key, "thumb-wheel tap inside the roll lockout — ignored");
-                return;
-            }
             if let Some(action) = plan.bindings.get(&button) {
                 debug!(key, ?button, action = %action.label(), "HID++ button → action");
                 dispatcher.dispatch(action, Some(key));
@@ -449,12 +425,10 @@ fn dispatch(
                 .cloned()
                 .unwrap_or_else(|| default_binding(button));
             let sensitivity = plan.thumbwheel_sensitivity;
-            let now = Instant::now();
             let wheels = accumulators.entry(key.to_owned()).or_default();
-            wheels.last_rotation = Some(now);
             let dir = if up { &mut wheels.up } else { &mut wheels.down };
             let magnitude = i32::from(rotation).abs();
-            match advance(dir, &action, magnitude, sensitivity, now) {
+            match advance(dir, &action, magnitude, sensitivity, Instant::now()) {
                 WheelOutput::Idle => {}
                 WheelOutput::Scroll(lines) => {
                     openlogi_inject::post_horizontal_scroll(lines);
@@ -466,12 +440,6 @@ fn dispatch(
             }
         }
     }
-}
-
-/// Whether a tap arriving at `now` is spill-over from a roll that ended at
-/// `last_rotation` rather than a deliberate tap. Pure given `now`.
-fn tap_is_roll_spillover(last_rotation: Option<Instant>, now: Instant) -> bool {
-    last_rotation.is_some_and(|rolled| now.saturating_duration_since(rolled) < TAP_ROLL_LOCKOUT)
 }
 
 /// Advance one direction's accumulator by `magnitude` rotation increments and
@@ -544,30 +512,6 @@ fn advance(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A wheel whose last rotation was `ago` before `now`.
-    fn rolled(now: Instant, ago: Duration) -> Option<Instant> {
-        now.checked_sub(ago)
-    }
-
-    #[test]
-    fn a_tap_trailing_a_roll_is_spillover() {
-        let now = Instant::now();
-        assert!(
-            tap_is_roll_spillover(rolled(now, TAP_ROLL_LOCKOUT / 2), now),
-            "the touch sensor flags the finger that just rolled the wheel"
-        );
-    }
-
-    #[test]
-    fn a_tap_on_a_settled_wheel_is_deliberate() {
-        let now = Instant::now();
-        assert!(!tap_is_roll_spillover(rolled(now, TAP_ROLL_LOCKOUT), now));
-        assert!(
-            !tap_is_roll_spillover(None, now),
-            "a wheel that never rolled cannot be spilling over"
-        );
-    }
 
     #[test]
     fn multiplier_is_unity_at_default_sensitivity() {

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -48,6 +48,16 @@ const ACTION_DECAY: Duration = Duration::from_millis(300);
 /// deliberate flick triggers once instead of repeating across a fast spin.
 const ACTION_COOLDOWN: Duration = Duration::from_millis(200);
 
+/// How long a rotation report keeps the wheel's tap suppressed.
+///
+/// The wheel's touch sensor flags a tap on the finger that rolled it, and the
+/// flag can land in its own report a beat after the rotation stops — so a
+/// brisk flick otherwise fires the tap's action on top of the scroll. The
+/// capture session already drops the tap a *rolling* report carries
+/// (`openlogi-device`'s `thumbwheel_input`); this covers the trailing one.
+/// Deliberate taps are unaffected: they follow a still wheel.
+const TAP_ROLL_LOCKOUT: Duration = Duration::from_millis(300);
+
 /// Spawn the capture-manager thread. It owns a current-thread tokio runtime that
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
@@ -348,6 +358,9 @@ fn spawn_session(
 struct WheelAccumulators {
     up: WheelDirection,
     down: WheelDirection,
+    /// When this wheel last reported rotation, in either direction — the
+    /// clock behind [`TAP_ROLL_LOCKOUT`].
+    last_rotation: Option<Instant>,
 }
 
 /// Running state for one rotation direction.
@@ -404,6 +417,17 @@ fn dispatch(
             }
         }
         CapturedInput::ButtonPressed(button, _) => {
+            if button == ButtonId::Thumbwheel
+                && tap_is_roll_spillover(
+                    accumulators
+                        .get(key)
+                        .and_then(|wheels| wheels.last_rotation),
+                    Instant::now(),
+                )
+            {
+                debug!(key, "thumb-wheel tap inside the roll lockout — ignored");
+                return;
+            }
             if let Some(action) = plan.bindings.get(&button) {
                 debug!(key, ?button, action = %action.label(), "HID++ button → action");
                 dispatcher.dispatch(action, Some(key));
@@ -425,10 +449,12 @@ fn dispatch(
                 .cloned()
                 .unwrap_or_else(|| default_binding(button));
             let sensitivity = plan.thumbwheel_sensitivity;
+            let now = Instant::now();
             let wheels = accumulators.entry(key.to_owned()).or_default();
+            wheels.last_rotation = Some(now);
             let dir = if up { &mut wheels.up } else { &mut wheels.down };
             let magnitude = i32::from(rotation).abs();
-            match advance(dir, &action, magnitude, sensitivity, Instant::now()) {
+            match advance(dir, &action, magnitude, sensitivity, now) {
                 WheelOutput::Idle => {}
                 WheelOutput::Scroll(lines) => {
                     openlogi_inject::post_horizontal_scroll(lines);
@@ -440,6 +466,12 @@ fn dispatch(
             }
         }
     }
+}
+
+/// Whether a tap arriving at `now` is spill-over from a roll that ended at
+/// `last_rotation` rather than a deliberate tap. Pure given `now`.
+fn tap_is_roll_spillover(last_rotation: Option<Instant>, now: Instant) -> bool {
+    last_rotation.is_some_and(|rolled| now.saturating_duration_since(rolled) < TAP_ROLL_LOCKOUT)
 }
 
 /// Advance one direction's accumulator by `magnitude` rotation increments and
@@ -512,6 +544,30 @@ fn advance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A wheel whose last rotation was `ago` before `now`.
+    fn rolled(now: Instant, ago: Duration) -> Option<Instant> {
+        now.checked_sub(ago)
+    }
+
+    #[test]
+    fn a_tap_trailing_a_roll_is_spillover() {
+        let now = Instant::now();
+        assert!(
+            tap_is_roll_spillover(rolled(now, TAP_ROLL_LOCKOUT / 2), now),
+            "the touch sensor flags the finger that just rolled the wheel"
+        );
+    }
+
+    #[test]
+    fn a_tap_on_a_settled_wheel_is_deliberate() {
+        let now = Instant::now();
+        assert!(!tap_is_roll_spillover(rolled(now, TAP_ROLL_LOCKOUT), now));
+        assert!(
+            !tap_is_roll_spillover(None, now),
+            "a wheel that never rolled cannot be spilling over"
+        );
+    }
 
     #[test]
     fn multiplier_is_unity_at_default_sensitivity() {

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -7,17 +7,24 @@ use super::value::Binding;
 
 /// Sensible defaults for a fresh device so the panel isn't empty on first run.
 ///
-/// Thumbwheel / GestureButton defaults match what Logi Options+ ships for
-/// MX-line devices: thumb wheel click → App Exposé, gesture button →
-/// Mission Control. The thumb wheel isn't captured yet; the dedicated gesture button is
-/// (per-direction, see [`default_gesture_binding`]). The bindings persist
-/// regardless so the user only configures once.
+/// `GestureButton` matches what Logi Options+ ships for MX-line devices:
+/// gesture button → Mission Control, captured per-direction (see
+/// [`default_gesture_binding`]).
 ///
 /// `GestureButton`'s entry here is vestigial: in the merged [`Binding`] model
 /// the gesture button defaults to [`Binding::Gesture`] (see
 /// [`default_binding_for`]), so this single-action value is never the source of
 /// truth for it. It is retained only so the per-button-`Action` callers (the
 /// hook map, scroll defaults, labels) stay total.
+///
+/// [`ButtonId::Thumbwheel`] — the wheel's capacitive tap — is deliberately
+/// inert. The mouse model surfaces the wheel as one paired rotation control,
+/// so the tap has no GUI hotspot to discover or clear it, while the firmware
+/// reports a tap from incidental thumb contact (including mid-roll, from the
+/// ridges alone). Seeding it with a real action therefore fired that action
+/// for users who only changed the rotation bindings or the sensitivity — the
+/// two settings that divert the wheel over `0x2150` in the first place. A tap
+/// bound explicitly in the config still dispatches; only the seed is inert.
 #[must_use]
 pub fn default_binding(button: ButtonId) -> Action {
     match button {
@@ -27,7 +34,12 @@ pub fn default_binding(button: ButtonId) -> Action {
         ButtonId::Back => Action::BrowserBack,
         ButtonId::Forward => Action::BrowserForward,
         ButtonId::DpiToggle => Action::CycleDpiPresets,
-        ButtonId::Thumbwheel => Action::AppExpose,
+        #[expect(
+            clippy::match_same_arms,
+            reason = "the tap is inert because its captured events are noise (see above), \
+                      not because the control stays native like the keyboard arm below"
+        )]
+        ButtonId::Thumbwheel => Action::None,
         // The thumb wheel scrolls horizontally by default: rotating it produces
         // continuous horizontal scroll, with "up" → right and "down" → left.
         // The wheel watcher renders these two actions as smooth, sensitivity-

--- a/crates/openlogi-core/src/bindings.rs
+++ b/crates/openlogi-core/src/bindings.rs
@@ -150,6 +150,35 @@ mod tests {
     }
 
     #[test]
+    fn a_rotation_rebind_leaves_the_wheels_tap_inert() {
+        // Rebinding rotation (or moving the sensitivity slider) diverts the
+        // wheel over 0x2150, which is what starts delivering its capacitive
+        // taps. Those taps must stay inert until the user binds the tap
+        // itself — a seeded action here fires from incidental thumb contact.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b034",
+            ButtonId::ThumbwheelScrollUp,
+            Action::VolumeUp.into(),
+        );
+
+        let projected = bindings_for(&cfg, Some("2b034"), None);
+        assert_eq!(projected.get(&ButtonId::Thumbwheel), Some(&Action::None));
+    }
+
+    #[test]
+    fn an_explicitly_bound_tap_survives_the_inert_default() {
+        let mut cfg = Config::default();
+        cfg.set_binding("2b034", ButtonId::Thumbwheel, Action::AppExpose.into());
+
+        let projected = bindings_for(&cfg, Some("2b034"), None);
+        assert_eq!(
+            projected.get(&ButtonId::Thumbwheel),
+            Some(&Action::AppExpose)
+        );
+    }
+
+    #[test]
     fn explicit_gesture_click_overrides_default_in_projection() {
         // A gesture binding that DOES define `Click` projects that action.
         let mut cfg = Config::default();

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -218,13 +218,9 @@ pub async fn run_capture_session(
             }
             if let Some(idx) = thumb_index
                 && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
+                && let Some(input) = thumbwheel_input(event)
             {
-                if event.single_tap {
-                    let _ = sink.send(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None));
-                }
-                if event.rotation != 0 {
-                    let _ = sink.send(CapturedInput::Scroll(event.rotation));
-                }
+                let _ = sink.send(input);
             }
         }
     });
@@ -303,6 +299,24 @@ pub async fn run_capture_session(
     }
     debug!(index = device_index, "control capture stopped");
     Ok(())
+}
+
+/// The single input one diverted thumb-wheel report stands for, if any.
+///
+/// A report is a roll *or* a tap, never both: the wheel's touch sensor sets
+/// `single_tap` on the very contact that turned the wheel, so a report
+/// carrying rotation is a roll whose tap bit is an artifact of the finger that
+/// produced it. Forwarding both made a brisk flick fire the tap's action
+/// alongside the scroll. Taps that arrive in their *own* report right after a
+/// roll are the same artifact one report later; that half is the dispatcher's
+/// (see the roll lockout in `openlogi-agent-core`'s capture watcher).
+fn thumbwheel_input(event: thumbwheel::ThumbwheelEvent) -> Option<CapturedInput> {
+    if event.rotation != 0 {
+        return Some(CapturedInput::Scroll(event.rotation));
+    }
+    event
+        .single_tap
+        .then_some(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None))
 }
 
 /// Reason-aware capture: maps stop reasons onto a unit oneshot shutdown.

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -303,16 +303,23 @@ pub async fn run_capture_session(
 
 /// The single input one diverted thumb-wheel report stands for, if any.
 ///
-/// A report is a roll *or* a tap, never both: the wheel's touch sensor sets
-/// `single_tap` on the very contact that turned the wheel, so a report
-/// carrying rotation is a roll whose tap bit is an artifact of the finger that
-/// produced it. Forwarding both made a brisk flick fire the tap's action
-/// alongside the scroll. Taps that arrive in their *own* report right after a
-/// roll are the same artifact one report later; that half is the dispatcher's
-/// (see the roll lockout in `openlogi-agent-core`'s capture watcher).
+/// A report is a roll *or* a tap, never both, and `0x2150` says which: the
+/// wheel's touch sensor sets `single_tap` for the finger that turned the
+/// wheel, so every report from `Start` through `Stop` carries a tap bit that
+/// belongs to the roll rather than to the user. `Stop` is the one that needs
+/// the status field — it is the release, so it reports no rotation of its own
+/// and is otherwise indistinguishable from a tap on a settled wheel.
+///
+/// A report's own rotation is checked alongside the status rather than
+/// through it: both are direct statements that this report is part of a roll,
+/// and taking either keeps the roll recognised on a wheel whose firmware
+/// leaves byte 4 at zero.
 fn thumbwheel_input(event: thumbwheel::ThumbwheelEvent) -> Option<CapturedInput> {
     if event.rotation != 0 {
         return Some(CapturedInput::Scroll(event.rotation));
+    }
+    if event.rotation_status.is_rolling() {
+        return None;
     }
     event
         .single_tap

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -31,7 +31,7 @@ use crate::backend::{BackendError, HidBackend};
 use crate::channel::route::{DeviceRoute, open_route_channel};
 
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
-use crate::thumbwheel::{self, Thumbwheel};
+use crate::thumbwheel::{self, Thumbwheel, WheelResolution};
 
 /// How often the capture session pings its device to prove the channel still
 /// delivers input reports. Cheap: one HID++ round-trip per interval.
@@ -67,10 +67,18 @@ pub enum CapturedInput {
     /// ([`ButtonId::DpiToggle`]) or the thumb-wheel single tap
     /// ([`ButtonId::Thumbwheel`]).
     ButtonPressed(ButtonId, #[serde(skip)] Option<i32>),
-    /// Thumb-wheel rotation to re-synthesise as horizontal scroll, in the
-    /// wheel's `diverted_res` increments. Emitted while the wheel is diverted
-    /// (click bound, rotation rebound, or sensitivity changed).
-    Scroll(i16),
+    /// Thumb-wheel rotation to re-synthesise as horizontal scroll. Emitted
+    /// while the wheel is diverted (click bound, rotation rebound, or
+    /// sensitivity changed).
+    Scroll {
+        /// Rotation in the wheel's diverted increments.
+        increments: i16,
+        /// What one revolution measures in each mode, so the dispatcher can
+        /// scale those increments back to the wheel's native scroll amount
+        /// instead of scrolling by however finely this wheel happens to
+        /// report.
+        resolution: WheelResolution,
+    },
 }
 
 /// Why a capture session could not start (or had to stop).
@@ -196,7 +204,11 @@ pub async fn run_capture_session(
     let accum = Arc::new(Mutex::new(CaptureAccum::default()));
     let reprog_index = armed.reprog.as_ref().map(|(_, idx)| *idx);
     let gesture_cids = armed.gesture_cids.clone();
-    let thumb_index = armed.thumb.as_ref().map(|(_, idx)| *idx);
+    let thumb_index = armed.thumb.as_ref().map(|(_, idx, _)| *idx);
+    let thumb_resolution = armed
+        .thumb
+        .as_ref()
+        .map_or(WheelResolution::UNKNOWN, |(_, _, res)| *res);
     let dpi_set = armed.dpi_cids.clone();
     let button_set = armed.button_cids.clone();
     let listener = chan.add_msg_listener_guarded({
@@ -218,7 +230,7 @@ pub async fn run_capture_session(
             }
             if let Some(idx) = thumb_index
                 && let Some(event) = thumbwheel::decode_event(&msg, device_index, idx)
-                && let Some(input) = thumbwheel_input(event)
+                && let Some(input) = thumbwheel_input(event, thumb_resolution)
             {
                 let _ = sink.send(input);
             }
@@ -314,9 +326,15 @@ pub async fn run_capture_session(
 /// through it: both are direct statements that this report is part of a roll,
 /// and taking either keeps the roll recognised on a wheel whose firmware
 /// leaves byte 4 at zero.
-fn thumbwheel_input(event: thumbwheel::ThumbwheelEvent) -> Option<CapturedInput> {
+fn thumbwheel_input(
+    event: thumbwheel::ThumbwheelEvent,
+    resolution: WheelResolution,
+) -> Option<CapturedInput> {
     if event.rotation != 0 {
-        return Some(CapturedInput::Scroll(event.rotation));
+        return Some(CapturedInput::Scroll {
+            increments: event.rotation,
+            resolution,
+        });
     }
     if event.rotation_status.is_rolling() {
         return None;
@@ -370,9 +388,9 @@ struct ArmedControls {
     button_cids: Vec<(u16, ButtonId)>,
     /// Original reporting state for every diverted `0x1b04` control.
     reporting: Vec<ArmedCid>,
-    /// `0x2150` accessor + feature index, present when the thumb wheel is
-    /// diverted.
-    thumb: Option<(Thumbwheel, u8)>,
+    /// `0x2150` accessor, feature index, and the wheel's reported resolution,
+    /// present when the thumb wheel is diverted.
+    thumb: Option<(Thumbwheel, u8, WheelResolution)>,
 }
 
 #[derive(Clone, Copy)]
@@ -389,7 +407,7 @@ impl ArmedControls {
                 restore_reporting(rc, reporting, "captured control").await;
             }
         }
-        if let Some((tw, _)) = self.thumb.as_ref() {
+        if let Some((tw, _, _)) = self.thumb.as_ref() {
             restore(tw.set_reporting(false, false).await, "thumb wheel");
         }
     }
@@ -492,11 +510,11 @@ async fn arm_controls_into(
         // Consume the getInfo error here, before the next await: Hidpp20Error
         // isn't Send, so holding it across an await would make this future
         // (spawned on tokio) non-Send.
-        let supports_single_tap = match tw.get_info().await {
-            Ok(twinfo) => twinfo.supports_single_tap,
+        let (supports_single_tap, resolution) = match tw.get_info().await {
+            Ok(twinfo) => (twinfo.supports_single_tap, twinfo.resolution),
             Err(e) => {
                 warn!(error = ?e, "thumb wheel getInfo failed");
-                false
+                (false, WheelResolution::UNKNOWN)
             }
         };
         // Divert whenever capture was requested: rotation rebinds and the
@@ -514,7 +532,7 @@ async fn arm_controls_into(
             );
             return Err(error);
         }
-        armed.thumb = Some((tw, info.index));
+        armed.thumb = Some((tw, info.index, resolution));
     }
     Ok(())
 }

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -527,9 +527,14 @@ fn a_dpi_button_re_presses_after_a_release() {
     );
 }
 
-fn thumb_event(rotation: i16, single_tap: bool) -> thumbwheel::ThumbwheelEvent {
+fn thumb_event(
+    rotation: i16,
+    rotation_status: thumbwheel::RotationStatus,
+    single_tap: bool,
+) -> thumbwheel::ThumbwheelEvent {
     thumbwheel::ThumbwheelEvent {
         rotation,
+        rotation_status,
         single_tap,
         touch: true,
         proxy: true,
@@ -542,16 +547,37 @@ fn thumb_event(rotation: i16, single_tap: bool) -> thumbwheel::ThumbwheelEvent {
 #[test]
 fn a_rolling_report_is_a_roll_even_when_it_flags_a_tap() {
     assert_eq!(
-        thumbwheel_input(thumb_event(-3, true)),
+        thumbwheel_input(thumb_event(-3, thumbwheel::RotationStatus::Active, true)),
         Some(CapturedInput::Scroll(-3))
     );
 }
 
+/// The roll's closing report: the finger lifts, so it carries no rotation of
+/// its own while the sensor flags the contact that just rolled the wheel. Only
+/// `rotation_status` separates it from a deliberate tap.
 #[test]
-fn a_still_report_with_a_tap_is_a_tap() {
+fn the_release_that_ends_a_roll_is_not_a_tap() {
     assert_eq!(
-        thumbwheel_input(thumb_event(0, true)),
+        thumbwheel_input(thumb_event(0, thumbwheel::RotationStatus::Stop, true)),
+        None
+    );
+}
+
+#[test]
+fn a_tap_on_a_settled_wheel_is_a_tap() {
+    assert_eq!(
+        thumbwheel_input(thumb_event(0, thumbwheel::RotationStatus::Inactive, true)),
         Some(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None))
+    );
+}
+
+/// A wheel whose firmware leaves byte 4 at zero still has its own rotation to
+/// go on, so the roll is recognised without the status field.
+#[test]
+fn rotation_alone_still_marks_a_roll() {
+    assert_eq!(
+        thumbwheel_input(thumb_event(4, thumbwheel::RotationStatus::Inactive, true)),
+        Some(CapturedInput::Scroll(4))
     );
 }
 
@@ -559,5 +585,8 @@ fn a_still_report_with_a_tap_is_a_tap() {
 /// thumb rests near it.
 #[test]
 fn contact_without_rotation_or_a_tap_carries_no_input() {
-    assert_eq!(thumbwheel_input(thumb_event(0, false)), None);
+    assert_eq!(
+        thumbwheel_input(thumb_event(0, thumbwheel::RotationStatus::Inactive, false)),
+        None
+    );
 }

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -527,6 +527,13 @@ fn a_dpi_button_re_presses_after_a_release() {
     );
 }
 
+/// The resolutions an MX Master 4 reports: 20 ratchets natively, 120
+/// increments diverted, so one increment is a sixth of a native scroll unit.
+const TRACED_RES: thumbwheel::WheelResolution = thumbwheel::WheelResolution {
+    native_res: 20,
+    diverted_res: 120,
+};
+
 fn thumb_event(
     rotation: i16,
     rotation_status: thumbwheel::RotationStatus,
@@ -547,8 +554,14 @@ fn thumb_event(
 #[test]
 fn a_rolling_report_is_a_roll_even_when_it_flags_a_tap() {
     assert_eq!(
-        thumbwheel_input(thumb_event(-3, thumbwheel::RotationStatus::Active, true)),
-        Some(CapturedInput::Scroll(-3))
+        thumbwheel_input(
+            thumb_event(-3, thumbwheel::RotationStatus::Active, true),
+            TRACED_RES
+        ),
+        Some(CapturedInput::Scroll {
+            increments: -3,
+            resolution: TRACED_RES
+        })
     );
 }
 
@@ -558,7 +571,10 @@ fn a_rolling_report_is_a_roll_even_when_it_flags_a_tap() {
 #[test]
 fn the_release_that_ends_a_roll_is_not_a_tap() {
     assert_eq!(
-        thumbwheel_input(thumb_event(0, thumbwheel::RotationStatus::Stop, true)),
+        thumbwheel_input(
+            thumb_event(0, thumbwheel::RotationStatus::Stop, true),
+            TRACED_RES
+        ),
         None
     );
 }
@@ -566,7 +582,10 @@ fn the_release_that_ends_a_roll_is_not_a_tap() {
 #[test]
 fn a_tap_on_a_settled_wheel_is_a_tap() {
     assert_eq!(
-        thumbwheel_input(thumb_event(0, thumbwheel::RotationStatus::Inactive, true)),
+        thumbwheel_input(
+            thumb_event(0, thumbwheel::RotationStatus::Inactive, true),
+            TRACED_RES
+        ),
         Some(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None))
     );
 }
@@ -576,8 +595,14 @@ fn a_tap_on_a_settled_wheel_is_a_tap() {
 #[test]
 fn rotation_alone_still_marks_a_roll() {
     assert_eq!(
-        thumbwheel_input(thumb_event(4, thumbwheel::RotationStatus::Inactive, true)),
-        Some(CapturedInput::Scroll(4))
+        thumbwheel_input(
+            thumb_event(4, thumbwheel::RotationStatus::Inactive, true),
+            TRACED_RES
+        ),
+        Some(CapturedInput::Scroll {
+            increments: 4,
+            resolution: TRACED_RES
+        })
     );
 }
 
@@ -586,7 +611,10 @@ fn rotation_alone_still_marks_a_roll() {
 #[test]
 fn contact_without_rotation_or_a_tap_carries_no_input() {
     assert_eq!(
-        thumbwheel_input(thumb_event(0, thumbwheel::RotationStatus::Inactive, false)),
+        thumbwheel_input(
+            thumb_event(0, thumbwheel::RotationStatus::Inactive, false),
+            TRACED_RES
+        ),
         None
     );
 }

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -526,3 +526,38 @@ fn a_dpi_button_re_presses_after_a_release() {
         "press → release → press emits exactly two presses"
     );
 }
+
+fn thumb_event(rotation: i16, single_tap: bool) -> thumbwheel::ThumbwheelEvent {
+    thumbwheel::ThumbwheelEvent {
+        rotation,
+        single_tap,
+        touch: true,
+        proxy: true,
+    }
+}
+
+/// The wheel's touch sensor flags a tap on the same contact that rolled it, so
+/// a rolling report's tap bit is an artifact — forwarding it fired the tap's
+/// bound action in the middle of a scroll.
+#[test]
+fn a_rolling_report_is_a_roll_even_when_it_flags_a_tap() {
+    assert_eq!(
+        thumbwheel_input(thumb_event(-3, true)),
+        Some(CapturedInput::Scroll(-3))
+    );
+}
+
+#[test]
+fn a_still_report_with_a_tap_is_a_tap() {
+    assert_eq!(
+        thumbwheel_input(thumb_event(0, true)),
+        Some(CapturedInput::ButtonPressed(ButtonId::Thumbwheel, None))
+    );
+}
+
+/// Touch and proximity alone carry no input: the wheel reports them whenever a
+/// thumb rests near it.
+#[test]
+fn contact_without_rotation_or_a_tap_carries_no_input() {
+    assert_eq!(thumbwheel_input(thumb_event(0, false)), None);
+}

--- a/crates/openlogi-device/src/thumbwheel.rs
+++ b/crates/openlogi-device/src/thumbwheel.rs
@@ -45,6 +45,64 @@ const EV_PROXY: u8 = 0x04;
 /// `touch` bit in `thumbwheelEvent` byte 5.
 const EV_TOUCH: u8 = 0x02;
 
+/// Where a `thumbwheelEvent` sits in the life cycle of one roll
+/// (`thumbwheelEvent` byte 4).
+///
+/// This is what separates a deliberate tap from the tap the wheel's touch
+/// sensor flags for the finger that rolled it: every report from `Start`
+/// through `Stop` belongs to a roll, so a tap bit inside that span is an
+/// artifact of the same contact. Only [`RotationStatus::Inactive`] means the
+/// wheel is at rest and a tap is the user's own.
+///
+/// [`RotationStatus::Stop`] is why this field is read rather than inferred
+/// from the report's own rotation. Observed on an MX Master 4 (Bolt) with
+/// `examples/thumbwheel_trace`, one nudge of the wheel:
+///
+/// ```text
+/// rot=  -1  byte4=0x02  byte5=0x02  touch=true   → Active
+/// rot=   0  byte4=0x03  byte5=0x00  touch=false  → Stop
+/// ```
+///
+/// The release reports no rotation at all, so rotation alone cannot tell it
+/// from a tap on a settled wheel — and on a wheel that does support
+/// `single_tap` that release is exactly where the artifact lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationStatus {
+    /// No rotation — the wheel is at rest.
+    Inactive,
+    /// The first rotation report of a roll.
+    Start,
+    /// A subsequent rotation report.
+    Active,
+    /// The roll ended: released, no touch.
+    Stop,
+}
+
+impl RotationStatus {
+    /// Decode `thumbwheelEvent` byte 4. Values outside the four the spec
+    /// defines decode as [`RotationStatus::Inactive`] — a firmware that
+    /// reports something else has said nothing about a roll, and the caller
+    /// still has the report's own `rotation` to go on. Claiming a roll here
+    /// instead would let one unrecognised value make the tap permanently
+    /// undeliverable.
+    #[must_use]
+    fn from_byte(byte: u8) -> Self {
+        match byte {
+            1 => Self::Start,
+            2 => Self::Active,
+            3 => Self::Stop,
+            _ => Self::Inactive,
+        }
+    }
+
+    /// Whether this report belongs to a roll — including its `Stop`, which
+    /// carries no rotation of its own but is still the roll's own contact.
+    #[must_use]
+    pub fn is_rolling(self) -> bool {
+        !matches!(self, Self::Inactive)
+    }
+}
+
 /// Characteristics + capabilities returned by `getThumbwheelInfo`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ThumbwheelInfo {
@@ -65,6 +123,8 @@ pub struct ThumbwheelEvent {
     /// Relative wheel rotation since the last report (signed, in `diverted_res`
     /// increments). `+` follows `default_dir` unless inverted at divert time.
     pub rotation: i16,
+    /// Where this report sits in the life cycle of a roll.
+    pub rotation_status: RotationStatus,
     /// A single-tap gesture fired with this report.
     pub single_tap: bool,
     /// The user is touching the wheel.
@@ -96,6 +156,7 @@ pub fn decode_event(
     let p = msg.extend_payload();
     Some(ThumbwheelEvent {
         rotation: i16::from_be_bytes([p[0], p[1]]),
+        rotation_status: RotationStatus::from_byte(p[4]),
         single_tap: p[5] & EV_SINGLE_TAP != 0,
         touch: p[5] & EV_TOUCH != 0,
         proxy: p[5] & EV_PROXY != 0,
@@ -191,16 +252,48 @@ mod tests {
     fn decodes_rotation_and_tap() {
         let mut p = [0u8; 16];
         p[0..2].copy_from_slice(&(-7i16).to_be_bytes());
+        p[4] = 2;
         p[5] = EV_SINGLE_TAP | EV_TOUCH;
         assert_eq!(
             decode_event(&event(0, 0, p), 2, 6),
             Some(ThumbwheelEvent {
                 rotation: -7,
+                rotation_status: RotationStatus::Active,
                 single_tap: true,
                 touch: true,
                 proxy: false,
             })
         );
+    }
+
+    #[test]
+    fn decodes_every_rotation_status() {
+        let status = |byte| {
+            let mut p = [0u8; 16];
+            p[4] = byte;
+            decode_event(&event(0, 0, p), 2, 6)
+                .expect("event")
+                .rotation_status
+        };
+        assert_eq!(status(0), RotationStatus::Inactive);
+        assert_eq!(status(1), RotationStatus::Start);
+        assert_eq!(status(2), RotationStatus::Active);
+        assert_eq!(status(3), RotationStatus::Stop);
+        assert_eq!(
+            status(0xff),
+            RotationStatus::Inactive,
+            "an unrecognised value must not make the tap permanently undeliverable"
+        );
+    }
+
+    /// The roll's own `Stop` reports no rotation — it is the release — so
+    /// rotation alone cannot tell a settled wheel from one that just stopped.
+    #[test]
+    fn a_stop_report_is_still_part_of_the_roll() {
+        assert!(RotationStatus::Stop.is_rolling());
+        assert!(RotationStatus::Start.is_rolling());
+        assert!(RotationStatus::Active.is_rolling());
+        assert!(!RotationStatus::Inactive.is_rolling());
     }
 
     #[test]

--- a/crates/openlogi-device/src/thumbwheel.rs
+++ b/crates/openlogi-device/src/thumbwheel.rs
@@ -22,6 +22,7 @@ use hidpp::{
     nibble::U4,
     protocol::v20::{self, Hidpp20Error},
 };
+use serde::{Deserialize, Serialize};
 
 /// `Thumbwheel` HID++ feature ID.
 pub const FEATURE_ID: u16 = 0x2150;
@@ -103,13 +104,48 @@ impl RotationStatus {
     }
 }
 
-/// Characteristics + capabilities returned by `getThumbwheelInfo`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ThumbwheelInfo {
+/// What one revolution of the wheel measures in each reporting mode.
+///
+/// The two are not the same unit: an MX Master 4 reports 20 ratchets per
+/// revolution natively and 120 increments per revolution diverted. Anything
+/// re-synthesising scroll from diverted increments has to scale by the ratio,
+/// or the same physical motion scrolls six times as far as it did before the
+/// wheel was diverted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WheelResolution {
     /// Ratchets per revolution in native (HID) mode.
     pub native_res: u16,
     /// Rotation increments per revolution in diverted (HID++) mode.
     pub diverted_res: u16,
+}
+
+impl WheelResolution {
+    /// Resolutions a wheel did not report, scaling increments through
+    /// unchanged.
+    pub const UNKNOWN: Self = Self {
+        native_res: 0,
+        diverted_res: 0,
+    };
+
+    /// Native scroll units one diverted increment is worth.
+    ///
+    /// `1.0` when either resolution is missing — a wheel that did not answer
+    /// `getThumbwheelInfo` keeps the raw increment-per-unit behavior rather
+    /// than having its scroll silently scaled by a guess.
+    #[must_use]
+    pub fn native_per_increment(self) -> f32 {
+        if self.native_res == 0 || self.diverted_res == 0 {
+            return 1.0;
+        }
+        f32::from(self.native_res) / f32::from(self.diverted_res)
+    }
+}
+
+/// Characteristics + capabilities returned by `getThumbwheelInfo`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThumbwheelInfo {
+    /// What one revolution measures in each reporting mode.
+    pub resolution: WheelResolution,
     /// Original (un-inverted) positive rotation direction: `0` = positive toward
     /// the left/back of the device, `1` = positive toward the right/front.
     pub default_dir: u8,
@@ -213,8 +249,10 @@ impl Thumbwheel {
     pub async fn get_info(&self) -> Result<ThumbwheelInfo, Hidpp20Error> {
         let p = self.call(FN_GET_INFO, [0; 16]).await?;
         Ok(ThumbwheelInfo {
-            native_res: u16::from_be_bytes([p[0], p[1]]),
-            diverted_res: u16::from_be_bytes([p[2], p[3]]),
+            resolution: WheelResolution {
+                native_res: u16::from_be_bytes([p[0], p[1]]),
+                diverted_res: u16::from_be_bytes([p[2], p[3]]),
+            },
             default_dir: p[4] & 0x01,
             supports_single_tap: p[5] & CAP_SINGLE_TAP != 0,
         })

--- a/crates/openlogi-hid/examples/thumbwheel_trace.rs
+++ b/crates/openlogi-hid/examples/thumbwheel_trace.rs
@@ -1,0 +1,108 @@
+//! Dump one thumb wheel's raw `0x2150` `thumbwheelEvent` reports.
+//!
+//! The wheel reports rotation, a capacitive `single_tap`, and where the report
+//! sits in the life cycle of a roll (`rotation_status`, byte 4) — and firmware
+//! does not always populate all three. This prints the wire bytes next to
+//! their decoded form so a device's actual behavior can be checked against the
+//! spec before trusting a field.
+//!
+//! Quit OpenLogi first: one HID node cannot serve two channels, and the agent
+//! holds one whenever it captures.
+//!
+//! ```sh
+//! cargo run -p openlogi-hid --example thumbwheel_trace -- <receiver-uid> <slot>
+//! # e.g. the receiver id and slot printed by `openlogi list`
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use openlogi_hid::thumbwheel::{self, Thumbwheel};
+use openlogi_hid::{ChannelPool, DeviceRoute, host};
+
+/// Seconds the wheel stays diverted while reports are printed.
+const WATCH: Duration = Duration::from_secs(30);
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let (Some(receiver_uid), Some(slot)) = (args.next(), args.next()) else {
+        return Err("usage: thumbwheel_trace <receiver-uid> <slot>".into());
+    };
+    let slot: u8 = slot.parse()?;
+    let route = DeviceRoute::Bolt { receiver_uid, slot };
+
+    let pool = ChannelPool::with_backend(host::backend());
+    let Some(chan) = pool.open(&route).await? else {
+        return Err("no device on that route".into());
+    };
+    let device = hidpp::device::Device::new(Arc::clone(&chan), slot)
+        .await
+        .map_err(|e| format!("device did not answer HID++: {e:?}"))?;
+    let Some(feature) = device
+        .root()
+        .get_feature(thumbwheel::FEATURE_ID)
+        .await
+        .map_err(|e| format!("{e:?}"))?
+    else {
+        return Err("this device exposes no 0x2150 thumb wheel".into());
+    };
+
+    let tw = Thumbwheel::new(Arc::clone(&chan), slot, feature.index);
+    match tw.get_info().await {
+        Ok(info) => println!("getThumbwheelInfo: {info:?}"),
+        Err(e) => println!("getThumbwheelInfo failed: {e:?}"),
+    }
+
+    println!("0x2150 resolved at feature index {}", feature.index);
+    let feature_index = feature.index;
+    let listener = chan.add_msg_listener_guarded(move |raw, matched| {
+        let msg = hidpp::protocol::v20::Message::from(raw);
+        let header = msg.header();
+        if header.feature_index != feature_index
+            || header.software_id.to_lo() != 0
+            || header.function_id.to_lo() != 0
+        {
+            // Everything else on this channel, so "no reports" can be told
+            // apart from "reports arriving under something unexpected".
+            println!(
+                "   other: dev={} feat={} fn={} sw={} matched={matched}",
+                header.device_index,
+                header.feature_index,
+                header.function_id.to_lo(),
+                header.software_id.to_lo(),
+            );
+            return;
+        }
+        let p = msg.extend_payload();
+        let decoded = thumbwheel::decode_event(&msg, slot, feature_index);
+        println!(
+            "rot={:>5}  byte4={:#04x}  byte5={:#04x}  tap={:<5} touch={:<5} proxy={:<5} → {:?}",
+            i16::from_be_bytes([p[0], p[1]]),
+            p[4],
+            p[5],
+            p[5] & 0x08 != 0,
+            p[5] & 0x02 != 0,
+            p[5] & 0x04 != 0,
+            decoded.map(|e| e.rotation_status),
+        );
+    });
+
+    tw.set_reporting(true, false)
+        .await
+        .map_err(|e| format!("could not divert the wheel: {e:?}"))?;
+    println!("\n>>> diverted — roll the wheel, then lift your thumb off it ({WATCH:?})\n");
+    let mut elapsed = Duration::ZERO;
+    while elapsed < WATCH {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        elapsed += Duration::from_secs(5);
+        println!("   [{}s]", elapsed.as_secs());
+    }
+
+    drop(listener);
+    if let Err(e) = tw.set_reporting(false, false).await {
+        println!("could not restore native reporting: {e:?}");
+    }
+    println!("\n<<< native reporting restored");
+    Ok(())
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -52,7 +52,10 @@ Common device fields are:
 
 - `enabled`, `dpi`, `dpi_presets`, thumb-wheel sensitivity, scroll inversion,
   and scroll resolution
-- `bindings`: a button maps either to one action or to a gesture-direction map
+- `bindings`: a button maps either to one action or to a gesture-direction map.
+  `Thumbwheel` is the thumb wheel's capacitive tap — it has no GUI control and
+  stays inert unless bound here, because the wheel reports taps from incidental
+  thumb contact as well as from deliberate ones
 - `per_app_bindings`: sparse action overlays keyed by macOS bundle id, Linux
   application id, exact lower-cased Windows executable path, or
   `exe:<filename>.exe`

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -26,6 +26,9 @@ scroll_resolution = "high"
 [devices."receiver:aabbccdd:slot:1".bindings]
 Back = "BrowserBack"
 Forward = "BrowserForward"
+# The thumb wheel's capacitive tap. Inert unless set here; the wheel also
+# reports taps from incidental thumb contact.
+Thumbwheel = "AppExpose"
 
 [devices."receiver:aabbccdd:slot:1".bindings.GestureButton]
 Click = "MissionControl"


### PR DESCRIPTION
## Summary

Touching the MX thumb wheel — even rubbing its ridges without turning it — opened App Exposé on macOS and Task View on Windows. Reported seven times over two months: #340 (with the root cause), #641, #435, #477, #397, #295, #761, #737.

Three things had to line up:

1. `ButtonId::Thumbwheel` is the wheel's capacitive tap, and it was seeded with `AppExpose`.
2. The mouse model surfaces the wheel as one paired rotation control, so that binding has no GUI hotspot — nothing to discover it with, nothing to clear it with.
3. The wheel is diverted over HID++ `0x2150` — which is what starts delivering taps at all — as soon as either rotation binding or the sensitivity leaves its default.

So customizing the scroll direction, or nudging the sensitivity slider, armed an invisible Exposé trigger under the user's thumb. Logi Options+ does not do this because it never seeds the tap with an action.

The tap now seeds to `Action::None`. A tap bound explicitly in the config still dispatches, and nothing needs migrating: defaults are never persisted, so the only `Thumbwheel` entries on disk are hand-written ones — exactly the intent worth keeping.

## Telling a roll from a tap

A second defect stays live for anyone who *does* bind the tap: the wheel's touch sensor flags a tap for the finger that rolled it, so a brisk flick fired the tap's action on top of the scroll. This is what #340's "the faster you use the thumb scroll, the more frequent it happens" and #397's 快速滚动 describe, and what @tagawa0525 caught on MX Master 3S hardware in #464.

`0x2150` answers this in the protocol rather than by guesswork: `thumbwheelEvent` byte 4 is `rotation_status` (Inactive / Start / Active / Stop), and the decoder was dropping it on the floor. Every report from `Start` through `Stop` belongs to one roll, so a tap bit inside that span is an artifact of the same contact.

`Stop` is the case a rotation check cannot reach. Traced on an MX Master 4 over Bolt with the `thumbwheel_trace` example added here — one nudge of the wheel:

```
getThumbwheelInfo: { native_res: 20, diverted_res: 120, supports_single_tap: false }
rot=  -1  byte4=0x02  byte5=0x02  touch=true   → Active
rot=   0  byte4=0x03  byte5=0x00  touch=false  → Stop
```

The release reports no rotation at all, so `rotation != 0` reads it as "not a roll" — and on a wheel that supports `single_tap`, the release is exactly where the artifact lands. Only byte 4 separates it from a tap on a settled wheel.

Classification is therefore stateless and lives entirely in the decode layer: no timer, no window, no tuned constant. A report's own rotation is still honoured alongside the status, so a wheel whose firmware leaves byte 4 at zero behaves no worse than today; an unrecognised byte 4 decodes as `Inactive` rather than claiming a roll, so one odd value cannot make the tap permanently undeliverable.

## Scrolling by the wheel's native amount

The same trace shows a second thing: `native_res: 20` against `diverted_res: 120`. Diverting the wheel changes the unit it reports in, and the re-synthesised scroll was reading the new unit as if it were the old one — one posted scroll line per increment. So the moment anything diverted the wheel, the same physical motion scrolled **six times as far**, and the sensitivity slider's documented 1× was 1× of nothing in particular.

Arming already called `getThumbwheelInfo` and kept only `supports_single_tap`. Both resolutions now ride along on `CapturedInput::Scroll`, and increments are scaled back to native units before the sensitivity multiplier. A wheel that reports no resolution scales by 1.0 — today's behavior — rather than by a guess.

This is a **behavior change** for anyone who has a diverted wheel today: horizontal scrolling slows to what the wheel does natively. That is the documented contract (`14` is 1×), and it is the ratio the device itself reports, but it will feel different to anyone who had turned the sensitivity down to compensate.

## Changes

- `openlogi-core`: seed `ButtonId::Thumbwheel` with `Action::None`; document why the tap is inert where the default lives.
- `openlogi-device`: decode `rotation_status` (byte 4), previously discarded; group the two resolutions as `WheelResolution`; one diverted report resolves to at most one input, with a roll — including its release — never resolving to a tap.
- `openlogi-agent-core`: scale diverted increments to native scroll units before applying sensitivity.
- `openlogi-hid`: `examples/thumbwheel_trace`, which dumps a wheel's raw reports next to their decoded form. This is what produced the trace above.
- `docs`: document the `Thumbwheel` binding key and its inert default in CONFIGURATION.md and the example config.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (with `RUSTFLAGS=-D warnings`)
- `cargo test --workspace` — green
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items` (GUI crates excluded, as CI does)
- `cargo xtask ci` — 9 passed, 1 skipped. **`tests (linux)` was not run** (macOS host).
- New coverage: every `rotation_status` value including an unrecognised one, the release-that-ends-a-roll, a tap on a settled wheel, rotation-only rolls on firmware that leaves byte 4 at zero, a revolution scrolling its native amount at 1× and 2× sensitivity, an unreported resolution passing through unscaled, and the projection tests pinning an inert seed alongside a surviving explicit binding.

**Hardware status.** `rotation_status` and the resolution pair are confirmed on real MX firmware (the trace above, MX Master 4 / Bolt). Two things are **not** verified here: the artifact tap itself — MX Master 4 reports `supports_single_tap: false`, so that half still rests on the MX Master 3S evidence in #464 and #340 — and how the corrected scroll speed feels in the hand. To verify on a 3S: set the thumb-wheel rotation to anything non-default, then rub the wheel's ridges without turning it — no Exposé / Task View. Then add `Thumbwheel = "AppExpose"` under the device's `[…bindings]`, restart, and confirm a deliberate tap on a still wheel fires it while a brisk roll does not.

Supersedes #341 and #464, whose diagnosis and layering this adopts; both are credited as co-authors. Both had gone stale against master — #341 predates the `openlogi-device` split, and #464's tap provenance ended up living only in `#[cfg(test)]` helpers while the production path still compared against the default value.

Fixes #340
Fixes #435
Fixes #477
Fixes #641