### PR TITLE
feat(agent): hold shortcut output until button release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Things OpenLogi does that Options+ won't:
 ## Features
 
 - Devices connected over Logi Bolt receivers, Unifying receivers, Bluetooth, or a wired connection, with battery percentage and charge state
-- Button remapping via the OS input hook: a built-in action catalog plus custom keyboard shortcuts authored in the TOML config¹
+- Button remapping via the OS input hook: a built-in action catalog plus custom keyboard shortcuts authored in the TOML config, including hold-until-release chords for push-to-talk¹
 - Per-application profile overlays that auto-switch on app focus (macOS + Windows; Linux on X11 / XWayland only)
 - Litra lights: power, brightness, and color temperature, with optional auto power that follows camera activity
 

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -17,7 +17,9 @@ use openlogi_core::binding::{Action, ButtonId, KeyCombo};
 use openlogi_hid::{CaptureChannel, ChannelRegistry};
 use tracing::{info, warn};
 
-use self::button::{ButtonInputHandle, ButtonRuntimeEvent, ButtonRuntimeOwner, EndReason};
+use self::button::{
+    ButtonInputHandle, ButtonRuntimeEvent, ButtonRuntimeOwner, EndReason, PressControl,
+};
 pub(crate) use self::button::{HidppSessionId, PressToken};
 use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 use crate::receiver_access::ReceiverAccess;
@@ -30,7 +32,7 @@ enum HoldStart {
     NotHeld,
     /// This press newly owns one held chord.
     Started(KeyCombo),
-    /// The same press changed its held action; release the old chord first.
+    /// The same press changed its held action.
     Replaced { old: KeyCombo, new: KeyCombo },
 }
 
@@ -180,7 +182,14 @@ impl ButtonEventHandler {
                     openlogi_inject::release_hold(&combo);
                 }
                 if let EndReason::Canceled(reason) = reason {
-                    info!(button = %press.button(), ?reason, "button lifecycle canceled");
+                    match press.control() {
+                        PressControl::Button(button) => {
+                            info!(button = %button, ?reason, "button lifecycle canceled");
+                        }
+                        PressControl::Key(keycode) => {
+                            info!(keycode, ?reason, "key lifecycle canceled");
+                        }
+                    }
                 }
             }
         }
@@ -191,8 +200,7 @@ impl ButtonEventHandler {
             HoldStart::NotHeld => self.executor.dispatch(action, device_key),
             HoldStart::Started(combo) => openlogi_inject::press_hold(&combo),
             HoldStart::Replaced { old, new } => {
-                openlogi_inject::release_hold(&old);
-                openlogi_inject::press_hold(&new);
+                openlogi_inject::replace_hold(&old, &new);
             }
         }
     }
@@ -274,6 +282,16 @@ impl ActionDispatcher {
     /// Queue one OS-hook up edge without blocking the callback.
     pub(crate) fn try_hook_button_up(&self, button: ButtonId) -> bool {
         self.buttons.try_hook_up(button)
+    }
+
+    /// Queue one function-key down edge without blocking the hook callback.
+    pub(crate) fn try_hook_key_down(&self, keycode: u16, action: &Action) -> bool {
+        self.buttons.try_hook_key_down(keycode, action).is_some()
+    }
+
+    /// Queue one function-key up edge without blocking the hook callback.
+    pub(crate) fn try_hook_key_up(&self, keycode: u16) -> bool {
+        self.buttons.try_hook_key_up(keycode)
     }
 
     /// Execute a semantic gesture action only if its exact press is still live.

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -8,11 +8,12 @@
 mod button;
 pub mod hook;
 
+use std::collections::HashMap;
 use std::io;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Action, ButtonId, KeyCombo};
 use openlogi_hid::{CaptureChannel, ChannelRegistry};
 use tracing::{info, warn};
 
@@ -21,6 +22,44 @@ pub(crate) use self::button::{HidppSessionId, PressToken};
 use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 use crate::receiver_access::ReceiverAccess;
 use crate::{DpiCycleState, DpiCycles};
+
+/// Output transition when an action starts within one physical press.
+#[derive(Debug, PartialEq, Eq)]
+enum HoldStart {
+    /// The action is instantaneous and belongs to ordinary dispatch.
+    NotHeld,
+    /// This press newly owns one held chord.
+    Started(KeyCombo),
+    /// The same press changed its held action; release the old chord first.
+    Replaced { old: KeyCombo, new: KeyCombo },
+}
+
+/// Held output owned by accepted press capabilities rather than by a capture
+/// backend. Because every [`PressToken`] has exactly one terminal event, this
+/// map gives release, cancellation, invalidation, and shutdown one path.
+#[derive(Default)]
+struct HeldShortcuts {
+    by_press: HashMap<PressToken, KeyCombo>,
+}
+
+impl HeldShortcuts {
+    fn start(&mut self, press: &PressToken, action: &Action) -> HoldStart {
+        let Some(combo) = action.held_combo() else {
+            return HoldStart::NotHeld;
+        };
+        match self.by_press.insert(press.clone(), combo.clone()) {
+            Some(old) => HoldStart::Replaced {
+                old,
+                new: combo.clone(),
+            },
+            None => HoldStart::Started(combo.clone()),
+        }
+    }
+
+    fn end(&mut self, press: &PressToken) -> Option<KeyCombo> {
+        self.by_press.remove(press)
+    }
+}
 
 #[derive(Clone)]
 struct ActionExecutor {
@@ -113,6 +152,52 @@ impl ActionExecutor {
     }
 }
 
+struct ButtonEventHandler {
+    executor: ActionExecutor,
+    held: HeldShortcuts,
+}
+
+impl ButtonEventHandler {
+    fn new(executor: ActionExecutor) -> Self {
+        Self {
+            executor,
+            held: HeldShortcuts::default(),
+        }
+    }
+
+    fn handle(&mut self, event: ButtonRuntimeEvent) {
+        match event {
+            ButtonRuntimeEvent::Started(press) => {
+                if let Some(action) = press.action() {
+                    self.start_action(press.token(), action, press.device_key());
+                }
+            }
+            ButtonRuntimeEvent::Triggered { press, action } => {
+                self.start_action(press.token(), &action, press.device_key());
+            }
+            ButtonRuntimeEvent::Ended { press, reason } => {
+                if let Some(combo) = self.held.end(press.token()) {
+                    openlogi_inject::release_hold(&combo);
+                }
+                if let EndReason::Canceled(reason) = reason {
+                    info!(button = %press.button(), ?reason, "button lifecycle canceled");
+                }
+            }
+        }
+    }
+
+    fn start_action(&mut self, press: &PressToken, action: &Action, device_key: Option<&str>) {
+        match self.held.start(press, action) {
+            HoldStart::NotHeld => self.executor.dispatch(action, device_key),
+            HoldStart::Started(combo) => openlogi_inject::press_hold(&combo),
+            HoldStart::Replaced { old, new } => {
+                openlogi_inject::release_hold(&old);
+                openlogi_inject::press_hold(&new);
+            }
+        }
+    }
+}
+
 /// Runtime dependencies shared by every action source: the OS hook, HID++
 /// controls, keyboard capture, and Actions Ring slot activation.
 #[derive(Clone)]
@@ -146,27 +231,8 @@ impl ActionRuntime {
             receiver_access,
             action_ring,
         };
-        let button_executor = executor.clone();
-        let buttons = ButtonRuntimeOwner::spawn(move |event| match event {
-            ButtonRuntimeEvent::Started(press) => {
-                if let Some(action) = press.action() {
-                    button_executor.dispatch(action, press.device_key());
-                }
-            }
-            ButtonRuntimeEvent::Triggered { press, action } => {
-                button_executor.dispatch(&action, press.device_key());
-            }
-            ButtonRuntimeEvent::Ended {
-                press,
-                reason: EndReason::Canceled(reason),
-            } => {
-                info!(button = %press.button(), ?reason, "button lifecycle canceled");
-            }
-            ButtonRuntimeEvent::Ended {
-                reason: EndReason::Released,
-                ..
-            } => {}
-        })?;
+        let mut button_handler = ButtonEventHandler::new(executor.clone());
+        let buttons = ButtonRuntimeOwner::spawn(move |event| button_handler.handle(event))?;
         let input = buttons.input();
         Ok(Self {
             dispatcher: ActionDispatcher {
@@ -295,4 +361,68 @@ fn browser_nav_debounce_ok(action: &Action) -> bool {
         *slot = Some(now);
     }
     fire
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hold(label: &str) -> Action {
+        Action::HoldShortcut(label.parse().expect("test shortcut must be valid"))
+    }
+
+    #[test]
+    fn held_output_is_owned_by_the_exact_press_until_its_terminal_event() {
+        let first = PressToken::hook_for_test(1, ButtonId::Back);
+        let second = PressToken::hook_for_test(2, ButtonId::Forward);
+        let mut held = HeldShortcuts::default();
+
+        assert_eq!(
+            held.start(&first, &hold("Ctrl+Space")),
+            HoldStart::Started("Ctrl+Space".parse().expect("valid shortcut"))
+        );
+        assert_eq!(
+            held.start(&second, &hold("Alt+F2")),
+            HoldStart::Started("Alt+F2".parse().expect("valid shortcut"))
+        );
+        assert_eq!(
+            held.end(&first),
+            Some("Ctrl+Space".parse().expect("valid shortcut"))
+        );
+        assert_eq!(held.end(&first), None, "a press releases at most once");
+        assert_eq!(
+            held.end(&second),
+            Some("Alt+F2".parse().expect("valid shortcut"))
+        );
+    }
+
+    #[test]
+    fn changing_a_hold_within_one_press_balances_the_previous_chord() {
+        let press = PressToken::hook_for_test(1, ButtonId::Back);
+        let mut held = HeldShortcuts::default();
+        let old: KeyCombo = "Ctrl+Space".parse().expect("valid shortcut");
+        let new: KeyCombo = "Alt+F2".parse().expect("valid shortcut");
+
+        assert_eq!(
+            held.start(&press, &Action::HoldShortcut(old.clone())),
+            HoldStart::Started(old.clone())
+        );
+        assert_eq!(
+            held.start(&press, &Action::HoldShortcut(new.clone())),
+            HoldStart::Replaced {
+                old,
+                new: new.clone(),
+            }
+        );
+        assert_eq!(held.end(&press), Some(new));
+    }
+
+    #[test]
+    fn instantaneous_actions_do_not_enter_held_state() {
+        let press = PressToken::hook_for_test(1, ButtonId::Back);
+        let mut held = HeldShortcuts::default();
+
+        assert_eq!(held.start(&press, &Action::Copy), HoldStart::NotHeld);
+        assert_eq!(held.end(&press), None);
+    }
 }

--- a/crates/openlogi-agent-core/src/runtime/button.rs
+++ b/crates/openlogi-agent-core/src/runtime/button.rs
@@ -90,7 +90,7 @@ struct PressId(u64);
 /// Capability used to run a gesture action only while its originating press
 /// remains active. Future timers and repeat workers can use the same token to
 /// reject work scheduled by a superseded press.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct PressToken {
     id: PressId,
     key: PressKey,
@@ -116,6 +116,10 @@ pub(crate) struct ActivePress {
 }
 
 impl ActivePress {
+    pub(crate) fn token(&self) -> &PressToken {
+        &self.token
+    }
+
     pub(crate) fn button(&self) -> ButtonId {
         self.token.key.button
     }
@@ -399,7 +403,7 @@ pub(crate) struct ButtonRuntimeOwner {
 
 impl ButtonRuntimeOwner {
     pub(crate) fn spawn(
-        on_event: impl Fn(ButtonRuntimeEvent) + Send + 'static,
+        mut on_event: impl FnMut(ButtonRuntimeEvent) + Send + 'static,
     ) -> io::Result<Self> {
         let (events, event_rx) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
         let (shutdown, shutdown_rx) = mpsc::channel();
@@ -412,7 +416,7 @@ impl ButtonRuntimeOwner {
         };
         let worker = thread::Builder::new()
             .name("openlogi-buttons".into())
-            .spawn(move || run_worker(&event_rx, &shutdown_rx, &generation, &on_event))?;
+            .spawn(move || run_worker(&event_rx, &shutdown_rx, &generation, &mut on_event))?;
         Ok(Self {
             input,
             shutdown,
@@ -462,7 +466,7 @@ fn run_worker(
     events: &mpsc::Receiver<ButtonCommand>,
     shutdown: &mpsc::Receiver<ShutdownRequest>,
     shared_generation: &AtomicU64,
-    emit: &impl Fn(ButtonRuntimeEvent),
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
 ) {
     let mut state = ButtonState::default();
     let mut generation = shared_generation.load(Ordering::Acquire);
@@ -513,7 +517,11 @@ fn run_worker(
     }
 }
 
-fn process_input(state: &mut ButtonState, input: ButtonInput, emit: &impl Fn(ButtonRuntimeEvent)) {
+fn process_input(
+    state: &mut ButtonState,
+    input: ButtonInput,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) {
     match input {
         ButtonInput::Down(press) => {
             if let Some(stale) = state.press(press.clone()) {
@@ -558,7 +566,7 @@ fn process_input(state: &mut ButtonState, input: ButtonInput, emit: &impl Fn(But
 fn emit_canceled(
     presses: Vec<ActivePress>,
     reason: CancelReason,
-    emit: &impl Fn(ButtonRuntimeEvent),
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
 ) {
     for press in presses {
         emit(ButtonRuntimeEvent::Ended {

--- a/crates/openlogi-agent-core/src/runtime/button.rs
+++ b/crates/openlogi-agent-core/src/runtime/button.rs
@@ -1,4 +1,4 @@
-//! Source-independent button lifecycle state.
+//! Source-independent button and key lifecycle state.
 //!
 //! Capture backends report different raw shapes: OS hooks carry discrete
 //! edges, while HID++ diverted-control reports carry complete held-control
@@ -70,16 +70,35 @@ impl ButtonSource {
     }
 }
 
+/// Physical control carried through a press lifecycle.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum PressControl {
+    /// A mouse or HID++ control represented in the shared binding schema.
+    Button(ButtonId),
+    /// A function key represented by its platform-neutral macOS keycode.
+    Key(u16),
+}
+
 /// Correlation key shared by consecutive edges from one physical control.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct PressKey {
     source: ButtonSource,
-    button: ButtonId,
+    control: PressControl,
 }
 
 impl PressKey {
     fn new(source: ButtonSource, button: ButtonId) -> Self {
-        Self { source, button }
+        Self {
+            source,
+            control: PressControl::Button(button),
+        }
+    }
+
+    fn for_key(source: ButtonSource, keycode: u16) -> Self {
+        Self {
+            source,
+            control: PressControl::Key(keycode),
+        }
     }
 }
 
@@ -120,8 +139,8 @@ impl ActivePress {
         &self.token
     }
 
-    pub(crate) fn button(&self) -> ButtonId {
-        self.token.key.button
+    pub(crate) fn control(&self) -> &PressControl {
+        &self.token.key.control
     }
 
     pub(crate) fn device_key(&self) -> Option<&str> {
@@ -264,6 +283,26 @@ impl ButtonInputHandle {
         self.try_up(ButtonSource::current_hook(), button)
     }
 
+    pub(crate) fn try_hook_key_down(&self, keycode: u16, action: &Action) -> Option<PressToken> {
+        let generation = self.generation.load(Ordering::Acquire);
+        let press = self.new_press(
+            PressKey::for_key(ButtonSource::current_hook(), keycode),
+            Some(action),
+            generation,
+        );
+        let token = press.token.clone();
+        self.try_input(generation, ButtonInput::Down(press))
+            .then_some(token)
+    }
+
+    pub(crate) fn try_hook_key_up(&self, keycode: u16) -> bool {
+        let generation = self.generation.load(Ordering::Acquire);
+        self.try_input(
+            generation,
+            ButtonInput::Up(PressKey::for_key(ButtonSource::current_hook(), keycode)),
+        )
+    }
+
     pub(crate) fn cancel_hook_thread(&self) {
         self.try_command(ButtonCommand::CancelSource(ButtonSource::current_hook()));
     }
@@ -293,8 +332,7 @@ impl ButtonInputHandle {
     ) -> bool {
         let generation = self.generation.load(Ordering::Acquire);
         let press = self.new_press(
-            ButtonSource::Hidpp(session.clone()),
-            button,
+            PressKey::new(ButtonSource::Hidpp(session.clone()), button),
             action,
             generation,
         );
@@ -337,7 +375,7 @@ impl ButtonInputHandle {
         action: Option<&Action>,
     ) -> Option<PressToken> {
         let generation = self.generation.load(Ordering::Acquire);
-        let press = self.new_press(source, button, action, generation);
+        let press = self.new_press(PressKey::new(source, button), action, generation);
         let token = press.token.clone();
         self.try_input(generation, ButtonInput::Down(press))
             .then_some(token)
@@ -348,18 +386,12 @@ impl ButtonInputHandle {
         self.try_input(generation, ButtonInput::Up(PressKey::new(source, button)))
     }
 
-    fn new_press(
-        &self,
-        source: ButtonSource,
-        button: ButtonId,
-        action: Option<&Action>,
-        generation: u64,
-    ) -> ActivePress {
+    fn new_press(&self, key: PressKey, action: Option<&Action>, generation: u64) -> ActivePress {
         let id = PressId(self.next_press.fetch_add(1, Ordering::Relaxed));
         ActivePress {
             token: PressToken {
                 id,
-                key: PressKey::new(source, button),
+                key,
                 generation,
             },
             action: action.cloned(),

--- a/crates/openlogi-agent-core/src/runtime/button/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/button/tests.rs
@@ -237,16 +237,46 @@ fn worker_drops_input_queued_before_generation_invalidation() {
     let (_shutdown, shutdown) = mpsc::channel();
     let generation = AtomicU64::new(1);
     let (sent, received) = mpsc::channel();
-
-    run_worker(&queued, &shutdown, &generation, &|event| {
+    let mut emit = |event| {
         sent.send(event)
             .expect("test receiver should stay connected");
-    });
+    };
+
+    run_worker(&queued, &shutdown, &generation, &mut emit);
 
     assert!(
         received.try_recv().is_err(),
         "an old profile's queued down must not start a lifecycle"
     );
+}
+
+#[test]
+fn pulse_has_an_immediate_balanced_lifecycle() {
+    let (sent, received) = mpsc::channel();
+    let mut owner = ButtonRuntimeOwner::spawn(move |event| {
+        sent.send(event)
+            .expect("test receiver should stay connected");
+    })
+    .expect("button worker should start");
+    let input = owner.input();
+    let session = HidppSessionId::new("mouse-a", 7);
+    assert!(input.try_hidpp_pulse(
+        &session,
+        ButtonId::Back,
+        Some(&Action::HoldShortcut(
+            "Ctrl+Space".parse().expect("valid shortcut")
+        )),
+    ));
+
+    let ButtonRuntimeEvent::Started(started) = recv_event(&received) else {
+        panic!("pulse must start before ending");
+    };
+    let ButtonRuntimeEvent::Ended { press, reason } = recv_event(&received) else {
+        panic!("pulse must end immediately");
+    };
+    assert_eq!(press.token, started.token);
+    assert_eq!(reason, EndReason::Released);
+    assert!(owner.shutdown());
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/runtime/button/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/button/tests.rs
@@ -280,6 +280,34 @@ fn pulse_has_an_immediate_balanced_lifecycle() {
 }
 
 #[test]
+fn function_key_hold_has_one_balanced_lifecycle() {
+    let (sent, received) = mpsc::channel();
+    let mut owner = ButtonRuntimeOwner::spawn(move |event| {
+        sent.send(event)
+            .expect("test receiver should stay connected");
+    })
+    .expect("button worker should start");
+    let input = owner.input();
+    let action = Action::HoldShortcut("Ctrl+Space".parse().expect("valid shortcut"));
+    let token = input
+        .try_hook_key_down(0x7a, &action)
+        .expect("key down should be queued");
+
+    let ButtonRuntimeEvent::Started(started) = recv_event(&received) else {
+        panic!("function key must start its lifecycle");
+    };
+    assert_eq!(started.token, token);
+    assert_eq!(started.control(), &PressControl::Key(0x7a));
+    assert!(input.try_hook_key_up(0x7a));
+    let ButtonRuntimeEvent::Ended { press, reason } = recv_event(&received) else {
+        panic!("function key must end its lifecycle");
+    };
+    assert_eq!(press.token, token);
+    assert_eq!(reason, EndReason::Released);
+    assert!(owner.shutdown());
+}
+
+#[test]
 fn worker_emits_balanced_shutdown_and_rejects_later_input() {
     let (sent, received) = mpsc::channel();
     let mut owner = ButtonRuntimeOwner::spawn(move |event| {

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -321,6 +321,16 @@ fn remapped_release_disposition(
     }
 }
 
+/// Suppress only input accepted by an off-thread runtime. Rejected input must
+/// fail open so the hook never swallows an edge it could not dispatch.
+fn queued_event_disposition(queued: bool) -> EventDisposition {
+    if queued {
+        EventDisposition::Suppress
+    } else {
+        EventDisposition::PassThrough
+    }
+}
+
 /// Feed an in-progress gesture hold; always pass motion through so the cursor moves.
 fn handle_moved(
     delta_x: i32,
@@ -359,8 +369,7 @@ fn handle_key(
     if !pressed {
         return HELD_KEYS.with_borrow_mut(|keys| {
             if keys.remove(&keycode) {
-                dispatcher.try_hook_key_up(keycode);
-                EventDisposition::Suppress
+                queued_event_disposition(dispatcher.try_hook_key_up(keycode))
             } else {
                 EventDisposition::PassThrough
             }
@@ -393,11 +402,7 @@ fn handle_key(
     } else {
         try_queue_action(action_tx, action)
     };
-    if queued {
-        EventDisposition::Suppress
-    } else {
-        EventDisposition::PassThrough
-    }
+    queued_event_disposition(queued)
 }
 
 /// Attempt to start the OS hook. Returns `None` if Accessibility is not

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -15,7 +15,7 @@ use openlogi_core::binding::{
 };
 use openlogi_core::config::{KeyModifiers, KeyTrigger};
 use openlogi_hook::{
-    EventDevice, EventDisposition, Hook, HookEvent, MouseEvent, source_is_remappable,
+    EventDevice, EventDisposition, Hook, HookEvent, KeyEvent, MouseEvent, source_is_remappable,
 };
 use tracing::{info, warn};
 
@@ -174,6 +174,10 @@ thread_local! {
     /// rejected the remap. Their matching release must also pass through so
     /// apps never see a stuck auxiliary button (down without up).
     static FAIL_OPEN_PRESSES: RefCell<HashSet<ButtonId>> = RefCell::new(HashSet::new());
+    /// Function keys whose held action owns an accepted lifecycle. Repeated
+    /// key-down events are auto-repeat, not replacement presses; their first
+    /// matching key-up ends the lifecycle.
+    static HELD_KEYS: RefCell<HashSet<u16>> = RefCell::new(HashSet::new());
 }
 
 /// Whether a button event's physical source may be remapped/suppressed.
@@ -340,6 +344,62 @@ fn handle_moved(
     EventDisposition::PassThrough
 }
 
+/// Remap one function-key edge without blocking the hook callback.
+fn handle_key(
+    event: KeyEvent,
+    bindings: &SharedKeyboardBindings,
+    action_tx: &mpsc::SyncSender<Action>,
+    dispatcher: &ActionDispatcher,
+) -> EventDisposition {
+    let KeyEvent {
+        keycode,
+        pressed,
+        modifiers,
+    } = event;
+    if !pressed {
+        return HELD_KEYS.with_borrow_mut(|keys| {
+            if keys.remove(&keycode) {
+                dispatcher.try_hook_key_up(keycode);
+                EventDisposition::Suppress
+            } else {
+                EventDisposition::PassThrough
+            }
+        });
+    }
+    if HELD_KEYS.with_borrow(|keys| keys.contains(&keycode)) {
+        return EventDisposition::Suppress;
+    }
+    let trigger = KeyTrigger {
+        keycode,
+        modifiers: convert_modifiers(modifiers),
+    };
+    let Some(action) = bindings
+        .try_read()
+        .ok()
+        .and_then(|map| map.get(&trigger).cloned())
+    else {
+        return EventDisposition::PassThrough;
+    };
+
+    info!(keycode, action = %action.label(), "key → executing bound action");
+    let queued = if action.held_combo().is_some() {
+        let queued = dispatcher.try_hook_key_down(keycode, &action);
+        if queued {
+            HELD_KEYS.with_borrow_mut(|keys| {
+                keys.insert(keycode);
+            });
+        }
+        queued
+    } else {
+        try_queue_action(action_tx, action)
+    };
+    if queued {
+        EventDisposition::Suppress
+    } else {
+        EventDisposition::PassThrough
+    }
+}
+
 /// Attempt to start the OS hook. Returns `None` if Accessibility is not
 /// granted or on an unsupported platform — the app continues without crashing.
 pub fn start(
@@ -375,6 +435,7 @@ pub fn start(
                 }
                 MouseEvent::CaptureInterrupted => {
                     HOLD.with_borrow_mut(HoldState::cancel);
+                    HELD_KEYS.with_borrow_mut(HashSet::clear);
                     dispatcher.cancel_hook_thread_buttons();
                     EventDisposition::PassThrough
                 }
@@ -399,39 +460,11 @@ pub fn start(
                 }
             }
         }
-        // Function-key remapper: on key-down, look up a [keyboard.bindings]
-        // entry for this keycode + modifier mask. A match queues its action
-        // (suppressing the original key so it doesn't also type / trigger its
-        // native function); an unmatched key passes through untouched. Key-up
-        // is ignored to avoid double-firing the action.
-        HookEvent::Key(openlogi_hook::KeyEvent {
-            keycode,
-            pressed,
-            modifiers,
-        }) => {
-            if !pressed {
-                return EventDisposition::PassThrough;
-            }
-            let trigger = KeyTrigger {
-                keycode,
-                modifiers: convert_modifiers(modifiers),
-            };
-            match keyboard_bindings
-                .try_read()
-                .ok()
-                .and_then(|m| m.get(&trigger).cloned())
-            {
-                Some(action) => {
-                    info!(keycode, action = %action.label(), "key → executing bound action");
-                    if try_queue_action(&action_tx, action) {
-                        EventDisposition::Suppress
-                    } else {
-                        EventDisposition::PassThrough
-                    }
-                }
-                None => EventDisposition::PassThrough,
-            }
-        }
+        // Function-key remapper: ordinary actions remain one-shot, while a
+        // HoldShortcut enters the same down/up/cancel lifecycle as a mouse
+        // button. The active set pairs key-up even if modifier state or config
+        // changes while the key is down.
+        HookEvent::Key(event) => handle_key(event, &keyboard_bindings, &action_tx, &dispatcher),
     });
 
     match result {

--- a/crates/openlogi-agent-core/src/runtime/hook/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook/tests.rs
@@ -144,6 +144,15 @@ fn fail_open_press_pairs_release() {
 }
 
 #[test]
+fn rejected_key_edges_fail_open() {
+    assert_eq!(queued_event_disposition(true), EventDisposition::Suppress);
+    assert_eq!(
+        queued_event_disposition(false),
+        EventDisposition::PassThrough
+    );
+}
+
+#[test]
 fn rebound_horizontal_wheel_maps_to_thumbwheel_directions() {
     let maps = HookMaps {
         bindings: BTreeMap::from([

--- a/crates/openlogi-core/src/binding/action.rs
+++ b/crates/openlogi-core/src/binding/action.rs
@@ -178,6 +178,15 @@ pub enum Action {
     ShowActionsRing,
     /// Open an application, folder, filesystem path, or platform URL.
     OpenApplication(ApplicationTarget),
+    /// Hold an arbitrary recorded key chord for the lifetime of its physical
+    /// button press. This is the push-to-talk counterpart to
+    /// [`Action::CustomShortcut`], which emits an immediate down/up pair.
+    ///
+    /// Lifecycle-aware runtimes emit the chord's down edge when the press
+    /// starts and its up edge for every terminal outcome, including capture
+    /// cancellation and shutdown. Dispatchers without a release context must
+    /// degrade this action to a balanced tap rather than leave keys held.
+    HoldShortcut(KeyCombo),
 }
 
 /// One step in a [`Action::Workflow`]. A workflow is a `Vec<WorkflowStep>`
@@ -303,6 +312,7 @@ macro_rules! derive_action_core {
                     Action::RunShellCommand(_) => "Run Command".into(),
                     Action::Workflow(steps) => format!("Workflow ({} steps)", steps.len()),
                     Action::OpenApplication(target) => format!("Open {}", target.display_name()),
+                    Action::HoldShortcut(combo) => format!("Hold {}", combo.rendered_label()),
                 }
             }
 
@@ -317,7 +327,8 @@ macro_rules! derive_action_core {
                     | Action::TypeText(_)
                     | Action::RunAppleScript(_)
                     | Action::RunShellCommand(_)
-                    | Action::Workflow(_) => Category::Editing,
+                    | Action::Workflow(_)
+                    | Action::HoldShortcut(_) => Category::Editing,
                     Action::SetDpiPreset(_) => Category::Dpi,
                     Action::OpenApplication(_) => Category::System,
                 }
@@ -348,3 +359,15 @@ macro_rules! derive_action_core {
 }
 
 for_each_unit_action!(derive_action_core);
+
+impl Action {
+    /// The chord whose output must remain down until the originating press
+    /// ends, or `None` for an instantaneous action.
+    #[must_use]
+    pub fn held_combo(&self) -> Option<&KeyCombo> {
+        match self {
+            Self::HoldShortcut(combo) => Some(combo),
+            _ => None,
+        }
+    }
+}

--- a/crates/openlogi-core/src/binding/action_ring/icon.rs
+++ b/crates/openlogi-core/src/binding/action_ring/icon.rs
@@ -314,9 +314,10 @@ macro_rules! derive_action_icon {
                 match action {
                     $( Action::$variant => Self::$icon, )*
                     Action::SetDpiPreset(_) => Self::Gauge,
-                    Action::CustomShortcut(_) | Action::TypeText(_) | Action::Workflow(_) => {
-                        Self::Keyboard
-                    }
+                    Action::CustomShortcut(_)
+                    | Action::TypeText(_)
+                    | Action::Workflow(_)
+                    | Action::HoldShortcut(_) => Self::Keyboard,
                     Action::RunAppleScript(_) | Action::RunShellCommand(_) => Self::Terminal,
                     Action::OpenApplication(_) => Self::Applications,
                 }

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -38,6 +38,10 @@ pub enum Effect<'a> {
     /// Press an already-resolved keyboard chord: a user-recorded
     /// [`Action::CustomShortcut`], or a workflow's `PressKey` step.
     Key(&'a KeyCombo),
+    /// A user-recorded chord whose output is held by a lifecycle-aware
+    /// runtime. A one-shot executor treats this as [`Effect::Key`] so direct
+    /// dispatch remains balanced when no matching release can arrive.
+    HeldKey(&'a KeyCombo),
     /// Synthesise one scroll tick. `dx`/`dy` are unit direction (-1/0/1);
     /// each backend applies its own tick magnitude.
     Scroll {
@@ -270,6 +274,7 @@ impl Action {
             Action::HorizontalScrollRight => Effect::Scroll { dx: 1, dy: 0 },
 
             Action::CustomShortcut(combo) => Effect::Key(combo),
+            Action::HoldShortcut(combo) => Effect::HeldKey(combo),
 
             Action::TypeText(text) => Effect::Text(text),
             Action::RunAppleScript(src) => Effect::Script(Script::AppleScript(src)),

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -33,10 +33,28 @@ fn catalog_excludes_custom_shortcut() {
     let catalog = Action::catalog();
     for action in &catalog {
         assert!(
-            !matches!(action, Action::CustomShortcut(_)),
-            "catalog must not contain CustomShortcut"
+            !matches!(action, Action::CustomShortcut(_) | Action::HoldShortcut(_)),
+            "catalog must not contain recorded shortcut actions"
         );
     }
+}
+
+#[test]
+fn hold_shortcut_has_distinct_lifecycle_semantics() {
+    let combo: KeyCombo = "Alt+Space".parse().expect("valid shortcut failed");
+    let held = Action::HoldShortcut(combo.clone());
+
+    assert_eq!(held.label(), "Hold Alt+Space");
+    assert_eq!(held.category(), Category::Editing);
+    assert_eq!(held.held_combo(), Some(&combo));
+    assert_matches!(held.effect(), Effect::HeldKey(actual) if actual == &combo);
+    assert_eq!(Action::CustomShortcut(combo).held_combo(), None);
+}
+
+#[test]
+fn hold_shortcut_roundtrips_toml() {
+    let action = Action::HoldShortcut("Alt+Space".parse().expect("valid shortcut failed"));
+    assert_eq!(roundtrip(&action), action);
 }
 
 #[test]
@@ -264,6 +282,10 @@ fn persisted_action_variant_names_are_stable() {
             ApplicationTarget::new("/Applications/OpenLogi.app", "OpenLogi")
                 .unwrap_or_else(|error| panic!("valid target failed: {error}")),
         ),
+        Action::HoldShortcut(
+            "F2".parse()
+                .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+        ),
     ]);
     let mut actual: Vec<String> = actions
         .into_iter()
@@ -293,6 +315,7 @@ fn persisted_action_variant_names_are_stable() {
         "Find",
         "HorizontalScrollLeft",
         "HorizontalScrollRight",
+        "HoldShortcut",
         "LaunchpadShow",
         "LeftClick",
         "LockScreen",
@@ -516,6 +539,13 @@ fn power_user_and_device_side_actions_lower_to_the_expected_bucket() {
         .unwrap_or_else(|error| panic!("valid shortcut failed: {error}"));
     let custom_shortcut = Action::CustomShortcut(combo);
     assert_matches!(custom_shortcut.effect(), Effect::Key(_));
+
+    let hold_shortcut = Action::HoldShortcut(
+        "Ctrl+Space"
+            .parse()
+            .unwrap_or_else(|error| panic!("valid shortcut failed: {error}")),
+    );
+    assert_matches!(hold_shortcut.effect(), Effect::HeldKey(_));
 
     let type_text = Action::TypeText("hi".into());
     assert_matches!(type_text.effect(), Effect::Text("hi"));

--- a/crates/openlogi-desktop/src/features/action_ring/editor.rs
+++ b/crates/openlogi-desktop/src/features/action_ring/editor.rs
@@ -20,6 +20,7 @@ use openlogi_core::binding::{
 use super::action_icons::action_icon_path;
 use crate::features::mouse::picker::editor_section;
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::action::localized_action_label;
 use crate::ui::components::MenuRow;
 use crate::ui::theme::{self, Palette, Typography as _};
 
@@ -32,10 +33,9 @@ pub(super) fn action_library(
     pal: Palette,
 ) -> impl IntoElement {
     let current_action = current.map(ActionRingEntry::action).cloned();
-    let current_label = current_action.as_ref().map_or_else(
-        || tr!("Empty slot").to_string(),
-        |action| rust_i18n::t!(action.label()).into_owned(),
-    );
+    let current_label = current_action
+        .as_ref()
+        .map_or_else(|| tr!("Empty slot"), localized_action_label);
 
     v_flex()
         .flex_1()

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -45,6 +45,7 @@ use crate::features::mouse::picker::{
 };
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::action::localized_action_label;
 use crate::ui::components::MenuRow;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 use gpui::ease_in_out;
@@ -666,8 +667,7 @@ fn key_click_target(
 
 fn binding_label(action: Option<&Action>) -> gpui::SharedString {
     match action {
-        Some(Action::CustomShortcut(combo)) => combo.rendered_label().into(),
-        Some(a) => tr!(a.label()),
+        Some(action) => localized_action_label(action),
         None => tr!("Off"),
     }
 }

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -23,8 +23,9 @@ use super::picker::{
     GESTURE_BUTTON_ICON, PickFn, action_icon_path, action_rows_matching, editor_section,
 };
 use super::thumbwheel::ThumbwheelPreset;
-use super::view::{MouseModelView, localized_action_label};
+use super::view::MouseModelView;
 use crate::state::AppState;
+use crate::ui::action::localized_action_label;
 use crate::ui::components::MenuRow;
 use crate::ui::theme::{ACCENT_BLUE, Palette, Typography as _};
 

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -87,7 +87,9 @@ pub(crate) fn action_icon_path(action: &Action) -> &'static str {
         Action::ScrollDown => "action-icons/chevrons-down.svg",
         Action::HorizontalScrollLeft => "action-icons/chevrons-left.svg",
         Action::HorizontalScrollRight => "action-icons/chevrons-right.svg",
-        Action::CustomShortcut(_) | Action::TypeText(_) => "action-icons/keyboard.svg",
+        Action::CustomShortcut(_) | Action::HoldShortcut(_) | Action::TypeText(_) => {
+            "action-icons/keyboard.svg"
+        }
         Action::RunAppleScript(_) | Action::RunShellCommand(_) => "action-icons/terminal.svg",
     }
 }

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -28,6 +28,7 @@ use crate::app::{glow_canvas, keyboard_glow};
 use crate::features::profile_scope::{friendly_app_name, profile_canvas_status};
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, StateEvent};
+use crate::ui::action::localized_action_label;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
 const SIDE_GAP: f32 = 24.;
@@ -769,16 +770,6 @@ fn binding_label_for_control(
                 }
             }
         }
-    }
-}
-
-pub(super) fn localized_action_label(action: &Action) -> gpui::SharedString {
-    match action {
-        Action::SetDpiPreset(index) => {
-            tr!("DPI Preset %{index}", index => (index + 1).to_string())
-        }
-        Action::CustomShortcut(combo) => combo.rendered_label().into(),
-        _ => tr!(action.label()),
     }
 }
 

--- a/crates/openlogi-desktop/src/services/i18n.rs
+++ b/crates/openlogi-desktop/src/services/i18n.rs
@@ -58,6 +58,7 @@ mod tests {
             rust_i18n::t!("DPI Preset %{index}", index => "2"),
             "灵敏度预设 2"
         ); // parameterized action label
+        assert_eq!(rust_i18n::t!("Hold %{chord}", chord => "X"), "按住 X"); // held action label
         assert_eq!(rust_i18n::t!("Quit OpenLogi"), "退出 OpenLogi"); // menu-bar status item
         assert_eq!(rust_i18n::t!("No devices connected"), "未连接设备"); // menu-bar device line
         assert_eq!(rust_i18n::t!("Lighting"), "灯光"); // keyboard lighting tab
@@ -85,8 +86,9 @@ mod tests {
         );
 
         // Exhaustive: every non-parameterized device/action label has a `zh-CN`
-        // entry. Parameterized `Action`s (`SetDpiPreset`, `CustomShortcut`) are
-        // skipped here and checked explicitly above where needed.
+        // entry. Parameterized `Action`s (`SetDpiPreset`, `CustomShortcut`,
+        // `HoldShortcut`) are skipped here and checked explicitly above where
+        // needed.
         let covered = |label: &str| rust_i18n::t!(label) != label;
         for b in ButtonId::ALL {
             assert!(covered(b.label()), "no zh-CN for ButtonId::{b:?}");

--- a/crates/openlogi-desktop/src/ui/action.rs
+++ b/crates/openlogi-desktop/src/ui/action.rs
@@ -1,0 +1,18 @@
+//! Display helpers for the shared action vocabulary.
+
+use gpui::SharedString;
+use openlogi_core::binding::Action;
+
+/// Localized label for an action, including its dynamic payload.
+pub(crate) fn localized_action_label(action: &Action) -> SharedString {
+    match action {
+        Action::SetDpiPreset(index) => {
+            tr!("DPI Preset %{index}", index => (index + 1).to_string())
+        }
+        Action::CustomShortcut(combo) => combo.rendered_label().into(),
+        Action::HoldShortcut(combo) => {
+            tr!("Hold %{chord}", chord => combo.rendered_label())
+        }
+        _ => tr!(action.label()),
+    }
+}

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -1,5 +1,6 @@
 //! Shared settings-app UI components and theme.
 
+pub(crate) mod action;
 pub(crate) mod carousel;
 pub(crate) mod components;
 pub mod section;

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -6,7 +6,7 @@
 //! of which translates an [`Action`] into the native event(s) — CGEvent/NSEvent
 //! on macOS, uinput/D-Bus on Linux, SendInput on Windows.
 
-use openlogi_core::binding::Action;
+use openlogi_core::binding::{Action, KeyCombo};
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -16,6 +16,13 @@ mod linux;
 
 #[cfg(target_os = "windows")]
 mod windows;
+
+/// Which isolated edge of a held keyboard chord to synthesize.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeyPhase {
+    Down,
+    Up,
+}
 
 /// Synthesise the OS-level event for `action`.
 ///
@@ -77,6 +84,44 @@ pub fn execute(action: &Action) {
             tracing::warn!(
                 action = action.label(),
                 "execute unsupported on this platform"
+            );
+        }
+    }
+}
+
+/// Synthesise the down edge of `combo`, leaving its output held.
+///
+/// Every successful lifecycle start must be paired with [`release_hold`],
+/// including cancellation and shutdown paths. Prefer [`execute`] when the
+/// caller does not own a matching terminal event.
+pub fn press_hold(combo: &KeyCombo) {
+    hold_phase(combo, KeyPhase::Down);
+}
+
+/// Synthesise the up edge matching a prior [`press_hold`].
+///
+/// A redundant release is safe: platforms treat an up edge for an already-up
+/// key as a no-op, which lets cancellation paths release defensively.
+pub fn release_hold(combo: &KeyCombo) {
+    hold_phase(combo, KeyPhase::Up);
+}
+
+fn hold_phase(combo: &KeyCombo, phase: KeyPhase) {
+    cfg_select! {
+        target_os = "macos" => {
+            macos::hold_combo(combo, phase);
+        }
+        target_os = "linux" => {
+            linux::hold_combo(combo, phase);
+        }
+        target_os = "windows" => {
+            windows::hold_combo(combo, phase);
+        }
+        _ => {
+            tracing::warn!(
+                chord = %combo.rendered_label(),
+                ?phase,
+                "held shortcut output unsupported on this platform"
             );
         }
     }

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -6,12 +6,12 @@
 //! of which translates an [`Action`] into the native event(s) — CGEvent/NSEvent
 //! on macOS, uinput/D-Bus on Linux, SendInput on Windows.
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use std::collections::HashMap;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use std::sync::{LazyLock, Mutex, PoisonError};
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use openlogi_core::binding::KeyboardUsage;
 use openlogi_core::binding::{Action, KeyCombo};
 
@@ -31,34 +31,68 @@ enum KeyPhase {
     Up,
 }
 
-/// One physical keyboard output shared by held chords on Linux and Windows.
+/// One physical keyboard output shared by held chords.
 ///
-/// Both logical Cmd and Ctrl map to [`Self::Control`] on these platforms, so
-/// ownership is counted after that alias is resolved.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+/// Logical Cmd and Ctrl are distinct on macOS. Cmd aliases Ctrl on Linux and
+/// Windows, so ownership is counted after that platform mapping is resolved.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum HeldKey {
+    #[cfg(target_os = "macos")]
+    Command,
     Control,
     Shift,
     Alt,
     Key(KeyboardUsage),
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[derive(Debug, Default, PartialEq, Eq)]
 struct HoldTransition {
     up: Vec<HeldKey>,
     down: Vec<HeldKey>,
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct HeldModifiers(u8);
+
+#[cfg(target_os = "macos")]
+impl HeldModifiers {
+    fn set(&mut self, key: HeldKey, held: bool) {
+        let Some(mask) = Self::mask(key) else {
+            return;
+        };
+        if held {
+            self.0 |= mask;
+        } else {
+            self.0 &= !mask;
+        }
+    }
+
+    fn contains(self, key: HeldKey) -> bool {
+        Self::mask(key).is_some_and(|mask| self.0 & mask != 0)
+    }
+
+    fn mask(key: HeldKey) -> Option<u8> {
+        match key {
+            HeldKey::Command => Some(1 << 0),
+            HeldKey::Control => Some(1 << 1),
+            HeldKey::Shift => Some(1 << 2),
+            HeldKey::Alt => Some(1 << 3),
+            HeldKey::Key(_) => None,
+        }
+    }
+}
+
 /// Reference counts for physical keyboard outputs across active chords.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[derive(Default)]
 struct HeldOutput {
     owners: HashMap<HeldKey, usize>,
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 impl HeldOutput {
     fn transition(
         &mut self,
@@ -93,16 +127,39 @@ impl HeldOutput {
                 .collect(),
         }
     }
+
+    #[cfg(target_os = "macos")]
+    fn modifiers(&self) -> HeldModifiers {
+        let mut modifiers = HeldModifiers::default();
+        for key in [
+            HeldKey::Command,
+            HeldKey::Control,
+            HeldKey::Shift,
+            HeldKey::Alt,
+        ] {
+            modifiers.set(key, self.owners.contains_key(&key));
+        }
+        modifiers
+    }
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 static HELD_OUTPUT: LazyLock<Mutex<HeldOutput>> =
     LazyLock::new(|| Mutex::new(HeldOutput::default()));
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
     let mut keys = Vec::with_capacity(4);
+    #[cfg(target_os = "macos")]
+    if combo.has_command() {
+        keys.push(HeldKey::Command);
+    }
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     if combo.has_command() || combo.has_control() {
+        keys.push(HeldKey::Control);
+    }
+    #[cfg(target_os = "macos")]
+    if combo.has_control() {
         keys.push(HeldKey::Control);
     }
     if combo.has_shift() {
@@ -191,8 +248,9 @@ pub fn press_hold(combo: &KeyCombo) {
 
 /// Synthesise the up edge matching a prior [`press_hold`].
 ///
-/// A redundant release is safe: platforms treat an up edge for an already-up
-/// key as a no-op, which lets cancellation paths release defensively.
+/// Each successful [`press_hold`] must be released exactly once. The lifecycle
+/// owner provides that guarantee; duplicate releases would consume ownership
+/// retained for an overlapping chord.
 pub fn release_hold(combo: &KeyCombo) {
     hold_transition(Some(combo), None);
 }
@@ -205,12 +263,12 @@ pub fn replace_hold(old: &KeyCombo, new: &KeyCombo) {
 fn hold_transition(released: Option<&KeyCombo>, pressed: Option<&KeyCombo>) {
     cfg_select! {
         target_os = "macos" => {
-            if let Some(combo) = released {
-                macos::hold_combo(combo, KeyPhase::Up);
-            }
-            if let Some(combo) = pressed {
-                macos::hold_combo(combo, KeyPhase::Down);
-            }
+            let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
+            let modifiers = output.modifiers();
+            let transition = output.transition(released, pressed);
+            let modifiers = macos::hold_keys(&transition.up, KeyPhase::Up, modifiers);
+            let modifiers = macos::hold_keys(&transition.down, KeyPhase::Down, modifiers);
+            debug_assert_eq!(modifiers, output.modifiers());
         }
         target_os = "linux" => {
             let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
@@ -349,18 +407,18 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     use openlogi_core::binding::KeyCombo;
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     use super::{HeldKey, HeldOutput, HoldTransition};
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn combo(label: &str) -> KeyCombo {
         label.parse().expect("test shortcut must be valid")
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn shared_control_stays_down_until_its_last_chord_ends() {
         let control_a = combo("Ctrl+A");
@@ -421,7 +479,62 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn command_and_control_are_distinct_physical_outputs() {
+        let command_a = combo("Cmd+A");
+        let control_b = combo("Ctrl+B");
+        let mut output = HeldOutput::default();
+
+        output.transition(None, Some(&command_a));
+        assert_eq!(
+            output.transition(None, Some(&control_b)),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Control, HeldKey::Key(control_b.key())],
+            }
+        );
+        assert_eq!(
+            output.transition(Some(&command_a), None),
+            HoldTransition {
+                up: vec![HeldKey::Command, HeldKey::Key(command_a.key())],
+                down: vec![],
+            }
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn shared_command_stays_down_until_its_last_chord_ends() {
+        let command_a = combo("Cmd+A");
+        let command_b = combo("Cmd+B");
+        let mut output = HeldOutput::default();
+
+        output.transition(None, Some(&command_a));
+        assert_eq!(
+            output.transition(None, Some(&command_b)),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Key(command_b.key())],
+            }
+        );
+        assert_eq!(
+            output.transition(Some(&command_a), None),
+            HoldTransition {
+                up: vec![HeldKey::Key(command_a.key())],
+                down: vec![],
+            }
+        );
+        assert_eq!(
+            output.transition(Some(&command_b), None),
+            HoldTransition {
+                up: vec![HeldKey::Command, HeldKey::Key(command_b.key())],
+                down: vec![],
+            }
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn replacement_preserves_shared_physical_outputs() {
         let old = combo("Ctrl+A");

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -6,6 +6,13 @@
 //! of which translates an [`Action`] into the native event(s) — CGEvent/NSEvent
 //! on macOS, uinput/D-Bus on Linux, SendInput on Windows.
 
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use std::collections::HashMap;
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use std::sync::{LazyLock, Mutex, PoisonError};
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use openlogi_core::binding::KeyboardUsage;
 use openlogi_core::binding::{Action, KeyCombo};
 
 #[cfg(target_os = "macos")]
@@ -22,6 +29,90 @@ mod windows;
 enum KeyPhase {
     Down,
     Up,
+}
+
+/// One physical keyboard output shared by held chords on Linux and Windows.
+///
+/// Both logical Cmd and Ctrl map to [`Self::Control`] on these platforms, so
+/// ownership is counted after that alias is resolved.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum HeldKey {
+    Control,
+    Shift,
+    Alt,
+    Key(KeyboardUsage),
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[derive(Debug, Default, PartialEq, Eq)]
+struct HoldTransition {
+    up: Vec<HeldKey>,
+    down: Vec<HeldKey>,
+}
+
+/// Reference counts for physical keyboard outputs across active chords.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[derive(Default)]
+struct HeldOutput {
+    owners: HashMap<HeldKey, usize>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+impl HeldOutput {
+    fn transition(
+        &mut self,
+        released: Option<&KeyCombo>,
+        pressed: Option<&KeyCombo>,
+    ) -> HoldTransition {
+        let released = released.map_or_else(Vec::new, held_keys);
+        let pressed = pressed.map_or_else(Vec::new, held_keys);
+        let before = self.owners.clone();
+
+        for key in &released {
+            match self.owners.get_mut(key) {
+                Some(owners) if *owners > 1 => *owners -= 1,
+                Some(_) => {
+                    self.owners.remove(key);
+                }
+                None => {}
+            }
+        }
+        for key in &pressed {
+            *self.owners.entry(*key).or_default() += 1;
+        }
+
+        HoldTransition {
+            up: released
+                .into_iter()
+                .filter(|key| before.contains_key(key) && !self.owners.contains_key(key))
+                .collect(),
+            down: pressed
+                .into_iter()
+                .filter(|key| !before.contains_key(key) && self.owners.contains_key(key))
+                .collect(),
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+static HELD_OUTPUT: LazyLock<Mutex<HeldOutput>> =
+    LazyLock::new(|| Mutex::new(HeldOutput::default()));
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
+    let mut keys = Vec::with_capacity(4);
+    if combo.has_command() || combo.has_control() {
+        keys.push(HeldKey::Control);
+    }
+    if combo.has_shift() {
+        keys.push(HeldKey::Shift);
+    }
+    if combo.has_option() {
+        keys.push(HeldKey::Alt);
+    }
+    keys.push(HeldKey::Key(combo.key()));
+    keys
 }
 
 /// Synthesise the OS-level event for `action`.
@@ -95,7 +186,7 @@ pub fn execute(action: &Action) {
 /// including cancellation and shutdown paths. Prefer [`execute`] when the
 /// caller does not own a matching terminal event.
 pub fn press_hold(combo: &KeyCombo) {
-    hold_phase(combo, KeyPhase::Down);
+    hold_transition(None, Some(combo));
 }
 
 /// Synthesise the up edge matching a prior [`press_hold`].
@@ -103,24 +194,38 @@ pub fn press_hold(combo: &KeyCombo) {
 /// A redundant release is safe: platforms treat an up edge for an already-up
 /// key as a no-op, which lets cancellation paths release defensively.
 pub fn release_hold(combo: &KeyCombo) {
-    hold_phase(combo, KeyPhase::Up);
+    hold_transition(Some(combo), None);
 }
 
-fn hold_phase(combo: &KeyCombo, phase: KeyPhase) {
+/// Replace one held chord without releasing physical keys shared by both.
+pub fn replace_hold(old: &KeyCombo, new: &KeyCombo) {
+    hold_transition(Some(old), Some(new));
+}
+
+fn hold_transition(released: Option<&KeyCombo>, pressed: Option<&KeyCombo>) {
     cfg_select! {
         target_os = "macos" => {
-            macos::hold_combo(combo, phase);
+            if let Some(combo) = released {
+                macos::hold_combo(combo, KeyPhase::Up);
+            }
+            if let Some(combo) = pressed {
+                macos::hold_combo(combo, KeyPhase::Down);
+            }
         }
         target_os = "linux" => {
-            linux::hold_combo(combo, phase);
+            let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
+            let transition = output.transition(released, pressed);
+            linux::hold_keys(&transition.up, KeyPhase::Up);
+            linux::hold_keys(&transition.down, KeyPhase::Down);
         }
         target_os = "windows" => {
-            windows::hold_combo(combo, phase);
+            let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
+            let transition = output.transition(released, pressed);
+            windows::hold_keys(&transition.up, KeyPhase::Up);
+            windows::hold_keys(&transition.down, KeyPhase::Down);
         }
         _ => {
             tracing::warn!(
-                chord = %combo.rendered_label(),
-                ?phase,
                 "held shortcut output unsupported on this platform"
             );
         }
@@ -244,6 +349,95 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    use openlogi_core::binding::KeyCombo;
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    use super::{HeldKey, HeldOutput, HoldTransition};
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    fn combo(label: &str) -> KeyCombo {
+        label.parse().expect("test shortcut must be valid")
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn shared_control_stays_down_until_its_last_chord_ends() {
+        let control_a = combo("Ctrl+A");
+        let control_b = combo("Ctrl+B");
+        let mut output = HeldOutput::default();
+
+        assert_eq!(
+            output.transition(None, Some(&control_a)),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Control, HeldKey::Key(control_a.key())],
+            }
+        );
+        assert_eq!(
+            output.transition(None, Some(&control_b)),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Key(control_b.key())],
+            }
+        );
+        assert_eq!(
+            output.transition(Some(&control_a), None),
+            HoldTransition {
+                up: vec![HeldKey::Key(control_a.key())],
+                down: vec![],
+            }
+        );
+        assert_eq!(
+            output.transition(Some(&control_b), None),
+            HoldTransition {
+                up: vec![HeldKey::Control, HeldKey::Key(control_b.key())],
+                down: vec![],
+            }
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn command_and_control_share_one_physical_output() {
+        let command_a = combo("Cmd+A");
+        let control_b = combo("Ctrl+B");
+        let mut output = HeldOutput::default();
+
+        output.transition(None, Some(&command_a));
+        assert_eq!(
+            output.transition(None, Some(&control_b)),
+            HoldTransition {
+                up: vec![],
+                down: vec![HeldKey::Key(control_b.key())],
+            }
+        );
+        assert_eq!(
+            output.transition(Some(&command_a), None),
+            HoldTransition {
+                up: vec![HeldKey::Key(command_a.key())],
+                down: vec![],
+            }
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn replacement_preserves_shared_physical_outputs() {
+        let old = combo("Ctrl+A");
+        let new = combo("Ctrl+B");
+        let mut output = HeldOutput::default();
+
+        output.transition(None, Some(&old));
+        assert_eq!(
+            output.transition(Some(&old), Some(&new)),
+            HoldTransition {
+                up: vec![HeldKey::Key(old.key())],
+                down: vec![HeldKey::Key(new.key())],
+            }
+        );
+    }
+
     #[test]
     fn hid_usages_map_across_windows_key_categories() {
         use super::hid_usage_to_windows;

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -16,6 +16,8 @@ use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
 
+use super::KeyPhase;
+
 /// Linux implementation: classify `action` into an [`Effect`] and inject the
 /// resulting events via a shared `uinput` virtual device.
 pub(super) fn execute(action: &Action) {
@@ -25,7 +27,7 @@ pub(super) fn execute(action: &Action) {
         // buttons ("back"/"forward") browsers handle natively.
         Effect::Click(button) => click(mouse_button_code(button)),
         Effect::Shortcut(shortcut) => press_combo(&combo(shortcut)),
-        Effect::Key(combo) => press_combo(combo),
+        Effect::Key(combo) | Effect::HeldKey(combo) => press_combo(combo),
         Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         Effect::Media(key) => dispatch_media(key),
         Effect::Native(native) => dispatch_native(action, native),
@@ -101,6 +103,18 @@ fn press_combo(combo: &KeyCombo) {
         return;
     };
     press_key(&modifiers_to_keycodes(combo), key);
+}
+
+/// Emit one isolated edge of a held chord.
+pub(super) fn hold_combo(combo: &KeyCombo, phase: KeyPhase) {
+    let Some(key) = hid_usage_to_linux(combo.key().code()) else {
+        tracing::warn!(
+            usage = combo.key().code(),
+            "held shortcut usage has no Linux mapping — edge ignored"
+        );
+        return;
+    };
+    emit(&key_phase_events(&modifiers_to_keycodes(combo), key, phase));
 }
 
 /// MPRIS targets the running media player; XF86 volume keys go to the
@@ -319,23 +333,27 @@ fn rel_ev(axis: RelativeAxisCode, value: i32) -> InputEvent {
 /// release, which matches what the kernel `uinput` docs show and avoids
 /// toolkits treating a zero-duration event as invalid.
 fn press_key(mods: &[KeyCode], key: KeyCode) {
-    // Down phase.
-    let mut down: Vec<InputEvent> = Vec::with_capacity(mods.len() + 2);
-    for &m in mods {
-        down.push(key_ev(m, 1));
-    }
-    down.push(key_ev(key, 1));
-    down.push(syn());
-    emit(&down);
+    emit(&key_phase_events(mods, key, KeyPhase::Down));
+    emit(&key_phase_events(mods, key, KeyPhase::Up));
+}
 
-    // Up phase.
-    let mut up: Vec<InputEvent> = Vec::with_capacity(mods.len() + 2);
-    up.push(key_ev(key, 0));
-    for &m in mods.iter().rev() {
-        up.push(key_ev(m, 0));
+/// Build one `SYN_REPORT` frame. Down order is modifiers then key; up order
+/// is the exact reverse so the ordinary key never escapes as an unmodified
+/// release.
+fn key_phase_events(mods: &[KeyCode], key: KeyCode, phase: KeyPhase) -> Vec<InputEvent> {
+    let mut events = Vec::with_capacity(mods.len() + 2);
+    match phase {
+        KeyPhase::Down => {
+            events.extend(mods.iter().map(|modifier| key_ev(*modifier, 1)));
+            events.push(key_ev(key, 1));
+        }
+        KeyPhase::Up => {
+            events.push(key_ev(key, 0));
+            events.extend(mods.iter().rev().map(|modifier| key_ev(*modifier, 0)));
+        }
     }
-    up.push(syn());
-    emit(&up);
+    events.push(syn());
+    events
 }
 
 /// Inject a button-down in one SYN frame and button-up in a second.
@@ -611,7 +629,31 @@ mod tests {
     use evdev::KeyCode;
     use openlogi_core::binding::{KeyCombo, Shortcut};
 
-    use super::{combo, hid_usage_to_linux, modifiers_to_keycodes};
+    use super::{combo, hid_usage_to_linux, key_ev, key_phase_events, modifiers_to_keycodes, syn};
+    use crate::inject::KeyPhase;
+
+    #[test]
+    fn held_chord_edges_use_inverse_key_order() {
+        let modifiers = [KeyCode::KEY_LEFTCTRL, KeyCode::KEY_LEFTSHIFT];
+        assert_eq!(
+            key_phase_events(&modifiers, KeyCode::KEY_P, KeyPhase::Down),
+            vec![
+                key_ev(KeyCode::KEY_LEFTCTRL, 1),
+                key_ev(KeyCode::KEY_LEFTSHIFT, 1),
+                key_ev(KeyCode::KEY_P, 1),
+                syn(),
+            ]
+        );
+        assert_eq!(
+            key_phase_events(&modifiers, KeyCode::KEY_P, KeyPhase::Up),
+            vec![
+                key_ev(KeyCode::KEY_P, 0),
+                key_ev(KeyCode::KEY_LEFTSHIFT, 0),
+                key_ev(KeyCode::KEY_LEFTCTRL, 0),
+                syn(),
+            ]
+        );
+    }
 
     #[test]
     fn modifiers_map_to_linux_without_duplicate_control() {

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -16,7 +16,7 @@ use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
 
-use super::KeyPhase;
+use super::{HeldKey, KeyPhase};
 
 /// Linux implementation: classify `action` into an [`Effect`] and inject the
 /// resulting events via a shared `uinput` virtual device.
@@ -105,16 +105,12 @@ fn press_combo(combo: &KeyCombo) {
     press_key(&modifiers_to_keycodes(combo), key);
 }
 
-/// Emit one isolated edge of a held chord.
-pub(super) fn hold_combo(combo: &KeyCombo, phase: KeyPhase) {
-    let Some(key) = hid_usage_to_linux(combo.key().code()) else {
-        tracing::warn!(
-            usage = combo.key().code(),
-            "held shortcut usage has no Linux mapping — edge ignored"
-        );
-        return;
-    };
-    emit(&key_phase_events(&modifiers_to_keycodes(combo), key, phase));
+/// Emit one edge for the physical keys whose ownership changed.
+pub(super) fn hold_keys(keys: &[HeldKey], phase: KeyPhase) {
+    let keys: Vec<_> = keys.iter().filter_map(|key| held_keycode(*key)).collect();
+    if !keys.is_empty() {
+        emit(&held_key_events(&keys, phase));
+    }
 }
 
 /// MPRIS targets the running media player; XF86 volume keys go to the
@@ -341,15 +337,20 @@ fn press_key(mods: &[KeyCode], key: KeyCode) {
 /// is the exact reverse so the ordinary key never escapes as an unmodified
 /// release.
 fn key_phase_events(mods: &[KeyCode], key: KeyCode, phase: KeyPhase) -> Vec<InputEvent> {
-    let mut events = Vec::with_capacity(mods.len() + 2);
+    let mut keys = Vec::with_capacity(mods.len() + 1);
+    keys.extend_from_slice(mods);
+    keys.push(key);
+    held_key_events(&keys, phase)
+}
+
+fn held_key_events(keys: &[KeyCode], phase: KeyPhase) -> Vec<InputEvent> {
+    let mut events = Vec::with_capacity(keys.len() + 1);
     match phase {
         KeyPhase::Down => {
-            events.extend(mods.iter().map(|modifier| key_ev(*modifier, 1)));
-            events.push(key_ev(key, 1));
+            events.extend(keys.iter().map(|key| key_ev(*key, 1)));
         }
         KeyPhase::Up => {
-            events.push(key_ev(key, 0));
-            events.extend(mods.iter().rev().map(|modifier| key_ev(*modifier, 0)));
+            events.extend(keys.iter().rev().map(|key| key_ev(*key, 0)));
         }
     }
     events.push(syn());
@@ -405,6 +406,24 @@ fn modifiers_to_keycodes(combo: &openlogi_core::binding::KeyCombo) -> Vec<KeyCod
         modifiers.push(KeyCode::KEY_LEFTALT);
     }
     modifiers
+}
+
+fn held_keycode(key: HeldKey) -> Option<KeyCode> {
+    match key {
+        HeldKey::Control => Some(KeyCode::KEY_LEFTCTRL),
+        HeldKey::Shift => Some(KeyCode::KEY_LEFTSHIFT),
+        HeldKey::Alt => Some(KeyCode::KEY_LEFTALT),
+        HeldKey::Key(usage) => {
+            let key = hid_usage_to_linux(usage.code());
+            if key.is_none() {
+                tracing::warn!(
+                    usage = usage.code(),
+                    "held shortcut usage has no Linux mapping — edge ignored"
+                );
+            }
+            key
+        }
+    }
 }
 
 /// Map a platform-neutral USB HID keyboard usage to evdev.

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -12,7 +12,7 @@ use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
 
-use super::KeyPhase;
+use super::{HeldKey, HeldModifiers, KeyPhase};
 
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
 const NX_KEYTYPE_SOUND_UP: i32 = 0;
@@ -282,16 +282,72 @@ fn post_keycombo(combo: &KeyCombo) {
     }
 }
 
-/// Emit one isolated edge of a held chord.
-pub(super) fn hold_combo(combo: &KeyCombo, phase: KeyPhase) {
-    if let Some(vk) = hid_usage_to_macos(combo.key().code()) {
-        post_key_phase(vk, combo_flags(combo), phase);
-    } else {
-        tracing::warn!(
-            usage = combo.key().code(),
-            "held shortcut usage has no macOS mapping — edge ignored"
-        );
+/// Emit the physical-key edges whose shared ownership changed, preserving the
+/// aggregate synthetic modifier state on every event.
+pub(super) fn hold_keys(
+    keys: &[HeldKey],
+    phase: KeyPhase,
+    mut modifiers: HeldModifiers,
+) -> HeldModifiers {
+    match phase {
+        KeyPhase::Down => {
+            for &key in keys {
+                post_held_key(key, phase, &mut modifiers);
+            }
+        }
+        KeyPhase::Up => {
+            for &key in keys.iter().rev() {
+                post_held_key(key, phase, &mut modifiers);
+            }
+        }
     }
+    modifiers
+}
+
+fn post_held_key(key: HeldKey, phase: KeyPhase, modifiers: &mut HeldModifiers) {
+    let Some((vk, flags)) = held_key_event(key, phase, modifiers) else {
+        if let HeldKey::Key(usage) = key {
+            tracing::warn!(
+                usage = usage.code(),
+                "held shortcut usage has no macOS mapping — edge ignored"
+            );
+        }
+        return;
+    };
+    post_key_phase(vk, flags, phase);
+}
+
+fn held_key_event(
+    key: HeldKey,
+    phase: KeyPhase,
+    modifiers: &mut HeldModifiers,
+) -> Option<(u16, CGEventFlags)> {
+    modifiers.set(key, phase == KeyPhase::Down);
+    let vk = match key {
+        HeldKey::Command => Some(0x37),
+        HeldKey::Shift => Some(0x38),
+        HeldKey::Alt => Some(0x3a),
+        HeldKey::Control => Some(0x3b),
+        HeldKey::Key(usage) => hid_usage_to_macos(usage.code()),
+    }?;
+    Some((vk, held_modifier_flags(*modifiers)))
+}
+
+fn held_modifier_flags(modifiers: HeldModifiers) -> CGEventFlags {
+    let mut flags = CGEventFlags::CGEventFlagNull;
+    if modifiers.contains(HeldKey::Command) {
+        flags |= CGEventFlags::CGEventFlagCommand;
+    }
+    if modifiers.contains(HeldKey::Shift) {
+        flags |= CGEventFlags::CGEventFlagShift;
+    }
+    if modifiers.contains(HeldKey::Control) {
+        flags |= CGEventFlags::CGEventFlagControl;
+    }
+    if modifiers.contains(HeldKey::Alt) {
+        flags |= CGEventFlags::CGEventFlagAlternate;
+    }
+    flags
 }
 
 fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
@@ -358,9 +414,11 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
+    use core_graphics::event::CGEventFlags;
     use openlogi_core::binding::Shortcut;
 
-    use super::{combo, hid_usage_to_macos};
+    use super::{combo, held_key_event, hid_usage_to_macos};
+    use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
     #[test]
     fn hid_usages_map_to_macos_virtual_keys() {
@@ -396,6 +454,30 @@ mod tests {
                 "{shortcut:?} table entry has no macOS virtual-key mapping"
             );
         }
+    }
+
+    #[test]
+    fn held_edges_carry_the_aggregate_modifier_state() {
+        let mut modifiers = HeldModifiers::default();
+        let (_, flags) = held_key_event(HeldKey::Command, KeyPhase::Down, &mut modifiers)
+            .expect("Command has a macOS virtual-key mapping");
+        assert!(flags.contains(CGEventFlags::CGEventFlagCommand));
+
+        let (_, flags) = held_key_event(HeldKey::Control, KeyPhase::Down, &mut modifiers)
+            .expect("Control has a macOS virtual-key mapping");
+        assert!(flags.contains(CGEventFlags::CGEventFlagCommand));
+        assert!(flags.contains(CGEventFlags::CGEventFlagControl));
+
+        let key = combo(Shortcut::Copy).key();
+        let (_, flags) = held_key_event(HeldKey::Key(key), KeyPhase::Up, &mut modifiers)
+            .expect("Copy's key has a macOS virtual-key mapping");
+        assert!(flags.contains(CGEventFlags::CGEventFlagCommand));
+        assert!(flags.contains(CGEventFlags::CGEventFlagControl));
+
+        let (_, flags) = held_key_event(HeldKey::Command, KeyPhase::Up, &mut modifiers)
+            .expect("Command has a macOS virtual-key mapping");
+        assert!(!flags.contains(CGEventFlags::CGEventFlagCommand));
+        assert!(flags.contains(CGEventFlags::CGEventFlagControl));
     }
 }
 

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -12,6 +12,8 @@ use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
 
+use super::KeyPhase;
+
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
 const NX_KEYTYPE_SOUND_UP: i32 = 0;
 const NX_KEYTYPE_SOUND_DOWN: i32 = 1;
@@ -31,7 +33,7 @@ pub(super) fn execute(action: &Action) {
         // this — the hook passes it straight through to the OS.
         Effect::Click(button) => dispatch_click(button),
         Effect::Shortcut(shortcut) => post_keycombo(&combo(shortcut)),
-        Effect::Key(combo) => post_keycombo(combo),
+        Effect::Key(combo) | Effect::HeldKey(combo) => post_keycombo(combo),
         Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         // Media/volume controls are NX system-defined keys, not ordinary
         // keyboard virtual-key events. Posting kVK_Volume* through
@@ -226,24 +228,25 @@ fn tag_synthetic(ev: &CGEvent) {
     );
 }
 
-/// Post a key-down + key-up pair for `vk` with `flags` set.
-fn post_key(vk: u16, flags: CGEventFlags) {
+/// Post one keyboard edge for `vk` with `flags` set.
+fn post_key_phase(vk: u16, flags: CGEventFlags, phase: KeyPhase) {
     let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
         tracing::warn!("CGEventSource::new failed");
         return;
     };
-    let Ok(down) = CGEvent::new_keyboard_event(src.clone(), vk, true) else {
-        tracing::warn!("CGEvent::new_keyboard_event(down) failed");
+    let down = phase == KeyPhase::Down;
+    let Ok(event) = CGEvent::new_keyboard_event(src, vk, down) else {
+        tracing::warn!(?phase, "CGEvent::new_keyboard_event failed");
         return;
     };
-    down.set_flags(flags);
-    down.post(CGEventTapLocation::HID);
-    let Ok(up) = CGEvent::new_keyboard_event(src, vk, false) else {
-        tracing::warn!("CGEvent::new_keyboard_event(up) failed");
-        return;
-    };
-    up.set_flags(flags);
-    up.post(CGEventTapLocation::HID);
+    event.set_flags(flags);
+    event.post(CGEventTapLocation::HID);
+}
+
+/// Post a key-down + key-up pair for `vk` with `flags` set.
+fn post_key(vk: u16, flags: CGEventFlags) {
+    post_key_phase(vk, flags, KeyPhase::Down);
+    post_key_phase(vk, flags, KeyPhase::Up);
 }
 
 /// Type an arbitrary unicode string by emitting one key event per character,
@@ -269,6 +272,29 @@ fn post_unicode(text: &str) {
 /// Press a key chord described by a `KeyCombo` modifier bitmask + virtual
 /// keycode. Used by the workflow sequencer's `PressKey` step.
 fn post_keycombo(combo: &KeyCombo) {
+    if let Some(vk) = hid_usage_to_macos(combo.key().code()) {
+        post_key(vk, combo_flags(combo));
+    } else {
+        tracing::warn!(
+            usage = combo.key().code(),
+            "shortcut usage has no macOS mapping"
+        );
+    }
+}
+
+/// Emit one isolated edge of a held chord.
+pub(super) fn hold_combo(combo: &KeyCombo, phase: KeyPhase) {
+    if let Some(vk) = hid_usage_to_macos(combo.key().code()) {
+        post_key_phase(vk, combo_flags(combo), phase);
+    } else {
+        tracing::warn!(
+            usage = combo.key().code(),
+            "held shortcut usage has no macOS mapping — edge ignored"
+        );
+    }
+}
+
+fn combo_flags(combo: &KeyCombo) -> CGEventFlags {
     let mut flags = CGEventFlags::CGEventFlagNull;
     if combo.has_command() {
         flags |= CGEventFlags::CGEventFlagCommand;
@@ -282,14 +308,7 @@ fn post_keycombo(combo: &KeyCombo) {
     if combo.has_option() {
         flags |= CGEventFlags::CGEventFlagAlternate;
     }
-    if let Some(vk) = hid_usage_to_macos(combo.key().code()) {
-        post_key(vk, flags);
-    } else {
-        tracing::warn!(
-            usage = combo.key().code(),
-            "shortcut usage has no macOS mapping"
-        );
-    }
+    flags
 }
 
 /// Map a platform-neutral USB HID keyboard usage to a macOS virtual key.

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -14,7 +14,7 @@ use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
 
-use super::KeyPhase;
+use super::{HeldKey, KeyPhase};
 
 const WHEEL_DELTA: i32 = 120;
 
@@ -278,34 +278,36 @@ fn combo_modifiers(combo: &KeyCombo) -> Vec<u16> {
     modifiers
 }
 
-/// Emit one isolated edge of a held chord in a single `SendInput` batch.
-pub(super) fn hold_combo(combo: &KeyCombo, phase: KeyPhase) {
-    let Some(vk) = super::hid_usage_to_windows(combo.key().code()) else {
-        tracing::warn!(
-            usage = combo.key().code(),
-            chord = %combo.rendered_label(),
-            "held shortcut usage has no Windows mapping — edge ignored"
-        );
-        return;
-    };
-    let modifiers = combo_modifiers(combo);
-    let mut inputs = Vec::with_capacity(modifiers.len() + 1);
-    match phase {
-        KeyPhase::Down => {
-            inputs.extend(modifiers.iter().map(|modifier| key_input(*modifier, false)));
-            inputs.push(key_input(vk, false));
-        }
-        KeyPhase::Up => {
-            inputs.push(key_input(vk, true));
-            inputs.extend(
-                modifiers
-                    .iter()
-                    .rev()
-                    .map(|modifier| key_input(*modifier, true)),
-            );
-        }
+/// Emit one edge for the physical keys whose ownership changed.
+pub(super) fn hold_keys(keys: &[HeldKey], phase: KeyPhase) {
+    let keys: Vec<_> = keys
+        .iter()
+        .filter_map(|key| held_virtual_key(*key))
+        .collect();
+    let key_up = phase == KeyPhase::Up;
+    let mut inputs: Vec<_> = keys.iter().map(|key| key_input(*key, key_up)).collect();
+    if key_up {
+        inputs.reverse();
     }
     send_inputs(&inputs);
+}
+
+fn held_virtual_key(key: HeldKey) -> Option<u16> {
+    match key {
+        HeldKey::Control => Some(VK_CONTROL),
+        HeldKey::Shift => Some(VK_SHIFT),
+        HeldKey::Alt => Some(VK_MENU),
+        HeldKey::Key(usage) => {
+            let key = super::hid_usage_to_windows(usage.code());
+            if key.is_none() {
+                tracing::warn!(
+                    usage = usage.code(),
+                    "held shortcut usage has no Windows mapping — edge ignored"
+                );
+            }
+            key
+        }
+    }
 }
 
 fn send_inputs(inputs: &[INPUT]) {

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -14,6 +14,8 @@ use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
 
+use super::KeyPhase;
+
 const WHEEL_DELTA: i32 = 120;
 
 const VK_D: u16 = 0x44;
@@ -50,7 +52,7 @@ pub(super) fn execute(action: &Action) {
         Effect::None => {}
         Effect::Click(button) => post_click(button),
         Effect::Shortcut(shortcut) => press_shortcut(shortcut),
-        Effect::Key(combo) => post_custom_shortcut(combo),
+        Effect::Key(combo) | Effect::HeldKey(combo) => post_custom_shortcut(combo),
         Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         Effect::Media(key) => dispatch_media(key),
         Effect::Native(native) => dispatch_native(native),
@@ -256,6 +258,10 @@ fn post_custom_shortcut(combo: &KeyCombo) {
         return;
     };
 
+    post_key(vk, &combo_modifiers(combo));
+}
+
+fn combo_modifiers(combo: &KeyCombo) -> Vec<u16> {
     let mut modifiers = Vec::new();
     if combo.has_command() {
         modifiers.push(VK_CONTROL);
@@ -269,7 +275,37 @@ fn post_custom_shortcut(combo: &KeyCombo) {
     if combo.has_option() {
         modifiers.push(VK_MENU);
     }
-    post_key(vk, &modifiers);
+    modifiers
+}
+
+/// Emit one isolated edge of a held chord in a single `SendInput` batch.
+pub(super) fn hold_combo(combo: &KeyCombo, phase: KeyPhase) {
+    let Some(vk) = super::hid_usage_to_windows(combo.key().code()) else {
+        tracing::warn!(
+            usage = combo.key().code(),
+            chord = %combo.rendered_label(),
+            "held shortcut usage has no Windows mapping — edge ignored"
+        );
+        return;
+    };
+    let modifiers = combo_modifiers(combo);
+    let mut inputs = Vec::with_capacity(modifiers.len() + 1);
+    match phase {
+        KeyPhase::Down => {
+            inputs.extend(modifiers.iter().map(|modifier| key_input(*modifier, false)));
+            inputs.push(key_input(vk, false));
+        }
+        KeyPhase::Up => {
+            inputs.push(key_input(vk, true));
+            inputs.extend(
+                modifiers
+                    .iter()
+                    .rev()
+                    .map(|modifier| key_input(*modifier, true)),
+            );
+        }
+    }
+    send_inputs(&inputs);
 }
 
 fn send_inputs(inputs: &[INPUT]) {

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -2,7 +2,10 @@
 
 mod inject;
 
-pub use inject::{SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_horizontal_scroll};
+pub use inject::{
+    SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_horizontal_scroll, press_hold,
+    release_hold,
+};
 
 #[cfg(target_os = "linux")]
 pub use inject::action_device_path;

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -4,7 +4,7 @@ mod inject;
 
 pub use inject::{
     SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_horizontal_scroll, press_hold,
-    release_hold,
+    release_hold, replace_hold,
 };
 
 #[cfg(target_os = "linux")]

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -58,7 +58,8 @@ pub use succession::Identity;
 /// v26: `AgentStatus::hid_open_failures` appended.
 /// v27: `AgentSnapshot::foreground` appended — the frontmost application the
 ///      agent matches per-app profiles against, plus the ones it saw recently.
-pub const PROTOCOL_VERSION: u32 = 27;
+/// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
+pub const PROTOCOL_VERSION: u32 = 28;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -101,7 +101,7 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 27);
+    assert_eq!(PROTOCOL_VERSION, 28);
 }
 
 #[test]

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 retninger"
 "Middle": "Midterknap"
 "DPI Preset %{index}": "DPI-forindstilling %{index}"
+"Hold %{chord}": "Hold %{chord}"
 "Gesture %{name}": "Bevægelse %{name}"
 "Left Click": "Venstreklik"
 "Right Click": "Højreklik"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 Richtungen"
 "Middle": "Mitteltaste"
 "DPI Preset %{index}": "DPI-Voreinstellung %{index}"
+"Hold %{chord}": "%{chord} halten"
 "Gesture %{name}": "Geste %{name}"
 "Left Click": "Linksklick"
 "Right Click": "Rechtsklick"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 κατευθύνσεις"
 "Middle": "Μεσαίο"
 "DPI Preset %{index}": "Προεπιλογή DPI %{index}"
+"Hold %{chord}": "Κράτημα %{chord}"
 "Gesture %{name}": "Χειρονομία %{name}"
 "Left Click": "Αριστερό κλικ"
 "Right Click": "Δεξί κλικ"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 directions"
 "Middle": "Middle"
 "DPI Preset %{index}": "DPI Preset %{index}"
+"Hold %{chord}": "Hold %{chord}"
 "Gesture %{name}": "Gesture %{name}"
 "Left Click": "Left Click"
 "Right Click": "Right Click"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 direcciones"
 "Middle": "Central"
 "DPI Preset %{index}": "Preajuste de DPI %{index}"
+"Hold %{chord}": "Mantener %{chord}"
 "Gesture %{name}": "Gesto %{name}"
 "Left Click": "Clic izquierdo"
 "Right Click": "Clic derecho"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 suuntaa"
 "Middle": "Keskipainike"
 "DPI Preset %{index}": "DPI-esiasetus %{index}"
+"Hold %{chord}": "Pidä %{chord}"
 "Gesture %{name}": "Ele %{name}"
 "Left Click": "Vasen napsautus"
 "Right Click": "Oikea napsautus"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 directions"
 "Middle": "Milieu"
 "DPI Preset %{index}": "Préréglage DPI %{index}"
+"Hold %{chord}": "Maintenir %{chord}"
 "Gesture %{name}": "Geste %{name}"
 "Left Click": "Clic gauche"
 "Right Click": "Clic droit"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 direzioni"
 "Middle": "Centrale"
 "DPI Preset %{index}": "Preset DPI %{index}"
+"Hold %{chord}": "Tieni premuto %{chord}"
 "Gesture %{name}": "Gesture %{name}"
 "Left Click": "Click sinistro"
 "Right Click": "Click destro"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 方向"
 "Middle": "中ボタン"
 "DPI Preset %{index}": "DPI プリセット %{index}"
+"Hold %{chord}": "%{chord} を長押し"
 "Gesture %{name}": "ジェスチャー %{name}"
 "Left Click": "左クリック"
 "Right Click": "右クリック"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5방향"
 "Middle": "가운데 버튼"
 "DPI Preset %{index}": "DPI 프리셋 %{index}"
+"Hold %{chord}": "%{chord} 길게 누르기"
 "Gesture %{name}": "제스처 %{name}"
 "Left Click": "왼쪽 클릭"
 "Right Click": "오른쪽 클릭"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 retninger"
 "Middle": "Midtknapp"
 "DPI Preset %{index}": "DPI-forhåndsinnstilling %{index}"
+"Hold %{chord}": "Hold %{chord}"
 "Gesture %{name}": "Bevegelse %{name}"
 "Left Click": "Venstreklikk"
 "Right Click": "Høyreklikk"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 richtingen"
 "Middle": "Middenknop"
 "DPI Preset %{index}": "DPI-voorinstelling %{index}"
+"Hold %{chord}": "%{chord} ingedrukt houden"
 "Gesture %{name}": "Gebaar %{name}"
 "Left Click": "Linkerklik"
 "Right Click": "Rechterklik"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 kierunków"
 "Middle": "Środkowy"
 "DPI Preset %{index}": "Ustawienie wstępne DPI %{index}"
+"Hold %{chord}": "Przytrzymaj %{chord}"
 "Gesture %{name}": "Gest %{name}"
 "Left Click": "Lewy przycisk"
 "Right Click": "Prawy przycisk"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 direções"
 "Middle": "Meio"
 "DPI Preset %{index}": "Predefinição de DPI %{index}"
+"Hold %{chord}": "Manter %{chord}"
 "Gesture %{name}": "Gesto %{name}"
 "Left Click": "Clique Esquerdo"
 "Right Click": "Clique Direito"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 direções"
 "Middle": "Central"
 "DPI Preset %{index}": "Predefinição de DPI %{index}"
+"Hold %{chord}": "Manter %{chord}"
 "Gesture %{name}": "Gesto %{name}"
 "Left Click": "Clique esquerdo"
 "Right Click": "Clique direito"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 направлений"
 "Middle": "Средняя"
 "DPI Preset %{index}": "Пресет DPI %{index}"
+"Hold %{chord}": "Удерживать %{chord}"
 "Gesture %{name}": "Жест %{name}"
 "Left Click": "Левый щелчок"
 "Right Click": "Правый щелчок"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 riktningar"
 "Middle": "Mittenknapp"
 "DPI Preset %{index}": "DPI-förinställning %{index}"
+"Hold %{chord}": "Håll %{chord}"
 "Gesture %{name}": "Gest %{name}"
 "Left Click": "Vänsterklick"
 "Right Click": "Högerklick"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 yön"
 "Middle": "Orta"
 "DPI Preset %{index}": "DPI Ön Ayarı %{index}"
+"Hold %{chord}": "%{chord} basılı tut"
 "Gesture %{name}": "%{name} hareketi"
 "Left Click": "Sol Tık"
 "Right Click": "Sağ Tık"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 напрямків"
 "Middle": "Середня"
 "DPI Preset %{index}": "Пресет DPI %{index}"
+"Hold %{chord}": "Утримувати %{chord}"
 "Gesture %{name}": "Жест %{name}"
 "Left Click": "Клацання лівою"
 "Right Click": "Клацання правою"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 个方向"
 "Middle": "中键"
 "DPI Preset %{index}": "灵敏度预设 %{index}"
+"Hold %{chord}": "按住 %{chord}"
 "Gesture %{name}": "手势 %{name}"
 "Left Click": "左键单击"
 "Right Click": "右键单击"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 個方向"
 "Middle": "中鍵"
 "DPI Preset %{index}": "靈敏度預設 %{index}"
+"Hold %{chord}": "按住 %{chord}"
 "Gesture %{name}": "手勢 %{name}"
 "Left Click": "左鍵單擊"
 "Right Click": "右鍵單擊"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -165,6 +165,7 @@ _version: 1
 "5 directions": "5 個方向"
 "Middle": "中鍵"
 "DPI Preset %{index}": "靈敏度預設 %{index}"
+"Hold %{chord}": "按住 %{chord}"
 "Gesture %{name}": "手勢 %{name}"
 "Left Click": "左鍵按一下"
 "Right Click": "右鍵按一下"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,8 +87,14 @@ Payload actions use a one-key inline table:
 
 ```toml
 Back = { CustomShortcut = "Cmd+Shift+P" }
+Forward = { HoldShortcut = "Ctrl+Space" }
 MiddleClick = { OpenApplication = { path = "~/Downloads", display_name = "Downloads" } }
 ```
+
+`CustomShortcut` emits an immediate key-down/key-up pair. `HoldShortcut` keeps
+the chord down until the originating physical button is released, and also
+releases it if capture is interrupted, the binding becomes invalid, or the
+agent shuts down. Use it for push-to-talk and other hold-to-activate controls.
 
 An Actions Ring entry wraps the action and may add an icon or literal label:
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -29,6 +29,8 @@ scroll_resolution = "high"
 [devices."receiver:aabbccdd:slot:1".bindings]
 Back = "BrowserBack"
 Forward = "BrowserForward"
+# Hold the chord for exactly as long as the physical button is held.
+MiddleClick = { HoldShortcut = "Ctrl+Space" }
 # The thumb wheel's capacitive tap. Inert unless set here; the wheel also
 # reports taps from incidental thumb contact.
 Thumbwheel = "AppExpose"


### PR DESCRIPTION
## Summary

Add a lifecycle-aware `HoldShortcut` action for push-to-talk and other controls that must stay down for exactly one physical button press.

## Changes

- **core / IPC:** add the append-only `Action::HoldShortcut(KeyCombo)` model, preserve distinct held-output semantics through `Effect`, and bump the protocol to v28.
- **agent:** own held chords in the unified button worker by exact `PressToken`; release them through the same terminal path for normal release, cancellation, invalidation, session replacement, and graceful shutdown.
- **inject:** add typed down/up chord edges for macOS, Linux, and Windows while keeping ordinary dispatch balanced as a tap.
- **desktop / i18n:** render localized dynamic hold labels consistently across mouse, keyboard, and Actions Ring editors, with matching keys in every shipped locale.
- **docs:** document `HoldShortcut` TOML configuration and its cleanup behavior.

This adapts the useful action/injector work from #433 to the unified lifecycle introduced by #933; Theo Ephraim is preserved as a co-author on the commit.

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci clippy-windows`
- Linux compile and tests passed; the macOS backend was hand-audited but not built on this Linux host.
- Not runtime-tested on Logitech hardware. Verify by binding `Forward = { HoldShortcut = "Ctrl+Space" }`, holding the physical button in a push-to-talk app, and checking normal release plus agent/config interruption cleanup.

Fixes #399
