### PR TITLE
refactor(gui): clean up render paths and element ids

### DIFF
--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -37,7 +37,15 @@ use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::features::profile_scope::{ProfileIconCache, profile_scope_bar};
 use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::components::{PanelCard, Toggle};
-use crate::ui::theme::{DETAIL_RAIL_W, HEADER_H, Palette, SCREEN_PAD, Typography as _};
+use crate::ui::theme::{
+    CONTENT_W_2XL, CONTENT_W_LG, CONTENT_W_MD, CONTENT_W_SM, CONTENT_W_XL, DETAIL_RAIL_W, HEADER_H,
+    Palette, SCREEN_PAD, Typography as _,
+};
+
+const CAMERA_PREVIEW_W: f32 = 514.;
+const CAMERA_CONTROLS_W: f32 = 500.;
+const LIGHT_CONTROLS_W: f32 = 400.;
+const LIGHT_CONTROLS_MIN_W: f32 = 360.;
 
 /// Compact device identity bar. Section navigation belongs to the workspace
 /// rail below; pairing belongs to the Devices screen, so neither competes with
@@ -275,24 +283,10 @@ fn buttons_tab(
         .child(mouse_model.clone())
 }
 
-/// Keys tab: the function-row remapper for a keyboard.
-fn keys_tab(keyboard_model: &gpui::Entity<FunctionRowView>) -> impl IntoElement {
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .items_center()
-        .justify_center()
-        .p(px(SCREEN_PAD))
-        .child(
-            div()
-                .w_full()
-                .max_w(px(1040.))
-                .child(keyboard_model.clone()),
-        )
-}
-
-fn action_ring_tab(panel: &gpui::Entity<ActionRingPanel>) -> impl IntoElement {
+fn tab_body(
+    width: f32,
+    content: impl IntoElement,
+) -> gpui_component::scroll::Scrollable<gpui::Div> {
     v_flex()
         .flex_1()
         .w_full()
@@ -300,7 +294,16 @@ fn action_ring_tab(panel: &gpui::Entity<ActionRingPanel>) -> impl IntoElement {
         .items_center()
         .overflow_y_scrollbar()
         .p(px(SCREEN_PAD))
-        .child(div().w_full().max_w(px(680.)).child(panel.clone()))
+        .child(div().w_full().max_w(px(width)).child(content))
+}
+
+/// Keys tab: the function-row remapper for a keyboard.
+fn keys_tab(keyboard_model: &gpui::Entity<FunctionRowView>) -> impl IntoElement {
+    tab_body(CONTENT_W_2XL, keyboard_model.clone()).justify_center()
+}
+
+fn action_ring_tab(panel: &gpui::Entity<ActionRingPanel>) -> impl IntoElement {
+    tab_body(CONTENT_W_MD, panel.clone())
 }
 
 /// Pointer tab: the DPI panel, the SmartShift wheel controls, and the
@@ -313,43 +316,36 @@ fn pointer_tab(
     pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .items_center()
-        .overflow_y_scrollbar()
-        .p(px(SCREEN_PAD))
-        .child(
-            h_flex()
-                .w_full()
-                .max_w(px(920.))
-                .items_stretch()
-                .gap_4()
-                .flex_wrap()
-                .child(pointer_grid_card(
-                    PanelCard::new(
-                        tr!("Pointer tuning"),
-                        Icon::empty().path("action-icons/gauge.svg"),
-                        dpi_panel.clone().into_any_element(),
-                    )
-                    .fill(),
-                ))
-                .child(pointer_grid_card(
-                    PanelCard::new(
-                        tr!("SmartShift"),
-                        Icon::empty().path("action-icons/refresh-cw.svg"),
-                        smartshift_panel.clone().into_any_element(),
-                    )
-                    .fill(),
-                ))
-                .child(
-                    div()
-                        .min_w(px(332.))
-                        .flex_1()
-                        .child(scrolling_card(pal, cx)),
-                ),
-        )
+    tab_body(
+        CONTENT_W_LG,
+        h_flex()
+            .w_full()
+            .items_stretch()
+            .gap_4()
+            .flex_wrap()
+            .child(pointer_grid_card(
+                PanelCard::new(
+                    tr!("Pointer tuning"),
+                    Icon::empty().path("action-icons/gauge.svg"),
+                    dpi_panel.clone().into_any_element(),
+                )
+                .fill(),
+            ))
+            .child(pointer_grid_card(
+                PanelCard::new(
+                    tr!("SmartShift"),
+                    Icon::empty().path("action-icons/refresh-cw.svg"),
+                    smartshift_panel.clone().into_any_element(),
+                )
+                .fill(),
+            ))
+            .child(
+                div()
+                    .min_w(px(332.))
+                    .flex_1()
+                    .child(scrolling_card(pal, cx)),
+            ),
+    )
 }
 
 fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
@@ -498,18 +494,14 @@ fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -
 /// card. Shown when the device reports a lighting capability — see
 /// [`DetailTab::tabs_for`].
 fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>) -> impl IntoElement {
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .items_center()
-        .overflow_y_scrollbar()
-        .p(px(SCREEN_PAD))
-        .child(div().w_full().max_w(px(560.)).child(PanelCard::new(
+    tab_body(
+        CONTENT_W_SM,
+        PanelCard::new(
             tr!("Lighting"),
             Icon::new(IconName::Palette),
             lighting_panel.clone().into_any_element(),
-        )))
+        ),
+    )
 }
 
 /// Camera tab: the live webcam preview beside the device-level image controls,
@@ -536,16 +528,26 @@ fn camera_tab(
                 .justify_center()
                 .items_start()
                 .gap_3()
-                .child(div().w(px(514.)).flex_shrink_0().child(PanelCard::new(
-                    tr!("Camera"),
-                    Icon::new(IconName::Eye),
-                    camera_preview.clone().into_any_element(),
-                )))
-                .child(div().w(px(500.)).flex_shrink_0().child(PanelCard::new(
-                    tr!("Camera controls"),
-                    Icon::new(IconName::Settings),
-                    camera_controls.clone().into_any_element(),
-                ))),
+                .child(
+                    div()
+                        .w(px(CAMERA_PREVIEW_W))
+                        .flex_shrink_0()
+                        .child(PanelCard::new(
+                            tr!("Camera"),
+                            Icon::new(IconName::Eye),
+                            camera_preview.clone().into_any_element(),
+                        )),
+                )
+                .child(
+                    div()
+                        .w(px(CAMERA_CONTROLS_W))
+                        .flex_shrink_0()
+                        .child(PanelCard::new(
+                            tr!("Camera controls"),
+                            Icon::new(IconName::Settings),
+                            camera_controls.clone().into_any_element(),
+                        )),
+                ),
         )
 }
 
@@ -574,46 +576,37 @@ fn light_tab(
             )
         },
     );
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .items_center()
-        .overflow_y_scrollbar()
-        .p(px(SCREEN_PAD))
-        .child(
-            h_flex()
-                .w_full()
-                .max_w(px(980.))
-                .gap_4()
-                .flex_wrap()
-                .items_start()
-                .child(light_visual::detail(asset, online, enabled, settings, pal))
-                .child(div().w(px(400.)).min_w(px(360.)).child(PanelCard::new(
-                    tr!("Lighting"),
-                    Icon::new(IconName::Sun),
-                    light_panel.clone().into_any_element(),
-                ))),
-        )
+    tab_body(
+        CONTENT_W_XL,
+        h_flex()
+            .w_full()
+            .gap_4()
+            .flex_wrap()
+            .items_start()
+            .child(light_visual::detail(asset, online, enabled, settings, pal))
+            .child(
+                div()
+                    .w(px(LIGHT_CONTROLS_W))
+                    .min_w(px(LIGHT_CONTROLS_MIN_W))
+                    .child(PanelCard::new(
+                        tr!("Lighting"),
+                        Icon::new(IconName::Sun),
+                        light_panel.clone().into_any_element(),
+                    )),
+            ),
+    )
 }
 
 /// Device tab: device details and configuration cards stacked.
 fn device_tab(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .items_center()
-        .overflow_y_scrollbar()
-        .p(px(SCREEN_PAD))
-        .child(
-            v_flex()
-                .w_full()
-                .max_w(px(560.))
-                .gap_3()
-                .child(device_details_card(pal, cx))
-                .child(configuration_card(pal, cx)),
-        )
+    tab_body(
+        CONTENT_W_SM,
+        v_flex()
+            .w_full()
+            .gap_3()
+            .child(device_details_card(pal, cx))
+            .child(configuration_card(pal, cx)),
+    )
 }
 
 fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -56,7 +56,7 @@ pub(super) fn home_header(pal: Palette) -> impl IntoElement {
 const GALLERY_GAP: f32 = 24.;
 
 /// The Home device list: an equal-size, horizontally scrollable row of device
-/// cards (Logi Options+ style), via [`Carousel`]'s `uniform` mode. Each card
+/// cards (Logi Options+ style), via [`Carousel`]. Each card
 /// floats the device photo on the window background above its name and battery;
 /// the row centres while the cards fit the viewport and scrolls once they don't.
 /// Clicking a card opens its detail screen and makes it the active device.
@@ -75,18 +75,13 @@ pub(super) fn device_gallery(cx: &mut Context<AppView>) -> impl IntoElement {
     let view = cx.entity();
 
     v_flex().flex_1().w_full().min_h_0().child(
-        Carousel::new("device-carousel")
+        Carousel::new("device-carousel", px(theme::GALLERY_CARD_W))
             .len(len)
             .selected(active_idx)
-            .uniform(px(theme::GALLERY_CARD_W))
             .gap(px(GALLERY_GAP))
             // The arrows stay: they are the only tab-focusable control that
             // moves the selection (and the row scrolls to the selected card),
-            // so they are the keyboard path to off-screen devices. The dots go:
-            // they duplicate the scroll position and, as plain divs, were never
-            // keyboard-operable anyway.
-            .indicators(false)
-            .accent(rgb(theme::ACCENT_BLUE).into())
+            // so they are the keyboard path to off-screen devices.
             .render_item(move |idx, focused, _window, cx| {
                 let pal = theme::palette(cx);
                 let Some(record) = AppState::try_global(cx)

--- a/crates/openlogi-desktop/src/features/action_ring/editor.rs
+++ b/crates/openlogi-desktop/src/features/action_ring/editor.rs
@@ -18,7 +18,7 @@ use openlogi_core::binding::{
 };
 
 use super::action_icons::action_icon_path;
-use crate::features::mouse::picker::popover_section;
+use crate::features::mouse::picker::editor_section;
 use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::components::MenuRow;
 use crate::ui::theme::{self, Palette, Typography as _};
@@ -121,7 +121,7 @@ fn icon_editor(
 
     v_flex()
         .gap_1()
-        .child(popover_section(tr!("Icon"), pal))
+        .child(editor_section(tr!("Icon"), pal))
         .child(
             h_flex().flex_wrap().gap_1().child(default).children(
                 ActionRingIcon::ALL
@@ -164,7 +164,7 @@ fn shortcut_editor(
     let submit_input = input.clone();
     v_flex()
         .gap_1()
-        .child(popover_section(tr!("Custom shortcut"), pal))
+        .child(editor_section(tr!("Custom shortcut"), pal))
         .child(
             h_flex()
                 .gap_2()
@@ -192,7 +192,7 @@ fn path_editor(slot: ActionRingSlot, input: &Entity<InputState>, pal: Palette) -
     let submit_input = input.clone();
     v_flex()
         .gap_1()
-        .child(popover_section(tr!("Open application or folder"), pal))
+        .child(editor_section(tr!("Open application or folder"), pal))
         .child(
             h_flex()
                 .gap_2()
@@ -220,7 +220,7 @@ fn action_rows(slot: ActionRingSlot, current: Option<&Action>, pal: Palette) -> 
     let mut index = 0usize;
     let mut rows = Vec::new();
     for (category, actions) in ring_catalog() {
-        rows.push(popover_section(rust_i18n::t!(category.label()), pal));
+        rows.push(editor_section(rust_i18n::t!(category.label()), pal));
         for action in actions {
             let selected = current == Some(&action);
             let action_to_commit = action.clone();

--- a/crates/openlogi-desktop/src/features/keyboard/editors.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/editors.rs
@@ -1,12 +1,12 @@
 //! Inline editors for the parameterised power-user actions, shown inside the
 //! config panel (the side inspector) once one is selected from the list.
 //!
-//! Each editor reuses the shared [`menu_card`] surface. Draft state lives on
+//! Each editor reuses the shared [`compact_panel`] surface. Draft state lives on
 //! the [`FunctionRowView`] so it survives re-rendering. Closing the editor
 //! returns to the action list; the panel itself closes when the key is
 //! deselected.
 //!
-//! [`menu_card`]: crate::features::mouse::picker::menu_card
+//! [`compact_panel`]: crate::features::mouse::picker::compact_panel
 
 #![expect(
     clippy::needless_pass_by_value,
@@ -29,7 +29,7 @@ use openlogi_core::binding::{Action, KeyCombo, WorkflowStep};
 use openlogi_core::config::KeyTrigger;
 
 use super::function_row::FunctionRowView;
-use crate::features::mouse::picker::{divider, menu_card, scroll_list, title};
+use crate::features::mouse::picker::{compact_panel, divider, editor_scroll_list, title};
 use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::components::MenuRow;
 use crate::ui::theme::{Palette, Typography as _};
@@ -93,7 +93,7 @@ pub fn editor_card(
         PowerUserKind::Workflow => workflow_editor_card(trigger, workflow_draft, view, pal, cx),
         _ => match text_state {
             Some(state) => text_editor_card(trigger, kind, state, view, pal, cx),
-            None => menu_card(pal)
+            None => compact_panel(pal)
                 .w(px(300.))
                 .child(title(tr!("Editor unavailable"), pal))
                 .into_any_element(),
@@ -114,7 +114,7 @@ fn text_editor_card(
     let heading = kind.heading();
     let key_name = trigger.to_string();
 
-    menu_card(pal)
+    compact_panel(pal)
         .w(px(300.))
         .child(title(
             tr!("%{action} · %{key}", action => heading, key => key_name),
@@ -198,11 +198,11 @@ fn workflow_editor_card(
         rows.push(workflow_step_row(idx, step.clone(), view, pal, cx));
     }
 
-    menu_card(pal)
+    compact_panel(pal)
         .w(px(320.))
         .child(title(tr!("Workflow · %{key}", key => key_name), pal))
         .child(divider(pal))
-        .child(scroll_list("workflow-steps", rows))
+        .child(editor_scroll_list("workflow-steps", rows))
         .child(
             h_flex()
                 .p_2()

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -40,7 +40,8 @@ use super::editors::{
 use crate::app::{glow_canvas, keyboard_glow};
 use crate::features::mouse::geometry::asset_dimensions_for_png;
 use crate::features::mouse::picker::{
-    PickFn, action_icon_path, action_rows, divider, menu_card, popover_section, scroll_list,
+    PickFn, action_icon_path, action_rows, compact_panel, divider, editor_scroll_list,
+    editor_section,
 };
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, DeviceRecord, StateEvent};
@@ -238,32 +239,21 @@ impl FunctionRowView {
     }
 }
 
-/// The app-state slice the view renders from: the device's asset, the global
-/// keyboard bindings, and the lighting glow (geometry + tinted colour).
-type StateSnapshot = (
-    Option<ResolvedAsset>,
-    Vec<(KeyTrigger, Action)>,
-    Option<(Arc<GlowGeometry>, Hsla)>,
-);
-
 impl Render for FunctionRowView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let (asset, bindings, glow): StateSnapshot = AppState::try_read(cx)
-            .map(|s| {
-                (
-                    s.current_record().and_then(|r| r.asset.clone()),
-                    s.keyboard_bindings
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect(),
-                    s.current_record().and_then(|r| keyboard_glow(s, r)),
-                )
-            })
-            .unwrap_or_default();
+        let state = AppState::try_read(cx);
+        let asset = state.and_then(|state| state.current_record()?.asset.as_ref());
+        let bindings = state.map(|state| &state.keyboard_bindings);
+        let glow = state.and_then(|state| {
+            state
+                .current_record()
+                .and_then(|record| keyboard_glow(state, record))
+        });
 
         let viewport_h = f32::from(window.viewport_size().height);
-        let render_size = keyboard_render_size(asset.as_ref(), viewport_h);
-        let points = key_points(asset.as_ref());
+        let render_size = keyboard_render_size(asset, viewport_h);
+        let points = key_points(asset);
+        let image_path = asset.map(|asset| asset.image_path.clone());
         let slots: Vec<KeySlot> = FUNCTION_KEYS
             .iter()
             .zip(points.iter())
@@ -273,17 +263,15 @@ impl Render for FunctionRowView {
                     keycode: *keycode,
                     modifiers: KeyModifiers::default(),
                 };
-                let bound = bindings
-                    .iter()
-                    .find(|(k, _)| *k == trigger)
-                    .map(|(_, a)| a.clone());
+                let bound = bindings.and_then(|bindings| bindings.get(&trigger));
                 KeySlot {
                     idx,
                     label,
                     trigger,
                     x_frac: point.x_frac,
                     y_frac: point.y_frac,
-                    bound,
+                    binding: binding_label(bound),
+                    binding_icon: bound.map(action_icon_path),
                 }
             })
             .collect();
@@ -302,10 +290,7 @@ impl Render for FunctionRowView {
         if let (Some(selected_idx), Some(kind)) = (selected, active_editor)
             && let Some(slot) = slots.get(selected_idx)
         {
-            let current_action = bindings
-                .iter()
-                .find(|(trigger, _)| trigger == &slot.trigger)
-                .map(|(_, action)| action);
+            let current_action = bindings.and_then(|bindings| bindings.get(&slot.trigger));
             match kind {
                 PowerUserKind::Workflow => {
                     if self.workflow_draft.is_empty() {
@@ -325,9 +310,10 @@ impl Render for FunctionRowView {
             }
         }
         let view = cx.entity();
-        let keyboard = KeyboardPane::new(slots.clone(), asset, glow, render_size, view.clone())
-            .selected(selected)
-            .hovered(hovered);
+        let keyboard =
+            KeyboardPane::new(slots.clone(), image_path, glow, render_size, view.clone())
+                .selected(selected)
+                .hovered(hovered);
         let panel = selected.map(|selected| self.config_panel(selected, &slots, &view, cx));
 
         // The whole row animates as one: when a key is selected the right-side
@@ -360,7 +346,8 @@ struct KeySlot {
     trigger: KeyTrigger,
     x_frac: f32,
     y_frac: f32,
-    bound: Option<Action>,
+    binding: gpui::SharedString,
+    binding_icon: Option<&'static str>,
 }
 
 /// The two-pane row: keyboard photo + an optional side panel.
@@ -419,7 +406,7 @@ impl RenderOnce for InspectorRow {
 #[derive(IntoElement)]
 struct KeyboardPane {
     slots: Vec<KeySlot>,
-    asset: Option<ResolvedAsset>,
+    image_path: Option<std::path::PathBuf>,
     glow: Option<(Arc<GlowGeometry>, Hsla)>,
     render_size: (f32, f32),
     selected: Option<usize>,
@@ -430,14 +417,14 @@ struct KeyboardPane {
 impl KeyboardPane {
     fn new(
         slots: Vec<KeySlot>,
-        asset: Option<ResolvedAsset>,
+        image_path: Option<std::path::PathBuf>,
         glow: Option<(Arc<GlowGeometry>, Hsla)>,
         render_size: (f32, f32),
         view: Entity<FunctionRowView>,
     ) -> Self {
         Self {
             slots,
-            asset,
+            image_path,
             glow,
             render_size,
             selected: None,
@@ -462,7 +449,7 @@ impl KeyboardPane {
 impl RenderOnce for KeyboardPane {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let (img_w, img_h) = self.render_size;
-        let img_path = self.asset.map(|asset| asset.image_path);
+        let img_path = self.image_path;
         let view_clone = self.view;
         let selected = self.selected;
         let hovered = self.hovered;
@@ -532,8 +519,8 @@ fn key_callout(
     let top = callout_top_px(idx);
     let view_hover = view.clone();
     let view_click = view.clone();
-    let binding = binding_label(slot.bound.as_ref());
-    let binding_icon = slot.bound.as_ref().map(action_icon_path);
+    let binding = slot.binding;
+    let binding_icon = slot.binding_icon;
 
     v_flex()
         .id(("key-callout", idx))
@@ -834,12 +821,12 @@ impl FunctionRowView {
 
         let rows = panel_action_rows(current.as_ref(), &on_pick, view, &pal);
 
-        menu_card(pal)
+        compact_panel(pal)
             .w(px(PANEL_W))
             .max_h(px(500.))
             .child(title_header(&key_name, &pal))
             .child(divider(pal))
-            .child(scroll_list("key-panel-scroll", rows))
+            .child(editor_scroll_list("key-panel-scroll", rows))
             .into_any_element()
     }
 }
@@ -869,7 +856,7 @@ fn panel_action_rows(
     pal: &Palette,
 ) -> Vec<AnyElement> {
     let mut children = action_rows("panel-action", current, on_pick, *pal);
-    children.push(popover_section(tr!("Power User").to_string(), *pal));
+    children.push(editor_section(tr!("Power User").to_string(), *pal));
 
     let power_user_actions: &[(PowerUserKind, &str, &'static str)] = &[
         (

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -1,6 +1,6 @@
 //! Fixed binding inspector for the Buttons workspace.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use gpui::{
@@ -20,7 +20,7 @@ use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding
 
 use super::hotspots::MouseControlId;
 use super::picker::{
-    GESTURE_BUTTON_ICON, PickFn, action_icon_path, action_rows_matching, popover_section,
+    GESTURE_BUTTON_ICON, PickFn, action_icon_path, action_rows_matching, editor_section,
 };
 use super::thumbwheel::ThumbwheelPreset;
 use super::view::{MouseModelView, localized_action_label};
@@ -38,7 +38,7 @@ pub(super) struct BindingInspectorData<'a> {
     pub bindings: &'a BTreeMap<ButtonId, Action>,
     pub gesture_maps: &'a BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
     pub editing_app: Option<&'a str>,
-    pub overridden: &'a BTreeSet<ButtonId>,
+    pub overridden: Option<&'a BTreeMap<ButtonId, Action>>,
 }
 
 #[derive(Clone, Copy)]
@@ -53,7 +53,7 @@ pub(super) fn binding_inspector(
     action_search: &Entity<InputState>,
     view: &Entity<MouseModelView>,
     pal: Palette,
-    cx: &mut Context<MouseModelView>,
+    cx: &Context<MouseModelView>,
 ) -> AnyElement {
     let picker = ActionPickerContext {
         open: data.action_picker_open,
@@ -61,7 +61,11 @@ pub(super) fn binding_inspector(
         view,
     };
     let body = match data.selected {
-        None => empty_inspector(data.editing_app, data.overridden.len(), pal),
+        None => empty_inspector(
+            data.editing_app,
+            data.overridden.map_or(0, BTreeMap::len),
+            pal,
+        ),
         Some(MouseControlId::ThumbwheelRotation) => thumbwheel_inspector(
             data.bindings,
             data.editing_app,
@@ -121,10 +125,12 @@ fn button_inspector(
     data: &BindingInspectorData<'_>,
     picker: ActionPickerContext<'_>,
     pal: Palette,
-    cx: &mut Context<MouseModelView>,
+    cx: &Context<MouseModelView>,
 ) -> AnyElement {
     let gesture_map = data.gesture_maps.get(&button);
-    let overridden = data.overridden.contains(&button);
+    let overridden = data
+        .overridden
+        .is_some_and(|overrides| overrides.contains_key(&button));
     if data.editing_app.is_none()
         && let Some(gesture_map) = gesture_map
     {
@@ -225,7 +231,7 @@ fn inherited_gesture_inspector(
     app: &str,
     picker: ActionPickerContext<'_>,
     pal: Palette,
-    cx: &mut Context<MouseModelView>,
+    cx: &Context<MouseModelView>,
 ) -> AnyElement {
     let observer = picker.view.clone();
     let on_pick: PickFn = Rc::new(move |action, _window, cx| {
@@ -280,7 +286,7 @@ fn gesture_inspector(
     selected_direction: Option<GestureDirection>,
     picker: ActionPickerContext<'_>,
     pal: Palette,
-    cx: &mut Context<MouseModelView>,
+    cx: &Context<MouseModelView>,
 ) -> AnyElement {
     let direction = selected_direction.unwrap_or(GestureDirection::Click);
     let current = gesture_action(gesture_map, button, direction);
@@ -348,7 +354,7 @@ fn gesture_directions(
 ) -> AnyElement {
     v_flex()
         .gap_1()
-        .child(popover_section(tr!("Direction"), pal))
+        .child(editor_section(tr!("Direction"), pal))
         .children(
             GestureDirection::ALL
                 .into_iter()
@@ -397,7 +403,7 @@ fn gesture_directions(
 fn thumbwheel_inspector(
     bindings: &BTreeMap<ButtonId, Action>,
     editing_app: Option<&str>,
-    overridden: &BTreeSet<ButtonId>,
+    overridden: Option<&BTreeMap<ButtonId, Action>>,
     picker: ActionPickerContext<'_>,
     pal: Palette,
 ) -> AnyElement {
@@ -410,8 +416,10 @@ fn thumbwheel_inspector(
         .cloned()
         .unwrap_or_else(|| default_binding(ButtonId::ThumbwheelScrollUp));
     let current = ThumbwheelPreset::recognize(&backward, &forward);
-    let is_overridden = overridden.contains(&ButtonId::ThumbwheelScrollDown)
-        || overridden.contains(&ButtonId::ThumbwheelScrollUp);
+    let is_overridden = overridden.is_some_and(|overrides| {
+        overrides.contains_key(&ButtonId::ThumbwheelScrollDown)
+            || overrides.contains_key(&ButtonId::ThumbwheelScrollUp)
+    });
     let status = match (editing_app, is_overridden) {
         (Some(app), true) => tr!("Overridden in %{app}", app => app.to_string()),
         (Some(_), false) => tr!("Inherited from Default"),
@@ -436,7 +444,7 @@ fn thumbwheel_inspector(
             panel.child(
                 v_flex()
                     .gap_1()
-                    .child(popover_section(tr!("Preset"), pal))
+                    .child(editor_section(tr!("Preset"), pal))
                     .children(ThumbwheelPreset::ALL.into_iter().enumerate().map(
                         |(index, preset)| {
                             let selected = current == Some(preset);
@@ -629,7 +637,7 @@ fn action_library(
     v_flex()
         .gap_2()
         .pt_1()
-        .child(popover_section(tr!("Actions"), pal))
+        .child(editor_section(tr!("Actions"), pal))
         .child(Input::new(action_search).small().cleanable(true))
         .child(
             v_flex()

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -14,8 +14,8 @@ use crate::ui::components::MenuRow;
 use crate::ui::section::section_label;
 use crate::ui::theme::{ACCENT_BLUE, Palette, Typography as _};
 
-/// Cap for action lists hosted in a popover.
-pub(crate) const POPOVER_LIST_MAX_H: f32 = 360.;
+/// Height cap shared by compact inspector and editor lists.
+pub(crate) const EDITOR_LIST_MAX_H: f32 = 360.;
 
 /// Commit callback invoked when an action row is clicked.
 pub(crate) type PickFn = Rc<dyn Fn(Action, &mut Window, &mut App)>;
@@ -111,14 +111,21 @@ pub(crate) fn action_rows_matching(
     pal: Palette,
 ) -> Vec<AnyElement> {
     let query = query.trim().to_lowercase();
-    let mut index = 0usize;
+    let mut catalog_index = 0usize;
     let mut children: Vec<AnyElement> = Vec::new();
     for (category, actions) in grouped_catalog() {
         let category_label = rust_i18n::t!(category.label());
         let category_matches = category_label.to_lowercase().contains(&query);
-        let actions: Vec<Action> = actions
+        // Number the full catalog before filtering so typing in the search box
+        // never changes an action row's element identity.
+        let actions: Vec<(usize, Action)> = actions
             .into_iter()
-            .filter(|action| {
+            .map(|action| {
+                let key = catalog_index;
+                catalog_index += 1;
+                (key, action)
+            })
+            .filter(|(_, action)| {
                 query.is_empty()
                     || category_matches
                     || rust_i18n::t!(action.label())
@@ -130,17 +137,15 @@ pub(crate) fn action_rows_matching(
         if actions.is_empty() {
             continue;
         }
-        children.push(popover_section(category_label.into_owned(), pal));
-        for action in actions {
+        children.push(editor_section(category_label.into_owned(), pal));
+        for (action_key, action) in actions {
             let selected = current == Some(&action);
             let label = tr!(action.label());
             let accessible_label = label.clone();
             let icon_path = action_icon_path(&action);
             let on_pick = on_pick.clone();
-            let row_id = index;
-            index += 1;
             children.push(
-                MenuRow::new((id_prefix, row_id))
+                MenuRow::new((id_prefix, action_key))
                     .selected(selected)
                     .role(Role::MenuItem)
                     .aria_label(accessible_label)
@@ -172,8 +177,8 @@ pub(crate) fn action_rows_matching(
     children
 }
 
-/// The shared floating-card surface for compact binding menus.
-pub(crate) fn menu_card(pal: Palette) -> gpui::Div {
+/// Shared card surface for compact binding panels and menus.
+pub(crate) fn compact_panel(pal: Palette) -> gpui::Div {
     v_flex()
         .bg(pal.panel)
         .border_1()
@@ -184,7 +189,7 @@ pub(crate) fn menu_card(pal: Palette) -> gpui::Div {
 }
 
 /// A group heading inset to line up with the rows under it.
-pub(crate) fn popover_section(label: impl Into<gpui::SharedString>, pal: Palette) -> AnyElement {
+pub(crate) fn editor_section(label: impl Into<gpui::SharedString>, pal: Palette) -> AnyElement {
     section_label(label, pal)
         .w_full()
         .px_2()
@@ -208,11 +213,11 @@ pub(crate) fn divider(pal: Palette) -> impl IntoElement {
     div().mb_1().h(px(1.)).w_full().bg(pal.border)
 }
 
-/// Height-capped scroll region for popover-hosted rows.
-pub(crate) fn scroll_list(id: &'static str, rows: Vec<AnyElement>) -> impl IntoElement {
+/// Height-capped scroll region for compact editor rows.
+pub(crate) fn editor_scroll_list(id: &'static str, rows: Vec<AnyElement>) -> impl IntoElement {
     div()
         .id(id)
-        .max_h(px(POPOVER_LIST_MAX_H))
+        .max_h(px(EDITOR_LIST_MAX_H))
         .overflow_y_scroll()
         .children(rows)
 }

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use gpui::{
@@ -56,47 +56,61 @@ const MODEL_HORIZONTAL_RESERVE: f32 =
 /// Floor for the model's available width on a narrow window.
 const MODEL_MIN_CONTENT_W: f32 = 200.;
 
-#[derive(Default)]
-struct MouseWorkspaceData {
-    device_key: Option<String>,
-    asset: Option<ResolvedAsset>,
+struct MouseWorkspaceData<'a> {
+    device_key: Option<&'a str>,
+    asset: Option<&'a ResolvedAsset>,
     active: Option<MouseControlId>,
-    bindings: BTreeMap<ButtonId, Action>,
-    gesture_maps: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
+    bindings: &'a BTreeMap<ButtonId, Action>,
+    gesture_maps: &'a BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
     glow: Option<(Arc<GlowGeometry>, Hsla)>,
     thumbwheel: bool,
     editing_app: Option<String>,
-    overridden: BTreeSet<ButtonId>,
+    overridden: Option<&'a BTreeMap<ButtonId, Action>>,
 }
 
-impl MouseWorkspaceData {
-    fn read(cx: &App) -> Self {
-        AppState::try_read(cx)
-            .map(|state| Self {
-                device_key: state
-                    .current_record()
-                    .map(|record| record.config_key.clone()),
-                asset: state
-                    .current_record()
-                    .and_then(|record| record.asset.clone()),
-                active: state.active_button.map(MouseControlId::from_active_button),
-                bindings: state.button_bindings.clone(),
-                gesture_maps: state.device_gesture_maps(),
-                glow: state
-                    .current_record()
-                    .and_then(|record| keyboard_glow(state, record)),
-                thumbwheel: state
-                    .current_record()
-                    .and_then(|record| record.capabilities)
-                    .is_some_and(|capabilities| capabilities.thumbwheel),
-                editing_app: state.editing_app().map(|app| {
-                    state
-                        .recent_app_name(app)
-                        .map_or_else(|| friendly_app_name(app), str::to_string)
-                }),
-                overridden: state.editing_app_overrides(),
-            })
-            .unwrap_or_default()
+impl<'a> MouseWorkspaceData<'a> {
+    fn read(cx: &'a App) -> Option<Self> {
+        AppState::try_read(cx).map(|state| Self {
+            device_key: state
+                .current_record()
+                .map(|record| record.config_key.as_str()),
+            asset: state
+                .current_record()
+                .and_then(|record| record.asset.as_ref()),
+            active: state.active_button.map(MouseControlId::from_active_button),
+            bindings: &state.button_bindings,
+            gesture_maps: &state.gesture_bindings,
+            glow: state
+                .current_record()
+                .and_then(|record| keyboard_glow(state, record)),
+            thumbwheel: state
+                .current_record()
+                .and_then(|record| record.capabilities)
+                .is_some_and(|capabilities| capabilities.thumbwheel),
+            editing_app: state.editing_app().map(|app| {
+                state
+                    .recent_app_name(app)
+                    .map_or_else(|| friendly_app_name(app), str::to_string)
+            }),
+            overridden: state.editing_app_overrides(),
+        })
+    }
+
+    fn empty(
+        bindings: &'a BTreeMap<ButtonId, Action>,
+        gesture_maps: &'a BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
+    ) -> Self {
+        Self {
+            device_key: None,
+            asset: None,
+            active: None,
+            bindings,
+            gesture_maps,
+            glow: None,
+            thumbwheel: false,
+            editing_app: None,
+            overridden: None,
+        }
     }
 }
 
@@ -168,6 +182,17 @@ impl MouseModelView {
         self.action_picker_open = false;
     }
 
+    fn reset_for_device(&mut self, device_key: Option<&str>) {
+        if self.current_device_key.as_deref() == device_key {
+            return;
+        }
+        self.current_device_key = device_key.map(str::to_string);
+        self.hovered = None;
+        self.selected = None;
+        self.gesture_active_dir = None;
+        self.action_picker_open = false;
+    }
+
     fn select(&mut self, control: MouseControlId) {
         if self.selected != Some(control) {
             self.selected = Some(control);
@@ -201,6 +226,7 @@ fn set_control_hovered(
 
 impl Render for MouseModelView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let (empty_bindings, empty_gesture_maps) = (BTreeMap::new(), BTreeMap::new());
         let MouseWorkspaceData {
             device_key,
             asset,
@@ -211,20 +237,18 @@ impl Render for MouseModelView {
             thumbwheel,
             editing_app,
             overridden,
-        } = MouseWorkspaceData::read(cx);
+        } = MouseWorkspaceData::read(cx)
+            .unwrap_or_else(|| MouseWorkspaceData::empty(&empty_bindings, &empty_gesture_maps));
 
-        if self.current_device_key != device_key {
-            self.current_device_key = device_key;
-            self.hovered = None;
-            self.selected = None;
-            self.gesture_active_dir = None;
-            self.action_picker_open = false;
-        }
+        self.reset_for_device(device_key);
 
         let gesture_buttons: Vec<ButtonId> = gesture_maps
             .keys()
             .copied()
-            .filter(|button| editing_app.is_none() || !overridden.contains(button))
+            .filter(|button| {
+                editing_app.is_none()
+                    || !overridden.is_some_and(|overrides| overrides.contains_key(button))
+            })
             .collect();
 
         let viewport_h = f32::from(window.viewport_size().height);
@@ -236,7 +260,7 @@ impl Render for MouseModelView {
             mouse_h,
             hotspots,
             labels,
-        } = model_layout(asset.as_ref(), viewport_w, viewport_h, thumbwheel);
+        } = model_layout(asset, viewport_w, viewport_h, thumbwheel);
         let canvas_h = mouse_h;
 
         let highlight = self.hovered.or(active);
@@ -248,7 +272,7 @@ impl Render for MouseModelView {
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
-        let breathing_art = breathing_art(asset.as_ref(), mouse_left, mouse_w, mouse_h, pal, glow);
+        let breathing_art = breathing_art(asset, mouse_left, mouse_w, mouse_h, pal, glow);
         let hotspots_layer = hotspots_layer(
             &hotspots_outer,
             ModelRect {
@@ -268,7 +292,7 @@ impl Render for MouseModelView {
             .child(breathing_art)
             .child(leader_canvas)
             .children(labels_outer.iter().enumerate().map(|(idx, label)| {
-                let binding = binding_label_for_control(label.id, &bindings, &gesture_buttons);
+                let binding = binding_label_for_control(label.id, bindings, &gesture_buttons);
                 label_control(
                     idx,
                     *label,
@@ -289,10 +313,10 @@ impl Render for MouseModelView {
                 selected: self.selected,
                 gesture_direction: self.gesture_active_dir,
                 action_picker_open: self.action_picker_open,
-                bindings: &bindings,
-                gesture_maps: &gesture_maps,
+                bindings,
+                gesture_maps,
                 editing_app: editing_app.as_deref(),
-                overridden: &overridden,
+                overridden,
             },
             &self.action_search,
             &view,
@@ -651,7 +675,7 @@ impl RenderOnce for LabelTrigger {
                 .border_color(rgb(ACCENT_BLUE))
             })
             // Button name — the caption (xs / muted), the same size as the
-            // popover title and category headers it shares the binding flow with.
+            // inspector title and category headers it shares the binding flow with.
             .child(
                 div()
                     .text_caption()
@@ -947,7 +971,6 @@ mod tests {
                 )]),
             )]);
             let bindings = BTreeMap::new();
-            let overridden = BTreeSet::new();
             let entity = cx.entity();
 
             binding_inspector(
@@ -958,7 +981,7 @@ mod tests {
                     bindings: &bindings,
                     gesture_maps: &gesture_maps,
                     editing_app: None,
-                    overridden: &overridden,
+                    overridden: None,
                 },
                 &view.action_search,
                 &entity,

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -1,6 +1,6 @@
 //! Profile context bar for the Buttons workspace.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use gpui::{
@@ -20,7 +20,7 @@ use crate::state::AppState;
 use crate::ui::components::MenuRow;
 use crate::ui::theme::{self, Palette, SelectableStyle as _, Typography as _};
 
-use super::mouse::picker::{divider, menu_card, title};
+use super::mouse::picker::{compact_panel, divider, title};
 
 const PROFILE_CONTROL_H: f32 = 30.;
 
@@ -132,7 +132,8 @@ pub(crate) fn profile_canvas_status(pal: Palette, cx: &App) -> Option<AnyElement
             .recent_app_name(app)
             .map_or_else(|| friendly_app_name(app), str::to_string)
     });
-    let summary = profile_summary(editing_app.as_deref(), state.editing_app_overrides().len());
+    let override_count = state.editing_app_overrides().map_or(0, BTreeMap::len);
+    let summary = profile_summary(editing_app.as_deref(), override_count);
     let active = state
         .active_profile_name()
         .map_or_else(|| tr!("Default"), gpui::SharedString::from);
@@ -361,7 +362,7 @@ fn add_app_popover(apps: Vec<ProfileChoice>, pal: Palette) -> AnyElement {
                 })
                 .collect::<Vec<_>>();
 
-            menu_card(pal)
+            compact_panel(pal)
                 .w(px(260.))
                 .child(title(tr!("Add app profile"), pal))
                 .child(divider(pal))
@@ -392,7 +393,7 @@ fn profile_options_popover(profile: ProfileChoice, pal: Palette) -> AnyElement {
         .content(move |_state, _window, cx| {
             let popover = cx.entity().downgrade();
             let profile = profile.clone();
-            menu_card(pal)
+            compact_panel(pal)
                 .w(px(224.))
                 .child(title(tr!("Profile options"), pal))
                 .child(divider(pal))

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -221,7 +221,7 @@ pub struct AppState {
     light_command_status: Option<(DeviceKey, u64, LightCommandStatus)>,
     next_light_request_id: u64,
     /// The hotspot the user most recently armed by clicking. Drives the
-    /// "selected button" outline on the mouse model and the popover content.
+    /// "selected button" outline on the mouse model and inspector content.
     pub active_button: Option<ButtonId>,
     /// Everything the GUI knows about the agent connection — the last status
     /// snapshot, or why there isn't one. The render path branches on this
@@ -231,11 +231,13 @@ pub struct AppState {
     /// Bindings for the *currently selected* device. Reloaded whenever the
     /// carousel selection changes.
     pub button_bindings: BTreeMap<ButtonId, Action>,
-    /// Per-direction sub-bindings for every gesture-mode button of the current
-    /// device, keyed by button. Edited via each button's gesture menu and
-    /// persisted as that button's [`Binding::Gesture`] entry in the device's
-    /// unified binding map ([`DeviceConfig::bindings`]). Rebuilt by
-    /// [`Self::current_gesture_maps`].
+    /// Cached per-direction sub-bindings for every gesture-mode button of the
+    /// current device's global profile, keyed by button. The cache remains
+    /// populated while editing a per-app profile so the inspector can describe
+    /// inherited gestures without rebuilding the maps during rendering. Edited
+    /// via each button's gesture menu and persisted as that button's
+    /// [`Binding::Gesture`] entry in the device's unified binding map
+    /// ([`DeviceConfig::bindings`]).
     ///
     /// [`DeviceConfig::bindings`]: openlogi_core::config::DeviceConfig::bindings
     pub gesture_bindings: BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>>,
@@ -394,7 +396,7 @@ impl AppState {
             state.persist_config("device identity");
         }
         state.button_bindings = state.bindings_for_current();
-        state.gesture_bindings = state.current_gesture_maps();
+        state.gesture_bindings = state.device_gesture_maps();
         // Keyboard bindings are global, so they seed straight from the config
         // map — no per-device resolution like mouse bindings above.
         state.keyboard_bindings = state
@@ -461,7 +463,7 @@ impl AppState {
     fn restore_persisted_config(&mut self) {
         self.config.clone_from(&self.persisted_config);
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.current_gesture_maps();
+        self.gesture_bindings = self.device_gesture_maps();
         self.keyboard_bindings = self.config.keyboard.bindings.clone();
         if let Some(dpi) = self
             .current_record()
@@ -551,7 +553,7 @@ impl AppState {
             )
             .map(|(app, device_key)| EditingScope { device_key, app });
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.current_gesture_maps();
+        self.gesture_bindings = self.device_gesture_maps();
     }
 
     /// Whether the active device can carry saved configuration at all. A

--- a/crates/openlogi-desktop/src/state/bindings.rs
+++ b/crates/openlogi-desktop/src/state/bindings.rs
@@ -1,6 +1,6 @@
 //! Mouse, gesture, and keyboard binding commits.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use gpui::App;
 use openlogi_core::binding::{Action, Binding, ButtonId, GestureDirection};
@@ -135,21 +135,16 @@ impl AppState {
         self.persist_and_reload("per-app profile");
     }
 
-    /// The buttons the open per-app profile overrides, so the panel can tell an
-    /// override apart from a binding inherited from the global profile. Empty
-    /// in the global profile, where there is nothing to distinguish.
+    /// The open per-app profile's overrides, so the panel can tell an override
+    /// apart from a binding inherited from the global profile. `None` in the
+    /// global profile, where there is nothing to distinguish.
     #[must_use]
-    pub fn editing_app_overrides(&self) -> BTreeSet<ButtonId> {
-        let Some(key) = self
+    pub fn editing_app_overrides(&self) -> Option<&BTreeMap<ButtonId, Action>> {
+        let key = self
             .current_record()
-            .and_then(DeviceRecord::persistent_config_key)
-        else {
-            return BTreeSet::new();
-        };
+            .and_then(DeviceRecord::persistent_config_key)?;
         self.editing_app()
             .and_then(|app| self.config.per_app_overrides(key, app))
-            .map(|overrides| overrides.keys().copied().collect())
-            .unwrap_or_default()
     }
 
     /// Apply one paired thumb-wheel preset atomically. Both directional
@@ -249,6 +244,7 @@ impl AppState {
     /// in that app. Offering the gesture menu instead would edit the global
     /// profile from a screen labelled with an application.
     #[must_use]
+    #[cfg(test)]
     pub fn current_gesture_maps(&self) -> BTreeMap<ButtonId, BTreeMap<GestureDirection, Action>> {
         if self.editing_app().is_some() {
             return BTreeMap::new();
@@ -282,7 +278,7 @@ impl AppState {
         self.config.set_gesture_mode(&key, button, enabled);
         // The mode change shuffles bindings between the single + gesture maps.
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.current_gesture_maps();
+        self.gesture_bindings = self.device_gesture_maps();
         self.persist_and_reload("gesture-mode change");
     }
 

--- a/crates/openlogi-desktop/src/state/inventory.rs
+++ b/crates/openlogi-desktop/src/state/inventory.rs
@@ -126,7 +126,7 @@ impl AppState {
         // tracks the now-current device rather than the old one.
         self.dpi = self.dpi_for_current();
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.current_gesture_maps();
+        self.gesture_bindings = self.device_gesture_maps();
         // Display state only — the agent runs its own inventory watcher and
         // rebuilds the live binding/DPI maps itself.
         true
@@ -298,7 +298,7 @@ impl AppState {
         // device's number until a fresh read lands.
         self.dpi = self.dpi_for_current();
         self.button_bindings = self.bindings_for_current();
-        self.gesture_bindings = self.current_gesture_maps();
+        self.gesture_bindings = self.device_gesture_maps();
         let Some(key) = self
             .current_record()
             .and_then(DeviceRecord::persistent_config_key)

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -331,6 +331,10 @@ fn a_gesture_button_stays_one_when_the_scope_returns_to_the_default_profile() {
 
     state.set_editing_app(Some("com.apple.Safari".into()));
     assert!(state.current_gesture_maps().is_empty());
+    assert_eq!(
+        state.gesture_bindings, global,
+        "the inspector cache keeps inherited gestures while per-app editing hides their controls"
+    );
     // The device still has its gestures — only the open profile cannot show
     // them, which is what the device card must keep reporting.
     assert_eq!(

--- a/crates/openlogi-desktop/src/ui/carousel.rs
+++ b/crates/openlogi-desktop/src/ui/carousel.rs
@@ -1,36 +1,32 @@
-//! A centered coverflow carousel.
+//! A centered, horizontally scrolling carousel of equal-size cards.
 //!
-//! The selected item is rendered large and centred; its immediate neighbours
-//! peek smaller on either side. Selecting a neighbour — by clicking it, an
-//! arrow, or a dot — brings it to the centre with a grow animation. All sizing
-//! is relative to the viewport, so the carousel scales with the window without
-//! any measurement.
+//! The row centres while its cards fit the viewport and becomes scrollable when
+//! they overflow. Selecting an item scrolls it into view; arrows navigate the
+//! controlled selection.
 //!
 //! Controlled, in the same spirit as [`gpui_component::tab::TabBar`]: the caller
 //! owns the selected index ([`Carousel::selected`]) and item count
 //! ([`Carousel::len`]), supplies items through [`Carousel::render_item`] (invoked
-//! per visible slot with whether it is the focused/centre item), and reacts to
+//! per slot with whether it is selected), and reacts to
 //! navigation through [`Carousel::on_select`].
 //!
 //! ```ignore
-//! Carousel::new("devices")
+//! Carousel::new("devices", px(240.))
 //!     .len(devices.len())
 //!     .selected(current)
-//!     .render_item(move |ix, focused, _w, cx| render_device(ix, focused, cx))
+//!     .render_item(move |ix, selected, _w, cx| render_device(ix, selected, cx))
 //!     .on_select(cx.listener(|this, ix: &usize, _, cx| this.select(*ix, cx)))
 //! ```
 
 use std::rc::Rc;
-use std::time::Duration;
 
 use gpui::{
-    Animation, AnimationExt as _, AnyElement, App, ElementId, Hsla, InteractiveElement as _,
-    IntoElement, ParentElement as _, Pixels, RenderOnce, ScrollHandle, SharedString,
-    StatefulInteractiveElement as _, Styled, Window, div, ease_in_out, prelude::FluentBuilder as _,
-    px, relative,
+    AnyElement, App, ElementId, InteractiveElement as _, IntoElement, ParentElement as _, Pixels,
+    RenderOnce, ScrollHandle, StatefulInteractiveElement as _, Styled, Window, div,
+    prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
-    ActiveTheme as _, Disableable as _, IconName, Sizable as _, Size,
+    Disableable as _, IconName, Sizable as _, Size,
     button::{Button, ButtonVariants as _},
     h_flex, v_flex,
 };
@@ -38,47 +34,31 @@ use gpui_component::{
 type SelectHandler = Rc<dyn Fn(&usize, &mut Window, &mut App) + 'static>;
 type ItemRenderer = Rc<dyn Fn(usize, bool, &mut Window, &mut App) -> AnyElement + 'static>;
 
-/// Side padding of the uniform-mode row.
-const UNIFORM_PAD: f32 = 24.;
+/// Side padding of the scrolling row.
+const ROW_PAD: f32 = 24.;
 
-/// A centre-stage carousel. See the module docs.
+/// A controlled equal-size card carousel. See the module docs.
 #[derive(IntoElement)]
 pub struct Carousel {
     id: ElementId,
+    card_w: Pixels,
     len: usize,
     selected: usize,
     render_item: Option<ItemRenderer>,
-    /// When set, switch from coverflow to an equal-size scrolling row whose
-    /// cards are this wide; coverflow's magnify/peek options are then ignored.
-    uniform: Option<Pixels>,
-    focused_frac: f32,
-    side_frac: f32,
     gap: Pixels,
-    arrows: bool,
-    indicators: bool,
-    accent: Option<Hsla>,
     on_select: Option<SelectHandler>,
 }
 
-#[expect(
-    dead_code,
-    reason = "complete, reusable carousel API — not every builder option is exercised by the current device-list call site"
-)]
 impl Carousel {
-    /// Create a carousel. `id` keys the per-transition grow animation.
-    pub fn new(id: impl Into<ElementId>) -> Self {
+    /// Create a carousel whose cards are `card_w` wide. `id` keys scroll state.
+    pub fn new(id: impl Into<ElementId>, card_w: Pixels) -> Self {
         Self {
             id: id.into(),
+            card_w,
             len: 0,
             selected: 0,
             render_item: None,
-            uniform: None,
-            focused_frac: 0.44,
-            side_frac: 0.17,
             gap: px(16.),
-            arrows: true,
-            indicators: true,
-            accent: None,
             on_select: None,
         }
     }
@@ -90,47 +70,21 @@ impl Carousel {
         self
     }
 
-    /// The selected (centre) item, clamped to range when rendered.
+    /// The selected item, clamped to range when rendered.
     #[must_use]
     pub fn selected(mut self, index: usize) -> Self {
         self.selected = index;
         self
     }
 
-    /// Item renderer, called per visible slot with `(index, focused)`. `focused`
-    /// is `true` for the centre item. Reads live data each render, so it never
-    /// goes stale.
+    /// Item renderer, called per slot with `(index, selected)`. Reads live data
+    /// each render, so it never goes stale.
     #[must_use]
     pub fn render_item(
         mut self,
         f: impl Fn(usize, bool, &mut Window, &mut App) -> AnyElement + 'static,
     ) -> Self {
         self.render_item = Some(Rc::new(f));
-        self
-    }
-
-    /// Lay the items out as an equal-size, horizontally scrollable row (each
-    /// card `card_w` wide) instead of the centre-stage coverflow. In this mode
-    /// `render_item`'s `focused` flag marks the *active* item (so the caller can
-    /// style it), clicks are wired by `render_item` itself, and the coverflow
-    /// options (`focused_frac` / `side_frac` / arrows / dots) are ignored.
-    #[must_use]
-    pub fn uniform(mut self, card_w: Pixels) -> Self {
-        self.uniform = Some(card_w);
-        self
-    }
-
-    /// Width of the focused item as a fraction of the viewport. Default 0.44.
-    #[must_use]
-    pub fn focused_frac(mut self, frac: f32) -> Self {
-        self.focused_frac = frac;
-        self
-    }
-
-    /// Width of each side (peek) item as a fraction of the viewport. Default 0.17.
-    #[must_use]
-    pub fn side_frac(mut self, frac: f32) -> Self {
-        self.side_frac = frac;
         self
     }
 
@@ -141,28 +95,7 @@ impl Carousel {
         self
     }
 
-    /// Show the prev/next arrows. Default `true`.
-    #[must_use]
-    pub fn arrows(mut self, show: bool) -> Self {
-        self.arrows = show;
-        self
-    }
-
-    /// Show the page-indicator dots. Default `true`.
-    #[must_use]
-    pub fn indicators(mut self, show: bool) -> Self {
-        self.indicators = show;
-        self
-    }
-
-    /// Accent colour for the active indicator dot. Defaults to the theme primary.
-    #[must_use]
-    pub fn accent(mut self, accent: Hsla) -> Self {
-        self.accent = Some(accent);
-        self
-    }
-
-    /// Called with the new index when a neighbour, arrow, or dot is activated.
+    /// Called with the new index when an arrow is activated.
     #[must_use]
     pub fn on_select(mut self, handler: impl Fn(&usize, &mut Window, &mut App) + 'static) -> Self {
         self.on_select = Some(Rc::new(handler));
@@ -172,46 +105,34 @@ impl Carousel {
 
 impl RenderOnce for Carousel {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        match self.uniform {
-            Some(card_w) => self.render_uniform(card_w, window, cx),
-            None => self.render_coverflow(window, cx),
-        }
+        self.render_row(window, cx)
     }
 }
 
 impl Carousel {
-    /// Equal-size scrolling row — see [`Carousel::uniform`]. Every item renders
-    /// at `card_w` in a horizontally scrollable row that centres while the cards
-    /// fit the viewport and left-aligns (so the scroll reaches the first card)
-    /// once they overflow. Prev/next arrows hug the screen edges and the page
-    /// dots sit underneath; each card's click and active styling come from
-    /// `render_item`. The coverflow magnify/peek and slide are the only parts
-    /// dropped.
-    fn render_uniform(self, card_w: Pixels, window: &mut Window, cx: &mut App) -> AnyElement {
+    /// Every item renders at `card_w` in a horizontally scrollable row that
+    /// centres while the cards fit the viewport and left-aligns (so the scroll
+    /// reaches the first card) once they overflow. Prev/next arrows hug the
+    /// screen edges; each card's click and selected styling come from
+    /// `render_item`.
+    fn render_row(self, window: &mut Window, cx: &mut App) -> AnyElement {
         let Self {
             id,
+            card_w,
             len,
             selected,
             render_item,
             gap,
-            arrows,
-            indicators,
-            accent,
             on_select,
-            ..
         } = self;
         let Some(render_item) = render_item.filter(|_| len > 0) else {
             return div().into_any_element();
         };
         let selected = selected.min(len - 1);
         let multi = len > 1;
-        let accent = accent.unwrap_or(cx.theme().primary);
-        let dot_idle = cx.theme().border;
 
         let scroll_state =
-            window.use_keyed_state(SharedString::from(format!("{id}-scroll")), cx, |_, _| {
-                (usize::MAX, ScrollHandle::new())
-            });
+            window.use_keyed_state((id, "scroll"), cx, |_, _| (usize::MAX, ScrollHandle::new()));
         let previous = scroll_state.read(cx).0;
         let scroll_handle = scroll_state.read(cx).1.clone();
         if previous != selected {
@@ -233,9 +154,9 @@ impl Carousel {
         // Flexible edge spacers centre short rows without putting overflowing
         // cards at a negative, unreachable offset. They are immediate children,
         // so the scroll handle targets cards at `selected + 1`.
-        let edge_spacer = px((UNIFORM_PAD - f32::from(gap)).max(0.));
+        let edge_spacer = px((ROW_PAD - f32::from(gap)).max(0.));
         let row = h_flex()
-            .id("carousel-uniform")
+            .id("carousel-row")
             .flex_1()
             .min_w_0()
             .h_full()
@@ -248,15 +169,14 @@ impl Carousel {
             .children(items)
             .child(div().flex_1().min_w(edge_spacer));
 
-        // Prev/next arrows hug the left and right edges (vertically centred),
-        // flanking the scrollable row; the page dots sit centred underneath.
+        // Prev/next arrows hug the left and right edges, flanking the row.
         let stage = h_flex()
             .w_full()
             .flex_1()
             .min_h_0()
             .items_center()
             .px_4()
-            .when(multi && arrows, |this| {
+            .when(multi, |this| {
                 this.child(arrow(
                     "carousel-prev",
                     IconName::ChevronLeft,
@@ -267,7 +187,7 @@ impl Carousel {
                 ))
             })
             .child(row)
-            .when(multi && arrows, |this| {
+            .when(multi, |this| {
                 this.child(arrow(
                     "carousel-next",
                     IconName::ChevronRight,
@@ -278,222 +198,7 @@ impl Carousel {
                 ))
             });
 
-        v_flex()
-            .size_full()
-            .gap_3()
-            .pb_6()
-            .child(stage)
-            .when(multi && indicators, |this| {
-                this.child(
-                    h_flex()
-                        .w_full()
-                        .items_center()
-                        .justify_center()
-                        .gap_1p5()
-                        .children(
-                            (0..len).map(|i| {
-                                dot(i, i == selected, accent, dot_idle, on_select.clone())
-                            }),
-                        ),
-                )
-            })
-            .into_any_element()
-    }
-
-    /// Centre-stage ("coverflow") layout — the default. See the module docs.
-    fn render_coverflow(self, window: &mut Window, cx: &mut App) -> AnyElement {
-        let Self {
-            id,
-            len,
-            selected,
-            render_item,
-            focused_frac,
-            side_frac,
-            gap,
-            arrows,
-            indicators,
-            accent,
-            on_select,
-            ..
-        } = self;
-
-        let Some(render_item) = render_item.filter(|_| len > 0) else {
-            return div().into_any_element();
-        };
-
-        let selected = selected.min(len - 1);
-        let multi = len > 1;
-        let accent = accent.unwrap_or(cx.theme().primary);
-        let dot_idle = cx.theme().border;
-        let has_prev = selected > 0;
-        let has_next = selected + 1 < len;
-
-        // Direction of the most recent selection change (+1 → moved to a later
-        // device, -1 → earlier), persisted across renders so the focused card's
-        // slide-in keeps a stable sign for the whole transition even if the view
-        // repaints mid-glide. Updated — and so notifies — only when `selected`
-        // actually changes, otherwise it would loop.
-        let slide_dir = {
-            let state =
-                window.use_keyed_state(SharedString::from(format!("{id}-dir")), cx, |_, _| {
-                    (selected, 0i8)
-                });
-            let (prev, last) = *state.read(cx);
-            if selected == prev {
-                f32::from(last)
-            } else {
-                let d: i8 = if selected > prev { 1 } else { -1 };
-                state.update(cx, |s, _| *s = (selected, d));
-                f32::from(d)
-            }
-        };
-
-        // Render the visible slot items fresh (the callback reads live data).
-        let prev_el = has_prev.then(|| render_item(selected - 1, false, window, cx));
-        let next_el = has_next.then(|| render_item(selected + 1, false, window, cx));
-        let focused_el = render_item(selected, true, window, cx);
-
-        // The focused slot transitions in on each selection change: its relative
-        // width/height ramp from a smaller fraction up to the full focused
-        // fraction, it fades up, and it slides horizontally into place from the
-        // side it was navigated from (a later device enters from the right, an
-        // earlier one from the left). Keyed by `selected` so it re-fires per
-        // change; `relative`-inset `left` translates it visually without
-        // disturbing the neighbouring peek slots.
-        let fw = focused_frac;
-        let fh = 0.92_f32;
-        let fw0 = focused_frac * 0.72;
-        let fh0 = fh * 0.74;
-        let focused_slot = div()
-            .flex_shrink_0()
-            .overflow_hidden()
-            .child(focused_el)
-            .with_animation(
-                ElementId::NamedInteger(format!("{id}-focus").into(), selected as u64),
-                Animation::new(Duration::from_millis(240)).with_easing(ease_in_out),
-                move |this, delta| {
-                    this.w(relative(fw0 + (fw - fw0) * delta))
-                        .h(relative(fh0 + (fh - fh0) * delta))
-                        .opacity(0.65 + 0.35 * delta)
-                        .left(px(slide_dir * 72. * (1. - delta)))
-                },
-            );
-
-        let stage = h_flex()
-            .id("carousel-stage")
-            .w_full()
-            .flex_1()
-            .min_h_0()
-            .items_center()
-            .justify_center()
-            .gap(gap)
-            .overflow_hidden()
-            .when(multi, |this| {
-                this.child(side_slot(
-                    prev_el,
-                    selected.saturating_sub(1),
-                    side_frac,
-                    on_select.clone(),
-                ))
-            })
-            .child(focused_slot)
-            .when(multi, |this| {
-                this.child(side_slot(
-                    next_el,
-                    selected + 1,
-                    side_frac,
-                    on_select.clone(),
-                ))
-            });
-
-        v_flex()
-            .size_full()
-            .gap_3()
-            .child(stage)
-            .when(multi, |this| {
-                this.child(controls(
-                    len,
-                    selected,
-                    arrows,
-                    indicators,
-                    accent,
-                    dot_idle,
-                    on_select.as_ref(),
-                ))
-            })
-            .into_any_element()
-    }
-}
-
-/// The bottom control row: prev/next arrows flanking the page-indicator dots.
-fn controls(
-    len: usize,
-    selected: usize,
-    arrows: bool,
-    indicators: bool,
-    accent: Hsla,
-    idle: Hsla,
-    on_select: Option<&SelectHandler>,
-) -> impl IntoElement {
-    h_flex()
-        .w_full()
-        .items_center()
-        .justify_center()
-        .gap_3()
-        .when(arrows, |t| {
-            t.child(arrow(
-                "carousel-prev",
-                IconName::ChevronLeft,
-                selected.saturating_sub(1),
-                selected == 0,
-                Size::XSmall,
-                on_select.cloned(),
-            ))
-        })
-        .when(indicators, |t| {
-            t.child(h_flex().items_center().gap_1p5().children(
-                (0..len).map(|i| dot(i, i == selected, accent, idle, on_select.cloned())),
-            ))
-        })
-        .when(arrows, |t| {
-            t.child(arrow(
-                "carousel-next",
-                IconName::ChevronRight,
-                (selected + 1).min(len - 1),
-                selected + 1 >= len,
-                Size::XSmall,
-                on_select.cloned(),
-            ))
-        })
-}
-
-/// A side (peek) slot: the smaller neighbour, clickable to bring it to centre,
-/// or an empty spacer at the ends so the focused item stays centred.
-fn side_slot(
-    el: Option<AnyElement>,
-    index: usize,
-    frac: f32,
-    on_select: Option<SelectHandler>,
-) -> AnyElement {
-    let base = div()
-        .flex_shrink_0()
-        .w(relative(frac))
-        .h(relative(0.62))
-        .flex()
-        .items_center()
-        .justify_center();
-    match el {
-        Some(el) => base
-            .id(("carousel-peek", index))
-            .opacity(0.6)
-            .cursor_pointer()
-            .hover(|s| s.opacity(0.85))
-            .when_some(on_select, |this, handler| {
-                this.on_click(move |_, window, cx| handler(&index, window, cx))
-            })
-            .child(el)
-            .into_any_element(),
-        None => base.into_any_element(),
+        v_flex().size_full().pb_6().child(stage).into_any_element()
     }
 }
 
@@ -512,25 +217,5 @@ fn arrow(
         .disabled(disabled)
         .when_some(on_select.filter(|_| !disabled), |this, handler| {
             this.on_click(move |_, window, cx| handler(&target, window, cx))
-        })
-}
-
-fn dot(
-    index: usize,
-    active: bool,
-    accent: Hsla,
-    idle: Hsla,
-    on_select: Option<SelectHandler>,
-) -> impl IntoElement {
-    let size = if active { px(8.) } else { px(6.) };
-    div()
-        .id(("carousel-dot", index))
-        .w(size)
-        .h(size)
-        .rounded_full()
-        .bg(if active { accent } else { idle })
-        .cursor_pointer()
-        .when_some(on_select, |this, handler| {
-            this.on_click(move |_, window, cx| handler(&index, window, cx))
         })
 }

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -39,6 +39,13 @@ pub const HEADER_H: f32 = 64.;
 pub const FOOTER_H: f32 = 40.;
 pub const DETAIL_RAIL_W: f32 = 168.;
 
+/// Maximum-width scale for detail-tab content.
+pub const CONTENT_W_SM: f32 = 560.;
+pub const CONTENT_W_MD: f32 = 680.;
+pub const CONTENT_W_LG: f32 = 920.;
+pub const CONTENT_W_XL: f32 = 980.;
+pub const CONTENT_W_2XL: f32 = 1040.;
+
 /// Semantic spacing tokens (px), so surfaces that must agree share one value
 /// instead of each call site hand-picking a `p_*` / `gap_*` step.
 ///

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -536,7 +536,7 @@ fn theme_card(
     let dark = mode.is_dark();
     let stored = name.clone();
     v_flex()
-        .id(SharedString::from(format!("theme-{index}")))
+        .id(("theme", index))
         .w(px(132.))
         .p(px(8.))
         .gap_2()


### PR DESCRIPTION
## Summary

- remove avoidable allocations and clones from mouse and keyboard render paths
- stabilize GUI element identities and consolidate detail-tab sizing
- delete the unreachable Carousel coverflow implementation and rename vestigial popover helpers

## Changes

- **openlogi-desktop**: use tuple-key element IDs and stable action-catalog row keys
- **openlogi-desktop**: add a named content-width scale and shared detail-tab wrapper
- **openlogi-desktop**: borrow render data from `AppState` and cache device gesture maps without changing per-app editing behavior
- **openlogi-desktop**: reduce Carousel to its only live equal-card scrolling mode and align helper names with inline editors

## Testing

- `export RUSTFLAGS="-D warnings"; cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace && RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 7 passed; `typos`, `shell`, `tests (macos)`, `cargo-deny`, and `wasm (portable crates)` skipped because their tools/platform were unavailable in the Linux orb
- Not visually runtime-tested or runtime-tested on hardware

Fixes #898