### PR TITLE
fix(macos): use reliable async-hid report writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,26 +420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-hid"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f70c6f427f9dc3942b5863b2677a34dfcdd5ec46fe3c21a57883c50403269c5"
-dependencies = [
- "async-io",
- "atomic-waker",
- "block2 0.6.2",
- "crossbeam-queue",
- "dispatch2",
- "futures-lite",
- "log",
- "nix 0.29.0",
- "objc2-core-foundation",
- "objc2-io-kit",
- "static_assertions",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5306,6 +5286,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "openlogi-async-hid"
+version = "0.5.3-openlogi.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883f2f413df036fd1b943bcd99d83cb0cfd76d0dc2586a16773f6d9aee1f5887"
+dependencies = [
+ "async-io",
+ "atomic-waker",
+ "block2 0.6.2",
+ "crossbeam-queue",
+ "dispatch2",
+ "futures-lite",
+ "log",
+ "nix 0.29.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "static_assertions",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "openlogi-camera"
 version = "0.7.10"
 dependencies = [
@@ -5426,11 +5426,11 @@ version = "0.7.10"
 name = "openlogi-hid"
 version = "0.7.10"
 dependencies = [
- "async-hid",
  "atomic-write-file",
  "futures-concurrency",
  "futures-lite",
  "objc2-io-kit",
+ "openlogi-async-hid",
  "openlogi-core",
  "openlogi-device",
  "openlogi-hidpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ description = "Lightweight, local-first alternative to Logitech Options+ for HID
 [workspace.dependencies]
 hidpp = { package = "openlogi-hidpp", path = "crates/openlogi-hidpp", version = "0.7.10" }
 openlogi-device-registry = { path = "crates/openlogi-device-registry", version = "0.7.10" }
-async-hid = "0.5.3"
+async-hid = { package = "openlogi-async-hid", version = "=0.5.3-openlogi.1" }
 interprocess = { version = "2", features = ["tokio"] }
 # The agent <-> GUI RPC layer itself, over the `interprocess` transport above.
 # 0.38 is a hard floor: earlier releases hard-depend on opentelemetry 0.30 (not


### PR DESCRIPTION
## Summary

Use the published OpenLogi-maintained `async-hid` fork containing upstream [async-hid PR #46](https://github.com/sidit77/async-hid/pull/46). On macOS, it uses synchronous report writes so long-lived Bluetooth-direct handles keep receiving HID++ input reports after a write.

## Changes

- **Workspace dependency:** replace `async-hid` 0.5.3 with the exact crates.io release `openlogi-async-hid` 0.5.3-openlogi.1 while preserving the Rust crate name `async_hid`.
- **Lockfile:** record the published package and registry checksum; no Git dependency or source allowlist is needed.
- **Fork:** [AprilNEA/async-hid](https://github.com/AprilNEA/async-hid) now carries the upstream fix, tagged `v0.5.3-openlogi.1` and published as [`openlogi-async-hid`](https://crates.io/crates/openlogi-async-hid).

## Testing

- `RUSTFLAGS='-D warnings' cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci cargo-deny`

Not runtime-tested on local hardware in this Linux environment. The reporter in #798 validated the same macOS write-path change on an MX Master 4 over Bluetooth Direct, including complete feature enumeration, model/name, battery state, and online inventory status.

Fixes #798