### PR TITLE
fix(agent): stop unarmable devices from holding a capture channel open

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -382,6 +382,7 @@ impl Orchestrator {
         self.devices
             .iter()
             .filter(|dev| dev.online && self.config.device_enabled(&dev.config_key))
+            .filter(|dev| device_can_capture(dev.capabilities))
             .filter_map(|dev| {
                 let route = dev.route.clone()?;
                 Some(plan_for_device(
@@ -790,6 +791,25 @@ impl Orchestrator {
             }
         }
     }
+}
+
+/// Whether the device can arm any HID++ capture at all.
+///
+/// Every captured control — standard buttons, gesture sources, the haptic
+/// panel, the DPI button, the thumb wheel — is diverted through reprog
+/// controls (`0x1b04`) or the dedicated thumb-wheel feature (`0x2150`). A
+/// device exposing neither (a G Pro Wireless over a Lightspeed receiver
+/// reports no `0x1bxx` entry at all) can never arm anything, yet a session
+/// would still hold one HID++ channel open for its whole life — and on macOS
+/// a concurrently-opened receiver node routes replies to the newest opener,
+/// so that idle channel starves the inventory prober: probes time out, the
+/// device reads as unreachable, and its battery / DPI / lighting panels hide.
+/// Its side-button bindings keep working regardless through the OS hook,
+/// which never needed the session. An unknown capability set (the probe has
+/// not answered yet) keeps the session, preserving the pre-existing behavior
+/// until the first successful probe settles it.
+fn device_can_capture(capabilities: Option<Capabilities>) -> bool {
+    capabilities.is_none_or(|caps| caps.buttons || caps.thumbwheel)
 }
 
 /// Resolve the two independently-gated HiResWheel settings for one device.

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -2,10 +2,10 @@
 
 use super::{
     AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
-    any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
-    pick_current, plan_reapply, reapply_targets,
+    any_device_needs_capture_rearm, build_devices, configured_wheel_mode, device_can_capture,
+    host_switch_links, pick_current, plan_reapply, reapply_targets,
 };
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
@@ -774,4 +774,47 @@ fn app_switch_republishes_capture_plans() {
     );
     orch.set_current_app(Some("com.example.editor".into()));
     assert_eq!(published_back_binding(&orch), Some(Action::Undo));
+}
+
+/// A device that can arm nothing must earn no capture plan: its session would
+/// hold a HID++ channel open for life and, on macOS, starve the inventory
+/// prober of replies (observed on a G Pro Wireless over Lightspeed).
+#[test]
+fn a_device_without_capturable_features_gets_no_capture_plan() {
+    let no_hidpp_controls = Capabilities {
+        buttons: false,
+        pointer: true,
+        lighting: true,
+        ..Capabilities::default()
+    };
+    assert!(device_can_capture(None));
+    assert!(!device_can_capture(Some(no_hidpp_controls)));
+    let mut config = Config::default();
+    config.set_binding("a", ButtonId::Back, Binding::Single(Action::Undo));
+
+    // Unknown capabilities keep the plan (probe has not answered yet).
+    let mut orch = orchestrator(config.clone());
+    orch.devices = vec![dev("a", 1, true)];
+    orch.rebuild();
+    assert_eq!(orch.shared.capture_plans.read().unwrap().len(), 1);
+
+    // No reprog controls + no thumb wheel → no plan, binding or not.
+    let mut orch = orchestrator(config.clone());
+    orch.devices = vec![dev("a", 1, true)];
+    orch.devices[0].capabilities = Some(no_hidpp_controls);
+    orch.rebuild();
+    assert!(
+        orch.shared.capture_plans.read().unwrap().is_empty(),
+        "an unarmable device must not hold a capture channel"
+    );
+
+    // Reprog controls present → plan again.
+    let mut orch = orchestrator(config);
+    orch.devices = vec![dev("a", 1, true)];
+    orch.devices[0].capabilities = Some(Capabilities {
+        buttons: true,
+        ..no_hidpp_controls
+    });
+    orch.rebuild();
+    assert_eq!(orch.shared.capture_plans.read().unwrap().len(), 1);
 }

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -101,6 +101,24 @@ fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
     }
 }
 
+/// Whether arming this spec would divert nothing at all.
+///
+/// A session for an empty spec earns its keep nowhere: its only job is
+/// delivering diverted controls, yet it still holds one HID++ channel open for
+/// its whole life. On macOS a concurrently-opened receiver node silently
+/// routes replies to the newest opener, so that permanent idle channel keeps
+/// stealing reply routing from the inventory prober — probes time out, the
+/// device reads as unreachable, and its battery / DPI / lighting panels hide
+/// (observed on a G Pro Wireless over a Lightspeed receiver, where every
+/// probe timed out while the empty-spec session was live). A device with
+/// nothing diverted is therefore better served by no session at all: probes
+/// answer, and its DPI / SmartShift writes take the fresh-open path.
+fn spec_is_empty(spec: &CaptureSpec) -> bool {
+    !spec.capture_thumbwheel
+        && spec.divert_gesture_sources.is_empty()
+        && spec.divert_buttons.is_empty()
+}
+
 /// One capture session tracked by the manager.
 struct RunningSession {
     route: DeviceRoute,
@@ -188,7 +206,7 @@ async fn manage(
                 // While pairing is waiting or active, release every capture
                 // session so run_pairing can own the receiver's HID node (one
                 // process can't read it through two channels).
-                let want: HashMap<String, (DeviceRoute, CaptureSpec, u64)> =
+                let mut want: HashMap<String, (DeviceRoute, CaptureSpec, u64)> =
                     if receiver_access.exclusive_requested() {
                         HashMap::new()
                     } else {
@@ -211,6 +229,10 @@ async fn manage(
                             })
                             .unwrap_or_default()
                     };
+                // An empty-spec device gets no session — see `spec_is_empty`.
+                // Filtering here (not at plan build time) also stops a live
+                // session the moment its spec drains to empty.
+                want.retain(|_, (_, spec, _)| !spec_is_empty(spec));
                 // Stop sessions whose device disappeared or whose plan changed.
                 // Sending on the oneshot lets the session restore its controls.
                 // A stopped session stays tracked — stop sender taken — until
@@ -548,6 +570,35 @@ fn advance(
 mod tests {
     use super::*;
     use openlogi_hid::thumbwheel::WheelResolution;
+
+    #[test]
+    fn an_empty_spec_earns_no_session() {
+        // A device with nothing diverted (no thumb wheel, no gesture sources,
+        // no bound buttons) must not hold a capture channel open — on macOS
+        // that idle channel steals reply routing from the inventory prober.
+        assert!(spec_is_empty(&CaptureSpec::default()));
+    }
+
+    #[test]
+    fn any_armed_control_keeps_the_session() {
+        let thumbwheel = CaptureSpec {
+            capture_thumbwheel: true,
+            ..CaptureSpec::default()
+        };
+        assert!(!spec_is_empty(&thumbwheel));
+
+        let gestures = CaptureSpec {
+            divert_gesture_sources: GESTURE_SOURCE_BUTTONS.iter().map(|(cid, _)| *cid).collect(),
+            ..CaptureSpec::default()
+        };
+        assert!(!spec_is_empty(&gestures));
+
+        let buttons = CaptureSpec {
+            divert_buttons: vec![(0x0053, ButtonId::Back)],
+            ..CaptureSpec::default()
+        };
+        assert!(!spec_is_empty(&buttons));
+    }
 
     /// The resolutions traced off an MX Master 4 over Bolt: 20 ratchets per
     /// revolution natively, 120 increments per revolution diverted.


### PR DESCRIPTION
## Summary

Devices that cannot arm any HID++ capture (no `0x1b04` reprog controls, no `0x2150` thumbwheel) no longer get a capture session. Such a session diverts nothing but still holds one HID++ channel open for the device's whole life — and on macOS that idle channel starves the inventory prober of replies, so the device reads as unreachable and its battery / DPI / lighting panels never appear.

## Reproduction

G Pro Wireless (wpid 4079) paired to a Lightspeed receiver (046d:c539), macOS:

- With the agent running, **every** device probe times out (`device probe timed out … budget=13s`, then `node probe keeps failing — retiring its channel before reopen` in a loop), even while the mouse is actively being used. The GUI shows "Unknown device", `battery=—`, and hides the DPI / battery / lighting panels; only OS-hook button remapping works.
- Killing the agent and running `openlogi list` standalone probes the same receiver instantly: full identity + `battery=22% low (discharging)`.
- `openlogi diag features` shows why the mouse *is* supported at protocol level: `0x2201` AdjustableDpi, `0x1001` BatteryVoltage, `0x8070` ColorLedEffects — and notably **no** `0x1bxx` entries.
- `diag dpi` round-trips fine (read 6400 → write 6450 → read back → restore).

The agent's startup log confirms the empty session: `control capture active index=1 gesture_sources=0 dpi_buttons=0 buttons=0 thumbwheel=false`.

## Root cause

`capture_plans_for()` builds a plan for every online device, and the watcher opens a permanent channel per plan — regardless of whether anything can be armed. On macOS, concurrently-opened nodes of one receiver silently route replies to the newest opener (the same hazard already documented on the capture session's liveness watchdog). A permanent idle channel therefore keeps stealing reply routing from the prober's channels.

## Fix

Two gates:

1. **orchestrator** (`capture_plans_for`): skip devices whose capability set proves nothing is armable (`!buttons && !thumbwheel`). An unknown set (probe not answered yet) keeps the current behavior until the first successful probe.
2. **watcher**: stop a live session whose spec drains to empty (e.g. bindings removed).

Side-button bindings on such devices are unaffected — they deliver through the OS hook, which never needed the session. DPI/SmartShift writes take the existing fresh-open path when no capture channel is published.

## Testing

- New unit tests: `a_device_without_capturable_features_gets_no_capture_plan`, `an_empty_spec_earns_no_session`, `any_armed_control_keeps_the_session`.
- `cargo test -p openlogi-agent-core`: 112 passed.
- `cargo clippy -p openlogi-agent-core --all-targets`: clean.
- On-device (G Pro Wireless + c539): patched agent probes succeed whenever the mouse is awake (`● G Pro … battery=20% low (discharging)` via the running agent); GUI shows the device with battery percentage and working DPI / lighting panels. Remaining timeouts occur only while the mouse is asleep, and recover on wake.