### PR TITLE
refactor(gui): improve shared component quality

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -45,6 +45,9 @@ paths:
   a genuinely heterogeneous branch, collection, callback, or stored field requires
   `AnyElement`. Prefer one typed `.when()` / `.when_some()` / `.children()` pipeline to
   branching early and erasing each result.
+- Key dynamic `ElementId`s by a stable domain identity, not a filtered position or a
+  formatted display label. Derive reusable-component child IDs from the component's
+  caller-provided root ID so multiple instances cannot share focus or scroll state.
 - A view, entity, or app service owns every `Task` and `Subscription` whose work belongs
   to its lifetime. Use `.detach()` only for true process-lifetime work or bounded
   one-shots whose completion is safe after the initiating view disappears.

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -1,7 +1,7 @@
 use gpui::{
     AnyElement, App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement,
     IntoElement, MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription,
-    Window, div, prelude::FluentBuilder as _, px, rgb,
+    Window, div, prelude::FluentBuilder as _, rgb,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -26,7 +26,7 @@ use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::features::profile_scope::ProfileIconCache;
 use crate::services::assets::AssetResolver;
 use crate::state::{AgentLink, AppState, DeviceRecord, StateEvent};
-use crate::ui::theme::{self, Palette, Typography as _};
+use crate::ui::theme::{self, ContentWidth, Palette, Typography as _};
 
 pub(crate) mod deeplink;
 mod detail;
@@ -382,7 +382,7 @@ impl AppView {
             )
             .child(
                 div()
-                    .max_w(px(440.))
+                    .max_w(ContentWidth::Narrow.rems())
                     .text_body()
                     .text_color(pal.text_muted)
                     .child(tr!(
@@ -394,7 +394,7 @@ impl AppView {
             )
             .child(
                 div()
-                    .max_w(px(440.))
+                    .max_w(ContentWidth::Narrow.rems())
                     .text_body()
                     .text_color(pal.text_muted)
                     .child(tr!(

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -1,9 +1,9 @@
 use gpui::{
     AnyElement, App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, MouseButton, NavigationDirection, ParentElement, Render,
-    StatefulInteractiveElement as _, Styled, Subscription, Window, div,
-    prelude::FluentBuilder as _, px, rgb,
+    IntoElement, MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription,
+    Window, div, prelude::FluentBuilder as _, px, rgb,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Icon, IconName, TitleBar,
     button::{Button, ButtonVariants as _},
@@ -415,12 +415,13 @@ impl AppView {
                 "Takes effect automatically once granted — no restart needed."
             )))
             .child(
-                div()
-                    .id("skip-accessibility")
+                BaseButton::new("skip-accessibility")
+                    .accessibility_label(tr!("Not now (use DPI and other features only)"))
                     .text_caption()
                     .text_color(pal.text_muted)
                     .cursor_pointer()
                     .hover(|s| s.text_color(pal.text_primary))
+                    .focus_visible(|s| s.text_color(pal.text_primary))
                     .child(tr!("Not now (use DPI and other features only)"))
                     .on_click(cx.listener(|this, _, _, cx| {
                         this.accessibility_dismissed = true;

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -11,8 +11,9 @@ pub(super) use views::ordered_device_indices;
 use std::sync::Arc;
 
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Hsla, IntoElement, ParentElement, SharedString,
-    Styled, Window, canvas, div, fill, img, point, prelude::FluentBuilder as _, px, rgb, svg,
+    AnyElement, App, AppContext as _, Context, ElementId, Hsla, IntoElement, ParentElement,
+    SharedString, Styled, Window, canvas, div, fill, img, point, prelude::FluentBuilder as _, px,
+    rgb, svg,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -36,7 +37,7 @@ use super::widgets::{
 };
 use crate::features::lighting::visual as light_visual;
 use crate::services::assets::GlowGeometry;
-use crate::state::{AppState, DeviceRecord};
+use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::theme::{self, HEADER_H, Palette, SelectableStyle as _, Typography as _};
 
 /// Home (gallery) top bar: title/count, the persisted layout switcher, Settings,
@@ -159,7 +160,7 @@ fn device_card(
     light_settings: LightSettings,
     pal: Palette,
 ) -> BaseButton {
-    BaseButton::new(format!("device-card-{}", record.record_key()))
+    BaseButton::new((ElementId::from("device-card"), record.record_key()))
         .w_full()
         .flex()
         .flex_col()
@@ -277,7 +278,7 @@ fn rename_device_button(record: &DeviceRecord, pal: Palette) -> Button {
         record.display_name.clone()
     };
     let model_name = record.model_name.clone();
-    Button::new(SharedString::from(format!("rename-device-{record_key}")))
+    Button::new((ElementId::from("rename-device"), record_key.clone()))
         .ghost()
         .xsmall()
         .text_color(pal.text_muted)
@@ -333,9 +334,8 @@ fn open_rename_dialog(
                     let custom_name = input.read(cx).value().to_string();
                     AppState::update(cx, |state, cx| {
                         state.set_device_custom_name(&record_key, &custom_name);
-                        cx.notify();
+                        cx.emit(StateEvent::InventoryChanged);
                     });
-                    cx.refresh_windows();
                     true
                 }
             })

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -38,7 +38,9 @@ use super::widgets::{
 use crate::features::lighting::visual as light_visual;
 use crate::services::assets::GlowGeometry;
 use crate::state::{AppState, DeviceRecord, StateEvent};
-use crate::ui::theme::{self, HEADER_H, Palette, SelectableStyle as _, Typography as _};
+use crate::ui::theme::{
+    self, ContentWidth, HEADER_H, Palette, SelectableStyle as _, Typography as _,
+};
 
 /// Home (gallery) top bar: title/count, the persisted layout switcher, Settings,
 /// and Add Device.
@@ -572,7 +574,7 @@ pub(super) fn device_empty_state(pal: Palette) -> AnyElement {
         )
         .child(
             div()
-                .max_w(px(440.))
+                .max_w(ContentWidth::Narrow.rems())
                 .text_body()
                 .text_center()
                 .child(tr!(
@@ -586,7 +588,7 @@ pub(super) fn device_empty_state(pal: Palette) -> AnyElement {
                 .label(tr!("Add Device"))
                 .on_click(|_, _, cx| crate::windows::add_device::open(cx)),
         )
-        .child(div().mt_1().max_w(px(440.)).text_caption().text_center().text_color(pal.text_muted).child(tr!(
+        .child(div().mt_1().max_w(ContentWidth::Narrow.rems()).text_caption().text_center().text_color(pal.text_muted).child(tr!(
             "Using Logi Options+? Quit it first — both apps compete for HID++ access."
         )))
         .into_any_element()

--- a/crates/openlogi-desktop/src/app/home/views.rs
+++ b/crates/openlogi-desktop/src/app/home/views.rs
@@ -1,7 +1,7 @@
 //! Switchable grid, list, and carousel layouts for the Home device gallery.
 
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, SharedString,
+    AnyElement, Context, ElementId, InteractiveElement, IntoElement, ParentElement, SharedString,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rgb,
 };
 use gpui_base::Button as BaseButton;
@@ -279,7 +279,7 @@ fn device_list_row(
     let glow = keyboard_glow(state, record);
     let record_key = record.record_key();
 
-    BaseButton::new(format!("device-list-row-{record_key}"))
+    BaseButton::new((ElementId::from("device-list-row"), record_key.clone()))
         .w_full()
         .min_h(px(96.))
         .flex()

--- a/crates/openlogi-desktop/src/app/home/views.rs
+++ b/crates/openlogi-desktop/src/app/home/views.rs
@@ -1,8 +1,9 @@
 //! Switchable grid, list, and carousel layouts for the Home device gallery.
 
 use gpui::{
-    AnyElement, Context, ElementId, InteractiveElement, IntoElement, ParentElement, SharedString,
-    StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rgb,
+    AnyElement, Context, ElementId, InteractiveElement, IntoElement, ParentElement, Rems,
+    SharedString, StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px,
+    rems, rgb,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -70,12 +71,12 @@ pub(super) fn device_view_switcher(
     ])
 }
 
-/// Gap between gallery cards, in pixels.
-const GALLERY_GAP: f32 = 16.;
+/// Gap between gallery cards.
+const GALLERY_GAP: Rems = rems(1.);
 /// Fixed carousel width: three cards plus navigation fit the default window.
-const CAROUSEL_CARD_W: f32 = 340.;
+const CAROUSEL_CARD_W: Rems = rems(21.25);
 /// Maximum width of the grid: three cards at their maximum width plus gaps.
-const GALLERY_MAX_W: f32 = theme::GALLERY_CARD_MAX_W * 3. + GALLERY_GAP * 2.;
+const GALLERY_MAX_W: Rems = rems(77.9375);
 
 /// Render the persisted Home layout. All three modes share ordering, metadata,
 /// accessibility, and active-device semantics; only spatial density changes.
@@ -84,9 +85,9 @@ pub(in crate::app) fn device_gallery(cx: &mut Context<AppView>) -> AnyElement {
         state.app_settings().device_view_mode
     });
     match mode {
-        DeviceViewMode::Grid => device_grid(cx),
-        DeviceViewMode::List => device_list(cx),
-        DeviceViewMode::Carousel => device_carousel(cx),
+        DeviceViewMode::Grid => device_grid(cx).into_any_element(),
+        DeviceViewMode::List => device_list(cx).into_any_element(),
+        DeviceViewMode::Carousel => device_carousel(cx).into_any_element(),
     }
 }
 
@@ -98,7 +99,7 @@ pub(in crate::app) fn ordered_device_indices(records: &[DeviceRecord]) -> Vec<us
     indices
 }
 
-fn device_grid(cx: &mut Context<AppView>) -> AnyElement {
+fn device_grid(cx: &mut Context<AppView>) -> impl IntoElement {
     let view = cx.entity();
     let pal = theme::palette(cx);
     let cards = AppState::try_read(cx).map_or_else(Vec::new, |state| {
@@ -109,10 +110,9 @@ fn device_grid(cx: &mut Context<AppView>) -> AnyElement {
             .into_iter()
             .map(|idx| {
                 device_card_element(state, idx, active_idx, view.clone(), pal)
-                    .min_w(px(theme::GALLERY_CARD_MIN_W))
-                    .max_w(px(theme::GALLERY_CARD_MAX_W))
+                    .min_w(theme::GALLERY_CARD_MIN_W)
+                    .max_w(theme::GALLERY_CARD_MAX_W)
                     .flex_1()
-                    .into_any_element()
             })
             .collect()
     });
@@ -127,16 +127,15 @@ fn device_grid(cx: &mut Context<AppView>) -> AnyElement {
         .child(
             h_flex()
                 .w_full()
-                .max_w(px(GALLERY_MAX_W))
+                .max_w(GALLERY_MAX_W)
                 .items_stretch()
                 .flex_wrap()
-                .gap(px(GALLERY_GAP))
+                .gap(GALLERY_GAP)
                 .children(cards),
         )
-        .into_any_element()
 }
 
-fn device_list(cx: &mut Context<AppView>) -> AnyElement {
+fn device_list(cx: &mut Context<AppView>) -> impl IntoElement {
     let view = cx.entity();
     let pal = theme::palette(cx);
     let rows = AppState::try_read(cx).map_or_else(Vec::new, |state| {
@@ -163,10 +162,9 @@ fn device_list(cx: &mut Context<AppView>) -> AnyElement {
                 .gap_2()
                 .children(rows),
         )
-        .into_any_element()
 }
 
-fn device_carousel(cx: &mut Context<AppView>) -> AnyElement {
+fn device_carousel(cx: &mut Context<AppView>) -> impl IntoElement {
     let view = cx.entity();
     let (order, selected) = AppState::try_read(cx).map_or_else(
         || (Vec::new(), 0),
@@ -182,46 +180,40 @@ fn device_carousel(cx: &mut Context<AppView>) -> AnyElement {
     let render_order = order.clone();
     let select_order = order.clone();
 
-    v_flex()
-        .flex_1()
-        .w_full()
-        .min_h_0()
-        .child(
-            Carousel::new("device-carousel", px(CAROUSEL_CARD_W))
-                .len(order.len())
-                .selected(selected)
-                .gap(px(GALLERY_GAP))
-                .render_item(move |position, _, _, cx| {
-                    let pal = theme::palette(cx);
-                    let Some(state) = AppState::try_read(cx) else {
-                        return div().into_any_element();
-                    };
-                    let Some(&idx) = render_order.get(position) else {
-                        return div().into_any_element();
-                    };
-                    let active_idx = state
-                        .current_device
-                        .min(state.device_list.len().saturating_sub(1));
-                    device_card_element(state, idx, active_idx, view.clone(), pal)
-                        .into_any_element()
-                })
-                .on_select(cx.listener(move |_, position: &usize, _, cx| {
-                    let Some(&idx) = select_order.get(*position) else {
+    v_flex().flex_1().w_full().min_h_0().child(
+        Carousel::new("device-carousel", CAROUSEL_CARD_W)
+            .len(order.len())
+            .selected(selected)
+            .gap(GALLERY_GAP)
+            .render_item(move |position, _, _, cx| {
+                let pal = theme::palette(cx);
+                let Some(state) = AppState::try_read(cx) else {
+                    return div().into_any_element();
+                };
+                let Some(&idx) = render_order.get(position) else {
+                    return div().into_any_element();
+                };
+                let active_idx = state
+                    .current_device
+                    .min(state.device_list.len().saturating_sub(1));
+                device_card_element(state, idx, active_idx, view.clone(), pal).into_any_element()
+            })
+            .on_select(cx.listener(move |_, position: &usize, _, cx| {
+                let Some(&idx) = select_order.get(*position) else {
+                    return;
+                };
+                AppState::global(cx).update(cx, |state, cx| {
+                    if state.current_device == idx || idx >= state.device_list.len() {
                         return;
-                    };
-                    AppState::global(cx).update(cx, |state, cx| {
-                        if state.current_device == idx || idx >= state.device_list.len() {
-                            return;
-                        }
-                        state.set_current_device(idx);
-                        cx.emit(StateEvent::DeviceSelected(
-                            state.device_list[idx].device_key(),
-                        ));
-                    });
-                    AppState::load_current_device_reads(cx);
-                })),
-        )
-        .into_any_element()
+                    }
+                    state.set_current_device(idx);
+                    cx.emit(StateEvent::DeviceSelected(
+                        state.device_list[idx].device_key(),
+                    ));
+                });
+                AppState::load_current_device_reads(cx);
+            })),
+    )
 }
 
 fn device_card_element(
@@ -269,7 +261,7 @@ fn device_list_row(
     active_idx: usize,
     view: gpui::Entity<AppView>,
     pal: Palette,
-) -> AnyElement {
+) -> BaseButton {
     let record = &state.device_list[idx];
     let active = idx == active_idx;
     let enabled = state.device_enabled(&record.config_key);
@@ -331,7 +323,7 @@ fn device_list_row(
         )
         .child(
             v_flex()
-                .min_w(px(132.))
+                .min_w(rems(8.25))
                 .flex_none()
                 .items_end()
                 .gap_2()
@@ -362,7 +354,6 @@ fn device_list_row(
                 this.open_device(record_key.clone(), cx);
             });
         })
-        .into_any_element()
 }
 
 fn device_accessibility_description(record: &DeviceRecord) -> SharedString {

--- a/crates/openlogi-desktop/src/app/status.rs
+++ b/crates/openlogi-desktop/src/app/status.rs
@@ -153,14 +153,18 @@ fn accessibility_status(pal: Palette) -> AnyElement {
     // macOS-gated affordance (`.id()` + `.on_click()`), so an ungated import
     // would be unused — and a hard error under `-D warnings` — on Linux/Windows.
     use gpui::{InteractiveElement as _, StatefulInteractiveElement as _};
+    use gpui_base::Button as BaseButton;
 
-    h_flex()
-        .id("footer-accessibility")
+    BaseButton::new("footer-accessibility")
+        .accessibility_label(tr!("Accessibility not granted · click to grant"))
+        .flex()
         .gap_2()
         .items_center()
         .text_caption()
         .text_color(pal.text_primary)
         .cursor_pointer()
+        .hover(|style| style.text_color(pal.text_muted))
+        .focus_visible(|style| style.text_color(pal.text_muted))
         .child(
             div()
                 .size_1p5()

--- a/crates/openlogi-desktop/src/app/status.rs
+++ b/crates/openlogi-desktop/src/app/status.rs
@@ -12,7 +12,7 @@ use gpui_component::{
 };
 
 use crate::app::menu::OpenConfigFolder;
-use crate::ui::theme::{self, FOOTER_H, Palette, Typography as _};
+use crate::ui::theme::{self, ContentWidth, FOOTER_H, Palette, Typography as _};
 
 /// Centered spinner over a muted one-line caption — the quiet "still working"
 /// body shared by the pre-connection frame and the scanning state, so the two
@@ -50,7 +50,7 @@ pub(super) fn notice_body(headline: SharedString, caption: SharedString, pal: Pa
         .child(div().text_title().child(headline))
         .child(
             div()
-                .max_w(px(440.))
+                .max_w(ContentWidth::Narrow.rems())
                 .text_body()
                 .text_center()
                 .text_color(pal.text_muted)

--- a/crates/openlogi-desktop/src/app/status.rs
+++ b/crates/openlogi-desktop/src/app/status.rs
@@ -150,9 +150,9 @@ pub(super) fn attention_footer(pal: Palette) -> impl IntoElement {
 #[cfg(target_os = "macos")]
 fn accessibility_status(pal: Palette) -> AnyElement {
     // Scoped here rather than at module level: these traits' only user is this
-    // macOS-gated affordance (`.id()` + `.on_click()`), so an ungated import
+    // macOS-gated affordance (`.hover()` + `.on_click()`), so an ungated import
     // would be unused — and a hard error under `-D warnings` — on Linux/Windows.
-    use gpui::{InteractiveElement as _, StatefulInteractiveElement as _};
+    use gpui::InteractiveElement as _;
     use gpui_base::Button as BaseButton;
 
     BaseButton::new("footer-accessibility")

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -13,10 +13,11 @@
 
 use gpui::{
     AnyElement, App, AppContext as _, ClickEvent, Context, Entity, InteractiveElement, IntoElement,
-    MouseButton, MouseDownEvent, ParentElement, Render, SharedString,
-    StatefulInteractiveElement as _, Styled, Subscription, Window, div,
+    MouseButton, MouseDownEvent, ParentElement, Render, Role, SharedString,
+    StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, div,
     prelude::FluentBuilder as _, px, rgb,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Selectable as _, h_flex,
     slider::{Slider, SliderEvent, SliderState},
@@ -883,8 +884,11 @@ fn control_row(
     {
         let accent = rgb(ACCENT_BLUE);
         auto_cell = auto_cell.child(
-            div()
-                .id(("camera-control-auto", ix))
+            BaseButton::new(("camera-control-auto", ix))
+                .role(Role::CheckBox)
+                .selected(on)
+                .accessibility_label(tr!("Auto"))
+                .aria_toggled(if on { Toggled::True } else { Toggled::False })
                 .px_1p5()
                 .py_0p5()
                 .rounded_full()
@@ -897,13 +901,8 @@ fn control_row(
                 } else {
                     pal.control
                 })
-                .hover(move |s| {
-                    s.bg(if on {
-                        theme::accent_tint_hover()
-                    } else {
-                        pal.control_hover
-                    })
-                })
+                .hover(move |s| s.bg(chip_hover_fill(on, pal)))
+                .focus_visible(move |s| s.bg(chip_hover_fill(on, pal)))
                 .child(tr!("Auto"))
                 .on_click(cx.listener(move |panel, _: &ClickEvent, _window, cx| {
                     panel.toggle_auto(auto_ix, cx);
@@ -935,9 +934,18 @@ fn frequency_row(
     {
         let active = value == current;
         let accent = rgb(ACCENT_BLUE);
+        let accessibility_label = label.clone();
         choices = choices.child(
-            div()
-                .id(("camera-frequency", choice_ix))
+            BaseButton::new(("camera-frequency", choice_ix))
+                .role(Role::RadioButton)
+                .selected(active)
+                .accessibility_label(accessibility_label)
+                .aria_toggled(if active {
+                    Toggled::True
+                } else {
+                    Toggled::False
+                })
+                .aria_selected(active)
                 .px_1p5()
                 .py_0p5()
                 .rounded_full()
@@ -954,13 +962,8 @@ fn frequency_row(
                 } else {
                     pal.control
                 })
-                .hover(move |s| {
-                    s.bg(if active {
-                        theme::accent_tint_hover()
-                    } else {
-                        pal.control_hover
-                    })
-                })
+                .hover(move |s| s.bg(chip_hover_fill(active, pal)))
+                .focus_visible(move |s| s.bg(chip_hover_fill(active, pal)))
                 .child(label)
                 .on_click(cx.listener(move |panel, _: &ClickEvent, window, cx| {
                     let (Some(key), Some(uid)) = (panel.key.clone(), panel.uid.clone()) else {
@@ -1017,8 +1020,11 @@ fn binary_control_row(
         )
         .child(div().flex_1())
         .child(
-            div()
-                .id("camera-low-light")
+            BaseButton::new("camera-low-light")
+                .role(Role::CheckBox)
+                .selected(on)
+                .accessibility_label(tr!("Low light compensation"))
+                .aria_toggled(if on { Toggled::True } else { Toggled::False })
                 .px_1p5()
                 .py_0p5()
                 .rounded_full()
@@ -1031,13 +1037,8 @@ fn binary_control_row(
                 } else {
                     pal.control
                 })
-                .hover(move |s| {
-                    s.bg(if on {
-                        theme::accent_tint_hover()
-                    } else {
-                        pal.control_hover
-                    })
-                })
+                .hover(move |s| s.bg(chip_hover_fill(on, pal)))
+                .focus_visible(move |s| s.bg(chip_hover_fill(on, pal)))
                 .child(if on { tr!("On") } else { tr!("Off") })
                 .on_click(cx.listener(move |panel, _: &ClickEvent, window, cx| {
                     let (Some(key), Some(uid)) = (panel.key.clone(), panel.uid.clone()) else {
@@ -1064,8 +1065,8 @@ fn reset_button(pal: Palette, cx: &mut Context<CameraControlsPanel>) -> AnyEleme
         .w_full()
         .justify_end()
         .child(
-            div()
-                .id("camera-controls-reset")
+            BaseButton::new("camera-controls-reset")
+                .accessibility_label(tr!("Reset to defaults"))
                 .px_2p5()
                 .py_0p5()
                 .rounded_md()
@@ -1073,6 +1074,7 @@ fn reset_button(pal: Palette, cx: &mut Context<CameraControlsPanel>) -> AnyEleme
                 .border_color(pal.border)
                 .bg(pal.control)
                 .hover(|s| s.bg(pal.control_hover))
+                .focus_visible(|s| s.bg(pal.control_hover))
                 .text_caption()
                 .text_color(pal.text_muted)
                 .child(tr!("Reset to defaults"))
@@ -1081,6 +1083,14 @@ fn reset_button(pal: Palette, cx: &mut Context<CameraControlsPanel>) -> AnyEleme
                 })),
         )
         .into_any_element()
+}
+
+fn chip_hover_fill(selected: bool, pal: Palette) -> gpui::Hsla {
+    if selected {
+        theme::accent_tint_hover()
+    } else {
+        pal.control_hover
+    }
 }
 
 fn builtin_label(id: &str) -> SharedString {

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -12,8 +12,8 @@
 //! a single batched device-open.
 
 use gpui::{
-    AnyElement, App, AppContext as _, ClickEvent, Context, Entity, InteractiveElement, IntoElement,
-    MouseButton, MouseDownEvent, ParentElement, Render, Role, SharedString,
+    AnyElement, App, AppContext as _, ClickEvent, Context, ElementId, Entity, InteractiveElement,
+    IntoElement, MouseButton, MouseDownEvent, ParentElement, Render, Role, SharedString,
     StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, div,
     prelude::FluentBuilder as _, px, rgb,
 };
@@ -884,7 +884,7 @@ fn control_row(
     {
         let accent = rgb(ACCENT_BLUE);
         auto_cell = auto_cell.child(
-            BaseButton::new(("camera-control-auto", ix))
+            BaseButton::new((ElementId::from("camera-control-auto"), toggle.name()))
                 .role(Role::CheckBox)
                 .selected(on)
                 .accessibility_label(tr!("Auto"))
@@ -923,20 +923,19 @@ fn frequency_row(
     let slider = &panel.sliders[ix];
     let current = from_slider(slider.state.read(cx).value().start());
     let mut choices = h_flex().flex_1().justify_end().gap_1();
-    for (choice_ix, (value, label)) in [
-        (1, SharedString::from("50 Hz")),
-        (2, SharedString::from("60 Hz")),
-        (3, tr!("Auto")),
+    for (value, id, label) in [
+        (1, 1_u32, SharedString::from("50 Hz")),
+        (2, 2_u32, SharedString::from("60 Hz")),
+        (3, 3_u32, tr!("Auto")),
     ]
     .into_iter()
-    .filter(|(value, _)| slider.range.supports(*value))
-    .enumerate()
+    .filter(|(value, _, _)| slider.range.supports(*value))
     {
         let active = value == current;
         let accent = rgb(ACCENT_BLUE);
         let accessibility_label = label.clone();
         choices = choices.child(
-            BaseButton::new(("camera-frequency", choice_ix))
+            BaseButton::new(("camera-frequency", id))
                 .role(Role::RadioButton)
                 .selected(active)
                 .accessibility_label(accessibility_label)

--- a/crates/openlogi-desktop/src/features/camera/preview.rs
+++ b/crates/openlogi-desktop/src/features/camera/preview.rs
@@ -24,8 +24,9 @@ use std::time::Duration;
 
 use gpui::{
     AnyElement, Context, InteractiveElement, IntoElement, ParentElement, Render, RenderImage,
-    SharedString, StatefulInteractiveElement, Styled, Subscription, Task, Window, div, img, px,
+    SharedString, Styled, Subscription, Task, Window, div, img, px,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::v_flex;
 use image::{Frame as ImageFrame, RgbaImage};
 use openlogi_camera::{CameraAuthorization, CameraStream, Frame};
@@ -186,12 +187,13 @@ impl Render for CameraPreview {
             openlogi_camera::camera_authorization(),
             CameraAuthorization::Undetermined
         ) {
-            div()
-                .id("camera-request-access")
+            BaseButton::new("camera-request-access")
+                .accessibility_label(tr!("Click to enable camera access."))
                 .text_body()
                 .text_color(pal.text_muted)
                 .cursor_pointer()
                 .hover(|s| s.text_color(pal.text_primary))
+                .focus_visible(|s| s.text_color(pal.text_primary))
                 .child(tr!("Click to enable camera access."))
                 .on_click(|_, _, cx| crate::features::camera::request_camera_access(cx))
                 .into_any_element()

--- a/crates/openlogi-desktop/src/features/lighting/device.rs
+++ b/crates/openlogi-desktop/src/features/lighting/device.rs
@@ -119,8 +119,7 @@ impl Render for LightingPanel {
 
         let swatches: Vec<AnyElement> = PALETTE
             .iter()
-            .enumerate()
-            .map(|(idx, &color)| swatch(idx, color, &lighting, pal))
+            .map(|&color| swatch(color, &lighting, pal))
             .collect();
 
         v_flex()
@@ -175,9 +174,9 @@ impl Render for LightingPanel {
 }
 
 /// One color swatch. Clicking it turns lighting on and sets that color.
-fn swatch(idx: usize, color: Rgb, current: &Lighting, pal: Palette) -> AnyElement {
+fn swatch(color: Rgb, current: &Lighting, pal: Palette) -> AnyElement {
     let selected = current.enabled && current.color == color;
-    BaseButton::new(("light-swatch", idx))
+    BaseButton::new(("light-swatch", color.packed()))
         .role(Role::RadioButton)
         .selected(selected)
         .accessibility_label(format!("{} #{:06X}", tr!("Lighting"), color.packed()))

--- a/crates/openlogi-desktop/src/features/lighting/device.rs
+++ b/crates/openlogi-desktop/src/features/lighting/device.rs
@@ -7,8 +7,10 @@
 
 use gpui::{
     AnyElement, AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement,
-    Render, StatefulInteractiveElement as _, Styled, Subscription, Window, div, px, rgb,
+    Render, Role, StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, div, px,
+    rgb,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     Selectable as _, h_flex,
     slider::{Slider, SliderEvent, SliderState},
@@ -175,8 +177,16 @@ impl Render for LightingPanel {
 /// One color swatch. Clicking it turns lighting on and sets that color.
 fn swatch(idx: usize, color: Rgb, current: &Lighting, pal: Palette) -> AnyElement {
     let selected = current.enabled && current.color == color;
-    div()
-        .id(("light-swatch", idx))
+    BaseButton::new(("light-swatch", idx))
+        .role(Role::RadioButton)
+        .selected(selected)
+        .accessibility_label(format!("{} #{:06X}", tr!("Lighting"), color.packed()))
+        .aria_toggled(if selected {
+            Toggled::True
+        } else {
+            Toggled::False
+        })
+        .aria_selected(selected)
         .size(px(SWATCH))
         .rounded(pal.control_radius)
         .border_2()
@@ -187,6 +197,7 @@ fn swatch(idx: usize, color: Rgb, current: &Lighting, pal: Palette) -> AnyElemen
         })
         .bg(rgb(color.packed()))
         .cursor_pointer()
+        .focus_visible(|style| style.border_color(theme::accent()))
         .on_click(move |_event, _window, cx| {
             AppState::update(cx, |state, cx| {
                 let key = state.current_record().map(DeviceRecord::device_key);

--- a/crates/openlogi-desktop/src/main.rs
+++ b/crates/openlogi-desktop/src/main.rs
@@ -61,6 +61,12 @@ use crate::ui::theme;
 fn main() -> Result<()> {
     init_tracing();
 
+    #[cfg(debug_assertions)]
+    if std::env::var_os("OPENLOGI_COMPONENT_GALLERY").is_some_and(|value| value == "1") {
+        ui::gallery::run();
+        return Ok(());
+    }
+
     let _guard = match openlogi_core::single_instance::acquire("openlogi.lock") {
         Ok(g) => g,
         Err(openlogi_core::single_instance::InstanceError::AlreadyRunning { path }) => {

--- a/crates/openlogi-desktop/src/ui/carousel.rs
+++ b/crates/openlogi-desktop/src/ui/carousel.rs
@@ -131,8 +131,9 @@ impl Carousel {
         let selected = selected.min(len - 1);
         let multi = len > 1;
 
-        let scroll_state =
-            window.use_keyed_state((id, "scroll"), cx, |_, _| (usize::MAX, ScrollHandle::new()));
+        let scroll_state = window.use_keyed_state((id.clone(), "scroll"), cx, |_, _| {
+            (usize::MAX, ScrollHandle::new())
+        });
         let previous = scroll_state.read(cx).0;
         let scroll_handle = scroll_state.read(cx).1.clone();
         if previous != selected {
@@ -156,7 +157,7 @@ impl Carousel {
         // so the scroll handle targets cards at `selected + 1`.
         let edge_spacer = px((ROW_PAD - f32::from(gap)).max(0.));
         let row = h_flex()
-            .id("carousel-row")
+            .id((id.clone(), "row"))
             .flex_1()
             .min_w_0()
             .h_full()
@@ -178,7 +179,7 @@ impl Carousel {
             .px_4()
             .when(multi, |this| {
                 this.child(arrow(
-                    "carousel-prev",
+                    (id.clone(), "previous").into(),
                     IconName::ChevronLeft,
                     selected.saturating_sub(1),
                     selected == 0,
@@ -189,7 +190,7 @@ impl Carousel {
             .child(row)
             .when(multi, |this| {
                 this.child(arrow(
-                    "carousel-next",
+                    (id.clone(), "next").into(),
                     IconName::ChevronRight,
                     (selected + 1).min(len - 1),
                     selected + 1 >= len,
@@ -203,7 +204,7 @@ impl Carousel {
 }
 
 fn arrow(
-    id: &'static str,
+    id: ElementId,
     icon: IconName,
     target: usize,
     disabled: bool,
@@ -218,4 +219,92 @@ fn arrow(
         .when_some(on_select.filter(|_| !disabled), |this, handler| {
             this.on_click(move |_, window, cx| handler(&target, window, cx))
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use gpui::{Context, KeyDownEvent, KeyUpEvent, Keystroke, Render, TestAppContext, div, px};
+
+    use super::*;
+
+    struct CarouselHarness {
+        selected: usize,
+        instances: usize,
+        selections: Rc<RefCell<Vec<(usize, usize)>>>,
+    }
+
+    impl Render for CarouselHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let mut row = h_flex().tab_group().size(px(600.));
+            for instance in 0..self.instances {
+                let selections = self.selections.clone();
+                row = row.child(
+                    Carousel::new(("test-carousel", instance), px(120.))
+                        .len(3)
+                        .selected(self.selected)
+                        .render_item(|index, _, _, _| {
+                            div().child(format!("Item {index}")).into_any_element()
+                        })
+                        .on_select(move |index, _, _| {
+                            selections.borrow_mut().push((instance, *index));
+                        }),
+                );
+            }
+            row
+        }
+    }
+
+    fn activate_key(cx: &mut gpui::VisualTestContext, key: &str) {
+        let keystroke = Keystroke::parse(key).unwrap();
+        cx.simulate_event(KeyDownEvent {
+            keystroke: keystroke.clone(),
+            is_held: false,
+            prefer_character_input: false,
+        });
+        cx.simulate_event(KeyUpEvent { keystroke });
+    }
+
+    #[gpui::test]
+    fn carousel_arrows_are_controlled_and_instance_local(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let selections = Rc::new(RefCell::new(Vec::new()));
+        let (_, cx) = cx.add_window_view({
+            let selections = selections.clone();
+            move |_, _| CarouselHarness {
+                selected: 1,
+                instances: 2,
+                selections,
+            }
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+
+        for _ in 0..3 {
+            cx.update(Window::focus_next);
+            activate_key(cx, "enter");
+        }
+
+        assert_eq!(&*selections.borrow(), &[(0, 0), (0, 2), (1, 0)]);
+    }
+
+    #[gpui::test]
+    fn carousel_clamps_selection_before_navigating(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let selections = Rc::new(RefCell::new(Vec::new()));
+        let (_, cx) = cx.add_window_view({
+            let selections = selections.clone();
+            move |_, _| CarouselHarness {
+                selected: usize::MAX,
+                instances: 1,
+                selections,
+            }
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+
+        cx.update(Window::focus_next);
+        activate_key(cx, "space");
+
+        assert_eq!(&*selections.borrow(), &[(0, 1)]);
+    }
 }

--- a/crates/openlogi-desktop/src/ui/carousel.rs
+++ b/crates/openlogi-desktop/src/ui/carousel.rs
@@ -11,7 +11,7 @@
 //! navigation through [`Carousel::on_select`].
 //!
 //! ```ignore
-//! Carousel::new("devices", px(240.))
+//! Carousel::new("devices", rems(15.))
 //!     .len(devices.len())
 //!     .selected(current)
 //!     .render_item(move |ix, selected, _w, cx| render_device(ix, selected, cx))
@@ -21,9 +21,9 @@
 use std::rc::Rc;
 
 use gpui::{
-    AnyElement, App, ElementId, InteractiveElement as _, IntoElement, ParentElement as _, Pixels,
+    AnyElement, App, ElementId, InteractiveElement as _, IntoElement, ParentElement as _, Rems,
     RenderOnce, ScrollHandle, StatefulInteractiveElement as _, Styled, Window, div,
-    prelude::FluentBuilder as _, px,
+    prelude::FluentBuilder as _, rems,
 };
 use gpui_component::{
     Disableable as _, IconName, Sizable as _, Size,
@@ -35,30 +35,30 @@ type SelectHandler = Rc<dyn Fn(&usize, &mut Window, &mut App) + 'static>;
 type ItemRenderer = Rc<dyn Fn(usize, bool, &mut Window, &mut App) -> AnyElement + 'static>;
 
 /// Side padding of the scrolling row.
-const ROW_PAD: f32 = 24.;
+const ROW_PAD: Rems = rems(1.5);
 
 /// A controlled equal-size card carousel. See the module docs.
 #[derive(IntoElement)]
 pub struct Carousel {
     id: ElementId,
-    card_w: Pixels,
+    card_w: Rems,
     len: usize,
     selected: usize,
     render_item: Option<ItemRenderer>,
-    gap: Pixels,
+    gap: Rems,
     on_select: Option<SelectHandler>,
 }
 
 impl Carousel {
     /// Create a carousel whose cards are `card_w` wide. `id` keys scroll state.
-    pub fn new(id: impl Into<ElementId>, card_w: Pixels) -> Self {
+    pub fn new(id: impl Into<ElementId>, card_w: Rems) -> Self {
         Self {
             id: id.into(),
             card_w,
             len: 0,
             selected: 0,
             render_item: None,
-            gap: px(16.),
+            gap: rems(1.),
             on_select: None,
         }
     }
@@ -88,9 +88,9 @@ impl Carousel {
         self
     }
 
-    /// Gap between items. Default 16px.
+    /// Gap between items. Default 1rem.
     #[must_use]
-    pub fn gap(mut self, gap: Pixels) -> Self {
+    pub fn gap(mut self, gap: Rems) -> Self {
         self.gap = gap;
         self
     }
@@ -155,7 +155,7 @@ impl Carousel {
         // Flexible edge spacers centre short rows without putting overflowing
         // cards at a negative, unreachable offset. They are immediate children,
         // so the scroll handle targets cards at `selected + 1`.
-        let edge_spacer = px((ROW_PAD - f32::from(gap)).max(0.));
+        let edge_spacer = rems((ROW_PAD.0 - gap.0).max(0.));
         let row = h_flex()
             .id((id.clone(), "row"))
             .flex_1()
@@ -241,7 +241,7 @@ mod tests {
             for instance in 0..self.instances {
                 let selections = self.selections.clone();
                 row = row.child(
-                    Carousel::new(("test-carousel", instance), px(120.))
+                    Carousel::new(("test-carousel", instance), rems(7.5))
                         .len(3)
                         .selected(self.selected)
                         .render_item(|index, _, _, _| {

--- a/crates/openlogi-desktop/src/ui/choice_card.rs
+++ b/crates/openlogi-desktop/src/ui/choice_card.rs
@@ -1,0 +1,215 @@
+//! Semantic selectable cards for bespoke pickers.
+
+use gpui::{
+    AnyElement, App, ClickEvent, ElementId, InteractiveElement, Interactivity, IntoElement,
+    ParentElement, RenderOnce, Role, SharedString, StatefulInteractiveElement, StyleRefinement,
+    Styled, Toggled, Window, prelude::FluentBuilder as _,
+};
+use gpui_base::Button as BaseButton;
+use gpui_component::{Disableable, Selectable};
+
+type ClickHandler = std::rc::Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>;
+
+/// A controlled radio-card that keeps custom layout and styling while using
+/// the shared semantic button primitive for focus, keyboard activation, and
+/// accessibility state.
+#[derive(IntoElement)]
+pub(crate) struct ChoiceCard {
+    base: BaseButton,
+    selected: bool,
+    disabled: bool,
+    label: SharedString,
+    children: Vec<AnyElement>,
+    on_click: Option<ClickHandler>,
+}
+
+impl ChoiceCard {
+    pub(crate) fn new(
+        id: impl Into<ElementId>,
+        accessibility_label: impl Into<SharedString>,
+    ) -> Self {
+        Self {
+            base: BaseButton::new(id),
+            selected: false,
+            disabled: false,
+            label: accessibility_label.into(),
+            children: Vec::new(),
+            on_click: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(std::rc::Rc::new(handler));
+        self
+    }
+}
+
+impl Selectable for ChoiceCard {
+    fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    fn is_selected(&self) -> bool {
+        self.selected
+    }
+}
+
+impl Disableable for ChoiceCard {
+    fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+}
+
+impl Styled for ChoiceCard {
+    fn style(&mut self) -> &mut StyleRefinement {
+        self.base.style()
+    }
+}
+
+impl ParentElement for ChoiceCard {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl InteractiveElement for ChoiceCard {
+    fn interactivity(&mut self) -> &mut Interactivity {
+        self.base.interactivity()
+    }
+}
+
+impl StatefulInteractiveElement for ChoiceCard {}
+
+impl RenderOnce for ChoiceCard {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let selected = self.selected;
+        self.base
+            .role(Role::RadioButton)
+            .selected(selected)
+            .disabled(self.disabled)
+            .accessibility_label(self.label)
+            .aria_toggled(if selected {
+                Toggled::True
+            } else {
+                Toggled::False
+            })
+            .aria_selected(selected)
+            .children(self.children)
+            .when_some(self.on_click, |card, handler| {
+                card.on_click(move |event, window, cx| handler(event, window, cx))
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::Cell, rc::Rc};
+
+    use gpui::{
+        Context, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, Render, TestAppContext, div,
+        point, px,
+    };
+
+    use super::*;
+
+    struct ChoiceHarness {
+        selected: bool,
+        disabled: bool,
+        activations: Rc<Cell<usize>>,
+        parent_clicks: Rc<Cell<usize>>,
+    }
+
+    impl Render for ChoiceHarness {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let activations = self.activations.clone();
+            let parent_clicks = self.parent_clicks.clone();
+            div()
+                .id("choice-parent")
+                .tab_group()
+                .size(px(100.))
+                .on_click(move |_, _, _| parent_clicks.set(parent_clicks.get() + 1))
+                .child(
+                    ChoiceCard::new("keyboard-choice", "Choice")
+                        .selected(self.selected)
+                        .disabled(self.disabled)
+                        .size_full()
+                        .child("Choice")
+                        .on_click(move |_, _, _| activations.set(activations.get() + 1)),
+                )
+        }
+    }
+
+    fn activate_key(cx: &mut gpui::VisualTestContext, key: &str) {
+        let keystroke = Keystroke::parse(key).unwrap();
+        cx.simulate_event(KeyDownEvent {
+            keystroke: keystroke.clone(),
+            is_held: false,
+            prefer_character_input: false,
+        });
+        cx.simulate_event(KeyUpEvent { keystroke });
+    }
+
+    #[gpui::test]
+    fn choice_card_is_focusable_and_activates_in_both_controlled_states(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let activations = Rc::new(Cell::new(0));
+        let parent_clicks = Rc::new(Cell::new(0));
+        let (view, cx) = cx.add_window_view({
+            let activations = activations.clone();
+            let parent_clicks = parent_clicks.clone();
+            move |_, _| ChoiceHarness {
+                selected: false,
+                disabled: false,
+                activations,
+                parent_clicks,
+            }
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        cx.update(Window::focus_next);
+        cx.update(|window, cx| assert!(window.focused(cx).is_some()));
+
+        activate_key(cx, "enter");
+        view.update(cx, |view, cx| {
+            view.selected = true;
+            cx.notify();
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        activate_key(cx, "space");
+
+        assert_eq!(activations.get(), 2);
+        assert_eq!(parent_clicks.get(), 0);
+    }
+
+    #[gpui::test]
+    fn disabled_choice_card_is_inert_and_blocks_its_parent(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let activations = Rc::new(Cell::new(0));
+        let parent_clicks = Rc::new(Cell::new(0));
+        let (_, cx) = cx.add_window_view({
+            let activations = activations.clone();
+            let parent_clicks = parent_clicks.clone();
+            move |_, _| ChoiceHarness {
+                selected: false,
+                disabled: true,
+                activations,
+                parent_clicks,
+            }
+        });
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+
+        cx.update(Window::focus_next);
+        cx.update(|window, cx| assert!(window.focused(cx).is_none()));
+        cx.simulate_click(point(px(10.), px(10.)), Modifiers::default());
+        activate_key(cx, "enter");
+        activate_key(cx, "space");
+
+        assert_eq!(activations.get(), 0);
+        assert_eq!(parent_clicks.get(), 0);
+    }
+}

--- a/crates/openlogi-desktop/src/ui/gallery.rs
+++ b/crates/openlogi-desktop/src/ui/gallery.rs
@@ -1,0 +1,481 @@
+//! Debug-only gallery for reviewing shared controls without app runtime state.
+
+use gpui::{
+    App, AppContext as _, Bounds, Context, InteractiveElement, IntoElement, ParentElement, Render,
+    Role, SharedString, Size, Styled, Window, WindowBounds, WindowOptions, div, px, rems,
+};
+use gpui_base::Button as BaseButton;
+use gpui_component::{
+    ActiveTheme as _, Disableable as _, Icon, IconName, Root, Selectable as _, Sizable as _, Theme,
+    ThemeMode, ThemeRegistry,
+    button::{Button, ButtonVariants as _},
+    h_flex,
+    scroll::ScrollableElement as _,
+    v_flex,
+};
+use openlogi_core::brand::APP_ID;
+use openlogi_core::config::UiScale;
+
+use super::carousel::Carousel;
+use super::choice_card::ChoiceCard;
+use super::components::{MenuRow, PanelCard, PresetChip, ProfileTab, Toggle};
+use super::theme::{self, ContentWidth, OPENLOGI_DARK, OPENLOGI_LIGHT, Palette, Typography as _};
+
+const TITLE: &str = "OpenLogi Component Gallery";
+
+/// Run the isolated development gallery application.
+pub(crate) fn run() {
+    let app = gpui_platform::application().with_assets(crate::app_assets::AppAssets);
+    app.run(|cx| {
+        gpui_component::init(cx);
+        theme::register_builtin_themes(cx);
+        install_openlogi_themes(cx);
+
+        cx.on_window_closed(|cx, _| {
+            if cx.windows().is_empty() {
+                cx.quit();
+            }
+        })
+        .detach();
+
+        let bounds = Bounds::centered(None, Size::new(px(1100.), px(800.)), cx);
+        let options = WindowOptions {
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            window_min_size: Some(Size::new(px(760.), px(600.))),
+            app_id: Some(APP_ID.into()),
+            titlebar: Some(crate::windows::titlebar_options(TITLE)),
+            ..WindowOptions::default()
+        };
+        let opened = cx.open_window(options, |window, cx| {
+            theme::apply_scale(window, UiScale::Normal);
+            let view = cx.new(ComponentGallery::new);
+            cx.new(|cx| Root::new(view, window, cx).bg(cx.theme().background))
+        });
+
+        match opened {
+            Ok(handle) => {
+                let _ = handle.update(cx, |_, window, _| window.activate_window());
+                cx.activate(true);
+            }
+            Err(error) => {
+                tracing::error!(%error, "could not open component gallery");
+                cx.quit();
+            }
+        }
+    });
+}
+
+fn install_openlogi_themes(cx: &mut App) {
+    let (light, dark) = {
+        let registry = ThemeRegistry::global(cx);
+        (
+            registry.themes().get(OPENLOGI_LIGHT).cloned(),
+            registry.themes().get(OPENLOGI_DARK).cloned(),
+        )
+    };
+    let active = Theme::global_mut(cx);
+    if let Some(light) = light {
+        active.light_theme = light;
+    }
+    if let Some(dark) = dark {
+        active.dark_theme = dark;
+    }
+    Theme::change(ThemeMode::Light, None, cx);
+}
+
+struct ComponentGallery {
+    mode: ThemeMode,
+    scale: UiScale,
+    choice_selected: usize,
+    toggle_selected: bool,
+    menu_selected: usize,
+    profile_selected: usize,
+    preset_selected: bool,
+    carousel_selected: usize,
+}
+
+impl ComponentGallery {
+    fn new(_: &mut Context<Self>) -> Self {
+        Self {
+            mode: ThemeMode::Light,
+            scale: UiScale::Normal,
+            choice_selected: 0,
+            toggle_selected: true,
+            menu_selected: 0,
+            profile_selected: 1,
+            preset_selected: true,
+            carousel_selected: 1,
+        }
+    }
+
+    fn toolbar(&self, pal: Palette, cx: &mut Context<Self>) -> impl IntoElement {
+        let mode = self.mode;
+        let scale = self.scale;
+        h_flex()
+            .w_full()
+            .items_center()
+            .justify_between()
+            .flex_wrap()
+            .gap_4()
+            .px_5()
+            .py_3()
+            .border_b_1()
+            .border_color(pal.border)
+            .child(
+                v_flex()
+                    .gap_0p5()
+                    .child(div().text_heading().child(TITLE))
+                    .child(
+                        div()
+                            .text_caption()
+                            .text_color(pal.text_muted)
+                            .child("Debug-only · no config, IPC, or hardware"),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .items_center()
+                    .flex_wrap()
+                    .gap_2()
+                    .child(
+                        Button::new("gallery-mode-light")
+                            .outline()
+                            .label("Light")
+                            .selected(mode == ThemeMode::Light)
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.mode = ThemeMode::Light;
+                                Theme::change(ThemeMode::Light, Some(window), cx);
+                                cx.notify();
+                            })),
+                    )
+                    .child(
+                        Button::new("gallery-mode-dark")
+                            .outline()
+                            .label("Dark")
+                            .selected(mode == ThemeMode::Dark)
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.mode = ThemeMode::Dark;
+                                Theme::change(ThemeMode::Dark, Some(window), cx);
+                                cx.notify();
+                            })),
+                    )
+                    .children(UiScale::ALL.map(|candidate| {
+                        Button::new(("gallery-scale", u32::from(candidate.percent())))
+                            .outline()
+                            .label(format!("{}%", candidate.percent()))
+                            .selected(scale == candidate)
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                this.scale = candidate;
+                                theme::apply_scale(window, candidate);
+                                cx.notify();
+                            }))
+                    })),
+            )
+    }
+
+    fn controls(&self, pal: Palette, cx: &mut Context<Self>) -> impl IntoElement {
+        h_flex()
+            .w_full()
+            .items_start()
+            .flex_wrap()
+            .gap_4()
+            .child(self.choice_panel(pal, cx))
+            .child(self.toggle_panel(pal, cx))
+            .child(self.menu_panel(pal, cx))
+            .child(self.profile_panel(pal, cx))
+            .child(self.preset_panel(pal, cx))
+    }
+
+    fn choice_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
+        gallery_panel(
+            "ChoiceCard",
+            IconName::LayoutDashboard,
+            v_flex()
+                .gap_2()
+                .child(
+                    choice_card(
+                        "gallery-choice-active",
+                        "Primary choice",
+                        self.choice_selected == 0,
+                        pal,
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.choice_selected = 0;
+                        cx.notify();
+                    })),
+                )
+                .child(
+                    choice_card(
+                        "gallery-choice-secondary",
+                        "Secondary choice",
+                        self.choice_selected == 1,
+                        pal,
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.choice_selected = 1;
+                        cx.notify();
+                    })),
+                )
+                .child(
+                    choice_card("gallery-choice-disabled", "Disabled choice", false, pal)
+                        .disabled(true),
+                ),
+            pal,
+        )
+    }
+
+    fn toggle_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
+        let label = if self.toggle_selected {
+            "Enabled"
+        } else {
+            "Disabled"
+        };
+        gallery_panel(
+            "Toggle",
+            IconName::Settings,
+            v_flex()
+                .gap_3()
+                .child(
+                    Toggle::new("gallery-toggle")
+                        .selected(self.toggle_selected)
+                        .label(Some(SharedString::from(label)))
+                        .on_change(cx.listener(|this, selected: &bool, _, cx| {
+                            this.toggle_selected = *selected;
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    Toggle::new("gallery-toggle-disabled")
+                        .selected(true)
+                        .label(Some(SharedString::from("Unavailable")))
+                        .disabled(true),
+                ),
+            pal,
+        )
+    }
+
+    fn menu_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
+        gallery_panel(
+            "MenuRow",
+            IconName::Menu,
+            v_flex()
+                .gap_1()
+                .child(
+                    MenuRow::new("gallery-menu-primary")
+                        .role(Role::MenuItem)
+                        .selected(self.menu_selected == 0)
+                        .child("Primary action")
+                        .child(Icon::new(IconName::ChevronRight).size_3())
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.menu_selected = 0;
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    MenuRow::new("gallery-menu-secondary")
+                        .role(Role::MenuItem)
+                        .selected(self.menu_selected == 1)
+                        .child("Secondary action")
+                        .child(Icon::new(IconName::ChevronRight).size_3())
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.menu_selected = 1;
+                            cx.notify();
+                        })),
+                ),
+            pal,
+        )
+    }
+
+    fn profile_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
+        gallery_panel(
+            "ProfileTab",
+            IconName::Eye,
+            h_flex()
+                .gap_2()
+                .flex_wrap()
+                .child(
+                    ProfileTab::new("gallery-profile-default", "Default")
+                        .selected(self.profile_selected == 0)
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.profile_selected = 0;
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    ProfileTab::new("gallery-profile-custom", "Custom")
+                        .selected(self.profile_selected == 1)
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.profile_selected = 1;
+                            cx.notify();
+                        }))
+                        .on_delete("gallery-profile-delete", |_, _, _| {}),
+                ),
+            pal,
+        )
+    }
+
+    fn preset_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
+        gallery_panel(
+            "PresetChip",
+            IconName::Cpu,
+            PresetChip::new("gallery-preset")
+                .selected(self.preset_selected)
+                .child(
+                    Button::new("gallery-preset-apply")
+                        .ghost()
+                        .xsmall()
+                        .label("800 DPI")
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.preset_selected = !this.preset_selected;
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    BaseButton::new("gallery-preset-remove")
+                        .accessibility_label("Remove preset")
+                        .px_1()
+                        .text_color(pal.text_muted)
+                        .child("×"),
+                ),
+            pal,
+        )
+    }
+
+    fn carousel(&self, pal: Palette, cx: &mut Context<Self>) -> impl IntoElement {
+        let selected = self.carousel_selected;
+        let view = cx.entity();
+        div().w_full().child(PanelCard::new(
+            "Carousel",
+            Icon::new(IconName::GalleryVerticalEnd).text_color(pal.text_muted),
+            div().w_full().h(rems(13.)).child(
+                Carousel::new("gallery-carousel", rems(12.))
+                    .len(4)
+                    .selected(selected)
+                    .render_item(move |index, selected, _, cx| {
+                        let pal = theme::palette(cx);
+                        let view = view.clone();
+                        ChoiceCard::new(
+                            ("gallery-carousel-card", index),
+                            format!("Card {}", index + 1),
+                        )
+                        .selected(selected)
+                        .size_full()
+                        .p_3()
+                        .rounded(pal.card_radius)
+                        .border_1()
+                        .border_color(if selected {
+                            theme::accent()
+                        } else {
+                            pal.border
+                        })
+                        .bg(pal.control)
+                        .items_center()
+                        .justify_center()
+                        .text_body()
+                        .child(format!("Card {}", index + 1))
+                        .on_click(move |_, _, cx| {
+                            view.update(cx, |this, cx| {
+                                this.carousel_selected = index;
+                                cx.notify();
+                            });
+                        })
+                        .into_any_element()
+                    })
+                    .on_select(cx.listener(|this, index: &usize, _, cx| {
+                        this.carousel_selected = *index;
+                        cx.notify();
+                    })),
+            ),
+        ))
+    }
+}
+
+impl Render for ComponentGallery {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        theme::apply_scale(window, self.scale);
+        let pal = theme::palette(cx);
+        v_flex()
+            .size_full()
+            .bg(pal.page)
+            .text_color(pal.text_primary)
+            .child(crate::windows::aux_title_bar(TITLE, cx))
+            .child(self.toolbar(pal, cx))
+            .child(
+                v_flex()
+                    .flex_1()
+                    .min_h_0()
+                    .overflow_y_scrollbar()
+                    .items_center()
+                    .p_5()
+                    .child(
+                        v_flex()
+                            .w_full()
+                            .max_w(ContentWidth::DoubleExtraLarge.rems())
+                            .gap_4()
+                            .child(self.controls(pal, cx))
+                            .child(self.carousel(pal, cx)),
+                    ),
+            )
+    }
+}
+
+fn gallery_panel(
+    title: impl Into<SharedString>,
+    icon: IconName,
+    content: impl IntoElement,
+    pal: Palette,
+) -> gpui::Div {
+    div()
+        .w(rems(20.))
+        .min_w(rems(18.))
+        .flex_1()
+        .child(PanelCard::new(
+            title,
+            Icon::new(icon).text_color(pal.text_muted),
+            content,
+        ))
+}
+
+fn choice_card(id: &'static str, label: &'static str, selected: bool, pal: Palette) -> ChoiceCard {
+    ChoiceCard::new(id, label)
+        .selected(selected)
+        .w_full()
+        .p_2()
+        .rounded(pal.control_radius)
+        .border_1()
+        .border_color(if selected {
+            theme::accent()
+        } else {
+            pal.border
+        })
+        .bg(pal.control)
+        .hover(move |style| style.bg(pal.control_hover))
+        .focus_visible(move |style| style.border_color(theme::accent()))
+        .child(div().text_body().child(label))
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::TestAppContext;
+
+    use super::*;
+
+    #[gpui::test]
+    fn gallery_renders_without_application_state(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(theme::register_builtin_themes);
+        cx.update(install_openlogi_themes);
+        let (view, cx) = cx.add_window_view(|_, cx| ComponentGallery::new(cx));
+
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        view.update(cx, |gallery, cx| {
+            gallery.mode = ThemeMode::Dark;
+            gallery.scale = UiScale::ExtraLarge;
+            cx.notify();
+        });
+        cx.update(|window, cx| {
+            Theme::change(ThemeMode::Dark, Some(window), cx);
+            window.draw(cx).clear(cx);
+        });
+    }
+}

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -1,6 +1,7 @@
 //! Shared settings-app UI components and theme.
 
 pub(crate) mod carousel;
+pub(crate) mod choice_card;
 pub(crate) mod components;
 pub mod section;
 pub mod status;

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -3,6 +3,8 @@
 pub(crate) mod carousel;
 pub(crate) mod choice_card;
 pub(crate) mod components;
+#[cfg(debug_assertions)]
+pub(crate) mod gallery;
 pub mod section;
 pub mod status;
 pub mod theme;

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -257,6 +257,11 @@ fn rem_size(scale: UiScale) -> Pixels {
     px(BASE_REM_SIZE * f32::from(scale.percent()) / 100.)
 }
 
+/// Apply one semantic interface scale to a window.
+pub(crate) fn apply_scale(window: &mut Window, scale: UiScale) {
+    window.set_rem_size(rem_size(scale));
+}
+
 /// Apply the stored interface scale to one desktop window.
 ///
 /// Root views call this before building their elements so text and every
@@ -265,7 +270,7 @@ fn rem_size(scale: UiScale) -> Pixels {
 pub fn apply_ui_scale(window: &mut Window, cx: &App) {
     let scale =
         AppState::try_read(cx).map_or_else(UiScale::default, |state| state.app_settings().ui_scale);
-    window.set_rem_size(rem_size(scale));
+    apply_scale(window, scale);
 }
 
 /// Resolve the user's stored appearance preference and apply it to the global

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -44,6 +44,8 @@ const BASE_REM_SIZE: f32 = 16.;
 /// Maximum-width scale for detail-tab content.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ContentWidth {
+    /// Compact explanatory copy and empty-state text (440 px at 100%).
+    Narrow,
     /// A single compact settings card (560 px at 100%).
     Small,
     /// A wider single panel (680 px at 100%).
@@ -61,6 +63,7 @@ impl ContentWidth {
     #[must_use]
     pub const fn rems(self) -> Rems {
         match self {
+            Self::Narrow => rems(27.5),
             Self::Small => rems(35.),
             Self::Medium => rems(42.5),
             Self::Large => rems(57.5),
@@ -85,12 +88,13 @@ pub const CARD_GAP: Rems = rems(0.75);
 /// Apple HIG / WCAG minimum contrast for normal text up to 17pt.
 const MIN_TEXT_CONTRAST: f32 = 4.5;
 
-/// Responsive bounds for a device card in the Home grid. At the 720 px minimum
-/// window width, two cards fit after the screen inset and gap; at the normal
-/// wide window, three grow to [`GALLERY_CARD_MAX_W`]. `GALLERY_PHOTO_H` is the
-/// product-image stage above the identity and status rows.
-pub const GALLERY_CARD_MIN_W: f32 = 310.;
-pub const GALLERY_CARD_MAX_W: f32 = 405.;
+/// Responsive bounds for a device card in the Home grid. At standard scale,
+/// two cards fit the 720 px minimum window after the screen inset and gap; at
+/// the normal wide window, three grow to [`GALLERY_CARD_MAX_W`].
+/// `GALLERY_PHOTO_H` is the fixed product-image stage above the scalable
+/// identity and status rows.
+pub const GALLERY_CARD_MIN_W: Rems = rems(19.375);
+pub const GALLERY_CARD_MAX_W: Rems = rems(25.3125);
 pub const GALLERY_PHOTO_H: f32 = 196.;
 
 /// Appearance-dependent surface + text colours for the bespoke (non
@@ -451,6 +455,7 @@ mod tests {
     fn content_width_scale_preserves_the_standard_layout() {
         assert_eq!(
             [
+                ContentWidth::Narrow,
                 ContentWidth::Small,
                 ContentWidth::Medium,
                 ContentWidth::Large,
@@ -458,7 +463,7 @@ mod tests {
                 ContentWidth::DoubleExtraLarge,
             ]
             .map(|width| width.rems().to_pixels(px(BASE_REM_SIZE))),
-            [px(560.), px(680.), px(920.), px(980.), px(1040.)]
+            [px(440.), px(560.), px(680.), px(920.), px(980.), px(1040.),]
         );
     }
 

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -16,9 +16,10 @@
 
 use gpui::{
     App, Context, FocusHandle, FontWeight, Global, InteractiveElement, IntoElement,
-    ParentElement as _, Render, SharedString, Size, StatefulInteractiveElement as _, Styled as _,
-    Subscription, Window, div, prelude::FluentBuilder as _, px,
+    ParentElement as _, Render, SharedString, Size, Styled as _, Subscription, Window, div,
+    prelude::FluentBuilder as _, px,
 };
+use gpui_base::Button as BaseButton;
 use gpui_component::{
     button::{Button, ButtonVariants as _},
     v_flex,
@@ -312,8 +313,9 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
 /// A discovered-device row; clicking it pairs with that device.
 fn device_row(idx: usize, device: &FoundDevice, pal: Palette) -> impl IntoElement {
     let address = device.address;
-    div()
-        .id(("found-device", idx))
+    let name = SharedString::from(device.name.clone());
+    BaseButton::new(("found-device", idx))
+        .accessibility_label(name.clone())
         .w_full()
         .px_4()
         .py_3()
@@ -323,11 +325,8 @@ fn device_row(idx: usize, device: &FoundDevice, pal: Palette) -> impl IntoElemen
         .cursor_pointer()
         .bg(pal.control)
         .hover(|s| s.bg(pal.control_hover))
-        .child(
-            div()
-                .text_body()
-                .child(SharedString::from(device.name.clone())),
-        )
+        .focus_visible(|s| s.bg(pal.control_hover))
+        .child(div().text_body().child(name))
         .on_click(move |_, _, cx| send(cx, Command::PairDevice(address)))
 }
 

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -246,8 +246,8 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
                 col = col.child(hint(tr!("No devices found yet…"), pal));
             } else {
                 col = col.child(hint(tr!("Select a device to pair:"), pal));
-                for (idx, device) in devices.iter().enumerate() {
-                    col = col.child(device_row(idx, device, pal));
+                for device in devices {
+                    col = col.child(device_row(device, pal));
                 }
             }
             col = col.child(cancel_button());
@@ -311,10 +311,13 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
 }
 
 /// A discovered-device row; clicking it pairs with that device.
-fn device_row(idx: usize, device: &FoundDevice, pal: Palette) -> impl IntoElement {
+fn device_row(device: &FoundDevice, pal: Palette) -> impl IntoElement {
     let address = device.address;
+    let address_id = u64::from_be_bytes([
+        0, 0, address[0], address[1], address[2], address[3], address[4], address[5],
+    ]);
     let name = SharedString::from(device.name.clone());
-    BaseButton::new(("found-device", idx))
+    BaseButton::new(("found-device", address_id))
         .accessibility_label(name.clone())
         .w_full()
         .px_4()

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -13,6 +13,7 @@ use super::{
     v_flex,
 };
 use crate::platform::app_icon;
+use crate::ui::choice_card::ChoiceCard;
 use crate::ui::theme::Typography as _;
 
 /// The Appearance page: light/dark mode, the theme grid, corner radius, and the
@@ -221,11 +222,12 @@ fn mode_card(
             ),
         });
 
-    v_flex()
-        .id(id)
+    ChoiceCard::new(id, label.clone())
+        .selected(selected)
         .gap(px(6.))
         .items_center()
         .cursor_pointer()
+        .focus_visible(move |style| style.text_color(pal.text_primary))
         .child(thumb)
         .child(
             h_flex()
@@ -254,11 +256,12 @@ fn icon_picker(pal: Palette, cx: &App) -> gpui::Div {
 /// the app is wearing.
 fn icon_card(icon: AppIcon, selected: bool, accent: Hsla, pal: Palette) -> impl IntoElement {
     let preview = app_icon::preview(icon);
-    v_flex()
-        .id(SharedString::from(icon.to_string()))
+    ChoiceCard::new(SharedString::from(icon.to_string()), icon_label(icon))
+        .selected(selected)
         .gap(px(6.))
         .items_center()
         .cursor_pointer()
+        .focus_visible(move |style| style.text_color(pal.text_primary))
         .child(
             div()
                 .size(px(80.))
@@ -573,8 +576,8 @@ fn theme_card(
 ) -> impl IntoElement {
     let dark = mode.is_dark();
     let stored = name.clone();
-    v_flex()
-        .id(("theme", index))
+    ChoiceCard::new(("theme", index), name.clone())
+        .selected(selected)
         .w(px(132.))
         .p(px(8.))
         .gap_2()
@@ -592,6 +595,7 @@ fn theme_card(
                 style.border_color(pal.text_muted)
             }
         })
+        .focus_visible(move |style| style.border_color(swatch.primary).shadow_sm())
         .active(gpui::Styled::shadow_2xs)
         .child(
             v_flex()
@@ -674,8 +678,8 @@ fn filter_chip(
 ) -> impl IntoElement {
     let selected = value == current;
     let view = view.clone();
-    div()
-        .id(id)
+    ChoiceCard::new(id, label.clone())
+        .selected(selected)
         .px_3()
         .py_1()
         .rounded_full()
@@ -690,6 +694,7 @@ fn filter_chip(
                 this.border_color(pal.border)
                     .text_color(pal.text_muted)
                     .hover(|h| h.border_color(pal.text_muted))
+                    .focus_visible(|h| h.border_color(pal.text_muted))
             }
         })
         .child(label)

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -1,7 +1,7 @@
 //! Appearance settings page: mode, theme grid, radius, scale, language.
 
 use super::language::{LanguageOption, language_select_field};
-use gpui::img;
+use gpui::{ElementId, img};
 use openlogi_core::config::AppIcon;
 
 use super::{
@@ -412,7 +412,7 @@ fn scale_segment(cx: &App) -> ButtonGroup {
     ButtonGroup::new("interface-scale")
         .outline()
         .children(UiScale::ALL.map(|scale| {
-            Button::new(format!("interface-scale-{}", scale.percent()))
+            Button::new(("interface-scale", u32::from(scale.percent())))
                 .label(format!("{}%", scale.percent()))
                 .selected(current == scale)
         }))
@@ -475,15 +475,10 @@ fn theme_picker(
             grid.flex()
                 .flex_wrap()
                 .gap_2()
-                .children(
-                    themes
-                        .into_iter()
-                        .enumerate()
-                        .map(|(i, (name, mode, swatch))| {
-                            let selected = name == active;
-                            theme_card(i, name, mode, swatch, selected, pal)
-                        }),
-                )
+                .children(themes.into_iter().map(|(name, mode, swatch)| {
+                    let selected = name == active;
+                    theme_card(name, mode, swatch, selected, pal)
+                }))
         });
 
     v_flex()
@@ -567,7 +562,6 @@ struct Swatch {
 }
 
 fn theme_card(
-    index: usize,
     name: SharedString,
     mode: ThemeMode,
     swatch: Swatch,
@@ -576,7 +570,7 @@ fn theme_card(
 ) -> impl IntoElement {
     let dark = mode.is_dark();
     let stored = name.clone();
-    ChoiceCard::new(("theme", index), name.clone())
+    ChoiceCard::new((ElementId::from("theme"), name.clone()), name.clone())
         .selected(selected)
         .w(px(132.))
         .p(px(8.))

--- a/crates/openlogi-desktop/src/windows/settings/assets.rs
+++ b/crates/openlogi-desktop/src/windows/settings/assets.rs
@@ -1,13 +1,14 @@
 //! Assets (device-image cache) settings page.
 
 use crate::ui::theme::Typography as _;
+use gpui_base::Button as BaseButton;
 use std::time::Duration;
 
 use super::{
     App, AppState, AssetCommand, AssetControl, AssetSourcePreference, Entity, IconName, IndexPath,
     InteractiveElement, IntoElement, Palette, ParentElement, Select, SelectItem, SelectState,
     SettingField, SettingGroup, SettingItem, SettingPage, SettingsView, SharedString, Sizable,
-    StateEvent, StatefulInteractiveElement, Styled, div, px,
+    StateEvent, Styled, div, px,
 };
 
 #[derive(Clone)]
@@ -205,8 +206,8 @@ fn action_button(
     pal: Palette,
     on_click: impl Fn(&mut App) + 'static,
 ) -> impl IntoElement {
-    div()
-        .id(id)
+    BaseButton::new(id)
+        .accessibility_label(label.clone())
         .flex_shrink_0()
         .px_2()
         .py_1()
@@ -217,6 +218,7 @@ fn action_button(
         .cursor_pointer()
         .bg(pal.control)
         .hover(move |s| s.bg(pal.control_hover))
+        .focus_visible(move |s| s.bg(pal.control_hover))
         .child(label)
         .on_click(move |_, _, cx| on_click(cx))
 }

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -1,9 +1,7 @@
 //! Permissions settings page (macOS / Linux).
 
 #[cfg(target_os = "macos")]
-use super::{
-    AnyElement, App, AppState, InteractiveElement, Permission, StatefulInteractiveElement,
-};
+use super::{AnyElement, App, AppState, InteractiveElement, Permission};
 use super::{IconName, Palette, SettingPage};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use super::{

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -11,6 +11,8 @@ use super::{
     SharedString, Styled, div, h_flex, px, rgb, theme,
 };
 use crate::ui::theme::Typography as _;
+#[cfg(target_os = "macos")]
+use gpui_base::Button as BaseButton;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use openlogi_permissions as permissions;
 
@@ -225,8 +227,8 @@ fn permission_field(
         .gap_3()
         .child(status_el)
         .child(
-            div()
-                .id(id)
+            BaseButton::new(id)
+                .accessibility_label(action_label.clone())
                 .px_2()
                 .py_1()
                 .rounded(pal.control_radius)
@@ -236,6 +238,7 @@ fn permission_field(
                 .cursor_pointer()
                 .bg(pal.control)
                 .hover(move |s| s.bg(pal.control_hover))
+                .focus_visible(move |s| s.bg(pal.control_hover))
                 .child(action_label)
                 .on_click(move |_, _, cx| {
                     // Accessibility must be prompted in the agent (it owns the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,6 +153,19 @@ flow (discovery → passkey → paired). Its agent version carries a `-mock` suf
 so a mock session is identifiable in the UI. It is a dev tool only and is never
 bundled.
 
+### Component gallery
+
+Use the debug-only component gallery to review shared controls across light and
+dark themes and every supported interface scale without config, IPC, or hardware:
+
+```sh
+OPENLOGI_COMPONENT_GALLERY=1 cargo run -p openlogi-desktop
+```
+
+Gallery mode opens one isolated window and bypasses the normal single-instance,
+config, agent, asset-sync, and updater startup paths. The environment variable is
+ignored by release builds.
+
 ## Project layout
 
 ```


### PR DESCRIPTION
## Summary

Follow up on the GUI quality audit with semantic keyboard controls, stable component identity, scalable layout tokens, and an isolated development gallery.

## Changes

- **openlogi-desktop:** add a typed `ChoiceCard` primitive and convert bespoke picker/action targets to keyboard-accessible controls with behavior-contract tests
- **openlogi-desktop:** key dynamic elements and carousel internals by stable domain IDs, use typed inventory events for rename updates, and test carousel clamping and instance isolation
- **openlogi-desktop:** keep Home layout sizing in `rem`, add the narrow content-width token, and delay `AnyElement` erasure until heterogeneous boundaries
- **openlogi-desktop:** add a debug-only component gallery covering light/dark themes, all UI scales, and representative shared controls without config, IPC, or hardware state
- **docs/rules:** document the gallery workflow and stable `ElementId` review convention

## Testing

- `RUSTFLAGS=\"-D warnings\" cargo fmt --all -- --check`
- `RUSTFLAGS=\"-D warnings\" cargo clippy -p openlogi-desktop --all-targets -- -D warnings`
- `RUSTFLAGS=\"-D warnings\" cargo test -p openlogi-desktop` (160 passed)
- `cargo check -p openlogi-desktop --release`
- Not runtime-tested on hardware
- Interactive visual review was not run because the development orb is headless; the GPUI smoke test renders the gallery in light mode and again in dark mode at the largest UI scale

Follow-up to #900