### PR TITLE
fix(gui): restore full-phrase thumb-wheel preset labels

### DIFF
--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -135,7 +135,7 @@ pub(crate) fn thumbwheel_picker<T: 'static>(
         .enumerate()
         .map(|(idx, preset)| {
             let selected = current == Some(preset);
-            let label = preset.label();
+            let label = tr!(preset.label());
             let observer = observer.clone();
             let popover = popover.clone();
             menu_row(("thumbwheel-preset", idx), pal, selected)

--- a/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
+++ b/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
@@ -72,24 +72,21 @@ impl ThumbwheelPreset {
         })
     }
 
-    /// Localized display label, rendered as "<backward> / <forward>" composed
-    /// from each side's already-translated action name. The flat "X / Y"
-    /// strings are keys in no locale file — every preset row used to fall back
-    /// to English regardless of app language — while per-action names carry
-    /// translations for all locales, so composing reuses that reviewed
-    /// coverage instead of duplicating it. CycleDpi fires one action in both
-    /// directions and renders as a single name without the separator.
     #[must_use]
-    pub(crate) fn label(self) -> String {
-        let pair = self.pair();
-        if pair.backward == pair.forward {
-            return rust_i18n::t!(pair.backward.label()).into_owned();
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::BackForward => "Back / Forward",
+            Self::UndoRedo => "Undo / Redo",
+            Self::BrowserHistory => "Browser Back / Forward",
+            Self::Tabs => "Previous / Next Tab",
+            Self::Desktops => "Previous / Next Desktop",
+            Self::Tracks => "Previous / Next Track",
+            Self::Volume => "Volume Down / Up",
+            Self::VolumeReversed => "Volume Up / Down",
+            Self::CycleDpi => "Cycle DPI Presets",
+            Self::VerticalScroll => "Vertical Scroll",
+            Self::HorizontalScroll => "Horizontal Scroll",
         }
-        format!(
-            "{} / {}",
-            rust_i18n::t!(pair.backward.label()),
-            rust_i18n::t!(pair.forward.label())
-        )
     }
 
     #[must_use]
@@ -132,20 +129,6 @@ mod tests {
         for (preset, (backward, forward)) in ThumbwheelPreset::ALL.into_iter().zip(expected) {
             assert_eq!(preset.pair(), ThumbwheelPair { backward, forward });
         }
-    }
-
-    #[test]
-    fn label_composes_translated_sides_and_keeps_single_action_undivided() {
-        // Locale-independent shape assertions: a two-action preset renders
-        // both sides around the separator; the one-action preset (CycleDpi)
-        // must not grow one.
-        assert!(ThumbwheelPreset::BackForward.label().contains(" / "));
-        let dpi = ThumbwheelPreset::CycleDpi.label();
-        assert!(!dpi.contains(" / "));
-        assert_eq!(
-            dpi,
-            rust_i18n::t!(Action::CycleDpiPresets.label()).into_owned()
-        );
     }
 
     #[test]

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -654,7 +654,7 @@ fn binding_label_for_control(
                 .unwrap_or_else(|| default_binding(ButtonId::ThumbwheelScrollUp));
             if let Some(preset) = ThumbwheelPreset::recognize(&backward, &forward) {
                 BindingLabel {
-                    text: preset.label().into(),
+                    text: tr!(preset.label()),
                     is_default: preset == ThumbwheelPreset::HorizontalScroll,
                     icon: Some(preset.icon()),
                 }

--- a/crates/openlogi-desktop/src/services/i18n.rs
+++ b/crates/openlogi-desktop/src/services/i18n.rs
@@ -41,6 +41,8 @@ mod tests {
     fn locale_file_resolves_keys() {
         use openlogi_core::binding::{Action, ButtonId, GestureDirection};
 
+        use crate::features::mouse::thumbwheel::ThumbwheelPreset;
+
         // The accessibility blurb is the longest, most typo-prone key.
         const BLURB: &str = "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.";
 
@@ -100,6 +102,24 @@ mod tests {
                 a.category()
             );
         }
+
+        // Thumb-wheel preset labels are flat full-phrase keys ("Back /
+        // Forward", not a composition of the two action names) with reviewed
+        // translations in every catalog. #910 replaced them with per-action
+        // composition on the wrong belief that these keys were untranslated;
+        // these assertions pin both the coverage and the full-phrase wording
+        // so that diagnosis cannot recur.
+        for preset in ThumbwheelPreset::ALL {
+            assert!(covered(preset.label()), "no zh-CN for {preset:?}");
+        }
+        assert_eq!(
+            rust_i18n::t!(ThumbwheelPreset::BackForward.label()),
+            "后退 / 前进"
+        );
+        assert_eq!(
+            rust_i18n::t!(ThumbwheelPreset::VerticalScroll.label()),
+            "垂直滚动"
+        );
 
         rust_i18n::set_locale("ja");
         assert_eq!(rust_i18n::t!("Settings"), "設定");


### PR DESCRIPTION
## Summary

Reverts #910 and adds a regression test pinning the localized preset labels.

#910's premise — "the flat 'X / Y' strings are keys in no locale file — every preset row used to fall back to English" — is false. Before it merged, all 21 catalogs in `crates/openlogi-ui/locales/` carried dedicated translations for every one of the 11 flat preset labels (verified per file against `24c6e5cd^`: 11/11 keys in each), and both call sites already resolved them at runtime via `tr!(preset.label())` (`rust-i18n` 4 looks up expression keys at runtime).

Composing the label from the two per-action names therefore fixed nothing and regressed 185 of 231 locale × preset display combinations from reviewed full phrases to mechanical concatenations, e.g. zh-CN:

- `后退 / 前进` → `后退（侧键4） / 前进（侧键5）`
- `垂直滚动` → `向下滚动 / 向上滚动`
- `水平滚动` → `向左滚动 / 向右滚动`

It also orphaned the 10 full-phrase keys still present in every catalog.

## Changes

- `openlogi-desktop`: revert 24c6e5cd — `ThumbwheelPreset::label()` returns the flat English key again and the picker/diagram call sites translate it with `tr!`; drops #910's shape-only test (it passed under the old implementation too and proved no translation bug).
- `openlogi-desktop`: extend `locale_file_resolves_keys` to assert every `ThumbwheelPreset` label has a zh-CN entry and to pin two concrete full-phrase values (`后退 / 前进`, `垂直滚动`), so the labels cannot again be mistaken for untranslated keys.

## Testing

- `cargo test -p openlogi-desktop` — 126 passed, 0 failed (Linux)
- `cargo fmt --all -- --check` and `RUSTFLAGS="-D warnings" cargo clippy -p openlogi-desktop --all-targets -- -D warnings` — clean
- Not run locally (Linux box, no prek hooks installed): full-workspace clippy/rustdoc, macOS `--all-targets` tests — covered by CI
- Not runtime-tested on hardware. To verify: set the app language to zh-CN, open a thumb-wheel capable mouse, and check the thumb-wheel binding rows show the full-phrase labels (e.g. `垂直滚动`, not `向下滚动 / 向上滚动`)