### PR TITLE
fix: make Actions Ring selectable in action pickers

### DIFF
--- a/crates/openlogi-core/src/binding/action.rs
+++ b/crates/openlogi-core/src/binding/action.rs
@@ -269,7 +269,7 @@ macro_rules! for_each_unit_action {
             Screenshot "Screenshot" System Camera,
             CaptureRegion "Capture Region" System Camera,
             Sleep "Sleep" System Monitor,
-            ShowActionsRing "Actions Ring" System Grid not_pickable,
+            ShowActionsRing "Actions Ring" System Grid,
             // Media
             PlayPause "Play / Pause" Media Play,
             NextTrack "Next Track" Media NextTrack,
@@ -338,9 +338,7 @@ macro_rules! derive_action_core {
             ///
             /// [`Action::CustomShortcut`] is intentionally excluded — it is opened via
             /// "Record shortcut…" (P1.3), not selected from the catalog. Table rows
-            /// tagged `not_pickable` (currently only [`Action::ShowActionsRing`], the
-            /// fixed default for [`ButtonId::HapticPanel`](super::ButtonId::HapticPanel))
-            /// are excluded from the catalog the same way.
+            /// tagged `not_pickable` are excluded from the catalog the same way.
             #[must_use]
             pub fn catalog() -> Vec<Action> {
                 [ $( derive_action_core!(@item $variant $( $tag )?) ),* ]

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -134,6 +134,17 @@ fn workflow_roundtrips_toml() {
     assert_eq!(wf, back);
 }
 
+#[test]
+fn actions_ring_is_available_to_normal_and_gesture_pickers() {
+    assert_eq!(Action::ShowActionsRing.label(), "Actions Ring");
+    assert_eq!(Action::ShowActionsRing.category(), Category::System);
+    assert!(Action::catalog().contains(&Action::ShowActionsRing));
+    assert_eq!(
+        RingAction::new(Action::ShowActionsRing),
+        Err(RingActionError::RecursiveTrigger)
+    );
+}
+
 // ── Binding (merged model) serde routing ──────────────────────────────────
 
 /// On-disk shape: a `ButtonId` → [`Binding`] map, as `DeviceConfig.bindings`
@@ -298,7 +309,6 @@ fn persisted_action_variant_names_are_stable() {
         Action::RunAppleScript(String::new()),
         Action::RunShellCommand(String::new()),
         Action::Workflow(Vec::new()),
-        Action::ShowActionsRing,
         Action::OpenApplication(
             ApplicationTarget::new("/Applications/OpenLogi.app", "OpenLogi")
                 .unwrap_or_else(|error| panic!("valid target failed: {error}")),

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -234,3 +234,17 @@ pub(crate) fn editor_scroll_list(
         .overflow_y_scroll()
         .children(rows)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gesture_action_catalog_includes_actions_ring() {
+        let actions = grouped_catalog()
+            .into_iter()
+            .flat_map(|(_, actions)| actions)
+            .collect::<Vec<_>>();
+        assert!(actions.contains(&Action::ShowActionsRing));
+    }
+}


### PR DESCRIPTION
Summary changes:
- Adds ShowActionsRing to the shared action catalog.
- Verifies normal and gesture picker availability.
- Retains RingAction validation against recursive Actions Ring entries.

Now that option will be listed here:
<img width="248" height="452" alt="image" src="https://github.com/user-attachments/assets/3c7a5ecc-a1b5-43de-a49d-ed377819bc6e" />



Fixes #630
