### PR TITLE
fix(linux): skip udev reload without control socket

### DIFF
--- a/packaging/linux/nfpm-scripts/postinstall.sh
+++ b/packaging/linux/nfpm-scripts/postinstall.sh
@@ -6,7 +6,7 @@ set -eu
 # before the script exits so the agent can open /dev/hidraw* and the mouse's
 # /dev/input/event* node immediately, even for a device connected before the
 # install.
-if command -v udevadm >/dev/null 2>&1; then
+if command -v udevadm >/dev/null 2>&1 && [ -S /run/udev/control ]; then
   udevadm control --reload-rules
   udevadm trigger --subsystem-match=hidraw
   udevadm trigger --subsystem-match=input


### PR DESCRIPTION
## Summary

Avoid failing RPM post-install scripts on rpm-ostree systems when the udev control socket is unavailable.

## Changes

- Only reload and trigger udev when `/run/udev/control` is available.

## Testing

- `dash -n packaging/linux/nfpm-scripts/postinstall.sh`
- `bash -n packaging/linux/nfpm-scripts/postinstall.sh`

Fixes #681