### PR TITLE
fix(macos): recover missing Input Monitoring access

### DIFF
--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -830,6 +830,10 @@ impl Agent for MockAgent {
         info!("request_accessibility_prompt (no-op in the mock)");
     }
 
+    async fn restart_after_input_monitoring_change(self, _: Context) {
+        info!("restart_after_input_monitoring_change (no-op in the mock)");
+    }
+
     async fn start_pairing(
         self,
         _: Context,

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -834,6 +834,10 @@ impl Agent for MockAgent {
         info!("restart_after_input_monitoring_change (no-op in the mock)");
     }
 
+    async fn request_input_monitoring_access(self, _: Context) {
+        info!("request_input_monitoring_access (no-op in the mock)");
+    }
+
     async fn start_pairing(
         self,
         _: Context,

--- a/crates/openlogi-agent/src/binary_watch.rs
+++ b/crates/openlogi-agent/src/binary_watch.rs
@@ -35,7 +35,7 @@ use tracing::{info, warn};
 mod relaunch;
 
 #[cfg(target_os = "macos")]
-pub use relaunch::relaunch_after_input_monitoring_grant;
+pub use relaunch::restart_after_input_monitoring_change;
 
 /// How often to stat the executable: one `metadata` call per tick — noise next
 /// to the 2 s HID enumerate — while keeping the update-to-restart window short.

--- a/crates/openlogi-agent/src/binary_watch/relaunch.rs
+++ b/crates/openlogi-agent/src/binary_watch/relaunch.rs
@@ -64,14 +64,14 @@ pub(super) fn restart(path: &Path) {
     }
 }
 
-/// Relaunch the macOS agent after Input Monitoring is granted.
+/// Relaunch the macOS agent after Input Monitoring changes.
 ///
-/// macOS does not apply a new Input Monitoring grant to the running process.
+/// macOS does not apply a new Input Monitoring decision to the running process.
 /// The successor starts only after this process exits and releases its
 /// singleton lock and IPC socket. If the relaunch cannot be scheduled, the
 /// current process stays alive so the user can restart it manually.
 #[cfg(target_os = "macos")]
-pub fn relaunch_after_input_monitoring_grant() {
+pub fn restart_after_input_monitoring_change() {
     let path = match std::env::current_exe() {
         Ok(path) => path,
         Err(e) => {
@@ -79,7 +79,7 @@ pub fn relaunch_after_input_monitoring_grant() {
             return;
         }
     };
-    info!("Input Monitoring granted — relaunching the macOS agent");
+    info!("Input Monitoring changed — relaunching the macOS agent");
     if let Err(e) = schedule_macos_relaunch_and_exit(&path) {
         warn!(error = %e, "could not schedule agent relaunch after Input Monitoring was granted — restart the agent manually");
     }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -329,7 +329,7 @@ async fn request_input_monitoring() {
         })
         .await;
         match access_after_prompt {
-            Ok(true) => binary_watch::relaunch_after_input_monitoring_grant(),
+            Ok(true) => binary_watch::restart_after_input_monitoring_change(),
             Ok(false) => {}
             Err(e) => {
                 warn!(error = %e, "Input Monitoring permission request task failed");

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -316,7 +316,7 @@ fn prompt_missing_accessibility(capture_mouse_events: bool) {
 /// binary the user authorizes. A newly granted permission requires a process
 /// relaunch before macOS lets the agent open HID devices.
 #[cfg(target_os = "macos")]
-async fn request_input_monitoring() {
+pub(crate) async fn request_input_monitoring() {
     // Without this, macOS never registers a decision at all:
     // `IOHIDDeviceOpen` is silently denied, the permission never appears in
     // System Settings for the user to grant, and no HID++ device is ever

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -271,6 +271,11 @@ impl Agent for AgentServer {
         crate::binary_watch::restart_after_input_monitoring_change();
     }
 
+    async fn request_input_monitoring_access(self, _: Context) {
+        #[cfg(target_os = "macos")]
+        crate::request_input_monitoring().await;
+    }
+
     async fn action_ring_hover(
         self,
         _: Context,

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -266,6 +266,11 @@ impl Agent for AgentServer {
         self.action_ring.observe(since).await
     }
 
+    async fn restart_after_input_monitoring_change(self, _: Context) {
+        #[cfg(target_os = "macos")]
+        crate::binary_watch::restart_after_input_monitoring_change();
+    }
+
     async fn action_ring_hover(
         self,
         _: Context,

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -369,6 +369,62 @@ impl AppView {
             )
             .into_any_element()
     }
+
+    #[cfg(target_os = "macos")]
+    fn input_monitoring_gate(pal: Palette) -> AnyElement {
+        v_flex()
+            .size_full()
+            .bg(pal.bg)
+            .text_color(pal.text_primary)
+            .items_center()
+            .justify_center()
+            .gap_4()
+            .p_8()
+            .child(
+                Icon::new(IconName::TriangleAlert)
+                    .size_8()
+                    .text_color(rgb(theme::STATUS_CONNECTING)),
+            )
+            .child(
+                div()
+                    .text_title()
+                    .child(tr!("Input Monitoring permission required")),
+            )
+            .child(
+                div()
+                    .max_w(px(440.))
+                    .text_body()
+                    .text_color(pal.text_muted)
+                    .child(tr!(
+                        "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+                    )),
+            )
+            .child(
+                div()
+                    .max_w(px(440.))
+                    .text_body()
+                    .text_color(pal.text_muted)
+                    .child(tr!(
+                        "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+                    )),
+            )
+            .child(
+                Button::new("open-input-monitoring")
+                    .primary()
+                    .icon(IconName::Settings)
+                    .label(tr!("Open System Settings to grant access"))
+                    .on_click(|_, _, _| open_input_monitoring_settings()),
+            )
+            .child(
+                Button::new("restart-after-input-monitoring")
+                    .label(tr!("I’ve granted access — continue"))
+                    .on_click(|_, _, cx| restart_after_input_monitoring_change(cx)),
+            )
+            .child(div().text_caption().text_color(pal.text_muted).child(tr!(
+                "The background agent restarts once, then OpenLogi continues automatically."
+            )))
+            .into_any_element()
+    }
 }
 
 fn request_accessibility(cx: &mut App) {
@@ -381,6 +437,17 @@ fn request_accessibility(cx: &mut App) {
         state.request_accessibility_prompt();
     }
     permissions::open_pane(Permission::Accessibility);
+}
+
+pub(crate) fn open_input_monitoring_settings() {
+    use openlogi_permissions::{self as permissions, Permission};
+    permissions::open_pane(Permission::InputMonitoring);
+}
+
+pub(crate) fn restart_after_input_monitoring_change(cx: &mut App) {
+    if let Some(state) = cx.try_global::<AppState>() {
+        state.restart_after_input_monitoring_change();
+    }
 }
 
 /// Client-side main-window titlebar: window controls (minimize / maximize /
@@ -468,6 +535,14 @@ impl Render for AppView {
             }
             AgentLink::Ready(status) => status,
         };
+
+        #[cfg(target_os = "macos")]
+        if !status.input_monitoring_granted {
+            window.set_window_title("OpenLogi");
+            return root
+                .child(Self::input_monitoring_gate(pal))
+                .into_any_element();
+        }
 
         let granted = status.accessibility_granted;
         if !granted && !self.accessibility_dismissed {

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -413,7 +413,7 @@ impl AppView {
                     .primary()
                     .icon(IconName::Settings)
                     .label(tr!("Open System Settings to grant access"))
-                    .on_click(|_, _, _| open_input_monitoring_settings()),
+                    .on_click(|_, _, cx| request_input_monitoring(cx)),
             )
             .child(
                 Button::new("restart-after-input-monitoring")
@@ -439,8 +439,13 @@ fn request_accessibility(cx: &mut App) {
     permissions::open_pane(Permission::Accessibility);
 }
 
-pub(crate) fn open_input_monitoring_settings() {
+pub(crate) fn request_input_monitoring(cx: &mut App) {
     use openlogi_permissions::{self as permissions, Permission};
+    // Only the agent may request this permission: it owns HID access, and TCC
+    // attributes the resulting prompt and Settings row to the caller.
+    if let Some(state) = cx.try_global::<AppState>() {
+        state.request_input_monitoring_access();
+    }
     permissions::open_pane(Permission::InputMonitoring);
 }
 

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -111,6 +111,10 @@ pub enum Command {
     /// Restart the macOS agent after the user changes Input Monitoring so the
     /// new TCC decision applies to HID device opens.
     RestartAfterInputMonitoringChange,
+    /// Ask the agent to raise the macOS Input Monitoring request. The agent
+    /// owns HID access, so prompting in the GUI would authorize the wrong
+    /// process.
+    RequestInputMonitoringAccess,
     /// Pairing (agent-owned, since it opens the receiver): begin a session,
     /// pair a discovered device by address, or cancel. Events stream back via
     /// the separate [`IpcClient::pairing`] long-poll, not these commands.
@@ -528,6 +532,10 @@ async fn handle(
             .map_err(|_| ())?,
         Command::RestartAfterInputMonitoringChange => client
             .restart_after_input_monitoring_change(ctx)
+            .await
+            .map_err(|_| ())?,
+        Command::RequestInputMonitoringAccess => client
+            .request_input_monitoring_access(ctx)
             .await
             .map_err(|_| ())?,
         Command::StartPairing(selector) => {

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -108,6 +108,9 @@ pub enum Command {
     /// CGEventTap, so the system dialog must name (and authorize) the *agent*
     /// binary, not the GUI — prompting locally would grant the wrong process.
     RequestAccessibilityPrompt,
+    /// Restart the macOS agent after the user changes Input Monitoring so the
+    /// new TCC decision applies to HID device opens.
+    RestartAfterInputMonitoringChange,
     /// Pairing (agent-owned, since it opens the receiver): begin a session,
     /// pair a discovered device by address, or cancel. Events stream back via
     /// the separate [`IpcClient::pairing`] long-poll, not these commands.
@@ -521,6 +524,10 @@ async fn handle(
         }
         Command::RequestAccessibilityPrompt => client
             .request_accessibility_prompt(ctx)
+            .await
+            .map_err(|_| ())?,
+        Command::RestartAfterInputMonitoringChange => client
+            .restart_after_input_monitoring_change(ctx)
             .await
             .map_err(|_| ())?,
         Command::StartPairing(selector) => {

--- a/crates/openlogi-desktop/src/state/agent.rs
+++ b/crates/openlogi-desktop/src/state/agent.rs
@@ -43,6 +43,11 @@ impl AppState {
     pub fn restart_after_input_monitoring_change(&self) {
         self.send_ipc(crate::services::ipc::Command::RestartAfterInputMonitoringChange);
     }
+    /// Ask the agent to raise the macOS Input Monitoring request. The agent
+    /// owns HID access, so TCC must attribute the request to that helper.
+    pub fn request_input_monitoring_access(&self) {
+        self.send_ipc(crate::services::ipc::Command::RequestInputMonitoringAccess);
+    }
     /// The agent connection state the render path branches on.
     #[must_use]
     pub fn agent_link(&self) -> &AgentLink {

--- a/crates/openlogi-desktop/src/state/agent.rs
+++ b/crates/openlogi-desktop/src/state/agent.rs
@@ -37,6 +37,12 @@ impl AppState {
     pub fn request_accessibility_prompt(&self) {
         self.send_ipc(crate::services::ipc::Command::RequestAccessibilityPrompt);
     }
+    /// Restart the agent after the user changes Input Monitoring in macOS
+    /// System Settings, where the new decision is not applied to a process
+    /// that was already running.
+    pub fn restart_after_input_monitoring_change(&self) {
+        self.send_ipc(crate::services::ipc::Command::RestartAfterInputMonitoringChange);
+    }
     /// The agent connection state the render path branches on.
     #[must_use]
     pub fn agent_link(&self) -> &AgentLink {

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -64,7 +64,12 @@ pub fn open(cx: &mut App) {
             PairingUi::Searching | PairingUi::Found(_) | PairingUi::Pairing | PairingUi::Passkey(_)
         )
     );
-    if !active {
+    let input_monitoring_missing = cfg!(target_os = "macos")
+        && cx
+            .try_global::<AppState>()
+            .and_then(AppState::agent_status)
+            .is_some_and(|status| !status.input_monitoring_granted);
+    if !active && !input_monitoring_missing {
         start_search(cx);
     }
     windows::open_or_focus(
@@ -184,6 +189,11 @@ impl Render for AddDeviceView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let pal = theme::palette(cx);
         let state = cx.try_global::<PairingUi>().cloned().unwrap_or_default();
+        let input_monitoring_missing = cfg!(target_os = "macos")
+            && cx
+                .try_global::<AppState>()
+                .and_then(AppState::agent_status)
+                .is_some_and(|status| !status.input_monitoring_granted);
 
         v_flex()
             .size_full()
@@ -210,14 +220,17 @@ impl Render for AddDeviceView {
                             .text_heading()
                             .child(tr!("Add Device")),
                     )
-                    .child(body(&state, pal)),
+                    .child(body(&state, input_monitoring_missing, pal)),
             )
     }
 }
 
 /// The state-dependent body of the window.
-fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
+fn body(state: &PairingUi, input_monitoring_missing: bool, pal: Palette) -> impl IntoElement {
     let mut col = v_flex().w_full().flex_1().gap_4();
+    if input_monitoring_missing {
+        return col.child(input_monitoring_body(pal));
+    }
     match state {
         PairingUi::Idle => {
             col = col
@@ -307,6 +320,40 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
         }
     }
     col
+}
+
+fn input_monitoring_body(pal: Palette) -> impl IntoElement {
+    v_flex()
+        .w_full()
+        .gap_4()
+        .child(
+            div()
+                .text_color(pal.text_primary)
+                .font_weight(FontWeight::MEDIUM)
+                .child(tr!("Input Monitoring permission required")),
+        )
+        .child(hint(
+            tr!(
+                "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+            ),
+            pal,
+        ))
+        .child(
+            action_button(
+                "ad-open-input-monitoring",
+                tr!("Open System Settings to grant access"),
+                true,
+            )
+            .on_click(|_, _, _| crate::app::open_input_monitoring_settings()),
+        )
+        .child(
+            action_button(
+                "ad-restart-after-input-monitoring",
+                tr!("I’ve granted access — continue"),
+                false,
+            )
+            .on_click(|_, _, cx| crate::app::restart_after_input_monitoring_change(cx)),
+        )
 }
 
 /// A discovered-device row; clicking it pairs with that device.

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -344,7 +344,7 @@ fn input_monitoring_body(pal: Palette) -> impl IntoElement {
                 tr!("Open System Settings to grant access"),
                 true,
             )
-            .on_click(|_, _, _| crate::app::open_input_monitoring_settings()),
+            .on_click(|_, _, cx| crate::app::request_input_monitoring(cx)),
         )
         .child(
             action_button(

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -240,6 +240,10 @@ fn permission_field(
                     {
                         state.request_accessibility_prompt();
                     }
+                    if matches!(permission, Permission::InputMonitoring) {
+                        crate::app::request_input_monitoring(cx);
+                        return;
+                    }
                     // The Camera pane only lists an app after its first
                     // AVFoundation request, so a deep link can't grant it.
                     if prompts_here {

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -56,7 +56,8 @@ pub use succession::Identity;
 /// v25: `AgentStatus::input_monitoring_granted` appended.
 /// v26: `AgentStatus::hid_open_failures` appended.
 /// v27: [`Agent::restart_after_input_monitoring_change`] appended.
-pub const PROTOCOL_VERSION: u32 = 27;
+/// v28: [`Agent::request_input_monitoring_access`] appended.
+pub const PROTOCOL_VERSION: u32 = 28;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -500,4 +501,11 @@ pub trait Agent {
     /// The GUI calls this only on macOS. Other platforms accept it as a no-op
     /// so the IPC contract stays portable.
     async fn restart_after_input_monitoring_change();
+    /// Ask the agent to request Input Monitoring from macOS, so TCC attributes
+    /// the prompt and Settings row to the helper that actually opens HID
+    /// devices rather than to the GUI.
+    ///
+    /// The GUI calls this only on macOS. Other platforms accept it as a no-op
+    /// so the IPC contract stays portable.
+    async fn request_input_monitoring_access();
 }

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -55,7 +55,8 @@ pub use succession::Identity;
 /// v24: `StandaloneDevice::registry_model_id` is always encoded (bincode fix).
 /// v25: `AgentStatus::input_monitoring_granted` appended.
 /// v26: `AgentStatus::hid_open_failures` appended.
-pub const PROTOCOL_VERSION: u32 = 26;
+/// v27: [`Agent::restart_after_input_monitoring_change`] appended.
+pub const PROTOCOL_VERSION: u32 = 27;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to
@@ -493,4 +494,10 @@ pub trait Agent {
     /// then return it. Same contract as [`Agent::observe`] — whole state, hold
     /// window, `0` for "seen nothing" — over the ring's own cell.
     async fn observe_action_ring(since: Generation) -> RingObservation;
+    /// Restart the agent after the user changes Input Monitoring in System
+    /// Settings, so macOS applies the new TCC decision to device opens.
+    ///
+    /// The GUI calls this only on macOS. Other platforms accept it as a no-op
+    /// so the IPC contract stays portable.
+    async fn restart_after_input_monitoring_change();
 }

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -100,7 +100,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 26);
+    assert_eq!(PROTOCOL_VERSION, 27);
 }
 
 #[test]
@@ -187,6 +187,7 @@ fn request_variant_order() {
     assert_wire(&AgentRequest::Identity {}, "16");
     assert_wire(&AgentRequest::Observe { since: 7 }, "1707");
     assert_wire(&AgentRequest::ObserveActionRing { since: 7 }, "1807");
+    assert_wire(&AgentRequest::RestartAfterInputMonitoringChange {}, "19");
 }
 
 /// The agent identity is frozen: a helper from any build has to be able to

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -100,7 +100,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 27);
+    assert_eq!(PROTOCOL_VERSION, 28);
 }
 
 #[test]
@@ -188,6 +188,7 @@ fn request_variant_order() {
     assert_wire(&AgentRequest::Observe { since: 7 }, "1707");
     assert_wire(&AgentRequest::ObserveActionRing { since: 7 }, "1807");
     assert_wire(&AgentRequest::RestartAfterInputMonitoringChange {}, "19");
+    assert_wire(&AgentRequest::RequestInputMonitoringAccess {}, "1a");
 }
 
 /// The agent identity is frozen: a helper from any build has to be able to

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Genvej, f.eks. Cmd+Shift+P"
 "Application, folder path, or URL": "Program, mappesti eller URL"
 "Open application or folder": "Åbn program eller mappe"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Tastenkürzel, z. B. Cmd+Shift+P"
 "Application, folder path, or URL": "Anwendung, Ordnerpfad oder URL"
 "Open application or folder": "Anwendung oder Ordner öffnen"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Συντόμευση, π.χ. Cmd+Shift+P"
 "Application, folder path, or URL": "Εφαρμογή, διαδρομή φακέλου ή URL"
 "Open application or folder": "Άνοιγμα εφαρμογής ή φακέλου"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Shortcut, e.g. Cmd+Shift+P"
 "Application, folder path, or URL": "Application, folder path, or URL"
 "Open application or folder": "Open application or folder"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Atajo, p. ej. Cmd+Shift+P"
 "Application, folder path, or URL": "Aplicación, ruta de carpeta o URL"
 "Open application or folder": "Abrir aplicación o carpeta"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Pikanäppäin, esim. Cmd+Shift+P"
 "Application, folder path, or URL": "Sovellus, kansiopolku tai URL"
 "Open application or folder": "Avaa sovellus tai kansio"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Raccourci, p. ex. Cmd+Shift+P"
 "Application, folder path, or URL": "Application, chemin de dossier ou URL"
 "Open application or folder": "Ouvrir une application ou un dossier"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Scorciatoia, ad es. Cmd+Shift+P"
 "Application, folder path, or URL": "Applicazione, percorso cartella o URL"
 "Open application or folder": "Apri applicazione o cartella"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "ショートカット（例: Cmd+Shift+P）"
 "Application, folder path, or URL": "アプリ、フォルダのパス、またはURL"
 "Open application or folder": "アプリまたはフォルダを開く"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "단축키(예: Cmd+Shift+P)"
 "Application, folder path, or URL": "앱, 폴더 경로 또는 URL"
 "Open application or folder": "앱 또는 폴더 열기"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Snarvei, f.eks. Cmd+Shift+P"
 "Application, folder path, or URL": "Program, mappebane eller URL"
 "Open application or folder": "Åpne program eller mappe"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Sneltoets, bijv. Cmd+Shift+P"
 "Application, folder path, or URL": "Toepassing, mappad of URL"
 "Open application or folder": "Toepassing of map openen"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Skrót, np. Cmd+Shift+P"
 "Application, folder path, or URL": "Aplikacja, ścieżka folderu lub URL"
 "Open application or folder": "Otwórz aplikację lub folder"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Atalho, por exemplo, Cmd+Shift+P"
 "Application, folder path, or URL": "Aplicativo, caminho de pasta ou URL"
 "Open application or folder": "Abrir aplicativo ou pasta"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Atalho, por exemplo, Cmd+Shift+P"
 "Application, folder path, or URL": "Aplicação, caminho de pasta ou URL"
 "Open application or folder": "Abrir aplicação ou pasta"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Сочетание, например Cmd+Shift+P"
 "Application, folder path, or URL": "Приложение, путь к папке или URL"
 "Open application or folder": "Открыть приложение или папку"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Kortkommando, t.ex. Cmd+Shift+P"
 "Application, folder path, or URL": "Program, mappsökväg eller URL"
 "Open application or folder": "Öppna program eller mapp"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "Сполучення клавіш, напр. Cmd+Shift+P"
 "Application, folder path, or URL": "Програма, шлях до папки або URL"
 "Open application or folder": "Відкрити програму або папку"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "快捷键，例如 Cmd+Shift+P"
 "Application, folder path, or URL": "应用、文件夹路径或 URL"
 "Open application or folder": "打开应用或文件夹"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "快速鍵，例如 Cmd+Shift+P"
 "Application, folder path, or URL": "應用程式、資料夾路徑或 URL"
 "Open application or folder": "開啟應用程式或資料夾"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -402,3 +402,8 @@ _version: 1
 "Shortcut, e.g. Cmd+Shift+P": "快速鍵，例如 Cmd+Shift+P"
 "Application, folder path, or URL": "應用程式、資料夾路徑或 URL"
 "Open application or folder": "開啟應用程式或資料夾"
+"Input Monitoring permission required": "Input Monitoring permission required"
+"OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices.": "OpenLogi needs Input Monitoring to discover, pair, and configure Logitech devices."
+"Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app.": "Enable “OpenLogi Agent” in the Input Monitoring list — the background agent owns device access, not the OpenLogi app."
+"I’ve granted access — continue": "I’ve granted access — continue"
+"The background agent restarts once, then OpenLogi continues automatically.": "The background agent restarts once, then OpenLogi continues automatically."


### PR DESCRIPTION
## Summary

Make a denied macOS Input Monitoring permission recoverable from the UI instead of surfacing a raw HID transport error.

## Changes

- **GUI:** Gate device discovery on the agent's Input Monitoring status and provide direct request, System Settings, and continue actions.
- **Agent:** Request Input Monitoring through `IOHIDRequestAccess` when the user clicks the recovery action, so macOS attributes the prompt and Settings row to the helper that owns HID access.
- **Agent:** Restart the responsible helper after the user grants access so macOS applies the new TCC decision.
- **IPC:** Append the request and restart methods, bump protocol version to 28, and pin their request wire format.
- **i18n:** Add the permission-recovery copy to every locale catalog.
- **Pairing:** Replace the raw missing-permission failure with the same actionable recovery flow.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — rustfmt, publish closure, macOS clippy, macOS MSRV, rustdoc, and macOS arm64 tests passed; Linux tests were not run on this host.
- `cargo xtask ci shell cargo-deny clippy-windows wasm`
- `cargo xtask ci clippy-windows wasm`
- `RUSTFLAGS="-D warnings" cargo clippy --target aarch64-unknown-linux-musl -p openlogi-hook -p openlogi-inject -p openlogi-hid -p openlogi-hidpp -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-ipc -p openlogi-permissions --all-targets -- -D warnings`
- `cargo run -p openlogi-desktop` — the signed dev bundle launched, connected to its matching protocol-v28 agent, and discovered an MX Master 4.
- Hardware: device discovery was runtime-tested with an MX Master 4. The denied-state click was not re-tested after access had already become granted. To verify it, revoke Input Monitoring for OpenLogi Agent, launch OpenLogi, click **Open System Settings to grant access**, confirm macOS requests/registers OpenLogi Agent, grant it, click **I've granted access — continue**, and confirm the helper restarts and device discovery resumes.

Fixes #707
