### PR TITLE
fix(gui): allow clearing function-key bindings

### DIFF
--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -774,6 +774,10 @@ fn callout_lane_is_lower(idx: usize) -> bool {
     idx.is_multiple_of(2)
 }
 
+fn binding_after_pick(current: Option<&Action>, picked: Action) -> Option<Action> {
+    (current != Some(&picked)).then_some(picked)
+}
+
 /// The scrollable config panel for the selected key. Lists the same action
 /// catalog the mouse picker uses, plus a Power User section. Renders the rows
 /// directly (no popover) in a tall card.
@@ -808,10 +812,14 @@ impl FunctionRowView {
 
         let view_for_pick = view.clone();
         let trigger_for_pick = trigger.clone();
+        let current_for_pick = current.clone();
         let on_pick: PickFn = Rc::new(move |action, _window, cx| {
             AppState::update(cx, |state, cx| {
                 let key = state.current_record().map(DeviceRecord::device_key);
-                state.commit_keyboard_binding(trigger_for_pick.clone(), Some(action));
+                state.commit_keyboard_binding(
+                    trigger_for_pick.clone(),
+                    binding_after_pick(current_for_pick.as_ref(), action),
+                );
                 if let Some(key) = key {
                     cx.emit(StateEvent::BindingsChanged(key));
                 }
@@ -1169,6 +1177,20 @@ mod tests {
         assert_eq!(next_selection_after_click(None, 3), Some(3));
         assert_eq!(next_selection_after_click(Some(3), 3), None);
         assert_eq!(next_selection_after_click(Some(3), 4), Some(4));
+    }
+
+    #[test]
+    fn picking_the_current_action_clears_the_binding() {
+        assert_eq!(binding_after_pick(Some(&Action::Copy), Action::Copy), None);
+    }
+
+    #[test]
+    fn picking_an_action_sets_or_replaces_the_binding() {
+        assert_eq!(binding_after_pick(None, Action::Copy), Some(Action::Copy));
+        assert_eq!(
+            binding_after_pick(Some(&Action::Paste), Action::Copy),
+            Some(Action::Copy)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Allow users to remove a function-key override without adding a new control or changing the existing layout. Clicking the currently selected action again clears the override and restores the key's native behavior.

## Changes

- **openlogi-desktop**: toggle the selected keyboard action through the existing optional binding path
- Preserve `Action::None` as “capture the key and do nothing”; clearing a binding remains a distinct operation
- Compare internal action values rather than localized labels, so the behavior is identical across all supported locales
- Add focused tests for setting, replacing, and clearing a function-key binding

## Testing

- `cargo +1.98.0 fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo +1.98.0 clippy -p openlogi-desktop --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo +1.98.0 test -p openlogi-desktop` (155 passed)
- Hardware verification: not runtime-tested on hardware; select an action for a function key, click the selected action again, and verify that the native key behavior returns
