### PR TITLE
feat(gui): add scalable interface presets

### DIFF
--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -32,7 +32,7 @@ pub use settings::LightSettings;
 pub use settings::{
     AppIcon, AppSettings, Appearance, AssetSourcePreference, CameraControls, Lighting,
     SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, SMARTSHIFT_MIN_AUTO_DISENGAGE, ScrollResolution, SmartShift,
-    ThumbwheelSensitivity, WheelMode,
+    ThumbwheelSensitivity, UiScale, WheelMode,
 };
 
 use crate::binding::{
@@ -45,6 +45,9 @@ use settings::GestureOwner;
 /// The schema version the current build produces. Bumped whenever the
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
+///
+/// v5 adds the app-wide `ui_scale` preference. Older files default to the
+/// standard 100% scale.
 ///
 /// v4 removes the one-gesture-button-per-device owner lock: gesture mode is a
 /// per-button fact read from the binding shape, so `gesture_owner` no longer
@@ -64,7 +67,7 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 4;
+pub const SCHEMA_VERSION: u32 = 5;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -1,5 +1,5 @@
 //! App-wide and per-device *value* settings: [`AppSettings`], [`Appearance`],
-//! [`AppIcon`], [`Lighting`], [`ScrollResolution`], [`WheelMode`] /
+//! [`UiScale`], [`AppIcon`], [`Lighting`], [`ScrollResolution`], [`WheelMode`] /
 //! [`SmartShift`], and the legacy [`GestureOwner`], plus their serde helpers.
 
 use std::collections::BTreeMap;
@@ -26,6 +26,41 @@ pub enum Appearance {
     Light,
     /// Always use the dark variant of the selected theme.
     Dark,
+}
+
+/// User-selected scale for text and rem-based interface spacing.
+///
+/// The core stores a semantic choice rather than GPUI pixels; the desktop maps
+/// each variant's percentage onto the window's rem size. Keeping the supported
+/// range finite lets every layout be verified at every scale.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UiScale {
+    /// 90% of the standard interface size.
+    Small,
+    /// The standard interface size.
+    #[default]
+    Normal,
+    /// 110% of the standard interface size.
+    Large,
+    /// 125% of the standard interface size.
+    ExtraLarge,
+}
+
+impl UiScale {
+    /// Every supported scale, in the order Settings offers them.
+    pub const ALL: [Self; 4] = [Self::Small, Self::Normal, Self::Large, Self::ExtraLarge];
+
+    /// The displayed percentage for this scale.
+    #[must_use]
+    pub const fn percent(self) -> u16 {
+        match self {
+            Self::Small => 90,
+            Self::Normal => 100,
+            Self::Large => 110,
+            Self::ExtraLarge => 125,
+        }
+    }
 }
 
 /// Which icon the app wears.
@@ -181,6 +216,9 @@ pub struct AppSettings {
     /// Light/dark appearance preference. Defaults to following the OS.
     #[serde(default)]
     pub appearance: Appearance,
+    /// Text and rem-based interface scale. Defaults to 100%.
+    #[serde(default)]
+    pub ui_scale: UiScale,
     /// Name of the theme used in light mode (a [`crate`]-agnostic string
     /// matching a gpui-component theme, e.g. `"OpenLogi Light"`). `None` uses
     /// the OpenLogi brand light theme.
@@ -307,6 +345,7 @@ impl Default for AppSettings {
             language: None,
             thumbwheel_sensitivity: ThumbwheelSensitivity::DEFAULT,
             appearance: Appearance::System,
+            ui_scale: UiScale::Normal,
             app_icon: AppIcon::Openlogi,
             theme_light: None,
             theme_dark: None,

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -467,7 +467,7 @@ fn human_readable_toml_layout() {
     // The key only contains [A-Za-z0-9_], so TOML emits it as a bare-word
     // table key (no surrounding quotes). The test asserts the observable
     // structure rather than locking in a specific quoting.
-    assert!(body.contains("schema_version = 4"), "got: {body}");
+    assert!(body.contains("schema_version = 5"), "got: {body}");
     assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
     // A `Single` binding serializes byte-identically to the pre-v2 bare
     // `Action`, so the leaf line is unchanged.
@@ -777,6 +777,28 @@ fn app_settings_launch_at_login_roundtrips() {
 }
 
 #[test]
+fn app_settings_ui_scale_roundtrips() {
+    let mut cfg = Config::default();
+    cfg.app_settings.ui_scale = UiScale::ExtraLarge;
+
+    let body = toml::to_string_pretty(&cfg).expect("serialize");
+    let parsed = write_and_read(&cfg);
+
+    assert!(body.contains("ui_scale = \"extra_large\""));
+    assert_eq!(parsed.app_settings.ui_scale, UiScale::ExtraLarge);
+}
+
+#[test]
+fn config_without_ui_scale_uses_standard_scale() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, "schema_version = 4\n").expect("write v4 config");
+    let parsed = Config::load_from_path(&path).expect("v4 config should load");
+
+    assert_eq!(parsed.app_settings.ui_scale, UiScale::Normal);
+}
+
+#[test]
 fn asset_source_preference_roundtrips() {
     let mut cfg = Config::default();
     cfg.app_settings.asset_source = AssetSourcePreference::OpenLogi;
@@ -873,7 +895,7 @@ Click = \"Paste\"
     // Saving self-heals to the current shape: stamped version + merged table,
     // legacy field names gone.
     let body = toml::to_string_pretty(&cfg).expect("serialize");
-    assert!(body.contains("schema_version = 4"), "got: {body}");
+    assert!(body.contains("schema_version = 5"), "got: {body}");
     assert!(body.contains("[devices.2b042.bindings]"), "got: {body}");
     assert!(!body.contains("button_bindings"), "got: {body}");
     assert!(!body.contains("gesture_bindings"), "got: {body}");
@@ -994,7 +1016,7 @@ fn current_schema_rejects_unknown_and_obsolete_fields() {
     let path = dir.path().join("config.toml");
     fs::write(
         &path,
-        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivty = 14\n",
+        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivty = 14\n",
     )
     .expect("write typo");
     assert_matches!(
@@ -1004,7 +1026,7 @@ fn current_schema_rejects_unknown_and_obsolete_fields() {
 
     fs::write(
         &path,
-        r#"schema_version = 4
+        r#"schema_version = 5
 [devices.mouse.identity]
 display_name = "Mouse"
 kind = "mouse"
@@ -1019,11 +1041,11 @@ capabilities = { buttons = true, pointer = true, lighting = false, scroll_invers
 
     fs::write(
         &path,
-        "schema_version = 4\n[devices.mouse]\ngesture_owner = \"Off\"\n",
+        "schema_version = 5\n[devices.mouse]\ngesture_owner = \"Off\"\n",
     )
     .expect("write obsolete field");
     assert_matches!(
-        Config::load_from_path(&path).expect_err("v4 legacy field must fail"),
+        Config::load_from_path(&path).expect_err("current-schema legacy field must fail"),
         ConfigError::ObsoleteField { .. }
     );
 }
@@ -1031,12 +1053,12 @@ capabilities = { buttons = true, pointer = true, lighting = false, scroll_invers
 #[test]
 fn persisted_numeric_contracts_reject_unsafe_values() {
     for body in [
-        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivity = 0\n",
-        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivity = 101\n",
-        "schema_version = 4\n[app_settings]\nthumbwheel_sensitivity = -2147483648\n",
-        "schema_version = 4\n[devices.mouse]\nthumbwheel_sensitivity = -1\n",
-        "schema_version = 4\n[devices.mouse]\ndpi = 65536\n",
-        "schema_version = 4\n[devices.mouse]\ndpi_presets = [800, 70000]\n",
+        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = 0\n",
+        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = 101\n",
+        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = -2147483648\n",
+        "schema_version = 5\n[devices.mouse]\nthumbwheel_sensitivity = -1\n",
+        "schema_version = 5\n[devices.mouse]\ndpi = 65536\n",
+        "schema_version = 5\n[devices.mouse]\ndpi_presets = [800, 70000]\n",
     ] {
         assert!(toml::from_str::<Config>(body).is_err(), "accepted: {body}");
     }
@@ -1048,7 +1070,7 @@ fn tracked_save_preserves_comments_and_rejects_concurrent_edits() {
     let path = dir.path().join("config.toml");
     fs::write(
         &path,
-        "# keep this comment\nschema_version = 4\nselected_device = \"one\" # and this one\n",
+        "# keep this comment\nschema_version = 5\nselected_device = \"one\" # and this one\n",
     )
     .expect("write");
     let (mut config, mut file) = ConfigFile::load_from_path(&path).expect("load tracked");

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -467,6 +467,7 @@ impl Render for AppView {
         reason = "root view assembles every screen branch inline"
     )]
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        theme::apply_ui_scale(window, cx);
         let pal = theme::palette(cx);
 
         // Every frame — including the pre-connection and error frames — hangs

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -45,6 +45,7 @@ const CAMERA_PREVIEW_W: Rems = rems(32.125);
 const CAMERA_CONTROLS_W: Rems = rems(31.25);
 const LIGHT_CONTROLS_W: Rems = rems(25.);
 const LIGHT_CONTROLS_MIN_W: Rems = rems(22.5);
+const POINTER_CARD_MIN_W: Rems = rems(20.75);
 
 /// Compact device identity bar. Section navigation belongs to the workspace
 /// rail below; pairing belongs to the Devices screen, so neither competes with
@@ -340,7 +341,7 @@ fn pointer_tab(
             ))
             .child(
                 div()
-                    .min_w(px(332.))
+                    .min_w(POINTER_CARD_MIN_W)
                     .flex_1()
                     .child(scrolling_card(pal, cx)),
             ),
@@ -352,7 +353,11 @@ fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
     // window minimum after this tab's 20 px side insets, while still leaving a
     // usable slider: 332·2 + 16 + 20·2 = 720. In rems, the whole relationship
     // scales together.
-    div().min_w(rems(20.75)).flex_1().h_full().child(card)
+    div()
+        .min_w(POINTER_CARD_MIN_W)
+        .flex_1()
+        .h_full()
+        .child(card)
 }
 
 /// Scrolling card: per-device native inversion and wheel-resolution controls.

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -2,8 +2,8 @@
 //! section bodies (Buttons, Keys, Pointer, Lighting, Camera, Device).
 
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, Role,
-    StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
+    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, Rems, Role,
+    StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rems,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -38,14 +38,13 @@ use crate::features::profile_scope::{ProfileIconCache, profile_scope_bar};
 use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::components::{PanelCard, Toggle};
 use crate::ui::theme::{
-    CONTENT_W_2XL, CONTENT_W_LG, CONTENT_W_MD, CONTENT_W_SM, CONTENT_W_XL, DETAIL_RAIL_W, HEADER_H,
-    Palette, SCREEN_PAD, Typography as _,
+    ContentWidth, DETAIL_RAIL_W, HEADER_H, Palette, SCREEN_PAD, Typography as _,
 };
 
-const CAMERA_PREVIEW_W: f32 = 514.;
-const CAMERA_CONTROLS_W: f32 = 500.;
-const LIGHT_CONTROLS_W: f32 = 400.;
-const LIGHT_CONTROLS_MIN_W: f32 = 360.;
+const CAMERA_PREVIEW_W: Rems = rems(32.125);
+const CAMERA_CONTROLS_W: Rems = rems(31.25);
+const LIGHT_CONTROLS_W: Rems = rems(25.);
+const LIGHT_CONTROLS_MIN_W: Rems = rems(22.5);
 
 /// Compact device identity bar. Section navigation belongs to the workspace
 /// rail below; pairing belongs to the Devices screen, so neither competes with
@@ -284,7 +283,7 @@ fn buttons_tab(
 }
 
 fn tab_body(
-    width: f32,
+    width: ContentWidth,
     content: impl IntoElement,
 ) -> gpui_component::scroll::Scrollable<gpui::Div> {
     v_flex()
@@ -293,17 +292,17 @@ fn tab_body(
         .min_h_0()
         .items_center()
         .overflow_y_scrollbar()
-        .p(px(SCREEN_PAD))
-        .child(div().w_full().max_w(px(width)).child(content))
+        .p(SCREEN_PAD)
+        .child(div().w_full().max_w(width.rems()).child(content))
 }
 
 /// Keys tab: the function-row remapper for a keyboard.
 fn keys_tab(keyboard_model: &gpui::Entity<FunctionRowView>) -> impl IntoElement {
-    tab_body(CONTENT_W_2XL, keyboard_model.clone()).justify_center()
+    tab_body(ContentWidth::DoubleExtraLarge, keyboard_model.clone()).justify_center()
 }
 
 fn action_ring_tab(panel: &gpui::Entity<ActionRingPanel>) -> impl IntoElement {
-    tab_body(CONTENT_W_MD, panel.clone())
+    tab_body(ContentWidth::Medium, panel.clone())
 }
 
 /// Pointer tab: the DPI panel, the SmartShift wheel controls, and the
@@ -317,7 +316,7 @@ fn pointer_tab(
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
     tab_body(
-        CONTENT_W_LG,
+        ContentWidth::Large,
         h_flex()
             .w_full()
             .items_stretch()
@@ -349,10 +348,11 @@ fn pointer_tab(
 }
 
 fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
-    // Two cards plus one 16 px gap fit exactly inside the 720 px window minimum
-    // after this tab's `SCREEN_PAD` (20 px) side inset, while still leaving a
-    // usable slider: 332·2 + 16 + 20·2 = 720.
-    div().min_w(px(332.)).flex_1().h_full().child(card)
+    // At 100%, two cards plus one 16 px gap fit exactly inside the 720 px
+    // window minimum after this tab's 20 px side insets, while still leaving a
+    // usable slider: 332·2 + 16 + 20·2 = 720. In rems, the whole relationship
+    // scales together.
+    div().min_w(rems(20.75)).flex_1().h_full().child(card)
 }
 
 /// Scrolling card: per-device native inversion and wheel-resolution controls.
@@ -495,7 +495,7 @@ fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -
 /// [`DetailTab::tabs_for`].
 fn lighting_tab(lighting_panel: &gpui::Entity<LightingPanel>) -> impl IntoElement {
     tab_body(
-        CONTENT_W_SM,
+        ContentWidth::Small,
         PanelCard::new(
             tr!("Lighting"),
             Icon::new(IconName::Palette),
@@ -514,41 +514,35 @@ fn camera_tab(
     camera_preview: &gpui::Entity<CameraPreview>,
     camera_controls: &gpui::Entity<CameraControlsPanel>,
 ) -> impl IntoElement {
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .items_center()
-        .overflow_y_scrollbar()
-        .p_6()
-        .child(
-            h_flex()
-                .w_full()
-                .flex_wrap()
-                .justify_center()
-                .items_start()
-                .gap_3()
-                .child(
-                    div()
-                        .w(px(CAMERA_PREVIEW_W))
-                        .flex_shrink_0()
-                        .child(PanelCard::new(
-                            tr!("Camera"),
-                            Icon::new(IconName::Eye),
-                            camera_preview.clone().into_any_element(),
-                        )),
-                )
-                .child(
-                    div()
-                        .w(px(CAMERA_CONTROLS_W))
-                        .flex_shrink_0()
-                        .child(PanelCard::new(
-                            tr!("Camera controls"),
-                            Icon::new(IconName::Settings),
-                            camera_controls.clone().into_any_element(),
-                        )),
-                ),
-        )
+    tab_body(
+        ContentWidth::DoubleExtraLarge,
+        h_flex()
+            .w_full()
+            .flex_wrap()
+            .justify_center()
+            .items_start()
+            .gap_3()
+            .child(
+                div()
+                    .w(CAMERA_PREVIEW_W)
+                    .flex_shrink_0()
+                    .child(PanelCard::new(
+                        tr!("Camera"),
+                        Icon::new(IconName::Eye),
+                        camera_preview.clone().into_any_element(),
+                    )),
+            )
+            .child(
+                div()
+                    .w(CAMERA_CONTROLS_W)
+                    .flex_shrink_0()
+                    .child(PanelCard::new(
+                        tr!("Camera controls"),
+                        Icon::new(IconName::Settings),
+                        camera_controls.clone().into_any_element(),
+                    )),
+            ),
+    )
 }
 
 /// Standalone-light controls in a separate panel from HID++ keyboard RGB.
@@ -577,7 +571,7 @@ fn light_tab(
         },
     );
     tab_body(
-        CONTENT_W_XL,
+        ContentWidth::ExtraLarge,
         h_flex()
             .w_full()
             .gap_4()
@@ -586,8 +580,8 @@ fn light_tab(
             .child(light_visual::detail(asset, online, enabled, settings, pal))
             .child(
                 div()
-                    .w(px(LIGHT_CONTROLS_W))
-                    .min_w(px(LIGHT_CONTROLS_MIN_W))
+                    .w(LIGHT_CONTROLS_W)
+                    .min_w(LIGHT_CONTROLS_MIN_W)
                     .child(PanelCard::new(
                         tr!("Lighting"),
                         Icon::new(IconName::Sun),
@@ -600,7 +594,7 @@ fn light_tab(
 /// Device tab: device details and configuration cards stacked.
 fn device_tab(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
     tab_body(
-        CONTENT_W_SM,
+        ContentWidth::Small,
         v_flex()
             .w_full()
             .gap_3()

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -3,7 +3,7 @@
 use super::AppState;
 use gpui::App;
 use openlogi_core::config::{
-    AppIcon, AppSettings, Appearance, AssetSourcePreference, ThumbwheelSensitivity,
+    AppIcon, AppSettings, Appearance, AssetSourcePreference, ThumbwheelSensitivity, UiScale,
 };
 
 impl AppState {
@@ -75,6 +75,15 @@ impl AppState {
         }
         self.config.app_settings.appearance = appearance;
         self.persist_config("appearance setting");
+    }
+    /// Persist the text and interface scale. Open window roots apply the new
+    /// rem size when the caller refreshes them. No-op when unchanged.
+    pub fn set_ui_scale(&mut self, scale: UiScale) {
+        if self.config.app_settings.ui_scale == scale {
+            return;
+        }
+        self.config.app_settings.ui_scale = scale;
+        self.persist_config("UI scale setting");
     }
     /// Persist the chosen theme name for one mode (`None` = the OpenLogi brand
     /// theme). No-op when unchanged.

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -165,10 +165,10 @@ impl RenderOnce for PanelCard {
             .border_1()
             .border_color(pal.border)
             .bg(pal.panel)
-            .p(px(theme::CARD_PAD))
+            .p(theme::CARD_PAD)
             .child(
                 v_flex()
-                    .gap(px(theme::CARD_GAP))
+                    .gap(theme::CARD_GAP)
                     .when(!self.title.is_empty(), |this| {
                         this.child(
                             h_flex()

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -14,9 +14,9 @@
 
 #[cfg(test)]
 use gpui::rgb;
-use gpui::{App, FontWeight, Hsla, Pixels, Rgba, Styled, Window, hsla, px, relative};
+use gpui::{App, FontWeight, Hsla, Pixels, Rems, Rgba, Styled, Window, hsla, px, relative, rems};
 use gpui_component::{ActiveTheme as _, Theme, ThemeMode, ThemeRegistry};
-use openlogi_core::config::Appearance;
+use openlogi_core::config::{Appearance, UiScale};
 
 use crate::state::AppState;
 
@@ -39,14 +39,38 @@ pub const HEADER_H: f32 = 64.;
 pub const FOOTER_H: f32 = 40.;
 pub const DETAIL_RAIL_W: f32 = 168.;
 
-/// Maximum-width scale for detail-tab content.
-pub const CONTENT_W_SM: f32 = 560.;
-pub const CONTENT_W_MD: f32 = 680.;
-pub const CONTENT_W_LG: f32 = 920.;
-pub const CONTENT_W_XL: f32 = 980.;
-pub const CONTENT_W_2XL: f32 = 1040.;
+const BASE_REM_SIZE: f32 = 16.;
 
-/// Semantic spacing tokens (px), so surfaces that must agree share one value
+/// Maximum-width scale for detail-tab content.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContentWidth {
+    /// A single compact settings card (560 px at 100%).
+    Small,
+    /// A wider single panel (680 px at 100%).
+    Medium,
+    /// A two-column settings layout (920 px at 100%).
+    Large,
+    /// A device visual beside its controls (980 px at 100%).
+    ExtraLarge,
+    /// The widest workspace layout (1040 px at 100%).
+    DoubleExtraLarge,
+}
+
+impl ContentWidth {
+    /// Resolve this semantic width in scalable rem units.
+    #[must_use]
+    pub const fn rems(self) -> Rems {
+        match self {
+            Self::Small => rems(35.),
+            Self::Medium => rems(42.5),
+            Self::Large => rems(57.5),
+            Self::ExtraLarge => rems(61.25),
+            Self::DoubleExtraLarge => rems(65.),
+        }
+    }
+}
+
+/// Semantic spacing tokens, so surfaces that must agree share one value
 /// instead of each call site hand-picking a `p_*` / `gap_*` step.
 ///
 /// - `SCREEN_PAD` — the inset around a detail-tab body. Uniform across tabs so
@@ -54,9 +78,9 @@ pub const CONTENT_W_2XL: f32 = 1040.;
 ///   two-column grid is sized against this exact value; see its card min-width).
 /// - `CARD_PAD` / `CARD_GAP` — a card's inner padding and its title-to-content
 ///   gap, so every [`panel_card`](crate::app) reads the same.
-pub const SCREEN_PAD: f32 = 20.;
-pub const CARD_PAD: f32 = 16.;
-pub const CARD_GAP: f32 = 12.;
+pub const SCREEN_PAD: Rems = rems(1.25);
+pub const CARD_PAD: Rems = rems(1.);
+pub const CARD_GAP: Rems = rems(0.75);
 
 /// Apple HIG / WCAG minimum contrast for normal text up to 17pt.
 const MIN_TEXT_CONTRAST: f32 = 4.5;
@@ -224,6 +248,21 @@ pub fn register_builtin_themes(cx: &mut App) {
     }
 }
 
+fn rem_size(scale: UiScale) -> Pixels {
+    px(BASE_REM_SIZE * f32::from(scale.percent()) / 100.)
+}
+
+/// Apply the stored interface scale to one desktop window.
+///
+/// Root views call this before building their elements so text and every
+/// rem-based layout token change together. The Actions Ring is a separate
+/// process and deliberately keeps its cursor-centred pixel geometry.
+pub fn apply_ui_scale(window: &mut Window, cx: &App) {
+    let scale =
+        AppState::try_read(cx).map_or_else(UiScale::default, |state| state.app_settings().ui_scale);
+    window.set_rem_size(rem_size(scale));
+}
+
 /// Resolve the user's stored appearance preference and apply it to the global
 /// [`Theme`]. Reads [`AppState`] live, so it is the single entry point for first
 /// paint, OS-appearance changes, and live edits on the Appearance page:
@@ -364,7 +403,7 @@ pub trait Typography: Styled + Sized {
     /// heaviest, largest step — the one place Bold is used.
     #[must_use]
     fn text_title(self) -> Self {
-        self.text_size(px(26.))
+        self.text_size(rems(1.625))
             .font_weight(FontWeight::BOLD)
             .line_height(relative(1.2))
     }
@@ -373,7 +412,7 @@ pub trait Typography: Styled + Sized {
     /// primary heading.
     #[must_use]
     fn text_heading(self) -> Self {
-        self.text_size(px(20.))
+        self.text_size(rems(1.25))
             .font_weight(FontWeight::SEMIBOLD)
             .line_height(relative(1.3))
     }
@@ -382,7 +421,7 @@ pub trait Typography: Styled + Sized {
     /// inside a card rather than titling a screen.
     #[must_use]
     fn text_subheading(self) -> Self {
-        self.text_size(px(15.))
+        self.text_size(rems(0.9375))
             .font_weight(FontWeight::SEMIBOLD)
             .line_height(relative(1.4))
     }
@@ -390,14 +429,14 @@ pub trait Typography: Styled + Sized {
     /// Default body copy — control labels, descriptions, values.
     #[must_use]
     fn text_body(self) -> Self {
-        self.text_size(px(15.)).line_height(relative(1.45))
+        self.text_size(rems(0.9375)).line_height(relative(1.45))
     }
 
     /// De-emphasised metadata and helper text — the muted line under a label,
     /// battery readouts, hints. Pair with `pal.text_muted`.
     #[must_use]
     fn text_caption(self) -> Self {
-        self.text_size(px(12.)).line_height(relative(1.4))
+        self.text_size(rems(0.75)).line_height(relative(1.4))
     }
 }
 
@@ -406,6 +445,29 @@ impl<E: Styled> Typography for E {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn content_width_scale_preserves_the_standard_layout() {
+        assert_eq!(
+            [
+                ContentWidth::Small,
+                ContentWidth::Medium,
+                ContentWidth::Large,
+                ContentWidth::ExtraLarge,
+                ContentWidth::DoubleExtraLarge,
+            ]
+            .map(|width| width.rems().to_pixels(px(BASE_REM_SIZE))),
+            [px(560.), px(680.), px(920.), px(980.), px(1040.)]
+        );
+    }
+
+    #[test]
+    fn ui_scale_presets_map_to_expected_rem_sizes() {
+        assert_eq!(
+            UiScale::ALL.map(rem_size),
+            [px(14.4), px(16.), px(17.6), px(20.)]
+        );
+    }
 
     #[test]
     fn openlogi_theme_text_pairs_meet_normal_text_contrast() {

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -180,7 +180,8 @@ impl AuxWindow for AddDeviceView {
 }
 
 impl Render for AddDeviceView {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        theme::apply_ui_scale(window, cx);
         let pal = theme::palette(cx);
         let state = cx.try_global::<PairingUi>().cloned().unwrap_or_default();
 

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -33,7 +33,9 @@ pub(super) use gpui_component::{
 };
 pub(super) use gpui_updater::{UpdateStatus, Updater};
 pub(super) use openlogi_core::brand::{HELP_URL, RELEASES_URL, REPO_URL};
-pub(super) use openlogi_core::config::{Appearance, AssetSourcePreference, ThumbwheelSensitivity};
+pub(super) use openlogi_core::config::{
+    Appearance, AssetSourcePreference, ThumbwheelSensitivity, UiScale,
+};
 
 pub(super) use crate::app::menu::{CloseWindow, Minimize, Zoom};
 pub(super) use crate::services::assets::sync::{AssetCommand, AssetControl};
@@ -358,7 +360,8 @@ pub fn open_at(page: SettingsPage, cx: &mut App) {
 }
 
 impl Render for SettingsView {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        theme::apply_ui_scale(window, cx);
         let pal = theme::palette(cx);
         let view = cx.entity();
         // Only surface the Camera permission when a webcam is actually present,

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -1,4 +1,4 @@
-//! Appearance settings page: mode, theme grid, radius, language.
+//! Appearance settings page: mode, theme grid, radius, scale, language.
 
 use super::language::{LanguageOption, language_select_field};
 use gpui::img;
@@ -9,7 +9,8 @@ use super::{
     IconName, Input, InputState, InteractiveElement, IntoElement, Palette, ParentElement, Rc,
     SelectState, Selectable, SettingField, SettingGroup, SettingItem, SettingPage, SettingsView,
     SharedString, Sizable, StateEvent, StatefulInteractiveElement, Styled, Theme, ThemeColor,
-    ThemeConfig, ThemeFilter, ThemeMode, ThemeRegistry, div, h_flex, px, rgb, theme, v_flex,
+    ThemeConfig, ThemeFilter, ThemeMode, ThemeRegistry, UiScale, div, h_flex, px, rgb, theme,
+    v_flex,
 };
 use crate::platform::app_icon;
 use crate::ui::theme::Typography as _;
@@ -64,15 +65,23 @@ pub(super) fn appearance_page(
         );
     }
 
-    let theme_group = theme_group.item(
-        // Compact control → inline on the right of the label (HIG), unlike the
-        // wide thumbnail/grid controls which stack below.
-        SettingItem::new(
-            tr!("Corner radius"),
-            SettingField::render(move |_, _, cx| radius_segment(cx)),
+    let theme_group = theme_group
+        .item(
+            // Compact control → inline on the right of the label (HIG), unlike the
+            // wide thumbnail/grid controls which stack below.
+            SettingItem::new(
+                tr!("Corner radius"),
+                SettingField::render(move |_, _, cx| radius_segment(cx)),
+            )
+            .description(tr!("Roundness of buttons, cards, and controls.")),
         )
-        .description(tr!("Roundness of buttons, cards, and controls.")),
-    );
+        .item(
+            SettingItem::new(
+                tr!("Interface scale"),
+                SettingField::render(move |_, _, cx| scale_segment(cx)),
+            )
+            .description(tr!("Scale text and interface spacing.")),
+        );
 
     let language_group = SettingGroup::new().title(tr!("Language")).item(
         SettingItem::new(
@@ -111,6 +120,17 @@ fn set_radius(cx: &mut App, radius: Option<u8>) {
         cx.emit(StateEvent::SettingsChanged);
     });
     theme::apply_from_settings(None, cx);
+}
+
+/// Persist an interface-scale choice and repaint every desktop window. Each
+/// root applies its own rem size on that repaint, avoiding a re-entrant update
+/// of the Settings window currently dispatching this click.
+fn set_scale(cx: &mut App, scale: UiScale) {
+    AppState::update(cx, |state, cx| {
+        state.set_ui_scale(scale);
+        cx.emit(StateEvent::SettingsChanged);
+    });
+    cx.refresh_windows();
 }
 
 /// The Light / Dark / Follow-system appearance picker — three macOS-style
@@ -377,6 +397,31 @@ fn radius_segment(cx: &App) -> ButtonGroup {
             if let Some(&ix) = clicks.first() {
                 set_radius(cx, options[ix]);
             }
+        })
+}
+
+/// The supported interface-scale presets. Keeping this finite makes every
+/// layout state reviewable and avoids arbitrary values that can render a
+/// window unusable.
+fn scale_segment(cx: &App) -> ButtonGroup {
+    let current =
+        AppState::try_read(cx).map_or_else(UiScale::default, |state| state.app_settings().ui_scale);
+    ButtonGroup::new("interface-scale")
+        .outline()
+        .children(UiScale::ALL.map(|scale| {
+            Button::new(format!("interface-scale-{}", scale.percent()))
+                .label(format!("{}%", scale.percent()))
+                .selected(current == scale)
+        }))
+        .on_click(|clicks, _, cx| {
+            let Some(scale) = clicks
+                .first()
+                .and_then(|index| UiScale::ALL.get(*index))
+                .copied()
+            else {
+                return;
+            };
+            set_scale(cx, scale);
         })
 }
 

--- a/crates/openlogi-desktop/src/windows/update_consent.rs
+++ b/crates/openlogi-desktop/src/windows/update_consent.rs
@@ -69,7 +69,8 @@ fn answer(enabled: bool, window: &mut Window, cx: &mut App) {
 }
 
 impl Render for UpdateConsentView {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        theme::apply_ui_scale(window, cx);
         let pal = theme::palette(cx);
 
         v_flex()

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Motyw"
 "Corner radius": "Promień narożników"
 "Roundness of buttons, cards, and controls.": "Zaokrąglenie przycisków, kart i elementów sterujących."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Ostry"
 "Round": "Zaokrąglony"
 "All": "Wszystkie"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Theme"
 "Corner radius": "Corner radius"
 "Roundness of buttons, cards, and controls.": "Roundness of buttons, cards, and controls."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Sharp"
 "Round": "Round"
 "All": "All"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "Тема"
 "Corner radius": "Радіус заокруглення"
 "Roundness of buttons, cards, and controls.": "Заокругленість кнопок, карток і елементів керування."
+"Interface scale": "Interface scale"
+"Scale text and interface spacing.": "Scale text and interface spacing."
 "Sharp": "Гострі"
 "Round": "Заокруглені"
 "All": "Усі"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "主题"
 "Corner radius": "圆角"
 "Roundness of buttons, cards, and controls.": "按钮、卡片与控件的圆角程度。"
+"Interface scale": "界面缩放"
+"Scale text and interface spacing.": "缩放文字与界面间距。"
 "Sharp": "直角"
 "Round": "圆润"
 "All": "全部"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "主題"
 "Corner radius": "圓角"
 "Roundness of buttons, cards, and controls.": "按鈕、卡片與控制項的圓角程度。"
+"Interface scale": "介面縮放"
+"Scale text and interface spacing.": "縮放文字與介面間距。"
 "Sharp": "直角"
 "Round": "圓潤"
 "All": "全部"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -333,6 +333,8 @@ _version: 1
 "Theme": "主題"
 "Corner radius": "圓角"
 "Roundness of buttons, cards, and controls.": "按鈕、卡片與控制項的圓角程度。"
+"Interface scale": "介面縮放"
+"Scale text and interface spacing.": "縮放文字與介面間距。"
 "Sharp": "直角"
 "Round": "圓潤"
 "All": "全部"

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,5 +1,5 @@
 # OpenLogi configuration example. Copy only the sections you need.
-schema_version = 4
+schema_version = 5
 selected_device = "receiver:aabbccdd:slot:1"
 
 [app_settings]
@@ -13,6 +13,7 @@ asset_source = "automatic"
 language = "en"
 thumbwheel_sensitivity = 14
 appearance = "system"
+ui_scale = "normal"
 # macOS only: "openlogi" (the signed icon) or "prism".
 app_icon = "openlogi"
 


### PR DESCRIPTION
## Summary

Add a finite, persisted interface scale for the desktop app as a follow-up to #900. Text, semantic spacing, and detail content widths now scale together while device images, input hotspots, camera geometry, and the separate Actions Ring overlay retain their pixel-based behavior.

## Changes

- **openlogi-core**
  - add `UiScale` presets for 90%, 100%, 110%, and 125%
  - persist the selection in `AppSettings`, default older configs to 100%, and bump the config schema to v5
- **openlogi-desktop**
  - apply the selected rem size in every desktop root window
  - convert the semantic typography, card spacing, and detail content-width scale to rem units
  - replace raw detail width constants with `ContentWidth` and move the Camera tab onto the shared `tab_body` pipeline
  - expose the presets in Settings → Appearance and refresh open windows live
- **openlogi-ui**
  - add the interface-scale copy to all locale catalogs
- **docs**
  - document the v5 `ui_scale` setting in the canonical config example

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS=\"-D warnings\" cargo test --workspace`
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci wasm`
- `cargo test -p openlogi-desktop i18n`
- Not runtime-tested on hardware; this change does not alter device I/O.
- Native window visuals were not captured in the headless Linux orb; preset mappings and 100% layout dimensions are covered by focused tests.

Follow-up to #900