### PR TITLE
feat(scroll): smooth diverted thumbwheel input

### DIFF
--- a/crates/openlogi-agent-core/src/runtime/scroll.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll.rs
@@ -141,13 +141,11 @@ impl MotionSegment {
 }
 
 /// A source exists in the state map only while it has a non-zero remaining
-/// target. `output_started` records whether a macOS `Began` phase needs to be
-/// emitted before its terminal phase.
+/// target.
 struct ActiveMotion {
     segment: MotionSegment,
     emitted: WheelDelta,
     next_frame: Instant,
-    output_started: bool,
 }
 
 impl ActiveMotion {
@@ -160,95 +158,121 @@ impl ActiveMotion {
             },
             emitted: WheelDelta::ZERO,
             next_frame: at + FRAME_INTERVAL,
-            output_started: false,
         }
     }
 
     /// Evaluate the old segment at the impulse timestamp, then restart toward
-    /// the cumulative target. Returns `false` when opposing input exactly
-    /// consumes the remaining target and this motion is finished immediately.
-    fn retarget(
-        &mut self,
-        impulse: WheelDelta,
-        at: Instant,
-        emit: &mut impl FnMut(ScrollFrame),
-    ) -> bool {
+    /// the cumulative target.
+    fn retarget(&mut self, impulse: WheelDelta, at: Instant) -> MotionUpdate {
         let position = self.segment.position_at(at);
         let target = self.segment.target.plus(impulse);
+        let delta = self.delta_to(position);
         if target == position {
-            self.finish_at(position, emit);
-            return false;
+            return MotionUpdate::Finished(delta);
         }
 
-        self.emit_progress(position, emit);
         self.segment = MotionSegment {
             from: position,
             target,
             started_at: at,
         };
         self.next_frame = at + FRAME_INTERVAL;
-        true
+        MotionUpdate::Active(delta)
     }
 
-    /// Emit the position at `at`. Returns whether the segment is complete.
-    fn advance(&mut self, at: Instant, emit: &mut impl FnMut(ScrollFrame)) -> bool {
+    /// Evaluate the position at `at` and report whether the source remains
+    /// active after this update.
+    fn advance(&mut self, at: Instant) -> MotionUpdate {
         let complete = self.segment.is_complete_at(at);
         let position = self.segment.position_at(at);
+        let delta = self.delta_to(position);
         if complete {
-            self.finish_at(position, emit);
+            MotionUpdate::Finished(delta)
         } else {
-            self.emit_progress(position, emit);
             while self.next_frame <= at {
                 self.next_frame += FRAME_INTERVAL;
             }
             self.next_frame = self.next_frame.min(self.segment.ends_at());
+            MotionUpdate::Active(delta)
         }
-        complete
     }
 
-    fn emit_progress(&mut self, position: WheelDelta, emit: &mut impl FnMut(ScrollFrame)) {
+    fn delta_to(&mut self, position: WheelDelta) -> WheelDelta {
         let delta = position.minus(self.emitted);
+        self.emitted = position;
+        delta
+    }
+}
+
+/// Result of evaluating one source-local motion.
+#[derive(Clone, Copy)]
+enum MotionUpdate {
+    Active(WheelDelta),
+    Finished(WheelDelta),
+}
+
+impl MotionUpdate {
+    fn is_finished(&self) -> bool {
+        matches!(self, Self::Finished(_))
+    }
+}
+
+/// The one phase stream visible to the foreground application. Source-local
+/// motions may overlap, but Core Graphics has no source identity with which to
+/// pair multiple synthetic gestures; all distances therefore share this single
+/// balanced lifecycle.
+#[derive(Default)]
+enum OutputStream {
+    #[default]
+    Idle,
+    Active,
+}
+
+impl OutputStream {
+    fn progress(&mut self, delta: WheelDelta, emit: &mut impl FnMut(ScrollFrame)) {
         if delta.is_zero() {
             return;
         }
-        let phase = if self.output_started {
-            SmoothScrollPhase::Changed
-        } else {
-            self.output_started = true;
-            SmoothScrollPhase::Began
+        let phase = match self {
+            Self::Idle => {
+                *self = Self::Active;
+                SmoothScrollPhase::Began
+            }
+            Self::Active => SmoothScrollPhase::Changed,
         };
-        self.emitted = position;
         emit(ScrollFrame::new(delta, phase));
     }
 
-    fn finish_at(&mut self, position: WheelDelta, emit: &mut impl FnMut(ScrollFrame)) {
-        let delta = position.minus(self.emitted);
-        if self.output_started {
-            self.emitted = position;
-            emit(ScrollFrame::new(delta, SmoothScrollPhase::Ended));
-        } else if !delta.is_zero() {
-            self.emitted = position;
-            self.output_started = true;
-            emit(ScrollFrame::new(delta, SmoothScrollPhase::Began));
-            emit(ScrollFrame::new(WheelDelta::ZERO, SmoothScrollPhase::Ended));
+    fn finish(&mut self, delta: WheelDelta, emit: &mut impl FnMut(ScrollFrame)) {
+        match self {
+            Self::Idle if !delta.is_zero() => {
+                emit(ScrollFrame::new(delta, SmoothScrollPhase::Began));
+                emit(ScrollFrame::new(WheelDelta::ZERO, SmoothScrollPhase::Ended));
+            }
+            Self::Active => emit(ScrollFrame::new(delta, SmoothScrollPhase::Ended)),
+            Self::Idle => {}
         }
+        *self = Self::Idle;
     }
 
-    fn cancel(self, emit: &mut impl FnMut(ScrollFrame)) {
-        if self.output_started {
+    fn cancel(&mut self, emit: &mut impl FnMut(ScrollFrame)) {
+        if matches!(self, Self::Active) {
             emit(ScrollFrame::new(
                 WheelDelta::ZERO,
                 SmoothScrollPhase::Cancelled,
             ));
         }
+        *self = Self::Idle;
     }
 }
 
 /// Pure per-source state machine. Absence from the map represents idle, so an
-/// idle source cannot accidentally retain a target or scheduled deadline.
+/// idle source cannot accidentally retain a target or scheduled deadline. All
+/// source-local distances feed one application-visible [`OutputStream`].
 #[derive(Default)]
 struct ScrollEngine {
     active: HashMap<ScrollSource, ActiveMotion>,
+    output: OutputStream,
 }
 
 impl ScrollEngine {
@@ -265,18 +289,25 @@ impl ScrollEngine {
             .is_some_and(|motion| motion.segment.is_complete_at(at))
             && let Some(mut completed) = self.active.remove(&source)
         {
-            completed.advance(at, emit);
+            let update = completed.advance(at);
+            self.emit_update(update, emit);
         }
 
-        match self.active.entry(source) {
+        let update = match self.active.entry(source) {
             Entry::Occupied(mut entry) => {
-                if !entry.get_mut().retarget(impulse, at, emit) {
+                let update = entry.get_mut().retarget(impulse, at);
+                if update.is_finished() {
                     entry.remove();
                 }
+                Some(update)
             }
             Entry::Vacant(entry) => {
                 entry.insert(ActiveMotion::new(impulse, at));
+                None
             }
+        };
+        if let Some(update) = update {
+            self.emit_update(update, emit);
         }
     }
 
@@ -288,13 +319,17 @@ impl ScrollEngine {
             .map(|(source, _)| source.clone())
             .collect();
         for source in due {
-            let complete = self
+            let Some(update) = self
                 .active
                 .get_mut(&source)
-                .is_some_and(|motion| motion.advance(at, emit));
-            if complete {
+                .map(|motion| motion.advance(at))
+            else {
+                continue;
+            };
+            if update.is_finished() {
                 self.active.remove(&source);
             }
+            self.emit_update(update, emit);
         }
     }
 
@@ -303,14 +338,24 @@ impl ScrollEngine {
     }
 
     fn cancel_source(&mut self, source: &ScrollSource, emit: &mut impl FnMut(ScrollFrame)) {
-        if let Some(motion) = self.active.remove(source) {
-            motion.cancel(emit);
+        if self.active.remove(source).is_some() && self.active.is_empty() {
+            self.output.cancel(emit);
         }
     }
 
     fn cancel_all(&mut self, emit: &mut impl FnMut(ScrollFrame)) {
-        for (_, motion) in self.active.drain() {
-            motion.cancel(emit);
+        self.active.clear();
+        self.output.cancel(emit);
+    }
+
+    fn emit_update(&mut self, update: MotionUpdate, emit: &mut impl FnMut(ScrollFrame)) {
+        match update {
+            MotionUpdate::Finished(delta) if self.active.is_empty() => {
+                self.output.finish(delta, emit);
+            }
+            MotionUpdate::Active(delta) | MotionUpdate::Finished(delta) => {
+                self.output.progress(delta, emit);
+            }
         }
     }
 }

--- a/crates/openlogi-agent-core/src/runtime/scroll.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll.rs
@@ -18,6 +18,8 @@ use std::time::{Duration, Instant};
 use openlogi_core::scroll::ScrollDelta;
 use openlogi_inject::SmoothScrollPhase;
 
+use crate::runtime::HidppSessionId;
+
 /// Duration of every segment, including a segment restarted by retargeting.
 const ANIMATION_DURATION: Duration = Duration::from_millis(100);
 /// Output cadence. Position is evaluated from absolute time, so delayed wakes
@@ -99,10 +101,13 @@ impl ScrollFrame {
 }
 
 /// One physical producer. Linux runs one hook callback thread per grabbed
-/// mouse; macOS and Windows use one global callback thread.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// mouse; macOS and Windows use one global callback thread. HID++ capture
+/// sessions use their epoch-bearing identity so a restarted session cannot
+/// inherit motion from the one it replaced.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum ScrollSource {
     OsHook(ThreadId),
+    Hidpp(HidppSessionId),
 }
 
 impl ScrollSource {
@@ -279,7 +284,8 @@ impl ScrollEngine {
         let due: Vec<ScrollSource> = self
             .active
             .iter()
-            .filter_map(|(source, motion)| (motion.next_frame <= at).then_some(*source))
+            .filter(|(_, motion)| motion.next_frame <= at)
+            .map(|(source, _)| source.clone())
             .collect();
         for source in due {
             let complete = self
@@ -294,6 +300,12 @@ impl ScrollEngine {
 
     fn next_deadline(&self) -> Option<Instant> {
         self.active.values().map(|motion| motion.next_frame).min()
+    }
+
+    fn cancel_source(&mut self, source: &ScrollSource, emit: &mut impl FnMut(ScrollFrame)) {
+        if let Some(motion) = self.active.remove(source) {
+            motion.cancel(emit);
+        }
     }
 
     fn cancel_all(&mut self, emit: &mut impl FnMut(ScrollFrame)) {

--- a/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
@@ -7,6 +7,10 @@ fn source() -> ScrollSource {
     ScrollSource::current_hook()
 }
 
+fn hidpp_source(device_key: &str, epoch: u64) -> ScrollSource {
+    ScrollSource::Hidpp(HidppSessionId::new(device_key, epoch))
+}
+
 fn wheel(x: f64, y: f64) -> WheelDelta {
     WheelDelta { x, y }
 }
@@ -221,4 +225,40 @@ fn cancellation_emits_one_terminal_phase_only_after_output_began() {
         Some(SmoothScrollPhase::Cancelled)
     );
     assert_delta(cumulative(&frames), wheel(0.15625, 0.0));
+}
+
+#[test]
+fn source_cancellation_does_not_interrupt_another_device() {
+    let base = Instant::now();
+    let first = hidpp_source("mouse-a", 1);
+    let second = hidpp_source("mouse-b", 1);
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(first.clone(), wheel(1.0, 0.0), base, &mut |_| {});
+    engine.impulse(second.clone(), wheel(0.0, 1.0), base, &mut |_| {});
+    engine.advance_due(base + Duration::from_millis(25), &mut |frame| {
+        frames.push(frame);
+    });
+
+    engine.cancel_source(&first, &mut |frame| frames.push(frame));
+    assert!(!engine.active.contains_key(&first));
+    assert!(engine.active.contains_key(&second));
+    assert_eq!(
+        frames
+            .iter()
+            .filter(|frame| frame.phase == SmoothScrollPhase::Cancelled)
+            .count(),
+        1
+    );
+
+    engine.advance_due(base + ANIMATION_DURATION, &mut |frame| frames.push(frame));
+    assert!(engine.active.is_empty());
+    assert_eq!(
+        frames
+            .iter()
+            .filter(|frame| frame.phase == SmoothScrollPhase::Ended)
+            .count(),
+        1,
+        "the other device completes normally"
+    );
 }

--- a/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
@@ -228,7 +228,50 @@ fn cancellation_emits_one_terminal_phase_only_after_output_began() {
 }
 
 #[test]
-fn source_cancellation_does_not_interrupt_another_device() {
+fn concurrent_sources_share_one_balanced_output_stream() {
+    let base = Instant::now();
+    let first = hidpp_source("mouse-a", 1);
+    let second = hidpp_source("mouse-b", 1);
+    let mut engine = ScrollEngine::default();
+    let mut frames = Vec::new();
+    engine.impulse(first, wheel(1.0, 0.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.impulse(second, wheel(0.0, 1.0), base, &mut |frame| {
+        frames.push(frame);
+    });
+    engine.advance_due(base + Duration::from_millis(25), &mut |frame| {
+        frames.push(frame);
+    });
+    engine.advance_due(base + ANIMATION_DURATION, &mut |frame| {
+        frames.push(frame);
+    });
+
+    assert_delta(cumulative(&frames), wheel(1.0, 1.0));
+    assert_eq!(
+        frames
+            .iter()
+            .filter(|frame| frame.phase == SmoothScrollPhase::Began)
+            .count(),
+        1
+    );
+    assert_eq!(
+        frames
+            .iter()
+            .filter(|frame| frame.phase == SmoothScrollPhase::Ended)
+            .count(),
+        1
+    );
+    assert!(
+        frames
+            .iter()
+            .all(|frame| { !matches!(frame.phase, SmoothScrollPhase::Cancelled) })
+    );
+    assert!(engine.active.is_empty());
+}
+
+#[test]
+fn source_cancellation_does_not_interrupt_another_source() {
     let base = Instant::now();
     let first = hidpp_source("mouse-a", 1);
     let second = hidpp_source("mouse-b", 1);
@@ -248,7 +291,8 @@ fn source_cancellation_does_not_interrupt_another_device() {
             .iter()
             .filter(|frame| frame.phase == SmoothScrollPhase::Cancelled)
             .count(),
-        1
+        0,
+        "a source-local cancellation cannot terminate the shared output stream"
     );
 
     engine.advance_due(base + ANIMATION_DURATION, &mut |frame| frames.push(frame));

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -1,5 +1,6 @@
 //! Worker ownership and non-blocking producer capability for smooth scrolling.
 
+use std::collections::HashSet;
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -35,6 +36,12 @@ struct ShutdownRequest {
     done: mpsc::SyncSender<()>,
 }
 
+/// Lossless fallback for overflow cancellation and graceful shutdown.
+enum ScrollControl {
+    CancelOverflowSource(ScrollSource),
+    Shutdown(ShutdownRequest),
+}
+
 /// Cloneable, non-owning capability for physical input producers.
 ///
 /// Submission is always non-blocking. `false` asks each producer to use its
@@ -42,6 +49,7 @@ struct ShutdownRequest {
 #[derive(Clone)]
 pub struct ScrollInputHandle {
     commands: mpsc::SyncSender<ScrollCommand>,
+    controls: mpsc::Sender<ScrollControl>,
     generation: Arc<AtomicU64>,
     accepting: Arc<AtomicBool>,
     enabled: Arc<AtomicBool>,
@@ -100,13 +108,19 @@ impl ScrollInputHandle {
     /// Cancel output belonging to one HID++ capture-session incarnation.
     pub(crate) fn cancel_hidpp_session(&self, session: &HidppSessionId) {
         let source = ScrollSource::Hidpp(session.clone());
-        match self.commands.try_send(ScrollCommand::CancelSource(source)) {
+        match self
+            .commands
+            .try_send(ScrollCommand::CancelSource(source.clone()))
+        {
             Ok(()) | Err(mpsc::TrySendError::Disconnected(_)) => {}
             Err(mpsc::TrySendError::Full(_)) => {
-                // A stale diverted session must not retain active output. The
-                // bounded queue cannot guarantee source-local cancellation
-                // here, so invalidate all accepted input as the safe fallback.
-                self.cancel_all();
+                if self
+                    .controls
+                    .send(ScrollControl::CancelOverflowSource(source))
+                    .is_ok()
+                {
+                    self.wake();
+                }
             }
         }
     }
@@ -129,7 +143,7 @@ impl ScrollInputHandle {
 /// Unique owner of the smooth-scroll worker and its graceful shutdown.
 pub struct ScrollRuntime {
     input: ScrollInputHandle,
-    shutdown: mpsc::Sender<ShutdownRequest>,
+    controls: mpsc::Sender<ScrollControl>,
     worker: Option<JoinHandle<()>>,
 }
 
@@ -144,10 +158,11 @@ impl ScrollRuntime {
         mut emit: impl FnMut(ScrollFrame) + Send + 'static,
     ) -> io::Result<Self> {
         let (commands, command_rx) = mpsc::sync_channel(INPUT_QUEUE_CAPACITY);
-        let (shutdown, shutdown_rx) = mpsc::channel();
+        let (controls, control_rx) = mpsc::channel();
         let generation = Arc::new(AtomicU64::new(0));
         let input = ScrollInputHandle {
             commands,
+            controls: controls.clone(),
             generation: Arc::clone(&generation),
             accepting: Arc::new(AtomicBool::new(true)),
             enabled: Arc::clone(&enabled),
@@ -155,11 +170,11 @@ impl ScrollRuntime {
         let worker = thread::Builder::new()
             .name("openlogi-scroll".into())
             .spawn(move || {
-                run_worker(&command_rx, &shutdown_rx, &generation, &enabled, &mut emit);
+                run_worker(&command_rx, &control_rx, &generation, &enabled, &mut emit);
             })?;
         Ok(Self {
             input,
-            shutdown,
+            controls,
             worker: Some(worker),
         })
     }
@@ -181,7 +196,11 @@ impl ScrollRuntime {
         };
         self.input.stop_accepting();
         let (done, wait) = mpsc::sync_channel(0);
-        if self.shutdown.send(ShutdownRequest { done }).is_err() {
+        if self
+            .controls
+            .send(ScrollControl::Shutdown(ShutdownRequest { done }))
+            .is_err()
+        {
             let _ = worker.join();
             return false;
         }
@@ -208,18 +227,29 @@ impl Drop for ScrollRuntime {
 
 fn run_worker(
     commands: &mpsc::Receiver<ScrollCommand>,
-    shutdown: &mpsc::Receiver<ShutdownRequest>,
+    controls: &mpsc::Receiver<ScrollControl>,
     shared_generation: &AtomicU64,
     enabled: &AtomicBool,
     emit: &mut impl FnMut(ScrollFrame),
 ) {
     let mut engine = ScrollEngine::default();
+    // An overflow-cancelled incarnation stays tombstoned so accepted input that
+    // was already queued when control overtook the saturated queue is ignored.
+    let mut overflow_cancelled_sources = HashSet::new();
     let mut generation = shared_generation.load(Ordering::Acquire);
     loop {
-        if let Ok(request) = shutdown.try_recv() {
-            engine.cancel_all(emit);
-            let _ = request.done.send(());
-            return;
+        while let Ok(control) = controls.try_recv() {
+            match control {
+                ScrollControl::CancelOverflowSource(source) => {
+                    engine.cancel_source(&source, emit);
+                    overflow_cancelled_sources.insert(source);
+                }
+                ScrollControl::Shutdown(request) => {
+                    engine.cancel_all(emit);
+                    let _ = request.done.send(());
+                    return;
+                }
+            }
         }
 
         let current_generation = shared_generation.load(Ordering::Acquire);
@@ -238,7 +268,9 @@ fn run_worker(
         );
         match command {
             Ok(ScrollCommand::Input(input))
-                if input.generation == generation && enabled.load(Ordering::Relaxed) =>
+                if input.generation == generation
+                    && enabled.load(Ordering::Relaxed)
+                    && !overflow_cancelled_sources.contains(&input.source) =>
             {
                 engine.impulse(input.source, input.impulse, input.at, emit);
             }
@@ -260,25 +292,32 @@ mod tests {
     fn standalone_input(
         capacity: usize,
         enabled: bool,
-    ) -> (ScrollInputHandle, mpsc::Receiver<ScrollCommand>) {
+    ) -> (
+        ScrollInputHandle,
+        mpsc::Receiver<ScrollCommand>,
+        mpsc::Receiver<ScrollControl>,
+    ) {
         let (commands, receiver) = mpsc::sync_channel(capacity);
+        let (controls, control_rx) = mpsc::channel();
         (
             ScrollInputHandle {
                 commands,
+                controls,
                 generation: Arc::new(AtomicU64::new(0)),
                 accepting: Arc::new(AtomicBool::new(true)),
                 enabled: Arc::new(AtomicBool::new(enabled)),
             },
             receiver,
+            control_rx,
         )
     }
 
     #[test]
     fn callback_submission_rejects_ineligible_input_and_fails_open_when_full() {
-        let (disabled, _receiver) = standalone_input(1, false);
+        let (disabled, _commands, _controls) = standalone_input(1, false);
         assert!(!disabled.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
 
-        let (input, _receiver) = standalone_input(1, true);
+        let (input, _commands, _controls) = standalone_input(1, true);
         assert!(!input.try_hook_scroll(ScrollDelta::pixels(0.0, 1.0)));
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
         assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
@@ -286,12 +325,12 @@ mod tests {
 
     #[test]
     fn hidpp_cancellation_targets_its_session() {
-        let (input, receiver) = standalone_input(1, true);
+        let (input, commands, _controls) = standalone_input(1, true);
         let session = HidppSessionId::new("mouse-a", 7);
         input.cancel_hidpp_session(&session);
 
         let ScrollCommand::CancelSource(ScrollSource::Hidpp(cancelled)) =
-            receiver.recv().expect("queued cancellation")
+            commands.recv().expect("queued cancellation")
         else {
             panic!("expected HID++ source cancellation");
         };
@@ -300,12 +339,60 @@ mod tests {
     }
 
     #[test]
-    fn full_queue_falls_back_to_global_cancellation() {
-        let (input, _receiver) = standalone_input(1, true);
-        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+    fn cancellation_overtakes_a_full_queue_without_discarding_another_source() {
+        let (input, commands, controls) = standalone_input(2, true);
+        let cancelled = HidppSessionId::new("mouse-a", 7);
+        let survivor = HidppSessionId::new("mouse-b", 3);
+        assert!(input.try_hidpp_scroll(&cancelled, ScrollDelta::wheel_ticks(1.0, 0.0)));
+        assert!(input.try_hidpp_scroll(&survivor, ScrollDelta::wheel_ticks(0.0, 1.0)));
 
-        input.cancel_hidpp_session(&HidppSessionId::new("mouse-a", 7));
-        assert_eq!(input.generation.load(Ordering::Acquire), 1);
+        input.cancel_hidpp_session(&cancelled);
+        assert_eq!(
+            input.generation.load(Ordering::Acquire),
+            0,
+            "source-local cancellation must not invalidate unrelated accepted input"
+        );
+
+        let generation = Arc::clone(&input.generation);
+        let enabled = Arc::clone(&input.enabled);
+        let (emitted, frames) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            run_worker(&commands, &controls, &generation, &enabled, &mut |frame| {
+                emitted.send(frame).expect("frame receiver remains open");
+            });
+        });
+
+        let mut output = Vec::new();
+        loop {
+            let frame = frames
+                .recv_timeout(Duration::from_secs(1))
+                .expect("surviving source completes");
+            output.push(frame);
+            if frame.phase == openlogi_inject::SmoothScrollPhase::Ended {
+                break;
+            }
+        }
+
+        let (done, wait) = mpsc::sync_channel(0);
+        input
+            .controls
+            .send(ScrollControl::Shutdown(ShutdownRequest { done }))
+            .expect("worker control channel remains open");
+        input.wake();
+        wait.recv_timeout(Duration::from_secs(1))
+            .expect("worker acknowledges shutdown");
+        worker.join().expect("worker exits cleanly");
+
+        let total = output
+            .iter()
+            .fold(WheelDelta::ZERO, |sum, frame| sum.plus(frame.delta));
+        assert!(total.x.abs() < f64::EPSILON, "cancelled source emitted");
+        assert!((total.y - 1.0).abs() < f64::EPSILON);
+        assert!(
+            output
+                .iter()
+                .all(|frame| frame.phase != openlogi_inject::SmoothScrollPhase::Cancelled)
+        );
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -11,6 +11,7 @@ use openlogi_core::scroll::ScrollDelta;
 use tracing::warn;
 
 use super::{ScrollEngine, ScrollFrame, ScrollSource, WheelDelta};
+use crate::runtime::HidppSessionId;
 
 /// OS-hook callbacks must fail open rather than wait for the worker.
 const INPUT_QUEUE_CAPACITY: usize = 128;
@@ -26,6 +27,7 @@ struct ScrollInput {
 
 enum ScrollCommand {
     Input(ScrollInput),
+    CancelSource(ScrollSource),
     Wake,
 }
 
@@ -33,10 +35,10 @@ struct ShutdownRequest {
     done: mpsc::SyncSender<()>,
 }
 
-/// Cloneable, non-owning capability for hook callbacks.
+/// Cloneable, non-owning capability for physical input producers.
 ///
-/// Submission is always non-blocking. `false` means the caller must pass the
-/// physical event through unchanged.
+/// Submission is always non-blocking. `false` asks each producer to use its
+/// source-appropriate direct-output fallback.
 #[derive(Clone)]
 pub struct ScrollInputHandle {
     commands: mpsc::SyncSender<ScrollCommand>,
@@ -50,7 +52,21 @@ impl ScrollInputHandle {
     ///
     /// Pixel input, zero/non-finite distance, a disabled preference, a full
     /// queue, or an unavailable worker are rejected so the callback fails open.
+    #[must_use]
     pub fn try_hook_scroll(&self, delta: ScrollDelta) -> bool {
+        self.try_scroll(ScrollSource::current_hook(), delta)
+    }
+
+    /// Queue one diverted thumb-wheel impulse from an active HID++ session.
+    ///
+    /// Rejection tells the already-diverted caller to inject the distance
+    /// directly; unlike an OS hook, there is no physical event to pass through.
+    #[must_use]
+    pub(crate) fn try_hidpp_scroll(&self, session: &HidppSessionId, delta: ScrollDelta) -> bool {
+        self.try_scroll(ScrollSource::Hidpp(session.clone()), delta)
+    }
+
+    fn try_scroll(&self, source: ScrollSource, delta: ScrollDelta) -> bool {
         if !self.accepting.load(Ordering::Acquire) || !self.enabled.load(Ordering::Relaxed) {
             return false;
         }
@@ -59,18 +75,18 @@ impl ScrollInputHandle {
         };
         let input = ScrollInput {
             generation: self.generation.load(Ordering::Acquire),
-            source: ScrollSource::current_hook(),
+            source,
             impulse,
             at: Instant::now(),
         };
         match self.commands.try_send(ScrollCommand::Input(input)) {
             Ok(()) => true,
             Err(mpsc::TrySendError::Full(_)) => {
-                warn!("smooth-scroll queue full — physical wheel event passed through");
+                warn!("smooth-scroll queue full — input rejected");
                 false
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
-                warn!("smooth-scroll worker unavailable — physical wheel event passed through");
+                warn!("smooth-scroll worker unavailable — input rejected");
                 false
             }
         }
@@ -78,6 +94,24 @@ impl ScrollInputHandle {
 
     /// Invalidate every accepted OS-hook animation without blocking.
     pub fn cancel_hooks(&self) {
+        self.cancel_all();
+    }
+
+    /// Cancel output belonging to one HID++ capture-session incarnation.
+    pub(crate) fn cancel_hidpp_session(&self, session: &HidppSessionId) {
+        let source = ScrollSource::Hidpp(session.clone());
+        match self.commands.try_send(ScrollCommand::CancelSource(source)) {
+            Ok(()) | Err(mpsc::TrySendError::Disconnected(_)) => {}
+            Err(mpsc::TrySendError::Full(_)) => {
+                // A stale diverted session must not retain active output. The
+                // bounded queue cannot guarantee source-local cancellation
+                // here, so invalidate all accepted input as the safe fallback.
+                self.cancel_all();
+            }
+        }
+    }
+
+    fn cancel_all(&self) {
         self.generation.fetch_add(1, Ordering::AcqRel);
         self.wake();
     }
@@ -130,7 +164,7 @@ impl ScrollRuntime {
         })
     }
 
-    /// Clone the non-owning input capability for an OS hook.
+    /// Clone the non-owning input capability for physical input producers.
     #[must_use]
     pub fn input(&self) -> ScrollInputHandle {
         self.input.clone()
@@ -208,6 +242,7 @@ fn run_worker(
             {
                 engine.impulse(input.source, input.impulse, input.at, emit);
             }
+            Ok(ScrollCommand::CancelSource(source)) => engine.cancel_source(&source, emit),
             Ok(ScrollCommand::Input(_) | ScrollCommand::Wake) => {}
             Err(mpsc::RecvTimeoutError::Timeout) => engine.advance_due(Instant::now(), emit),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
@@ -247,6 +282,30 @@ mod tests {
         assert!(!input.try_hook_scroll(ScrollDelta::pixels(0.0, 1.0)));
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
         assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+    }
+
+    #[test]
+    fn hidpp_cancellation_targets_its_session() {
+        let (input, receiver) = standalone_input(1, true);
+        let session = HidppSessionId::new("mouse-a", 7);
+        input.cancel_hidpp_session(&session);
+
+        let ScrollCommand::CancelSource(ScrollSource::Hidpp(cancelled)) =
+            receiver.recv().expect("queued cancellation")
+        else {
+            panic!("expected HID++ source cancellation");
+        };
+        assert_eq!(cancelled, session);
+        assert_eq!(input.generation.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn full_queue_falls_back_to_global_cancellation() {
+        let (input, _receiver) = standalone_input(1, true);
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+
+        input.cancel_hidpp_session(&HidppSessionId::new("mouse-a", 7));
+        assert_eq!(input.generation.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -460,10 +460,6 @@ struct WheelAccumulators {
 /// Running state for one rotation direction.
 #[derive(Default)]
 struct WheelDirection {
-    /// Fractional line accumulator for continuous scroll.
-    scroll: f32,
-    /// Scroll binding whose fractional progress is currently retained.
-    scroll_binding: Option<ScrollBinding>,
     /// Integer rotation-increment accumulator for a custom (non-scroll) action.
     action: i32,
     /// When the last rotation event for this direction arrived (decay clock).
@@ -472,38 +468,13 @@ struct WheelDirection {
     last_fired: Option<Instant>,
 }
 
-/// Identity of a continuous scroll binding.
-///
-/// A direction's effective binding can change with configuration or the
-/// foreground application. Retained fractional progress belongs to the
-/// binding that earned it and must not leak into another axis or sign.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ScrollBinding {
-    Up,
-    Down,
-    Right,
-    Left,
-}
-
-impl ScrollBinding {
-    fn from_action(action: &Action) -> Option<Self> {
-        match action {
-            Action::ScrollUp => Some(Self::Up),
-            Action::ScrollDown => Some(Self::Down),
-            Action::HorizontalScrollRight => Some(Self::Right),
-            Action::HorizontalScrollLeft => Some(Self::Left),
-            _ => None,
-        }
-    }
-}
-
 /// What advancing a direction's accumulator should produce.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum WheelOutput {
     /// Below threshold / suppressed — emit nothing.
     Idle,
-    /// Post signed horizontal and vertical scroll lines.
-    Scroll { delta_x: i32, delta_y: i32 },
+    /// Post a typed fractional scroll distance.
+    Scroll(ScrollDelta),
     /// Fire the direction's bound custom action.
     FireAction,
 }
@@ -613,12 +584,7 @@ fn dispatch(
                 Instant::now(),
             ) {
                 WheelOutput::Idle => {}
-                WheelOutput::Scroll { delta_x, delta_y } => {
-                    outputs.post_scroll(
-                        session,
-                        ScrollDelta::wheel_ticks(f64::from(delta_x), f64::from(delta_y)),
-                    );
-                }
+                WheelOutput::Scroll(delta) => outputs.post_scroll(session, delta),
                 WheelOutput::FireAction => {
                     debug!(key, ?button, action = %action.label(), "thumb wheel → action");
                     outputs.actions.dispatch(&action, Some(key));
@@ -637,14 +603,14 @@ struct ScrollScale {
     /// increments — so without this the same physical motion scrolls six times
     /// as far as it did natively, and the sensitivity slider's 1× is 1× of
     /// nothing recognisable.
-    native_per_increment: f32,
+    native_per_increment: f64,
     /// The user's own multiplier, relative to that native amount.
     sensitivity: ThumbwheelSensitivity,
 }
 
 impl ScrollScale {
     /// Scroll units one increment contributes.
-    fn per_increment(self) -> f32 {
+    fn per_increment(self) -> f64 {
         self.native_per_increment * self.sensitivity.scroll_multiplier()
     }
 }
@@ -652,12 +618,6 @@ impl ScrollScale {
 /// Advance one direction's accumulator by `magnitude` rotation increments and
 /// decide what to emit. Pure given `now`, so the decay/cooldown/threshold logic
 /// is unit-testable without touching the OS.
-#[expect(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    reason = "magnitude/sensitivity are small integers and `lines` is a trunc'd \
-              whole number — both well within f32/i32 range"
-)]
 fn advance(
     dir: &mut WheelDirection,
     action: &Action,
@@ -666,11 +626,6 @@ fn advance(
     now: Instant,
 ) -> WheelOutput {
     let sensitivity = scale.sensitivity;
-    let scroll_binding = ScrollBinding::from_action(action);
-    if dir.scroll_binding != scroll_binding {
-        dir.scroll = 0.0;
-        dir.scroll_binding = scroll_binding;
-    }
     match action {
         // Suppressed: captured but produces nothing.
         Action::None => WheelOutput::Idle,
@@ -681,32 +636,18 @@ fn advance(
         | Action::ScrollDown
         | Action::HorizontalScrollRight
         | Action::HorizontalScrollLeft => {
-            dir.scroll += magnitude as f32 * scale.per_increment();
-            let lines = dir.scroll.trunc();
-            if lines >= 1.0 {
-                dir.scroll -= lines;
-                let lines = lines as i32;
-                match action {
-                    Action::ScrollUp => WheelOutput::Scroll {
-                        delta_x: 0,
-                        delta_y: lines,
-                    },
-                    Action::ScrollDown => WheelOutput::Scroll {
-                        delta_x: 0,
-                        delta_y: -lines,
-                    },
-                    Action::HorizontalScrollRight => WheelOutput::Scroll {
-                        delta_x: lines,
-                        delta_y: 0,
-                    },
-                    Action::HorizontalScrollLeft => WheelOutput::Scroll {
-                        delta_x: -lines,
-                        delta_y: 0,
-                    },
-                    _ => unreachable!("scroll actions are matched above"),
-                }
-            } else {
+            let distance = f64::from(magnitude) * scale.per_increment();
+            let delta = match action {
+                Action::ScrollUp => ScrollDelta::wheel_ticks(0.0, distance),
+                Action::ScrollDown => ScrollDelta::wheel_ticks(0.0, -distance),
+                Action::HorizontalScrollRight => ScrollDelta::wheel_ticks(distance, 0.0),
+                Action::HorizontalScrollLeft => ScrollDelta::wheel_ticks(-distance, 0.0),
+                _ => unreachable!("scroll actions are matched above"),
+            };
+            if distance == 0.0 {
                 WheelOutput::Idle
+            } else {
+                WheelOutput::Scroll(delta)
             }
         }
         // Any other action: fire once per `action_threshold` increments, with

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -25,6 +25,7 @@ use std::time::{Duration, Instant};
 
 use openlogi_core::binding::{Action, ButtonId, default_binding};
 use openlogi_core::config::ThumbwheelSensitivity;
+use openlogi_core::scroll::ScrollDelta;
 use openlogi_hid::session::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
 use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
 use tokio::sync::{mpsc, oneshot};
@@ -32,6 +33,7 @@ use tracing::{debug, warn};
 
 use crate::capture_plan::{DeviceCapturePlan, SharedCapturePlans};
 use crate::receiver_access::{ReceiverAccess, SessionReceiverLease};
+use crate::runtime::scroll::ScrollInputHandle;
 use crate::runtime::{ActionDispatcher, HidppSessionId, PressToken};
 
 /// How often to re-read the active device target + thumb-wheel arming so a
@@ -47,6 +49,34 @@ const ACTION_DECAY: Duration = Duration::from_millis(300);
 /// deliberate flick triggers once instead of repeating across a fast spin.
 const ACTION_COOLDOWN: Duration = Duration::from_millis(200);
 
+/// Output capabilities shared by every HID++ gesture capture session.
+#[derive(Clone)]
+pub struct GestureOutputs {
+    actions: ActionDispatcher,
+    scroll: ScrollInputHandle,
+}
+
+impl GestureOutputs {
+    /// Build gesture outputs backed by the shared action and scroll runtimes.
+    #[must_use]
+    pub fn new(actions: ActionDispatcher, scroll: ScrollInputHandle) -> Self {
+        Self { actions, scroll }
+    }
+
+    fn cancel_session(&self, session: &HidppSessionId) {
+        self.actions.cancel_hidpp_session(session);
+        self.scroll.cancel_hidpp_session(session);
+    }
+
+    fn post_scroll(&self, session: &HidppSessionId, delta: ScrollDelta) {
+        if !self.scroll.try_hidpp_scroll(session, delta) {
+            // HID++ diversion consumed the physical input already, so direct
+            // synthesis is this source's fail-open path.
+            openlogi_inject::post_scroll(delta);
+        }
+    }
+}
+
 /// Spawn the capture-manager thread. It owns a current-thread tokio runtime that
 /// keeps one capture session pointed at the active device and dispatches each
 /// captured input.
@@ -54,7 +84,7 @@ pub fn spawn(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
-    dispatcher: ActionDispatcher,
+    outputs: GestureOutputs,
 ) {
     thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -71,7 +101,7 @@ pub fn spawn(
             capture_plans,
             capture_channel,
             receiver_access,
-            dispatcher,
+            outputs,
         ));
     });
 }
@@ -240,7 +270,7 @@ async fn manage(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
-    dispatcher: ActionDispatcher,
+    outputs: GestureOutputs,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedEvent>();
     let mut sessions: HashMap<String, RunningSession> = HashMap::new();
@@ -286,10 +316,10 @@ async fn manage(
                         &mut accumulators,
                         &mut gesture_presses,
                         &capture_plans,
-                        &dispatcher,
+                        &outputs,
                     );
                 } else {
-                    dispatcher.cancel_hidpp_session(&event.session);
+                    outputs.cancel_session(&event.session);
                     gesture_presses.cancel_session(&event.session);
                     debug!(key, epoch = event.session.epoch(), "input from a stale capture session — ignored");
                 }
@@ -311,7 +341,7 @@ async fn manage(
                 for (key, session) in &mut sessions {
                     let keep = want.get(key).is_some_and(|target| *target == session.target);
                     if !keep && let Some(stop) = session.stop.take() {
-                        dispatcher.cancel_hidpp_session(&session.id);
+                        outputs.cancel_session(&session.id);
                         gesture_presses.cancel_session(&session.id);
                         let _ = stop.send(());
                     }
@@ -353,7 +383,7 @@ async fn manage(
                 // device can't hot-loop. A stale epoch (an already-superseded
                 // session) is a no-op.
                 if let DoneAction::Remove { unexpected } = on_done(&done.session, sessions.get(key)) {
-                    dispatcher.cancel_hidpp_session(&done.session);
+                    outputs.cancel_session(&done.session);
                     gesture_presses.cancel_session(&done.session);
                     if unexpected {
                         warn!(key, "capture session ended unexpectedly, re-arming");
@@ -486,7 +516,7 @@ fn dispatch(
     accumulators: &mut HashMap<String, WheelAccumulators>,
     gesture_presses: &mut GesturePresses,
     capture_plans: &SharedCapturePlans,
-    dispatcher: &ActionDispatcher,
+    outputs: &GestureOutputs,
 ) {
     let key = session.device_key();
     let Ok(plans) = capture_plans.read() else {
@@ -508,7 +538,7 @@ fn dispatch(
                 .and_then(|map| map.get(&direction))
             {
                 debug!(key, %button, ?direction, action = %action.label(), "gesture → action");
-                if !dispatcher.try_dispatch_while_pressed(press, action) {
+                if !outputs.actions.try_dispatch_while_pressed(press, action) {
                     debug!(key, %button, ?direction, "gesture press no longer active — ignored");
                 }
             } else {
@@ -526,7 +556,9 @@ fn dispatch(
             } else {
                 debug!(key, ?button, "HID++ button with no binding — ignored");
             }
-            let press = dispatcher.try_hidpp_button_down(session, button, action);
+            let press = outputs
+                .actions
+                .try_hidpp_button_down(session, button, action);
             if is_gesture {
                 if let Some(press) = press {
                     gesture_presses.start(session, button, press);
@@ -536,7 +568,7 @@ fn dispatch(
             }
         }
         CapturedInput::ButtonUp(button) => {
-            dispatcher.try_hidpp_button_up(session, button);
+            outputs.actions.try_hidpp_button_up(session, button);
             gesture_presses.end(session, button);
         }
         CapturedInput::ButtonPulse(button) => {
@@ -546,7 +578,9 @@ fn dispatch(
             } else {
                 debug!(key, ?button, "HID++ button pulse with no binding — ignored");
             }
-            dispatcher.dispatch_hidpp_button_pulse(session, button, action);
+            outputs
+                .actions
+                .dispatch_hidpp_button_pulse(session, button, action);
         }
         CapturedInput::Scroll {
             increments,
@@ -580,11 +614,14 @@ fn dispatch(
             ) {
                 WheelOutput::Idle => {}
                 WheelOutput::Scroll { delta_x, delta_y } => {
-                    openlogi_inject::post_thumbwheel_scroll(delta_x, delta_y);
+                    outputs.post_scroll(
+                        session,
+                        ScrollDelta::wheel_ticks(f64::from(delta_x), f64::from(delta_y)),
+                    );
                 }
                 WheelOutput::FireAction => {
                     debug!(key, ?button, action = %action.label(), "thumb wheel → action");
-                    dispatcher.dispatch(&action, Some(key));
+                    outputs.actions.dispatch(&action, Some(key));
                 }
             }
         }

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -1,9 +1,10 @@
 use super::*;
 use openlogi_hid::thumbwheel::WheelResolution;
 
-/// The resolutions traced off an MX Master 4 over Bolt: 20 ratchets per
-/// revolution natively, 120 increments per revolution diverted.
-const TRACED: WheelResolution = WheelResolution {
+/// Resolution metadata observed from an MX Master 4 over Bolt: 20 ratchets per
+/// revolution natively, 120 increments per revolution diverted. The event
+/// sequences below are synthetic algorithm fixtures, not hardware captures.
+const MX_MASTER_4_REPORTED_RESOLUTION: WheelResolution = WheelResolution {
     native_res: 20,
     diverted_res: 120,
 };
@@ -17,9 +18,24 @@ fn unscaled(sensitivity: ThumbwheelSensitivity) -> ScrollScale {
     }
 }
 
+fn assert_distance(actual: f64, expected: f64) {
+    const EPSILON: f64 = 1.0e-12;
+    assert!(
+        (actual - expected).abs() < EPSILON,
+        "{actual} != {expected}"
+    );
+}
+
+fn scroll_delta(output: WheelOutput) -> ScrollDelta {
+    let WheelOutput::Scroll(delta) = output else {
+        panic!("expected fractional scroll output");
+    };
+    delta
+}
+
 #[test]
 fn multiplier_is_unity_at_default_sensitivity() {
-    assert!((ThumbwheelSensitivity::DEFAULT.scroll_multiplier() - 1.0).abs() < f32::EPSILON);
+    assert!((ThumbwheelSensitivity::DEFAULT.scroll_multiplier() - 1.0).abs() < f64::EPSILON);
     assert!(ThumbwheelSensitivity::from_rounded(28.0).scroll_multiplier() > 1.9);
     assert!(ThumbwheelSensitivity::MIN.scroll_multiplier() < 0.1);
 }
@@ -49,52 +65,59 @@ fn action_threshold_drops_with_sensitivity_and_floors_at_one() {
 #[test]
 fn a_revolution_scrolls_its_native_amount_however_finely_the_wheel_reports() {
     let scale = ScrollScale {
-        native_per_increment: TRACED.native_per_increment(),
+        native_per_increment: MX_MASTER_4_REPORTED_RESOLUTION.native_per_increment(),
         sensitivity: ThumbwheelSensitivity::DEFAULT,
     };
     let mut dir = WheelDirection::default();
     let now = Instant::now();
-    let mut lines = 0;
+    let mut distance = 0.0;
     for _ in 0..120 {
-        if let WheelOutput::Scroll { delta_x, .. } =
-            advance(&mut dir, &Action::HorizontalScrollRight, 1, scale, now)
-        {
-            lines += delta_x;
-        }
+        distance += scroll_delta(advance(
+            &mut dir,
+            &Action::HorizontalScrollRight,
+            1,
+            scale,
+            now,
+        ))
+        .x();
     }
-    assert_eq!(lines, 20, "one revolution is 20 native scroll units");
+    assert_distance(distance, 20.0);
 }
 
 /// The sensitivity slider stays a multiplier *of that native amount*.
 #[test]
 fn sensitivity_multiplies_the_native_amount() {
     let scale = ScrollScale {
-        native_per_increment: TRACED.native_per_increment(),
+        native_per_increment: MX_MASTER_4_REPORTED_RESOLUTION.native_per_increment(),
         sensitivity: ThumbwheelSensitivity::from_rounded(28.0), // 2x
     };
     let mut dir = WheelDirection::default();
     let now = Instant::now();
-    let mut lines = 0;
+    let mut distance = 0.0;
     for _ in 0..120 {
-        if let WheelOutput::Scroll { delta_x, .. } =
-            advance(&mut dir, &Action::HorizontalScrollRight, 1, scale, now)
-        {
-            lines += delta_x;
-        }
+        distance += scroll_delta(advance(
+            &mut dir,
+            &Action::HorizontalScrollRight,
+            1,
+            scale,
+            now,
+        ))
+        .x();
     }
-    assert_eq!(lines, 40, "2x sensitivity doubles the native 20");
+    assert_distance(distance, 40.0);
 }
 
 #[test]
 fn an_unreported_resolution_leaves_increments_unscaled() {
-    assert!((WheelResolution::UNKNOWN.native_per_increment() - 1.0).abs() < f32::EPSILON);
+    assert!((WheelResolution::UNKNOWN.native_per_increment() - 1.0).abs() < f64::EPSILON);
 }
 
 #[test]
-fn scroll_accumulates_fractionally_at_sub_unity_sensitivity() {
+fn sub_tick_distance_is_emitted_without_integer_accumulation() {
     let mut dir = WheelDirection::default();
     let now = Instant::now();
-    // multiplier 0.5: two increments make one whole line.
+    // A 0.5× increment remains one typed half-tick all the way to the smooth
+    // runtime or the platform injector.
     let half = ThumbwheelSensitivity::from_rounded(7.0);
     assert_eq!(
         advance(
@@ -104,128 +127,52 @@ fn scroll_accumulates_fractionally_at_sub_unity_sensitivity() {
             unscaled(half),
             now
         ),
-        WheelOutput::Idle
-    );
-    assert_eq!(
-        advance(
-            &mut dir,
-            &Action::HorizontalScrollRight,
-            1,
-            unscaled(half),
-            now
-        ),
-        WheelOutput::Scroll {
-            delta_x: 1,
-            delta_y: 0,
-        }
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.5, 0.0))
     );
 }
 
 #[test]
-fn scroll_left_emits_negative_lines() {
+fn scroll_actions_encode_axis_and_sign_in_the_typed_delta() {
     let mut dir = WheelDirection::default();
     let now = Instant::now();
-    assert_eq!(
-        advance(
-            &mut dir,
-            &Action::HorizontalScrollLeft,
-            1,
-            unscaled(ThumbwheelSensitivity::DEFAULT),
-            now
-        ),
-        WheelOutput::Scroll {
-            delta_x: -1,
-            delta_y: 0,
-        }
-    );
-}
-
-#[test]
-fn vertical_scroll_actions_emit_on_the_vertical_axis() {
-    let now = Instant::now();
-    let mut up = WheelDirection::default();
-    let mut down = WheelDirection::default();
     let scale = unscaled(ThumbwheelSensitivity::DEFAULT);
-
     assert_eq!(
-        advance(&mut up, &Action::ScrollUp, 1, scale, now),
-        WheelOutput::Scroll {
-            delta_x: 0,
-            delta_y: 1,
-        }
+        advance(&mut dir, &Action::HorizontalScrollLeft, 1, scale, now),
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(-1.0, 0.0))
     );
     assert_eq!(
-        advance(&mut down, &Action::ScrollDown, 1, scale, now),
-        WheelOutput::Scroll {
-            delta_x: 0,
-            delta_y: -1,
-        }
+        advance(&mut dir, &Action::ScrollDown, 1, scale, now),
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.0, -1.0))
     );
 }
 
 #[test]
-fn binding_changes_do_not_reuse_fractional_scroll_progress() {
+fn binding_changes_have_no_hidden_fractional_progress_to_reassign() {
     let mut dir = WheelDirection::default();
     let now = Instant::now();
     let half = unscaled(ThumbwheelSensitivity::from_rounded(7.0));
 
     assert_eq!(
         advance(&mut dir, &Action::HorizontalScrollRight, 1, half, now),
-        WheelOutput::Idle
-    );
-    // The half-line earned horizontally must not complete a vertical line
-    // after a live binding or application-context change.
-    assert_eq!(
-        advance(&mut dir, &Action::ScrollUp, 1, half, now),
-        WheelOutput::Idle
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.5, 0.0))
     );
     assert_eq!(
         advance(&mut dir, &Action::ScrollUp, 1, half, now),
-        WheelOutput::Scroll {
-            delta_x: 0,
-            delta_y: 1,
-        }
+        WheelOutput::Scroll(ScrollDelta::wheel_ticks(0.0, 0.5))
     );
 }
 
 #[test]
-fn directions_accumulate_independently() {
-    let mut up = WheelDirection::default();
-    let mut down = WheelDirection::default();
-    let now = Instant::now();
-    let half = ThumbwheelSensitivity::from_rounded(7.0);
+fn zero_magnitude_emits_nothing() {
     assert_eq!(
         advance(
-            &mut up,
+            &mut WheelDirection::default(),
             &Action::HorizontalScrollRight,
-            1,
-            unscaled(half),
-            now
+            0,
+            unscaled(ThumbwheelSensitivity::DEFAULT),
+            Instant::now(),
         ),
         WheelOutput::Idle
-    );
-    assert_eq!(
-        advance(
-            &mut down,
-            &Action::HorizontalScrollLeft,
-            1,
-            unscaled(half),
-            now
-        ),
-        WheelOutput::Idle
-    );
-    assert_eq!(
-        advance(
-            &mut up,
-            &Action::HorizontalScrollRight,
-            1,
-            unscaled(half),
-            now
-        ),
-        WheelOutput::Scroll {
-            delta_x: 1,
-            delta_y: 0,
-        }
     );
 }
 

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -44,7 +44,7 @@ use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::{Orchestrator, SharedRuntime};
 use openlogi_agent_core::runtime::scroll::{ScrollInputHandle, ScrollRuntime};
 use openlogi_agent_core::runtime::{ActionDispatcher, ActionRuntime, hook};
-use openlogi_agent_core::watchers;
+use openlogi_agent_core::watchers::{self, gesture::GestureOutputs};
 use openlogi_core::config::Config;
 use openlogi_hook::Hook;
 use tokio::sync::Mutex;
@@ -144,12 +144,12 @@ fn main() {
 }
 
 /// Start the HID++ background sessions that do not need Accessibility.
-fn spawn_hidpp_watchers(shared: &SharedRuntime, dispatcher: ActionDispatcher) {
+fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputServices) {
     watchers::gesture::spawn(
         shared.capture_plans.clone(),
         shared.capture_channel.clone(),
         shared.receiver_access.clone(),
-        dispatcher.clone(),
+        GestureOutputs::new(inputs.dispatcher.clone(), inputs.scroll_input.clone()),
     );
     watchers::host_switch::spawn(
         shared.host_switch_links.clone(),
@@ -161,7 +161,7 @@ fn spawn_hidpp_watchers(shared: &SharedRuntime, dispatcher: ActionDispatcher) {
         shared.keyboard_channel.clone(),
         shared.receiver_access.clone(),
         shared.channel_registry.clone(),
-        dispatcher,
+        inputs.dispatcher.clone(),
     );
 }
 
@@ -497,7 +497,7 @@ async fn run(
     ));
 
     // HID++ watchers need no Accessibility permission — start them up front.
-    spawn_hidpp_watchers(&shared, inputs.dispatcher.clone());
+    spawn_hidpp_watchers(&shared, &inputs);
 
     let mut inventory_rx = watchers::inventory::spawn_with_registry(
         Duration::from_secs(2),

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -321,8 +321,8 @@ impl ThumbwheelSensitivity {
 
     /// Continuous-scroll speed multiplier relative to [`Self::DEFAULT`].
     #[must_use]
-    pub fn scroll_multiplier(self) -> f32 {
-        f32::from(self) / f32::from(Self::DEFAULT)
+    pub fn scroll_multiplier(self) -> f64 {
+        f64::from(self.into_inner()) / f64::from(Self::DEFAULT.into_inner())
     }
 
     /// Rotation increments required to fire a discrete thumb-wheel action.

--- a/crates/openlogi-device/src/thumbwheel.rs
+++ b/crates/openlogi-device/src/thumbwheel.rs
@@ -133,11 +133,11 @@ impl WheelResolution {
     /// `getThumbwheelInfo` keeps the raw increment-per-unit behavior rather
     /// than having its scroll silently scaled by a guess.
     #[must_use]
-    pub fn native_per_increment(self) -> f32 {
+    pub fn native_per_increment(self) -> f64 {
         if self.native_res == 0 || self.diverted_res == 0 {
             return 1.0;
         }
-        f32::from(self.native_res) / f32::from(self.diverted_res)
+        f64::from(self.native_res) / f64::from(self.diverted_res)
     }
 }
 

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -414,21 +414,6 @@ pub fn post_smooth_scroll(delta: ScrollDelta, phase: SmoothScrollPhase) {
     }
 }
 
-/// Synthesise a scroll of `(delta_x, delta_y)` wheel lines at the current focus.
-///
-/// Used by the gesture/thumbwheel capture watcher to re-inject the MX thumb
-/// wheel's scrolling after the wheel has been diverted over HID++. The caller
-/// maps physical rotation onto the configured horizontal or vertical axis and
-/// scales it from diverted increments back to native wheel lines.
-///
-/// No-op (logs nothing) on platforms without a supported injection mechanism.
-pub fn post_thumbwheel_scroll(delta_x: i32, delta_y: i32) {
-    post_scroll(ScrollDelta::wheel_ticks(
-        f64::from(delta_x),
-        f64::from(delta_y),
-    ));
-}
-
 /// Return the `/dev/input/eventN` node for the action-injector uinput device,
 /// initialising it if needed.
 ///

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -4,7 +4,7 @@ mod inject;
 
 pub use inject::{
     SYNTHETIC_EVENT_USER_DATA, SmoothScrollPhase, ax_navigate_browser, execute, post_scroll,
-    post_smooth_scroll, post_thumbwheel_scroll, press_hold, release_hold, replace_hold,
+    post_smooth_scroll, press_hold, release_hold, replace_hold,
 };
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Route already-diverted HID++ thumb-wheel scrolling through the finite smooth-scroll runtime without changing custom wheel-action thresholds, decay, or cooldown behavior. If smoothing is disabled or the bounded queue rejects input, inject the typed distance directly because HID++ diversion has already consumed the physical event.

This PR is stacked on #975, which adds the smooth-scroll runtime and preference.

## Changes

- **openlogi-agent-core**
  - model HID++ capture-session epochs as independent scroll sources so restarted sessions cannot inherit stale motion
  - cancel only the ending session's active animation on stale input, planned teardown, or unexpected completion
  - fall back to global cancellation if the bounded queue cannot accept a required source-local cancel
  - group action and scroll capabilities in a typed `GestureOutputs` boundary
  - emit fractional `ScrollDelta` values directly instead of truncating through a watcher-local integer accumulator
  - preserve the existing custom-action threshold, 300 ms decay, and 200 ms cooldown path
- **openlogi-core / openlogi-device**
  - calculate thumb-wheel sensitivity and diverted-to-native resolution ratios as `f64`
- **openlogi-inject**
  - remove the obsolete integer-only thumb-wheel injection helper
- **openlogi-agent**
  - share the scroll input capability with the HID++ gesture watcher

## Testing

- `RUSTFLAGS='-D warnings' cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo clippy --target aarch64-apple-darwin -p openlogi-core -p openlogi-device -p openlogi-inject -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo clippy --target x86_64-pc-windows-gnu -p openlogi-core -p openlogi-device -p openlogi-inject -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`

The synthetic algorithm fixture uses observed MX Master 4 resolution metadata (20 native ratchets and 120 diverted increments per revolution) and verifies that the generated sequence conserves exactly 20 native wheel ticks. Event sequences are synthetic, not hardware captures.

Not runtime-tested on hardware. Verify with `smooth_scroll = true` and an MX thumb wheel that is diverted by a non-default sensitivity or binding: scrolling should animate smoothly, custom wheel actions should retain their prior trigger timing, and disabling smoothing should preserve direct scrolling.

Related to #390 and #884