### PR TITLE
fix(gui): open the config folder from the fail-closed config screen

### DIFF
--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -21,7 +21,7 @@ use openlogi_core::hid::DeviceRoute;
 
 use super::widgets::{back_button, kind_label, route_label, sidebar_action, status_badge};
 use super::{AppView, DetailTab};
-use crate::app::menu::file_url;
+use crate::app::menu::open_config_folder;
 use crate::features::action_ring::ActionRingPanel;
 use crate::features::camera::controls::CameraControlsPanel;
 use crate::features::camera::preview::CameraPreview;
@@ -681,10 +681,6 @@ fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElem
     )
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "the configuration card is clearest as one declarative UI tree"
-)]
 fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
     let device_enabled = AppState::try_read(cx)
         .and_then(|state| {
@@ -777,13 +773,7 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
                     "right-panel-config-folder",
                     IconName::Folder,
                     tr!("profiles.config_folder"),
-                    |_event, _window, cx| {
-                        if let Ok(path) = openlogi_core::paths::config_dir()
-                            && let Some(url) = file_url(&path)
-                        {
-                            cx.open_url(&url);
-                        }
-                    },
+                    |_event, _window, cx| open_config_folder(cx),
                 )),
         );
 

--- a/crates/openlogi-desktop/src/app/menu.rs
+++ b/crates/openlogi-desktop/src/app/menu.rs
@@ -83,13 +83,7 @@ pub fn install(cx: &mut App) {
     cx.on_action(|_: &OpenAddDevice, cx| crate::windows::add_device::open(cx));
     cx.on_action(|_: &BringAllToFront, cx| cx.activate(true));
     cx.on_action(|_: &CheckForUpdates, cx| check_for_updates(cx));
-    cx.on_action(|_: &OpenConfigFolder, cx| {
-        if let Ok(path) = openlogi_core::paths::config_dir()
-            && let Some(url) = file_url(&path)
-        {
-            cx.open_url(&url);
-        }
-    });
+    cx.on_action(|_: &OpenConfigFolder, cx| open_config_folder(cx));
     cx.on_action(|_: &OpenHelp, cx| cx.open_url(HELP_URL));
     cx.on_action(|_: &OpenLatestRelease, cx| cx.open_url(RELEASES_URL));
     cx.on_action(|_: &OpenRepository, cx| cx.open_url(REPO_URL));
@@ -263,6 +257,23 @@ fn device_menu_items(cx: &App) -> Vec<MenuItem> {
     items
 }
 
-pub(crate) fn file_url(path: &std::path::Path) -> Option<String> {
+fn file_url(path: &std::path::Path) -> Option<String> {
     Url::from_file_path(path).ok().map(Into::into)
+}
+
+/// Reveal the user's configuration directory in the OS file manager.
+///
+/// Every in-window button that offers this calls here directly instead of
+/// dispatching [`OpenConfigFolder`]. `App::dispatch_action` routes through
+/// the *active* window and drops the action when that window cannot be
+/// resolved — it logs "window not found" and swallows the error — which left
+/// the button on the fail-closed configuration-error screen doing nothing at
+/// all. Only the menu bar, which has no view to call from, goes through the
+/// action.
+pub(crate) fn open_config_folder(cx: &mut App) {
+    if let Ok(path) = openlogi_core::paths::config_dir()
+        && let Some(url) = file_url(&path)
+    {
+        cx.open_url(&url);
+    }
 }

--- a/crates/openlogi-desktop/src/app/status.rs
+++ b/crates/openlogi-desktop/src/app/status.rs
@@ -11,7 +11,7 @@ use gpui_component::{
     v_flex,
 };
 
-use crate::app::menu::OpenConfigFolder;
+use crate::app::menu::open_config_folder;
 use crate::ui::theme::{self, ContentWidth, FOOTER_H, Palette, Typography as _};
 
 /// Centered spinner over a muted one-line caption — the quiet "still working"
@@ -110,7 +110,7 @@ pub(super) fn config_issue_body(message: SharedString, cx: &App) -> Div {
                 .child(
                     Button::new("open-config-folder")
                         .label(tr!("app.open_configuration_folder"))
-                        .on_click(|_, _, cx| cx.dispatch_action(&OpenConfigFolder)),
+                        .on_click(|_, _, cx| open_config_folder(cx)),
                 )
                 .child(
                     Button::new("restart-after-config-error")

--- a/crates/openlogi-desktop/src/windows/settings/about.rs
+++ b/crates/openlogi-desktop/src/windows/settings/about.rs
@@ -5,6 +5,7 @@ use super::{
     ParentElement, RELEASES_URL, REPO_URL, SettingGroup, SettingItem, SettingPage, SettingsView,
     SharedString, Sizable, Styled, div, h_flex, img, px, v_flex,
 };
+use crate::app::menu::open_config_folder;
 use crate::ui::theme::Typography as _;
 
 /// The About page: a hero card with the build identity and outbound links, the
@@ -161,13 +162,7 @@ fn about_config(cx: &App) -> gpui::Div {
                 Button::new("about-reveal-config")
                     .outline()
                     .label(tr!("about.show_in_file_manager"))
-                    .on_click(|_, _, cx| {
-                        if let Ok(dir) = openlogi_core::paths::config_dir()
-                            && let Ok(url) = url::Url::from_file_path(&dir)
-                        {
-                            cx.open_url(url.as_str());
-                        }
-                    }),
+                    .on_click(|_, _, cx| open_config_folder(cx)),
             ),
         )
 }


### PR DESCRIPTION
## Summary

The **Open Configuration Folder** button on the fail-closed configuration-error
screen did nothing on Windows — no Explorer window, no error, no feedback.

It was the only `cx.dispatch_action` call site in the GUI. `App::dispatch_action`
routes through the *active* window instead of dispatching globally, and swallows
the failure when that window cannot be resolved:

```rust
if let Some(active_window) = self.active_window() {
    active_window
        .update(self, |_, window, cx| window.dispatch_action(action.boxed_clone(), cx))
        .log_err();               // <- "window not found", action dropped
} else {
    self.dispatch_global_action(action);
}
```

On that frame `active_window()` yields a handle `update()` cannot resolve, so the
`OpenConfigFolder` handler never ran. Instrumented capture of a real click:

```
WARN  openlogi_desktop::app::status: open-config-folder button clicked
ERROR gpui::app: window not found
```

The click reaches `on_click`; the handler is never entered.

This is also the one screen where a second window is always in play — an
unreadable config falls back to `Config::ephemeral()`, so `update_prompt_seen`
stays false and `runtime.rs:113` opens the update-consent window alongside the
error frame on every launch. That is the likely trigger for the unresolvable
handle; the dropped dispatch is what was directly observed.

The other two buttons that reveal the same folder (right panel → **Config
folder**, Settings → About → **Show in file manager**) call `cx.open_url`
directly and were unaffected. Verified during diagnosis that the path and URL
themselves are fine on Windows: `config_dir()` resolves to a mixed-separator
`C:\Users\…\.config/openlogi` (etcetera's `".config/"` default), which
`Url::from_file_path` normalizes to an identical, working
`file:///C:/Users/…/.config/openlogi`. That separator wart is real but cosmetic
and is left for a separate change.

## Changes

**`crates/openlogi-desktop`**

- `app/menu.rs`: add `open_config_folder`, the single reveal helper; the
  `OpenConfigFolder` action now delegates to it, and `file_url` becomes private.
- `app/status.rs`: the config-error button calls the helper directly instead of
  dispatching the action. This is the fix.
- `app/detail.rs`, `windows/settings/about.rs`: call the same helper, replacing
  two near-duplicate inline implementations (`about.rs` had its own copy of
  `Url::from_file_path`).

Only the menu bar, which has no view to call from, still goes through the action.

## Testing

Runtime-verified on Windows 11 Pro (10.0.26200) against a deterministic
reproduction - `schema_version = 99` in `config.toml` to force the error frame,
then clicking the button:

- **before:** click logged, `ERROR gpui::app: window not found`, no Explorer window.
- **after:** Explorer opens at `file:///C:/Users/.../.config/openlogi`, no error.

Not exercised on macOS or Linux; the changed code is not cfg-gated. That runtime
check predates the rebase; the rebased tip is verified by the gate below rather
than re-clicked.

Gate on Windows 11 Pro (10.0.26200), `RUSTFLAGS="-D warnings"`, on this branch rebased onto current `master` (`d5e2b880`).

- `cargo fmt --all -- --check` - pass
- `cargo clippy --workspace --all-targets -- -D warnings` - pass
- `cargo test -p openlogi-desktop` - pass

Two workspace steps fail on this Windows host, both **before** this change and
both on an untouched `master`:

- `cargo test --workspace` - `xtask` `ci_yml_runs_what_this_runner_runs`
- workspace rustdoc - unresolved link to `PermissionStatus::Unknown` in `openlogi-permissions`

Neither is touched by this diff. Both are Windows-only: `PermissionStatus` is
`cfg`-gated away on Windows, and the xtask parity test misparses `ci.yml` line
continuations under a CRLF checkout, so CI's Linux rustdoc and Linux/macOS test
jobs are unaffected. #970 fixes both, and all four steps pass on its branch off
the same `master` tip - which is the evidence they are not caused by this change.

### Rebase note

`master` migrated the locale catalogs to semantic TOML keys (#1169), which
rewrote the three `tr!` call sites this PR also edits. The conflicts are resolved
in favour of `master`'s keys (`profiles.config_folder`,
`app.open_configuration_folder`, `about.show_in_file_manager`) with this PR's
direct `open_config_folder(cx)` calls.

Collapsing the closure also drops `configuration_card` under
`clippy::too_many_lines`, so its `#[expect]` became unfulfilled and is removed -
`-D warnings` promotes `unfulfilled_lint_expectations` to an error, so this was a
hard clippy failure, not a warning.

Fixes #941
