### PR TITLE
refactor(gui): tighten typed rendering and async ownership

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -41,6 +41,20 @@ paths:
   new capability in `Capabilities::from_feature_ids` plus a `tabs_for` arm.
 - Mouse-diagram hotspots come from Logi metadata; if the metadata omits a button
   marker, omit the button — never synthesize hotspot positions.
+- Keep render helpers statically typed (`impl IntoElement` or a concrete element) until
+  a genuinely heterogeneous branch, collection, callback, or stored field requires
+  `AnyElement`. Prefer one typed `.when()` / `.when_some()` / `.children()` pipeline to
+  branching early and erasing each result.
+- A view, entity, or app service owns every `Task` and `Subscription` whose work belongs
+  to its lifetime. Use `.detach()` only for true process-lifetime work or bounded
+  one-shots whose completion is safe after the initiating view disappears.
+- When an async UI operation captures inputs that may change before it completes
+  (device, route, query, selection, or request), capture their identity or generation
+  at launch and compare again before committing the result. Cancellation is useful,
+  but is not the stale-result fence.
+- When changing reusable controls, prefer focused `#[gpui::test]` behavior contracts
+  over screenshot coverage: keyboard activation, disabled no-op, controlled selected
+  state/callbacks, and independent parent/child interaction targets.
 - Verifying UI changes needs the running app: re-`cargo run -p openlogi-desktop` (a plain
   `cargo build` leaves the dev bundle stale) after quitting the previous instance
   (singleton lock). The GUI shows only the empty state unless the agent is running.

--- a/crates/openlogi-desktop/src/features/camera/mod.rs
+++ b/crates/openlogi-desktop/src/features/camera/mod.rs
@@ -7,34 +7,7 @@ pub mod preview;
 /// it resolves (the dialog is answered outside the app, so nothing else emits).
 #[cfg(target_os = "macos")]
 pub(crate) fn request_camera_access(cx: &mut gpui::App) {
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::time::Duration;
-
-    static POLL_ACTIVE: AtomicBool = AtomicBool::new(false);
-    const TICK: Duration = Duration::from_millis(250);
-    const TICKS_MAX: u32 = 2400; // 10 minutes
-
-    openlogi_camera::request_camera_access();
-    if POLL_ACTIVE.swap(true, Ordering::SeqCst) {
-        return;
-    }
-    cx.spawn(async move |cx| {
-        for _ in 0..TICKS_MAX {
-            cx.background_executor().timer(TICK).await;
-            if openlogi_camera::camera_authorization()
-                != openlogi_camera::CameraAuthorization::Undetermined
-            {
-                break;
-            }
-        }
-        POLL_ACTIVE.store(false, Ordering::SeqCst);
-        cx.update(|cx| {
-            crate::state::AppState::update(cx, |_, cx| {
-                cx.emit(crate::state::StateEvent::CameraPermissionChanged);
-            });
-        });
-    })
-    .detach();
+    crate::state::AppState::request_camera_access(cx);
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -273,13 +273,14 @@ impl Render for MouseModelView {
         let labels_outer = labels.clone();
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
         let breathing_art = breathing_art(asset, mouse_left, mouse_w, mouse_h, pal, glow);
+        let model = ModelRect {
+            left: mouse_left,
+            width: mouse_w,
+            height: mouse_h,
+        };
         let hotspots_layer = hotspots_layer(
             &hotspots_outer,
-            ModelRect {
-                left: mouse_left,
-                width: mouse_w,
-                height: mouse_h,
-            },
+            model,
             hovered,
             active,
             self.selected,
@@ -297,11 +298,8 @@ impl Render for MouseModelView {
                     idx,
                     *label,
                     binding,
-                    highlight == Some(label.id),
-                    mouse_left,
-                    mouse_w,
-                    hovered,
-                    active,
+                    hovered == Some(label.id) || active == Some(label.id),
+                    model,
                     self.selected == Some(label.id),
                     &view,
                 )
@@ -557,33 +555,25 @@ fn hotspots_layer(
 
 /// Position a selectable control card at the label's slot in the side gutter.
 /// Selection updates the fixed inspector; labels never own editor overlays.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "wrapper position + trigger \
-state both need this many inputs; bundling would just hide the dependency"
-)]
 fn label_control(
     idx: usize,
     label: Label,
     binding: BindingLabel,
     highlighted: bool,
-    mouse_left: f32,
-    mouse_w: f32,
-    hovered: Option<MouseControlId>,
-    active: Option<MouseControlId>,
+    model: ModelRect,
     selected: bool,
     view: &Entity<MouseModelView>,
 ) -> AnyElement {
     let x = match label.side {
-        Side::Left => mouse_left - SIDE_GAP - LABEL_W,
-        Side::Right => mouse_left + mouse_w + SIDE_GAP,
+        Side::Left => model.left - SIDE_GAP - LABEL_W,
+        Side::Right => model.left + model.width + SIDE_GAP,
     };
     let view = view.clone();
     let trigger = LabelTrigger {
         id: ("label-trigger", idx).into(),
         label,
         binding,
-        highlighted: highlighted || hovered == Some(label.id) || active == Some(label.id),
+        highlighted,
         selected,
         view,
     };

--- a/crates/openlogi-desktop/src/features/pointer/dpi.rs
+++ b/crates/openlogi-desktop/src/features/pointer/dpi.rs
@@ -322,16 +322,19 @@ fn slider_element(
                 tr!("Fixed DPI: %{dpi}", dpi => info.capabilities.min()),
                 pal,
             )
+            .into_any_element()
         }
         (DpiStatus::Ready(_), Some(slider_state)) => {
             Slider::new(slider_state).horizontal().into_any_element()
         }
-        (DpiStatus::Ready(_), None) => status_line(tr!("Preparing DPI slider…"), pal),
+        (DpiStatus::Ready(_), None) => {
+            status_line(tr!("Preparing DPI slider…"), pal).into_any_element()
+        }
         (DpiStatus::Unknown | DpiStatus::Loading, _) if !reachable => {
-            status_line(tr!("Device offline — DPI unavailable."), pal)
+            status_line(tr!("Device offline — DPI unavailable."), pal).into_any_element()
         }
         (DpiStatus::Unknown | DpiStatus::Loading, _) => {
-            status_line(tr!("Reading supported DPI values…"), pal)
+            status_line(tr!("Reading supported DPI values…"), pal).into_any_element()
         }
         // Clickable: reselecting is a no-op for a single-device carousel, so the
         // retry must work in place.
@@ -342,11 +345,13 @@ fn slider_element(
             move |cx| {
                 AppState::retry_dpi_read(cx, key.clone());
             },
-        ),
+        )
+        .into_any_element(),
         (DpiStatus::Unsupported(_), _) => status_line(
             tr!("This device did not report Adjustable DPI support."),
             pal,
-        ),
+        )
+        .into_any_element(),
     }
 }
 

--- a/crates/openlogi-desktop/src/features/pointer/smartshift.rs
+++ b/crates/openlogi-desktop/src/features/pointer/smartshift.rs
@@ -343,19 +343,20 @@ impl Render for SmartShiftPanel {
         let content: AnyElement = match status {
             SmartShiftLoad::Ready(s) => self.ready_body(s, window, pal, cx),
             SmartShiftLoad::Loading | SmartShiftLoad::Unknown if !reachable => {
-                status_line(tr!("Device offline — SmartShift unavailable."), pal)
+                status_line(tr!("Device offline — SmartShift unavailable."), pal).into_any_element()
             }
             SmartShiftLoad::Loading | SmartShiftLoad::Unknown => {
-                status_line(tr!("Reading SmartShift settings…"), pal)
+                status_line(tr!("Reading SmartShift settings…"), pal).into_any_element()
             }
             SmartShiftLoad::Failed(_) => retry_line(
                 "smartshift-retry",
                 tr!("Couldn't read SmartShift — click to retry."),
                 pal,
                 retry_smartshift_closure(key.clone()),
-            ),
+            )
+            .into_any_element(),
             SmartShiftLoad::Unsupported(_) => {
-                status_line(tr!("This device does not support SmartShift."), pal)
+                status_line(tr!("This device does not support SmartShift."), pal).into_any_element()
             }
         };
 
@@ -382,15 +383,20 @@ fn smartshift_write_feedback(
 ) -> Option<AnyElement> {
     match status {
         Some(SmartShiftWriteStatus::Applying { .. }) => {
-            Some(status_line(tr!("Reading SmartShift settings…"), pal))
+            Some(status_line(tr!("Reading SmartShift settings…"), pal).into_any_element())
         }
-        Some(SmartShiftWriteStatus::Confirmed) => Some(status_line(tr!("Done"), pal)),
-        Some(SmartShiftWriteStatus::Failed) => Some(retry_line(
-            "smartshift-confirm-retry",
-            tr!("Couldn't read SmartShift — click to retry."),
-            pal,
-            retry_smartshift_closure(key),
-        )),
+        Some(SmartShiftWriteStatus::Confirmed) => {
+            Some(status_line(tr!("Done"), pal).into_any_element())
+        }
+        Some(SmartShiftWriteStatus::Failed) => Some(
+            retry_line(
+                "smartshift-confirm-retry",
+                tr!("Couldn't read SmartShift — click to retry."),
+                pal,
+                retry_smartshift_closure(key),
+            )
+            .into_any_element(),
+        ),
         None => None,
     }
 }

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -211,6 +211,11 @@ pub struct AppState {
     editing_scope: Option<EditingScope>,
     /// Aggregate host-camera activity reported by the agent. Runtime only.
     camera_active: bool,
+    /// Camera-consent poll started by an in-app macOS prompt. The app-state
+    /// entity owns it because permission can resolve after the initiating view
+    /// or window closes; dropping the entity at process shutdown cancels it.
+    #[cfg(target_os = "macos")]
+    camera_permission_poll: Option<gpui::Task<()>>,
     /// Per-device UI state outside the persisted config and the lazily-loaded
     /// DPI/SmartShift reads ([`Self::reads`]) —
     /// manual camera-light overrides, volatile light settings, in-flight
@@ -366,6 +371,8 @@ impl AppState {
             foreground: ForegroundApps::default(),
             editing_scope: None,
             camera_active: false,
+            #[cfg(target_os = "macos")]
+            camera_permission_poll: None,
             device_ui: BTreeMap::new(),
             light_command_status: None,
             next_light_request_id: 0,

--- a/crates/openlogi-desktop/src/state/camera.rs
+++ b/crates/openlogi-desktop/src/state/camera.rs
@@ -3,8 +3,45 @@
 use openlogi_camera::CameraControl;
 
 use super::AppState;
+#[cfg(target_os = "macos")]
+use super::StateEvent;
 
 impl AppState {
+    /// Request Camera access and retain the permission poll for the app
+    /// entity's lifetime. Repeated requests reuse an active poll; a completed
+    /// poll may be replaced if authorization is still undetermined.
+    #[cfg(target_os = "macos")]
+    pub(crate) fn request_camera_access(cx: &mut gpui::App) {
+        use std::time::Duration;
+
+        const TICK: Duration = Duration::from_millis(250);
+        const TICKS_MAX: u32 = 2400; // 10 minutes
+
+        openlogi_camera::request_camera_access();
+        Self::update(cx, |state, cx| {
+            if state
+                .camera_permission_poll
+                .as_ref()
+                .is_some_and(|poll| !poll.is_ready())
+            {
+                return;
+            }
+            state.camera_permission_poll = Some(cx.spawn(async move |state, cx| {
+                for _ in 0..TICKS_MAX {
+                    cx.background_executor().timer(TICK).await;
+                    if openlogi_camera::camera_authorization()
+                        != openlogi_camera::CameraAuthorization::Undetermined
+                    {
+                        break;
+                    }
+                }
+                state
+                    .update(cx, |_, cx| cx.emit(StateEvent::CameraPermissionChanged))
+                    .ok();
+            }));
+        });
+    }
+
     /// Whether any connected device is a webcam. Gates the camera-permission UI
     /// so it only appears when there is actually a camera to grant access to.
     /// Only the platforms that register the permission page (macOS/Linux) call

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -491,9 +491,36 @@ impl RenderOnce for PresetChip {
 mod tests {
     use std::{cell::Cell, rc::Rc};
 
-    use gpui::{Context, KeyDownEvent, KeyUpEvent, Keystroke, Render, TestAppContext};
+    use gpui::{
+        Context, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, Render, TestAppContext, point,
+    };
 
     use super::*;
+
+    struct ToggleHarness {
+        selected: bool,
+        disabled: bool,
+        changes: Rc<Cell<Option<bool>>>,
+        parent_clicks: Rc<Cell<usize>>,
+    }
+
+    impl Render for ToggleHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let changes = self.changes.clone();
+            let parent_clicks = self.parent_clicks.clone();
+            div()
+                .id("toggle-parent")
+                .tab_group()
+                .size(px(100.))
+                .on_click(move |_, _, _| parent_clicks.set(parent_clicks.get() + 1))
+                .child(
+                    Toggle::new("keyboard-toggle")
+                        .selected(self.selected)
+                        .disabled(self.disabled)
+                        .on_change(move |selected, _, _| changes.set(Some(*selected))),
+                )
+        }
+    }
 
     struct MenuRowHarness {
         activations: Rc<Cell<usize>>,
@@ -507,6 +534,34 @@ mod tests {
                     .role(Role::MenuItem)
                     .child("Action")
                     .on_click(move |_, _, _| activations.set(activations.get() + 1)),
+            )
+        }
+    }
+
+    struct PresetChipHarness {
+        applications: Rc<Cell<usize>>,
+        removals: Rc<Cell<usize>>,
+    }
+
+    impl Render for PresetChipHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let applications = self.applications.clone();
+            let removals = self.removals.clone();
+            div().tab_group().size(px(100.)).child(
+                PresetChip::new("keyboard-preset-chip")
+                    .selected(true)
+                    .child(
+                        BaseButton::new("keyboard-preset-apply")
+                            .child("800")
+                            .on_click(move |_, _, _| {
+                                applications.set(applications.get() + 1);
+                            }),
+                    )
+                    .child(
+                        BaseButton::new("keyboard-preset-remove")
+                            .child("×")
+                            .on_click(move |_, _, _| removals.set(removals.get() + 1)),
+                    ),
             )
         }
     }
@@ -538,6 +593,70 @@ mod tests {
             prefer_character_input: false,
         });
         cx.simulate_event(KeyUpEvent { keystroke });
+    }
+
+    #[gpui::test]
+    fn toggle_is_tab_focusable_and_reports_controlled_next_state(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let changes = Rc::new(Cell::new(None));
+        let parent_clicks = Rc::new(Cell::new(0));
+        let (view, cx) = cx.add_window_view({
+            let changes = changes.clone();
+            let parent_clicks = parent_clicks.clone();
+            move |_, _| ToggleHarness {
+                selected: false,
+                disabled: false,
+                changes,
+                parent_clicks,
+            }
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+        cx.update(Window::focus_next);
+        cx.update(|window, cx| assert!(window.focused(cx).is_some()));
+
+        activate_key(cx, "enter");
+        assert_eq!(changes.get(), Some(true));
+
+        view.update(cx, |view, cx| {
+            view.selected = true;
+            cx.notify();
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+        activate_key(cx, "space");
+        assert_eq!(changes.get(), Some(false));
+    }
+
+    #[gpui::test]
+    fn disabled_toggle_is_inert_and_blocks_its_parent(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let changes = Rc::new(Cell::new(None));
+        let parent_clicks = Rc::new(Cell::new(0));
+        let (_, cx) = cx.add_window_view({
+            let changes = changes.clone();
+            let parent_clicks = parent_clicks.clone();
+            move |_, _| ToggleHarness {
+                selected: false,
+                disabled: true,
+                changes,
+                parent_clicks,
+            }
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+
+        cx.update(Window::focus_next);
+        cx.update(|window, cx| assert!(window.focused(cx).is_none()));
+        cx.simulate_click(point(px(10.), px(10.)), Modifiers::default());
+        activate_key(cx, "enter");
+        activate_key(cx, "space");
+
+        assert_eq!(changes.get(), None);
+        assert_eq!(parent_clicks.get(), 0);
     }
 
     #[gpui::test]
@@ -579,12 +698,44 @@ mod tests {
 
         cx.update(Window::focus_next);
         activate_key(cx, "enter");
-        assert_eq!(applications.get(), 1);
+        activate_key(cx, "space");
+        assert_eq!(applications.get(), 2);
         assert_eq!(deletions.get(), 0);
 
         cx.update(Window::focus_next);
+        activate_key(cx, "enter");
         activate_key(cx, "space");
-        assert_eq!(applications.get(), 1);
-        assert_eq!(deletions.get(), 1);
+        assert_eq!(applications.get(), 2);
+        assert_eq!(deletions.get(), 2);
+    }
+
+    #[gpui::test]
+    fn preset_chip_children_are_separate_keyboard_targets(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let applications = Rc::new(Cell::new(0));
+        let removals = Rc::new(Cell::new(0));
+        let (_, cx) = cx.add_window_view({
+            let applications = applications.clone();
+            let removals = removals.clone();
+            move |_, _| PresetChipHarness {
+                applications,
+                removals,
+            }
+        });
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+        });
+
+        cx.update(Window::focus_next);
+        activate_key(cx, "enter");
+        activate_key(cx, "space");
+        assert_eq!(applications.get(), 2);
+        assert_eq!(removals.get(), 0);
+
+        cx.update(Window::focus_next);
+        activate_key(cx, "enter");
+        activate_key(cx, "space");
+        assert_eq!(applications.get(), 2);
+        assert_eq!(removals.get(), 2);
     }
 }

--- a/crates/openlogi-desktop/src/ui/status.rs
+++ b/crates/openlogi-desktop/src/ui/status.rs
@@ -6,7 +6,7 @@
 //! rendering of those rows so they read identically across panels; only the
 //! retry action differs, injected by the caller.
 
-use gpui::{AnyElement, App, ElementId, IntoElement, ParentElement, SharedString, Styled, div, px};
+use gpui::{App, ElementId, ParentElement, SharedString, Styled, div, px};
 use gpui_component::button::{Button, ButtonVariants as _};
 
 use crate::ui::theme::{Palette, Typography as _};
@@ -17,13 +17,12 @@ const ROW_H: f32 = 28.;
 
 /// A muted, non-interactive status line — "Reading…", "offline", "unsupported".
 /// The text is pre-localized by the caller (panels hold their own `tr!` keys).
-pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
+pub fn status_line(text: impl Into<SharedString>, pal: Palette) -> gpui::Div {
     div()
         .h(px(ROW_H))
         .text_body()
         .text_color(pal.text_muted)
         .child(text.into())
-        .into_any_element()
 }
 
 /// A clickable accent line that re-arms a failed read on click. `on_retry` runs
@@ -34,7 +33,7 @@ pub fn retry_line(
     text: impl Into<SharedString>,
     pal: Palette,
     on_retry: impl Fn(&mut App) + 'static,
-) -> AnyElement {
+) -> Button {
     Button::new(id)
         .text()
         .h(px(ROW_H))
@@ -42,5 +41,4 @@ pub fn retry_line(
         .text_color(pal.text_primary)
         .label(text)
         .on_click(move |_event, _window, cx| on_retry(cx))
-        .into_any_element()
 }

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -5,12 +5,11 @@ use gpui::img;
 use openlogi_core::config::AppIcon;
 
 use super::{
-    ActiveTheme, AnyElement, App, AppState, Appearance, Axis, Button, ButtonGroup, Entity,
-    FluentBuilder, Hsla, IconName, Input, InputState, InteractiveElement, IntoElement, Palette,
-    ParentElement, Rc, SelectState, Selectable, SettingField, SettingGroup, SettingItem,
-    SettingPage, SettingsView, SharedString, Sizable, StateEvent, StatefulInteractiveElement,
-    Styled, Theme, ThemeColor, ThemeConfig, ThemeFilter, ThemeMode, ThemeRegistry, div, h_flex, px,
-    rgb, theme, v_flex,
+    ActiveTheme, App, AppState, Appearance, Axis, Button, ButtonGroup, Entity, FluentBuilder, Hsla,
+    IconName, Input, InputState, InteractiveElement, IntoElement, Palette, ParentElement, Rc,
+    SelectState, Selectable, SettingField, SettingGroup, SettingItem, SettingPage, SettingsView,
+    SharedString, Sizable, StateEvent, StatefulInteractiveElement, Styled, Theme, ThemeColor,
+    ThemeConfig, ThemeFilter, ThemeMode, ThemeRegistry, div, h_flex, px, rgb, theme, v_flex,
 };
 use crate::platform::app_icon;
 use crate::ui::theme::Typography as _;
@@ -116,40 +115,38 @@ fn set_radius(cx: &mut App, radius: Option<u8>) {
 
 /// The Light / Dark / Follow-system appearance picker — three macOS-style
 /// preview thumbnails, each with a radio + label, mirroring System Settings.
-fn mode_segment(pal: Palette, cx: &App) -> AnyElement {
+fn mode_segment(pal: Palette, cx: &App) -> gpui::Div {
     let current = appearance_of(cx);
     let accent = cx.theme().primary;
-    h_flex()
-        .gap_4()
-        .items_start()
-        .child(mode_card(
+    h_flex().gap_4().items_start().children([
+        mode_card(
             "mode-light",
             tr!("Light"),
             ModePreview::Light,
             current == Appearance::Light,
             accent,
             pal,
-            |cx| set_appearance(cx, Appearance::Light),
-        ))
-        .child(mode_card(
+            Appearance::Light,
+        ),
+        mode_card(
             "mode-dark",
             tr!("Dark"),
             ModePreview::Dark,
             current == Appearance::Dark,
             accent,
             pal,
-            |cx| set_appearance(cx, Appearance::Dark),
-        ))
-        .child(mode_card(
+            Appearance::Dark,
+        ),
+        mode_card(
             "mode-system",
             tr!("Follow system"),
             ModePreview::Auto,
             current == Appearance::System,
             accent,
             pal,
-            |cx| set_appearance(cx, Appearance::System),
-        ))
-        .into_any_element()
+            Appearance::System,
+        ),
+    ])
 }
 
 /// Which scheme a mode card's thumbnail paints.
@@ -169,7 +166,7 @@ fn mode_card(
     selected: bool,
     accent: Hsla,
     pal: Palette,
-    on_click: impl Fn(&mut App) + 'static,
+    appearance: Appearance,
 ) -> impl IntoElement {
     let thumb = div()
         .w(px(104.))
@@ -217,13 +214,13 @@ fn mode_card(
                 .child(radio_dot(selected, accent, pal))
                 .child(div().text_body().child(label)),
         )
-        .on_click(move |_, _, cx| on_click(cx))
+        .on_click(move |_, _, cx| set_appearance(cx, appearance))
 }
 
 /// The app-icon picker: one card per icon, each showing a render of the
 /// compiled icon rather than its artwork, so the choice looks like what macOS
 /// will draw.
-fn icon_picker(pal: Palette, cx: &App) -> AnyElement {
+fn icon_picker(pal: Palette, cx: &App) -> gpui::Div {
     let current =
         AppState::try_read(cx).map_or_else(AppIcon::default, |state| state.app_settings().app_icon);
     let accent = cx.theme().primary;
@@ -231,7 +228,6 @@ fn icon_picker(pal: Palette, cx: &App) -> AnyElement {
         .gap_4()
         .items_start()
         .children(AppIcon::ALL.map(|icon| icon_card(icon, current == icon, accent, pal)))
-        .into_any_element()
 }
 
 /// One icon card: the preview above a radio + label, ringed when it is the icon
@@ -357,7 +353,7 @@ fn radio_dot(selected: bool, accent: Hsla, pal: Palette) -> impl IntoElement {
 /// `None` — defer to the active theme's own radius — rather than a fixed 6px, so
 /// it neither mis-highlights under themes with a different radius nor traps the
 /// user away from the theme default.
-fn radius_segment(cx: &App) -> AnyElement {
+fn radius_segment(cx: &App) -> ButtonGroup {
     let current = AppState::try_read(cx).and_then(|s| s.app_settings().ui_radius);
     let options: [Option<u8>; 3] = [Some(0), None, Some(12)];
     ButtonGroup::new("corner-radius")
@@ -382,7 +378,6 @@ fn radius_segment(cx: &App) -> AnyElement {
                 set_radius(cx, options[ix]);
             }
         })
-        .into_any_element()
 }
 
 /// Filter chips + the theme grid. Each card previews the theme's own colours
@@ -393,7 +388,7 @@ fn theme_picker(
     filter: ThemeFilter,
     pal: Palette,
     cx: &App,
-) -> AnyElement {
+) -> gpui::Div {
     let active = cx.theme().theme_name().clone();
     let query = theme_search.read(cx).value().trim().to_lowercase();
     // Collect just the preview colours per theme (small + `Copy`), so the 1.8 KB
@@ -421,28 +416,27 @@ fn theme_picker(
             .collect()
     };
 
-    let grid = if themes.is_empty() {
-        div()
-            .text_body()
-            .text_color(pal.text_muted)
-            .child(tr!("No themes match “%{query}”.", query => query))
-            .into_any_element()
-    } else {
-        div()
-            .flex()
-            .flex_wrap()
-            .gap_2()
-            .children(
-                themes
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, (name, mode, swatch))| {
-                        let selected = name == active;
-                        theme_card(i, name, mode, swatch, selected, pal)
-                    }),
-            )
-            .into_any_element()
-    };
+    let no_matches = themes.is_empty();
+    let grid = div()
+        .when(no_matches, |grid| {
+            grid.text_body()
+                .text_color(pal.text_muted)
+                .child(tr!("No themes match “%{query}”.", query => query))
+        })
+        .when(!no_matches, |grid| {
+            grid.flex()
+                .flex_wrap()
+                .gap_2()
+                .children(
+                    themes
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, (name, mode, swatch))| {
+                            let selected = name == active;
+                            theme_card(i, name, mode, swatch, selected, pal)
+                        }),
+                )
+        });
 
     v_flex()
         .w_full()
@@ -497,7 +491,6 @@ fn theme_picker(
                 ),
         )
         .child(grid)
-        .into_any_element()
 }
 
 /// Resolve a theme config's colours into a concrete [`ThemeColor`] for its


### PR DESCRIPTION
## Summary

Apply the small GPUI quality follow-ups identified after the GUI architecture uplift without mechanically chasing metrics. Render helpers now stay statically typed until a real heterogeneous boundary, long-lived camera consent polling has an explicit owner, and reusable controls have focused interaction contracts.

## Changes

- `openlogi-desktop`
  - reduce direct `AnyElement` return sites from 73 to 67 and keep Appearance conditionals in typed builder pipelines
  - retain the macOS camera-permission poll in `AppState` instead of detaching it behind a process-global atomic flag
  - expand `#[gpui::test]` coverage from 5 to 8, including Toggle and PresetChip keyboard, disabled, controlled-state, and nested-target behavior
  - reuse `ModelRect` and one computed highlight input in mouse labels, removing the remaining `too_many_arguments` exception
  - keep the 131 explicit `pal: Palette` parameters: the audit found these are predominantly cheap, local rendering dependencies rather than missing component boundaries
- developer guidance
  - document typed rendering, async ownership, stale-result fencing, and component behavior-test conventions in the GUI rules

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy -p openlogi-desktop --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test -p openlogi-desktop` — 144 passed
- `cargo test -p openlogi-desktop ui::components::tests -- --nocapture` — 5 passed
- `cargo test -p openlogi-desktop features::mouse::view::tests -- --nocapture` — 4 passed
- Not run: macOS camera-consent runtime testing or macOS target compilation (Linux orb; Apple SDK unavailable)
- Not run: Windows cross-Clippy proxy (devenv unavailable in the orb)
- Not runtime-tested on real hardware

Related to #900
