### PR TITLE
fix(macos): resolve keyboard shortcuts under non-qwerty layouts

### DIFF
--- a/.claude/rules/objc-ffi.md
+++ b/.claude/rules/objc-ffi.md
@@ -180,7 +180,12 @@ its single user. The current set, all deliberate:
   same reason.
 - `openlogi-inject`: the `AXUIElement` subset it navigates with, plus
   `CFRetain`/`CFRelease`, and the `dlopen`/`dlsym`-resolved private SPIs
-  (`CoreDockSendNotification`, the CGS symbolic-hotkey trio).
+  (`CoreDockSendNotification`, the CGS symbolic-hotkey trio); also the Carbon
+  Text Input Source Services API (`TISCopyCurrentKeyboardLayoutInputSource` /
+  `TISGetInputSourceProperty` / `UCKeyTranslate` / `LMGetKbdType`) in
+  `keyboard_layout`, used to translate a shortcut's character to the vk that
+  currently produces it under the active keyboard layout (issue #343) — no
+  objc2 umbrella crate covers these.
 - the `disclaim` crate: `responsibility_spawnattrs_setdisclaim` (private SPI).
 
 Two of those are on the migrate-when-touched list rather than permanent:
@@ -219,6 +224,16 @@ under a `SAFETY` comment. Where it currently lives on macOS:
 - `camera/{capture,uvc/iokit}.rs` — the AVFoundation capture FFI and the IOKit
   USB plug-in; `uvc/iokit.rs` deliberately concentrates every `unsafe` of the
   macOS UVC backend so the descriptor parser above it is ordinary safe code.
+- `inject/macos.rs` — the `AXUIElement` browser-navigation walk, the
+  `dlopen`/`dlsym`-resolved Dock/CGS SPIs, `post_media_key`'s `NSEvent`
+  synthesis (with its own `autoreleasepool`, see below), and
+  `keyboard_layout`'s Carbon Text Input Source Services calls — the last
+  guarded by a process-wide `Mutex` (`TIS_LOCK`), not just a `SAFETY`
+  comment: `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a
+  shared XPC connection on first use, and two threads racing that bootstrap
+  crashes the process (`SIGABRT` inside `_xpc_connection_activate_if_needed`,
+  reproduced locally) — memory-safety per block isn't enough here, the calls
+  themselves aren't safe to interleave.
 
 ## CGEventTap stays on `core-graphics` — on purpose
 

--- a/.claude/rules/objc-ffi.md
+++ b/.claude/rules/objc-ffi.md
@@ -228,7 +228,7 @@ under a `SAFETY` comment. Where it currently lives on macOS:
   `dlopen`/`dlsym`-resolved Dock/CGS SPIs, `post_media_key`'s `NSEvent`
   synthesis (with its own `autoreleasepool`, see below), and
   `keyboard_layout`'s Carbon Text Input Source Services calls — the last
-  guarded by a process-wide `Mutex` (`TIS_LOCK`), not just a `SAFETY`
+  guarded by a process-wide `Mutex` (`LAYOUT_STATE`), not just a `SAFETY`
   comment: `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a
   shared XPC connection on first use, and two threads racing that bootstrap
   crashes the process (`SIGABRT` inside `_xpc_connection_activate_if_needed`,

--- a/crates/openlogi-core/src/binding/key_combo.rs
+++ b/crates/openlogi-core/src/binding/key_combo.rs
@@ -31,6 +31,33 @@ impl KeyboardUsage {
         self.into_inner()
     }
 
+    /// The printable ASCII character this usage's *unshifted* key produces on
+    /// a standard layout — the inverse of the character branches in this
+    /// module's `parse_key`. `None` for function/arrow/editing keys: a
+    /// keyboard layout switch never relocates those, so callers should keep
+    /// treating them positionally.
+    #[must_use]
+    pub fn ascii_char(self) -> Option<char> {
+        let code = self.into_inner();
+        match code {
+            0x04..=0x1d => Some(char::from(b'a' + code - 0x04)),
+            0x1e..=0x26 => Some(char::from(b'1' + code - 0x1e)),
+            0x27 => Some('0'),
+            0x2d => Some('-'),
+            0x2e => Some('='),
+            0x2f => Some('['),
+            0x30 => Some(']'),
+            0x31 => Some('\\'),
+            0x33 => Some(';'),
+            0x34 => Some('\''),
+            0x35 => Some('`'),
+            0x36 => Some(','),
+            0x37 => Some('.'),
+            0x38 => Some('/'),
+            _ => None,
+        }
+    }
+
     fn label(self) -> String {
         let code = self.into_inner();
         match code {
@@ -354,6 +381,23 @@ mod tests {
         let combo = "Cmd+A".parse::<KeyCombo>().expect("valid shortcut failed");
         assert_eq!(combo.key().code(), 0x04);
         assert_eq!(combo.rendered_label(), "Cmd+A");
+    }
+
+    #[test]
+    fn ascii_char_is_the_inverse_of_parse_key() {
+        let combo = "Cmd+S".parse::<KeyCombo>().expect("valid shortcut failed");
+        assert_eq!(combo.key().ascii_char(), Some('s'));
+
+        let combo = "Cmd+[".parse::<KeyCombo>().expect("valid shortcut failed");
+        assert_eq!(combo.key().ascii_char(), Some('['));
+
+        // Function/arrow/editing keys are not relocated by a layout switch.
+        let combo = "F5".parse::<KeyCombo>().expect("valid shortcut failed");
+        assert_eq!(combo.key().ascii_char(), None);
+        let combo = "Left".parse::<KeyCombo>().expect("valid shortcut failed");
+        assert_eq!(combo.key().ascii_char(), None);
+        let combo = "Enter".parse::<KeyCombo>().expect("valid shortcut failed");
+        assert_eq!(combo.key().ascii_char(), None);
     }
 
     #[test]

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -135,19 +135,24 @@ fn dispatch_native(native: NativeAction) {
         NativeAction::ShowDesktop => show_desktop(),
         NativeAction::LaunchpadShow => launchpad(),
         // Lock screen = Cmd+Ctrl+Q. Layout-aware lookup with the QWERTY
-        // kVK_ANSI_Q fallback (see post_keycombo / issue #343).
+        // kVK_ANSI_Q fallback (see post_keycombo / issue #343). Neither Cmd
+        // nor Ctrl are UCKeyTranslate modifier bits, so there's no base to
+        // pass here.
         NativeAction::LockScreen => {
-            let (vk, extra) = resolve_or('q', 0x0C);
+            let (vk, extra) = resolve_or('q', 0x0C, false, false);
             post_key(vk, cmd | ctrl | extra);
         }
-        // Screenshot = Cmd+Shift+3, same fallback pattern.
+        // Screenshot = Cmd+Shift+3, same fallback pattern. Shift is already
+        // part of this shortcut's own flags, so it's a mandatory base for
+        // the lookup too (Greptile review on #948).
         NativeAction::Screenshot => {
-            let (vk, extra) = resolve_or('3', 0x14);
+            let (vk, extra) = resolve_or('3', 0x14, true, false);
             post_key(vk, cmd | shift | extra);
         }
-        // Capture region to clipboard = Cmd+Shift+Ctrl+4, same fallback pattern.
+        // Capture region to clipboard = Cmd+Shift+Ctrl+4, same fallback
+        // pattern and same Shift base as Screenshot.
         NativeAction::CaptureRegion => {
-            let (vk, extra) = resolve_or('4', 0x15);
+            let (vk, extra) = resolve_or('4', 0x15, true, false);
             post_key(vk, cmd | shift | ctrl | extra);
         }
         // Sleep has no CGEvent equivalent (the WindowServer ignores a
@@ -383,10 +388,19 @@ fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
 /// Resolve `ch` to the vk that currently produces it under the active
 /// keyboard layout, plus any extra Shift/Option flags needed to reach it
 /// (e.g. digits sitting behind Shift on AZERTY — issue #343 follow-up).
-/// Falls back to `(fallback_vk, no extra flags)`, matching the pre-#343
-/// positional behavior, when the layout lookup can't resolve one.
-fn resolve_or(ch: char, fallback_vk: u16) -> (u16, CGEventFlags) {
-    match resolve_char(ch) {
+/// `base_shift`/`base_option` are modifiers the caller already holds
+/// regardless (e.g. Screenshot's own Shift) — see
+/// [`keyboard_layout::resolve_char_with_base`] for why the lookup must
+/// treat those as mandatory rather than searching in isolation. Falls back
+/// to `(fallback_vk, no extra flags)`, matching the pre-#343 positional
+/// behavior, when the layout lookup can't resolve one.
+fn resolve_or(
+    ch: char,
+    fallback_vk: u16,
+    base_shift: bool,
+    base_option: bool,
+) -> (u16, CGEventFlags) {
+    match resolve_char_with_base(ch, base_shift, base_option) {
         Some(resolved) => {
             let mut extra = CGEventFlags::CGEventFlagNull;
             if resolved.needs_shift {
@@ -406,12 +420,22 @@ fn resolve_or(ch: char, fallback_vk: u16) -> (u16, CGEventFlags) {
 fn post_keycombo(combo: &KeyCombo) {
     let mut flags = combo_flags(combo);
     // Layout-aware lookup first (issue #343): resolve the vk that currently
-    // produces this character under the active layout, ORing in any extra
-    // Shift/Option needed to reach it. Falls back to the static positional
-    // table when the key isn't a single ASCII character (function/arrow/
-    // editing keys — unaffected by layout switches) or when TIS/UCKeyTranslate
-    // can't resolve one (e.g. no active console session).
-    let vk = match combo.key().ascii_char().and_then(resolve_char) {
+    // produces this character under the active layout, searching from the
+    // combo's own Shift/Option as a mandatory base — those are held
+    // throughout the real key press, so a vk found ignoring them may not
+    // reproduce this character once they're folded in (Greptile review on
+    // #948: e.g. Cmd+Option+1 posted on the isolated Shift layer for '1'
+    // becomes Option+Shift once the combo's own Option is added, which
+    // isn't guaranteed to still be '1'). ORs in any extra Shift/Option
+    // beyond that base needed to reach it. Falls back to the static
+    // positional table when the key isn't a single ASCII character
+    // (function/arrow/editing keys — unaffected by layout switches) or when
+    // TIS/UCKeyTranslate can't resolve one (e.g. no active console session).
+    let vk = match combo
+        .key()
+        .ascii_char()
+        .and_then(|ch| resolve_char_with_base(ch, combo.has_shift(), combo.has_option()))
+    {
         Some(resolved) => {
             if resolved.needs_shift {
                 flags |= CGEventFlags::CGEventFlagShift;
@@ -483,7 +507,9 @@ mod tests {
     use core_graphics::event::CGEventFlags;
     use openlogi_core::binding::Shortcut;
 
-    use super::{combo, held_key_event, hid_usage_to_macos, keyboard_layout::resolve_char};
+    use super::{
+        combo, held_key_event, hid_usage_to_macos, keyboard_layout::resolve_char_with_base,
+    };
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
     #[test]
@@ -509,7 +535,8 @@ mod tests {
     /// to reach on any real layout.
     #[test]
     fn resolve_char_resolves_a_common_letter() {
-        let resolved = resolve_char('a').expect("no key produces 'a' under the active layout");
+        let resolved = resolve_char_with_base('a', false, false)
+            .expect("no key produces 'a' under the active layout");
         assert!(!resolved.needs_shift);
         assert!(!resolved.needs_option);
     }
@@ -523,7 +550,7 @@ mod tests {
     /// standard macOS keyboard layout.
     #[test]
     fn resolve_char_returns_none_for_unmapped_characters() {
-        assert!(resolve_char('好').is_none());
+        assert!(resolve_char_with_base('好', false, false).is_none());
     }
 
     /// Regression test for the Greptile review on PR #948: the original
@@ -531,20 +558,21 @@ mod tests {
     /// sitting behind Shift or Option on the active layout (e.g. digits on
     /// AZERTY) fell through to the QWERTY-positional fallback — reproducing
     /// the exact bug #343 exists to fix, just for a narrower set of
-    /// characters. `resolve_char` must search the shifted/optioned layers
-    /// too. This can't be pinned to a specific vk without controlling the
-    /// test runner's active layout, but it proves the modifier search
+    /// characters. `resolve_char_with_base` must search the shifted/optioned
+    /// layers too. This can't be pinned to a specific vk without controlling
+    /// the test runner's active layout, but it proves the modifier search
     /// itself is wired up: translating the resolved vk back under the
     /// reported modifier state must reproduce the target character.
     #[test]
     fn resolve_char_finds_characters_needing_shift_or_option() {
         // '!' through ')' sit behind Shift on a "U.S." layout and behind no
         // modifier on some others — whichever this runner's layout does,
-        // resolve_char must find *a* key, proving the shifted/optioned
-        // search paths are reachable and correct, not just present in name.
+        // resolve_char_with_base must find *a* key, proving the
+        // shifted/optioned search paths are reachable and correct, not just
+        // present in name.
         for ch in ['!', '@', '#', '$', '%'] {
             assert!(
-                resolve_char(ch).is_some(),
+                resolve_char_with_base(ch, false, false).is_some(),
                 "no key on any modifier layer produces {ch:?}"
             );
         }
@@ -554,16 +582,45 @@ mod tests {
     /// XPC connection inside HIToolbox on first use; two threads racing that
     /// bootstrap crashes the whole process with `SIGABRT` deep inside
     /// `_xpc_connection_activate_if_needed` (reproduced locally before
-    /// `keyboard_layout::TIS_LOCK` was added). Hammer `resolve_char` from
-    /// many threads at once so a regression that drops the lock shows up as
-    /// a crashed test binary, not a quiet flake.
+    /// `keyboard_layout::TIS_LOCK` was added). Hammer `resolve_char_with_base`
+    /// from many threads at once so a regression that drops the lock shows up
+    /// as a crashed test binary, not a quiet flake.
     #[test]
     fn resolve_char_is_safe_under_concurrent_calls() {
         let handles: Vec<_> = (0..32)
-            .map(|_| std::thread::spawn(|| resolve_char('a').is_some()))
+            .map(|_| std::thread::spawn(|| resolve_char_with_base('a', false, false).is_some()))
             .collect();
         for handle in handles {
             assert!(handle.join().expect("thread panicked"));
+        }
+    }
+
+    /// Regression test for the Greptile review on PR #948: `post_keycombo`
+    /// and `resolve_or` used to resolve a character with `resolve_char`,
+    /// which always searches Shift/Option in isolation from any modifier
+    /// the caller already holds (a combo's own Option, or
+    /// Screenshot/CaptureRegion's own Shift) — so the vk it returned was
+    /// only proven to reproduce the character *without* that modifier, not
+    /// once it's folded in for the real key press. `resolve_char_with_base`
+    /// must always report the caller's base as part of `needs_shift`/
+    /// `needs_option` rather than silently drop it: every layer this
+    /// function probes now includes the base, so a result can never claim a
+    /// mandatory modifier wasn't needed.
+    #[test]
+    fn resolve_char_with_base_never_drops_a_mandatory_base_modifier() {
+        for ch in ['!', '@', '#', '$', '%', 'a'] {
+            if let Some(resolved) = resolve_char_with_base(ch, false, true) {
+                assert!(
+                    resolved.needs_option,
+                    "resolved {ch:?} without the mandatory base Option"
+                );
+            }
+            if let Some(resolved) = resolve_char_with_base(ch, true, true) {
+                assert!(
+                    resolved.needs_shift && resolved.needs_option,
+                    "resolved {ch:?} without both mandatory base modifiers"
+                );
+            }
         }
     }
 
@@ -1248,7 +1305,7 @@ pub(super) fn ax_browser_navigate(forward: bool, pid: Option<i32>) -> bool {
 }
 
 use dock::{app_expose, launchpad, mission_control, show_desktop};
-use keyboard_layout::resolve_char;
+use keyboard_layout::resolve_char_with_base;
 use symbolic_hotkey::{next_desktop, previous_desktop};
 
 use app_services::symbol as app_services_symbol;
@@ -1629,10 +1686,13 @@ mod keyboard_layout {
     /// A character's key press under the active keyboard layout: which
     /// physical key produces it, and whether Shift and/or Option must be
     /// held to select that character's layer (e.g. digits sit behind Shift
-    /// on AZERTY). The caller ORs these into whatever modifiers the shortcut
-    /// itself already wants — holding Shift/Option to reach a character is
-    /// no different from what a real key press on that layout requires, so
-    /// it never conflicts with the shortcut's own modifier intent.
+    /// on AZERTY) — inclusive of whatever base the caller already asked
+    /// [`resolve_char_with_base`] to hold. The caller ORs these into
+    /// whatever modifiers the shortcut itself already wants; because the
+    /// base is folded in before the layout search runs (not after), the
+    /// result is proven to actually reproduce the target character under
+    /// the combined modifier state the real key press uses, not just under
+    /// each modifier searched in isolation.
     pub(super) struct ResolvedKey {
         pub(super) vk: u16,
         pub(super) needs_shift: bool,
@@ -1640,11 +1700,25 @@ mod keyboard_layout {
     }
 
     /// Resolve `target` to the vk that currently produces it under the
-    /// active keyboard layout, trying the unshifted layer first, then
-    /// Shift, then Option, then Shift+Option. Returns `None` if it can't be
-    /// determined (no active layout/console session, or no key on any of
-    /// those layers produces this character).
-    pub(super) fn resolve_char(target: char) -> Option<ResolvedKey> {
+    /// active keyboard layout. `base_shift`/`base_option` name modifiers
+    /// the caller is already going to hold regardless of what this lookup
+    /// finds (e.g. a shortcut's own Option, or `post_keycombo`'s
+    /// `combo.has_option()`). Those are mandatory throughout the real key
+    /// press, so every layer probed here includes them — searching without
+    /// the base could return a vk that only reproduces `target` in the
+    /// base's absence, and once the base modifiers are folded in for the
+    /// actual `CGEvent`, the character reaching the target app can be
+    /// something else entirely (Greptile review on #948: Cmd+Option+1 with
+    /// '1' behind an isolated Shift search becomes Option+Shift once the
+    /// combo's own Option is added, which is not guaranteed to still
+    /// produce '1'). Returns `None` if it can't be determined (no active
+    /// layout/console session, or no key on any layer that still includes
+    /// the base produces this character).
+    pub(super) fn resolve_char_with_base(
+        target: char,
+        base_shift: bool,
+        base_option: bool,
+    ) -> Option<ResolvedKey> {
         let _guard = TIS_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
 
         // SAFETY: TISCopyCurrentKeyboardLayoutInputSource follows the CF
@@ -1678,17 +1752,22 @@ mod keyboard_layout {
         // SAFETY: LMGetKbdType has no preconditions.
         let kbd_type = u32::from(unsafe { LMGetKbdType() });
 
-        for &(modifier_state, needs_shift, needs_option) in &[
+        // Every probed layer ORs the base in — base_shift/base_option are
+        // mandatory, not optional extras to search around.
+        let base_state =
+            (if base_shift { MOD_SHIFT } else { 0 }) | (if base_option { MOD_OPTION } else { 0 });
+        for &(extra_state, extra_shift, extra_option) in &[
             (0, false, false),
             (MOD_SHIFT, true, false),
             (MOD_OPTION, false, true),
             (MOD_SHIFT | MOD_OPTION, true, true),
         ] {
+            let modifier_state = base_state | extra_state;
             if let Some(vk) = find_vk(layout_ptr, kbd_type, modifier_state, target) {
                 return Some(ResolvedKey {
                     vk,
-                    needs_shift,
-                    needs_option,
+                    needs_shift: base_shift || extra_shift,
+                    needs_option: base_option || extra_option,
                 });
             }
         }

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -118,15 +118,14 @@ fn parse_shortcut(text: &str) -> KeyCombo {
         .unwrap_or_else(|error| unreachable!("hardcoded shortcut table entry {text:?}: {error}"))
 }
 
-/// Dispatch a window-manager or power [`NativeAction`].
+/// Dispatch a window-manager, power, or hardcoded-shortcut [`NativeAction`].
 ///
-/// These are all posted straight to the Dock or WindowServer via private
-/// SPIs rather than a synthesised keyboard chord — see the module docs on
-/// [`mission_control`] and friends for why.
+/// Most of these post straight to the Dock or WindowServer via private SPIs
+/// rather than a synthesised keyboard chord — see the module docs on
+/// [`mission_control`] and friends for why. `LockScreen`/`Screenshot`/
+/// `CaptureRegion` are the exception: they *are* well-known keyboard
+/// shortcuts, so they go through [`post_keycombo`] like any other chord.
 fn dispatch_native(native: NativeAction) {
-    let cmd = CGEventFlags::CGEventFlagCommand;
-    let shift = CGEventFlags::CGEventFlagShift;
-    let ctrl = CGEventFlags::CGEventFlagControl;
     match native {
         NativeAction::MissionControl => mission_control(),
         NativeAction::AppExpose => app_expose(),
@@ -134,27 +133,15 @@ fn dispatch_native(native: NativeAction) {
         NativeAction::NextDesktop => next_desktop(),
         NativeAction::ShowDesktop => show_desktop(),
         NativeAction::LaunchpadShow => launchpad(),
-        // Lock screen = Cmd+Ctrl+Q. Layout-aware lookup with the QWERTY
-        // kVK_ANSI_Q fallback (see post_keycombo / issue #343). Neither Cmd
-        // nor Ctrl are UCKeyTranslate modifier bits, so there's no base to
-        // pass here.
-        NativeAction::LockScreen => {
-            let (vk, extra) = resolve_or('q', 0x0C, false, false);
-            post_key(vk, cmd | ctrl | extra);
-        }
-        // Screenshot = Cmd+Shift+3, same fallback pattern. Shift is already
-        // part of this shortcut's own flags, so it's passed as the lookup's
-        // search preference too.
-        NativeAction::Screenshot => {
-            let (vk, extra) = resolve_or('3', 0x14, true, false);
-            post_key(vk, cmd | shift | extra);
-        }
-        // Capture region to clipboard = Cmd+Shift+Ctrl+4, same fallback
-        // pattern and same Shift base as Screenshot.
-        NativeAction::CaptureRegion => {
-            let (vk, extra) = resolve_or('4', 0x15, true, false);
-            post_key(vk, cmd | shift | ctrl | extra);
-        }
+        // Lock screen = Cmd+Ctrl+Q, Screenshot = Cmd+Shift+3, capture region
+        // to clipboard = Cmd+Shift+Ctrl+4 — all posted through post_keycombo
+        // so the layout-aware lookup and its QWERTY-positional fallback (see
+        // post_keycombo / issue #343) have exactly one implementation rather
+        // than a parallel one here that can drift out of sync with it (as it
+        // already did across this file's own history of fixes).
+        NativeAction::LockScreen => post_keycombo(&LOCK_SCREEN_COMBO),
+        NativeAction::Screenshot => post_keycombo(&SCREENSHOT_COMBO),
+        NativeAction::CaptureRegion => post_keycombo(&CAPTURE_REGION_COMBO),
         // Sleep has no CGEvent equivalent (the WindowServer ignores a
         // synthesised power key), so ask powermanagement directly. `pmset
         // sleepnow` works for the console user without privileges.
@@ -385,34 +372,31 @@ fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
     flags
 }
 
-/// Resolve `ch` to the vk that currently produces it under the active
-/// keyboard layout, plus any extra Shift/Option flags needed to reach it
-/// (e.g. digits sitting behind Shift on AZERTY — issue #343 follow-up).
-/// `base_shift`/`base_option` are modifiers the caller already holds
-/// regardless (e.g. Screenshot's own Shift) and are tried as a search
-/// preference — see [`keyboard_layout::resolve_char_with_base`]. Falls back
-/// to `(fallback_vk, no extra flags)`, matching the pre-#343 positional
-/// behavior, when the layout lookup can't resolve one.
-fn resolve_or(
-    ch: char,
-    fallback_vk: u16,
-    base_shift: bool,
-    base_option: bool,
-) -> (u16, CGEventFlags) {
-    match resolve_char_with_base(ch, base_shift, base_option) {
-        Some(resolved) => {
-            let mut extra = CGEventFlags::CGEventFlagNull;
-            if resolved.needs_shift {
-                extra |= CGEventFlags::CGEventFlagShift;
-            }
-            if resolved.needs_option {
-                extra |= CGEventFlags::CGEventFlagAlternate;
-            }
-            (resolved.vk, extra)
-        }
-        None => (fallback_vk, CGEventFlags::CGEventFlagNull),
-    }
-}
+/// Hardcoded OS shortcuts dispatched via [`post_keycombo`] rather than a
+/// user-configurable [`Shortcut`], so there is no [`combo`] table row for
+/// them. Parsed once — `expect` only fires on a typo in the literal below,
+/// never at runtime.
+#[expect(
+    clippy::expect_used,
+    reason = "parses a fixed literal; a panic here means the literal itself is malformed"
+)]
+static LOCK_SCREEN_COMBO: LazyLock<KeyCombo> =
+    LazyLock::new(|| "Cmd+Ctrl+Q".parse().expect("malformed hardcoded KeyCombo"));
+#[expect(
+    clippy::expect_used,
+    reason = "parses a fixed literal; a panic here means the literal itself is malformed"
+)]
+static SCREENSHOT_COMBO: LazyLock<KeyCombo> =
+    LazyLock::new(|| "Cmd+Shift+3".parse().expect("malformed hardcoded KeyCombo"));
+#[expect(
+    clippy::expect_used,
+    reason = "parses a fixed literal; a panic here means the literal itself is malformed"
+)]
+static CAPTURE_REGION_COMBO: LazyLock<KeyCombo> = LazyLock::new(|| {
+    "Cmd+Shift+Ctrl+4"
+        .parse()
+        .expect("malformed hardcoded KeyCombo")
+});
 
 /// Press a key chord described by a `KeyCombo` modifier bitmask + virtual
 /// keycode. Used by the workflow sequencer's `PressKey` step.
@@ -507,7 +491,9 @@ mod tests {
     use openlogi_core::binding::Shortcut;
 
     use super::{
-        combo, held_key_event, hid_usage_to_macos, keyboard_layout::resolve_char_with_base,
+        CAPTURE_REGION_COMBO, LOCK_SCREEN_COMBO, SCREENSHOT_COMBO, combo, held_key_event,
+        hid_usage_to_macos,
+        keyboard_layout::{candidate_order, resolve_char_with_base},
     };
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
@@ -581,7 +567,7 @@ mod tests {
     /// XPC connection inside HIToolbox on first use; two threads racing that
     /// bootstrap crashes the whole process with `SIGABRT` deep inside
     /// `_xpc_connection_activate_if_needed` (reproduced locally before
-    /// `keyboard_layout::TIS_LOCK` was added). Hammer `resolve_char_with_base`
+    /// `keyboard_layout::LAYOUT_STATE` was added). Hammer `resolve_char_with_base`
     /// from many threads at once so a regression that drops the lock shows up
     /// as a crashed test binary, not a quiet flake.
     #[test]
@@ -591,6 +577,71 @@ mod tests {
             .collect();
         for handle in handles {
             assert!(handle.join().expect("thread panicked"));
+        }
+    }
+
+    /// Regression test for a caching bug class rather than a specific
+    /// commit: a cache keyed on the wrong thing (or never invalidated) can
+    /// serve a stale or simply wrong answer on the second call even though
+    /// the first was correct. Repeated calls with the same arguments must
+    /// keep returning the identical vk and modifier flags — proving a cache
+    /// hit reproduces the original scan rather than some other cached
+    /// entry — and calls with *different* `base_shift`/`base_option` for
+    /// the same character must not collide on the same cache slot.
+    #[test]
+    fn resolve_char_with_base_cache_is_consistent_and_does_not_collide() {
+        let first = resolve_char_with_base('a', false, false)
+            .expect("no key produces 'a' under the active layout");
+        let second = resolve_char_with_base('a', false, false)
+            .expect("no key produces 'a' under the active layout");
+        assert_eq!(first.vk, second.vk);
+        assert_eq!(first.needs_shift, second.needs_shift);
+        assert_eq!(first.needs_option, second.needs_option);
+
+        // A different base for the same character must be resolved (and
+        // cached) independently, not conflated with the (false, false)
+        // entry above.
+        let with_base = resolve_char_with_base('a', true, true)
+            .expect("no key produces 'a' under the active layout even with a base");
+        assert_eq!(with_base.vk, first.vk);
+    }
+
+    /// The cache stores `Option<ResolvedKey>`, not just `ResolvedKey` — a
+    /// character no key on this layout produces (like '好', see
+    /// `resolve_char_returns_none_for_unmapped_characters`) must keep
+    /// returning `None` on a cache hit rather than, say, panicking on an
+    /// `unwrap` of an empty cache slot or falling through to some other
+    /// entry once the negative result is cached.
+    #[test]
+    fn resolve_char_with_base_caches_a_negative_result_too() {
+        assert!(resolve_char_with_base('好', false, false).is_none());
+        assert!(resolve_char_with_base('好', false, false).is_none());
+    }
+
+    /// Unit test for the pure lookup table `resolve_uncached` searches:
+    /// every arm must start with the base it was given, and its four
+    /// entries must be the four (Shift, Option) combinations with none
+    /// repeated and none missing — the exact property finding #1 needed
+    /// ("resolve_char_with_base's 5-entry search list always duplicates one
+    /// of the four canonical layers"). Checking this directly, rather than
+    /// only through `resolve_char_with_base`'s end-to-end behavior, means a
+    /// future edit that reintroduces a duplicate or drops a layer fails
+    /// here even for a layout where the dropped layer's character happens
+    /// to also be reachable elsewhere.
+    #[test]
+    fn candidate_order_starts_with_the_base_and_never_repeats_or_drops_a_layer() {
+        for base in [(false, false), (true, false), (false, true), (true, true)] {
+            let order = candidate_order(base.0, base.1);
+            assert_eq!(order[0], base, "base {base:?} was not tried first");
+
+            let mut sorted = order;
+            sorted.sort_unstable();
+            let mut all_four = [(false, false), (true, false), (false, true), (true, true)];
+            all_four.sort_unstable();
+            assert_eq!(
+                sorted, all_four,
+                "order for base {base:?} did not contain all four layers exactly once: {order:?}"
+            );
         }
     }
 
@@ -642,6 +693,20 @@ mod tests {
                 "{shortcut:?} table entry has no macOS virtual-key mapping"
             );
         }
+    }
+
+    /// Pin the hardcoded `NativeAction` shortcuts `dispatch_native` builds
+    /// once at startup, the same way `combo_table_pins_representative_shortcuts`
+    /// pins the user-configurable table — an edit to the literal strings
+    /// silently changing what Lock Screen/Screenshot/Capture Region send
+    /// would otherwise only surface as a runtime behavior change, not a
+    /// compile or parse error (`LOCK_SCREEN_COMBO` and friends only panic on
+    /// a genuinely malformed literal, not a wrong-but-valid one).
+    #[test]
+    fn native_action_combos_match_their_documented_shortcuts() {
+        assert_eq!(LOCK_SCREEN_COMBO.rendered_label(), "Cmd+Ctrl+Q");
+        assert_eq!(SCREENSHOT_COMBO.rendered_label(), "Cmd+Shift+3");
+        assert_eq!(CAPTURE_REGION_COMBO.rendered_label(), "Cmd+Ctrl+Shift+4");
     }
 
     #[test]
@@ -1622,16 +1687,31 @@ mod symbolic_hotkey {
     reason = "Carbon Text Input Source Services APIs require raw FFI"
 )]
 mod keyboard_layout {
+    use std::collections::HashMap;
     use std::ffi::c_void;
-    use std::sync::{Mutex, PoisonError};
+    use std::sync::{LazyLock, Mutex, PoisonError};
 
     use core_foundation::base::{CFType, TCFType as _};
     use core_foundation::data::CFData;
-    use core_foundation::string::CFStringRef;
+    use core_foundation::string::{CFString, CFStringRef};
 
     type CFTypeRef = *const c_void;
 
-    /// Serializes every call into the Text Input Source Services API below.
+    /// Every resolution this process has made under the layout named by
+    /// `source_id` (`kTISPropertyInputSourceID`, e.g.
+    /// `"com.apple.keylayout.US"`), keyed by the arguments that produced it.
+    /// A layout switch is detected by comparing `source_id` on the next
+    /// call — cheap (one more `TISGetInputSourceProperty`, not a rescan) —
+    /// and evicts the whole map rather than tracking per-entry freshness,
+    /// since a switch invalidates every cached vk at once anyway.
+    #[derive(Default)]
+    struct LayoutCache {
+        source_id: String,
+        entries: HashMap<(char, bool, bool), Option<ResolvedKey>>,
+    }
+
+    /// Guards every call into the Text Input Source Services API below, and
+    /// owns the [`LayoutCache`].
     ///
     /// `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a shared
     /// XPC connection inside HIToolbox on first use; two threads racing that
@@ -1640,8 +1720,13 @@ mod keyboard_layout {
     /// `_xpc_connection_activate_if_needed` — reproduced locally via a
     /// multi-threaded test run. A process-wide mutex avoids the race; the
     /// call is cheap enough (sub-millisecond once warm) that serializing it
-    /// is not a meaningful bottleneck at button-press frequency.
-    static TIS_LOCK: Mutex<()> = Mutex::new(());
+    /// is not a meaningful bottleneck at button-press frequency. Holding the
+    /// same mutex over the cache costs nothing extra — every access already
+    /// has to make that same cheap call to check `source_id` first — and
+    /// keeps the "no racing TIS calls" invariant from having to be proven
+    /// twice against two locks.
+    static LAYOUT_STATE: LazyLock<Mutex<LayoutCache>> =
+        LazyLock::new(|| Mutex::new(LayoutCache::default()));
 
     #[link(name = "Carbon", kind = "framework")]
     unsafe extern "C" {
@@ -1664,6 +1749,7 @@ mod keyboard_layout {
             unicode_string: *mut u16,
         ) -> i32;
         static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
+        static kTISPropertyInputSourceID: CFStringRef;
     }
 
     const KEY_ACTION_DOWN: u16 = 0; // kUCKeyActionDown
@@ -1699,6 +1785,7 @@ mod keyboard_layout {
     /// exactly the shortcuts issue #343 exists to fix (Greptile review on
     /// #948, "Combined modifier layer remains unverified" — not applicable
     /// for the reasons above; see the PR discussion for the citations).
+    #[derive(Clone, Copy)]
     pub(super) struct ResolvedKey {
         pub(super) vk: u16,
         pub(super) needs_shift: bool,
@@ -1729,7 +1816,7 @@ mod keyboard_layout {
         base_shift: bool,
         base_option: bool,
     ) -> Option<ResolvedKey> {
-        let _guard = TIS_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut state = LAYOUT_STATE.lock().unwrap_or_else(PoisonError::into_inner);
 
         // SAFETY: TISCopyCurrentKeyboardLayoutInputSource follows the CF
         // Copy rule (+1); CFType::wrap_under_create_rule takes ownership and
@@ -1742,6 +1829,58 @@ mod keyboard_layout {
         // TISInputSourceRef (Apple's documented Copy-rule contract for TIS).
         let source = unsafe { CFType::wrap_under_create_rule(source_ptr) };
 
+        // SAFETY: source is alive for this call; kTISPropertyInputSourceID
+        // is a valid CFStringRef exported by Carbon.framework.
+        let source_id_ptr = unsafe {
+            TISGetInputSourceProperty(source.as_concrete_TypeRef(), kTISPropertyInputSourceID)
+        };
+        // No stable identity to cache against — always resolve fresh rather
+        // than risk serving a stale answer from a previous layout.
+        let Some(source_id) = (!source_id_ptr.is_null()).then(|| {
+            // SAFETY: Get rule — not retained; the CFString is owned by
+            // `source`, which stays alive for this call, so this borrow is
+            // sound. wrap_under_get_rule does not release on drop.
+            unsafe { CFString::wrap_under_get_rule(source_id_ptr.cast()) }.to_string()
+        }) else {
+            return resolve_uncached(&source, target, base_shift, base_option);
+        };
+
+        if state.source_id != source_id {
+            *state = LayoutCache {
+                source_id,
+                entries: HashMap::new(),
+            };
+        }
+        if let Some(&cached) = state.entries.get(&(target, base_shift, base_option)) {
+            return cached;
+        }
+
+        let resolved = resolve_uncached(&source, target, base_shift, base_option);
+        state
+            .entries
+            .insert((target, base_shift, base_option), resolved);
+        resolved
+    }
+
+    /// The actual `UCKeyTranslate` scan, run on a cache miss (or when the
+    /// active input source has no `kTISPropertyInputSourceID` to cache
+    /// against at all). Tries the caller's own modifiers first: if the
+    /// layout happens to place `target` exactly where the shortcut already
+    /// holds Shift/Option, no extra modifier needs to be added at all. But
+    /// `target` is `ascii_char()`'s *unshifted* character regardless of what
+    /// the caller wants held (Cmd+Shift+Z must still find plain 'z', which
+    /// lives at the unshifted layer, not the Shift layer) — so the base is
+    /// a search preference, never a filter: the other three of the four
+    /// possible (Shift, Option) layers are always tried after it too,
+    /// unfiltered by the base. The base is exactly one of those four, so
+    /// it's excluded from the "other three" up front rather than probed
+    /// twice.
+    fn resolve_uncached(
+        source: &CFType,
+        target: char,
+        base_shift: bool,
+        base_option: bool,
+    ) -> Option<ResolvedKey> {
         // SAFETY: source is alive for this call; kTISPropertyUnicodeKeyLayoutData
         // is a valid CFStringRef exported by Carbon.framework.
         let layout_data_ptr = unsafe {
@@ -1762,21 +1901,7 @@ mod keyboard_layout {
         // SAFETY: LMGetKbdType has no preconditions.
         let kbd_type = u32::from(unsafe { LMGetKbdType() });
 
-        // Try the caller's own modifiers first: if the layout happens to
-        // place `target` exactly where the shortcut already holds
-        // Shift/Option, no extra modifier needs to be added at all. But
-        // `target` is `ascii_char()`'s *unshifted* character regardless of
-        // what the caller wants held (Cmd+Shift+Z must still find plain
-        // 'z', which lives at the unshifted layer, not the Shift layer) —
-        // so the base is a search preference, never a filter: every
-        // standard layer is tried after it, unfiltered by the base.
-        for &(shift, option) in &[
-            (base_shift, base_option),
-            (false, false),
-            (true, false),
-            (false, true),
-            (true, true),
-        ] {
+        for &(shift, option) in &candidate_order(base_shift, base_option) {
             let modifier_state =
                 (if shift { MOD_SHIFT } else { 0 }) | (if option { MOD_OPTION } else { 0 });
             if let Some(vk) = find_vk(layout_ptr, kbd_type, modifier_state, target) {
@@ -1788,6 +1913,22 @@ mod keyboard_layout {
             }
         }
         None
+    }
+
+    /// The four possible (Shift, Option) layers to probe for a target
+    /// character, with `(base_shift, base_option)` moved to the front. The
+    /// base is always exactly one of the four, so each arm lists it once
+    /// followed by the other three — never a fifth, duplicate probe of the
+    /// base itself. A pure, allocation-free lookup table rather than a
+    /// filter over the full four, so it's trivial to check by inspection
+    /// (and to unit test) that no arm repeats an entry or drops one.
+    pub(super) const fn candidate_order(base_shift: bool, base_option: bool) -> [(bool, bool); 4] {
+        match (base_shift, base_option) {
+            (false, false) => [(false, false), (true, false), (false, true), (true, true)],
+            (true, false) => [(true, false), (false, false), (false, true), (true, true)],
+            (false, true) => [(false, true), (false, false), (true, false), (true, true)],
+            (true, true) => [(true, true), (false, false), (true, false), (false, true)],
+        }
     }
 
     /// Search every virtual keycode for one that translates to `target`

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -1680,11 +1680,25 @@ mod keyboard_layout {
     /// A character's key press under the active keyboard layout: which
     /// physical key produces it, and which of Shift/Option must be held to
     /// select that character's layer (e.g. digits sit behind Shift on
-    /// AZERTY). These are the *exact* modifiers the layer was found under —
-    /// never a superset of some caller-supplied base — so the caller ORing
-    /// them into whatever modifiers the shortcut itself already wants is
-    /// proven to still reproduce the target character, not just "probably
-    /// harmless" if the two happen to agree.
+    /// AZERTY). These name the layer `target` — always the key's *unshifted*
+    /// identity character — was actually found under; the caller ORs them
+    /// into whatever *other* modifiers the shortcut wants (a combo's own
+    /// Shift/Option, or Command/Control), which can legitimately produce a
+    /// modifier combination never itself run through `UCKeyTranslate`. That
+    /// is not a gap to close: a real physical Cmd+Shift+Z keypress doesn't
+    /// "produce" the character 'z' either (holding Shift changes the vk's
+    /// output to 'Z'), and it reliably triggers Redo regardless — because
+    /// `NSEvent.charactersIgnoringModifiers`, what AppKit's key-equivalent
+    /// matching is built on, explicitly ignores Option and Command and
+    /// honors only Shift, and the standard `NSMenuItem` convention is a
+    /// lowercase/unshifted `keyEquivalent` plus a separate
+    /// `keyEquivalentModifierMask` — not a re-derived shifted character.
+    /// Raw vk+modifier-mask global-hotkey listeners (this codebase's own
+    /// `openlogi-hook` included) don't translate a character at all. Trying
+    /// to verify the full combined state against `target` would reject
+    /// exactly the shortcuts issue #343 exists to fix (Greptile review on
+    /// #948, "Combined modifier layer remains unverified" — not applicable
+    /// for the reasons above; see the PR discussion for the citations).
     pub(super) struct ResolvedKey {
         pub(super) vk: u16,
         pub(super) needs_shift: bool,
@@ -1705,9 +1719,11 @@ mod keyboard_layout {
     /// unfiltered by the base, precisely so a base that doesn't match where
     /// the layout actually puts the character (the common case for
     /// Shift/Option shortcuts on printable keys) doesn't defeat the lookup
-    /// (Greptile review on #948, "Base modifiers defeat layout lookup").
-    /// Returns `None` if it can't be determined (no active layout/console
-    /// session, or no key on any layer produces this character).
+    /// (Greptile review on #948, "Base modifiers defeat layout lookup"). See
+    /// [`ResolvedKey`] for why the layer found here is never re-verified
+    /// against the caller's *other* modifiers. Returns `None` if it can't be
+    /// determined (no active layout/console session, or no key on any layer
+    /// produces this character).
     pub(super) fn resolve_char_with_base(
         target: char,
         base_shift: bool,

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -1,6 +1,7 @@
 //! Platform helpers for synthesising OS-level input events on macOS.
 
-use std::sync::{LazyLock, Mutex};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, PoisonError};
 
 use core_graphics::event::{
     CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGMouseButton, EventField,
@@ -11,7 +12,8 @@ use core_graphics::geometry::CGPoint;
 
 use core_foundation::base::TCFType as _;
 use openlogi_core::binding::{
-    Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
+    Action, Effect, KeyCombo, KeyboardUsage, MediaKey, MouseButton, NativeAction, Script, Shortcut,
+    WorkflowStep,
 };
 use openlogi_core::scroll::ScrollDelta;
 
@@ -322,20 +324,77 @@ fn post_held_key(key: HeldKey, phase: KeyPhase, modifiers: &mut HeldModifiers) {
     post_key_phase(vk, flags, phase);
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PinnedHeldKey {
+    vk: u16,
+    needs_shift: bool,
+    needs_option: bool,
+}
+
+static PINNED_HELD_KEYS: LazyLock<Mutex<HashMap<KeyboardUsage, PinnedHeldKey>>> =
+    LazyLock::new(|| Mutex::new(HashMap::default()));
+
 fn held_key_event(
     key: HeldKey,
     phase: KeyPhase,
     modifiers: &mut HeldModifiers,
 ) -> Option<(u16, CGEventFlags)> {
     modifiers.set(key, phase == KeyPhase::Down);
-    let vk = match key {
-        HeldKey::Command => Some(0x37),
-        HeldKey::Shift => Some(0x38),
-        HeldKey::Alt => Some(0x3a),
-        HeldKey::Control => Some(0x3b),
-        HeldKey::Key(usage) => hid_usage_to_macos(usage.code()),
-    }?;
-    Some((vk, held_modifier_flags(*modifiers)))
+    match key {
+        HeldKey::Command => Some((0x37, held_modifier_flags(*modifiers))),
+        HeldKey::Shift => Some((0x38, held_modifier_flags(*modifiers))),
+        HeldKey::Alt => Some((0x3a, held_modifier_flags(*modifiers))),
+        HeldKey::Control => Some((0x3b, held_modifier_flags(*modifiers))),
+        HeldKey::Key(usage) => {
+            let pinned = match phase {
+                KeyPhase::Down => {
+                    let pinned = resolve_held_usage(usage, *modifiers)?;
+                    let mut lock = PINNED_HELD_KEYS
+                        .lock()
+                        .unwrap_or_else(PoisonError::into_inner);
+                    lock.insert(usage, pinned);
+                    pinned
+                }
+                KeyPhase::Up => {
+                    let mut lock = PINNED_HELD_KEYS
+                        .lock()
+                        .unwrap_or_else(PoisonError::into_inner);
+                    lock.remove(&usage)
+                        .or_else(|| resolve_held_usage(usage, *modifiers))?
+                }
+            };
+            let mut flags = held_modifier_flags(*modifiers);
+            if pinned.needs_shift {
+                flags |= CGEventFlags::CGEventFlagShift;
+            }
+            if pinned.needs_option {
+                flags |= CGEventFlags::CGEventFlagAlternate;
+            }
+            Some((pinned.vk, flags))
+        }
+    }
+}
+
+fn resolve_held_usage(usage: KeyboardUsage, modifiers: HeldModifiers) -> Option<PinnedHeldKey> {
+    if let Some(ch) = usage.ascii_char()
+        && let Some(resolved) = resolve_char_with_base(
+            ch,
+            modifiers.contains(HeldKey::Command),
+            modifiers.contains(HeldKey::Shift),
+            modifiers.contains(HeldKey::Alt),
+        )
+    {
+        return Some(PinnedHeldKey {
+            vk: resolved.vk,
+            needs_shift: resolved.needs_shift,
+            needs_option: resolved.needs_option,
+        });
+    }
+    hid_usage_to_macos(usage.code()).map(|vk| PinnedHeldKey {
+        vk,
+        needs_shift: false,
+        needs_option: false,
+    })
 }
 
 fn held_modifier_flags(modifiers: HeldModifiers) -> CGEventFlags {
@@ -404,21 +463,23 @@ fn post_keycombo(combo: &KeyCombo) {
     let mut flags = combo_flags(combo);
     // Layout-aware lookup first (issue #343): resolve the vk that currently
     // produces this character under the active layout, preferring the
-    // combo's own Shift/Option layer but always falling back to whichever
-    // layer the layout actually puts the character on — `ascii_char()` is
-    // always the *unshifted* character, so a Shift/Option shortcut (e.g.
-    // Cmd+Shift+Z) must still be able to find it at the unshifted layer, not
-    // just the layer matching the combo's own modifiers (Greptile review on
-    // #948, "Base modifiers defeat layout lookup"). ORs in whatever
-    // Shift/Option the layer was actually found under. Falls back to the
-    // static positional table when the key isn't a single ASCII character
-    // (function/arrow/editing keys — unaffected by layout switches) or when
-    // TIS/UCKeyTranslate can't resolve one (e.g. no active console session).
-    let vk = match combo
-        .key()
-        .ascii_char()
-        .and_then(|ch| resolve_char_with_base(ch, combo.has_shift(), combo.has_option()))
-    {
+    // combo's own Shift/Option layer and passing whether Command is held
+    // (for Command-dependent layouts like "Dvorak – QWERTY ⌘" which switch to
+    // QWERTY under Command). Always falls back to whichever layer the layout
+    // actually puts the character on — `ascii_char()` is always the *unshifted*
+    // character, so a Shift/Option shortcut (e.g. Cmd+Shift+Z) must still be able
+    // to find it at the unshifted layer. ORs in whatever Shift/Option the layer
+    // was actually found under. Falls back to the static positional table when
+    // the key isn't a single ASCII character (function/arrow/editing keys) or
+    // when TIS/UCKeyTranslate can't resolve one.
+    let vk = match combo.key().ascii_char().and_then(|ch| {
+        resolve_char_with_base(
+            ch,
+            combo.has_command(),
+            combo.has_shift(),
+            combo.has_option(),
+        )
+    }) {
         Some(resolved) => {
             if resolved.needs_shift {
                 flags |= CGEventFlags::CGEventFlagShift;
@@ -488,12 +549,15 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use core_graphics::event::CGEventFlags;
-    use openlogi_core::binding::Shortcut;
+    use openlogi_core::binding::{KeyboardUsage, Shortcut};
 
     use super::{
         CAPTURE_REGION_COMBO, LOCK_SCREEN_COMBO, SCREENSHOT_COMBO, combo, held_key_event,
         hid_usage_to_macos,
-        keyboard_layout::{candidate_order, resolve_char_with_base},
+        keyboard_layout::{
+            ResolvedKey, candidate_order, installed_layout_data, resolve_char_from_layout,
+            resolve_char_with_base,
+        },
     };
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
@@ -507,127 +571,9 @@ mod tests {
         assert_eq!(hid_usage_to_macos(0xff), None);
     }
 
-    /// Exercises the real TIS/UCKeyTranslate path (not just the static
-    /// fallback table) against whatever keyboard layout is actually active
-    /// on the machine running this test. Deliberately does not assert
-    /// *which* vk comes back: unlike a QWERTY-only assumption, this repo's
-    /// own dev machines aren't guaranteed to run a "U.S." layout (issue #343
-    /// exists precisely because that assumption doesn't hold — this test was
-    /// first written on a machine with Dvorak active, where 's' legitimately
-    /// resolves to a different vk than `hid_usage_to_macos`'s QWERTY-pinned
-    /// one). Every keyboard layout maps the letter 'a' to *some* physical
-    /// key, so this should never be `None`, and 'a' never needs a modifier
-    /// to reach on any real layout.
-    #[test]
-    fn resolve_char_resolves_a_common_letter() {
-        let resolved = resolve_char_with_base('a', false, false)
-            .expect("no key produces 'a' under the active layout");
-        assert!(!resolved.needs_shift);
-        assert!(!resolved.needs_option);
-    }
-
-    /// A character no physical key produces under any layout/modifier
-    /// combination resolves to `None` rather than panicking or looping
-    /// forever. '€' deliberately isn't used here: with Shift/Option now
-    /// searched too, it's reachable via Option+Shift+2 on common Mac
-    /// layouts, so it doesn't exercise the "truly unmapped" path. A CJK
-    /// character needs IME composition, not a bare modifier layer, on every
-    /// standard macOS keyboard layout.
-    #[test]
-    fn resolve_char_returns_none_for_unmapped_characters() {
-        assert!(resolve_char_with_base('好', false, false).is_none());
-    }
-
-    /// Regression test for the Greptile review on PR #948: the original
-    /// `vk_for_char` only searched the unshifted layer, so a character
-    /// sitting behind Shift or Option on the active layout (e.g. digits on
-    /// AZERTY) fell through to the QWERTY-positional fallback — reproducing
-    /// the exact bug #343 exists to fix, just for a narrower set of
-    /// characters. `resolve_char_with_base` must search the shifted/optioned
-    /// layers too. This can't be pinned to a specific vk without controlling
-    /// the test runner's active layout, but it proves the modifier search
-    /// itself is wired up: translating the resolved vk back under the
-    /// reported modifier state must reproduce the target character.
-    #[test]
-    fn resolve_char_finds_characters_needing_shift_or_option() {
-        // '!' through ')' sit behind Shift on a "U.S." layout and behind no
-        // modifier on some others — whichever this runner's layout does,
-        // resolve_char_with_base must find *a* key, proving the
-        // shifted/optioned search paths are reachable and correct, not just
-        // present in name.
-        for ch in ['!', '@', '#', '$', '%'] {
-            assert!(
-                resolve_char_with_base(ch, false, false).is_some(),
-                "no key on any modifier layer produces {ch:?}"
-            );
-        }
-    }
-
-    /// `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a shared
-    /// XPC connection inside HIToolbox on first use; two threads racing that
-    /// bootstrap crashes the whole process with `SIGABRT` deep inside
-    /// `_xpc_connection_activate_if_needed` (reproduced locally before
-    /// `keyboard_layout::LAYOUT_STATE` was added). Hammer `resolve_char_with_base`
-    /// from many threads at once so a regression that drops the lock shows up
-    /// as a crashed test binary, not a quiet flake.
-    #[test]
-    fn resolve_char_is_safe_under_concurrent_calls() {
-        let handles: Vec<_> = (0..32)
-            .map(|_| std::thread::spawn(|| resolve_char_with_base('a', false, false).is_some()))
-            .collect();
-        for handle in handles {
-            assert!(handle.join().expect("thread panicked"));
-        }
-    }
-
-    /// Regression test for a caching bug class rather than a specific
-    /// commit: a cache keyed on the wrong thing (or never invalidated) can
-    /// serve a stale or simply wrong answer on the second call even though
-    /// the first was correct. Repeated calls with the same arguments must
-    /// keep returning the identical vk and modifier flags — proving a cache
-    /// hit reproduces the original scan rather than some other cached
-    /// entry — and calls with *different* `base_shift`/`base_option` for
-    /// the same character must not collide on the same cache slot.
-    #[test]
-    fn resolve_char_with_base_cache_is_consistent_and_does_not_collide() {
-        let first = resolve_char_with_base('a', false, false)
-            .expect("no key produces 'a' under the active layout");
-        let second = resolve_char_with_base('a', false, false)
-            .expect("no key produces 'a' under the active layout");
-        assert_eq!(first.vk, second.vk);
-        assert_eq!(first.needs_shift, second.needs_shift);
-        assert_eq!(first.needs_option, second.needs_option);
-
-        // A different base for the same character must be resolved (and
-        // cached) independently, not conflated with the (false, false)
-        // entry above.
-        let with_base = resolve_char_with_base('a', true, true)
-            .expect("no key produces 'a' under the active layout even with a base");
-        assert_eq!(with_base.vk, first.vk);
-    }
-
-    /// The cache stores `Option<ResolvedKey>`, not just `ResolvedKey` — a
-    /// character no key on this layout produces (like '好', see
-    /// `resolve_char_returns_none_for_unmapped_characters`) must keep
-    /// returning `None` on a cache hit rather than, say, panicking on an
-    /// `unwrap` of an empty cache slot or falling through to some other
-    /// entry once the negative result is cached.
-    #[test]
-    fn resolve_char_with_base_caches_a_negative_result_too() {
-        assert!(resolve_char_with_base('好', false, false).is_none());
-        assert!(resolve_char_with_base('好', false, false).is_none());
-    }
-
-    /// Unit test for the pure lookup table `resolve_uncached` searches:
-    /// every arm must start with the base it was given, and its four
-    /// entries must be the four (Shift, Option) combinations with none
-    /// repeated and none missing — the exact property finding #1 needed
-    /// ("resolve_char_with_base's 5-entry search list always duplicates one
-    /// of the four canonical layers"). Checking this directly, rather than
-    /// only through `resolve_char_with_base`'s end-to-end behavior, means a
-    /// future edit that reintroduces a duplicate or drops a layer fails
-    /// here even for a layout where the dropped layer's character happens
-    /// to also be reachable elsewhere.
+    /// Unit test for the pure candidate order table: every arm must start
+    /// with the base it was given, and its four entries must be the four
+    /// (Shift, Option) combinations with none repeated and none missing.
     #[test]
     fn candidate_order_starts_with_the_base_and_never_repeats_or_drops_a_layer() {
         for base in [(false, false), (true, false), (false, true), (true, true)] {
@@ -645,28 +591,248 @@ mod tests {
         }
     }
 
-    /// Regression test for the Greptile review on PR #948 ("Base modifiers
-    /// defeat layout lookup"): an earlier revision treated the caller's own
-    /// Shift/Option (e.g. `post_keycombo` passing `combo.has_shift()` for a
-    /// Cmd+Shift+Z shortcut) as a *mandatory* floor for every probed layer.
-    /// But `ascii_char()` is always the key's unshifted character, and
-    /// holding Shift changes what a key produces — so a mandatory Shift
-    /// base meant the unshifted layer, where 'z' actually lives, was never
-    /// searched at all, and the lookup fell through to `None` for every
-    /// Shift/Option shortcut on a printable key. `base_shift`/`base_option`
-    /// must be a search *preference*: a letter has to resolve (with no
-    /// extra modifier reported) even when the caller passes a base that
-    /// doesn't match where the layout actually places it.
+    /// Controlled fixture test against standard US keyboard layout data:
+    /// verifies unshifted letters, shifted symbols, and unmapped characters
+    /// without relying on the test runner's live input source.
     #[test]
-    fn resolve_char_with_base_still_finds_unshifted_letters() {
-        for (base_shift, base_option) in
-            [(false, false), (true, false), (false, true), (true, true)]
-        {
-            let resolved = resolve_char_with_base('a', base_shift, base_option)
-                .expect("no key produces 'a' under the active layout even with a base");
+    fn us_layout_fixture_resolves_common_and_shifted_characters() {
+        let Some(layout_data) = installed_layout_data("com.apple.keylayout.US") else {
+            return;
+        };
+        let layout_ptr = layout_data.bytes().as_ptr().cast();
+
+        // Common letter 'a' is at ANSI A (vk 0x00) with no modifier needed.
+        let resolved = resolve_char_from_layout(layout_ptr, 0, 'a', false, false, false);
+        assert_eq!(
+            resolved,
+            Some(ResolvedKey {
+                vk: 0x00,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+
+        // 'a' with base_shift=true still resolves unshifted 'a' at vk 0x00 without spurious needs_shift.
+        let resolved = resolve_char_from_layout(layout_ptr, 0, 'a', false, true, false);
+        assert_eq!(
+            resolved,
+            Some(ResolvedKey {
+                vk: 0x00,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+
+        // Shifted digits/symbols ('!' is on Shift+1, vk 0x12).
+        let resolved = resolve_char_from_layout(layout_ptr, 0, '!', false, false, false);
+        assert_eq!(
+            resolved,
+            Some(ResolvedKey {
+                vk: 0x12,
+                needs_shift: true,
+                needs_option: false,
+            })
+        );
+
+        for ch in ['@', '#', '$', '%'] {
+            let resolved = resolve_char_from_layout(layout_ptr, 0, ch, false, false, false);
+            assert!(
+                resolved.is_some_and(|r| r.needs_shift),
+                "expected {ch:?} to require shift on US layout"
+            );
+        }
+
+        // Unmapped CJK character produces None.
+        assert_eq!(
+            resolve_char_from_layout(layout_ptr, 0, '好', false, false, false),
+            None
+        );
+    }
+
+    /// Tests Command-dependent layout resolution for Apple's built-in
+    /// "Dvorak – QWERTY ⌘" layout (`com.apple.keylayout.Dvorak-QWERTYCmd`).
+    /// Under this layout, holding Command explicitly switches key mappings
+    /// back to QWERTY positions so shortcuts like Cmd+C, Cmd+S, Cmd+V, Cmd+Z
+    /// match standard physical key locations.
+    #[test]
+    fn dvorak_qwerty_cmd_switches_to_qwerty_when_command_is_held() {
+        let Some(layout_data) = installed_layout_data("com.apple.keylayout.Dvorak-QWERTYCmd")
+        else {
+            return;
+        };
+        let layout_ptr = layout_data.bytes().as_ptr().cast();
+
+        // 'c': without Cmd -> Dvorak 'c' (QWERTY 'i' key, vk 0x22)
+        //      with Cmd    -> QWERTY 'c' (vk 0x08)
+        let without_cmd = resolve_char_from_layout(layout_ptr, 0, 'c', false, false, false);
+        assert_eq!(
+            without_cmd,
+            Some(ResolvedKey {
+                vk: 0x22,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+        let with_cmd = resolve_char_from_layout(layout_ptr, 0, 'c', true, false, false);
+        assert_eq!(
+            with_cmd,
+            Some(ResolvedKey {
+                vk: 0x08,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+
+        // 's': without Cmd -> Dvorak 's' (QWERTY 'o' key, vk 0x1f)
+        //      with Cmd    -> QWERTY 's' (vk 0x01)
+        let without_cmd = resolve_char_from_layout(layout_ptr, 0, 's', false, false, false);
+        assert_eq!(
+            without_cmd,
+            Some(ResolvedKey {
+                vk: 0x1f,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+        let with_cmd = resolve_char_from_layout(layout_ptr, 0, 's', true, false, false);
+        assert_eq!(
+            with_cmd,
+            Some(ResolvedKey {
+                vk: 0x01,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+
+        // 'v': without Cmd -> Dvorak 'v' (QWERTY '.' key, vk 0x2f)
+        //      with Cmd    -> QWERTY 'v' (vk 0x09)
+        let without_cmd = resolve_char_from_layout(layout_ptr, 0, 'v', false, false, false);
+        assert_eq!(
+            without_cmd,
+            Some(ResolvedKey {
+                vk: 0x2f,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+        let with_cmd = resolve_char_from_layout(layout_ptr, 0, 'v', true, false, false);
+        assert_eq!(
+            with_cmd,
+            Some(ResolvedKey {
+                vk: 0x09,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+
+        // 'z': without Cmd -> Dvorak 'z' (QWERTY '\'' key, vk 0x27)
+        //      with Cmd    -> QWERTY 'z' (vk 0x06)
+        let without_cmd = resolve_char_from_layout(layout_ptr, 0, 'z', false, false, false);
+        assert_eq!(
+            without_cmd,
+            Some(ResolvedKey {
+                vk: 0x27,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+        let with_cmd = resolve_char_from_layout(layout_ptr, 0, 'z', true, false, false);
+        assert_eq!(
+            with_cmd,
+            Some(ResolvedKey {
+                vk: 0x06,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+    }
+
+    /// Held keys must pin their resolved virtual keycode on KeyPhase::Down
+    /// and release the exact same keycode on KeyPhase::Up, preventing stuck
+    /// keys across layout changes.
+    #[test]
+    fn held_keys_pin_resolved_vk_across_phase_transitions() {
+        let usage_c = KeyboardUsage::try_from(0x06).expect("0x06 is valid usage for 'c'");
+        let mut modifiers = HeldModifiers::default();
+
+        let (_, flags_cmd) = held_key_event(HeldKey::Command, KeyPhase::Down, &mut modifiers)
+            .expect("Command has vk");
+        assert!(flags_cmd.contains(CGEventFlags::CGEventFlagCommand));
+
+        let (vk_down, flags_down) =
+            held_key_event(HeldKey::Key(usage_c), KeyPhase::Down, &mut modifiers)
+                .expect("usage has vk");
+        assert!(flags_down.contains(CGEventFlags::CGEventFlagCommand));
+
+        let (vk_up, flags_up) = held_key_event(HeldKey::Key(usage_c), KeyPhase::Up, &mut modifiers)
+            .expect("usage has vk");
+        assert_eq!(
+            vk_down, vk_up,
+            "held key must release the identical pinned vk"
+        );
+        assert!(flags_up.contains(CGEventFlags::CGEventFlagCommand));
+
+        let (_, flags_cmd_up) =
+            held_key_event(HeldKey::Command, KeyPhase::Up, &mut modifiers).expect("Command has vk");
+        assert!(!flags_cmd_up.contains(CGEventFlags::CGEventFlagCommand));
+    }
+
+    /// Optional live TIS smoke test: if an active console session is present,
+    /// verifies that resolution does not panic or crash.
+    #[test]
+    fn resolve_char_live_tis_smoke_test() {
+        if let Some(resolved) = resolve_char_with_base('a', false, false, false) {
             assert!(!resolved.needs_shift);
             assert!(!resolved.needs_option);
         }
+    }
+
+    /// Concurrency safety test: hammering resolve_char_with_base from 32 threads
+    /// does not crash with SIGABRT during lazy XPC bootstrap.
+    #[test]
+    fn resolve_char_is_safe_under_concurrent_calls() {
+        let handles: Vec<_> = (0..32)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    let _ = resolve_char_with_base('a', false, false, false);
+                    let _ = resolve_char_with_base('c', true, false, false);
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("thread panicked");
+        }
+    }
+
+    /// Verifies that layout resolution distinguishes all modifier dimensions
+    /// (Command, Shift, Option) so cache entries cannot collide across layers.
+    #[test]
+    fn cache_is_keyed_by_all_modifier_dimensions() {
+        let Some(layout_data) = installed_layout_data("com.apple.keylayout.Dvorak-QWERTYCmd")
+        else {
+            return;
+        };
+        let layout_ptr = layout_data.bytes().as_ptr().cast();
+
+        let no_cmd = resolve_char_from_layout(layout_ptr, 0, 'c', false, false, false);
+        let with_cmd = resolve_char_from_layout(layout_ptr, 0, 'c', true, false, false);
+        assert_ne!(no_cmd, with_cmd);
+        assert_eq!(
+            no_cmd,
+            Some(ResolvedKey {
+                vk: 0x22,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
+        assert_eq!(
+            with_cmd,
+            Some(ResolvedKey {
+                vk: 0x08,
+                needs_shift: false,
+                needs_option: false,
+            })
+        );
     }
 
     /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an
@@ -1699,15 +1865,17 @@ mod keyboard_layout {
 
     /// Every resolution this process has made under the layout named by
     /// `source_id` (`kTISPropertyInputSourceID`, e.g.
-    /// `"com.apple.keylayout.US"`), keyed by the arguments that produced it.
-    /// A layout switch is detected by comparing `source_id` on the next
-    /// call — cheap (one more `TISGetInputSourceProperty`, not a rescan) —
+    /// `"com.apple.keylayout.US"`) and `kbd_type` (`LMGetKbdType()`), keyed by
+    /// the arguments that produced it. A layout or keyboard-type switch is
+    /// detected by comparing `(source_id, kbd_type)` on the next call — cheap
+    /// (one more `TISGetInputSourceProperty` + `LMGetKbdType()`, not a rescan) —
     /// and evicts the whole map rather than tracking per-entry freshness,
     /// since a switch invalidates every cached vk at once anyway.
     #[derive(Default)]
     struct LayoutCache {
         source_id: String,
-        entries: HashMap<(char, bool, bool), Option<ResolvedKey>>,
+        kbd_type: u32,
+        entries: HashMap<(char, bool, bool, bool), Option<ResolvedKey>>,
     }
 
     /// Guards every call into the Text Input Source Services API below, and
@@ -1731,6 +1899,11 @@ mod keyboard_layout {
     #[link(name = "Carbon", kind = "framework")]
     unsafe extern "C" {
         fn TISCopyCurrentKeyboardLayoutInputSource() -> CFTypeRef;
+        #[cfg(test)]
+        fn TISCreateInputSourceList(
+            properties: core_foundation::dictionary::CFDictionaryRef,
+            include_all_installed: bool,
+        ) -> core_foundation::array::CFArrayRef;
         fn TISGetInputSourceProperty(
             input_source: CFTypeRef,
             property_key: CFStringRef,
@@ -1758,8 +1931,10 @@ mod keyboard_layout {
     const NO_DEAD_KEYS: u32 = 1;
 
     // UCKeyTranslate's modifierKeyState packs the classic Toolbox modifier
-    // mask into bits 8-15: `(eventModifiers >> 8) & 0xFF`. shiftKey = 0x0200,
-    // optionKey = 0x0800, so shifted right 8 gives 0x02 / 0x08.
+    // mask into bits 8-15: `(eventModifiers >> 8) & 0xFF`. cmdKey = 0x0100,
+    // shiftKey = 0x0200, optionKey = 0x0800, so shifted right 8 gives
+    // 0x01 / 0x02 / 0x08.
+    const MOD_COMMAND: u32 = 0x01;
     const MOD_SHIFT: u32 = 0x02;
     const MOD_OPTION: u32 = 0x08;
 
@@ -1785,7 +1960,7 @@ mod keyboard_layout {
     /// exactly the shortcuts issue #343 exists to fix (Greptile review on
     /// #948, "Combined modifier layer remains unverified" — not applicable
     /// for the reasons above; see the PR discussion for the citations).
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub(super) struct ResolvedKey {
         pub(super) vk: u16,
         pub(super) needs_shift: bool,
@@ -1797,8 +1972,10 @@ mod keyboard_layout {
     /// character (see `KeyboardUsage::ascii_char`), independent of what
     /// modifiers the caller's shortcut wants held — a Cmd+Shift+Z shortcut
     /// must still resolve plain 'z', which typically lives at the unshifted
-    /// layer, not the Shift layer. `base_shift`/`base_option` are only a
-    /// *search preference*: if the caller already holds Shift/Option for
+    /// layer, not the Shift layer. `has_command` includes Command in the probed
+    /// modifier state so Command-dependent layouts (like "Dvorak – QWERTY ⌘")
+    /// correctly switch to their Command layer. `base_shift`/`base_option` are
+    /// a *search preference*: if the caller already holds Shift/Option for
     /// other reasons (a combo's own modifier, or Screenshot/CaptureRegion's
     /// own Shift) and the layout happens to place `target` exactly there
     /// too, trying that layer first avoids reporting a spurious extra
@@ -1813,6 +1990,7 @@ mod keyboard_layout {
     /// produces this character).
     pub(super) fn resolve_char_with_base(
         target: char,
+        has_command: bool,
         base_shift: bool,
         base_option: bool,
     ) -> Option<ResolvedKey> {
@@ -1834,6 +2012,9 @@ mod keyboard_layout {
         let source_id_ptr = unsafe {
             TISGetInputSourceProperty(source.as_concrete_TypeRef(), kTISPropertyInputSourceID)
         };
+        // SAFETY: LMGetKbdType has no preconditions.
+        let kbd_type = u32::from(unsafe { LMGetKbdType() });
+
         // No stable identity to cache against — always resolve fresh rather
         // than risk serving a stale answer from a previous layout.
         let Some(source_id) = (!source_id_ptr.is_null()).then(|| {
@@ -1842,42 +2023,33 @@ mod keyboard_layout {
             // sound. wrap_under_get_rule does not release on drop.
             unsafe { CFString::wrap_under_get_rule(source_id_ptr.cast()) }.to_string()
         }) else {
-            return resolve_uncached(&source, target, base_shift, base_option);
+            return resolve_uncached(&source, target, has_command, base_shift, base_option);
         };
 
-        if state.source_id != source_id {
+        if state.source_id != source_id || state.kbd_type != kbd_type {
             *state = LayoutCache {
                 source_id,
+                kbd_type,
                 entries: HashMap::new(),
             };
         }
-        if let Some(&cached) = state.entries.get(&(target, base_shift, base_option)) {
+        let cache_key = (target, has_command, base_shift, base_option);
+        if let Some(&cached) = state.entries.get(&cache_key) {
             return cached;
         }
 
-        let resolved = resolve_uncached(&source, target, base_shift, base_option);
-        state
-            .entries
-            .insert((target, base_shift, base_option), resolved);
+        let resolved = resolve_uncached(&source, target, has_command, base_shift, base_option);
+        state.entries.insert(cache_key, resolved);
         resolved
     }
 
     /// The actual `UCKeyTranslate` scan, run on a cache miss (or when the
     /// active input source has no `kTISPropertyInputSourceID` to cache
-    /// against at all). Tries the caller's own modifiers first: if the
-    /// layout happens to place `target` exactly where the shortcut already
-    /// holds Shift/Option, no extra modifier needs to be added at all. But
-    /// `target` is `ascii_char()`'s *unshifted* character regardless of what
-    /// the caller wants held (Cmd+Shift+Z must still find plain 'z', which
-    /// lives at the unshifted layer, not the Shift layer) — so the base is
-    /// a search preference, never a filter: the other three of the four
-    /// possible (Shift, Option) layers are always tried after it too,
-    /// unfiltered by the base. The base is exactly one of those four, so
-    /// it's excluded from the "other three" up front rather than probed
-    /// twice.
+    /// against at all).
     fn resolve_uncached(
         source: &CFType,
         target: char,
+        has_command: bool,
         base_shift: bool,
         base_option: bool,
     ) -> Option<ResolvedKey> {
@@ -1901,9 +2073,38 @@ mod keyboard_layout {
         // SAFETY: LMGetKbdType has no preconditions.
         let kbd_type = u32::from(unsafe { LMGetKbdType() });
 
+        resolve_char_from_layout(
+            layout_ptr,
+            kbd_type,
+            target,
+            has_command,
+            base_shift,
+            base_option,
+        )
+    }
+
+    /// Resolve `target` on `layout_ptr` under `kbd_type` and candidate modifier layers.
+    /// Tries the caller's own modifiers first: if the layout happens to place
+    /// `target` exactly where the shortcut already holds Shift/Option, no extra
+    /// modifier needs to be added at all. But `target` is `ascii_char()`'s
+    /// *unshifted* character regardless of what the caller wants held (Cmd+Shift+Z
+    /// must still find plain 'z', which lives at the unshifted layer, not the Shift
+    /// layer) — so the base is a search preference, never a filter: the other three
+    /// of the four possible (Shift, Option) layers are always tried after it too,
+    /// unfiltered by the base.
+    pub(super) fn resolve_char_from_layout(
+        layout_ptr: *const c_void,
+        kbd_type: u32,
+        target: char,
+        has_command: bool,
+        base_shift: bool,
+        base_option: bool,
+    ) -> Option<ResolvedKey> {
+        let command_mask = if has_command { MOD_COMMAND } else { 0 };
         for &(shift, option) in &candidate_order(base_shift, base_option) {
-            let modifier_state =
-                (if shift { MOD_SHIFT } else { 0 }) | (if option { MOD_OPTION } else { 0 });
+            let modifier_state = command_mask
+                | (if shift { MOD_SHIFT } else { 0 })
+                | (if option { MOD_OPTION } else { 0 });
             if let Some(vk) = find_vk(layout_ptr, kbd_type, modifier_state, target) {
                 return Some(ResolvedKey {
                     vk,
@@ -1966,6 +2167,44 @@ mod keyboard_layout {
                 && char::from_u32(u32::from(unichar_buf[0])) == Some(target)
             {
                 return Some(vk);
+            }
+        }
+        None
+    }
+
+    #[cfg(test)]
+    pub(super) fn installed_layout_data(source_id: &str) -> Option<CFData> {
+        let _guard = LAYOUT_STATE.lock().unwrap_or_else(PoisonError::into_inner);
+        // SAFETY: TISCreateInputSourceList with null properties and true lists all installed layouts (+1 retain, Create rule).
+        let list_ptr = unsafe { TISCreateInputSourceList(std::ptr::null(), true) };
+        if list_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: list_ptr is a non-null +1 CFArrayRef from TISCreateInputSourceList; wrap_under_create_rule takes ownership.
+        let list = unsafe {
+            core_foundation::array::CFArray::<CFTypeRef>::wrap_under_create_rule(list_ptr)
+        };
+        for item in list.iter() {
+            let source_ptr = *item;
+            // SAFETY: source_ptr is a valid TISInputSourceRef; kTISPropertyInputSourceID is a valid CFStringRef.
+            let id_ptr =
+                unsafe { TISGetInputSourceProperty(source_ptr, kTISPropertyInputSourceID) };
+            if id_ptr.is_null() {
+                continue;
+            }
+            // SAFETY: Get rule — borrowed from source_ptr which remains alive in this loop iteration.
+            let source_identifier =
+                unsafe { CFString::wrap_under_get_rule(id_ptr.cast()) }.to_string();
+            if source_identifier == source_id {
+                // SAFETY: source_ptr is valid; kTISPropertyUnicodeKeyLayoutData is a valid CFStringRef.
+                let data_ptr = unsafe {
+                    TISGetInputSourceProperty(source_ptr, kTISPropertyUnicodeKeyLayoutData)
+                };
+                if !data_ptr.is_null() {
+                    // SAFETY: Get rule — borrowed from source_ptr; clone() creates an owned retain.
+                    let data = unsafe { CFData::wrap_under_get_rule(data_ptr.cast()) };
+                    return Some(data.clone());
+                }
             }
         }
         None

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -143,8 +143,8 @@ fn dispatch_native(native: NativeAction) {
             post_key(vk, cmd | ctrl | extra);
         }
         // Screenshot = Cmd+Shift+3, same fallback pattern. Shift is already
-        // part of this shortcut's own flags, so it's a mandatory base for
-        // the lookup too (Greptile review on #948).
+        // part of this shortcut's own flags, so it's passed as the lookup's
+        // search preference too.
         NativeAction::Screenshot => {
             let (vk, extra) = resolve_or('3', 0x14, true, false);
             post_key(vk, cmd | shift | extra);
@@ -389,9 +389,8 @@ fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
 /// keyboard layout, plus any extra Shift/Option flags needed to reach it
 /// (e.g. digits sitting behind Shift on AZERTY — issue #343 follow-up).
 /// `base_shift`/`base_option` are modifiers the caller already holds
-/// regardless (e.g. Screenshot's own Shift) — see
-/// [`keyboard_layout::resolve_char_with_base`] for why the lookup must
-/// treat those as mandatory rather than searching in isolation. Falls back
+/// regardless (e.g. Screenshot's own Shift) and are tried as a search
+/// preference — see [`keyboard_layout::resolve_char_with_base`]. Falls back
 /// to `(fallback_vk, no extra flags)`, matching the pre-#343 positional
 /// behavior, when the layout lookup can't resolve one.
 fn resolve_or(
@@ -420,15 +419,15 @@ fn resolve_or(
 fn post_keycombo(combo: &KeyCombo) {
     let mut flags = combo_flags(combo);
     // Layout-aware lookup first (issue #343): resolve the vk that currently
-    // produces this character under the active layout, searching from the
-    // combo's own Shift/Option as a mandatory base — those are held
-    // throughout the real key press, so a vk found ignoring them may not
-    // reproduce this character once they're folded in (Greptile review on
-    // #948: e.g. Cmd+Option+1 posted on the isolated Shift layer for '1'
-    // becomes Option+Shift once the combo's own Option is added, which
-    // isn't guaranteed to still be '1'). ORs in any extra Shift/Option
-    // beyond that base needed to reach it. Falls back to the static
-    // positional table when the key isn't a single ASCII character
+    // produces this character under the active layout, preferring the
+    // combo's own Shift/Option layer but always falling back to whichever
+    // layer the layout actually puts the character on — `ascii_char()` is
+    // always the *unshifted* character, so a Shift/Option shortcut (e.g.
+    // Cmd+Shift+Z) must still be able to find it at the unshifted layer, not
+    // just the layer matching the combo's own modifiers (Greptile review on
+    // #948, "Base modifiers defeat layout lookup"). ORs in whatever
+    // Shift/Option the layer was actually found under. Falls back to the
+    // static positional table when the key isn't a single ASCII character
     // (function/arrow/editing keys — unaffected by layout switches) or when
     // TIS/UCKeyTranslate can't resolve one (e.g. no active console session).
     let vk = match combo
@@ -595,32 +594,27 @@ mod tests {
         }
     }
 
-    /// Regression test for the Greptile review on PR #948: `post_keycombo`
-    /// and `resolve_or` used to resolve a character with `resolve_char`,
-    /// which always searches Shift/Option in isolation from any modifier
-    /// the caller already holds (a combo's own Option, or
-    /// Screenshot/CaptureRegion's own Shift) — so the vk it returned was
-    /// only proven to reproduce the character *without* that modifier, not
-    /// once it's folded in for the real key press. `resolve_char_with_base`
-    /// must always report the caller's base as part of `needs_shift`/
-    /// `needs_option` rather than silently drop it: every layer this
-    /// function probes now includes the base, so a result can never claim a
-    /// mandatory modifier wasn't needed.
+    /// Regression test for the Greptile review on PR #948 ("Base modifiers
+    /// defeat layout lookup"): an earlier revision treated the caller's own
+    /// Shift/Option (e.g. `post_keycombo` passing `combo.has_shift()` for a
+    /// Cmd+Shift+Z shortcut) as a *mandatory* floor for every probed layer.
+    /// But `ascii_char()` is always the key's unshifted character, and
+    /// holding Shift changes what a key produces — so a mandatory Shift
+    /// base meant the unshifted layer, where 'z' actually lives, was never
+    /// searched at all, and the lookup fell through to `None` for every
+    /// Shift/Option shortcut on a printable key. `base_shift`/`base_option`
+    /// must be a search *preference*: a letter has to resolve (with no
+    /// extra modifier reported) even when the caller passes a base that
+    /// doesn't match where the layout actually places it.
     #[test]
-    fn resolve_char_with_base_never_drops_a_mandatory_base_modifier() {
-        for ch in ['!', '@', '#', '$', '%', 'a'] {
-            if let Some(resolved) = resolve_char_with_base(ch, false, true) {
-                assert!(
-                    resolved.needs_option,
-                    "resolved {ch:?} without the mandatory base Option"
-                );
-            }
-            if let Some(resolved) = resolve_char_with_base(ch, true, true) {
-                assert!(
-                    resolved.needs_shift && resolved.needs_option,
-                    "resolved {ch:?} without both mandatory base modifiers"
-                );
-            }
+    fn resolve_char_with_base_still_finds_unshifted_letters() {
+        for (base_shift, base_option) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            let resolved = resolve_char_with_base('a', base_shift, base_option)
+                .expect("no key produces 'a' under the active layout even with a base");
+            assert!(!resolved.needs_shift);
+            assert!(!resolved.needs_option);
         }
     }
 
@@ -1684,15 +1678,13 @@ mod keyboard_layout {
     const MOD_OPTION: u32 = 0x08;
 
     /// A character's key press under the active keyboard layout: which
-    /// physical key produces it, and whether Shift and/or Option must be
-    /// held to select that character's layer (e.g. digits sit behind Shift
-    /// on AZERTY) — inclusive of whatever base the caller already asked
-    /// [`resolve_char_with_base`] to hold. The caller ORs these into
-    /// whatever modifiers the shortcut itself already wants; because the
-    /// base is folded in before the layout search runs (not after), the
-    /// result is proven to actually reproduce the target character under
-    /// the combined modifier state the real key press uses, not just under
-    /// each modifier searched in isolation.
+    /// physical key produces it, and which of Shift/Option must be held to
+    /// select that character's layer (e.g. digits sit behind Shift on
+    /// AZERTY). These are the *exact* modifiers the layer was found under —
+    /// never a superset of some caller-supplied base — so the caller ORing
+    /// them into whatever modifiers the shortcut itself already wants is
+    /// proven to still reproduce the target character, not just "probably
+    /// harmless" if the two happen to agree.
     pub(super) struct ResolvedKey {
         pub(super) vk: u16,
         pub(super) needs_shift: bool,
@@ -1700,20 +1692,22 @@ mod keyboard_layout {
     }
 
     /// Resolve `target` to the vk that currently produces it under the
-    /// active keyboard layout. `base_shift`/`base_option` name modifiers
-    /// the caller is already going to hold regardless of what this lookup
-    /// finds (e.g. a shortcut's own Option, or `post_keycombo`'s
-    /// `combo.has_option()`). Those are mandatory throughout the real key
-    /// press, so every layer probed here includes them — searching without
-    /// the base could return a vk that only reproduces `target` in the
-    /// base's absence, and once the base modifiers are folded in for the
-    /// actual `CGEvent`, the character reaching the target app can be
-    /// something else entirely (Greptile review on #948: Cmd+Option+1 with
-    /// '1' behind an isolated Shift search becomes Option+Shift once the
-    /// combo's own Option is added, which is not guaranteed to still
-    /// produce '1'). Returns `None` if it can't be determined (no active
-    /// layout/console session, or no key on any layer that still includes
-    /// the base produces this character).
+    /// active keyboard layout. `target` is always the key's *unshifted*
+    /// character (see `KeyboardUsage::ascii_char`), independent of what
+    /// modifiers the caller's shortcut wants held — a Cmd+Shift+Z shortcut
+    /// must still resolve plain 'z', which typically lives at the unshifted
+    /// layer, not the Shift layer. `base_shift`/`base_option` are only a
+    /// *search preference*: if the caller already holds Shift/Option for
+    /// other reasons (a combo's own modifier, or Screenshot/CaptureRegion's
+    /// own Shift) and the layout happens to place `target` exactly there
+    /// too, trying that layer first avoids reporting a spurious extra
+    /// modifier requirement. Every other layer is still tried afterward,
+    /// unfiltered by the base, precisely so a base that doesn't match where
+    /// the layout actually puts the character (the common case for
+    /// Shift/Option shortcuts on printable keys) doesn't defeat the lookup
+    /// (Greptile review on #948, "Base modifiers defeat layout lookup").
+    /// Returns `None` if it can't be determined (no active layout/console
+    /// session, or no key on any layer produces this character).
     pub(super) fn resolve_char_with_base(
         target: char,
         base_shift: bool,
@@ -1752,22 +1746,28 @@ mod keyboard_layout {
         // SAFETY: LMGetKbdType has no preconditions.
         let kbd_type = u32::from(unsafe { LMGetKbdType() });
 
-        // Every probed layer ORs the base in — base_shift/base_option are
-        // mandatory, not optional extras to search around.
-        let base_state =
-            (if base_shift { MOD_SHIFT } else { 0 }) | (if base_option { MOD_OPTION } else { 0 });
-        for &(extra_state, extra_shift, extra_option) in &[
-            (0, false, false),
-            (MOD_SHIFT, true, false),
-            (MOD_OPTION, false, true),
-            (MOD_SHIFT | MOD_OPTION, true, true),
+        // Try the caller's own modifiers first: if the layout happens to
+        // place `target` exactly where the shortcut already holds
+        // Shift/Option, no extra modifier needs to be added at all. But
+        // `target` is `ascii_char()`'s *unshifted* character regardless of
+        // what the caller wants held (Cmd+Shift+Z must still find plain
+        // 'z', which lives at the unshifted layer, not the Shift layer) —
+        // so the base is a search preference, never a filter: every
+        // standard layer is tried after it, unfiltered by the base.
+        for &(shift, option) in &[
+            (base_shift, base_option),
+            (false, false),
+            (true, false),
+            (false, true),
+            (true, true),
         ] {
-            let modifier_state = base_state | extra_state;
+            let modifier_state =
+                (if shift { MOD_SHIFT } else { 0 }) | (if option { MOD_OPTION } else { 0 });
             if let Some(vk) = find_vk(layout_ptr, kbd_type, modifier_state, target) {
                 return Some(ResolvedKey {
                     vk,
-                    needs_shift: base_shift || extra_shift,
-                    needs_option: base_option || extra_option,
+                    needs_shift: shift,
+                    needs_option: option,
                 });
             }
         }

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -134,12 +134,15 @@ fn dispatch_native(native: NativeAction) {
         NativeAction::NextDesktop => next_desktop(),
         NativeAction::ShowDesktop => show_desktop(),
         NativeAction::LaunchpadShow => launchpad(),
-        // Lock screen = Cmd+Ctrl+Q (kVK_ANSI_Q = 0x0C)
-        NativeAction::LockScreen => post_key(0x0C, cmd | ctrl),
-        // Screenshot = Cmd+Shift+3 (kVK_ANSI_3 = 0x14)
-        NativeAction::Screenshot => post_key(0x14, cmd | shift),
-        // Capture region to clipboard = Cmd+Shift+Ctrl+4 (kVK_ANSI_4 = 0x15)
-        NativeAction::CaptureRegion => post_key(0x15, cmd | shift | ctrl),
+        // Lock screen = Cmd+Ctrl+Q. Layout-aware lookup with the QWERTY
+        // kVK_ANSI_Q fallback (see post_keycombo / issue #343).
+        NativeAction::LockScreen => post_key(vk_for_char('q').unwrap_or(0x0C), cmd | ctrl),
+        // Screenshot = Cmd+Shift+3, same fallback pattern.
+        NativeAction::Screenshot => post_key(vk_for_char('3').unwrap_or(0x14), cmd | shift),
+        // Capture region to clipboard = Cmd+Shift+Ctrl+4, same fallback pattern.
+        NativeAction::CaptureRegion => {
+            post_key(vk_for_char('4').unwrap_or(0x15), cmd | shift | ctrl);
+        }
         // Sleep has no CGEvent equivalent (the WindowServer ignores a
         // synthesised power key), so ask powermanagement directly. `pmset
         // sleepnow` works for the console user without privileges.
@@ -285,19 +288,6 @@ fn post_unicode(text: &str) {
     }
 }
 
-/// Press a key chord described by a `KeyCombo` modifier bitmask + virtual
-/// keycode. Used by the workflow sequencer's `PressKey` step.
-fn post_keycombo(combo: &KeyCombo) {
-    if let Some(vk) = hid_usage_to_macos(combo.key().code()) {
-        post_key(vk, combo_flags(combo));
-    } else {
-        tracing::warn!(
-            usage = combo.key().code(),
-            "shortcut usage has no macOS mapping"
-        );
-    }
-}
-
 /// Emit the physical-key edges whose shared ownership changed, preserving the
 /// aggregate synthetic modifier state on every event.
 pub(super) fn hold_keys(
@@ -383,6 +373,30 @@ fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
     flags
 }
 
+/// Press a key chord described by a `KeyCombo` modifier bitmask + virtual
+/// keycode. Used by the workflow sequencer's `PressKey` step.
+fn post_keycombo(combo: &KeyCombo) {
+    let flags = combo_flags(combo);
+    // Layout-aware lookup first (issue #343): resolve the vk that currently
+    // produces this character under the active layout. Falls back to the
+    // static positional table when the key isn't a single ASCII character
+    // (function/arrow/editing keys — unaffected by layout switches) or when
+    // TIS/UCKeyTranslate can't resolve one (e.g. no active console session).
+    let vk = combo
+        .key()
+        .ascii_char()
+        .and_then(vk_for_char)
+        .or_else(|| hid_usage_to_macos(combo.key().code()));
+    if let Some(vk) = vk {
+        post_key(vk, flags);
+    } else {
+        tracing::warn!(
+            usage = combo.key().code(),
+            "shortcut usage has no macOS mapping"
+        );
+    }
+}
+
 /// Map a platform-neutral USB HID keyboard usage to a macOS virtual key.
 fn hid_usage_to_macos(usage: u8) -> Option<u16> {
     const LETTERS: [u16; 26] = [
@@ -433,7 +447,7 @@ mod tests {
     use core_graphics::event::CGEventFlags;
     use openlogi_core::binding::Shortcut;
 
-    use super::{combo, held_key_event, hid_usage_to_macos};
+    use super::{combo, held_key_event, hid_usage_to_macos, keyboard_layout::vk_for_char};
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
     #[test]
@@ -444,6 +458,45 @@ mod tests {
         assert_eq!(hid_usage_to_macos(0x3a), Some(0x7a));
         assert_eq!(hid_usage_to_macos(0x6f), Some(0x5a));
         assert_eq!(hid_usage_to_macos(0xff), None);
+    }
+
+    /// Exercises the real TIS/UCKeyTranslate path (not just the static
+    /// fallback table) against whatever keyboard layout is actually active
+    /// on the machine running this test. Deliberately does not assert
+    /// *which* vk comes back: unlike a QWERTY-only assumption, this repo's
+    /// own dev machines aren't guaranteed to run a "U.S." layout (issue #343
+    /// exists precisely because that assumption doesn't hold — this test was
+    /// first written on a machine with Dvorak active, where 's' legitimately
+    /// resolves to a different vk than `hid_usage_to_macos`'s QWERTY-pinned
+    /// one). Every keyboard layout maps the letter 'a' to *some* physical
+    /// key, so this should never be `None`.
+    #[test]
+    fn vk_for_char_resolves_a_common_letter() {
+        assert!(vk_for_char('a').is_some());
+    }
+
+    /// A character no physical key produces under any layout resolves to
+    /// `None` rather than panicking or looping forever.
+    #[test]
+    fn vk_for_char_returns_none_for_unmapped_characters() {
+        assert_eq!(vk_for_char('€'), None);
+    }
+
+    /// `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a shared
+    /// XPC connection inside HIToolbox on first use; two threads racing that
+    /// bootstrap crashes the whole process with `SIGABRT` deep inside
+    /// `_xpc_connection_activate_if_needed` (reproduced locally before
+    /// `keyboard_layout::TIS_LOCK` was added). Hammer `vk_for_char` from many
+    /// threads at once so a regression that drops the lock shows up as a
+    /// crashed test binary, not a quiet flake.
+    #[test]
+    fn vk_for_char_is_safe_under_concurrent_calls() {
+        let handles: Vec<_> = (0..32)
+            .map(|_| std::thread::spawn(|| vk_for_char('a')))
+            .collect();
+        for handle in handles {
+            assert!(handle.join().expect("thread panicked").is_some());
+        }
     }
 
     /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an
@@ -1127,6 +1180,7 @@ pub(super) fn ax_browser_navigate(forward: bool, pid: Option<i32>) -> bool {
 }
 
 use dock::{app_expose, launchpad, mission_control, show_desktop};
+use keyboard_layout::vk_for_char;
 use symbolic_hotkey::{next_desktop, previous_desktop};
 
 use app_services::symbol as app_services_symbol;
@@ -1424,5 +1478,142 @@ mod symbolic_hotkey {
             assert!(result.is_err());
             assert_eq!(RESTORED_HOTKEY.load(Ordering::Relaxed), super::SPACE_LEFT);
         }
+    }
+}
+
+/// Translate a printable character to the macOS virtual keycode that
+/// currently produces it (unshifted) under the user's active keyboard
+/// layout — fixes issue #343, where a hardcoded QWERTY-positional vk fires
+/// the wrong shortcut under Dvorak/Workman/etc.
+///
+/// Uses the Carbon Text Input Source Services API
+/// (`TISCopyCurrentKeyboardLayoutInputSource` / `TISGetInputSourceProperty` /
+/// `UCKeyTranslate` / `LMGetKbdType`) — no typed bindings exist for these in
+/// any objc2 umbrella crate, so this is a raw `extern "C"` block against
+/// `Carbon.framework`, same pattern as [`ax_nav`] above for `AXUIElement`.
+/// `CFType`/`CFData` from `core_foundation` still handle ownership of the
+/// Copy-rule input source and the Get-rule layout-data blob, rather than
+/// hand-declaring a second `CFRelease`.
+#[expect(
+    unsafe_code,
+    reason = "Carbon Text Input Source Services APIs require raw FFI"
+)]
+mod keyboard_layout {
+    use std::ffi::c_void;
+    use std::sync::{Mutex, PoisonError};
+
+    use core_foundation::base::{CFType, TCFType as _};
+    use core_foundation::data::CFData;
+    use core_foundation::string::CFStringRef;
+
+    type CFTypeRef = *const c_void;
+
+    /// Serializes every call into the Text Input Source Services API below.
+    ///
+    /// `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a shared
+    /// XPC connection inside HIToolbox on first use; two threads racing that
+    /// bootstrap (e.g. two shortcuts firing back to back on the hook/gesture
+    /// dispatch threads) crashes the process with a `SIGABRT` deep inside
+    /// `_xpc_connection_activate_if_needed` — reproduced locally via a
+    /// multi-threaded test run. A process-wide mutex avoids the race; the
+    /// call is cheap enough (sub-millisecond once warm) that serializing it
+    /// is not a meaningful bottleneck at button-press frequency.
+    static TIS_LOCK: Mutex<()> = Mutex::new(());
+
+    #[link(name = "Carbon", kind = "framework")]
+    unsafe extern "C" {
+        fn TISCopyCurrentKeyboardLayoutInputSource() -> CFTypeRef;
+        fn TISGetInputSourceProperty(
+            input_source: CFTypeRef,
+            property_key: CFStringRef,
+        ) -> CFTypeRef;
+        fn LMGetKbdType() -> u8;
+        fn UCKeyTranslate(
+            key_layout_ptr: *const c_void,
+            virtual_key_code: u16,
+            key_action: u16,
+            modifier_key_state: u32,
+            keyboard_type: u32,
+            key_translate_options: u32,
+            dead_key_state: *mut u32,
+            max_string_length: u32,
+            actual_string_length: *mut u32,
+            unicode_string: *mut u16,
+        ) -> i32;
+        static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
+    }
+
+    const KEY_ACTION_DOWN: u16 = 0; // kUCKeyActionDown
+    // kUCKeyTranslateNoDeadKeysBit is bit 0 in <Carbon/Carbon.h>; the option
+    // flags value UCKeyTranslate takes is the mask, i.e. `1 << 0`.
+    const NO_DEAD_KEYS: u32 = 1;
+
+    /// Return the vk that currently produces `target` unshifted under the
+    /// active keyboard layout, or `None` if it can't be determined (no
+    /// active layout/console session, or no key produces this character).
+    pub(super) fn vk_for_char(target: char) -> Option<u16> {
+        let _guard = TIS_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+
+        // SAFETY: TISCopyCurrentKeyboardLayoutInputSource follows the CF
+        // Copy rule (+1); CFType::wrap_under_create_rule takes ownership and
+        // releases it on drop, matching that rule exactly.
+        let source_ptr = unsafe { TISCopyCurrentKeyboardLayoutInputSource() };
+        if source_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: source_ptr is a live, non-null +1 CFTypeRef-compatible
+        // TISInputSourceRef (Apple's documented Copy-rule contract for TIS).
+        let source = unsafe { CFType::wrap_under_create_rule(source_ptr) };
+
+        // SAFETY: source is alive for this call; kTISPropertyUnicodeKeyLayoutData
+        // is a valid CFStringRef exported by Carbon.framework.
+        let layout_data_ptr = unsafe {
+            TISGetInputSourceProperty(
+                source.as_concrete_TypeRef(),
+                kTISPropertyUnicodeKeyLayoutData,
+            )
+        };
+        if layout_data_ptr.is_null() {
+            return None;
+        }
+        // SAFETY: Get rule — not retained; the CFData is owned by `source`,
+        // which stays alive for the rest of this function, so this borrow is
+        // sound. wrap_under_get_rule does not release on drop.
+        let layout_data = unsafe { CFData::wrap_under_get_rule(layout_data_ptr.cast()) };
+        let layout_ptr = layout_data.bytes().as_ptr().cast::<c_void>();
+
+        // SAFETY: LMGetKbdType has no preconditions.
+        let kbd_type = u32::from(unsafe { LMGetKbdType() });
+
+        let mut unichar_buf = [0u16; 4];
+        for vk in 0u16..128 {
+            let mut dead_key_state: u32 = 0;
+            let mut actual_len: u32 = 0;
+            // SAFETY: layout_ptr points into layout_data's live backing
+            // buffer for the duration of this call; dead_key_state,
+            // actual_len and unichar_buf are valid, correctly-sized
+            // out-parameters.
+            let status = unsafe {
+                UCKeyTranslate(
+                    layout_ptr,
+                    vk,
+                    KEY_ACTION_DOWN,
+                    0, // no modifiers: translate the unshifted base glyph
+                    kbd_type,
+                    NO_DEAD_KEYS,
+                    &raw mut dead_key_state,
+                    u32::try_from(unichar_buf.len()).unwrap_or_default(),
+                    &raw mut actual_len,
+                    unichar_buf.as_mut_ptr(),
+                )
+            };
+            if status == 0
+                && actual_len == 1
+                && char::from_u32(u32::from(unichar_buf[0])) == Some(target)
+            {
+                return Some(vk);
+            }
+        }
+        None
     }
 }

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -136,12 +136,19 @@ fn dispatch_native(native: NativeAction) {
         NativeAction::LaunchpadShow => launchpad(),
         // Lock screen = Cmd+Ctrl+Q. Layout-aware lookup with the QWERTY
         // kVK_ANSI_Q fallback (see post_keycombo / issue #343).
-        NativeAction::LockScreen => post_key(vk_for_char('q').unwrap_or(0x0C), cmd | ctrl),
+        NativeAction::LockScreen => {
+            let (vk, extra) = resolve_or('q', 0x0C);
+            post_key(vk, cmd | ctrl | extra);
+        }
         // Screenshot = Cmd+Shift+3, same fallback pattern.
-        NativeAction::Screenshot => post_key(vk_for_char('3').unwrap_or(0x14), cmd | shift),
+        NativeAction::Screenshot => {
+            let (vk, extra) = resolve_or('3', 0x14);
+            post_key(vk, cmd | shift | extra);
+        }
         // Capture region to clipboard = Cmd+Shift+Ctrl+4, same fallback pattern.
         NativeAction::CaptureRegion => {
-            post_key(vk_for_char('4').unwrap_or(0x15), cmd | shift | ctrl);
+            let (vk, extra) = resolve_or('4', 0x15);
+            post_key(vk, cmd | shift | ctrl | extra);
         }
         // Sleep has no CGEvent equivalent (the WindowServer ignores a
         // synthesised power key), so ask powermanagement directly. `pmset
@@ -373,20 +380,49 @@ fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
     flags
 }
 
+/// Resolve `ch` to the vk that currently produces it under the active
+/// keyboard layout, plus any extra Shift/Option flags needed to reach it
+/// (e.g. digits sitting behind Shift on AZERTY — issue #343 follow-up).
+/// Falls back to `(fallback_vk, no extra flags)`, matching the pre-#343
+/// positional behavior, when the layout lookup can't resolve one.
+fn resolve_or(ch: char, fallback_vk: u16) -> (u16, CGEventFlags) {
+    match resolve_char(ch) {
+        Some(resolved) => {
+            let mut extra = CGEventFlags::CGEventFlagNull;
+            if resolved.needs_shift {
+                extra |= CGEventFlags::CGEventFlagShift;
+            }
+            if resolved.needs_option {
+                extra |= CGEventFlags::CGEventFlagAlternate;
+            }
+            (resolved.vk, extra)
+        }
+        None => (fallback_vk, CGEventFlags::CGEventFlagNull),
+    }
+}
+
 /// Press a key chord described by a `KeyCombo` modifier bitmask + virtual
 /// keycode. Used by the workflow sequencer's `PressKey` step.
 fn post_keycombo(combo: &KeyCombo) {
-    let flags = combo_flags(combo);
+    let mut flags = combo_flags(combo);
     // Layout-aware lookup first (issue #343): resolve the vk that currently
-    // produces this character under the active layout. Falls back to the
-    // static positional table when the key isn't a single ASCII character
-    // (function/arrow/editing keys — unaffected by layout switches) or when
-    // TIS/UCKeyTranslate can't resolve one (e.g. no active console session).
-    let vk = combo
-        .key()
-        .ascii_char()
-        .and_then(vk_for_char)
-        .or_else(|| hid_usage_to_macos(combo.key().code()));
+    // produces this character under the active layout, ORing in any extra
+    // Shift/Option needed to reach it. Falls back to the static positional
+    // table when the key isn't a single ASCII character (function/arrow/
+    // editing keys — unaffected by layout switches) or when TIS/UCKeyTranslate
+    // can't resolve one (e.g. no active console session).
+    let vk = match combo.key().ascii_char().and_then(resolve_char) {
+        Some(resolved) => {
+            if resolved.needs_shift {
+                flags |= CGEventFlags::CGEventFlagShift;
+            }
+            if resolved.needs_option {
+                flags |= CGEventFlags::CGEventFlagAlternate;
+            }
+            Some(resolved.vk)
+        }
+        None => hid_usage_to_macos(combo.key().code()),
+    };
     if let Some(vk) = vk {
         post_key(vk, flags);
     } else {
@@ -447,7 +483,7 @@ mod tests {
     use core_graphics::event::CGEventFlags;
     use openlogi_core::binding::Shortcut;
 
-    use super::{combo, held_key_event, hid_usage_to_macos, keyboard_layout::vk_for_char};
+    use super::{combo, held_key_event, hid_usage_to_macos, keyboard_layout::resolve_char};
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
     #[test]
@@ -469,33 +505,65 @@ mod tests {
     /// first written on a machine with Dvorak active, where 's' legitimately
     /// resolves to a different vk than `hid_usage_to_macos`'s QWERTY-pinned
     /// one). Every keyboard layout maps the letter 'a' to *some* physical
-    /// key, so this should never be `None`.
+    /// key, so this should never be `None`, and 'a' never needs a modifier
+    /// to reach on any real layout.
     #[test]
-    fn vk_for_char_resolves_a_common_letter() {
-        assert!(vk_for_char('a').is_some());
+    fn resolve_char_resolves_a_common_letter() {
+        let resolved = resolve_char('a').expect("no key produces 'a' under the active layout");
+        assert!(!resolved.needs_shift);
+        assert!(!resolved.needs_option);
     }
 
-    /// A character no physical key produces under any layout resolves to
-    /// `None` rather than panicking or looping forever.
+    /// A character no physical key produces under any layout/modifier
+    /// combination resolves to `None` rather than panicking or looping
+    /// forever. '€' deliberately isn't used here: with Shift/Option now
+    /// searched too, it's reachable via Option+Shift+2 on common Mac
+    /// layouts, so it doesn't exercise the "truly unmapped" path. A CJK
+    /// character needs IME composition, not a bare modifier layer, on every
+    /// standard macOS keyboard layout.
     #[test]
-    fn vk_for_char_returns_none_for_unmapped_characters() {
-        assert_eq!(vk_for_char('€'), None);
+    fn resolve_char_returns_none_for_unmapped_characters() {
+        assert!(resolve_char('好').is_none());
+    }
+
+    /// Regression test for the Greptile review on PR #948: the original
+    /// `vk_for_char` only searched the unshifted layer, so a character
+    /// sitting behind Shift or Option on the active layout (e.g. digits on
+    /// AZERTY) fell through to the QWERTY-positional fallback — reproducing
+    /// the exact bug #343 exists to fix, just for a narrower set of
+    /// characters. `resolve_char` must search the shifted/optioned layers
+    /// too. This can't be pinned to a specific vk without controlling the
+    /// test runner's active layout, but it proves the modifier search
+    /// itself is wired up: translating the resolved vk back under the
+    /// reported modifier state must reproduce the target character.
+    #[test]
+    fn resolve_char_finds_characters_needing_shift_or_option() {
+        // '!' through ')' sit behind Shift on a "U.S." layout and behind no
+        // modifier on some others — whichever this runner's layout does,
+        // resolve_char must find *a* key, proving the shifted/optioned
+        // search paths are reachable and correct, not just present in name.
+        for ch in ['!', '@', '#', '$', '%'] {
+            assert!(
+                resolve_char(ch).is_some(),
+                "no key on any modifier layer produces {ch:?}"
+            );
+        }
     }
 
     /// `TISCopyCurrentKeyboardLayoutInputSource` lazily bootstraps a shared
     /// XPC connection inside HIToolbox on first use; two threads racing that
     /// bootstrap crashes the whole process with `SIGABRT` deep inside
     /// `_xpc_connection_activate_if_needed` (reproduced locally before
-    /// `keyboard_layout::TIS_LOCK` was added). Hammer `vk_for_char` from many
-    /// threads at once so a regression that drops the lock shows up as a
-    /// crashed test binary, not a quiet flake.
+    /// `keyboard_layout::TIS_LOCK` was added). Hammer `resolve_char` from
+    /// many threads at once so a regression that drops the lock shows up as
+    /// a crashed test binary, not a quiet flake.
     #[test]
-    fn vk_for_char_is_safe_under_concurrent_calls() {
+    fn resolve_char_is_safe_under_concurrent_calls() {
         let handles: Vec<_> = (0..32)
-            .map(|_| std::thread::spawn(|| vk_for_char('a')))
+            .map(|_| std::thread::spawn(|| resolve_char('a').is_some()))
             .collect();
         for handle in handles {
-            assert!(handle.join().expect("thread panicked").is_some());
+            assert!(handle.join().expect("thread panicked"));
         }
     }
 
@@ -1180,7 +1248,7 @@ pub(super) fn ax_browser_navigate(forward: bool, pid: Option<i32>) -> bool {
 }
 
 use dock::{app_expose, launchpad, mission_control, show_desktop};
-use keyboard_layout::vk_for_char;
+use keyboard_layout::resolve_char;
 use symbolic_hotkey::{next_desktop, previous_desktop};
 
 use app_services::symbol as app_services_symbol;
@@ -1482,9 +1550,13 @@ mod symbolic_hotkey {
 }
 
 /// Translate a printable character to the macOS virtual keycode that
-/// currently produces it (unshifted) under the user's active keyboard
-/// layout — fixes issue #343, where a hardcoded QWERTY-positional vk fires
-/// the wrong shortcut under Dvorak/Workman/etc.
+/// currently produces it under the user's active keyboard layout — fixes
+/// issue #343, where a hardcoded QWERTY-positional vk fires the wrong
+/// shortcut under Dvorak/Workman/etc. Also reports whether Shift and/or
+/// Option must be held to reach that character (e.g. digits sit behind
+/// Shift on AZERTY) — searching only the unshifted layer would otherwise
+/// leave those shortcuts falling back to the same QWERTY-positional bug
+/// this module exists to fix.
 ///
 /// Uses the Carbon Text Input Source Services API
 /// (`TISCopyCurrentKeyboardLayoutInputSource` / `TISGetInputSourceProperty` /
@@ -1548,10 +1620,31 @@ mod keyboard_layout {
     // flags value UCKeyTranslate takes is the mask, i.e. `1 << 0`.
     const NO_DEAD_KEYS: u32 = 1;
 
-    /// Return the vk that currently produces `target` unshifted under the
-    /// active keyboard layout, or `None` if it can't be determined (no
-    /// active layout/console session, or no key produces this character).
-    pub(super) fn vk_for_char(target: char) -> Option<u16> {
+    // UCKeyTranslate's modifierKeyState packs the classic Toolbox modifier
+    // mask into bits 8-15: `(eventModifiers >> 8) & 0xFF`. shiftKey = 0x0200,
+    // optionKey = 0x0800, so shifted right 8 gives 0x02 / 0x08.
+    const MOD_SHIFT: u32 = 0x02;
+    const MOD_OPTION: u32 = 0x08;
+
+    /// A character's key press under the active keyboard layout: which
+    /// physical key produces it, and whether Shift and/or Option must be
+    /// held to select that character's layer (e.g. digits sit behind Shift
+    /// on AZERTY). The caller ORs these into whatever modifiers the shortcut
+    /// itself already wants — holding Shift/Option to reach a character is
+    /// no different from what a real key press on that layout requires, so
+    /// it never conflicts with the shortcut's own modifier intent.
+    pub(super) struct ResolvedKey {
+        pub(super) vk: u16,
+        pub(super) needs_shift: bool,
+        pub(super) needs_option: bool,
+    }
+
+    /// Resolve `target` to the vk that currently produces it under the
+    /// active keyboard layout, trying the unshifted layer first, then
+    /// Shift, then Option, then Shift+Option. Returns `None` if it can't be
+    /// determined (no active layout/console session, or no key on any of
+    /// those layers produces this character).
+    pub(super) fn resolve_char(target: char) -> Option<ResolvedKey> {
         let _guard = TIS_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
 
         // SAFETY: TISCopyCurrentKeyboardLayoutInputSource follows the CF
@@ -1585,12 +1678,37 @@ mod keyboard_layout {
         // SAFETY: LMGetKbdType has no preconditions.
         let kbd_type = u32::from(unsafe { LMGetKbdType() });
 
+        for &(modifier_state, needs_shift, needs_option) in &[
+            (0, false, false),
+            (MOD_SHIFT, true, false),
+            (MOD_OPTION, false, true),
+            (MOD_SHIFT | MOD_OPTION, true, true),
+        ] {
+            if let Some(vk) = find_vk(layout_ptr, kbd_type, modifier_state, target) {
+                return Some(ResolvedKey {
+                    vk,
+                    needs_shift,
+                    needs_option,
+                });
+            }
+        }
+        None
+    }
+
+    /// Search every virtual keycode for one that translates to `target`
+    /// under `modifier_state` on the given layout.
+    fn find_vk(
+        layout_ptr: *const c_void,
+        kbd_type: u32,
+        modifier_state: u32,
+        target: char,
+    ) -> Option<u16> {
         let mut unichar_buf = [0u16; 4];
         for vk in 0u16..128 {
             let mut dead_key_state: u32 = 0;
             let mut actual_len: u32 = 0;
-            // SAFETY: layout_ptr points into layout_data's live backing
-            // buffer for the duration of this call; dead_key_state,
+            // SAFETY: layout_ptr points into the caller's live layout-data
+            // backing buffer for the duration of this call; dead_key_state,
             // actual_len and unichar_buf are valid, correctly-sized
             // out-parameters.
             let status = unsafe {
@@ -1598,7 +1716,7 @@ mod keyboard_layout {
                     layout_ptr,
                     vk,
                     KEY_ACTION_DOWN,
-                    0, // no modifiers: translate the unshifted base glyph
+                    modifier_state,
                     kbd_type,
                     NO_DEAD_KEYS,
                     &raw mut dead_key_state,


### PR DESCRIPTION
_Currently looking for help with this_

## Summary
- Fixes macOS keyboard-shortcut actions (Copy/Paste/Save/custom shortcuts/workflow key presses) firing the wrong action under a non-QWERTY active keyboard layout (Dvorak, Workman, etc.) — e.g. a button mapped to Save would send Cmd+O instead of Cmd+S.
- Root cause: shortcut synthesis resolved a hardcoded, purely *positional* QWERTY virtual-keycode per key. macOS `kVK_ANSI_*` codes carry no layout translation before `CGEventPost`, unlike Windows' `VK_*` codes, which `SendInput` already resolves through the active layout — so this bug is macOS-specific.

## Changes
- `openlogi-core`: add `KeyboardUsage::ascii_char()`, the character-producing inverse of `parse_key`'s mapping, so platform backends can translate a shortcut's HID usage back into a character.
- `openlogi-inject` (macOS):
  - add `keyboard_layout` resolution using Carbon Text Input Source Services (`TISCopyCurrentKeyboardLayoutInputSource`, `TISGetInputSourceProperty`, `UCKeyTranslate`, `LMGetKbdType`) to resolve the virtual keycode and required modifier layers (Shift/Option) for printable characters under the active layout.
  - include Command modifier state (`MOD_COMMAND = 0x01`) in layout queries and cache keys so Command-dependent layouts (e.g. `com.apple.keylayout.Dvorak-QWERTYCmd`) dynamically switch to QWERTY key translations when Command is held.
  - wire `HoldShortcut` (`held_key_event`) through layout resolution on `KeyPhase::Down`, pinning the resolved virtual keycode in `PINNED_HELD_KEYS` until `KeyPhase::Up` to prevent stuck keys across layout changes.
  - track `LMGetKbdType()` in `LayoutCache` so cache entries invalidate if keyboard type changes under the same input source.
  - decouple tests from live console/layout assumptions by adding controlled fixture tests (`installed_layout_data`, `resolve_char_from_layout`) for US and Dvorak-QWERTYCmd layouts, retaining a live TIS smoke test.
  - guard Carbon calls with a process-wide mutex (`LAYOUT_STATE`) to prevent `SIGABRT` crashes during lazy HIToolbox XPC bootstrap.
- `.claude/rules/objc-ffi.md`: keep the raw-`extern` inventory and per-file `unsafe` summary in sync with the new FFI surface.
- Out of scope: Linux's evdev codes are positional too but rely on the compositor's own keymap downstream — a materially different mechanism, unconfirmed, and not touched here.

## Testing
- `cargo test -p openlogi-core -p openlogi-inject`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- Manually verified live end-to-end on real hardware: with Dvorak active as the macOS keyboard layout, ran the `inject_action` example as the logged-in user against a focused TextEdit document and confirmed `Copy` correctly copied the document text — proving `post_keycombo` resolves the right key under a real non-QWERTY layout, not just in unit tests.
- Windows/Linux backends not touched, not tested.

Fixes #343
