### PR TITLE
fix(thumbwheel): scale remapped vertical scrolling

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -432,12 +432,39 @@ struct WheelAccumulators {
 struct WheelDirection {
     /// Fractional line accumulator for continuous scroll.
     scroll: f32,
+    /// Scroll binding whose fractional progress is currently retained.
+    scroll_binding: Option<ScrollBinding>,
     /// Integer rotation-increment accumulator for a custom (non-scroll) action.
     action: i32,
     /// When the last rotation event for this direction arrived (decay clock).
     last_event: Option<Instant>,
     /// When this direction last fired its custom action (cooldown clock).
     last_fired: Option<Instant>,
+}
+
+/// Identity of a continuous scroll binding.
+///
+/// A direction's effective binding can change with configuration or the
+/// foreground application. Retained fractional progress belongs to the
+/// binding that earned it and must not leak into another axis or sign.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScrollBinding {
+    Up,
+    Down,
+    Right,
+    Left,
+}
+
+impl ScrollBinding {
+    fn from_action(action: &Action) -> Option<Self> {
+        match action {
+            Action::ScrollUp => Some(Self::Up),
+            Action::ScrollDown => Some(Self::Down),
+            Action::HorizontalScrollRight => Some(Self::Right),
+            Action::HorizontalScrollLeft => Some(Self::Left),
+            _ => None,
+        }
+    }
 }
 
 /// What advancing a direction's accumulator should produce.
@@ -602,6 +629,11 @@ fn advance(
     now: Instant,
 ) -> WheelOutput {
     let sensitivity = scale.sensitivity;
+    let scroll_binding = ScrollBinding::from_action(action);
+    if dir.scroll_binding != scroll_binding {
+        dir.scroll = 0.0;
+        dir.scroll_binding = scroll_binding;
+    }
     match action {
         // Suppressed: captured but produces nothing.
         Action::None => WheelOutput::Idle,

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -10,8 +10,7 @@
 //! - a DPI/ModeShift or thumb-wheel-tap press through the button binding map,
 //! - thumb-wheel rotation through the [`ButtonId::ThumbwheelScrollUp`] /
 //!   [`ButtonId::ThumbwheelScrollDown`] bindings — either re-synthesised as
-//!   continuous, sensitivity-scaled horizontal scroll or accumulated into a
-//!   custom action,
+//!   continuous, sensitivity-scaled scroll or accumulated into a custom action,
 //!
 //! all via the common [`crate::runtime::ActionDispatcher`].
 //!
@@ -431,7 +430,7 @@ struct WheelAccumulators {
 /// Running state for one rotation direction.
 #[derive(Default)]
 struct WheelDirection {
-    /// Fractional line accumulator for continuous horizontal scroll.
+    /// Fractional line accumulator for continuous scroll.
     scroll: f32,
     /// Integer rotation-increment accumulator for a custom (non-scroll) action.
     action: i32,
@@ -446,8 +445,8 @@ struct WheelDirection {
 enum WheelOutput {
     /// Below threshold / suppressed — emit nothing.
     Idle,
-    /// Post this many horizontal scroll lines (signed: + right, − left).
-    Scroll(i32),
+    /// Post signed horizontal and vertical scroll lines.
+    Scroll { delta_x: i32, delta_y: i32 },
     /// Fire the direction's bound custom action.
     FireAction,
 }
@@ -553,8 +552,8 @@ fn dispatch(
                 Instant::now(),
             ) {
                 WheelOutput::Idle => {}
-                WheelOutput::Scroll(lines) => {
-                    openlogi_inject::post_horizontal_scroll(lines);
+                WheelOutput::Scroll { delta_x, delta_y } => {
+                    openlogi_inject::post_thumbwheel_scroll(delta_x, delta_y);
                 }
                 WheelOutput::FireAction => {
                     debug!(key, ?button, action = %action.label(), "thumb wheel → action");
@@ -606,20 +605,37 @@ fn advance(
     match action {
         // Suppressed: captured but produces nothing.
         Action::None => WheelOutput::Idle,
-        // Continuous horizontal scroll, scaled from the wheel's diverted
+        // Continuous scroll, scaled from the wheel's diverted
         // increments back to its native amount and then by the user's
         // sensitivity. Direction comes from the action.
-        Action::HorizontalScrollRight | Action::HorizontalScrollLeft => {
+        Action::ScrollUp
+        | Action::ScrollDown
+        | Action::HorizontalScrollRight
+        | Action::HorizontalScrollLeft => {
             dir.scroll += magnitude as f32 * scale.per_increment();
             let lines = dir.scroll.trunc();
             if lines >= 1.0 {
                 dir.scroll -= lines;
-                let sign = if matches!(action, Action::HorizontalScrollRight) {
-                    1
-                } else {
-                    -1
-                };
-                WheelOutput::Scroll(sign * lines as i32)
+                let lines = lines as i32;
+                match action {
+                    Action::ScrollUp => WheelOutput::Scroll {
+                        delta_x: 0,
+                        delta_y: lines,
+                    },
+                    Action::ScrollDown => WheelOutput::Scroll {
+                        delta_x: 0,
+                        delta_y: -lines,
+                    },
+                    Action::HorizontalScrollRight => WheelOutput::Scroll {
+                        delta_x: lines,
+                        delta_y: 0,
+                    },
+                    Action::HorizontalScrollLeft => WheelOutput::Scroll {
+                        delta_x: -lines,
+                        delta_y: 0,
+                    },
+                    _ => unreachable!("scroll actions are matched above"),
+                }
             } else {
                 WheelOutput::Idle
             }

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -164,6 +164,31 @@ fn vertical_scroll_actions_emit_on_the_vertical_axis() {
 }
 
 #[test]
+fn binding_changes_do_not_reuse_fractional_scroll_progress() {
+    let mut dir = WheelDirection::default();
+    let now = Instant::now();
+    let half = unscaled(ThumbwheelSensitivity::from_rounded(7.0));
+
+    assert_eq!(
+        advance(&mut dir, &Action::HorizontalScrollRight, 1, half, now),
+        WheelOutput::Idle
+    );
+    // The half-line earned horizontally must not complete a vertical line
+    // after a live binding or application-context change.
+    assert_eq!(
+        advance(&mut dir, &Action::ScrollUp, 1, half, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        advance(&mut dir, &Action::ScrollUp, 1, half, now),
+        WheelOutput::Scroll {
+            delta_x: 0,
+            delta_y: 1,
+        }
+    );
+}
+
+#[test]
 fn directions_accumulate_independently() {
     let mut up = WheelDirection::default();
     let mut down = WheelDirection::default();

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -56,10 +56,10 @@ fn a_revolution_scrolls_its_native_amount_however_finely_the_wheel_reports() {
     let now = Instant::now();
     let mut lines = 0;
     for _ in 0..120 {
-        if let WheelOutput::Scroll(n) =
+        if let WheelOutput::Scroll { delta_x, .. } =
             advance(&mut dir, &Action::HorizontalScrollRight, 1, scale, now)
         {
-            lines += n;
+            lines += delta_x;
         }
     }
     assert_eq!(lines, 20, "one revolution is 20 native scroll units");
@@ -76,10 +76,10 @@ fn sensitivity_multiplies_the_native_amount() {
     let now = Instant::now();
     let mut lines = 0;
     for _ in 0..120 {
-        if let WheelOutput::Scroll(n) =
+        if let WheelOutput::Scroll { delta_x, .. } =
             advance(&mut dir, &Action::HorizontalScrollRight, 1, scale, now)
         {
-            lines += n;
+            lines += delta_x;
         }
     }
     assert_eq!(lines, 40, "2x sensitivity doubles the native 20");
@@ -114,7 +114,10 @@ fn scroll_accumulates_fractionally_at_sub_unity_sensitivity() {
             unscaled(half),
             now
         ),
-        WheelOutput::Scroll(1)
+        WheelOutput::Scroll {
+            delta_x: 1,
+            delta_y: 0,
+        }
     );
 }
 
@@ -130,7 +133,33 @@ fn scroll_left_emits_negative_lines() {
             unscaled(ThumbwheelSensitivity::DEFAULT),
             now
         ),
-        WheelOutput::Scroll(-1)
+        WheelOutput::Scroll {
+            delta_x: -1,
+            delta_y: 0,
+        }
+    );
+}
+
+#[test]
+fn vertical_scroll_actions_emit_on_the_vertical_axis() {
+    let now = Instant::now();
+    let mut up = WheelDirection::default();
+    let mut down = WheelDirection::default();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+
+    assert_eq!(
+        advance(&mut up, &Action::ScrollUp, 1, scale, now),
+        WheelOutput::Scroll {
+            delta_x: 0,
+            delta_y: 1,
+        }
+    );
+    assert_eq!(
+        advance(&mut down, &Action::ScrollDown, 1, scale, now),
+        WheelOutput::Scroll {
+            delta_x: 0,
+            delta_y: -1,
+        }
     );
 }
 
@@ -168,7 +197,10 @@ fn directions_accumulate_independently() {
             unscaled(half),
             now
         ),
-        WheelOutput::Scroll(1)
+        WheelOutput::Scroll {
+            delta_x: 1,
+            delta_y: 0,
+        }
     );
 }
 

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -223,10 +223,10 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     /// Thumb-wheel responsiveness. It scales both the speed of the wheel's
-    /// continuous horizontal scroll and how few rotation increments a custom
-    /// wheel action needs to fire. [`ThumbwheelSensitivity::DEFAULT`] means 1×
-    /// scroll speed; the wheel is only diverted from native scrolling once
-    /// this leaves the default.
+    /// continuous horizontal or remapped vertical scroll and how few rotation
+    /// increments a custom wheel action needs to fire.
+    /// [`ThumbwheelSensitivity::DEFAULT`] means 1× scroll speed; the wheel is
+    /// only diverted from native scrolling once this leaves the default.
     #[serde(default)]
     pub thumbwheel_sensitivity: ThumbwheelSensitivity,
     /// Light/dark appearance preference. Defaults to following the OS.
@@ -285,8 +285,8 @@ impl ThumbwheelSensitivity {
         Ok(value) => value,
         Err(_) => panic!("valid maximum thumb-wheel sensitivity"),
     };
-    /// Out-of-the-box sensitivity. At this value horizontal scrolling runs at
-    /// 1× and remains native unless a thumb-wheel binding is customized.
+    /// Out-of-the-box sensitivity. At this value scrolling runs at 1× and
+    /// remains native unless a thumb-wheel binding is customized.
     pub const DEFAULT: Self = match Self::try_new(14) {
         Ok(value) => value,
         Err(_) => panic!("valid default thumb-wheel sensitivity"),

--- a/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
+++ b/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
@@ -26,11 +26,12 @@ pub(crate) enum ThumbwheelPreset {
     VolumeReversed,
     CycleDpi,
     VerticalScroll,
+    VerticalScrollReversed,
     HorizontalScroll,
 }
 
 impl ThumbwheelPreset {
-    pub(crate) const ALL: [Self; 11] = [
+    pub(crate) const ALL: [Self; 12] = [
         Self::BackForward,
         Self::UndoRedo,
         Self::BrowserHistory,
@@ -41,6 +42,7 @@ impl ThumbwheelPreset {
         Self::VolumeReversed,
         Self::CycleDpi,
         Self::VerticalScroll,
+        Self::VerticalScrollReversed,
         Self::HorizontalScroll,
     ];
 
@@ -57,6 +59,7 @@ impl ThumbwheelPreset {
             Self::VolumeReversed => (Action::VolumeUp, Action::VolumeDown),
             Self::CycleDpi => (Action::CycleDpiPresets, Action::CycleDpiPresets),
             Self::VerticalScroll => (Action::ScrollDown, Action::ScrollUp),
+            Self::VerticalScrollReversed => (Action::ScrollUp, Action::ScrollDown),
             Self::HorizontalScroll => (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
         };
         ThumbwheelPair { backward, forward }
@@ -85,6 +88,7 @@ impl ThumbwheelPreset {
             Self::VolumeReversed => "Volume Up / Down",
             Self::CycleDpi => "Cycle DPI Presets",
             Self::VerticalScroll => "Vertical Scroll",
+            Self::VerticalScrollReversed => "Vertical Scroll (Reversed)",
             Self::HorizontalScroll => "Horizontal Scroll",
         }
     }
@@ -100,7 +104,7 @@ impl ThumbwheelPreset {
             Self::Tracks => "action-icons/skip-forward.svg",
             Self::Volume | Self::VolumeReversed => "action-icons/volume-2.svg",
             Self::CycleDpi => "action-icons/gauge.svg",
-            Self::VerticalScroll => "action-icons/chevrons-up.svg",
+            Self::VerticalScroll | Self::VerticalScrollReversed => "action-icons/chevrons-up.svg",
             Self::HorizontalScroll => "action-icons/chevrons-right.svg",
         }
     }
@@ -123,6 +127,7 @@ mod tests {
             (Action::VolumeUp, Action::VolumeDown),
             (Action::CycleDpiPresets, Action::CycleDpiPresets),
             (Action::ScrollDown, Action::ScrollUp),
+            (Action::ScrollUp, Action::ScrollDown),
             (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
         ];
 

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -64,8 +64,8 @@ pub enum CapturedInput {
     Gesture(ButtonId, GestureDirection),
     /// A diverted button's physical down edge.
     ButtonDown(ButtonId),
-    /// Thumb-wheel rotation to re-synthesise as horizontal scroll. Emitted
-    /// while the wheel is diverted (click bound, rotation rebound, or
+    /// Thumb-wheel rotation to re-synthesise on the configured scroll axis.
+    /// Emitted while the wheel is diverted (click bound, rotation rebound, or
     /// sensitivity changed).
     Scroll {
         /// Rotation in the wheel's diverted increments.

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -310,33 +310,32 @@ pub fn ax_navigate_browser(pid: i32, forward: bool) -> bool {
     }
 }
 
-/// Synthesise a horizontal scroll of `delta` wheel lines at the current focus.
+/// Synthesise a scroll of `(delta_x, delta_y)` wheel lines at the current focus.
 ///
 /// Used by the gesture/thumbwheel capture watcher to re-inject the MX thumb
-/// wheel's scrolling after the wheel has been diverted over HID++ to capture its
-/// click. `delta` is the device's raw rotation; its sign follows the wheel's
-/// rotation convention and its magnitude (one line per rotation increment) may
-/// need tuning per device, since the diverted resolution differs from native.
+/// wheel's scrolling after the wheel has been diverted over HID++. The caller
+/// maps physical rotation onto the configured horizontal or vertical axis and
+/// scales it from diverted increments back to native wheel lines.
 ///
 /// No-op (logs nothing) on platforms without a supported injection mechanism.
-pub fn post_horizontal_scroll(delta: i32) {
+pub fn post_thumbwheel_scroll(delta_x: i32, delta_y: i32) {
     cfg_select! {
         target_os = "macos" => {
-            macos::post_horizontal_scroll(delta);
+            macos::post_scroll(delta_x, delta_y);
         }
         target_os = "linux" => {
-            // `delta` is already in "one line per rotation increment" units (see
-            // doc above), which matches REL_HWHEEL's convention of one unit per
-            // detent. This is intentionally different from
-            // Action::HorizontalScrollLeft/Right, which hardcode ±3 as a fixed
-            // "scroll tick" with no device delta involved.
-            linux::scroll(evdev::RelativeAxisCode::REL_HWHEEL, delta);
+            if delta_y != 0 {
+                linux::scroll(evdev::RelativeAxisCode::REL_WHEEL, delta_y);
+            }
+            if delta_x != 0 {
+                linux::scroll(evdev::RelativeAxisCode::REL_HWHEEL, delta_x);
+            }
         }
         target_os = "windows" => {
-            windows::post_horizontal_scroll(delta);
+            windows::post_scroll(delta_x, delta_y);
         }
         _ => {
-            let _ = delta;
+            let _ = (delta_x, delta_y);
         }
     }
 }

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -602,14 +602,18 @@ fn dispatch_scroll(dx: i8, dy: i8) {
     ev.post(CGEventTapLocation::HID);
 }
 
-/// Post a horizontal scroll of `delta` lines (wheel2 axis). Line units suit
-/// the thumb wheel's ratchet-like increments better than pixels.
-pub(super) fn post_horizontal_scroll(delta: i32) {
+/// Post `(delta_x, delta_y)` scroll lines. Line units suit the thumb wheel's
+/// ratchet-like increments better than pixels.
+pub(super) fn post_scroll(delta_x: i32, delta_y: i32) {
+    if delta_x == 0 && delta_y == 0 {
+        return;
+    }
     let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
         tracing::warn!("CGEventSource::new failed for thumbwheel scroll");
         return;
     };
-    let Ok(ev) = CGEvent::new_scroll_event(src, ScrollEventUnit::LINE, 2, 0, delta, 0) else {
+    let Ok(ev) = CGEvent::new_scroll_event(src, ScrollEventUnit::LINE, 2, delta_y, delta_x, 0)
+    else {
         tracing::warn!("CGEvent::new_scroll_event failed for thumbwheel");
         return;
     };

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -238,14 +238,23 @@ fn dispatch_scroll(dx: i8, dy: i8) {
     }
 }
 
-pub(super) fn post_horizontal_scroll(delta: i32) {
-    if delta == 0 {
-        return;
+pub(super) fn post_scroll(delta_x: i32, delta_y: i32) {
+    let mut inputs = Vec::with_capacity(2);
+    if delta_y != 0 {
+        inputs.push(mouse_input(
+            MOUSEEVENTF_WHEEL,
+            delta_y.saturating_mul(WHEEL_DELTA),
+        ));
     }
-    send_inputs(&[mouse_input(
-        MOUSEEVENTF_HWHEEL,
-        delta.saturating_mul(WHEEL_DELTA),
-    )]);
+    if delta_x != 0 {
+        inputs.push(mouse_input(
+            MOUSEEVENTF_HWHEEL,
+            delta_x.saturating_mul(WHEEL_DELTA),
+        ));
+    }
+    if !inputs.is_empty() {
+        send_inputs(&inputs);
+    }
 }
 
 fn post_custom_shortcut(combo: &KeyCombo) {

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -3,7 +3,7 @@
 mod inject;
 
 pub use inject::{
-    SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_horizontal_scroll, press_hold,
+    SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_thumbwheel_scroll, press_hold,
     release_hold, replace_hold,
 };
 

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Skru ned / op"
 "Volume Up / Down": "Skru op / ned"
 "Vertical Scroll": "Lodret rulning"
+"Vertical Scroll (Reversed)": "Lodret rulning (omvendt)"
 "Horizontal Scroll": "Vandret rulning"
 "Custom": "Brugerdefineret"
 "Gesture Button": "Bevægelsesknap"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Leiser / Lauter"
 "Volume Up / Down": "Lauter / Leiser"
 "Vertical Scroll": "Vertikales Scrollen"
+"Vertical Scroll (Reversed)": "Vertikales Scrollen (umgekehrt)"
 "Horizontal Scroll": "Horizontales Scrollen"
 "Custom": "Benutzerdefiniert"
 "Gesture Button": "Gestentaste"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Μείωση / αύξηση έντασης"
 "Volume Up / Down": "Αύξηση / μείωση έντασης"
 "Vertical Scroll": "Κατακόρυφη κύλιση"
+"Vertical Scroll (Reversed)": "Κατακόρυφη κύλιση (αντίστροφη)"
 "Horizontal Scroll": "Οριζόντια κύλιση"
 "Custom": "Προσαρμοσμένο"
 "Gesture Button": "Κουμπί χειρονομιών"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Volume Down / Up"
 "Volume Up / Down": "Volume Up / Down"
 "Vertical Scroll": "Vertical Scroll"
+"Vertical Scroll (Reversed)": "Vertical Scroll (Reversed)"
 "Horizontal Scroll": "Horizontal Scroll"
 "Custom": "Custom"
 "Gesture Button": "Gesture Button"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Bajar / subir volumen"
 "Volume Up / Down": "Subir / bajar volumen"
 "Vertical Scroll": "Desplazamiento vertical"
+"Vertical Scroll (Reversed)": "Desplazamiento vertical (invertido)"
 "Horizontal Scroll": "Desplazamiento horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botón de gestos"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Äänenvoimakkuus alas / ylös"
 "Volume Up / Down": "Äänenvoimakkuus ylös / alas"
 "Vertical Scroll": "Pystyvieritys"
+"Vertical Scroll (Reversed)": "Pystyvieritys (käänteinen)"
 "Horizontal Scroll": "Vaakavieritys"
 "Custom": "Mukautettu"
 "Gesture Button": "Eletoiminto"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Baisser / augmenter le volume"
 "Volume Up / Down": "Augmenter / baisser le volume"
 "Vertical Scroll": "Défilement vertical"
+"Vertical Scroll (Reversed)": "Défilement vertical (inversé)"
 "Horizontal Scroll": "Défilement horizontal"
 "Custom": "Personnalisé"
 "Gesture Button": "Bouton de gestes"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Volume giù / su"
 "Volume Up / Down": "Volume su / giù"
 "Vertical Scroll": "Scorrimento verticale"
+"Vertical Scroll (Reversed)": "Scorrimento verticale (invertito)"
 "Horizontal Scroll": "Scorrimento orizzontale"
 "Custom": "Personalizzato"
 "Gesture Button": "Pulsante gesture"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "音量を下げる / 上げる"
 "Volume Up / Down": "音量を上げる / 下げる"
 "Vertical Scroll": "縦スクロール"
+"Vertical Scroll (Reversed)": "縦スクロール（反転）"
 "Horizontal Scroll": "横スクロール"
 "Custom": "カスタム"
 "Gesture Button": "ジェスチャーボタン"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "볼륨 낮추기 / 높이기"
 "Volume Up / Down": "볼륨 높이기 / 낮추기"
 "Vertical Scroll": "세로 스크롤"
+"Vertical Scroll (Reversed)": "세로 스크롤(반대 방향)"
 "Horizontal Scroll": "가로 스크롤"
 "Custom": "사용자 지정"
 "Gesture Button": "제스처 버튼"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Volum ned / opp"
 "Volume Up / Down": "Volum opp / ned"
 "Vertical Scroll": "Vertikal rulling"
+"Vertical Scroll (Reversed)": "Vertikal rulling (omvendt)"
 "Horizontal Scroll": "Horisontal rulling"
 "Custom": "Egendefinert"
 "Gesture Button": "Bevegelsesknapp"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Volume omlaag / omhoog"
 "Volume Up / Down": "Volume omhoog / omlaag"
 "Vertical Scroll": "Verticaal scrollen"
+"Vertical Scroll (Reversed)": "Verticaal scrollen (omgekeerd)"
 "Horizontal Scroll": "Horizontaal scrollen"
 "Custom": "Aangepast"
 "Gesture Button": "Gebarenknop"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Ciszej / głośniej"
 "Volume Up / Down": "Głośniej / ciszej"
 "Vertical Scroll": "Przewijanie pionowe"
+"Vertical Scroll (Reversed)": "Przewijanie pionowe (odwrócone)"
 "Horizontal Scroll": "Przewijanie poziome"
 "Custom": "Niestandardowe"
 "Gesture Button": "Przycisk gestów"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Diminuir / aumentar volume"
 "Volume Up / Down": "Aumentar / diminuir volume"
 "Vertical Scroll": "Rolagem vertical"
+"Vertical Scroll (Reversed)": "Rolagem vertical (invertida)"
 "Horizontal Scroll": "Rolagem horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de Gesto"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Diminuir / aumentar volume"
 "Volume Up / Down": "Aumentar / diminuir volume"
 "Vertical Scroll": "Deslocamento vertical"
+"Vertical Scroll (Reversed)": "Deslocamento vertical (invertido)"
 "Horizontal Scroll": "Deslocamento horizontal"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de gesto"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Тише / громче"
 "Volume Up / Down": "Громче / тише"
 "Vertical Scroll": "Вертикальная прокрутка"
+"Vertical Scroll (Reversed)": "Вертикальная прокрутка (обратная)"
 "Horizontal Scroll": "Горизонтальная прокрутка"
 "Custom": "Свой"
 "Gesture Button": "Кнопка жестов"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Sänk / höj volymen"
 "Volume Up / Down": "Höj / sänk volymen"
 "Vertical Scroll": "Vertikal rullning"
+"Vertical Scroll (Reversed)": "Vertikal rullning (omvänd)"
 "Horizontal Scroll": "Horisontell rullning"
 "Custom": "Anpassad"
 "Gesture Button": "Gestknapp"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Sesi Azalt / Artır"
 "Volume Up / Down": "Sesi Artır / Azalt"
 "Vertical Scroll": "Dikey Kaydırma"
+"Vertical Scroll (Reversed)": "Dikey Kaydırma (Ters)"
 "Horizontal Scroll": "Yatay Kaydırma"
 "Custom": "Özel"
 "Gesture Button": "Hareket Düğmesi"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "Гучність тихіше / гучніше"
 "Volume Up / Down": "Гучність гучніше / тихіше"
 "Vertical Scroll": "Вертикальне прокручування"
+"Vertical Scroll (Reversed)": "Вертикальне прокручування (зворотне)"
 "Horizontal Scroll": "Горизонтальне прокручування"
 "Custom": "Власна"
 "Gesture Button": "Кнопка жестів"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "减小 / 增大音量"
 "Volume Up / Down": "增大 / 减小音量"
 "Vertical Scroll": "垂直滚动"
+"Vertical Scroll (Reversed)": "垂直滚动（反向）"
 "Horizontal Scroll": "水平滚动"
 "Custom": "自定义"
 "Gesture Button": "手势按钮"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "調低 / 調高音量"
 "Volume Up / Down": "調高 / 調低音量"
 "Vertical Scroll": "垂直捲動"
+"Vertical Scroll (Reversed)": "垂直捲動（反向）"
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -187,6 +187,7 @@ _version: 1
 "Volume Down / Up": "調低 / 調高音量"
 "Volume Up / Down": "調高 / 調低音量"
 "Vertical Scroll": "垂直捲動"
+"Vertical Scroll (Reversed)": "垂直捲動（反向）"
 "Horizontal Scroll": "水平捲動"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"


### PR DESCRIPTION
## Summary

Remapped thumb-wheel `ScrollUp` / `ScrollDown` actions currently go through the discrete-action path, so `thumbwheel_sensitivity` changes their trigger threshold but not the amount scrolled. On affected devices this produces the very slow vertical scrolling reported in #737, and setting the sensitivity as high as 100 still does not meaningfully change the scroll distance.

Route vertical scroll actions through the same continuous, native-resolution-aware accumulator used by horizontal thumb-wheel scrolling. The configured sensitivity is now a proportional multiplier for either scroll axis.

## Changes

- `openlogi-agent-core`: treat all four scroll actions as continuous thumb-wheel output, carrying explicit horizontal and vertical deltas; add vertical-axis regression coverage.
- `openlogi-inject`: generalize diverted thumb-wheel injection to `(delta_x, delta_y)` on macOS, Linux, and Windows.
- `openlogi-core`: document that thumb-wheel sensitivity scales remapped vertical scrolling too.
- `openlogi-desktop`: add a `Vertical Scroll (Reversed)` thumb-wheel preset and cover its binding pair.
- `openlogi-ui`: add the new preset label to every locale catalog.

## Related work

- #857 fixed the hidden thumb-wheel tap action and corrected diverted resolution scaling, but vertical scroll actions still bypass that proportional scroll path.
- #619 tracks a separate horizontal default-direction mismatch; this PR does not change horizontal defaults.
- #764 adds continuous thumb-wheel zoom and may overlap the accumulator/injection files, but does not implement proportional vertical scrolling.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p openlogi-agent-core watchers::gesture::tests` — 16 passed, including binding-change accumulator isolation
- `cargo test -p openlogi-desktop thumbwheel` — 12 passed
- `cargo test -p openlogi-desktop services::i18n::tests::locale_file_resolves_keys` — passed
- `cargo test -p openlogi-ui locale` — 3 passed
- `cargo check -p openlogi-inject`
- `cargo doc -p openlogi-inject -p openlogi-agent-core --no-deps --document-private-items` with `RUSTDOCFLAGS=-D warnings`

`cargo test --workspace` passes all product and feature suites locally, but the command exits on an existing Windows-only `xtask` assertion: its workflow parser joins `\\\n` continuations while this checkout contains `\\\r\n`. The full non-GUI rustdoc command likewise reaches an existing Windows-gated broken link in `openlogi-permissions`; warnings-denied rustdoc passes for both changed non-GUI crates.

Not runtime-tested on hardware. The Windows injector compiled on the test host; macOS and Linux injection branches were hand-audited but not compiled locally.

Fixes #737
