### PR TITLE
fix(hid): suppress duplicate Bolt pairing slots

### DIFF
--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -143,18 +143,62 @@ pub(super) fn assemble_bolt_probe(
     pairing_count: Option<u8>,
     slot_results: Vec<(PairedDevice, CacheOutcome)>,
 ) -> NodeProbe {
-    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().unzip();
+    // The pairing table can retain the same physical unit in more than one
+    // slot after a re-pair. The receiver still counts both occupied slots, so
+    // keep the raw count for probe health, but publish only one route for a
+    // non-zero unit id. Otherwise the Agent, CLI, and GUI all treat an offline
+    // stale slot as a second device. Prefer the online route; ordered slot
+    // results make the lower slot the stable tie-breaker.
+    let readable_slots = slot_results.len();
+    let mut paired = Vec::<PairedDevice>::with_capacity(readable_slots);
+    let mut outcomes = Vec::with_capacity(readable_slots);
+    let mut by_unit_id = HashMap::<[u8; 4], usize>::new();
+    for (device, outcome) in slot_results {
+        let unit_id = match &outcome {
+            CacheOutcome::Fresh(CacheKey::Bolt { unit_id }, _)
+            | CacheOutcome::Update(CacheKey::Bolt { unit_id }, _)
+            | CacheOutcome::Seen(CacheKey::Bolt { unit_id }) => Some(*unit_id),
+            CacheOutcome::Fresh(..)
+            | CacheOutcome::Update(..)
+            | CacheOutcome::Seen(..)
+            | CacheOutcome::Unkeyed => None,
+        };
+        if let Some(unit_id) = unit_id {
+            if let Some(&existing) = by_unit_id.get(&unit_id) {
+                let kept = &mut paired[existing];
+                if device.online && !kept.online {
+                    debug!(
+                        dropped_slot = kept.slot,
+                        kept_slot = device.slot,
+                        "duplicate Bolt pairing identity — keeping online slot"
+                    );
+                    *kept = device;
+                } else {
+                    debug!(
+                        kept_slot = kept.slot,
+                        dropped_slot = device.slot,
+                        "duplicate Bolt pairing identity — suppressing duplicate slot"
+                    );
+                }
+                outcomes.push(outcome);
+                continue;
+            }
+            by_unit_id.insert(unit_id, paired.len());
+        }
+        paired.push(device);
+        outcomes.push(outcome);
+    }
 
     if let Some(count) = pairing_count
-        && paired.len() != usize::from(count)
+        && readable_slots != usize::from(count)
     {
         warn!(
             expected = count,
-            found = paired.len(),
+            found = readable_slots,
             "paired-device count mismatch — some slots may be unreadable"
         );
     }
-    let complete = pairing_count.is_some_and(|count| paired.len() == usize::from(count));
+    let complete = pairing_count.is_some_and(|count| readable_slots == usize::from(count));
 
     NodeProbe {
         inventory: Some(DeviceInventory { receiver, paired }),

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -445,20 +445,26 @@ fn bolt_receiver_info() -> ReceiverInfo {
 /// timeout produces (#251): the device still surfaces from its pairing-register
 /// identity, so a timed-out slot counts as readable here.
 fn bolt_slot(slot: u8) -> (PairedDevice, CacheOutcome) {
+    bolt_slot_with_identity(slot, [0, 0, 0, slot], true)
+}
+
+fn bolt_slot_with_identity(
+    slot: u8,
+    unit_id: [u8; 4],
+    online: bool,
+) -> (PairedDevice, CacheOutcome) {
     (
         PairedDevice {
             slot,
             codename: Some(format!("device-{slot}")),
             wpid: None,
             kind: DeviceKind::Mouse,
-            online: true,
+            online,
             battery: None,
             model_info: None,
             capabilities: None,
         },
-        CacheOutcome::Seen(CacheKey::Bolt {
-            unit_id: [0, 0, 0, slot],
-        }),
+        CacheOutcome::Seen(CacheKey::Bolt { unit_id }),
     )
 }
 
@@ -487,6 +493,83 @@ fn bolt_probe_is_complete_when_count_matches_readable_slots() {
         probe.outcomes.len(),
         2,
         "one cache outcome per readable slot"
+    );
+}
+
+#[test]
+fn bolt_probe_suppresses_offline_duplicate_pairing_slot() {
+    let unit_id = [0x4e, 0x51, 0x01, 0xc4];
+    let probe = assemble_bolt_probe(
+        bolt_receiver_info(),
+        Some(2),
+        vec![
+            bolt_slot_with_identity(2, unit_id, true),
+            bolt_slot_with_identity(3, unit_id, false),
+        ],
+    );
+
+    assert!(probe.complete, "both receiver slots were readable");
+    assert!(
+        probe.healthy,
+        "deduplication must not make a complete walk unhealthy"
+    );
+    assert_eq!(paired_slots(&probe), vec![2], "the online slot wins");
+    assert_eq!(
+        probe.outcomes.len(),
+        2,
+        "both raw slots still contribute their cache outcome"
+    );
+}
+
+#[test]
+fn bolt_probe_replaces_earlier_offline_duplicate_with_online_slot() {
+    let unit_id = [0x4e, 0x51, 0x01, 0xc4];
+    let probe = assemble_bolt_probe(
+        bolt_receiver_info(),
+        Some(2),
+        vec![
+            bolt_slot_with_identity(2, unit_id, false),
+            bolt_slot_with_identity(3, unit_id, true),
+        ],
+    );
+
+    assert_eq!(
+        paired_slots(&probe),
+        vec![3],
+        "a later online slot replaces the stale route"
+    );
+}
+
+#[test]
+fn bolt_probe_keeps_distinct_units_of_the_same_model() {
+    let probe = assemble_bolt_probe(
+        bolt_receiver_info(),
+        Some(2),
+        vec![
+            bolt_slot_with_identity(2, [1, 2, 3, 4], true),
+            bolt_slot_with_identity(3, [1, 2, 3, 5], false),
+        ],
+    );
+
+    assert_eq!(
+        paired_slots(&probe),
+        vec![2, 3],
+        "model equality without physical-identity equality is not enough to merge devices"
+    );
+}
+
+#[test]
+fn bolt_probe_keeps_unkeyed_slots_separate() {
+    let unkeyed = |slot| {
+        let (device, _) = bolt_slot_with_identity(slot, [0; 4], false);
+        (device, CacheOutcome::Unkeyed)
+    };
+    let probe = assemble_bolt_probe(bolt_receiver_info(), Some(2), vec![unkeyed(2), unkeyed(3)]);
+
+    assert_eq!(
+        paired_slots(&probe),
+        vec![2, 3],
+        "all-zero identities are not strong enough to deduplicate"
     );
 }
 


### PR DESCRIPTION
## Summary

Suppress duplicate Bolt receiver pairing slots when the receiver reports the same non-zero unit ID more than once. This keeps one card per physical device while preserving distinct devices of the same model.

## Changes

- **openlogi-device**: coalesce readable Bolt slots that share a non-zero unit ID
- Prefer the online entry when duplicate slots disagree about connectivity
- Preserve the raw readable-slot count used by probe completeness checks
- Keep same-model devices with different unit IDs and entries without a usable unit ID distinct
- Add regression coverage for duplicate, online-preference, same-model-distinct, and unkeyed-slot cases

## Testing

- `cargo +1.98.0 fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo +1.98.0 clippy -p openlogi-device -p openlogi-hid -p openlogi-agent-core -p openlogi-agent -p openlogi-cli -p openlogi --all-targets -- -D warnings`
- `cargo +1.98.0 test -p openlogi-device -p openlogi-hid -p openlogi-agent-core -p openlogi-agent -p openlogi-cli -p openlogi`
- WASM portability checks passed for the affected device layer
- Hardware verification: verified on a Bolt receiver with Alto Keys K75M in slot 1 and MX Master 3S in slot 2; the stale duplicate slot 3 is no longer published
