### PR TITLE
feat(agent): dispatch independent long-press actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Things OpenLogi does that Options+ won't:
 ## Features
 
 - Devices connected over Logi Bolt receivers, Unifying receivers, Bluetooth, or a wired connection, with battery percentage and charge state
-- Button remapping via the OS input hook: a built-in action catalog plus custom keyboard shortcuts authored in the TOML config, including hold-until-release chords for push-to-talk¹
+- Button remapping via the OS input hook: a built-in action catalog plus custom keyboard shortcuts authored in the TOML config, including independent short/long-press actions and hold-until-release chords for push-to-talk¹
 - Per-application profile overlays that auto-switch on app focus (macOS + Windows; Linux on X11 / XWayland only)
 - Litra lights: power, brightness, and color temperature, with optional auto power that follows camera activity
 

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -11,8 +11,8 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
-use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
-use openlogi_core::bindings::{bindings_for, hidpp_gesture_maps_for, oshook_gestures_for};
+use openlogi_core::binding::{Action, Binding, ButtonId, GestureDirection, default_binding};
+use openlogi_core::bindings::{button_bindings_for, hidpp_gesture_maps_for, oshook_gestures_for};
 use openlogi_core::config::{Config, ThumbwheelSensitivity};
 use openlogi_hid::DeviceRoute;
 use openlogi_hid::session::gesture::{DIVERTABLE_STANDARD_BUTTONS, GESTURE_SOURCE_BUTTONS};
@@ -25,8 +25,8 @@ pub struct DeviceCapturePlan {
     pub config_key: String,
     /// HID++ route the session opens.
     pub route: DeviceRoute,
-    /// Per-button single actions for this device (per-app effective).
-    pub bindings: BTreeMap<ButtonId, Action>,
+    /// Per-button immediate or threshold bindings for this device (per-app effective).
+    pub bindings: BTreeMap<ButtonId, Binding>,
     /// Per-direction map for each HID++ gesture source (the dedicated gesture
     /// button, the MX Master 4 haptic panel) in gesture mode on this device,
     /// keyed by the button its captured swipes dispatch as; empty when none
@@ -59,7 +59,7 @@ pub fn plan_for_device(
     app: Option<&str>,
     rearm_generation: u64,
 ) -> DeviceCapturePlan {
-    let bindings = bindings_for(config, Some(config_key), app);
+    let bindings = button_bindings_for(config, Some(config_key), app);
     // A gesture-mode OS-hook button must stay native: the hook needs to see
     // its press to run hold+swipe detection, and diverting it would starve the
     // hook of events.
@@ -80,14 +80,18 @@ pub fn plan_for_device(
         .chain(plain_sources)
         .filter(|(_, button)| !oshook.contains_key(button))
         .filter(|(_, button)| {
-            bindings.get(button).is_some_and(|action| {
+            bindings.get(button).is_some_and(|binding| {
+                if matches!(binding, Binding::LongPress(_)) {
+                    return true;
+                }
+                let action = binding.click_action();
                 // The panel's default is ShowActionsRing, which must be
                 // diverted to open the ring. Action::None means "leave native
                 // firmware haptics alone", so treat None as the only non-divert.
                 if *button == ButtonId::HapticPanel {
-                    *action != Action::None
+                    action != Action::None
                 } else {
-                    *action != default_binding(*button)
+                    action != default_binding(*button)
                 }
             })
         })
@@ -101,7 +105,7 @@ pub fn plan_for_device(
     .any(|button| {
         bindings
             .get(button)
-            .is_some_and(|action| *action != default_binding(*button))
+            .is_some_and(|binding| binding.click_action() != default_binding(*button))
     });
     DeviceCapturePlan {
         config_key: config_key.to_owned(),
@@ -117,7 +121,7 @@ pub fn plan_for_device(
 
 #[cfg(test)]
 mod tests {
-    use openlogi_core::binding::Binding;
+    use openlogi_core::binding::{Binding, LongPressBinding};
     use openlogi_hid::reprog_controls::{GESTURE_BUTTON_CID, HAPTIC_PANEL_CID};
 
     use super::*;
@@ -180,6 +184,27 @@ mod tests {
                 .iter()
                 .any(|&(_, button)| button == ButtonId::WheelTiltRight),
             "the untouched right tilt must keep its native horizontal scroll"
+        );
+    }
+
+    #[test]
+    fn long_press_is_diverted_even_when_its_short_action_matches_the_native_default() {
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b01a",
+            ButtonId::Back,
+            Binding::LongPress(LongPressBinding::new(
+                default_binding(ButtonId::Back),
+                Action::MissionControl,
+            )),
+        );
+
+        let plan = plan_for_device(&cfg, "2b01a", route(), None, 0);
+        assert!(
+            plan.divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::Back),
+            "the runtime needs both edges even when the short action is native"
         );
     }
 

--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -15,8 +15,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use openlogi_core::app::ForegroundApp;
-use openlogi_core::binding::Action;
-use openlogi_core::bindings::{bindings_for, oshook_gestures_for};
+use openlogi_core::binding::{Action, Binding};
+use openlogi_core::bindings::{button_bindings_for, oshook_gestures_for};
 use openlogi_core::config::{Config, LightSettings, ScrollResolution};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, LightCapabilities, StandaloneDevice,
@@ -257,7 +257,7 @@ impl Orchestrator {
             return HookMaps::default();
         }
         HookMaps {
-            bindings: bindings_for(&self.config, key, app),
+            bindings: button_bindings_for(&self.config, key, app),
             gestures: oshook_gestures_for(&self.config, key, app),
         }
     }
@@ -278,7 +278,7 @@ impl Orchestrator {
             .devices
             .iter()
             .find(|d| d.kind == DeviceKind::Keyboard && d.route.is_some())?;
-        let bindings = bindings_for(
+        let bindings = button_bindings_for(
             &self.config,
             Some(&dev.config_key),
             self.current_app.as_deref(),
@@ -286,9 +286,10 @@ impl Orchestrator {
         let wanted: BTreeMap<u16, _> = KEYBOARD_KEY_CIDS
             .iter()
             .filter(|(_, button)| {
-                bindings
-                    .get(button)
-                    .is_some_and(|action| *action != Action::None)
+                bindings.get(button).is_some_and(|binding| {
+                    matches!(binding, Binding::LongPress(_))
+                        || binding.click_action() != Action::None
+                })
             })
             .copied()
             .collect();

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -6,7 +6,7 @@ use super::{
     pick_current, plan_reapply, reapply_targets, stable_id,
 };
 use openlogi_core::app::ForegroundApp;
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_core::config::{
     Config, DeviceConfig, LightSettings, LinkConfig, ScrollResolution, VerticalScrollSensitivity,
 };
@@ -870,9 +870,11 @@ fn config_reload_clears_override_when_camera_mode_changes() {
 /// The published capture plan's Back binding for the first device, if any.
 fn published_back_binding(orch: &Orchestrator) -> Option<Action> {
     orch.shared.capture_plans.read().ok().and_then(|plans| {
-        plans
-            .first()
-            .and_then(|plan| plan.bindings.get(&ButtonId::Back).cloned())
+        plans.first().and_then(|plan| {
+            plan.bindings
+                .get(&ButtonId::Back)
+                .map(Binding::click_action)
+        })
     })
 }
 

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, ButtonId, KeyCombo};
+use openlogi_core::binding::{Action, Binding, ButtonId, KeyCombo};
 use openlogi_hid::{CaptureChannel, ChannelRegistry};
 use tracing::{info, warn};
 
@@ -171,7 +171,7 @@ impl ButtonEventHandler {
     fn handle(&mut self, event: ButtonRuntimeEvent) {
         match event {
             ButtonRuntimeEvent::Started(press) => {
-                if let Some(action) = press.action() {
+                if let Some(action) = press.start_action() {
                     self.start_action(press.token(), action, press.device_key());
                 }
             }
@@ -275,9 +275,9 @@ impl ActionDispatcher {
     pub(crate) fn try_hook_button_down(
         &self,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) -> Option<PressToken> {
-        self.buttons.try_hook_down(button, action)
+        self.buttons.try_hook_down(button, binding)
     }
 
     /// Queue one OS-hook up edge without blocking the callback.
@@ -318,9 +318,9 @@ impl ActionDispatcher {
         &self,
         session: &HidppSessionId,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) -> Option<PressToken> {
-        self.buttons.try_hidpp_down(session, button, action)
+        self.buttons.try_hidpp_down(session, button, binding)
     }
 
     /// Queue one HID++ up edge for a specific capture session.
@@ -334,9 +334,9 @@ impl ActionDispatcher {
         &self,
         session: &HidppSessionId,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) {
-        self.buttons.try_hidpp_pulse(session, button, action);
+        self.buttons.try_hidpp_pulse(session, button, binding);
     }
 
     /// Cancel presses from a HID++ session that is stopping or has died.

--- a/crates/openlogi-agent-core/src/runtime/button.rs
+++ b/crates/openlogi-agent-core/src/runtime/button.rs
@@ -12,9 +12,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle, ThreadId};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Action, Binding, ButtonId, LONG_PRESS_THRESHOLD};
 use tracing::warn;
 
 /// OS-hook callbacks must fail open rather than block.
@@ -131,7 +131,72 @@ impl PressToken {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ActivePress {
     token: PressToken,
-    action: Option<Action>,
+    behavior: PressBehavior,
+}
+
+/// Runtime-only state of the action semantics attached to one active press.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PressBehavior {
+    /// Gesture lifecycles dispatch their semantic action separately.
+    LifecycleOnly,
+    /// Existing behavior: fire once when the press starts.
+    Immediate(Action),
+    /// Wait for either release or the threshold, whichever occurs first.
+    LongPressPending {
+        short: Action,
+        long: Action,
+        deadline: Instant,
+    },
+    /// The long action fired; release must not also fire the short action.
+    LongPressFired,
+}
+
+impl PressBehavior {
+    fn new(binding: Option<&Binding>, pressed_at: Instant) -> Self {
+        match binding {
+            None => Self::LifecycleOnly,
+            Some(Binding::Single(action)) => Self::Immediate(action.clone()),
+            Some(binding @ Binding::Gesture(_)) => Self::Immediate(binding.click_action()),
+            Some(Binding::LongPress(binding)) => Self::LongPressPending {
+                short: binding.short().clone(),
+                long: binding.long().clone(),
+                deadline: pressed_at + LONG_PRESS_THRESHOLD,
+            },
+        }
+    }
+
+    fn deadline(&self) -> Option<Instant> {
+        match self {
+            Self::LongPressPending { deadline, .. } => Some(*deadline),
+            Self::LifecycleOnly | Self::Immediate(_) | Self::LongPressFired => None,
+        }
+    }
+
+    fn start_action(&self) -> Option<&Action> {
+        match self {
+            Self::Immediate(action) => Some(action),
+            Self::LifecycleOnly | Self::LongPressPending { .. } | Self::LongPressFired => None,
+        }
+    }
+
+    fn release_action(&self) -> Option<&Action> {
+        match self {
+            Self::LongPressPending { short, .. } => Some(short),
+            Self::LifecycleOnly | Self::Immediate(_) | Self::LongPressFired => None,
+        }
+    }
+
+    fn fire_long(&mut self, now: Instant) -> Option<Action> {
+        let Self::LongPressPending { long, deadline, .. } = self else {
+            return None;
+        };
+        if now < *deadline {
+            return None;
+        }
+        let action = long.clone();
+        *self = Self::LongPressFired;
+        Some(action)
+    }
 }
 
 impl ActivePress {
@@ -147,8 +212,16 @@ impl ActivePress {
         self.token.key.source.device_key()
     }
 
-    pub(crate) fn action(&self) -> Option<&Action> {
-        self.action.as_ref()
+    pub(crate) fn start_action(&self) -> Option<&Action> {
+        self.behavior.start_action()
+    }
+
+    fn release_action(&self) -> Option<&Action> {
+        self.behavior.release_action()
+    }
+
+    fn fire_long(&mut self, now: Instant) -> Option<Action> {
+        self.behavior.fire_long(now)
     }
 }
 
@@ -183,7 +256,8 @@ pub(crate) enum ButtonRuntimeEvent {
         press: ActivePress,
         reason: EndReason,
     },
-    /// A semantic gesture action admitted only while `press` is still active.
+    /// An action admitted by an active press: a gesture, a long-press
+    /// threshold, or a short release.
     Triggered {
         press: ActivePress,
         action: Action,
@@ -193,7 +267,7 @@ pub(crate) enum ButtonRuntimeEvent {
 /// Inputs cannot represent `Up + action` or a source-authored `Cancel`.
 enum ButtonInput {
     Down(ActivePress),
-    Up(PressKey),
+    Up { key: PressKey, released_at: Instant },
     Pulse(ActivePress),
     TriggerWhilePressed { token: PressToken, action: Action },
 }
@@ -248,6 +322,43 @@ impl ButtonState {
         self.active.drain().map(|(_, press)| press).collect()
     }
 
+    fn fire_selected_long_presses(
+        &mut self,
+        tokens: &[PressToken],
+        now: Instant,
+    ) -> Vec<(ActivePress, Action)> {
+        tokens
+            .iter()
+            .filter_map(|token| {
+                let press = self.active.get_mut(&token.key)?;
+                if press.token != *token {
+                    return None;
+                }
+                press.fire_long(now).map(|action| (press.clone(), action))
+            })
+            .collect()
+    }
+
+    fn has_due_long_press(&self, now: Instant) -> bool {
+        self.active
+            .values()
+            .filter_map(|press| press.behavior.deadline())
+            .any(|deadline| deadline <= now)
+    }
+
+    fn due_long_presses(&self, now: Instant) -> Vec<PressToken> {
+        self.active
+            .values()
+            .filter(|press| {
+                press
+                    .behavior
+                    .deadline()
+                    .is_some_and(|deadline| deadline <= now)
+            })
+            .map(|press| press.token.clone())
+            .collect()
+    }
+
     fn cancel_where(&mut self, matches: impl Fn(&PressKey) -> bool) -> Vec<ActivePress> {
         let keys: Vec<PressKey> = self
             .active
@@ -274,9 +385,9 @@ impl ButtonInputHandle {
     pub(crate) fn try_hook_down(
         &self,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) -> Option<PressToken> {
-        self.try_down(ButtonSource::current_hook(), button, action)
+        self.try_down(ButtonSource::current_hook(), button, binding)
     }
 
     pub(crate) fn try_hook_up(&self, button: ButtonId) -> bool {
@@ -287,7 +398,7 @@ impl ButtonInputHandle {
         let generation = self.generation.load(Ordering::Acquire);
         let press = self.new_press(
             PressKey::for_key(ButtonSource::current_hook(), keycode),
-            Some(action),
+            PressBehavior::Immediate(action.clone()),
             generation,
         );
         let token = press.token.clone();
@@ -299,7 +410,10 @@ impl ButtonInputHandle {
         let generation = self.generation.load(Ordering::Acquire);
         self.try_input(
             generation,
-            ButtonInput::Up(PressKey::for_key(ButtonSource::current_hook(), keycode)),
+            ButtonInput::Up {
+                key: PressKey::for_key(ButtonSource::current_hook(), keycode),
+                released_at: Instant::now(),
+            },
         )
     }
 
@@ -315,9 +429,9 @@ impl ButtonInputHandle {
         &self,
         session: &HidppSessionId,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) -> Option<PressToken> {
-        self.try_down(ButtonSource::Hidpp(session.clone()), button, action)
+        self.try_down(ButtonSource::Hidpp(session.clone()), button, binding)
     }
 
     pub(crate) fn try_hidpp_up(&self, session: &HidppSessionId, button: ButtonId) -> bool {
@@ -328,12 +442,12 @@ impl ButtonInputHandle {
         &self,
         session: &HidppSessionId,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) -> bool {
         let generation = self.generation.load(Ordering::Acquire);
         let press = self.new_press(
             PressKey::new(ButtonSource::Hidpp(session.clone()), button),
-            action,
+            PressBehavior::new(binding, Instant::now()),
             generation,
         );
         self.try_input(generation, ButtonInput::Pulse(press))
@@ -372,10 +486,14 @@ impl ButtonInputHandle {
         &self,
         source: ButtonSource,
         button: ButtonId,
-        action: Option<&Action>,
+        binding: Option<&Binding>,
     ) -> Option<PressToken> {
         let generation = self.generation.load(Ordering::Acquire);
-        let press = self.new_press(PressKey::new(source, button), action, generation);
+        let press = self.new_press(
+            PressKey::new(source, button),
+            PressBehavior::new(binding, Instant::now()),
+            generation,
+        );
         let token = press.token.clone();
         self.try_input(generation, ButtonInput::Down(press))
             .then_some(token)
@@ -383,10 +501,16 @@ impl ButtonInputHandle {
 
     fn try_up(&self, source: ButtonSource, button: ButtonId) -> bool {
         let generation = self.generation.load(Ordering::Acquire);
-        self.try_input(generation, ButtonInput::Up(PressKey::new(source, button)))
+        self.try_input(
+            generation,
+            ButtonInput::Up {
+                key: PressKey::new(source, button),
+                released_at: Instant::now(),
+            },
+        )
     }
 
-    fn new_press(&self, key: PressKey, action: Option<&Action>, generation: u64) -> ActivePress {
+    fn new_press(&self, key: PressKey, behavior: PressBehavior, generation: u64) -> ActivePress {
         let id = PressId(self.next_press.fetch_add(1, Ordering::Relaxed));
         ActivePress {
             token: PressToken {
@@ -394,7 +518,7 @@ impl ButtonInputHandle {
                 key,
                 generation,
             },
-            action: action.cloned(),
+            behavior,
         }
     }
 
@@ -422,7 +546,6 @@ impl ButtonInputHandle {
 
     fn stop_accepting(&self) {
         self.accepting.store(false, Ordering::Release);
-        self.generation.fetch_add(1, Ordering::AcqRel);
     }
 }
 
@@ -503,49 +626,236 @@ fn run_worker(
     let mut state = ButtonState::default();
     let mut generation = shared_generation.load(Ordering::Acquire);
     loop {
-        if let Ok(request) = shutdown.try_recv() {
-            emit_canceled(state.cancel_all(), CancelReason::Shutdown, emit);
-            let _ = request.done.send(());
+        if finish_shutdown_if_requested(shutdown, &mut state, emit) {
             return;
         }
         let command = match events.recv_timeout(SHUTDOWN_POLL_INTERVAL) {
             Ok(command) => command,
-            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if settle_due_long_presses(
+                    events,
+                    shutdown,
+                    shared_generation,
+                    &mut generation,
+                    &mut state,
+                    None,
+                    emit,
+                ) {
+                    return;
+                }
+                continue;
+            }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 emit_canceled(state.cancel_all(), CancelReason::SourceEnded, emit);
                 return;
             }
         };
-        let current = shared_generation.load(Ordering::Acquire);
-        if current != generation {
-            emit_canceled(state.cancel_all(), CancelReason::Invalidated, emit);
-            generation = current;
-        }
-        match command {
-            ButtonCommand::Input {
-                generation: input_generation,
-                input,
-            } if input_generation == generation => process_input(&mut state, input, emit),
-            ButtonCommand::Input { .. } | ButtonCommand::Wake => {}
-            ButtonCommand::CancelStalePress(token) => {
-                if let Some(press) = state.cancel_press(&token) {
-                    emit(ButtonRuntimeEvent::Ended {
-                        press,
-                        reason: EndReason::Canceled(CancelReason::StaleHold),
-                    });
-                }
+        synchronize_generation(&mut state, shared_generation, &mut generation, emit);
+        if state.has_due_long_press(Instant::now()) {
+            if settle_due_long_presses(
+                events,
+                shutdown,
+                shared_generation,
+                &mut generation,
+                &mut state,
+                Some(command),
+                emit,
+            ) {
+                return;
             }
-            ButtonCommand::CancelSource(source) => {
+            continue;
+        }
+        process_command(&mut state, command, generation, emit);
+        if settle_due_long_presses(
+            events,
+            shutdown,
+            shared_generation,
+            &mut generation,
+            &mut state,
+            None,
+            emit,
+        ) {
+            return;
+        }
+    }
+}
+
+fn process_command(
+    state: &mut ButtonState,
+    command: ButtonCommand,
+    generation: u64,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) {
+    match command {
+        ButtonCommand::Input {
+            generation: input_generation,
+            input,
+        } if input_generation == generation => process_input(state, input, emit),
+        ButtonCommand::Input { .. } | ButtonCommand::Wake => {}
+        ButtonCommand::CancelStalePress(token) => {
+            if let Some(press) = state.cancel_press(&token) {
+                emit(ButtonRuntimeEvent::Ended {
+                    press,
+                    reason: EndReason::Canceled(CancelReason::StaleHold),
+                });
+            }
+        }
+        ButtonCommand::CancelSource(source) => {
+            emit_canceled(
+                state.cancel_source(&source),
+                CancelReason::SourceEnded,
+                emit,
+            );
+        }
+        ButtonCommand::CancelHooks => {
+            emit_canceled(state.cancel_hooks(), CancelReason::SourceEnded, emit);
+        }
+    }
+}
+
+fn settle_due_long_presses(
+    events: &mpsc::Receiver<ButtonCommand>,
+    shutdown: &mpsc::Receiver<ShutdownRequest>,
+    shared_generation: &AtomicU64,
+    generation: &mut u64,
+    state: &mut ButtonState,
+    first_command: Option<ButtonCommand>,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) -> bool {
+    if finish_shutdown_if_requested(shutdown, state, emit) {
+        return true;
+    }
+    // An event handler may have blocked while another thread invalidated
+    // this generation. Observe that transition before any overdue timer.
+    synchronize_generation(state, shared_generation, generation, emit);
+    let due_presses = state.due_long_presses(Instant::now());
+    if due_presses.is_empty() {
+        if let Some(command) = first_command {
+            process_command(state, command, *generation, emit);
+        }
+        return false;
+    }
+
+    // Before firing an overdue timer, settle one channel-capacity snapshot.
+    // FIFO ordering guarantees that this includes every command that was
+    // already queued at the checkpoint. State transitions are separated from
+    // synchronous handlers so unrelated actions cannot delay the deadline.
+    let mut deferred = Vec::new();
+    let queued_limit = if let Some(command) = first_command {
+        process_command(state, command, *generation, &mut |event| {
+            deferred.push(event);
+        });
+        if finish_deferred_shutdown_if_requested(shutdown, state, &due_presses, &mut deferred, emit)
+        {
+            return true;
+        }
+        synchronize_generation(state, shared_generation, generation, &mut |event| {
+            deferred.push(event);
+        });
+        EVENT_QUEUE_CAPACITY - 1
+    } else {
+        EVENT_QUEUE_CAPACITY
+    };
+    for _ in 0..queued_limit {
+        if finish_deferred_shutdown_if_requested(shutdown, state, &due_presses, &mut deferred, emit)
+        {
+            return true;
+        }
+        synchronize_generation(state, shared_generation, generation, &mut |event| {
+            deferred.push(event);
+        });
+        let command = match events.try_recv() {
+            Ok(command) => command,
+            Err(mpsc::TryRecvError::Empty) => break,
+            Err(mpsc::TryRecvError::Disconnected) => {
                 emit_canceled(
-                    state.cancel_source(&source),
+                    state.cancel_all(),
                     CancelReason::SourceEnded,
-                    emit,
+                    &mut |event| deferred.push(event),
                 );
+                emit_settled_events(deferred, &due_presses, emit);
+                return true;
             }
-            ButtonCommand::CancelHooks => {
-                emit_canceled(state.cancel_hooks(), CancelReason::SourceEnded, emit);
-            }
+        };
+        process_command(state, command, *generation, &mut |event| {
+            deferred.push(event);
+        });
+        if finish_deferred_shutdown_if_requested(shutdown, state, &due_presses, &mut deferred, emit)
+        {
+            return true;
         }
+        synchronize_generation(state, shared_generation, generation, &mut |event| {
+            deferred.push(event);
+        });
+    }
+
+    emit_selected_long_presses(state, &due_presses, Instant::now(), &mut |event| {
+        deferred.push(event);
+    });
+    emit_settled_events(deferred, &due_presses, emit);
+    false
+}
+
+fn finish_deferred_shutdown_if_requested(
+    shutdown: &mpsc::Receiver<ShutdownRequest>,
+    state: &mut ButtonState,
+    due_presses: &[PressToken],
+    deferred: &mut Vec<ButtonRuntimeEvent>,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) -> bool {
+    let Ok(request) = shutdown.try_recv() else {
+        return false;
+    };
+    emit_canceled(state.cancel_all(), CancelReason::Shutdown, &mut |event| {
+        deferred.push(event);
+    });
+    emit_settled_events(std::mem::take(deferred), due_presses, emit);
+    let _ = request.done.send(());
+    true
+}
+
+fn emit_settled_events(
+    events: Vec<ButtonRuntimeEvent>,
+    due_presses: &[PressToken],
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) {
+    let (deadline_events, ordered_events): (Vec<_>, Vec<_>) =
+        events.into_iter().partition(|event| match event {
+            ButtonRuntimeEvent::Triggered { press, .. }
+            | ButtonRuntimeEvent::Ended { press, .. } => {
+                matches!(press.behavior, PressBehavior::LongPressFired)
+                    && due_presses.contains(press.token())
+            }
+            ButtonRuntimeEvent::Started(_) => false,
+        });
+    for event in deadline_events.into_iter().chain(ordered_events) {
+        emit(event);
+    }
+}
+
+fn finish_shutdown_if_requested(
+    shutdown: &mpsc::Receiver<ShutdownRequest>,
+    state: &mut ButtonState,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) -> bool {
+    let Ok(request) = shutdown.try_recv() else {
+        return false;
+    };
+    emit_canceled(state.cancel_all(), CancelReason::Shutdown, emit);
+    let _ = request.done.send(());
+    true
+}
+
+fn synchronize_generation(
+    state: &mut ButtonState,
+    shared_generation: &AtomicU64,
+    generation: &mut u64,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) {
+    let current = shared_generation.load(Ordering::Acquire);
+    if current != *generation {
+        emit_canceled(state.cancel_all(), CancelReason::Invalidated, emit);
+        *generation = current;
     }
 }
 
@@ -564,12 +874,15 @@ fn process_input(
             }
             emit(ButtonRuntimeEvent::Started(press));
         }
-        ButtonInput::Up(key) => {
-            if let Some(press) = state.release(&key) {
-                emit(ButtonRuntimeEvent::Ended {
-                    press,
-                    reason: EndReason::Released,
-                });
+        ButtonInput::Up { key, released_at } => {
+            if let Some(mut press) = state.release(&key) {
+                if let Some(action) = press.fire_long(released_at) {
+                    emit(ButtonRuntimeEvent::Triggered {
+                        press: press.clone(),
+                        action,
+                    });
+                }
+                emit_released(press, emit);
             }
         }
         ButtonInput::Pulse(press) => {
@@ -581,10 +894,7 @@ fn process_input(
             }
             emit(ButtonRuntimeEvent::Started(press.clone()));
             if let Some(press) = state.release(&press.token.key) {
-                emit(ButtonRuntimeEvent::Ended {
-                    press,
-                    reason: EndReason::Released,
-                });
+                emit_released(press, emit);
             }
         }
         ButtonInput::TriggerWhilePressed { token, action } => {
@@ -593,6 +903,30 @@ fn process_input(
             }
         }
     }
+}
+
+fn emit_selected_long_presses(
+    state: &mut ButtonState,
+    tokens: &[PressToken],
+    now: Instant,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) {
+    for (press, action) in state.fire_selected_long_presses(tokens, now) {
+        emit(ButtonRuntimeEvent::Triggered { press, action });
+    }
+}
+
+fn emit_released(press: ActivePress, emit: &mut impl FnMut(ButtonRuntimeEvent)) {
+    if let Some(action) = press.release_action().cloned() {
+        emit(ButtonRuntimeEvent::Triggered {
+            press: press.clone(),
+            action,
+        });
+    }
+    emit(ButtonRuntimeEvent::Ended {
+        press,
+        reason: EndReason::Released,
+    });
 }
 
 fn emit_canceled(

--- a/crates/openlogi-agent-core/src/runtime/button/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/button/tests.rs
@@ -2,19 +2,34 @@
 
 use std::time::Instant;
 
+use openlogi_core::binding::LongPressBinding;
+
 use super::*;
 
 fn hook_press(id: u64, button: ButtonId) -> ActivePress {
     ActivePress {
         token: PressToken::hook_for_test(id, button),
-        action: Some(Action::Copy),
+        behavior: PressBehavior::Immediate(Action::Copy),
     }
+}
+
+fn long_press(short: Action, long: Action) -> Binding {
+    Binding::LongPress(LongPressBinding::new(short, long))
 }
 
 fn recv_event(receiver: &mpsc::Receiver<ButtonRuntimeEvent>) -> ButtonRuntimeEvent {
     receiver
         .recv_timeout(Duration::from_secs(1))
         .expect("button worker should emit an event")
+}
+
+fn emit_due_long_presses(
+    state: &mut ButtonState,
+    now: Instant,
+    emit: &mut impl FnMut(ButtonRuntimeEvent),
+) {
+    let due_presses = state.due_long_presses(now);
+    emit_selected_long_presses(state, &due_presses, now, emit);
 }
 
 #[test]
@@ -49,7 +64,7 @@ fn cancellation_is_scoped_to_one_session() {
             key: PressKey::new(first_source.clone(), ButtonId::Back),
             generation: 0,
         },
-        action: None,
+        behavior: PressBehavior::LifecycleOnly,
     };
     let second = ActivePress {
         token: PressToken {
@@ -57,7 +72,7 @@ fn cancellation_is_scoped_to_one_session() {
             key: PressKey::new(second_source, ButtonId::Back),
             generation: 0,
         },
-        action: None,
+        behavior: PressBehavior::LifecycleOnly,
     };
     state.press(first.clone());
     state.press(second.clone());
@@ -79,7 +94,7 @@ fn hook_cancellation_leaves_hidpp_presses_active() {
             ),
             generation: 0,
         },
-        action: None,
+        behavior: PressBehavior::LifecycleOnly,
     };
     state.press(hook.clone());
     state.press(hidpp.clone());
@@ -260,13 +275,10 @@ fn pulse_has_an_immediate_balanced_lifecycle() {
     .expect("button worker should start");
     let input = owner.input();
     let session = HidppSessionId::new("mouse-a", 7);
-    assert!(input.try_hidpp_pulse(
-        &session,
-        ButtonId::Back,
-        Some(&Action::HoldShortcut(
-            "Ctrl+Space".parse().expect("valid shortcut")
-        )),
+    let binding = Binding::Single(Action::HoldShortcut(
+        "Ctrl+Space".parse().expect("valid shortcut"),
     ));
+    assert!(input.try_hidpp_pulse(&session, ButtonId::Back, Some(&binding)));
 
     let ButtonRuntimeEvent::Started(started) = recv_event(&received) else {
         panic!("pulse must start before ending");
@@ -276,6 +288,414 @@ fn pulse_has_an_immediate_balanced_lifecycle() {
     };
     assert_eq!(press.token, started.token);
     assert_eq!(reason, EndReason::Released);
+    assert!(owner.shutdown());
+}
+
+#[test]
+fn release_before_long_press_threshold_fires_only_the_short_action() {
+    let binding = long_press(Action::Copy, Action::Paste);
+    let mut state = ButtonState::default();
+    let pressed_at = Instant::now();
+    let press = ActivePress {
+        token: PressToken::hook_for_test(1, ButtonId::Back),
+        behavior: PressBehavior::new(Some(&binding), pressed_at),
+    };
+    state.press(press.clone());
+    let mut events = Vec::new();
+
+    process_input(
+        &mut state,
+        ButtonInput::Up {
+            key: press.token.key.clone(),
+            released_at: pressed_at + LONG_PRESS_THRESHOLD.saturating_sub(Duration::from_millis(1)),
+        },
+        &mut |event| events.push(event),
+    );
+
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0],
+        ButtonRuntimeEvent::Triggered {
+            action: Action::Copy,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[1],
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Released,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn threshold_fires_long_once_and_suppresses_short_on_release() {
+    let binding = long_press(Action::Copy, Action::Paste);
+    let mut state = ButtonState::default();
+    let pressed_at = Instant::now();
+    let press = ActivePress {
+        token: PressToken::hook_for_test(1, ButtonId::Back),
+        behavior: PressBehavior::new(Some(&binding), pressed_at),
+    };
+    state.press(press.clone());
+    let mut events = Vec::new();
+
+    emit_due_long_presses(
+        &mut state,
+        pressed_at + LONG_PRESS_THRESHOLD,
+        &mut |event| events.push(event),
+    );
+    emit_due_long_presses(
+        &mut state,
+        pressed_at + LONG_PRESS_THRESHOLD + Duration::from_secs(1),
+        &mut |event| events.push(event),
+    );
+    process_input(
+        &mut state,
+        ButtonInput::Up {
+            key: press.token.key.clone(),
+            released_at: pressed_at + LONG_PRESS_THRESHOLD + Duration::from_secs(1),
+        },
+        &mut |event| events.push(event),
+    );
+
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0],
+        ButtonRuntimeEvent::Triggered {
+            action: Action::Paste,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[1],
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Released,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn cancellation_never_fires_a_pending_short_or_long_action() {
+    let binding = long_press(Action::Copy, Action::Paste);
+    let mut state = ButtonState::default();
+    let pressed_at = Instant::now();
+    let press = ActivePress {
+        token: PressToken::hook_for_test(1, ButtonId::Back),
+        behavior: PressBehavior::new(Some(&binding), pressed_at),
+    };
+    state.press(press);
+    let mut events = Vec::new();
+
+    emit_canceled(
+        state.cancel_all(),
+        CancelReason::Invalidated,
+        &mut |event| events.push(event),
+    );
+    emit_due_long_presses(
+        &mut state,
+        pressed_at + LONG_PRESS_THRESHOLD,
+        &mut |event| events.push(event),
+    );
+
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Canceled(CancelReason::Invalidated),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn pulse_degrades_long_press_to_its_short_action() {
+    let (sent, received) = mpsc::channel();
+    let mut owner = ButtonRuntimeOwner::spawn(move |event| {
+        sent.send(event)
+            .expect("test receiver should stay connected");
+    })
+    .expect("button worker should start");
+    let input = owner.input();
+    let session = HidppSessionId::new("keyboard-a", 4);
+    let binding = long_press(Action::Copy, Action::Paste);
+
+    assert!(input.try_hidpp_pulse(&session, ButtonId::Back, Some(&binding)));
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Started(_)
+    ));
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Triggered {
+            action: Action::Copy,
+            ..
+        }
+    ));
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Released,
+            ..
+        }
+    ));
+    assert!(owner.shutdown());
+}
+
+#[test]
+fn worker_schedules_the_long_action_without_a_capture_thread_timer() {
+    let (sent, received) = mpsc::channel();
+    let mut owner = ButtonRuntimeOwner::spawn(move |event| {
+        sent.send(event)
+            .expect("test receiver should stay connected");
+    })
+    .expect("button worker should start");
+    let input = owner.input();
+    let binding = long_press(Action::Copy, Action::Paste);
+
+    assert!(
+        input
+            .try_hook_down(ButtonId::Back, Some(&binding))
+            .is_some()
+    );
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Started(_)
+    ));
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Triggered {
+            action: Action::Paste,
+            ..
+        }
+    ));
+    assert!(input.try_hook_up(ButtonId::Back));
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Released,
+            ..
+        }
+    ));
+    assert!(owner.shutdown());
+}
+
+#[test]
+fn overdue_long_press_precedes_unrelated_queued_actions() {
+    let (commands, queued) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
+    let binding = long_press(Action::Copy, Action::Paste);
+    let pressed_at = Instant::now()
+        .checked_sub(LONG_PRESS_THRESHOLD)
+        .expect("test process should have run beyond the long-press threshold");
+    let mut state = ButtonState::default();
+    let press = ActivePress {
+        token: PressToken::hook_for_test(1, ButtonId::Back),
+        behavior: PressBehavior::new(Some(&binding), pressed_at),
+    };
+    state.press(press.clone());
+    commands
+        .send(ButtonCommand::Input {
+            generation: 0,
+            input: ButtonInput::Pulse(hook_press(2, ButtonId::Forward)),
+        })
+        .expect("test queue should accept the unrelated pulse");
+    commands
+        .send(ButtonCommand::Input {
+            generation: 0,
+            input: ButtonInput::Up {
+                key: press.token.key.clone(),
+                released_at: Instant::now(),
+            },
+        })
+        .expect("test queue should accept the overdue release");
+    let (_shutdown, shutdown) = mpsc::channel();
+    let shared_generation = AtomicU64::new(0);
+    let mut generation = 0;
+    let mut events = Vec::new();
+
+    assert!(!settle_due_long_presses(
+        &queued,
+        &shutdown,
+        &shared_generation,
+        &mut generation,
+        &mut state,
+        None,
+        &mut |event| events.push(event),
+    ));
+
+    assert_eq!(events.len(), 4);
+    assert!(matches!(
+        &events[0],
+        ButtonRuntimeEvent::Triggered {
+            action: Action::Paste,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &events[1],
+        ButtonRuntimeEvent::Ended {
+            press: ended,
+            reason: EndReason::Released,
+        } if ended.token == press.token
+    ));
+    assert!(matches!(&events[2], ButtonRuntimeEvent::Started(_)));
+}
+
+#[test]
+fn continuous_commands_cannot_starve_a_long_press_deadline() {
+    let (commands, queued) = mpsc::sync_channel(EVENT_QUEUE_CAPACITY);
+    let binding = long_press(Action::Copy, Action::Paste);
+    let pressed_at = Instant::now();
+    commands
+        .send(ButtonCommand::Input {
+            generation: 0,
+            input: ButtonInput::Down(ActivePress {
+                token: PressToken::hook_for_test(1, ButtonId::Back),
+                behavior: PressBehavior::new(Some(&binding), pressed_at),
+            }),
+        })
+        .expect("test queue should accept the press");
+    for _ in 1..EVENT_QUEUE_CAPACITY {
+        commands
+            .send(ButtonCommand::Wake)
+            .expect("test queue should accept the initial backlog");
+    }
+
+    let producer_running = Arc::new(AtomicBool::new(true));
+    let producer_commands = commands.clone();
+    let producer_flag = Arc::clone(&producer_running);
+    let producer = thread::spawn(move || {
+        while producer_flag.load(Ordering::Acquire)
+            && producer_commands.send(ButtonCommand::Wake).is_ok()
+        {}
+    });
+
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    let generation = Arc::new(AtomicU64::new(0));
+    let worker_generation = Arc::clone(&generation);
+    let (sent, received) = mpsc::channel();
+    let worker = thread::spawn(move || {
+        run_worker(&queued, &shutdown_rx, &worker_generation, &mut |event| {
+            sent.send(event)
+                .expect("test receiver should stay connected");
+        });
+    });
+
+    let wait_until = pressed_at + LONG_PRESS_THRESHOLD + Duration::from_millis(250);
+    let triggered_after = loop {
+        let Some(remaining) = wait_until.checked_duration_since(Instant::now()) else {
+            break None;
+        };
+        match received.recv_timeout(remaining) {
+            Ok(ButtonRuntimeEvent::Triggered {
+                action: Action::Paste,
+                ..
+            }) => break Some(pressed_at.elapsed()),
+            Ok(_) => {}
+            Err(_) => break None,
+        }
+    };
+
+    producer_running.store(false, Ordering::Release);
+    producer.join().expect("producer should stop");
+    let (done, wait) = mpsc::sync_channel(0);
+    shutdown_tx
+        .send(ShutdownRequest { done })
+        .expect("worker should accept shutdown");
+    wait.recv_timeout(Duration::from_secs(1))
+        .expect("worker should finish shutdown");
+    worker.join().expect("worker should stop");
+
+    let triggered_after = triggered_after.expect("continuous input starved the long-press timer");
+    assert!(triggered_after <= LONG_PRESS_THRESHOLD + Duration::from_millis(250));
+}
+
+#[test]
+fn invalidation_during_a_blocked_handler_wins_over_an_overdue_long_action() {
+    let (sent, received) = mpsc::channel();
+    let (resume, blocked) = mpsc::sync_channel(0);
+    let mut owner = ButtonRuntimeOwner::spawn(move |event| {
+        let should_block = matches!(&event, ButtonRuntimeEvent::Started(_));
+        sent.send(event)
+            .expect("test receiver should stay connected");
+        if should_block {
+            blocked.recv().expect("test should resume the handler");
+        }
+    })
+    .expect("button worker should start");
+    let input = owner.input();
+    let binding = long_press(Action::Copy, Action::Paste);
+
+    assert!(
+        input
+            .try_hook_down(ButtonId::Back, Some(&binding))
+            .is_some()
+    );
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Started(_)
+    ));
+    input.invalidate_all();
+    thread::sleep(LONG_PRESS_THRESHOLD + Duration::from_millis(20));
+    resume.send(()).expect("worker should still be blocked");
+
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Canceled(CancelReason::Invalidated),
+            ..
+        }
+    ));
+    assert!(received.recv_timeout(Duration::from_millis(30)).is_err());
+    assert!(owner.shutdown());
+}
+
+#[test]
+fn a_release_observed_before_the_threshold_wins_despite_worker_backlog() {
+    let (sent, received) = mpsc::channel();
+    let (resume, blocked) = mpsc::sync_channel(0);
+    let mut owner = ButtonRuntimeOwner::spawn(move |event| {
+        let should_block = matches!(&event, ButtonRuntimeEvent::Started(_));
+        sent.send(event)
+            .expect("test receiver should stay connected");
+        if should_block {
+            blocked.recv().expect("test should resume the handler");
+        }
+    })
+    .expect("button worker should start");
+    let input = owner.input();
+    let binding = long_press(Action::Copy, Action::Paste);
+
+    assert!(
+        input
+            .try_hook_down(ButtonId::Back, Some(&binding))
+            .is_some()
+    );
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Started(_)
+    ));
+    assert!(input.try_hook_up(ButtonId::Back));
+    thread::sleep(LONG_PRESS_THRESHOLD + Duration::from_millis(20));
+    resume.send(()).expect("worker should still be blocked");
+
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Triggered {
+            action: Action::Copy,
+            ..
+        }
+    ));
+    assert!(matches!(
+        recv_event(&received),
+        ButtonRuntimeEvent::Ended {
+            reason: EndReason::Released,
+            ..
+        }
+    ));
+    assert!(received.recv_timeout(Duration::from_millis(30)).is_err());
     assert!(owner.shutdown());
 }
 
@@ -317,8 +737,9 @@ fn worker_emits_balanced_shutdown_and_rejects_later_input() {
     .expect("button worker should start");
     let input = owner.input();
 
+    let binding = Binding::Single(Action::Copy);
     let token = input
-        .try_hook_down(ButtonId::Back, Some(&Action::Copy))
+        .try_hook_down(ButtonId::Back, Some(&binding))
         .expect("down should be queued");
     let ButtonRuntimeEvent::Started(started) = recv_event(&received) else {
         panic!("expected a started event");

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -11,7 +11,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{
-    Action, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
+    Action, Binding, ButtonId, GestureDirection, SwipeAccumulator, default_binding,
 };
 use openlogi_core::config::{KeyModifiers, KeyTrigger};
 use openlogi_hook::{
@@ -29,8 +29,8 @@ use crate::event_monitor::SharedEventMonitor;
 /// versa), and the common case reads one lock instead of two.
 #[derive(Default)]
 pub struct HookMaps {
-    /// Per-button single action — the single-action dispatch path.
-    pub bindings: BTreeMap<ButtonId, Action>,
+    /// Per-button immediate or threshold binding — the non-gesture dispatch path.
+    pub bindings: BTreeMap<ButtonId, Binding>,
     /// Per-direction maps for the OS-hook gesture buttons (Middle/Back/Forward in
     /// gesture mode), so a hold+swipe resolves to a bound action. The dedicated
     /// HID++ gesture button (0x00c3) uses the gesture watcher's separate map
@@ -284,23 +284,29 @@ fn handle_button(
         }
     }
 
-    let action = hooks
+    let binding = hooks
         .try_read()
         .ok()
         .and_then(|m| m.bindings.get(&id).cloned());
-    let Some(action) = action else {
+    let Some(binding) = binding else {
         return EventDisposition::PassThrough;
     };
-    if is_native_click(id, &action) {
+    if binding_is_native_click(id, &binding) {
         return EventDisposition::PassThrough;
     }
     if pressed {
-        info!(button = %id, action = %action.label(), "button → executing bound action");
-        let queued = dispatcher.try_hook_button_down(id, Some(&action)).is_some();
+        info!(button = %id, action = %binding.click_action().label(), "button → handling binding");
+        let queued = dispatcher
+            .try_hook_button_down(id, Some(&binding))
+            .is_some();
         return FAIL_OPEN_PRESSES.with_borrow_mut(|s| remapped_press_disposition(id, queued, s));
     }
     dispatcher.try_hook_button_up(id);
     FAIL_OPEN_PRESSES.with_borrow_mut(|s| remapped_release_disposition(id, s))
+}
+
+fn binding_is_native_click(id: ButtonId, binding: &Binding) -> bool {
+    !matches!(binding, Binding::LongPress(_)) && is_native_click(id, &binding.click_action())
 }
 
 /// Press of a remapped single-action button: suppress when the action was
@@ -512,7 +518,7 @@ fn rebound_thumbwheel_action(maps: &HookMaps, delta_x: f64) -> Option<(ButtonId,
     } else {
         return None;
     };
-    let action = maps.bindings.get(&button)?.clone();
+    let action = maps.bindings.get(&button)?.click_action();
     (action != default_binding(button)).then_some((button, action))
 }
 

--- a/crates/openlogi-agent-core/src/runtime/hook/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook/tests.rs
@@ -1,7 +1,7 @@
 //! Regression tests for OS-hook state and dispatch policy.
 
 use super::*;
-use openlogi_core::binding::GESTURE_SWIPE_THRESHOLD;
+use openlogi_core::binding::{GESTURE_SWIPE_THRESHOLD, LongPressBinding};
 
 fn token(id: u64, button: ButtonId) -> PressToken {
     PressToken::hook_for_test(id, button)
@@ -178,8 +178,8 @@ fn scroll_interception_uses_the_button_source_safety_policy_and_skips_trackpads(
 fn rebound_horizontal_wheel_maps_to_thumbwheel_directions() {
     let maps = HookMaps {
         bindings: BTreeMap::from([
-            (ButtonId::ThumbwheelScrollUp, Action::NextTab),
-            (ButtonId::ThumbwheelScrollDown, Action::PrevTab),
+            (ButtonId::ThumbwheelScrollUp, Action::NextTab.into()),
+            (ButtonId::ThumbwheelScrollDown, Action::PrevTab.into()),
         ]),
         gestures: BTreeMap::new(),
     };
@@ -200,17 +200,26 @@ fn native_thumbwheel_scroll_stays_os_native() {
         bindings: BTreeMap::from([
             (
                 ButtonId::ThumbwheelScrollUp,
-                default_binding(ButtonId::ThumbwheelScrollUp),
+                default_binding(ButtonId::ThumbwheelScrollUp).into(),
             ),
             (
                 ButtonId::ThumbwheelScrollDown,
-                default_binding(ButtonId::ThumbwheelScrollDown),
+                default_binding(ButtonId::ThumbwheelScrollDown).into(),
             ),
         ]),
         gestures: BTreeMap::new(),
     };
     assert_eq!(rebound_thumbwheel_action(&maps, 1.0), None);
     assert_eq!(rebound_thumbwheel_action(&maps, -1.0), None);
+}
+
+#[test]
+fn long_press_never_passes_through_as_a_native_click() {
+    let binding = Binding::LongPress(LongPressBinding::new(
+        default_binding(ButtonId::Back),
+        Action::MissionControl,
+    ));
+    assert!(!binding_is_native_click(ButtonId::Back, &binding));
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, ButtonId, default_binding};
+use openlogi_core::binding::{Action, Binding, ButtonId, default_binding};
 use openlogi_core::config::ThumbwheelSensitivity;
 use openlogi_core::scroll::ScrollDelta;
 use openlogi_hid::session::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
@@ -521,15 +521,15 @@ fn dispatch(
             // lifecycle is still tracked, but it must not also fire the
             // single-action projection on down.
             let is_gesture = plan.gesture_bindings.contains_key(&button);
-            let action = (!is_gesture).then(|| plan.bindings.get(&button)).flatten();
-            if let Some(action) = action {
-                debug!(key, ?button, action = %action.label(), "HID++ button → action");
+            let binding = (!is_gesture).then(|| plan.bindings.get(&button)).flatten();
+            if let Some(binding) = binding {
+                debug!(key, ?button, action = %binding.click_action().label(), "HID++ button → binding");
             } else {
                 debug!(key, ?button, "HID++ button with no binding — ignored");
             }
             let press = outputs
                 .actions
-                .try_hidpp_button_down(session, button, action);
+                .try_hidpp_button_down(session, button, binding);
             if is_gesture {
                 if let Some(press) = press {
                     gesture_presses.start(session, button, press);
@@ -543,15 +543,15 @@ fn dispatch(
             gesture_presses.end(session, button);
         }
         CapturedInput::ButtonPulse(button) => {
-            let action = plan.bindings.get(&button);
-            if let Some(action) = action {
-                debug!(key, ?button, action = %action.label(), "HID++ button pulse → action");
+            let binding = plan.bindings.get(&button);
+            if let Some(binding) = binding {
+                debug!(key, ?button, action = %binding.click_action().label(), "HID++ button pulse → binding");
             } else {
                 debug!(key, ?button, "HID++ button pulse with no binding — ignored");
             }
             outputs
                 .actions
-                .dispatch_hidpp_button_pulse(session, button, action);
+                .dispatch_hidpp_button_pulse(session, button, binding);
         }
         CapturedInput::Scroll {
             increments,
@@ -567,8 +567,7 @@ fn dispatch(
             let action = plan
                 .bindings
                 .get(&button)
-                .cloned()
-                .unwrap_or_else(|| default_binding(button));
+                .map_or_else(|| default_binding(button), Binding::click_action);
             let sensitivity = plan.thumbwheel_sensitivity;
             let wheels = accumulators.entry(key.to_owned()).or_default();
             let dir = if up { &mut wheels.up } else { &mut wheels.down };

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
-use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::binding::{Binding, ButtonId};
 use openlogi_hid::{
     CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute,
     run_keyboard_capture_session_with_registry,
@@ -40,8 +40,8 @@ pub struct KeyboardSpec {
     pub route: DeviceRoute,
     /// `0x1b04` control ID → button, for exactly the bound keys.
     pub wanted: BTreeMap<u16, ButtonId>,
-    /// Effective per-key single-action map (per-app overlay applied).
-    pub bindings: BTreeMap<ButtonId, Action>,
+    /// Effective per-key immediate or threshold map (per-app overlay applied).
+    pub bindings: BTreeMap<ButtonId, Binding>,
 }
 
 /// Shared keyboard-capture spec, `None` when no online keyboard has bound
@@ -126,13 +126,13 @@ fn dispatch_input(
 ) {
     match input {
         CapturedInput::ButtonDown(button) => {
-            let action = spec.bindings.get(&button);
-            if let Some(action) = action {
-                info!(button = %button, action = %action.label(), "keyboard key → executing bound action");
+            let binding = spec.bindings.get(&button);
+            if let Some(binding) = binding {
+                info!(button = %button, action = %binding.click_action().label(), "keyboard key → handling binding");
             } else {
                 debug!(?button, "keyboard key with no binding — ignored");
             }
-            dispatcher.try_hidpp_button_down(session, button, action);
+            dispatcher.try_hidpp_button_down(session, button, binding);
         }
         CapturedInput::ButtonUp(button) => {
             dispatcher.try_hidpp_button_up(session, button);

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -40,4 +40,4 @@ pub use swipe::{
     GESTURE_HOLD_FOR_SWIPE, GESTURE_SWIPE_DEADZONE, GESTURE_SWIPE_THRESHOLD, SwipeAccumulator,
     detect_swipe,
 };
-pub use value::Binding;
+pub use value::{Binding, LONG_PRESS_THRESHOLD, LongPressBinding};

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -187,6 +187,27 @@ fn binding_gesture_roundtrips() {
     assert_eq!(back[&ButtonId::GestureButton], Binding::Gesture(map));
 }
 
+#[test]
+fn binding_long_press_roundtrips_without_overlapping_other_table_shapes() {
+    let binding = Binding::LongPress(LongPressBinding::new(Action::Copy, Action::MissionControl));
+    let back = binding_roundtrip(BTreeMap::from([(ButtonId::Back, binding.clone())]));
+    assert_eq!(back[&ButtonId::Back], binding);
+
+    let toml = toml::to_string_pretty(&BindingWrapper { bindings: back }).expect("serialize");
+    assert!(toml.contains("short = \"Copy\""));
+    assert!(toml.contains("long = \"MissionControl\""));
+    assert!(!toml.contains("LongPress"));
+}
+
+#[test]
+fn binding_long_press_requires_exact_short_and_long_fields() {
+    let missing_long = "[bindings.Back]\nshort = \"Copy\"";
+    assert!(toml::from_str::<BindingWrapper>(missing_long).is_err());
+
+    let unknown = "[bindings.Back]\nshort = \"Copy\"\nlong = \"Paste\"\nthreshold_ms = 900";
+    assert!(toml::from_str::<BindingWrapper>(unknown).is_err());
+}
+
 /// The untagged-routing safety guard. A TOML table keyed by ANY
 /// [`GestureDirection`] name must deserialize as [`Binding::Gesture`], never
 /// [`Binding::Single`]. If a future [`Action`] payload variant is ever named

--- a/crates/openlogi-core/src/binding/value.rs
+++ b/crates/openlogi-core/src/binding/value.rs
@@ -1,6 +1,7 @@
 //! Single-action vs per-direction gesture bindings.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -8,10 +9,45 @@ use super::action::Action;
 use super::defaults::default_gesture_binding;
 use super::gesture::GestureDirection;
 
-/// What a single rebindable [`ButtonId`](crate::binding::ButtonId) does: either
-/// one [`Action`], or — for a raw-XY-capable button placed in gesture mode — a
-/// per-[`GestureDirection`] map (hold + swipe up/down/left/right, or a plain
-/// click).
+/// How long a physical button must remain down before its independent long
+/// action fires.
+pub const LONG_PRESS_THRESHOLD: Duration = Duration::from_millis(500);
+
+/// The mutually exclusive actions of a threshold-based button binding.
+///
+/// `short` fires only on an ordinary release before the threshold. `long`
+/// fires once when the threshold elapses and suppresses `short` for that press.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LongPressBinding {
+    short: Action,
+    long: Action,
+}
+
+impl LongPressBinding {
+    /// Pair the release-before-threshold action with the threshold action.
+    #[must_use]
+    pub const fn new(short: Action, long: Action) -> Self {
+        Self { short, long }
+    }
+
+    /// Action fired by a normal release before the threshold.
+    #[must_use]
+    pub const fn short(&self) -> &Action {
+        &self.short
+    }
+
+    /// Action fired once when the threshold is reached.
+    #[must_use]
+    pub const fn long(&self) -> &Action {
+        &self.long
+    }
+}
+
+/// What a single rebindable [`ButtonId`](crate::binding::ButtonId) does: one
+/// immediate [`Action`], an independent short/long action pair, or — for a
+/// raw-XY-capable button placed in gesture mode — a per-[`GestureDirection`]
+/// map (hold + swipe up/down/left/right, or a plain click).
 ///
 /// There has only ever been one binding map per device; a gesture binding is
 /// just a binding whose payload is a direction map instead of a single action.
@@ -20,19 +56,15 @@ use super::gesture::GestureDirection;
 ///
 /// `#[serde(untagged)]`: [`Single`](Binding::Single) serializes exactly as the
 /// bare [`Action`] did before (a string `"BrowserBack"`, or a single-key table
-/// for the payload variants), and [`Gesture`](Binding::Gesture) serializes as a
+/// for the payload variants), [`Gesture`](Binding::Gesture) serializes as a
 /// table keyed by [`GestureDirection`] names (`Up`/`Down`/`Left`/`Right`/
-/// `Click`).
+/// `Click`), and [`LongPress`](Binding::LongPress) as the structurally distinct
+/// `{ short = ..., long = ... }` table.
 ///
-/// The two arms are disambiguated by the **zero overlap** between [`Action`]
-/// variant names and [`GestureDirection`] variant names — untagged tries
-/// `Single(Action)` first, and a table keyed by `Up` etc. cannot parse as an
-/// externally-tagged `Action`, so it falls through to `Gesture`. A payload
-/// action like `{ SetDpiPreset = 2 }` is a valid externally-tagged `Action`, so
-/// it stays `Single` and never reaches the `Gesture` arm. This invariant is the
-/// entire safety basis for untagged routing; the `binding_untagged_*` tests
-/// guard it (a future `Action` named `Up`/`Down`/`Left`/`Right`/`Click` would
-/// silently mis-route, and those tests would fail).
+/// The arms are disambiguated structurally: action variant names and gesture
+/// direction names have zero overlap, while a long press requires both
+/// lowercase `short` and `long` fields and rejects unknown fields. The
+/// `binding_untagged_*` tests guard these routing invariants.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Binding {
@@ -42,13 +74,16 @@ pub enum Binding {
     /// committed swipe direction, with [`GestureDirection::Click`] holding the
     /// plain-click (no-swipe) action.
     Gesture(BTreeMap<GestureDirection, Action>),
+    /// Independent release-before-threshold and threshold actions.
+    LongPress(LongPressBinding),
 }
 
 impl Binding {
     /// The plain-click action for this binding: the [`Single`](Binding::Single)
-    /// action, or the [`Gesture`](Binding::Gesture) map's
-    /// [`Click`](GestureDirection::Click) entry. Falls back to [`Action::None`]
-    /// when a gesture binding has no explicit `Click`.
+    /// action, the [`Gesture`](Binding::Gesture) map's
+    /// [`Click`](GestureDirection::Click) entry, or a
+    /// [`LongPress`](Binding::LongPress) binding's short action. Falls back to
+    /// [`Action::None`] when a gesture binding has no explicit `Click`.
     ///
     /// Lets the click-dispatch path stay binding-shape-agnostic.
     #[must_use]
@@ -59,6 +94,7 @@ impl Binding {
                 .get(&GestureDirection::Click)
                 .cloned()
                 .unwrap_or(Action::None),
+            Binding::LongPress(binding) => binding.short().clone(),
         }
     }
 
@@ -67,7 +103,7 @@ impl Binding {
     #[must_use]
     pub fn direction_action(&self, direction: GestureDirection) -> Option<&Action> {
         match self {
-            Binding::Single(_) => None,
+            Binding::Single(_) | Binding::LongPress(_) => None,
             Binding::Gesture(map) => map.get(&direction),
         }
     }
@@ -82,20 +118,23 @@ impl Binding {
     /// Promote a [`Single`](Binding::Single) binding in place to a
     /// [`Gesture`](Binding::Gesture), keeping its action as the
     /// [`GestureDirection::Click`] entry and leaving the swipe arms unbound.
+    /// A long-press binding keeps its short action as `Click`; its long action
+    /// is discarded because gesture and threshold modes are mutually exclusive.
     /// A no-op when this is already a [`Gesture`](Binding::Gesture).
     pub fn upgrade_to_gesture(&mut self) {
-        if let Binding::Single(action) = self {
-            let mut map = BTreeMap::new();
-            map.insert(GestureDirection::Click, action.clone());
-            *self = Binding::Gesture(map);
-        }
+        let click = match self {
+            Binding::Single(action) => action.clone(),
+            Binding::LongPress(binding) => binding.short().clone(),
+            Binding::Gesture(_) => return,
+        };
+        *self = Binding::Gesture(BTreeMap::from([(GestureDirection::Click, click)]));
     }
 
     /// Demote a [`Gesture`](Binding::Gesture) binding in place to a
     /// [`Single`](Binding::Single) of its [`Click`](GestureDirection::Click)
     /// entry, falling back to `fallback` when the map has no explicit `Click` —
     /// the inverse of [`Self::upgrade_to_gesture`]. A no-op on a
-    /// [`Single`](Binding::Single).
+    /// [`Single`](Binding::Single) or [`LongPress`](Binding::LongPress).
     pub fn demote_to_single(&mut self, fallback: Action) {
         if let Binding::Gesture(map) = self {
             let click = map

--- a/crates/openlogi-core/src/bindings.rs
+++ b/crates/openlogi-core/src/bindings.rs
@@ -15,34 +15,48 @@ use crate::config::Config;
 /// `app_bundle`'s per-app overlay applied. Unset buttons fall back to
 /// [`default_binding`].
 ///
-/// This is the map the OS hook and the HID++ button-press path consume, so a
-/// `Binding::Gesture` is projected to its `click_action()` — a gesture-mode
-/// button's per-direction swipes are dispatched via the separate
-/// [`hidpp_gesture_maps_for`] / [`oshook_gestures_for`] maps, not here.
+/// This projection is for one-shot consumers such as thumb-wheel rotation and
+/// the GUI. Lifecycle-aware button paths use [`button_bindings_for`] so a long
+/// press keeps both actions. `Binding::Gesture` is projected to its
+/// `click_action()`; per-direction swipes are dispatched via the separate
+/// [`hidpp_gesture_maps_for`] / [`oshook_gestures_for`] maps.
 #[must_use]
 pub fn bindings_for(
     config: &Config,
     config_key: Option<&str>,
     app_bundle: Option<&str>,
 ) -> BTreeMap<ButtonId, Action> {
+    button_bindings_for(config, config_key, app_bundle)
+        .into_iter()
+        .map(|(button, binding)| (button, binding.click_action()))
+        .collect()
+}
+
+/// Effective binding shapes for lifecycle-aware button consumers.
+///
+/// Unlike [`bindings_for`], this preserves threshold-based long presses. A
+/// sparse gesture map receives only its missing `Click` default so it keeps its
+/// gesture identity while retaining the same plain-click fallback.
+#[must_use]
+pub fn button_bindings_for(
+    config: &Config,
+    config_key: Option<&str>,
+    app_bundle: Option<&str>,
+) -> BTreeMap<ButtonId, Binding> {
     let stored = config_key
         .map(|key| config.effective_bindings(key, app_bundle))
         .unwrap_or_default();
-    let mut bindings: BTreeMap<ButtonId, Action> = ButtonId::ALL
+    let mut bindings: BTreeMap<ButtonId, Binding> = ButtonId::ALL
         .iter()
         .copied()
-        .map(|b| (b, default_binding(b)))
+        .map(|button| (button, Binding::Single(default_binding(button))))
         .collect();
-    for (k, binding) in stored {
-        // A gesture binding with no explicit `Click` has no opinion on the
-        // plain-press action, so leave the button's default seed in place rather
-        // than clobbering it with the `Action::None` that `click_action()` would
-        // project. (An explicit `Single(Action::None)` — a user-disabled button —
-        // still overrides, as it should.)
-        if binding.is_gesture() && binding.direction_action(GestureDirection::Click).is_none() {
-            continue;
+    for (button, mut binding) in stored {
+        if let Binding::Gesture(map) = &mut binding {
+            map.entry(GestureDirection::Click)
+                .or_insert_with(|| default_binding(button));
         }
-        bindings.insert(k, binding.click_action());
+        bindings.insert(button, binding);
     }
     bindings
 }
@@ -76,7 +90,7 @@ pub fn hidpp_gesture_maps_for(
             binding.fill_gesture_defaults();
             match binding {
                 Binding::Gesture(map) => Some((button, map)),
-                Binding::Single(_) => None,
+                Binding::Single(_) | Binding::LongPress(_) => None,
             }
         })
         .collect()
@@ -120,14 +134,14 @@ pub fn oshook_gestures_for(
         .filter(|(id, _)| id.is_os_hook_button())
         .filter_map(|(id, binding)| match binding {
             Binding::Gesture(map) => Some((id, map)),
-            Binding::Single(_) => None,
+            Binding::Single(_) | Binding::LongPress(_) => None,
         })
         .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::binding::default_gesture_binding;
+    use crate::binding::{LongPressBinding, default_gesture_binding};
 
     use super::*;
 
@@ -147,6 +161,18 @@ mod tests {
             Some(&default_binding(ButtonId::GestureButton)),
             "a Click-less gesture must keep the default click, not None"
         );
+    }
+
+    #[test]
+    fn lifecycle_projection_preserves_long_press_while_action_projection_uses_short() {
+        let mut cfg = Config::default();
+        let binding = Binding::LongPress(LongPressBinding::new(Action::Copy, Action::Paste));
+        cfg.set_binding("2b042", ButtonId::Back, binding.clone());
+
+        let lifecycle = button_bindings_for(&cfg, Some("2b042"), None);
+        assert_eq!(lifecycle.get(&ButtonId::Back), Some(&binding));
+        let actions = bindings_for(&cfg, Some("2b042"), None);
+        assert_eq!(actions.get(&ButtonId::Back), Some(&Action::Copy));
     }
 
     #[test]

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -49,6 +49,8 @@ use settings::GestureOwner;
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
 ///
+/// v6 adds threshold-based `{ short = ..., long = ... }` button bindings.
+///
 /// v5 also drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
 /// names the mouse *and the cable it was plugged into*, so a device moved to a
 /// different route was silently orphaned from its settings.
@@ -84,7 +86,7 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 5;
+pub const SCHEMA_VERSION: u32 = 6;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -250,10 +252,11 @@ impl Config {
         {
             return Some(*id);
         }
-        // A dedicated HID++ gesture button explicitly demoted to a single action means gestures off.
+        // A dedicated HID++ gesture button explicitly assigned non-gesture
+        // behavior means gestures were off.
         if matches!(
             bindings.get(&ButtonId::GestureButton),
-            Some(Binding::Single(_))
+            Some(Binding::Single(_) | Binding::LongPress(_))
         ) {
             return None;
         }

--- a/crates/openlogi-core/src/config/device.rs
+++ b/crates/openlogi-core/src/config/device.rs
@@ -174,8 +174,9 @@ pub struct DeviceConfig {
     /// [`DeviceStableId::route_key`]: crate::device_order::DeviceStableId::route_key
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub links: BTreeMap<String, LinkConfig>,
-    /// Every rebindable button's binding: a single [`Action`], or — for a
-    /// button in gesture mode — a [`Binding::Gesture`] per-direction map.
+    /// Every rebindable button's binding: a single [`Action`], an independent
+    /// short/long action pair, or — for a button in gesture mode — a
+    /// [`Binding::Gesture`] per-direction map.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub bindings: BTreeMap<ButtonId, Binding>,
     /// Direction maps of buttons whose gesture mode is currently OFF, keyed by

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -18,6 +18,12 @@ fn canonical_configuration_example_parses() {
     let body = include_str!("../../../../docs/config.example.toml");
     let config: Config = toml::from_str(body).expect("documented config must parse");
     assert_eq!(config.schema_version, SCHEMA_VERSION);
+    let bindings = config.bindings_for("receiver:aabbccdd:slot:1");
+    let Some(Binding::LongPress(long_press)) = bindings.get(&ButtonId::DpiToggle) else {
+        panic!("documented long-press binding should keep its shape");
+    };
+    assert_eq!(long_press.short(), &Action::ShowDesktop);
+    assert_eq!(long_press.long(), &Action::MissionControl);
 }
 
 #[test]
@@ -1155,7 +1161,7 @@ fn current_schema_rejects_unknown_and_obsolete_fields() {
     let path = dir.path().join("config.toml");
     fs::write(
         &path,
-        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivty = 14\n",
+        "schema_version = 6\n[app_settings]\nthumbwheel_sensitivty = 14\n",
     )
     .expect("write typo");
     assert_matches!(
@@ -1165,7 +1171,7 @@ fn current_schema_rejects_unknown_and_obsolete_fields() {
 
     fs::write(
         &path,
-        r#"schema_version = 5
+        r#"schema_version = 6
 [devices.mouse.identity]
 display_name = "Mouse"
 kind = "mouse"
@@ -1180,7 +1186,7 @@ capabilities = { buttons = true, pointer = true, lighting = false, scroll_invers
 
     fs::write(
         &path,
-        "schema_version = 5\n[devices.mouse]\ngesture_owner = \"Off\"\n",
+        "schema_version = 6\n[devices.mouse]\ngesture_owner = \"Off\"\n",
     )
     .expect("write obsolete field");
     assert_matches!(
@@ -1192,15 +1198,15 @@ capabilities = { buttons = true, pointer = true, lighting = false, scroll_invers
 #[test]
 fn persisted_numeric_contracts_reject_unsafe_values() {
     for body in [
-        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = 0\n",
-        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = 101\n",
-        "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = -2147483648\n",
-        "schema_version = 5\n[app_settings]\nvertical_scroll_sensitivity = 0\n",
-        "schema_version = 5\n[app_settings]\nvertical_scroll_sensitivity = 101\n",
-        "schema_version = 5\n[app_settings]\nvertical_scroll_sensitivity = -2147483648\n",
-        "schema_version = 5\n[devices.mouse]\nthumbwheel_sensitivity = -1\n",
-        "schema_version = 5\n[devices.mouse]\ndpi = 65536\n",
-        "schema_version = 5\n[devices.mouse]\ndpi_presets = [800, 70000]\n",
+        "schema_version = 6\n[app_settings]\nthumbwheel_sensitivity = 0\n",
+        "schema_version = 6\n[app_settings]\nthumbwheel_sensitivity = 101\n",
+        "schema_version = 6\n[app_settings]\nthumbwheel_sensitivity = -2147483648\n",
+        "schema_version = 6\n[app_settings]\nvertical_scroll_sensitivity = 0\n",
+        "schema_version = 6\n[app_settings]\nvertical_scroll_sensitivity = 101\n",
+        "schema_version = 6\n[app_settings]\nvertical_scroll_sensitivity = -2147483648\n",
+        "schema_version = 6\n[devices.mouse]\nthumbwheel_sensitivity = -1\n",
+        "schema_version = 6\n[devices.mouse]\ndpi = 65536\n",
+        "schema_version = 6\n[devices.mouse]\ndpi_presets = [800, 70000]\n",
     ] {
         assert!(toml::from_str::<Config>(body).is_err(), "accepted: {body}");
     }
@@ -1212,7 +1218,7 @@ fn tracked_save_preserves_comments_and_rejects_concurrent_edits() {
     let path = dir.path().join("config.toml");
     fs::write(
         &path,
-        "# keep this comment\nschema_version = 5\nselected_device = \"one\" # and this one\n",
+        "# keep this comment\nschema_version = 6\nselected_device = \"one\" # and this one\n",
     )
     .expect("write");
     let (mut config, mut file) = ConfigFile::load_from_path(&path).expect("load tracked");

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -61,7 +61,8 @@ Common device fields are:
 
 - `custom_name`, `enabled`, `dpi`, `dpi_presets`, thumb-wheel sensitivity,
   scroll inversion, and scroll resolution
-- `bindings`: a button maps either to one action or to a gesture-direction map.
+- `bindings`: a button maps to one action, an independent short/long action
+  pair, or a gesture-direction map.
   `Thumbwheel` is the thumb wheel's capacitive tap — it has no GUI control and
   stays inert unless bound here, because the wheel reports taps from incidental
   thumb contact as well as from deliberate ones
@@ -92,12 +93,27 @@ Payload actions use a one-key inline table:
 Back = { CustomShortcut = "Cmd+Shift+P" }
 Forward = { HoldShortcut = "Ctrl+Space" }
 MiddleClick = { OpenApplication = { path = "~/Downloads", display_name = "Downloads" } }
+DpiToggle = { short = "ShowDesktop", long = "MissionControl" }
 ```
 
 `CustomShortcut` emits an immediate key-down/key-up pair. `HoldShortcut` keeps
 the chord down until the originating physical button is released, and also
 releases it if capture is interrupted, the binding becomes invalid, or the
 agent shuts down. Use it for push-to-talk and other hold-to-activate controls.
+
+A `{ short = ..., long = ... }` binding waits for the button's outcome instead
+of firing on press. Releasing before 500 ms fires `short`; keeping the button
+down for 500 ms fires `long` exactly once, and the later release does not also
+fire `short`. If capture is interrupted, the binding changes, or the agent
+shuts down before either outcome, neither action fires. A source that can only
+report an instantaneous button pulse falls back to `short`. `long` may itself
+be a `HoldShortcut`, in which case its chord stays down from the 500 ms
+threshold until the physical release.
+
+Long-press pairs currently apply to global device `bindings` and are authored
+in TOML. The GUI presents their `short` action; changing that button in the GUI
+replaces the whole pair with the selected single action. `per_app_bindings` and
+`keyboard.bindings` remain single-action maps.
 
 An Actions Ring entry wraps the action and may add an icon or literal label:
 

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,5 +1,5 @@
 # OpenLogi configuration example. Copy only the sections you need.
-schema_version = 5
+schema_version = 6
 selected_device = "receiver:aabbccdd:slot:1"
 
 [app_settings]
@@ -33,6 +33,8 @@ Back = "BrowserBack"
 Forward = "BrowserForward"
 # Hold the chord for exactly as long as the physical button is held.
 MiddleClick = { HoldShortcut = "Ctrl+Space" }
+# Release before 500 ms runs `short`; reaching 500 ms runs `long` once.
+DpiToggle = { short = "ShowDesktop", long = "MissionControl" }
 # The thumb wheel's capacitive tap. Inert unless set here; the wheel also
 # reports taps from incidental thumb contact.
 Thumbwheel = "AppExpose"


### PR DESCRIPTION
## Summary

Add independent short/long-press button bindings with a fixed 500 ms threshold. A quick release fires the short action, reaching the threshold fires the long action exactly once, and cancellation fires neither.

This PR is stacked on #960 and implements the next step from #930. Review only the commit on top of `feat/hold-shortcut-action`.

## Changes

- add a structurally distinct `{ short = ..., long = ... }` TOML binding and bump the config schema to v6
- preserve full binding shapes through OS-hook, HID++, and keyboard capture plans
- model pending/fired long presses as explicit runtime states owned by the button worker
- timestamp release edges so a quick release remains short even when worker handling is delayed
- keep long-press actions exactly-once across release, invalidation, capture interruption, and shutdown
- degrade pulse-only inputs to the short action and allow `HoldShortcut` as the long action
- document the TOML-only global-device scope and 500 ms behavior

## Testing

- `RUSTFLAGS='-D warnings' cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-cli -p openlogi -p openlogi-desktop -p openlogi-device -p openlogi-hid -p openlogi-hook -p openlogi-inject -p openlogi-ipc -p openlogi-overlay -p openlogi-permissions -p openlogi-ui -p xtask --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-cli -p openlogi -p openlogi-desktop -p openlogi-device -p openlogi-hid -p openlogi-hook -p openlogi-inject -p openlogi-ipc -p openlogi-overlay -p openlogi-permissions -p openlogi-ui -p xtask`
- `cargo test -p openlogi-ipc --test wire_format`
- `cargo xtask ci clippy-windows`
- not runtime-tested on Logitech hardware in this orb