### PR TITLE
fix(mouse): compose thumb-wheel preset labels from translated action names

### DIFF
--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -127,7 +127,7 @@ pub(crate) fn thumbwheel_picker<T: 'static>(
         .enumerate()
         .map(|(idx, preset)| {
             let selected = current == Some(preset);
-            let label = tr!(preset.label());
+            let label = preset.label();
             let observer = observer.clone();
             let popover = popover.clone();
             menu_row(("thumbwheel-preset", idx), pal, selected)

--- a/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
+++ b/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
@@ -72,21 +72,24 @@ impl ThumbwheelPreset {
         })
     }
 
+    /// Localized display label, rendered as "<backward> / <forward>" composed
+    /// from each side's already-translated action name. The flat "X / Y"
+    /// strings are keys in no locale file — every preset row used to fall back
+    /// to English regardless of app language — while per-action names carry
+    /// translations for all locales, so composing reuses that reviewed
+    /// coverage instead of duplicating it. CycleDpi fires one action in both
+    /// directions and renders as a single name without the separator.
     #[must_use]
-    pub(crate) const fn label(self) -> &'static str {
-        match self {
-            Self::BackForward => "Back / Forward",
-            Self::UndoRedo => "Undo / Redo",
-            Self::BrowserHistory => "Browser Back / Forward",
-            Self::Tabs => "Previous / Next Tab",
-            Self::Desktops => "Previous / Next Desktop",
-            Self::Tracks => "Previous / Next Track",
-            Self::Volume => "Volume Down / Up",
-            Self::VolumeReversed => "Volume Up / Down",
-            Self::CycleDpi => "Cycle DPI Presets",
-            Self::VerticalScroll => "Vertical Scroll",
-            Self::HorizontalScroll => "Horizontal Scroll",
+    pub(crate) fn label(self) -> String {
+        let pair = self.pair();
+        if pair.backward == pair.forward {
+            return rust_i18n::t!(pair.backward.label()).into_owned();
         }
+        format!(
+            "{} / {}",
+            rust_i18n::t!(pair.backward.label()),
+            rust_i18n::t!(pair.forward.label())
+        )
     }
 
     #[must_use]
@@ -129,6 +132,20 @@ mod tests {
         for (preset, (backward, forward)) in ThumbwheelPreset::ALL.into_iter().zip(expected) {
             assert_eq!(preset.pair(), ThumbwheelPair { backward, forward });
         }
+    }
+
+    #[test]
+    fn label_composes_translated_sides_and_keeps_single_action_undivided() {
+        // Locale-independent shape assertions: a two-action preset renders
+        // both sides around the separator; the one-action preset (CycleDpi)
+        // must not grow one.
+        assert!(ThumbwheelPreset::BackForward.label().contains(" / "));
+        let dpi = ThumbwheelPreset::CycleDpi.label();
+        assert!(!dpi.contains(" / "));
+        assert_eq!(
+            dpi,
+            rust_i18n::t!(Action::CycleDpiPresets.label()).into_owned()
+        );
     }
 
     #[test]

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -637,7 +637,7 @@ fn binding_label_for_control(
                 .unwrap_or_else(|| default_binding(ButtonId::ThumbwheelScrollUp));
             if let Some(preset) = ThumbwheelPreset::recognize(&backward, &forward) {
                 BindingLabel {
-                    text: tr!(preset.label()),
+                    text: preset.label().into(),
                     is_default: preset == ThumbwheelPreset::HorizontalScroll,
                     icon: Some(preset.icon()),
                 }


### PR DESCRIPTION
## Summary
Split out of #764 at review request (@AprilNEA): the preset-label localization fix travels alone so the zoom feature PR stays focused.

The thumb-wheel preset rows rendered flat `"X / Y"` strings that are keys in **no** locale file — every preset row fell back to English regardless of app language. This composes each row label from its two sides' already-translated action names instead:

- per-action names carry translations for all locales, so composition reuses that reviewed coverage instead of adding ~21 locales × 11 presets of new keys;
- `CycleDpi` fires one action in both directions and renders as a single undivided name;
- callers (`picker.rs`, `view.rs`) drop their now-redundant `tr!` wrapping since `label()` returns a localized `String`.

## Testing
- new unit test: two-action presets contain the " / " separator; CycleDpi equals the single translated action name with no separator (locale-independent shape assertions);
- `cargo clippy -p openlogi-desktop --all-targets` clean; all 12 thumbwheel-related desktop tests pass locally.

#764 will rebase on top of this once it lands (its preset entries then need no label() change at all — `pair()` + composition cover them).