### PR TITLE
fix(gui): live brightness drag

### DIFF
--- a/crates/openlogi-desktop/src/features/lighting/device.rs
+++ b/crates/openlogi-desktop/src/features/lighting/device.rs
@@ -44,6 +44,8 @@ pub struct LightingPanel {
     /// must be resynced; an unchanged value during a drag must not, or we'd
     /// fight the user's in-progress drag (which only commits on release).
     last_brightness: u8,
+    /// The live drag value, shown in the numeric label until release commits.
+    pending_brightness: Option<u8>,
     _brightness_sub: Subscription,
     _state_obs: Subscription,
 }
@@ -55,15 +57,22 @@ impl LightingPanel {
             SliderState::new()
                 .max(100.)
                 .min(0.)
-                .step(5.)
+                .step(1.)
                 .default_value(f32::from(initial))
         });
         // The slider drives the device only on release, to avoid streaming a
         // frame burst to the keyboard for every intermediate drag value.
-        let brightness_sub =
-            cx.subscribe(&brightness, |_panel, _slider, event: &SliderEvent, cx| {
-                if let SliderEvent::Release(value) = event {
+        let brightness_sub = cx.subscribe(
+            &brightness,
+            |panel, _slider, event: &SliderEvent, cx| match event {
+                SliderEvent::Change(value) => {
+                    panel.pending_brightness = Some(clamp_brightness(value.start()));
+                    cx.notify();
+                }
+                SliderEvent::Release(value) => {
                     let pct = clamp_brightness(value.start());
+                    panel.pending_brightness = None;
+                    panel.last_brightness = pct;
                     AppState::update(cx, |state, cx| {
                         let key = state.current_record().map(DeviceRecord::device_key);
                         let mut lighting = state.lighting();
@@ -76,7 +85,8 @@ impl LightingPanel {
                     });
                     cx.notify();
                 }
-            });
+            },
+        );
         let state_obs = cx.subscribe(&AppState::global(cx), |_, _, event: &StateEvent, cx| {
             let relevant = match event {
                 StateEvent::InventoryChanged | StateEvent::DeviceSelected(_) => true,
@@ -92,6 +102,7 @@ impl LightingPanel {
         Self {
             brightness,
             last_brightness: initial,
+            pending_brightness: None,
             _brightness_sub: brightness_sub,
             _state_obs: state_obs,
         }
@@ -104,6 +115,8 @@ impl Render for LightingPanel {
         let lighting = AppState::try_read(cx)
             .map(AppState::lighting)
             .unwrap_or_default();
+
+        let display = self.pending_brightness.unwrap_or(lighting.brightness);
 
         // Pull the slider thumb to the active device's brightness whenever it
         // changed in `AppState` (device switch / external edit), without
@@ -165,7 +178,7 @@ impl Render for LightingPanel {
                         div()
                             .text_caption()
                             .text_color(pal.text_primary)
-                            .child(format!("{}%", lighting.brightness)),
+                            .child(format!("{display}%")),
                     ),
             )
             .child(Slider::new(&self.brightness).horizontal())


### PR DESCRIPTION
## Summary

The brightness label in the device Lighting panel only updated when you let go of
the slider. During a drag the thumb moved but the number sat still.

`LightingPanel` subscribed to `SliderEvent::Release` only, and the label rendered
the committed `AppState` value, which nothing updates mid-drag.

The DPI, SmartShift, thumb-wheel sensitivity and camera panels all already handle
`Change` for the label and `Release` for the write. This makes the lighting panel
do the same.

The HID++ write still happens once on release. Dragging sends nothing to the
device.

The slider also stepped by 5. The config stores a 0-100 percent and the agent
scales each colour channel by it, so 1% works end to end. G HUB uses 1% for the
same control. Changed to 1.

## Changes

**`openlogi-desktop`**

- `features/lighting/device.rs`: add `pending_brightness` to `LightingPanel`.
  `SliderEvent::Change` sets it, `Release` clears it, and the label reads
  `pending_brightness.unwrap_or(lighting.brightness)`. `Release` also updates
  `last_brightness` so the thumb resync in `render` does not fire on the value
  that was just committed.
- `features/lighting/device.rs`: slider step 5 to 1.

## Testing

Tested on Windows 10 with a wired G203 LIGHTSYNC. The percentage follows the drag
in 1% steps, and the LED updates on release. Not tested on macOS or Linux. The
changed code has no `cfg` blocks.

```
cargo fmt --all -- --check                                # pass
cargo clippy --workspace --all-targets -- -D warnings     # pass, RUSTFLAGS=-D warnings
cargo test -p openlogi-desktop                            # 150/150 pass
```

`cargo test --workspace` and the rustdoc gate both fail on this Windows host, and
both also fail on unmodified master. The xtask test
`ci_yml_runs_what_this_runner_runs` joins `ci.yml` line continuations assuming LF,
and a Windows checkout has CRLF. The rustdoc gate hits a doc link to
`PermissionStatus` in `openlogi-permissions`, which is `#[cfg(any(macos, linux))]`.
CI runs both jobs on Linux, so neither shows up there. I left both alone.

No wire types, cfg-gated files or locale keys changed.
