### PR TITLE
fix(bindings): apply per-app overlay to HID++ gesture-source maps

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -66,8 +66,10 @@ pub fn plan_for_device(
     let oshook = oshook_gestures_for(config, Some(config_key), app);
     // One direction map per HID++ source in gesture mode — several may
     // gesture at once, each armed with its own raw-XY divert (the watcher
-    // derives the CIDs to divert from this map's keys).
-    let gesture_bindings = hidpp_gesture_maps_for(config, Some(config_key));
+    // derives the CIDs to divert from this map's keys). The per-app overlay
+    // applies: a source overridden for `app` drops out of gesture mode there
+    // and falls through to the plain-divert single-action path below.
+    let gesture_bindings = hidpp_gesture_maps_for(config, Some(config_key), app);
     // The HID++ gesture sources never reach the OS hook, so a non-default
     // single binding on one is deliverable only via a plain HID++ divert — but
     // only while the source is NOT in gesture mode (the raw-XY gesture divert

--- a/crates/openlogi-core/src/bindings.rs
+++ b/crates/openlogi-core/src/bindings.rs
@@ -53,15 +53,22 @@ pub fn bindings_for(
 /// via [`Binding::fill_gesture_defaults`] — the one canonical seeding rule —
 /// so the watcher always dispatches the full five-direction set the GUI
 /// shows. Empty when no HID++ source gestures (or `config_key` is `None`).
+///
+/// `app_bundle`'s per-app overlay is applied first: a per-app override turns
+/// a gesture source into a [`Binding::Single`], which drops it from this
+/// app's gesture set entirely — the capture plan then diverts it as a plain
+/// source and its press dispatches via the single-action path, mirroring how
+/// [`oshook_gestures_for`] treats overridden OS-hook buttons.
 #[must_use]
 pub fn hidpp_gesture_maps_for(
     config: &Config,
     config_key: Option<&str>,
+    app_bundle: Option<&str>,
 ) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
     let Some(key) = config_key else {
         return BTreeMap::new();
     };
-    let stored = config.bindings_for(key);
+    let stored = config.effective_bindings(key, app_bundle);
     ButtonId::ALL
         .iter()
         .copied()
@@ -248,7 +255,7 @@ mod tests {
         let mut cfg = Config::default();
         cfg.set_gesture_mode("2b042", ButtonId::HapticPanel, true);
 
-        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"));
+        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"), None);
         // The dedicated button gestures by default...
         let dedicated = maps
             .get(&ButtonId::GestureButton)
@@ -301,7 +308,7 @@ mod tests {
         // Default device: the dedicated HID++ gesture button gestures, with its
         // defaults seeded.
         let mut cfg = Config::default();
-        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"));
+        let maps = hidpp_gesture_maps_for(&cfg, Some("2b042"), None);
         assert_eq!(
             maps.get(&ButtonId::GestureButton)
                 .and_then(|m| m.get(&GestureDirection::Up)),
@@ -314,8 +321,39 @@ mod tests {
         cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
         cfg.set_gesture_mode("2b042", ButtonId::Back, true);
         assert!(
-            hidpp_gesture_maps_for(&cfg, Some("2b042")).is_empty(),
+            hidpp_gesture_maps_for(&cfg, Some("2b042"), None).is_empty(),
             "a demoted dedicated button must dispatch nothing over HID++"
         );
+    }
+
+    #[test]
+    fn per_app_override_drops_the_dedicated_button_from_the_gesture_set() {
+        // The dedicated HID++ gesture button gestures globally (Click → its
+        // seeded default)...  
+        let mut cfg = Config::default();
+        assert!(
+            hidpp_gesture_maps_for(&cfg, Some("2b042"), None)
+                .contains_key(&ButtonId::GestureButton),
+            "the dedicated button gestures globally"
+        );
+
+        // ...but a per-app override replaces it with a Single for that app, so
+        // it must drop out of the gesture set there — the capture plan then
+        // diverts it as a plain source and its press dispatches via the
+        // single-action path (plan.bindings), which carries the override.
+        cfg.set_per_app_binding(
+            "2b042",
+            "com.mitchellh.ghostty",
+            ButtonId::GestureButton,
+            Some(Action::RunShellCommand(String::from("echo hi"))),
+        );
+        let overlaid = hidpp_gesture_maps_for(&cfg, Some("2b042"), Some("com.mitchellh.ghostty"));
+        assert!(
+            !overlaid.contains_key(&ButtonId::GestureButton),
+            "a per-app override must remove GestureButton from the gesture set, got: {overlaid:?}"
+        );
+        // Other apps are unaffected — it still gestures.
+        assert!(hidpp_gesture_maps_for(&cfg, Some("2b042"), Some("com.other.App"))
+            .contains_key(&ButtonId::GestureButton));
     }
 }

--- a/crates/openlogi-desktop/src/state/bindings.rs
+++ b/crates/openlogi-desktop/src/state/bindings.rs
@@ -222,8 +222,8 @@ impl AppState {
         // Both halves come from the same helpers the runtime dispatches with,
         // so the menus can never drift from what the agent actually does:
         // HID++ sources seeded like the gesture watcher, OS-hook buttons raw
-        // like the hook.
-        let mut maps = hidpp_gesture_maps_for(&self.config, Some(key));
+        // like the hook (global view — no per-app overlay here).
+        let mut maps = hidpp_gesture_maps_for(&self.config, Some(key), None);
         maps.extend(oshook_gestures_for(&self.config, Some(key), None));
         maps
     }


### PR DESCRIPTION
Closes #878

## Summary

`hidpp_gesture_maps_for()` never consulted `per_app_bindings` — it resolved against `config.bindings_for(key)` (global only) while its siblings `bindings_for()` and `oshook_gestures_for()` both resolve via `effective_bindings(key, app)`. A per-app override of a dedicated HID++ gesture source therefore never took effect: the source stayed in gesture mode with its seeded Click default.

Fix threads `app_bundle: Option<\&str>` through `hidpp_gesture_maps_for` → `effective_bindings(key, app_bundle)`. A per-app `Single` then drops that source from the app's gesture map (existing `Binding::Single ⇒ None` arm); `plan_for_device`'s already-documented "plain HID++ divert" path takes over and the press dispatches via `plan.bindings`, mirroring `oshook_gestures_for`.

## Evidence / repro

- Per-app `GestureButton = { RunShellCommand = ".../herdr-mouse zoom-toggle" }` under `per_app_bindings."com.mitchellh.ghostty"` — press still fired App Exposé (seeded `Binding::Gesture` Click default) instead of the shell command.
- `plan_for_device(config, key, route, app, …)` already has `app` and passes it to `bindings_for` / `oshook_gestures_for` — just not to `hidpp_gesture_maps_for`.

## Changes

- `crates/openlogi-core/src/bindings.rs`: add `app_bundle` param, use `effective_bindings`, docs + regression test `per_app_override_drops_the_dedicated_button_from_the_gesture_set`
- `crates/openlogi-agent-core/src/capture_plan.rs`: pass `app` through
- `crates/openlogi-desktop/src/state/bindings.rs`: pass explicit `None` (global view)

## How to verify

`cargo test -p openlogi-core bindings -- --nocapture` — new test proves `GestureButton` gestures globally but drops out for `com.mitchellh.ghostty` when that app overrides it, while other apps remain unaffected. Existing binding/gesture tests still pass.

## Issue

https://github.com/AprilNEA/OpenLogi/issues/878
