### PR TITLE
fix(core,gui,agent): key device settings by identity, not by transport

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -21,7 +21,7 @@ use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, LightCapabilities, StandaloneDevice,
 };
-use openlogi_core::device_order::DeviceStableId;
+use openlogi_core::device_order::{DeviceIdentity, DeviceStableId};
 use openlogi_hid::{
     CaptureChannel, ChannelPool, ChannelRegistry, DIRECT_DEVICE_INDEX, DeviceRoute,
     KEYBOARD_KEY_CIDS,
@@ -428,7 +428,7 @@ impl Orchestrator {
             standalone: standalone.to_vec(),
         };
         self.publish_inventory();
-        let devices = build_devices(inventories, standalone);
+        let devices = build_devices(&self.config, inventories, standalone);
         // Volatile settings (lighting colour, sensor DPI, SmartShift, native
         // wheel mode) live in device RAM and reset on a power cycle. Every
         // reconnect shape re-applies the persisted values (#189): a first
@@ -500,11 +500,12 @@ impl Orchestrator {
             return;
         };
         let key = &dev.config_key;
+        let route_key = stable_id(dev).route_key();
+        let device = self.config.devices.get(key.as_str());
         let (resolution, inverted) = configured_wheel_mode(&self.config, dev);
-        let dpi = self.config.dpi(key);
-        let smartshift = self
-            .config
-            .smartshift(key)
+        let dpi = device.and_then(|d| d.effective_dpi(&route_key));
+        let smartshift = device
+            .and_then(|d| d.effective_smartshift(&route_key))
             .map(openlogi_hid::SmartShiftStatus::from);
         if resolution.is_some() || inverted.is_some() || dpi.is_some() || smartshift.is_some() {
             crate::hardware::reapply_mouse_volatile_in_background(
@@ -515,8 +516,11 @@ impl Orchestrator {
                 smartshift,
             );
         }
-        if let Some(lighting) = self.config.lighting(key).filter(|l| l.enabled) {
-            crate::hardware::set_lighting_in_background(self.shared.device(&route), &lighting);
+        if let Some(lighting) = device
+            .and_then(|d| d.effective_lighting(&route_key))
+            .filter(|l| l.enabled)
+        {
+            crate::hardware::set_lighting_in_background(self.shared.device(&route), lighting);
         }
         if let Some(fn_lock) = self.config.fn_lock(key) {
             crate::hardware::write_fn_lock_in_background(
@@ -827,13 +831,15 @@ fn configured_wheel_mode(
     let Some(capabilities) = dev.capabilities else {
         return (None, None);
     };
+    let route_key = stable_id(dev).route_key();
+    let device = config.devices.get(dev.config_key.as_str());
     let resolution = capabilities
         .hires_wheel
-        .then(|| config.scroll_resolution(&dev.config_key))
+        .then(|| device.and_then(|d| d.effective_scroll_resolution(&route_key)))
         .flatten();
     let inverted = capabilities
         .scroll_inversion
-        .then(|| config.invert_scroll(&dev.config_key));
+        .then(|| device.is_some_and(|d| d.effective_invert_scroll(&route_key)));
     (resolution, inverted)
 }
 
@@ -841,7 +847,14 @@ fn configured_wheel_mode(
 /// `build_device_list` minus the asset/display fields: a device is included
 /// only once its HID++ DeviceInformation (`model_info`) has resolved, since the
 /// model key is derived from it.
+///
+/// `config` is read, never written: [`Config::resolve_device_key`] needs it to
+/// answer where a device's settings actually live, which depends on what the
+/// persisted `links` index and the existing entries say. The agent never
+/// adopts a route — that is the GUI's job — so this call cannot change the
+/// answer for the next tick.
 fn build_devices(
+    config: &Config,
     inventories: &[DeviceInventory],
     standalone: &[StandaloneDevice],
 ) -> Vec<AgentDevice> {
@@ -858,7 +871,15 @@ fn build_devices(
                 model.serial_number.as_deref(),
                 model.unit_id,
             );
-            let Some(config_key) = stable_id.physical_key() else {
+            // An offline probe reports an all-zero unit id, which is not a
+            // physical identity — offer it only while the device is online,
+            // exactly as the GUI does, or every sleeping device would resolve
+            // to the same non-key.
+            let identity =
+                DeviceIdentity::from_parts(model.serial_number.as_deref(), model.unit_id);
+            let Some(config_key) =
+                config.resolve_device_key(&stable_id, paired.online.then_some(&identity))
+            else {
                 continue;
             };
             devices.push(AgentDevice {
@@ -889,7 +910,10 @@ fn build_devices(
             device.serial_number.as_deref(),
             device.unit_id,
         );
-        let Some(config_key) = stable_id.physical_key() else {
+        let identity = DeviceIdentity::from_parts(device.serial_number.as_deref(), device.unit_id);
+        let Some(config_key) =
+            config.resolve_device_key(&stable_id, device.online.then_some(&identity))
+        else {
             continue;
         };
         devices.push(AgentDevice {

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -3,15 +3,19 @@
 use super::{
     AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
     any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
-    pick_current, plan_reapply, reapply_targets,
+    pick_current, plan_reapply, reapply_targets, stable_id,
 };
 use openlogi_core::app::ForegroundApp;
 use openlogi_core::binding::{Action, ButtonId};
-use openlogi_core::config::{Config, LightSettings, ScrollResolution, VerticalScrollSensitivity};
+use openlogi_core::config::{
+    Config, DeviceConfig, LightSettings, LinkConfig, ScrollResolution, VerticalScrollSensitivity,
+};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
+use openlogi_core::device_order::{DeviceIdentity, DeviceStableId};
+use openlogi_core::hid::Dpi;
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use std::sync::Arc;
 
@@ -127,13 +131,75 @@ fn direct_inventory_state(
     }
 }
 
+fn bolt_inventory(unit_id: [u8; 4]) -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "Bolt Receiver".to_string(),
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+            unique_id: Some("82839805".to_string()),
+        },
+        paired: vec![PairedDevice {
+            slot: 1,
+            codename: Some("MX Master 3S".to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 1,
+                serial_number: None,
+                unit_id,
+                transports: DeviceTransports::default(),
+                model_ids: [0xb034, 0, 0],
+                extended_model_id: 2,
+            }),
+            capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+        }],
+    }
+}
+
+#[test]
+fn build_devices_still_finds_settings_left_under_a_pre_upgrade_receiver_key() {
+    // The agent autostarts at login and never adopts a route — only the GUI
+    // does, and the GUI is launched by hand. The schema-4 -> 5 migration
+    // deliberately does not rename `receiver:` keys, so if this resolved
+    // straight to `unit:6be9d300` every receiver-paired device would apply
+    // pure defaults from the moment of the upgrade until the user next
+    // happened to open the settings window.
+    let mut config = Config::default();
+    config
+        .devices
+        .entry("receiver:82839805:slot:1".to_string())
+        .or_default()
+        .dpi = Some(Dpi::new(3200));
+
+    let devices = build_devices(&config, &[bolt_inventory([0x6b, 0xe9, 0xd3, 0x00])], &[]);
+    let device = devices.first().expect("one paired device");
+    assert_eq!(device.config_key, "receiver:82839805:slot:1");
+    assert_eq!(
+        config
+            .devices
+            .get(device.config_key.as_str())
+            .map(|entry| entry.effective_dpi(&stable_id(device).route_key())),
+        Some(Some(Dpi::new(3200))),
+        "the DPI the agent re-applies on reconnect is still reachable"
+    );
+}
+
 #[test]
 fn build_devices_skips_transient_zero_unit_direct_identity() {
-    assert!(build_devices(&[direct_inventory(None, [0; 4])], &[]).is_empty());
+    assert!(build_devices(&Config::default(), &[direct_inventory(None, [0; 4])], &[]).is_empty());
 
-    let devices = build_devices(&[direct_inventory(Some("ABC123"), [0; 4])], &[]);
+    let devices = build_devices(
+        &Config::default(),
+        &[direct_inventory(Some("ABC123"), [0; 4])],
+        &[],
+    );
     assert_eq!(devices.len(), 1);
-    assert_eq!(devices[0].config_key, "direct:046d:b023:serial:abc123");
+    // Bare identity, route-independent: the same key the GUI resolves for
+    // this device regardless of which route it's reached by.
+    assert_eq!(devices[0].config_key, "serial:abc123");
 }
 
 #[test]
@@ -162,7 +228,11 @@ fn build_devices_keeps_serial_backed_standalone_lights_beside_hidpp_devices() {
         registry_model_id: Some("8c900".to_string()),
     };
 
-    let devices = build_devices(&[direct_inventory(Some("ABC123"), [0; 4])], &[standalone]);
+    let devices = build_devices(
+        &Config::default(),
+        &[direct_inventory(Some("ABC123"), [0; 4])],
+        &[standalone],
+    );
 
     assert_eq!(devices.len(), 2);
     let Some(light) = devices
@@ -171,9 +241,38 @@ fn build_devices_keeps_serial_backed_standalone_lights_beside_hidpp_devices() {
     else {
         panic!("standalone light should be retained");
     };
-    assert_eq!(light.config_key, "raw:046d:c900:ff43:0202:serial:glow-1");
+    // Bare identity, route-independent, same as above.
+    assert_eq!(light.config_key, "serial:glow-1");
     assert_eq!(light.light_capabilities, Some(light_capabilities));
     assert!(matches!(light.route, Some(DeviceRoute::RawHid { .. })));
+}
+
+/// A cabled direct device whose own identity wasn't readable — the shape an
+/// offline probe reports, or a device seen for the first time.
+fn direct_stable_id() -> DeviceStableId {
+    DeviceStableId::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xc08d,
+        identity: DeviceIdentity::Unit([0; 4]),
+    }
+}
+
+#[test]
+fn the_agent_reads_settings_under_the_device_key() {
+    // The agent must look under the same key the GUI wrote, or a cabled
+    // mouse silently gets no settings applied.
+    let mut config = Config::default();
+    let mut device = DeviceConfig::default();
+    device
+        .links
+        .insert("direct:046d:c08d".to_string(), LinkConfig::default());
+    config.devices.insert("unit:6be9d300".to_string(), device);
+    config.set_dpi("unit:6be9d300", Dpi::new(1600));
+
+    let key = config
+        .resolve_device_key(&direct_stable_id(), None)
+        .expect("resolves through the indexed route");
+    assert_eq!(config.devices[key.as_str()].dpi, Some(Dpi::new(1600)));
 }
 
 #[test]
@@ -207,8 +306,10 @@ fn runtime_selection_keeps_saved_device_when_all_devices_are_offline() {
 
 #[test]
 fn runtime_selection_tracks_online_transition_without_device_set_change() {
-    let saved_key = "direct:046d:b023:unit:01000000";
-    let other_key = "direct:046d:b034:unit:02000000";
+    // Both keys are the bare-identity form `resolve_device_key` returns while
+    // the device is online (route-independent, per cross-transport identity).
+    let saved_key = "unit:01000000";
+    let other_key = "unit:02000000";
     let mut config = Config::default();
     config.set_selected_device(Some(saved_key.to_string()));
     let mut orchestrator = orchestrator(config);

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -49,7 +49,7 @@ use settings::GestureOwner;
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
 ///
-/// v6 drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
+/// v5 also drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
 /// names the mouse *and the cable it was plugged into*, so a device moved to a
 /// different route was silently orphaned from its settings.
 /// [`Config::migrate_transport_scoped_keys`] rewrites such a key to its bare
@@ -84,7 +84,7 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 6;
+pub const SCHEMA_VERSION: u32 = 5;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 mod device;
 #[cfg(feature = "fs")]
 mod file;
+mod identity;
 mod key_trigger;
 mod settings;
 
@@ -22,11 +23,12 @@ mod settings;
 #[cfg(feature = "fs")]
 mod tests;
 
-pub use device::{DeviceConfig, DeviceIdentity};
+pub use device::{DeviceConfig, DeviceIdentity, LinkConfig, LinkOverrides};
 #[cfg(feature = "fs")]
 pub use file::{ConfigError, ConfigFile};
 #[cfg(all(test, feature = "fs"))]
 use file::{backup_existing_config, config_backup_path};
+pub use identity::canonical_device_key;
 pub use key_trigger::{KeyModifiers, KeyTrigger, KeyboardConfig, ParseTriggerError};
 pub use settings::LightSettings;
 pub use settings::{
@@ -39,12 +41,23 @@ use crate::binding::{
     Action, ActionRingConfig, ActionRingIcon, ActionRingSlot, Binding, ButtonId, GestureDirection,
     RingAction, default_binding, default_binding_for, default_gesture_binding,
 };
+use crate::device_order::PhysicalDeviceKey;
 use crate::hid::Dpi;
 #[cfg(feature = "fs")]
 use settings::GestureOwner;
 /// The schema version the current build produces. Bumped whenever the
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
+///
+/// v6 drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
+/// names the mouse *and the cable it was plugged into*, so a device moved to a
+/// different route was silently orphaned from its settings.
+/// [`Config::migrate_transport_scoped_keys`] rewrites such a key to its bare
+/// identity fragment (`unit:6be9d300`) — including `selected_device` and every
+/// `host_switch_targets` entry — and keeps the dropped route as a
+/// [`DeviceConfig::links`] entry. `receiver:` keys are left alone: nothing on
+/// disk says which device occupies a pairing slot, so those are folded at
+/// runtime instead, on the next online sighting (see `adopt_route`).
 ///
 /// v5 adds the app-wide `ui_scale` preference. Older files default to the
 /// standard 100% scale.
@@ -71,7 +84,7 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 5;
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -411,6 +424,91 @@ impl Config {
                     .bindings
                     .entry(ButtonId::GestureButton)
                     .or_insert_with(|| Binding::Single(default_binding(ButtonId::GestureButton)));
+            }
+        }
+    }
+
+    /// Rewrite v4 transport-scoped direct keys to identity keys.
+    ///
+    /// `direct:046d:c08d:unit:6be9d300` names one mouse *and the cable it was
+    /// plugged into*; `unit:6be9d300` names the mouse. The route it came from
+    /// is kept as a link so the index survives the rename. Receiver keys are
+    /// left alone — nothing on disk says which device is in a pairing slot, so
+    /// they are folded at runtime instead (see `adopt_route`).
+    ///
+    /// A `direct:` key can appear three ways: as a device's own map key, as
+    /// `selected_device`, or inside another device's `host_switch_targets` —
+    /// and the last of those can name a device with no `[devices.…]` table of
+    /// its own (nothing but the reference survives). The rename is computed
+    /// once over every occurrence so all three are rewritten consistently,
+    /// not just the ones that also own a device entry.
+    ///
+    /// Two entries can rename onto the same key — one mouse reached over both
+    /// USB and Bluetooth-direct has a v4 entry per route — so the second one
+    /// is folded in rather than inserted over the first. That is the one case
+    /// where this pass would otherwise not be lossless.
+    pub fn migrate_transport_scoped_keys(&mut self) {
+        // A v4 direct key is `direct:<vid>:<pid>:<identity-kind>:<identity>`.
+        // Splitting off the two leading id fields recovers the route to keep
+        // and the identity fragment that becomes the new key.
+        let parse_rename = |key: &str| -> Option<(String, String)> {
+            let rest = key.strip_prefix("direct:")?;
+            let mut parts = rest.splitn(3, ':');
+            let vendor = parts.next()?;
+            let product = parts.next()?;
+            let identity = parts.next()?;
+            PhysicalDeviceKey::parse(identity)?;
+            Some((identity.to_string(), format!("direct:{vendor}:{product}")))
+        };
+
+        let renames: BTreeMap<String, (String, String)> = self
+            .devices
+            .keys()
+            .cloned()
+            .chain(self.selected_device.iter().cloned())
+            .chain(
+                self.devices
+                    .values()
+                    .flat_map(|device| device.host_switch_targets.iter().cloned()),
+            )
+            .filter_map(|key| {
+                let renamed = parse_rename(&key)?;
+                Some((key, renamed))
+            })
+            .collect();
+
+        for (old, (new, route)) in &renames {
+            let Some(mut device) = self.devices.remove(old) else {
+                continue;
+            };
+            device.links.entry(route.clone()).or_default();
+            // One device reached on two direct routes — an MX Master 3S over
+            // USB and over Bluetooth-direct — has two v4 entries that rename
+            // to the same identity key. Inserting would drop whichever lost
+            // the `BTreeMap` ordering, bindings and all; folding is what
+            // makes this phase lossless, and it is the same merge adoption
+            // performs at runtime, so the second entry's disagreements land
+            // as overrides on the route they were set for.
+            match self.devices.get_mut(new) {
+                Some(existing) => identity::fold(existing, device, route),
+                None => {
+                    self.devices.insert(new.clone(), device);
+                }
+            }
+        }
+        if let Some(new) = self
+            .selected_device
+            .as_deref()
+            .and_then(|old| renames.get(old))
+            .map(|(new, _)| new.clone())
+        {
+            self.selected_device = Some(new);
+        }
+        for device in self.devices.values_mut() {
+            for target in &mut device.host_switch_targets {
+                if let Some((new, _)) = renames.get(target) {
+                    *target = new.clone();
+                }
             }
         }
     }

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -72,6 +72,58 @@ impl DeviceIdentity {
     }
 }
 
+/// One route a device has been seen on, plus what differs on it.
+///
+/// The key of the containing map is [`DeviceStableId::route_key`]. The set of
+/// keys doubles as the index that identifies a device while it is asleep and
+/// only its route is known, which is why it is persisted rather than
+/// recomputed.
+///
+/// [`DeviceStableId::route_key`]: crate::device_order::DeviceStableId::route_key
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LinkConfig {
+    /// Capabilities measured on this link. A device may genuinely expose
+    /// different features per transport — a G502 LIGHTSPEED publishes
+    /// `0x2121 HiResWheel` over its receiver and not over USB — so this is
+    /// recorded per link rather than per device.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Capabilities>,
+    /// Settings the user deliberately made different on this link. Empty for
+    /// the overwhelmingly common case where a device behaves the same either
+    /// way.
+    #[serde(default, skip_serializing_if = "LinkOverrides::is_empty")]
+    pub overrides: LinkOverrides,
+}
+
+/// Per-link settings overrides. Each `Some` shadows the device-level value
+/// for as long as the device is reached by that route.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LinkOverrides {
+    /// Pointer resolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dpi: Option<Dpi>,
+    /// Native wheel inversion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invert_scroll: Option<bool>,
+    /// Wheel resolution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scroll_resolution: Option<ScrollResolution>,
+    /// Lighting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lighting: Option<Lighting>,
+    /// SmartShift.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smartshift: Option<SmartShift>,
+}
+
+impl LinkOverrides {
+    /// Whether nothing is overridden on this link.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 /// Settings scoped to a single physical device.
 ///
 /// Deserialization goes through `RawDeviceConfig` (`#[serde(from)]`) so
@@ -79,7 +131,7 @@ impl DeviceIdentity {
 /// `gesture_bindings` — fold into the unified [`Self::bindings`] map. Only
 /// `bindings` is ever serialized, so a migrated file is rewritten to the v2
 /// shape on its next save.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(from = "RawDeviceConfig")]
 pub struct DeviceConfig {
     /// Whether OpenLogi manages this device at all. `false` leaves the device
@@ -116,6 +168,12 @@ pub struct DeviceConfig {
     /// `None` for configs written before this field existed or by hand.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<DeviceIdentity>,
+    /// Routes this device has been seen on. Keys are
+    /// [`DeviceStableId::route_key`]; see [`LinkConfig`].
+    ///
+    /// [`DeviceStableId::route_key`]: crate::device_order::DeviceStableId::route_key
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub links: BTreeMap<String, LinkConfig>,
     /// Every rebindable button's binding: a single [`Action`], or — for a
     /// button in gesture mode — a [`Binding::Gesture`] per-direction map.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -213,6 +271,77 @@ pub struct DeviceConfig {
     pub fn_lock: Option<bool>,
 }
 
+impl DeviceConfig {
+    /// Pointer resolution on `route_key`: the link's override when the user
+    /// set one there, else the device-level value.
+    #[must_use]
+    pub fn effective_dpi(&self, route_key: &str) -> Option<Dpi> {
+        self.link_overrides(route_key)
+            .and_then(|overrides| overrides.dpi)
+            .or(self.dpi)
+    }
+
+    /// Native wheel inversion on `route_key`: the link's override when the
+    /// user set one there, else the device-level value.
+    #[must_use]
+    pub fn effective_invert_scroll(&self, route_key: &str) -> bool {
+        self.link_overrides(route_key)
+            .and_then(|overrides| overrides.invert_scroll)
+            .unwrap_or(self.invert_scroll)
+    }
+
+    /// Wheel resolution on `route_key`: the link's override when the user set
+    /// one there, else the device-level value.
+    #[must_use]
+    pub fn effective_scroll_resolution(&self, route_key: &str) -> Option<ScrollResolution> {
+        self.link_overrides(route_key)
+            .and_then(|overrides| overrides.scroll_resolution)
+            .or(self.scroll_resolution)
+    }
+
+    /// Lighting on `route_key`: the link's override when the user set one
+    /// there, else the device-level value.
+    #[must_use]
+    pub fn effective_lighting(&self, route_key: &str) -> Option<&Lighting> {
+        self.link_overrides(route_key)
+            .and_then(|overrides| overrides.lighting.as_ref())
+            .or(self.lighting.as_ref())
+    }
+
+    /// SmartShift on `route_key`: the link's override when the user set one
+    /// there, else the device-level value.
+    #[must_use]
+    pub fn effective_smartshift(&self, route_key: &str) -> Option<SmartShift> {
+        self.link_overrides(route_key)
+            .and_then(|overrides| overrides.smartshift)
+            .or(self.smartshift)
+    }
+
+    fn link_overrides(&self, route_key: &str) -> Option<&LinkOverrides> {
+        self.links.get(route_key).map(|link| &link.overrides)
+    }
+
+    /// Whether this entry carries anything the *user* configured, as opposed
+    /// to nothing but the metadata OpenLogi writes on its own: the probed
+    /// [`Self::identity`] and the [`Self::links`] route index.
+    ///
+    /// This is what lets [`Config::resolve_device_key`] tell a bare entry
+    /// created by an identity probe from a pre-upgrade entry holding real
+    /// bindings and DPI. Comparing a stripped clone against [`Default`],
+    /// rather than testing fields one by one, keeps the answer honest as the
+    /// struct grows: a setting added tomorrow counts from the day it exists,
+    /// with nothing here to remember to update.
+    ///
+    /// [`Config::resolve_device_key`]: crate::config::Config::resolve_device_key
+    #[must_use]
+    pub fn holds_settings(&self) -> bool {
+        let mut stripped = self.clone();
+        stripped.identity = None;
+        stripped.links = BTreeMap::new();
+        stripped != Self::default()
+    }
+}
+
 impl Default for DeviceConfig {
     fn default() -> Self {
         Self {
@@ -222,6 +351,7 @@ impl Default for DeviceConfig {
             custom_name: None,
             gesture_owner: None,
             identity: None,
+            links: BTreeMap::new(),
             bindings: BTreeMap::new(),
             disabled_gestures: BTreeMap::new(),
             per_app_bindings: BTreeMap::new(),
@@ -314,6 +444,9 @@ struct RawDeviceConfig {
     gesture_owner: Option<GestureOwner>,
     #[serde(default)]
     identity: Option<DeviceIdentity>,
+    /// See [`DeviceConfig::links`].
+    #[serde(default)]
+    links: BTreeMap<String, LinkConfig>,
     /// v2 shape — present on already-migrated files; wins on any key collision.
     #[serde(default)]
     bindings: BTreeMap<ButtonId, Binding>,
@@ -398,6 +531,7 @@ impl From<RawDeviceConfig> for DeviceConfig {
             custom_name: raw.custom_name,
             gesture_owner: raw.gesture_owner,
             identity: raw.identity.map(DeviceIdentity::without_unit_identifiers),
+            links: raw.links,
             bindings,
             disabled_gestures: raw.disabled_gestures,
             per_app_bindings: raw.per_app_bindings,

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -100,6 +100,11 @@ pub enum ConfigError {
 pub struct ConfigFile {
     path: PathBuf,
     source: Option<String>,
+    /// Text of the file as loaded, when it was written by an older schema.
+    /// Copied aside on the first save so a key-rewriting migration is
+    /// recoverable; cleared once that save lands, so only the first
+    /// *successful* one pays for it and a failed save still owes the copy.
+    migrated_from: Option<(u32, String)>,
 }
 
 #[derive(Deserialize)]
@@ -118,12 +123,15 @@ impl ConfigFile {
     pub fn load_from_path(path: &Path) -> Result<(Config, Self), ConfigError> {
         match fs::read_to_string(path) {
             Ok(source) => {
-                let config = parse_config(path, &source)?;
+                let (config, loaded_version) = parse_config(path, &source)?;
+                let migrated_from =
+                    (loaded_version < SCHEMA_VERSION).then(|| (loaded_version, source.clone()));
                 Ok((
                     config,
                     Self {
                         path: path.to_path_buf(),
                         source: Some(source),
+                        migrated_from,
                     },
                 ))
             }
@@ -132,6 +140,7 @@ impl ConfigFile {
                 Self {
                     path: path.to_path_buf(),
                     source: None,
+                    migrated_from: None,
                 },
             )),
             Err(source) => Err(ConfigError::Read {
@@ -159,6 +168,19 @@ impl ConfigFile {
             });
         }
 
+        // Borrowed, not taken: a failed write must leave the recovery copy
+        // still owed. Taking here and then failing — a full disk, a
+        // read-only directory — would spend the only chance to keep the
+        // pre-migration file, and the next save that *did* succeed would
+        // overwrite it with migrated content and no backup anywhere.
+        if let Some((version, original)) = self.migrated_from.as_ref() {
+            let backup = self.path.with_extension(format!("v{version}.bak"));
+            fs::write(&backup, original).map_err(|source| ConfigError::Write {
+                path: backup,
+                source,
+            })?;
+        }
+
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
                 path: self.path.clone(),
@@ -174,6 +196,11 @@ impl ConfigFile {
             path: self.path.clone(),
             source,
         })?;
+        // The migrated file is gone from disk now, and its copy is safely
+        // beside it — only here is the debt actually settled, so only here is
+        // it cleared. A second save from this `ConfigFile` must not rewrite
+        // the backup with content that is no longer pre-migration.
+        self.migrated_from = None;
         self.source = Some(body);
         Ok(())
     }
@@ -209,7 +236,10 @@ impl Config {
     }
 }
 
-fn parse_config(path: &Path, source: &str) -> Result<Config, ConfigError> {
+/// Parse `source`, applying every migration its declared `schema_version`
+/// needs. Returns the migrated config plus the version the file actually
+/// declared, so callers can tell a migrated load from an already-current one.
+fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError> {
     let header: ConfigHeader = toml::from_str(source).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source: Box::new(source),
@@ -228,8 +258,14 @@ fn parse_config(path: &Path, source: &str) -> Result<Config, ConfigError> {
     if header.schema_version <= 3 {
         config.migrate_owner_locked_gestures();
     }
+    // Through v5, not v4: v5 was the `ui_scale` bump, which left device keys
+    // exactly as v4 wrote them. Gating on v4 here would leave every config a
+    // v5 build had touched holding transport-scoped keys forever.
+    if header.schema_version <= 5 {
+        config.migrate_transport_scoped_keys();
+    }
     config.schema_version = SCHEMA_VERSION;
-    Ok(config)
+    Ok((config, header.schema_version))
 }
 
 fn reject_obsolete_fields(path: &Path, source: &str, version: u32) -> Result<(), ConfigError> {

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -175,7 +175,10 @@ impl ConfigFile {
         // overwrite it with migrated content and no backup anywhere.
         if let Some((version, original)) = self.migrated_from.as_ref() {
             let backup = self.path.with_extension(format!("v{version}.bak"));
-            fs::write(&backup, original).map_err(|source| ConfigError::Write {
+            // Atomic like the config write itself: this is the only copy of
+            // the pre-migration file, so an interrupted write must not be
+            // able to leave a truncated one behind.
+            write_atomic(&backup, original.as_bytes()).map_err(|source| ConfigError::Write {
                 path: backup,
                 source,
             })?;

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -266,10 +266,11 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
     if header.schema_version <= 3 {
         config.migrate_owner_locked_gestures();
     }
-    // Through v5, not v4: v5 was the `ui_scale` bump, which left device keys
-    // exactly as v4 wrote them. Gating on v4 here would leave every config a
-    // v5 build had touched holding transport-scoped keys forever.
-    if header.schema_version <= 5 {
+    // v5 is the schema this change is part of, so every *released* schema —
+    // v4 and below — is what needs the rename. A file already declaring v5 was
+    // written by an unpublished build of this branch and is not something users
+    // have on disk.
+    if header.schema_version <= 4 {
         config.migrate_transport_scoped_keys();
     }
     config.schema_version = SCHEMA_VERSION;

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -174,7 +174,12 @@ impl ConfigFile {
         // pre-migration file, and the next save that *did* succeed would
         // overwrite it with migrated content and no backup anywhere.
         if let Some((version, original)) = self.migrated_from.as_ref() {
-            let backup = self.path.with_extension(format!("v{version}.bak"));
+            let backup = migration_backup_path(&self.path, *version).map_err(|source| {
+                ConfigError::Write {
+                    path: self.path.clone(),
+                    source,
+                }
+            })?;
             // Atomic like the config write itself: this is the only copy of
             // the pre-migration file, so an interrupted write must not be
             // able to leave a truncated one behind.
@@ -381,6 +386,23 @@ pub(super) fn backup_existing_config(path: &Path) -> io::Result<()> {
         }
     }
     write_atomic(&config_backup_path(path, 1)?, &fs::read(path)?)
+}
+
+/// Path of the pre-migration copy: the config's own name with
+/// `.v<version>.bak` appended, so `config.toml` yields
+/// `config.toml.v4.bak`. Appended, not substituted — `with_extension` would
+/// replace `.toml` and hand back `config.v4.bak`, which no longer names the
+/// file it is a copy of.
+pub(super) fn migration_backup_path(path: &Path, version: u32) -> io::Result<PathBuf> {
+    let Some(file_name) = path.file_name() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "config path has no file name",
+        ));
+    };
+    let mut backup_name = OsString::from(file_name);
+    backup_name.push(format!(".v{version}.bak"));
+    Ok(path.with_file_name(backup_name))
 }
 
 pub(super) fn config_backup_path(path: &Path, generation: usize) -> io::Result<PathBuf> {

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -284,10 +284,19 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
 
     // Collections with no natural per-item override: take the legacy value
     // wholesale when the canonical side is empty (i.e. never configured).
+    // Merging two curated lists is not a safe default — a DPI cycle is
+    // ordered and a host-switch list is positional — so a populated
+    // canonical side wins, and the list it displaces is logged.
     macro_rules! fold_if_empty {
         ($field:ident) => {
             if device.$field.is_empty() {
                 device.$field = legacy.$field;
+            } else if !legacy.$field.is_empty() && device.$field != legacy.$field {
+                tracing::warn!(
+                    %route_key,
+                    field = stringify!($field),
+                    "list differs between merged entries; keeping the canonical one"
+                );
             }
         };
     }

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -10,6 +10,7 @@ use crate::binding::{Action, ButtonId};
 use crate::config::{Config, DeviceConfig};
 #[cfg(test)]
 use crate::config::{LightSettings, Lighting, LinkConfig};
+use crate::device::Capabilities;
 use crate::device_order::{DeviceIdentity, DeviceStableId, PhysicalDeviceKey};
 #[cfg(test)]
 use crate::hid::Dpi;
@@ -109,9 +110,19 @@ impl Config {
     /// Record that the device keyed `canonical` was reached by `route_key`,
     /// folding in any entry still keyed by that route.
     ///
+    /// `capabilities` is what the device just measured on this route, and it
+    /// is what makes the per-link table a record of the hardware rather than
+    /// a leftover of migration: a G502 that answers `0x2121` over its
+    /// receiver and not over USB only differs in the config once both links
+    /// have been sighted. Stored on every online sighting, so a link whose
+    /// capabilities genuinely change stops reporting the old ones. `None`
+    /// leaves whatever the link already recorded — an unprobed sighting is
+    /// not evidence the capability went away.
+    ///
     /// Returns whether anything actually changed — a route was newly
-    /// registered in the entry's `links` index, a stale link pointing a
-    /// re-paired route at its previous device was removed, or a legacy entry
+    /// registered in the entry's `links` index, its measured capabilities
+    /// differ from what was recorded, a stale link pointing a re-paired
+    /// route at its previous device was removed, or a legacy entry
     /// was folded in. Callers use this to decide whether the mutation needs
     /// persisting; a `false` means the entry already recorded this exact
     /// route and there is nothing new to write. Called on an online
@@ -125,7 +136,12 @@ impl Config {
     /// [`Config::migrate_transport_scoped_keys`] does for the keys it renames
     /// at load; leaving either reference behind would drop the carousel
     /// selection and silently unlink a host-switch target.
-    pub fn adopt_route(&mut self, canonical: &PhysicalDeviceKey, route_key: &str) -> bool {
+    pub fn adopt_route(
+        &mut self,
+        canonical: &PhysicalDeviceKey,
+        route_key: &str,
+        capabilities: Option<Capabilities>,
+    ) -> bool {
         let mut changed = false;
         // A route names one device at a time. Re-pairing a different unit into
         // a slot must move the index, not leave the slot pointing at both.
@@ -144,7 +160,14 @@ impl Config {
         if !device.links.contains_key(route_key) {
             changed = true;
         }
-        device.links.entry(route_key.to_string()).or_default();
+        let link = device.links.entry(route_key.to_string()).or_default();
+        // Only a probe that actually answered may overwrite the record, and
+        // only when it says something new — rewriting an identical value on
+        // every poll would persist the config on every tick.
+        if capabilities.is_some() && link.capabilities != capabilities {
+            link.capabilities = capabilities;
+            changed = true;
+        }
         let Some(legacy) = legacy else {
             return changed;
         };
@@ -195,7 +218,10 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
         .as_ref()
         .map(|identity| identity.capabilities)
     {
-        link.capabilities = Some(capabilities);
+        // Only where the link has no measurement of its own: the legacy
+        // entry's copy can be arbitrarily old, and the sighting that
+        // triggered this fold just measured the same route.
+        link.capabilities.get_or_insert(capabilities);
     }
 
     // Values with a per-link override slot: canonical stays the device
@@ -527,7 +553,7 @@ mod tests {
         config.selected_device = Some("receiver:82839805:slot:1".to_string());
 
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1"));
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1", None));
 
         assert_eq!(config.selected_device.as_deref(), Some("unit:6be9d300"));
         assert_eq!(
@@ -605,7 +631,7 @@ mod tests {
             .insert("unit:6be9d300".to_string(), DeviceConfig::default());
 
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1"));
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1", None));
 
         let device = &config.devices["unit:6be9d300"];
         assert!(device.lighting.is_some(), "lighting moved to device level");
@@ -613,6 +639,43 @@ mod tests {
         assert!(
             !config.devices.contains_key("receiver:82839805:slot:1"),
             "the legacy entry is consumed, not left behind"
+        );
+    }
+
+    #[test]
+    fn a_sighting_records_what_the_link_measured() {
+        // Without this the per-link table only ever gets capabilities from a
+        // migration fold, so the "supported on your other connection" notice
+        // could never appear for anyone who installed at schema 5.
+        let mut config = Config::default();
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        let wired = Capabilities {
+            hires_wheel: false,
+            ..Capabilities::default()
+        };
+        let wireless = Capabilities {
+            hires_wheel: true,
+            ..Capabilities::default()
+        };
+
+        assert!(config.adopt_route(&canonical, "direct:046d:c08d", Some(wired)));
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1", Some(wireless)));
+
+        let links = &config.devices["unit:6be9d300"].links;
+        assert_eq!(links["direct:046d:c08d"].capabilities, Some(wired));
+        assert_eq!(
+            links["receiver:82839805:slot:1"].capabilities,
+            Some(wireless)
+        );
+
+        // Re-sighting the same route with the same answer is not a change:
+        // reporting one would persist the config on every poll.
+        assert!(!config.adopt_route(&canonical, "direct:046d:c08d", Some(wired)));
+        // An unprobed sighting is not evidence the capability went away.
+        assert!(!config.adopt_route(&canonical, "direct:046d:c08d", None));
+        assert_eq!(
+            config.devices["unit:6be9d300"].links["direct:046d:c08d"].capabilities,
+            Some(wired)
         );
     }
 
@@ -638,7 +701,7 @@ mod tests {
             .insert("unit:6be9d300".to_string(), canonical_entry);
 
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1", None);
 
         let device = &config.devices["unit:6be9d300"];
         assert_eq!(device.dpi, Some(Dpi::new(1600)), "canonical stays default");
@@ -660,7 +723,7 @@ mod tests {
             .insert("unit:6be9d300".to_string(), DeviceConfig::default());
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
 
-        assert!(config.adopt_route(&canonical, "direct:046d:c08d"));
+        assert!(config.adopt_route(&canonical, "direct:046d:c08d", None));
         assert!(
             config.devices["unit:6be9d300"]
                 .links
@@ -682,7 +745,7 @@ mod tests {
         config.devices.insert("unit:6be9d300".to_string(), device);
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
 
-        assert!(!config.adopt_route(&canonical, "direct:046d:c08d"));
+        assert!(!config.adopt_route(&canonical, "direct:046d:c08d", None));
     }
 
     #[test]
@@ -701,7 +764,7 @@ mod tests {
             .insert("unit:bbbbbbbb".to_string(), DeviceConfig::default());
 
         let second = PhysicalDeviceKey::parse("unit:bbbbbbbb").expect("valid");
-        config.adopt_route(&second, "receiver:82839805:slot:1");
+        config.adopt_route(&second, "receiver:82839805:slot:1", None);
 
         assert!(
             !config.devices["unit:aaaaaaaa"]
@@ -736,7 +799,7 @@ mod tests {
             .insert("unit:6be9d300".to_string(), DeviceConfig::default());
 
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1", None);
 
         let device = &config.devices["unit:6be9d300"];
         assert_eq!(
@@ -766,7 +829,7 @@ mod tests {
             .insert("unit:6be9d300".to_string(), DeviceConfig::default());
 
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1", None);
 
         assert_eq!(
             config.devices["unit:6be9d300"].light,
@@ -793,7 +856,7 @@ mod tests {
             .insert("unit:6be9d300".to_string(), DeviceConfig::default());
 
         let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1", None);
 
         assert!(
             !config.devices["unit:6be9d300"].enabled,

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -276,6 +276,10 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
     fold_option_field!(camera_profile);
     fold_option_field!(thumbwheel_sensitivity);
     fold_option_field!(fn_lock);
+    // The user-assigned alias. Without this a legacy entry carrying a name
+    // folded into a canonical entry with none would drop it silently — the
+    // one field here a user typed by hand, so the loss is the most visible.
+    fold_option_field!(custom_name);
 
     if device.identity.is_none() {
         device.identity = legacy.identity;
@@ -612,6 +616,64 @@ mod tests {
             identity: DeviceIdentity::Unit([0; 4]),
         };
         assert_eq!(config.resolve_device_key(&anonymous, None), None);
+    }
+
+    #[test]
+    fn folding_takes_a_custom_name_the_canonical_entry_lacks() {
+        // The alias is the one field in an entry the user typed by hand. A
+        // legacy entry carrying it must not lose it to a canonical entry that
+        // was created by, say, a first DPI write and never named.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            custom_name: Some("Desk mouse".to_string()),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), DeviceConfig::default());
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1", None));
+
+        assert_eq!(
+            config.devices["unit:6be9d300"].custom_name.as_deref(),
+            Some("Desk mouse"),
+            "the user's alias survives the fold"
+        );
+    }
+
+    #[test]
+    fn folding_keeps_the_canonical_custom_name_when_both_are_named() {
+        // Two names cannot be merged and there is no per-link slot for one, so
+        // the canonical entry wins. `fold` logs the loss rather than dropping
+        // it silently; this pins which of the two survives.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            custom_name: Some("Old name".to_string()),
+            ..DeviceConfig::default()
+        };
+        let canonical_entry = DeviceConfig {
+            custom_name: Some("Current name".to_string()),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), canonical_entry);
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1", None));
+
+        assert_eq!(
+            config.devices["unit:6be9d300"].custom_name.as_deref(),
+            Some("Current name"),
+            "the canonical alias wins a genuine conflict"
+        );
     }
 
     #[test]

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -49,7 +49,7 @@ impl Config {
     ///
     /// Prefers the device's own identity — that is the whole point of the
     /// schema-5 model — but only once the settings are actually there. A
-    /// `receiver:`/`raw:` entry is not renamed by the schema-4→5 migration
+    /// `receiver:`/`raw:` entry is not renamed by the load-time migration
     /// (nothing on disk says which device occupies a pairing slot), so
     /// immediately after an upgrade every such device's settings still live
     /// under its route-derived key while its identity key holds nothing.
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn settings_still_under_the_pre_upgrade_key_are_read_from_it() {
-        // The upgrade path the agent lives through: the schema-4→5 migration
+        // The upgrade path the agent lives through: the load-time migration
         // deliberately leaves `receiver:` keys alone, and only the GUI folds
         // them. Answering with `unit:6be9d300` here would hand the agent an
         // empty entry, so every receiver-paired device would silently revert
@@ -503,7 +503,7 @@ mod tests {
         // which only works because a Bolt/RawHid/Unknown route key *is* the
         // key such an entry was written under. A Direct route key deliberately
         // is not: its identity moved into the entry key, which is exactly why
-        // the schema-4→5 migration can rename direct entries at load and
+        // the load-time migration can rename direct entries and
         // cannot rename the others. Three doc comments say so; this asserts it.
         for stable in [on_receiver(), litra()] {
             let physical = stable.physical_key().expect("physical");

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -212,6 +212,8 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
     for (key, value) in std::mem::take(&mut legacy.links) {
         device.links.entry(key).or_insert(value);
     }
+    fold_maps(device, &mut legacy, route_key);
+
     let link = device.links.entry(route_key.to_string()).or_default();
     if let Some(capabilities) = legacy
         .identity
@@ -282,35 +284,8 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
     fold_option_field!(custom_name);
 
     if device.identity.is_none() {
-        device.identity = legacy.identity;
+        device.identity = legacy.identity.take();
     }
-
-    // Maps merge key by key: a legacy entry is taken only where the
-    // canonical map has no entry for that key. A genuine conflict on a
-    // shared key keeps the canonical entry and is logged, not silently
-    // dropped.
-    macro_rules! fold_map_field {
-        ($field:ident) => {
-            for (key, value) in legacy.$field {
-                if let Some(existing) = device.$field.get(&key) {
-                    if *existing != value {
-                        tracing::warn!(
-                            %route_key,
-                            field = stringify!($field),
-                            key = ?key,
-                            "entry differs between merged entries; keeping the canonical one"
-                        );
-                    }
-                } else {
-                    device.$field.insert(key, value);
-                }
-            }
-        };
-    }
-    fold_map_field!(bindings);
-    fold_map_field!(disabled_gestures);
-    fold_map_field!(per_app_bindings);
-    fold_map_field!(camera_profiles);
 
     // Collections with no natural per-item override: take the legacy value
     // wholesale when the canonical side is empty (i.e. never configured).
@@ -333,9 +308,17 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
     fold_if_empty!(dpi_presets);
     fold_if_empty!(host_switch_targets);
 
-    // `ActionRingConfig` has its own notion of "unset".
-    if device.action_ring.is_default() && !legacy.action_ring.is_default() {
-        device.action_ring = legacy.action_ring;
+    // `ActionRingConfig` has its own notion of "unset". Two configured rings
+    // cannot be merged — the slots are positional — so the canonical one wins
+    // and the displaced one is logged, as elsewhere.
+    if device.action_ring.is_default() {
+        device.action_ring = legacy.action_ring.clone();
+    } else if !legacy.action_ring.is_default() && device.action_ring != legacy.action_ring {
+        tracing::warn!(
+            %route_key,
+            field = "action_ring",
+            "ring differs between merged entries; keeping the canonical one"
+        );
     }
 
     // `enabled` defaults to `true` and is only ever persisted when `false`,
@@ -344,6 +327,37 @@ pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_ke
     if device.enabled && !legacy.enabled {
         device.enabled = false;
     }
+}
+
+/// The map-valued halves of [`fold`], split out to keep that function inside
+/// the workspace's line budget.
+///
+/// Maps merge key by key: a legacy entry is taken only where the canonical map
+/// has no entry for that key. A genuine conflict on a shared key keeps the
+/// canonical entry and is logged, not silently dropped.
+fn fold_maps(device: &mut DeviceConfig, legacy: &mut DeviceConfig, route_key: &str) {
+    macro_rules! fold_map_field {
+        ($field:ident) => {
+            for (key, value) in std::mem::take(&mut legacy.$field) {
+                if let Some(existing) = device.$field.get(&key) {
+                    if *existing != value {
+                        tracing::warn!(
+                            %route_key,
+                            field = stringify!($field),
+                            key = ?key,
+                            "entry differs between merged entries; keeping the canonical one"
+                        );
+                    }
+                } else {
+                    device.$field.insert(key, value);
+                }
+            }
+        };
+    }
+    fold_map_field!(bindings);
+    fold_map_field!(disabled_gestures);
+    fold_map_field!(per_app_bindings);
+    fold_map_field!(camera_profiles);
 }
 
 #[cfg(test)]

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -1,0 +1,794 @@
+//! Resolving a device's configuration key from its route and its own identity.
+//!
+//! A device's entry is keyed by what it *is* — its unit id or serial — so
+//! settings follow the device when it moves between a receiver and a cable.
+//! When the device is asleep its identity is unreadable and only the route is
+//! known, so the entry's `links` table doubles as a route index.
+
+#[cfg(test)]
+use crate::binding::{Action, ButtonId};
+use crate::config::{Config, DeviceConfig};
+#[cfg(test)]
+use crate::config::{LightSettings, Lighting, LinkConfig};
+use crate::device_order::{DeviceIdentity, DeviceStableId, PhysicalDeviceKey};
+#[cfg(test)]
+use crate::hid::Dpi;
+
+impl DeviceIdentity {
+    /// This identity as a transport-free configuration key, or `None` when the
+    /// device reported no identity worth keying on.
+    #[must_use]
+    pub fn config_key(&self) -> Option<String> {
+        self.is_physical().then(|| self.key())
+    }
+}
+
+/// The key a device's settings ultimately belong under: its own identity when
+/// it reported one, else the route-derived key that is the best available
+/// stand-in.
+///
+/// This is the *destination* of the schema-5 model, independent of what is on
+/// disk right now. [`Config::resolve_device_key`] may legitimately answer with
+/// a different, pre-upgrade key while the settings still live there; this is
+/// the key those settings are folded onto by [`Config::adopt_route`].
+#[must_use]
+pub fn canonical_device_key(
+    stable: &DeviceStableId,
+    identity: Option<&DeviceIdentity>,
+) -> Option<PhysicalDeviceKey> {
+    identity
+        .and_then(DeviceIdentity::config_key)
+        .and_then(|key| PhysicalDeviceKey::parse(&key))
+        .or_else(|| stable.physical_key())
+}
+
+impl Config {
+    /// The configuration key to *read and write* for a device reached by
+    /// `stable`, given whatever `identity` the current probe could read.
+    ///
+    /// Prefers the device's own identity — that is the whole point of the
+    /// schema-5 model — but only once the settings are actually there. A
+    /// `receiver:`/`raw:` entry is not renamed by the schema-4→5 migration
+    /// (nothing on disk says which device occupies a pairing slot), so
+    /// immediately after an upgrade every such device's settings still live
+    /// under its route-derived key while its identity key holds nothing.
+    /// Answering with the identity key there would silently apply defaults to
+    /// every receiver-paired device until the GUI next ran
+    /// [`Self::adopt_route`] — which happens only when the user opens the GUI,
+    /// and the agent runs unattended from login. So the pre-upgrade key wins
+    /// for exactly as long as it is the one holding the settings.
+    ///
+    /// "Holding the settings" is [`DeviceConfig::holds_settings`], not mere
+    /// existence: an entry carrying only the probed identity and the `links`
+    /// route index is metadata OpenLogi wrote itself, and must not out-rank a
+    /// legacy entry holding the user's actual bindings and DPI.
+    ///
+    /// Failing both, and for a device whose identity is unreadable (asleep),
+    /// the route is resolved through the persisted `links` index, then finally
+    /// through the route-derived key that every entry used before this
+    /// indirection existed.
+    #[must_use]
+    pub fn resolve_device_key(
+        &self,
+        stable: &DeviceStableId,
+        identity: Option<&DeviceIdentity>,
+    ) -> Option<PhysicalDeviceKey> {
+        if let Some(key) = identity
+            .and_then(DeviceIdentity::config_key)
+            .and_then(|key| PhysicalDeviceKey::parse(&key))
+        {
+            let holds_settings = |key: &str| {
+                self.devices
+                    .get(key)
+                    .is_some_and(DeviceConfig::holds_settings)
+            };
+            let legacy = stable
+                .physical_key()
+                .filter(|legacy| legacy.as_str() != key.as_str());
+            if let Some(legacy) = legacy
+                && !holds_settings(key.as_str())
+                && holds_settings(legacy.as_str())
+            {
+                return Some(legacy);
+            }
+            return Some(key);
+        }
+        let route = stable.route_key();
+        if let Some(key) = self
+            .devices
+            .iter()
+            .find(|(_, device)| device.links.contains_key(&route))
+            .map(|(key, _)| key.as_str())
+            .and_then(PhysicalDeviceKey::parse)
+        {
+            return Some(key);
+        }
+        stable.physical_key()
+    }
+
+    /// Record that the device keyed `canonical` was reached by `route_key`,
+    /// folding in any entry still keyed by that route.
+    ///
+    /// Returns whether anything actually changed — a route was newly
+    /// registered in the entry's `links` index, a stale link pointing a
+    /// re-paired route at its previous device was removed, or a legacy entry
+    /// was folded in. Callers use this to decide whether the mutation needs
+    /// persisting; a `false` means the entry already recorded this exact
+    /// route and there is nothing new to write. Called on an online
+    /// sighting, where the device's identity is known and the route can
+    /// therefore be attributed to it with confidence.
+    ///
+    /// Consuming a legacy entry is a rename, and a device key lives in three
+    /// places — the `devices` map, [`Config::selected_device`], and every
+    /// entry of some keyboard's [`DeviceConfig::host_switch_targets`]. All
+    /// three are re-pointed here, exactly as
+    /// [`Config::migrate_transport_scoped_keys`] does for the keys it renames
+    /// at load; leaving either reference behind would drop the carousel
+    /// selection and silently unlink a host-switch target.
+    pub fn adopt_route(&mut self, canonical: &PhysicalDeviceKey, route_key: &str) -> bool {
+        let mut changed = false;
+        // A route names one device at a time. Re-pairing a different unit into
+        // a slot must move the index, not leave the slot pointing at both.
+        for (key, device) in &mut self.devices {
+            if key != canonical.as_str() && device.links.remove(route_key).is_some() {
+                changed = true;
+            }
+        }
+        let legacy = (route_key != canonical.as_str())
+            .then(|| self.devices.remove(route_key))
+            .flatten();
+        let device = self
+            .devices
+            .entry(canonical.as_str().to_string())
+            .or_default();
+        if !device.links.contains_key(route_key) {
+            changed = true;
+        }
+        device.links.entry(route_key.to_string()).or_default();
+        let Some(legacy) = legacy else {
+            return changed;
+        };
+        fold(device, legacy, route_key);
+        self.repoint_references(route_key, canonical.as_str());
+        true
+    }
+
+    /// Rewrite every reference to `old` — the carousel selection and any
+    /// host-switch target — to `new`, after `old`'s entry was consumed.
+    fn repoint_references(&mut self, old: &str, new: &str) {
+        if self.selected_device.as_deref() == Some(old) {
+            self.selected_device = Some(new.to_string());
+        }
+        for device in self.devices.values_mut() {
+            for target in &mut device.host_switch_targets {
+                if target == old {
+                    *target = new.to_string();
+                }
+            }
+        }
+    }
+}
+
+/// Merge a legacy route-keyed entry into its device's canonical entry.
+///
+/// A value the canonical side does not have is simply taken. A value both
+/// sides have and disagree on is not a conflict to resolve but a difference to
+/// preserve: the canonical value stays the device default and the legacy one
+/// becomes an override on its own link, when the field has an override slot
+/// to preserve it in; otherwise the canonical value wins and the disagreement
+/// is logged rather than silently discarded.
+///
+/// Routes `legacy` itself indexed come along, so folding is closed over the
+/// `links` map: a route the canonical entry already knows keeps the canonical
+/// link (its overrides are the ones expressed against the canonical
+/// defaults). At runtime that map is always empty — `links` did not exist
+/// before schema 5, so a route-keyed entry on disk cannot carry one — but
+/// [`Config::migrate_transport_scoped_keys`] folds two *renamed* entries that
+/// each already carry the route they were renamed out of.
+pub(super) fn fold(device: &mut DeviceConfig, mut legacy: DeviceConfig, route_key: &str) {
+    for (key, value) in std::mem::take(&mut legacy.links) {
+        device.links.entry(key).or_insert(value);
+    }
+    let link = device.links.entry(route_key.to_string()).or_default();
+    if let Some(capabilities) = legacy
+        .identity
+        .as_ref()
+        .map(|identity| identity.capabilities)
+    {
+        link.capabilities = Some(capabilities);
+    }
+
+    // Values with a per-link override slot: canonical stays the device
+    // default and a disagreeing legacy value survives as an override scoped
+    // to the route it was set on.
+    macro_rules! fold_field {
+        ($field:ident) => {
+            match (&device.$field, legacy.$field) {
+                (None, Some(value)) => device.$field = Some(value),
+                (Some(ours), Some(theirs)) if *ours != theirs => {
+                    link.overrides.$field = Some(theirs);
+                }
+                _ => {}
+            }
+        };
+    }
+    fold_field!(dpi);
+    fold_field!(scroll_resolution);
+    fold_field!(lighting);
+    fold_field!(smartshift);
+
+    // `invert_scroll` is a bare bool, so `false` is indistinguishable from
+    // never-set: only a legacy `true` is evidence the user chose anything.
+    // Recording an override for a legacy `false` would fire far more often
+    // wrongly (a device that simply never had the setting touched) than
+    // rightly.
+    if device.invert_scroll != legacy.invert_scroll && legacy.invert_scroll {
+        link.overrides.invert_scroll = Some(legacy.invert_scroll);
+    }
+
+    // Scalar values with no per-link override slot: take the legacy value
+    // when the canonical side is unset. A genuine disagreement keeps the
+    // canonical value — there is nowhere to park the legacy one — and is
+    // logged so the loss is visible instead of silent.
+    macro_rules! fold_option_field {
+        ($field:ident) => {
+            match (&device.$field, legacy.$field) {
+                (None, Some(value)) => device.$field = Some(value),
+                (Some(ours), Some(theirs)) if *ours != theirs => {
+                    tracing::warn!(
+                        %route_key,
+                        field = stringify!($field),
+                        "value differs between merged entries; keeping the canonical one"
+                    );
+                }
+                _ => {}
+            }
+        };
+    }
+    fold_option_field!(light);
+    fold_option_field!(camera_controls);
+    fold_option_field!(camera_profile);
+    fold_option_field!(thumbwheel_sensitivity);
+    fold_option_field!(fn_lock);
+
+    if device.identity.is_none() {
+        device.identity = legacy.identity;
+    }
+
+    // Maps merge key by key: a legacy entry is taken only where the
+    // canonical map has no entry for that key. A genuine conflict on a
+    // shared key keeps the canonical entry and is logged, not silently
+    // dropped.
+    macro_rules! fold_map_field {
+        ($field:ident) => {
+            for (key, value) in legacy.$field {
+                if let Some(existing) = device.$field.get(&key) {
+                    if *existing != value {
+                        tracing::warn!(
+                            %route_key,
+                            field = stringify!($field),
+                            key = ?key,
+                            "entry differs between merged entries; keeping the canonical one"
+                        );
+                    }
+                } else {
+                    device.$field.insert(key, value);
+                }
+            }
+        };
+    }
+    fold_map_field!(bindings);
+    fold_map_field!(disabled_gestures);
+    fold_map_field!(per_app_bindings);
+    fold_map_field!(camera_profiles);
+
+    // Collections with no natural per-item override: take the legacy value
+    // wholesale when the canonical side is empty (i.e. never configured).
+    macro_rules! fold_if_empty {
+        ($field:ident) => {
+            if device.$field.is_empty() {
+                device.$field = legacy.$field;
+            }
+        };
+    }
+    fold_if_empty!(dpi_presets);
+    fold_if_empty!(host_switch_targets);
+
+    // `ActionRingConfig` has its own notion of "unset".
+    if device.action_ring.is_default() && !legacy.action_ring.is_default() {
+        device.action_ring = legacy.action_ring;
+    }
+
+    // `enabled` defaults to `true` and is only ever persisted when `false`,
+    // so a legacy `false` is a deliberate "leave this device alone" choice
+    // that must not be lost under a canonical entry that never opted out.
+    if device.enabled && !legacy.enabled {
+        device.enabled = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device_order::{DeviceIdentity, DeviceStableId};
+
+    fn cabled() -> DeviceStableId {
+        DeviceStableId::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc08d,
+            identity: DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]),
+        }
+    }
+
+    fn on_receiver() -> DeviceStableId {
+        DeviceStableId::Bolt {
+            receiver_uid: "82839805".to_string(),
+            slot: 1,
+        }
+    }
+
+    #[test]
+    fn a_known_unit_keys_the_entry_directly() {
+        let config = Config::default();
+        let unit = DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]);
+        let key = config
+            .resolve_device_key(&cabled(), Some(&unit))
+            .expect("a non-zero unit is a physical identity");
+        assert_eq!(key.as_str(), "unit:6be9d300");
+    }
+
+    #[test]
+    fn the_same_unit_resolves_alike_on_either_route() {
+        // The whole point: one mouse, two routes, one entry.
+        let config = Config::default();
+        let unit = DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]);
+        assert_eq!(
+            config.resolve_device_key(&cabled(), Some(&unit)),
+            config.resolve_device_key(&on_receiver(), Some(&unit)),
+        );
+    }
+
+    fn litra() -> DeviceStableId {
+        DeviceStableId::RawHid {
+            vendor_id: 0x046d,
+            product_id: 0xc901,
+            usage_page: 0xff43,
+            usage_id: 0x0202,
+            identity: "serial:beam-1".to_string(),
+        }
+    }
+
+    #[test]
+    fn settings_still_under_the_pre_upgrade_key_are_read_from_it() {
+        // The upgrade path the agent lives through: the schema-4→5 migration
+        // deliberately leaves `receiver:` keys alone, and only the GUI folds
+        // them. Answering with `unit:6be9d300` here would hand the agent an
+        // empty entry, so every receiver-paired device would silently revert
+        // to default bindings and DPI until the user next opened the GUI.
+        let mut config = Config::default();
+        config.devices.insert(
+            "receiver:82839805:slot:1".to_string(),
+            DeviceConfig {
+                dpi: Some(Dpi::new(3200)),
+                ..DeviceConfig::default()
+            },
+        );
+
+        let unit = DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]);
+        let key = config
+            .resolve_device_key(&on_receiver(), Some(&unit))
+            .expect("resolves");
+        assert_eq!(key.as_str(), "receiver:82839805:slot:1");
+        assert_eq!(
+            config.devices[key.as_str()].dpi,
+            Some(Dpi::new(3200)),
+            "the settings are where the key says they are"
+        );
+    }
+
+    #[test]
+    fn a_standalone_raw_entry_keeps_its_light_settings() {
+        // A Litra has no migration at all: its key would move from
+        // `raw:…:serial:beam-1` to `serial:beam-1` the moment the identity
+        // won, orphaning the light settings the user configured.
+        let mut config = Config::default();
+        config.devices.insert(
+            "raw:046d:c901:ff43:0202:serial:beam-1".to_string(),
+            DeviceConfig {
+                light: Some(LightSettings::default()),
+                ..DeviceConfig::default()
+            },
+        );
+
+        let serial = DeviceIdentity::Serial("beam-1".to_string());
+        let key = config
+            .resolve_device_key(&litra(), Some(&serial))
+            .expect("resolves");
+        assert_eq!(key.as_str(), "raw:046d:c901:ff43:0202:serial:beam-1");
+    }
+
+    #[test]
+    fn a_canonical_entry_holding_only_metadata_does_not_shadow_the_legacy_one() {
+        // `persist_identities` and the `links` index write entries on their
+        // own. Neither is a user setting, so neither may out-rank the entry
+        // that actually holds the bindings.
+        let mut config = Config::default();
+        config.devices.insert(
+            "receiver:82839805:slot:1".to_string(),
+            DeviceConfig {
+                dpi: Some(Dpi::new(3200)),
+                ..DeviceConfig::default()
+            },
+        );
+        let mut bare = DeviceConfig::default();
+        bare.links.insert(
+            "receiver:82839805:slot:1".to_string(),
+            LinkConfig::default(),
+        );
+        config.devices.insert("unit:6be9d300".to_string(), bare);
+
+        let unit = DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]);
+        let key = config
+            .resolve_device_key(&on_receiver(), Some(&unit))
+            .expect("resolves");
+        assert_eq!(key.as_str(), "receiver:82839805:slot:1");
+    }
+
+    #[test]
+    fn a_canonical_entry_with_settings_wins_over_a_legacy_one() {
+        // Once adoption (or a plain first-run write) has put real settings
+        // under the identity key, that is the answer — the legacy entry is a
+        // leftover the next fold will consume.
+        let mut config = Config::default();
+        config.devices.insert(
+            "receiver:82839805:slot:1".to_string(),
+            DeviceConfig {
+                dpi: Some(Dpi::new(3200)),
+                ..DeviceConfig::default()
+            },
+        );
+        config.devices.insert(
+            "unit:6be9d300".to_string(),
+            DeviceConfig {
+                dpi: Some(Dpi::new(800)),
+                ..DeviceConfig::default()
+            },
+        );
+
+        let unit = DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]);
+        let key = config
+            .resolve_device_key(&on_receiver(), Some(&unit))
+            .expect("resolves");
+        assert_eq!(key.as_str(), "unit:6be9d300");
+    }
+
+    #[test]
+    fn the_route_key_is_the_legacy_entry_key_for_every_variant_but_direct() {
+        // `adopt_route` finds a legacy entry with `devices.remove(route_key)`,
+        // which only works because a Bolt/RawHid/Unknown route key *is* the
+        // key such an entry was written under. A Direct route key deliberately
+        // is not: its identity moved into the entry key, which is exactly why
+        // the schema-4→5 migration can rename direct entries at load and
+        // cannot rename the others. Three doc comments say so; this asserts it.
+        for stable in [on_receiver(), litra()] {
+            let physical = stable.physical_key().expect("physical");
+            assert_eq!(
+                stable.route_key(),
+                physical.as_str(),
+                "{stable:?}: the route key must find the legacy entry"
+            );
+        }
+        let unknown = DeviceStableId::Unknown {
+            slot: 2,
+            identity: DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]),
+        };
+        assert_eq!(
+            unknown.route_key(),
+            unknown.physical_key().expect("physical").as_str()
+        );
+
+        let direct = cabled();
+        assert_ne!(
+            direct.route_key(),
+            direct.physical_key().expect("physical").as_str(),
+            "a direct route key drops the identity that keys the entry"
+        );
+    }
+
+    #[test]
+    fn adoption_repoints_the_selection_and_any_host_switch_target() {
+        // Adoption is a rename, and a device key lives in three places. A
+        // stale `selected_device` silently jumps the carousel to the first
+        // device; a stale host-switch target silently drops out of the group.
+        let mut config = Config::default();
+        config.devices.insert(
+            "receiver:82839805:slot:1".to_string(),
+            DeviceConfig {
+                dpi: Some(Dpi::new(800)),
+                ..DeviceConfig::default()
+            },
+        );
+        config.devices.insert(
+            "receiver:82839805:slot:2".to_string(),
+            DeviceConfig {
+                host_switch_targets: vec!["receiver:82839805:slot:1".to_string()],
+                ..DeviceConfig::default()
+            },
+        );
+        config.selected_device = Some("receiver:82839805:slot:1".to_string());
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1"));
+
+        assert_eq!(config.selected_device.as_deref(), Some("unit:6be9d300"));
+        assert_eq!(
+            config.devices["receiver:82839805:slot:2"].host_switch_targets,
+            vec!["unit:6be9d300".to_string()],
+            "the keyboard still switches the mouse it was linked to"
+        );
+    }
+
+    #[test]
+    fn an_asleep_device_resolves_through_its_indexed_route() {
+        // Offline: no unit id was readable, only the receiver slot. The links
+        // table recorded on an earlier online sighting is the only way back
+        // to the entry.
+        let mut config = Config::default();
+        let mut device = DeviceConfig::default();
+        device.links.insert(
+            "receiver:82839805:slot:1".to_string(),
+            LinkConfig::default(),
+        );
+        config.devices.insert("unit:6be9d300".to_string(), device);
+
+        let key = config
+            .resolve_device_key(&on_receiver(), None)
+            .expect("the indexed route resolves");
+        assert_eq!(key.as_str(), "unit:6be9d300");
+    }
+
+    #[test]
+    fn an_unindexed_route_falls_back_to_todays_key() {
+        let config = Config::default();
+        let key = config
+            .resolve_device_key(&on_receiver(), None)
+            .expect("receiver keys are physical");
+        assert_eq!(key.as_str(), "receiver:82839805:slot:1");
+    }
+
+    #[test]
+    fn an_all_zero_unit_over_a_receiver_keeps_its_route_key() {
+        // Not every device reports a unit id. Such a device simply never
+        // correlates across transports rather than colliding on `unit:00000000`.
+        let config = Config::default();
+        let zero = DeviceIdentity::Unit([0; 4]);
+        let key = config
+            .resolve_device_key(&on_receiver(), Some(&zero))
+            .expect("falls back rather than failing");
+        assert_eq!(key.as_str(), "receiver:82839805:slot:1");
+    }
+
+    #[test]
+    fn a_direct_device_with_no_identity_stays_non_persistent() {
+        let config = Config::default();
+        let anonymous = DeviceStableId::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc08d,
+            identity: DeviceIdentity::Unit([0; 4]),
+        };
+        assert_eq!(config.resolve_device_key(&anonymous, None), None);
+    }
+
+    #[test]
+    fn adopting_a_route_folds_the_legacy_entry_in() {
+        // The lighting configured over the receiver has to survive onto the
+        // cable — that is the user-visible bug this whole change exists for.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            lighting: Some(Lighting::default()),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), DeviceConfig::default());
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1"));
+
+        let device = &config.devices["unit:6be9d300"];
+        assert!(device.lighting.is_some(), "lighting moved to device level");
+        assert!(device.links.contains_key("receiver:82839805:slot:1"));
+        assert!(
+            !config.devices.contains_key("receiver:82839805:slot:1"),
+            "the legacy entry is consumed, not left behind"
+        );
+    }
+
+    #[test]
+    fn a_conflicting_value_becomes_a_per_link_override() {
+        // Both sides set a DPI and they disagree. Neither is wrong — the user
+        // set each one — so the legacy value survives as an override on its
+        // own link rather than being overwritten.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            dpi: Some(Dpi::new(800)),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        let canonical_entry = DeviceConfig {
+            dpi: Some(Dpi::new(1600)),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), canonical_entry);
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+
+        let device = &config.devices["unit:6be9d300"];
+        assert_eq!(device.dpi, Some(Dpi::new(1600)), "canonical stays default");
+        assert_eq!(
+            device.links["receiver:82839805:slot:1"].overrides.dpi,
+            Some(Dpi::new(800)),
+            "the legacy value survives on its own link"
+        );
+    }
+
+    #[test]
+    fn adopting_an_unseen_route_registers_it_and_reports_a_change() {
+        // No legacy entry to fold in, but a new route in the links index is
+        // itself a change worth persisting — the return value means "did
+        // anything change", not "was a legacy entry folded".
+        let mut config = Config::default();
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), DeviceConfig::default());
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+
+        assert!(config.adopt_route(&canonical, "direct:046d:c08d"));
+        assert!(
+            config.devices["unit:6be9d300"]
+                .links
+                .contains_key("direct:046d:c08d")
+        );
+    }
+
+    #[test]
+    fn adopting_an_already_indexed_route_reports_no_change() {
+        // The route is already recorded and there is no legacy entry to
+        // fold — calling `adopt_route` again must be a safe no-op that
+        // reports nothing changed, so a caller polling every refresh does
+        // not persist and reload on every tick.
+        let mut config = Config::default();
+        let mut device = DeviceConfig::default();
+        device
+            .links
+            .insert("direct:046d:c08d".to_string(), LinkConfig::default());
+        config.devices.insert("unit:6be9d300".to_string(), device);
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+
+        assert!(!config.adopt_route(&canonical, "direct:046d:c08d"));
+    }
+
+    #[test]
+    fn a_re_paired_slot_points_at_the_new_unit() {
+        // Unpair mouse A from slot 1, pair mouse B into it. Today B inherits
+        // A's bindings because the key *is* the slot. It must not.
+        let mut config = Config::default();
+        let mut first = DeviceConfig::default();
+        first.links.insert(
+            "receiver:82839805:slot:1".to_string(),
+            LinkConfig::default(),
+        );
+        config.devices.insert("unit:aaaaaaaa".to_string(), first);
+        config
+            .devices
+            .insert("unit:bbbbbbbb".to_string(), DeviceConfig::default());
+
+        let second = PhysicalDeviceKey::parse("unit:bbbbbbbb").expect("valid");
+        config.adopt_route(&second, "receiver:82839805:slot:1");
+
+        assert!(
+            !config.devices["unit:aaaaaaaa"]
+                .links
+                .contains_key("receiver:82839805:slot:1"),
+            "the route no longer points at the previous unit"
+        );
+        assert!(
+            config.devices["unit:bbbbbbbb"]
+                .links
+                .contains_key("receiver:82839805:slot:1")
+        );
+    }
+
+    #[test]
+    fn per_app_bindings_merge_key_by_key() {
+        // A route-keyed entry could carry an app overlay the canonical side
+        // never bound — the fold must not silently drop it.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            per_app_bindings: std::collections::BTreeMap::from([(
+                "com.example.App".to_string(),
+                std::collections::BTreeMap::from([(ButtonId::MiddleClick, Action::Copy)]),
+            )]),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), DeviceConfig::default());
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+
+        let device = &config.devices["unit:6be9d300"];
+        assert_eq!(
+            device.per_app_bindings.get("com.example.App"),
+            Some(&std::collections::BTreeMap::from([(
+                ButtonId::MiddleClick,
+                Action::Copy
+            )])),
+            "the app overlay survives adoption"
+        );
+    }
+
+    #[test]
+    fn light_is_taken_when_the_canonical_side_has_none() {
+        // `light` (standalone-light settings) has no per-link override slot,
+        // unlike `lighting` — it must still be taken rather than dropped.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            light: Some(LightSettings::default()),
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), DeviceConfig::default());
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+
+        assert_eq!(
+            config.devices["unit:6be9d300"].light,
+            Some(LightSettings::default()),
+            "the standalone-light setting is not silently discarded"
+        );
+    }
+
+    #[test]
+    fn a_legacy_disabled_flag_disables_the_canonical_entry() {
+        // `enabled` defaults to `true` and is only ever persisted as `false`,
+        // so a legacy `false` is a deliberate "leave this device alone"
+        // choice that adoption must not silently override.
+        let mut config = Config::default();
+        let legacy = DeviceConfig {
+            enabled: false,
+            ..DeviceConfig::default()
+        };
+        config
+            .devices
+            .insert("receiver:82839805:slot:1".to_string(), legacy);
+        config
+            .devices
+            .insert("unit:6be9d300".to_string(), DeviceConfig::default());
+
+        let canonical = PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+        config.adopt_route(&canonical, "receiver:82839805:slot:1");
+
+        assert!(
+            !config.devices["unit:6be9d300"].enabled,
+            "the legacy opt-out survives adoption"
+        );
+    }
+}

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -45,6 +45,53 @@ fn first_save_preserves_the_previous_config_for_recovery() {
 }
 
 #[test]
+fn migrated_load_backs_up_the_pre_migration_source_exactly_once() {
+    // A key-rewriting migration touches every entry, so the pre-migration
+    // file is the user's only recovery path if the rewrite is wrong. The
+    // backup must hold the source exactly as loaded — not the migrated,
+    // re-serialized output — and must not be retaken on a later save from
+    // the same `ConfigFile` (`migrated_from` is consumed with `Option::take`).
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let backup = path.with_extension("v4.bak");
+    let original =
+        b"schema_version = 4\n\n[devices.\"direct:046d:c08d:unit:6be9d300\"]\ninvert_scroll = true\n";
+    fs::write(&path, original).expect("write v4 config");
+
+    let (config, mut file) = ConfigFile::load_from_path(&path).expect("load v4 config");
+    assert!(
+        config.devices.contains_key("unit:6be9d300"),
+        "sanity: the key migration ran"
+    );
+
+    file.save(&config).expect("save migrated config");
+    assert_eq!(
+        fs::read(&backup).expect("read migration backup"),
+        original,
+        "the backup preserves the pre-migration source, not the rewritten output"
+    );
+
+    // Replace the backup with a sentinel that `original` never equals, so a
+    // second write is observable even though it would write the same bytes
+    // as the first: re-asserting against `original` here cannot distinguish
+    // "not rewritten" from "rewritten with identical content", which is
+    // exactly the regression this test exists to catch (`migrated_from`
+    // going from a consuming `Option::take` to a plain read).
+    let sentinel = b"sentinel: a second save must not touch this file";
+    fs::write(&backup, sentinel).expect("overwrite backup with sentinel");
+
+    let mut second = config.clone();
+    second.selected_device = Some("unit:6be9d300".to_string());
+    file.save(&second)
+        .expect("save again from the same ConfigFile");
+    assert_eq!(
+        fs::read(&backup).expect("read backup after second save"),
+        sentinel,
+        "a second save from the same ConfigFile must not rewrite the backup"
+    );
+}
+
+#[test]
 fn config_backups_rotate_between_generations() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
@@ -1652,5 +1699,323 @@ Back = { Up = \"Copy\" }
     assert_eq!(
         cfg.bindings_for("2b042").get(&ButtonId::GestureButton),
         Some(&Binding::Single(default_binding(ButtonId::GestureButton)))
+    );
+}
+
+#[test]
+fn a_config_without_links_round_trips_unchanged() {
+    // Every existing file has no `links`; serializing must not start writing
+    // an empty table into files that never had one.
+    let source =
+        "schema_version = 4\n\n[devices.\"receiver:82839805:slot:1\"]\ninvert_scroll = true\n";
+    let config: Config = toml::from_str(source).expect("parses");
+    let device = config
+        .devices
+        .get("receiver:82839805:slot:1")
+        .expect("entry");
+    assert!(device.links.is_empty());
+    let written = toml::to_string(&config).expect("serializes");
+    assert!(!written.contains("links"), "got: {written}");
+}
+
+#[test]
+fn a_link_carries_measured_capabilities_and_overrides() {
+    let source = r#"
+schema_version = 5
+
+[devices."unit:6be9d300".links."direct:046d:c08d".capabilities]
+buttons = false
+pointer = true
+lighting = true
+scroll_inversion = false
+hires_wheel = false
+thumbwheel = false
+haptic_feedback = false
+haptic_panel = false
+
+[devices."unit:6be9d300".links."direct:046d:c08d".overrides]
+dpi = 1600
+invert_scroll = true
+"#;
+    let config: Config = toml::from_str(source).expect("parses");
+    let link = config.devices["unit:6be9d300"].links["direct:046d:c08d"].clone();
+    assert!(!link.capabilities.expect("measured").hires_wheel);
+    assert_eq!(link.overrides.dpi, Some(Dpi::new(1600)));
+    assert_eq!(link.overrides.invert_scroll, Some(true));
+}
+
+#[test]
+fn migrating_v4_drops_the_transport_prefix_from_direct_keys() {
+    let source = r#"
+schema_version = 4
+selected_device = "direct:046d:c08d:unit:6be9d300"
+
+[devices."direct:046d:c08d:unit:6be9d300"]
+invert_scroll = true
+
+[devices."receiver:82839805:slot:1"]
+dpi = 1600
+"#;
+    let mut config: Config = toml::from_str(source).expect("parses");
+    config.migrate_transport_scoped_keys();
+
+    assert!(config.devices.contains_key("unit:6be9d300"));
+    assert!(
+        !config
+            .devices
+            .contains_key("direct:046d:c08d:unit:6be9d300")
+    );
+    assert_eq!(
+        config.selected_device.as_deref(),
+        Some("unit:6be9d300"),
+        "the selection follows the key"
+    );
+    assert!(
+        config.devices["unit:6be9d300"]
+            .links
+            .contains_key("direct:046d:c08d"),
+        "the route it came from is remembered, not discarded"
+    );
+    assert!(
+        config.devices.contains_key("receiver:82839805:slot:1"),
+        "receiver entries are left for runtime adoption"
+    );
+}
+
+#[test]
+fn migrating_two_direct_routes_of_one_device_folds_instead_of_dropping_one() {
+    // An MX Master 3S reached over USB *and* over Bluetooth-direct has two v4
+    // entries whose keys both rename to `unit:6be9d300`. Inserting would let
+    // whichever came later in `BTreeMap` order silently delete the other's
+    // bindings, DPI and lighting — the one case where phase A of the
+    // migration is neither mechanical nor lossless.
+    let source = r#"
+schema_version = 4
+
+[devices."direct:046d:b034:unit:6be9d300"]
+dpi = 1600
+invert_scroll = true
+
+[devices."direct:046d:b034:unit:6be9d300".bindings]
+Back = "BrowserBack"
+
+[devices."direct:046d:c08d:unit:6be9d300"]
+dpi = 800
+
+[devices."direct:046d:c08d:unit:6be9d300".bindings]
+Forward = "BrowserForward"
+"#;
+    let mut config: Config = toml::from_str(source).expect("parses");
+    config.migrate_transport_scoped_keys();
+
+    assert_eq!(config.devices.len(), 1, "one device, one entry");
+    let device = &config.devices["unit:6be9d300"];
+    assert_eq!(
+        device.bindings.len(),
+        2,
+        "both routes' bindings survive: {:?}",
+        device.bindings
+    );
+    assert_eq!(
+        device.dpi,
+        Some(Dpi::new(1600)),
+        "one value stays canonical"
+    );
+    assert_eq!(
+        device.links["direct:046d:c08d"].overrides.dpi,
+        Some(Dpi::new(800)),
+        "the other survives as an override on the route it was set for"
+    );
+    assert!(
+        device.links.contains_key("direct:046d:b034"),
+        "both routes are indexed: {:?}",
+        device.links
+    );
+}
+
+#[test]
+fn an_empty_link_table_survives_a_save_and_reload() {
+    // The set of `links` keys *is* the route index — the only thing that can
+    // identify a sleeping device from its route alone. A link with nothing
+    // special about it is an empty sub-table, so if serialization or the
+    // comment-preserving `reconcile_table` merge ever drops one, the index
+    // quietly empties on every save and every sleeping device falls back to
+    // its route key.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(
+        &path,
+        "schema_version = 5\n\n# a hand-written comment\n[devices.\"unit:6be9d300\"]\ndpi = 1600\n",
+    )
+    .expect("write v5 config");
+
+    let mut config = Config::load_from_path(&path).expect("load");
+    let canonical = crate::device_order::PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
+    assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1"));
+    assert!(
+        config.devices["unit:6be9d300"].links["receiver:82839805:slot:1"]
+            .overrides
+            .is_empty(),
+        "sanity: the link carries nothing but its own existence"
+    );
+    config.save_to_path(&path).expect("save");
+
+    let reloaded = Config::load_from_path(&path).expect("reload");
+    assert!(
+        reloaded.devices["unit:6be9d300"]
+            .links
+            .contains_key("receiver:82839805:slot:1"),
+        "the route index survives the round trip: {}",
+        fs::read_to_string(&path).expect("read back")
+    );
+}
+
+#[test]
+fn a_failed_backup_write_leaves_the_migration_backup_still_owed() {
+    // The pre-migration file is the user's only recovery path from a
+    // key-rewriting migration. If the backup write fails — full disk,
+    // read-only directory — and the debt is cleared anyway, the next save
+    // that *does* succeed overwrites the v4 file with v5 content and no copy
+    // ever exists.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let backup = path.with_extension("v4.bak");
+    let original =
+        b"schema_version = 4\n\n[devices.\"direct:046d:c08d:unit:6be9d300\"]\ninvert_scroll = true\n";
+    fs::write(&path, original).expect("write v4 config");
+    // A directory where the backup file belongs: the write fails, and
+    // nothing about the config file itself is wrong.
+    fs::create_dir(&backup).expect("occupy the backup path");
+
+    let (config, mut file) = ConfigFile::load_from_path(&path).expect("load v4 config");
+    let error = file.save(&config).expect_err("the backup write must fail");
+    assert_matches!(error, ConfigError::Write { .. });
+    assert_eq!(
+        fs::read(&path).expect("read config"),
+        original,
+        "a failed save leaves the v4 file in place"
+    );
+
+    fs::remove_dir(&backup).expect("free the backup path");
+    file.save(&config).expect("save once the path is writable");
+    assert_eq!(
+        fs::read(&backup).expect("read migration backup"),
+        original,
+        "the retried save still has the pre-migration source to write"
+    );
+}
+
+#[test]
+fn migrating_rewrites_host_switch_targets() {
+    let source = r#"
+schema_version = 4
+
+[devices."receiver:82839805:slot:2"]
+host_switch_targets = ["direct:046d:c08d:unit:6be9d300"]
+"#;
+    let mut config: Config = toml::from_str(source).expect("parses");
+    config.migrate_transport_scoped_keys();
+    assert_eq!(
+        config.devices["receiver:82839805:slot:2"].host_switch_targets,
+        vec!["unit:6be9d300".to_string()],
+    );
+}
+
+#[test]
+fn a_v4_file_with_no_direct_entries_is_untouched() {
+    let source = "schema_version = 4\n\n[devices.\"receiver:82839805:slot:1\"]\ndpi = 1600\n";
+    let mut config: Config = toml::from_str(source).expect("parses");
+    let before = config.devices.clone();
+    config.migrate_transport_scoped_keys();
+    assert_eq!(config.devices.len(), before.len());
+    assert!(config.devices.contains_key("receiver:82839805:slot:1"));
+}
+
+#[test]
+fn migrating_v4_drops_the_transport_prefix_from_serial_keyed_direct_keys() {
+    // The identity fragment is not always `unit:<hex>` — a device that
+    // reports a serial keys as `serial:<s>` instead, and the brief names
+    // both halves of the mapping equally.
+    let source = r#"
+schema_version = 4
+
+[devices."direct:046d:c08d:serial:abc123"]
+invert_scroll = true
+"#;
+    let mut config: Config = toml::from_str(source).expect("parses");
+    config.migrate_transport_scoped_keys();
+
+    assert!(config.devices.contains_key("serial:abc123"));
+    assert!(
+        !config
+            .devices
+            .contains_key("direct:046d:c08d:serial:abc123")
+    );
+    assert!(
+        config.devices["serial:abc123"]
+            .links
+            .contains_key("direct:046d:c08d"),
+        "the route it came from is remembered, not discarded"
+    );
+}
+
+#[test]
+fn migrating_leaves_a_direct_key_with_no_physical_identity_untouched() {
+    // An all-zero unit id is not a physical identity (see
+    // `PhysicalDeviceKey::parse`), so this key must not be rewritten — doing
+    // so would collide every never-identified direct device onto one
+    // `unit:00000000` entry.
+    let source = "schema_version = 4\n\n[devices.\"direct:046d:c08d:unit:00000000\"]\ninvert_scroll = true\n";
+    let mut config: Config = toml::from_str(source).expect("parses");
+    config.migrate_transport_scoped_keys();
+
+    assert!(
+        config
+            .devices
+            .contains_key("direct:046d:c08d:unit:00000000"),
+        "a non-physical identity is left keyed exactly as it was loaded"
+    );
+    assert!(!config.devices.contains_key("unit:00000000"));
+}
+
+#[test]
+fn a_link_override_shadows_the_device_value() {
+    let mut device = DeviceConfig {
+        dpi: Some(Dpi::new(1600)),
+        ..DeviceConfig::default()
+    };
+    device.links.insert(
+        "receiver:82839805:slot:1".to_string(),
+        LinkConfig {
+            capabilities: None,
+            overrides: LinkOverrides {
+                dpi: Some(Dpi::new(800)),
+                ..LinkOverrides::default()
+            },
+        },
+    );
+
+    assert_eq!(
+        device.effective_dpi("receiver:82839805:slot:1"),
+        Some(Dpi::new(800)),
+        "the link the user set it on wins"
+    );
+    assert_eq!(
+        device.effective_dpi("direct:046d:c08d"),
+        Some(Dpi::new(1600)),
+        "every other link keeps the device default"
+    );
+}
+
+#[test]
+fn an_unknown_route_gets_the_device_value() {
+    // A device seen on a route with no entry yet must not lose its settings.
+    let device = DeviceConfig {
+        dpi: Some(Dpi::new(1600)),
+        ..DeviceConfig::default()
+    };
+    assert_eq!(
+        device.effective_dpi("direct:046d:ffff"),
+        Some(Dpi::new(1600))
     );
 }

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1853,7 +1853,7 @@ fn an_empty_link_table_survives_a_save_and_reload() {
 
     let mut config = Config::load_from_path(&path).expect("load");
     let canonical = crate::device_order::PhysicalDeviceKey::parse("unit:6be9d300").expect("valid");
-    assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1"));
+    assert!(config.adopt_route(&canonical, "receiver:82839805:slot:1", None));
     assert!(
         config.devices["unit:6be9d300"].links["receiver:82839805:slot:1"]
             .overrides

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -516,7 +516,10 @@ fn human_readable_toml_layout() {
     // The key only contains [A-Za-z0-9_], so TOML emits it as a bare-word
     // table key (no surrounding quotes). The test asserts the observable
     // structure rather than locking in a specific quoting.
-    assert!(body.contains("schema_version = 5"), "got: {body}");
+    assert!(
+        body.contains(&format!("schema_version = {SCHEMA_VERSION}")),
+        "got: {body}"
+    );
     assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
     // A `Single` binding serializes byte-identically to the pre-v2 bare
     // `Action`, so the leaf line is unchanged.
@@ -1028,7 +1031,10 @@ Click = \"Paste\"
     // Saving self-heals to the current shape: stamped version + merged table,
     // legacy field names gone.
     let body = toml::to_string_pretty(&cfg).expect("serialize");
-    assert!(body.contains("schema_version = 5"), "got: {body}");
+    assert!(
+        body.contains(&format!("schema_version = {SCHEMA_VERSION}")),
+        "got: {body}"
+    );
     assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
     assert!(!body.contains("button_bindings"), "got: {body}");
     assert!(!body.contains("gesture_bindings"), "got: {body}");
@@ -1877,7 +1883,7 @@ fn a_failed_backup_write_leaves_the_migration_backup_still_owed() {
     // The pre-migration file is the user's only recovery path from a
     // key-rewriting migration. If the backup write fails — full disk,
     // read-only directory — and the debt is cleared anyway, the next save
-    // that *does* succeed overwrites the v4 file with v5 content and no copy
+    // that *does* succeed overwrites the v4 file with migrated content and no copy
     // ever exists.
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -53,7 +53,9 @@ fn migrated_load_backs_up_the_pre_migration_source_exactly_once() {
     // the same `ConfigFile` (`migrated_from` is consumed with `Option::take`).
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
-    let backup = path.with_extension("v4.bak");
+    // Appended to the full file name, not substituted for its extension:
+    // `config.toml` + `.v4.bak`, never `config.v4.bak`.
+    let backup = dir.path().join("config.toml.v4.bak");
     let original =
         b"schema_version = 4\n\n[devices.\"direct:046d:c08d:unit:6be9d300\"]\ninvert_scroll = true\n";
     fs::write(&path, original).expect("write v4 config");
@@ -1879,7 +1881,9 @@ fn a_failed_backup_write_leaves_the_migration_backup_still_owed() {
     // ever exists.
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("config.toml");
-    let backup = path.with_extension("v4.bak");
+    // Appended to the full file name, not substituted for its extension:
+    // `config.toml` + `.v4.bak`, never `config.v4.bak`.
+    let backup = dir.path().join("config.toml.v4.bak");
     let original =
         b"schema_version = 4\n\n[devices.\"direct:046d:c08d:unit:6be9d300\"]\ninvert_scroll = true\n";
     fs::write(&path, original).expect("write v4 config");

--- a/crates/openlogi-core/src/device_order.rs
+++ b/crates/openlogi-core/src/device_order.rs
@@ -164,6 +164,27 @@ impl DeviceStableId {
         }
     }
 
+    /// Key naming the *path* a device was reached by, with the device's own
+    /// identity removed.
+    ///
+    /// Used as the key of a config entry's `links` table, so one device
+    /// reached two ways indexes one entry. Only [`Self::Direct`] carries a
+    /// device identity that moves to the entry key; the others keep
+    /// [`Self::runtime_key`] unchanged — a receiver key already names the
+    /// receiver rather than the paired device, and raw/routeless identities
+    /// are OS node ids that cannot become an entry key.
+    #[must_use]
+    pub fn route_key(&self) -> String {
+        match self {
+            Self::Direct {
+                vendor_id,
+                product_id,
+                ..
+            } => format!("direct:{vendor_id:04x}:{product_id:04x}"),
+            Self::Bolt { .. } | Self::RawHid { .. } | Self::Unknown { .. } => self.runtime_key(),
+        }
+    }
+
     /// Stable key for persisted per-physical-device configuration.
     ///
     /// Receiver-connected devices are identified by receiver UID + pairing
@@ -186,14 +207,23 @@ impl DeviceStableId {
 }
 
 impl DeviceIdentity {
-    fn is_physical(&self) -> bool {
+    /// Whether this identity is non-trivial: a non-empty serial, or a unit id
+    /// that is not all-zero.
+    ///
+    /// A device that reports neither has no identity worth keying on, either
+    /// for [`DeviceStableId::physical_key`] or for a route-independent
+    /// [`Self::key`].
+    pub(crate) fn is_physical(&self) -> bool {
         match self {
             Self::Serial(serial) => !serial.is_empty(),
             Self::Unit(unit) => *unit != [0; 4],
         }
     }
 
-    fn key(&self) -> String {
+    /// This identity formatted as a bare `serial:`/`unit:` fragment, with no
+    /// route information. Callers that only want a key for a physical
+    /// identity should gate this behind [`Self::is_physical`] first.
+    pub(crate) fn key(&self) -> String {
         match self {
             Self::Serial(serial) => format!("serial:{serial}"),
             Self::Unit(unit) => format!("unit:{}", hex_unit(*unit)),
@@ -213,6 +243,7 @@ impl PhysicalDeviceKey {
             || direct_identity_fragment(value).is_some_and(identity_fragment_is_physical)
             || raw_identity_fragment(value).is_some_and(raw_identity_is_physical)
             || unknown_identity_fragment(value).is_some_and(identity_fragment_is_physical)
+            || identity_fragment_is_physical(value)
         {
             Some(Self(value.to_string()))
         } else {
@@ -314,7 +345,7 @@ fn hex_unit(unit: [u8; 4]) -> String {
 mod tests {
     use crate::hid::DeviceRoute;
 
-    use super::{DeviceStableId, PhysicalDeviceKey};
+    use super::{DeviceIdentity, DeviceStableId, PhysicalDeviceKey};
 
     #[test]
     fn unifying_route_maps_to_bolt_stable_id() {
@@ -446,5 +477,37 @@ mod tests {
             .physical_key()
             .map(PhysicalDeviceKey::into_string);
         assert_eq!(key, Some("raw:046d:c900:ff43:0202:serial:glow-1".into()));
+    }
+
+    #[test]
+    fn a_direct_route_key_drops_the_device_identity() {
+        // The identity moves to the entry key; the route names only the path, so
+        // the same mouse cabled and on its receiver can index the same entry.
+        let id = DeviceStableId::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xc08d,
+            identity: DeviceIdentity::Unit([0x6b, 0xe9, 0xd3, 0x00]),
+        };
+        assert_eq!(id.runtime_key(), "direct:046d:c08d:unit:6be9d300");
+        assert_eq!(id.route_key(), "direct:046d:c08d");
+    }
+
+    #[test]
+    fn other_routes_keep_their_runtime_key() {
+        // A receiver key names the receiver and slot, never the paired device, so
+        // there is no identity to strip. Raw and routeless keys keep their
+        // identity because it is an OS node id, not a device identity that can
+        // move to the entry key.
+        let bolt = DeviceStableId::Bolt {
+            receiver_uid: "82839805".to_string(),
+            slot: 1,
+        };
+        assert_eq!(bolt.route_key(), bolt.runtime_key());
+
+        let unknown = DeviceStableId::Unknown {
+            slot: 255,
+            identity: DeviceIdentity::Unit([1, 2, 3, 4]),
+        };
+        assert_eq!(unknown.route_key(), unknown.runtime_key());
     }
 }

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -779,7 +779,9 @@ mod tests {
     fn record(kind: DeviceKind, capabilities: Option<Capabilities>) -> DeviceRecord {
         DeviceRecord {
             config_key: "test".to_string(),
+            canonical_key: None,
             persistent: true,
+            route_key: "test".to_string(),
             model_key: "test".to_string(),
             model_name: "Test".to_string(),
             display_name: "Test".to_string(),

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -341,13 +341,14 @@ fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
 /// Pure config — no hardware read — so it is a plain settings block rather than
 /// an `Entity` panel like DPI / SmartShift.
 fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
-    let (inverted, inversion_supported, resolution, hires_supported) = AppState::try_read(cx)
-        .map_or((false, false, None, false), |state| {
+    let (inverted, inversion_supported, resolution, hires_supported, hires_elsewhere) =
+        AppState::try_read(cx).map_or((false, false, None, false, false), |state| {
             (
                 state.current_invert_scroll(),
                 state.current_scroll_inversion_supported(),
                 state.current_scroll_resolution(),
                 state.current_hires_wheel_supported(),
+                state.hires_wheel_supported_on_another_link(),
             )
         });
     let inversion_description = if inversion_supported {
@@ -397,6 +398,8 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
                 tr!("Detects finer movement between ratchet steps.")
             }
         }
+    } else if hires_elsewhere {
+        tr!("This device supports wheel resolution on its other connection, but not this one.")
     } else {
         tr!("This device does not support wheel resolution control.")
     };

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -97,7 +97,7 @@ pub(crate) fn keyboard_glow(
         return None;
     }
     let lighting = state
-        .lighting_for(&record.config_key)
+        .lighting_for(&record.config_key, &record.route_key)
         .filter(|l| l.enabled)?;
     let geom = record.asset.as_ref()?.glow.clone()?;
     let (r, g, b) = lighting.color.components();

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -233,6 +233,19 @@ impl AppState {
     ) -> Self {
         let mut config = ConfigState::new(config, config_persistence);
         let device_list = build_device_list(inventories, standalone, cache, &config, cameras);
+        // Fold each online device's route into its canonical entry before
+        // anything writes to the config — the first frame after a schema-5
+        // upgrade is the earliest moment this can happen, and the ordering
+        // against `persist_identities` matters for the same reason it does in
+        // `refresh_inventories`: identities keyed off a legacy `config_key`
+        // would leave a bare canonical entry beside the un-folded legacy one.
+        let adopted = config.edit(|config| inventory::adopt_routes(config, &device_list));
+        // Adoption re-keyed entries, so rebuild before reading the list again.
+        let device_list = if adopted {
+            build_device_list(inventories, standalone, cache, &config, cameras)
+        } else {
+            device_list
+        };
         // Record any device probed at launch so it survives the next cold start.
         let identities_changed =
             config.edit(|config| inventory::persist_identities(config, &device_list));
@@ -254,7 +267,15 @@ impl AppState {
             #[cfg(target_os = "macos")]
             camera_permission_poll: None,
         };
-        if identities_changed {
+        // Plain `persist_config`, not `persist_and_reload` as
+        // `refresh_inventories` uses for the same fold: there is no agent
+        // connection to reload yet this early in startup, and the
+        // unconditional `ReloadConfig` send at the end of this constructor
+        // (below) already covers both branches once `state` is fully built —
+        // sending it here too would just queue a second, redundant reload.
+        if adopted {
+            state.persist_config("adopt device route");
+        } else if identities_changed {
             state.persist_config("device identity");
         }
         if state.config.should_reload_agent() {
@@ -298,11 +319,12 @@ impl AppState {
 
     fn restore_config_projections(&mut self) {
         self.restore_binding_projections();
-        if let Some(dpi) = self
-            .current_record()
-            .and_then(DeviceRecord::persistent_config_key)
-            .and_then(|key| self.config.dpi(key))
-        {
+        if let Some(dpi) = self.current_record().and_then(|record| {
+            record
+                .persistent_config_key()
+                .and_then(|key| self.config.devices.get(key))
+                .and_then(|device| device.effective_dpi(&record.route_key))
+        }) {
             self.pointer.dpi = dpi;
         }
     }

--- a/crates/openlogi-desktop/src/state/devices.rs
+++ b/crates/openlogi-desktop/src/state/devices.rs
@@ -1,14 +1,17 @@
 //! Device-list construction and selection helpers for [`super::AppState`].
 
-use std::collections::HashSet;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, HashSet};
 
 use openlogi_camera::Camera;
-use openlogi_core::config::{Config, DeviceIdentity};
+use openlogi_core::config::{Config, DeviceIdentity, canonical_device_key};
 use openlogi_core::device::{
     BatteryInfo, Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, StandaloneDevice,
 };
-use openlogi_core::device_order::{DeviceStableId, PhysicalDeviceKey};
+use openlogi_core::device_order::{
+    DeviceIdentity as RouteIdentity, DeviceStableId, PhysicalDeviceKey,
+};
 use openlogi_core::hid::DeviceRoute;
 use tracing::debug;
 
@@ -31,9 +34,25 @@ pub struct DeviceRecord {
     /// model-scoped key here, so use [`Self::record_key`] when one user-facing
     /// record must be distinguished from another.
     pub config_key: String,
-    /// Whether `config_key` is safe to write to configuration. False for a
-    /// direct/routeless all-zero unit identity.
+    /// The key this device's settings ultimately belong under — derived from
+    /// the device's own identity, not from the route it was reached on.
+    ///
+    /// Usually equal to [`Self::config_key`]. They differ for exactly as long
+    /// as the settings still live under a pre-schema-5 route key that the
+    /// load migration could not rename (`receiver:`, `raw:`): `config_key`
+    /// then names where they are *now* and this names where
+    /// [`Config::adopt_route`] will move them. `None` for a record with no
+    /// identity-derived key of its own — a camera, an offline placeholder, a
+    /// transient probe, the dev-only demo keyboard.
+    pub(crate) canonical_key: Option<String>,
+    /// Whether `config_key` identifies one physical device and may be written
+    /// to configuration. False for a direct/routeless all-zero unit identity.
     pub(crate) persistent: bool,
+    /// Key of the route this record was reached by — [`DeviceStableId::route_key`].
+    /// A record with no route of its own (a camera, an offline placeholder,
+    /// or the dev-only demo keyboard) repeats [`Self::config_key`] here
+    /// instead.
+    pub route_key: String,
     /// Stable model key used only for asset/model lookup and diagnostics.
     pub model_key: String,
     /// Hardware model name, unaffected by the user's per-device alias.
@@ -172,10 +191,17 @@ pub(super) fn build_device_list(
                 serial_number.as_deref(),
                 unit_id,
             );
-            let (config_key, persistent) = stable_id.physical_key().map_or_else(
-                || (stable_id.runtime_key(), false),
-                |key| (key.into_string(), true),
-            );
+            let identity = RouteIdentity::from_parts(serial_number.as_deref(), unit_id);
+            let (config_key, persistent) = config
+                .resolve_device_key(&stable_id, paired.online.then_some(&identity))
+                .map_or_else(
+                    || (stable_id.runtime_key(), false),
+                    |key| (key.into_string(), true),
+                );
+            let canonical_key =
+                canonical_device_key(&stable_id, paired.online.then_some(&identity))
+                    .map(PhysicalDeviceKey::into_string);
+            let route_key = stable_id.route_key();
 
             let display_name = asset
                 .as_ref()
@@ -185,7 +211,9 @@ pub(super) fn build_device_list(
             let kind = effective_kind(paired.kind, asset.as_ref().map(|a| a.kind));
             list.push(DeviceRecord {
                 config_key,
+                canonical_key,
                 persistent,
+                route_key,
                 model_key,
                 model_name: display_name.clone(),
                 display_name,
@@ -207,7 +235,7 @@ pub(super) fn build_device_list(
             });
         }
     }
-    append_standalone(&mut list, standalone, cache);
+    append_standalone(&mut list, standalone, cache, config);
     #[cfg(debug_assertions)]
     if std::env::var_os("OPENLOGI_DEMO_KEYBOARD").is_some() {
         list.push(demo_keyboard());
@@ -222,6 +250,7 @@ pub(super) fn build_device_list(
         config.known_identities(),
         cache,
         &present_receivers,
+        config,
     );
     // Cameras are UVC, not HID++, so they come from a parallel discovery path
     // (AVFoundation on macOS) rather than the receiver inventory. The caller
@@ -261,12 +290,20 @@ fn apply_custom_names(list: &mut [DeviceRecord], config: &Config) {
 /// [`DeviceModelInfo`] from the USB pid.
 fn camera_record(camera: &Camera, cache: &AssetResolver) -> DeviceRecord {
     let config_key = camera.config_key();
+    // Cameras are UVC, not HID++, so they carry no `DeviceStableId` route of
+    // their own — the config key doubles as the route key.
+    let route_key = config_key.clone();
     let model_info = camera_model_info(camera);
     let asset = cache.resolve(&model_info, Some(&camera.name));
     DeviceRecord {
         model_key: format!("{:04x}", camera.product_id),
         config_key,
+        // A camera is UVC, not HID++: it never resolves through
+        // `Config::resolve_device_key`, so it has no identity-derived key
+        // distinct from the one it already uses.
+        canonical_key: None,
         persistent: true,
+        route_key,
         model_name: camera.name.clone(),
         display_name: camera.name.clone(),
         asset,
@@ -305,6 +342,7 @@ fn append_standalone(
     list: &mut Vec<DeviceRecord>,
     devices: &[StandaloneDevice],
     cache: &AssetResolver,
+    config: &Config,
 ) {
     for device in devices {
         let route = Some(DeviceRoute::RawHid {
@@ -320,10 +358,16 @@ fn append_standalone(
             device.serial_number.as_deref(),
             device.unit_id,
         );
-        let (config_key, persistent) = stable_id.physical_key().map_or_else(
-            || (stable_id.runtime_key(), false),
-            |key| (key.into_string(), true),
-        );
+        let identity = RouteIdentity::from_parts(device.serial_number.as_deref(), device.unit_id);
+        let (config_key, persistent) = config
+            .resolve_device_key(&stable_id, device.online.then_some(&identity))
+            .map_or_else(
+                || (stable_id.runtime_key(), false),
+                |key| (key.into_string(), true),
+            );
+        let canonical_key = canonical_device_key(&stable_id, device.online.then_some(&identity))
+            .map(PhysicalDeviceKey::into_string);
+        let route_key = stable_id.route_key();
         let asset = device
             .registry_model_id
             .as_deref()
@@ -337,7 +381,9 @@ fn append_standalone(
             );
         list.push(DeviceRecord {
             config_key,
+            canonical_key,
             persistent,
+            route_key,
             // The registry id is presentation metadata, not a replacement for
             // the raw-device model identity used before registry integration.
             model_key: format!("raw:{:04x}", device.address.product_id),
@@ -369,9 +415,9 @@ fn append_standalone(
 /// physical identity:
 /// - an exact physical key match against a live record — the device is already
 ///   in the list;
-/// - a `receiver:` key whose receiver is not plugged in — its paired devices
-///   are unreachable until that receiver returns (e.g. the work receiver's
-///   mouse while at home);
+/// - every route the entry could be reached by names a receiver that is not
+///   plugged in — its paired devices are unreachable until that receiver
+///   returns (e.g. the work receiver's mouse while at home);
 /// - a historical direct/routeless all-zero unit key, which never identified a
 ///   physical device;
 /// - for legacy model-scoped keys only, a model/PID already visible live or as
@@ -382,6 +428,7 @@ fn append_offline_known<'a>(
     known: impl Iterator<Item = (&'a str, &'a DeviceIdentity)>,
     cache: &AssetResolver,
     present_receivers: &HashSet<String>,
+    config: &Config,
 ) {
     let mut present_keys: HashSet<String> = list
         .iter()
@@ -398,7 +445,7 @@ fn append_offline_known<'a>(
         if PhysicalDeviceKey::is_transient(key) {
             continue;
         }
-        if receiver_uid_of(key).is_some_and(|uid| !present_receivers.contains(&uid)) {
+        if entry_is_unreachable(key, config, present_receivers) {
             continue;
         }
         if present_keys.contains(key) {
@@ -437,9 +484,48 @@ fn receiver_uid_of(key: &str) -> Option<String> {
         .map(str::to_ascii_lowercase)
 }
 
+/// Whether every receiver-shaped route this entry could be reached by names a
+/// receiver that is not currently plugged in.
+///
+/// Checks the entry key itself — the legacy shape for a device never adopted
+/// since Task 6 (`migrate_transport_scoped_keys` deliberately leaves a
+/// `receiver:` key as-is; it is only folded into its transport-free entry at
+/// runtime by `Config::adopt_route`) — plus every route recorded in the
+/// entry's persisted `links` table, since an adopted device's entry key may
+/// now be its own identity (`unit:…`) rather than `receiver:<uid>:slot:<n>`.
+/// A device with no receiver-shaped route at all (never receiver-paired, or
+/// never adopted) is never considered unreachable by this check — nor is a
+/// device with a mix of routes, one of them a non-receiver (direct/raw) link:
+/// a recorded direct route might still reach it, so only an entry whose
+/// *every* route is receiver-shaped is judged by receiver presence alone.
+fn entry_is_unreachable(key: &str, config: &Config, present_receivers: &HashSet<String>) -> bool {
+    let linked_routes: Vec<&str> = config
+        .devices
+        .get(key)
+        .into_iter()
+        .flat_map(|device| device.links.keys().map(String::as_str))
+        .collect();
+    // A linked route that is not receiver-shaped (a direct/raw route) means
+    // the device might still be reachable that way, so its presence alone
+    // keeps the entry reachable regardless of any receiver-shaped route's
+    // presence — only when *every* linked route names a receiver does
+    // that receiver's absence matter.
+    if linked_routes
+        .iter()
+        .any(|route| receiver_uid_of(route).is_none())
+    {
+        return false;
+    }
+    let mut receiver_uids = std::iter::once(key)
+        .chain(linked_routes)
+        .filter_map(receiver_uid_of)
+        .peekable();
+    receiver_uids.peek().is_some() && receiver_uids.all(|uid| !present_receivers.contains(&uid))
+}
+
 /// The record's wire product id, used to suppress legacy same-model duplicate
 /// cards without conflating physical device keys.
-fn record_wire_pid(record: &DeviceRecord) -> Option<String> {
+pub(super) fn record_wire_pid(record: &DeviceRecord) -> Option<String> {
     match record.model_info.as_ref().map(|m| m.model_ids[0]) {
         Some(pid) if pid != 0 => Some(format!("{pid:04x}")),
         // A degenerate `model_ids[0] == 0` falls through to `None` (no PID dedup);
@@ -492,7 +578,12 @@ fn offline_record(
         );
     DeviceRecord {
         config_key: config_key.to_string(),
+        // Nothing was probed this session: the persisted key is all there is.
+        canonical_key: None,
         persistent: true,
+        // No live route: the offline placeholder was never reached on any
+        // particular route this session, so its route key is its config key.
+        route_key: config_key.to_string(),
         model_key,
         model_name: display_name.clone(),
         display_name,
@@ -545,7 +636,10 @@ pub(super) fn direct_key_prefix(key: &str) -> Option<&str> {
 pub(super) fn adopt_transient_record(known: &DeviceRecord, live: DeviceRecord) -> DeviceRecord {
     DeviceRecord {
         config_key: known.config_key.clone(),
+        canonical_key: live.canonical_key.or_else(|| known.canonical_key.clone()),
         persistent: true,
+        // The live probe supplies the route this sighting came in on.
+        route_key: live.route_key,
         model_key: known.model_key.clone(),
         model_name: known.model_name.clone(),
         display_name: known.display_name.clone(),
@@ -571,6 +665,40 @@ pub(super) fn adopt_transient_record(known: &DeviceRecord, live: DeviceRecord) -
         online: live.online,
         battery: live.battery.or_else(|| known.battery.clone()),
     }
+}
+
+/// Collapse records that resolve the same [`DeviceRecord::inventory_key`] into
+/// one, which is how a device sighted on two routes in the same snapshot
+/// becomes a single card.
+///
+/// **An online record always wins.** The surviving record carries the route
+/// every HID++ write goes to, so picking the sleeping one leaves the UI
+/// writing into a dead link while the device is in active use. Leaving that to
+/// sort order would be right only by luck: `sort_device_list` orders by
+/// [`DeviceStableId`], whose derived `Ord` puts `Bolt` before `Direct`, so the
+/// direct record wins whether or not it is the live one — right for the
+/// headline case (cable live, receiver asleep), wrong for an already-adopted
+/// but disconnected Bluetooth-direct node beside a live receiver link.
+///
+/// Between two records of equal liveness the later one in sort order wins, as
+/// it always has.
+pub(super) fn fold_by_inventory_key(
+    list: impl IntoIterator<Item = DeviceRecord>,
+) -> BTreeMap<String, DeviceRecord> {
+    let mut by_key: BTreeMap<String, DeviceRecord> = BTreeMap::new();
+    for record in list {
+        match by_key.entry(record.inventory_key()) {
+            Entry::Vacant(slot) => {
+                slot.insert(record);
+            }
+            Entry::Occupied(mut slot) => {
+                if record.online || !slot.get().online {
+                    slot.insert(record);
+                }
+            }
+        }
+    }
+    by_key
 }
 
 /// Order the gallery by physical route. HID enumeration order can change as
@@ -603,7 +731,9 @@ fn device_order_key(record: &DeviceRecord) -> (DeviceStableId, String, String) {
 fn demo_keyboard() -> DeviceRecord {
     DeviceRecord {
         config_key: "demo-g513".to_string(),
+        canonical_key: None,
         persistent: true,
+        route_key: "demo-g513".to_string(),
         model_key: "demo-g513".to_string(),
         model_name: "Logitech G513".to_string(),
         display_name: "Logitech G513".to_string(),
@@ -698,7 +828,7 @@ fn prettify_codename(raw: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use openlogi_core::config::Config;
+    use openlogi_core::config::{Config, DeviceConfig, LinkConfig};
     use openlogi_core::device::{
         DeviceInventory, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
     };
@@ -710,8 +840,10 @@ mod tests {
     use super::{
         Camera, Capabilities, DeviceIdentity, DeviceKind, DeviceModelInfo, DeviceRecord,
         DeviceTransports, append_offline_known, build_device_list, direct_key_prefix,
-        effective_kind, offline_record, pick_initial_device,
+        effective_kind, fold_by_inventory_key, offline_record, pick_initial_device,
     };
+    use crate::state::inventory::adopt_routes;
+    use openlogi_core::hid::Dpi;
 
     fn paired_device_no_model_info(slot: u8, wpid: Option<u16>) -> PairedDevice {
         PairedDevice {
@@ -759,10 +891,99 @@ mod tests {
         }
     }
 
+    /// The same mouse, paired to a Bolt receiver — reachable by receiver UID
+    /// and slot. Shares `unit_id` and `online: true` with [`cabled_inventory`]
+    /// so both routes resolve to the same physical device.
+    fn receiver_inventory() -> DeviceInventory {
+        DeviceInventory {
+            receiver: ReceiverInfo {
+                name: "Bolt Receiver".into(),
+                vendor_id: 0x046d,
+                product_id: 0xc548,
+                unique_id: Some("82839805".into()),
+            },
+            paired: vec![PairedDevice {
+                slot: 1,
+                codename: Some("MX Master 3S".into()),
+                wpid: None,
+                kind: DeviceKind::Mouse,
+                online: true,
+                battery: None,
+                model_info: Some(DeviceModelInfo {
+                    entity_count: 1,
+                    serial_number: None,
+                    unit_id: [0x6b, 0xe9, 0xd3, 0x00],
+                    transports: DeviceTransports::default(),
+                    model_ids: [0xb034, 0, 0],
+                    extended_model_id: 2,
+                }),
+                capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+            }],
+        }
+    }
+
+    /// The same mouse, attached directly over a cable — reachable by its own
+    /// vendor/product id. Shares `unit_id` and `online: true` with
+    /// [`receiver_inventory`] so both routes resolve to the same physical
+    /// device.
+    fn cabled_inventory() -> DeviceInventory {
+        DeviceInventory {
+            receiver: ReceiverInfo {
+                name: "MX Master 3S".into(),
+                vendor_id: 0x046d,
+                product_id: 0xc08d,
+                unique_id: None,
+            },
+            paired: vec![PairedDevice {
+                slot: openlogi_core::hid::DIRECT_DEVICE_INDEX,
+                codename: Some("MX Master 3S".into()),
+                wpid: None,
+                kind: DeviceKind::Mouse,
+                online: true,
+                battery: None,
+                model_info: Some(DeviceModelInfo {
+                    entity_count: 1,
+                    serial_number: None,
+                    unit_id: [0x6b, 0xe9, 0xd3, 0x00],
+                    transports: DeviceTransports::default(),
+                    model_ids: [0xc08d, 0, 0],
+                    extended_model_id: 2,
+                }),
+                capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+            }],
+        }
+    }
+
+    /// Build the device list and fold it the way
+    /// [`super::super::AppState::merge_inventory_snapshot`] does on every
+    /// refresh. This calls the real [`fold_by_inventory_key`] that method
+    /// uses, so the two cannot drift; the rest of that method (transient
+    /// adoption, miss grace, prior-selection carry-over) is deliberately not
+    /// reproduced. Folding alone is enough to prove [`build_device_list`]
+    /// resolves one config key for a device sighted on two routes in the same
+    /// snapshot.
+    fn records_from(config: &Config, inventories: &[DeviceInventory]) -> Vec<DeviceRecord> {
+        let cache = AssetResolver::new();
+        let list = build_device_list(inventories, &[], &cache, config, &[]);
+        fold_by_inventory_key(list).into_values().collect()
+    }
+
+    #[test]
+    fn one_mouse_on_two_routes_is_one_record() {
+        // The user-visible symptom: the same mouse listed twice, once offline
+        // on its receiver and once live on the cable.
+        let config = Config::default();
+        let records = records_from(&config, &[receiver_inventory(), cabled_inventory()]);
+        assert_eq!(records.len(), 1, "got {records:#?}");
+        assert_eq!(records[0].config_key, "unit:6be9d300");
+    }
+
     fn online_record(key: &str) -> DeviceRecord {
         DeviceRecord {
             config_key: key.to_string(),
+            canonical_key: None,
             persistent: true,
+            route_key: key.to_string(),
             model_key: key.to_string(),
             model_name: format!("live {key}"),
             display_name: format!("live {key}"),
@@ -782,6 +1003,85 @@ mod tests {
             online: true,
             battery: None,
         }
+    }
+
+    #[test]
+    fn folding_two_records_of_one_device_keeps_the_online_one() {
+        // The surviving record carries the route every HID++ write goes to.
+        // Picking the sleeping one writes into a dead link while the device is
+        // in active use — and the UI shows it offline while the user is using
+        // it. Insertion order must not decide this, so both are tried.
+        for live_first in [true, false] {
+            let live = online_record("unit:6be9d300");
+            let mut asleep = online_record("unit:6be9d300");
+            asleep.online = false;
+            asleep.route_key = "direct:046d:c08d".to_string();
+            let list = if live_first {
+                vec![live, asleep]
+            } else {
+                vec![asleep, live]
+            };
+
+            let folded = fold_by_inventory_key(list);
+            let record = &folded["unit:6be9d300"];
+            assert!(record.online, "live_first = {live_first}");
+            assert_eq!(
+                record.route_key, "unit:6be9d300",
+                "the live record's route survives, live_first = {live_first}"
+            );
+        }
+    }
+
+    fn receiver_only_config() -> Config {
+        let mut config = Config::default();
+        config
+            .devices
+            .entry("receiver:82839805:slot:1".to_string())
+            .or_default()
+            .dpi = Some(Dpi::new(3200));
+        config
+    }
+
+    #[test]
+    fn a_receiver_paired_device_still_reads_its_pre_upgrade_entry() {
+        // Straight after the schema-5 upgrade the settings are under the
+        // receiver key the migration deliberately left alone, and only the
+        // GUI ever folds them. Until it does, that key is the answer.
+        let config = receiver_only_config();
+        let records = records_from(&config, &[receiver_inventory()]);
+        assert_eq!(records.len(), 1, "got {records:#?}");
+        assert_eq!(records[0].config_key, "receiver:82839805:slot:1");
+        assert_eq!(
+            records[0].canonical_key.as_deref(),
+            Some("unit:6be9d300"),
+            "the fold target is known even while the settings are elsewhere"
+        );
+    }
+
+    #[test]
+    fn adoption_folds_the_pre_upgrade_entry_and_converges() {
+        // Adoption keys off the record's canonical key, not its current
+        // `config_key`. Folding onto `config_key` would fold the legacy entry
+        // onto itself and nothing would ever move.
+        let mut config = receiver_only_config();
+        let cache = AssetResolver::new();
+        let list = build_device_list(&[receiver_inventory()], &[], &cache, &config, &[]);
+        assert!(adopt_routes(&mut config, &list), "the fold is a change");
+
+        assert_eq!(
+            config.devices["unit:6be9d300"].dpi,
+            Some(Dpi::new(3200)),
+            "the DPI moved to the identity key"
+        );
+        assert!(
+            !config.devices.contains_key("receiver:82839805:slot:1"),
+            "the legacy entry is consumed"
+        );
+        let list = build_device_list(&[receiver_inventory()], &[], &cache, &config, &[]);
+        assert_eq!(
+            list[0].config_key, "unit:6be9d300",
+            "the next build reads the canonical key"
+        );
     }
 
     fn mouse_identity(name: &str) -> DeviceIdentity {
@@ -839,7 +1139,9 @@ mod tests {
         assert_eq!(list[0].driver_id.as_deref(), Some("litra"));
         assert_eq!(list[0].registry_model_id.as_deref(), Some("8c901"));
         assert_eq!(list[0].model_key, "raw:c901");
-        assert_eq!(list[0].config_key, "raw:046d:c901:ff43:0202:serial:beam-1");
+        // Online with a known serial: the device's own identity resolves the
+        // key, transport-free — not the route-embedded `raw:…` runtime key.
+        assert_eq!(list[0].config_key, "serial:beam-1");
         assert!(list[0].asset.is_none());
     }
 
@@ -944,6 +1246,7 @@ mod tests {
             [("A", &a), ("B", &b)].into_iter(),
             &cache,
             &HashSet::new(),
+            &Config::default(),
         );
 
         assert_eq!(list.len(), 2);
@@ -996,6 +1299,7 @@ mod tests {
             [("direct:046d:b023:unit:00000000", &id)].into_iter(),
             &cache,
             &HashSet::new(),
+            &Config::default(),
         );
 
         assert!(list.is_empty());
@@ -1018,6 +1322,7 @@ mod tests {
             .into_iter(),
             &cache,
             &HashSet::new(),
+            &Config::default(),
         );
 
         assert_eq!(list.len(), 2);
@@ -1048,6 +1353,7 @@ mod tests {
             [("receiver:aabb:slot:1", &id)].into_iter(),
             &cache,
             &HashSet::new(),
+            &Config::default(),
         );
         assert!(list.is_empty());
         append_offline_known(
@@ -1055,8 +1361,78 @@ mod tests {
             [("receiver:aabb:slot:1", &id)].into_iter(),
             &cache,
             &HashSet::from(["aabb".to_string()]),
+            &Config::default(),
         );
         assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn adopted_placeholder_is_hidden_when_its_linked_receiver_is_absent() {
+        // Once a Bolt device is adopted its entry key becomes its own
+        // identity (`unit:…`), not `receiver:<uid>:slot:<n>` — reachability
+        // must be resolved through the entry's `links`, not its key, or the
+        // work receiver's mouse haunts the list at home again.
+        let mut config = Config::default();
+        let mut device = DeviceConfig::default();
+        device
+            .links
+            .insert("receiver:aabb:slot:1".to_string(), LinkConfig::default());
+        config.devices.insert("unit:6be9d300".to_string(), device);
+        let id = mouse_identity("MX Master 3S");
+        let cache = AssetResolver::new();
+
+        let mut list = Vec::new();
+        append_offline_known(
+            &mut list,
+            [("unit:6be9d300", &id)].into_iter(),
+            &cache,
+            &HashSet::new(),
+            &config,
+        );
+        assert!(list.is_empty());
+
+        append_offline_known(
+            &mut list,
+            [("unit:6be9d300", &id)].into_iter(),
+            &cache,
+            &HashSet::from(["aabb".to_string()]),
+            &config,
+        );
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn adopted_placeholder_stays_visible_with_a_non_receiver_link_too() {
+        // A device seen both over a receiver and directly by cable is not
+        // unreachable just because its receiver link's receiver is absent —
+        // the recorded direct route might still reach it. Hiding the card
+        // would dent the very "a sleeping device never drops out of the
+        // list" invariant this function exists to uphold.
+        let mut config = Config::default();
+        let mut device = DeviceConfig::default();
+        device
+            .links
+            .insert("receiver:aabb:slot:1".to_string(), LinkConfig::default());
+        device
+            .links
+            .insert("direct:046d:c08d".to_string(), LinkConfig::default());
+        config.devices.insert("unit:cafebabe".to_string(), device);
+        let id = mouse_identity("MX Master 3S");
+        let cache = AssetResolver::new();
+
+        let mut list = Vec::new();
+        append_offline_known(
+            &mut list,
+            [("unit:cafebabe", &id)].into_iter(),
+            &cache,
+            &HashSet::new(),
+            &config,
+        );
+        assert_eq!(
+            list.len(),
+            1,
+            "a recorded direct link keeps the entry reachable even though its receiver link's receiver is absent"
+        );
     }
 
     #[test]
@@ -1075,6 +1451,7 @@ mod tests {
             [("0b034", &id)].into_iter(),
             &cache,
             &HashSet::new(),
+            &Config::default(),
         );
         assert_eq!(list.len(), 1);
     }
@@ -1092,6 +1469,7 @@ mod tests {
             [("0b034", &id_a), ("2b034", &id_b)].into_iter(),
             &cache,
             &HashSet::new(),
+            &Config::default(),
         );
         assert_eq!(list.len(), 1);
     }

--- a/crates/openlogi-desktop/src/state/inventory.rs
+++ b/crates/openlogi-desktop/src/state/inventory.rs
@@ -522,7 +522,7 @@ pub(super) fn adopt_routes(config: &mut Config, list: &[DeviceRecord]) -> bool {
         let Some(key) = PhysicalDeviceKey::parse(canonical) else {
             continue;
         };
-        adopted |= config.adopt_route(&key, &record.route_key);
+        adopted |= config.adopt_route(&key, &record.route_key, record.capabilities);
     }
     adopted
 }

--- a/crates/openlogi-desktop/src/state/inventory.rs
+++ b/crates/openlogi-desktop/src/state/inventory.rs
@@ -4,12 +4,14 @@ use std::collections::{BTreeMap, HashSet};
 
 use openlogi_core::config::{Config, DeviceIdentity};
 use openlogi_core::device::{DeviceInventory, StandaloneDevice};
+use openlogi_core::device_order::PhysicalDeviceKey;
 use tracing::debug;
 
 use crate::services::assets::AssetResolver;
 use crate::services::assets::sync::{AssetTarget, model_key};
 use crate::state::devices::{
-    DeviceRecord, adopt_transient_record, build_device_list, direct_key_prefix, sort_device_list,
+    DeviceRecord, adopt_transient_record, build_device_list, direct_key_prefix,
+    fold_by_inventory_key, record_wire_pid, sort_device_list,
 };
 
 use super::device_key::DeviceKey;
@@ -61,22 +63,65 @@ impl AppState {
         cameras: &[openlogi_camera::Camera],
     ) -> bool {
         let new_list = build_device_list(inventories, standalone, cache, &self.config, cameras);
+        // Adoption runs before anything else touches the config. Only an
+        // online record's identity was actually read this snapshot, so only an
+        // online sighting can attribute its route to a device with confidence
+        // — an offline route/identity pairing would be a guess. The agent
+        // never writes config, so the GUI is the only adopter.
+        //
+        // Ordering is load-bearing: `persist_identities` keys off each
+        // record's `config_key`, so running it first would write a bare
+        // canonical entry beside the un-folded legacy one — and a bare entry
+        // is exactly what `Config::resolve_device_key` must not let out-rank
+        // the legacy entry holding the user's settings.
+        let adopted = self.config.edit(|config| adopt_routes(config, &new_list));
+        // The fold moved those settings to the canonical key, so records built
+        // a moment ago still name the key it consumed. Rebuild, or
+        // `persist_identities` would resurrect the entry adoption just
+        // retired.
+        //
+        // The rebuild only fixes `new_list`; `merge_inventory_snapshot` below
+        // can still re-inject a grace-kept record naming the consumed key
+        // from `self.device_list`. What actually keeps that record from
+        // getting a bare entry written back under it is that
+        // `persist_identities`' `if !record.online { continue; }` (below)
+        // skips it — a grace-kept record is never online. That guard existing
+        // for its own reason is what this rebuild silently depends on.
+        let new_list = if adopted {
+            build_device_list(inventories, standalone, cache, &self.config, cameras)
+        } else {
+            new_list
+        };
         let merged_list = self.merge_inventory_snapshot(new_list);
         // Capture any newly-probed identity before the unchanged-check can early
         // out: a device whose capabilities just resolved keeps the same
         // config_key + route, so that guard would otherwise skip the write.
-        if self
+        let identities_changed = self
             .config
-            .edit(|config| persist_identities(config, &merged_list))
-        {
+            .edit(|config| persist_identities(config, &merged_list));
+        if adopted {
+            // One write covers both: a re-keyed entry needs the agent to
+            // reload, and the identity update rides along with it. A failed
+            // write rolls `self.config` back to the pre-fold, legacy-keyed
+            // state (`persist_config`'s `restore_config_projections`), which
+            // makes `merged_list` — built from the folded config — name a
+            // `config_key` that no longer exists in `self.config`. Bail out
+            // before it can be assigned to the record list: the list this
+            // struct is still showing (built from the pre-fold config) is the
+            // truthful one, and the next tick will retry the fold.
+            if !self.persist_and_reload("adopt device route") {
+                return false;
+            }
+        } else if identities_changed {
             self.persist_config("device identity");
         }
-        // Whole-record equality, not a field allowlist. Every field of a
-        // `DeviceRecord` is rendered somewhere, so any of them differing is a
-        // real change; an allowlist silently drops the fields nobody thought to
-        // add — `battery` and the resolved `asset` were both being swallowed
-        // here. Structural comparison also makes the guard immune to new
-        // fields, which is what an allowlist can never be.
+        // Whole-record equality, not a field allowlist. Most fields of a
+        // `DeviceRecord` are rendered somewhere, so almost any of them
+        // differing is a real change; an allowlist silently drops the fields
+        // nobody thought to add — `battery` and the resolved `asset` were
+        // both being swallowed here. Structural comparison also makes the
+        // guard immune to new fields, which is what an allowlist can never
+        // be.
         if merged_list == self.devices.records {
             return false;
         }
@@ -139,10 +184,7 @@ impl AppState {
         &mut self,
         new_list: Vec<DeviceRecord>,
     ) -> Vec<DeviceRecord> {
-        let mut by_key = new_list
-            .into_iter()
-            .map(|record| (record.inventory_key(), record))
-            .collect::<BTreeMap<_, _>>();
+        let mut by_key = fold_by_inventory_key(new_list);
         let mut adopted = self.adopt_transient_records(&mut by_key);
         let mut merged = Vec::with_capacity(by_key.len().max(self.devices.records.len()));
 
@@ -218,33 +260,63 @@ impl AppState {
     /// With no such card the transient is dropped as probe noise when its wire
     /// product is already live online, and an ambiguous one (two known
     /// same-model cards absent) is left alone.
+    ///
+    /// The wire identity is compared through [`DeviceRecord::route_key`], not
+    /// `config_key`: since Task 6 a persistent record's `config_key` may
+    /// already be the device's own transport-free identity (`unit:…`) rather
+    /// than a `direct:<vid>:<pid>:…` runtime key, so `direct_key_prefix` can
+    /// no longer be relied on to parse it back out. The persisted link index
+    /// backs an offline placeholder that has already been adopted once, but
+    /// two same-model direct devices can only ever have *one* owner for a
+    /// shared `direct:<vid>:<pid>` route (`Config::adopt_route` is
+    /// exclusive), so the absent twin also needs a route-independent proof:
+    /// [`record_wire_pid`] compares the HID++ model id the offline
+    /// placeholder persisted against the one the half-read probe itself
+    /// reports (`model_info` survives a half read even when the unit id
+    /// does not).
     pub(crate) fn adopt_transient_records(
         &self,
         by_key: &mut BTreeMap<String, DeviceRecord>,
     ) -> BTreeMap<String, DeviceRecord> {
-        let transient_keys: Vec<String> = by_key
+        let transient_keys: Vec<(String, Option<String>)> = by_key
             .values()
             .filter(|record| !record.is_persistent())
-            .map(|record| record.config_key.clone())
+            .map(|record| (record.config_key.clone(), record_wire_pid(record)))
             .collect();
         let mut adopted = BTreeMap::new();
-        for key in transient_keys {
+        for (key, transient_wire_pid) in transient_keys {
             let Some(prefix) = direct_key_prefix(&key) else {
                 continue;
             };
-            let same_wire = |key: &str, record: &DeviceRecord| {
-                record.is_persistent() && direct_key_prefix(key) == Some(prefix)
+            // A live record's own `route_key` proves wire compatibility
+            // directly. An offline placeholder carries no live route, so
+            // fall back first to its persisted link index (the route it was
+            // last adopted on) and, failing that, to a wire-pid match
+            // against the transient probe itself — the only proof available
+            // for a same-model sibling that has never been adopted, since a
+            // shared `direct:<vid>:<pid>` route can be indexed to at most one
+            // device at a time.
+            let same_wire = |record: &DeviceRecord| {
+                record.is_persistent()
+                    && (record.route_key == prefix
+                        || self
+                            .config
+                            .devices
+                            .get(record.config_key.as_str())
+                            .is_some_and(|device| device.links.contains_key(prefix))
+                        || transient_wire_pid.is_some()
+                            && record_wire_pid(record) == transient_wire_pid)
             };
             // A live online sibling is accounted for and never a candidate,
             // but it must not discard the transient — the half-read probe may
             // be the *other* same-model device.
             let mut candidates: Vec<String> = by_key
                 .iter()
-                .filter(|(k, record)| same_wire(k, record) && !record.online)
+                .filter(|(_, record)| same_wire(record) && !record.online)
                 .map(|(k, _)| k.clone())
                 .collect();
             for previous in &self.devices.records {
-                if same_wire(&previous.config_key, previous)
+                if same_wire(previous)
                     && !by_key.contains_key(&previous.config_key)
                     && !candidates.contains(&previous.config_key)
                 {
@@ -255,7 +327,7 @@ impl AppState {
                 if candidates.is_empty()
                     && by_key
                         .iter()
-                        .any(|(k, record)| same_wire(k, record) && record.online)
+                        .any(|(_, record)| same_wire(record) && record.online)
                 {
                     by_key.remove(&key);
                 }
@@ -404,6 +476,55 @@ pub(super) fn persist_identities(config: &mut Config, list: &[DeviceRecord]) -> 
         }
     }
     changed
+}
+
+/// Fold every online, persistent record's route into its canonical config
+/// entry, so a device reached both ways in one snapshot resolves to the one
+/// entry its settings actually live under.
+///
+/// A route two online records share cannot be attributed to either one —
+/// `route_key` for a Direct route strips the device's own identity, so two
+/// same-model direct devices seen online in the same snapshot report the
+/// *same* route key. `Config::adopt_route` is exclusive per route, so
+/// adopting it for one twin only gets it stolen back by the other on the
+/// very next tick — a persist-and-reload storm that also churns the loser's
+/// `LinkConfig` (including any per-link overrides) on every refresh. Such a
+/// route is therefore skipped entirely; the route-derived key each twin
+/// already falls back to is the correct answer when nothing can tell them
+/// apart by route alone. Returns whether any entry changed.
+///
+/// The fold target is the record's *canonical* key, never its `config_key`:
+/// those differ precisely in the case adoption exists to resolve — settings
+/// still under a pre-schema-5 route key — so folding onto `config_key` would
+/// fold the legacy entry onto itself and the branch would never converge.
+pub(super) fn adopt_routes(config: &mut Config, list: &[DeviceRecord]) -> bool {
+    let mut route_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for record in list {
+        if record.is_persistent() && record.online {
+            *route_counts.entry(record.route_key.as_str()).or_insert(0) += 1;
+        }
+    }
+    let mut adopted = false;
+    for record in list {
+        if !record.is_persistent() || !record.online {
+            continue;
+        }
+        if route_counts
+            .get(record.route_key.as_str())
+            .is_some_and(|&count| count > 1)
+        {
+            continue;
+        }
+        let canonical = record
+            .canonical_key
+            .as_deref()
+            .unwrap_or(&record.config_key);
+        let Some(key) = PhysicalDeviceKey::parse(canonical) else {
+            continue;
+        };
+        adopted |= config.adopt_route(&key, &record.route_key);
+    }
+    adopted
 }
 
 /// Reset `key`'s consecutive-miss counter — the device was just confirmed

--- a/crates/openlogi-desktop/src/state/lighting.rs
+++ b/crates/openlogi-desktop/src/state/lighting.rs
@@ -4,8 +4,6 @@ use openlogi_core::config::Lighting;
 use openlogi_core::device_order::PhysicalDeviceKey;
 use tracing::debug;
 
-use crate::state::devices::DeviceRecord;
-
 use super::AppState;
 
 impl AppState {
@@ -14,13 +12,16 @@ impl AppState {
     #[must_use]
     pub fn lighting(&self) -> Lighting {
         self.current_record()
-            .and_then(DeviceRecord::persistent_config_key)
-            .and_then(|key| self.config.lighting(key))
+            .and_then(|record| {
+                let key = record.persistent_config_key()?;
+                self.lighting_for(key, &record.route_key)
+            })
             .unwrap_or_default()
     }
-    /// The stored lighting config for `key`, or `None` when unset.
+    /// The stored lighting config for `key` on `route_key`, or `None` when
+    /// unset (or overridden to unset on that link).
     #[must_use]
-    pub fn lighting_for(&self, key: &str) -> Option<Lighting> {
+    pub fn lighting_for(&self, key: &str, route_key: &str) -> Option<Lighting> {
         if PhysicalDeviceKey::is_transient(key)
             || self
                 .devices
@@ -30,7 +31,11 @@ impl AppState {
         {
             return None;
         }
-        self.config.lighting(key)
+        self.config
+            .devices
+            .get(key)
+            .and_then(|device| device.effective_lighting(route_key))
+            .cloned()
     }
     /// Persist a new lighting config for the active device and push it to the
     /// hardware (best-effort). No-op when no device is selected.

--- a/crates/openlogi-desktop/src/state/scroll.rs
+++ b/crates/openlogi-desktop/src/state/scroll.rs
@@ -13,9 +13,12 @@ impl AppState {
     /// `false` when no device is selected or the device hasn't opted in.
     #[must_use]
     pub fn current_invert_scroll(&self) -> bool {
-        self.current_record()
-            .and_then(DeviceRecord::persistent_config_key)
-            .is_some_and(|key| self.config.invert_scroll(key))
+        self.current_record().is_some_and(|record| {
+            record
+                .persistent_config_key()
+                .and_then(|key| self.config.devices.get(key))
+                .is_some_and(|device| device.effective_invert_scroll(&record.route_key))
+        })
     }
     /// Whether the active device reports native HID++ wheel inversion support.
     #[must_use]
@@ -48,9 +51,12 @@ impl AppState {
     /// leaves the device default untouched.
     #[must_use]
     pub fn current_scroll_resolution(&self) -> Option<openlogi_core::config::ScrollResolution> {
-        self.current_record()
-            .and_then(DeviceRecord::persistent_config_key)
-            .and_then(|key| self.config.scroll_resolution(key))
+        self.current_record().and_then(|record| {
+            record
+                .persistent_config_key()
+                .and_then(|key| self.config.devices.get(key))
+                .and_then(|device| device.effective_scroll_resolution(&record.route_key))
+        })
     }
     /// Whether the active device exposes HID++ `0x2121 HiResWheel`.
     #[must_use]
@@ -58,6 +64,27 @@ impl AppState {
         self.current_record()
             .and_then(|record| record.capabilities)
             .is_some_and(|capabilities| capabilities.hires_wheel)
+    }
+    /// Whether some *other* link of the active device measured a hi-res wheel.
+    ///
+    /// A device may expose `0x2121` on one transport and not another, so an
+    /// absent capability here is not the same claim as "this device cannot do
+    /// it" — and telling a user their mouse lacks a feature it demonstrably
+    /// has on its receiver is the confusing half of #660.
+    #[must_use]
+    pub fn hires_wheel_supported_on_another_link(&self) -> bool {
+        let Some(record) = self.current_record() else {
+            return false;
+        };
+        self.config
+            .devices
+            .get(record.config_key.as_str())
+            .is_some_and(|device| {
+                device.links.iter().any(|(route, link)| {
+                    route != &record.route_key
+                        && link.capabilities.is_some_and(|caps| caps.hires_wheel)
+                })
+            })
     }
     /// Persist the active device's wheel resolution and ask the agent to reload
     /// it. `None` removes OpenLogi's override. No-op without a selected,
@@ -100,4 +127,108 @@ pub(crate) fn set_scroll_resolution_if_supported(
     }
     config.set_scroll_resolution(key, resolution);
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use openlogi_core::config::{Config, DeviceConfig, LinkConfig, LinkOverrides};
+    use openlogi_core::device::{Capabilities, DeviceKind};
+
+    use crate::services::assets::AssetResolver;
+    use crate::state::ConfigPersistence;
+    use crate::state::devices::DeviceRecord;
+
+    use super::AppState;
+
+    impl AppState {
+        /// Test-only: select a single synthetic record without going through
+        /// inventory enumeration, so a test can pin `config_key` / `route_key`
+        /// independently of any real HID++ probe.
+        fn set_current_record_for_test(&mut self, config_key: &str, route_key: &str) {
+            let record = DeviceRecord {
+                config_key: config_key.to_string(),
+                canonical_key: None,
+                persistent: true,
+                route_key: route_key.to_string(),
+                model_key: config_key.to_string(),
+                model_name: "test device".to_string(),
+                display_name: "test device".to_string(),
+                asset: None,
+                model_info: None,
+                codename: None,
+                serial_number: None,
+                unit_id: [0; 4],
+                driver_id: None,
+                registry_model_id: None,
+                route: None,
+                capture_id: None,
+                kind: DeviceKind::Mouse,
+                capabilities: None,
+                light_capabilities: None,
+                slot: 1,
+                online: true,
+                battery: None,
+            };
+            // #974 moved the record list and its selection into one store, so
+            // the fixture installs both together.
+            self.devices.replace(vec![record], 0);
+        }
+    }
+
+    /// An in-memory-only `AppState` around `config`, with no live inventory.
+    fn test_state(config: Config) -> AppState {
+        let cache = AssetResolver::new();
+        let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        AppState::with_runtime(
+            config,
+            &[],
+            &[],
+            &cache,
+            &[],
+            ConfigPersistence::MemoryOnly,
+            commands,
+        )
+    }
+
+    /// An `AppState` whose selected device is on the **first** listed link and
+    /// whose config records `hires_wheel` per link as given.
+    fn state_with_links(links: &[(&str, bool)]) -> AppState {
+        let mut device = DeviceConfig::default();
+        for (route, hires_wheel) in links {
+            device.links.insert(
+                (*route).to_string(),
+                LinkConfig {
+                    capabilities: Some(Capabilities {
+                        hires_wheel: *hires_wheel,
+                        ..Capabilities::default()
+                    }),
+                    overrides: LinkOverrides::default(),
+                },
+            );
+        }
+        let mut config = Config::default();
+        config.devices.insert("unit:6be9d300".to_string(), device);
+        let mut state = test_state(config);
+        state.set_current_record_for_test("unit:6be9d300", links[0].0);
+        state
+    }
+
+    #[test]
+    fn a_capability_present_on_another_link_is_distinguishable() {
+        // A G502 has no hi-res wheel over USB and does over its receiver.
+        // "This device does not support wheel resolution control" is wrong for
+        // that device; it does, just not on this cable.
+        let state = state_with_links(&[
+            ("direct:046d:c08d", false),
+            ("receiver:82839805:slot:1", true),
+        ]);
+        assert!(!state.current_hires_wheel_supported());
+        assert!(state.hires_wheel_supported_on_another_link());
+    }
+
+    #[test]
+    fn a_device_that_never_had_it_is_not_excused() {
+        let state = state_with_links(&[("direct:046d:b012", false)]);
+        assert!(!state.hires_wheel_supported_on_another_link());
+    }
 }

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -111,7 +111,11 @@ fn agent_reload_error_stays_visible_until_a_successful_confirmation() {
 }
 
 /// Config key of the mouse [`direct_inventory`] builds with a real unit id.
-const KNOWN_MOUSE_KEY: &str = "direct:046d:b023:unit:a393cae0";
+///
+/// The transport-free identity, not the `direct:046d:b023:…` route it is
+/// reached on: a device whose unit id is known resolves to its identity key,
+/// which is what settings are now written under.
+const KNOWN_MOUSE_KEY: &str = "unit:a393cae0";
 
 fn direct_inventory(unit_id: [u8; 4]) -> DeviceInventory {
     DeviceInventory {
@@ -147,6 +151,102 @@ fn second_mouse_inventory() -> DeviceInventory {
     inventory.receiver.name = "MX Anywhere 3S".to_string();
     inventory.receiver.product_id = 0xb037;
     inventory
+}
+
+/// A mouse paired to a Bolt receiver, reachable by receiver UID + slot.
+/// Shares its receiver UID (`82839805`) and unit id (`6be9d300`) with
+/// `identity::tests::settings_still_under_the_pre_upgrade_key_are_read_from_it`,
+/// so a config entry pre-seeded at `"receiver:82839805:slot:1"` is exactly
+/// the legacy, route-keyed entry `adopt_routes` folds into `"unit:6be9d300"`.
+fn receiver_inventory() -> DeviceInventory {
+    DeviceInventory {
+        receiver: ReceiverInfo {
+            name: "Bolt Receiver".to_string(),
+            vendor_id: 0x046d,
+            product_id: 0xc548,
+            unique_id: Some("82839805".to_string()),
+        },
+        paired: vec![PairedDevice {
+            slot: 1,
+            codename: Some("MX Master 3S".to_string()),
+            wpid: None,
+            kind: DeviceKind::Mouse,
+            online: true,
+            battery: None,
+            model_info: Some(DeviceModelInfo {
+                entity_count: 1,
+                serial_number: None,
+                unit_id: [0x6b, 0xe9, 0xd3, 0x00],
+                transports: DeviceTransports::default(),
+                model_ids: [0xb034, 0, 0],
+                extended_model_id: 2,
+            }),
+            capabilities: Some(Capabilities::presumed_from_kind(DeviceKind::Mouse)),
+        }],
+    }
+}
+
+#[test]
+fn failed_fold_persist_does_not_orphan_the_device_list() {
+    // Reproduces the bug traced in the pre-PR review: `refresh_inventories`
+    // folds a legacy route-keyed config entry into the device's canonical
+    // identity key, then tries to persist. When the write fails (here,
+    // `ConfigPersistence::ReadOnly`), `persist_config` rolls `self.config`
+    // back to its pre-fold, legacy-keyed state — but without the fix,
+    // `refresh_inventories` still assigned `self.device_list` from the
+    // now-stale, folded `merged_list`. From then on `device_list` names a
+    // `config_key` that does not exist in `config`, so every
+    // `config.devices.get(record.config_key)` lookup silently misses.
+    let cache = AssetResolver::new();
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut config = Config::ephemeral();
+    config.set_dpi("receiver:82839805:slot:1", Dpi::new(3200));
+    let mut state = AppState::with_runtime(
+        config,
+        &[],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::ReadOnly("simulated unwritable config.toml".to_string()),
+        commands,
+    );
+    assert!(state.devices().is_empty(), "no inventory seen yet");
+
+    let changed = state.refresh_inventories(&[receiver_inventory()], &[], &cache, &[]);
+
+    assert!(
+        !changed,
+        "a failed fold-persist must not report a change — a caller \
+         acting on `true` would treat the now-discarded `merged_list` as live"
+    );
+    assert!(
+        state.devices().is_empty(),
+        "device_list must stay at its pre-refresh value — built from the \
+         folded config that failed to persist and was rolled back, the new \
+         list would no longer agree with `state.config`"
+    );
+    assert!(
+        state
+            .config
+            .devices
+            .contains_key("receiver:82839805:slot:1"),
+        "the rollback must restore the legacy entry still holding the \
+         user's settings"
+    );
+    assert!(
+        !state.config.devices.contains_key("unit:6be9d300"),
+        "the folded canonical entry must not survive a rolled-back persist"
+    );
+    for record in state.devices() {
+        let Some(config_key) = record.persistent_config_key() else {
+            continue;
+        };
+        assert!(
+            state.config.devices.contains_key(config_key),
+            "device_list record names {config_key}, which must exist in \
+             `config` — device_list and config must never disagree"
+        );
+    }
 }
 
 fn superseded_litra_light() -> StandaloneDevice {
@@ -640,7 +740,9 @@ fn transient_identity_is_not_persisted_or_retained_after_resolution() {
     let merged = state.merge_inventory_snapshot(stable_list);
 
     assert_eq!(merged.len(), 1);
-    assert_eq!(merged[0].config_key, "direct:046d:b023:unit:a393cae0");
+    // The device's own unit id is known and online: the transport-free
+    // identity key wins over the direct-route runtime key.
+    assert_eq!(merged[0].config_key, "unit:a393cae0");
     assert!(merged[0].is_persistent());
 }
 
@@ -660,7 +762,9 @@ fn transient_probe_folds_into_its_known_card() {
         ConfigPersistence::MemoryOnly,
         commands,
     );
-    let stable_key = "direct:046d:b023:unit:a393cae0";
+    // The device's own unit id is known and online: the transport-free
+    // identity key wins over the direct-route runtime key.
+    let stable_key = "unit:a393cae0";
     assert_eq!(state.devices()[0].config_key, stable_key);
 
     let transient_list =
@@ -704,7 +808,7 @@ fn transient_record_beside_its_live_device_is_dropped() {
     let merged = state.merge_inventory_snapshot(both);
 
     assert_eq!(merged.len(), 1);
-    assert_eq!(merged[0].config_key, "direct:046d:b023:unit:a393cae0");
+    assert_eq!(merged[0].config_key, "unit:a393cae0");
     assert!(merged[0].online);
 }
 
@@ -739,10 +843,9 @@ fn transient_probe_adopts_the_absent_sibling_of_a_live_twin() {
     let merged = state.merge_inventory_snapshot(snapshot);
 
     assert_eq!(merged.len(), 2, "no third card for the half-read probe");
-    let Some(sibling) = merged
-        .iter()
-        .find(|r| r.config_key == "direct:046d:b023:unit:02020202")
-    else {
+    // The sibling's own unit id is known and online: the transport-free
+    // identity key wins over the direct-route runtime key.
+    let Some(sibling) = merged.iter().find(|r| r.config_key == "unit:02020202") else {
         panic!("the sibling card must survive under its physical key");
     };
     assert!(
@@ -785,6 +888,53 @@ fn ambiguous_transient_probe_is_not_adopted() {
 }
 
 #[test]
+fn a_route_shared_by_two_online_twins_is_never_adopted() {
+    // #482 corollary: `route_key` for a Direct route strips the device's own
+    // identity, so two same-model direct devices online in the same
+    // snapshot report the *same* route key. `Config::adopt_route` is
+    // exclusive per route, so adopting it for either twin would just get it
+    // stolen back by the other on the very next tick — a persist-and-reload
+    // storm. The route cannot be attributed to either by route alone, so
+    // neither claims it, and nothing is persisted or reloaded.
+    let cache = AssetResolver::new();
+    let (commands, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    state.refresh_inventories(
+        &[
+            direct_inventory([1, 1, 1, 1]),
+            direct_inventory([2, 2, 2, 2]),
+        ],
+        &[],
+        &cache,
+        &[],
+    );
+
+    for key in ["unit:01010101", "unit:02020202"] {
+        assert!(
+            !state
+                .config
+                .devices
+                .get(key)
+                .is_some_and(|device| device.links.contains_key("direct:046d:b023")),
+            "{key} must not claim a route its twin equally owns"
+        );
+    }
+    assert!(
+        receiver.try_recv().is_err(),
+        "a route that was never adopted must not trigger a persist/reload"
+    );
+}
+
+#[test]
 fn historical_transient_lighting_is_not_exposed_without_a_live_record() {
     let transient_key = "direct:046d:b023:unit:00000000";
     let mut config = Config::ephemeral();
@@ -802,7 +952,7 @@ fn historical_transient_lighting_is_not_exposed_without_a_live_record() {
     );
 
     assert!(state.devices().is_empty());
-    assert!(state.lighting_for(transient_key).is_none());
+    assert!(state.lighting_for(transient_key, transient_key).is_none());
 }
 
 #[test]

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Ruller én gang pr. fysisk rastertrin."
 "Detects finer movement between ratchet steps.": "Registrerer finere bevægelser mellem rastertrin."
 "This device does not support wheel resolution control.": "Denne enhed understøtter ikke styring af hjulopløsning."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Om"
 "Updates": "Opdateringer"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Scrollt einmal pro physischer Rasterstufe."
 "Detects finer movement between ratchet steps.": "Erkennt feinere Bewegungen zwischen den Rasterstufen."
 "This device does not support wheel resolution control.": "Dieses Gerät unterstützt keine Steuerung der Mausradauflösung."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Über"
 "Updates": "Updates"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Κύλιση μία φορά ανά φυσικό βήμα καστάνιας."
 "Detects finer movement between ratchet steps.": "Ανιχνεύει λεπτότερη κίνηση μεταξύ των βημάτων καστάνιας."
 "This device does not support wheel resolution control.": "Αυτή η συσκευή δεν υποστηρίζει έλεγχο ανάλυσης τροχού."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Σχετικά"
 "Updates": "Ενημερώσεις"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Scrolls once per physical ratchet step."
 "Detects finer movement between ratchet steps.": "Detects finer movement between ratchet steps."
 "This device does not support wheel resolution control.": "This device does not support wheel resolution control."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "About"
 "Updates": "Updates"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Se desplaza una vez por cada paso físico del trinquete."
 "Detects finer movement between ratchet steps.": "Detecta movimientos más finos entre los pasos del trinquete."
 "This device does not support wheel resolution control.": "Este dispositivo no admite el control de resolución de la rueda."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Acerca de"
 "Updates": "Actualizaciones"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Vierittää kerran fyysistä pykälää kohti."
 "Detects finer movement between ratchet steps.": "Tunnistaa hienovaraisemman liikkeen pykälien välillä."
 "This device does not support wheel resolution control.": "Tämä laite ei tue vierityspyörän tarkkuuden hallintaa."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Tietoja"
 "Updates": "Päivitykset"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Défile une fois par cran physique."
 "Detects finer movement between ratchet steps.": "Détecte les mouvements plus fins entre les crans."
 "This device does not support wheel resolution control.": "Cet appareil ne prend pas en charge le réglage de la résolution de la molette."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "À propos"
 "Updates": "Mises à jour"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Scorre una volta per ogni scatto fisico."
 "Detects finer movement between ratchet steps.": "Rileva movimenti più fini tra gli scatti."
 "This device does not support wheel resolution control.": "Questo dispositivo non supporta il controllo della risoluzione della rotellina."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Informazioni"
 "Updates": "Aggiornamenti"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "物理的なラチェット1段ごとに1回スクロールします。"
 "Detects finer movement between ratchet steps.": "ラチェットの段間にある細かな動きを検出します。"
 "This device does not support wheel resolution control.": "このデバイスはホイール解像度の制御に対応していません。"
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "概要"
 "Updates": "アップデート"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "물리적 래칫 한 단계마다 한 번 스크롤합니다."
 "Detects finer movement between ratchet steps.": "래칫 단계 사이의 미세한 움직임을 감지합니다."
 "This device does not support wheel resolution control.": "이 기기는 휠 해상도 제어를 지원하지 않습니다."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "정보"
 "Updates": "업데이트"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Ruller én gang per fysiske hakk."
 "Detects finer movement between ratchet steps.": "Oppdager finere bevegelse mellom hakkene."
 "This device does not support wheel resolution control.": "Denne enheten støtter ikke styring av hjuloppløsning."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Om"
 "Updates": "Oppdateringer"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Scrolt één keer per fysieke ratelstap."
 "Detects finer movement between ratchet steps.": "Detecteert fijnere bewegingen tussen ratelstappen."
 "This device does not support wheel resolution control.": "Dit apparaat ondersteunt geen regeling van de wielresolutie."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Over"
 "Updates": "Updates"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Przewija raz na każdy fizyczny skok zapadki."
 "Detects finer movement between ratchet steps.": "Wykrywa drobniejsze ruchy między skokami zapadki."
 "This device does not support wheel resolution control.": "To urządzenie nie obsługuje sterowania rozdzielczością kółka."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "O programie"
 "Updates": "Aktualizacje"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Domyślnie wyłączone — sprawdzanie aktualizacji to jedyne opcjonalne połączenie wychodzące OpenLogi."

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Rola uma vez por etapa física da catraca."
 "Detects finer movement between ratchet steps.": "Detecta movimentos mais sutis entre as etapas da catraca."
 "This device does not support wheel resolution control.": "Este dispositivo não oferece controle de resolução da roda."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Sobre"
 "Updates": "Atualizações"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Desloca uma vez por cada passo físico da catraca."
 "Detects finer movement between ratchet steps.": "Deteta movimentos mais finos entre os passos da catraca."
 "This device does not support wheel resolution control.": "Este dispositivo não suporta o controlo da resolução da roda."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Acerca de"
 "Updates": "Atualizações"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Прокручивает один раз на каждый физический шаг трещотки."
 "Detects finer movement between ratchet steps.": "Обнаруживает более мелкие движения между шагами трещотки."
 "This device does not support wheel resolution control.": "Это устройство не поддерживает управление разрешением колеса."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "О программе"
 "Updates": "Обновления"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Rullar en gång per fysiskt spärrsteg."
 "Detects finer movement between ratchet steps.": "Upptäcker finare rörelser mellan spärrstegen."
 "This device does not support wheel resolution control.": "Den här enheten stöder inte styrning av hjulupplösning."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Om"
 "Updates": "Uppdateringar"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Off by default — checking for updates is OpenLogi's only optional outbound network request."

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Her fiziksel kademe adımında bir kez kaydırır."
 "Detects finer movement between ratchet steps.": "Kademeler arasındaki daha ince hareketi algılar."
 "This device does not support wheel resolution control.": "Bu cihaz tekerlek çözünürlüğü denetimini desteklemiyor."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Hakkında"
 "Updates": "Güncellemeler"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Varsayılan olarak kapalı — güncelleme denetimi OpenLogi'nin tek isteğe bağlı dış ağ isteğidir."

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "Прокручує один раз на кожен фізичний крок покрокового обертання."
 "Detects finer movement between ratchet steps.": "Розпізнає дрібніші рухи між кроками покрокового обертання."
 "This device does not support wheel resolution control.": "Цей пристрій не підтримує керування роздільністю коліщатка."
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "Про програму"
 "Updates": "Оновлення"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "Вимкнено за замовчуванням — перевірка оновлень є єдиним необов'язковим вихідним мережевим запитом OpenLogi."

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "每个物理棘轮刻度滚动一次。"
 "Detects finer movement between ratchet steps.": "检测棘轮刻度之间更细微的移动。"
 "This device does not support wheel resolution control.": "此设备不支持滚轮分辨率控制。"
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "关于"
 "Updates": "更新"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "默认关闭 —— 检查更新是 OpenLogi 唯一可选的对外网络请求。"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "每個實體棘輪段落捲動一次。"
 "Detects finer movement between ratchet steps.": "偵測棘輪段落之間更細微的移動。"
 "This device does not support wheel resolution control.": "此裝置不支援滾輪解析度控制。"
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "關於"
 "Updates": "更新"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "預設關閉 —— 檢查更新是 OpenLogi 唯一可選的對外網路請求。"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -329,6 +329,7 @@ _version: 1
 "Scrolls once per physical ratchet step.": "每個實體棘輪段落捲動一次。"
 "Detects finer movement between ratchet steps.": "偵測棘輪段落之間更細微的移動。"
 "This device does not support wheel resolution control.": "此裝置不支援滾輪解析度控制。"
+"This device supports wheel resolution on its other connection, but not this one.": "This device supports wheel resolution on its other connection, but not this one."
 "About": "關於"
 "Updates": "更新"
 "Off by default — checking for updates is OpenLogi's only optional outbound network request.": "預設關閉 —— 檢查更新是 OpenLogi 唯一可選的對外網路請求。"

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -28,8 +28,10 @@ took `serial` and `unit_id` and discarded both for receiver routes.
   a G502 LIGHTSPEED publishes `0x2121 HiResWheel` over its receiver and
   `0x00c2 DfuControlSigned` over USB, same firmware image either way (#660).
   The probe was never wrong; one device simply could not own both readings.
-  Settings that disagree between links become per-link overrides rather than
-  one link overwriting the other.
+  Each link's capabilities are rewritten from the sighting that reached it, so
+  the table describes the hardware rather than whatever a migration happened to
+  leave behind. Settings that disagree between links become per-link overrides
+  rather than one link overwriting the other.
 - Migration is two-phase because a v4 direct key carries the unit id in the key
   string while a receiver key says nothing about the device: schema 4 → 5
   renames direct keys mechanically at load, and receiver entries fold into

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,6 +4,41 @@ Durable "why we did it this way" records that are not obvious from the code.
 Add a dated entry when a non-obvious architectural or dependency decision is
 made or revisited.
 
+## 2026-08: Device settings are keyed by identity, not by transport
+
+A device's config key was derived from how it was reached, so the same mouse
+on a receiver and on a cable became two devices: two entries, two carousel
+cards, settings left behind on whichever link set them. The correlating value
+was already read on both paths and thrown away — `DeviceStableId::from_parts`
+took `serial` and `unit_id` and discarded both for receiver routes.
+
+- Keys are now `unit:<hex>` or `serial:<s>`, with a persisted `links` table
+  naming the routes the device has been seen on. That table is also the index
+  that identifies a sleeping device when only its route is known, which is why
+  it is stored rather than recomputed. It fixes a second bug in passing:
+  unpairing mouse A from a slot and pairing B into it no longer hands B all of
+  A's bindings, because the key is no longer the slot. Not retroactively,
+  though — a pre-upgrade config records nothing about which device wrote a slot
+  entry, so the first sighting after the upgrade still folds it into whatever
+  now occupies the slot. Only from that point on is the entry keyed by unit and
+  the slot empty.
+- A device whose unit id reads all-zero keeps its route key and never
+  correlates — degradation, not an assumption about hardware we cannot sample.
+- Capabilities are measured per link, because they genuinely differ per link:
+  a G502 LIGHTSPEED publishes `0x2121 HiResWheel` over its receiver and
+  `0x00c2 DfuControlSigned` over USB, same firmware image either way (#660).
+  The probe was never wrong; one device simply could not own both readings.
+  Settings that disagree between links become per-link overrides rather than
+  one link overwriting the other.
+- Migration is two-phase because a v4 direct key carries the unit id in the key
+  string while a receiver key says nothing about the device: schema 4 → 5
+  renames direct keys mechanically at load, and receiver entries fold into
+  their canonical entry on the next online sighting. Until that sighting the
+  legacy entry stays orphaned. Closing that window at load time by matching
+  entries on identical `model_ids` was rejected — model ids are model-scoped,
+  so two identical mice, one on a receiver and one cabled, would merge into one
+  device. That is the property slot-keying protected, and it must not regress.
+
 ## 2026-08: Suppressions are `expect`, and tests are exempt by config
 
 A sweep of every lint suppression in the tree (207 attributes, 247 lints) found

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -78,6 +78,35 @@ fn_lock = false
 KeySearch = "MissionControl"
 KeyScreenCapture = "Sleep"
 
+# Since schema 5 a device is keyed by what it *is* — `unit:<hex>` or
+# `serial:<s>` — rather than by the route it was reached on, so its settings
+# follow it between its receiver and a cable instead of splitting into two
+# entries. `receiver:…` entries above are the pre-5 shape; they are folded onto
+# an identity key the first time the device is seen online with the GUI running.
+[devices."unit:6be9d300"]
+dpi = 1600
+
+# Every route this device has been seen on. The set of keys is also the index
+# that identifies the device while it is asleep and only the route is known,
+# which is why a route with nothing special about it is still written out as an
+# empty table.
+[devices."unit:6be9d300".links."receiver:aabbccdd:slot:3"]
+
+# Capabilities as measured on one link. A device can genuinely expose different
+# features per transport — a G502 LIGHTSPEED publishes hi-res wheel over its
+# receiver and not over USB — so this is recorded per link, not per device.
+[devices."unit:6be9d300".links."direct:046d:c08d".capabilities]
+buttons = true
+pointer = true
+lighting = false
+scroll_inversion = true
+hires_wheel = false
+
+# Settings deliberately made different on this link. Anything not overridden
+# here falls through to the device-level value above.
+[devices."unit:6be9d300".links."direct:046d:c08d".overrides]
+dpi = 800
+
 # Global function-key remapping, independent of a device.
 [keyboard.bindings]
 f1 = "MissionControl"


### PR DESCRIPTION
## Summary

Device settings were keyed by how a device was connected rather than by which
device it was. Connecting the same mouse a different way produced a new config
entry, so settings did not carry over and the carousel showed two cards for one
mouse.

From a real `config.toml`, one G502 LIGHTSPEED:

```toml
[devices."receiver:82839805:slot:1".lighting]
color = "ff9500"

[devices."direct:046d:c08d:unit:6be9d300"]
# no lighting section — the wired route never saw the colour
```

Entries are now keyed on the device itself — `unit:6be9d300`, or `serial:…`
when a serial is reported — with a per-device `links` table recording the
routes it has been seen on. That table also identifies a device while it is
asleep and only its route is known, which is why it is persisted rather than
recomputed at runtime.

The value needed to correlate the two entries was already read on both
transports: `DeviceStableId::from_parts` received `serial` and `unit_id` and
discarded both for receiver routes.

## How a device is identified

Three steps, in order:

1. **Identity known** — the device is online and `0x0003` answered. Key on it.
2. **Identity unknown, route indexed** — a sleeping receiver slot. Resolve the
   route through the persisted index.
3. **Identity unknown, route not indexed** — fall back to the existing
   route-derived key.

A device whose unit id reads all-zero over a receiver keeps its route key and
never correlates. It degrades to current behaviour rather than relying on an
assumption about hardware that has not been sampled.

The index maps route to last-seen unit and is rewritten on every online
sighting. That also fixes a pre-existing bug: unpairing mouse A from slot 1 and
pairing B into it currently gives B all of A's bindings, because the key is the
slot.

That fix takes effect from the first sighting onwards, not retroactively. On a
pre-upgrade config the slot entry is all there is, and nothing on disk records
which device wrote it — so if A's settings sit under `receiver:…:slot:1` and B
now occupies that slot, B's first sighting still folds A's settings in, exactly
as today. After that the entry is keyed `unit:A` and the route key holds
nothing, so it cannot happen again.

## Migration

Two phases, because a pre-v5 direct key contains the unit id while a receiver key
contains nothing that identifies the device.

- **At load (any released schema — v4 and below — to v5), mechanical and lossless.**
  `direct:<vid>:<pid>:unit:<hex>` becomes `unit:<hex>`, the old route is
  recorded under `links`, `selected_device` and `host_switch_targets` are
  rewritten through the same mapping, and a `config.toml.v<N>.bak` naming the
  version it came from is written before the first save. Two direct keys that rename to the same target are
  folded rather than one overwriting the other.
- **At runtime, on the first online sighting.** The legacy entry folds into the
  canonical one section by section. A value the canonical entry lacks is taken
  as-is; a value both entries hold that differs becomes a per-link override
  instead of overwriting the canonical value.

Matching `receiver:` entries by `model_ids` at load time was considered and
rejected: model ids are model-scoped, so two identical mice — one on a
receiver, one cabled — would merge into a single device.

**Known gap:** between the upgrade and the next sighting on the other link, the
legacy entry stays orphaned. In practice that is until the mouse is next used
on that link.

## Per-link capabilities

A G502 LIGHTSPEED publishes `0x2121 HiResWheel` over its receiver but not over
USB — same firmware image and build, 30 features either way, with `0x2121` and
`0x00c2` swapped. Now that one device owns both measurements, the Scrolling
card explains that the device supports wheel resolution on its other connection
but not the current one, instead of reporting the capability as absent.

## Changes

**`crates/openlogi-core`**

- `DeviceStableId::route_key` — the route a device was reached by, with the
  device's own identity stripped. Only `Direct` strips; the other variants
  return `runtime_key`
- `DeviceConfig::links: BTreeMap<String, LinkConfig>` — measured capabilities
  and opt-in `LinkOverrides` per route, skipped by serde when empty so
  untouched files round-trip byte-identically
- `Config::resolve_device_key` and `Config::adopt_route` in a new
  `config/identity.rs`. `adopt_route` records what the sighting measured on
  that route, re-points the selection and any host-switch target, and will not
  let a bare canonical entry displace a legacy entry that still holds settings.
  It reports a change only when something actually differs, so an unchanged
  poll does not rewrite the config
- `DeviceConfig::effective_*` for the five overridable settings, resolving link
  override → device value → default
- schema 5 and its migration, with the pre-migration backup. The rename runs
  for released schemas — v4 and below. Schema 5 has not shipped, so this change
  and master's `ui_scale` bump land together in the final schema-5 shape

**`crates/openlogi-desktop`**

- records resolve through the new API, adopt their route on an online sighting,
  and collapse to one card per physical device, preferring the online record
  when a device is live on two routes
- absent-receiver reachability resolves through `links` rather than by parsing
  the config key, so an adopted device does not resurrect the ghost card

**`crates/openlogi-agent-core`**

- the orchestrator reads settings under the same key the GUI writes, and keeps
  applying settings still stored under a pre-upgrade key. The agent stays a
  pure reader and never adopts a route

**`crates/openlogi-ui`** — one new string in all 21 locales.

**`docs`** — a `DECISIONS.md` entry for the identity-keying decision, and the
`links` table documented in `config.example.toml`.

## Testing

- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
  — clean
- `cargo test --workspace` — one failure,
  `xtask commands::ci::jobs::tests::ci_yml_runs_what_this_runner_runs`, which is
  pre-existing and unrelated to this branch: `git diff origin/master...HEAD --
  xtask .github` is empty. It reports `ci.yml` not running the rustdoc command
  the local runner runs, and reproduces on master on this Windows host. Because
  cargo stops at the first failing test binary, the run was repeated as
  `cargo test --workspace --exclude xtask` for full coverage: 1081 passing,
  0 failures
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
  --document-private-items` (GPUI crates excluded as the gate does) — clean
  except `openlogi-permissions`, whose crate-doc link to `PermissionStatus` does
  not resolve on Windows because the type is cfg-gated away there. Present on
  master since 0f028a8; CI's Linux run passes it
- `cargo test -p openlogi-ipc --test wire_format` — 14 passing. No wire change:
  `ipc.rs` imports exactly one config type, `Lighting`, so `DeviceConfig` never
  crosses the boundary and `PROTOCOL_VERSION` is unchanged
- `cargo test -p openlogi-desktop i18n` and `cargo test -p openlogi-ui` — green
- `cargo check -p openlogi-core --no-default-features` — clean. `openlogi-core`
  gained an `fs` feature while this branch was out; the new `config/identity.rs`
  is pure and stays outside the gate
- **Not run locally:** the `wasm (portable crates)` CI job. It needs
  `wasm32-unknown-unknown`, and this host has only `x86_64-pc-windows-msvc`
  installed, so `cargo xtask ci` skips it — it passed on CI
- **Hardware: runtime-tested on a G502 LIGHTSPEED** (Windows), receiver and USB,
  against a real schema-4 `config.toml`. The migration produced one
  `unit:6be9d300` entry from the previous `receiver:82839805:slot:1` +
  `direct:046d:c08d:unit:6be9d300` pair, re-pointed `selected_device`, and left
  `config.toml.v4.bak` beside it; a second device (MX Master) migrated the same
  way. The carousel showed one card, and the Scrolling card reported wheel
  resolution as available on the other connection while wired. Both links
  recorded their own measurement — `hires_wheel = true` over the receiver,
  `false` over USB — which is #660 captured as per-link data on one device

  Two defects came out of that run and are fixed here:

  - the pre-migration copy was written as `config.v4.bak`, because
    `with_extension` replaces `.toml` rather than appending. Both unit tests
    built their expected path with the same call, so they mirrored the bug
    instead of catching it
  - `links.<route>.capabilities` was only ever written by the migration fold, so
    the "supported on your other connection" notice worked solely for upgraded
    configs and could never fire for a fresh schema-5 install — and the values it
    did show were frozen at whatever v4 held. Sightings now record it

  Re-run on the rebased branch, both paths from a cleared config
  directory:

  - **Fresh install**, no config at all: the file is created at
    `schema_version = 5`, keyed `unit:6be9d300` from the first sighting, with
    no `.bak` (nothing was migrated). Both links recorded their own live
    measurement — `hires_wheel = true` over the receiver, `false` over USB.
    This is the case the second fix above is about: with no legacy entry to
    fold, the old code left both link tables empty
  - **4 → 5 migration**, restoring the original v4 file: one `unit:6be9d300`
    entry from the previous pair, `selected_device` re-pointed, MX Master
    migrated alongside it, and `config.toml.v4.bak` written under the correct
    name holding the untouched v4 source

  *(The hardware run above predates the renumbering: the same code stamped 6
  at the time. Nothing else about the run changes — only the version written
  into the file.)*

  One gallery card in both runs, and the Scrolling card showed the
  other-connection notice while wired

Fixes #667
Refs #660

