### PR TITLE
fix(linux): restore glibc 2.35 package baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -763,11 +763,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # The native build host defines the oldest GLIBC these binaries can
+          # load against. Keep both architectures on the documented 2.35 floor.
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             nfpm_sha256: "d6417f99d5fa32bba7a4e007084615d3897651498c2e443118c26b9ec3b698a8"
           - arch: arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04-arm
             nfpm_sha256: "dc63aa7228ec70490bae67ad3146883055a055639dcf0dffc82fa965bac75a31"
     permissions:
       contents: read
@@ -779,7 +781,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust
-          shared-key: linux-stable-release
+          # Cargo does not include the host GLIBC in its freshness checks. Do
+          # not restore release objects previously linked on Ubuntu 24.04.
+          shared-key: linux-jammy-stable-release
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       # The nfpm `arch` and the runner's native arch must agree — the packages
@@ -821,6 +825,29 @@ jobs:
 
       - name: Build and package
         run: cargo run -p xtask -- linux package
+
+      - name: Verify GLIBC baseline
+        env:
+          MAX_GLIBC_VERSION: "2.35"
+        run: |
+          for binary in openlogi openlogi-desktop openlogi-overlay openlogi-agent; do
+            required=$(
+              readelf --version-info "target/release/$binary" \
+                | sed -n 's/.*Name: GLIBC_\([0-9][0-9.]*\).*/\1/p' \
+                | sort -Vu \
+                | tail -n 1
+            )
+            if [ -z "$required" ]; then
+              echo "could not determine the GLIBC requirement for $binary" >&2
+              exit 1
+            fi
+            echo "$binary requires GLIBC $required"
+            newest=$(printf '%s\n%s\n' "$MAX_GLIBC_VERSION" "$required" | sort -V | tail -n 1)
+            if [ "$newest" != "$MAX_GLIBC_VERSION" ]; then
+              echo "$binary exceeds the GLIBC $MAX_GLIBC_VERSION release baseline" >&2
+              exit 1
+            fi
+          done
 
       - name: Collect packages
         env:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 
 Packages are published for both `x86_64`/`amd64` and `arm64`/`aarch64`.
+Pre-built packages require GLIBC 2.35 or newer (Ubuntu 22.04 baseline).
 
 NixOS users can instead import the repository's module, which installs the
 package and udev rules and starts the agent with the graphical session:

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -12,6 +12,7 @@
 - A kernel with `hidraw` and `uinput` module support (standard on all major
   distros).
 - `systemd` + `udev` (standard on Ubuntu, Fedora, Arch, Debian, openSUSE, …).
+- GLIBC 2.35 or newer for the pre-built packages (Ubuntu 22.04 baseline).
 
 ## NixOS
 


### PR DESCRIPTION
## Summary

Restore Ubuntu 22.04 compatibility for the pre-built Linux packages. The current release's agent, desktop, and overlay binaries require GLIBC 2.39 because they are linked on Ubuntu 24.04; this prevents them from loading on Ubuntu 22.04 and Deepin 25 even though the CLI still runs.

## Changes

- pin native amd64 and arm64 release builds to Ubuntu 22.04
- isolate the Jammy release cache from objects previously linked on Ubuntu 24.04
- reject any packaged binary whose maximum GLIBC symbol version exceeds 2.35
- document the GLIBC 2.35 pre-built package baseline

## Testing

- `actionlint .github/workflows/build.yml`
- `cargo run -p xtask -- linux package --output /tmp/openlogi-packages`
- `cargo run -p xtask -- linux package --output /tmp/openlogi-packages --no-build` after rebasing onto the latest `master`
- ran the new ABI check against all four locally built binaries: CLI/agent require GLIBC 2.34; desktop/overlay require GLIBC 2.35
- ran the ABI check against the v0.7.10 release package and confirmed it rejects the desktop's GLIBC 2.39 requirement
- not runtime-tested on hardware; install the generated package on Ubuntu 22.04 and start `openlogi-agent` and `openlogi-desktop` for end-to-end verification

Fixes #676
