### PR TITLE
fix(agent): queue HID requests before response timeout

### DIFF
--- a/crates/openlogi-agent-core/src/hardware.rs
+++ b/crates/openlogi-agent-core/src/hardware.rs
@@ -18,6 +18,7 @@
 //! and avoids holding a long-lived async runtime alongside GPUI's executor.
 
 use std::future::Future;
+use std::sync::{Arc, Mutex, PoisonError, Weak};
 use std::time::Duration;
 
 use openlogi_core::config::Lighting;
@@ -39,6 +40,79 @@ pub use light::{apply_light, cancel_light_reapply, set_light_in_background};
 /// this background thread forever; a write to a live device completes in well
 /// under a second.
 const WRITE_BUDGET: Duration = Duration::from_secs(5);
+
+/// Physical HID transport behind a route. Receiver slots share one writer, so
+/// they must share one turnstile even though their HID++ device indices differ.
+#[derive(Clone, PartialEq, Eq)]
+enum DeviceIoTransport {
+    Bolt(String),
+    Unifying(String),
+    Direct(u16, u16),
+    RawHid(u16, u16, u16, u16, String),
+}
+
+impl From<&DeviceRoute> for DeviceIoTransport {
+    fn from(route: &DeviceRoute) -> Self {
+        match route {
+            DeviceRoute::Bolt { receiver_uid, .. } => Self::Bolt(receiver_uid.clone()),
+            DeviceRoute::Unifying { receiver_uid, .. } => Self::Unifying(receiver_uid.clone()),
+            DeviceRoute::Direct {
+                vendor_id,
+                product_id,
+            } => Self::Direct(*vendor_id, *product_id),
+            DeviceRoute::RawHid {
+                vendor_id,
+                product_id,
+                usage_page,
+                usage_id,
+                identity,
+            } => Self::RawHid(
+                *vendor_id,
+                *product_id,
+                *usage_page,
+                *usage_id,
+                identity.clone(),
+            ),
+        }
+    }
+}
+
+/// Per-transport FIFO turnstiles for agent-owned HID requests.
+///
+/// The HID channel's writer mutex serializes report writes, but its callers
+/// used to start their device-response timeout before they acquired that mutex.
+/// A slow background reconciliation could therefore consume a queued GUI
+/// write's entire budget before the GUI request sent its first report. These
+/// gates move that queue outside the response budget while preserving the
+/// existing timeout once a request owns the transport.
+#[derive(Clone, Default)]
+pub struct DeviceIoGates {
+    inner: Arc<Mutex<DeviceIoTurns>>,
+}
+
+type DeviceIoTurn = tokio::sync::Mutex<()>;
+type DeviceIoTurns = Vec<(DeviceIoTransport, Weak<DeviceIoTurn>)>;
+
+impl DeviceIoGates {
+    fn turn_for(&self, route: &DeviceRoute) -> Arc<DeviceIoTurn> {
+        let transport = DeviceIoTransport::from(route);
+        let mut entries = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        entries.retain(|(_, turn)| turn.strong_count() != 0);
+        if let Some(turn) = entries.iter().find_map(|(candidate, turn)| {
+            (candidate == &transport).then(|| turn.upgrade()).flatten()
+        }) {
+            return turn;
+        }
+        let turn = Arc::new(DeviceIoTurn::new(()));
+        entries.push((transport, Arc::downgrade(&turn)));
+        turn
+    }
+}
+
+async fn with_io_turn<T>(turn: &DeviceIoTurn, operation: impl Future<Output = T>) -> T {
+    let _guard = turn.lock().await;
+    operation.await
+}
 
 /// Select the only Agent-authoritative channel for `route`.
 fn authoritative_channel(
@@ -87,6 +161,7 @@ pub struct DeviceOp<'a> {
     capture: &'a CaptureChannel,
     registry: &'a ChannelRegistry,
     receiver_access: &'a ReceiverAccess,
+    device_io: &'a DeviceIoGates,
     route: DeviceRoute,
 }
 
@@ -95,12 +170,14 @@ impl<'a> DeviceOp<'a> {
         capture: &'a CaptureChannel,
         registry: &'a ChannelRegistry,
         receiver_access: &'a ReceiverAccess,
+        device_io: &'a DeviceIoGates,
         route: &DeviceRoute,
     ) -> Self {
         Self {
             capture,
             registry,
             receiver_access,
+            device_io,
             route: route.clone(),
         }
     }
@@ -113,34 +190,39 @@ impl<'a> DeviceOp<'a> {
         authoritative_channel(Some(self.capture), self.registry, &self.route)
     }
 
-    /// Lease the receiver, resolve the authoritative channel, then run `f`
-    /// against it under `WRITE_BUDGET`, mapping a timeout to
-    /// [`WriteError::RequestTimedOut`].
+    /// Wait for this transport's I/O turn, lease the receiver, resolve the
+    /// authoritative channel, then run `f` against it under `WRITE_BUDGET`,
+    /// mapping a timeout to [`WriteError::RequestTimedOut`]. Queue and lease
+    /// waits sit outside that budget; it measures only the device transaction.
     ///
-    /// Lease-then-resolve, not the other way around: the lease wait is
-    /// unbounded, and a channel resolved before it would risk being retired
-    /// by the inventory enumerator while still queued — the write itself
-    /// would likely still succeed on the stale handle, but anything that
-    /// caches a feature off it (see the haptic feature cache's
-    /// `EpochGuarded` note) would then pin a channel the enumerator can never
-    /// reopen. Used by every awaited device call: the IPC server's
-    /// DPI/SmartShift/lighting reads and writes, and the Actions Ring haptic
-    /// path.
+    /// Turn-then-lease-then-resolve, not the other way around: both waits are
+    /// unbounded, and a channel resolved before them could be retired by the
+    /// inventory enumerator while still queued — the write itself would likely
+    /// still succeed on the stale handle, but anything that caches a feature
+    /// off it (see the haptic feature cache's `EpochGuarded` note) would then
+    /// pin a channel the enumerator can never reopen. Used by every awaited
+    /// device call: the IPC server's DPI/SmartShift/lighting reads and writes,
+    /// and the Actions Ring haptic path.
     pub async fn run<F, Fut, T>(self, op: HidppOperation, f: F) -> Result<T, WriteError>
     where
         F: FnOnce(SharedChannel) -> Fut,
         Fut: Future<Output = Result<T, WriteError>>,
     {
-        let _lease = self.receiver_access.acquire_for_io().await;
-        let shared = self.resolve()?;
-        timed(op, f(shared)).await
+        let turn = self.device_io.turn_for(&self.route);
+        with_io_turn(&turn, async move {
+            let _lease = self.receiver_access.acquire_for_io().await;
+            let shared = self.resolve()?;
+            timed(op, f(shared)).await
+        })
+        .await
     }
 
     /// Fire-and-forget `f` on its own OS thread and one-shot runtime, with the
     /// standard three-arm outcome logging: a completed write and a failed
-    /// write both log at their own level, keyed by `label`; a device that
-    /// never answers within `WRITE_BUDGET` warns instead of hanging the
-    /// thread forever.
+    /// write both log at their own level, keyed by `label`; a device that never
+    /// answers within `WRITE_BUDGET` warns instead of hanging the thread
+    /// forever. Like [`Self::run`], it waits for the transport turn before
+    /// starting that budget.
     ///
     /// Resolves the channel on the calling thread before spawning — every
     /// `*_in_background` write did this, so a resolution failure (no target,
@@ -185,15 +267,16 @@ impl<'a> DeviceOp<'a> {
             debug!(route = %self.route, label, "no inventory channel — write skipped");
             return;
         };
+        let turn = self.device_io.turn_for(&self.route);
         let receiver_access = self.receiver_access.clone();
         std::thread::spawn(move || {
             let Some(rt) = one_shot_runtime(label) else {
                 return;
             };
-            let result = rt.block_on(async {
+            let result = rt.block_on(with_io_turn(&turn, async {
                 let _lease = receiver_access.acquire_for_io().await;
                 tokio::time::timeout(WRITE_BUDGET, f(shared)).await
-            });
+            }));
             log(result);
         });
     }
@@ -223,6 +306,7 @@ pub fn toggle_smartshift_in_background(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
+    device_io: &DeviceIoGates,
     target: Option<DeviceRoute>,
 ) {
     let Some(target) = target else {
@@ -230,7 +314,7 @@ pub fn toggle_smartshift_in_background(
         return;
     };
     let index = target.device_index();
-    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
+    DeviceOp::new(capture, registry, receiver_access, device_io, &target).spawn_write(
         "SmartShift toggle",
         |c| async move { openlogi_hid::toggle_smartshift_on(&c).await },
         move |result| match result {
@@ -290,12 +374,13 @@ pub fn reapply_mouse_volatile_in_background(
         return;
     };
     let receiver_access = op.receiver_access.clone();
+    let turn = op.device_io.turn_for(&op.route);
     let index = op.route.device_index();
     std::thread::spawn(move || {
         let Some(rt) = one_shot_runtime("volatile reapply") else {
             return;
         };
-        rt.block_on(async {
+        rt.block_on(with_io_turn(&turn, async {
             let _lease = receiver_access.acquire_for_io().await;
             if resolution.is_some() || inverted.is_some() {
                 let result = tokio::time::timeout(WRITE_BUDGET, async {
@@ -338,7 +423,7 @@ pub fn reapply_mouse_volatile_in_background(
                     ),
                 }
             }
-        });
+        }));
     });
 }
 
@@ -394,6 +479,7 @@ pub fn write_dpi_in_background(
     capture: &CaptureChannel,
     registry: &ChannelRegistry,
     receiver_access: &ReceiverAccess,
+    device_io: &DeviceIoGates,
     target: Option<DeviceRoute>,
     dpi: Dpi,
 ) {
@@ -402,7 +488,7 @@ pub fn write_dpi_in_background(
         return;
     };
     let index = target.device_index();
-    DeviceOp::new(capture, registry, receiver_access, &target).spawn_write(
+    DeviceOp::new(capture, registry, receiver_access, device_io, &target).spawn_write(
         "DPI write",
         move |c| async move { openlogi_hid::set_dpi_on(&c, dpi).await },
         move |result| match result {
@@ -568,6 +654,74 @@ mod tests {
         }
     }
 
+    #[test]
+    fn receiver_slots_share_one_io_turn() {
+        let gates = DeviceIoGates::default();
+        let first = DeviceRoute::Bolt {
+            receiver_uid: "receiver-a".into(),
+            slot: 1,
+        };
+        let second = DeviceRoute::Bolt {
+            receiver_uid: "receiver-a".into(),
+            slot: 2,
+        };
+
+        let first_turn = gates.turn_for(&first);
+        let second_turn = gates.turn_for(&second);
+
+        assert!(Arc::ptr_eq(&first_turn, &second_turn));
+    }
+
+    #[test]
+    fn independent_transports_get_independent_io_turns() {
+        let gates = DeviceIoGates::default();
+        let first = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb034,
+        };
+        let second = DeviceRoute::Direct {
+            vendor_id: 0x046d,
+            product_id: 0xb035,
+        };
+
+        let first_turn = gates.turn_for(&first);
+        let second_turn = gates.turn_for(&second);
+
+        assert!(!Arc::ptr_eq(&first_turn, &second_turn));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn queued_operation_gets_its_full_response_budget() {
+        let gates = DeviceIoGates::default();
+        let route = unresolvable_route();
+        let turn = gates.turn_for(&route);
+        let held_turn = turn.lock().await;
+        let queued_turn = Arc::clone(&turn);
+        let queued = tokio::spawn(async move {
+            with_io_turn(&queued_turn, async {
+                timed(HidppOperation::WriteSmartShift, async {
+                    tokio::task::yield_now().await;
+                    Ok::<(), WriteError>(())
+                })
+                .await
+            })
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(WRITE_BUDGET + Duration::from_millis(1)).await;
+
+        assert!(
+            !queued.is_finished(),
+            "queue time must not consume the device-response budget"
+        );
+        drop(held_turn);
+        queued
+            .await
+            .expect("queued operation must not panic")
+            .expect("queue wait must not spend the response budget");
+    }
+
     /// `DeviceOp::run` must fail fast on a registry miss ([`DeviceNotFound`],
     /// the same path `authoritative_channel` uses to clear the haptic feature
     /// cache) and must never invoke `f` — a route that can't be resolved has no
@@ -578,11 +732,12 @@ mod tests {
         let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
         let registry = ChannelRegistry::default();
         let receiver_access = ReceiverAccess::default();
+        let device_io = DeviceIoGates::default();
         let route = unresolvable_route();
         let called = std::sync::Arc::new(AtomicBool::new(false));
         let called_for_closure = std::sync::Arc::clone(&called);
 
-        let result = DeviceOp::new(&capture, &registry, &receiver_access, &route)
+        let result = DeviceOp::new(&capture, &registry, &receiver_access, &device_io, &route)
             .run(HidppOperation::WriteDpi, move |_shared| {
                 called_for_closure.store(true, Ordering::SeqCst);
                 async move { Ok::<(), WriteError>(()) }
@@ -603,11 +758,12 @@ mod tests {
         let capture: CaptureChannel = std::sync::Arc::new(RwLock::new(None));
         let registry = ChannelRegistry::default();
         let receiver_access = ReceiverAccess::default();
+        let device_io = DeviceIoGates::default();
         let route = unresolvable_route();
         let called = std::sync::Arc::new(AtomicBool::new(false));
         let called_for_closure = std::sync::Arc::clone(&called);
 
-        DeviceOp::new(&capture, &registry, &receiver_access, &route).detach(
+        DeviceOp::new(&capture, &registry, &receiver_access, &device_io, &route).detach(
             "test write",
             move |_shared| {
                 called_for_closure.store(true, Ordering::SeqCst);

--- a/crates/openlogi-agent-core/src/hook_runtime.rs
+++ b/crates/openlogi-agent-core/src/hook_runtime.rs
@@ -23,7 +23,7 @@ use openlogi_hook::{
 use tracing::{info, warn};
 
 use crate::event_monitor::SharedEventMonitor;
-use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
+use crate::hardware::{DeviceIoGates, toggle_smartshift_in_background, write_dpi_in_background};
 use crate::receiver_access::ReceiverAccess;
 use crate::{DpiCycleState, DpiCycles};
 
@@ -35,6 +35,7 @@ pub struct ActionDispatcher {
     capture: CaptureChannel,
     registry: ChannelRegistry,
     receiver_access: ReceiverAccess,
+    device_io: DeviceIoGates,
     action_ring: tokio::sync::mpsc::UnboundedSender<Option<String>>,
 }
 
@@ -46,6 +47,7 @@ impl ActionDispatcher {
         capture: CaptureChannel,
         registry: ChannelRegistry,
         receiver_access: ReceiverAccess,
+        device_io: DeviceIoGates,
         action_ring: tokio::sync::mpsc::UnboundedSender<Option<String>>,
     ) -> Self {
         Self {
@@ -53,6 +55,7 @@ impl ActionDispatcher {
             capture,
             registry,
             receiver_access,
+            device_io,
             action_ring,
         }
     }
@@ -76,6 +79,7 @@ impl ActionDispatcher {
             &self.capture,
             Some(&self.registry),
             &self.receiver_access,
+            &self.device_io,
         );
     }
 }
@@ -574,6 +578,7 @@ pub fn dispatch_action(
     capture: &CaptureChannel,
     registry: Option<&ChannelRegistry>,
     receiver_access: &ReceiverAccess,
+    device_io: &DeviceIoGates,
 ) {
     let next = match action {
         Action::CycleDpiPresets => match dpi_cycle.write() {
@@ -596,7 +601,13 @@ pub fn dispatch_action(
             let target = dpi_cycle.read().ok().and_then(|g| g.target_for(device_key));
             info!("SmartShift toggle → flipping wheel mode");
             if let Some(registry) = registry {
-                toggle_smartshift_in_background(capture, registry, receiver_access, target);
+                toggle_smartshift_in_background(
+                    capture,
+                    registry,
+                    receiver_access,
+                    device_io,
+                    target,
+                );
             } else {
                 warn!("no inventory registry — SmartShift toggle skipped");
             }
@@ -626,7 +637,7 @@ pub fn dispatch_action(
     if let Some((dpi, target)) = next {
         info!(%dpi, "DPI action → writing to device");
         if let Some(registry) = registry {
-            write_dpi_in_background(capture, registry, receiver_access, target, dpi);
+            write_dpi_in_background(capture, registry, receiver_access, device_io, target, dpi);
         } else {
             warn!("no inventory registry — DPI action skipped");
         }

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -584,19 +584,17 @@ impl Orchestrator {
         true
     }
 
-    /// Push the saved native wheel resolution/inversion to every currently online
-    /// device. Separated from [`Self::rebuild`] (which also runs on
-    /// foreground-app changes) because the HID++ write is only needed when
-    /// config or device presence changes. The write short-circuits at the
-    /// `0x2121` layer when the wheel already holds the desired state, so calling
-    /// it on every reload costs at most one wheel-mode read per device — and
-    /// still recovers a device whose earlier write timed out while it was waking.
-    fn apply_native_wheel_modes(&self) {
-        for dev in self.devices.iter().filter(|dev| dev.online) {
-            let Some(route) = dev.route.clone() else {
-                continue;
-            };
-            let (resolution, inverted) = configured_wheel_mode(&self.config, dev);
+    /// Push native wheel resolution/inversion only where this config reload
+    /// changed the effective wheel settings.
+    ///
+    /// Every persisted GUI edit reloads the whole config. Starting an unchanged
+    /// wheel-mode transaction for a SmartShift-only edit makes that transaction
+    /// race the explicit SmartShift write on the same HID writer; a slow wheel
+    /// read can then consume the SmartShift write and confirmation budgets.
+    fn apply_changed_native_wheel_modes(&self, previous_config: &Config) {
+        for (route, resolution, inverted) in
+            wheel_mode_reapply_plan(previous_config, &self.config, &self.devices)
+        {
             crate::hardware::write_scroll_wheel_mode_in_background(
                 self.shared.device(&route),
                 resolution,
@@ -745,7 +743,7 @@ impl Orchestrator {
     pub fn reload_config(&mut self, config: Config) {
         // Parameter-only edits must not erase a transient manual choice while
         // the light remains camera-linked. Changing the policy invalidates it.
-        self.config = config;
+        let previous_config = std::mem::replace(&mut self.config, config);
         self.observable
             .set_launch_at_login(self.config.app_settings.launch_at_login);
         let retained_overrides: HashSet<String> = self
@@ -762,7 +760,7 @@ impl Orchestrator {
             .retain(|key, _| retained_overrides.contains(key));
         self.current = pick_current(&self.devices, self.config.selected_device());
         self.rebuild();
-        self.apply_native_wheel_modes();
+        self.apply_changed_native_wheel_modes(&previous_config);
         self.apply_fn_locks();
         self.reapply_light_settings();
     }
@@ -819,6 +817,25 @@ fn configured_wheel_mode(
         .scroll_inversion
         .then(|| config.invert_scroll(&dev.config_key));
     (resolution, inverted)
+}
+
+/// Plan the native wheel writes required by a config reload. Returning data
+/// keeps change detection independent from thread spawning and device I/O.
+fn wheel_mode_reapply_plan(
+    previous_config: &Config,
+    config: &Config,
+    devices: &[AgentDevice],
+) -> Vec<(DeviceRoute, Option<ScrollResolution>, Option<bool>)> {
+    devices
+        .iter()
+        .filter(|device| device.online)
+        .filter_map(|device| {
+            let route = device.route.clone()?;
+            let previous = configured_wheel_mode(previous_config, device);
+            let current = configured_wheel_mode(config, device);
+            (previous != current).then_some((route, current.0, current.1))
+        })
+        .collect()
 }
 
 /// Build the agent device list from an inventory snapshot. Mirrors the GUI's

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -31,7 +31,7 @@ use tracing::{debug, info, warn};
 
 use crate::action_ring::ActionRingSessionSpec;
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans, plan_for_device};
-use crate::hardware::DeviceOp;
+use crate::hardware::{DeviceIoGates, DeviceOp};
 use crate::hook_runtime::{HookMaps, SharedHookMaps};
 use crate::observable::ObservableState;
 use crate::receiver_access::ReceiverAccess;
@@ -97,6 +97,9 @@ pub struct SharedRuntime {
     /// Receiver access shared by HID++ sessions and pairing. Pairing/host
     /// transitions are exclusive; capture sessions share under read leases.
     pub receiver_access: ReceiverAccess,
+    /// Per-transport turnstiles for agent-owned HID++ requests. Waiting for an
+    /// older request never spends the next request's device-response budget.
+    pub device_io: DeviceIoGates,
     /// Keyboard → pointing-device routes resolved from `config.toml`.
     pub host_switch_links: HostSwitchLinks,
 }
@@ -111,6 +114,7 @@ impl SharedRuntime {
             &self.capture_channel,
             &self.channel_registry,
             &self.receiver_access,
+            &self.device_io,
             route,
         )
     }
@@ -124,6 +128,7 @@ impl SharedRuntime {
             &self.keyboard_channel,
             &self.channel_registry,
             &self.receiver_access,
+            &self.device_io,
             route,
         )
     }
@@ -202,6 +207,7 @@ impl Orchestrator {
             keyboard_channel: Arc::new(RwLock::new(None)),
             capture_rearm_generation: Arc::new(AtomicU64::new(0)),
             receiver_access: ReceiverAccess::default(),
+            device_io: DeviceIoGates::default(),
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
         };
         let orch = Self {
@@ -584,18 +590,19 @@ impl Orchestrator {
         true
     }
 
-    /// Reconcile native wheel resolution/inversion after a config reload.
-    ///
-    /// Every persisted GUI edit reloads the whole config. Starting an unchanged
-    /// wheel-mode transaction for a SmartShift-only edit makes that transaction
-    /// race the explicit SmartShift write on the same HID writer; a slow wheel
-    /// read can then consume the SmartShift write and confirmation budgets. An
-    /// ordinary reload still retries unchanged wheel settings so it can recover
-    /// from an earlier transient write failure while the device stayed online.
-    fn apply_reload_native_wheel_modes(&self, previous_config: &Config) {
-        for (route, resolution, inverted) in
-            wheel_mode_reapply_plan(previous_config, &self.config, &self.devices)
-        {
+    /// Push the saved native wheel resolution/inversion to every currently online
+    /// device. Separated from [`Self::rebuild`] (which also runs on
+    /// foreground-app changes) because the HID++ write is only needed when
+    /// config or device presence changes. The write short-circuits at the
+    /// `0x2121` layer when the wheel already holds the desired state, so calling
+    /// it on every reload costs at most one wheel-mode read per device — and
+    /// still recovers a device whose earlier write timed out while it was waking.
+    fn apply_native_wheel_modes(&self) {
+        for dev in self.devices.iter().filter(|dev| dev.online) {
+            let Some(route) = dev.route.clone() else {
+                continue;
+            };
+            let (resolution, inverted) = configured_wheel_mode(&self.config, dev);
             crate::hardware::write_scroll_wheel_mode_in_background(
                 self.shared.device(&route),
                 resolution,
@@ -744,7 +751,7 @@ impl Orchestrator {
     pub fn reload_config(&mut self, config: Config) {
         // Parameter-only edits must not erase a transient manual choice while
         // the light remains camera-linked. Changing the policy invalidates it.
-        let previous_config = std::mem::replace(&mut self.config, config);
+        self.config = config;
         self.observable
             .set_launch_at_login(self.config.app_settings.launch_at_login);
         let retained_overrides: HashSet<String> = self
@@ -761,7 +768,7 @@ impl Orchestrator {
             .retain(|key, _| retained_overrides.contains(key));
         self.current = pick_current(&self.devices, self.config.selected_device());
         self.rebuild();
-        self.apply_reload_native_wheel_modes(&previous_config);
+        self.apply_native_wheel_modes();
         self.apply_fn_locks();
         self.reapply_light_settings();
     }
@@ -818,32 +825,6 @@ fn configured_wheel_mode(
         .scroll_inversion
         .then(|| config.invert_scroll(&dev.config_key));
     (resolution, inverted)
-}
-
-/// Plan the native wheel writes required by a config reload. Returning data
-/// keeps change detection independent from thread spawning and device I/O.
-///
-/// An unchanged wheel configuration is normally retried: the preceding
-/// fire-and-forget write may have failed while the device was waking. The one
-/// exception is a SmartShift change for the same device, because the GUI follows
-/// that reload with an explicit SmartShift transaction on the shared writer.
-fn wheel_mode_reapply_plan(
-    previous_config: &Config,
-    config: &Config,
-    devices: &[AgentDevice],
-) -> Vec<(DeviceRoute, Option<ScrollResolution>, Option<bool>)> {
-    devices
-        .iter()
-        .filter(|device| device.online)
-        .filter_map(|device| {
-            let route = device.route.clone()?;
-            let previous = configured_wheel_mode(previous_config, device);
-            let current = configured_wheel_mode(config, device);
-            let smartshift_changed = previous_config.smartshift(&device.config_key)
-                != config.smartshift(&device.config_key);
-            (previous != current || !smartshift_changed).then_some((route, current.0, current.1))
-        })
-        .collect()
 }
 
 /// Build the agent device list from an inventory snapshot. Mirrors the GUI's

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -584,14 +584,15 @@ impl Orchestrator {
         true
     }
 
-    /// Push native wheel resolution/inversion only where this config reload
-    /// changed the effective wheel settings.
+    /// Reconcile native wheel resolution/inversion after a config reload.
     ///
     /// Every persisted GUI edit reloads the whole config. Starting an unchanged
     /// wheel-mode transaction for a SmartShift-only edit makes that transaction
     /// race the explicit SmartShift write on the same HID writer; a slow wheel
-    /// read can then consume the SmartShift write and confirmation budgets.
-    fn apply_changed_native_wheel_modes(&self, previous_config: &Config) {
+    /// read can then consume the SmartShift write and confirmation budgets. An
+    /// ordinary reload still retries unchanged wheel settings so it can recover
+    /// from an earlier transient write failure while the device stayed online.
+    fn apply_reload_native_wheel_modes(&self, previous_config: &Config) {
         for (route, resolution, inverted) in
             wheel_mode_reapply_plan(previous_config, &self.config, &self.devices)
         {
@@ -760,7 +761,7 @@ impl Orchestrator {
             .retain(|key, _| retained_overrides.contains(key));
         self.current = pick_current(&self.devices, self.config.selected_device());
         self.rebuild();
-        self.apply_changed_native_wheel_modes(&previous_config);
+        self.apply_reload_native_wheel_modes(&previous_config);
         self.apply_fn_locks();
         self.reapply_light_settings();
     }
@@ -821,6 +822,11 @@ fn configured_wheel_mode(
 
 /// Plan the native wheel writes required by a config reload. Returning data
 /// keeps change detection independent from thread spawning and device I/O.
+///
+/// An unchanged wheel configuration is normally retried: the preceding
+/// fire-and-forget write may have failed while the device was waking. The one
+/// exception is a SmartShift change for the same device, because the GUI follows
+/// that reload with an explicit SmartShift transaction on the shared writer.
 fn wheel_mode_reapply_plan(
     previous_config: &Config,
     config: &Config,
@@ -833,7 +839,9 @@ fn wheel_mode_reapply_plan(
             let route = device.route.clone()?;
             let previous = configured_wheel_mode(previous_config, device);
             let current = configured_wheel_mode(config, device);
-            (previous != current).then_some((route, current.0, current.1))
+            let smartshift_changed = previous_config.smartshift(&device.config_key)
+                != config.smartshift(&device.config_key);
+            (previous != current || !smartshift_changed).then_some((route, current.0, current.1))
         })
         .collect()
 }

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -3,15 +3,19 @@
 use super::{
     AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
     any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
-    pick_current, plan_reapply, reapply_targets,
+    pick_current, plan_reapply, reapply_targets, wheel_mode_reapply_plan,
 };
 use openlogi_core::app::ForegroundApp;
 use openlogi_core::binding::{Action, ButtonId};
-use openlogi_core::config::{Config, LightSettings, ScrollResolution};
+use openlogi_core::config::{
+    Config, LightSettings, SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, ScrollResolution, SmartShift,
+    WheelMode,
+};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
+use openlogi_core::hid::SmartShiftAutoDisengage;
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use std::sync::Arc;
 
@@ -273,6 +277,57 @@ fn configured_wheel_mode_leaves_unset_resolution_unmanaged() {
     });
 
     assert_eq!(configured_wheel_mode(&config, &device), (None, None));
+}
+
+#[test]
+fn smartshift_only_reload_plans_no_wheel_mode_write() {
+    let mut previous = Config::default();
+    previous.set_scroll_resolution("a", Some(ScrollResolution::Low));
+    previous.set_invert_scroll("a", true);
+    let mut updated = previous.clone();
+    updated.set_smartshift(
+        "a",
+        SmartShift {
+            mode: WheelMode::Ratchet,
+            auto_disengage: SmartShiftAutoDisengage::Threshold(SMARTSHIFT_AUTO_DISENGAGE_DEFAULT),
+            tunable_torque: None,
+        },
+    );
+    let mut device = dev("a", 1, true);
+    device.capabilities = Some(Capabilities {
+        hires_wheel: true,
+        scroll_inversion: true,
+        ..Capabilities::default()
+    });
+
+    let plan = wheel_mode_reapply_plan(&previous, &updated, &[device]);
+
+    assert!(
+        plan.is_empty(),
+        "an unrelated SmartShift edit must not occupy the wheel writer"
+    );
+}
+
+#[test]
+fn wheel_mode_reload_plans_the_updated_values() {
+    let previous = Config::default();
+    let mut updated = previous.clone();
+    updated.set_scroll_resolution("a", Some(ScrollResolution::High));
+    updated.set_invert_scroll("a", true);
+    let mut device = dev("a", 1, true);
+    device.capabilities = Some(Capabilities {
+        hires_wheel: true,
+        scroll_inversion: true,
+        ..Capabilities::default()
+    });
+    let expected_route = device.route.clone().expect("test device has a route");
+
+    let plan = wheel_mode_reapply_plan(&previous, &updated, &[device]);
+
+    assert_eq!(
+        plan,
+        vec![(expected_route, Some(ScrollResolution::High), Some(true))]
+    );
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -3,19 +3,15 @@
 use super::{
     AgentDevice, InventoryHealth, Orchestrator, VOLATILE_REAPPLY_CONFIRM_RETRIES,
     any_device_needs_capture_rearm, build_devices, configured_wheel_mode, host_switch_links,
-    pick_current, plan_reapply, reapply_targets, wheel_mode_reapply_plan,
+    pick_current, plan_reapply, reapply_targets,
 };
 use openlogi_core::app::ForegroundApp;
 use openlogi_core::binding::{Action, ButtonId};
-use openlogi_core::config::{
-    Config, LightSettings, SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, ScrollResolution, SmartShift,
-    WheelMode,
-};
+use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
-use openlogi_core::hid::SmartShiftAutoDisengage;
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use std::sync::Arc;
 
@@ -277,78 +273,6 @@ fn configured_wheel_mode_leaves_unset_resolution_unmanaged() {
     });
 
     assert_eq!(configured_wheel_mode(&config, &device), (None, None));
-}
-
-#[test]
-fn smartshift_only_reload_plans_no_wheel_mode_write() {
-    let mut previous = Config::default();
-    previous.set_scroll_resolution("a", Some(ScrollResolution::Low));
-    previous.set_invert_scroll("a", true);
-    let mut updated = previous.clone();
-    updated.set_smartshift(
-        "a",
-        SmartShift {
-            mode: WheelMode::Ratchet,
-            auto_disengage: SmartShiftAutoDisengage::Threshold(SMARTSHIFT_AUTO_DISENGAGE_DEFAULT),
-            tunable_torque: None,
-        },
-    );
-    let mut device = dev("a", 1, true);
-    device.capabilities = Some(Capabilities {
-        hires_wheel: true,
-        scroll_inversion: true,
-        ..Capabilities::default()
-    });
-
-    let plan = wheel_mode_reapply_plan(&previous, &updated, &[device]);
-
-    assert!(
-        plan.is_empty(),
-        "an unrelated SmartShift edit must not occupy the wheel writer"
-    );
-}
-
-#[test]
-fn unchanged_wheel_reload_plans_recovery_write() {
-    let mut config = Config::default();
-    config.set_scroll_resolution("a", Some(ScrollResolution::Low));
-    config.set_invert_scroll("a", true);
-    let mut device = dev("a", 1, true);
-    device.capabilities = Some(Capabilities {
-        hires_wheel: true,
-        scroll_inversion: true,
-        ..Capabilities::default()
-    });
-    let expected_route = device.route.clone().expect("test device has a route");
-
-    let plan = wheel_mode_reapply_plan(&config, &config, &[device]);
-
-    assert_eq!(
-        plan,
-        vec![(expected_route, Some(ScrollResolution::Low), Some(true))]
-    );
-}
-
-#[test]
-fn wheel_mode_reload_plans_the_updated_values() {
-    let previous = Config::default();
-    let mut updated = previous.clone();
-    updated.set_scroll_resolution("a", Some(ScrollResolution::High));
-    updated.set_invert_scroll("a", true);
-    let mut device = dev("a", 1, true);
-    device.capabilities = Some(Capabilities {
-        hires_wheel: true,
-        scroll_inversion: true,
-        ..Capabilities::default()
-    });
-    let expected_route = device.route.clone().expect("test device has a route");
-
-    let plan = wheel_mode_reapply_plan(&previous, &updated, &[device]);
-
-    assert_eq!(
-        plan,
-        vec![(expected_route, Some(ScrollResolution::High), Some(true))]
-    );
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -309,6 +309,27 @@ fn smartshift_only_reload_plans_no_wheel_mode_write() {
 }
 
 #[test]
+fn unchanged_wheel_reload_plans_recovery_write() {
+    let mut config = Config::default();
+    config.set_scroll_resolution("a", Some(ScrollResolution::Low));
+    config.set_invert_scroll("a", true);
+    let mut device = dev("a", 1, true);
+    device.capabilities = Some(Capabilities {
+        hires_wheel: true,
+        scroll_inversion: true,
+        ..Capabilities::default()
+    });
+    let expected_route = device.route.clone().expect("test device has a route");
+
+    let plan = wheel_mode_reapply_plan(&config, &config, &[device]);
+
+    assert_eq!(
+        plan,
+        vec![(expected_route, Some(ScrollResolution::Low), Some(true))]
+    );
+}
+
+#[test]
 fn wheel_mode_reload_plans_the_updated_values() {
     let previous = Config::default();
     let mut updated = previous.clone();

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -178,6 +178,7 @@ fn action_ring_runtime(
         shared.capture_channel.clone(),
         shared.channel_registry.clone(),
         shared.receiver_access.clone(),
+        shared.device_io.clone(),
         sender,
     );
     (manager, receiver, dispatcher)

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -310,6 +310,7 @@ mod tests {
             keyboard_channel: Arc::new(RwLock::new(None)),
             capture_rearm_generation: Arc::new(0.into()),
             receiver_access: ReceiverAccess::default(),
+            device_io: openlogi_agent_core::hardware::DeviceIoGates::default(),
             host_switch_links: Arc::new(RwLock::new(Vec::new())),
         }
     }


### PR DESCRIPTION
## Summary

Queue agent-owned HID++ requests per physical transport before starting their device-response timeout. A slow background wheel reconciliation can now finish without consuming the queued SmartShift write or confirmation read's five-second budget, while the reconciliation itself remains intact for recovery from earlier failures.

## Changes

- **agent-core:** add FIFO I/O turnstiles keyed by physical transport; all slots on one receiver share a turn while independent devices remain independent
- **agent-core:** route awaited IPC operations, background actions, and reconnect reapplication through the same turnstiles, acquiring the turn before the existing response timeout begins
- **agent-core tests:** prove receiver slots share a turn, unrelated transports do not, and a queued SmartShift operation retains its full response budget
- **agent:** carry the shared turnstiles into action dispatch and pairing test runtime construction

## Testing

- `RUSTFLAGS='-D warnings' cargo test -p openlogi-agent-core -p openlogi-agent --locked`
- `cargo xtask ci rustfmt clippy rustdoc`

Not runtime-tested on hardware. To verify, repeatedly change SmartShift mode and sensitivity on a Bluetooth-direct mouse while a config reload also reconciles native wheel settings; each write should confirm without entering the retry state.

Fixes #780
