### PR TITLE
fix(gui): stop discarding correctly rebuilt device records

### DIFF
--- a/crates/openlogi-assets/src/metadata.rs
+++ b/crates/openlogi-assets/src/metadata.rs
@@ -45,12 +45,12 @@ use serde::Deserialize;
 use crate::error::AssetError;
 use crate::http;
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct Metadata {
     pub images: Vec<ImageEntry>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct ImageEntry {
     pub key: String,
     pub origin: Origin,
@@ -58,13 +58,13 @@ pub struct ImageEntry {
     pub assignments: Vec<Assignment>,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct Origin {
     pub width: u32,
     pub height: u32,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Assignment {
     /// Empty on older keyboard depots whose assignments carry only `slotId`;
     /// `map_slot_name`-style consumers treat unknown names as "no hotspot".
@@ -79,13 +79,13 @@ pub struct Assignment {
     pub label: Direction,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq)]
 pub struct Point {
     pub x: f32,
     pub y: f32,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
 pub struct Direction {
     pub x: i32,
     pub y: i32,

--- a/crates/openlogi-desktop/src/runtime.rs
+++ b/crates/openlogi-desktop/src/runtime.rs
@@ -274,7 +274,6 @@ impl Runtime {
                             &snapshot.inventory,
                             &snapshot.standalone,
                             &self.cache,
-                            false,
                             &self.cams,
                         );
                     if inventory_ready {
@@ -403,7 +402,6 @@ impl Runtime {
                     &self.inventories,
                     &self.standalone,
                     &self.cache,
-                    true,
                     &self.cams,
                 )
             });

--- a/crates/openlogi-desktop/src/runtime.rs
+++ b/crates/openlogi-desktop/src/runtime.rs
@@ -149,7 +149,7 @@ pub(crate) fn spawn(startup: Startup, cx: &mut gpui::App) {
                     // this moment: re-issue it now that the cache is no longer
                     // being written. The command arm runs it (the sync is idle
                     // again) — or re-defers if a new sync already started.
-                    if let Some(cmd) = rt.on_sync_finished(ok) {
+                    if let Some(cmd) = rt.on_sync_finished(ok, cx) {
                         let _ = asset_self_tx.send(cmd);
                     }
                 }
@@ -261,17 +261,6 @@ impl Runtime {
             self.inventories.clone_from(&snapshot.inventory);
             self.standalone.clone_from(&snapshot.standalone);
         }
-        // A completed sync may have put real photos where silhouettes were
-        // resolved: the resolver was rebuilt when its outcome landed; force
-        // this merge through the unchanged-list early-return so the fresh
-        // records become visible. Only consume the flag on a `Ready` snapshot
-        // that will actually run the merge below — `refresh_inventories` is
-        // skipped while the agent is still `Scanning`, so taking it there would
-        // drop the repaint and strand the device on its silhouette until the
-        // next inventory change or a restart (seen after an update relaunches
-        // GUI and agent together: the agent's Scanning window overlaps the
-        // first sync's completion).
-        let force_refresh = inventory_ready && self.sync.take_dirty();
         let pairing_changed =
             cx.update(|cx| windows::add_device::apply_state(cx, snapshot.pairing.clone()));
         let (auto_download, asset_source, models) = cx.update(|cx| {
@@ -285,7 +274,7 @@ impl Runtime {
                             &snapshot.inventory,
                             &snapshot.standalone,
                             &self.cache,
-                            force_refresh,
+                            false,
                             &self.cams,
                         );
                     if inventory_ready {
@@ -397,10 +386,11 @@ impl Runtime {
 
     /// A background fetch finished. Returns the manual command that was waiting
     /// on it, if any.
-    fn on_sync_finished(&mut self, ok: bool) -> Option<AssetCommand> {
+    fn on_sync_finished(&mut self, ok: bool, cx: &AsyncApp) -> Option<AssetCommand> {
         let deferred = self.sync.finish(ok);
         if ok {
             self.cache = assets::AssetResolver::new();
+            self.refresh_devices(cx);
         }
         deferred
     }

--- a/crates/openlogi-desktop/src/services/assets.rs
+++ b/crates/openlogi-desktop/src/services/assets.rs
@@ -102,7 +102,7 @@ fn open_in_file_manager(path: &Path) {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedAsset {
     pub depot: String,
     pub display_name: String,

--- a/crates/openlogi-desktop/src/services/assets/glow.rs
+++ b/crates/openlogi-desktop/src/services/assets/glow.rs
@@ -50,7 +50,7 @@ struct MetaGlow {
 
 /// One horizontal run of inter-key holes, normalized to the mask's `[0, 1]`
 /// extent so it scales to whatever size the device image renders at.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct GlowSeg {
     pub x: f32,
     pub y: f32,
@@ -62,7 +62,7 @@ pub(crate) struct GlowSeg {
 /// ratio, ready to paint over the device image at any size. Decoded once per
 /// asset resolve; the segment list is the entire runtime footprint — there is
 /// no recoloured texture, so a session that cycles colours costs nothing extra.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct GlowGeometry {
     pub aspect: f32,
     pub segments: Vec<GlowSeg>,

--- a/crates/openlogi-desktop/src/services/assets/scheduler.rs
+++ b/crates/openlogi-desktop/src/services/assets/scheduler.rs
@@ -47,7 +47,6 @@ pub(crate) struct AssetSync {
     last_at: Option<Instant>,
     index_refreshed: bool,
     synced_keys: HashSet<String>,
-    dirty: bool,
 }
 
 impl AssetSync {
@@ -59,24 +58,12 @@ impl AssetSync {
             last_at: None,
             index_refreshed: false,
             synced_keys: HashSet::new(),
-            dirty: false,
         }
     }
 
     /// Whether a fetch is writing the cache right now.
     pub(crate) fn is_running(&self) -> bool {
         matches!(self.state, SyncState::Running { .. })
-    }
-
-    /// Take the "a fetch landed new art" flag, which asks the next merge to
-    /// push past the unchanged-device-list early return so the fresh records
-    /// become visible.
-    ///
-    /// Only call this on a merge that will actually run: consuming the flag on
-    /// a skipped merge strands the device on its silhouette until the next
-    /// inventory change (#218).
-    pub(crate) fn take_dirty(&mut self) -> bool {
-        std::mem::take(&mut self.dirty)
     }
 
     /// The automatic path, offered every merged snapshot: fetch the index once
@@ -159,7 +146,6 @@ impl AssetSync {
             self.last_at = None;
             self.index_refreshed = true;
             self.synced_keys.extend(keys);
-            self.dirty = true;
         }
         deferred
     }
@@ -335,22 +321,5 @@ mod tests {
             sync.poll_auto(vec![target("a")], true, now),
             Some(vec![target("a")])
         );
-    }
-
-    #[test]
-    fn only_a_successful_fetch_asks_for_a_repaint_and_only_once() {
-        let mut sync = AssetSync::new(true);
-        let now = Instant::now();
-        assert!(sync.poll_auto(Vec::new(), true, now).is_some());
-        assert!(sync.finish(false).is_none());
-        assert!(!sync.take_dirty());
-
-        assert!(
-            sync.poll_auto(Vec::new(), true, now + Duration::from_secs(1))
-                .is_some()
-        );
-        assert!(sync.finish(true).is_none());
-        assert!(sync.take_dirty());
-        assert!(!sync.take_dirty());
     }
 }

--- a/crates/openlogi-desktop/src/state/devices.rs
+++ b/crates/openlogi-desktop/src/state/devices.rs
@@ -25,7 +25,7 @@ use crate::services::assets::{AssetResolver, ResolvedAsset};
 /// carousel can render straight from the device list — the list is the single
 /// source of truth for "which devices exist", keeping carousel order aligned
 /// with [`super::AppState::current_device`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeviceRecord {
     /// Route-derived key used for runtime state and, when [`Self::persistent`]
     /// is true, persisted settings.

--- a/crates/openlogi-desktop/src/state/inventory.rs
+++ b/crates/openlogi-desktop/src/state/inventory.rs
@@ -47,18 +47,16 @@ impl AppState {
     /// the previously-selected device disappeared, the selection falls back
     /// to index 0. Returns whether anything actually changed.
     ///
-    /// No-op (returning `false`) when the new list has the same `config_key`
-    /// sequence as the current one — the caller skips the window refresh, and
-    /// quiet polling cycles cause no spurious re-renders (P1.6). `force`
-    /// pushes through that early-return: the records embed resolved asset
-    /// paths, so a completed asset sync needs one rebuild even though the
-    /// device *set* is unchanged.
+    /// No-op (returning `false`) when the rebuilt list equals the current one,
+    /// so the caller skips the window refresh. The comparison is whole-record,
+    /// which is what lets every input tier — the agent snapshot, the camera
+    /// scan, and the asset cache — share one rebuild path without any of them
+    /// needing to announce which fields it might have touched.
     pub fn refresh_inventories(
         &mut self,
         inventories: &[DeviceInventory],
         standalone: &[StandaloneDevice],
         cache: &AssetResolver,
-        force: bool,
         cameras: &[openlogi_camera::Camera],
     ) -> bool {
         let new_list = build_device_list(inventories, standalone, cache, &self.config, cameras);
@@ -69,29 +67,13 @@ impl AppState {
         if persist_identities(&mut self.config, &merged_list) {
             self.persist_config("device identity");
         }
-        // Compare more than config_key: a device can reconnect on a new HID++
-        // index while keeping its physical config key, and the fresh route must
-        // replace the stale one so reads/writes don't target a dead index.
-        // `online` and `capabilities` are compared too, so a device waking up or
-        // a probe that resolves its feature table on a stable route still
-        // refreshes the carousel (and its config panels) instead of being
-        // swallowed by this guard.
-        let unchanged = merged_list.len() == self.device_list.len()
-            && merged_list
-                .iter()
-                .zip(self.device_list.iter())
-                .all(|(a, b)| {
-                    a.config_key == b.config_key
-                        && a.capture_id == b.capture_id
-                        && a.route == b.route
-                        && a.online == b.online
-                        && a.capabilities == b.capabilities
-                        && a.light_capabilities == b.light_capabilities
-                        && a.driver_id == b.driver_id
-                        && a.registry_model_id == b.registry_model_id
-                        && a.kind == b.kind
-                });
-        if unchanged && !force {
+        // Whole-record equality, not a field allowlist. Every field of a
+        // `DeviceRecord` is rendered somewhere, so any of them differing is a
+        // real change; an allowlist silently drops the fields nobody thought to
+        // add — `battery` and the resolved `asset` were both being swallowed
+        // here. Structural comparison also makes the guard immune to new
+        // fields, which is what an allowlist can never be.
+        if merged_list == self.device_list {
             return false;
         }
 

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -5,9 +5,9 @@ use openlogi_core::config::{
     Config, DeviceIdentity, LightSettings, Lighting, ScrollResolution, ThumbwheelSensitivity,
 };
 use openlogi_core::device::{
-    Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
-    LightCapabilities, LightValueRange, LightValueUnit, PairedDevice, RawDeviceAddress,
-    ReceiverInfo, StandaloneDevice,
+    BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
+    DeviceModelInfo, DeviceTransports, LightCapabilities, LightValueRange, LightValueUnit,
+    PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
 use openlogi_core::hid::{
     Dpi, SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, WriteError,
@@ -1005,4 +1005,71 @@ fn gesture_maps_cover_every_gesture_mode_button() {
         maps.contains_key(&ButtonId::Back),
         "a promoted OS-hook button gets its own menu simultaneously"
     );
+}
+
+/// A battery reading that changed on an otherwise identical device must reach
+/// the device list. The old guard compared nine hand-picked fields and
+/// `battery` was not among them, so the rebuilt list — carrying the fresh
+/// percentage — was discarded and every battery readout in the UI (gallery
+/// card, detail page, native Device menu) stayed frozen until some *other*
+/// compared field happened to move.
+#[test]
+fn a_battery_only_change_reaches_the_device_list() {
+    let cache = AssetResolver::new();
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let unit_id = [1, 2, 3, 4];
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[inventory_with_battery(unit_id, 50)],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+    assert_eq!(
+        state.device_list[0].battery.as_ref().map(|b| b.percentage),
+        Some(50)
+    );
+
+    let changed =
+        state.refresh_inventories(&[inventory_with_battery(unit_id, 40)], &[], &cache, &[]);
+
+    assert!(changed, "a battery change is a change");
+    assert_eq!(
+        state.device_list[0].battery.as_ref().map(|b| b.percentage),
+        Some(40),
+        "the fresh reading must replace the stale one"
+    );
+}
+
+/// The guard still exists: an identical snapshot is a no-op, so quiet cycles
+/// cost no window refresh. Without this the previous test could be satisfied
+/// by simply always returning `true`.
+#[test]
+fn an_identical_snapshot_is_still_a_no_op() {
+    let cache = AssetResolver::new();
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let unit_id = [1, 2, 3, 4];
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[inventory_with_battery(unit_id, 50)],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    assert!(!state.refresh_inventories(&[inventory_with_battery(unit_id, 50)], &[], &cache, &[]));
+}
+
+fn inventory_with_battery(unit_id: [u8; 4], percentage: u8) -> DeviceInventory {
+    let mut inventory = direct_inventory(unit_id);
+    inventory.paired[0].battery = Some(BatteryInfo {
+        percentage,
+        level: BatteryLevel::Good,
+        status: BatteryStatus::Discharging,
+    });
+    inventory
 }


### PR DESCRIPTION
## Summary

Two things the device list had already computed correctly were being thrown away before they reached the screen: art that downloaded after a device card was built, and a battery percentage that changed on an otherwise identical device. Same shape both times — a correct recomputation discarded — and both invisible, because the guard doing the discarding compares nine of a `DeviceRecord`'s nineteen fields.

**Commit 1 — the repaint had no carrier.** A completed asset sync rebuilt the resolver and raised a `dirty` flag for the next inventory merge to consume. That worked while the GUI resampled the agent on a timer. Since the state channel became level-triggered, `observe` answers only when the agent's own state changed, so no merge is guaranteed to follow: art that landed after a card was built never reached the screen. A depot seen for the first time — a webcam plugged in a minute after launch — kept its placeholder until an unrelated device change or a restart. The sync-finished arm now rebuilds the records itself, and the flag goes with the poll it was riding.

**Commit 2 — the guard was an allowlist.** `refresh_inventories` guarded its only write with a hand-picked field list, and `battery` was not on it, so the gallery card, the detail page and the native Device menu kept showing the previous reading until some other compared field happened to move. The comment above that list read as a changelog of the same failure: `route`, then `online`, then `capabilities`, each added after it had been swallowed once. Comparing the whole record makes the guard immune to fields added later instead of needing to learn about each one, and `force` — which existed only to push past the list for the one field somebody had already noticed — goes with it.

## Changes

- `openlogi-desktop`: rebuild device records from the sync-finished arm; delete `AssetSync::dirty` / `take_dirty` and the `force` parameter; compare whole `DeviceRecord`s in `refresh_inventories`; derive `PartialEq` on `DeviceRecord`, `ResolvedAsset`, `GlowGeometry`, `GlowSeg`
- `openlogi-assets`: derive `PartialEq` on `Metadata`, `ImageEntry`, `Origin`, `Assignment`, `Point`, `Direction`

## Testing

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items \
  --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
cargo xtask ci        # 9 passed, 0 failed, 1 skipped
```

`tests (linux)` was skipped — wrong host — and is not claimed as passing.

New test `a_battery_only_change_reaches_the_device_list` was checked against the old guard: restoring the nine-field comparison makes it fail on `a battery change is a change`, and the new comparison makes it pass. `an_identical_snapshot_is_still_a_no_op` covers the other direction, so the fix cannot be satisfied by always reporting a change.

**Not runtime-tested on hardware.** To verify: with a device whose depot has never been cached on that machine (clear `~/.local/share/openlogi/assets`, or plug in a model you have not used before), launch the GUI and confirm the card picks up its render without a restart. For the battery half, watch a percentage change land on the gallery card and in the native Device menu.

Related but not claimed: #569 reports the same symptom (image present in the cache, not shown) and may be this bug or may be the metadata-filename cause tracked in #782 — this change does nothing about the latter.