### PR TITLE
fix(hook,hid): revive gesture mode on Middle/Back/Forward

### DIFF
--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -216,19 +216,34 @@ thread_local! {
 
 /// Whether a button event's physical source may be remapped/suppressed.
 ///
-/// macOS attributes every CGEvent to an IOKit sender and fails closed: only
-/// known Logitech non-trackpad devices are remappable, so the built-in
-/// trackpad can never be swallowed. Linux/Windows often lack attribution
-/// (`device: None`); those platforms already restrict which devices the hook
-/// attaches to, so unknown sources stay remappable.
-fn button_source_may_remap(device: Option<&EventDevice>) -> bool {
+/// An attributed event is judged on identity alone: only known Logitech
+/// non-trackpad devices are remappable, so the built-in trackpad can never be
+/// swallowed. Linux/Windows often lack attribution (`device: None`); those
+/// platforms already restrict which devices the hook attaches to, so unknown
+/// sources stay remappable there.
+///
+/// macOS normally attributes every CGEvent to an IOKit sender, but not always —
+/// see the unattributed arm for which buttons still get the benefit of the
+/// doubt when it does not.
+fn button_source_may_remap(id: ButtonId, device: Option<&EventDevice>) -> bool {
     match device {
         Some(d) => source_is_remappable(Some(d)),
         None => {
             // Attribution missing: safe on Linux/Windows (device selection is
-            // upstream of the callback). On macOS fail closed — an unattributed
-            // event is more likely a trackpad/system source than a Logi mouse.
-            !cfg!(target_os = "macos")
+            // upstream of the callback).
+            //
+            // On macOS a CGEvent can reach the tap with no IOHIDEvent attached,
+            // and then there is no sender to resolve. Failing closed on that is
+            // right for the primary buttons — an unattributed left/right click
+            // is more likely a trackpad or a system source than a Logi mouse.
+            // It is wrong for the auxiliary ones: no trackpad emits button
+            // 2/3/4 at all, so nothing this rule protects can be the source,
+            // while a mouse that delivers Middle/Back/Forward through a HID
+            // collection carrying no sender loses every binding on those
+            // buttons — silently, since the events still reach the tap.
+            // Gesture mode is the worst of it: the hook never claims the press,
+            // so hold-and-swipe simply never fires.
+            !cfg!(target_os = "macos") || id.is_os_hook_button()
         }
     }
 }
@@ -266,7 +281,7 @@ fn handle_button(
     action_tx: &mpsc::SyncSender<Action>,
 ) -> EventDisposition {
     // Primary L/R always pass through (suppressing them would brick the mouse).
-    if !id.is_os_hook_button() || !button_source_may_remap(device) {
+    if !id.is_os_hook_button() || !button_source_may_remap(id, device) {
         return EventDisposition::PassThrough;
     }
 
@@ -846,6 +861,69 @@ mod tests {
         assert_eq!(
             resolve_gesture_click(&empty, ButtonId::Forward),
             default_binding(ButtonId::Forward)
+        );
+    }
+}
+
+#[cfg(test)]
+mod source_tests {
+    use super::*;
+
+    fn logitech() -> EventDevice {
+        EventDevice {
+            vendor_id: Some(0x046d),
+            product_id: Some(0xc548),
+            product_name: Some("USB Receiver".into()),
+        }
+    }
+
+    fn trackpad() -> EventDevice {
+        EventDevice {
+            vendor_id: Some(0x05ac),
+            product_id: Some(0x0324),
+            product_name: Some("Apple Internal Keyboard / Trackpad".into()),
+        }
+    }
+
+    /// The regression this arm exists for. Some mice deliver their auxiliary
+    /// buttons through a HID collection whose CGEvent carries no IOHIDEvent, so
+    /// there is no sender to resolve and `device` arrives as `None`. Failing
+    /// closed there loses every Middle/Back/Forward binding on that mouse —
+    /// and silently, because the events do reach the tap.
+    #[test]
+    fn an_unattributed_auxiliary_button_is_still_remappable() {
+        for id in [ButtonId::MiddleClick, ButtonId::Back, ButtonId::Forward] {
+            assert!(
+                button_source_may_remap(id, None),
+                "{id:?} must stay remappable without attribution, or its bindings can never fire"
+            );
+        }
+    }
+
+    /// The primary buttons keep the conservative rule: an unattributed left or
+    /// right click is far more likely a trackpad or a system source than a
+    /// mouse, and suppressing either would brick the pointer.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn an_unattributed_primary_button_still_fails_closed() {
+        assert!(
+            !button_source_may_remap(ButtonId::LeftClick, None),
+            "an unattributed primary click must not be remappable on macOS"
+        );
+    }
+
+    /// Attribution, when present, still decides on identity alone — the
+    /// unattributed arm must not have loosened anything for a device the hook
+    /// can actually see.
+    #[test]
+    fn an_attributed_source_is_judged_on_identity() {
+        assert!(
+            button_source_may_remap(ButtonId::MiddleClick, Some(&logitech())),
+            "a Logitech mouse is remappable"
+        );
+        assert!(
+            !button_source_may_remap(ButtonId::MiddleClick, Some(&trackpad())),
+            "a trackpad must never be swallowed, whatever the button"
         );
     }
 }

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -17,6 +17,7 @@
 //! is therefore only diverted when the user's thumbwheel config leaves its
 //! defaults (click bound, rotation rebound, or sensitivity changed).
 
+use std::collections::BTreeSet;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
 use hidpp::{channel::HidppChannel, device::Device, protocol::v20};
@@ -505,6 +506,18 @@ async fn arm_controls_into(
                 armed.button_cids.push((cid, button));
             }
         }
+
+        // Everything this session wants diverted is now diverted; anything
+        // else of ours that the device still reports as diverted is a leftover
+        // and has to be handed back, not merely left un-renewed.
+        let owned: BTreeSet<u16> = armed
+            .gesture_cids
+            .iter()
+            .copied()
+            .chain(armed.dpi_cids.iter().copied())
+            .chain(armed.button_cids.iter().map(|&(cid, _)| cid))
+            .collect();
+        release_unowned_diversions(&rc, &controls, &owned).await;
     }
 
     if spec.capture_thumbwheel
@@ -543,6 +556,88 @@ async fn arm_controls_into(
         armed.thumb = Some((tw, info.index, resolution));
     }
     Ok(())
+}
+
+/// The `0x1b04` controls OpenLogi ever diverts: the gesture sources, the
+/// DPI/ModeShift family, and the rebindable standard buttons. A control
+/// outside this set is none of OpenLogi's business — another application's
+/// diversion is left exactly as found.
+fn managed_cids() -> BTreeSet<u16> {
+    GESTURE_SOURCE_BUTTONS
+        .iter()
+        .map(|&(cid, _)| cid)
+        .chain(reprog_controls::DPI_MODE_SHIFT_CIDS)
+        .chain(DIVERTABLE_STANDARD_BUTTONS.iter().map(|&(cid, _)| cid))
+        .collect()
+}
+
+/// The controls this session deliberately leaves native: OpenLogi-managed,
+/// exposed by this device as divertable, and not in `owned`. Each is a
+/// candidate for [`release_unowned_diversions`].
+///
+/// Split out from the async walk so the ownership rule is unit-testable
+/// without a device on the other end of a channel.
+fn unowned_divertable_cids(
+    controls: &[reprog_controls::CtrlIdInfo],
+    owned: &BTreeSet<u16>,
+) -> Vec<u16> {
+    let managed = managed_cids();
+    controls
+        .iter()
+        .filter(|control| control.is_divertable())
+        .map(|control| control.cid)
+        .filter(|cid| managed.contains(cid) && !owned.contains(cid))
+        .collect()
+}
+
+/// Hand back every OpenLogi-managed control that this session does not own but
+/// the device still reports as diverted.
+///
+/// Diversion is volatile device state with no owner of its own: whoever set it
+/// last has to clear it, and an agent that died mid-session never does (nor
+/// does a Logi Options+ install that left its own behind). The arming loops
+/// above only ever touch the CIDs they divert, so a leftover diversion on a
+/// control the *current* config wants native used to survive every restart —
+/// the button then produces no OS event (it is diverted) and no HID++ one
+/// (nothing armed it): dead until the device sleeps or reconnects.
+///
+/// A button in gesture mode is exactly that case. Middle/Back/Forward swipes
+/// are detected by the OS hook, so `plan_for_device` deliberately keeps a
+/// gesture-mode button out of `spec.divert_buttons` — diverting it would
+/// starve the hook of the very press it must see. Moving a button that was
+/// diverted for a single action into gesture mode therefore has to *clear*
+/// that diversion; stopping renewal is not enough.
+///
+/// Costs one `getCidReporting` per unowned managed control the device exposes
+/// (at most a handful, once per arm) and only writes when one is actually
+/// diverted. Failures are logged, not propagated: a control that will not
+/// answer here is no reason to abort an otherwise healthy session.
+async fn release_unowned_diversions(
+    rc: &ReprogControlsV4,
+    controls: &[reprog_controls::CtrlIdInfo],
+    owned: &BTreeSet<u16>,
+) {
+    for cid in unowned_divertable_cids(controls, owned) {
+        match rc.get_cid_reporting(cid).await {
+            Ok(reporting) if reporting.diverted => {
+                info!(cid, "releasing a diversion this session does not own");
+                restore(
+                    rc.set_cid_reporting_full(cid, undivert_change(reporting))
+                        .await
+                        .map(|_| ()),
+                    "unowned diversion",
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                debug!(
+                    cid,
+                    ?error,
+                    "could not read reporting while releasing diversions"
+                );
+            }
+        }
+    }
 }
 
 async fn arm_reprog_control(

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -618,3 +618,78 @@ fn contact_without_rotation_or_a_tap_carries_no_input() {
         None
     );
 }
+
+/// A control the device exposes as divertable, for the ownership tests.
+fn divertable(cid: u16) -> reprog_controls::CtrlIdInfo {
+    reprog_controls::CtrlIdInfo {
+        cid,
+        task_id: 0,
+        flags: reprog_controls::CidFlags::DIVERTABLE.bits(),
+    }
+}
+
+/// The regression this whole release step exists for. Bind Middle Click to a
+/// single action and it gets diverted over `0x1b04`; move it into gesture mode
+/// and the plan deliberately stops diverting it, because the OS hook has to see
+/// the physical press to run hold+swipe detection. If the earlier diversion is
+/// merely left un-renewed — the agent was killed, so nothing restored it — the
+/// button emits no OS event and no HID++ event: gestures silently never fire
+/// and the button is dead until the mouse sleeps.
+#[test]
+fn a_gesture_mode_button_left_diverted_is_released() {
+    let controls = [divertable(0x0052)];
+    let owned = BTreeSet::new();
+
+    assert_eq!(
+        unowned_divertable_cids(&controls, &owned),
+        vec![0x0052],
+        "a managed control this session leaves native must be released if still diverted"
+    );
+}
+
+/// The mirror rule: a control this session just armed is in active use, and
+/// releasing it would undo the diversion one line after setting it.
+#[test]
+fn a_control_this_session_armed_is_never_released() {
+    let controls = [divertable(0x0052), divertable(0x0053)];
+    let owned = BTreeSet::from([0x0052]);
+
+    assert_eq!(
+        unowned_divertable_cids(&controls, &owned),
+        vec![0x0053],
+        "an owned CID must stay diverted; only the unowned one is a candidate"
+    );
+}
+
+/// Diversion has no owner field on the wire, so "not ours" is decided by the
+/// managed tables alone. A divertable control OpenLogi never touches — another
+/// application's, or one this version has no binding for — is left exactly as
+/// found rather than being stolen back to native.
+#[test]
+fn a_control_openlogi_never_diverts_is_left_alone() {
+    let controls = [divertable(0x00ff), divertable(0x0052)];
+    let owned = BTreeSet::new();
+
+    assert_eq!(
+        unowned_divertable_cids(&controls, &owned),
+        vec![0x0052],
+        "only OpenLogi-managed CIDs are candidates for release"
+    );
+}
+
+/// Arming only ever diverts what `getCtrlIdInfo` reports as divertable, so the
+/// release walk must apply the same filter — writing to a control the firmware
+/// does not divert is a wasted round-trip at best.
+#[test]
+fn a_non_divertable_control_is_not_a_candidate() {
+    let controls = [reprog_controls::CtrlIdInfo {
+        cid: 0x0052,
+        task_id: 0,
+        flags: reprog_controls::CidFlags::REPROGRAMMABLE.bits(),
+    }];
+
+    assert!(
+        unowned_divertable_cids(&controls, &BTreeSet::new()).is_empty(),
+        "a control the device will not divert is never a release candidate"
+    );
+}


### PR DESCRIPTION
## Summary

Middle-button gesture mode is dead on my MX Anywhere 3S: no direction fires, the plain click stops working too, and it survives restarts and reboots. Chasing it turned up **two independent bugs**, both on the path between the button and the hook. Either one alone is enough to kill gestures on Middle/Back/Forward; this branch fixes both, one commit each.

With both applied, hold-and-swipe works on this hardware — confirmed end to end, see Testing.

### 1. A stale `0x1b04` diversion is never released (#917)

`arm_controls_into` only writes the CIDs the current `CaptureSpec` wants diverted. A diversion left behind by a session that never tore down (agent killed, crash, force quit) is therefore never cleared, and since diversion is volatile device state with no owner on the wire, nothing else clears it. The control then emits **no OS event** (it is diverted) and **no HID++ event** (nothing armed it).

A gesture-mode Middle/Back/Forward button lands exactly there. `plan_for_device` deliberately keeps it out of `divert_buttons` — "diverting it would starve the hook of events" — which correctly stops *renewing* the diversion but never *clears* the one already set. So "bind Middle Click to a single action, then later switch it to gesture mode" leaves the button diverted forever.

The code already knows this state exists; `arm_reprog_control` logs `control was already diverted before arming`. It just only looks at CIDs it is arming, so a control the current config wants native is never read and never handed back.

### 2. Unattributed auxiliary buttons fail closed (#920)

`handle_button` gives up before it reads the binding when `button_source_may_remap` says no, and that fails closed when macOS attribution is missing. On this mouse the middle button's CGEvent carries **no IOHIDEvent at all** — `CGEventCopyIOHIDEvent` returns null — so `device` arrives as `None`, every time.

Nothing the closed rule protects can be the source there: no trackpad emits button 2/3/4, and `handle_button` has already narrowed to the OS-hook buttons before the check runs. So it buys nothing on those three while costing every binding on them, silently.

## Changes

**`crates/openlogi-device`** — `session/gesture.rs`

- After diverting what the spec wants, `release_unowned_diversions` reads back every OpenLogi-managed control the device exposes as divertable that this session does not own, and undiverts the ones still diverted. Ownership comes from what actually armed (`gesture_cids` + `dpi_cids` + `button_cids`), so the guard against undoing a diversion set moments earlier is exact.
- `unowned_divertable_cids` / `managed_cids` split the ownership rule out as pure functions, unit-testable without a device on the far end of a channel. Only `GESTURE_SOURCE_BUTTONS`, `DPI_MODE_SHIFT_CIDS` and `DIVERTABLE_STANDARD_BUTTONS` are consulted — another application's diversion is left exactly as found, and a control the firmware will not divert is skipped.
- Reuses the existing `undivert_change`, so the semantics match the teardown path: clear `diverted`/`raw_xy`, re-assert `remap`, leave every other bit untouched.
- Costs one `getCidReporting` per unowned managed control the device exposes — a handful, once per arm — and only writes when one is actually diverted.
- Side effect worth naming: any ungraceful agent exit becomes self-healing on the next arm, instead of leaving a button dead until the device sleeps or reconnects.
- 4 tests on the release rule.

**`crates/openlogi-agent-core`** — `hook_runtime.rs`

- `button_source_may_remap` takes the `ButtonId` and, when attribution is absent on macOS, keeps Middle/Back/Forward remappable while the primary buttons still fail closed. Linux/Windows are unchanged (they already treat unknown sources as remappable).
- 3 tests covering the unattributed auxiliary arm, the unattributed primary arm, and that an attributed source is still judged on identity alone.

## Testing

Commands run, from the final tree:

```sh
export RUSTFLAGS="-D warnings"
cargo fmt --all -- --check                                          # clean
cargo clippy -p openlogi-device -p openlogi-hid -p openlogi-agent \
             -p openlogi-agent-core -p openlogi-cli -p openlogi \
             --all-targets -- -D warnings                           # clean
cargo test   -p openlogi-device -p openlogi-hid -p openlogi-agent \
             -p openlogi-agent-core -p openlogi-cli -p openlogi     # all green
RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-device \
             -p openlogi-agent-core --no-deps --document-private-items   # clean
```

Affected-package tier. `cargo tree --workspace --target all --invert` gives `openlogi-device → openlogi-hid → {openlogi-agent, openlogi-agent-core, openlogi-cli → openlogi}` and `openlogi-agent-core → openlogi-agent`. No GUI crate depends on either change.

**Not run:** the full-workspace tier and `cargo xtask ci`. This machine has Command Line Tools only, not full Xcode, so the GPUI crates do not build here. No cross-lint either — `aarch64-apple-darwin` is the only installed target, so `clippy-windows` and the Linux jobs are **not run**, not green. The diff touches no wire type, no locale, and no `#[cfg(target_os = …)]` block; the one platform-conditional expression is a `cfg!()` in `button_source_may_remap`, whose Linux/Windows arm is unchanged, and the one platform-gated test is `#[cfg(target_os = "macos")]` while the other two hold on every target.

**Hardware verification** — MX Anywhere 3S over a Logi Bolt receiver, macOS 26.5 Apple Silicon:

1. Reproduced on 0.7.10 and `master` @ 013ab99: middle button completely inert in gesture mode.
2. Instrumented `master` showed the config, plan and hook maps all correct (`gkeys=[MiddleClick]`) while the event never reached the binding.
3. Bug 1 confirmed: a tail-append `CGEventTap` of my own saw *nothing* from button 2 while seeing every `LeftClick`. With the first commit the agent logs, on first arm:

   ```
   INFO openlogi_device::session::gesture: releasing a diversion this session does not own cid=82
   ```

   `cid=82` is `0x0052`, Middle Click — and button-2 events start reaching macOS again (470 of them in the next test).

4. Bug 2 then surfaced underneath, with probes on `handle_button`:

   ```
   id=LeftClick   device=Some(EventDevice { vendor_id: Some(1133), … }) may_remap=true
   id=MiddleClick device=None                                          may_remap=false
   ```

   110 `MiddleClick` events, every one unattributed.

5. With **both** commits: hold-and-swipe fires the bound direction, and a tap without a swipe still sends a plain middle click. Verified against this layout:

   ```toml
   [devices."receiver:…:slot:1".bindings.MiddleClick]
   Up    = "MissionControl"
   Down  = "CaptureRegion"
   Left  = "PrevTab"
   Right = "ShowActionsRing"
   Click = "MiddleClick"
   ```

   All five behave as configured, including the Actions Ring opening on a rightward swipe.

Worth a maintainer's pass on a device with a dedicated gesture button or an MX Master 4 haptic panel, to confirm nothing that *should* stay diverted gets released by the first commit.

Fixes #917
Fixes #920
