### PR TITLE
feat(scroll): preserve precise scroll distances

### DIFF
--- a/crates/openlogi-agent-core/src/event_monitor.rs
+++ b/crates/openlogi-agent-core/src/event_monitor.rs
@@ -58,12 +58,17 @@ impl EventMonitor {
                 button: id.to_string(),
                 pressed: *pressed,
             },
-            MouseEvent::Scroll {
-                delta_x, delta_y, ..
-            } => MonitorEvent::Scroll {
-                delta_x: *delta_x,
-                delta_y: *delta_y,
-            },
+            MouseEvent::Scroll { delta, .. } =>
+            {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "the monitor wire format is diagnostic f32 data; runtime scroll keeps f64"
+                )]
+                MonitorEvent::Scroll {
+                    delta_x: delta.x() as f32,
+                    delta_y: delta.y() as f32,
+                }
+            }
             MouseEvent::CaptureInterrupted => MonitorEvent::CaptureInterrupted,
             MouseEvent::Moved { .. } => return,
         };
@@ -173,8 +178,7 @@ mod tests {
         m.poll(); // enable
         for _ in 0..(CAPACITY + 10) {
             m.record(&MouseEvent::Scroll {
-                delta_x: 0.0,
-                delta_y: 1.0,
+                delta: openlogi_hook::ScrollDelta::wheel_ticks(0.0, 1.0),
                 from_trackpad: false,
                 device: None,
             });

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -444,17 +444,15 @@ pub fn start(
                     dispatcher.cancel_hook_thread_buttons();
                     EventDisposition::PassThrough
                 }
-                MouseEvent::Scroll {
-                    delta_x, delta_y, ..
-                } => {
+                MouseEvent::Scroll { delta, .. } => {
                     #[cfg(not(target_os = "windows"))]
-                    let _ = (delta_x, delta_y);
+                    let _ = delta;
                     #[cfg(target_os = "windows")]
-                    if delta_y == 0.0
+                    if delta.y() == 0.0
                         && let Some((button, action)) = hooks
                             .try_read()
                             .ok()
-                            .and_then(|maps| rebound_thumbwheel_action(&maps, delta_x))
+                            .and_then(|maps| rebound_thumbwheel_action(&maps, delta.x()))
                     {
                         info!(button = %button, action = %action.label(), "native thumb wheel → executing bound action");
                         if try_queue_action(&action_tx, action) {
@@ -490,7 +488,7 @@ pub fn start(
 /// Windows/MX Master 2S, positive `WM_MOUSEHWHEEL` delta is the physical
 /// backward/down direction, so it maps to `ThumbwheelScrollDown`.
 #[cfg(any(target_os = "windows", test))]
-fn rebound_thumbwheel_action(maps: &HookMaps, delta_x: f32) -> Option<(ButtonId, Action)> {
+fn rebound_thumbwheel_action(maps: &HookMaps, delta_x: f64) -> Option<(ButtonId, Action)> {
     let button = if delta_x > 0.0 {
         ButtonId::ThumbwheelScrollDown
     } else if delta_x < 0.0 {

--- a/crates/openlogi-core/src/lib.rs
+++ b/crates/openlogi-core/src/lib.rs
@@ -24,5 +24,6 @@ pub mod diagnostics;
 pub mod hid;
 #[cfg(feature = "fs")]
 pub mod paths;
+pub mod scroll;
 #[cfg(feature = "fs")]
 pub mod single_instance;

--- a/crates/openlogi-core/src/scroll.rs
+++ b/crates/openlogi-core/src/scroll.rs
@@ -1,0 +1,82 @@
+//! Platform-neutral scroll distances.
+
+/// A signed two-axis scroll distance with an explicit unit.
+///
+/// Positive horizontal values scroll right; positive vertical values scroll
+/// up. Keeping pixels distinct from standard wheel ticks prevents a smooth
+/// scrolling runtime from accidentally interpolating or accumulating unlike
+/// quantities.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ScrollDelta {
+    /// Pixel-precise scrolling, as reported by continuous macOS wheel events.
+    Pixels {
+        /// Horizontal distance; positive scrolls right.
+        x: f64,
+        /// Vertical distance; positive scrolls up.
+        y: f64,
+    },
+    /// Standard wheel ticks. One tick is one detent, represented by 120
+    /// high-resolution wheel units on Linux and Windows.
+    WheelTicks {
+        /// Horizontal distance; positive scrolls right.
+        x: f64,
+        /// Vertical distance; positive scrolls up.
+        y: f64,
+    },
+}
+
+impl ScrollDelta {
+    /// Construct a pixel-precise scroll distance.
+    #[must_use]
+    pub const fn pixels(x: f64, y: f64) -> Self {
+        Self::Pixels { x, y }
+    }
+
+    /// Construct a scroll distance in standard wheel ticks.
+    #[must_use]
+    pub const fn wheel_ticks(x: f64, y: f64) -> Self {
+        Self::WheelTicks { x, y }
+    }
+
+    /// Return the signed horizontal distance in this value's unit.
+    #[must_use]
+    pub const fn x(self) -> f64 {
+        match self {
+            Self::Pixels { x, .. } | Self::WheelTicks { x, .. } => x,
+        }
+    }
+
+    /// Return the signed vertical distance in this value's unit.
+    #[must_use]
+    pub const fn y(self) -> f64 {
+        match self {
+            Self::Pixels { y, .. } | Self::WheelTicks { y, .. } => y,
+        }
+    }
+
+    /// Whether both components are finite numbers suitable for interpolation.
+    #[must_use]
+    pub fn is_finite(self) -> bool {
+        self.x().is_finite() && self.y().is_finite()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScrollDelta;
+
+    #[test]
+    fn units_remain_distinct() {
+        assert_ne!(
+            ScrollDelta::pixels(1.0, -2.0),
+            ScrollDelta::wheel_ticks(1.0, -2.0)
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_components() {
+        assert!(!ScrollDelta::pixels(f64::NAN, 0.0).is_finite());
+        assert!(!ScrollDelta::wheel_ticks(0.0, f64::INFINITY).is_finite());
+        assert!(ScrollDelta::wheel_ticks(0.25, -1.0).is_finite());
+    }
+}

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -29,6 +29,7 @@ use std::cfg_select;
 
 pub use openlogi_core::app::ForegroundApp;
 pub use openlogi_core::binding::ButtonId;
+pub use openlogi_core::scroll::ScrollDelta;
 
 /// Logitech's USB/Bluetooth vendor id (`0x046D`), widened from
 /// [`openlogi_core::hid::LOGITECH_VENDOR_ID`] because the hook's identity
@@ -148,12 +149,10 @@ pub enum MouseEvent {
         /// attribute the event (Windows today) or it was synthetic.
         device: Option<EventDevice>,
     },
-    /// A scroll-wheel tick (or continuous momentum scroll).
+    /// A scroll-wheel tick or pixel-precise continuous scroll.
     Scroll {
-        /// Positive = right, negative = left.
-        delta_x: f32,
-        /// Positive = down, negative = up.
-        delta_y: f32,
+        /// Signed two-axis distance with its native unit preserved.
+        delta: ScrollDelta,
         /// `true` when the OS attributes this scroll to a trackpad / Magic Mouse
         /// gesture rather than a mouse wheel, so a consumer can transform the
         /// wheel while leaving native trackpad scrolling alone (issue #126).

--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -352,12 +352,11 @@ fn wait_readable(device_fd: i32, stop_fd: i32) -> bool {
     }
 }
 
-fn scroll(delta_x: f32, delta_y: f32) -> MouseEvent {
+fn scroll(delta_x: f64, delta_y: f64) -> MouseEvent {
     // evdev delivers the wheel and the trackpad as distinct devices, so a wheel
     // event is always a mouse wheel — never a trackpad gesture.
     MouseEvent::Scroll {
-        delta_x,
-        delta_y,
+        delta: crate::ScrollDelta::wheel_ticks(delta_x, delta_y),
         from_trackpad: false,
         device: None,
     }
@@ -389,18 +388,14 @@ fn translate(event: &evdev::InputEvent, hires_scroll: bool) -> Option<MouseEvent
                 delta_y: value,
             }),
             _ => {
-                #[expect(
-                    clippy::cast_precision_loss,
-                    reason = "scroll deltas fit comfortably in the f32 mantissa"
-                )]
-                let v = value as f32;
+                let v = f64::from(value);
                 if hires_scroll {
                     match axis {
                         RelativeAxisCode::REL_WHEEL_HI_RES => {
-                            Some(scroll(0.0, v / HIRES_UNITS_PER_TICK))
+                            Some(scroll(0.0, v / f64::from(HIRES_UNITS_PER_TICK)))
                         }
                         RelativeAxisCode::REL_HWHEEL_HI_RES => {
-                            Some(scroll(v / HIRES_UNITS_PER_TICK, 0.0))
+                            Some(scroll(v / f64::from(HIRES_UNITS_PER_TICK), 0.0))
                         }
                         // Low-res ticks are redundant when hi-res is active.
                         _ => None,
@@ -876,9 +871,9 @@ mod tests {
         let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_WHEEL.0, 3);
         let result = translate(&event, false);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
-                if delta_x.abs() < f32::EPSILON && (delta_y - 3.0).abs() < f32::EPSILON),
-            "expected Scroll {{ delta_x: 0.0, delta_y: 3.0 }}, got {result:?}"
+            matches!(result, Some(MouseEvent::Scroll { delta, .. })
+                if delta == crate::ScrollDelta::wheel_ticks(0.0, 3.0)),
+            "expected a three-tick vertical scroll, got {result:?}"
         );
     }
 
@@ -887,9 +882,9 @@ mod tests {
         let event = InputEvent::new(EventType::RELATIVE.0, RelativeAxisCode::REL_HWHEEL.0, -2);
         let result = translate(&event, false);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
-                if (delta_x - -2.0).abs() < f32::EPSILON && delta_y.abs() < f32::EPSILON),
-            "expected Scroll {{ delta_x: -2.0, delta_y: 0.0 }}, got {result:?}"
+            matches!(result, Some(MouseEvent::Scroll { delta, .. })
+                if delta == crate::ScrollDelta::wheel_ticks(-2.0, 0.0)),
+            "expected a negative two-tick horizontal scroll, got {result:?}"
         );
     }
 
@@ -905,9 +900,9 @@ mod tests {
         );
         let result = translate(&event, true);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
-                if delta_x.abs() < f32::EPSILON && (delta_y - 0.5).abs() < f32::EPSILON),
-            "expected Scroll {{ delta_x: 0.0, delta_y: 0.5 }}, got {result:?}"
+            matches!(result, Some(MouseEvent::Scroll { delta, .. })
+                if delta == crate::ScrollDelta::wheel_ticks(0.0, 0.5)),
+            "expected a half-tick vertical scroll, got {result:?}"
         );
     }
 
@@ -920,9 +915,9 @@ mod tests {
         );
         let result = translate(&event, true);
         assert!(
-            matches!(result, Some(MouseEvent::Scroll { delta_x, delta_y, .. })
-                if (delta_x - -1.0).abs() < f32::EPSILON && delta_y.abs() < f32::EPSILON),
-            "expected Scroll {{ delta_x: -1.0, delta_y: 0.0 }}, got {result:?}"
+            matches!(result, Some(MouseEvent::Scroll { delta, .. })
+                if delta == crate::ScrollDelta::wheel_ticks(-1.0, 0.0)),
+            "expected a negative one-tick horizontal scroll, got {result:?}"
         );
     }
 

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -341,8 +341,9 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
         }
         CGEventType::ScrollWheel => {
             // axis 1 = vertical scroll; axis 2 = horizontal scroll. Continuous
-            // events carry pixel-precise distance; ordinary ratchets carry line
-            // deltas. Preserve that distinction instead of handing consumers an
+            // events carry pixel-precise distance; non-continuous events carry
+            // line distance, including fractional lines in the 16.16 fields.
+            // Preserve that distinction instead of handing consumers an
             // unlabelled number that cannot be safely interpolated.
             let continuous =
                 event.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0;
@@ -352,10 +353,7 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
                     precise_scroll_delta(event, VERTICAL),
                 )
             } else {
-                ScrollDelta::wheel_ticks(
-                    line_scroll_delta(event, HORIZONTAL),
-                    line_scroll_delta(event, VERTICAL),
-                )
+                non_continuous_scroll_delta(event)
             };
             // Device identity is the reliable signal: a free-spinning Logitech
             // wheel sets the CGEvent phase, so phase alone misclassifies it as a
@@ -445,6 +443,34 @@ fn precise_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
         return fixed;
     }
     0.0
+}
+
+/// Preserve fractional line distance from a non-continuous high-resolution
+/// wheel. `CGEventGetDoubleValueField` decodes the signed 16.16 field for us;
+/// the integer line field is only the fallback for older event producers.
+///
+/// A producer may expose only point distance. Apple defines no universal
+/// point-to-line ratio, so retain that event as pixels instead of inventing a
+/// wheel-tick conversion or dropping it as a zero-line event.
+fn non_continuous_scroll_delta(event: &CGEvent) -> ScrollDelta {
+    let x = fractional_line_scroll_delta(event, HORIZONTAL);
+    let y = fractional_line_scroll_delta(event, VERTICAL);
+    if x != 0.0 || y != 0.0 {
+        return ScrollDelta::wheel_ticks(x, y);
+    }
+
+    ScrollDelta::pixels(
+        event.get_double_value_field(HORIZONTAL.point),
+        event.get_double_value_field(VERTICAL.point),
+    )
+}
+
+fn fractional_line_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
+    let fixed = event.get_double_value_field(axis.fixed);
+    if fixed != 0.0 {
+        return fixed;
+    }
+    line_scroll_delta(event, axis)
 }
 
 #[expect(

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -31,7 +31,8 @@ use tracing::{debug, error, warn};
 
 use crate::{
     ButtonId, CursorPosition, EventDevice, EventDisposition, EventTapInfo, ForegroundApp,
-    HookBackend, HookError, HookEvent, KeyEvent, KeyModifiers, MouseEvent, TapLocation,
+    HookBackend, HookError, HookEvent, KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
+    TapLocation,
 };
 use watchdog::{
     LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, RearmBudget,
@@ -339,12 +340,23 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             })
         }
         CGEventType::ScrollWheel => {
-            // axis 1 = vertical scroll; axis 2 = horizontal scroll. Read the
-            // pixel-precise delta in preference to the coarse line delta (a hi-res
-            // wheel reports its motion in the pixel field with the line field at 0,
-            // so reading only the line field would look like "no scroll").
-            let dy = usable_scroll_delta(event, VERTICAL);
-            let dx = usable_scroll_delta(event, HORIZONTAL);
+            // axis 1 = vertical scroll; axis 2 = horizontal scroll. Continuous
+            // events carry pixel-precise distance; ordinary ratchets carry line
+            // deltas. Preserve that distinction instead of handing consumers an
+            // unlabelled number that cannot be safely interpolated.
+            let continuous =
+                event.get_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS) != 0;
+            let delta = if continuous {
+                ScrollDelta::pixels(
+                    precise_scroll_delta(event, HORIZONTAL),
+                    precise_scroll_delta(event, VERTICAL),
+                )
+            } else {
+                ScrollDelta::wheel_ticks(
+                    line_scroll_delta(event, HORIZONTAL),
+                    line_scroll_delta(event, VERTICAL),
+                )
+            };
             // Device identity is the reliable signal: a free-spinning Logitech
             // wheel sets the CGEvent phase, so phase alone misclassifies it as a
             // trackpad. Fall back to the phase heuristic only for a sender-less
@@ -355,13 +367,8 @@ fn translate(etype: CGEventType, event: &CGEvent) -> Option<MouseEvent> {
             let sender = event_sender_id(event);
             let device_info = sender.map(sender_device_info);
             let from_trackpad = device_info.as_ref().map_or(phase, |info| info.is_trackpad);
-            #[expect(
-                clippy::cast_possible_truncation,
-                reason = "scroll deltas are small fractional values that fit comfortably in f32"
-            )]
             Some(MouseEvent::Scroll {
-                delta_x: dx as f32,
-                delta_y: dy as f32,
+                delta,
                 from_trackpad,
                 device: device_info.map(|info| info.event_device),
             })
@@ -426,15 +433,9 @@ const SCROLL_PHASE: CGEventField = 99; // kCGScrollWheelEventScrollPhase
 const SCROLL_COUNT: CGEventField = 100; // kCGScrollWheelEventScrollCount
 const MOMENTUM_PHASE: CGEventField = 123; // kCGScrollWheelEventMomentumPhase
 
-/// The scroll magnitude for `axis`, preferring the pixel-precise field, then the
-/// fixed-point, then the integer line — the order the reference tools use, so a
-/// hi-res wheel (which reports in the pixel field with the line field at 0) is
-/// not mistaken for "no scroll".
-#[expect(
-    clippy::cast_precision_loss,
-    reason = "scroll line deltas are small integers, exact in f64"
-)]
-fn usable_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
+/// The pixel magnitude for continuous `axis`, preferring the point field and
+/// falling back to the fixed-point field used by older producers.
+fn precise_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
     let point = event.get_double_value_field(axis.point);
     if point != 0.0 {
         return point;
@@ -443,6 +444,14 @@ fn usable_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
     if fixed != 0.0 {
         return fixed;
     }
+    0.0
+}
+
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "physical per-event line deltas are small integers, exactly represented by f64"
+)]
+fn line_scroll_delta(event: &CGEvent, axis: ScrollAxisFields) -> f64 {
     event.get_integer_value_field(axis.line) as f64
 }
 

--- a/crates/openlogi-hook/src/tests.rs
+++ b/crates/openlogi-hook/src/tests.rs
@@ -29,8 +29,7 @@ fn mouse_event_clone_and_debug() {
             device: None,
         },
         MouseEvent::Scroll {
-            delta_x: 1.0,
-            delta_y: -1.5,
+            delta: ScrollDelta::wheel_ticks(1.0, -1.5),
             from_trackpad: false,
             device: None,
         },

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -29,10 +29,10 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 
 use crate::{
     ButtonId, CursorPosition, EventDisposition, ForegroundApp, HookBackend, HookError, HookEvent,
-    KeyEvent, KeyModifiers, MouseEvent,
+    KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
 };
 
-const WHEEL_DELTA: f32 = 120.0;
+const WHEEL_DELTA: f64 = 120.0;
 
 thread_local! {
     /// Cursor position carried by the previous mouse message of any kind,
@@ -401,14 +401,18 @@ fn translate_event(wparam: WPARAM, data: MSLLHOOKSTRUCT) -> Option<MouseEvent> {
         // WM_MOUSEWHEEL and precision-touchpad scrolling as separate input, so
         // a wheel event is unambiguously a mouse wheel (unlike macOS).
         WM_MOUSEWHEEL => Some(MouseEvent::Scroll {
-            delta_x: 0.0,
-            delta_y: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
+            delta: ScrollDelta::wheel_ticks(
+                0.0,
+                f64::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
+            ),
             from_trackpad: false,
             device: None,
         }),
         WM_MOUSEHWHEEL => Some(MouseEvent::Scroll {
-            delta_x: f32::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
-            delta_y: 0.0,
+            delta: ScrollDelta::wheel_ticks(
+                f64::from(signed_high_word(data.mouseData)) / WHEEL_DELTA,
+                0.0,
+            ),
             from_trackpad: false,
             device: None,
         }),
@@ -708,16 +712,16 @@ mod tests {
             mouseData: 120u32 << 16,
             ..MSLLHOOKSTRUCT::default()
         };
-        let Some(MouseEvent::Scroll {
-            delta_x, delta_y, ..
-        }) = translate_event(WM_MOUSEWHEEL as WPARAM, forward)
+        let Some(MouseEvent::Scroll { delta, .. }) =
+            translate_event(WM_MOUSEWHEEL as WPARAM, forward)
         else {
             panic!("expected a scroll event");
         };
-        assert!(delta_x.abs() < f32::EPSILON);
+        assert!(delta.x().abs() < f64::EPSILON);
         assert!(
-            delta_y > 0.0,
-            "wheel-forward should scroll up, got {delta_y}"
+            delta.y() > 0.0,
+            "wheel-forward should scroll up, got {}",
+            delta.y()
         );
     }
 }

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -14,6 +14,7 @@ use std::sync::{LazyLock, Mutex, PoisonError};
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 use openlogi_core::binding::KeyboardUsage;
 use openlogi_core::binding::{Action, KeyCombo};
+use openlogi_core::scroll::ScrollDelta;
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -310,6 +311,69 @@ pub fn ax_navigate_browser(pid: i32, forward: bool) -> bool {
     }
 }
 
+/// Integer scroll units ready for a platform API.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct QuantizedScroll {
+    x: i32,
+    y: i32,
+}
+
+/// Carries fractional platform units across frames so rounding never changes
+/// the cumulative distance.
+#[derive(Default)]
+struct ScrollQuantizer {
+    residual_x: f64,
+    residual_y: f64,
+}
+
+impl ScrollQuantizer {
+    fn quantize(&mut self, delta: ScrollDelta, units_per_input: f64) -> QuantizedScroll {
+        QuantizedScroll {
+            x: quantize_axis(&mut self.residual_x, delta.x(), units_per_input),
+            y: quantize_axis(&mut self.residual_y, delta.y(), units_per_input),
+        }
+    }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the rounded value is clamped to the i32 range before conversion"
+)]
+fn quantize_axis(residual: &mut f64, input: f64, units_per_input: f64) -> i32 {
+    let exact = input.mul_add(units_per_input, *residual);
+    let rounded = exact
+        .round()
+        .clamp(f64::from(i32::MIN), f64::from(i32::MAX));
+    let output = rounded as i32;
+    *residual = exact - f64::from(output);
+    output
+}
+
+/// Synthesise a typed scroll distance at the current focus.
+///
+/// Fractional wheel ticks are retained until the platform can represent them,
+/// so a sequence of high-resolution frames preserves its cumulative distance.
+/// Non-finite input is rejected at this I/O boundary.
+pub fn post_scroll(delta: ScrollDelta) {
+    if !delta.is_finite() || (delta.x() == 0.0 && delta.y() == 0.0) {
+        return;
+    }
+    cfg_select! {
+        target_os = "macos" => {
+            macos::post_scroll(delta);
+        }
+        target_os = "linux" => {
+            linux::post_scroll(delta);
+        }
+        target_os = "windows" => {
+            windows::post_scroll(delta);
+        }
+        _ => {
+            let _ = delta;
+        }
+    }
+}
+
 /// Synthesise a scroll of `(delta_x, delta_y)` wheel lines at the current focus.
 ///
 /// Used by the gesture/thumbwheel capture watcher to re-inject the MX thumb
@@ -319,25 +383,10 @@ pub fn ax_navigate_browser(pid: i32, forward: bool) -> bool {
 ///
 /// No-op (logs nothing) on platforms without a supported injection mechanism.
 pub fn post_thumbwheel_scroll(delta_x: i32, delta_y: i32) {
-    cfg_select! {
-        target_os = "macos" => {
-            macos::post_scroll(delta_x, delta_y);
-        }
-        target_os = "linux" => {
-            if delta_y != 0 {
-                linux::scroll(evdev::RelativeAxisCode::REL_WHEEL, delta_y);
-            }
-            if delta_x != 0 {
-                linux::scroll(evdev::RelativeAxisCode::REL_HWHEEL, delta_x);
-            }
-        }
-        target_os = "windows" => {
-            windows::post_scroll(delta_x, delta_y);
-        }
-        _ => {
-            let _ = (delta_x, delta_y);
-        }
-    }
+    post_scroll(ScrollDelta::wheel_ticks(
+        f64::from(delta_x),
+        f64::from(delta_y),
+    ));
 }
 
 /// Return the `/dev/input/eventN` node for the action-injector uinput device,
@@ -406,11 +455,39 @@ fn hid_usage_to_windows(usage: u8) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
+    use openlogi_core::scroll::ScrollDelta;
+
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     use openlogi_core::binding::KeyCombo;
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     use super::{HeldKey, HeldOutput, HoldTransition};
+    use super::{QuantizedScroll, ScrollQuantizer};
+
+    /// Synthetic high-resolution input: eight eighth-ticks must total exactly
+    /// one Windows/Linux wheel detent (120 raw units). This is deterministic
+    /// model data, not a hardware capture.
+    #[test]
+    fn fractional_frames_preserve_cumulative_wheel_distance() {
+        let mut quantizer = ScrollQuantizer::default();
+        let total = (0..8)
+            .map(|_| {
+                quantizer
+                    .quantize(ScrollDelta::wheel_ticks(0.0, 0.125), 120.0)
+                    .y
+            })
+            .sum::<i32>();
+        assert_eq!(total, 120);
+    }
+
+    #[test]
+    fn opposing_fractional_input_cancels_without_rounding_drift() {
+        let mut quantizer = ScrollQuantizer::default();
+        let forward = quantizer.quantize(ScrollDelta::wheel_ticks(0.25, 0.0), 120.0);
+        let backward = quantizer.quantize(ScrollDelta::wheel_ticks(-0.25, 0.0), 120.0);
+        assert_eq!(forward, QuantizedScroll { x: 30, y: 0 });
+        assert_eq!(backward, QuantizedScroll { x: -30, y: 0 });
+    }
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn combo(label: &str) -> KeyCombo {

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -15,8 +15,20 @@ use zbus::blocking::Connection as DbusConn;
 use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
+use openlogi_core::scroll::ScrollDelta;
 
-use super::{HeldKey, KeyPhase};
+use super::{HeldKey, KeyPhase, QuantizedScroll, ScrollQuantizer};
+
+const HIGH_RES_UNITS_PER_TICK: f64 = 120.0;
+
+#[derive(Default)]
+struct ScrollOutput {
+    high_resolution: ScrollQuantizer,
+    legacy: ScrollQuantizer,
+}
+
+static SCROLL_OUTPUT: LazyLock<Mutex<ScrollOutput>> =
+    LazyLock::new(|| Mutex::new(ScrollOutput::default()));
 
 /// Linux implementation: classify `action` into an [`Effect`] and inject the
 /// resulting events via a shared `uinput` virtual device.
@@ -284,7 +296,12 @@ fn build() -> io::Result<VirtualDevice> {
     // which can otherwise cause injected key/wheel events to be grabbed by
     // pointer-grabbing X11 clients or routed oddly by some Wayland compositors.
     let mut axes = AttributeSet::<RelativeAxisCode>::default();
-    for a in [RelativeAxisCode::REL_WHEEL, RelativeAxisCode::REL_HWHEEL] {
+    for a in [
+        RelativeAxisCode::REL_WHEEL,
+        RelativeAxisCode::REL_HWHEEL,
+        RelativeAxisCode::REL_WHEEL_HI_RES,
+        RelativeAxisCode::REL_HWHEEL_HI_RES,
+    ] {
         axes.insert(a);
     }
 
@@ -364,8 +381,56 @@ fn click(button: KeyCode) {
 }
 
 /// Inject a single relative-axis delta followed by `SYN_REPORT`.
-pub(super) fn scroll(axis: RelativeAxisCode, value: i32) {
+fn scroll(axis: RelativeAxisCode, value: i32) {
     emit(&[rel_ev(axis, value), syn()]);
+}
+
+pub(super) fn post_scroll(delta: ScrollDelta) {
+    let ScrollDelta::WheelTicks { .. } = delta else {
+        tracing::debug!("pixel scroll output is unsupported on Linux");
+        return;
+    };
+    let Ok(mut output) = SCROLL_OUTPUT.lock() else {
+        tracing::warn!("Linux scroll quantizer mutex poisoned");
+        return;
+    };
+    let high_resolution = output
+        .high_resolution
+        .quantize(delta, HIGH_RES_UNITS_PER_TICK);
+    let legacy = output.legacy.quantize(delta, 1.0);
+    drop(output);
+
+    let mut events = Vec::with_capacity(5);
+    push_scroll_axes(
+        &mut events,
+        high_resolution,
+        RelativeAxisCode::REL_HWHEEL_HI_RES,
+        RelativeAxisCode::REL_WHEEL_HI_RES,
+    );
+    push_scroll_axes(
+        &mut events,
+        legacy,
+        RelativeAxisCode::REL_HWHEEL,
+        RelativeAxisCode::REL_WHEEL,
+    );
+    if !events.is_empty() {
+        events.push(syn());
+        emit(&events);
+    }
+}
+
+fn push_scroll_axes(
+    events: &mut Vec<InputEvent>,
+    delta: QuantizedScroll,
+    horizontal: RelativeAxisCode,
+    vertical: RelativeAxisCode,
+) {
+    if delta.x != 0 {
+        events.push(rel_ev(horizontal, delta.x));
+    }
+    if delta.y != 0 {
+        events.push(rel_ev(vertical, delta.y));
+    }
 }
 
 /// Force the virtual device to initialise (if it hasn't already) and return

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -1,5 +1,7 @@
 //! Platform helpers for synthesising OS-level input events on macOS.
 
+use std::sync::{LazyLock, Mutex};
+
 use core_graphics::event::{
     CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGMouseButton, EventField,
     ScrollEventUnit,
@@ -11,8 +13,14 @@ use core_foundation::base::TCFType as _;
 use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
+use openlogi_core::scroll::ScrollDelta;
 
-use super::{HeldKey, HeldModifiers, KeyPhase};
+use super::{HeldKey, HeldModifiers, KeyPhase, QuantizedScroll, ScrollQuantizer};
+
+static LINE_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
+    LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
+static PIXEL_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
+    LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
 
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
 const NX_KEYTYPE_SOUND_UP: i32 = 0;
@@ -602,23 +610,67 @@ fn dispatch_scroll(dx: i8, dy: i8) {
     ev.post(CGEventTapLocation::HID);
 }
 
-/// Post `(delta_x, delta_y)` scroll lines. Line units suit the thumb wheel's
-/// ratchet-like increments better than pixels.
-pub(super) fn post_scroll(delta_x: i32, delta_y: i32) {
-    if delta_x == 0 && delta_y == 0 {
+pub(super) fn post_scroll(delta: ScrollDelta) {
+    let (quantizer, unit) = match delta {
+        ScrollDelta::Pixels { .. } => (&PIXEL_SCROLL_QUANTIZER, ScrollEventUnit::PIXEL),
+        ScrollDelta::WheelTicks { .. } => (&LINE_SCROLL_QUANTIZER, ScrollEventUnit::LINE),
+    };
+    let Ok(mut quantizer) = quantizer.lock() else {
+        tracing::warn!("macOS scroll quantizer mutex poisoned");
+        return;
+    };
+    let delta = quantizer.quantize(delta, 1.0);
+    drop(quantizer);
+    if delta == QuantizedScroll::default() {
         return;
     }
+
     let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
-        tracing::warn!("CGEventSource::new failed for thumbwheel scroll");
+        tracing::warn!("CGEventSource::new failed for precise scroll");
         return;
     };
-    let Ok(ev) = CGEvent::new_scroll_event(src, ScrollEventUnit::LINE, 2, delta_y, delta_x, 0)
-    else {
-        tracing::warn!("CGEvent::new_scroll_event failed for thumbwheel");
+    let Ok(ev) = CGEvent::new_scroll_event(src, unit, 2, delta.y, delta.x, 0) else {
+        tracing::warn!("CGEvent::new_scroll_event failed for precise scroll");
         return;
     };
+    if unit == ScrollEventUnit::PIXEL {
+        set_continuous_scroll_fields(&ev, delta);
+    }
     tag_synthetic(&ev);
     ev.post(CGEventTapLocation::HID);
+}
+
+fn set_continuous_scroll_fields(event: &CGEvent, delta: QuantizedScroll) {
+    event.set_integer_value_field(EventField::SCROLL_WHEEL_EVENT_IS_CONTINUOUS, 1);
+    set_continuous_axis(
+        event,
+        delta.y,
+        EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_1,
+        EventField::SCROLL_WHEEL_EVENT_FIXED_POINT_DELTA_AXIS_1,
+        EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_1,
+    );
+    set_continuous_axis(
+        event,
+        delta.x,
+        EventField::SCROLL_WHEEL_EVENT_DELTA_AXIS_2,
+        EventField::SCROLL_WHEEL_EVENT_FIXED_POINT_DELTA_AXIS_2,
+        EventField::SCROLL_WHEEL_EVENT_POINT_DELTA_AXIS_2,
+    );
+}
+
+fn set_continuous_axis(
+    event: &CGEvent,
+    points: i32,
+    line_field: u32,
+    fixed_field: u32,
+    point_field: u32,
+) {
+    const POINTS_PER_LINE: i64 = 10;
+    const FIXED_POINT_SCALE: i64 = 1 << 16;
+    let points = i64::from(points);
+    event.set_integer_value_field(point_field, points);
+    event.set_integer_value_field(line_field, points / POINTS_PER_LINE);
+    event.set_integer_value_field(fixed_field, points * FIXED_POINT_SCALE / POINTS_PER_LINE);
 }
 
 /// Raw FFI surface for the AXUIElement/CF calls used by [`ax_browser_navigate`]

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -2,6 +2,7 @@
 #![expect(unsafe_code, reason = "SendInput is the Win32 API for synthetic input")]
 
 use std::mem::size_of;
+use std::sync::{LazyLock, Mutex};
 
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
     INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT, KEYEVENTF_KEYUP, MOUSEEVENTF_HWHEEL,
@@ -13,10 +14,15 @@ use windows_sys::Win32::UI::Input::KeyboardAndMouse::{
 use openlogi_core::binding::{
     Action, Effect, KeyCombo, MediaKey, MouseButton, NativeAction, Script, Shortcut, WorkflowStep,
 };
+use openlogi_core::scroll::ScrollDelta;
 
-use super::{HeldKey, KeyPhase};
+use super::{HeldKey, KeyPhase, ScrollQuantizer};
 
 const WHEEL_DELTA: i32 = 120;
+const WHEEL_DELTA_F64: f64 = 120.0;
+
+static SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
+    LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
 
 const VK_D: u16 = 0x44;
 const VK_L: u16 = 0x4C;
@@ -238,19 +244,24 @@ fn dispatch_scroll(dx: i8, dy: i8) {
     }
 }
 
-pub(super) fn post_scroll(delta_x: i32, delta_y: i32) {
+pub(super) fn post_scroll(delta: ScrollDelta) {
+    let ScrollDelta::WheelTicks { .. } = delta else {
+        tracing::debug!("pixel scroll output is unsupported on Windows");
+        return;
+    };
+    let Ok(mut quantizer) = SCROLL_QUANTIZER.lock() else {
+        tracing::warn!("Windows scroll quantizer mutex poisoned");
+        return;
+    };
+    let delta = quantizer.quantize(delta, WHEEL_DELTA_F64);
+    drop(quantizer);
+
     let mut inputs = Vec::with_capacity(2);
-    if delta_y != 0 {
-        inputs.push(mouse_input(
-            MOUSEEVENTF_WHEEL,
-            delta_y.saturating_mul(WHEEL_DELTA),
-        ));
+    if delta.y != 0 {
+        inputs.push(mouse_input(MOUSEEVENTF_WHEEL, delta.y));
     }
-    if delta_x != 0 {
-        inputs.push(mouse_input(
-            MOUSEEVENTF_HWHEEL,
-            delta_x.saturating_mul(WHEEL_DELTA),
-        ));
+    if delta.x != 0 {
+        inputs.push(mouse_input(MOUSEEVENTF_HWHEEL, delta.x));
     }
     if !inputs.is_empty() {
         send_inputs(&inputs);

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -3,8 +3,8 @@
 mod inject;
 
 pub use inject::{
-    SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_thumbwheel_scroll, press_hold,
-    release_hold, replace_hold,
+    SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_scroll, post_thumbwheel_scroll,
+    press_hold, release_hold, replace_hold,
 };
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Establish an explicit, lossless scroll-distance contract before adding interpolation. Pixel deltas and standard wheel ticks can no longer be mixed accidentally, and fractional wheel output survives platform quantization.

## Changes

- **openlogi-core**
  - add a typed `ScrollDelta` that distinguishes pixels from wheel ticks and fixes the cross-platform sign contract
- **openlogi-hook**
  - preserve macOS continuous pixel events and Linux/Windows high-resolution wheel ticks as `f64`
  - keep trackpad provenance and synthetic-event filtering unchanged
- **openlogi-inject**
  - add typed precise scroll injection with cumulative fractional carry
  - emit Linux `REL_*WHEEL_HI_RES` plus legacy compatibility ticks
  - send sub-120 Windows wheel deltas instead of forcing every output to a full detent
  - populate macOS continuous point, line, and fixed-point fields
- **openlogi-agent-core**
  - adapt hook dispatch and the event monitor without changing the IPC monitor format

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo test -p openlogi-ipc --test wire_format`
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hook -p openlogi-inject -p openlogi-agent-core --all-targets -- -D warnings`
- `cargo clippy --target aarch64-apple-darwin -p openlogi-hook -p openlogi-inject -p openlogi-agent-core --all-targets -- -D warnings`

Synthetic quantization traces cover fractional accumulation and direction reversal. They are deterministic model inputs, not hardware captures.

Not runtime-tested on hardware. Verify with a high-resolution Logitech wheel that sub-detent motion is preserved on Windows/Linux and ordinary wheel/trackpad behavior is unchanged on macOS.

Related to #884
