### PR TITLE
feat(hid): allow DPI button gesture bindings

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -119,7 +119,9 @@ pub fn plan_for_device(
 #[cfg(test)]
 mod tests {
     use openlogi_core::binding::Binding;
-    use openlogi_hid::reprog_controls::{GESTURE_BUTTON_CID, HAPTIC_PANEL_CID};
+    use openlogi_hid::reprog_controls::{
+        DPI_MODE_SHIFT_CIDS, GESTURE_BUTTON_CID, HAPTIC_PANEL_CID,
+    };
 
     use super::*;
 
@@ -136,6 +138,24 @@ mod tests {
         assert!(GESTURE_SOURCE_BUTTONS.iter().any(|(_, button)| {
             *button == ButtonId::DpiToggle
         }));
+    }
+
+    #[test]
+    fn single_bound_dpi_toggle_uses_one_plain_capture_path() {
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b042",
+            ButtonId::DpiToggle,
+            Binding::Single(Action::Copy),
+        );
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            plan.divert_buttons.iter().any(|&(cid, button)| {
+                DPI_MODE_SHIFT_CIDS.contains(&cid) && button == ButtonId::DpiToggle
+            }),
+            "a non-default DPI binding must use the generic button capture"
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -28,7 +28,8 @@ pub struct DeviceCapturePlan {
     /// Per-button single actions for this device (per-app effective).
     pub bindings: BTreeMap<ButtonId, Action>,
     /// Per-direction map for each HID++ gesture source (the dedicated gesture
-    /// button, the MX Master 4 haptic panel) in gesture mode on this device,
+    /// button, the MX Master 4 haptic panel, or a compatible DPI / ModeShift
+    /// control) in gesture mode on this device,
     /// keyed by the button its captured swipes dispatch as; empty when none
     /// gestures.
     pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
@@ -127,6 +128,14 @@ mod tests {
             receiver_uid: "cafe".into(),
             slot: 2,
         }
+    }
+
+    #[test]
+    fn dpi_toggle_is_a_hidpp_gesture_source() {
+        assert!(ButtonId::DpiToggle.is_hidpp_gesture_source());
+        assert!(GESTURE_SOURCE_BUTTONS.iter().any(|(_, button)| {
+            *button == ButtonId::DpiToggle
+        }));
     }
 
     #[test]

--- a/crates/openlogi-core/src/binding/button.rs
+++ b/crates/openlogi-core/src/binding/button.rs
@@ -121,11 +121,15 @@ impl ButtonId {
     /// Whether this button is a HID++ gesture source — a control that is
     /// captured over HID++ raw-XY diversion (never the OS hook) and can
     /// therefore own the gesture role with swipe directions: the dedicated
-    /// gesture button, or the MX Master 4 haptic panel. The capture layer maps
-    /// each to its control ID.
+    /// gesture button, the MX Master 4 haptic panel, or a DPI / ModeShift
+    /// control that advertises raw-XY. The capture layer maps each to its
+    /// control ID.
     #[must_use]
     pub fn is_hidpp_gesture_source(self) -> bool {
-        matches!(self, ButtonId::GestureButton | ButtonId::HapticPanel)
+        matches!(
+            self,
+            ButtonId::GestureButton | ButtonId::HapticPanel | ButtonId::DpiToggle
+        )
     }
 
     /// Human-readable label for popovers and tooltips.

--- a/crates/openlogi-core/src/bindings.rs
+++ b/crates/openlogi-core/src/bindings.rs
@@ -48,7 +48,8 @@ pub fn bindings_for(
 }
 
 /// Per-direction maps for every HID++ gesture source (the dedicated gesture
-/// button, the MX Master 4 haptic panel) in gesture mode on `config_key`,
+/// button, the MX Master 4 haptic panel, or a compatible DPI / ModeShift
+/// control) in gesture mode on `config_key`,
 /// keyed by the button its captured swipes dispatch as. Each map is seeded
 /// via [`Binding::fill_gesture_defaults`] — the one canonical seeding rule —
 /// so the watcher always dispatches the full five-direction set the GUI

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -1,5 +1,6 @@
 //! Live control capture for one device: divert the device's gesture sources
-//! (the MX dedicated gesture button and/or the MX Master 4 haptic panel), the
+//! (the MX dedicated gesture button, MX Master 4 haptic panel, and compatible
+//! DPI / ModeShift controls), the
 //! DPI/ModeShift button, and the thumb wheel over HID++ and turn their events
 //! into [`CapturedInput`] the GUI can dispatch.
 //!
@@ -142,13 +143,16 @@ pub const DIVERTABLE_STANDARD_BUTTONS: [(u16, ButtonId); 3] = [
 ];
 
 /// HID++ gesture sources: the `0x1b04` control ID and the [`ButtonId`] it
-/// delivers — the dedicated gesture button on most MX mice, and the Haptic
-/// Sense Panel on MX Master 4 (two distinct physical controls). Each source in
-/// gesture mode is diverted with raw-XY; one with a non-default single binding
-/// instead is plain-diverted like a standard button.
-pub const GESTURE_SOURCE_BUTTONS: [(u16, ButtonId); 2] = [
+/// delivers — the dedicated gesture button on most MX mice, the Haptic Sense
+/// Panel on MX Master 4, or a DPI / ModeShift control that advertises raw-XY.
+/// Each source in gesture mode is diverted with raw-XY; one with a non-default
+/// single binding instead is plain-diverted like a standard button.
+pub const GESTURE_SOURCE_BUTTONS: [(u16, ButtonId); 5] = [
     (reprog_controls::GESTURE_BUTTON_CID, ButtonId::GestureButton),
     (reprog_controls::HAPTIC_PANEL_CID, ButtonId::HapticPanel),
+    (reprog_controls::DPI_MODE_SHIFT_CIDS[0], ButtonId::DpiToggle),
+    (reprog_controls::DPI_MODE_SHIFT_CIDS[1], ButtonId::DpiToggle),
+    (reprog_controls::DPI_MODE_SHIFT_CIDS[2], ButtonId::DpiToggle),
 ];
 
 /// Which of one device's controls a capture session should divert.
@@ -478,6 +482,11 @@ async fn arm_controls_into(
             }
         }
         for &cid in &reprog_controls::DPI_MODE_SHIFT_CIDS {
+            // A DPI / ModeShift control used as a gesture source must keep its
+            // raw-XY diversion; do not overwrite it with a plain DPI arm.
+            if armed.gesture_cids.contains(&cid) {
+                continue;
+            }
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
                 let reporting = arm_reprog_control(&rc, cid, false).await?;
                 armed.reporting.push(reporting);

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -487,6 +487,18 @@ async fn arm_controls_into(
             if armed.gesture_cids.contains(&cid) {
                 continue;
             }
+            // A non-default single DpiToggle binding is delivered by the
+            // generic button path below. Arming the dedicated DPI path too
+            // would emit the same press twice.
+            if spec
+                .divert_buttons
+                .iter()
+                .any(|&(button_cid, button)| {
+                    button_cid == cid && button == ButtonId::DpiToggle
+                })
+            {
+                continue;
+            }
             if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
                 let reporting = arm_reprog_control(&rc, cid, false).await?;
                 armed.reporting.push(reporting);


### PR DESCRIPTION
## Summary

Allow compatible DPI / ModeShift controls to carry the HID++ gesture role.

Fixes #806

## Changes

- Treat `DpiToggle` as a HID++ gesture source.
- Map all DPI / ModeShift control IDs to `DpiToggle`.
- Preserve raw-XY diversion when a DPI control is configured for gestures.
- Add a regression test for DPI gesture-source recognition.

## Testing

- `git diff --check`
- Rust tests not run: the environment has no `cargo`/`rustc`; rustup and Homebrew installation both stalled on network downloads.
- Not runtime-tested on hardware.