### PR TITLE
fix(hidpp): read Unifying link encryption from bit 5, not the software-present bit

### DIFF
--- a/crates/openlogi-hidpp/src/receiver/bolt/event.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt/event.rs
@@ -448,8 +448,8 @@ mod tests {
     #[test]
     fn device_connection_decodes_its_status_bits() {
         // Bit 5 is the link encryption flag and bit 6 is *inverted*: it is set
-        // when the device is offline. Bolt puts encryption on a different bit
-        // than Unifying does (bit 4), so this is not a shared layout.
+        // when the device is offline. Unifying uses the same layout — bit 4 is
+        // the software-present flag on both receivers.
         let connection = |status: u8| {
             let mut payload = [0u8; 17];
             payload[1] = status;

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -226,7 +226,7 @@ impl Receiver {
             // Kind is identity-only: an unrecognised nibble folds to
             // `Unknown` instead of failing the whole pairing-info read.
             kind: DeviceKind::from(response[1] & 0x0f),
-            encrypted: response[1] & (1 << 4) != 0,
+            encrypted: response[1] & (1 << 5) != 0,
             online: response[1] & (1 << 6) == 0,
             unit_id: [response[4], response[5], response[6], response[7]],
         })
@@ -278,7 +278,10 @@ pub fn decode_notification(msg: &v10::Message) -> Option<Event> {
         // dropping the event would hide the device entirely, since arrival
         // notifications are the only device source on this path.
         kind: DeviceKind::from(payload[1] & 0x0f),
-        encrypted: payload[1] & (1 << 4) != 0,
+        // Device-info high nibble: bit 6 = link not established, bit 5 = link
+        // encrypted, bit 4 = software present (same layout as Bolt; Solaar
+        // decodes both receivers with one mask table).
+        encrypted: payload[1] & (1 << 5) != 0,
         online: payload[1] & (1 << 6) == 0,
         wpid: u16::from_le_bytes([payload[2], payload[3]]),
     }))
@@ -428,9 +431,10 @@ mod tests {
     }
 
     #[test]
-    fn encryption_sits_on_bit_4_unlike_bolt() {
-        // Unifying reports link encryption on bit 4; Bolt uses bit 5. Reading
-        // Bolt's bit here would report every encrypted link as plaintext.
+    fn encryption_sits_on_bit_5_and_bit_4_is_software_present() {
+        // Both receivers report link encryption on bit 5 of the device-info
+        // byte; bit 4 is the software-present flag. This decoder used to read
+        // bit 4, reporting "Options+ seen" as link encryption.
         let connection = |status: u8| {
             let mut payload = [0u8; 17];
             payload[1] = status;
@@ -440,8 +444,8 @@ mod tests {
             }
         };
 
-        assert!(connection(1 << 4).encrypted);
-        assert!(!connection(1 << 5).encrypted);
+        assert!(connection(1 << 5).encrypted);
+        assert!(!connection(1 << 4).encrypted);
     }
 
     #[test]

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -381,10 +381,14 @@ pub enum Event {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::{
-        DeviceConnection, DeviceKind, Event, decode_notification, update_wireless_notification_flag,
+        DeviceConnection, DeviceKind, DevicePairingInformation, Event, InfoSubRegister, Receiver,
+        Register, decode_notification, update_wireless_notification_flag,
     };
-    use crate::protocol::v10::{Message, MessageHeader};
+    use crate::channel::tests::{MockRawHidChannel, channel_with_reader};
+    use crate::protocol::v10::{Message, MessageHeader, MessageType};
 
     /// Builds the long notification the receiver broadcasts, with `payload`
     /// laid out exactly as the 17 bytes following the header.
@@ -446,6 +450,61 @@ mod tests {
 
         assert!(connection(1 << 5).encrypted);
         assert!(!connection(1 << 4).encrypted);
+    }
+
+    #[test]
+    fn pairing_information_reads_encryption_from_bit_5() {
+        // The pairing register carries the same device-info byte as the 0x41
+        // notification, decoded independently — pin its bits too so the two
+        // paths cannot diverge unnoticed.
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let chan = Arc::new(channel_with_reader(raw).await);
+            let receiver =
+                Receiver::new(chan).expect("the mock's VID/PID routes as a Unifying receiver");
+
+            // First response: bit 5 + bit 6 — encrypted, offline. Second:
+            // bit 4 only (software present), which must not read as
+            // encryption.
+            for status in [0x62, 0x12] {
+                let mut payload = [0u8; 17];
+                payload[0] = Register::ReceiverInfo.into(); // RAP matches on the address echo
+                payload[1] = u8::from(InfoSubRegister::DevicePairingInformation) | 0x02;
+                payload[2] = status;
+                payload[3] = 0x69; // wpid, little-endian
+                payload[4] = 0x40;
+                payload[5..9].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+                handle.queue_response(
+                    Message::Long(
+                        MessageHeader {
+                            device_index: super::RECEIVER_DEVICE_INDEX,
+                            sub_id: MessageType::GetLongRegister.into(),
+                        },
+                        payload,
+                    )
+                    .into(),
+                );
+            }
+
+            let encrypted_offline = receiver.get_device_pairing_information(2).await.unwrap();
+            assert_eq!(
+                encrypted_offline,
+                DevicePairingInformation {
+                    wpid: 0x4069,
+                    kind: DeviceKind::Mouse,
+                    encrypted: true,
+                    online: false,
+                    unit_id: [0xde, 0xad, 0xbe, 0xef],
+                }
+            );
+
+            let software_present = receiver.get_device_pairing_information(2).await.unwrap();
+            assert!(
+                !software_present.encrypted,
+                "bit 4 is software-present, not encryption"
+            );
+            assert!(software_present.online);
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Unifying receiver decoded link encryption from bit 4 of the device-info
byte — that bit is the software-present flag. Encryption sits on bit 5 on
Unifying and Bolt alike; Solaar decodes both receivers with one mask table
(`link_encrypted = bool(flags & 0x20)` in `logitech_receiver/notifications.py`
and `receiver.py`). The bit-4 read came in with the vendored hidpp fork, and
#628 pinned it with a test asserting a Unifying/Bolt difference that does not
exist.

The bug is latent today — nothing outside `openlogi-hidpp` consumes
`encrypted` yet — but it would surface the moment link security is shown
anywhere.

## Changes

- `openlogi-hidpp`:
  - `decode_notification` (0x41) and `get_device_pairing_information` now read
    `encrypted` from bit 5; documented the device-info high-nibble layout at
    the decode site.
  - Rewrote the pinning test as
    `encryption_sits_on_bit_5_and_bit_4_is_software_present` (bit 5 set ⇒
    encrypted, bit 4 set ⇒ not).
  - Corrected the mirrored comment in the Bolt status-bits test that claimed
    the layouts differ.

## Testing

- `cargo test -p openlogi-hidpp` — 202 passed
- Full local gate on the final tree: `cargo fmt --all -- --check`;
  `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`;
  `cargo test --workspace` (0 failures);
  non-GUI rustdoc with `RUSTDOCFLAGS="-D warnings"`
- `cargo xtask ci typos "wasm (portable crates)"` — both PASS
- Not run on this host: tests (macos), clippy (windows), cargo-deny (no
  dependency changes)
- Not runtime-tested on hardware. To verify on a Unifying device: pair an
  encrypted device, decode its 0x41 arrival (e.g. the `04 62 69 40` capture
  from #853 has bit 5 set), and confirm `encrypted` reads true.

Fixes #923
