### PR TITLE
feat(scroll): expose smooth scrolling setting

### DIFF
--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -244,6 +244,17 @@ impl AppState {
             .edit(|config| config.app_settings.thumbwheel_sensitivity = sensitivity);
         self.persist_and_reload("thumbwheel sensitivity");
     }
+    /// Toggle finite animation for traditional mouse-wheel input and persist
+    /// it. The agent publishes the change to the scroll worker on config
+    /// reload. No-op when unchanged; disk failures restore the persisted value.
+    pub fn set_smooth_scroll(&mut self, enabled: bool) {
+        if self.config.app_settings.smooth_scroll == enabled {
+            return;
+        }
+        self.config
+            .edit(|config| config.app_settings.smooth_scroll = enabled);
+        self.persist_and_reload("smooth scroll");
+    }
     /// Set traditional vertical mouse-wheel sensitivity and persist it. The
     /// agent publishes the value to its scroll worker on config reload. No-op
     /// when unchanged; disk failures restore the persisted value.

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -45,17 +45,45 @@ fn read_only_config_rolls_back_mutations_and_does_not_reload_agent() {
     );
 
     state.set_thumbwheel_sensitivity(ThumbwheelSensitivity::from_rounded(50.0));
+    state.set_smooth_scroll(true);
     state.set_vertical_scroll_sensitivity(VerticalScrollSensitivity::from_rounded(7.0));
 
     assert_eq!(
         state.app_settings().thumbwheel_sensitivity,
         ThumbwheelSensitivity::DEFAULT
     );
+    assert!(!state.app_settings().smooth_scroll);
     assert_eq!(
         state.app_settings().vertical_scroll_sensitivity,
         VerticalScrollSensitivity::DEFAULT
     );
     assert_eq!(state.config_issue(), Some("invalid config"));
+    assert!(receiver.try_recv().is_err());
+}
+
+#[test]
+fn smooth_scroll_change_reloads_the_agent_once() {
+    let cache = AssetResolver::new();
+    let (commands, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    state.set_smooth_scroll(true);
+
+    assert!(state.app_settings().smooth_scroll);
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(crate::services::ipc::Command::ReloadConfig)
+    ));
+
+    state.set_smooth_scroll(true);
     assert!(receiver.try_recv().is_err());
 }
 

--- a/crates/openlogi-desktop/src/windows/settings/general.rs
+++ b/crates/openlogi-desktop/src/windows/settings/general.rs
@@ -14,6 +14,25 @@ pub(super) fn general_page(
     let group = SettingGroup::new()
         .item(
             SettingItem::new(
+                tr!("Smooth scrolling"),
+                SettingField::switch(
+                    |cx| {
+                        AppState::try_read(cx).is_some_and(|s| s.app_settings().smooth_scroll)
+                    },
+                    |enabled, cx| {
+                        AppState::update(cx, move |state, cx| {
+                            state.set_smooth_scroll(enabled);
+                            cx.emit(StateEvent::SettingsChanged);
+                        });
+                    },
+                ),
+            )
+            .description(tr!(
+                "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
+            )),
+        )
+        .item(
+            SettingItem::new(
                 tr!("Vertical Scroll Sensitivity"),
                 SettingField::render(move |_, _, cx| {
                     vertical_scroll_sensitivity_field(&vertical_scroll_sensitivity_slider, cx)

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Tommelfingerhjul op"
 "Thumb Wheel Down": "Tommelfingerhjul ned"
 "Do Nothing": "Gør ingenting"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Følsomhed for tommelfingerhjul"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Daumenrad nach oben"
 "Thumb Wheel Down": "Daumenrad nach unten"
 "Do Nothing": "Nichts tun"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Daumenrad-Empfindlichkeit"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Πλαϊνός τροχός πάνω"
 "Thumb Wheel Down": "Πλαϊνός τροχός κάτω"
 "Do Nothing": "Καμία ενέργεια"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Ευαισθησία πλαϊνού τροχού"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Thumb Wheel Up"
 "Thumb Wheel Down": "Thumb Wheel Down"
 "Do Nothing": "Do Nothing"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Thumb Wheel Sensitivity"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Rueda lateral hacia arriba"
 "Thumb Wheel Down": "Rueda lateral hacia abajo"
 "Do Nothing": "No hacer nada"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilidad de la rueda lateral"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Peukalorulla ylös"
 "Thumb Wheel Down": "Peukalorulla alas"
 "Do Nothing": "Älä tee mitään"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Peukalorullan herkkyys"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Molette latérale vers le haut"
 "Thumb Wheel Down": "Molette latérale vers le bas"
 "Do Nothing": "Ne rien faire"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilité de la molette latérale"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Rotella pollice su"
 "Thumb Wheel Down": "Rotella pollice giù"
 "Do Nothing": "Non fare nulla"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilità rotella pollice"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "サムホイール 上"
 "Thumb Wheel Down": "サムホイール 下"
 "Do Nothing": "何もしない"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "サムホイールの感度"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "썸휠 위로"
 "Thumb Wheel Down": "썸휠 아래로"
 "Do Nothing": "동작 없음"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "썸휠 민감도"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Tommelhjul opp"
 "Thumb Wheel Down": "Tommelhjul ned"
 "Do Nothing": "Gjør ingenting"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Tommelhjulfølsomhet"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Duimwiel omhoog"
 "Thumb Wheel Down": "Duimwiel omlaag"
 "Do Nothing": "Niets doen"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Duimwielgevoeligheid"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Rolka kciukowa w górę"
 "Thumb Wheel Down": "Rolka kciukowa w dół"
 "Do Nothing": "Nic nie rób"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Czułość rolki kciukowej"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Roda do Polegar para Cima"
 "Thumb Wheel Down": "Roda do Polegar para Baixo"
 "Do Nothing": "Não Fazer Nada"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilidade da Roda do Polegar"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Roda de polegar para cima"
 "Thumb Wheel Down": "Roda de polegar para baixo"
 "Do Nothing": "Não fazer nada"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Sensibilidade da roda de polegar"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Колесо большого пальца вверх"
 "Thumb Wheel Down": "Колесо большого пальца вниз"
 "Do Nothing": "Ничего не делать"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Чувствительность колеса большого пальца"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Tumhjul upp"
 "Thumb Wheel Down": "Tumhjul ned"
 "Do Nothing": "Gör ingenting"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Tumhjulskänslighet"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Başparmak Tekerleği Yukarı"
 "Thumb Wheel Down": "Başparmak Tekerleği Aşağı"
 "Do Nothing": "Hiçbir Şey Yapma"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Başparmak Tekerleği Hassasiyeti"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "Бічне коліщатко вгору"
 "Thumb Wheel Down": "Бічне коліщатко вниз"
 "Do Nothing": "Нічого не робити"
+"Smooth scrolling": "Smooth scrolling"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
 "Vertical Scroll Sensitivity": "Vertical Scroll Sensitivity"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling."
 "Thumb Wheel Sensitivity": "Чутливість бічного коліщатка"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "拇指滚轮向上"
 "Thumb Wheel Down": "拇指滚轮向下"
 "Do Nothing": "不执行任何操作"
+"Smooth scrolling": "平滑滚动"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "为传统鼠标滚轮输入添加平滑动画，不影响触控板滚动。"
 "Vertical Scroll Sensitivity": "垂直滚动灵敏度"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "调整传统鼠标滚轮的垂直滚动距离，不影响触控板滚动。"
 "Thumb Wheel Sensitivity": "拇指滚轮灵敏度"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "拇指滾輪向上"
 "Thumb Wheel Down": "拇指滾輪向下"
 "Do Nothing": "不執行任何操作"
+"Smooth scrolling": "平滑捲動"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "為傳統滑鼠滾輪輸入加入平滑動畫，不影響觸控板捲動。"
 "Vertical Scroll Sensitivity": "垂直捲動靈敏度"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "調整傳統滑鼠滾輪的垂直捲動距離，不影響觸控板捲動。"
 "Thumb Wheel Sensitivity": "拇指滾輪靈敏度"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -301,6 +301,8 @@ _version: 1
 "Thumb Wheel Up": "拇指滾輪向上"
 "Thumb Wheel Down": "拇指滾輪向下"
 "Do Nothing": "不執行任何操作"
+"Smooth scrolling": "平滑捲動"
+"Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged.": "為傳統滑鼠滾輪輸入加入平滑動畫，不影響觸控板捲動。"
 "Vertical Scroll Sensitivity": "垂直捲動靈敏度"
 "Scales traditional mouse-wheel vertical distance without changing trackpad scrolling.": "調整傳統滑鼠滾輪的垂直捲動距離，不影響觸控板捲動。"
 "Thumb Wheel Sensitivity": "拇指滾輪靈敏度"


### PR DESCRIPTION
## Summary

Expose the existing opt-in smooth-scroll runtime in Settings so users no longer need to edit TOML to enable it. The switch persists through the same app-state boundary as other live agent settings and keeps trackpad input native.

This PR is stacked on #978.

## Changes

- **openlogi-desktop**
  - add a General settings switch backed by `app_settings.smooth_scroll`
  - persist changes through `AppState` and reload the agent only when the value changes
  - cover successful live reload, unchanged no-op, and read-only rollback behavior
- **openlogi-ui**
  - add matching keys to all 22 locale catalogs, with Chinese translations and permitted temporary English fallback elsewhere

## Testing

- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo clippy -p openlogi-ui -p openlogi-desktop -p openlogi-overlay --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' CARGO_INCREMENTAL=0 cargo test -p openlogi-ui -p openlogi-desktop -p openlogi-overlay`
- repository pre-push hooks

Not runtime-tested on hardware. Verify in Settings → General that enabling Smooth scrolling updates `config.toml`, takes effect without restarting the app, leaves trackpad scrolling unchanged, and remains enabled after relaunch.

Related to #884
