### PR TITLE
refactor(gui): move device reads onto swr

### DIFF
--- a/crates/openlogi-desktop/src/features/pointer/dpi.rs
+++ b/crates/openlogi-desktop/src/features/pointer/dpi.rs
@@ -271,7 +271,7 @@ fn dpi_panel_snapshot(cx: &mut Context<DpiPanel>) -> DpiPanelSnapshot {
             let record = s.current_record()?;
             let device_key = record.device_key();
             Some(DpiPanelSnapshot {
-                status: s.reads.dpi.status(&device_key),
+                status: s.reads.dpi_status(&device_key),
                 device_key,
                 dpi: s.dpi,
                 presets: s.dpi_presets(),

--- a/crates/openlogi-desktop/src/features/pointer/smartshift.rs
+++ b/crates/openlogi-desktop/src/features/pointer/smartshift.rs
@@ -330,7 +330,7 @@ impl Render for SmartShiftPanel {
         let (key, status) = AppState::try_read(cx)
             .and_then(|state| {
                 let key = state.current_record()?.device_key();
-                Some((Some(key.clone()), state.reads.smartshift.status(&key)))
+                Some((Some(key.clone()), state.reads.smartshift_status(&key)))
             })
             .unwrap_or((None, SmartShiftLoad::Unknown));
         let write_status =
@@ -341,7 +341,7 @@ impl Render for SmartShiftPanel {
 
         let show_write_status = matches!(status, SmartShiftLoad::Ready(_));
         let content: AnyElement = match status {
-            SmartShiftLoad::Ready(s) => self.ready_body(s, window, pal, cx),
+            SmartShiftLoad::Ready(s) => self.ready_body(*s, window, pal, cx),
             SmartShiftLoad::Loading | SmartShiftLoad::Unknown if !reachable => {
                 status_line(tr!("Device offline — SmartShift unavailable."), pal)
             }

--- a/crates/openlogi-desktop/src/runtime.rs
+++ b/crates/openlogi-desktop/src/runtime.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use gpui::{App, AppContext as _, AsyncApp, Task};
+use gpui::{AppContext as _, AsyncApp, Task};
 use openlogi_camera::Camera;
 use openlogi_core::brand::DeeplinkCommand;
 use openlogi_core::config::{AssetSourcePreference, Config};
@@ -73,11 +73,15 @@ pub(crate) fn spawn(startup: Startup, cx: &mut gpui::App) {
         // unresponsive device must not be able to wedge the main thread before
         // the window opens. The agent's first snapshot wires up devices,
         // bindings and the hook live.
-        cx.update(|cx| {
+        let swr = cx.update(|cx| {
+            let swr_runtime: Arc<dyn swr_core::Runtime> = Arc::new(GpuiRuntime::new(cx));
+            let swr = SwrClient::builder()
+                .default_options(assets::queries::default_options())
+                .build(swr_runtime.clone());
             if AppState::try_global(cx).is_none() {
                 let cache = assets::AssetResolver::new();
                 let state = cx.new(|_| {
-                    AppState::with_runtime(
+                    let mut state = AppState::with_runtime(
                         config,
                         &[],
                         &[],
@@ -85,12 +89,19 @@ pub(crate) fn spawn(startup: Startup, cx: &mut gpui::App) {
                         &cams,
                         persistence,
                         ipc_commands,
-                    )
+                    );
+                    state.reads.connect(swr.clone(), swr_runtime.clone());
+                    state
                 });
                 AppState::set_global(state, cx);
                 AppState::load_current_device_reads(cx);
+            } else {
+                AppState::update(cx, |state, _| {
+                    state.reads.connect(swr.clone(), swr_runtime);
+                });
             }
             windows::main_window::open(&[], cx);
+            swr
         });
 
         // First launch only: offer to opt in to the update check, since it
@@ -109,7 +120,7 @@ pub(crate) fn spawn(startup: Startup, cx: &mut gpui::App) {
         std::thread::spawn(assets::cleanup_legacy_glow_pngs);
 
         let (sync_tx, mut sync_done) = tokio::sync::mpsc::unbounded_channel::<bool>();
-        let mut rt = cx.update(|cx| Runtime::new(cams, sync_tx, cx));
+        let mut rt = Runtime::new(cams, sync_tx, swr);
         let mut camera_scan = Box::pin(cx.background_executor().timer(CAMERA_SCAN_PERIOD));
         // Cleared when the IPC update channel closes (the client thread died),
         // so the select stops polling a closed receiver.
@@ -174,8 +185,9 @@ struct Runtime {
     /// snapshot was pure waste: the unchanged-list early-return discarded the
     /// fresh records anyway.
     cache: assets::AssetResolver,
-    /// The asset tier's cache. Owns the mirror probe and every depot download
-    /// as keyed entries — see [`assets::queries`].
+    /// The process-wide swr cache, shared with `AppState`'s device reads. This
+    /// runtime owns the asset mirror probe and depot-download subscriptions —
+    /// see [`assets::queries`].
     swr: SwrClient,
     /// Whether the *automatic* download path runs in this build at all: a
     /// release bundle already ships the art. Manual actions ignore it.
@@ -192,12 +204,9 @@ struct Runtime {
 }
 
 impl Runtime {
-    fn new(cams: Vec<Camera>, sync_tx: UnboundedSender<bool>, cx: &App) -> Self {
+    fn new(cams: Vec<Camera>, sync_tx: UnboundedSender<bool>, swr: SwrClient) -> Self {
         let cache = assets::AssetResolver::new();
         let auto_sync = sync::should_run(cache.has_bundle_root());
-        let swr = SwrClient::builder()
-            .default_options(assets::queries::default_options())
-            .build(Arc::new(GpuiRuntime::new(cx)));
         Self {
             cams,
             camera_misses: 0,

--- a/crates/openlogi-desktop/src/services/device_reads.rs
+++ b/crates/openlogi-desktop/src/services/device_reads.rs
@@ -181,12 +181,16 @@ impl DeviceReads {
         let load = project_load(query.read(cx), smartshift_error_is_permanent);
         let observed_key = key.clone();
         let observer = cx.observe(query.state(), move |state, query_state, cx| {
-            let load = project_load(query_state.read(cx), smartshift_error_is_permanent);
+            let query_state = query_state.read(cx);
+            let settled = smartshift_read_is_settled(query_state);
+            let load = project_load(query_state, smartshift_error_is_permanent);
             if state
                 .reads
                 .update_smartshift(&observed_key, generation, load)
             {
-                state.apply_smartshift_read(&observed_key, write_id);
+                if settled {
+                    state.apply_smartshift_read(&observed_key, write_id);
+                }
                 cx.emit(StateEvent::SmartShiftChanged(observed_key.clone()));
             }
         });
@@ -411,11 +415,17 @@ fn smartshift_error_is_permanent(error: &WriteError) -> bool {
     matches!(error, WriteError::FeatureUnsupported { .. })
 }
 
+/// Stale data remains renderable while SWR revalidates, but only the settled
+/// snapshot represents the device-facing result of a confirmation read.
+fn smartshift_read_is_settled(state: &QueryState<Cached<SmartShiftStatus>, WriteError>) -> bool {
+    !state.is_validating
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
-    use openlogi_core::hid::{Dpi, DpiCapabilities};
+    use openlogi_core::hid::{Dpi, DpiCapabilities, SmartShiftAutoDisengage, SmartShiftMode};
     use swr_core::{Fetcher as _, Instant, RuntimeFuture};
 
     use super::*;
@@ -522,6 +532,29 @@ mod tests {
             ),
             Load::Unsupported(_)
         ));
+    }
+
+    #[test]
+    fn validating_smartshift_data_is_visible_but_not_confirmed() {
+        let optimistic = Arc::new(SmartShiftStatus {
+            mode: SmartShiftMode::Ratchet,
+            auto_disengage: SmartShiftAutoDisengage::Permanent,
+            tunable_torque: None,
+        });
+        let validating = state(Some(Arc::new(Some(optimistic.clone()))), None, false, true);
+
+        assert_eq!(
+            project_load(&validating, smartshift_error_is_permanent),
+            Load::Ready(optimistic.clone()),
+            "the optimistic value stays visible while confirmation is in flight"
+        );
+        assert!(
+            !smartshift_read_is_settled(&validating),
+            "validating stale data is not a device confirmation"
+        );
+
+        let settled = state(Some(Arc::new(Some(optimistic))), None, false, false);
+        assert!(smartshift_read_is_settled(&settled));
     }
 
     #[tokio::test]

--- a/crates/openlogi-desktop/src/services/device_reads.rs
+++ b/crates/openlogi-desktop/src/services/device_reads.rs
@@ -1,0 +1,552 @@
+//! SWR-backed DPI and SmartShift reads keyed by device identity.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use gpui::{Context, Subscription};
+use openlogi_core::hid::{DeviceRoute, DpiInfo, SmartShiftStatus, WriteError};
+use swr_core::{
+    MaybeSend, MaybeSync, QueryOptions, QueryState, Retry, RetryPolicy, Runtime, SwrClient,
+};
+use swr_gpui::Query;
+use tokio::sync::mpsc;
+
+use super::ipc::Command;
+use crate::state::{AppState, DeviceKey, DpiStatus, Load, SmartShiftLoad, StateEvent};
+
+const ROOT: &str = "device-read";
+const DPI: &str = "dpi";
+const SMARTSHIFT: &str = "smartshift";
+
+/// Preserve the old budget: one initial attempt and two retries.
+const READ_RETRY_POLICY: RetryPolicy = RetryPolicy {
+    // The previous cache retried immediately. Keeping a zero interval changes
+    // the owner of retry policy without adding latency to device tabs.
+    interval: Duration::ZERO,
+    max_retries: Some(2),
+};
+
+type Cached<T> = Option<Arc<T>>;
+
+struct DeviceRead<T: 'static> {
+    route: DeviceRoute,
+    generation: u64,
+    load: Load<Arc<T>>,
+    query: Query<Cached<T>, WriteError>,
+    _observer: Subscription,
+}
+
+/// The state entity's live device-read queries.
+///
+/// The maps own subscriptions, not retry counters or result caches: swr owns
+/// those. `Load<T>` is only the synchronous view-model projection consumed by
+/// render paths.
+#[derive(Default)]
+pub(crate) struct DeviceReads {
+    client: Option<SwrClient>,
+    runtime: Option<Arc<dyn Runtime>>,
+    next_generation: u64,
+    dpi: BTreeMap<DeviceKey, DeviceRead<DpiInfo>>,
+    smartshift: BTreeMap<DeviceKey, DeviceRead<SmartShiftStatus>>,
+}
+
+impl DeviceReads {
+    /// Attach the shared cache and runtime after the GPUI app exists.
+    pub(crate) fn connect(&mut self, client: SwrClient, runtime: Arc<dyn Runtime>) {
+        self.client = Some(client);
+        self.runtime = Some(runtime);
+    }
+
+    /// Start the DPI query unless the same device route is already subscribed.
+    pub(crate) fn ensure_dpi(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) {
+        if self.dpi.get(&key).is_some_and(|read| read.route == route) {
+            return;
+        }
+        self.remove_dpi(&key);
+        let Some((client, runtime)) = self.cache() else {
+            return;
+        };
+        let generation = self.take_generation();
+        let fetch_route = route.clone();
+        let fetcher = Retry::new(
+            runtime,
+            move |_| {
+                let commands = commands.clone();
+                let route = fetch_route.clone();
+                read_ipc(move |reply| Command::ReadDpi(route, reply), commands)
+            },
+            READ_RETRY_POLICY,
+        )
+        .retry_if(|error| !dpi_error_is_permanent(error));
+        let handle = client.subscribe(query_key(DPI, &key), fetcher, QueryOptions::immutable());
+        let query = Query::new(&client, handle, cx);
+        let load = project_load(query.read(cx), dpi_error_is_permanent);
+        let observed_key = key.clone();
+        let observer = cx.observe(query.state(), move |state, query_state, cx| {
+            let load = project_load(query_state.read(cx), dpi_error_is_permanent);
+            if state.reads.update_dpi(&observed_key, generation, load) {
+                state.apply_dpi_read(&observed_key);
+                cx.emit(StateEvent::DpiChanged(observed_key.clone()));
+            }
+        });
+        self.dpi.insert(
+            key,
+            DeviceRead {
+                route,
+                generation,
+                load,
+                query,
+                _observer: observer,
+            },
+        );
+    }
+
+    /// Start an initial SmartShift query unless this route is already watched.
+    pub(crate) fn ensure_smartshift(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) {
+        if self
+            .smartshift
+            .get(&key)
+            .is_some_and(|read| read.route == route)
+        {
+            return;
+        }
+        self.subscribe_smartshift(key, route, None, false, commands, cx);
+    }
+
+    /// Replace the active SmartShift query with a write-confirmation read.
+    pub(crate) fn confirm_smartshift(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        write_id: u64,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) -> bool {
+        self.subscribe_smartshift(key, route, Some(write_id), true, commands, cx)
+    }
+
+    fn subscribe_smartshift(
+        &mut self,
+        key: DeviceKey,
+        route: DeviceRoute,
+        write_id: Option<u64>,
+        preserve_data: bool,
+        commands: mpsc::UnboundedSender<Command>,
+        cx: &mut Context<AppState>,
+    ) -> bool {
+        let Some((client, runtime)) = self.cache() else {
+            return false;
+        };
+        let previous = self.smartshift.remove(&key);
+        let had_previous = previous.is_some();
+        drop(previous);
+        if preserve_data {
+            // A confirming read keeps the optimistic write visible as stale
+            // data while invalidation starts the replacement query.
+            client.invalidate(query_key(SMARTSHIFT, &key));
+        } else if had_previous {
+            self.clear::<SmartShiftStatus>(SMARTSHIFT, &key);
+        }
+        let generation = self.take_generation();
+        let fetch_route = route.clone();
+        let fetcher = Retry::new(
+            runtime,
+            move |_| {
+                let commands = commands.clone();
+                let route = fetch_route.clone();
+                read_ipc(move |reply| Command::ReadSmartShift(route, reply), commands)
+            },
+            READ_RETRY_POLICY,
+        )
+        .retry_if(|error| !smartshift_error_is_permanent(error));
+        let handle = client.subscribe(
+            query_key(SMARTSHIFT, &key),
+            fetcher,
+            QueryOptions::immutable(),
+        );
+        let query = Query::new(&client, handle, cx);
+        let load = project_load(query.read(cx), smartshift_error_is_permanent);
+        let observed_key = key.clone();
+        let observer = cx.observe(query.state(), move |state, query_state, cx| {
+            let load = project_load(query_state.read(cx), smartshift_error_is_permanent);
+            if state
+                .reads
+                .update_smartshift(&observed_key, generation, load)
+            {
+                state.apply_smartshift_read(&observed_key, write_id);
+                cx.emit(StateEvent::SmartShiftChanged(observed_key.clone()));
+            }
+        });
+        self.smartshift.insert(
+            key,
+            DeviceRead {
+                route,
+                generation,
+                load,
+                query,
+                _observer: observer,
+            },
+        );
+        true
+    }
+
+    #[must_use]
+    pub(crate) fn dpi_status(&self, key: &DeviceKey) -> DpiStatus {
+        self.dpi
+            .get(key)
+            .map_or(Load::Unknown, |read| read.load.clone())
+    }
+
+    #[must_use]
+    pub(crate) fn dpi_load(&self, key: &DeviceKey) -> Option<&DpiStatus> {
+        self.dpi.get(key).map(|read| &read.load)
+    }
+
+    #[must_use]
+    pub(crate) fn smartshift_status(&self, key: &DeviceKey) -> SmartShiftLoad {
+        self.smartshift
+            .get(key)
+            .map_or(Load::Unknown, |read| read.load.clone())
+    }
+
+    #[must_use]
+    pub(crate) fn smartshift_load(&self, key: &DeviceKey) -> Option<&SmartShiftLoad> {
+        self.smartshift.get(key).map(|read| &read.load)
+    }
+
+    /// Retry an exhausted DPI query without changing its registered fetcher.
+    pub(crate) fn retry_dpi(&mut self, key: &DeviceKey) {
+        let Some(read) = self.dpi.get_mut(key) else {
+            return;
+        };
+        if !matches!(read.load, Load::Ready(_)) {
+            read.load = Load::Loading;
+        }
+        read.query.revalidate();
+    }
+
+    /// Retry an exhausted initial SmartShift query.
+    pub(crate) fn retry_smartshift(&mut self, key: &DeviceKey) {
+        let Some(read) = self.smartshift.get_mut(key) else {
+            return;
+        };
+        if !matches!(read.load, Load::Ready(_)) {
+            read.load = Load::Loading;
+        }
+        read.query.revalidate();
+    }
+
+    /// Publish a SmartShift write optimistically into swr and the view model.
+    pub(crate) fn set_smartshift_ready(&mut self, key: &DeviceKey, status: SmartShiftStatus) {
+        let value = Arc::new(status);
+        if let Some(client) = &self.client {
+            client.set::<_, Cached<SmartShiftStatus>, WriteError>(
+                query_key(SMARTSHIFT, key),
+                Some(value.clone()),
+            );
+        }
+        if let Some(read) = self.smartshift.get_mut(key) {
+            read.load = Load::Ready(value);
+        }
+    }
+
+    /// Forget both feature queries for a device and fence their old flights.
+    pub(crate) fn remove(&mut self, key: &DeviceKey) {
+        self.remove_dpi(key);
+        self.remove_smartshift(key);
+    }
+
+    pub(crate) fn remove_dpi(&mut self, key: &DeviceKey) {
+        if let Some(read) = self.dpi.remove(key) {
+            drop(read);
+            self.clear::<DpiInfo>(DPI, key);
+        }
+    }
+
+    pub(crate) fn remove_smartshift(&mut self, key: &DeviceKey) {
+        if let Some(read) = self.smartshift.remove(key) {
+            drop(read);
+            self.clear::<SmartShiftStatus>(SMARTSHIFT, key);
+        }
+    }
+
+    /// Forget every query whose device is no longer present.
+    pub(crate) fn retain_present(&mut self, present: impl Fn(&str) -> bool) {
+        let removed: BTreeSet<_> = self
+            .dpi
+            .keys()
+            .chain(self.smartshift.keys())
+            .filter(|key| !present(key.as_str()))
+            .cloned()
+            .collect();
+        for key in removed {
+            self.remove(&key);
+        }
+    }
+
+    fn cache(&self) -> Option<(SwrClient, Arc<dyn Runtime>)> {
+        Some((
+            self.client.as_ref()?.clone(),
+            self.runtime.as_ref()?.clone(),
+        ))
+    }
+
+    fn clear<T>(&self, kind: &'static str, key: &DeviceKey)
+    where
+        T: MaybeSend + MaybeSync + 'static,
+    {
+        let Some(client) = &self.client else {
+            return;
+        };
+        // Drop subscribers before this call. `set(None)` fences the old flight;
+        // invalidation then leaves the empty entry stale for the next route.
+        client.set::<_, Cached<T>, WriteError>(query_key(kind, key), None);
+        client.invalidate(query_key(kind, key));
+    }
+
+    fn take_generation(&mut self) -> u64 {
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.saturating_add(1);
+        generation
+    }
+
+    fn update_dpi(&mut self, key: &DeviceKey, generation: u64, load: DpiStatus) -> bool {
+        let Some(read) = self
+            .dpi
+            .get_mut(key)
+            .filter(|read| read.generation == generation)
+        else {
+            return false;
+        };
+        if read.load == load {
+            return false;
+        }
+        read.load = load;
+        true
+    }
+
+    fn update_smartshift(
+        &mut self,
+        key: &DeviceKey,
+        generation: u64,
+        load: SmartShiftLoad,
+    ) -> bool {
+        let Some(read) = self
+            .smartshift
+            .get_mut(key)
+            .filter(|read| read.generation == generation)
+        else {
+            return false;
+        };
+        // A confirmation commonly resolves to the optimistic value already in
+        // `load`. It must still reach `apply_smartshift_read` so Applying can
+        // transition to Confirmed; the generation check is the stale guard.
+        read.load = load;
+        true
+    }
+}
+
+fn query_key(kind: &'static str, key: &DeviceKey) -> (&'static str, &'static str, String) {
+    (ROOT, kind, key.to_string())
+}
+
+async fn read_ipc<T>(
+    command: impl FnOnce(tokio::sync::oneshot::Sender<Result<T, WriteError>>) -> Command,
+    commands: mpsc::UnboundedSender<Command>,
+) -> Result<Cached<T>, WriteError>
+where
+    T: MaybeSend + MaybeSync + 'static,
+{
+    let (reply, result) = tokio::sync::oneshot::channel();
+    commands
+        .send(command(reply))
+        .map_err(|_| WriteError::AgentUnavailable)?;
+    result
+        .await
+        .map_err(|_| WriteError::AgentUnavailable)?
+        .map(|value| Some(Arc::new(value)))
+}
+
+fn project_load<T>(
+    state: &QueryState<Cached<T>, WriteError>,
+    is_permanent: impl Fn(&WriteError) -> bool,
+) -> Load<Arc<T>> {
+    let data = state.data.as_deref().and_then(Option::as_ref);
+    if state.is_validating && data.is_none() {
+        return Load::Loading;
+    }
+    if !state.is_validating
+        && let Some(error) = state.error.as_deref()
+    {
+        return if is_permanent(error) {
+            Load::Unsupported(error.to_string())
+        } else {
+            Load::Failed(error.to_string())
+        };
+    }
+    data.cloned().map_or(Load::Unknown, Load::Ready)
+}
+
+fn dpi_error_is_permanent(error: &WriteError) -> bool {
+    matches!(
+        error,
+        WriteError::FeatureUnsupported { .. } | WriteError::EmptyDpiList
+    )
+}
+
+fn smartshift_error_is_permanent(error: &WriteError) -> bool {
+    matches!(error, WriteError::FeatureUnsupported { .. })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use openlogi_core::hid::{Dpi, DpiCapabilities};
+    use swr_core::{Fetcher as _, Instant, RuntimeFuture};
+
+    use super::*;
+
+    struct TokioRuntime;
+
+    impl Runtime for TokioRuntime {
+        fn now(&self) -> Instant {
+            Instant::now()
+        }
+
+        fn spawn(&self, future: RuntimeFuture) {
+            tokio::spawn(future);
+        }
+
+        fn sleep_until(&self, at: Instant) -> RuntimeFuture {
+            Box::pin(async move {
+                tokio::time::sleep_until(tokio::time::Instant::from_std(at)).await;
+            })
+        }
+    }
+
+    fn state<T>(
+        data: Option<Arc<Cached<T>>>,
+        error: Option<Arc<WriteError>>,
+        is_loading: bool,
+        is_validating: bool,
+    ) -> QueryState<Cached<T>, WriteError> {
+        QueryState {
+            data,
+            error,
+            is_loading,
+            is_validating,
+            updated_at: None,
+        }
+    }
+
+    async fn attempt_count(error: WriteError, is_permanent: fn(&WriteError) -> bool) -> u32 {
+        let calls = Arc::new(AtomicU32::new(0));
+        let fetcher = {
+            let calls = calls.clone();
+            move |_key: &'static str| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                std::future::ready(Err::<(), _>(error.clone()))
+            }
+        };
+        let retry = Retry::new(Arc::new(TokioRuntime), fetcher, READ_RETRY_POLICY)
+            .retry_if(move |error| !is_permanent(error));
+
+        assert!(retry.fetch("device-read").await.is_err());
+        calls.load(Ordering::SeqCst)
+    }
+
+    #[test]
+    fn swr_state_projects_to_the_five_load_states() {
+        let info = Arc::new(DpiInfo {
+            current: Dpi::new(1600),
+            capabilities: DpiCapabilities::new(vec![800, 1600]).expect("valid DPI list"),
+        });
+        assert_eq!(
+            project_load(
+                &state::<DpiInfo>(None, None, false, false),
+                dpi_error_is_permanent
+            ),
+            Load::Unknown
+        );
+        assert_eq!(
+            project_load(
+                &state::<DpiInfo>(None, None, true, true),
+                dpi_error_is_permanent
+            ),
+            Load::Loading
+        );
+        assert_eq!(
+            project_load(
+                &state(Some(Arc::new(Some(info.clone()))), None, false, false),
+                dpi_error_is_permanent,
+            ),
+            Load::Ready(info.clone())
+        );
+        assert_eq!(
+            project_load(
+                &state(Some(Arc::new(Some(info.clone()))), None, false, true),
+                dpi_error_is_permanent,
+            ),
+            Load::Ready(info.clone())
+        );
+        assert!(matches!(
+            project_load(
+                &state(
+                    Some(Arc::new(Some(info))),
+                    Some(Arc::new(WriteError::AgentUnavailable)),
+                    false,
+                    false,
+                ),
+                dpi_error_is_permanent,
+            ),
+            Load::Failed(_)
+        ));
+        assert!(matches!(
+            project_load(
+                &state::<DpiInfo>(None, Some(Arc::new(WriteError::EmptyDpiList)), false, false,),
+                dpi_error_is_permanent,
+            ),
+            Load::Unsupported(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn transient_reads_keep_the_three_attempt_budget() {
+        assert_eq!(
+            attempt_count(WriteError::AgentUnavailable, smartshift_error_is_permanent).await,
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn permanent_errors_are_not_retried() {
+        assert_eq!(
+            attempt_count(
+                WriteError::FeatureUnsupported {
+                    feature_hex: 0x2111,
+                },
+                smartshift_error_is_permanent,
+            )
+            .await,
+            1
+        );
+        assert_eq!(
+            attempt_count(WriteError::EmptyDpiList, dpi_error_is_permanent).await,
+            1
+        );
+    }
+}

--- a/crates/openlogi-desktop/src/services/diagnostics.rs
+++ b/crates/openlogi-desktop/src/services/diagnostics.rs
@@ -125,7 +125,7 @@ fn collect_devices(state: &AppState) -> Vec<DeviceDiag> {
                 online: record.online,
                 battery: record.battery.clone(),
                 capabilities: record.capabilities,
-                dpi: dpi_summary(state.reads.dpi.get(&record.device_key()).cloned()),
+                dpi: dpi_summary(state.reads.dpi_load(&record.device_key()).cloned()),
                 // Diagnostics are model-level by contract. The runtime config
                 // key may contain a receiver UID or raw-device serial.
                 config_key: record.model_key.clone(),

--- a/crates/openlogi-desktop/src/services/mod.rs
+++ b/crates/openlogi-desktop/src/services/mod.rs
@@ -1,6 +1,7 @@
 //! Settings-app infrastructure services.
 
 pub mod assets;
+pub(crate) mod device_reads;
 pub mod diagnostics;
 pub mod i18n;
 pub mod ipc;

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -27,8 +27,7 @@ use tracing::warn;
 pub(crate) use device_key::DeviceKey;
 pub use devices::DeviceRecord;
 pub use light::LightCommandStatus;
-#[cfg(test)]
-pub use load::Load;
+pub(crate) use load::Load;
 pub use load::{DpiStatus, SmartShiftLoad};
 
 /// Result of confirming a SmartShift write by reading the value back.
@@ -49,9 +48,9 @@ pub enum SmartShiftWriteStatus {
 
 use device_ui::DeviceUiState;
 pub(crate) use devices::camera_model_info;
-use load::DeviceReads;
 
 use crate::services::assets::AssetResolver;
+use crate::services::device_reads::DeviceReads;
 use crate::state::devices::{build_device_list, pick_initial_device};
 
 mod agent;
@@ -248,11 +247,9 @@ pub struct AppState {
     /// Sorted (`BTreeMap`) for stable render order in the function-row view.
     pub keyboard_bindings: BTreeMap<KeyTrigger, Action>,
     pub dpi: Dpi,
-    /// Lazily-loaded DPI and SmartShift read caches, keyed by [`DeviceKey`].
-    /// HID++ reads must not block device switching or rendering, so callers
-    /// reach these directly (`state.reads.dpi.retry(&key)`,
-    /// `state.reads.smartshift.status(&key)`, …) rather than through a
-    /// per-subsystem forwarding method.
+    /// SWR-backed DPI and SmartShift reads keyed by [`DeviceKey`]. HID++ reads
+    /// must not block device switching or rendering; feature modules project
+    /// this service into synchronous [`Load`] values for their render paths.
     pub(crate) reads: DeviceReads,
     /// Monotonic identity assigned to the next confirmable SmartShift write.
     next_smartshift_write_id: u64,

--- a/crates/openlogi-desktop/src/state/device_key.rs
+++ b/crates/openlogi-desktop/src/state/device_key.rs
@@ -3,8 +3,8 @@
 use std::borrow::Borrow;
 
 /// Identifies one device across [`AppState`](super::AppState)'s per-device UI
-/// caches: the DPI/SmartShift lazy-read state
-/// ([`DeviceReads`](super::load::DeviceReads)) and the consolidated
+/// caches: the DPI/SmartShift query state
+/// ([`DeviceReads`](crate::services::device_reads::DeviceReads)) and the consolidated
 /// per-device row ([`DeviceUiState`](super::device_ui::DeviceUiState)).
 ///
 /// Wraps a device's config key — see

--- a/crates/openlogi-desktop/src/state/device_ui.rs
+++ b/crates/openlogi-desktop/src/state/device_ui.rs
@@ -6,7 +6,7 @@ use super::SmartShiftWriteStatus;
 use super::light::PendingLightCommand;
 
 /// Everything `AppState` tracks per device outside the persisted config and
-/// the lazily-loaded DPI/SmartShift reads ([`super::load::LazyDeviceData`]).
+/// the swr-backed DPI/SmartShift reads.
 ///
 /// Replaces six parallel `BTreeMap<String, _>` fields that all shared the
 /// same device-key domain — manual camera-light override, volatile light

--- a/crates/openlogi-desktop/src/state/dpi.rs
+++ b/crates/openlogi-desktop/src/state/dpi.rs
@@ -1,8 +1,8 @@
-//! DPI presets and live writes. Capability discovery itself lives in
-//! [`super::load::LazyDeviceData`], reached directly as `self.reads.dpi`.
+//! DPI presets and live writes. Capability discovery is an swr-backed query
+//! owned by the device-read service.
 
 use gpui::{App, Context};
-use openlogi_core::hid::{DeviceRoute, Dpi, DpiCapabilities, DpiInfo, WriteError};
+use openlogi_core::hid::{Dpi, DpiCapabilities};
 use tracing::debug;
 
 use crate::state::devices::DeviceRecord;
@@ -13,42 +13,20 @@ use super::{AppState, DEFAULT_DPI, StateEvent};
 
 impl AppState {
     pub(super) fn load_current_dpi(&mut self, cx: &mut Context<Self>) {
-        let Some(record) = self.current_record() else {
+        let Some((key, route)) = self
+            .current_record()
+            .and_then(|record| Some((record.device_key(), record.route.clone()?)))
+        else {
             return;
         };
-        let key = record.device_key();
-        if !self.reads.dpi.unqueried(&key) {
-            return;
-        }
-        let Some(route) = record.route.clone() else {
-            return;
-        };
-        self.reads.dpi.mark_loading(&key);
-        self.issue_device_read(
-            cx,
-            (key.clone(), route),
-            crate::services::ipc::Command::ReadDpi,
-            |state, key, route, result, cx| {
-                state.store_dpi_info(key.clone(), route, result);
-                // Transient failures clear back to Unknown until the retry
-                // budget is exhausted; continue those retries off render.
-                if state.reads.dpi.unqueried(&key)
-                    && state
-                        .current_record()
-                        .is_some_and(|record| record.device_key() == key)
-                {
-                    state.load_current_dpi(cx);
-                }
-            },
-            |state, key| state.reads.dpi.clear_loading(key),
-            StateEvent::DpiChanged(key),
-        );
+        self.reads
+            .ensure_dpi(key.clone(), route, self.ipc_sender(), cx);
+        self.apply_dpi_read(&key);
     }
 
     pub(crate) fn retry_dpi_read(cx: &mut App, key: DeviceKey) {
         Self::update(cx, |state, cx| {
-            state.reads.dpi.retry(&key);
-            state.load_current_dpi(cx);
+            state.reads.retry_dpi(&key);
             cx.emit(StateEvent::DpiChanged(key));
         });
     }
@@ -87,43 +65,24 @@ impl AppState {
     #[must_use]
     pub(crate) fn dpi_for_current(&self) -> Dpi {
         self.current_record()
-            .and_then(|record| self.reads.dpi.get(&record.device_key()))
+            .and_then(|record| self.reads.dpi_load(&record.device_key()))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(info.current),
                 _ => None,
             })
             .unwrap_or(DEFAULT_DPI)
     }
-    /// Store a DPI capability discovery result if it still matches the known
-    /// device route. This guards against async reads completing after the
-    /// carousel or inventory changed.
-    pub fn store_dpi_info(
-        &mut self,
-        key: DeviceKey,
-        route: &DeviceRoute,
-        result: Result<DpiInfo, WriteError>,
-    ) {
-        let is_active = self.current_record().is_some_and(|r| r.device_key() == key);
-        let matches_route = self
-            .device_list
-            .iter()
-            .any(|record| record.device_key() == key && record.route.as_ref() == Some(route));
-        let still_present = self
-            .device_list
-            .iter()
-            .any(|record| record.device_key() == key);
-        // Only the active device owns the shared `self.dpi`; a result landing for
-        // a background device after a carousel switch must not clobber the
-        // visible value.
-        if let Some(info) = self.reads.dpi.store(
-            key,
-            result,
-            dpi_error_is_permanent,
-            matches_route,
-            still_present,
-            "DPI",
-        ) && is_active
+    /// Seed the active panel from the latest query. Query generations fence
+    /// disconnected routes; this selected-device check prevents an old
+    /// carousel page from changing the shared visible value.
+    pub(crate) fn apply_dpi_read(&mut self, key: &DeviceKey) {
+        if self
+            .current_record()
+            .is_none_or(|record| record.device_key() != *key)
         {
+            return;
+        }
+        if let Some(DpiStatus::Ready(info)) = self.reads.dpi_load(key) {
             self.dpi = info.current;
         }
     }
@@ -131,7 +90,7 @@ impl AppState {
     #[must_use]
     pub fn active_dpi_capabilities(&self) -> Option<&DpiCapabilities> {
         self.current_record()
-            .and_then(|record| self.reads.dpi.get(&record.device_key()))
+            .and_then(|record| self.reads.dpi_load(&record.device_key()))
             .and_then(|status| match status {
                 DpiStatus::Ready(info) => Some(&info.capabilities),
                 DpiStatus::Unknown
@@ -173,11 +132,4 @@ impl AppState {
             self.send_ipc(crate::services::ipc::Command::SetDpi(route, dpi));
         }
     }
-}
-
-pub(crate) fn dpi_error_is_permanent(error: &WriteError) -> bool {
-    matches!(
-        error,
-        WriteError::FeatureUnsupported { .. } | WriteError::EmptyDpiList
-    )
 }

--- a/crates/openlogi-desktop/src/state/inventory.rs
+++ b/crates/openlogi-desktop/src/state/inventory.rs
@@ -92,8 +92,8 @@ impl AppState {
             "inventory refreshed"
         );
 
-        // A device that came back on a different route must re-discover DPI —
-        // its cached status/attempts were keyed to the now-dead route.
+        // A device that came back on a different route must re-run its device
+        // queries — their subscriptions targeted the now-dead route.
         let rerouted: Vec<DeviceKey> = merged_list
             .iter()
             .filter(|new| {
@@ -106,20 +106,18 @@ impl AppState {
 
         self.device_list = merged_list;
         for key in &rerouted {
-            self.reads.dpi.remove(key);
-            self.reads.smartshift.remove(key);
+            self.reads.remove(key);
             if let Some(entry) = self.device_ui.get_mut(key) {
                 entry.smartshift_pending_confirm = None;
                 entry.smartshift_write_status = None;
             }
         }
-        let present = |key: &str| {
-            self.device_list
-                .iter()
-                .any(|r| r.config_key.as_str() == key)
-        };
-        self.reads.dpi.retain_present(present);
-        self.reads.smartshift.retain_present(present);
+        let present: HashSet<_> = self
+            .device_list
+            .iter()
+            .map(|record| record.config_key.as_str())
+            .collect();
+        self.reads.retain_present(|key| present.contains(key));
         self.current_device = new_index;
         // The active device may have changed (selection fell back to index 0
         // when the previous one vanished); re-seed the displayed DPI so it
@@ -286,10 +284,10 @@ impl AppState {
         // A device left in `Failed` (transient read errors exhausted its retry
         // budget) gets one fresh attempt each time it is re-selected.
         if let Some(key) = self.current_record().map(DeviceRecord::device_key) {
-            if matches!(self.reads.dpi.get(&key), Some(Load::Failed(_))) {
-                self.reads.dpi.retry(&key);
+            if matches!(self.reads.dpi_load(&key), Some(Load::Failed(_))) {
+                self.reads.retry_dpi(&key);
             }
-            if matches!(self.reads.smartshift.get(&key), Some(Load::Failed(_))) {
+            if matches!(self.reads.smartshift_load(&key), Some(Load::Failed(_))) {
                 self.retry_smartshift(&key);
             }
         }

--- a/crates/openlogi-desktop/src/state/load.rs
+++ b/crates/openlogi-desktop/src/state/load.rs
@@ -1,72 +1,11 @@
-//! Lazy per-device load state for background HID++ reads, shared by DPI
-//! capability discovery and SmartShift reads.
+//! View-model projection of background device reads.
 
-use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use gpui::Context;
-use openlogi_core::hid::{DeviceRoute, DpiInfo, SmartShiftStatus, WriteError};
-use tokio::sync::oneshot;
-use tracing::debug;
+use openlogi_core::hid::{DpiInfo, SmartShiftStatus};
 
-use super::device_key::DeviceKey;
-use super::{AppState, StateEvent};
-use crate::services::ipc::Command;
-
-/// How many times to retry a device read (DPI capability discovery or a
-/// SmartShift read) after a transient HID++ error (read timeout, busy device)
-/// before giving up. A genuine "feature not supported" reply is permanent and
-/// never retried.
-const LOAD_MAX_ATTEMPTS: u8 = 3;
-
-/// Issue one typed device read from the state entity and apply its result back
-/// to that same entity. The caller owns the feature-specific cache transition;
-/// this helper only owns the IPC/reply lifecycle.
-impl AppState {
-    pub(super) fn issue_device_read<T>(
-        &mut self,
-        cx: &mut Context<Self>,
-        target: (DeviceKey, DeviceRoute),
-        make_command: impl FnOnce(DeviceRoute, oneshot::Sender<T>) -> Command,
-        store: impl FnOnce(&mut Self, DeviceKey, &DeviceRoute, T, &mut Context<Self>) + 'static,
-        clear: impl Fn(&mut Self, &DeviceKey) + 'static,
-        event: StateEvent,
-    ) where
-        T: 'static,
-    {
-        let (key, route) = target;
-        let (tx, rx) = oneshot::channel();
-        if self
-            .ipc_sender()
-            .send(make_command(route.clone(), tx))
-            .is_err()
-        {
-            clear(self, &key);
-            cx.emit(event);
-            return;
-        }
-        cx.spawn(async move |entity, cx| {
-            let result = rx.await;
-            entity
-                .update(cx, move |state, cx| {
-                    match result {
-                        Ok(result) => store(state, key, &route, result, cx),
-                        // The client thread dropped the reply. Reset the loading
-                        // marker so a later inventory/selection event may retry.
-                        Err(_) => clear(state, &key),
-                    }
-                    cx.emit(event);
-                })
-                .ok();
-        })
-        .detach();
-    }
-}
-
-/// Lazy per-device load state for a background HID++ read: unqueried, in flight,
-/// resolved, transiently failed (retryable on re-select), or permanently
-/// unsupported. Shared by DPI capability discovery and SmartShift reads through
-/// [`LazyDeviceData`]; the two differ only in payload type `T` and in which
-/// errors count as permanent.
+/// State projected from an swr-backed device query: unqueried, in flight,
+/// resolved, transiently failed, or permanently unsupported.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Load<T> {
     /// The selected device has not been queried yet.
@@ -77,179 +16,17 @@ pub enum Load<T> {
     Ready(T),
     /// Transient errors (read timeouts, busy device) exhausted the retry budget.
     /// Distinct from [`Self::Unsupported`] because the device may well support
-    /// the feature — re-selecting it (see
-    /// [`AppState::set_current_device`](super::AppState::set_current_device))
-    /// grants a fresh attempt.
+    /// the feature — re-selecting it grants a fresh attempt.
     Failed(String),
     /// The device genuinely does not support the feature; never retried.
     Unsupported(String),
 }
 
 /// Per-device DPI capability load state. See [`Load`].
-pub type DpiStatus = Load<DpiInfo>;
+pub type DpiStatus = Load<Arc<DpiInfo>>;
 
 /// Per-device SmartShift (`0x2111`) config load state. See [`Load`]. Unlike DPI
 /// presets, the resolved config is *not* persisted to `config.toml` — the device
 /// stores wheel mode / threshold / torque in its own non-volatile memory, so the
 /// GUI only ever reads and writes the device.
-pub type SmartShiftLoad = Load<SmartShiftStatus>;
-
-/// The lazily-loaded DPI and SmartShift read caches, grouped so callers reach
-/// them as `state.reads.dpi` / `state.reads.smartshift` and use
-/// [`LazyDeviceData`]'s own methods directly — instead of `AppState` growing
-/// a same-shaped forwarding method twice, once per subsystem, for every
-/// operation the generic already provides.
-#[derive(Default)]
-pub(crate) struct DeviceReads {
-    pub(crate) dpi: LazyDeviceData<DpiInfo>,
-    pub(crate) smartshift: LazyDeviceData<SmartShiftStatus>,
-}
-
-/// Per-device lazy-load cache for a background HID++ read, keyed by
-/// [`DeviceKey`]. Holds each device's [`Load`] state plus its transient-retry
-/// counter, and carries the stale-route guard + retry-budget policy once, for
-/// both DPI and SmartShift.
-pub(crate) struct LazyDeviceData<T> {
-    by_device: BTreeMap<DeviceKey, Load<T>>,
-    /// Consecutive transient read failures per device, capped by
-    /// [`LOAD_MAX_ATTEMPTS`] before the device settles on [`Load::Failed`].
-    attempts: BTreeMap<DeviceKey, u8>,
-}
-
-// Manual `Default` (not derived): a derive would demand `T: Default`, but the
-// empty maps need nothing of `T`.
-impl<T> Default for LazyDeviceData<T> {
-    fn default() -> Self {
-        Self {
-            by_device: BTreeMap::new(),
-            attempts: BTreeMap::new(),
-        }
-    }
-}
-
-impl<T: Clone> LazyDeviceData<T> {
-    /// The recorded state for `key`, or [`Load::Unknown`] if never queried.
-    pub(crate) fn status(&self, key: &DeviceKey) -> Load<T> {
-        self.by_device.get(key).cloned().unwrap_or(Load::Unknown)
-    }
-
-    /// The raw recorded entry for `key`, for callers that match on `Ready`
-    /// without cloning the payload.
-    pub(crate) fn get(&self, key: &DeviceKey) -> Option<&Load<T>> {
-        self.by_device.get(key)
-    }
-
-    /// Whether `key` still needs a read (nothing recorded yet). Cheaper than
-    /// cloning [`status`](Self::status) on the per-frame render path.
-    pub(crate) fn unqueried(&self, key: &DeviceKey) -> bool {
-        !self.by_device.contains_key(key)
-    }
-
-    /// Mark a read as in flight for `key`.
-    pub(crate) fn mark_loading(&mut self, key: &DeviceKey) {
-        self.by_device.insert(key.clone(), Load::Loading);
-    }
-
-    /// Reset a stuck `Loading` for `key` back to unqueried — the read worker
-    /// vanished without delivering a result, so the next completed inventory
-    /// snapshot or device selection can re-issue instead of wedging the device
-    /// on "Reading…".
-    pub(crate) fn clear_loading(&mut self, key: &DeviceKey) {
-        if matches!(self.by_device.get(key), Some(Load::Loading)) {
-            self.by_device.remove(key);
-        }
-    }
-
-    /// Drop `key`'s recorded state and retry budget so the caller can re-read.
-    /// Backs the "click to retry" affordance and the re-select-grants-a-retry
-    /// rule for a [`Load::Failed`] device.
-    pub(crate) fn retry(&mut self, key: &DeviceKey) {
-        self.by_device.remove(key);
-        self.attempts.remove(key);
-    }
-
-    /// Forget `key` entirely — the device disappeared, or reconnected on a new
-    /// route, so its cached state (keyed to the dead route) is stale.
-    pub(crate) fn remove(&mut self, key: &DeviceKey) {
-        self.by_device.remove(key);
-        self.attempts.remove(key);
-    }
-
-    /// Forget every device the `present` predicate rejects (not in the live set).
-    pub(crate) fn retain_present(&mut self, present: impl Fn(&str) -> bool) {
-        self.by_device.retain(|key, _| present(key.as_str()));
-        self.attempts.retain(|key, _| present(key.as_str()));
-    }
-
-    /// Optimistically record a resolved value with no read involved — e.g. a
-    /// just-written SmartShift config, shown until a confirming re-read replaces
-    /// it. Leaves the retry budget untouched.
-    pub(crate) fn set_ready(&mut self, key: DeviceKey, value: T) {
-        self.by_device.insert(key, Load::Ready(value));
-    }
-
-    /// Store a read result under the stale-route guard and the transient-retry /
-    /// permanent-unsupported policy. `matches_route` is whether a live device
-    /// still holds `key` *on the route the read targeted*; `still_present` is
-    /// whether `key` exists at all. Returns the resolved value when the result
-    /// settled to [`Load::Ready`], so the caller can run a side effect (the DPI
-    /// panel seeds the shared current value). `label` tags the debug logs.
-    pub(crate) fn store(
-        &mut self,
-        key: DeviceKey,
-        result: Result<T, WriteError>,
-        is_permanent: impl Fn(&WriteError) -> bool,
-        matches_route: bool,
-        still_present: bool,
-        label: &'static str,
-    ) -> Option<T> {
-        if !matches_route {
-            debug!(key = %key, label, "stale device read result ignored");
-            // The device reconnected on a different route mid-read: drop the
-            // orphaned `Loading` marker so the owning state update can re-read
-            // against the live route instead of spinning on "Reading…" forever.
-            if still_present {
-                self.by_device.remove(&key);
-            }
-            return None;
-        }
-
-        let status = match result {
-            Ok(value) => {
-                self.attempts.remove(&key);
-                Load::Ready(value)
-            }
-            // A genuine "feature not supported" reply never changes — record it
-            // and stop probing.
-            Err(error) if is_permanent(&error) => {
-                self.attempts.remove(&key);
-                Load::Unsupported(error.to_string())
-            }
-            // Transient failures get a few more tries: clear the status so the
-            // owning state update can re-read, until the budget runs out, then
-            // settle on `Failed` (retryable on re-select) rather than
-            // `Unsupported`.
-            Err(error) => {
-                let attempts = self.attempts.entry(key.clone()).or_insert(0);
-                *attempts = attempts.saturating_add(1);
-                if *attempts < LOAD_MAX_ATTEMPTS {
-                    debug!(key = %key, attempts = *attempts, error = %error, label, "transient device read error — will retry");
-                    self.by_device.remove(&key);
-                    return None;
-                }
-                self.attempts.remove(&key);
-                Load::Failed(error.to_string())
-            }
-        };
-
-        // Clone out the resolved value (cheap; once per completed read) before
-        // the status moves into the map, so the caller can seed derived state
-        // without re-borrowing `self`.
-        let resolved = match &status {
-            Load::Ready(value) => Some(value.clone()),
-            _ => None,
-        };
-        self.by_device.insert(key, status);
-        resolved
-    }
-}
+pub type SmartShiftLoad = Load<Arc<SmartShiftStatus>>;

--- a/crates/openlogi-desktop/src/state/smartshift.rs
+++ b/crates/openlogi-desktop/src/state/smartshift.rs
@@ -1,9 +1,8 @@
-//! SmartShift optimistic writes and post-write confirmation. The lazy read
-//! cache itself lives in [`super::load::LazyDeviceData`], reached directly as
-//! `self.reads.smartshift`.
+//! SmartShift optimistic writes and post-write confirmation. Device reads are
+//! swr-backed queries owned by the device-read service.
 
 use gpui::{App, Context};
-use openlogi_core::hid::{DeviceRoute, SmartShiftStatus, WriteError};
+use openlogi_core::hid::{DeviceRoute, SmartShiftStatus};
 use tracing::debug;
 
 use super::device_key::DeviceKey;
@@ -13,77 +12,32 @@ use super::{AppState, SmartShiftWriteStatus, StateEvent};
 
 impl AppState {
     pub(super) fn load_current_smartshift(&mut self, cx: &mut Context<Self>) {
-        let Some((key, route, write_id)) = self.current_record().and_then(|record| {
-            let key = record.device_key();
-            if !self.reads.smartshift.unqueried(&key) {
-                return None;
-            }
-            let write_id = match self.current_smartshift_write_status() {
-                Some(SmartShiftWriteStatus::Applying { write_id, .. }) => Some(write_id),
-                Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => {
-                    None
-                }
-            };
-            Some((key, record.route.clone()?, write_id))
-        }) else {
+        let Some((key, route)) = self
+            .current_record()
+            .and_then(|record| Some((record.device_key(), record.route.clone()?)))
+        else {
             return;
         };
-        self.reads.smartshift.mark_loading(&key);
-        self.issue_smartshift_read(
-            key,
-            route,
-            write_id,
-            |state, key| {
-                state.reads.smartshift.clear_loading(key);
-            },
-            cx,
-        );
+        self.reads
+            .ensure_smartshift(key.clone(), route, self.ipc_sender(), cx);
+        self.apply_smartshift_read(&key, None);
     }
 
     pub(super) fn confirm_current_smartshift(&mut self, cx: &mut Context<Self>) {
         let Some((key, route, write_id)) = self.take_active_smartshift_confirm() else {
             return;
         };
-        self.issue_smartshift_read(
-            key,
-            route,
-            Some(write_id),
-            move |state, key| state.fail_smartshift_confirm(key, write_id),
-            cx,
-        );
-    }
-
-    fn issue_smartshift_read(
-        &mut self,
-        key: DeviceKey,
-        route: DeviceRoute,
-        write_id: Option<u64>,
-        clear: impl Fn(&mut AppState, &DeviceKey) + 'static,
-        cx: &mut Context<Self>,
-    ) {
-        self.issue_device_read(
-            cx,
-            (key.clone(), route),
-            crate::services::ipc::Command::ReadSmartShift,
-            move |state, key, route, result, cx| {
-                state.store_smartshift_status(key.clone(), route, write_id, result);
-                if state.reads.smartshift.unqueried(&key)
-                    && state
-                        .current_record()
-                        .is_some_and(|record| record.device_key() == key)
-                {
-                    state.load_current_smartshift(cx);
-                }
-            },
-            clear,
-            StateEvent::SmartShiftChanged(key),
-        );
+        if !self
+            .reads
+            .confirm_smartshift(key.clone(), route, write_id, self.ipc_sender(), cx)
+        {
+            self.fail_smartshift_confirm(&key, write_id);
+        }
     }
 
     pub(crate) fn retry_smartshift_read(cx: &mut App, key: DeviceKey) {
         Self::update(cx, |state, cx| {
             state.retry_smartshift(&key);
-            state.load_current_smartshift(cx);
             cx.emit(StateEvent::SmartShiftChanged(key));
         });
     }
@@ -105,9 +59,9 @@ impl AppState {
     #[must_use]
     pub fn current_smartshift_ready(&self) -> Option<SmartShiftStatus> {
         self.current_record()
-            .and_then(|record| self.reads.smartshift.get(&record.device_key()))
+            .and_then(|record| self.reads.smartshift_load(&record.device_key()))
             .and_then(|status| match status {
-                SmartShiftLoad::Ready(s) => Some(*s),
+                SmartShiftLoad::Ready(s) => Some(**s),
                 SmartShiftLoad::Unknown
                 | SmartShiftLoad::Loading
                 | SmartShiftLoad::Failed(_)
@@ -128,58 +82,36 @@ impl AppState {
     /// Backs the "click to retry" affordance on a [`SmartShiftLoad::Failed`]
     /// device and on a failed write confirmation.
     pub fn retry_smartshift(&mut self, key: &DeviceKey) {
-        self.reads.smartshift.retry(key);
+        self.reads.retry_smartshift(key);
         if let Some(entry) = self.device_ui.get_mut(key) {
             entry.smartshift_write_status = None;
         }
     }
-    /// Store a SmartShift read result if it still matches the known device
-    /// route and write identity, with the same transient-retry /
-    /// permanent-unsupported handling as [`Self::store_dpi_info`].
-    pub fn store_smartshift_status(
-        &mut self,
-        key: DeviceKey,
-        route: &DeviceRoute,
-        write_id: Option<u64>,
-        result: Result<SmartShiftStatus, WriteError>,
-    ) {
+    /// Apply a settled query to write-confirmation state if it still belongs to
+    /// the current write. The service's generation guard independently rejects
+    /// callbacks from queries replaced by a newer confirmation.
+    pub(crate) fn apply_smartshift_read(&mut self, key: &DeviceKey, write_id: Option<u64>) {
         let current_write_status = self
             .device_ui
-            .get(&key)
+            .get(key)
             .and_then(|entry| entry.smartshift_write_status);
         if !smartshift_read_is_current(write_id, current_write_status.as_ref()) {
             debug!(key = %key, ?write_id, "stale SmartShift read result ignored");
             return;
         }
-        let matches_route = self
-            .device_list
-            .iter()
-            .any(|record| record.device_key() == key && record.route.as_ref() == Some(route));
-        let still_present = self
-            .device_list
-            .iter()
-            .any(|record| record.device_key() == key);
-        self.reads.smartshift.store(
-            key.clone(),
-            result,
-            smartshift_error_is_permanent,
-            matches_route,
-            still_present,
-            "SmartShift",
-        );
         let expected = match self
             .device_ui
-            .get(&key)
+            .get(key)
             .and_then(|entry| entry.smartshift_write_status)
         {
             Some(SmartShiftWriteStatus::Applying { expected, .. }) => Some(expected),
             Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
         };
         if let Some(status) = expected.and_then(|expected| {
-            smartshift_write_outcome(expected, self.reads.smartshift.get(&key))
+            smartshift_write_outcome(expected, self.reads.smartshift_load(key))
         }) {
             self.device_ui
-                .entry(key)
+                .entry(key.clone())
                 .or_default()
                 .smartshift_write_status = Some(status);
         }
@@ -216,7 +148,7 @@ impl AppState {
         // rejected or timed it out would otherwise leave this optimistic value
         // showing as "applied" forever (Ready blocks any further read).
         let expected = status;
-        self.reads.smartshift.set_ready(key.clone(), expected);
+        self.reads.set_smartshift_ready(&key, expected);
         let write_id = can_confirm.then(|| {
             let write_id = self.next_smartshift_write_id;
             self.next_smartshift_write_id = self.next_smartshift_write_id.saturating_add(1);
@@ -265,16 +197,12 @@ impl AppState {
     }
 }
 
-pub(crate) fn smartshift_error_is_permanent(error: &WriteError) -> bool {
-    matches!(error, WriteError::FeatureUnsupported { .. })
-}
-
 pub(crate) fn smartshift_write_outcome(
     expected: SmartShiftStatus,
     load: Option<&SmartShiftLoad>,
 ) -> Option<SmartShiftWriteStatus> {
     match load {
-        Some(SmartShiftLoad::Ready(actual)) if *actual == expected => {
+        Some(SmartShiftLoad::Ready(actual)) if **actual == expected => {
             Some(SmartShiftWriteStatus::Confirmed)
         }
         Some(SmartShiftLoad::Ready(_)) => Some(SmartShiftWriteStatus::Failed),

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -1,6 +1,7 @@
 //! AppState unit tests.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_core::config::{
@@ -659,25 +660,27 @@ fn smartshift_write_feedback_requires_the_written_value() {
     };
     assert_eq!(smartshift_write_outcome(expected, None), None);
     assert_eq!(
-        smartshift_write_outcome(expected, Some(&Load::Ready(expected))),
+        smartshift_write_outcome(expected, Some(&Load::Ready(Arc::new(expected)))),
         Some(SmartShiftWriteStatus::Confirmed)
     );
     assert_eq!(
         smartshift_write_outcome(
             expected,
-            Some(&Load::Ready(SmartShiftStatus {
+            Some(&Load::Ready(Arc::new(SmartShiftStatus {
                 auto_disengage: SmartShiftAutoDisengage::Threshold(
                     SmartShiftThreshold::from_rounded(13.0),
                 ),
                 ..expected
-            })),
+            }))),
         ),
         Some(SmartShiftWriteStatus::Failed)
     );
     assert_eq!(
         smartshift_write_outcome(
             expected,
-            Some(&Load::<SmartShiftStatus>::Failed("timeout".to_string(),))
+            Some(&Load::<Arc<SmartShiftStatus>>::Failed(
+                "timeout".to_string(),
+            ))
         ),
         Some(SmartShiftWriteStatus::Failed)
     );

--- a/crates/openlogi-desktop/src/ui/status.rs
+++ b/crates/openlogi-desktop/src/ui/status.rs
@@ -27,7 +27,7 @@ pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
 }
 
 /// A clickable accent line that re-arms a failed read on click. `on_retry` runs
-/// the panel's retry (e.g. `state.reads.dpi.retry(&key)`) — the only recovery
+/// the panel's query retry — the only recovery
 /// path when the carousel holds a single device, where re-selecting is a no-op.
 pub fn retry_line(
     id: impl Into<ElementId>,


### PR DESCRIPTION
## Summary

- replace the hand-rolled per-device read cache with swr queries keyed by `DeviceKey`
- share the process `SwrClient` between device reads and asset queries
- complete the final implementation sub-issue in #900

## Changes

- **openlogi-desktop**: add swr-backed DPI and SmartShift query ownership to `AppState`
- **openlogi-desktop**: preserve the three-attempt retry budget, permanent-error mapping, route fencing, and retry-on-reselect behavior
- **openlogi-desktop**: preserve optimistic SmartShift values during confirmation and reject superseded query/write results
- **openlogi-desktop**: reduce `state/load.rs` to the pure five-state `Load<T>` view-model projection

## Testing

- `export RUSTFLAGS="-D warnings"; cargo fmt --all -- --check`
- `export RUSTFLAGS="-D warnings"; cargo clippy --workspace --all-targets -- -D warnings`
- `export RUSTFLAGS="-D warnings"; cargo test --workspace`
- `export RUSTFLAGS="-D warnings" RUSTDOCFLAGS="-D warnings"; cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci` — 7 passed; `typos`, `shell`, `tests (macos)`, `cargo-deny`, and `wasm (portable crates)` skipped because their tools/platform were unavailable in the Linux orb
- Not visually runtime-tested or runtime-tested on hardware

Fixes #899
