### PR TITLE
refactor(agent): complete thumbwheel state machine

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -8,9 +8,11 @@
 //!
 //! - a gesture swipe through the gesture binding map,
 //! - a DPI/ModeShift or thumb-wheel-tap press through the button binding map,
-//! - thumb-wheel rotation through the [`ButtonId::ThumbwheelScrollUp`] /
-//!   [`ButtonId::ThumbwheelScrollDown`] bindings — either re-synthesised as
-//!   continuous, sensitivity-scaled scroll or accumulated into a custom action,
+//! - thumb-wheel rotation through the
+//!   [`ThumbwheelScrollUp`](openlogi_core::binding::ButtonId::ThumbwheelScrollUp) /
+//!   [`ThumbwheelScrollDown`](openlogi_core::binding::ButtonId::ThumbwheelScrollDown)
+//!   bindings — either re-synthesised as continuous, sensitivity-scaled scroll
+//!   or accumulated into a custom action,
 //!
 //! all via the common [`crate::runtime::ActionDispatcher`].
 //!
@@ -18,12 +20,13 @@
 //! the events arrive over HID++, and the bound action is synthesised the same
 //! way regardless.
 
+mod dispatch;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use openlogi_core::binding::{Action, Binding, ButtonId, default_binding};
 use openlogi_core::config::ThumbwheelSensitivity;
 use openlogi_core::scroll::ScrollDelta;
 use openlogi_hid::session::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
@@ -31,23 +34,16 @@ use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_sessi
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
+use self::dispatch::{InputDispatcher, WheelConfiguration};
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
 use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
 use crate::runtime::scroll::ScrollInputHandle;
-use crate::runtime::{ActionDispatcher, HidppSessionId, PressToken};
+use crate::runtime::{ActionDispatcher, HidppSessionId};
 
 /// How often to re-read the active device target + thumb-wheel arming so a
 /// carousel switch or a binding/sensitivity edit re-points / re-arms capture.
 /// It also paces the respawn of a session that ended on its own (see `manage`).
 const TARGET_POLL: Duration = Duration::from_secs(1);
-
-/// Idle gap after which a partly-accumulated *custom* wheel action is forgotten,
-/// so slow intermittent nudges don't eventually cross the threshold.
-const ACTION_DECAY: Duration = Duration::from_millis(300);
-
-/// Minimum gap between two fires of the same custom wheel action, so one
-/// deliberate flick triggers once instead of repeating across a fast spin.
-const ACTION_COOLDOWN: Duration = Duration::from_millis(200);
 
 /// Output capabilities shared by every HID++ gesture capture session.
 #[derive(Clone)]
@@ -130,11 +126,13 @@ fn spec_for(plan: &DeviceCapturePlan) -> CaptureSpec {
     }
 }
 
-/// Capture configuration that determines whether a session can stay armed.
+/// Capture and wheel-state configuration that determines whether a session can
+/// stay armed without leaking state across a binding epoch.
 #[derive(Clone, PartialEq)]
 struct SessionTarget {
     route: DeviceRoute,
     spec: CaptureSpec,
+    wheel: WheelConfiguration,
     rearm_generation: u64,
 }
 
@@ -143,6 +141,7 @@ impl SessionTarget {
         Self {
             route: plan.route.clone(),
             spec: spec_for(plan),
+            wheel: WheelConfiguration::for_plan(plan),
             rearm_generation: plan.rearm_generation,
         }
     }
@@ -172,32 +171,6 @@ struct SessionChannels {
     inputs: mpsc::UnboundedSender<CapturedEvent>,
     done: mpsc::UnboundedSender<SessionDone>,
     capture: CaptureChannel,
-}
-
-/// Correlates completed HID++ gesture semantics with the exact physical press
-/// token admitted by the shared button runtime. The runtime remains the sole
-/// authority on whether the token is still active.
-#[derive(Default)]
-struct GesturePresses {
-    tokens: HashMap<(HidppSessionId, ButtonId), PressToken>,
-}
-
-impl GesturePresses {
-    fn start(&mut self, session: &HidppSessionId, button: ButtonId, press: PressToken) {
-        self.tokens.insert((session.clone(), button), press);
-    }
-
-    fn get(&self, session: &HidppSessionId, button: ButtonId) -> Option<&PressToken> {
-        self.tokens.get(&(session.clone(), button))
-    }
-
-    fn end(&mut self, session: &HidppSessionId, button: ButtonId) {
-        self.tokens.remove(&(session.clone(), button));
-    }
-
-    fn cancel_session(&mut self, session: &HidppSessionId) {
-        self.tokens.retain(|(candidate, _), _| candidate != session);
-    }
 }
 
 /// What the manager should do with one session-completion report.
@@ -275,8 +248,7 @@ async fn manage(
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedEvent>();
     let mut sessions: HashMap<String, RunningSession> = HashMap::new();
     let mut ticker = tokio::time::interval(TARGET_POLL);
-    let mut accumulators: HashMap<String, WheelAccumulators> = HashMap::new();
-    let mut gesture_presses = GesturePresses::default();
+    let mut input_dispatcher = InputDispatcher::new(Arc::clone(&capture_plans), outputs);
     // Capture sessions run as detached tasks, so an unexpected exit (a transient
     // HID++ read error, a sleep-wake glitch, brief radio loss) would otherwise go
     // unnoticed. Each session reports its completion here, tagged with its device
@@ -310,17 +282,9 @@ async fn manage(
                             .is_some_and(|plan| live.is_some_and(|session| session_matches_plan(session, plan)))
                     });
                 if current {
-                    dispatch(
-                        &event.session,
-                        event.input,
-                        &mut accumulators,
-                        &mut gesture_presses,
-                        &capture_plans,
-                        &outputs,
-                    );
+                    input_dispatcher.dispatch(&event.session, event.input);
                 } else {
-                    outputs.cancel_session(&event.session);
-                    gesture_presses.cancel_session(&event.session);
+                    input_dispatcher.cancel_session(&event.session);
                     debug!(key, epoch = event.session.epoch(), "input from a stale capture session — ignored");
                 }
             }
@@ -341,12 +305,11 @@ async fn manage(
                 for (key, session) in &mut sessions {
                     let keep = want.get(key).is_some_and(|target| *target == session.target);
                     if !keep && let Some(stop) = session.stop.take() {
-                        outputs.cancel_session(&session.id);
-                        gesture_presses.cancel_session(&session.id);
+                        input_dispatcher.cancel_session(&session.id);
                         let _ = stop.send(());
                     }
                 }
-                accumulators.retain(|key, _| want.contains_key(key));
+                input_dispatcher.retain_devices(|key| want.contains_key(key));
                 for (key, target) in want {
                     if sessions.contains_key(&key) {
                         continue;
@@ -383,8 +346,7 @@ async fn manage(
                 // device can't hot-loop. A stale epoch (an already-superseded
                 // session) is a no-op.
                 if let DoneAction::Remove { unexpected } = on_done(&done.session, sessions.get(key)) {
-                    outputs.cancel_session(&done.session);
-                    gesture_presses.cancel_session(&done.session);
+                    input_dispatcher.cancel_session(&done.session);
                     if unexpected {
                         warn!(key, "capture session ended unexpectedly, re-arming");
                     }
@@ -445,238 +407,6 @@ fn spawn_session(
         id,
         target,
         stop: Some(stop_tx),
-    }
-}
-
-/// Per-direction wheel accumulators. The thumb wheel's two rotation directions
-/// bind to independent actions, so each keeps its own running total — sharing
-/// one would let a reversal cancel the other direction's progress.
-#[derive(Default)]
-struct WheelAccumulators {
-    up: WheelDirection,
-    down: WheelDirection,
-}
-
-/// Running state for one rotation direction.
-#[derive(Default)]
-struct WheelDirection {
-    /// Integer rotation-increment accumulator for a custom (non-scroll) action.
-    action: i32,
-    /// When the last rotation event for this direction arrived (decay clock).
-    last_event: Option<Instant>,
-    /// When this direction last fired its custom action (cooldown clock).
-    last_fired: Option<Instant>,
-}
-
-/// What advancing a direction's accumulator should produce.
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum WheelOutput {
-    /// Below threshold / suppressed — emit nothing.
-    Idle,
-    /// Post a typed fractional scroll distance.
-    Scroll(ScrollDelta),
-    /// Fire the direction's bound custom action.
-    FireAction,
-}
-
-/// Route one captured input from `session` to its bound action (or
-/// re-synthesised scroll), using that device's own plan maps.
-fn dispatch(
-    session: &HidppSessionId,
-    input: CapturedInput,
-    accumulators: &mut HashMap<String, WheelAccumulators>,
-    gesture_presses: &mut GesturePresses,
-    capture_plans: &SharedCapturePlans,
-    outputs: &GestureOutputs,
-) {
-    let key = session.device_key();
-    let Ok(plans) = capture_plans.read() else {
-        return;
-    };
-    let Some(plan) = plans.iter().find(|plan| plan.config_key == key) else {
-        debug!(key, "input from a device with no capture plan — ignored");
-        return;
-    };
-    match input {
-        CapturedInput::Gesture(button, direction) => {
-            let Some(press) = gesture_presses.get(session, button) else {
-                debug!(key, %button, ?direction, "gesture from a canceled button lifecycle — ignored");
-                return;
-            };
-            if let Some(action) = plan
-                .gesture_bindings
-                .get(&button)
-                .and_then(|map| map.get(&direction))
-            {
-                debug!(key, %button, ?direction, action = %action.label(), "gesture → action");
-                if !outputs.actions.try_dispatch_while_pressed(press, action) {
-                    debug!(key, %button, ?direction, "gesture press no longer active — ignored");
-                }
-            } else {
-                debug!(key, %button, ?direction, "gesture with no binding — ignored");
-            }
-        }
-        CapturedInput::ButtonDown(button) => {
-            // A raw-XY gesture source owns its click/swipe map; its physical
-            // lifecycle is still tracked, but it must not also fire the
-            // single-action projection on down.
-            let is_gesture = plan.gesture_bindings.contains_key(&button);
-            let binding = (!is_gesture).then(|| plan.bindings.get(&button)).flatten();
-            if let Some(binding) = binding {
-                debug!(key, ?button, action = %binding.click_action().label(), "HID++ button → binding");
-            } else {
-                debug!(key, ?button, "HID++ button with no binding — ignored");
-            }
-            let press = outputs
-                .actions
-                .try_hidpp_button_down(session, button, binding);
-            if is_gesture {
-                if let Some(press) = press {
-                    gesture_presses.start(session, button, press);
-                } else {
-                    gesture_presses.end(session, button);
-                }
-            }
-        }
-        CapturedInput::ButtonUp(button) => {
-            outputs.actions.try_hidpp_button_up(session, button);
-            gesture_presses.end(session, button);
-        }
-        CapturedInput::ButtonPulse(button) => {
-            let binding = plan.bindings.get(&button);
-            if let Some(binding) = binding {
-                debug!(key, ?button, action = %binding.click_action().label(), "HID++ button pulse → binding");
-            } else {
-                debug!(key, ?button, "HID++ button pulse with no binding — ignored");
-            }
-            outputs
-                .actions
-                .dispatch_hidpp_button_pulse(session, button, binding);
-        }
-        CapturedInput::Scroll {
-            increments,
-            resolution,
-        } => {
-            // Positive rotation is "up"; each direction has its own binding.
-            let up = increments >= 0;
-            let button = if up {
-                ButtonId::ThumbwheelScrollUp
-            } else {
-                ButtonId::ThumbwheelScrollDown
-            };
-            let action = plan
-                .bindings
-                .get(&button)
-                .map_or_else(|| default_binding(button), Binding::click_action);
-            let sensitivity = plan.thumbwheel_sensitivity;
-            let wheels = accumulators.entry(key.to_owned()).or_default();
-            let dir = if up { &mut wheels.up } else { &mut wheels.down };
-            let magnitude = i32::from(increments).abs();
-            match advance(
-                dir,
-                &action,
-                magnitude,
-                ScrollScale {
-                    native_per_increment: resolution.native_per_increment(),
-                    sensitivity,
-                },
-                Instant::now(),
-            ) {
-                WheelOutput::Idle => {}
-                WheelOutput::Scroll(delta) => outputs.post_scroll(session, delta),
-                WheelOutput::FireAction => {
-                    debug!(key, ?button, action = %action.label(), "thumb wheel → action");
-                    outputs.actions.dispatch(&action, Some(key));
-                }
-            }
-        }
-    }
-}
-
-/// How far one rotation increment should scroll.
-#[derive(Debug, Clone, Copy)]
-struct ScrollScale {
-    /// Native scroll units one diverted increment is worth, from the wheel's
-    /// own `getThumbwheelInfo`. Diverting the wheel changes the unit it
-    /// reports in — an MX Master 4 goes from 20 ratchets per revolution to 120
-    /// increments — so without this the same physical motion scrolls six times
-    /// as far as it did natively, and the sensitivity slider's 1× is 1× of
-    /// nothing recognisable.
-    native_per_increment: f64,
-    /// The user's own multiplier, relative to that native amount.
-    sensitivity: ThumbwheelSensitivity,
-}
-
-impl ScrollScale {
-    /// Scroll units one increment contributes.
-    fn per_increment(self) -> f64 {
-        self.native_per_increment * self.sensitivity.scroll_multiplier()
-    }
-}
-
-/// Advance one direction's accumulator by `magnitude` rotation increments and
-/// decide what to emit. Pure given `now`, so the decay/cooldown/threshold logic
-/// is unit-testable without touching the OS.
-fn advance(
-    dir: &mut WheelDirection,
-    action: &Action,
-    magnitude: i32,
-    scale: ScrollScale,
-    now: Instant,
-) -> WheelOutput {
-    let sensitivity = scale.sensitivity;
-    match action {
-        // Suppressed: captured but produces nothing.
-        Action::None => WheelOutput::Idle,
-        // Continuous scroll, scaled from the wheel's diverted
-        // increments back to its native amount and then by the user's
-        // sensitivity. Direction comes from the action.
-        Action::ScrollUp
-        | Action::ScrollDown
-        | Action::HorizontalScrollRight
-        | Action::HorizontalScrollLeft => {
-            let distance = f64::from(magnitude) * scale.per_increment();
-            let delta = match action {
-                Action::ScrollUp => ScrollDelta::wheel_ticks(0.0, distance),
-                Action::ScrollDown => ScrollDelta::wheel_ticks(0.0, -distance),
-                Action::HorizontalScrollRight => ScrollDelta::wheel_ticks(distance, 0.0),
-                Action::HorizontalScrollLeft => ScrollDelta::wheel_ticks(-distance, 0.0),
-                _ => unreachable!("scroll actions are matched above"),
-            };
-            if distance == 0.0 {
-                WheelOutput::Idle
-            } else {
-                WheelOutput::Scroll(delta)
-            }
-        }
-        // Any other action: fire once per `action_threshold` increments, with
-        // decay (forget stale partial progress) and cooldown (one flick = one
-        // fire).
-        _ => {
-            if dir
-                .last_event
-                .is_some_and(|t| now.saturating_duration_since(t) > ACTION_DECAY)
-            {
-                dir.action = 0;
-            }
-            dir.last_event = Some(now);
-
-            if dir
-                .last_fired
-                .is_some_and(|t| now.saturating_duration_since(t) < ACTION_COOLDOWN)
-            {
-                return WheelOutput::Idle;
-            }
-
-            dir.action += magnitude;
-            if dir.action >= sensitivity.action_threshold() {
-                dir.action = 0;
-                dir.last_fired = Some(now);
-                WheelOutput::FireAction
-            } else {
-                WheelOutput::Idle
-            }
-        }
     }
 }
 

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch.rs
@@ -1,0 +1,232 @@
+//! Resolve captured HID++ inputs against the active per-device plan.
+
+mod wheel;
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use openlogi_core::binding::{Action, Binding, ButtonId, default_binding};
+use openlogi_core::config::ThumbwheelSensitivity;
+use openlogi_hid::CapturedInput;
+use tracing::debug;
+
+use self::wheel::{ScrollScale, WheelAccumulators, WheelOutput, WheelRotation};
+use super::GestureOutputs;
+use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
+use crate::runtime::{HidppSessionId, PressToken};
+
+/// Effective thumb-wheel configuration whose continuity is tied to one capture
+/// session. A binding or sensitivity change starts a new session epoch even
+/// when the HID++ divert set itself stays the same.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct WheelConfiguration {
+    up: Action,
+    down: Action,
+    sensitivity: ThumbwheelSensitivity,
+}
+
+impl WheelConfiguration {
+    /// Resolve both directional bindings and their shared sensitivity.
+    pub(super) fn for_plan(plan: &DeviceCapturePlan) -> Self {
+        let action = |button| {
+            plan.bindings
+                .get(&button)
+                .map_or_else(|| default_binding(button), Binding::click_action)
+        };
+        Self {
+            up: action(ButtonId::ThumbwheelScrollUp),
+            down: action(ButtonId::ThumbwheelScrollDown),
+            sensitivity: plan.thumbwheel_sensitivity,
+        }
+    }
+
+    fn action(&self, rotation: WheelRotation) -> &Action {
+        match rotation.button() {
+            ButtonId::ThumbwheelScrollUp => &self.up,
+            ButtonId::ThumbwheelScrollDown => &self.down,
+            _ => unreachable!("wheel rotations only map to thumb-wheel directions"),
+        }
+    }
+}
+
+/// Correlates completed HID++ gesture semantics with the exact physical press
+/// token admitted by the shared button runtime. The runtime remains the sole
+/// authority on whether the token is still active.
+#[derive(Default)]
+struct GesturePresses {
+    tokens: HashMap<(HidppSessionId, ButtonId), PressToken>,
+}
+
+impl GesturePresses {
+    fn start(&mut self, session: &HidppSessionId, button: ButtonId, press: PressToken) {
+        self.tokens.insert((session.clone(), button), press);
+    }
+
+    fn get(&self, session: &HidppSessionId, button: ButtonId) -> Option<&PressToken> {
+        self.tokens.get(&(session.clone(), button))
+    }
+
+    fn end(&mut self, session: &HidppSessionId, button: ButtonId) {
+        self.tokens.remove(&(session.clone(), button));
+    }
+
+    fn cancel_session(&mut self, session: &HidppSessionId) {
+        self.tokens.retain(|(candidate, _), _| candidate != session);
+    }
+}
+
+/// Wheel state scoped to exact capture-session incarnations. Keying by session
+/// rather than device prevents a replacement epoch from inheriting progress or
+/// having its state removed by a stale completion from the previous epoch.
+#[derive(Default)]
+struct SessionWheels(HashMap<HidppSessionId, WheelAccumulators>);
+
+impl SessionWheels {
+    fn for_session(&mut self, session: &HidppSessionId) -> &mut WheelAccumulators {
+        self.0.entry(session.clone()).or_default()
+    }
+
+    fn cancel_session(&mut self, session: &HidppSessionId) {
+        self.0.remove(session);
+    }
+
+    fn retain_devices(&mut self, mut keep: impl FnMut(&str) -> bool) {
+        self.0.retain(|session, _| keep(session.device_key()));
+    }
+}
+
+/// Input routing plus the per-session state retained between
+/// captured events. Capture-session lifecycle remains owned by the parent.
+pub(super) struct InputDispatcher {
+    capture_plans: SharedCapturePlans,
+    outputs: GestureOutputs,
+    wheels: SessionWheels,
+    gesture_presses: GesturePresses,
+}
+
+impl InputDispatcher {
+    /// Build a dispatcher over the agent's live capture plans.
+    pub(super) fn new(capture_plans: SharedCapturePlans, outputs: GestureOutputs) -> Self {
+        Self {
+            capture_plans,
+            outputs,
+            wheels: SessionWheels::default(),
+            gesture_presses: GesturePresses::default(),
+        }
+    }
+
+    /// Cancel every input lifecycle retained for one capture session.
+    pub(super) fn cancel_session(&mut self, session: &HidppSessionId) {
+        self.outputs.cancel_session(session);
+        self.wheels.cancel_session(session);
+        self.gesture_presses.cancel_session(session);
+    }
+
+    /// Drop wheel state for devices that no longer have a capture session.
+    pub(super) fn retain_devices(&mut self, keep: impl FnMut(&str) -> bool) {
+        self.wheels.retain_devices(keep);
+    }
+
+    /// Route one captured input from `session` to its bound action or
+    /// re-synthesised scroll output.
+    pub(super) fn dispatch(&mut self, session: &HidppSessionId, input: CapturedInput) {
+        let key = session.device_key();
+        let Ok(plans) = self.capture_plans.read() else {
+            return;
+        };
+        let Some(plan) = plans.iter().find(|plan| plan.config_key == key) else {
+            debug!(key, "input from a device with no capture plan — ignored");
+            return;
+        };
+        match input {
+            CapturedInput::Gesture(button, direction) => {
+                let Some(press) = self.gesture_presses.get(session, button) else {
+                    debug!(key, %button, ?direction, "gesture from a canceled button lifecycle — ignored");
+                    return;
+                };
+                if let Some(action) = plan
+                    .gesture_bindings
+                    .get(&button)
+                    .and_then(|map| map.get(&direction))
+                {
+                    debug!(key, %button, ?direction, action = %action.label(), "gesture → action");
+                    if !self
+                        .outputs
+                        .actions
+                        .try_dispatch_while_pressed(press, action)
+                    {
+                        debug!(key, %button, ?direction, "gesture press no longer active — ignored");
+                    }
+                } else {
+                    debug!(key, %button, ?direction, "gesture with no binding — ignored");
+                }
+            }
+            CapturedInput::ButtonDown(button) => {
+                // A raw-XY gesture source owns its click/swipe map; its physical
+                // lifecycle is still tracked, but it must not also fire the
+                // single-action projection on down.
+                let is_gesture = plan.gesture_bindings.contains_key(&button);
+                let binding = (!is_gesture).then(|| plan.bindings.get(&button)).flatten();
+                if let Some(binding) = binding {
+                    debug!(key, ?button, action = %binding.click_action().label(), "HID++ button → binding");
+                } else {
+                    debug!(key, ?button, "HID++ button with no binding — ignored");
+                }
+                let press = self
+                    .outputs
+                    .actions
+                    .try_hidpp_button_down(session, button, binding);
+                if is_gesture {
+                    if let Some(press) = press {
+                        self.gesture_presses.start(session, button, press);
+                    } else {
+                        self.gesture_presses.end(session, button);
+                    }
+                }
+            }
+            CapturedInput::ButtonUp(button) => {
+                self.outputs.actions.try_hidpp_button_up(session, button);
+                self.gesture_presses.end(session, button);
+            }
+            CapturedInput::ButtonPulse(button) => {
+                let binding = plan.bindings.get(&button);
+                if let Some(binding) = binding {
+                    debug!(key, ?button, action = %binding.click_action().label(), "HID++ button pulse → binding");
+                } else {
+                    debug!(key, ?button, "HID++ button pulse with no binding — ignored");
+                }
+                self.outputs
+                    .actions
+                    .dispatch_hidpp_button_pulse(session, button, binding);
+            }
+            CapturedInput::Scroll {
+                increments,
+                resolution,
+            } => {
+                let Some(rotation) = WheelRotation::from_increments(increments) else {
+                    return;
+                };
+                let button = rotation.button();
+                let configuration = WheelConfiguration::for_plan(plan);
+                let action = configuration.action(rotation);
+                let wheels = self.wheels.for_session(session);
+                match wheels.advance(
+                    rotation,
+                    action,
+                    ScrollScale::new(resolution, configuration.sensitivity),
+                    Instant::now(),
+                ) {
+                    WheelOutput::Idle => {}
+                    WheelOutput::Scroll(delta) => self.outputs.post_scroll(session, delta),
+                    WheelOutput::FireAction => {
+                        debug!(key, ?button, action = %action.label(), "thumb wheel → action");
+                        self.outputs.actions.dispatch(action, Some(key));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch/tests.rs
@@ -1,0 +1,68 @@
+use openlogi_hid::thumbwheel::WheelResolution;
+
+use super::wheel::{ScrollScale, WheelOutput, WheelRotation};
+use super::*;
+
+fn rotation(magnitude: i32) -> WheelRotation {
+    let increments = i16::try_from(magnitude).expect("test magnitude fits in i16");
+    WheelRotation::from_increments(increments).expect("non-zero test rotation")
+}
+
+fn scale() -> ScrollScale {
+    ScrollScale::new(WheelResolution::UNKNOWN, ThumbwheelSensitivity::DEFAULT)
+}
+
+#[test]
+fn replacement_session_does_not_inherit_progress_or_cooldown() {
+    let old = HidppSessionId::new("mouse-a", 7);
+    let replacement = HidppSessionId::new("mouse-a", 8);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+    let now = Instant::now();
+    let mut wheels = SessionWheels::default();
+
+    assert_eq!(
+        wheels
+            .for_session(&old)
+            .advance(rotation(threshold), &Action::VolumeUp, scale(), now,),
+        WheelOutput::FireAction
+    );
+    assert_eq!(
+        wheels.for_session(&replacement).advance(
+            rotation(threshold),
+            &Action::VolumeUp,
+            scale(),
+            now,
+        ),
+        WheelOutput::FireAction,
+        "a new session must not inherit the old session's cooldown"
+    );
+
+    wheels.cancel_session(&old);
+    assert!(
+        wheels.0.contains_key(&replacement),
+        "canceling a stale epoch must not erase its replacement's state"
+    );
+}
+
+#[test]
+fn replacement_session_does_not_inherit_partial_progress() {
+    let old = HidppSessionId::new("mouse-a", 7);
+    let replacement = HidppSessionId::new("mouse-a", 8);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+    let now = Instant::now();
+    let mut wheels = SessionWheels::default();
+
+    assert_eq!(
+        wheels
+            .for_session(&old)
+            .advance(rotation(threshold - 1), &Action::VolumeUp, scale(), now,),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        wheels
+            .for_session(&replacement)
+            .advance(rotation(1), &Action::VolumeUp, scale(), now,),
+        WheelOutput::Idle,
+        "a new session must start with no action progress"
+    );
+}

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch/wheel.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch/wheel.rs
@@ -1,0 +1,286 @@
+//! Thumb-wheel binding state for one captured session's input dispatcher.
+//!
+//! Each physical rotation direction owns an independent state machine. Within
+//! one direction, continuous scrolling and discrete actions are mutually
+//! exclusive states; suppressed input clears either. Changing the effective
+//! binding or sensitivity discards progress and cooldown from the previous
+//! configuration.
+
+use std::time::{Duration, Instant};
+
+use openlogi_core::binding::{Action, ButtonId};
+use openlogi_core::config::ThumbwheelSensitivity;
+use openlogi_core::scroll::ScrollDelta;
+use openlogi_hid::thumbwheel::WheelResolution;
+
+/// Idle gap after which a partly accumulated discrete action is forgotten, so
+/// slow intermittent nudges do not eventually cross the threshold.
+const ACTION_DECAY: Duration = Duration::from_millis(300);
+
+/// Minimum gap between two fires of the same discrete action, so one deliberate
+/// flick triggers once instead of repeating across a fast spin.
+const ACTION_COOLDOWN: Duration = Duration::from_millis(200);
+
+/// Per-direction wheel state. Reversing the physical wheel must not cancel
+/// progress already earned in the other direction.
+#[derive(Default)]
+pub(super) struct WheelAccumulators {
+    up: WheelDirection,
+    down: WheelDirection,
+}
+
+impl WheelAccumulators {
+    /// Advance the state belonging to `rotation`'s physical direction.
+    pub(super) fn advance(
+        &mut self,
+        rotation: WheelRotation,
+        action: &Action,
+        scale: ScrollScale,
+        now: Instant,
+    ) -> WheelOutput {
+        let direction = match rotation.direction {
+            PhysicalDirection::Up => &mut self.up,
+            PhysicalDirection::Down => &mut self.down,
+        };
+        direction.advance(action, rotation.magnitude, scale, now)
+    }
+}
+
+/// One non-zero captured wheel rotation, split into physical direction and
+/// positive magnitude once at the input boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct WheelRotation {
+    direction: PhysicalDirection,
+    magnitude: i32,
+}
+
+impl WheelRotation {
+    /// Decode the signed HID++ increment count. Zero carries no rotation.
+    pub(super) fn from_increments(increments: i16) -> Option<Self> {
+        let direction = match increments.cmp(&0) {
+            std::cmp::Ordering::Greater => PhysicalDirection::Up,
+            std::cmp::Ordering::Less => PhysicalDirection::Down,
+            std::cmp::Ordering::Equal => return None,
+        };
+        Some(Self {
+            direction,
+            // Convert before `abs` so i16::MIN remains representable.
+            magnitude: i32::from(increments).abs(),
+        })
+    }
+
+    /// Binding key for this physical direction.
+    pub(super) const fn button(self) -> ButtonId {
+        match self.direction {
+            PhysicalDirection::Up => ButtonId::ThumbwheelScrollUp,
+            PhysicalDirection::Down => ButtonId::ThumbwheelScrollDown,
+        }
+    }
+}
+
+/// Physical sign of one captured rotation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PhysicalDirection {
+    Up,
+    Down,
+}
+
+/// Running state for one physical rotation direction.
+#[derive(Default)]
+struct WheelDirection {
+    state: WheelState,
+}
+
+impl WheelDirection {
+    /// Advance this direction for its current effective binding.
+    fn advance(
+        &mut self,
+        action: &Action,
+        magnitude: i32,
+        scale: ScrollScale,
+        now: Instant,
+    ) -> WheelOutput {
+        if matches!(action, Action::None) {
+            self.state = WheelState::Idle;
+            return WheelOutput::Idle;
+        }
+        if let Some(binding) = ScrollBinding::from_action(action) {
+            return self.advance_scroll(binding, magnitude, scale);
+        }
+        self.advance_action(action, magnitude, scale.sensitivity, now)
+    }
+
+    /// Emit continuous scroll immediately as a typed fractional delta. The
+    /// smooth-scroll runtime owns interpolation; this state only records the
+    /// mutually exclusive mode so returning to a discrete action starts fresh.
+    fn advance_scroll(
+        &mut self,
+        binding: ScrollBinding,
+        magnitude: i32,
+        scale: ScrollScale,
+    ) -> WheelOutput {
+        let context = ScrollContext { binding, scale };
+        if !matches!(&self.state, WheelState::Scroll(previous) if *previous == context) {
+            self.state = WheelState::Scroll(context);
+        }
+        let distance = f64::from(magnitude) * scale.per_increment();
+        if distance == 0.0 {
+            WheelOutput::Idle
+        } else {
+            binding.output(distance)
+        }
+    }
+
+    /// Accumulate one discrete action. Progress, decay, and cooldown all belong
+    /// to the exact action and sensitivity that earned them.
+    fn advance_action(
+        &mut self,
+        action: &Action,
+        magnitude: i32,
+        sensitivity: ThumbwheelSensitivity,
+        now: Instant,
+    ) -> WheelOutput {
+        let next_binding = DiscreteBinding {
+            action: action.clone(),
+            sensitivity,
+        };
+        let (mut increments, last_event, last_fired) = match std::mem::take(&mut self.state) {
+            WheelState::Action {
+                binding,
+                increments,
+                last_event,
+                last_fired,
+            } if binding == next_binding => (increments, Some(last_event), last_fired),
+            _ => (0, None, None),
+        };
+
+        if last_event.is_some_and(|time| now.saturating_duration_since(time) > ACTION_DECAY) {
+            increments = 0;
+        }
+
+        let cooling_down =
+            last_fired.is_some_and(|time| now.saturating_duration_since(time) < ACTION_COOLDOWN);
+        let (output, last_fired) = if cooling_down {
+            (WheelOutput::Idle, last_fired)
+        } else {
+            increments += magnitude;
+            if increments >= next_binding.sensitivity.action_threshold() {
+                increments = 0;
+                (WheelOutput::FireAction, Some(now))
+            } else {
+                (WheelOutput::Idle, last_fired)
+            }
+        };
+        self.state = WheelState::Action {
+            binding: next_binding,
+            increments,
+            last_event: now,
+            last_fired,
+        };
+        output
+    }
+}
+
+/// Mutually exclusive state for one physical wheel direction.
+#[derive(Default)]
+enum WheelState {
+    /// No binding has retained state.
+    #[default]
+    Idle,
+    /// Continuous scrolling under one exact axis, resolution, and sensitivity.
+    Scroll(ScrollContext),
+    /// Increment progress and timing retained for one exact discrete binding.
+    Action {
+        binding: DiscreteBinding,
+        increments: i32,
+        last_event: Instant,
+        last_fired: Option<Instant>,
+    },
+}
+
+/// Identity of one continuous-scroll mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ScrollContext {
+    binding: ScrollBinding,
+    scale: ScrollScale,
+}
+
+/// Identity of one discrete binding, including the threshold it uses.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DiscreteBinding {
+    action: Action,
+    sensitivity: ThumbwheelSensitivity,
+}
+
+/// Axis and sign encoded by a continuous-scroll action.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScrollBinding {
+    Up,
+    Down,
+    Right,
+    Left,
+}
+
+impl ScrollBinding {
+    fn from_action(action: &Action) -> Option<Self> {
+        match action {
+            Action::ScrollUp => Some(Self::Up),
+            Action::ScrollDown => Some(Self::Down),
+            Action::HorizontalScrollRight => Some(Self::Right),
+            Action::HorizontalScrollLeft => Some(Self::Left),
+            _ => None,
+        }
+    }
+
+    /// Convert positive distance into the configured axis and sign.
+    fn output(self, distance: f64) -> WheelOutput {
+        let delta = match self {
+            Self::Up => ScrollDelta::wheel_ticks(0.0, distance),
+            Self::Down => ScrollDelta::wheel_ticks(0.0, -distance),
+            Self::Right => ScrollDelta::wheel_ticks(distance, 0.0),
+            Self::Left => ScrollDelta::wheel_ticks(-distance, 0.0),
+        };
+        WheelOutput::Scroll(delta)
+    }
+}
+
+/// What advancing one direction should produce.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum WheelOutput {
+    /// Below threshold or suppressed.
+    Idle,
+    /// Typed fractional distance for the smooth-scroll runtime or injector.
+    Scroll(ScrollDelta),
+    /// Fire the direction's bound discrete action.
+    FireAction,
+}
+
+/// Device-native scroll scale combined with the user's sensitivity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ScrollScale {
+    /// Native and diverted increments per revolution reported by the device.
+    resolution: WheelResolution,
+    /// User multiplier relative to the device's native amount.
+    sensitivity: ThumbwheelSensitivity,
+}
+
+impl ScrollScale {
+    /// Pair one captured event's device resolution with the active setting.
+    pub(super) const fn new(
+        resolution: WheelResolution,
+        sensitivity: ThumbwheelSensitivity,
+    ) -> Self {
+        Self {
+            resolution,
+            sensitivity,
+        }
+    }
+
+    /// Native scroll ticks one diverted increment contributes.
+    fn per_increment(self) -> f64 {
+        self.resolution.native_per_increment() * self.sensitivity.scroll_multiplier()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch/wheel/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch/wheel/tests.rs
@@ -1,0 +1,362 @@
+//! Thumb-wheel state-transition tests.
+
+use super::*;
+
+/// The resolutions traced off an MX Master 4 over Bolt: 20 ratchets per
+/// revolution natively, 120 increments per revolution diverted.
+const TRACED: WheelResolution = WheelResolution {
+    native_res: 20,
+    diverted_res: 120,
+};
+const UNSCALED: WheelResolution = WheelResolution {
+    native_res: 1,
+    diverted_res: 1,
+};
+
+fn unscaled(sensitivity: ThumbwheelSensitivity) -> ScrollScale {
+    ScrollScale::new(UNSCALED, sensitivity)
+}
+
+fn scroll_delta(output: WheelOutput) -> ScrollDelta {
+    let WheelOutput::Scroll(delta) = output else {
+        panic!("expected fractional scroll output");
+    };
+    delta
+}
+
+fn assert_distance(actual: f64, expected: f64) {
+    const EPSILON: f64 = 1.0e-12;
+    assert!(
+        (actual - expected).abs() < EPSILON,
+        "{actual} != {expected}"
+    );
+}
+
+#[test]
+fn multiplier_is_unity_at_default_sensitivity() {
+    assert!((unscaled(ThumbwheelSensitivity::DEFAULT).per_increment() - 1.0).abs() < f64::EPSILON);
+    assert!(unscaled(ThumbwheelSensitivity::from_rounded(28.0)).per_increment() > 1.9);
+    assert!(unscaled(ThumbwheelSensitivity::MIN).per_increment() < 0.1);
+}
+
+#[test]
+fn action_threshold_drops_with_sensitivity_and_floors_at_one() {
+    assert_eq!(
+        ThumbwheelSensitivity::DEFAULT.action_threshold(),
+        i32::from(ThumbwheelSensitivity::DEFAULT)
+    );
+    assert!(
+        ThumbwheelSensitivity::MIN.action_threshold()
+            > ThumbwheelSensitivity::DEFAULT.action_threshold(),
+        "low sensitivity needs more increments"
+    );
+    assert_eq!(
+        ThumbwheelSensitivity::MAX.action_threshold(),
+        1,
+        "high sensitivity floors at one"
+    );
+}
+
+#[test]
+fn an_unreported_resolution_leaves_increments_unscaled() {
+    let scale = ScrollScale::new(WheelResolution::UNKNOWN, ThumbwheelSensitivity::DEFAULT);
+    assert!((scale.per_increment() - 1.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn rotation_separates_direction_and_positive_magnitude() {
+    let up = WheelRotation::from_increments(3).expect("non-zero rotation");
+    assert_eq!(up.button(), ButtonId::ThumbwheelScrollUp);
+    assert_eq!(up.magnitude, 3);
+
+    let down = WheelRotation::from_increments(-3).expect("non-zero rotation");
+    assert_eq!(down.button(), ButtonId::ThumbwheelScrollDown);
+    assert_eq!(down.magnitude, 3);
+    assert_eq!(WheelRotation::from_increments(0), None);
+}
+
+#[test]
+fn a_revolution_scrolls_its_native_amount_however_finely_the_wheel_reports() {
+    let scale = ScrollScale::new(TRACED, ThumbwheelSensitivity::DEFAULT);
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let mut distance = 0.0;
+    for _ in 0..120 {
+        distance +=
+            scroll_delta(direction.advance(&Action::HorizontalScrollRight, 1, scale, now)).x();
+    }
+    assert_distance(distance, 20.0);
+}
+
+#[test]
+fn sensitivity_multiplies_the_native_amount() {
+    let scale = ScrollScale::new(TRACED, ThumbwheelSensitivity::from_rounded(28.0));
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let mut distance = 0.0;
+    for _ in 0..120 {
+        distance +=
+            scroll_delta(direction.advance(&Action::HorizontalScrollRight, 1, scale, now)).x();
+    }
+    assert_distance(distance, 40.0);
+}
+
+#[test]
+fn sub_tick_distance_is_emitted_without_integer_accumulation() {
+    let output = WheelDirection::default().advance(
+        &Action::HorizontalScrollRight,
+        1,
+        unscaled(ThumbwheelSensitivity::from_rounded(7.0)),
+        Instant::now(),
+    );
+    assert_eq!(
+        output,
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.5, 0.0))
+    );
+}
+
+#[test]
+fn all_scroll_bindings_emit_on_their_configured_axis_and_sign() {
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    for (action, expected) in [
+        (Action::ScrollUp, ScrollDelta::wheel_ticks(0.0, 1.0)),
+        (Action::ScrollDown, ScrollDelta::wheel_ticks(0.0, -1.0)),
+        (
+            Action::HorizontalScrollRight,
+            ScrollDelta::wheel_ticks(1.0, 0.0),
+        ),
+        (
+            Action::HorizontalScrollLeft,
+            ScrollDelta::wheel_ticks(-1.0, 0.0),
+        ),
+    ] {
+        assert_eq!(
+            WheelDirection::default().advance(&action, 1, scale, now),
+            WheelOutput::Scroll(expected)
+        );
+    }
+}
+
+#[test]
+fn scroll_scale_changes_apply_only_to_the_current_delta() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let traced = ScrollScale::new(TRACED, ThumbwheelSensitivity::DEFAULT);
+
+    assert_distance(
+        scroll_delta(direction.advance(&Action::HorizontalScrollRight, 1, traced, now)).x(),
+        1.0 / 6.0,
+    );
+    assert_eq!(
+        direction.advance(
+            &Action::HorizontalScrollRight,
+            1,
+            unscaled(ThumbwheelSensitivity::DEFAULT),
+            now,
+        ),
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(1.0, 0.0)),
+        "the new resolution must not combine with hidden old-scale progress"
+    );
+}
+
+#[test]
+fn physical_directions_accumulate_independently() {
+    let mut wheel = WheelAccumulators::default();
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+    let up = WheelRotation::from_increments(1).expect("non-zero rotation");
+    let down = WheelRotation::from_increments(-1).expect("non-zero rotation");
+
+    assert_eq!(
+        wheel.advance(up, &Action::VolumeUp, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        wheel.advance(down, &Action::VolumeDown, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        wheel.advance(
+            WheelRotation {
+                magnitude: threshold - 1,
+                ..up
+            },
+            &Action::VolumeUp,
+            scale,
+            now,
+        ),
+        WheelOutput::FireAction
+    );
+    assert_eq!(
+        wheel.advance(
+            WheelRotation {
+                magnitude: threshold - 1,
+                ..down
+            },
+            &Action::VolumeDown,
+            scale,
+            now,
+        ),
+        WheelOutput::FireAction
+    );
+}
+
+#[test]
+fn custom_action_fires_on_threshold_then_respects_its_cooldown() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold, scale, now),
+        WheelOutput::FireAction
+    );
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold, scale, now + ACTION_COOLDOWN),
+        WheelOutput::FireAction,
+        "the same action may fire again at the cooldown boundary"
+    );
+}
+
+#[test]
+fn custom_binding_changes_discard_progress_and_cooldown() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold - 1, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        direction.advance(&Action::NextTab, 1, scale, now),
+        WheelOutput::Idle,
+        "the new action must not inherit the previous action's progress"
+    );
+    assert_eq!(
+        direction.advance(&Action::NextTab, threshold - 1, scale, now),
+        WheelOutput::FireAction
+    );
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold, scale, now),
+        WheelOutput::FireAction,
+        "the new binding must not inherit another action's cooldown"
+    );
+}
+
+#[test]
+fn sensitivity_changes_discard_progress_and_cooldown() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let default = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold - 1, default, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        direction.advance(
+            &Action::VolumeUp,
+            1,
+            unscaled(ThumbwheelSensitivity::MIN),
+            now,
+        ),
+        WheelOutput::Idle,
+        "a new threshold must not inherit progress earned under the old one"
+    );
+
+    assert_eq!(
+        direction.advance(
+            &Action::VolumeUp,
+            ThumbwheelSensitivity::MIN.action_threshold(),
+            unscaled(ThumbwheelSensitivity::MIN),
+            now,
+        ),
+        WheelOutput::FireAction
+    );
+    assert_eq!(
+        direction.advance(
+            &Action::VolumeUp,
+            ThumbwheelSensitivity::MAX.action_threshold(),
+            unscaled(ThumbwheelSensitivity::MAX),
+            now,
+        ),
+        WheelOutput::FireAction,
+        "a sensitivity change must not inherit the old threshold's cooldown"
+    );
+}
+
+#[test]
+fn changing_modes_discards_discrete_progress() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold - 1, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        direction.advance(&Action::HorizontalScrollRight, 1, scale, now),
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(1.0, 0.0))
+    );
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, 1, scale, now),
+        WheelOutput::Idle,
+        "returning to an action must not recover progress from before scrolling"
+    );
+}
+
+#[test]
+fn none_suppresses_input_and_clears_retained_progress() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold - 1, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        direction.advance(&Action::None, 1, scale, now),
+        WheelOutput::Idle
+    );
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, 1, scale, now),
+        WheelOutput::Idle
+    );
+}
+
+#[test]
+fn stale_custom_progress_decays() {
+    let mut direction = WheelDirection::default();
+    let now = Instant::now();
+    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
+    let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
+
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold - 1, scale, now),
+        WheelOutput::Idle
+    );
+    let after_decay = now + ACTION_DECAY + Duration::from_millis(1);
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, 1, scale, after_decay),
+        WheelOutput::Idle,
+        "the stale partial action must have been discarded"
+    );
+    assert_eq!(
+        direction.advance(&Action::VolumeUp, threshold - 1, scale, after_decay),
+        WheelOutput::FireAction
+    );
+}

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -1,234 +1,11 @@
 use super::*;
-use openlogi_hid::thumbwheel::WheelResolution;
+use openlogi_core::binding::{Action, Binding, ButtonId};
 
-/// Resolution metadata observed from an MX Master 4 over Bolt: 20 ratchets per
-/// revolution natively, 120 increments per revolution diverted. The event
-/// sequences below are synthetic algorithm fixtures, not hardware captures.
-const MX_MASTER_4_REPORTED_RESOLUTION: WheelResolution = WheelResolution {
-    native_res: 20,
-    diverted_res: 120,
-};
-
-/// A wheel whose increments are already native scroll units — what the
-/// scaling tests below vary, and what every other test here assumes.
-fn unscaled(sensitivity: ThumbwheelSensitivity) -> ScrollScale {
-    ScrollScale {
-        native_per_increment: 1.0,
-        sensitivity,
+fn route() -> DeviceRoute {
+    DeviceRoute::Direct {
+        vendor_id: 0x046d,
+        product_id: 0xc548,
     }
-}
-
-fn assert_distance(actual: f64, expected: f64) {
-    const EPSILON: f64 = 1.0e-12;
-    assert!(
-        (actual - expected).abs() < EPSILON,
-        "{actual} != {expected}"
-    );
-}
-
-fn scroll_delta(output: WheelOutput) -> ScrollDelta {
-    let WheelOutput::Scroll(delta) = output else {
-        panic!("expected fractional scroll output");
-    };
-    delta
-}
-
-#[test]
-fn multiplier_is_unity_at_default_sensitivity() {
-    assert!((ThumbwheelSensitivity::DEFAULT.scroll_multiplier() - 1.0).abs() < f64::EPSILON);
-    assert!(ThumbwheelSensitivity::from_rounded(28.0).scroll_multiplier() > 1.9);
-    assert!(ThumbwheelSensitivity::MIN.scroll_multiplier() < 0.1);
-}
-
-#[test]
-fn action_threshold_drops_with_sensitivity_and_floors_at_one() {
-    assert_eq!(
-        ThumbwheelSensitivity::DEFAULT.action_threshold(),
-        i32::from(ThumbwheelSensitivity::DEFAULT)
-    );
-    assert!(
-        ThumbwheelSensitivity::MIN.action_threshold()
-            > ThumbwheelSensitivity::DEFAULT.action_threshold(),
-        "low sensitivity needs more increments"
-    );
-    assert_eq!(
-        ThumbwheelSensitivity::MAX.action_threshold(),
-        1,
-        "high sensitivity floors at one"
-    );
-}
-
-/// Diverting the wheel changes the unit it reports in. An MX Master 4
-/// sends 120 increments per revolution where native scrolling produced 20
-/// ratchets, so a revolution has to keep scrolling 20 units — not 120 —
-/// with the sensitivity slider left alone.
-#[test]
-fn a_revolution_scrolls_its_native_amount_however_finely_the_wheel_reports() {
-    let scale = ScrollScale {
-        native_per_increment: MX_MASTER_4_REPORTED_RESOLUTION.native_per_increment(),
-        sensitivity: ThumbwheelSensitivity::DEFAULT,
-    };
-    let mut dir = WheelDirection::default();
-    let now = Instant::now();
-    let mut distance = 0.0;
-    for _ in 0..120 {
-        distance += scroll_delta(advance(
-            &mut dir,
-            &Action::HorizontalScrollRight,
-            1,
-            scale,
-            now,
-        ))
-        .x();
-    }
-    assert_distance(distance, 20.0);
-}
-
-/// The sensitivity slider stays a multiplier *of that native amount*.
-#[test]
-fn sensitivity_multiplies_the_native_amount() {
-    let scale = ScrollScale {
-        native_per_increment: MX_MASTER_4_REPORTED_RESOLUTION.native_per_increment(),
-        sensitivity: ThumbwheelSensitivity::from_rounded(28.0), // 2x
-    };
-    let mut dir = WheelDirection::default();
-    let now = Instant::now();
-    let mut distance = 0.0;
-    for _ in 0..120 {
-        distance += scroll_delta(advance(
-            &mut dir,
-            &Action::HorizontalScrollRight,
-            1,
-            scale,
-            now,
-        ))
-        .x();
-    }
-    assert_distance(distance, 40.0);
-}
-
-#[test]
-fn an_unreported_resolution_leaves_increments_unscaled() {
-    assert!((WheelResolution::UNKNOWN.native_per_increment() - 1.0).abs() < f64::EPSILON);
-}
-
-#[test]
-fn sub_tick_distance_is_emitted_without_integer_accumulation() {
-    let mut dir = WheelDirection::default();
-    let now = Instant::now();
-    // A 0.5× increment remains one typed half-tick all the way to the smooth
-    // runtime or the platform injector.
-    let half = ThumbwheelSensitivity::from_rounded(7.0);
-    assert_eq!(
-        advance(
-            &mut dir,
-            &Action::HorizontalScrollRight,
-            1,
-            unscaled(half),
-            now
-        ),
-        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.5, 0.0))
-    );
-}
-
-#[test]
-fn scroll_actions_encode_axis_and_sign_in_the_typed_delta() {
-    let mut dir = WheelDirection::default();
-    let now = Instant::now();
-    let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
-    assert_eq!(
-        advance(&mut dir, &Action::HorizontalScrollLeft, 1, scale, now),
-        WheelOutput::Scroll(ScrollDelta::wheel_ticks(-1.0, 0.0))
-    );
-    assert_eq!(
-        advance(&mut dir, &Action::ScrollDown, 1, scale, now),
-        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.0, -1.0))
-    );
-}
-
-#[test]
-fn binding_changes_have_no_hidden_fractional_progress_to_reassign() {
-    let mut dir = WheelDirection::default();
-    let now = Instant::now();
-    let half = unscaled(ThumbwheelSensitivity::from_rounded(7.0));
-
-    assert_eq!(
-        advance(&mut dir, &Action::HorizontalScrollRight, 1, half, now),
-        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.5, 0.0))
-    );
-    assert_eq!(
-        advance(&mut dir, &Action::ScrollUp, 1, half, now),
-        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.0, 0.5))
-    );
-}
-
-#[test]
-fn zero_magnitude_emits_nothing() {
-    assert_eq!(
-        advance(
-            &mut WheelDirection::default(),
-            &Action::HorizontalScrollRight,
-            0,
-            unscaled(ThumbwheelSensitivity::DEFAULT),
-            Instant::now(),
-        ),
-        WheelOutput::Idle
-    );
-}
-
-#[test]
-fn custom_action_fires_on_threshold_then_respects_cooldown() {
-    let mut dir = WheelDirection::default();
-    let now = Instant::now();
-    for _ in 0..i32::from(ThumbwheelSensitivity::DEFAULT) - 1 {
-        assert_eq!(
-            advance(
-                &mut dir,
-                &Action::VolumeUp,
-                1,
-                unscaled(ThumbwheelSensitivity::DEFAULT),
-                now
-            ),
-            WheelOutput::Idle
-        );
-    }
-    assert_eq!(
-        advance(
-            &mut dir,
-            &Action::VolumeUp,
-            1,
-            unscaled(ThumbwheelSensitivity::DEFAULT),
-            now
-        ),
-        WheelOutput::FireAction
-    );
-    for _ in 0..i32::from(ThumbwheelSensitivity::DEFAULT) {
-        assert_eq!(
-            advance(
-                &mut dir,
-                &Action::VolumeUp,
-                1,
-                unscaled(ThumbwheelSensitivity::DEFAULT),
-                now
-            ),
-            WheelOutput::Idle
-        );
-    }
-}
-
-#[test]
-fn none_action_is_suppressed() {
-    let mut dir = WheelDirection::default();
-    assert_eq!(
-        advance(
-            &mut dir,
-            &Action::None,
-            5,
-            unscaled(ThumbwheelSensitivity::DEFAULT),
-            Instant::now()
-        ),
-        WheelOutput::Idle
-    );
 }
 
 fn session_id(epoch: u64) -> HidppSessionId {
@@ -236,16 +13,16 @@ fn session_id(epoch: u64) -> HidppSessionId {
 }
 
 fn stopped_session_with_epoch(epoch: u64) -> RunningSession {
+    let plan = crate::capture_plan::plan_for_device(
+        &openlogi_core::config::Config::default(),
+        "mouse-a",
+        route(),
+        None,
+        0,
+    );
     RunningSession {
         id: session_id(epoch),
-        target: SessionTarget {
-            route: DeviceRoute::Direct {
-                vendor_id: 0x046d,
-                product_id: 0xc548,
-            },
-            spec: CaptureSpec::default(),
-            rearm_generation: 0,
-        },
+        target: SessionTarget::for_plan(&plan),
         stop: None,
     }
 }
@@ -317,7 +94,7 @@ fn accepts_inputs_only_from_the_current_live_session() {
 
 #[test]
 fn rejects_input_after_the_published_capture_plan_changes() {
-    let mut session = live_session_with_epoch(7);
+    let session = live_session_with_epoch(7);
     let mut plan = crate::capture_plan::plan_for_device(
         &openlogi_core::config::Config::default(),
         "mouse-a",
@@ -325,12 +102,49 @@ fn rejects_input_after_the_published_capture_plan_changes() {
         None,
         0,
     );
-    session.target.spec = spec_for(&plan);
     assert!(session_matches_plan(&session, &plan));
 
     plan.rearm_generation = 1;
     assert!(
         !session_matches_plan(&session, &plan),
         "an input queued before a capture-plan epoch change is stale"
+    );
+}
+
+#[test]
+fn wheel_configuration_changes_invalidate_the_capture_epoch() {
+    let mut config = openlogi_core::config::Config::default();
+    config.set_binding(
+        "mouse-a",
+        ButtonId::ThumbwheelScrollUp,
+        Binding::Single(Action::NextTab),
+    );
+    let first = crate::capture_plan::plan_for_device(&config, "mouse-a", route(), None, 0);
+    let mut session = live_session_with_epoch(7);
+    session.target = SessionTarget::for_plan(&first);
+
+    config.set_binding(
+        "mouse-a",
+        ButtonId::ThumbwheelScrollUp,
+        Binding::Single(Action::VolumeUp),
+    );
+    let rebound = crate::capture_plan::plan_for_device(&config, "mouse-a", route(), None, 0);
+    assert_eq!(
+        spec_for(&first),
+        spec_for(&rebound),
+        "both custom bindings require the same HID++ diversion"
+    );
+    assert!(
+        !session_matches_plan(&session, &rebound),
+        "binding changes must end the epoch even when the divert set is unchanged"
+    );
+
+    session.target = SessionTarget::for_plan(&rebound);
+    config.set_device_thumbwheel_sensitivity("mouse-a", Some(ThumbwheelSensitivity::MIN));
+    let rescaled = crate::capture_plan::plan_for_device(&config, "mouse-a", route(), None, 0);
+    assert_eq!(spec_for(&rebound), spec_for(&rescaled));
+    assert!(
+        !session_matches_plan(&session, &rescaled),
+        "sensitivity changes must not reuse an old action threshold or cooldown"
     );
 }


### PR DESCRIPTION
## Summary

- Make thumb-wheel state mutually exclusive, session-scoped, and binding-aware.
- Separate capture-session management, input dispatch, and pure wheel transition logic.
- Prevent retained progress or cooldown from leaking across binding, profile, sensitivity, resolution, and capture-session changes.
- Preserve smooth fractional scrolling and the current HID++ button/long-press lifecycle on top of the latest `master`.

## Changes

- **openlogi-agent-core**
  - Keep capture-session lifecycle in `gesture.rs`, input routing in `gesture/dispatch.rs`, and the pure wheel state machine in `gesture/dispatch/wheel.rs`.
  - Scope wheel state to the exact `HidppSessionId`, so replacement sessions cannot inherit state and stale completion cannot erase a replacement.
  - Model each physical wheel direction with `WheelState::{Idle, Scroll, Action}` instead of parallel optional fields.
  - Attach discrete progress, decay, and cooldown to the exact action and sensitivity that earned them.
  - Include the effective wheel configuration in the capture-session target, so live binding or sensitivity changes invalidate the old epoch even when the HID++ divert set is unchanged.
  - Preserve the merged `Binding` model by passing complete button bindings to the button runtime while projecting wheel rotation through `Binding::click_action()`.
  - Normalize signed HID++ input through `WheelRotation` and emit typed fractional `ScrollDelta` values to the smooth-scroll runtime.
  - Move lifecycle, dispatcher, and transition tests beside their owning modules.

## Testing

- `cargo test -p openlogi-agent-core watchers::gesture` (26 passed)
- `cargo fmt --all -- --check`
- `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS=\"-D warnings\" cargo test --workspace`
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- Not runtime-tested on hardware.

Hardware verification: bind the two thumb-wheel directions independently to vertical scroll, horizontal scroll, and discrete actions; switch bindings, sensitivity, or foreground-app profiles with partial progress retained; confirm the new configuration does not inherit scroll progress or action cooldown from the previous one.