### PR TITLE
style(gui): refine profile toolbar layout

### DIFF
--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -11,6 +11,7 @@ use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName, h_flex,
     input::{InputEvent, InputState},
+    v_flex,
 };
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 
@@ -24,7 +25,7 @@ use super::leader_lines::{Geometry as LeaderGeometry, Label, Side, paint as pain
 use super::picker::{GESTURE_BUTTON_ICON, action_icon_path};
 use super::thumbwheel::ThumbwheelPreset;
 use crate::app::{glow_canvas, keyboard_glow};
-use crate::features::profile_scope::friendly_app_name;
+use crate::features::profile_scope::{friendly_app_name, profile_canvas_status};
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, StateEvent};
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
@@ -242,6 +243,7 @@ impl Render for MouseModelView {
         let view = cx.entity();
         let hovered = self.hovered;
         let pal = theme::palette(cx);
+        let profile_status = profile_canvas_status(pal, cx);
 
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
@@ -297,12 +299,18 @@ impl Render for MouseModelView {
             pal,
             cx,
         );
-        workspace_layout(canvas.into_any_element(), inspector, &self.focus_handle)
+        workspace_layout(
+            canvas.into_any_element(),
+            profile_status,
+            inspector,
+            &self.focus_handle,
+        )
     }
 }
 
 fn workspace_layout(
     canvas: AnyElement,
+    profile_status: Option<AnyElement>,
     inspector: AnyElement,
     focus_handle: &FocusHandle,
 ) -> AnyElement {
@@ -314,16 +322,24 @@ fn workspace_layout(
         .tab_group()
         .track_focus(focus_handle)
         .child(
-            div()
+            v_flex()
                 .flex_1()
                 .min_w_0()
                 .h_full()
                 .overflow_hidden()
-                .flex()
-                .items_center()
-                .justify_center()
-                .p_4()
-                .child(canvas),
+                .children(profile_status)
+                .child(
+                    div()
+                        .flex_1()
+                        .min_h_0()
+                        .w_full()
+                        .overflow_hidden()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .p_4()
+                        .child(canvas),
+                ),
         )
         .child(inspector)
         .into_any_element()

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -14,7 +14,6 @@ use gpui_component::{
     dialog::DialogButtonProps,
     h_flex,
     popover::Popover,
-    v_flex,
 };
 
 use crate::state::AppState;
@@ -22,6 +21,8 @@ use crate::ui::components::MenuRow;
 use crate::ui::theme::{self, Palette, SelectableStyle as _, Typography as _};
 
 use super::mouse::picker::{divider, menu_card, title};
+
+const PROFILE_CONTROL_H: f32 = 30.;
 
 #[derive(Clone)]
 struct ProfileChoice {
@@ -60,9 +61,6 @@ pub fn profile_scope_bar(
         return None;
     }
     let editing_app = state.editing_app().map(str::to_string);
-    let active_profile = state
-        .active_profile_name()
-        .map_or_else(|| tr!("Default"), gpui::SharedString::from);
     let mut profiles: Vec<ProfileChoice> = state
         .app_profiles()
         .map(|(app, count)| ProfileChoice {
@@ -95,7 +93,6 @@ pub fn profile_scope_bar(
         .map(|(app, name)| (app.to_string(), name.to_string()))
         .collect();
 
-    let summary = profile_summary(editing_app.as_deref(), &profiles);
     let persisted_ids: Vec<String> = profiles
         .iter()
         .filter(|profile| profile.persisted)
@@ -118,20 +115,52 @@ pub fn profile_scope_bar(
 
     Some(profile_scope_content(
         editing_app.as_deref(),
-        &active_profile,
         &profiles,
         available_apps,
-        summary,
         pal,
     ))
 }
 
+/// Profile inheritance and active-app context shown above the device canvas.
+pub(crate) fn profile_canvas_status(pal: Palette, cx: &App) -> Option<AnyElement> {
+    let state = AppState::try_read(cx)?;
+    if !state.current_device_is_persistent() {
+        return None;
+    }
+    let editing_app = state.editing_app().map(|app| {
+        state
+            .recent_app_name(app)
+            .map_or_else(|| friendly_app_name(app), str::to_string)
+    });
+    let summary = profile_summary(editing_app.as_deref(), state.editing_app_overrides().len());
+    let active = state
+        .active_profile_name()
+        .map_or_else(|| tr!("Default"), gpui::SharedString::from);
+
+    Some(
+        h_flex()
+            .flex_none()
+            .w_full()
+            .items_start()
+            .gap_3()
+            .px_4()
+            .pt_4()
+            .text_caption()
+            .text_color(pal.text_muted)
+            .child(div().flex_1().min_w_0().child(summary))
+            .child(
+                div()
+                    .flex_none()
+                    .child(tr!("Active: %{profile}", profile => active)),
+            )
+            .into_any_element(),
+    )
+}
+
 fn profile_scope_content(
     editing_app: Option<&str>,
-    active_profile: &gpui::SharedString,
     profiles: &[ProfileChoice],
     available_apps: Vec<ProfileChoice>,
-    summary: gpui::SharedString,
     pal: Palette,
 ) -> AnyElement {
     let default_selected = editing_app.is_none();
@@ -159,71 +188,51 @@ fn profile_scope_content(
         })
         .collect::<Vec<_>>();
 
-    v_flex()
+    h_flex()
         .flex_shrink_0()
         .w_full()
-        .gap_1p5()
+        .items_center()
+        .gap_2()
         .border_b_1()
         .border_color(pal.border)
         .bg(pal.panel)
         .px_4()
         .py_2()
         .child(
-            h_flex()
-                .w_full()
-                .items_center()
-                .gap_2()
-                .child(
-                    div()
-                        .flex_none()
-                        .text_body()
-                        .text_color(pal.text_muted)
-                        .child(tr!("Profile")),
-                )
-                .child(
-                    h_flex()
-                        .id("profile-tabs-scroll")
-                        .flex_1()
-                        .min_w_0()
-                        .items_center()
-                        .gap_1()
-                        .overflow_x_scroll()
-                        .child(
-                            profile_tab(
-                                "default-profile",
-                                tr!("Default"),
-                                None,
-                                default_selected,
-                                pal,
-                            )
-                            .on_click(|_event, _window, cx| {
-                                AppState::update_bindings(cx, |state| {
-                                    state.set_editing_app(None);
-                                });
-                            }),
-                        )
-                        .children(profile_tabs),
-                )
-                .child(add_app_popover(available_apps, pal))
-                .when_some(
-                    selected_profile.filter(|profile| profile.persisted),
-                    |row, profile| row.child(profile_options_popover(profile, pal)),
-                ),
+            div()
+                .flex_none()
+                .text_body()
+                .text_color(pal.text_muted)
+                .child(tr!("Profile")),
         )
         .child(
             h_flex()
-                .w_full()
+                .id("profile-tabs-scroll")
+                .flex_1()
+                .min_w_0()
                 .items_center()
-                .justify_between()
-                .gap_4()
-                .text_caption()
-                .text_color(pal.text_muted)
-                .child(summary)
+                .gap_1()
+                .overflow_x_scroll()
                 .child(
-                    div()
-                        .flex_none()
-                        .child(tr!("Active: %{profile}", profile => active_profile.clone())),
-                ),
+                    profile_tab(
+                        "default-profile",
+                        tr!("Default"),
+                        None,
+                        default_selected,
+                        pal,
+                    )
+                    .on_click(|_event, _window, cx| {
+                        AppState::update_bindings(cx, |state| {
+                            state.set_editing_app(None);
+                        });
+                    }),
+                )
+                .children(profile_tabs),
+        )
+        .child(add_app_popover(available_apps, pal))
+        .when_some(
+            selected_profile.filter(|profile| profile.persisted),
+            |row, profile| row.child(profile_options_popover(profile, pal)),
         )
         .into_any_element()
 }
@@ -245,8 +254,8 @@ fn profile_tab(
         .flex_none()
         .items_center()
         .gap_1p5()
+        .h(px(PROFILE_CONTROL_H))
         .px_2p5()
-        .py_1()
         .rounded(pal.control_radius)
         .cursor_pointer()
         .text_body()
@@ -292,25 +301,22 @@ fn application_mark(icon: Option<Arc<Image>>, name: &str, pal: Palette) -> AnyEl
         .into_any_element()
 }
 
-fn profile_summary(editing_app: Option<&str>, profiles: &[ProfileChoice]) -> gpui::SharedString {
+fn profile_summary(editing_app: Option<&str>, override_count: usize) -> gpui::SharedString {
     let Some(app) = editing_app else {
         return tr!("Default bindings apply unless an app profile overrides them.");
     };
-    let Some(profile) = profiles.iter().find(|profile| profile.app == app) else {
-        return gpui::SharedString::default();
-    };
-    match profile.override_count {
+    match override_count {
         0 => tr!(
             "No overrides yet. Select a button to customize for %{app}.",
-            app => profile.name.clone()
+            app => app
         ),
         1 => tr!(
             "%{app} overrides 1 button. Others inherit Default.",
-            app => profile.name.clone()
+            app => app
         ),
         count => tr!(
             "%{app} overrides %{count} buttons. Others inherit Default.",
-            app => profile.name.clone(),
+            app => app,
             count => count
         ),
     }
@@ -322,7 +328,8 @@ fn add_app_popover(apps: Vec<ProfileChoice>, pal: Palette) -> AnyElement {
         .trigger(
             Button::new("add-app-profile")
                 .outline()
-                .xsmall()
+                .small()
+                .h(px(PROFILE_CONTROL_H))
                 .icon(IconName::Plus)
                 .label(tr!("Add app")),
         )


### PR DESCRIPTION
## Summary

Refine the Profile controls introduced in #907 so the toolbar stays compact and the canvas carries its own contextual guidance.

## Changes

- `openlogi-desktop`: keep the Profile label, tabs, and actions on one toolbar row
- `openlogi-desktop`: move profile inheritance and active-profile status to the canvas top-left
- `openlogi-desktop`: give profile tabs and the Add app button the same 30 px control height

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS=\"-D warnings\" cargo test --workspace`
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 10 passed, 0 failed, 2 skipped (`typos`, `tests (linux)`)
- Not runtime-tested on hardware
- Visual runtime verification was not performed because the existing GUI/mock session was not disturbed

Follow-up to #907.