### PR TITLE
feat(scroll): add vertical scroll sensitivity

### DIFF
--- a/crates/openlogi-agent-core/src/orchestrator.rs
+++ b/crates/openlogi-agent-core/src/orchestrator.rs
@@ -11,7 +11,7 @@
 //! (still valid) values — exactly the GUI's "window never opened" behaviour.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use openlogi_core::app::ForegroundApp;
@@ -35,6 +35,7 @@ use crate::hardware::DeviceOp;
 use crate::observable::ObservableState;
 use crate::receiver_access::ReceiverAccess;
 use crate::runtime::hook::{HookMaps, SharedHookMaps};
+use crate::runtime::scroll::ScrollPreferences;
 use crate::watchers::host_switch::{HostSwitchLink, HostSwitchLinks};
 use crate::watchers::keyboard::{KeyboardSpec, SharedKeyboardSpec};
 use crate::{DpiCycleState, DpiCycles};
@@ -74,9 +75,9 @@ pub struct SharedRuntime {
     /// Function-key remapper bindings (keycode+modifiers → action). Not
     /// per-app-profile in M1 (spec non-goal), so a single shared map.
     pub keyboard_bindings: crate::runtime::hook::SharedKeyboardBindings,
-    /// Live smooth-scroll preference read by the OS-hook callback without
+    /// Live smooth-scroll and vertical sensitivity settings read without
     /// taking the orchestrator/config lock.
-    pub smooth_scroll_enabled: Arc<AtomicBool>,
+    pub scroll_preferences: Arc<ScrollPreferences>,
     pub dpi_cycle: Arc<RwLock<DpiCycles>>,
     /// One capture plan per online device — what to divert and how to
     /// dispatch, keyed by the device the events arrive on. Carries each
@@ -196,7 +197,10 @@ impl Orchestrator {
         let shared = SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(config.keyboard.bindings.clone())),
-            smooth_scroll_enabled: Arc::new(AtomicBool::new(config.app_settings.smooth_scroll)),
+            scroll_preferences: Arc::new(ScrollPreferences::new(
+                config.app_settings.smooth_scroll,
+                config.app_settings.vertical_scroll_sensitivity,
+            )),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),
@@ -754,9 +758,10 @@ impl Orchestrator {
         // Parameter-only edits must not erase a transient manual choice while
         // the light remains camera-linked. Changing the policy invalidates it.
         self.config = config;
-        self.shared
-            .smooth_scroll_enabled
-            .store(self.config.app_settings.smooth_scroll, Ordering::Relaxed);
+        self.shared.scroll_preferences.publish(
+            self.config.app_settings.smooth_scroll,
+            self.config.app_settings.vertical_scroll_sensitivity,
+        );
         self.observable
             .set_launch_at_login(self.config.app_settings.launch_at_login);
         let retained_overrides: HashSet<String> = self

--- a/crates/openlogi-agent-core/src/orchestrator/tests.rs
+++ b/crates/openlogi-agent-core/src/orchestrator/tests.rs
@@ -7,14 +7,13 @@ use super::{
 };
 use openlogi_core::app::ForegroundApp;
 use openlogi_core::binding::{Action, ButtonId};
-use openlogi_core::config::{Config, LightSettings, ScrollResolution};
+use openlogi_core::config::{Config, LightSettings, ScrollResolution, VerticalScrollSensitivity};
 use openlogi_core::device::{
     Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
     LightCapabilities, PairedDevice, RawDeviceAddress, ReceiverInfo, StandaloneDevice,
 };
 use openlogi_hid::{DIRECT_DEVICE_INDEX, DeviceRoute};
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use crate::observable::ObservableState;
 
@@ -707,16 +706,26 @@ fn config_reload_keeps_manual_override_for_parameter_edits() {
 }
 
 #[test]
-fn config_reload_publishes_smooth_scroll_without_restarting_the_hook() {
+fn config_reload_publishes_scroll_preferences_without_restarting_the_hook() {
     let mut orch = orchestrator(Config::default());
-    let setting = Arc::clone(&orch.shared.smooth_scroll_enabled);
-    assert!(!setting.load(Ordering::Relaxed));
+    let preferences = Arc::clone(&orch.shared.scroll_preferences);
+    assert!(!preferences.smooth_scroll_enabled());
+    assert_eq!(
+        preferences.vertical_sensitivity(),
+        VerticalScrollSensitivity::DEFAULT
+    );
 
     let mut config = Config::default();
     config.app_settings.smooth_scroll = true;
+    config.app_settings.vertical_scroll_sensitivity =
+        VerticalScrollSensitivity::try_new(7).expect("valid sensitivity");
     orch.reload_config(config);
 
-    assert!(setting.load(Ordering::Relaxed));
+    assert!(preferences.smooth_scroll_enabled());
+    assert_eq!(
+        preferences.vertical_sensitivity(),
+        VerticalScrollSensitivity::try_new(7).expect("valid sensitivity")
+    );
 }
 
 #[test]

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -206,7 +206,7 @@ fn button_source_may_remap(device: Option<&EventDevice>) -> bool {
 /// requires a known Logitech sender; Linux and Windows perform device
 /// selection before this callback and therefore admit their unattributed
 /// wheel events through the same policy as button remapping.
-fn scroll_source_may_smooth(from_trackpad: bool, device: Option<&EventDevice>) -> bool {
+fn scroll_source_may_intercept(from_trackpad: bool, device: Option<&EventDevice>) -> bool {
     !from_trackpad && button_source_may_remap(device)
 }
 
@@ -472,7 +472,7 @@ pub fn start(
                         info!(button = %button, action = %action.label(), "native thumb wheel → executing bound action");
                         return queued_event_disposition(try_queue_action(&action_tx, action));
                     }
-                    if scroll_source_may_smooth(from_trackpad, device.as_ref()) {
+                    if scroll_source_may_intercept(from_trackpad, device.as_ref()) {
                         return queued_event_disposition(scroll.try_hook_scroll(delta));
                     }
                     EventDisposition::PassThrough

--- a/crates/openlogi-agent-core/src/runtime/hook/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook/tests.rs
@@ -153,7 +153,7 @@ fn rejected_key_edges_fail_open() {
 }
 
 #[test]
-fn smooth_scroll_uses_the_button_source_safety_policy_and_skips_trackpads() {
+fn scroll_interception_uses_the_button_source_safety_policy_and_skips_trackpads() {
     let logitech = EventDevice {
         vendor_id: Some(openlogi_hook::LOGITECH_VENDOR_ID),
         product_name: Some("Logitech MX Master".to_string()),
@@ -164,11 +164,11 @@ fn smooth_scroll_uses_the_button_source_safety_policy_and_skips_trackpads() {
         ..EventDevice::default()
     };
 
-    assert!(scroll_source_may_smooth(false, Some(&logitech)));
-    assert!(!scroll_source_may_smooth(true, Some(&logitech)));
-    assert!(!scroll_source_may_smooth(false, Some(&trackpad)));
+    assert!(scroll_source_may_intercept(false, Some(&logitech)));
+    assert!(!scroll_source_may_intercept(true, Some(&logitech)));
+    assert!(!scroll_source_may_intercept(false, Some(&trackpad)));
     assert_eq!(
-        scroll_source_may_smooth(false, None),
+        scroll_source_may_intercept(false, None),
         !cfg!(target_os = "macos"),
         "only macOS requires callback-time device attribution"
     );

--- a/crates/openlogi-agent-core/src/runtime/scroll.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll.rs
@@ -1,14 +1,14 @@
-//! Finite smooth-scroll animation owned by one dedicated worker.
+//! Traditional wheel output owned by one dedicated worker.
 //!
 //! Hook callbacks submit typed wheel impulses through [`ScrollInputHandle`]
-//! without blocking. The worker evaluates motion from absolute timestamps,
-//! retargets an active segment when more input arrives, and emits balanced
-//! phased output. Pixel-precise input never enters this runtime, so native
-//! trackpad and continuous wheel streams cannot be mixed with wheel ticks.
+//! without blocking. The worker either scales and emits them directly or
+//! evaluates finite smooth motion from absolute timestamps. Pixel-precise input
+//! never enters this runtime, so native trackpad and continuous wheel streams
+//! cannot be mixed with wheel ticks.
 
 mod worker;
 
-pub use worker::{ScrollInputHandle, ScrollRuntime};
+pub use worker::{ScrollInputHandle, ScrollPreferences, ScrollRuntime};
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -58,6 +58,15 @@ impl WheelDelta {
             x: self.x * factor,
             y: self.y * factor,
         }
+    }
+
+    fn with_vertical_scale(self, factor: f64) -> Option<Self> {
+        let y = self.y * factor;
+        y.is_finite().then_some(Self { x: self.x, y })
+    }
+
+    fn post(self) {
+        openlogi_inject::post_scroll(self.into());
     }
 }
 

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -1,13 +1,14 @@
-//! Worker ownership and non-blocking producer capability for smooth scrolling.
+//! Worker ownership and non-blocking producer capability for wheel output.
 
 use std::collections::HashSet;
 use std::io;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use openlogi_core::config::VerticalScrollSensitivity;
 use openlogi_core::scroll::ScrollDelta;
 use tracing::warn;
 
@@ -18,12 +19,84 @@ use crate::runtime::HidppSessionId;
 const INPUT_QUEUE_CAPACITY: usize = 128;
 /// Bounds graceful process shutdown if platform injection stops returning.
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
+const SMOOTH_SCROLL_FLAG: u8 = 0x80;
+const SENSITIVITY_MASK: u8 = !SMOOTH_SCROLL_FLAG;
+
+#[derive(Clone, Copy)]
+struct ScrollPreferenceSnapshot {
+    smooth_scroll: bool,
+    vertical_sensitivity: VerticalScrollSensitivity,
+}
+
+/// Atomically published settings read from input callbacks and the scroll
+/// worker without taking the orchestrator's config lock.
+///
+/// The smooth-scroll flag occupies the high bit and the validated `1..=100`
+/// sensitivity occupies the low seven bits. One byte therefore publishes a
+/// consistent settings snapshot instead of two independently changing values.
+pub struct ScrollPreferences {
+    encoded: AtomicU8,
+}
+
+impl ScrollPreferences {
+    /// Create a live settings cell from validated config values.
+    #[must_use]
+    pub fn new(smooth_scroll: bool, vertical_sensitivity: VerticalScrollSensitivity) -> Self {
+        Self {
+            encoded: AtomicU8::new(Self::encode(smooth_scroll, vertical_sensitivity)),
+        }
+    }
+
+    /// Publish both settings as one snapshot.
+    pub fn publish(&self, smooth_scroll: bool, vertical_sensitivity: VerticalScrollSensitivity) {
+        self.encoded.store(
+            Self::encode(smooth_scroll, vertical_sensitivity),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Whether finite smooth scrolling is currently enabled.
+    #[must_use]
+    pub fn smooth_scroll_enabled(&self) -> bool {
+        self.load().smooth_scroll
+    }
+
+    /// The current traditional vertical wheel sensitivity.
+    #[must_use]
+    pub fn vertical_sensitivity(&self) -> VerticalScrollSensitivity {
+        self.load().vertical_sensitivity
+    }
+
+    fn encode(smooth_scroll: bool, vertical_sensitivity: VerticalScrollSensitivity) -> u8 {
+        let sensitivity = u8::from(vertical_sensitivity);
+        debug_assert_eq!(sensitivity & SMOOTH_SCROLL_FLAG, 0);
+        sensitivity | if smooth_scroll { SMOOTH_SCROLL_FLAG } else { 0 }
+    }
+
+    fn load(&self) -> ScrollPreferenceSnapshot {
+        let encoded = self.encoded.load(Ordering::Relaxed);
+        let raw_sensitivity = encoded & SENSITIVITY_MASK;
+        let Ok(vertical_sensitivity) = VerticalScrollSensitivity::try_new(raw_sensitivity) else {
+            unreachable!("ScrollPreferences is initialized and published from validated values");
+        };
+        ScrollPreferenceSnapshot {
+            smooth_scroll: encoded & SMOOTH_SCROLL_FLAG != 0,
+            vertical_sensitivity,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ScrollOutputMode {
+    Smooth { at: Instant },
+    Direct,
+}
 
 struct ScrollInput {
     generation: u64,
     source: ScrollSource,
     impulse: WheelDelta,
-    at: Instant,
+    output: ScrollOutputMode,
 }
 
 enum ScrollCommand {
@@ -52,17 +125,38 @@ pub struct ScrollInputHandle {
     controls: mpsc::Sender<ScrollControl>,
     generation: Arc<AtomicU64>,
     accepting: Arc<AtomicBool>,
-    enabled: Arc<AtomicBool>,
+    preferences: Arc<ScrollPreferences>,
 }
 
 impl ScrollInputHandle {
     /// Queue one ordinary wheel impulse from the current OS-hook thread.
     ///
-    /// Pixel input, zero/non-finite distance, a disabled preference, a full
-    /// queue, or an unavailable worker are rejected so the callback fails open.
+    /// Pixel input, zero/non-finite distance, a full queue, or an unavailable
+    /// worker are rejected so the callback fails open. With smoothing disabled,
+    /// only a changed vertical distance is accepted; the worker emits that
+    /// distance directly and the callback remains injection-free.
     #[must_use]
     pub fn try_hook_scroll(&self, delta: ScrollDelta) -> bool {
-        self.try_scroll(ScrollSource::current_hook(), delta)
+        if !self.accepting.load(Ordering::Acquire) {
+            return false;
+        }
+        let Ok(impulse) = WheelDelta::try_from(delta) else {
+            return false;
+        };
+        let preferences = self.preferences.load();
+        let Some(scaled) =
+            impulse.with_vertical_scale(preferences.vertical_sensitivity.scroll_multiplier())
+        else {
+            return false;
+        };
+        let output = if preferences.smooth_scroll {
+            ScrollOutputMode::Smooth { at: Instant::now() }
+        } else if scaled != impulse {
+            ScrollOutputMode::Direct
+        } else {
+            return false;
+        };
+        self.try_enqueue(ScrollSource::current_hook(), scaled, output)
     }
 
     /// Queue one diverted thumb-wheel impulse from an active HID++ session.
@@ -71,30 +165,39 @@ impl ScrollInputHandle {
     /// directly; unlike an OS hook, there is no physical event to pass through.
     #[must_use]
     pub(crate) fn try_hidpp_scroll(&self, session: &HidppSessionId, delta: ScrollDelta) -> bool {
-        self.try_scroll(ScrollSource::Hidpp(session.clone()), delta)
-    }
-
-    fn try_scroll(&self, source: ScrollSource, delta: ScrollDelta) -> bool {
-        if !self.accepting.load(Ordering::Acquire) || !self.enabled.load(Ordering::Relaxed) {
+        if !self.accepting.load(Ordering::Acquire) || !self.preferences.smooth_scroll_enabled() {
             return false;
         }
         let Ok(impulse) = WheelDelta::try_from(delta) else {
             return false;
         };
+        self.try_enqueue(
+            ScrollSource::Hidpp(session.clone()),
+            impulse,
+            ScrollOutputMode::Smooth { at: Instant::now() },
+        )
+    }
+
+    fn try_enqueue(
+        &self,
+        source: ScrollSource,
+        impulse: WheelDelta,
+        output: ScrollOutputMode,
+    ) -> bool {
         let input = ScrollInput {
             generation: self.generation.load(Ordering::Acquire),
             source,
             impulse,
-            at: Instant::now(),
+            output,
         };
         match self.commands.try_send(ScrollCommand::Input(input)) {
             Ok(()) => true,
             Err(mpsc::TrySendError::Full(_)) => {
-                warn!("smooth-scroll queue full — input rejected");
+                warn!("scroll output queue full — input rejected");
                 false
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
-                warn!("smooth-scroll worker unavailable — input rejected");
+                warn!("scroll output worker unavailable — input rejected");
                 false
             }
         }
@@ -140,7 +243,7 @@ impl ScrollInputHandle {
     }
 }
 
-/// Unique owner of the smooth-scroll worker and its graceful shutdown.
+/// Unique owner of the scroll output worker and its graceful shutdown.
 pub struct ScrollRuntime {
     input: ScrollInputHandle,
     controls: mpsc::Sender<ScrollControl>,
@@ -148,14 +251,15 @@ pub struct ScrollRuntime {
 }
 
 impl ScrollRuntime {
-    /// Start the dedicated animation worker using the live opt-in setting.
-    pub fn spawn(enabled: Arc<AtomicBool>) -> io::Result<Self> {
-        Self::spawn_with(enabled, ScrollFrame::post)
+    /// Start the dedicated output worker using the live scroll settings.
+    pub fn spawn(preferences: Arc<ScrollPreferences>) -> io::Result<Self> {
+        Self::spawn_with(preferences, ScrollFrame::post, WheelDelta::post)
     }
 
     pub(super) fn spawn_with(
-        enabled: Arc<AtomicBool>,
-        mut emit: impl FnMut(ScrollFrame) + Send + 'static,
+        preferences: Arc<ScrollPreferences>,
+        mut emit_smooth: impl FnMut(ScrollFrame) + Send + 'static,
+        mut emit_direct: impl FnMut(WheelDelta) + Send + 'static,
     ) -> io::Result<Self> {
         let (commands, command_rx) = mpsc::sync_channel(INPUT_QUEUE_CAPACITY);
         let (controls, control_rx) = mpsc::channel();
@@ -165,12 +269,19 @@ impl ScrollRuntime {
             controls: controls.clone(),
             generation: Arc::clone(&generation),
             accepting: Arc::new(AtomicBool::new(true)),
-            enabled: Arc::clone(&enabled),
+            preferences: Arc::clone(&preferences),
         };
         let worker = thread::Builder::new()
             .name("openlogi-scroll".into())
             .spawn(move || {
-                run_worker(&command_rx, &control_rx, &generation, &enabled, &mut emit);
+                run_worker(
+                    &command_rx,
+                    &control_rx,
+                    &generation,
+                    &preferences,
+                    &mut emit_smooth,
+                    &mut emit_direct,
+                );
             })?;
         Ok(Self {
             input,
@@ -229,8 +340,9 @@ fn run_worker(
     commands: &mpsc::Receiver<ScrollCommand>,
     controls: &mpsc::Receiver<ScrollControl>,
     shared_generation: &AtomicU64,
-    enabled: &AtomicBool,
-    emit: &mut impl FnMut(ScrollFrame),
+    preferences: &ScrollPreferences,
+    emit_smooth: &mut impl FnMut(ScrollFrame),
+    emit_direct: &mut impl FnMut(WheelDelta),
 ) {
     let mut engine = ScrollEngine::default();
     // An overflow-cancelled incarnation stays tombstoned so accepted input that
@@ -241,11 +353,11 @@ fn run_worker(
         while let Ok(control) = controls.try_recv() {
             match control {
                 ScrollControl::CancelOverflowSource(source) => {
-                    engine.cancel_source(&source, emit);
+                    engine.cancel_source(&source, emit_smooth);
                     overflow_cancelled_sources.insert(source);
                 }
                 ScrollControl::Shutdown(request) => {
-                    engine.cancel_all(emit);
+                    engine.cancel_all(emit_smooth);
                     let _ = request.done.send(());
                     return;
                 }
@@ -253,8 +365,8 @@ fn run_worker(
         }
 
         let current_generation = shared_generation.load(Ordering::Acquire);
-        if current_generation != generation || !enabled.load(Ordering::Relaxed) {
-            engine.cancel_all(emit);
+        if current_generation != generation || !preferences.smooth_scroll_enabled() {
+            engine.cancel_all(emit_smooth);
             generation = current_generation;
         }
 
@@ -269,16 +381,28 @@ fn run_worker(
         match command {
             Ok(ScrollCommand::Input(input))
                 if input.generation == generation
-                    && enabled.load(Ordering::Relaxed)
                     && !overflow_cancelled_sources.contains(&input.source) =>
             {
-                engine.impulse(input.source, input.impulse, input.at, emit);
+                match input.output {
+                    ScrollOutputMode::Smooth { at } if preferences.smooth_scroll_enabled() => {
+                        engine.impulse(input.source, input.impulse, at, emit_smooth);
+                    }
+                    ScrollOutputMode::Direct => {
+                        engine.cancel_source(&input.source, emit_smooth);
+                        emit_direct(input.impulse);
+                    }
+                    ScrollOutputMode::Smooth { .. } => {}
+                }
             }
-            Ok(ScrollCommand::CancelSource(source)) => engine.cancel_source(&source, emit),
+            Ok(ScrollCommand::CancelSource(source)) => {
+                engine.cancel_source(&source, emit_smooth);
+            }
             Ok(ScrollCommand::Input(_) | ScrollCommand::Wake) => {}
-            Err(mpsc::RecvTimeoutError::Timeout) => engine.advance_due(Instant::now(), emit),
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                engine.advance_due(Instant::now(), emit_smooth);
+            }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                engine.cancel_all(emit);
+                engine.cancel_all(emit_smooth);
                 return;
             }
         }
@@ -289,9 +413,20 @@ fn run_worker(
 mod tests {
     use super::*;
 
+    fn sensitivity(raw: u8) -> VerticalScrollSensitivity {
+        VerticalScrollSensitivity::try_new(raw).expect("test sensitivity is valid")
+    }
+
+    fn preferences(smooth_scroll: bool, sensitivity: u8) -> Arc<ScrollPreferences> {
+        Arc::new(ScrollPreferences::new(
+            smooth_scroll,
+            self::sensitivity(sensitivity),
+        ))
+    }
+
     fn standalone_input(
         capacity: usize,
-        enabled: bool,
+        preferences: Arc<ScrollPreferences>,
     ) -> (
         ScrollInputHandle,
         mpsc::Receiver<ScrollCommand>,
@@ -305,27 +440,92 @@ mod tests {
                 controls,
                 generation: Arc::new(AtomicU64::new(0)),
                 accepting: Arc::new(AtomicBool::new(true)),
-                enabled: Arc::new(AtomicBool::new(enabled)),
+                preferences,
             },
             receiver,
             control_rx,
         )
     }
 
+    fn queued_input(receiver: &mpsc::Receiver<ScrollCommand>) -> ScrollInput {
+        let ScrollCommand::Input(input) = receiver.recv().expect("queued input") else {
+            panic!("expected scroll input");
+        };
+        input
+    }
+
     #[test]
     fn callback_submission_rejects_ineligible_input_and_fails_open_when_full() {
-        let (disabled, _commands, _controls) = standalone_input(1, false);
+        let (disabled, _commands, _controls) = standalone_input(
+            1,
+            preferences(false, u8::from(VerticalScrollSensitivity::DEFAULT)),
+        );
         assert!(!disabled.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
 
-        let (input, _commands, _controls) = standalone_input(1, true);
+        let (input, _commands, _controls) = standalone_input(
+            1,
+            preferences(true, u8::from(VerticalScrollSensitivity::DEFAULT)),
+        );
         assert!(!input.try_hook_scroll(ScrollDelta::pixels(0.0, 1.0)));
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
         assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
     }
 
     #[test]
+    fn hook_scales_only_vertical_wheel_distance_and_selects_direct_output() {
+        let (input, receiver, _controls) = standalone_input(2, preferences(false, 7));
+        assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(2.0, 0.0)));
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(2.0, 2.0)));
+
+        let queued = queued_input(&receiver);
+        assert_eq!(queued.impulse, WheelDelta { x: 2.0, y: 1.0 });
+        assert!(matches!(queued.output, ScrollOutputMode::Direct));
+    }
+
+    #[test]
+    fn hook_scales_vertical_distance_before_smoothing() {
+        let (input, receiver, _controls) = standalone_input(1, preferences(true, 7));
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(2.0, 2.0)));
+
+        let queued = queued_input(&receiver);
+        assert_eq!(queued.impulse, WheelDelta { x: 2.0, y: 1.0 });
+        assert!(matches!(queued.output, ScrollOutputMode::Smooth { .. }));
+    }
+
+    #[test]
+    fn hidpp_smoothing_does_not_apply_main_wheel_sensitivity() {
+        let (input, receiver, _controls) = standalone_input(1, preferences(true, 7));
+        let session = HidppSessionId::new("mouse-a", 7);
+        assert!(input.try_hidpp_scroll(&session, ScrollDelta::wheel_ticks(0.0, 2.0)));
+
+        let queued = queued_input(&receiver);
+        assert_eq!(queued.impulse, WheelDelta { x: 0.0, y: 2.0 });
+        assert!(matches!(queued.output, ScrollOutputMode::Smooth { .. }));
+    }
+
+    #[test]
+    fn live_preferences_change_hook_admission_and_output_mode() {
+        let preferences = preferences(false, u8::from(VerticalScrollSensitivity::DEFAULT));
+        let (input, receiver, _controls) = standalone_input(2, Arc::clone(&preferences));
+        assert!(!input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+
+        preferences.publish(false, sensitivity(7));
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 2.0)));
+        assert!(matches!(
+            queued_input(&receiver).output,
+            ScrollOutputMode::Direct
+        ));
+
+        preferences.publish(true, sensitivity(28));
+        assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));
+        let queued = queued_input(&receiver);
+        assert_eq!(queued.impulse, WheelDelta { x: 0.0, y: 2.0 });
+        assert!(matches!(queued.output, ScrollOutputMode::Smooth { .. }));
+    }
+
+    #[test]
     fn hidpp_cancellation_targets_its_session() {
-        let (input, commands, _controls) = standalone_input(1, true);
+        let (input, commands, _controls) = standalone_input(1, preferences(true, 14));
         let session = HidppSessionId::new("mouse-a", 7);
         input.cancel_hidpp_session(&session);
 
@@ -340,7 +540,8 @@ mod tests {
 
     #[test]
     fn cancellation_overtakes_a_full_queue_without_discarding_another_source() {
-        let (input, commands, controls) = standalone_input(2, true);
+        let preferences = preferences(true, 14);
+        let (input, commands, controls) = standalone_input(2, Arc::clone(&preferences));
         let cancelled = HidppSessionId::new("mouse-a", 7);
         let survivor = HidppSessionId::new("mouse-b", 3);
         assert!(input.try_hidpp_scroll(&cancelled, ScrollDelta::wheel_ticks(1.0, 0.0)));
@@ -354,12 +555,18 @@ mod tests {
         );
 
         let generation = Arc::clone(&input.generation);
-        let enabled = Arc::clone(&input.enabled);
         let (emitted, frames) = mpsc::channel();
         let worker = thread::spawn(move || {
-            run_worker(&commands, &controls, &generation, &enabled, &mut |frame| {
-                emitted.send(frame).expect("frame receiver remains open");
-            });
+            run_worker(
+                &commands,
+                &controls,
+                &generation,
+                &preferences,
+                &mut |frame| {
+                    emitted.send(frame).expect("frame receiver remains open");
+                },
+                &mut |_| {},
+            );
         });
 
         let mut output = Vec::new();
@@ -397,20 +604,57 @@ mod tests {
 
     #[test]
     fn idle_worker_shutdown_wakes_after_publishing_its_request() {
-        let mut runtime = ScrollRuntime::spawn_with(Arc::new(AtomicBool::new(false)), |_| {})
+        let mut runtime = ScrollRuntime::spawn_with(preferences(false, 14), |_| {}, |_| {})
             .expect("spawn scroll worker");
         assert!(runtime.shutdown_with_timeout(Duration::from_millis(100)));
     }
 
     #[test]
+    fn direct_scaled_output_is_emitted_by_the_worker() {
+        let (outputs, received) = mpsc::channel();
+        let smooth_outputs = outputs.clone();
+        let mut runtime = ScrollRuntime::spawn_with(
+            preferences(false, 7),
+            move |frame| {
+                smooth_outputs
+                    .send(Err(frame))
+                    .expect("test output receiver remains open");
+            },
+            move |delta| {
+                outputs
+                    .send(Ok(delta))
+                    .expect("test output receiver remains open");
+            },
+        )
+        .expect("spawn scroll worker");
+        assert!(
+            runtime
+                .input()
+                .try_hook_scroll(ScrollDelta::wheel_ticks(3.0, 2.0))
+        );
+
+        assert_eq!(
+            received
+                .recv_timeout(Duration::from_secs(1))
+                .expect("direct worker output")
+                .expect("output must be direct"),
+            WheelDelta { x: 3.0, y: 1.0 }
+        );
+        runtime.shutdown();
+    }
+
+    #[test]
     fn generation_invalidation_cancels_started_output_out_of_band() {
-        let enabled = Arc::new(AtomicBool::new(true));
         let (frames, received) = mpsc::channel();
-        let mut runtime = ScrollRuntime::spawn_with(enabled, move |frame| {
-            frames
-                .send(frame)
-                .expect("test frame receiver remains open");
-        })
+        let mut runtime = ScrollRuntime::spawn_with(
+            preferences(true, 14),
+            move |frame| {
+                frames
+                    .send(frame)
+                    .expect("test frame receiver remains open");
+            },
+            |_| {},
+        )
         .expect("spawn scroll worker");
         let input = runtime.input();
         assert!(input.try_hook_scroll(ScrollDelta::wheel_ticks(0.0, 1.0)));

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -191,7 +191,7 @@ impl InputServices {
                 return None;
             }
         };
-        let scroll_runtime = match ScrollRuntime::spawn(Arc::clone(&shared.smooth_scroll_enabled)) {
+        let scroll_runtime = match ScrollRuntime::spawn(Arc::clone(&shared.scroll_preferences)) {
             Ok(runtime) => runtime,
             Err(e) => {
                 warn!(error = %e, "could not start smooth-scroll worker — agent exiting");

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -296,12 +296,17 @@ mod tests {
     use openlogi_agent_core::DpiCycles;
     use openlogi_agent_core::receiver_access::ReceiverAccess;
     use openlogi_agent_core::runtime::hook::HookMaps;
+    use openlogi_agent_core::runtime::scroll::ScrollPreferences;
+    use openlogi_core::config::VerticalScrollSensitivity;
 
     fn shared_runtime() -> SharedRuntime {
         SharedRuntime {
             hook_maps: Arc::new(RwLock::new(HookMaps::default())),
             keyboard_bindings: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
-            smooth_scroll_enabled: Arc::new(false.into()),
+            scroll_preferences: Arc::new(ScrollPreferences::new(
+                false,
+                VerticalScrollSensitivity::DEFAULT,
+            )),
             dpi_cycle: Arc::new(RwLock::new(DpiCycles::default())),
             capture_plans: Arc::new(RwLock::new(Vec::new())),
             capture_channel: Arc::new(RwLock::new(None)),

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -32,7 +32,7 @@ pub use settings::LightSettings;
 pub use settings::{
     AppIcon, AppSettings, Appearance, AssetSourcePreference, CameraControls, DeviceViewMode,
     Lighting, SMARTSHIFT_AUTO_DISENGAGE_DEFAULT, SMARTSHIFT_MIN_AUTO_DISENGAGE, ScrollResolution,
-    SmartShift, ThumbwheelSensitivity, UiScale, WheelMode,
+    SmartShift, ThumbwheelSensitivity, UiScale, VerticalScrollSensitivity, WheelMode,
 };
 
 use crate::binding::{

--- a/crates/openlogi-core/src/config/settings.rs
+++ b/crates/openlogi-core/src/config/settings.rs
@@ -199,6 +199,11 @@ pub struct AppSettings {
     /// message there.
     #[serde(default)]
     pub smooth_scroll: bool,
+    /// Distance multiplier for traditional vertical mouse-wheel input.
+    /// [`VerticalScrollSensitivity::DEFAULT`] means 1×; trackpad and other
+    /// continuous pixel input is never scaled.
+    #[serde(default)]
+    pub vertical_scroll_sensitivity: VerticalScrollSensitivity,
     /// Which app icon the user picked. Applied at launch, and whenever it
     /// changes, by whichever process owns a surface showing one — on macOS the
     /// GUI hands the choice to the Dock and writes it onto the bundle (so the
@@ -262,10 +267,86 @@ pub struct AppSettings {
     pub ui_radius: Option<u8>,
 }
 
+const SENSITIVITY_MIN: u8 = 1;
+const SENSITIVITY_MAX: u8 = 100;
+const SENSITIVITY_DEFAULT: u8 = 14;
+
+/// Traditional vertical mouse-wheel responsiveness on OpenLogi's `1..=100`
+/// scale.
+///
+/// This is deliberately distinct from [`ThumbwheelSensitivity`]: vertical
+/// sensitivity changes only scroll distance and never changes a custom action
+/// threshold.
+#[nutype(
+    const_fn,
+    validate(greater_or_equal = SENSITIVITY_MIN, less_or_equal = SENSITIVITY_MAX),
+    derive(
+        Debug,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        TryFrom,
+        Into,
+        Display,
+        Serialize,
+        Deserialize
+    )
+)]
+pub struct VerticalScrollSensitivity(u8);
+
+impl VerticalScrollSensitivity {
+    /// Lowest selectable sensitivity.
+    pub const MIN: Self = match Self::try_new(SENSITIVITY_MIN) {
+        Ok(value) => value,
+        Err(_) => panic!("valid minimum vertical scroll sensitivity"),
+    };
+    /// Highest selectable sensitivity.
+    pub const MAX: Self = match Self::try_new(SENSITIVITY_MAX) {
+        Ok(value) => value,
+        Err(_) => panic!("valid maximum vertical scroll sensitivity"),
+    };
+    /// Out-of-the-box sensitivity. At this value scrolling runs at 1×.
+    pub const DEFAULT: Self = match Self::try_new(SENSITIVITY_DEFAULT) {
+        Ok(value) => value,
+        Err(_) => panic!("valid default vertical scroll sensitivity"),
+    };
+
+    /// Round and clamp a floating-point slider value into the valid range.
+    #[must_use]
+    pub fn from_rounded(value: f32) -> Self {
+        let raw = rounded_sensitivity(value);
+        let Ok(value) = Self::try_new(raw) else {
+            unreachable!("clamped vertical scroll sensitivity is always valid");
+        };
+        value
+    }
+
+    /// Vertical scroll-distance multiplier relative to [`Self::DEFAULT`].
+    #[must_use]
+    pub fn scroll_multiplier(self) -> f64 {
+        f64::from(self.into_inner()) / f64::from(Self::DEFAULT.into_inner())
+    }
+}
+
+impl Default for VerticalScrollSensitivity {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl From<VerticalScrollSensitivity> for f32 {
+    fn from(sensitivity: VerticalScrollSensitivity) -> Self {
+        Self::from(sensitivity.into_inner())
+    }
+}
+
 /// Thumb-wheel responsiveness on OpenLogi's `1..=100` scale.
 #[nutype(
     const_fn,
-    validate(greater_or_equal = 1, less_or_equal = 100),
+    validate(greater_or_equal = SENSITIVITY_MIN, less_or_equal = SENSITIVITY_MAX),
     derive(
         Debug,
         Clone,
@@ -285,18 +366,18 @@ pub struct ThumbwheelSensitivity(u8);
 
 impl ThumbwheelSensitivity {
     /// Lowest selectable sensitivity.
-    pub const MIN: Self = match Self::try_new(1) {
+    pub const MIN: Self = match Self::try_new(SENSITIVITY_MIN) {
         Ok(value) => value,
         Err(_) => panic!("valid minimum thumb-wheel sensitivity"),
     };
     /// Highest selectable sensitivity.
-    pub const MAX: Self = match Self::try_new(100) {
+    pub const MAX: Self = match Self::try_new(SENSITIVITY_MAX) {
         Ok(value) => value,
         Err(_) => panic!("valid maximum thumb-wheel sensitivity"),
     };
     /// Out-of-the-box sensitivity. At this value scrolling runs at 1× and
     /// remains native unless a thumb-wheel binding is customized.
-    pub const DEFAULT: Self = match Self::try_new(14) {
+    pub const DEFAULT: Self = match Self::try_new(SENSITIVITY_DEFAULT) {
         Ok(value) => value,
         Err(_) => panic!("valid default thumb-wheel sensitivity"),
     };
@@ -304,15 +385,7 @@ impl ThumbwheelSensitivity {
     /// Round and clamp a floating-point slider value into the valid range.
     #[must_use]
     pub fn from_rounded(value: f32) -> Self {
-        let value = if value.is_nan() {
-            f32::from(Self::MIN)
-        } else {
-            value
-        };
-        let raw = value
-            .clamp(f32::from(Self::MIN), f32::from(Self::MAX))
-            .round()
-            .saturating_as::<u8>();
+        let raw = rounded_sensitivity(value);
         let Ok(value) = Self::try_new(raw) else {
             unreachable!("clamped thumb-wheel sensitivity is always valid");
         };
@@ -350,6 +423,18 @@ impl From<ThumbwheelSensitivity> for i32 {
     }
 }
 
+fn rounded_sensitivity(value: f32) -> u8 {
+    let value = if value.is_nan() {
+        f32::from(SENSITIVITY_MIN)
+    } else {
+        value
+    };
+    value
+        .clamp(f32::from(SENSITIVITY_MIN), f32::from(SENSITIVITY_MAX))
+        .round()
+        .saturating_as::<u8>()
+}
+
 impl AppSettings {
     /// `skip_serializing_if` helper: true when nothing diverges from the
     /// default, so empty settings don't clutter `config.toml`.
@@ -369,6 +454,7 @@ impl Default for AppSettings {
             show_in_menu_bar: true,
             capture_mouse_events: true,
             smooth_scroll: false,
+            vertical_scroll_sensitivity: VerticalScrollSensitivity::DEFAULT,
             auto_download_assets: true,
             asset_source: AssetSourcePreference::Automatic,
             language: None,
@@ -708,6 +794,23 @@ mod tests {
         assert_eq!(
             ThumbwheelSensitivity::from_rounded(f32::INFINITY),
             ThumbwheelSensitivity::MAX
+        );
+    }
+
+    #[test]
+    fn floating_vertical_scroll_sensitivity_rounds_and_saturates_into_the_domain() {
+        assert_eq!(u8::from(VerticalScrollSensitivity::from_rounded(49.6)), 50);
+        assert_eq!(
+            VerticalScrollSensitivity::from_rounded(f32::NAN),
+            VerticalScrollSensitivity::MIN
+        );
+        assert_eq!(
+            VerticalScrollSensitivity::from_rounded(f32::NEG_INFINITY),
+            VerticalScrollSensitivity::MIN
+        );
+        assert_eq!(
+            VerticalScrollSensitivity::from_rounded(f32::INFINITY),
+            VerticalScrollSensitivity::MAX
         );
     }
 }

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -822,6 +822,24 @@ fn app_settings_smooth_scroll_is_opt_in_and_roundtrips() {
 }
 
 #[test]
+fn app_settings_vertical_scroll_sensitivity_defaults_and_roundtrips() {
+    let default: Config = toml::from_str("schema_version = 5").expect("parse defaults");
+    assert_eq!(
+        default.app_settings.vertical_scroll_sensitivity,
+        VerticalScrollSensitivity::DEFAULT
+    );
+
+    let mut cfg = Config::default();
+    cfg.app_settings.vertical_scroll_sensitivity =
+        VerticalScrollSensitivity::try_new(7).expect("valid sensitivity");
+    let parsed = write_and_read(&cfg);
+    assert_eq!(
+        parsed.app_settings.vertical_scroll_sensitivity,
+        VerticalScrollSensitivity::try_new(7).expect("valid sensitivity")
+    );
+}
+
+#[test]
 fn app_settings_ui_scale_roundtrips() {
     let mut cfg = Config::default();
     cfg.app_settings.ui_scale = UiScale::ExtraLarge;
@@ -1122,6 +1140,9 @@ fn persisted_numeric_contracts_reject_unsafe_values() {
         "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = 0\n",
         "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = 101\n",
         "schema_version = 5\n[app_settings]\nthumbwheel_sensitivity = -2147483648\n",
+        "schema_version = 5\n[app_settings]\nvertical_scroll_sensitivity = 0\n",
+        "schema_version = 5\n[app_settings]\nvertical_scroll_sensitivity = 101\n",
+        "schema_version = 5\n[app_settings]\nvertical_scroll_sensitivity = -2147483648\n",
         "schema_version = 5\n[devices.mouse]\nthumbwheel_sensitivity = -1\n",
         "schema_version = 5\n[devices.mouse]\ndpi = 65536\n",
         "schema_version = 5\n[devices.mouse]\ndpi_presets = [800, 70000]\n",

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -4,7 +4,7 @@ use super::AppState;
 use gpui::App;
 use openlogi_core::config::{
     AppIcon, AppSettings, Appearance, AssetSourcePreference, DeviceViewMode, ThumbwheelSensitivity,
-    UiScale,
+    UiScale, VerticalScrollSensitivity,
 };
 
 impl AppState {
@@ -243,6 +243,16 @@ impl AppState {
         self.config
             .edit(|config| config.app_settings.thumbwheel_sensitivity = sensitivity);
         self.persist_and_reload("thumbwheel sensitivity");
+    }
+    /// Set traditional vertical mouse-wheel sensitivity and persist it. The
+    /// agent publishes the value to its scroll worker on config reload. No-op
+    /// when unchanged; disk failures restore the persisted value.
+    pub fn set_vertical_scroll_sensitivity(&mut self, sensitivity: VerticalScrollSensitivity) {
+        if self.config.app_settings.vertical_scroll_sensitivity == sensitivity {
+            return;
+        }
+        self.config.app_settings.vertical_scroll_sensitivity = sensitivity;
+        self.persist_and_reload("vertical scroll sensitivity");
     }
     pub fn set_auto_download_assets(&mut self, enabled: bool) {
         if self.config.app_settings.auto_download_assets == enabled {

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -251,7 +251,8 @@ impl AppState {
         if self.config.app_settings.vertical_scroll_sensitivity == sensitivity {
             return;
         }
-        self.config.app_settings.vertical_scroll_sensitivity = sensitivity;
+        self.config
+            .edit(|config| config.app_settings.vertical_scroll_sensitivity = sensitivity);
         self.persist_and_reload("vertical scroll sensitivity");
     }
     pub fn set_auto_download_assets(&mut self, enabled: bool) {

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -7,6 +7,7 @@ use openlogi_camera::Camera;
 use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_core::config::{
     Config, DeviceIdentity, LightSettings, Lighting, ScrollResolution, ThumbwheelSensitivity,
+    VerticalScrollSensitivity,
 };
 use openlogi_core::device::{
     BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
@@ -44,10 +45,15 @@ fn read_only_config_rolls_back_mutations_and_does_not_reload_agent() {
     );
 
     state.set_thumbwheel_sensitivity(ThumbwheelSensitivity::from_rounded(50.0));
+    state.set_vertical_scroll_sensitivity(VerticalScrollSensitivity::from_rounded(7.0));
 
     assert_eq!(
         state.app_settings().thumbwheel_sensitivity,
         ThumbwheelSensitivity::DEFAULT
+    );
+    assert_eq!(
+        state.app_settings().vertical_scroll_sensitivity,
+        VerticalScrollSensitivity::DEFAULT
     );
     assert_eq!(state.config_issue(), Some("invalid config"));
     assert!(receiver.try_recv().is_err());

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -317,16 +317,23 @@ impl SettingsView {
     )]
     fn on_vertical_scroll_sensitivity_slider(
         &mut self,
-        _: &Entity<SliderState>,
+        slider: &Entity<SliderState>,
         event: &SliderEvent,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let SliderEvent::Release(value) = event {
             let sensitivity = VerticalScrollSensitivity::from_rounded(value.start());
-            AppState::update(cx, |state, cx| {
+            let committed = AppState::update(cx, |state, cx| {
                 state.set_vertical_scroll_sensitivity(sensitivity);
                 cx.emit(StateEvent::SettingsChanged);
+                state.app_settings().vertical_scroll_sensitivity
+            });
+            // A failed write restores AppState's persisted configuration. Re-seat
+            // this independently owned slider so it cannot keep presenting the
+            // rejected value after that rollback.
+            slider.update(cx, |slider, cx| {
+                slider.set_value(f32::from(committed), window, cx);
             });
         }
         cx.notify();

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -34,7 +34,7 @@ pub(super) use gpui_component::{
 pub(super) use gpui_updater::{UpdateStatus, Updater};
 pub(super) use openlogi_core::brand::{HELP_URL, RELEASES_URL, REPO_URL};
 pub(super) use openlogi_core::config::{
-    Appearance, AssetSourcePreference, ThumbwheelSensitivity, UiScale,
+    Appearance, AssetSourcePreference, ThumbwheelSensitivity, UiScale, VerticalScrollSensitivity,
 };
 
 pub(super) use crate::app::menu::{CloseWindow, Minimize, Zoom};
@@ -117,7 +117,8 @@ pub struct SettingsView {
     initial_page: SettingsPage,
     language_select: Entity<SelectState<Vec<language::LanguageOption>>>,
     asset_source_select: Entity<SelectState<Vec<assets::AssetSourceOption>>>,
-    sensitivity_slider: Entity<SliderState>,
+    thumbwheel_sensitivity_slider: Entity<SliderState>,
+    vertical_scroll_sensitivity_slider: Entity<SliderState>,
     /// Shared app-wide updater, surfaced on the Updates page. A launch-time
     /// check result is already visible when the window opens.
     updater: Entity<Updater>,
@@ -190,17 +191,9 @@ impl SettingsView {
         cx.subscribe_in(&asset_source_select, window, Self::on_asset_source_select)
             .detach();
 
-        let sensitivity = AppState::try_read(cx).map_or(ThumbwheelSensitivity::DEFAULT, |s| {
-            s.app_settings().thumbwheel_sensitivity
-        });
-        let sensitivity_slider = cx.new(|_| {
-            SliderState::new()
-                .min(f32::from(ThumbwheelSensitivity::MIN))
-                .max(f32::from(ThumbwheelSensitivity::MAX))
-                .default_value(f32::from(sensitivity))
-        });
-        cx.subscribe_in(&sensitivity_slider, window, Self::on_sensitivity_slider)
-            .detach();
+        let thumbwheel_sensitivity_slider = Self::thumbwheel_sensitivity_slider(window, cx);
+        let vertical_scroll_sensitivity_slider =
+            Self::vertical_scroll_sensitivity_slider(window, cx);
 
         // Poll the agent's live event monitor while this window is open. The task
         // is held in the view, so closing Settings drops it, polling stops, and
@@ -246,7 +239,8 @@ impl SettingsView {
             initial_page,
             language_select,
             asset_source_select,
-            sensitivity_slider,
+            thumbwheel_sensitivity_slider,
+            vertical_scroll_sensitivity_slider,
             updater,
             updater_obs,
             copied: false,
@@ -257,14 +251,49 @@ impl SettingsView {
         }
     }
 
+    fn thumbwheel_sensitivity_slider(
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<SliderState> {
+        let current = AppState::try_read(cx).map_or(ThumbwheelSensitivity::DEFAULT, |state| {
+            state.app_settings().thumbwheel_sensitivity
+        });
+        let slider = cx.new(|_| {
+            SliderState::new()
+                .min(f32::from(ThumbwheelSensitivity::MIN))
+                .max(f32::from(ThumbwheelSensitivity::MAX))
+                .default_value(f32::from(current))
+        });
+        cx.subscribe_in(&slider, window, Self::on_thumbwheel_sensitivity_slider)
+            .detach();
+        slider
+    }
+
+    fn vertical_scroll_sensitivity_slider(
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<SliderState> {
+        let current = AppState::try_read(cx).map_or(VerticalScrollSensitivity::DEFAULT, |state| {
+            state.app_settings().vertical_scroll_sensitivity
+        });
+        let slider = cx.new(|_| {
+            SliderState::new()
+                .min(f32::from(VerticalScrollSensitivity::MIN))
+                .max(f32::from(VerticalScrollSensitivity::MAX))
+                .default_value(f32::from(current))
+        });
+        cx.subscribe_in(&slider, window, Self::on_vertical_scroll_sensitivity_slider)
+            .detach();
+        slider
+    }
+
     /// Commit the thumb-wheel sensitivity slider. The label tracks the live
-    /// slider value on every `Change`; persistence (and the one shared-atomic
-    /// write the watcher reads) happens once on `Release`.
+    /// slider value on every `Change`; persistence happens once on `Release`.
     #[expect(
         clippy::unused_self,
         reason = "gpui subscription handlers must take &mut self"
     )]
-    fn on_sensitivity_slider(
+    fn on_thumbwheel_sensitivity_slider(
         &mut self,
         _: &Entity<SliderState>,
         event: &SliderEvent,
@@ -275,6 +304,28 @@ impl SettingsView {
             let sensitivity = ThumbwheelSensitivity::from_rounded(value.start());
             AppState::update(cx, |state, cx| {
                 state.set_thumbwheel_sensitivity(sensitivity);
+                cx.emit(StateEvent::SettingsChanged);
+            });
+        }
+        cx.notify();
+    }
+
+    /// Commit the vertical scroll sensitivity once the slider is released.
+    #[expect(
+        clippy::unused_self,
+        reason = "gpui subscription handlers must take &mut self"
+    )]
+    fn on_vertical_scroll_sensitivity_slider(
+        &mut self,
+        _: &Entity<SliderState>,
+        event: &SliderEvent,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let SliderEvent::Release(value) = event {
+            let sensitivity = VerticalScrollSensitivity::from_rounded(value.start());
+            AppState::update(cx, |state, cx| {
+                state.set_vertical_scroll_sensitivity(sensitivity);
                 cx.emit(StateEvent::SettingsChanged);
             });
         }
@@ -381,7 +432,10 @@ impl Render for SettingsView {
                 page_ix: self.initial_page.index(),
                 group_ix: None,
             })
-            .page(general::general_page(self.sensitivity_slider.clone()))
+            .page(general::general_page(
+                self.vertical_scroll_sensitivity_slider.clone(),
+                self.thumbwheel_sensitivity_slider.clone(),
+            ))
             .page(updates::updates_page(self.updater.clone(), pal));
         // Registered only where grants exist to manage — see the `mod
         // permissions` cfg for why Windows skips it.

--- a/crates/openlogi-desktop/src/windows/settings/general.rs
+++ b/crates/openlogi-desktop/src/windows/settings/general.rs
@@ -3,17 +3,31 @@
 use super::{
     AnyElement, App, AppState, Entity, FluentBuilder, IconName, IntoElement, ParentElement,
     SettingField, SettingGroup, SettingItem, SettingPage, Slider, SliderState, StateEvent, Styled,
-    ThumbwheelSensitivity, div, h_flex, px, theme, v_flex,
+    ThumbwheelSensitivity, VerticalScrollSensitivity, div, h_flex, px, theme, v_flex,
 };
 use crate::ui::theme::Typography as _;
 
-pub(super) fn general_page(sensitivity_slider: Entity<SliderState>) -> SettingPage {
+pub(super) fn general_page(
+    vertical_scroll_sensitivity_slider: Entity<SliderState>,
+    thumbwheel_sensitivity_slider: Entity<SliderState>,
+) -> SettingPage {
     let group = SettingGroup::new()
+        .item(
+            SettingItem::new(
+                tr!("Vertical Scroll Sensitivity"),
+                SettingField::render(move |_, _, cx| {
+                    vertical_scroll_sensitivity_field(&vertical_scroll_sensitivity_slider, cx)
+                }),
+            )
+            .description(tr!(
+                "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
+            )),
+        )
         .item(
             SettingItem::new(
                 tr!("Thumb Wheel Sensitivity"),
                 SettingField::render(move |_, _, cx| {
-                    sensitivity_field(&sensitivity_slider, cx)
+                    thumbwheel_sensitivity_field(&thumbwheel_sensitivity_slider, cx)
                 }),
             )
             .description(tr!(
@@ -83,9 +97,32 @@ pub(super) fn general_page(sensitivity_slider: Entity<SliderState>) -> SettingPa
         .group(group)
 }
 
-fn sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
+fn thumbwheel_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
     let value = ThumbwheelSensitivity::from_rounded(slider.read(cx).value().start());
-    let is_default = value == ThumbwheelSensitivity::DEFAULT;
+    sensitivity_field(
+        slider,
+        value.to_string(),
+        value == ThumbwheelSensitivity::DEFAULT,
+        cx,
+    )
+}
+
+fn vertical_scroll_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
+    let value = VerticalScrollSensitivity::from_rounded(slider.read(cx).value().start());
+    sensitivity_field(
+        slider,
+        value.to_string(),
+        value == VerticalScrollSensitivity::DEFAULT,
+        cx,
+    )
+}
+
+fn sensitivity_field(
+    slider: &Entity<SliderState>,
+    value: String,
+    is_default: bool,
+    cx: &mut App,
+) -> AnyElement {
     let pal = theme::palette(cx);
     v_flex()
         .flex_shrink_0()
@@ -100,7 +137,7 @@ fn sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
                         .w(px(72.))
                         .text_body()
                         .text_color(pal.text_muted)
-                        .child(value.to_string()),
+                        .child(value),
                 ),
         )
         .when(is_default, |this| {

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Tommelfingerhjul op"
 "Thumb Wheel Down": "Tommelfingerhjul ned"
 "Do Nothing": "Gør ingenting"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Følsomhed for tommelfingerhjul"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Skalerer tommelfingerhjulets vandrette rullehastighed og hvor let tilpassede hjulhandlinger udløses."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Daumenrad nach oben"
 "Thumb Wheel Down": "Daumenrad nach unten"
 "Do Nothing": "Nichts tun"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Daumenrad-Empfindlichkeit"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Skaliert die horizontale Scrollgeschwindigkeit des Daumenrads und wie leicht benutzerdefinierte Radaktionen ausgelöst werden."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Πλαϊνός τροχός πάνω"
 "Thumb Wheel Down": "Πλαϊνός τροχός κάτω"
 "Do Nothing": "Καμία ενέργεια"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Ευαισθησία πλαϊνού τροχού"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Ρυθμίζει την ταχύτητα οριζόντιας κύλισης του πλαϊνού τροχού και την ευκολία ενεργοποίησης προσαρμοσμένων ενεργειών τροχού."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Thumb Wheel Up"
 "Thumb Wheel Down": "Thumb Wheel Down"
 "Do Nothing": "Do Nothing"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Thumb Wheel Sensitivity"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Rueda lateral hacia arriba"
 "Thumb Wheel Down": "Rueda lateral hacia abajo"
 "Do Nothing": "No hacer nada"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilidad de la rueda lateral"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Ajusta la velocidad de desplazamiento horizontal de la rueda lateral y la facilidad con que se activan las acciones personalizadas de la rueda."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Peukalorulla ylös"
 "Thumb Wheel Down": "Peukalorulla alas"
 "Do Nothing": "Älä tee mitään"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Peukalorullan herkkyys"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Säätää peukalorullan vaakavieritysnopeutta ja sitä, kuinka herkästi mukautetut rullatoiminnot laukeavat."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Molette latérale vers le haut"
 "Thumb Wheel Down": "Molette latérale vers le bas"
 "Do Nothing": "Ne rien faire"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilité de la molette latérale"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Ajuste la vitesse de défilement horizontal de la molette latérale et la facilité de déclenchement des actions personnalisées."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Rotella pollice su"
 "Thumb Wheel Down": "Rotella pollice giù"
 "Do Nothing": "Non fare nulla"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilità rotella pollice"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Regola la velocità di scorrimento orizzontale della rotella del pollice e la facilità con cui si attivano le azioni personalizzate."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "サムホイール 上"
 "Thumb Wheel Down": "サムホイール 下"
 "Do Nothing": "何もしない"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "サムホイールの感度"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "サムホイールの横スクロール速度と、カスタムホイール操作の発動しやすさを調整します。"
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "썸휠 위로"
 "Thumb Wheel Down": "썸휠 아래로"
 "Do Nothing": "동작 없음"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "썸휠 민감도"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "썸휠의 가로 스크롤 속도와 사용자 지정 휠 동작이 실행되는 정도를 조절합니다."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Tommelhjul opp"
 "Thumb Wheel Down": "Tommelhjul ned"
 "Do Nothing": "Gjør ingenting"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Tommelhjulfølsomhet"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Justerer tommelhjulets horisontale rullehastighet og hvor lett egendefinerte hjulhandlinger utløses."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Duimwiel omhoog"
 "Thumb Wheel Down": "Duimwiel omlaag"
 "Do Nothing": "Niets doen"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Duimwielgevoeligheid"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Schaalt de horizontale scrollsnelheid van het duimwiel en hoe snel aangepaste wielacties worden geactiveerd."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Rolka kciukowa w górę"
 "Thumb Wheel Down": "Rolka kciukowa w dół"
 "Do Nothing": "Nic nie rób"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Czułość rolki kciukowej"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Skaluje prędkość poziomego przewijania rolki kciukowej oraz łatwość wyzwalania niestandardowych działań rolki."
 "Device offline — reconnect to read DPI range": "Urządzenie offline — połącz ponownie, aby odczytać zakres DPI"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Roda do Polegar para Cima"
 "Thumb Wheel Down": "Roda do Polegar para Baixo"
 "Do Nothing": "Não Fazer Nada"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilidade da Roda do Polegar"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Ajusta a velocidade da rolagem horizontal da roda do polegar e a facilidade com que as ações personalizadas da roda são acionadas."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Roda de polegar para cima"
 "Thumb Wheel Down": "Roda de polegar para baixo"
 "Do Nothing": "Não fazer nada"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilidade da roda de polegar"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Ajusta a velocidade de deslocamento horizontal da roda de polegar e a facilidade com que as ações personalizadas da roda são acionadas."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Колесо большого пальца вверх"
 "Thumb Wheel Down": "Колесо большого пальца вниз"
 "Do Nothing": "Ничего не делать"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Чувствительность колеса большого пальца"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Масштабирует скорость горизонтальной прокрутки колеса и лёгкость срабатывания пользовательских действий колеса."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Tumhjul upp"
 "Thumb Wheel Down": "Tumhjul ned"
 "Do Nothing": "Gör ingenting"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Tumhjulskänslighet"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Anpassar tumhjulets horisontella rullningshastighet och hur lätt anpassade hjulåtgärder utlöses."
 "Device offline — reconnect to read DPI range": "Device offline — reconnect to read DPI range"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Başparmak Tekerleği Yukarı"
 "Thumb Wheel Down": "Başparmak Tekerleği Aşağı"
 "Do Nothing": "Hiçbir Şey Yapma"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Başparmak Tekerleği Hassasiyeti"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Başparmak tekerleğinin yatay kaydırma hızını ve özel tekerlek eylemlerinin ne kadar kolay tetikleneceğini ölçekler."
 "Device offline — reconnect to read DPI range": "Cihaz çevrimdışı — DPI aralığını okumak için yeniden bağlanın"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "Бічне коліщатко вгору"
 "Thumb Wheel Down": "Бічне коліщатко вниз"
 "Do Nothing": "Нічого не робити"
+"Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Чутливість бічного коліщатка"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "Змінює швидкість горизонтального прокручування бічним коліщатком і те, наскільки легко спрацьовують власні дії коліщатка."
 "Device offline — reconnect to read DPI range": "Пристрій не в мережі — підключіть його знову, щоб прочитати діапазон DPI"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "拇指滚轮向上"
 "Thumb Wheel Down": "拇指滚轮向下"
 "Do Nothing": "不执行任何操作"
+"Vertical Scroll Sensitivity": "垂直滚动灵敏度"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "调整传统鼠标滚轮的垂直滚动距离，不影响触控板滚动。"
 "Thumb Wheel Sensitivity": "拇指滚轮灵敏度"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "调整拇指滚轮的横向滚动速度，以及自定义滚轮操作的触发难易程度。"
 "Device offline — reconnect to read DPI range": "设备离线 —— 重新连接以读取 DPI 范围"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "拇指滾輪向上"
 "Thumb Wheel Down": "拇指滾輪向下"
 "Do Nothing": "不執行任何操作"
+"Vertical Scroll Sensitivity": "垂直捲動靈敏度"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "調整傳統滑鼠滾輪的垂直捲動距離，不影響觸控板捲動。"
 "Thumb Wheel Sensitivity": "拇指滾輪靈敏度"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "調整拇指滾輪的水平捲動速度，以及自訂滾輪操作的觸發難易度。"
 "Device offline — reconnect to read DPI range": "裝置離線 —— 重新連接以讀取 DPI 範圍"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -296,6 +296,8 @@ _version: 1
 "Thumb Wheel Up": "拇指滾輪向上"
 "Thumb Wheel Down": "拇指滾輪向下"
 "Do Nothing": "不執行任何操作"
+"Vertical Scroll Sensitivity": "垂直捲動靈敏度"
+"Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "調整傳統滑鼠滾輪的垂直捲動距離，不影響觸控板捲動。"
 "Thumb Wheel Sensitivity": "拇指滾輪靈敏度"
 "Scales the thumb wheel's horizontal scroll speed and how readily custom wheel actions trigger.": "調整拇指滾輪的水平捲動速度，以及自訂滾輪操作的觸發難易度。"
 "Device offline — reconnect to read DPI range": "裝置離線 —— 重新連線以讀取 DPI 範圍"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,6 +43,9 @@ optional physical device key.
 - `asset_source`: `automatic`, `openlogi`, `cloudflare`, or `fastly`
 - `language`, `appearance`, `device_view_mode` (`grid`, `list`, or `carousel`),
   optional theme names, and optional UI radius
+- `smooth_scroll` toggles finite animation for traditional mouse-wheel input
+- `vertical_scroll_sensitivity`, from `1` through `100` (`14` is 1×);
+  continuous trackpad input remains native
 - `thumbwheel_sensitivity`, from `1` through `100` (`14` is 1×)
 
 `[devices."<physical-key>"]` contains per-device state. Receiver keys look like

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -9,6 +9,7 @@ auto_install_updates = false
 show_in_menu_bar = true
 capture_mouse_events = true
 smooth_scroll = false
+vertical_scroll_sensitivity = 14
 auto_download_assets = true
 asset_source = "automatic"
 language = "en"


### PR DESCRIPTION
## Summary

Add app-wide vertical sensitivity for traditional mouse-wheel input so users can reduce scrolling below the operating system's minimum. The setting works with or without finite smoothing, while trackpad/pixel input remains native.

This PR is stacked on #977.

## Changes

- **openlogi-core**
  - add a validated `VerticalScrollSensitivity` newtype on the `1..=100` scale, with `14` as 1×
  - keep vertical distance semantics separate from thumb-wheel custom-action thresholds
  - document and test the additive `vertical_scroll_sensitivity` config field
- **openlogi-agent-core / openlogi-agent**
  - publish smooth-scroll enablement and vertical sensitivity as one atomic typed snapshot
  - model queued output as `Smooth` or `Direct` rather than boolean combinations
  - scale only vertical `WheelTicks`; leave horizontal distance, pixel input, and HID++ thumb-wheel sensitivity unchanged
  - emit direct scaled output from the dedicated worker when smoothing is disabled, never from the hook callback
  - suppress physical input only after the bounded worker queue accepts it; queue rejection remains fail-open
- **openlogi-desktop / openlogi-ui**
  - add a General settings slider that persists on release and reloads the agent live
  - distinguish vertical and thumb-wheel slider ownership in the Settings view
  - add matching catalog keys to all 22 locales, with Chinese translations and English fallback elsewhere

## Testing

- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo clippy -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-cli -p openlogi -p openlogi-desktop -p openlogi-device -p openlogi-hid -p openlogi-hook -p openlogi-overlay -p openlogi-inject -p openlogi-ipc -p openlogi-permissions -p openlogi-ui -p xtask --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo test -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-cli -p openlogi -p openlogi-desktop -p openlogi-device -p openlogi-hid -p openlogi-hook -p openlogi-overlay -p openlogi-inject -p openlogi-ipc -p openlogi-permissions -p openlogi-ui -p xtask`
- `CARGO_INCREMENTAL=0 cargo test -p openlogi-ui locale`
- `CARGO_INCREMENTAL=0 cargo test -p openlogi-desktop i18n`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo clippy --target x86_64-pc-windows-gnu -p openlogi-core -p openlogi-inject -p openlogi-hook -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo clippy --target aarch64-apple-darwin -p openlogi-core -p openlogi-inject -p openlogi-hook -p openlogi-agent-core -p openlogi-agent --all-targets -- -D warnings`

No motion model or hardware trace was needed for this linear distance scale. Runtime worker tests cover default pass-through, direct and smooth scaled output, horizontal and pixel exclusions, queue-full fail-open behavior, live preference changes, and HID++ separation.

Not runtime-tested on hardware. Verify with a traditional mouse wheel at values below, equal to, and above `14`, both with `smooth_scroll = false` and `true`; vertical distance should scale, horizontal wheel and trackpad input should remain unchanged, and config changes should take effect without restarting the hook.

Fixes #935
