### PR TITLE
feat(gui): make custom controls keyboard-operable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,6 +5372,7 @@ dependencies = [
  "disclaim",
  "embed-resource",
  "gpui",
+ "gpui-base",
  "gpui-component",
  "gpui-component-assets",
  "gpui-updater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ block2 = "0.6.2"
 gpui = { git = "https://github.com/zed-industries/zed" }
 gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit", "x11", "wayland"] }
 gpui-component = { git = "https://github.com/longbridge/gpui-component", rev = "da4f93696dc2b2b4d91bcc42412b9053a3d24de8" }
+# The unstyled interaction primitives behind gpui-component. Desktop uses its
+# semantic Button for custom-painted controls that must retain native keyboard
+# and accessibility behavior without inheriting widget chrome.
+gpui-base = { git = "https://github.com/longbridge/gpui-component", rev = "da4f93696dc2b2b4d91bcc42412b9053a3d24de8" }
 # Pinned to the same rev as gpui-component: this crate embeds the lucide SVGs
 # that the `IconName` enum is macro-generated from, so the two must agree.
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component", rev = "da4f93696dc2b2b4d91bcc42412b9053a3d24de8" }

--- a/crates/openlogi-desktop/Cargo.toml
+++ b/crates/openlogi-desktop/Cargo.toml
@@ -28,6 +28,7 @@ tarpc = { workspace = true }
 gpui = { workspace = true }
 gpui_platform = { workspace = true }
 gpui-component = { workspace = true }
+gpui-base = { workspace = true }
 gpui-component-assets = { workspace = true }
 swr-core = { workspace = true }
 swr-gpui = { workspace = true }

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, FocusHandle, InteractiveElement,
+    AnyElement, App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement,
     IntoElement, MouseButton, NavigationDirection, ParentElement, Render,
     StatefulInteractiveElement as _, Styled, Subscription, Window, div,
     prelude::FluentBuilder as _, px, rgb,
@@ -13,7 +13,7 @@ use openlogi_core::device::{Capabilities, DeviceInventory, DeviceKind};
 use openlogi_ipc::InventoryHealth;
 use tracing::info;
 
-use self::menu::{CloseWindow, Minimize, Zoom};
+use self::menu::{APP_KEY_CONTEXT, CloseWindow, Minimize, NavigateBack, Zoom};
 use crate::features::action_ring::ActionRingPanel;
 use crate::features::camera::controls::CameraControlsPanel;
 use crate::features::camera::preview::CameraPreview;
@@ -187,6 +187,12 @@ pub struct AppView {
     active_tab: DetailTab,
 }
 
+impl Focusable for AppView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
 impl AppView {
     /// Construct the root view and its child entities.
     pub fn new(
@@ -335,9 +341,9 @@ impl AppView {
     /// Attach the window-level back-navigation listeners to `root`: a mouse
     /// configurator should honor the hardware it configures. Two routes reach
     /// us — the native navigate button (its default binding never diverts, so
-    /// the OS still sees it), and Alt+Left, which is both what a rebound
-    /// button's BrowserBack action injects on Linux and what keyboard users
-    /// expect.
+    /// the OS still sees it), and the contextual [`NavigateBack`] action, bound
+    /// to Alt+Left (what a rebound BrowserBack action injects on Linux and what
+    /// keyboard users expect).
     fn with_back_navigation(root: gpui::Div, cx: &mut Context<Self>) -> gpui::Div {
         root.on_mouse_down(
             MouseButton::Navigate(NavigationDirection::Back),
@@ -347,11 +353,8 @@ impl AppView {
                 }
             }),
         )
-        .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, _, cx| {
-            if event.keystroke.modifiers.alt
-                && event.keystroke.key == "left"
-                && !matches!(this.route, Route::Home)
-            {
+        .on_action(cx.listener(|this, _: &NavigateBack, _, cx| {
+            if !matches!(this.route, Route::Home) {
                 this.go_home(cx);
             }
         }))
@@ -473,7 +476,9 @@ impl Render for AppView {
             .size_full()
             .bg(pal.page)
             .text_color(pal.text_primary)
+            .tab_group()
             .track_focus(&self.focus_handle)
+            .key_context(APP_KEY_CONTEXT)
             .on_action(|_: &CloseWindow, window, _| window.remove_window())
             .on_action(|_: &Minimize, window, _| window.minimize_window())
             .on_action(|_: &Zoom, window, _| window.zoom_window())

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -5,6 +5,7 @@ use gpui::{
     AnyElement, Context, InteractiveElement, IntoElement, ParentElement, Role,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Disableable as _, Icon, IconName, Selectable as _,
     button::{Button, ButtonGroup},
@@ -198,11 +199,13 @@ fn detail_navigation(
         .p_3()
         .children(tabs.iter().copied().enumerate().map(|(index, tab)| {
             let selected = tab == active;
-            h_flex()
-                .id(("detail-navigation", index))
+            BaseButton::new(("detail-navigation", index))
                 .role(Role::Tab)
+                .selected(selected)
+                .accessibility_label(tab.label())
                 .aria_selected(selected)
                 .w_full()
+                .flex()
                 .items_center()
                 .gap_2p5()
                 .px_3()
@@ -217,6 +220,13 @@ fn detail_navigation(
                 })
                 .when(selected, |row| row.bg(crate::ui::theme::accent_tint()))
                 .hover(move |row| {
+                    row.bg(if selected {
+                        crate::ui::theme::accent_tint_hover()
+                    } else {
+                        pal.control_hover
+                    })
+                })
+                .focus_visible(move |row| {
                     row.bg(if selected {
                         crate::ui::theme::accent_tint_hover()
                     } else {

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -5,10 +5,11 @@
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, Context, Div, Hsla, InteractiveElement, IntoElement, ParentElement, Role,
-    SharedString, StatefulInteractiveElement as _, Styled, canvas, div, fill, img, point,
+    AnyElement, Context, Hsla, InteractiveElement, IntoElement, ParentElement, SharedString,
+    StatefulInteractiveElement as _, Styled, canvas, div, fill, img, point,
     prelude::FluentBuilder as _, px, rgb, svg,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName,
     button::{Button, ButtonVariants as _},
@@ -116,14 +117,15 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
                     light_settings,
                     pal,
                 )
-                .id(("device-card", idx))
                 .active(gpui::Styled::shadow_2xs)
-                .role(Role::Button)
-                .aria_label(record.display_name.clone())
+                .accessibility_label(record.display_name.clone())
                 .aria_description(device_accessibility_description(&record))
                 .aria_selected(focused)
                 .cursor_pointer()
                 .hover(move |s| s.border_color(rgb(theme::ACCENT_BLUE)).shadow_sm())
+                .focus_visible(move |s| {
+                    s.border_color(rgb(theme::ACCENT_BLUE)).shadow_sm()
+                })
                 .on_click(move |_, _, cx| {
                     view.update(cx, |this, cx| this.open_device(key.clone(), cx));
                 })
@@ -235,8 +237,8 @@ pub(crate) fn glow_canvas(geom: Arc<GlowGeometry>, color: Hsla) -> impl IntoElem
 /// bindings and DPI are live) keeps a persistent accent ring and faint fill;
 /// inactive cards gain the same ring on hover. A low resting shadow strengthens
 /// on hover and settles on press. The 1px border is always reserved so the hover
-/// ring never nudges the layout. Returns a bare [`Div`] so the gallery can wire
-/// the hover and click handlers.
+/// ring never nudges the layout. Returns an unstyled semantic button so the
+/// gallery can add its activation handler without giving up keyboard behavior.
 fn device_card(
     record: &DeviceRecord,
     enabled: bool,
@@ -245,7 +247,7 @@ fn device_card(
     light_enabled: bool,
     light_settings: LightSettings,
     pal: Palette,
-) -> Div {
+) -> BaseButton {
     // Disabled devices get a persistent red ring; active managed devices keep
     // the accent ring; otherwise transparent until hover (wired by the gallery).
     let ring = if !enabled {
@@ -255,9 +257,11 @@ fn device_card(
     } else {
         gpui::transparent_black()
     };
-    v_flex()
+    BaseButton::new(format!("device-card-{}", record.config_key))
         .w(px(theme::GALLERY_CARD_W))
         .flex_shrink_0()
+        .flex()
+        .flex_col()
         .items_center()
         .gap_3()
         .p_3()

--- a/crates/openlogi-desktop/src/app/menu.rs
+++ b/crates/openlogi-desktop/src/app/menu.rs
@@ -15,6 +15,9 @@ use url::Url;
 
 use crate::state::AppState;
 
+/// Keymap context installed on the main application surface.
+pub(crate) const APP_KEY_CONTEXT: &str = "OpenLogi";
+
 actions!(
     openlogi,
     [
@@ -30,6 +33,8 @@ actions!(
         HideOthers,
         /// Minimize the active window.
         Minimize,
+        /// Return from device details to the device gallery.
+        NavigateBack,
         /// Open the About window.
         OpenAbout,
         /// Open the Add Device (pairing) window.
@@ -103,6 +108,7 @@ pub fn install(cx: &mut App) {
         KeyBinding::new("cmd-m", Minimize, None),
         KeyBinding::new("cmd-w", CloseWindow, None),
         KeyBinding::new("cmd-,", OpenSettings, None),
+        KeyBinding::new("alt-left", NavigateBack, Some(APP_KEY_CONTEXT)),
     ]);
 
     cx.set_menus(menus(cx));

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -4,10 +4,11 @@ mod action_icons;
 mod editor;
 
 use gpui::{
-    AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement, Render, Role,
-    ScrollHandle, SharedString, StatefulInteractiveElement as _, Styled, Subscription, Window, div,
-    prelude::FluentBuilder as _, px, rgb, svg,
+    App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
+    ParentElement, Render, ScrollHandle, SharedString, StatefulInteractiveElement as _, Styled,
+    Subscription, Window, div, prelude::FluentBuilder as _, px, rgb, svg,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName, Selectable as _, button::Button, h_flex, input::InputState, tooltip::Tooltip,
     v_flex,
@@ -22,6 +23,7 @@ use crate::ui::theme::{self, Palette, Typography as _};
 /// Stateful Actions Ring editor. Ring configuration itself lives in
 /// [`AppState`]; this entity owns selection and editor input state.
 pub struct ActionRingPanel {
+    focus_handle: FocusHandle,
     selected_slot: ActionRingSlot,
     application_input: Option<Entity<InputState>>,
     shortcut_input: Option<Entity<InputState>>,
@@ -46,12 +48,19 @@ impl ActionRingPanel {
             }
         });
         Self {
+            focus_handle: cx.focus_handle(),
             selected_slot: ActionRingSlot::Top,
             application_input: None,
             shortcut_input: None,
             library_scroll: ScrollHandle::new(),
             state_obs,
         }
+    }
+}
+
+impl Focusable for ActionRingPanel {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
     }
 }
 
@@ -79,6 +88,8 @@ impl Render for ActionRingPanel {
         v_flex()
             .w_full()
             .gap_4()
+            .tab_group()
+            .track_focus(&self.focus_handle)
             .child(
                 v_flex()
                     .gap_1()
@@ -274,8 +285,8 @@ fn slot_button(
     let accessible_label = label.clone();
     let selected_view = view.clone();
 
-    div()
-        .id(("action-ring-slot", index))
+    BaseButton::new(("action-ring-slot", index))
+        .selected(selected)
         .absolute()
         .left(px(left))
         .top(px(top))
@@ -301,8 +312,7 @@ fn slot_button(
             pal.text_muted
         })
         .cursor_pointer()
-        .role(Role::Button)
-        .aria_label(accessible_label)
+        .accessibility_label(accessible_label)
         .tooltip(move |window, cx| Tooltip::new(label.clone()).build(window, cx))
         .when_some(icon_path, |button, path| {
             button.child(svg().path(path).size(px(20.0)).text_color(if selected {
@@ -320,6 +330,15 @@ fn slot_button(
             } else {
                 pal.control_hover
             })
+        })
+        .focus_visible(move |button| {
+            button
+                .border_color(rgb(theme::ACCENT_BLUE))
+                .bg(if selected {
+                    theme::accent_tint_hover()
+                } else {
+                    pal.control_hover
+                })
         })
         .on_click(move |_, _, cx| {
             selected_view.update(cx, |panel, cx| {

--- a/crates/openlogi-desktop/src/features/action_ring/editor.rs
+++ b/crates/openlogi-desktop/src/features/action_ring/editor.rs
@@ -20,7 +20,8 @@ use openlogi_core::binding::{
 use super::action_icons::action_icon_path;
 use crate::features::mouse::picker::popover_section;
 use crate::state::{AppState, DeviceRecord, StateEvent};
-use crate::ui::theme::{self, Palette, SelectableStyle as _, Typography as _};
+use crate::ui::components::MenuRow;
+use crate::ui::theme::{self, Palette, Typography as _};
 
 pub(super) fn action_library(
     slot: ActionRingSlot,
@@ -228,22 +229,10 @@ fn action_rows(slot: ActionRingSlot, current: Option<&Action>, pal: Palette) -> 
             let row_index = index;
             index += 1;
             rows.push(
-                h_flex()
-                    .id(("ring-action", row_index))
-                    .w_full()
-                    .items_center()
-                    .justify_between()
-                    .gap_2()
-                    .px_2()
-                    .py_1p5()
-                    .rounded(pal.control_radius)
-                    .text_body()
-                    .text_color(pal.text_primary)
-                    .selected_fill(selected)
+                MenuRow::new(("ring-action", row_index))
                     .role(Role::MenuItem)
                     .aria_label(label.clone())
-                    .aria_selected(selected)
-                    .cursor_pointer()
+                    .selected(selected)
                     .child(
                         h_flex()
                             .items_center()
@@ -263,13 +252,6 @@ fn action_rows(slot: ActionRingSlot, current: Option<&Action>, pal: Palette) -> 
                                 .size_3()
                                 .text_color(rgb(theme::ACCENT_BLUE)),
                         )
-                    })
-                    .hover(move |row| {
-                        row.bg(if selected {
-                            theme::accent_tint_hover()
-                        } else {
-                            pal.control_hover
-                        })
                     })
                     .on_click(move |_, _, cx| {
                         commit_action(slot, action_to_commit.clone(), cx);

--- a/crates/openlogi-desktop/src/features/keyboard/editors.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/editors.rs
@@ -15,8 +15,7 @@
 )]
 
 use gpui::{
-    AnyElement, Context, Entity, FontWeight, IntoElement, ParentElement,
-    StatefulInteractiveElement as _, Styled, div, px, svg,
+    AnyElement, Context, Entity, FontWeight, IntoElement, ParentElement, Styled, div, px, svg,
 };
 use gpui_component::{
     Icon, IconName, Sizable as _,

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use gpui::{
     AnyElement, App, AppContext as _, Bounds, Context, Entity, FontWeight, Hsla,
-    InteractiveElement, IntoElement, ParentElement, PathBuilder, Render, RenderOnce,
+    InteractiveElement, IntoElement, ParentElement, PathBuilder, Render, RenderOnce, Role,
     StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, point,
     prelude::FluentBuilder as _, px, rgb, svg,
 };
@@ -913,6 +913,7 @@ fn panel_action_rows(
         children.push(
             MenuRow::new(format!("panel-power-{idx}"))
                 .selected(selected)
+                .role(Role::MenuItem)
                 .child(
                     h_flex()
                         .items_center()

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -7,6 +7,7 @@ use gpui::{
     AnyElement, Context, Entity, InteractiveElement, IntoElement, ParentElement, Role,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rgb, svg,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName, Selectable as _, Sizable as _,
     button::Button,
@@ -359,7 +360,6 @@ fn gesture_directions(
                     MenuRow::new(("inspector-direction", index))
                         .selected(selected)
                         .role(Role::Button)
-                        .aria_selected(selected)
                         .child(
                             v_flex()
                                 .min_w_0()
@@ -444,7 +444,6 @@ fn thumbwheel_inspector(
                             MenuRow::new(("inspector-thumbwheel", index))
                                 .selected(selected)
                                 .role(Role::Button)
-                                .aria_selected(selected)
                                 .child(
                                     h_flex()
                                         .items_center()
@@ -554,11 +553,11 @@ fn selection_card(
     let search = picker.search.clone();
     let opening = !picker.open;
     let accessible_label = value.clone();
-    v_flex()
-        .id(id)
-        .role(Role::Button)
-        .aria_label(accessible_label)
+    BaseButton::new(id)
+        .accessibility_label(accessible_label)
         .aria_expanded(picker.open)
+        .flex()
+        .flex_col()
         .gap_2()
         .rounded(pal.control_radius)
         .border_1()
@@ -567,6 +566,7 @@ fn selection_card(
         .p_3()
         .cursor_pointer()
         .hover(move |card| card.bg(pal.control_hover))
+        .focus_visible(move |card| card.bg(pal.control_hover).border_color(rgb(ACCENT_BLUE)))
         .child(
             div()
                 .text_caption()

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -144,7 +144,6 @@ pub(crate) fn action_rows_matching(
                     .selected(selected)
                     .role(Role::MenuItem)
                     .aria_label(accessible_label)
-                    .aria_selected(selected)
                     .child(
                         h_flex()
                             .items_center()

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -2,14 +2,15 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, App, AppContext as _, Context, ElementId, Entity, Hsla, InteractiveElement,
-    IntoElement, ParentElement, Render, RenderOnce, Role, StatefulInteractiveElement as _, Styled,
-    Subscription, Window, canvas, div, hsla, img, prelude::FluentBuilder as _, px, rgb, svg,
+    AnyElement, App, AppContext as _, Context, ElementId, Entity, FocusHandle, Focusable, Hsla,
+    InteractiveElement, IntoElement, ParentElement, Render, RenderOnce,
+    StatefulInteractiveElement as _, Styled, Subscription, Window, canvas, div, hsla, img,
+    prelude::FluentBuilder as _, px, rgb, svg,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName, h_flex,
     input::{InputEvent, InputState},
-    v_flex,
 };
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 
@@ -100,6 +101,7 @@ impl MouseWorkspaceData {
 
 /// Interactive mouse model with button hotspots.
 pub struct MouseModelView {
+    focus_handle: FocusHandle,
     current_device_key: Option<String>,
     hovered: Option<MouseControlId>,
     selected: Option<MouseControlId>,
@@ -139,6 +141,7 @@ impl MouseModelView {
             }
         });
         Self {
+            focus_handle: cx.focus_handle(),
             current_device_key: None,
             hovered: None,
             selected: None,
@@ -171,6 +174,28 @@ impl MouseModelView {
             self.action_picker_open = false;
         }
     }
+}
+
+impl Focusable for MouseModelView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+fn set_control_hovered(
+    view: &Entity<MouseModelView>,
+    control: MouseControlId,
+    hovered: bool,
+    cx: &mut App,
+) {
+    view.update(cx, |this, cx| {
+        if hovered {
+            this.hovered = Some(control);
+        } else if this.hovered == Some(control) {
+            this.hovered = None;
+        }
+        cx.notify();
+    });
 }
 
 impl Render for MouseModelView {
@@ -272,16 +297,22 @@ impl Render for MouseModelView {
             pal,
             cx,
         );
-        workspace_layout(canvas.into_any_element(), inspector)
+        workspace_layout(canvas.into_any_element(), inspector, &self.focus_handle)
     }
 }
 
-fn workspace_layout(canvas: AnyElement, inspector: AnyElement) -> AnyElement {
+fn workspace_layout(
+    canvas: AnyElement,
+    inspector: AnyElement,
+    focus_handle: &FocusHandle,
+) -> AnyElement {
     h_flex()
         .flex_1()
         .min_h_0()
         .w_full()
         .items_stretch()
+        .tab_group()
+        .track_focus(focus_handle)
         .child(
             div()
                 .flex_1()
@@ -563,12 +594,13 @@ impl RenderOnce for LabelTrigger {
         let binding_description = binding.clone();
         let binding_icon = self.binding.icon;
         let button_name = tr!(self.label.id.label());
-        v_flex()
-            .id(self.id)
-            .role(Role::Button)
-            .aria_label(tr!("Bind %{name}", name => button_name.clone()))
+        BaseButton::new(self.id)
+            .selected(selected)
+            .accessibility_label(tr!("Bind %{name}", name => button_name.clone()))
             .aria_description(binding_description)
             .aria_selected(selected)
+            .flex()
+            .flex_col()
             .w(px(LABEL_W))
             .h(px(LABEL_H))
             .px_3()
@@ -593,6 +625,14 @@ impl RenderOnce for LabelTrigger {
                 } else {
                     pal.control_hover
                 })
+            })
+            .focus_visible(move |s| {
+                s.bg(if highlighted {
+                    theme::accent_tint_hover()
+                } else {
+                    pal.control_hover
+                })
+                .border_color(rgb(ACCENT_BLUE))
             })
             // Button name — the caption (xs / muted), the same size as the
             // popover title and category headers it shares the binding flow with.
@@ -646,15 +686,7 @@ impl RenderOnce for LabelTrigger {
                 });
             })
             .on_hover(move |hovered, _window, cx| {
-                let is_hovered = *hovered;
-                view.update(cx, |this, cx| {
-                    if is_hovered {
-                        this.hovered = Some(btn);
-                    } else if this.hovered == Some(btn) {
-                        this.hovered = None;
-                    }
-                    cx.notify();
-                });
+                set_control_hovered(&view, btn, *hovered, cx);
             })
     }
 }
@@ -810,10 +842,9 @@ impl RenderOnce for HotspotTrigger {
         let hotspot = self.hotspot;
         let btn = hotspot.id;
 
-        div()
-            .id(self.id)
-            .role(Role::Button)
-            .aria_label(tr!("Bind %{name}", name => tr!(btn.label())))
+        BaseButton::new(self.id)
+            .selected(selected)
+            .accessibility_label(tr!("Bind %{name}", name => tr!(btn.label())))
             .aria_selected(selected)
             .flex()
             .items_center()
@@ -837,6 +868,12 @@ impl RenderOnce for HotspotTrigger {
                         hsla(0., 0., 0.18, 0.85)
                     }),
             )
+            .focus_visible(|style| {
+                style
+                    .rounded_full()
+                    .border_2()
+                    .border_color(rgb(ACCENT_BLUE))
+            })
             .on_click(move |_event, _window, cx| {
                 click_view.update(cx, |this, cx| {
                     this.select(btn);
@@ -844,15 +881,7 @@ impl RenderOnce for HotspotTrigger {
                 });
             })
             .on_hover(move |hovered, _window, cx| {
-                let is_hovered = *hovered;
-                view.update(cx, |this, cx| {
-                    if is_hovered {
-                        this.hovered = Some(btn);
-                    } else if this.hovered == Some(btn) {
-                        this.hovered = None;
-                    }
-                    cx.notify();
-                });
+                set_control_hovered(&view, btn, *hovered, cx);
             })
     }
 }

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -7,6 +7,7 @@ use gpui::{
     Anchor, AnyElement, App, Image, InteractiveElement, IntoElement, ParentElement, Role,
     StatefulInteractiveElement as _, Styled, Window, div, img, prelude::FluentBuilder as _, px,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName, Sizable as _, WindowExt as _,
     button::{Button, ButtonVariant, ButtonVariants as _},
@@ -233,11 +234,14 @@ fn profile_tab(
     leading: Option<AnyElement>,
     selected: bool,
     pal: Palette,
-) -> gpui::Stateful<gpui::Div> {
-    h_flex()
-        .id(id)
+) -> BaseButton {
+    let label = label.into();
+    BaseButton::new(id)
         .role(Role::Tab)
+        .selected(selected)
+        .accessibility_label(label.clone())
         .aria_selected(selected)
+        .flex()
         .flex_none()
         .items_center()
         .gap_1p5()
@@ -255,8 +259,15 @@ fn profile_tab(
                 pal.control_hover
             })
         })
+        .focus_visible(move |tab| {
+            tab.bg(if selected {
+                theme::accent_tint_hover()
+            } else {
+                pal.control_hover
+            })
+        })
         .children(leading)
-        .child(label.into())
+        .child(label)
 }
 
 fn application_mark(icon: Option<Arc<Image>>, name: &str, pal: Palette) -> AnyElement {
@@ -324,6 +335,7 @@ fn add_app_popover(apps: Vec<ProfileChoice>, pal: Palette) -> AnyElement {
                     let app = choice.app.clone();
                     let popover = popover.clone();
                     MenuRow::new(("recent-app", index))
+                        .role(Role::MenuItem)
                         .child(
                             h_flex()
                                 .items_center()
@@ -379,6 +391,7 @@ fn profile_options_popover(profile: ProfileChoice, pal: Palette) -> AnyElement {
                 .child(divider(pal))
                 .child(
                     MenuRow::new("remove-profile")
+                        .role(Role::MenuItem)
                         .child(
                             h_flex()
                                 .items_center()

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -6,9 +6,10 @@
 
 use gpui::{
     AnyElement, App, ClickEvent, ElementId, InteractiveElement, Interactivity, IntoElement,
-    ParentElement, Pixels, RenderOnce, SharedString, Stateful, StatefulInteractiveElement, Styled,
-    Window, div, prelude::FluentBuilder as _, px, rgb,
+    ParentElement, Pixels, RenderOnce, Role, SharedString, Stateful, StatefulInteractiveElement,
+    Styled, Window, div, prelude::FluentBuilder as _, px, rgb,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Disableable, Icon, IconName, Selectable, Sizable, Size, h_flex, switch::Switch, v_flex,
 };
@@ -183,21 +184,41 @@ impl RenderOnce for PanelCard {
     }
 }
 
+type ClickHandler = std::rc::Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
+
 /// A full-width row in an action menu.
 #[derive(IntoElement)]
 pub(crate) struct MenuRow {
-    base: Stateful<gpui::Div>,
+    base: BaseButton,
     selected: bool,
     children: Vec<AnyElement>,
+    on_click: Option<ClickHandler>,
 }
 
 impl MenuRow {
     pub(crate) fn new(id: impl Into<ElementId>) -> Self {
         Self {
-            base: h_flex().id(id),
+            base: BaseButton::new(id),
             selected: false,
             children: Vec::new(),
+            on_click: None,
         }
+    }
+
+    /// Set the accessibility role for this row's semantic button.
+    #[must_use]
+    pub(crate) fn role(mut self, role: Role) -> Self {
+        self.base = self.base.role(role);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(std::rc::Rc::new(handler));
+        self
     }
 }
 
@@ -231,7 +252,10 @@ impl RenderOnce for MenuRow {
         let pal = theme::palette(cx);
         let selected = self.selected;
         self.base
+            .selected(selected)
+            .aria_selected(selected)
             .w_full()
+            .flex()
             .items_center()
             .justify_between()
             .gap_2()
@@ -248,31 +272,50 @@ impl RenderOnce for MenuRow {
                     pal.control_hover
                 })
             })
+            .focus_visible(move |style| {
+                style.bg(if selected {
+                    theme::accent_tint_hover()
+                } else {
+                    pal.control_hover
+                })
+            })
             .children(self.children)
+            .when_some(self.on_click, |row, handler| {
+                row.on_click(move |event, window, cx| handler(event, window, cx))
+            })
     }
 }
 
 /// A selectable camera-profile chip.
 #[derive(IntoElement)]
 pub(crate) struct ProfileTab {
-    base: Stateful<gpui::Div>,
+    base: BaseButton,
     label: SharedString,
     selected: bool,
     children: Vec<AnyElement>,
+    on_click: Option<ClickHandler>,
     delete: Option<(ElementId, ClickHandler)>,
 }
-
-type ClickHandler = std::rc::Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
 
 impl ProfileTab {
     pub(crate) fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
         Self {
-            base: h_flex().id(id),
+            base: BaseButton::new(id).role(Role::Tab),
             label: label.into(),
             selected: false,
             children: Vec::new(),
+            on_click: None,
             delete: None,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(std::rc::Rc::new(handler));
+        self
     }
 
     #[must_use]
@@ -316,9 +359,14 @@ impl RenderOnce for ProfileTab {
         let pal = theme::palette(cx);
         let accent = rgb(ACCENT_BLUE);
         let has_delete = self.delete.is_some();
+        let label = self.label;
         self.base
+            .selected(self.selected)
+            .aria_selected(self.selected)
+            .accessibility_label(label.clone())
             .when(!has_delete, gpui::Styled::px_2)
             .when(has_delete, |tab| tab.pl_2().pr_1())
+            .flex()
             .py_0p5()
             .gap_1()
             .items_center()
@@ -347,16 +395,29 @@ impl RenderOnce for ProfileTab {
                     pal.control_hover
                 })
             })
-            .child(self.label)
+            .focus_visible(move |style| {
+                style
+                    .bg(if self.selected {
+                        theme::accent_tint_hover()
+                    } else {
+                        pal.control_hover
+                    })
+                    .border_color(accent)
+            })
+            .child(label.clone())
             .children(self.children)
+            .when_some(self.on_click, |tab, handler| {
+                tab.on_click(move |event, window, cx| handler(event, window, cx))
+            })
             .when_some(self.delete, |tab, (id, handler)| {
                 tab.child(
-                    div()
-                        .id(id)
+                    BaseButton::new(id)
+                        .accessibility_label(format!("{label} ×"))
                         .px_0p5()
                         .rounded_full()
                         .text_color(pal.text_muted)
                         .hover(|style| style.text_color(pal.text_primary))
+                        .focus_visible(|style| style.text_color(pal.text_primary))
                         .child("×")
                         .on_click(move |event, window, cx| {
                             cx.stop_propagation();
@@ -423,5 +484,107 @@ impl RenderOnce for PresetChip {
                 })
             })
             .children(self.children)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use gpui::{Context, KeyDownEvent, KeyUpEvent, Keystroke, Render, TestAppContext};
+
+    use super::*;
+
+    struct MenuRowHarness {
+        activations: Rc<Cell<usize>>,
+    }
+
+    impl Render for MenuRowHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let activations = self.activations.clone();
+            div().tab_group().size(px(100.)).child(
+                MenuRow::new("keyboard-menu-row")
+                    .role(Role::MenuItem)
+                    .child("Action")
+                    .on_click(move |_, _, _| activations.set(activations.get() + 1)),
+            )
+        }
+    }
+
+    struct ProfileTabHarness {
+        applications: Rc<Cell<usize>>,
+        deletions: Rc<Cell<usize>>,
+    }
+
+    impl Render for ProfileTabHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let applications = self.applications.clone();
+            let deletions = self.deletions.clone();
+            div().tab_group().size(px(100.)).child(
+                ProfileTab::new("keyboard-profile-tab", "Custom")
+                    .on_click(move |_, _, _| applications.set(applications.get() + 1))
+                    .on_delete("keyboard-profile-delete", move |_, _, _| {
+                        deletions.set(deletions.get() + 1);
+                    }),
+            )
+        }
+    }
+
+    fn activate_key(cx: &mut gpui::VisualTestContext, key: &str) {
+        let keystroke = Keystroke::parse(key).unwrap();
+        cx.simulate_event(KeyDownEvent {
+            keystroke: keystroke.clone(),
+            is_held: false,
+            prefer_character_input: false,
+        });
+        cx.simulate_event(KeyUpEvent { keystroke });
+    }
+
+    #[gpui::test]
+    fn menu_row_is_tab_focusable_and_keyboard_activatable(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let activations = Rc::new(Cell::new(0));
+        let (_, cx) = cx.add_window_view({
+            let activations = activations.clone();
+            move |_, _| MenuRowHarness { activations }
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+        cx.update(Window::focus_next);
+        cx.update(|window, cx| assert!(window.focused(cx).is_some()));
+
+        activate_key(cx, "enter");
+        activate_key(cx, "space");
+
+        assert_eq!(activations.get(), 2);
+    }
+
+    #[gpui::test]
+    fn profile_tab_and_delete_are_separate_keyboard_targets(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let applications = Rc::new(Cell::new(0));
+        let deletions = Rc::new(Cell::new(0));
+        let (_, cx) = cx.add_window_view({
+            let applications = applications.clone();
+            let deletions = deletions.clone();
+            move |_, _| ProfileTabHarness {
+                applications,
+                deletions,
+            }
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+
+        cx.update(Window::focus_next);
+        activate_key(cx, "enter");
+        assert_eq!(applications.get(), 1);
+        assert_eq!(deletions.get(), 0);
+
+        cx.update(Window::focus_next);
+        activate_key(cx, "space");
+        assert_eq!(applications.get(), 1);
+        assert_eq!(deletions.get(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Make the desktop GUI's custom-painted controls keyboard-operable while preserving their existing visuals and pointer behavior.

## Changes

- **workspace / openlogi-desktop**: add the pinned unstyled `gpui-base` button primitive as a direct dependency for semantic focus and Enter/Space activation
- **openlogi-desktop**: make device cards, mouse labels and hotspots, gesture directions, Actions Ring slots, menu rows, profile-scope tabs, and camera profile controls Tab-reachable with visible focus states
- **openlogi-desktop**: make the fixed mouse binding inspector and action library keyboard-operable, including labels, hotspots, current-action cards, direction and preset rows, detail navigation, and action selection
- **openlogi-desktop**: add `Focusable` view roots and tab groups, and replace raw Alt+Left inspection with a contextual `NavigateBack` action and key binding
- **openlogi-desktop**: add GPUI regression tests for Tab focus and Enter/Space activation, including independent camera-profile apply and delete targets

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 7 passed; typos, shell, macOS tests, cargo-deny, and wasm portability were skipped because their tools/target or host OS were unavailable
- Not runtime-tested on hardware or visually on macOS; verification was performed in a Linux orb

Fixes #897
