### PR TITLE
refactor(gui): componentize free-function builders

### DIFF
--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -2,8 +2,7 @@
 //! section bodies (Buttons, Keys, Pointer, Lighting, Camera, Device).
 
 use gpui::{
-    AnyElement, Context, IntoElement, ParentElement, SharedString, Styled, div,
-    prelude::FluentBuilder as _, px,
+    AnyElement, Context, IntoElement, ParentElement, Styled, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     Disableable as _, Icon, IconName, Selectable as _,
@@ -19,8 +18,8 @@ use openlogi_core::config::ScrollResolution;
 use openlogi_core::device::DeviceKind;
 
 use super::widgets::{
-    add_device_button, back_button, battery_summary, kind_label, panel_card, panel_card_fill,
-    route_label, sidebar_action, status_badge,
+    add_device_button, back_button, battery_summary, kind_label, route_label, sidebar_action,
+    status_badge,
 };
 use super::{AppView, DetailTab};
 use crate::app::menu::file_url;
@@ -35,6 +34,7 @@ use crate::features::mouse::view::MouseModelView;
 use crate::features::pointer::dpi::DpiPanel;
 use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::components::{PanelCard, Toggle};
 use crate::ui::theme::{HEADER_H, Palette, SCREEN_PAD, Typography as _};
 
 /// Device-detail top bar, in three zones: a back affordance + device name
@@ -121,9 +121,9 @@ pub(super) fn detail_content(
         DetailTab::Pointer => {
             pointer_tab(panels.dpi_panel, panels.smartshift_panel, pal, cx).into_any_element()
         }
-        DetailTab::Lighting => lighting_tab(panels.lighting_panel, pal).into_any_element(),
+        DetailTab::Lighting => lighting_tab(panels.lighting_panel).into_any_element(),
         DetailTab::Camera => {
-            camera_tab(panels.camera_preview, panels.camera_controls, pal).into_any_element()
+            camera_tab(panels.camera_preview, panels.camera_controls).into_any_element()
         }
         DetailTab::Light => light_tab(panels.light_panel, pal, cx).into_any_element(),
         DetailTab::Device => device_tab(pal, cx).into_any_element(),
@@ -248,18 +248,22 @@ fn pointer_tab(
                 .items_stretch()
                 .gap_4()
                 .flex_wrap()
-                .child(pointer_grid_card(panel_card_fill(
-                    tr!("Pointer tuning"),
-                    Icon::empty().path("action-icons/gauge.svg"),
-                    pal,
-                    dpi_panel.clone().into_any_element(),
-                )))
-                .child(pointer_grid_card(panel_card_fill(
-                    tr!("SmartShift"),
-                    Icon::empty().path("action-icons/refresh-cw.svg"),
-                    pal,
-                    smartshift_panel.clone().into_any_element(),
-                )))
+                .child(pointer_grid_card(
+                    PanelCard::new(
+                        tr!("Pointer tuning"),
+                        Icon::empty().path("action-icons/gauge.svg"),
+                        dpi_panel.clone().into_any_element(),
+                    )
+                    .fill(),
+                ))
+                .child(pointer_grid_card(
+                    PanelCard::new(
+                        tr!("SmartShift"),
+                        Icon::empty().path("action-icons/refresh-cw.svg"),
+                        smartshift_panel.clone().into_any_element(),
+                    )
+                    .fill(),
+                ))
                 .child(
                     div()
                         .min_w(px(332.))
@@ -313,7 +317,21 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
                         .child(inversion_description),
                 ),
         )
-        .child(invert_scroll_toggle(inverted, inversion_supported, pal));
+        .child(
+            Toggle::new("invert-scroll-toggle")
+                .selected(inverted)
+                .disabled(!inversion_supported)
+                .label((!inversion_supported).then(|| tr!("Unavailable")))
+                .on_change(|inverted, _window, cx| {
+                    AppState::update(cx, |state, cx| {
+                        let key = state.current_record().map(DeviceRecord::device_key);
+                        state.commit_invert_scroll(*inverted);
+                        if let Some(key) = key {
+                            cx.emit(StateEvent::DeviceConfigChanged(key));
+                        }
+                    });
+                }),
+        );
     let resolution_description = if hires_supported {
         match resolution {
             None => tr!("OpenLogi does not change the wheel resolution."),
@@ -342,11 +360,10 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
                         .child(resolution_description),
                 ),
         )
-        .child(wheel_resolution_control(resolution, hires_supported, pal));
-    panel_card(
+        .child(wheel_resolution_control(resolution, hires_supported));
+    PanelCard::new(
         tr!("Scrolling"),
         Icon::empty().path("action-icons/mouse.svg"),
-        pal,
         v_flex()
             .gap_4()
             .child(inversion_row)
@@ -355,11 +372,7 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
     )
 }
 
-fn wheel_resolution_control(
-    selected: Option<ScrollResolution>,
-    enabled: bool,
-    _pal: Palette,
-) -> AnyElement {
+fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -> AnyElement {
     let values = [
         None,
         Some(ScrollResolution::Low),
@@ -402,42 +415,10 @@ fn wheel_resolution_control(
         .into_any_element()
 }
 
-/// On/Off pill that flips the active device's scroll-wheel inversion, mirroring
-/// the SmartShift permanent-ratchet toggle.
-fn invert_scroll_toggle(on: bool, enabled: bool, pal: Palette) -> AnyElement {
-    let label: SharedString = if on { tr!("On") } else { tr!("Off") };
-    if !enabled {
-        return div()
-            .px_2()
-            .py_1()
-            .rounded(pal.control_radius)
-            .border_1()
-            .border_color(pal.border)
-            .text_caption()
-            .text_color(pal.text_muted)
-            .child(tr!("Unavailable"))
-            .into_any_element();
-    }
-    Button::new("invert-scroll-toggle")
-        .compact()
-        .label(label)
-        .selected(on)
-        .on_click(move |_event, _window, cx| {
-            AppState::update(cx, |state, cx| {
-                let key = state.current_record().map(DeviceRecord::device_key);
-                state.commit_invert_scroll(!on);
-                if let Some(key) = key {
-                    cx.emit(StateEvent::DeviceConfigChanged(key));
-                }
-            });
-        })
-        .into_any_element()
-}
-
 /// Lighting tab: the RGB controls (swatches, on/off, brightness) in a titled
 /// card. Shown when the device reports a lighting capability — see
 /// [`DetailTab::tabs_for`].
-fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>, pal: Palette) -> impl IntoElement {
+fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>) -> impl IntoElement {
     v_flex()
         .flex_1()
         .w_full()
@@ -445,10 +426,9 @@ fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>, pal: Palette) -> i
         .items_center()
         .overflow_y_scrollbar()
         .p(px(SCREEN_PAD))
-        .child(div().w_full().max_w(px(560.)).child(panel_card(
+        .child(div().w_full().max_w(px(560.)).child(PanelCard::new(
             tr!("Lighting"),
             Icon::new(IconName::Palette),
-            pal,
             lighting_panel.clone().into_any_element(),
         )))
 }
@@ -462,7 +442,6 @@ fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>, pal: Palette) -> i
 fn camera_tab(
     camera_preview: &gpui::Entity<CameraPreview>,
     camera_controls: &gpui::Entity<CameraControlsPanel>,
-    pal: Palette,
 ) -> impl IntoElement {
     v_flex()
         .flex_1()
@@ -478,16 +457,14 @@ fn camera_tab(
                 .justify_center()
                 .items_start()
                 .gap_3()
-                .child(div().w(px(514.)).flex_shrink_0().child(panel_card(
+                .child(div().w(px(514.)).flex_shrink_0().child(PanelCard::new(
                     tr!("Camera"),
                     Icon::new(IconName::Eye),
-                    pal,
                     camera_preview.clone().into_any_element(),
                 )))
-                .child(div().w(px(500.)).flex_shrink_0().child(panel_card(
+                .child(div().w(px(500.)).flex_shrink_0().child(PanelCard::new(
                     tr!("Camera controls"),
                     Icon::new(IconName::Settings),
-                    pal,
                     camera_controls.clone().into_any_element(),
                 ))),
         )
@@ -533,10 +510,9 @@ fn light_tab(
                 .flex_wrap()
                 .items_start()
                 .child(light_visual::detail(asset, online, enabled, settings, pal))
-                .child(div().w(px(400.)).min_w(px(360.)).child(panel_card(
+                .child(div().w(px(400.)).min_w(px(360.)).child(PanelCard::new(
                     tr!("Lighting"),
                     Icon::new(IconName::Sun),
-                    pal,
                     light_panel.clone().into_any_element(),
                 ))),
         )
@@ -590,12 +566,7 @@ fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElem
             },
         );
 
-    panel_card(
-        tr!("Device details"),
-        Icon::new(IconName::Info),
-        pal,
-        content,
-    )
+    PanelCard::new(tr!("Device details"), Icon::new(IconName::Info), content)
 }
 
 fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
@@ -695,12 +666,7 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
         )
         .into_any_element();
 
-    panel_card(
-        tr!("Configuration"),
-        Icon::new(IconName::Folder),
-        pal,
-        content,
-    )
+    PanelCard::new(tr!("Configuration"), Icon::new(IconName::Folder), content)
 }
 
 fn device_summary(name: &str, kind: DeviceKind, online: bool, pal: Palette) -> impl IntoElement {

--- a/crates/openlogi-desktop/src/app/widgets.rs
+++ b/crates/openlogi-desktop/src/app/widgets.rs
@@ -3,11 +3,10 @@
 //! screens.
 
 use gpui::{
-    AnyElement, Context, IntoElement, ParentElement, SharedString, Styled, div,
-    prelude::FluentBuilder as _, px, relative, rgb,
+    AnyElement, Context, IntoElement, ParentElement, SharedString, Styled, div, px, relative, rgb,
 };
 use gpui_component::{
-    Icon, IconName, Sizable as _,
+    IconName, Sizable as _,
     button::{Button, ButtonVariants as _},
     h_flex, v_flex,
 };
@@ -68,58 +67,6 @@ pub(super) fn main_window_title(show_device: bool, cx: &Context<AppView>) -> Sha
         .map_or_else(
             || SharedString::from("OpenLogi"),
             |record| SharedString::from(format!("OpenLogi - {}", record.display_name)),
-        )
-}
-
-pub(super) fn panel_card(
-    title: SharedString,
-    icon: Icon,
-    pal: Palette,
-    content: AnyElement,
-) -> impl IntoElement {
-    panel_card_inner(title, icon, pal, content, false)
-}
-
-pub(super) fn panel_card_fill(
-    title: SharedString,
-    icon: Icon,
-    pal: Palette,
-    content: AnyElement,
-) -> impl IntoElement {
-    panel_card_inner(title, icon, pal, content, true)
-}
-
-fn panel_card_inner(
-    title: SharedString,
-    icon: Icon,
-    pal: Palette,
-    content: AnyElement,
-    fill_height: bool,
-) -> impl IntoElement {
-    div()
-        .w_full()
-        .when(fill_height, gpui::Styled::h_full)
-        .max_w_full()
-        .min_w_0()
-        .rounded(pal.card_radius)
-        .border_1()
-        .border_color(pal.border)
-        .bg(pal.surface)
-        .p(px(theme::CARD_PAD))
-        .child(
-            v_flex()
-                .gap(px(theme::CARD_GAP))
-                .when(!title.is_empty(), |this| {
-                    this.child(
-                        h_flex()
-                            .items_center()
-                            .gap_2()
-                            .text_color(pal.text_primary)
-                            .child(icon.size_4().text_color(pal.text_muted))
-                            .child(div().text_subheading().child(title)),
-                    )
-                })
-                .child(content),
         )
 }
 

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -18,7 +18,7 @@ use gpui::{
     prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::{
-    h_flex,
+    Selectable as _, h_flex,
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
 };
@@ -27,6 +27,7 @@ use openlogi_core::config::CameraControls;
 use tracing::debug;
 
 use crate::state::{AppState, StateEvent};
+use crate::ui::components::ProfileTab;
 use crate::ui::section::section_label;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
@@ -720,7 +721,7 @@ impl Render for CameraControlsPanel {
         let lens: Vec<usize> = section_indices(&self.sliders, true);
         let image: Vec<usize> = section_indices(&self.sliders, false);
 
-        let mut panel = v_flex().gap_2().w_full().child(profiles_row(&key, pal, cx));
+        let mut panel = v_flex().gap_2().w_full().child(profiles_row(&key, cx));
         if !lens.is_empty() && !image.is_empty() {
             panel = panel.child(section_label(tr!("Lens"), pal).mt_1());
         }
@@ -754,7 +755,7 @@ fn section_indices(sliders: &[ControlSlider], lens: bool) -> Vec<usize> {
 }
 
 /// The one-click profile chips: built-ins, saved customs, then Save.
-fn profiles_row(key: &str, pal: Palette, cx: &mut Context<CameraControlsPanel>) -> AnyElement {
+fn profiles_row(key: &str, cx: &mut Context<CameraControlsPanel>) -> AnyElement {
     let state = AppState::try_read(cx);
     let active = state.and_then(|s| s.camera_active_profile(key));
     let customs: Vec<String> = state
@@ -764,115 +765,39 @@ fn profiles_row(key: &str, pal: Palette, cx: &mut Context<CameraControlsPanel>) 
     let mut row = h_flex().flex_wrap().gap_1p5().items_center();
     for (ix, builtin) in BUILTIN_PROFILES.iter().enumerate() {
         let id = builtin.id;
-        row = row.child(profile_chip(
-            ("camera-profile-builtin", ix),
-            builtin_label(id),
-            active.as_deref() == Some(id),
-            pal,
-            cx.listener(move |panel, _: &ClickEvent, window, cx| {
-                panel.apply_profile(id, window, cx);
-            }),
-        ));
+        row = row.child(
+            ProfileTab::new(("camera-profile-builtin", ix), builtin_label(id))
+                .selected(active.as_deref() == Some(id))
+                .on_click(cx.listener(move |panel, _: &ClickEvent, window, cx| {
+                    panel.apply_profile(id, window, cx);
+                })),
+        );
     }
     for (ix, name) in customs.into_iter().enumerate() {
         let is_active = active.as_deref() == Some(name.as_str());
-        row = row.child(custom_profile_chip(ix, name, is_active, pal, cx));
+        let apply_name = name.clone();
+        let delete_name = name.clone();
+        let on_apply = cx.listener(move |panel, _: &ClickEvent, window, cx| {
+            panel.apply_profile(&apply_name, window, cx);
+        });
+        let on_delete = cx.listener(move |panel, _: &ClickEvent, _window, cx| {
+            panel.delete_profile(&delete_name, cx);
+        });
+        row = row.child(
+            ProfileTab::new(("camera-profile-custom", ix), name)
+                .selected(is_active)
+                .on_click(on_apply)
+                .on_delete(("camera-profile-del", ix), on_delete),
+        );
     }
     row = row.child(
-        div()
-            .id("camera-profile-save")
-            .px_2()
-            .py_0p5()
-            .rounded_full()
-            .border_1()
-            .border_color(pal.border)
-            .text_caption()
-            .text_color(pal.text_muted)
-            .hover(|s| s.bg(pal.surface_hover))
-            .child(format!("+ {}", tr!("New")))
-            .on_click(cx.listener(|panel, _: &ClickEvent, _window, cx| {
+        ProfileTab::new("camera-profile-save", format!("+ {}", tr!("New"))).on_click(cx.listener(
+            |panel, _: &ClickEvent, _window, cx| {
                 panel.save_profile(cx);
-            })),
+            },
+        )),
     );
     row.into_any_element()
-}
-
-fn profile_chip(
-    id: (&'static str, usize),
-    label: SharedString,
-    active: bool,
-    pal: Palette,
-    on_click: impl Fn(&ClickEvent, &mut Window, &mut gpui::App) + 'static,
-) -> AnyElement {
-    let accent = rgb(ACCENT_BLUE);
-    div()
-        .id(id)
-        .px_2()
-        .py_0p5()
-        .rounded_full()
-        .border_1()
-        .border_color(if active { accent.into() } else { pal.border })
-        .text_caption()
-        .text_color(if active {
-            accent.into()
-        } else {
-            pal.text_muted
-        })
-        .when(active, |s| s.bg(pal.surface))
-        .hover(move |s| s.bg(pal.surface_hover))
-        .child(label)
-        .on_click(on_click)
-        .into_any_element()
-}
-
-/// A saved custom profile's chip: click applies it, the trailing `×` deletes
-/// it (stopping propagation so a delete never also applies the profile).
-fn custom_profile_chip(
-    ix: usize,
-    name: String,
-    active: bool,
-    pal: Palette,
-    cx: &mut Context<CameraControlsPanel>,
-) -> AnyElement {
-    let accent = rgb(ACCENT_BLUE);
-    let apply_name = name.clone();
-    let delete_name = name.clone();
-    h_flex()
-        .id(("camera-profile-custom", ix))
-        .pl_2()
-        .pr_1()
-        .py_0p5()
-        .gap_1()
-        .items_center()
-        .rounded_full()
-        .border_1()
-        .border_color(if active { accent.into() } else { pal.border })
-        .text_caption()
-        .text_color(if active {
-            accent.into()
-        } else {
-            pal.text_muted
-        })
-        .when(active, |s| s.bg(pal.surface))
-        .hover(move |s| s.bg(pal.surface_hover))
-        .child(SharedString::from(name))
-        .on_click(cx.listener(move |panel, _: &ClickEvent, window, cx| {
-            panel.apply_profile(&apply_name, window, cx);
-        }))
-        .child(
-            div()
-                .id(("camera-profile-del", ix))
-                .px_0p5()
-                .rounded_full()
-                .text_color(pal.text_muted)
-                .hover(|s| s.text_color(gpui::white()))
-                .child("×")
-                .on_click(cx.listener(move |panel, _: &ClickEvent, _window, cx| {
-                    cx.stop_propagation();
-                    panel.delete_profile(&delete_name, cx);
-                })),
-        )
-        .into_any_element()
 }
 
 /// One compact control line: label · slider · live value (· Auto chip when the

--- a/crates/openlogi-desktop/src/features/keyboard/editors.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/editors.rs
@@ -30,8 +30,9 @@ use openlogi_core::binding::{Action, KeyCombo, WorkflowStep};
 use openlogi_core::config::KeyTrigger;
 
 use super::function_row::FunctionRowView;
-use crate::features::mouse::picker::{divider, menu_card, menu_row, scroll_list, title};
+use crate::features::mouse::picker::{divider, menu_card, scroll_list, title};
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::components::MenuRow;
 use crate::ui::theme::{Palette, Typography as _};
 
 /// Which power-user editor is showing for the selected key.
@@ -267,7 +268,7 @@ fn workflow_step_row(
     };
     let view_remove = view.clone();
 
-    menu_row(("wf-step", idx), pal, false)
+    MenuRow::new(("wf-step", idx))
         .child(
             h_flex()
                 .w_full()

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -12,8 +12,7 @@
 
 #![expect(
     clippy::needless_pass_by_value,
-    clippy::too_many_arguments,
-    reason = "GPUI builders take owned Copy palette values and slot tables"
+    reason = "GPUI builders take owned Copy palette values"
 )]
 // Not `expect`: these fire inside `assert_eq!`, and rustc does not credit an
 // expectation with a lint raised in a macro expansion.
@@ -26,11 +25,12 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, AppContext as _, Bounds, Context, Entity, FontWeight, Hsla, InteractiveElement,
-    IntoElement, ParentElement, PathBuilder, Render, StatefulInteractiveElement as _, Styled,
-    Subscription, Window, canvas, div, hsla, point, prelude::FluentBuilder as _, px, rgb, svg,
+    AnyElement, App, AppContext as _, Bounds, Context, Entity, FontWeight, Hsla,
+    InteractiveElement, IntoElement, ParentElement, PathBuilder, Render, RenderOnce,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, point,
+    prelude::FluentBuilder as _, px, rgb, svg,
 };
-use gpui_component::{h_flex, input::InputState, v_flex};
+use gpui_component::{Selectable as _, h_flex, input::InputState, v_flex};
 use openlogi_core::binding::{Action, WorkflowStep};
 use openlogi_core::config::{KeyModifiers, KeyTrigger};
 
@@ -40,11 +40,11 @@ use super::editors::{
 use crate::app::{glow_canvas, keyboard_glow};
 use crate::features::mouse::geometry::asset_dimensions_for_png;
 use crate::features::mouse::picker::{
-    PickFn, action_icon_path, action_rows, divider, menu_card, menu_row, popover_section,
-    scroll_list,
+    PickFn, action_icon_path, action_rows, divider, menu_card, popover_section, scroll_list,
 };
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::components::MenuRow;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 use gpui::ease_in_out;
 use gpui::{Animation, AnimationExt, img};
@@ -248,7 +248,6 @@ type StateSnapshot = (
 
 impl Render for FunctionRowView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let pal = theme::palette(cx);
         let (asset, bindings, glow): StateSnapshot = AppState::try_read(cx)
             .map(|s| {
                 (
@@ -325,27 +324,18 @@ impl Render for FunctionRowView {
                 }
             }
         }
-        let text_state = self.text_state.clone();
-        let workflow_draft = self.workflow_draft.clone();
         let view = cx.entity();
+        let keyboard = KeyboardPane::new(slots.clone(), asset, glow, render_size, view.clone())
+            .selected(selected)
+            .hovered(hovered);
+        let panel = selected.map(|selected| self.config_panel(selected, &slots, &view, cx));
 
         // The whole row animates as one: when a key is selected the right-side
         // panel grows in and the keyboard nudges left to make room.
-        v_flex().w_full().items_center().child(inspector_row(
-            slots,
-            asset,
-            glow,
-            render_size,
-            selected,
-            hovered,
-            active_editor,
-            text_state,
-            workflow_draft,
-            &view,
-            &pal,
-            window,
-            cx,
-        ))
+        v_flex()
+            .w_full()
+            .items_center()
+            .child(InspectorRow::new(keyboard).panel(panel))
     }
 }
 
@@ -373,92 +363,116 @@ struct KeySlot {
     bound: Option<Action>,
 }
 
-/// The two-pane row: keyboard photo + (when a key is selected) the side panel.
-fn inspector_row(
+/// The two-pane row: keyboard photo + an optional side panel.
+#[derive(IntoElement)]
+struct InspectorRow {
+    keyboard: AnyElement,
+    panel: Option<AnyElement>,
+}
+
+impl InspectorRow {
+    fn new(keyboard: impl IntoElement) -> Self {
+        Self {
+            keyboard: keyboard.into_any_element(),
+            panel: None,
+        }
+    }
+
+    #[must_use]
+    fn panel(mut self, panel: impl Into<Option<AnyElement>>) -> Self {
+        self.panel = panel.into();
+        self
+    }
+}
+
+impl RenderOnce for InspectorRow {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let Some(panel) = self.panel else {
+            return h_flex()
+                .w_full()
+                .justify_center()
+                .child(self.keyboard)
+                .into_any_element();
+        };
+
+        // The panel grows in from width 0 → PANEL_W over SLIDE_MS, easing in/out,
+        // always on the right as a stable inspector.
+        let animated_panel = div().overflow_hidden().child(panel).with_animation(
+            "panel-slide",
+            Animation::new(std::time::Duration::from_millis(SLIDE_MS)).with_easing(ease_in_out),
+            |element, delta| element.w(px(PANEL_W * delta)),
+        );
+
+        h_flex()
+            .w_full()
+            .gap_5()
+            .items_center()
+            .justify_center()
+            .child(self.keyboard)
+            .child(animated_panel)
+            .into_any_element()
+    }
+}
+
+/// The keyboard photo with callout bubbles above each function key, leader
+/// lines, and invisible click-targets over the real keys.
+#[derive(IntoElement)]
+struct KeyboardPane {
     slots: Vec<KeySlot>,
     asset: Option<ResolvedAsset>,
     glow: Option<(Arc<GlowGeometry>, Hsla)>,
     render_size: (f32, f32),
     selected: Option<usize>,
     hovered: Option<usize>,
-    active_editor: Option<PowerUserKind>,
-    text_state: Option<Entity<InputState>>,
-    workflow_draft: Vec<WorkflowStep>,
-    view: &Entity<FunctionRowView>,
-    pal: &Palette,
-    window: &mut Window,
-    cx: &mut Context<FunctionRowView>,
-) -> impl IntoElement {
-    let keyboard = keyboard_pane(
-        slots.clone(),
-        asset.as_ref(),
-        glow,
-        render_size,
-        selected,
-        hovered,
-        view,
-        pal,
-    );
-
-    // When nothing is selected, just the keyboard, full width.
-    let Some(selected) = selected else {
-        return h_flex()
-            .w_full()
-            .justify_center()
-            .child(keyboard)
-            .into_any_element();
-    };
-
-    let panel = config_panel(
-        selected,
-        &slots,
-        active_editor,
-        text_state,
-        workflow_draft,
-        view,
-        pal,
-        window,
-        cx,
-    );
-
-    // The panel grows in from width 0 → PANEL_W over SLIDE_MS, easing in/out,
-    // always on the right as a stable inspector.
-    let animated_panel = div().overflow_hidden().child(panel).with_animation(
-        "panel-slide",
-        Animation::new(std::time::Duration::from_millis(SLIDE_MS)).with_easing(ease_in_out),
-        |el, delta| el.w(px(PANEL_W * delta)),
-    );
-
-    h_flex()
-        .w_full()
-        .gap_5()
-        .items_center()
-        .justify_center()
-        .child(keyboard)
-        .child(animated_panel)
-        .into_any_element()
+    view: Entity<FunctionRowView>,
 }
 
-/// The keyboard photo with callout bubbles above each function key, leader
-/// lines, and invisible click-targets over the real keys.
-fn keyboard_pane(
-    slots: Vec<KeySlot>,
-    asset: Option<&ResolvedAsset>,
-    glow: Option<(Arc<GlowGeometry>, Hsla)>,
-    (img_w, img_h): (f32, f32),
-    selected: Option<usize>,
-    hovered: Option<usize>,
-    view: &Entity<FunctionRowView>,
-    pal: &Palette,
-) -> impl IntoElement {
-    let img_path = asset.map(|a| a.image_path.clone());
-    let view_clone = view.clone();
+impl KeyboardPane {
+    fn new(
+        slots: Vec<KeySlot>,
+        asset: Option<ResolvedAsset>,
+        glow: Option<(Arc<GlowGeometry>, Hsla)>,
+        render_size: (f32, f32),
+        view: Entity<FunctionRowView>,
+    ) -> Self {
+        Self {
+            slots,
+            asset,
+            glow,
+            render_size,
+            selected: None,
+            hovered: None,
+            view,
+        }
+    }
 
-    div()
-        .relative()
-        .w(px(img_w))
-        .h(px(CALLOUT_BAND_H + img_h))
-        .child(
+    #[must_use]
+    fn selected(mut self, selected: impl Into<Option<usize>>) -> Self {
+        self.selected = selected.into();
+        self
+    }
+
+    #[must_use]
+    fn hovered(mut self, hovered: impl Into<Option<usize>>) -> Self {
+        self.hovered = hovered.into();
+        self
+    }
+}
+
+impl RenderOnce for KeyboardPane {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let (img_w, img_h) = self.render_size;
+        let img_path = self.asset.map(|asset| asset.image_path);
+        let view_clone = self.view;
+        let selected = self.selected;
+        let hovered = self.hovered;
+        let pal = theme::palette(cx);
+
+        div()
+            .relative()
+            .w(px(img_w))
+            .h(px(CALLOUT_BAND_H + img_h))
+            .child(
             div()
                 .absolute()
                 .top(px(CALLOUT_BAND_H))
@@ -469,38 +483,39 @@ fn keyboard_pane(
                 // keys occlude it and the colour only reads through the
                 // inter-key gaps — same treatment as the home gallery and the
                 // mouse model.
-                .when_some(glow, |this, (geom, color)| {
+                    .when_some(self.glow, |this, (geom, color)| {
                     this.child(glow_canvas(geom, color))
                 })
-                .child(image_or_fallback(img_path, img_w, img_h, pal)),
-        )
-        .child(keyboard_leader_canvas(
-            slots.clone(),
-            selected,
-            hovered,
-            (img_w, img_h),
-        ))
-        .children({
-            let count = slots.len();
-            let view_for_callouts = view_clone.clone();
-            slots.iter().cloned().map(move |s| {
-                let highlighted = key_is_highlighted(s.idx, selected, hovered);
-                key_callout(s, count, highlighted, img_w, &view_for_callouts, pal)
+                    .child(image_or_fallback(img_path, img_w, img_h, &pal)),
+            )
+            .child(keyboard_leader_canvas(
+                self.slots.clone(),
+                selected,
+                hovered,
+                (img_w, img_h),
+            ))
+            .children({
+                let count = self.slots.len();
+                let view_for_callouts = view_clone.clone();
+                self.slots.iter().cloned().map(move |slot| {
+                    let highlighted = key_is_highlighted(slot.idx, selected, hovered);
+                    key_callout(slot, count, highlighted, img_w, &view_for_callouts, &pal)
+                })
             })
-        })
-        // Click-targets overlay, centered on each key's marker point.
-        .child(
-            div()
-                .absolute()
-                .top(px(CALLOUT_BAND_H))
-                .left(px(0.))
-                .w(px(img_w))
-                .h(px(img_h))
-                .children(slots.into_iter().map(|s| {
-                    let highlighted = key_is_highlighted(s.idx, selected, hovered);
-                    key_click_target(s, highlighted, (img_w, img_h), &view_clone, pal)
+            // Click-targets overlay, centered on each key's marker point.
+            .child(
+                div()
+                    .absolute()
+                    .top(px(CALLOUT_BAND_H))
+                    .left(px(0.))
+                    .w(px(img_w))
+                    .h(px(img_h))
+                    .children(self.slots.into_iter().map(|slot| {
+                    let highlighted = key_is_highlighted(slot.idx, selected, hovered);
+                    key_click_target(slot, highlighted, (img_w, img_h), &view_clone)
                 })),
-        )
+            )
+    }
 }
 
 /// One callout bubble in the band above the keyboard.
@@ -609,7 +624,6 @@ fn key_click_target(
     highlighted: bool,
     (img_w, img_h): (f32, f32),
     view: &Entity<FunctionRowView>,
-    _pal: &Palette,
 ) -> AnyElement {
     let idx = slot.idx;
     let x_frac = slot.x_frac;
@@ -776,58 +790,58 @@ fn callout_lane_is_lower(idx: usize) -> bool {
 /// The scrollable config panel for the selected key. Lists the same action
 /// catalog the mouse picker uses, plus a Power User section. Renders the rows
 /// directly (no popover) in a tall card.
-fn config_panel(
-    selected_idx: usize,
-    slots: &[KeySlot],
-    active_editor: Option<PowerUserKind>,
-    text_state: Option<Entity<InputState>>,
-    workflow_draft: Vec<WorkflowStep>,
-    view: &Entity<FunctionRowView>,
-    pal: &Palette,
-    _window: &mut Window,
-    cx: &mut Context<FunctionRowView>,
-) -> impl IntoElement {
-    let slot = &slots[selected_idx];
-    let trigger = slot.trigger.clone();
-    let key_name = trigger.to_string();
+impl FunctionRowView {
+    fn config_panel(
+        &self,
+        selected_idx: usize,
+        slots: &[KeySlot],
+        view: &Entity<Self>,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let pal = theme::palette(cx);
+        let slot = &slots[selected_idx];
+        let trigger = slot.trigger.clone();
+        let key_name = trigger.to_string();
 
-    // If an editor is active, render it instead of the list.
-    if let Some(kind) = active_editor {
-        return super::editors::editor_card(
-            trigger,
-            kind,
-            text_state,
-            workflow_draft,
-            view,
-            *pal,
-            cx,
-        );
-    }
+        // If an editor is active, render it instead of the list.
+        if let Some(kind) = self.active_editor {
+            return super::editors::editor_card(
+                trigger,
+                kind,
+                self.text_state.clone(),
+                self.workflow_draft.clone(),
+                view,
+                pal,
+                cx,
+            );
+        }
 
-    let current = AppState::try_read(cx).and_then(|s| s.keyboard_bindings.get(&trigger).cloned());
+        let current =
+            AppState::try_read(cx).and_then(|s| s.keyboard_bindings.get(&trigger).cloned());
 
-    let view_for_pick = view.clone();
-    let trigger_for_pick = trigger.clone();
-    let on_pick: PickFn = Rc::new(move |action, _window, cx| {
-        AppState::update(cx, |state, cx| {
-            let key = state.current_record().map(DeviceRecord::device_key);
-            state.commit_keyboard_binding(trigger_for_pick.clone(), Some(action));
-            if let Some(key) = key {
-                cx.emit(StateEvent::BindingsChanged(key));
-            }
+        let view_for_pick = view.clone();
+        let trigger_for_pick = trigger.clone();
+        let on_pick: PickFn = Rc::new(move |action, _window, cx| {
+            AppState::update(cx, |state, cx| {
+                let key = state.current_record().map(DeviceRecord::device_key);
+                state.commit_keyboard_binding(trigger_for_pick.clone(), Some(action));
+                if let Some(key) = key {
+                    cx.emit(StateEvent::BindingsChanged(key));
+                }
+            });
+            view_for_pick.update(cx, |_, vcx| vcx.notify());
         });
-        view_for_pick.update(cx, |_, vcx| vcx.notify());
-    });
 
-    let rows = panel_action_rows(current.as_ref(), &on_pick, view, pal);
+        let rows = panel_action_rows(current.as_ref(), &on_pick, view, &pal);
 
-    menu_card(*pal)
-        .w(px(PANEL_W))
-        .max_h(px(500.))
-        .child(title_header(&key_name, pal))
-        .child(divider(*pal))
-        .child(scroll_list("key-panel-scroll", rows))
-        .into_any_element()
+        menu_card(pal)
+            .w(px(PANEL_W))
+            .max_h(px(500.))
+            .child(title_header(&key_name, &pal))
+            .child(divider(pal))
+            .child(scroll_list("key-panel-scroll", rows))
+            .into_any_element()
+    }
 }
 
 /// The panel's title — shows which key is selected, e.g. "F1".
@@ -897,7 +911,8 @@ fn panel_action_rows(
                 | (Some(Action::Workflow(_)), PowerUserKind::Workflow)
         );
         children.push(
-            menu_row(format!("panel-power-{idx}"), *pal, selected)
+            MenuRow::new(format!("panel-power-{idx}"))
+                .selected(selected)
                 .child(
                     h_flex()
                         .items_center()

--- a/crates/openlogi-desktop/src/features/lighting/device.rs
+++ b/crates/openlogi-desktop/src/features/lighting/device.rs
@@ -10,7 +10,7 @@ use gpui::{
     Render, StatefulInteractiveElement as _, Styled, Subscription, Window, div, px, rgb,
 };
 use gpui_component::{
-    h_flex,
+    Selectable as _, h_flex,
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
 };
@@ -18,7 +18,8 @@ use openlogi_core::color::Rgb;
 use openlogi_core::config::Lighting;
 
 use crate::state::{AppState, DeviceRecord, StateEvent};
-use crate::ui::theme::{self, Palette, SelectableStyle, Typography as _};
+use crate::ui::components::Toggle;
+use crate::ui::theme::{self, Palette, Typography as _};
 
 const SWATCH: f32 = 28.;
 
@@ -133,7 +134,21 @@ impl Render for LightingPanel {
                             .text_color(pal.text_muted)
                             .child(tr!("Lighting")),
                     )
-                    .child(toggle(&lighting, pal)),
+                    .child(
+                        Toggle::new("light-toggle")
+                            .selected(lighting.enabled)
+                            .on_change(|enabled, _window, cx| {
+                                AppState::update(cx, |state, cx| {
+                                    let key = state.current_record().map(DeviceRecord::device_key);
+                                    let mut next = state.lighting();
+                                    next.enabled = *enabled;
+                                    state.commit_lighting(next);
+                                    if let Some(key) = key {
+                                        cx.emit(StateEvent::LightingChanged(key));
+                                    }
+                                });
+                            }),
+                    ),
             )
             .child(h_flex().gap_2().flex_wrap().children(swatches))
             .child(
@@ -178,34 +193,6 @@ fn swatch(idx: usize, color: Rgb, current: &Lighting, pal: Palette) -> AnyElemen
                 let mut next = state.lighting();
                 next.enabled = true;
                 next.color = color;
-                state.commit_lighting(next);
-                if let Some(key) = key {
-                    cx.emit(StateEvent::LightingChanged(key));
-                }
-            });
-        })
-        .into_any_element()
-}
-
-/// On/off pill.
-fn toggle(current: &Lighting, pal: Palette) -> AnyElement {
-    let on = current.enabled;
-    div()
-        .id("light-toggle")
-        .px_2()
-        .py_1()
-        .rounded(pal.control_radius)
-        .selected_border(on, pal)
-        .selected_fill(on)
-        .text_caption()
-        .text_color(if on { pal.text_primary } else { pal.text_muted })
-        .cursor_pointer()
-        .child(if on { tr!("On") } else { tr!("Off") })
-        .on_click(|_event, _window, cx| {
-            AppState::update(cx, |state, cx| {
-                let key = state.current_record().map(DeviceRecord::device_key);
-                let mut next = state.lighting();
-                next.enabled = !next.enabled;
                 state.commit_lighting(next);
                 if let Some(key) = key {
                     cx.emit(StateEvent::LightingChanged(key));

--- a/crates/openlogi-desktop/src/features/lighting/standalone.rs
+++ b/crates/openlogi-desktop/src/features/lighting/standalone.rs
@@ -1,14 +1,14 @@
 //! Controls for standalone lights.
 
 use crate::state::{AppState, DeviceRecord, LightCommandStatus, StateEvent};
-use crate::ui::theme::{self, ACCENT_BLUE, Palette, SelectableStyle as _, Typography as _};
+use crate::ui::components::Toggle;
+use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 use gpui::{
-    App, AppContext as _, BoxShadow, Context, Entity, Hsla, InteractiveElement, IntoElement,
-    ParentElement, Render, StatefulInteractiveElement as _, Styled, Subscription, Window, div,
-    hsla, point, prelude::FluentBuilder as _, px, rgb,
+    App, AppContext as _, BoxShadow, Context, Entity, Hsla, IntoElement, ParentElement, Render,
+    Styled, Subscription, Window, div, hsla, point, prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_component::{
-    Icon, IconName, h_flex,
+    Icon, IconName, Selectable as _, h_flex,
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
 };
@@ -274,7 +274,21 @@ fn light_hero(
                 .child(div().text_heading().child(device_name.to_owned()))
                 .child(light_status(online, effective_enabled, pal)),
         )
-        .child(toggle(effective_enabled, pal))
+        .child(
+            Toggle::new("standalone-light-toggle")
+                .selected(effective_enabled)
+                .icon(if effective_enabled {
+                    IconName::Sun
+                } else {
+                    IconName::Moon
+                })
+                .min_width(px(72.))
+                .on_change(|enabled, _window, cx| {
+                    update_light(cx, |state| {
+                        state.commit_manual_light_power(*enabled);
+                    });
+                }),
+        )
 }
 
 fn light_emblem(enabled: bool, pal: Palette) -> impl IntoElement {
@@ -357,34 +371,13 @@ fn camera_automation(current: LightSettings, pal: Palette) -> impl IntoElement {
                 ))),
         )
         .child(
-            h_flex()
-                .id("standalone-light-camera-automation")
-                .min_w(px(72.))
-                .justify_center()
-                .items_center()
-                .gap_2()
-                .px_3()
-                .py_2()
-                .rounded(pal.control_radius)
-                .selected_border(current.auto_camera, pal)
-                .selected_fill(current.auto_camera)
-                .text_caption()
-                .text_color(if current.auto_camera {
-                    pal.text_primary
-                } else {
-                    pal.text_muted
-                })
-                .cursor_pointer()
-                .hover(|style| style.bg(pal.surface_hover))
-                .child(if current.auto_camera {
-                    tr!("On")
-                } else {
-                    tr!("Off")
-                })
-                .on_click(|_event, _window, cx| {
+            Toggle::new("standalone-light-camera-automation")
+                .selected(current.auto_camera)
+                .min_width(px(72.))
+                .on_change(|auto_camera, _window, cx| {
                     update_light(cx, |state| {
                         let mut light = state.light();
-                        light.auto_camera = !light.auto_camera;
+                        light.auto_camera = *auto_camera;
                         state.commit_light(light);
                     });
                 }),
@@ -444,33 +437,6 @@ fn control_well(
                 .child(endpoints.0)
                 .child(endpoints.1),
         )
-}
-
-fn toggle(effective_enabled: bool, pal: Palette) -> impl IntoElement {
-    let on = effective_enabled;
-    let icon = if on { IconName::Sun } else { IconName::Moon };
-    h_flex()
-        .id("standalone-light-toggle")
-        .min_w(px(72.))
-        .justify_center()
-        .items_center()
-        .gap_2()
-        .px_3()
-        .py_2()
-        .rounded(pal.control_radius)
-        .selected_border(on, pal)
-        .selected_fill(on)
-        .text_caption()
-        .text_color(if on { pal.text_primary } else { pal.text_muted })
-        .cursor_pointer()
-        .hover(|style| style.bg(pal.surface_hover))
-        .child(Icon::new(icon).size_3())
-        .child(if on { tr!("On") } else { tr!("Off") })
-        .on_click(move |_event, _window, cx| {
-            update_light(cx, |state| {
-                state.commit_manual_light_power(!state.light_enabled());
-            });
-        })
 }
 
 fn format_range_endpoints(range: LightValueRange) -> (String, String) {

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -29,7 +29,7 @@ use gpui::{
     StatefulInteractiveElement as _, Styled, Window, div, prelude::FluentBuilder as _, px, rgb,
     svg,
 };
-use gpui_component::{Icon, IconName, h_flex, popover::PopoverState, v_flex};
+use gpui_component::{Icon, IconName, Selectable as _, h_flex, popover::PopoverState, v_flex};
 use openlogi_core::binding::{
     Action, ButtonId, Category, GestureDirection, default_binding, default_gesture_binding,
 };
@@ -37,6 +37,7 @@ use openlogi_core::binding::{
 use super::thumbwheel::ThumbwheelPreset;
 use super::view::MouseModelView;
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::components::MenuRow;
 use crate::ui::section::section_label;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, SelectableStyle, Typography as _};
 
@@ -138,7 +139,8 @@ pub(crate) fn thumbwheel_picker<T: 'static>(
             let label = tr!(preset.label());
             let observer = observer.clone();
             let popover = popover.clone();
-            menu_row(("thumbwheel-preset", idx), pal, selected)
+            MenuRow::new(("thumbwheel-preset", idx))
+                .selected(selected)
                 .child(
                     h_flex()
                         .items_center()
@@ -203,7 +205,7 @@ fn gesture_mode_row<T: 'static>(
 ) -> AnyElement {
     let observer = observer.clone();
     let popover = popover.clone();
-    menu_row("gesture-mode-row", pal, false)
+    MenuRow::new("gesture-mode-row")
         .child(
             h_flex()
                 .items_center()
@@ -354,7 +356,7 @@ fn plus_card(
         .child(
             // Demote back to a single action: the Click arm becomes the
             // button's action, and the reopened popover shows the plain picker.
-            menu_row("gesture-off-row", pal, false)
+            MenuRow::new("gesture-off-row")
                 .child(
                     h_flex()
                         .items_center()
@@ -589,7 +591,8 @@ pub(crate) fn action_rows(
             let row_id = idx;
             idx += 1;
             children.push(
-                menu_row((id_prefix, row_id), pal, selected)
+                MenuRow::new((id_prefix, row_id))
+                    .selected(selected)
                     .role(Role::MenuItem)
                     .aria_label(accessible_label)
                     .aria_selected(selected)
@@ -619,38 +622,6 @@ pub(crate) fn action_rows(
         }
     }
     children
-}
-
-/// A clickable, full-width menu row: `text-sm`, children spread left/right.
-/// The label stays in `text_primary` in both states for readability; selection
-/// is shown by a subtle accent fill (plus the caller's trailing check), and the
-/// fill deepens on hover. Unselected rows are transparent at rest, neutral on
-/// hover. One accent, one signal per state — no blue label text (which fails AA
-/// contrast on the near-white surface).
-pub(crate) fn menu_row(
-    id: impl Into<gpui::ElementId>,
-    pal: Palette,
-    selected: bool,
-) -> gpui::Stateful<gpui::Div> {
-    h_flex()
-        .id(id)
-        .w_full()
-        .items_center()
-        .justify_between()
-        .gap_2()
-        .px_2()
-        .py_1p5()
-        .rounded(pal.control_radius)
-        .text_body()
-        .text_color(pal.text_primary)
-        .selected_fill(selected)
-        .hover(move |s| {
-            s.bg(if selected {
-                theme::accent_tint_hover()
-            } else {
-                pal.surface_hover
-            })
-        })
 }
 
 /// A group heading in a popover list, inset to line up with the rows under it.

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -175,17 +175,16 @@ impl Render for MouseModelView {
         let labels_outer = labels.clone();
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
         let breathing_art = breathing_art(asset.as_ref(), mouse_left, mouse_w, mouse_h, pal, glow);
-        let hotspots_layer = hotspots_layer(
-            &hotspots_outer,
-            mouse_left,
-            mouse_w,
-            mouse_h,
-            hovered,
-            active,
-            &gesture_buttons,
-            self.open_binding_popover,
-            &view,
-        );
+        let frame = ModelFrame {
+            left: mouse_left,
+            width: mouse_w,
+            height: mouse_h,
+        };
+        let hotspots_layer = HotspotsLayer::new(hotspots_outer, frame, view.clone())
+            .hovered(hovered)
+            .active(active)
+            .gesture_buttons(gesture_buttons.clone())
+            .open_popover(self.open_binding_popover);
         let canvas = div()
             .relative()
             .w(px(canvas_w))
@@ -194,22 +193,17 @@ impl Render for MouseModelView {
             .child(leader_canvas)
             .children(labels_outer.iter().enumerate().map(|(idx, label)| {
                 let binding = binding_label_for_control(label.id, &bindings, &gesture_buttons);
-                label_popover(
-                    idx,
-                    *label,
-                    binding,
-                    highlight == Some(label.id),
-                    mouse_left,
-                    mouse_w,
-                    hovered,
-                    active,
-                    label
-                        .id
-                        .button()
-                        .filter(|button| gesture_buttons.contains(button)),
-                    self.open_binding_popover == Some(BindingPopover::Label(label.id)),
-                    &view,
-                )
+                LabelPopover::new(idx, *label, binding, frame, view.clone())
+                    .highlighted(highlight == Some(label.id))
+                    .hovered(hovered)
+                    .active(active)
+                    .gesture_button(
+                        label
+                            .id
+                            .button()
+                            .filter(|button| gesture_buttons.contains(button)),
+                    )
+                    .open(self.open_binding_popover == Some(BindingPopover::Label(label.id)))
             }))
             .child(hotspots_layer);
 
@@ -321,41 +315,91 @@ fn breathing_art(
         .child(device_art)
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "layout inputs + hover/active/gesture state; bundling would just hide the dependency"
-)]
-fn hotspots_layer(
-    hotspots: &[Hotspot],
-    mouse_left: f32,
-    mouse_w: f32,
-    mouse_h: f32,
+#[derive(Clone, Copy)]
+struct ModelFrame {
+    left: f32,
+    width: f32,
+    height: f32,
+}
+
+#[derive(IntoElement)]
+struct HotspotsLayer {
+    hotspots: Vec<Hotspot>,
+    frame: ModelFrame,
     hovered: Option<MouseControlId>,
     active: Option<MouseControlId>,
-    gesture_buttons: &[ButtonId],
+    gesture_buttons: Vec<ButtonId>,
     open_popover: Option<BindingPopover>,
-    view: &Entity<MouseModelView>,
-) -> impl IntoElement {
-    div()
-        .absolute()
-        .left(px(mouse_left))
-        .top(px(0.))
-        .w(px(mouse_w))
-        .h(px(mouse_h))
-        .children(hotspots.iter().enumerate().map(|(idx, hotspot)| {
-            hotspot_popover(
-                idx,
-                *hotspot,
-                hovered,
-                active,
-                hotspot
-                    .id
-                    .button()
-                    .filter(|button| gesture_buttons.contains(button)),
-                open_popover == Some(BindingPopover::Hotspot(hotspot.id)),
-                view,
-            )
-        }))
+    view: Entity<MouseModelView>,
+}
+
+impl HotspotsLayer {
+    fn new(hotspots: Vec<Hotspot>, frame: ModelFrame, view: Entity<MouseModelView>) -> Self {
+        Self {
+            hotspots,
+            frame,
+            hovered: None,
+            active: None,
+            gesture_buttons: Vec::new(),
+            open_popover: None,
+            view,
+        }
+    }
+
+    #[must_use]
+    fn hovered(mut self, hovered: impl Into<Option<MouseControlId>>) -> Self {
+        self.hovered = hovered.into();
+        self
+    }
+
+    #[must_use]
+    fn active(mut self, active: impl Into<Option<MouseControlId>>) -> Self {
+        self.active = active.into();
+        self
+    }
+
+    #[must_use]
+    fn gesture_buttons(mut self, gesture_buttons: Vec<ButtonId>) -> Self {
+        self.gesture_buttons = gesture_buttons;
+        self
+    }
+
+    #[must_use]
+    fn open_popover(mut self, open_popover: impl Into<Option<BindingPopover>>) -> Self {
+        self.open_popover = open_popover.into();
+        self
+    }
+}
+
+impl RenderOnce for HotspotsLayer {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let frame = self.frame;
+        let hovered = self.hovered;
+        let active = self.active;
+        let gesture_buttons = self.gesture_buttons;
+        let open_popover = self.open_popover;
+        let view = self.view;
+        div()
+            .absolute()
+            .left(px(frame.left))
+            .top(px(0.))
+            .w(px(frame.width))
+            .h(px(frame.height))
+            .children(self.hotspots.into_iter().enumerate().map(|(idx, hotspot)| {
+                hotspot_popover(
+                    idx,
+                    hotspot,
+                    hovered,
+                    active,
+                    hotspot
+                        .id
+                        .button()
+                        .filter(|button| gesture_buttons.contains(button)),
+                    open_popover == Some(BindingPopover::Hotspot(hotspot.id)),
+                    &view,
+                )
+            }))
+    }
 }
 
 /// Wrap `trigger` in a left-click [`Popover`] hosting the gesture button's
@@ -395,86 +439,135 @@ where
         .content(move |_state, _window, cx| gesture_overview(btn, &view, cx))
 }
 
-/// Position the popover wrapper at the label's slot in the side gutter and
-/// host a Popover whose trigger is the label card itself. Same picker
-/// content as the hotspot dot — clicking either entry point lands on the
-/// same binding flow.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "wrapper position + trigger \
-state both need this many inputs; bundling would just hide the dependency"
-)]
-fn label_popover(
+/// A label-side entry point for a control's binding popover.
+#[derive(IntoElement)]
+struct LabelPopover {
     idx: usize,
     label: Label,
     binding: BindingLabel,
     highlighted: bool,
-    mouse_left: f32,
-    mouse_w: f32,
+    frame: ModelFrame,
     hovered: Option<MouseControlId>,
     active: Option<MouseControlId>,
-    // `Some` exactly when the control is a button in gesture mode — that button
-    // opens its gesture menu instead of the plain picker.
     gesture_button: Option<ButtonId>,
     open: bool,
-    view: &Entity<MouseModelView>,
-) -> AnyElement {
-    let x = match label.side {
-        Side::Left => mouse_left - SIDE_GAP - SIDE_W,
-        Side::Right => mouse_left + mouse_w + SIDE_GAP,
-    };
-    let view = view.clone();
-    let binding_popover = BindingPopover::Label(label.id);
-    let trigger = LabelTrigger {
-        id: ("label-trigger", idx).into(),
-        label,
-        binding,
-        highlighted: highlighted || hovered == Some(label.id) || active == Some(label.id),
-        selected: false,
-        view: view.clone(),
-    };
-    let popover: AnyElement = if let Some(button) = gesture_button {
-        gesture_overview_popover(
-            ("label-popover", idx),
-            Anchor::TopLeft,
-            button,
-            trigger,
-            binding_popover,
-            open,
-            view.clone(),
-        )
-        .into_any_element()
-    } else {
-        let view_state = view.clone();
-        let view_content = view.clone();
-        Popover::new(("label-popover", idx))
-            // `action_picker` draws its own `menu_card` surface, matching the
-            // gesture menu — so suppress the framework popover surface.
-            .appearance(false)
-            .anchor(Anchor::TopLeft)
-            .mouse_button(MouseButton::Left)
-            .trigger(trigger)
-            .open(open)
-            .on_open_change(move |open, _window, cx| {
-                view_state.update(cx, |v, vcx| {
-                    v.set_binding_popover_open(binding_popover, *open);
-                    vcx.notify();
-                });
-            })
-            .content(move |_state, _window, cx| match label.id {
-                MouseControlId::Button(button) => action_picker(button, &view_content, cx),
-                MouseControlId::ThumbwheelRotation => thumbwheel_picker(&view, cx),
-            })
+    view: Entity<MouseModelView>,
+}
+
+impl LabelPopover {
+    fn new(
+        idx: usize,
+        label: Label,
+        binding: BindingLabel,
+        frame: ModelFrame,
+        view: Entity<MouseModelView>,
+    ) -> Self {
+        Self {
+            idx,
+            label,
+            binding,
+            highlighted: false,
+            frame,
+            hovered: None,
+            active: None,
+            gesture_button: None,
+            open: false,
+            view,
+        }
+    }
+
+    #[must_use]
+    fn highlighted(mut self, highlighted: bool) -> Self {
+        self.highlighted = highlighted;
+        self
+    }
+
+    #[must_use]
+    fn hovered(mut self, hovered: impl Into<Option<MouseControlId>>) -> Self {
+        self.hovered = hovered.into();
+        self
+    }
+
+    #[must_use]
+    fn active(mut self, active: impl Into<Option<MouseControlId>>) -> Self {
+        self.active = active.into();
+        self
+    }
+
+    #[must_use]
+    fn gesture_button(mut self, button: impl Into<Option<ButtonId>>) -> Self {
+        self.gesture_button = button.into();
+        self
+    }
+
+    #[must_use]
+    fn open(mut self, open: bool) -> Self {
+        self.open = open;
+        self
+    }
+}
+
+impl RenderOnce for LabelPopover {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let x = match self.label.side {
+            Side::Left => self.frame.left - SIDE_GAP - SIDE_W,
+            Side::Right => self.frame.left + self.frame.width + SIDE_GAP,
+        };
+        let label = self.label;
+        let view = self.view;
+        let binding_popover = BindingPopover::Label(label.id);
+        let trigger = LabelTrigger {
+            id: ("label-trigger", self.idx).into(),
+            label,
+            binding: self.binding,
+            highlighted: self.highlighted
+                || self.hovered == Some(label.id)
+                || self.active == Some(label.id),
+            selected: false,
+            view: view.clone(),
+        };
+        let popover: AnyElement = if let Some(button) = self.gesture_button {
+            gesture_overview_popover(
+                ("label-popover", self.idx),
+                Anchor::TopLeft,
+                button,
+                trigger,
+                binding_popover,
+                self.open,
+                view.clone(),
+            )
             .into_any_element()
-    };
-    div()
-        .absolute()
-        .left(px(x))
-        .top(px(label.y - LABEL_H / 2.))
-        .w(px(LABEL_W))
-        .h(px(LABEL_H))
-        .child(popover)
-        .into_any_element()
+        } else {
+            let view_state = view.clone();
+            let view_content = view.clone();
+            Popover::new(("label-popover", self.idx))
+                // `action_picker` draws its own `menu_card` surface, matching the
+                // gesture menu — so suppress the framework popover surface.
+                .appearance(false)
+                .anchor(Anchor::TopLeft)
+                .mouse_button(MouseButton::Left)
+                .trigger(trigger)
+                .open(self.open)
+                .on_open_change(move |open, _window, cx| {
+                    view_state.update(cx, |v, vcx| {
+                        v.set_binding_popover_open(binding_popover, *open);
+                        vcx.notify();
+                    });
+                })
+                .content(move |_state, _window, cx| match label.id {
+                    MouseControlId::Button(button) => action_picker(button, &view_content, cx),
+                    MouseControlId::ThumbwheelRotation => thumbwheel_picker(&view, cx),
+                })
+                .into_any_element()
+        };
+        div()
+            .absolute()
+            .left(px(x))
+            .top(px(label.y - LABEL_H / 2.))
+            .w(px(LABEL_W))
+            .h(px(LABEL_H))
+            .child(popover)
+    }
 }
 
 struct BindingLabel {

--- a/crates/openlogi-desktop/src/features/pointer/dpi.rs
+++ b/crates/openlogi-desktop/src/features/pointer/dpi.rs
@@ -6,8 +6,8 @@
 //! exposes exact device-supported values once the list is known.
 
 use gpui::{
-    AnyElement, AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement,
-    Render, SharedString, Styled, Subscription, Window, div, px,
+    AnyElement, AppContext as _, Context, Entity, IntoElement, ParentElement, Render, SharedString,
+    Styled, Subscription, Window, div, px,
 };
 use gpui_component::{
     IconName, Selectable as _, Sizable as _,
@@ -20,8 +20,9 @@ use openlogi_core::hid::{Dpi, DpiCapabilities};
 use tracing::debug;
 
 use crate::state::{AppState, DeviceKey, DeviceRecord, DpiStatus, StateEvent};
+use crate::ui::components::PresetChip;
 use crate::ui::status::{retry_line, status_line};
-use crate::ui::theme::{self, Palette, SelectableStyle, Typography as _};
+use crate::ui::theme::{self, Palette, Typography as _};
 
 pub struct DpiPanel {
     slider_state: Option<Entity<SliderState>>,
@@ -204,7 +205,7 @@ impl Render for DpiPanel {
                     .map_or(*value, |state| state.normalize_active_dpi(*value));
                 let active = !already_highlighted && normalized == snapshot.dpi;
                 already_highlighted |= active;
-                preset_chip(idx, *value, active, &snapshot.presets, pal)
+                preset_chip(idx, *value, active, &snapshot.presets)
             })
             .collect();
 
@@ -353,19 +354,10 @@ const CHIP_H: f32 = 28.;
 
 /// One DPI preset rendered as a chip. Clicking the chip writes that DPI to
 /// the device and updates `AppState.dpi`; the small × removes the preset.
-fn preset_chip(idx: usize, value: Dpi, active: bool, presets: &[Dpi], pal: Palette) -> AnyElement {
+fn preset_chip(idx: usize, value: Dpi, active: bool, presets: &[Dpi]) -> AnyElement {
     let presets_for_remove: Vec<Dpi> = presets.to_vec();
-    h_flex()
-        .id(("dpi-preset-chip", idx))
-        .h(px(CHIP_H))
-        .px_2()
-        .gap_2()
-        .items_center()
-        .rounded(pal.control_radius)
-        .selected_border(active, pal)
-        .bg(pal.surface)
-        .selected_fill(active)
-        .hover(|s| s.bg(pal.surface_hover))
+    PresetChip::new(("dpi-preset-chip", idx))
+        .selected(active)
         .child(
             Button::new(("dpi-preset-apply", idx))
                 .compact()

--- a/crates/openlogi-desktop/src/features/pointer/smartshift.rs
+++ b/crates/openlogi-desktop/src/features/pointer/smartshift.rs
@@ -31,6 +31,7 @@ use openlogi_core::hid::{
 };
 
 use crate::state::{AppState, DeviceKey, SmartShiftLoad, SmartShiftWriteStatus, StateEvent};
+use crate::ui::components::Toggle;
 use crate::ui::section::section_label;
 use crate::ui::status::{retry_line, status_line};
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
@@ -415,13 +416,26 @@ fn permanent_row(
                         .child(tr!("Never auto-switch to free-spin.")),
                 ),
         )
-        .child(permanent_toggle(
-            permanent,
-            ratchet,
-            restore_threshold,
-            status,
-            pal,
-        ))
+        .child(
+            Toggle::new("smartshift-permanent")
+                .selected(permanent)
+                .disabled(!ratchet)
+                .on_change(move |permanent, _window, cx| {
+                    let auto_disengage = if *permanent {
+                        SmartShiftAutoDisengage::Permanent
+                    } else {
+                        SmartShiftAutoDisengage::Threshold(restore_threshold)
+                    };
+                    AppState::update_smartshift(
+                        cx,
+                        SmartShiftStatus {
+                            mode: SmartShiftMode::Ratchet,
+                            auto_disengage,
+                            ..status
+                        },
+                    );
+                }),
+        )
 }
 
 /// One wheel-mode pill. Clicking it writes `target` while preserving the
@@ -442,39 +456,6 @@ fn mode_pill(
         .selected(selected)
         .on_click(move |_event, _window, cx| {
             AppState::update_smartshift(cx, status);
-        })
-        .into_any_element()
-}
-
-/// The permanent-ratchet on/off pill. Disabled (muted, non-clickable) under
-/// free-spin, where it has no meaning.
-fn permanent_toggle(
-    on: bool,
-    enabled: bool,
-    restore_threshold: SmartShiftThreshold,
-    status: SmartShiftStatus,
-    _pal: Palette,
-) -> AnyElement {
-    let label = if on { tr!("On") } else { tr!("Off") };
-    Button::new("smartshift-permanent")
-        .compact()
-        .label(label)
-        .selected(on)
-        .disabled(!enabled)
-        .on_click(move |_event, _window, cx| {
-            let auto_disengage = if on {
-                SmartShiftAutoDisengage::Threshold(restore_threshold)
-            } else {
-                SmartShiftAutoDisengage::Permanent
-            };
-            AppState::update_smartshift(
-                cx,
-                SmartShiftStatus {
-                    mode: SmartShiftMode::Ratchet,
-                    auto_disengage,
-                    ..status
-                },
-            );
         })
         .into_any_element()
 }

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -1,0 +1,410 @@
+//! Reusable, theme-aware desktop components.
+//!
+//! These components own their semantic state and resolve the active palette at
+//! render time, so callers do not have to thread colours through free-function
+//! builders.
+
+use gpui::{
+    AnyElement, App, ClickEvent, ElementId, InteractiveElement, Interactivity, IntoElement,
+    ParentElement, Pixels, RenderOnce, SharedString, Stateful, StatefulInteractiveElement, Styled,
+    Window, div, prelude::FluentBuilder as _, px, rgb,
+};
+use gpui_component::{
+    Disableable, Icon, IconName, Selectable, Sizable, Size, h_flex, switch::Switch, v_flex,
+};
+
+use super::theme::{self, ACCENT_BLUE, SelectableStyle as _, Typography as _};
+
+/// A controlled on/off switch with a compact state label.
+#[derive(IntoElement)]
+pub(crate) struct Toggle {
+    id: ElementId,
+    selected: bool,
+    disabled: bool,
+    size: Size,
+    label: Option<SharedString>,
+    icon: Option<IconName>,
+    min_width: Option<Pixels>,
+    on_change: Option<SwitchHandler>,
+}
+
+type SwitchHandler = std::rc::Rc<dyn Fn(&bool, &mut Window, &mut App)>;
+
+impl Toggle {
+    pub(crate) fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            id: id.into(),
+            selected: false,
+            disabled: false,
+            size: Size::Small,
+            label: None,
+            icon: None,
+            min_width: None,
+            on_change: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn label(mut self, label: impl Into<Option<SharedString>>) -> Self {
+        self.label = label.into();
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn icon(mut self, icon: impl Into<Option<IconName>>) -> Self {
+        self.icon = icon.into();
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn min_width(mut self, width: impl Into<Option<Pixels>>) -> Self {
+        self.min_width = width.into();
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn on_change(
+        mut self,
+        handler: impl Fn(&bool, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_change = Some(std::rc::Rc::new(handler));
+        self
+    }
+}
+
+impl Selectable for Toggle {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    fn is_selected(&self) -> bool {
+        self.selected
+    }
+}
+
+impl Disableable for Toggle {
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+impl Sizable for Toggle {
+    fn with_size(mut self, size: impl Into<Size>) -> Self {
+        self.size = size.into();
+        self
+    }
+}
+
+impl RenderOnce for Toggle {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let label = self
+            .label
+            .unwrap_or_else(|| if self.selected { tr!("On") } else { tr!("Off") });
+        let mut toggle = Switch::new(self.id)
+            .checked(self.selected)
+            .disabled(self.disabled)
+            .with_size(self.size)
+            .label(label)
+            .color(rgb(ACCENT_BLUE));
+        if let Some(handler) = self.on_change {
+            toggle = toggle.on_click(move |selected, window, cx| handler(selected, window, cx));
+        }
+        h_flex()
+            .items_center()
+            .gap_2()
+            .when_some(self.min_width, |row, width| {
+                row.min_w(width).justify_center()
+            })
+            .when_some(self.icon, |row, icon| row.child(Icon::new(icon).size_3()))
+            .child(toggle)
+    }
+}
+
+/// A titled card used by device-detail panels.
+#[derive(IntoElement)]
+pub(crate) struct PanelCard {
+    title: SharedString,
+    icon: Icon,
+    content: AnyElement,
+    fill: bool,
+}
+
+impl PanelCard {
+    pub(crate) fn new(
+        title: impl Into<SharedString>,
+        icon: Icon,
+        content: impl IntoElement,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            icon,
+            content: content.into_any_element(),
+            fill: false,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn fill(mut self) -> Self {
+        self.fill = true;
+        self
+    }
+}
+
+impl RenderOnce for PanelCard {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        div()
+            .w_full()
+            .when(self.fill, gpui::Styled::h_full)
+            .max_w_full()
+            .min_w_0()
+            .rounded(pal.card_radius)
+            .border_1()
+            .border_color(pal.border)
+            .bg(pal.surface)
+            .p(px(theme::CARD_PAD))
+            .child(
+                v_flex()
+                    .gap(px(theme::CARD_GAP))
+                    .when(!self.title.is_empty(), |this| {
+                        this.child(
+                            h_flex()
+                                .items_center()
+                                .gap_2()
+                                .text_color(pal.text_primary)
+                                .child(self.icon.size_4().text_color(pal.text_muted))
+                                .child(div().text_subheading().child(self.title)),
+                        )
+                    })
+                    .child(self.content),
+            )
+    }
+}
+
+/// A full-width row in an action menu.
+#[derive(IntoElement)]
+pub(crate) struct MenuRow {
+    base: Stateful<gpui::Div>,
+    selected: bool,
+    children: Vec<AnyElement>,
+}
+
+impl MenuRow {
+    pub(crate) fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            base: h_flex().id(id),
+            selected: false,
+            children: Vec::new(),
+        }
+    }
+}
+
+impl Selectable for MenuRow {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    fn is_selected(&self) -> bool {
+        self.selected
+    }
+}
+
+impl ParentElement for MenuRow {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl InteractiveElement for MenuRow {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl StatefulInteractiveElement for MenuRow {}
+
+impl RenderOnce for MenuRow {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        let selected = self.selected;
+        self.base
+            .w_full()
+            .items_center()
+            .justify_between()
+            .gap_2()
+            .px_2()
+            .py_1p5()
+            .rounded(pal.control_radius)
+            .text_body()
+            .text_color(pal.text_primary)
+            .selected_fill(selected)
+            .hover(move |style| {
+                style.bg(if selected {
+                    theme::accent_tint_hover()
+                } else {
+                    pal.surface_hover
+                })
+            })
+            .children(self.children)
+    }
+}
+
+/// A selectable camera-profile chip.
+#[derive(IntoElement)]
+pub(crate) struct ProfileTab {
+    base: Stateful<gpui::Div>,
+    label: SharedString,
+    selected: bool,
+    children: Vec<AnyElement>,
+    delete: Option<(ElementId, ClickHandler)>,
+}
+
+type ClickHandler = std::rc::Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
+
+impl ProfileTab {
+    pub(crate) fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
+        Self {
+            base: h_flex().id(id),
+            label: label.into(),
+            selected: false,
+            children: Vec::new(),
+            delete: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn on_delete(
+        mut self,
+        id: impl Into<ElementId>,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.delete = Some((id.into(), std::rc::Rc::new(handler)));
+        self
+    }
+}
+
+impl Selectable for ProfileTab {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    fn is_selected(&self) -> bool {
+        self.selected
+    }
+}
+
+impl ParentElement for ProfileTab {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl InteractiveElement for ProfileTab {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl StatefulInteractiveElement for ProfileTab {}
+
+impl RenderOnce for ProfileTab {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        let accent = rgb(ACCENT_BLUE);
+        let has_delete = self.delete.is_some();
+        self.base
+            .when(!has_delete, gpui::Styled::px_2)
+            .when(has_delete, |tab| tab.pl_2().pr_1())
+            .py_0p5()
+            .gap_1()
+            .items_center()
+            .rounded_full()
+            .border_1()
+            .border_color(if self.selected {
+                accent.into()
+            } else {
+                pal.border
+            })
+            .text_caption()
+            .text_color(if self.selected {
+                accent.into()
+            } else {
+                pal.text_muted
+            })
+            .when(self.selected, |style| style.bg(pal.surface))
+            .hover(move |style| style.bg(pal.surface_hover))
+            .child(self.label)
+            .children(self.children)
+            .when_some(self.delete, |tab, (id, handler)| {
+                tab.child(
+                    div()
+                        .id(id)
+                        .px_0p5()
+                        .rounded_full()
+                        .text_color(pal.text_muted)
+                        .hover(|style| style.text_color(gpui::white()))
+                        .child("×")
+                        .on_click(move |event, window, cx| {
+                            cx.stop_propagation();
+                            handler(event, window, cx);
+                        }),
+                )
+            })
+    }
+}
+
+/// A selected-state container for one DPI preset and its actions.
+#[derive(IntoElement)]
+pub(crate) struct PresetChip {
+    base: Stateful<gpui::Div>,
+    selected: bool,
+    children: Vec<AnyElement>,
+}
+
+impl PresetChip {
+    pub(crate) fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            base: h_flex().id(id),
+            selected: false,
+            children: Vec::new(),
+        }
+    }
+}
+
+impl Selectable for PresetChip {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    fn is_selected(&self) -> bool {
+        self.selected
+    }
+}
+
+impl ParentElement for PresetChip {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl RenderOnce for PresetChip {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        self.base
+            .h(px(28.))
+            .px_2()
+            .gap_2()
+            .items_center()
+            .rounded(pal.control_radius)
+            .selected_border(self.selected, pal)
+            .bg(pal.surface)
+            .selected_fill(self.selected)
+            .hover(|style| style.bg(pal.surface_hover))
+            .children(self.children)
+    }
+}

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -1,6 +1,7 @@
 //! Shared settings-app UI components and theme.
 
 pub mod carousel;
+pub(crate) mod components;
 pub mod section;
 pub mod status;
 pub mod theme;


### PR DESCRIPTION
## Summary

Replace the desktop GUI's highest-leverage free-function builders with theme-aware `RenderOnce` components and typed builder traits.

## Changes

- **openlogi-desktop**: add reusable `Toggle`, `PanelCard`, `MenuRow`, `ProfileTab`, and `PresetChip` components that resolve the active palette during rendering
- **openlogi-desktop**: consolidate five manual toggle implementations onto the controlled switch component and preserve disabled, icon, sizing, and callback behavior
- **openlogi-desktop**: migrate panel cards, action-menu rows, camera profile tabs, and DPI preset chips to component builders
- **openlogi-desktop**: convert the high-argument mouse hotspot/label and keyboard inspector builders into `RenderOnce` components, removing every `too_many_arguments` suppression
- Reduce exact `pal: Palette` occurrences from the current-tree baseline of 126 to 111 for the scoped high-leverage builders; unrelated low-level render helpers remain unchanged

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 7 passed; typos, shell, macOS tests, cargo-deny, and wasm checks were skipped because the tools/target or host OS were unavailable
- Not runtime-tested on hardware or visually on macOS; verification was performed in a Linux orb

Fixes #896
