### PR TITLE
fix(xtask,permissions): make the local gate runnable on Windows

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -59,7 +59,7 @@ warning that host clippy `-D warnings` does not surface still fails CI.
 | `tests (linux)` | `cargo test --workspace --exclude openlogi-desktop` | Linux |
 | `tests (macos, <arch>)` | `cargo test --workspace --all-targets` | macOS. CI matrix is arm64 (`macos-latest`) and x86_64 (`macos-15-intel`) |
 | `cargo-deny` | `cargo deny --config .cargo/deny.toml --all-features --manifest-path crates/openlogi/Cargo.toml check` | any (needs `cargo-deny`; `nix run nixpkgs#cargo-deny -- …` also works) |
-| `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings` | **Windows**. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
+| `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings`, then the `rustdoc` job's `cargo doc` line | **Windows**. Also carries the Windows rustdoc gate: a `cfg`-gated doc target missing only on Windows resolves fine in the Linux `rustdoc` job. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
 | `wasm (portable crates)` | `cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown` then `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown` | any (needs the `wasm32-unknown-unknown` std; devenv installs it) |
 
 CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
@@ -68,7 +68,8 @@ CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
 job deliberately skips sccache setup. `rust-cache` stores only Cargo registry/git
 inputs (`cache-targets: false`); sccache owns compiler outputs. PRs read the
 default branch's sccache objects but do not write their isolated merge-ref cache.
-There is no Windows test job — only `clippy (windows)`.
+There is no Windows test job — only `clippy (windows)`, which runs clippy and
+rustdoc but no tests.
 
 ### MSRV trap
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,10 @@ jobs:
       - name: cargo doc
         env:
           RUSTDOCFLAGS: "-D warnings"
+        # This job's default shell is pwsh, where a trailing backslash is not a
+        # line continuation and `--exclude` parses as a unary operator. bash keeps
+        # this command byte-identical to the Linux rustdoc job it mirrors.
+        shell: bash
         run: |
           cargo doc --workspace --no-deps --document-private-items \
             --exclude openlogi-ui \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,22 @@ jobs:
       # and the agent's HKCU-Run autostart) that the Linux/macOS clippy jobs
       # never compile.
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # The same docs the Linux `rustdoc` job builds, built again here because
+      # a `cfg`-gated doc target can exist on Linux and macOS yet be missing on
+      # Windows — an intra-doc link that then resolves everywhere CI looked.
+      # That is neither a compile error nor a clippy lint, so without this step
+      # nothing stands between such a break and a Windows contributor finding
+      # it by hand, which is how `PermissionStatus::Unknown` (fixed in this PR)
+      # reached master.
+      - name: cargo doc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc --workspace --no-deps --document-private-items \
+            --exclude openlogi-ui \
+            --exclude openlogi-desktop \
+            --exclude openlogi-overlay \
+            --exclude openlogi-agent
 
   wasm:
     name: wasm (portable crates)

--- a/crates/openlogi-permissions/src/lib.rs
+++ b/crates/openlogi-permissions/src/lib.rs
@@ -36,7 +36,12 @@ mod macos;
 mod tests;
 
 /// Tri-state result of a permission query.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+///
+/// Declared on every platform, like [`Permission::Accessibility`] beside it,
+/// rather than only on the two that can answer one. Windows has no permission
+/// to report, but the module docs above still name this type, and a `cfg` that
+/// deletes it there turns those docs into a broken intra-doc link that fails
+/// the whole crate's rustdoc build on Windows alone.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PermissionStatus {
     /// The app may use the capability.

--- a/xtask/src/commands/ci/jobs/tests.rs
+++ b/xtask/src/commands/ci/jobs/tests.rs
@@ -26,12 +26,39 @@ fn workflow() -> Option<String> {
 /// The workflow with its line continuations joined back up and every run of
 /// whitespace collapsed, so a command it wraps for readability is one line
 /// again.
+///
+/// Line endings are normalized first. Git hands Windows checkouts CRLF unless
+/// a `.gitattributes` overrides it, and a continuation is then a backslash
+/// followed by CRLF, which the join below does not match — leaving a stray
+/// backslash mid-command and failing every wrapped command in
+/// [`ci_yml_runs_what_this_runner_runs`] on exactly one platform.
 fn workflow_commands(workflow: &str) -> String {
     workflow
+        .replace("\r\n", "\n")
         .replace("\\\n", " ")
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+/// The parser must not care how git checked the workflow out. A CRLF tree
+/// wraps continuations as a backslash followed by CRLF; missing that leaves a
+/// stray backslash mid-command and fails every wrapped command on Windows
+/// alone — invisible to CI, which is Linux and macOS.
+#[test]
+fn line_continuations_join_under_either_line_ending() {
+    let lf = "run: cargo doc --workspace \\\n  --no-deps --document-private-items";
+    let crlf = lf.replace('\n', "\r\n");
+
+    assert_eq!(
+        workflow_commands(lf),
+        "run: cargo doc --workspace --no-deps --document-private-items"
+    );
+    assert_eq!(
+        workflow_commands(&crlf),
+        workflow_commands(lf),
+        "a CRLF checkout must parse to the same commands as an LF one"
+    );
 }
 
 /// `ci.yml` is the pipeline's source of truth and this runner is a copy of it.


### PR DESCRIPTION
## Summary

Two independent defects made AGENTS.md's "hard stop" local gate impossible to pass on a Windows checkout of unmodified `master`. Both are invisible to CI, because every job that would catch them runs on Linux or macOS. The practical effect is that a Windows contributor cannot tell their own breakage from the tree's, which is exactly what the gate exists to prevent.

Verified by running the gate against clean `master` before and after.

A third change stops the same class of breakage recurring: the Windows clippy job now builds the docs too, so the gap that let both defects reach master closes with them.

## Changes

- **`xtask`** — `workflow_commands` joined `ci.yml`'s line continuations by matching a backslash followed by LF. Git hands Windows checkouts CRLF unless a `.gitattributes` overrides it, and no rule covers `.github/`, so there the continuation is a backslash followed by CRLF and the join silently misses it, leaving a stray backslash mid-command:

  ```
  left:  "run: cargo doc --workspace \ --no-deps --document-private-items"
  right: "run: cargo doc --workspace --no-deps --document-private-items"
  ```

  Every wrapped command in `ci_yml_runs_what_this_runner_runs` failed as a result, so `cargo test --workspace` could not pass. Normalizing CRLF before the join fixes the parser rather than the checkout, so it holds however a contributor's git is configured — a `.gitattributes` would only help trees re-checked-out after it landed. A test asserts both line endings parse identically.

- **`openlogi-permissions`** — the module docs name `PermissionStatus::Unknown`, but the enum was `cfg(any(macos, linux))`. On Windows the link had no target, `lib.rs` denies `rustdoc::broken_intra_doc_links`, and the crate's docs failed to build, taking the rustdoc gate with them. The enum is now declared on every platform.

  Escaping the link to plain backticks was the other option and is the one to avoid: master settled the identical bug in `openlogi-hid` by keeping the link (#661), and `Permission::Accessibility` directly below is already declared everywhere despite documenting a macOS-only capability. The crate's vocabulary is uniform; only the platform code that answers with it is gated. Windows constructs no `PermissionStatus`, so the type is inert there rather than wrong.

- **`.github/workflows/ci.yml`** — the Windows clippy job now runs the `rustdoc` job's own `cargo doc` line after clippy. Both defects above reached master for the same structural reason: `rustdoc (non-GUI crates)` runs on ubuntu-latest, so a `cfg`-gated doc target present on Linux and macOS but missing on Windows leaves an intra-doc link that resolves everywhere CI looks. A broken link is neither a compile error nor a clippy lint, so the existing Windows job could not catch it either. The toolchain and cache are already set up there, so closing the gap costs one doc build and no new runner. Fixing the two instances without this leaves the third to be found by hand by whoever next runs the gate on Windows — the failure mode this PR exists to remove.

## Testing

Full gate on Windows 11 Pro (10.0.26200), `RUSTFLAGS="-D warnings"`, on this branch rebased onto current `master` (`d5e2b880`).

```
cargo fmt --all -- --check                                    pass
cargo clippy --workspace --all-targets -- -D warnings         pass
cargo test --workspace                                        pass
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps   --document-private-items --exclude openlogi-ui   --exclude openlogi-desktop --exclude openlogi-overlay   --exclude openlogi-agent                                    pass
```

All four pass together on a Windows checkout. The control is direct: #670 and
#942, rebased onto the same `master` tip on the same host, both fail exactly the
two things this PR fixes - `cargo test --workspace` on
`ci_yml_runs_what_this_runner_runs`, and workspace rustdoc on
unresolved link to `PermissionStatus::Unknown`. Both are green here.

The xtask fix is proven by its own test: reverting just the normalization line
makes `line_continuations_join_under_either_line_ending` fail on the stray
backslash.

Cross-linted `openlogi-permissions` for `x86_64-unknown-linux-gnu` and
`x86_64-apple-darwin` as well as the host - all clean, so the un-gating changes
nothing on the platforms that already had the type.

`cargo xtask ci typos` **not run** - this host has no `typos-cli`.

No hardware involved in any of the three changes.
