### PR TITLE
fix(hid): key the native handle cache on usage pair, not device id alone

### DIFF
--- a/crates/openlogi-hid/src/transport/native.rs
+++ b/crates/openlogi-hid/src/transport/native.rs
@@ -32,11 +32,30 @@ pub(crate) fn native_backend() -> Arc<dyn HidBackend> {
     Arc::clone(&NATIVE_BACKEND) as Arc<dyn HidBackend>
 }
 
+/// Cache key for one enumerated HID node: its reported id plus the usage pair
+/// that distinguishes the collections sharing that id. See [`NativeBackend`].
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct NodeKey {
+    id: NodeId,
+    usage_page: u16,
+    usage_id: u16,
+}
+
+impl NodeKey {
+    fn of(info: &NodeInfo) -> Self {
+        Self {
+            id: info.id.clone(),
+            usage_page: info.usage_page,
+            usage_id: info.usage_id,
+        }
+    }
+}
+
 /// [`HidBackend`] over `async-hid`.
 #[derive(Default)]
 pub(crate) struct NativeBackend {
     /// OS handles from the most recent enumeration, keyed by the id that
-    /// enumeration reported them under.
+    /// enumeration reported them under *plus its usage pair*.
     ///
     /// `async_hid::Device` is an OS handle, not a value: it cannot be rebuilt
     /// from a [`NodeId`], and re-finding one costs another enumeration. Since
@@ -44,7 +63,22 @@ pub(crate) struct NativeBackend {
     /// the handles from that enumeration is both cheaper and a truer model
     /// than looking them up again. Held behind an `Arc` so an open can borrow
     /// one without keeping the map locked across its await.
-    nodes: Mutex<HashMap<NodeId, Arc<Device>>>,
+    ///
+    /// The usage pair belongs in the key because macOS reports one
+    /// `DeviceInfo` per usage pair while giving them all the *same*
+    /// `DeviceId::RegistryEntryId`. Keying on the id alone collapses every
+    /// collection of a multi-collection device onto one entry and the last
+    /// enumerated one wins, so `handle()` can hand back a different collection
+    /// than the caller enumerated. That mis-sourced `usage_page`/`usage_id`
+    /// then flows into `is_long_only_collection()` in `open_hidpp_channel`,
+    /// which decides whether the channel advertises HID++ *short* report
+    /// support. A BLE-direct mouse (e.g. MX Master 4) is long-only, but if the
+    /// generic-desktop or haptics collection wins the key it is judged
+    /// short-capable, the `hidpp` channel skips up-converting short messages,
+    /// and every write goes out as report `0x10` — a report id that does not
+    /// exist on that device — which macOS rejects with `kIOReturnNotFound`
+    /// (0xE00002F0) before it ever reaches the radio.
+    nodes: Mutex<HashMap<NodeKey, Arc<Device>>>,
 }
 
 impl NativeBackend {
@@ -57,7 +91,7 @@ impl NativeBackend {
             .collect();
         let handles = devices
             .iter()
-            .map(|device| (super::node_id(device), Arc::clone(device)))
+            .map(|device| (NodeKey::of(&super::node_info(device)), Arc::clone(device)))
             .collect();
         *self.nodes.lock().unwrap_or_else(PoisonError::into_inner) = handles;
         Ok(devices)
@@ -68,7 +102,7 @@ impl NativeBackend {
         self.nodes
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
-            .get(&node.id)
+            .get(&NodeKey::of(node))
             .map(Arc::clone)
             .ok_or(BackendError::Disconnected)
     }


### PR DESCRIPTION
## Bug

macOS enumerates one `async_hid::DeviceInfo` per HID **usage collection**, but a multi-collection device shares one `DeviceId::RegistryEntryId` across all of them. My MX Master 4 (BLE-direct, no Bolt/Unifying receiver) exposes 4 collections on this id:

- `{usage_page: 0x0001, usage_id: 0x0002}` — generic desktop / mouse
- `{usage_page: 0x0001, usage_id: 0x0001}` — generic desktop / pointer
- `{usage_page: 0xff43, usage_id: 0x0202}` — vendor HID++ (this is the one we want)
- `{usage_page: 0x000e, usage_id: 0x0001}` — haptics

`NativeBackend::refresh()` (`crates/openlogi-hid/src/transport/native.rs`) cached handles keyed only on `node_id()` = `format!("{:?}", info.id)`, so all 4 collections collapsed onto one `HashMap` entry — last-enumerated wins.

`enumerate_hidpp()` correctly filters and returns the `0xff43/0x0202` `NodeInfo`. But `handle()` looks the OS handle back up by id alone, so it can hand back a *different* collection's handle than the one that was actually enumerated. `open_hidpp_channel()` then computes `long_only` from whichever collection `handle()` returned — on my machine that was the haptics collection, `is_long_only_collection(0x000e, 0x0001)` is `false`, so the channel decided the device supports HID++ *short* reports. It doesn't (BLE-direct is long-only), so the `hidpp` crate skipped up-converting outgoing short messages, and every write went out as report `0x10` — a report id that doesn't exist in this device's HID++ collection. macOS rejects it locally with `kIOReturnNotFound` (`0xE00002F0`) before it ever reaches the radio.

**Symptoms:** the vendor collection opens fine (so `opened HID++ channel` logs), but every read/write after that fails immediately, the feature walk never completes, and the inventory watcher logs `node probe keeps failing — retiring its channel before reopen` in a tight retry loop forever. `openlogi list` / the GUI report no devices found even though the peripheral shows connected at the OS level. This matches #880 exactly, and I suspect at least some of #757, #520, #468, #375 as well, since "node probe keeps failing" on macOS is a symptom of at least two distinct root causes (this one, and the separate known `kIOReturnTimeout` / async-hid#45 issue) currently sharing one log message.

## Fix

Cache handles under a `NodeKey { id, usage_page, usage_id }` instead of `NodeId` alone, so each collection gets its own cache entry and `handle()` returns the one the caller actually asked for.

## Testing

Verified against a Logitech MX Master 4 (VID `046d`, PID `b042`) paired Bluetooth-direct on macOS (Tahoe):

**Before:**
```
WARN openlogi_device::inventory: node probe keeps failing — retiring its channel before reopen
```
repeating indefinitely, `openlogi list` → `No Logitech HID++ devices or webcams found.`

**After:**
```
$ openlogi list
MX Master 4 (—, vid=046d pid=b042)
  └─ slot 255 ● MX Master 4 (mouse, wpid=?, battery=100% full (discharging))
          model_ids=[b042,0000,0000] ext=00 serial=2531ZAZ5CGX8 unit_id=3c28ac40 transports=btle

$ openlogi diag battery
device: MX Master 4 (direct 046d:b042)
  0x1004 UnifiedBattery: percentage=100 level=Full status=Discharging

$ openlogi diag smartshift
✓ SmartShift round-trip OK

$ openlogi diag dpi
✓ DPI round-trip OK
```

Full read/write/readback/restore round trips all pass. Action Ring, gesture routing, and haptic panel button handling also confirmed working end to end with the built `openlogi-overlay` alongside this fix.

Fixes #880