### PR TITLE
feat(core,gui): make the main wheel's tilt rebindable (MX anywhere 2s,...)

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -155,6 +155,35 @@ mod tests {
     }
 
     #[test]
+    fn bound_wheel_tilt_is_diverted_but_an_untouched_one_stays_native() {
+        // The main wheel's tilt scrolls horizontally in firmware, so the
+        // default binding must leave it native — diverting an untouched tilt
+        // would silently kill horizontal scrolling. Binding one side to a real
+        // action is what arms its `0x1b04` divert.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b01a",
+            ButtonId::WheelTiltLeft,
+            Binding::Single(Action::PrevTab),
+        );
+
+        let plan = plan_for_device(&cfg, "2b01a", route(), None, 0);
+        assert!(
+            plan.divert_buttons
+                .contains(&(0x005b, ButtonId::WheelTiltLeft)),
+            "a bound tilt must be diverted, or the binding can never fire: {:?}",
+            plan.divert_buttons
+        );
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::WheelTiltRight),
+            "the untouched right tilt must keep its native horizontal scroll"
+        );
+    }
+
+    #[test]
     fn haptic_panel_gestures_when_promoted() {
         // The MX Master 4 haptic panel is a HID++ gesture source: promoting it
         // into gesture mode must arm the raw-XY gesture divert, exactly like

--- a/crates/openlogi-core/src/binding/button.rs
+++ b/crates/openlogi-core/src/binding/button.rs
@@ -64,19 +64,31 @@ pub enum ButtonId {
     /// (Logi metadata slot `ASSIGNMENT_NAME_SHOW_RADIAL_MENU`, HID++ CID
     /// `0x01a0`). A separate physical control from [`ButtonId::GestureButton`];
     /// captured over HID++ like it, and eligible as the gesture owner.
+    HapticPanel,
+    /// Tilting the main wheel left — `0x1b04` CID `0x005b` ("Left Scroll"),
+    /// Logi metadata slot `SLOT_NAME_LEFT_SCROLL_BUTTON`. A distinct control
+    /// from the thumb wheel: it is a plain divertable button, not a rotation,
+    /// and it lives on the main wheel of mice like the MX Anywhere 2S.
+    WheelTiltLeft,
+    /// Tilting the main wheel right — `0x1b04` CID `0x005d` ("Right Scroll"),
+    /// Logi metadata slot `SLOT_NAME_RIGHT_SCROLL_BUTTON`. Counterpart to
+    /// [`ButtonId::WheelTiltLeft`].
+    ///
     /// Declared last: the TOML config and any serialized form encode the
     /// variant identifier / index, so new buttons are append-only.
-    HapticPanel,
+    WheelTiltRight,
 }
 
 impl ButtonId {
     /// Every rebindable button in declaration (physical front-to-side) order —
     /// the iteration source for default-binding seeding and the popover
     /// trigger list.
-    pub const ALL: [ButtonId; 11] = [
+    pub const ALL: [ButtonId; 13] = [
         ButtonId::LeftClick,
         ButtonId::RightClick,
         ButtonId::MiddleClick,
+        ButtonId::WheelTiltLeft,
+        ButtonId::WheelTiltRight,
         ButtonId::Back,
         ButtonId::Forward,
         ButtonId::DpiToggle,
@@ -135,6 +147,8 @@ impl ButtonId {
             ButtonId::LeftClick => "Left Click",
             ButtonId::RightClick => "Right Click",
             ButtonId::MiddleClick => "Middle Click",
+            ButtonId::WheelTiltLeft => "Tilt Left",
+            ButtonId::WheelTiltRight => "Tilt Right",
             ButtonId::Back => "Back",
             ButtonId::Forward => "Forward",
             ButtonId::DpiToggle => "DPI Toggle",

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -31,6 +31,23 @@ pub fn default_binding(button: ButtonId) -> Action {
         ButtonId::LeftClick => Action::LeftClick,
         ButtonId::RightClick => Action::RightClick,
         ButtonId::MiddleClick => Action::MiddleClick,
+        // The main wheel's tilt scrolls horizontally in firmware. Seeding each
+        // side with the matching scroll action is what keeps a tilt the user
+        // never touched native: the capture plan diverts a control only when
+        // its binding leaves this default (see `capture_plan`), so an untouched
+        // tilt is never diverted and its firmware scroll is untouched.
+        #[expect(
+            clippy::match_same_arms,
+            reason = "the tilt and the thumb wheel are separate physical controls that happen to \
+                      scroll the same way; merging their arms would tie two independent defaults \
+                      together"
+        )]
+        ButtonId::WheelTiltLeft => Action::HorizontalScrollLeft,
+        #[expect(
+            clippy::match_same_arms,
+            reason = "see the left tilt above — same control pair, mirrored direction"
+        )]
+        ButtonId::WheelTiltRight => Action::HorizontalScrollRight,
         ButtonId::Back => Action::BrowserBack,
         ButtonId::Forward => Action::BrowserForward,
         ButtonId::DpiToggle => Action::CycleDpiPresets,

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -467,6 +467,28 @@ fn haptic_panel_defaults_to_opening_the_actions_ring() {
     assert!(ButtonId::ALL.contains(&ButtonId::HapticPanel));
 }
 
+#[test]
+fn wheel_tilt_defaults_to_the_scroll_its_firmware_already_does() {
+    // The seed has to match the native behavior on both sides: the capture
+    // plan diverts a control only when its binding leaves the default, so any
+    // other seed would divert an untouched tilt and kill horizontal scroll.
+    assert_eq!(
+        default_binding(ButtonId::WheelTiltLeft),
+        Action::HorizontalScrollLeft
+    );
+    assert_eq!(
+        default_binding(ButtonId::WheelTiltRight),
+        Action::HorizontalScrollRight
+    );
+    for tilt in [ButtonId::WheelTiltLeft, ButtonId::WheelTiltRight] {
+        assert!(ButtonId::ALL.contains(&tilt));
+        // A tilt reaches the host over HID++ diversion only: the OS hook sees
+        // a horizontal scroll, not a button, and it swipes nothing.
+        assert!(!tilt.is_os_hook_button());
+        assert!(!tilt.is_hidpp_gesture_source());
+    }
+}
+
 // ── Effect classification ─────────────────────────────────────────────────
 //
 // `Action::effect()` is the platform-neutral IR `openlogi-inject`'s three

--- a/crates/openlogi-desktop/src/features/mouse/geometry.rs
+++ b/crates/openlogi-desktop/src/features/mouse/geometry.rs
@@ -181,6 +181,11 @@ fn map_slot_name(name: &str) -> Option<MouseControlId> {
         "SLOT_NAME_LEFT_BUTTON" => Some(MouseControlId::Button(ButtonId::LeftClick)),
         "SLOT_NAME_RIGHT_BUTTON" => Some(MouseControlId::Button(ButtonId::RightClick)),
         "SLOT_NAME_MIDDLE_BUTTON" => Some(MouseControlId::Button(ButtonId::MiddleClick)),
+        // The main wheel's tilt. Logi names the two slots after the scroll they
+        // produce in firmware; each is its own reprogrammable control
+        // (`0x1b04` CIDs `0x005b` / `0x005d`), not part of the middle click.
+        "SLOT_NAME_LEFT_SCROLL_BUTTON" => Some(MouseControlId::Button(ButtonId::WheelTiltLeft)),
+        "SLOT_NAME_RIGHT_SCROLL_BUTTON" => Some(MouseControlId::Button(ButtonId::WheelTiltRight)),
         "SLOT_NAME_BACK_BUTTON" => Some(MouseControlId::Button(ButtonId::Back)),
         "SLOT_NAME_FORWARD_BUTTON" => Some(MouseControlId::Button(ButtonId::Forward)),
         "SLOT_NAME_MODESHIFT_BUTTON" => Some(MouseControlId::Button(ButtonId::DpiToggle)),
@@ -220,6 +225,21 @@ mod tests {
         assert_eq!(
             map_slot_name("SLOT_NAME_THUMBWHEEL"),
             Some(MouseControlId::ThumbwheelRotation)
+        );
+    }
+
+    #[test]
+    fn wheel_tilt_slots_map_to_their_own_controls() {
+        // Logi ships the tilt as two slots named after the scroll it produces
+        // (MX Anywhere 2S and friends). Leaving them unmapped is what used to
+        // hide the tilt from the buttons panel entirely.
+        assert_eq!(
+            map_slot_name("SLOT_NAME_LEFT_SCROLL_BUTTON"),
+            Some(MouseControlId::Button(ButtonId::WheelTiltLeft))
+        );
+        assert_eq!(
+            map_slot_name("SLOT_NAME_RIGHT_SCROLL_BUTTON"),
+            Some(MouseControlId::Button(ButtonId::WheelTiltRight))
         );
     }
 

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -135,10 +135,18 @@ struct CaptureAccum {
 /// when its binding leaves the default, so an unbound button keeps its native
 /// HID behavior (no re-synthesis needed). The Haptic Sense Panel is a gesture
 /// source ([`GESTURE_SOURCE_BUTTONS`]), not a member of this table.
-pub const DIVERTABLE_STANDARD_BUTTONS: [(u16, ButtonId); 3] = [
+///
+/// The two wheel-tilt CIDs are the classic "Left/Right Scroll" controls that
+/// MX-line mice with a tilting main wheel (MX Anywhere 2S and friends) expose
+/// as divertable — the same mechanism Options+ uses to rebind a tilt. Arming
+/// only ever diverts what a device's own `getCtrlIdInfo` reports, so listing
+/// them here is inert on a mouse whose wheel does not tilt.
+pub const DIVERTABLE_STANDARD_BUTTONS: [(u16, ButtonId); 5] = [
     (0x0052, ButtonId::MiddleClick),
     (0x0053, ButtonId::Back),
     (0x0056, ButtonId::Forward),
+    (0x005b, ButtonId::WheelTiltLeft),
+    (0x005d, ButtonId::WheelTiltRight),
 ];
 
 /// HID++ gesture sources: the `0x1b04` control ID and the [`ButtonId`] it

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Venstreklik"
 "Right Click": "Højreklik"
 "Middle Click": "Midterklik"
+"Tilt Left": "Vip til venstre"
+"Tilt Right": "Vip til højre"
 "Back (Button 4)": "Tilbage (knap 4)"
 "Forward (Button 5)": "Frem (knap 5)"
 "Back": "Tilbage"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Linksklick"
 "Right Click": "Rechtsklick"
 "Middle Click": "Mittelklick"
+"Tilt Left": "Kippen links"
+"Tilt Right": "Kippen rechts"
 "Back (Button 4)": "Zurück (Taste 4)"
 "Forward (Button 5)": "Vor (Taste 5)"
 "Back": "Zurück"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Αριστερό κλικ"
 "Right Click": "Δεξί κλικ"
 "Middle Click": "Μεσαίο κλικ"
+"Tilt Left": "Κλίση αριστερά"
+"Tilt Right": "Κλίση δεξιά"
 "Back (Button 4)": "Πίσω (κουμπί 4)"
 "Forward (Button 5)": "Εμπρός (κουμπί 5)"
 "Back": "Πίσω"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Left Click"
 "Right Click": "Right Click"
 "Middle Click": "Middle Click"
+"Tilt Left": "Tilt Left"
+"Tilt Right": "Tilt Right"
 "Back (Button 4)": "Back (Button 4)"
 "Forward (Button 5)": "Forward (Button 5)"
 "Back": "Back"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Clic izquierdo"
 "Right Click": "Clic derecho"
 "Middle Click": "Clic central"
+"Tilt Left": "Inclinación izquierda"
+"Tilt Right": "Inclinación derecha"
 "Back (Button 4)": "Atrás (botón 4)"
 "Forward (Button 5)": "Adelante (botón 5)"
 "Back": "Atrás"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Vasen napsautus"
 "Right Click": "Oikea napsautus"
 "Middle Click": "Keskinapsautus"
+"Tilt Left": "Kallista vasemmalle"
+"Tilt Right": "Kallista oikealle"
 "Back (Button 4)": "Takaisin (painike 4)"
 "Forward (Button 5)": "Eteenpäin (painike 5)"
 "Back": "Takaisin"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Clic gauche"
 "Right Click": "Clic droit"
 "Middle Click": "Clic du milieu"
+"Tilt Left": "Inclinaison gauche"
+"Tilt Right": "Inclinaison droite"
 "Back (Button 4)": "Précédent (bouton 4)"
 "Forward (Button 5)": "Suivant (bouton 5)"
 "Back": "Précédent"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Click sinistro"
 "Right Click": "Click destro"
 "Middle Click": "Click centrale"
+"Tilt Left": "Inclinazione sinistra"
+"Tilt Right": "Inclinazione destra"
 "Back (Button 4)": "Indietro (pulsante 4)"
 "Forward (Button 5)": "Avanti (pulsante 5)"
 "Back": "Indietro"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "左クリック"
 "Right Click": "右クリック"
 "Middle Click": "中クリック"
+"Tilt Left": "左チルト"
+"Tilt Right": "右チルト"
 "Back (Button 4)": "戻る（サイドボタン4）"
 "Forward (Button 5)": "進む（サイドボタン5）"
 "Back": "戻る"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "왼쪽 클릭"
 "Right Click": "오른쪽 클릭"
 "Middle Click": "가운데 클릭"
+"Tilt Left": "왼쪽 틸트"
+"Tilt Right": "오른쪽 틸트"
 "Back (Button 4)": "뒤로 (버튼 4)"
 "Forward (Button 5)": "앞으로 (버튼 5)"
 "Back": "뒤로"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Venstreklikk"
 "Right Click": "Høyreklikk"
 "Middle Click": "Midtklikk"
+"Tilt Left": "Vipp til venstre"
+"Tilt Right": "Vipp til høyre"
 "Back (Button 4)": "Tilbake (knapp 4)"
 "Forward (Button 5)": "Frem (knapp 5)"
 "Back": "Tilbake"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Linkerklik"
 "Right Click": "Rechterklik"
 "Middle Click": "Middenklik"
+"Tilt Left": "Kantelen links"
+"Tilt Right": "Kantelen rechts"
 "Back (Button 4)": "Vorige (knop 4)"
 "Forward (Button 5)": "Volgende (knop 5)"
 "Back": "Vorige"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Lewy przycisk"
 "Right Click": "Prawy przycisk"
 "Middle Click": "Środkowy przycisk"
+"Tilt Left": "Przechył w lewo"
+"Tilt Right": "Przechył w prawo"
 "Back (Button 4)": "Wstecz (przycisk 4)"
 "Forward (Button 5)": "Do przodu (przycisk 5)"
 "Back": "Wstecz"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Clique Esquerdo"
 "Right Click": "Clique Direito"
 "Middle Click": "Clique do Meio"
+"Tilt Left": "Inclinar à esquerda"
+"Tilt Right": "Inclinar à direita"
 "Back (Button 4)": "Voltar (botão 4)"
 "Forward (Button 5)": "Avançar (botão 5)"
 "Back": "Voltar"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Clique esquerdo"
 "Right Click": "Clique direito"
 "Middle Click": "Clique central"
+"Tilt Left": "Inclinar à esquerda"
+"Tilt Right": "Inclinar à direita"
 "Back (Button 4)": "Retroceder (botão 4)"
 "Forward (Button 5)": "Avançar (botão 5)"
 "Back": "Retroceder"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Левый щелчок"
 "Right Click": "Правый щелчок"
 "Middle Click": "Средний щелчок"
+"Tilt Left": "Наклон влево"
+"Tilt Right": "Наклон вправо"
 "Back (Button 4)": "Назад (боковая кнопка 4)"
 "Forward (Button 5)": "Вперёд (боковая кнопка 5)"
 "Back": "Назад"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Vänsterklick"
 "Right Click": "Högerklick"
 "Middle Click": "Mittenklick"
+"Tilt Left": "Luta vänster"
+"Tilt Right": "Luta höger"
 "Back (Button 4)": "Bakåt (knapp 4)"
 "Forward (Button 5)": "Framåt (knapp 5)"
 "Back": "Bakåt"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "Клацання лівою"
 "Right Click": "Клацання правою"
 "Middle Click": "Клацання середньою"
+"Tilt Left": "Нахил ліворуч"
+"Tilt Right": "Нахил праворуч"
 "Back (Button 4)": "Назад (кнопка 4)"
 "Forward (Button 5)": "Вперед (кнопка 5)"
 "Back": "Назад"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "左键单击"
 "Right Click": "右键单击"
 "Middle Click": "中键单击"
+"Tilt Left": "向左倾斜"
+"Tilt Right": "向右倾斜"
 "Back (Button 4)": "后退（侧键4）"
 "Forward (Button 5)": "前进（侧键5）"
 "Back": "后退"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "左鍵單擊"
 "Right Click": "右鍵單擊"
 "Middle Click": "中鍵單擊"
+"Tilt Left": "向左傾斜"
+"Tilt Right": "向右傾斜"
 "Back (Button 4)": "後退（側鍵4）"
 "Forward (Button 5)": "前進（側鍵5）"
 "Back": "後退"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -150,6 +150,8 @@ _version: 1
 "Left Click": "左鍵按一下"
 "Right Click": "右鍵按一下"
 "Middle Click": "中鍵按一下"
+"Tilt Left": "向左傾斜"
+"Tilt Right": "向右傾斜"
 "Back (Button 4)": "後退（側鍵4）"
 "Forward (Button 5)": "前進（側鍵5）"
 "Back": "後退"


### PR DESCRIPTION
## Summary

Fixes #583, reproduced on the exact setup reported there: an MX Anywhere 2S
connected Bluetooth-direct on Windows 11, where the wheel tilt is neither
detected nor configurable.

Mice whose main wheel tilts left/right expose each direction as its own HID++
reprogrammable control, and Options+ lets users rebind both. OpenLogi showed
neither: the buttons panel had no hotspot for them, so there was nothing to
click.

Two independent gaps caused that:

- `ButtonId` had no variant for either tilt, so no layer could name one.
- `map_slot_name` did not know Logitech's slot names for them
  (`SLOT_NAME_LEFT_SCROLL_BUTTON` / `SLOT_NAME_RIGHT_SCROLL_BUTTON`), even
  though the device metadata OpenLogi already downloads ships a marker for
  each — placed beside the wheel, where the control physically is.

Verified against real hardware before writing any code. An MX Anywhere 2S
reports both controls as divertable:

```
$ openlogi diag controls
device: Wireless Mobile Mouse MX Anywhere 2S (direct 046d:b01a)
     cid    task   flags  capabilities
  0x0052  0x00a9  0x0131  divertable, raw-xy
  0x0053  0x003c  0x0131  divertable, raw-xy
  0x0056  0x003e  0x0131  divertable, raw-xy
  0x005b  0x003f  0x0131  divertable, raw-xy   <- tilt left
  0x005d  0x0040  0x0131  divertable, raw-xy   <- tilt right
```

HID++ diversion is the only workable path. A tilt reaches the host as a
horizontal scroll, not as a button, so capturing it in the OS hook would also
swallow a trackpad's horizontal scroll — the device-level divert affects only
the mouse the user rebound.

**An untouched tilt stays native.** Each side is seeded with the horizontal
scroll its firmware already performs, and the capture plan diverts a control
only when its binding leaves the default — so a user who never opens the
panel keeps firmware horizontal scrolling exactly as before.

## Changes

**`openlogi-core`**
- `ButtonId::WheelTiltLeft` / `WheelTiltRight`, appended after `HapticPanel`
  to keep the serialized form append-only, with labels `Tilt Left` /
  `Tilt Right`.
- Defaults are `HorizontalScrollLeft` / `HorizontalScrollRight` — matching the
  firmware behaviour is what keeps an unbound tilt out of the divert set.

**`openlogi-device`**
- CIDs `0x005b` / `0x005d` added to `DIVERTABLE_STANDARD_BUTTONS`. Arming
  already filters on what a device's own `getCtrlIdInfo` reports, so the
  entries are inert on a wheel that does not tilt, and press dispatch needed
  no change — the rising-edge path is per-CID and generic.

**`openlogi-desktop`**
- `map_slot_name` maps the two tilt slots, giving each a hotspot at the
  coordinates Logi publishes. Neither is an OS-hook button nor a HID++
  gesture source, so the picker offers them as plain buttons with no
  swipe-mode entry.

**`openlogi-ui`**
- `Tilt Left` / `Tilt Right` added to all 21 locale catalogues, at the same
  position, with per-language translations.

**Tests**
- `wheel_tilt_defaults_to_the_scroll_its_firmware_already_does` — pins the
  default on both sides, since a different seed would silently divert an
  untouched tilt.
- `bound_wheel_tilt_is_diverted_but_an_untouched_one_stays_native` — the
  capture-plan half of that contract.
- `wheel_tilt_slots_map_to_their_own_controls` — the slot names, which is what
  was missing.

No wire change: `ButtonId` does not cross the IPC boundary (bindings are read
from `config.toml` by the agent, not shipped over tarpc), so
`PROTOCOL_VERSION` is unchanged. The wire-format goldens are green as-is.

## Testing

Run on Windows 11, `x86_64-pc-windows-msvc`, rustc 1.98.0, on the final tree:

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| `cargo test --workspace` | pass |
| `cargo test -p openlogi-ipc --test wire_format` | pass (13 tests) |
| `cargo test -p openlogi-desktop i18n` | pass |
| `cargo xtask release check-publish` | pass |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent` | fails on `openlogi-permissions` only — see below |
| `cargo build --release -p openlogi-desktop -p openlogi-overlay -p openlogi-agent -p openlogi --target x86_64-pc-windows-msvc` | pass |

**Not run on this host** (`cargo xtask ci` reported 3 passed, 6 skipped): `shell`
(no shellcheck/shfmt), `MSRV (cargo check)` (linux/macos only), `tests (linux)`,
`tests (macos)`, `cargo-deny` (not installed), `wasm (portable crates)` (target
not installed). None of these are claimed green.

**Two pre-existing Windows-only failures, unrelated to this diff:**

1. The rustdoc gate fails on `openlogi-permissions`: its crate-level docs link
   to `PermissionStatus::Unknown`, a type declared
   `#[cfg(any(target_os = "macos", target_os = "linux"))]`. On Windows the type
   does not exist, so the link cannot resolve. That crate is untouched here and
   has no dependencies at all on Windows (both dependency blocks are cfg-gated
   away), so this diff cannot reach it. Excluding it, the gate passes. CI's
   rustdoc job runs on Linux and never sees this.
2. `cargo xtask ci` fails its own `publish closure` job on Windows: the job
   shells out to `cargo xtask release check-publish`, whose nested cargo tries
   to relink the running `xtask.exe`, which Windows locks. Run standalone, the
   same job passes (see the table above).

**Hardware verification: partial.** The control-ID dump above is from a real
MX Anywhere 2S, and the release build runs with the agent seeing the device.
Binding a tilt to an action and confirming it fires has **not** been
runtime-tested end to end. Screenshots of the two new hotspots are still to be
added.

Fixes #583

Nothing here keys off a model list: a tilt appears when the device itself
reports the CIDs as divertable and its metadata ships the two slots. So this
should also cover the MX Anywhere 2 reported in #583's thread, and likely #651
(MX Ergo S) and #100 (M500S) — none of those three were verified, no hardware
for any of them. A `openlogi diag controls` dump from one of those mice would
settle it.

