### PR TITLE
feat(scroll): add finite smooth scroll runtime

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -11,7 +11,7 @@
 //! (still valid) values — exactly the GUI's "window never opened" behaviour.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use openlogi_core::app::ForegroundApp;
@@ -74,6 +74,9 @@ pub struct SharedRuntime {
     /// Function-key remapper bindings (keycode+modifiers → action). Not
     /// per-app-profile in M1 (spec non-goal), so a single shared map.
     pub keyboard_bindings: crate::runtime::hook::SharedKeyboardBindings,
+    /// Live smooth-scroll preference read by the OS-hook callback without
+    /// taking the orchestrator/config lock.
+    pub smooth_scroll_enabled: Arc<AtomicBool>,
     pub dpi_cycle: Arc<RwLock<DpiCycles>>,
     /// One capture plan per online device — what to divert and how to
     /// dispatch, keyed by the device the events arrive on. Carries each
@@ -193,6 +196,7 @@ impl Orchestrator {
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
+            smooth_scroll_enabled: Arc::new(AtomicBool::new(config.app_settings.smooth_scroll)),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
@@ -750,6 +754,9 @@ impl Orchestrator {
         // Parameter-only edits must not erase a transient manual choice while
         // the light remains camera-linked. Changing the policy invalidates it.
         self.config = config;
+        self.shared
+            .smooth_scroll_enabled
+            .store(self.config.app_settings.smooth_scroll, Ordering::Relaxed);
         self.observable
             .set_launch_at_login(self.config.app_settings.launch_at_login);
         let retained_overrides: HashSet<String> = self

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -14,6 +14,7 @@ use openlogi_core::device::{
 };
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use crate::observable::ObservableState;
 
@@ -703,6 +704,19 @@ fn config_reload_keeps_manual_override_for_parameter_edits() {
         Some((true, 80, Some(6500)))
     );
     assert_eq!(orch.manual_light_overrides.get(key), Some(&true));
+}
+
+#[test]
+fn config_reload_publishes_smooth_scroll_without_restarting_the_hook() {
+    let mut orch = orchestrator(Config::default());
+    let setting = Arc::clone(&orch.shared.smooth_scroll_enabled);
+    assert!(!setting.load(Ordering::Relaxed));
+
+    let mut config = Config::default();
+    config.app_settings.smooth_scroll = true;
+    orch.reload_config(config);
+
+    assert!(setting.load(Ordering::Relaxed));
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -7,6 +7,7 @@
 
 mod button;
 pub mod hook;
+pub mod scroll;
 
 use std::collections::HashMap;
 use std::io;

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -19,6 +19,7 @@ use openlogi_hook::{
 };
 use tracing::{info, warn};
 
+use super::scroll::ScrollInputHandle;
 use super::{ActionDispatcher, PressToken};
 use crate::event_monitor::SharedEventMonitor;
 
@@ -197,6 +198,16 @@ fn button_source_may_remap(device: Option<&EventDevice>) -> bool {
             !cfg!(target_os = "macos")
         }
     }
+}
+
+/// Whether a wheel event may be replaced by host-side smooth output.
+///
+/// Native trackpad/pixel gestures always stay untouched. macOS additionally
+/// requires a known Logitech sender; Linux and Windows perform device
+/// selection before this callback and therefore admit their unattributed
+/// wheel events through the same policy as button remapping.
+fn scroll_source_may_smooth(from_trackpad: bool, device: Option<&EventDevice>) -> bool {
+    !from_trackpad && button_source_may_remap(device)
 }
 
 /// Off-thread worker for bound actions so the tap callback never injects input.
@@ -411,6 +422,7 @@ pub fn start(
     hooks: SharedHookMaps,
     keyboard_bindings: SharedKeyboardBindings,
     dispatcher: ActionDispatcher,
+    scroll: ScrollInputHandle,
     monitor: SharedEventMonitor,
 ) -> Option<Hook> {
     if !Hook::has_accessibility() {
@@ -442,11 +454,14 @@ pub fn start(
                     HOLD.with_borrow_mut(HoldState::cancel);
                     HELD_KEYS.with_borrow_mut(HashSet::clear);
                     dispatcher.cancel_hook_thread_buttons();
+                    scroll.cancel_hooks();
                     EventDisposition::PassThrough
                 }
-                MouseEvent::Scroll { delta, .. } => {
-                    #[cfg(not(target_os = "windows"))]
-                    let _ = delta;
+                MouseEvent::Scroll {
+                    delta,
+                    from_trackpad,
+                    device,
+                } => {
                     #[cfg(target_os = "windows")]
                     if delta.y() == 0.0
                         && let Some((button, action)) = hooks
@@ -455,9 +470,10 @@ pub fn start(
                             .and_then(|maps| rebound_thumbwheel_action(&maps, delta.x()))
                     {
                         info!(button = %button, action = %action.label(), "native thumb wheel → executing bound action");
-                        if try_queue_action(&action_tx, action) {
-                            return EventDisposition::Suppress;
-                        }
+                        return queued_event_disposition(try_queue_action(&action_tx, action));
+                    }
+                    if scroll_source_may_smooth(from_trackpad, device.as_ref()) {
+                        return queued_event_disposition(scroll.try_hook_scroll(delta));
                     }
                     EventDisposition::PassThrough
                 }

--- a/crates/openlogi-agent-core/src/runtime/hook/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook/tests.rs
@@ -153,6 +153,28 @@ fn rejected_key_edges_fail_open() {
 }
 
 #[test]
+fn smooth_scroll_uses_the_button_source_safety_policy_and_skips_trackpads() {
+    let logitech = EventDevice {
+        vendor_id: Some(openlogi_hook::LOGITECH_VENDOR_ID),
+        product_name: Some("Logitech MX Master".to_string()),
+        ..EventDevice::default()
+    };
+    let trackpad = EventDevice {
+        product_name: Some("Magic Trackpad".to_string()),
+        ..EventDevice::default()
+    };
+
+    assert!(scroll_source_may_smooth(false, Some(&logitech)));
+    assert!(!scroll_source_may_smooth(true, Some(&logitech)));
+    assert!(!scroll_source_may_smooth(false, Some(&trackpad)));
+    assert_eq!(
+        scroll_source_may_smooth(false, None),
+        !cfg!(target_os = "macos"),
+        "only macOS requires callback-time device attribution"
+    );
+}
+
+#[test]
 fn rebound_horizontal_wheel_maps_to_thumbwheel_directions() {
     let maps = HookMaps {
         bindings: BTreeMap::from([

--- a/crates/openlogi-agent-core/src/runtime/scroll.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll.rs
@@ -1,0 +1,307 @@
+//! Finite smooth-scroll animation owned by one dedicated worker.
+//!
+//! Hook callbacks submit typed wheel impulses through [`ScrollInputHandle`]
+//! without blocking. The worker evaluates motion from absolute timestamps,
+//! retargets an active segment when more input arrives, and emits balanced
+//! phased output. Pixel-precise input never enters this runtime, so native
+//! trackpad and continuous wheel streams cannot be mixed with wheel ticks.
+
+mod worker;
+
+pub use worker::{ScrollInputHandle, ScrollRuntime};
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::thread::{self, ThreadId};
+use std::time::{Duration, Instant};
+
+use openlogi_core::scroll::ScrollDelta;
+use openlogi_inject::SmoothScrollPhase;
+
+/// Duration of every segment, including a segment restarted by retargeting.
+const ANIMATION_DURATION: Duration = Duration::from_millis(100);
+/// Output cadence. Position is evaluated from absolute time, so delayed wakes
+/// do not slow or lengthen the animation.
+const FRAME_INTERVAL: Duration = Duration::from_millis(8);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct WheelDelta {
+    x: f64,
+    y: f64,
+}
+
+impl WheelDelta {
+    const ZERO: Self = Self { x: 0.0, y: 0.0 };
+
+    fn is_zero(self) -> bool {
+        self.x == 0.0 && self.y == 0.0
+    }
+
+    fn plus(self, other: Self) -> Self {
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+        }
+    }
+
+    fn minus(self, other: Self) -> Self {
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+        }
+    }
+
+    fn scale(self, factor: f64) -> Self {
+        Self {
+            x: self.x * factor,
+            y: self.y * factor,
+        }
+    }
+}
+
+impl TryFrom<ScrollDelta> for WheelDelta {
+    type Error = ();
+
+    fn try_from(delta: ScrollDelta) -> Result<Self, Self::Error> {
+        let ScrollDelta::WheelTicks { x, y } = delta else {
+            return Err(());
+        };
+        let delta = Self { x, y };
+        if x.is_finite() && y.is_finite() && !delta.is_zero() {
+            Ok(delta)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<WheelDelta> for ScrollDelta {
+    fn from(delta: WheelDelta) -> Self {
+        Self::wheel_ticks(delta.x, delta.y)
+    }
+}
+
+/// One output frame from the pure motion model.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct ScrollFrame {
+    delta: WheelDelta,
+    phase: SmoothScrollPhase,
+}
+
+impl ScrollFrame {
+    fn new(delta: WheelDelta, phase: SmoothScrollPhase) -> Self {
+        Self { delta, phase }
+    }
+
+    fn post(self) {
+        openlogi_inject::post_smooth_scroll(self.delta.into(), self.phase);
+    }
+}
+
+/// One physical producer. Linux runs one hook callback thread per grabbed
+/// mouse; macOS and Windows use one global callback thread.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum ScrollSource {
+    OsHook(ThreadId),
+}
+
+impl ScrollSource {
+    fn current_hook() -> Self {
+        Self::OsHook(thread::current().id())
+    }
+}
+
+/// A finite cubic smoothstep segment between two cumulative positions.
+struct MotionSegment {
+    from: WheelDelta,
+    target: WheelDelta,
+    started_at: Instant,
+}
+
+impl MotionSegment {
+    fn position_at(&self, at: Instant) -> WheelDelta {
+        let elapsed = at.saturating_duration_since(self.started_at);
+        let progress = (elapsed.as_secs_f64() / ANIMATION_DURATION.as_secs_f64()).clamp(0.0, 1.0);
+        let eased = progress * progress * (3.0 - 2.0 * progress);
+        self.from.plus(self.target.minus(self.from).scale(eased))
+    }
+
+    fn ends_at(&self) -> Instant {
+        self.started_at + ANIMATION_DURATION
+    }
+
+    fn is_complete_at(&self, at: Instant) -> bool {
+        at >= self.ends_at()
+    }
+}
+
+/// A source exists in the state map only while it has a non-zero remaining
+/// target. `output_started` records whether a macOS `Began` phase needs to be
+/// emitted before its terminal phase.
+struct ActiveMotion {
+    segment: MotionSegment,
+    emitted: WheelDelta,
+    next_frame: Instant,
+    output_started: bool,
+}
+
+impl ActiveMotion {
+    fn new(impulse: WheelDelta, at: Instant) -> Self {
+        Self {
+            segment: MotionSegment {
+                from: WheelDelta::ZERO,
+                target: impulse,
+                started_at: at,
+            },
+            emitted: WheelDelta::ZERO,
+            next_frame: at + FRAME_INTERVAL,
+            output_started: false,
+        }
+    }
+
+    /// Evaluate the old segment at the impulse timestamp, then restart toward
+    /// the cumulative target. Returns `false` when opposing input exactly
+    /// consumes the remaining target and this motion is finished immediately.
+    fn retarget(
+        &mut self,
+        impulse: WheelDelta,
+        at: Instant,
+        emit: &mut impl FnMut(ScrollFrame),
+    ) -> bool {
+        let position = self.segment.position_at(at);
+        let target = self.segment.target.plus(impulse);
+        if target == position {
+            self.finish_at(position, emit);
+            return false;
+        }
+
+        self.emit_progress(position, emit);
+        self.segment = MotionSegment {
+            from: position,
+            target,
+            started_at: at,
+        };
+        self.next_frame = at + FRAME_INTERVAL;
+        true
+    }
+
+    /// Emit the position at `at`. Returns whether the segment is complete.
+    fn advance(&mut self, at: Instant, emit: &mut impl FnMut(ScrollFrame)) -> bool {
+        let complete = self.segment.is_complete_at(at);
+        let position = self.segment.position_at(at);
+        if complete {
+            self.finish_at(position, emit);
+        } else {
+            self.emit_progress(position, emit);
+            while self.next_frame <= at {
+                self.next_frame += FRAME_INTERVAL;
+            }
+            self.next_frame = self.next_frame.min(self.segment.ends_at());
+        }
+        complete
+    }
+
+    fn emit_progress(&mut self, position: WheelDelta, emit: &mut impl FnMut(ScrollFrame)) {
+        let delta = position.minus(self.emitted);
+        if delta.is_zero() {
+            return;
+        }
+        let phase = if self.output_started {
+            SmoothScrollPhase::Changed
+        } else {
+            self.output_started = true;
+            SmoothScrollPhase::Began
+        };
+        self.emitted = position;
+        emit(ScrollFrame::new(delta, phase));
+    }
+
+    fn finish_at(&mut self, position: WheelDelta, emit: &mut impl FnMut(ScrollFrame)) {
+        let delta = position.minus(self.emitted);
+        if self.output_started {
+            self.emitted = position;
+            emit(ScrollFrame::new(delta, SmoothScrollPhase::Ended));
+        } else if !delta.is_zero() {
+            self.emitted = position;
+            self.output_started = true;
+            emit(ScrollFrame::new(delta, SmoothScrollPhase::Began));
+            emit(ScrollFrame::new(WheelDelta::ZERO, SmoothScrollPhase::Ended));
+        }
+    }
+
+    fn cancel(self, emit: &mut impl FnMut(ScrollFrame)) {
+        if self.output_started {
+            emit(ScrollFrame::new(
+                WheelDelta::ZERO,
+                SmoothScrollPhase::Cancelled,
+            ));
+        }
+    }
+}
+
+/// Pure per-source state machine. Absence from the map represents idle, so an
+/// idle source cannot accidentally retain a target or scheduled deadline.
+#[derive(Default)]
+struct ScrollEngine {
+    active: HashMap<ScrollSource, ActiveMotion>,
+}
+
+impl ScrollEngine {
+    fn impulse(
+        &mut self,
+        source: ScrollSource,
+        impulse: WheelDelta,
+        at: Instant,
+        emit: &mut impl FnMut(ScrollFrame),
+    ) {
+        if self
+            .active
+            .get(&source)
+            .is_some_and(|motion| motion.segment.is_complete_at(at))
+            && let Some(mut completed) = self.active.remove(&source)
+        {
+            completed.advance(at, emit);
+        }
+
+        match self.active.entry(source) {
+            Entry::Occupied(mut entry) => {
+                if !entry.get_mut().retarget(impulse, at, emit) {
+                    entry.remove();
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(ActiveMotion::new(impulse, at));
+            }
+        }
+    }
+
+    fn advance_due(&mut self, at: Instant, emit: &mut impl FnMut(ScrollFrame)) {
+        let due: Vec<ScrollSource> = self
+            .active
+            .iter()
+            .filter_map(|(source, motion)| (motion.next_frame <= at).then_some(*source))
+            .collect();
+        for source in due {
+            let complete = self
+                .active
+                .get_mut(&source)
+                .is_some_and(|motion| motion.advance(at, emit));
+            if complete {
+                self.active.remove(&source);
+            }
+        }
+    }
+
+    fn next_deadline(&self) -> Option<Instant> {
+        self.active.values().map(|motion| motion.next_frame).min()
+    }
+
+    fn cancel_all(&mut self, emit: &mut impl FnMut(ScrollFrame)) {
+        for (_, motion) in self.active.drain() {
+            motion.cancel(emit);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
@@ -1,0 +1,224 @@
+//! Synthetic motion-model traces. These values are algorithm fixtures, not
+//! measurements captured from physical hardware.
+
+use super::*;
+
+fn source() -> ScrollSource {
+    ScrollSource::current_hook()
+}
+
+fn wheel(x: f64, y: f64) -> WheelDelta {
+    WheelDelta { x, y }
+}
+
+fn cumulative(frames: &[ScrollFrame]) -> WheelDelta {
+    frames
+        .iter()
+        .fold(WheelDelta::ZERO, |sum, frame| sum.plus(frame.delta))
+}
+
+fn assert_delta(actual: WheelDelta, expected: WheelDelta) {
+    const EPSILON: f64 = 1.0e-12;
+    assert!(
+        (actual.x - expected.x).abs() < EPSILON,
+        "x: {} != {}",
+        actual.x,
+        expected.x
+    );
+    assert!(
+        (actual.y - expected.y).abs() < EPSILON,
+        "y: {} != {}",
+        actual.y,
+        expected.y
+    );
+}
+
+#[test]
+fn synthetic_ratchet_trace_follows_cubic_smoothstep_and_finishes_exactly() {
+    let base = Instant::now();
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(source(), wheel(0.0, 1.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+
+    engine.advance_due(base + Duration::from_millis(25), &mut |frame| {
+        frames.push(frame);
+    });
+    assert_delta(cumulative(&frames), wheel(0.0, 0.15625));
+
+    engine.advance_due(base + Duration::from_millis(50), &mut |frame| {
+        frames.push(frame);
+    });
+    assert_delta(cumulative(&frames), wheel(0.0, 0.5));
+
+    engine.advance_due(base + Duration::from_millis(100), &mut |frame| {
+        frames.push(frame);
+    });
+    assert_delta(cumulative(&frames), wheel(0.0, 1.0));
+    assert_eq!(
+        frames.first().map(|frame| frame.phase),
+        Some(SmoothScrollPhase::Began)
+    );
+    assert_eq!(
+        frames.last().map(|frame| frame.phase),
+        Some(SmoothScrollPhase::Ended)
+    );
+    assert!(engine.active.is_empty());
+}
+
+#[test]
+fn synthetic_high_resolution_burst_retargets_without_losing_distance() {
+    let base = Instant::now();
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    for (millis, delta) in [(0, 0.25), (10, 0.25), (20, 0.25)] {
+        engine.impulse(
+            source(),
+            wheel(0.0, delta),
+            base + Duration::from_millis(millis),
+            &mut |frame| frames.push(frame),
+        );
+    }
+    engine.advance_due(base + Duration::from_millis(120), &mut |frame| {
+        frames.push(frame);
+    });
+
+    assert_delta(cumulative(&frames), wheel(0.0, 0.75));
+    assert!(engine.active.is_empty());
+}
+
+#[test]
+fn synthetic_reversal_crosses_the_current_position_and_conserves_net_input() {
+    let base = Instant::now();
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(source(), wheel(0.0, 1.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.impulse(
+        source(),
+        wheel(0.0, -1.5),
+        base + Duration::from_millis(40),
+        &mut |frame| frames.push(frame),
+    );
+    assert_delta(cumulative(&frames), wheel(0.0, 0.352));
+
+    engine.advance_due(base + Duration::from_millis(140), &mut |frame| {
+        frames.push(frame);
+    });
+    assert_delta(cumulative(&frames), wheel(0.0, -0.5));
+    assert!(engine.active.is_empty());
+}
+
+#[test]
+fn synthetic_sparse_impulses_form_separate_finite_segments() {
+    let base = Instant::now();
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(source(), wheel(0.0, 1.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.advance_due(base + Duration::from_millis(100), &mut |frame| {
+        frames.push(frame);
+    });
+    assert!(engine.active.is_empty());
+
+    engine.impulse(
+        source(),
+        wheel(0.0, 2.0),
+        base + Duration::from_millis(300),
+        &mut |frame| frames.push(frame),
+    );
+    engine.advance_due(base + Duration::from_millis(400), &mut |frame| {
+        frames.push(frame);
+    });
+    assert_delta(cumulative(&frames), wheel(0.0, 3.0));
+    assert!(engine.active.is_empty());
+}
+
+#[test]
+fn synthetic_delayed_frames_use_absolute_time_not_frame_count() {
+    let base = Instant::now();
+    let mut dense = ScrollEngine::default();
+    let mut dense_frames = Vec::new();
+    dense.impulse(source(), wheel(0.0, 1.0), base, &mut |frame| {
+        dense_frames.push(frame);
+    });
+    for millis in (8..=80).step_by(8) {
+        dense.advance_due(base + Duration::from_millis(millis), &mut |frame| {
+            dense_frames.push(frame);
+        });
+    }
+
+    let mut delayed = ScrollEngine::default();
+    let mut delayed_frames = Vec::new();
+    delayed.impulse(source(), wheel(0.0, 1.0), base, &mut |frame| {
+        delayed_frames.push(frame);
+    });
+    delayed.advance_due(base + Duration::from_millis(80), &mut |frame| {
+        delayed_frames.push(frame);
+    });
+    assert_delta(cumulative(&dense_frames), cumulative(&delayed_frames));
+
+    dense.advance_due(base + Duration::from_millis(150), &mut |frame| {
+        dense_frames.push(frame);
+    });
+    delayed.advance_due(base + Duration::from_millis(150), &mut |frame| {
+        delayed_frames.push(frame);
+    });
+    assert_delta(cumulative(&dense_frames), wheel(0.0, 1.0));
+    assert_delta(cumulative(&delayed_frames), wheel(0.0, 1.0));
+}
+
+#[test]
+fn synthetic_opposing_impulses_cancel_before_output() {
+    let base = Instant::now();
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(source(), wheel(0.0, 1.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.impulse(source(), wheel(0.0, -1.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+
+    assert!(frames.is_empty());
+    assert!(engine.active.is_empty());
+}
+
+#[test]
+fn only_finite_nonzero_wheel_ticks_enter_the_model() {
+    assert_eq!(
+        WheelDelta::try_from(ScrollDelta::wheel_ticks(0.25, -1.0)),
+        Ok(wheel(0.25, -1.0))
+    );
+    WheelDelta::try_from(ScrollDelta::pixels(0.0, 1.0)).unwrap_err();
+    WheelDelta::try_from(ScrollDelta::wheel_ticks(0.0, 0.0)).unwrap_err();
+    WheelDelta::try_from(ScrollDelta::wheel_ticks(f64::NAN, 1.0)).unwrap_err();
+}
+
+#[test]
+fn cancellation_emits_one_terminal_phase_only_after_output_began() {
+    let base = Instant::now();
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(source(), wheel(1.0, 0.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.cancel_all(&mut |frame| frames.push(frame));
+    assert!(frames.is_empty());
+
+    engine.impulse(source(), wheel(1.0, 0.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.advance_due(base + Duration::from_millis(25), &mut |frame| {
+        frames.push(frame);
+    });
+    engine.cancel_all(&mut |frame| frames.push(frame));
+    assert_eq!(
+        frames.last().map(|frame| frame.phase),
+        Some(SmoothScrollPhase::Cancelled)
+    );
+    assert_delta(cumulative(&frames), wheel(0.15625, 0.0));
+}

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -14,8 +14,6 @@ use super::{ScrollEngine, ScrollFrame, ScrollSource, WheelDelta};
 
 /// OS-hook callbacks must fail open rather than wait for the worker.
 const INPUT_QUEUE_CAPACITY: usize = 128;
-/// Lets settings, invalidation, and shutdown interrupt an idle worker quickly.
-const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Bounds graceful process shutdown if platform injection stops returning.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -81,12 +79,16 @@ impl ScrollInputHandle {
     /// Invalidate every accepted OS-hook animation without blocking.
     pub fn cancel_hooks(&self) {
         self.generation.fetch_add(1, Ordering::AcqRel);
+        self.wake();
+    }
+
+    fn wake(&self) {
         let _ = self.commands.try_send(ScrollCommand::Wake);
     }
 
     fn stop_accepting(&self) {
         self.accepting.store(false, Ordering::Release);
-        self.cancel_hooks();
+        self.generation.fetch_add(1, Ordering::AcqRel);
     }
 }
 
@@ -136,22 +138,31 @@ impl ScrollRuntime {
 
     /// Reject new input, cancel active output, and join the worker.
     pub fn shutdown(&mut self) {
+        let _ = self.shutdown_with_timeout(SHUTDOWN_TIMEOUT);
+    }
+
+    fn shutdown_with_timeout(&mut self, timeout: Duration) -> bool {
         let Some(worker) = self.worker.take() else {
-            return;
+            return true;
         };
         self.input.stop_accepting();
         let (done, wait) = mpsc::sync_channel(0);
         if self.shutdown.send(ShutdownRequest { done }).is_err() {
             let _ = worker.join();
-            return;
+            return false;
         }
-        if wait.recv_timeout(SHUTDOWN_TIMEOUT).is_err() {
+        // Send the wake only after the shutdown request is visible. Otherwise
+        // an idle worker could consume it first and block again on `commands`.
+        self.input.wake();
+        if wait.recv_timeout(timeout).is_err() {
             warn!("smooth-scroll worker did not shut down before the deadline");
-            return;
+            return false;
         }
         if worker.join().is_err() {
             warn!("smooth-scroll worker panicked during shutdown");
+            return false;
         }
+        true
     }
 }
 
@@ -183,14 +194,15 @@ fn run_worker(
             generation = current_generation;
         }
 
-        let now = Instant::now();
-        let until_frame = engine
-            .next_deadline()
-            .map_or(WORKER_POLL_INTERVAL, |deadline| {
-                deadline.saturating_duration_since(now)
-            })
-            .min(WORKER_POLL_INTERVAL);
-        match commands.recv_timeout(until_frame) {
+        let command = engine.next_deadline().map_or_else(
+            || {
+                commands
+                    .recv()
+                    .map_err(|_| mpsc::RecvTimeoutError::Disconnected)
+            },
+            |deadline| commands.recv_timeout(deadline.saturating_duration_since(Instant::now())),
+        );
+        match command {
             Ok(ScrollCommand::Input(input))
                 if input.generation == generation && enabled.load(Ordering::Relaxed) =>
             {
@@ -235,6 +247,13 @@ mod tests {
         assert!(!input.try_hook_scroll(ScrollDelta::pixels(0.0, 1.0)));
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
         assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+    }
+
+    #[test]
+    fn idle_worker_shutdown_wakes_after_publishing_its_request() {
+        let mut runtime = ScrollRuntime::spawn_with(Arc::new(AtomicBool::new(false)), |_| {})
+            .expect("spawn scroll worker");
+        assert!(runtime.shutdown_with_timeout(Duration::from_millis(100)));
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -1,0 +1,273 @@
+//! Worker ownership and non-blocking producer capability for smooth scrolling.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use openlogi_core::scroll::ScrollDelta;
+use tracing::warn;
+
+use super::{ScrollEngine, ScrollFrame, ScrollSource, WheelDelta};
+
+/// OS-hook callbacks must fail open rather than wait for the worker.
+const INPUT_QUEUE_CAPACITY: usize = 128;
+/// Lets settings, invalidation, and shutdown interrupt an idle worker quickly.
+const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Bounds graceful process shutdown if platform injection stops returning.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+
+struct ScrollInput {
+    generation: u64,
+    source: ScrollSource,
+    impulse: WheelDelta,
+    at: Instant,
+}
+
+enum ScrollCommand {
+    Input(ScrollInput),
+    Wake,
+}
+
+struct ShutdownRequest {
+    done: mpsc::SyncSender<()>,
+}
+
+/// Cloneable, non-owning capability for hook callbacks.
+///
+/// Submission is always non-blocking. `false` means the caller must pass the
+/// physical event through unchanged.
+#[derive(Clone)]
+pub struct ScrollInputHandle {
+    commands: mpsc::SyncSender<ScrollCommand>,
+    generation: Arc<AtomicU64>,
+    accepting: Arc<AtomicBool>,
+    enabled: Arc<AtomicBool>,
+}
+
+impl ScrollInputHandle {
+    /// Queue one ordinary wheel impulse from the current OS-hook thread.
+    ///
+    /// Pixel input, zero/non-finite distance, a disabled preference, a full
+    /// queue, or an unavailable worker are rejected so the callback fails open.
+    pub fn try_hook_scroll(&self, delta: ScrollDelta) -> bool {
+        if !self.accepting.load(Ordering::Acquire) || !self.enabled.load(Ordering::Relaxed) {
+            return false;
+        }
+        let Ok(impulse) = WheelDelta::try_from(delta) else {
+            return false;
+        };
+        let input = ScrollInput {
+            generation: self.generation.load(Ordering::Acquire),
+            source: ScrollSource::current_hook(),
+            impulse,
+            at: Instant::now(),
+        };
+        match self.commands.try_send(ScrollCommand::Input(input)) {
+            Ok(()) => true,
+            Err(mpsc::TrySendError::Full(_)) => {
+                warn!("smooth-scroll queue full — physical wheel event passed through");
+                false
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                warn!("smooth-scroll worker unavailable — physical wheel event passed through");
+                false
+            }
+        }
+    }
+
+    /// Invalidate every accepted OS-hook animation without blocking.
+    pub fn cancel_hooks(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        let _ = self.commands.try_send(ScrollCommand::Wake);
+    }
+
+    fn stop_accepting(&self) {
+        self.accepting.store(false, Ordering::Release);
+        self.cancel_hooks();
+    }
+}
+
+/// Unique owner of the smooth-scroll worker and its graceful shutdown.
+pub struct ScrollRuntime {
+    input: ScrollInputHandle,
+    shutdown: mpsc::Sender<ShutdownRequest>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl ScrollRuntime {
+    /// Start the dedicated animation worker using the live opt-in setting.
+    pub fn spawn(enabled: Arc<AtomicBool>) -> io::Result<Self> {
+        Self::spawn_with(enabled, ScrollFrame::post)
+    }
+
+    pub(super) fn spawn_with(
+        enabled: Arc<AtomicBool>,
+        mut emit: impl FnMut(ScrollFrame) + Send + 'static,
+    ) -> io::Result<Self> {
+        let (commands, command_rx) = mpsc::sync_channel(INPUT_QUEUE_CAPACITY);
+        let (shutdown, shutdown_rx) = mpsc::channel();
+        let generation = Arc::new(AtomicU64::new(0));
+        let input = ScrollInputHandle {
+            commands,
+            generation: Arc::clone(&generation),
+            accepting: Arc::new(AtomicBool::new(true)),
+            enabled: Arc::clone(&enabled),
+        };
+        let worker = thread::Builder::new()
+            .name("openlogi-scroll".into())
+            .spawn(move || {
+                run_worker(&command_rx, &shutdown_rx, &generation, &enabled, &mut emit);
+            })?;
+        Ok(Self {
+            input,
+            shutdown,
+            worker: Some(worker),
+        })
+    }
+
+    /// Clone the non-owning input capability for an OS hook.
+    #[must_use]
+    pub fn input(&self) -> ScrollInputHandle {
+        self.input.clone()
+    }
+
+    /// Reject new input, cancel active output, and join the worker.
+    pub fn shutdown(&mut self) {
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+        self.input.stop_accepting();
+        let (done, wait) = mpsc::sync_channel(0);
+        if self.shutdown.send(ShutdownRequest { done }).is_err() {
+            let _ = worker.join();
+            return;
+        }
+        if wait.recv_timeout(SHUTDOWN_TIMEOUT).is_err() {
+            warn!("smooth-scroll worker did not shut down before the deadline");
+            return;
+        }
+        if worker.join().is_err() {
+            warn!("smooth-scroll worker panicked during shutdown");
+        }
+    }
+}
+
+impl Drop for ScrollRuntime {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn run_worker(
+    commands: &mpsc::Receiver<ScrollCommand>,
+    shutdown: &mpsc::Receiver<ShutdownRequest>,
+    shared_generation: &AtomicU64,
+    enabled: &AtomicBool,
+    emit: &mut impl FnMut(ScrollFrame),
+) {
+    let mut engine = ScrollEngine::default();
+    let mut generation = shared_generation.load(Ordering::Acquire);
+    loop {
+        if let Ok(request) = shutdown.try_recv() {
+            engine.cancel_all(emit);
+            let _ = request.done.send(());
+            return;
+        }
+
+        let current_generation = shared_generation.load(Ordering::Acquire);
+        if current_generation != generation || !enabled.load(Ordering::Relaxed) {
+            engine.cancel_all(emit);
+            generation = current_generation;
+        }
+
+        let now = Instant::now();
+        let until_frame = engine
+            .next_deadline()
+            .map_or(WORKER_POLL_INTERVAL, |deadline| {
+                deadline.saturating_duration_since(now)
+            })
+            .min(WORKER_POLL_INTERVAL);
+        match commands.recv_timeout(until_frame) {
+            Ok(ScrollCommand::Input(input))
+                if input.generation == generation && enabled.load(Ordering::Relaxed) =>
+            {
+                engine.impulse(input.source, input.impulse, input.at, emit);
+            }
+            Ok(ScrollCommand::Input(_) | ScrollCommand::Wake) => {}
+            Err(mpsc::RecvTimeoutError::Timeout) => engine.advance_due(Instant::now(), emit),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                engine.cancel_all(emit);
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn standalone_input(
+        capacity: usize,
+        enabled: bool,
+    ) -> (ScrollInputHandle, mpsc::Receiver<ScrollCommand>) {
+        let (commands, receiver) = mpsc::sync_channel(capacity);
+        (
+            ScrollInputHandle {
+                commands,
+                generation: Arc::new(AtomicU64::new(0)),
+                accepting: Arc::new(AtomicBool::new(true)),
+                enabled: Arc::new(AtomicBool::new(enabled)),
+            },
+            receiver,
+        )
+    }
+
+    #[test]
+    fn callback_submission_rejects_ineligible_input_and_fails_open_when_full() {
+        let (disabled, _receiver) = standalone_input(1, false);
+        assert!(!disabled.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+
+        let (input, _receiver) = standalone_input(1, true);
+        assert!(!input.try_hook_scroll(ScrollDelta::pixels(0.0, 1.0)));
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+        assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+    }
+
+    #[test]
+    fn generation_invalidation_cancels_started_output_out_of_band() {
+        let enabled = Arc::new(AtomicBool::new(true));
+        let (frames, received) = mpsc::channel();
+        let mut runtime = ScrollRuntime::spawn_with(enabled, move |frame| {
+            frames
+                .send(frame)
+                .expect("test frame receiver remains open");
+        })
+        .expect("spawn scroll worker");
+        let input = runtime.input();
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+        assert_eq!(
+            received
+                .recv_timeout(Duration::from_secs(1))
+                .expect("first animation frame")
+                .phase,
+            openlogi_inject::SmoothScrollPhase::Began
+        );
+
+        input.cancel_hooks();
+        loop {
+            let phase = received
+                .recv_timeout(Duration::from_secs(1))
+                .expect("cancellation frame")
+                .phase;
+            if phase == openlogi_inject::SmoothScrollPhase::Cancelled {
+                break;
+            }
+            assert_eq!(phase, openlogi_inject::SmoothScrollPhase::Changed);
+        }
+        runtime.shutdown();
+    }
+}

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -42,6 +42,7 @@ use openlogi_agent_core::action_ring::ActionRingManager;
 use openlogi_agent_core::event_monitor::EventMonitor;
 use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
+use openlogi_agent_core::runtime::scroll::{ScrollInputHandle, ScrollRuntime};
 use openlogi_agent_core::runtime::{ActionDispatcher, ActionRuntime, hook};
 use openlogi_agent_core::watchers;
 use openlogi_core::config::Config;
@@ -164,18 +165,20 @@ fn spawn_hidpp_watchers(shared: &SharedRuntime, dispatcher: ActionDispatcher) {
     );
 }
 
-struct ActionServices {
+struct InputServices {
     ring: Arc<ActionRingManager>,
     triggers: tokio::sync::mpsc::UnboundedReceiver<Option<String>>,
     dispatcher: ActionDispatcher,
-    runtime: ActionRuntime,
+    action_runtime: ActionRuntime,
+    scroll_input: ScrollInputHandle,
+    scroll_runtime: ScrollRuntime,
 }
 
-impl ActionServices {
+impl InputServices {
     fn start(shared: &SharedRuntime) -> Option<Self> {
         let ring = Arc::new(ActionRingManager::default());
         let (sender, triggers) = tokio::sync::mpsc::unbounded_channel();
-        let runtime = match ActionRuntime::new(
+        let action_runtime = match ActionRuntime::new(
             shared.dpi_cycle.clone(),
             shared.capture_channel.clone(),
             shared.channel_registry.clone(),
@@ -188,13 +191,28 @@ impl ActionServices {
                 return None;
             }
         };
-        let dispatcher = runtime.dispatcher();
+        let scroll_runtime = match ScrollRuntime::spawn(Arc::clone(&shared.smooth_scroll_enabled)) {
+            Ok(runtime) => runtime,
+            Err(e) => {
+                warn!(error = %e, "could not start smooth-scroll worker — agent exiting");
+                return None;
+            }
+        };
+        let dispatcher = action_runtime.dispatcher();
+        let scroll_input = scroll_runtime.input();
         Some(Self {
             ring,
             triggers,
             dispatcher,
-            runtime,
+            action_runtime,
+            scroll_input,
+            scroll_runtime,
         })
+    }
+
+    fn shutdown(&mut self) {
+        self.scroll_runtime.shutdown();
+        self.action_runtime.shutdown();
     }
 }
 
@@ -204,7 +222,7 @@ impl ActionServices {
 fn start_hook(
     capture_mouse_events: bool,
     shared: &SharedRuntime,
-    dispatcher: &ActionDispatcher,
+    inputs: &InputServices,
     event_monitor: &Arc<EventMonitor>,
 ) -> Option<Hook> {
     if !capture_mouse_events {
@@ -218,7 +236,8 @@ fn start_hook(
     hook::start(
         shared.hook_maps.clone(),
         shared.keyboard_bindings.clone(),
-        dispatcher.clone(),
+        inputs.dispatcher.clone(),
+        inputs.scroll_input.clone(),
         Arc::clone(event_monitor),
     )
 }
@@ -329,14 +348,10 @@ fn shutdown_signals() -> (Option<()>, Option<()>) {
 /// would any other way of leaving that skips destructors. The agent's run loop
 /// is not the process — macOS keeps the AppKit tray loop on the main thread —
 /// so the exit has to be explicit.
-fn release_hook_and_exit(
-    hook: Option<Hook>,
-    action_runtime: &mut ActionRuntime,
-    reason: &str,
-) -> ! {
+fn release_hook_and_exit(hook: Option<Hook>, inputs: &mut InputServices, reason: &str) -> ! {
     info!(reason, "releasing the input hook and exiting");
     drop(hook);
-    action_runtime.shutdown();
+    inputs.shutdown();
     #[expect(
         clippy::exit,
         reason = "a signalled shutdown must end the process, and the loop that observed it runs off the main thread"
@@ -345,9 +360,10 @@ fn release_hook_and_exit(
 }
 
 /// Stop the hook so no new edge can race the lifecycle cancellation.
-fn stop_hook(hook: &mut Option<Hook>, dispatcher: &ActionDispatcher) {
+fn stop_hook(hook: &mut Option<Hook>, inputs: &InputServices) {
     *hook = None;
-    dispatcher.cancel_hook_buttons();
+    inputs.dispatcher.cancel_hook_buttons();
+    inputs.scroll_input.cancel_hooks();
 }
 
 /// Prompt for Accessibility when the enabled mouse hook needs it.
@@ -464,7 +480,7 @@ async fn run(
         Arc::clone(&observable),
     )));
     let shared = orchestrator.lock().await.shared();
-    let Some(mut actions) = ActionServices::start(&shared) else {
+    let Some(mut inputs) = InputServices::start(&shared) else {
         return;
     };
 
@@ -481,7 +497,7 @@ async fn run(
     ));
 
     // HID++ watchers need no Accessibility permission — start them up front.
-    spawn_hidpp_watchers(&shared, actions.dispatcher.clone());
+    spawn_hidpp_watchers(&shared, inputs.dispatcher.clone());
 
     let mut inventory_rx = watchers::inventory::spawn_with_registry(
         Duration::from_secs(2),
@@ -503,8 +519,8 @@ async fn run(
         Arc::clone(&observable),
         Arc::clone(&pairing),
         Arc::clone(&event_monitor),
-        Arc::clone(&actions.ring),
-        actions.dispatcher.clone(),
+        Arc::clone(&inputs.ring),
+        inputs.dispatcher.clone(),
     );
 
     // The CGEventTap hook is installed once Accessibility is granted and dropped
@@ -542,21 +558,21 @@ async fn run(
                 camera_open = false;
             },
             Some(app) = app_rx.recv() => {
-                apply_foreground_update(app, &orchestrator, &actions.dispatcher).await;
+                apply_foreground_update(app, &orchestrator, &inputs.dispatcher).await;
             }
-            Some(device_key) = actions.triggers.recv() => {
-                begin_action_ring(&orchestrator, &actions.ring, &ring_haptics, device_key.as_deref()).await;
+            Some(device_key) = inputs.triggers.recv() => {
+                begin_action_ring(&orchestrator, &inputs.ring, &ring_haptics, device_key.as_deref()).await;
             }
             Some(granted) = accessibility_rx.recv() => {
                 observable.set_accessibility_granted(granted);
                 if !granted {
-                    stop_hook(&mut hook, &actions.dispatcher);
+                    stop_hook(&mut hook, &inputs);
                 }
                 if granted && hook.is_none() {
                     hook = start_hook(
                         capture_mouse_events,
                         &shared,
-                        &actions.dispatcher,
+                        &inputs,
                         &event_monitor,
                     );
                 }
@@ -565,12 +581,12 @@ async fn run(
                 observable.set_hook_installed(hook.is_some());
             }
             () = shutdown_signal(&mut sigterm, &mut sigint) => {
-                release_hook_and_exit(hook.take(), &mut actions.runtime, "shutdown signal")
+                release_hook_and_exit(hook.take(), &mut inputs, "shutdown signal")
             }
             // The app was removed while we kept running from its bundle. Leave
             // through the same door, so the event tap goes with us (#807).
             Some(()) = uninstalled.recv() => {
-                release_hook_and_exit(hook.take(), &mut actions.runtime, "the app was uninstalled")
+                release_hook_and_exit(hook.take(), &mut inputs, "the app was uninstalled")
             }
             Some(granted) = input_monitoring_rx.recv() => {
                 observable.set_input_monitoring_granted(granted);

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -301,6 +301,7 @@ mod tests {
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
+            smooth_scroll_enabled: Arc::new(false.into()),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -190,6 +190,13 @@ pub struct AppSettings {
     /// Takes effect on agent restart.
     #[serde(default = "default_true")]
     pub capture_mouse_events: bool,
+    /// Whether ordinary mouse-wheel input is replaced with a finite smooth
+    /// scroll animation. **Off by default**: while enabled the OS hook
+    /// suppresses eligible physical wheel events only after its non-blocking
+    /// scroll worker accepts them. Trackpad and other continuous pixel input
+    /// remains native.
+    #[serde(default)]
+    pub smooth_scroll: bool,
     /// Which app icon the user picked. Applied at launch, and whenever it
     /// changes, by whichever process owns a surface showing one — on macOS the
     /// GUI hands the choice to the Dock and writes it onto the bundle (so the
@@ -359,6 +366,7 @@ impl Default for AppSettings {
             update_prompt_seen: false,
             show_in_menu_bar: true,
             capture_mouse_events: true,
+            smooth_scroll: false,
             auto_download_assets: true,
             asset_source: AssetSourcePreference::Automatic,
             language: None,

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -194,7 +194,9 @@ pub struct AppSettings {
     /// scroll animation. **Off by default**: while enabled the OS hook
     /// suppresses eligible physical wheel events only after its non-blocking
     /// scroll worker accepts them. Trackpad and other continuous pixel input
-    /// remains native.
+    /// remains native. Windows' low-level hook cannot attribute wheel messages
+    /// to a device, so the preference applies to every traditional mouse-wheel
+    /// message there.
     #[serde(default)]
     pub smooth_scroll: bool,
     /// Which app icon the user picked. Applied at launch, and whenever it

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -811,6 +811,17 @@ fn app_settings_launch_at_login_roundtrips() {
 }
 
 #[test]
+fn app_settings_smooth_scroll_is_opt_in_and_roundtrips() {
+    let default: Config = toml::from_str("schema_version = 5").expect("parse defaults");
+    assert!(!default.app_settings.smooth_scroll);
+
+    let mut cfg = Config::default();
+    cfg.app_settings.smooth_scroll = true;
+    let parsed = write_and_read(&cfg);
+    assert!(parsed.app_settings.smooth_scroll);
+}
+
+#[test]
 fn app_settings_ui_scale_roundtrips() {
     let mut cfg = Config::default();
     cfg.app_settings.ui_scale = UiScale::ExtraLarge;

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -374,6 +374,46 @@ pub fn post_scroll(delta: ScrollDelta) {
     }
 }
 
+/// Lifecycle phase of one synthetic smooth-scroll frame.
+///
+/// macOS forwards this state to the scroll-wheel event so applications see a
+/// balanced continuous gesture. Linux and Windows have no equivalent field;
+/// there the phase is retained by the runtime contract but only the frame's
+/// distance is injected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SmoothScrollPhase {
+    /// First output frame of a new animation.
+    Began,
+    /// An intermediate output frame, including frames after retargeting.
+    Changed,
+    /// Final frame, carrying any correction needed to reach the exact target.
+    Ended,
+    /// The capture source ended before the animation reached its target.
+    Cancelled,
+}
+
+/// Synthesise one frame of a finite smooth-scroll animation.
+///
+/// On macOS wheel ticks become continuous pixel events at ten points per tick,
+/// matching the line/point relationship carried in native continuous events.
+/// Other platforms preserve fractional wheel ticks through their native
+/// high-resolution output. Non-finite distance is rejected at this I/O
+/// boundary; zero-distance terminal frames remain meaningful on macOS.
+pub fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
+    if !delta.is_finite() {
+        return;
+    }
+    cfg_select! {
+        target_os = "macos" => {
+            macos::post_smooth_scroll(delta, phase);
+        }
+        _ => {
+            let _ = phase;
+            post_scroll(delta);
+        }
+    }
+}
+
 /// Synthesise a scroll of `(delta_x, delta_y)` wheel lines at the current focus.
 ///
 /// Used by the gesture/thumbwheel capture watcher to re-inject the MX thumb

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -15,12 +15,20 @@ use openlogi_core::binding::{
 };
 use openlogi_core::scroll::ScrollDelta;
 
-use super::{HeldKey, HeldModifiers, KeyPhase, QuantizedScroll, ScrollQuantizer};
+use super::{
+    HeldKey, HeldModifiers, KeyPhase, QuantizedScroll, ScrollQuantizer, SmoothScrollPhase,
+};
 
 static LINE_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
     LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
 static PIXEL_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
     LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
+static SMOOTH_SCROLL_QUANTIZER: LazyLock<Mutex<ScrollQuantizer>> =
+    LazyLock::new(|| Mutex::new(ScrollQuantizer::default()));
+
+// `core-graphics` 0.25 does not expose these `CGEventTypes.h` fields.
+const SCROLL_PHASE: u32 = 99; // kCGScrollWheelEventScrollPhase
+const MOMENTUM_PHASE: u32 = 123; // kCGScrollWheelEventMomentumPhase
 
 // NX_KEYTYPE_* constants from <IOKit/hidsystem/ev_keymap.h>.
 const NX_KEYTYPE_SOUND_UP: i32 = 0;
@@ -638,6 +646,45 @@ pub(super) fn post_scroll(delta: ScrollDelta) {
     }
     tag_synthetic(&ev);
     ev.post(CGEventTapLocation::HID);
+}
+
+pub(super) fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
+    const POINTS_PER_WHEEL_TICK: f64 = 10.0;
+
+    let units_per_input = match delta {
+        ScrollDelta::Pixels { .. } => 1.0,
+        ScrollDelta::WheelTicks { .. } => POINTS_PER_WHEEL_TICK,
+    };
+    let Ok(mut quantizer) = SMOOTH_SCROLL_QUANTIZER.lock() else {
+        tracing::warn!("macOS smooth-scroll quantizer mutex poisoned");
+        return;
+    };
+    let delta = quantizer.quantize(delta, units_per_input);
+    drop(quantizer);
+
+    let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
+        tracing::warn!("CGEventSource::new failed for smooth scroll");
+        return;
+    };
+    let Ok(ev) = CGEvent::new_scroll_event(src, ScrollEventUnit::PIXEL, 2, delta.y, delta.x, 0)
+    else {
+        tracing::warn!("CGEvent::new_scroll_event failed for smooth scroll");
+        return;
+    };
+    set_continuous_scroll_fields(&ev, delta);
+    ev.set_integer_value_field(SCROLL_PHASE, scroll_phase_value(phase));
+    ev.set_integer_value_field(MOMENTUM_PHASE, 0);
+    tag_synthetic(&ev);
+    ev.post(CGEventTapLocation::HID);
+}
+
+const fn scroll_phase_value(phase: SmoothScrollPhase) -> i64 {
+    match phase {
+        SmoothScrollPhase::Began => 1,
+        SmoothScrollPhase::Changed => 2,
+        SmoothScrollPhase::Ended => 4,
+        SmoothScrollPhase::Cancelled => 8,
+    }
 }
 
 fn set_continuous_scroll_fields(event: &CGEvent, delta: QuantizedScroll) {

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -3,8 +3,8 @@
 mod inject;
 
 pub use inject::{
-    SYNTHETIC_EVENT_USER_DATA, ax_navigate_browser, execute, post_scroll, post_thumbwheel_scroll,
-    press_hold, release_hold, replace_hold,
+    SYNTHETIC_EVENT_USER_DATA, SmoothScrollPhase, ax_navigate_browser, execute, post_scroll,
+    post_smooth_scroll, post_thumbwheel_scroll, press_hold, release_hold, replace_hold,
 };
 
 #[cfg(target_os = "linux")]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -8,6 +8,7 @@ check_for_updates = false
 auto_install_updates = false
 show_in_menu_bar = true
 capture_mouse_events = true
+smooth_scroll = false
 auto_download_assets = true
 asset_source = "automatic"
 language = "en"


### PR DESCRIPTION
## Summary

Add an opt-in, finite smooth-scrolling runtime for physical mouse-wheel input. The hook suppresses a wheel event only after a bounded, non-blocking queue accepts it; rejected or ineligible input passes through unchanged.

This PR is stacked on #973, which establishes the typed precise-scroll unit contract it consumes.

## Changes

- **openlogi-core**
  - add a default-off `app_settings.smooth_scroll` preference and publish reloads live to the hook path
- **openlogi-inject**
  - add phased smooth output (`Began`, `Changed`, `Ended`, `Cancelled`)
  - emit macOS continuous point/line/fixed-point fields with balanced scroll phases
  - preserve fractional high-resolution output on Linux and Windows
- **openlogi-agent-core**
  - add a dedicated `runtime/scroll` worker with an explicit owner and cloneable non-blocking input capability
  - model finite 100 ms cubic-smoothstep segments from absolute timestamps
  - retarget same-direction bursts, reverse immediately, conserve net distance, and emit exact terminal correction
  - reject pixel/trackpad input at the typed boundary and invalidate active output on capture interruption or setting changes
  - fail open when the bounded queue is full or disconnected
- **openlogi-agent**
  - own the scroll worker beside the action runtime and stop capture before worker shutdown
  - preserve Windows thumbwheel remaps before considering smooth output
- **docs**
  - document the opt-in TOML setting

## Testing

- `RUSTFLAGS='-D warnings' cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo clippy --target aarch64-apple-darwin -p openlogi-inject -p openlogi-hook -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-inject -p openlogi-hook -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`

Synthetic traces cover ratchet input, high-resolution bursts, reversal, sparse segments, delayed frames, opposing cancellation, queue rejection, and cancellation. They are deterministic algorithm fixtures, not hardware captures.

Not runtime-tested on hardware. Verify with `smooth_scroll = true` using a Logitech ratchet/free-spin wheel on macOS, Linux, and Windows; trackpad scrolling must remain native, and Windows applies the setting to all traditional wheel messages because `WH_MOUSE_LL` cannot attribute a source device.

Related to #884
