### PR TITLE
chore: release v0.7.10

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ steps.app-token.outputs.cargo-registry-token }}
       # release-plz skips release=false app crates; git-cliff covers the whole repo.
-      - name: Find open release PR
+      - name: Find current release PR
         id: open_release_pr
         uses: actions/github-script@v8
         with:
@@ -63,7 +63,22 @@ jobs:
               state: "open",
               per_page: 100,
             });
-            const pull = openPulls.find(({ head }) => head.ref.startsWith("release-plz/"));
+            const releasePulls = openPulls.filter(({ head }) =>
+              head.ref.startsWith("release-plz/") &&
+              head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`
+            );
+            let pull;
+            for (const candidate of releasePulls) {
+              const { data: comparison } = await github.rest.repos.compareCommitsWithBasehead({
+                ...context.repo,
+                basehead: `${context.sha}...${candidate.head.sha}`,
+              });
+              if (comparison.status === "ahead" || comparison.status === "identical") {
+                pull = candidate;
+                break;
+              }
+              core.info(`Ignoring stale release PR #${candidate.number}: ${comparison.status}`);
+            }
             if (pull) {
               core.setOutput("branch", pull.head.ref);
               core.setOutput("number", pull.number);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.10] - 2026-08-23
+
+### Fixed
+
+- *(release)* publish the complete crates.io dependency closure
+- *(release)* ignore stale release pull requests during changelog post-processing
+
 ## [0.7.9] - 2026-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "openlogi-cli",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-agent"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "dispatch2",
  "embed-resource",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-agent-core"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "futures-lite",
  "openlogi-core",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-assets"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "atomic-write-file",
  "backon",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-camera"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "block2 0.6.2",
  "objc2 0.6.4",
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-cli"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-core"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "atomic-write-file",
  "az",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-desktop"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "appicon",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-device"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "futures-concurrency",
  "futures-lite",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-hid"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-hid",
  "atomic-write-file",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-hidpp"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-hidpp-derive"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-hook"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-inject"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-ipc"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "bincode",
  "interprocess",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-overlay"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "block2 0.6.2",
@@ -5467,7 +5467,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-permissions"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "objc2 0.6.4",
  "objc2-io-kit",
@@ -5479,7 +5479,7 @@ dependencies = [
 
 [[package]]
 name = "openlogi-ui"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "fluent-langneg",
  "gpui",
@@ -10034,7 +10034,7 @@ checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"
 
 [[package]]
 name = "xtask"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "appicon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 default-members = ["crates/openlogi"]
 
 [workspace.package]
-version = "0.7.9"
+version = "0.7.10"
 edition = "2024"
 # Tracks current stable rather than trailing it. OpenLogi ships as an app —
 # prebuilt installers, and no crate here has an external reverse dependency —
@@ -41,7 +41,7 @@ authors = ["AprilNEA <dev@aprilnea.me>"]
 description = "Lightweight, local-first alternative to Logitech Options+ for HID++ devices"
 
 [workspace.dependencies]
-hidpp = { package = "openlogi-hidpp", path = "crates/openlogi-hidpp", version = "0.7.9" }
+hidpp = { package = "openlogi-hidpp", path = "crates/openlogi-hidpp", version = "0.7.10" }
 async-hid = "0.5.3"
 interprocess = { version = "2", features = ["tokio"] }
 # The agent <-> GUI RPC layer itself, over the `interprocess` transport above.

--- a/crates/openlogi-cli/Cargo.toml
+++ b/crates/openlogi-cli/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["logitech", "hidpp", "hid", "mouse", "cli"]
 categories = ["command-line-utilities", "hardware-support"]
 
 [dependencies]
-openlogi-core = { path = "../openlogi-core", version = "0.7.9" }
-openlogi-hid = { path = "../openlogi-hid", version = "0.7.9" }
-openlogi-camera = { path = "../openlogi-camera", version = "0.7.9" }
-openlogi-assets = { path = "../openlogi-assets", version = "0.7.9" }
-openlogi-ipc = { path = "../openlogi-ipc", version = "0.7.9" }
+openlogi-core = { path = "../openlogi-core", version = "0.7.10" }
+openlogi-hid = { path = "../openlogi-hid", version = "0.7.10" }
+openlogi-camera = { path = "../openlogi-camera", version = "0.7.10" }
+openlogi-assets = { path = "../openlogi-assets", version = "0.7.10" }
+openlogi-ipc = { path = "../openlogi-ipc", version = "0.7.10" }
 tarpc = { workspace = true }
 png = "0.17"
 clap = { workspace = true }

--- a/crates/openlogi-device/Cargo.toml
+++ b/crates/openlogi-device/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["hardware-support"]
 # a dependency that cannot build for `wasm32-unknown-unknown` breaks that job.
 [dependencies]
 hidpp = { workspace = true }
-openlogi-core = { version = "0.7.9", path = "../openlogi-core", default-features = false }
+openlogi-core = { version = "0.7.10", path = "../openlogi-core", default-features = false }
 futures-lite = { workspace = true }
 futures-concurrency = "7"
 serde = { workspace = true }

--- a/crates/openlogi-hid/Cargo.toml
+++ b/crates/openlogi-hid/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["hardware-support", "asynchronous"]
 readme = "README.md"
 
 [dependencies]
-openlogi-core = { path = "../openlogi-core", version = "0.7.9" }
+openlogi-core = { path = "../openlogi-core", version = "0.7.10" }
 hidpp = { workspace = true }
 async-hid = { workspace = true }
 tokio = { workspace = true }
@@ -23,7 +23,7 @@ tracing = { workspace = true }
 futures-concurrency = "7"
 serde_json.workspace = true
 atomic-write-file = { workspace = true }
-openlogi-device = { version = "0.7.9", path = "../openlogi-device" }
+openlogi-device = { version = "0.7.10", path = "../openlogi-device" }
 
 # Native Win32 HID report writes (windows_hid.rs) — a fallback for async-hid's
 # write path on Windows, plus the composite short/long endpoint handling in

--- a/crates/openlogi-hidpp/Cargo.toml
+++ b/crates/openlogi-hidpp/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 # OpenLogi-specific: generates the mechanical CreatableFeature/Feature impls
 # for feature structs shaped `{ endpoint: FeatureEndpoint }` or `{ endpoint,
 # events: EventSource<Event> }`. Not in upstream hidpp; used only here.
-openlogi-hidpp-derive = { version = "0.7.9", path = "../openlogi-hidpp-derive" }
+openlogi-hidpp-derive = { version = "0.7.10", path = "../openlogi-hidpp-derive" }
 derive_more = { version = "2.1.1", default-features = false, features = ["from", "into"] }
 
 [lints]

--- a/crates/openlogi-hook/Cargo.toml
+++ b/crates/openlogi-hook/Cargo.toml
@@ -9,8 +9,8 @@ authors.workspace = true
 description = "OS-level mouse-event hook for OpenLogi. macOS via CGEventTap; Linux via evdev+uinput; Windows via WH_MOUSE_LL."
 
 [dependencies]
-openlogi-core = { path = "../openlogi-core", version = "0.7.9" }
-openlogi-inject = { path = "../openlogi-inject", version = "0.7.9" }
+openlogi-core = { path = "../openlogi-core", version = "0.7.10" }
+openlogi-inject = { path = "../openlogi-inject", version = "0.7.10" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/openlogi-inject/Cargo.toml
+++ b/crates/openlogi-inject/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["hardware-support", "os"]
 [dependencies]
 shellexpand.workspace = true
 opener.workspace = true
-openlogi-core = { path = "../openlogi-core", version = "0.7.9" }
+openlogi-core = { path = "../openlogi-core", version = "0.7.10" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/openlogi-ipc/Cargo.toml
+++ b/crates/openlogi-ipc/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 description = "The tarpc contract and local-socket transport shared by the OpenLogi agent and GUI."
 
 [dependencies]
-openlogi-core = { path = "../openlogi-core", version = "0.7.9" }
+openlogi-core = { path = "../openlogi-core", version = "0.7.10" }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tarpc = { workspace = true }

--- a/crates/openlogi-permissions/Cargo.toml
+++ b/crates/openlogi-permissions/Cargo.toml
@@ -21,7 +21,7 @@ tracing = { workspace = true }
 
 # Only for the Logitech vendor ID — `openlogi-core` is pure types, no I/O.
 [target.'cfg(target_os = "linux")'.dependencies]
-openlogi-core = { version = "0.7.9", path = "../openlogi-core" }
+openlogi-core = { version = "0.7.10", path = "../openlogi-core" }
 
 [lints]
 workspace = true

--- a/crates/openlogi/Cargo.toml
+++ b/crates/openlogi/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "hardware-support"]
 readme = "../../README.md"
 
 [dependencies]
-openlogi-cli = { path = "../openlogi-cli", version = "0.7.9" }
+openlogi-cli = { path = "../openlogi-cli", version = "0.7.10" }
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,7 @@ fs-err = "3.3.0"
 # For `brand`: the bundle-identifier family stamped into every Info.plist and
 # advertised by the update manifest. The app reads the same constants at
 # runtime, so what packaging builds and what the app claims cannot diverge.
-openlogi-core = { version = "0.7.9", path = "../crates/openlogi-core" }
+openlogi-core = { version = "0.7.10", path = "../crates/openlogi-core" }
 path-absolutize = "3.1.1"
 plist = "1.10.0"
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

Recover the interrupted v0.7.9 crates.io publish with a complete v0.7.10 release, and prevent stale release PRs from being selected for changelog post-processing.

## Changes

- bump the unified workspace and registry dependency versions to v0.7.10
- include the publishable `openlogi-ipc` dependency in the release closure
- select only release PR branches that contain the triggering `master` commit
- replace the stale, conflicting #872 release PR

## Testing

- `cargo xtask release check-publish`
- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 8 passed, 0 failed; shell, macOS tests, and cargo-deny were not run in the Linux orb
- not runtime-tested on hardware (release-only change)