### PR TITLE
fix(macos): honor XDG state dir in permission diagnostics

### DIFF
--- a/.claude/skills/openlogi-macos-permissions/SKILL.md
+++ b/.claude/skills/openlogi-macos-permissions/SKILL.md
@@ -70,7 +70,11 @@ read-only and safe to hand to a reporter.
 so the agent also writes a daily-rotated file (7 kept) a reporter can attach:
 
 ```sh
-ls ~/.local/state/openlogi/
+case ${XDG_STATE_HOME:-} in
+  /*) state_home=$XDG_STATE_HOME ;;
+  *) state_home=$HOME/.local/state ;;
+esac
+ls "$state_home/openlogi/"
 ```
 
 It carries panics too. Only when that file is missing or predates the failure

--- a/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
+++ b/.claude/skills/openlogi-macos-permissions/scripts/diagnose.sh
@@ -94,14 +94,21 @@ say "5. Designated requirement recorded against the agent's grant"
 [ -d "$agent" ] && codesign -d --requirements - "$agent" 2>&1 | grep '^designated' | sed 's/^/   /'
 
 say "6. The agent's own log"
+# The agent ignores a relative XDG_STATE_HOME, as required by the XDG spec.
+state_home=${XDG_STATE_HOME:-"$HOME/.local/state"}
+case "$state_home" in
+  /*) ;;
+  *) state_home="$HOME/.local/state" ;;
+esac
+log_dir="$state_home/openlogi"
 # Names are agent.<ISO date>.log, so the lexically last one is the newest.
-logs=("$HOME"/.local/state/openlogi/agent.*.log)
+logs=("$log_dir"/agent.*.log)
 latest_log=${logs[${#logs[@]} - 1]}
 if [ -f "$latest_log" ]; then
   echo "   $latest_log"
   echo "   attach this file — it holds the classified open errors and any panic"
 else
-  echo "   none under ~/.local/state/openlogi (agent predates the log file, or never ran)"
+  echo "   none under $log_dir (agent predates the log file, or never ran)"
 fi
 cat <<TXT
 


### PR DESCRIPTION
## Summary

Make the macOS permission diagnostics find agent logs when `XDG_STATE_HOME` overrides the default state directory.

## Changes

- Resolve the diagnostic log directory from an absolute `XDG_STATE_HOME`, matching the agent's XDG path handling.
- Ignore relative overrides and fall back to `~/.local/state`, as required by the XDG specification.
- Update the skill's manual log-discovery command to use the same rules.

## Testing

- `cargo xtask ci shell`
- Exercised `diagnose.sh` with isolated directories for an absolute override, no override, and a relative override; all three selected the expected log.
- Not runtime-tested on macOS hardware. To verify, start the agent with an absolute `XDG_STATE_HOME`, run the diagnostic script in the same environment, and confirm section 6 prints the newest agent log under that directory.

Follow-up to #841.
