### PR TITLE
fix(deps): bump crates for disclosed RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1805,7 +1805,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2072,7 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2118,11 +2118,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3148,9 +3147,9 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4350,9 +4349,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4625,7 +4624,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6240,7 +6239,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6765,7 +6764,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6778,7 +6777,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6845,7 +6844,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7846,7 +7845,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9259,7 +9258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Automated dependency bump to address disclosed RustSec advisories found by [osv-scanner](https://google.github.io/osv-scanner/).

- **CVE / Advisory:** RUSTSEC-2026-0258 ([GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)) — h2 unbounded empty DATA frames (low; DoS)
- **Package:** `h2` `0.4.14` → `0.4.16`
- **Advisory:** [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) — memmap2 unchecked pointer offset
- **Package:** `memmap2` `0.9.10` → `0.9.11`
- **Advisory:** [RUSTSEC-2026-0221](https://rustsec.org/advisories/RUSTSEC-2026-0221.html) — event-listener `!Send` tag soundness
- **Package:** `event-listener` `5.4.1` → `5.4.2`
- **Advisory:** [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204.html) — crossbeam-epoch invalid pointer dereference in `fmt::Pointer`
- **Package:** `crossbeam-epoch` `0.9.18` → `0.9.20`

### Severity
Low–moderate DoS / soundness issues in transitive deps (h2 via zed-reqwest/hyper for GUI HTTP; memmap2 via fontdb; event-listener also on the CLI/HID++ path; crossbeam-epoch via rayon/ignore). No application code changes.

### Verification
- Reproduced locally: yes
- Command: `osv-scanner scan source --recursive --no-ignore --format=json .` then `cargo update -p h2 --precise 0.4.16` (and the three sibling precise bumps)
- Before: lockfile pinned the vulnerable versions above
- After: lockfile pins the patched versions; `cargo metadata` resolves cleanly
- Environment: osv-scanner 2.5.1, cargo/rustc on linux amd64

Detected by [osv-scanner](https://google.github.io/osv-scanner/). No code changes outside the lockfile.

**Note:** `quick-xml@0.30.0` (RUSTSEC-2026-0194 / 0195) remains via `xcb` ← `zed-scap` and cannot be bumped without an upstream `xcb`/`scap` change. Unmaintained notices (bincode, paste, instant, …) left alone — bincode is already documented in `.cargo/deny.toml`.