### PR TITLE
refactor(gui): strengthen typed render boundaries

### DIFF
--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -591,7 +591,7 @@ impl Render for AppView {
             self.camera_preview
                 .update(cx, |preview, cx| preview.set_target(camera_target, cx));
             (
-                detail::detail_header(record.as_ref(), pal, cx).into_any_element(),
+                detail::detail_header(record.as_ref(), cx).into_any_element(),
                 detail::detail_content(
                     &detail::DetailPanels {
                         mouse_model: &self.mouse_model,
@@ -608,7 +608,6 @@ impl Render for AppView {
                     &self.app_catalog,
                     &tabs,
                     active,
-                    pal,
                     cx,
                 )
                 .into_any_element(),

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription,
-    Window, div, prelude::FluentBuilder as _, rgb,
+    App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
+    MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription, Window, div,
+    prelude::FluentBuilder as _, rgb,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -26,7 +26,7 @@ use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::features::profile_scope::{AppCatalogPicker, ProfileIconCache};
 use crate::services::assets::AssetResolver;
 use crate::state::{AgentLink, AppState, DeviceRecord, StateEvent};
-use crate::ui::theme::{self, ContentWidth, Palette, Typography as _};
+use crate::ui::theme::{self, ContentWidth, Typography as _};
 
 pub(crate) mod deeplink;
 mod detail;
@@ -361,7 +361,8 @@ impl AppView {
         }))
     }
 
-    fn accessibility_gate(pal: Palette, cx: &mut Context<Self>) -> AnyElement {
+    fn accessibility_gate(cx: &mut Context<Self>) -> impl IntoElement {
+        let pal = theme::palette(cx);
         v_flex()
             .size_full()
             .bg(pal.page)
@@ -428,7 +429,6 @@ impl AppView {
                         cx.notify();
                     })),
             )
-            .into_any_element()
     }
 }
 
@@ -450,7 +450,8 @@ fn request_accessibility(cx: &mut App) {
 /// server-side decorations and gpui falls back to client-side ones it doesn't
 /// paint — still gets a titlebar and window controls. On macOS the widget
 /// reserves the traffic-light space.
-fn app_title_bar(pal: Palette) -> impl IntoElement {
+fn app_title_bar(cx: &App) -> impl IntoElement {
+    let pal = theme::palette(cx);
     TitleBar::new().child(
         div()
             .flex_1()
@@ -490,7 +491,7 @@ impl Render for AppView {
             // error frames — so the chrome is present from the first frame on.
             // macOS / Windows keep their native titlebar.
             .when(cfg!(target_os = "linux"), |this| {
-                this.child(app_title_bar(pal))
+                this.child(app_title_bar(cx))
             });
         let root = Self::with_back_navigation(root, cx);
 
@@ -502,7 +503,7 @@ impl Render for AppView {
         if let Some(issue) = config_issue {
             window.set_window_title("OpenLogi");
             return root
-                .child(status::config_issue_body(issue, pal))
+                .child(status::config_issue_body(issue, cx))
                 .into_any_element();
         }
 
@@ -519,17 +520,15 @@ impl Render for AppView {
         let status = match link {
             AgentLink::Connecting => {
                 window.set_window_title("OpenLogi");
-                return root.child(status::connecting_body(pal)).into_any_element();
+                return root.child(status::connecting_body(cx)).into_any_element();
             }
             AgentLink::Unreachable => {
                 window.set_window_title("OpenLogi");
-                return root.child(status::unreachable_body(pal)).into_any_element();
+                return root.child(status::unreachable_body(cx)).into_any_element();
             }
             AgentLink::OutdatedGui => {
                 window.set_window_title("OpenLogi");
-                return root
-                    .child(status::outdated_gui_body(pal))
-                    .into_any_element();
+                return root.child(status::outdated_gui_body(cx)).into_any_element();
             }
             AgentLink::Ready(status) => status,
         };
@@ -537,9 +536,7 @@ impl Render for AppView {
         let granted = status.accessibility_granted;
         if !granted && !self.accessibility_dismissed {
             window.set_window_title("OpenLogi");
-            return root
-                .child(Self::accessibility_gate(pal, cx))
-                .into_any_element();
+            return root.child(Self::accessibility_gate(cx)).into_any_element();
         }
 
         let has_device = AppState::try_global(cx)
@@ -620,22 +617,23 @@ impl Render for AppView {
             self.camera_preview
                 .update(cx, |preview, cx| preview.set_target(None, cx));
             (
-                home::home_header(pal, cx).into_any_element(),
+                home::home_header(cx).into_any_element(),
                 if has_device {
                     home::device_gallery(cx).into_any_element()
                 } else {
                     match status.inventory {
-                        InventoryHealth::Scanning => home::device_scanning_state(pal),
-                        InventoryHealth::Unavailable => home::scanning_unavailable_state(pal),
-                        InventoryHealth::Ready => home::device_empty_state(pal),
+                        InventoryHealth::Scanning => home::device_scanning_state(cx),
+                        InventoryHealth::Unavailable => home::scanning_unavailable_state(cx),
+                        InventoryHealth::Ready => home::device_empty_state(cx),
                     }
+                    .into_any_element()
                 },
             )
         };
 
         root.child(header_el)
             .child(content_el)
-            .when(!granted, |this| this.child(status::attention_footer(pal)))
+            .when(!granted, |this| this.child(status::attention_footer(cx)))
             .into_any_element()
     }
 }

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -2,7 +2,7 @@
 //! section bodies (Buttons, Keys, Pointer, Lighting, Camera, Device).
 
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, Rems, Role,
+    Context, InteractiveElement, IntoElement, ParentElement, Rems, Role,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rems,
 };
 use gpui_base::Button as BaseButton;
@@ -37,7 +37,7 @@ use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::battery::BatteryIndicator;
 use crate::ui::components::{PanelCard, Toggle};
 use crate::ui::theme::{
-    ContentWidth, DETAIL_RAIL_W, HEADER_H, Palette, SCREEN_PAD, Typography as _,
+    self, ContentWidth, DETAIL_RAIL_W, HEADER_H, Palette, SCREEN_PAD, Typography as _,
 };
 
 const CAMERA_PREVIEW_W: Rems = rems(32.125);
@@ -112,21 +112,21 @@ pub(super) fn detail_content(
         .is_some_and(|record| record.online);
     let content = match active {
         DetailTab::Buttons => {
-            buttons_tab(panels.mouse_model, profile_icons, app_catalog, pal, cx).into_any_element()
+            buttons_tab(panels.mouse_model, profile_icons, app_catalog, cx).into_any_element()
         }
         DetailTab::ActionsRing => action_ring_tab(panels.action_ring).into_any_element(),
         DetailTab::Keys => keys_tab(panels.keyboard_model).into_any_element(),
         DetailTab::Pointer => {
-            pointer_tab(panels.dpi_panel, panels.smartshift_panel, pal, cx).into_any_element()
+            pointer_tab(panels.dpi_panel, panels.smartshift_panel, cx).into_any_element()
         }
         DetailTab::Lighting => lighting_tab(panels.lighting_panel).into_any_element(),
         DetailTab::Camera => {
             camera_tab(panels.camera_preview, panels.camera_controls).into_any_element()
         }
-        DetailTab::Light => light_tab(panels.light_panel, pal, cx).into_any_element(),
-        DetailTab::Device => device_tab(pal, cx).into_any_element(),
+        DetailTab::Light => light_tab(panels.light_panel, cx).into_any_element(),
+        DetailTab::Device => device_tab(cx).into_any_element(),
     };
-    let navigation = detail_navigation(tabs, active, pal, cx).into_any_element();
+    let navigation = detail_navigation(tabs, active, cx);
     v_flex()
         .flex_1()
         .min_h_0()
@@ -169,9 +169,9 @@ pub(super) fn detail_content(
 fn detail_navigation(
     tabs: &[DetailTab],
     active: DetailTab,
-    pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
+    let pal = theme::palette(cx);
     v_flex()
         .w(px(DETAIL_RAIL_W))
         .h_full()
@@ -249,14 +249,13 @@ fn buttons_tab(
     mouse_model: &gpui::Entity<MouseModelView>,
     profile_icons: &ProfileIconCache,
     app_catalog: &gpui::Entity<AppCatalogPicker>,
-    pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
     v_flex()
         .flex_1()
         .w_full()
         .min_h_0()
-        .children(profile_scope_bar(pal, profile_icons, app_catalog, cx))
+        .children(profile_scope_bar(profile_icons, app_catalog, cx))
         .child(mouse_model.clone())
 }
 
@@ -290,9 +289,9 @@ fn action_ring_tab(panel: &gpui::Entity<ActionRingPanel>) -> impl IntoElement {
 fn pointer_tab(
     dpi_panel: &gpui::Entity<DpiPanel>,
     smartshift_panel: &gpui::Entity<SmartShiftPanel>,
-    pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
+    let pal = theme::palette(cx);
     tab_body(
         ContentWidth::Large,
         h_flex()
@@ -421,15 +420,11 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
     PanelCard::new(
         tr!("Scrolling"),
         Icon::empty().path("action-icons/mouse.svg"),
-        v_flex()
-            .gap_4()
-            .child(inversion_row)
-            .child(resolution_row)
-            .into_any_element(),
+        v_flex().gap_4().child(inversion_row).child(resolution_row),
     )
 }
 
-fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -> AnyElement {
+fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -> impl IntoElement {
     let values = [
         None,
         Some(ScrollResolution::Low),
@@ -469,7 +464,6 @@ fn wheel_resolution_control(selected: Option<ScrollResolution>, enabled: bool) -
                 }
             });
         })
-        .into_any_element()
 }
 
 /// Lighting tab: the RGB controls (swatches, on/off, brightness) in a titled
@@ -530,9 +524,9 @@ fn camera_tab(
 /// Standalone-light controls in a separate panel from HID++ keyboard RGB.
 fn light_tab(
     light_panel: &gpui::Entity<LightPanel>,
-    pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
+    let pal = theme::palette(cx);
     let (asset, online, enabled, settings) = AppState::try_read(cx).map_or_else(
         || {
             (
@@ -574,7 +568,8 @@ fn light_tab(
 }
 
 /// Device tab: device details and configuration cards stacked.
-fn device_tab(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
+fn device_tab(cx: &mut Context<AppView>) -> impl IntoElement {
+    let pal = theme::palette(cx);
     tab_body(
         ContentWidth::Small,
         v_flex()
@@ -709,8 +704,7 @@ fn configuration_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoEleme
                         }
                     },
                 )),
-        )
-        .into_any_element();
+        );
 
     PanelCard::new(tr!("Configuration"), Icon::new(IconName::Folder), content)
 }

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -270,7 +270,7 @@ fn tab_body(
         .min_h_0()
         .items_center()
         .overflow_y_scrollbar()
-        .p(SCREEN_PAD)
+        .p(SCREEN_PAD.rems())
         .child(div().w_full().max_w(width.rems()).child(content))
 }
 

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -51,9 +51,9 @@ const POINTER_CARD_MIN_W: Rems = rems(20.75);
 /// the device name and status here.
 pub(super) fn detail_header(
     record: Option<&DeviceRecord>,
-    pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
+    let pal = theme::palette(cx);
     let name = record.map_or_else(|| tr!("Device").to_string(), |r| r.display_name.clone());
     let online = record.map(|r| r.online);
     let battery = record
@@ -104,9 +104,9 @@ pub(super) fn detail_content(
     app_catalog: &gpui::Entity<AppCatalogPicker>,
     tabs: &[DetailTab],
     active: DetailTab,
-    pal: Palette,
     cx: &mut Context<AppView>,
 ) -> impl IntoElement {
+    let pal = theme::palette(cx);
     let online = AppState::try_read(cx)
         .and_then(AppState::current_record)
         .is_some_and(|record| record.online);

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -11,7 +11,7 @@ pub(super) use views::ordered_device_indices;
 use std::sync::Arc;
 
 use gpui::{
-    Anchor, AnyElement, App, AppContext as _, Context, ElementId, Hsla, InteractiveElement,
+    Anchor, AnyElement, App, AppContext as _, Context, Div, ElementId, Hsla, InteractiveElement,
     IntoElement, ParentElement, SharedString, StatefulInteractiveElement as _, Styled, Window,
     canvas, div, fill, img, point, prelude::FluentBuilder as _, px, rgb, svg,
 };
@@ -44,7 +44,8 @@ use crate::ui::theme::{self, ContentWidth, HEADER_H, Palette, Typography as _};
 
 /// Home (gallery) top bar: title/count, the persisted layout switcher, Settings,
 /// and Add Device.
-pub(super) fn home_header(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
+pub(super) fn home_header(cx: &mut Context<AppView>) -> impl IntoElement {
+    let pal = theme::palette(cx);
     let device_count = AppState::try_read(cx).map_or(0, |state| state.devices().len());
     let current_mode = AppState::try_read(cx).map_or(DeviceViewMode::Grid, |state| {
         state.app_settings().device_view_mode
@@ -546,7 +547,8 @@ fn device_image(
             light_enabled,
             light_settings,
             pal,
-        );
+        )
+        .into_any_element();
     }
     if let Some(path) = record
         .asset
@@ -610,12 +612,11 @@ pub(super) fn connection_icon_path(
 /// user whose devices are about to appear. Swaps to the gallery, to
 /// [`device_empty_state`], or to [`scanning_unavailable_state`] the moment
 /// the agent reports where its enumeration landed.
-pub(super) fn device_scanning_state(pal: Palette) -> AnyElement {
-    loading_body(tr!("Scanning for devices…"), pal)
+pub(super) fn device_scanning_state(cx: &App) -> Div {
+    loading_body(tr!("Scanning for devices…"), cx)
         .flex_1()
         .w_full()
         .min_h_0()
-        .into_any_element()
 }
 
 /// Home body when the agent reports enumeration as broken
@@ -623,23 +624,23 @@ pub(super) fn device_scanning_state(pal: Palette) -> AnyElement {
 /// just by waiting, so showing a spinner (or claiming "no devices") would
 /// both be wrong. The agent keeps retrying and a recovery flows back in as a
 /// regular snapshot.
-pub(super) fn scanning_unavailable_state(pal: Palette) -> AnyElement {
+pub(super) fn scanning_unavailable_state(cx: &App) -> Div {
     notice_body(
         tr!("Device scanning is unavailable"),
         tr!("The background service couldn't scan for devices — check its log for details."),
-        pal,
+        cx,
     )
     .flex_1()
     .w_full()
     .min_h_0()
-    .into_any_element()
 }
 
 /// Body shown when the agent has completed an enumeration and found no
 /// devices. The polling keeps running and `AppView`'s `AppState` observer
 /// swaps the device UI back in the moment one appears, so this is purely a
 /// wait-and-pair placeholder.
-pub(super) fn device_empty_state(pal: Palette) -> AnyElement {
+pub(super) fn device_empty_state(cx: &App) -> Div {
+    let pal = theme::palette(cx);
     v_flex()
         .flex_1()
         .w_full()
@@ -677,5 +678,4 @@ pub(super) fn device_empty_state(pal: Palette) -> AnyElement {
         .child(div().mt_1().max_w(ContentWidth::Narrow.rems()).text_caption().text_center().text_color(pal.text_muted).child(tr!(
             "Using Logi Options+? Quit it first — both apps compete for HID++ access."
         )))
-        .into_any_element()
 }

--- a/crates/openlogi-desktop/src/app/status.rs
+++ b/crates/openlogi-desktop/src/app/status.rs
@@ -12,7 +12,7 @@ use gpui_component::{
 };
 
 use crate::app::menu::OpenConfigFolder;
-use crate::ui::theme::{self, ContentWidth, FOOTER_H, Typography as _};
+use crate::ui::theme::{self, ContentWidth, FOOTER_H, Palette, Typography as _};
 
 /// Centered spinner over a muted one-line caption — the quiet "still working"
 /// body shared by the pre-connection frame and the scanning state, so the two
@@ -134,19 +134,13 @@ pub(super) fn attention_footer(cx: &App) -> impl IntoElement {
         .items_center()
         .border_t_1()
         .border_color(pal.border)
-        .child({
-            #[cfg(target_os = "macos")]
-            let el = accessibility_status(pal);
-            #[cfg(not(target_os = "macos"))]
-            let el = div().into_any_element();
-            el
-        })
+        .child(accessibility_status(pal))
 }
 
 /// Accessibility affordance that requests the grant on click (the native
 /// prompt + System Settings, via [`super::request_accessibility`]).
 #[cfg(target_os = "macos")]
-fn accessibility_status(pal: Palette) -> AnyElement {
+fn accessibility_status(pal: Palette) -> impl IntoElement {
     // Scoped here rather than at module level: these traits' only user is this
     // macOS-gated affordance (`.hover()` + `.on_click()`), so an ungated import
     // would be unused — and a hard error under `-D warnings` — on Linux/Windows.
@@ -171,5 +165,9 @@ fn accessibility_status(pal: Palette) -> AnyElement {
         )
         .child(div().child(tr!("Accessibility not granted · click to grant")))
         .on_click(|_, _, cx| super::request_accessibility(cx))
-        .into_any_element()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn accessibility_status(_pal: Palette) -> impl IntoElement {
+    div()
 }

--- a/crates/openlogi-desktop/src/app/status.rs
+++ b/crates/openlogi-desktop/src/app/status.rs
@@ -2,7 +2,7 @@
 //! pre-connection / unreachable / outdated-build frames rendered in place of
 //! the real UI, and an attention bar shown only when action is required.
 
-use gpui::{AnyElement, Div, IntoElement, ParentElement, SharedString, Styled, div, px, rgb};
+use gpui::{App, Div, IntoElement, ParentElement, SharedString, Styled, div, px, rgb};
 use gpui_component::{
     Icon, IconName, Sizable as _,
     button::{Button, ButtonVariants as _},
@@ -12,7 +12,7 @@ use gpui_component::{
 };
 
 use crate::app::menu::OpenConfigFolder;
-use crate::ui::theme::{self, ContentWidth, FOOTER_H, Palette, Typography as _};
+use crate::ui::theme::{self, ContentWidth, FOOTER_H, Typography as _};
 
 /// Centered spinner over a muted one-line caption — the quiet "still working"
 /// body shared by the pre-connection frame and the scanning state, so the two
@@ -22,7 +22,8 @@ use crate::ui::theme::{self, ContentWidth, FOOTER_H, Palette, Typography as _};
 /// bounded: the connecting frame downgrades to the static
 /// [`unreachable_body`] when no snapshot arrives, and the scanning state ends
 /// with the agent reporting `Ready` or `Unavailable`.
-pub(super) fn loading_body(caption: SharedString, pal: Palette) -> Div {
+pub(super) fn loading_body(caption: SharedString, cx: &App) -> Div {
+    let pal = theme::palette(cx);
     v_flex()
         .items_center()
         .justify_center()
@@ -36,7 +37,8 @@ pub(super) fn loading_body(caption: SharedString, pal: Palette) -> Div {
 /// no animation: these frames can stay up indefinitely, and an infinite
 /// animation would pin the render loop for as long as they do (the same
 /// reasoning as the status dot's fixed glow).
-pub(super) fn notice_body(headline: SharedString, caption: SharedString, pal: Palette) -> Div {
+pub(super) fn notice_body(headline: SharedString, caption: SharedString, cx: &App) -> Div {
+    let pal = theme::palette(cx);
     v_flex()
         .items_center()
         .justify_center()
@@ -63,34 +65,31 @@ pub(super) fn notice_body(headline: SharedString, caption: SharedString, pal: Pa
 /// neutral: no chrome, no claims about permissions or devices. If the agent
 /// stays unreachable, the IPC client downgrades the link and
 /// [`unreachable_body`] replaces this frame.
-pub(super) fn connecting_body(pal: Palette) -> AnyElement {
-    loading_body(tr!("Connecting to the background service…"), pal)
-        .size_full()
-        .into_any_element()
+pub(super) fn connecting_body(cx: &App) -> Div {
+    loading_body(tr!("Connecting to the background service…"), cx).size_full()
 }
 
 /// Whole-window frame once the agent has been unreachable well past startup:
 /// the spinner would be a lie at this point. Polling (and the spawn retry)
 /// keeps running underneath, and the first snapshot swaps the real UI back in.
-pub(super) fn unreachable_body(pal: Palette) -> AnyElement {
+pub(super) fn unreachable_body(cx: &App) -> Div {
     notice_body(
         tr!("Can't reach the background service"),
         tr!("OpenLogi keeps retrying — if this persists, try reinstalling the app."),
-        pal,
+        cx,
     )
     .size_full()
-    .into_any_element()
 }
 
 /// Whole-window frame when the *agent* answered with a newer IPC protocol
 /// than this process speaks: the app bundle was updated while this window
 /// stayed open, and only a relaunch loads the new GUI. Without this frame the
 /// window would keep showing live-looking but frozen state.
-pub(super) fn outdated_gui_body(pal: Palette) -> AnyElement {
+pub(super) fn outdated_gui_body(cx: &App) -> Div {
     notice_body(
         tr!("OpenLogi was updated"),
         tr!("This window is from the previous version — relaunch to finish the update."),
-        pal,
+        cx,
     )
     .size_full()
     .child(
@@ -99,12 +98,11 @@ pub(super) fn outdated_gui_body(pal: Palette) -> AnyElement {
             .label(tr!("Relaunch OpenLogi"))
             .on_click(|_, _, cx| cx.restart()),
     )
-    .into_any_element()
 }
 
 /// Fail-closed frame for config load/save/conflict/reload failures.
-pub(super) fn config_issue_body(message: SharedString, pal: Palette) -> AnyElement {
-    notice_body(tr!("Configuration"), message, pal)
+pub(super) fn config_issue_body(message: SharedString, cx: &App) -> Div {
+    notice_body(tr!("Configuration"), message, cx)
         .size_full()
         .child(
             h_flex()
@@ -121,13 +119,13 @@ pub(super) fn config_issue_body(message: SharedString, pal: Palette) -> AnyEleme
                         .on_click(|_, _, cx| cx.restart()),
                 ),
         )
-        .into_any_element()
 }
 
 /// Contextual attention bar. Normal operation has no footer; this row appears
 /// only after the user dismissed the permission gate while Accessibility is
 /// still unavailable.
-pub(super) fn attention_footer(pal: Palette) -> impl IntoElement {
+pub(super) fn attention_footer(cx: &App) -> impl IntoElement {
+    let pal = theme::palette(cx);
     h_flex()
         .h(px(FOOTER_H))
         .flex_shrink_0()

--- a/crates/openlogi-desktop/src/app/widgets.rs
+++ b/crates/openlogi-desktop/src/app/widgets.rs
@@ -3,7 +3,7 @@
 //! screens.
 
 use gpui::{
-    AnyElement, Context, IntoElement, ParentElement, SharedString, Styled, div,
+    Context, IntoElement, ParentElement, SharedString, Styled, div,
     prelude::FluentBuilder as _,
 };
 use gpui_component::{
@@ -102,13 +102,12 @@ pub(super) fn sidebar_action(
     icon: IconName,
     label: SharedString,
     handler: impl Fn(&gpui::ClickEvent, &mut gpui::Window, &mut gpui::App) + 'static,
-) -> AnyElement {
+) -> impl IntoElement {
     control_button(id)
         .icon(icon)
         .label(label)
         .on_click(handler)
         .flex_1()
-        .into_any_element()
 }
 
 pub(super) fn route_label(route: Option<&DeviceRoute>) -> String {

--- a/crates/openlogi-desktop/src/app/widgets.rs
+++ b/crates/openlogi-desktop/src/app/widgets.rs
@@ -3,8 +3,7 @@
 //! screens.
 
 use gpui::{
-    Context, IntoElement, ParentElement, SharedString, Styled, div,
-    prelude::FluentBuilder as _,
+    Context, IntoElement, ParentElement, SharedString, Styled, div, prelude::FluentBuilder as _,
 };
 use gpui_component::{
     IconName, Sizable as _,

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -259,7 +259,6 @@ fn ring_preview(
                 view,
                 pal,
             )
-            .into_any_element()
         }))
 }
 

--- a/crates/openlogi-desktop/src/features/action_ring/editor.rs
+++ b/crates/openlogi-desktop/src/features/action_ring/editor.rs
@@ -1,7 +1,7 @@
 //! Categorized action, shortcut, path, and icon editor for one ring slot.
 
 use gpui::{
-    AnyElement, Entity, InteractiveElement, IntoElement, ParentElement, Role, ScrollHandle,
+    Entity, InteractiveElement, IntoElement, ParentElement, Role, ScrollHandle,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_component::{
@@ -82,7 +82,7 @@ pub(super) fn action_library(
                 })
                 .child(shortcut_editor(slot, shortcut_input, pal))
                 .child(path_editor(slot, application_input, pal))
-                .children(action_rows(slot, current_action.as_ref(), pal)),
+                .children(action_sections(slot, current_action.as_ref(), pal)),
             library_scroll,
         ))
 }
@@ -212,19 +212,22 @@ fn path_editor(slot: ActionRingSlot, input: &Entity<InputState>, pal: Palette) -
         )
 }
 
-fn action_rows(slot: ActionRingSlot, current: Option<&Action>, pal: Palette) -> Vec<AnyElement> {
+fn action_sections(
+    slot: ActionRingSlot,
+    current: Option<&Action>,
+    pal: Palette,
+) -> impl Iterator<Item = impl IntoElement> {
     let mut index = 0usize;
-    let mut rows = Vec::new();
-    for (category, actions) in ring_catalog() {
-        rows.push(editor_section(rust_i18n::t!(category.label()), pal));
-        for action in actions {
-            let selected = current == Some(&action);
-            let action_to_commit = action.clone();
-            let label = tr!(action.label());
-            let icon_path = action_icon_path(&action);
-            let row_index = index;
-            index += 1;
-            rows.push(
+    ring_catalog().into_iter().map(move |(category, actions)| {
+        v_flex()
+            .child(editor_section(rust_i18n::t!(category.label()), pal))
+            .children(actions.into_iter().map(|action| {
+                let selected = current == Some(&action);
+                let action_to_commit = action.clone();
+                let label = tr!(action.label());
+                let icon_path = action_icon_path(&action);
+                let row_index = index;
+                index += 1;
                 MenuRow::new(("ring-action", row_index))
                     .role(Role::MenuItem)
                     .aria_label(label.clone())
@@ -252,11 +255,8 @@ fn action_rows(slot: ActionRingSlot, current: Option<&Action>, pal: Palette) -> 
                     .on_click(move |_, _, cx| {
                         commit_action(slot, action_to_commit.clone(), cx);
                     })
-                    .into_any_element(),
-            );
-        }
-    }
-    rows
+            }))
+    })
 }
 
 fn ring_catalog() -> Vec<(Category, Vec<Action>)> {

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -12,8 +12,8 @@
 //! a single batched device-open.
 
 use gpui::{
-    AnyElement, App, AppContext as _, ClickEvent, Context, ElementId, Entity, InteractiveElement,
-    IntoElement, MouseButton, MouseDownEvent, ParentElement, Render, Role, SharedString,
+    App, AppContext as _, ClickEvent, Context, ElementId, Entity, InteractiveElement, IntoElement,
+    MouseButton, MouseDownEvent, ParentElement, Render, Role, SharedString,
     StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, div,
     prelude::FluentBuilder as _, px, rgb,
 };
@@ -727,15 +727,15 @@ impl Render for CameraControlsPanel {
             panel = panel.child(section_label(tr!("Lens"), pal).mt_1());
         }
         for ix in lens {
-            panel = panel.child(control_row(self, ix, cx, pal));
+            panel = panel.child(control_row(self, ix, cx));
         }
         if !image.is_empty() && self.sliders.len() != image.len() {
             panel = panel.child(section_label(tr!("Image"), pal).mt_1());
         }
         for ix in image {
-            panel = panel.child(control_row(self, ix, cx, pal));
+            panel = panel.child(control_row(self, ix, cx));
         }
-        panel.child(reset_button(pal, cx)).into_any_element()
+        panel.child(reset_button(cx)).into_any_element()
     }
 }
 
@@ -756,7 +756,7 @@ fn section_indices(sliders: &[ControlSlider], lens: bool) -> Vec<usize> {
 }
 
 /// The one-click profile chips: built-ins, saved customs, then Save.
-fn profiles_row(key: &str, cx: &mut Context<CameraControlsPanel>) -> AnyElement {
+fn profiles_row(key: &str, cx: &mut Context<CameraControlsPanel>) -> gpui::Div {
     let state = AppState::try_read(cx);
     let active = state.and_then(|s| s.camera_active_profile(key));
     let customs: Vec<String> = state
@@ -798,7 +798,7 @@ fn profiles_row(key: &str, cx: &mut Context<CameraControlsPanel>) -> AnyElement 
             },
         )),
     );
-    row.into_any_element()
+    row
 }
 
 /// One compact control line: label · slider · live value (· Auto chip when the
@@ -807,8 +807,8 @@ fn control_row(
     panel: &CameraControlsPanel,
     ix: usize,
     cx: &Context<CameraControlsPanel>,
-    pal: Palette,
-) -> AnyElement {
+) -> gpui::Stateful<gpui::Div> {
+    let pal = theme::palette(cx);
     let slider = &panel.sliders[ix];
     if slider.control == CameraControl::PowerLineFrequency
         && [1, 2, 3]
@@ -911,7 +911,7 @@ fn control_row(
     }
     row = row.child(auto_cell);
 
-    row.into_any_element()
+    row
 }
 
 fn frequency_row(
@@ -919,7 +919,7 @@ fn frequency_row(
     ix: usize,
     cx: &Context<CameraControlsPanel>,
     pal: Palette,
-) -> AnyElement {
+) -> gpui::Stateful<gpui::Div> {
     let slider = &panel.sliders[ix];
     let current = from_slider(slider.state.read(cx).value().start());
     let mut choices = h_flex().flex_1().justify_end().gap_1();
@@ -991,7 +991,6 @@ fn frequency_row(
                 .child(slider.label.clone()),
         )
         .child(choices)
-        .into_any_element()
 }
 
 fn binary_control_row(
@@ -999,7 +998,7 @@ fn binary_control_row(
     ix: usize,
     cx: &Context<CameraControlsPanel>,
     pal: Palette,
-) -> AnyElement {
+) -> gpui::Stateful<gpui::Div> {
     let slider = &panel.sliders[ix];
     let on = from_slider(slider.state.read(cx).value().start()) != 0;
     let accent = rgb(ACCENT_BLUE);
@@ -1056,32 +1055,28 @@ fn binary_control_row(
                     );
                 })),
         )
-        .into_any_element()
 }
 
-fn reset_button(pal: Palette, cx: &mut Context<CameraControlsPanel>) -> AnyElement {
-    h_flex()
-        .w_full()
-        .justify_end()
-        .child(
-            BaseButton::new("camera-controls-reset")
-                .accessibility_label(tr!("Reset to defaults"))
-                .px_2p5()
-                .py_0p5()
-                .rounded_md()
-                .border_1()
-                .border_color(pal.border)
-                .bg(pal.control)
-                .hover(|s| s.bg(pal.control_hover))
-                .focus_visible(|s| s.bg(pal.control_hover))
-                .text_caption()
-                .text_color(pal.text_muted)
-                .child(tr!("Reset to defaults"))
-                .on_click(cx.listener(|panel, _: &ClickEvent, window, cx| {
-                    panel.reset(window, cx);
-                })),
-        )
-        .into_any_element()
+fn reset_button(cx: &mut Context<CameraControlsPanel>) -> gpui::Div {
+    let pal = theme::palette(cx);
+    h_flex().w_full().justify_end().child(
+        BaseButton::new("camera-controls-reset")
+            .accessibility_label(tr!("Reset to defaults"))
+            .px_2p5()
+            .py_0p5()
+            .rounded_md()
+            .border_1()
+            .border_color(pal.border)
+            .bg(pal.control)
+            .hover(|s| s.bg(pal.control_hover))
+            .focus_visible(|s| s.bg(pal.control_hover))
+            .text_caption()
+            .text_color(pal.text_muted)
+            .child(tr!("Reset to defaults"))
+            .on_click(cx.listener(|panel, _: &ClickEvent, window, cx| {
+                panel.reset(window, cx);
+            })),
+    )
 }
 
 fn chip_hover_fill(selected: bool, pal: Palette) -> gpui::Hsla {

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -707,7 +707,7 @@ impl Render for CameraControlsPanel {
             self.uid = None;
             self.sliders.clear();
             self.autos.clear();
-            return div().into_any_element();
+            return div();
         };
         self.ensure_built(&key, &uid, cx);
 
@@ -715,8 +715,7 @@ impl Render for CameraControlsPanel {
             return div()
                 .text_body()
                 .text_color(pal.text_muted)
-                .child(tr!("This camera exposes no adjustable image controls."))
-                .into_any_element();
+                .child(tr!("This camera exposes no adjustable image controls."));
         }
 
         let lens: Vec<usize> = section_indices(&self.sliders, true);
@@ -735,7 +734,7 @@ impl Render for CameraControlsPanel {
         for ix in image {
             panel = panel.child(control_row(self, ix, cx));
         }
-        panel.child(reset_button(cx)).into_any_element()
+        panel.child(reset_button(cx))
     }
 }
 

--- a/crates/openlogi-desktop/src/features/camera/preview.rs
+++ b/crates/openlogi-desktop/src/features/camera/preview.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, Render, RenderImage,
-    SharedString, Styled, Subscription, Task, Window, div, img, px,
+    Context, InteractiveElement, IntoElement, ParentElement, Render, RenderImage, SharedString,
+    Styled, Subscription, Task, Window, div, img, prelude::FluentBuilder as _, px,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::v_flex;
@@ -170,37 +170,16 @@ impl Render for CameraPreview {
             }
         }
 
-        let surface: AnyElement = if let Some(image) = self.current_image.as_ref() {
-            img(image.clone())
-                .w(px(PREVIEW_W))
-                .h(px(PREVIEW_H))
-                .rounded_md()
-                .into_any_element()
-        } else if !openlogi_camera::capture_supported() {
-            note(
-                tr!("Live preview isn't available on this platform yet."),
-                pal,
-            )
-            .into_any_element()
-        } else if granted {
-            note(tr!("Starting preview…"), pal).into_any_element()
-        } else if matches!(
-            openlogi_camera::camera_authorization(),
-            CameraAuthorization::Undetermined
-        ) {
-            BaseButton::new("camera-request-access")
-                .accessibility_label(tr!("Click to enable camera access."))
-                .text_body()
-                .text_color(pal.text_muted)
-                .cursor_pointer()
-                .hover(|s| s.text_color(pal.text_primary))
-                .focus_visible(|s| s.text_color(pal.text_primary))
-                .child(tr!("Click to enable camera access."))
-                .on_click(|_, _, cx| crate::features::camera::request_camera_access(cx))
-                .into_any_element()
-        } else {
-            note(tr!("Enable Camera access in Settings to preview."), pal).into_any_element()
-        };
+        let image = self.current_image.clone();
+        let show_placeholder = image.is_none();
+        let capture_supported = !show_placeholder || openlogi_camera::capture_supported();
+        let authorization_undetermined = show_placeholder
+            && capture_supported
+            && !granted
+            && matches!(
+                openlogi_camera::camera_authorization(),
+                CameraAuthorization::Undetermined
+            );
 
         v_flex()
             .w(px(PREVIEW_W))
@@ -211,7 +190,46 @@ impl Render for CameraPreview {
             .border_1()
             .border_color(pal.border)
             .bg(pal.panel)
-            .child(surface)
+            .when_some(image, |surface, image| {
+                surface.child(img(image).w(px(PREVIEW_W)).h(px(PREVIEW_H)).rounded_md())
+            })
+            .when(show_placeholder && !capture_supported, |surface| {
+                surface.child(note(
+                    tr!("Live preview isn't available on this platform yet."),
+                    pal,
+                ))
+            })
+            .when(
+                show_placeholder && capture_supported && granted,
+                |surface| surface.child(note(tr!("Starting preview…"), pal)),
+            )
+            .when(
+                show_placeholder && capture_supported && !granted && authorization_undetermined,
+                |surface| {
+                    surface.child(
+                        BaseButton::new("camera-request-access")
+                            .accessibility_label(tr!("Click to enable camera access."))
+                            .text_body()
+                            .text_color(pal.text_muted)
+                            .cursor_pointer()
+                            .hover(|s| s.text_color(pal.text_primary))
+                            .focus_visible(|s| s.text_color(pal.text_primary))
+                            .child(tr!("Click to enable camera access."))
+                            .on_click(|_, _, cx| {
+                                crate::features::camera::request_camera_access(cx);
+                            }),
+                    )
+                },
+            )
+            .when(
+                show_placeholder && capture_supported && !granted && !authorization_undetermined,
+                |surface| {
+                    surface.child(note(
+                        tr!("Enable Camera access in Settings to preview."),
+                        pal,
+                    ))
+                },
+            )
     }
 }
 

--- a/crates/openlogi-desktop/src/features/camera/preview.rs
+++ b/crates/openlogi-desktop/src/features/camera/preview.rs
@@ -181,8 +181,9 @@ impl Render for CameraPreview {
                 tr!("Live preview isn't available on this platform yet."),
                 pal,
             )
+            .into_any_element()
         } else if granted {
-            note(tr!("Starting preview…"), pal)
+            note(tr!("Starting preview…"), pal).into_any_element()
         } else if matches!(
             openlogi_camera::camera_authorization(),
             CameraAuthorization::Undetermined
@@ -198,7 +199,7 @@ impl Render for CameraPreview {
                 .on_click(|_, _, cx| crate::features::camera::request_camera_access(cx))
                 .into_any_element()
         } else {
-            note(tr!("Enable Camera access in Settings to preview."), pal)
+            note(tr!("Enable Camera access in Settings to preview."), pal).into_any_element()
         };
 
         v_flex()
@@ -221,10 +222,9 @@ fn build_image(frame: Frame) -> Option<Arc<RenderImage>> {
     Some(Arc::new(RenderImage::new(vec![ImageFrame::new(buffer)])))
 }
 
-fn note(text: impl Into<SharedString>, pal: Palette) -> AnyElement {
+fn note(text: impl Into<SharedString>, pal: Palette) -> gpui::Div {
     div()
         .text_body()
         .text_color(pal.text_muted)
         .child(text.into())
-        .into_any_element()
 }

--- a/crates/openlogi-desktop/src/features/keyboard/editors.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/editors.rs
@@ -15,8 +15,7 @@
 )]
 
 use gpui::{
-    AnyElement, App, Entity, FontWeight, IntoElement, ParentElement, RenderOnce, Styled, Window,
-    div, px, svg,
+    App, Entity, FontWeight, IntoElement, ParentElement, RenderOnce, Styled, Window, div, px, svg,
 };
 use gpui_component::{
     Icon, IconName, Sizable as _,
@@ -87,17 +86,14 @@ pub fn editor_card(
     workflow_draft: Vec<WorkflowStep>,
     view: &Entity<FunctionRowView>,
     pal: Palette,
-) -> AnyElement {
+) -> gpui::Div {
     match kind {
-        PowerUserKind::Workflow => {
-            workflow_editor_card(trigger, workflow_draft, view, pal).into_any_element()
-        }
+        PowerUserKind::Workflow => workflow_editor_card(trigger, workflow_draft, view, pal),
         _ => match text_state {
-            Some(state) => text_editor_card(trigger, kind, state, view, pal).into_any_element(),
+            Some(state) => text_editor_card(trigger, kind, state, view, pal),
             None => compact_panel(pal)
                 .w(px(300.))
-                .child(title(tr!("Editor unavailable"), pal))
-                .into_any_element(),
+                .child(title(tr!("Editor unavailable"), pal)),
         },
     }
 }
@@ -110,7 +106,7 @@ fn text_editor_card(
     text_state: Entity<InputState>,
     view: &Entity<FunctionRowView>,
     pal: Palette,
-) -> impl IntoElement {
+) -> gpui::Div {
     let heading = kind.heading();
     let key_name = trigger.to_string();
 
@@ -185,20 +181,17 @@ fn workflow_editor_card(
     steps: Vec<WorkflowStep>,
     view: &Entity<FunctionRowView>,
     pal: Palette,
-) -> impl IntoElement {
+) -> gpui::Div {
     let key_name = trigger.to_string();
 
-    let mut rows: Vec<AnyElement> = Vec::new();
-    for (idx, step) in steps.iter().enumerate() {
-        rows.push(
-            WorkflowStepRow {
-                idx,
-                step: step.clone(),
-                view: view.clone(),
-            }
-            .into_any_element(),
-        );
-    }
+    let rows = steps
+        .into_iter()
+        .enumerate()
+        .map(|(idx, step)| WorkflowStepRow {
+            idx,
+            step,
+            view: view.clone(),
+        });
 
     compact_panel(pal)
         .w(px(320.))

--- a/crates/openlogi-desktop/src/features/keyboard/editors.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/editors.rs
@@ -15,7 +15,8 @@
 )]
 
 use gpui::{
-    AnyElement, Context, Entity, FontWeight, IntoElement, ParentElement, Styled, div, px, svg,
+    AnyElement, App, Entity, FontWeight, IntoElement, ParentElement, RenderOnce, Styled, Window,
+    div, px, svg,
 };
 use gpui_component::{
     Icon, IconName, Sizable as _,
@@ -31,7 +32,7 @@ use super::function_row::FunctionRowView;
 use crate::features::mouse::picker::{compact_panel, divider, editor_scroll_list, title};
 use crate::state::{AppState, DeviceRecord, StateEvent};
 use crate::ui::components::{MenuRow, control_input};
-use crate::ui::theme::{Palette, Typography as _};
+use crate::ui::theme::{self, Palette, Typography as _};
 
 /// Which power-user editor is showing for the selected key.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -86,12 +87,13 @@ pub fn editor_card(
     workflow_draft: Vec<WorkflowStep>,
     view: &Entity<FunctionRowView>,
     pal: Palette,
-    cx: &mut Context<FunctionRowView>,
 ) -> AnyElement {
     match kind {
-        PowerUserKind::Workflow => workflow_editor_card(trigger, workflow_draft, view, pal, cx),
+        PowerUserKind::Workflow => {
+            workflow_editor_card(trigger, workflow_draft, view, pal).into_any_element()
+        }
         _ => match text_state {
-            Some(state) => text_editor_card(trigger, kind, state, view, pal, cx),
+            Some(state) => text_editor_card(trigger, kind, state, view, pal).into_any_element(),
             None => compact_panel(pal)
                 .w(px(300.))
                 .child(title(tr!("Editor unavailable"), pal))
@@ -108,8 +110,7 @@ fn text_editor_card(
     text_state: Entity<InputState>,
     view: &Entity<FunctionRowView>,
     pal: Palette,
-    cx: &mut Context<FunctionRowView>,
-) -> AnyElement {
+) -> impl IntoElement {
     let heading = kind.heading();
     let key_name = trigger.to_string();
 
@@ -125,9 +126,8 @@ fn text_editor_card(
                 .p_2()
                 .gap_2()
                 .child(div().child(control_input(&text_state).cleanable(true)))
-                .child(editor_action_row(trigger, kind, view, pal, cx)),
+                .child(editor_action_row(trigger, kind, view)),
         )
-        .into_any_element()
 }
 
 /// Cancel (back to list) + Save (commit the drafted text).
@@ -135,9 +135,7 @@ fn editor_action_row(
     trigger: KeyTrigger,
     kind: PowerUserKind,
     view: &Entity<FunctionRowView>,
-    _pal: Palette,
-    _cx: &mut Context<FunctionRowView>,
-) -> AnyElement {
+) -> impl IntoElement {
     let view_save = view.clone();
     let trigger_save = trigger.clone();
     let view_cancel = view.clone();
@@ -179,7 +177,6 @@ fn editor_action_row(
                     view_save.update(cx, |v, vcx| v.close_editor(vcx));
                 }),
         )
-        .into_any_element()
 }
 
 /// The Workflow editor: a list of steps with add/remove.
@@ -188,13 +185,19 @@ fn workflow_editor_card(
     steps: Vec<WorkflowStep>,
     view: &Entity<FunctionRowView>,
     pal: Palette,
-    cx: &mut Context<FunctionRowView>,
-) -> AnyElement {
+) -> impl IntoElement {
     let key_name = trigger.to_string();
 
     let mut rows: Vec<AnyElement> = Vec::new();
     for (idx, step) in steps.iter().enumerate() {
-        rows.push(workflow_step_row(idx, step.clone(), view, pal, cx));
+        rows.push(
+            WorkflowStepRow {
+                idx,
+                step: step.clone(),
+                view: view.clone(),
+            }
+            .into_any_element(),
+        );
     }
 
     compact_panel(pal)
@@ -246,60 +249,62 @@ fn workflow_editor_card(
                         }),
                 ),
         )
-        .into_any_element()
 }
 
 /// One Workflow step row: type chip + payload preview + remove button.
-fn workflow_step_row(
+#[derive(IntoElement)]
+struct WorkflowStepRow {
     idx: usize,
     step: WorkflowStep,
-    view: &Entity<FunctionRowView>,
-    pal: Palette,
-    _cx: &mut Context<FunctionRowView>,
-) -> AnyElement {
-    let (type_label, glyph): (&'static str, &'static str) = match &step {
-        WorkflowStep::TypeText(_) => ("Type Text", "action-icons/keyboard.svg"),
-        WorkflowStep::PressKey(_) => ("Press Key", "action-icons/keyboard.svg"),
-        WorkflowStep::Delay { .. } => ("Delay", "action-icons/chevrons-right.svg"),
-        WorkflowStep::RunAppleScript(_) => ("AppleScript", "action-icons/terminal.svg"),
-        WorkflowStep::RunShellCommand(_) => ("Shell", "action-icons/terminal.svg"),
-    };
-    let view_remove = view.clone();
-
-    MenuRow::new(("wf-step", idx))
-        .child(
-            h_flex()
-                .w_full()
-                .items_center()
-                .gap_2()
-                .child(
-                    svg()
-                        .path(glyph)
-                        .size_4()
-                        .flex_none()
-                        .text_color(pal.text_muted),
-                )
-                .child(
-                    div()
-                        .text_caption()
-                        .font_weight(FontWeight::MEDIUM)
-                        .text_color(pal.text_muted)
-                        .child(type_label),
-                )
-                .child(div().flex_1().child(step_preview(&step, pal))),
-        )
-        .child(
-            Icon::new(IconName::Close)
-                .size_3()
-                .text_color(pal.text_muted),
-        )
-        .on_click(move |_e, _w, cx| {
-            view_remove.update(cx, |v, vcx| v.remove_workflow_step(idx, vcx));
-        })
-        .into_any_element()
+    view: Entity<FunctionRowView>,
 }
 
-fn step_preview(step: &WorkflowStep, pal: Palette) -> AnyElement {
+impl RenderOnce for WorkflowStepRow {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let (type_label, glyph): (&'static str, &'static str) = match &self.step {
+            WorkflowStep::TypeText(_) => ("Type Text", "action-icons/keyboard.svg"),
+            WorkflowStep::PressKey(_) => ("Press Key", "action-icons/keyboard.svg"),
+            WorkflowStep::Delay { .. } => ("Delay", "action-icons/chevrons-right.svg"),
+            WorkflowStep::RunAppleScript(_) => ("AppleScript", "action-icons/terminal.svg"),
+            WorkflowStep::RunShellCommand(_) => ("Shell", "action-icons/terminal.svg"),
+        };
+        let pal = theme::palette(cx);
+        let view_remove = self.view;
+
+        MenuRow::new(("wf-step", self.idx))
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        svg()
+                            .path(glyph)
+                            .size_4()
+                            .flex_none()
+                            .text_color(pal.text_muted),
+                    )
+                    .child(
+                        div()
+                            .text_caption()
+                            .font_weight(FontWeight::MEDIUM)
+                            .text_color(pal.text_muted)
+                            .child(type_label),
+                    )
+                    .child(div().flex_1().child(step_preview(&self.step, pal))),
+            )
+            .child(
+                Icon::new(IconName::Close)
+                    .size_3()
+                    .text_color(pal.text_muted),
+            )
+            .on_click(move |_e, _w, cx| {
+                view_remove.update(cx, |v, vcx| v.remove_workflow_step(self.idx, vcx));
+            })
+    }
+}
+
+fn step_preview(step: &WorkflowStep, pal: Palette) -> impl IntoElement {
     let text: String = match step {
         WorkflowStep::TypeText(s) => {
             if s.is_empty() {
@@ -322,7 +327,6 @@ fn step_preview(step: &WorkflowStep, pal: Palette) -> AnyElement {
         .text_caption()
         .text_color(pal.text_primary)
         .child(text)
-        .into_any_element()
 }
 
 fn key_combo_preview(combo: &KeyCombo) -> String {

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -354,14 +354,14 @@ struct KeySlot {
 /// The two-pane row: keyboard photo + an optional side panel.
 #[derive(IntoElement)]
 struct InspectorRow {
-    keyboard: AnyElement,
+    keyboard: KeyboardPane,
     panel: Option<AnyElement>,
 }
 
 impl InspectorRow {
-    fn new(keyboard: impl IntoElement) -> Self {
+    fn new(keyboard: KeyboardPane) -> Self {
         Self {
-            keyboard: keyboard.into_any_element(),
+            keyboard,
             panel: None,
         }
     }
@@ -375,30 +375,22 @@ impl InspectorRow {
 
 impl RenderOnce for InspectorRow {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
-        let Some(panel) = self.panel else {
-            return h_flex()
-                .w_full()
-                .justify_center()
-                .child(self.keyboard)
-                .into_any_element();
-        };
-
-        // The panel grows in from width 0 → PANEL_W over SLIDE_MS, easing in/out,
-        // always on the right as a stable inspector.
-        let animated_panel = div().overflow_hidden().child(panel).with_animation(
-            "panel-slide",
-            Animation::new(std::time::Duration::from_millis(SLIDE_MS)).with_easing(ease_in_out),
-            |element, delta| element.w(px(PANEL_W * delta)),
-        );
-
         h_flex()
             .w_full()
-            .gap_5()
             .items_center()
             .justify_center()
             .child(self.keyboard)
-            .child(animated_panel)
-            .into_any_element()
+            .when_some(self.panel, |row, panel| {
+                // The panel grows in from width 0 → PANEL_W over SLIDE_MS,
+                // easing in/out, always on the right as a stable inspector.
+                let animated_panel = div().overflow_hidden().child(panel).with_animation(
+                    "panel-slide",
+                    Animation::new(std::time::Duration::from_millis(SLIDE_MS))
+                        .with_easing(ease_in_out),
+                    |element, delta| element.w(px(PANEL_W * delta)),
+                );
+                row.gap_5().child(animated_panel)
+            })
     }
 }
 
@@ -487,7 +479,13 @@ impl RenderOnce for KeyboardPane {
                 let view_for_callouts = view_clone.clone();
                 self.slots.iter().cloned().map(move |slot| {
                     let highlighted = key_is_highlighted(slot.idx, selected, hovered);
-                    key_callout(slot, count, highlighted, img_w, &view_for_callouts, &pal)
+                    KeyCallout {
+                        slot,
+                        count,
+                        highlighted,
+                        img_w,
+                        view: view_for_callouts.clone(),
+                    }
                 })
             })
             // Click-targets overlay, centered on each key's marker point.
@@ -507,102 +505,107 @@ impl RenderOnce for KeyboardPane {
 }
 
 /// One callout bubble in the band above the keyboard.
-fn key_callout(
+#[derive(IntoElement)]
+struct KeyCallout {
     slot: KeySlot,
     count: usize,
     highlighted: bool,
     img_w: f32,
-    view: &Entity<FunctionRowView>,
-    pal: &Palette,
-) -> AnyElement {
-    let idx = slot.idx;
-    let left = callout_left_px(idx, count, img_w, KEY_CALLOUT_W);
-    let top = callout_top_px(idx);
-    let view_hover = view.clone();
-    let view_click = view.clone();
-    let binding = slot.binding;
-    let binding_icon = slot.binding_icon;
+    view: Entity<FunctionRowView>,
+}
 
-    v_flex()
-        .id(("key-callout", idx))
-        .absolute()
-        .top(px(top))
-        .left(px(left))
-        .w(px(KEY_CALLOUT_W))
-        .h(px(KEY_CALLOUT_H))
-        .px_1()
-        .justify_center()
-        .items_center()
-        .gap(px(1.))
-        .rounded_md()
-        .border_1()
-        .border_color(if highlighted {
-            rgb(ACCENT_BLUE).into()
-        } else {
-            pal.border
-        })
-        .bg(if highlighted {
-            theme::accent_tint()
-        } else {
-            pal.control
-        })
-        .cursor_pointer()
-        .hover(move |s| {
-            s.bg(if highlighted {
-                theme::accent_tint_hover()
+impl RenderOnce for KeyCallout {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        let idx = self.slot.idx;
+        let left = callout_left_px(idx, self.count, self.img_w, KEY_CALLOUT_W);
+        let top = callout_top_px(idx);
+        let view_hover = self.view.clone();
+        let view_click = self.view;
+        let binding = self.slot.binding;
+        let binding_icon = self.slot.binding_icon;
+        let highlighted = self.highlighted;
+
+        v_flex()
+            .id(("key-callout", idx))
+            .absolute()
+            .top(px(top))
+            .left(px(left))
+            .w(px(KEY_CALLOUT_W))
+            .h(px(KEY_CALLOUT_H))
+            .px_1()
+            .justify_center()
+            .items_center()
+            .gap(px(1.))
+            .rounded_md()
+            .border_1()
+            .border_color(if highlighted {
+                rgb(ACCENT_BLUE).into()
             } else {
-                pal.control_hover
+                pal.border
             })
-        })
-        .child(
-            div()
-                .text_caption()
-                .font_weight(FontWeight::SEMIBOLD)
-                .text_color(if highlighted {
-                    rgb(ACCENT_BLUE).into()
+            .bg(if highlighted {
+                theme::accent_tint()
+            } else {
+                pal.control
+            })
+            .cursor_pointer()
+            .hover(move |s| {
+                s.bg(if highlighted {
+                    theme::accent_tint_hover()
                 } else {
-                    pal.text_primary
+                    pal.control_hover
                 })
-                .child(slot.label),
-        )
-        .child(
-            h_flex()
-                .items_center()
-                .justify_center()
-                .gap(px(2.))
-                .max_w(px(KEY_CALLOUT_W - 8.))
-                .when_some(binding_icon, |row, icon| {
-                    row.child(svg().path(icon).size(px(9.)).flex_none().text_color(
-                        if highlighted {
-                            rgb(ACCENT_BLUE).into()
-                        } else {
-                            pal.text_muted
-                        },
-                    ))
-                })
-                .child(
-                    div()
-                        .min_w_0()
-                        .overflow_hidden()
-                        .text_ellipsis()
-                        .whitespace_nowrap()
-                        .text_caption()
-                        .text_color(if highlighted {
-                            rgb(ACCENT_BLUE).into()
-                        } else {
-                            pal.text_muted
-                        })
-                        .child(binding),
-                ),
-        )
-        .on_hover(move |hovered, _window, cx| {
-            let next = (*hovered).then_some(idx);
-            view_hover.update(cx, |v, vcx| v.set_hovered_key(next, vcx));
-        })
-        .on_click(move |_ev, _window, cx| {
-            view_click.update(cx, |v, vcx| v.click_key(idx, vcx));
-        })
-        .into_any_element()
+            })
+            .child(
+                div()
+                    .text_caption()
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(if highlighted {
+                        rgb(ACCENT_BLUE).into()
+                    } else {
+                        pal.text_primary
+                    })
+                    .child(self.slot.label),
+            )
+            .child(
+                h_flex()
+                    .items_center()
+                    .justify_center()
+                    .gap(px(2.))
+                    .max_w(px(KEY_CALLOUT_W - 8.))
+                    .when_some(binding_icon, |row, icon| {
+                        row.child(svg().path(icon).size(px(9.)).flex_none().text_color(
+                            if highlighted {
+                                rgb(ACCENT_BLUE).into()
+                            } else {
+                                pal.text_muted
+                            },
+                        ))
+                    })
+                    .child(
+                        div()
+                            .min_w_0()
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .whitespace_nowrap()
+                            .text_caption()
+                            .text_color(if highlighted {
+                                rgb(ACCENT_BLUE).into()
+                            } else {
+                                pal.text_muted
+                            })
+                            .child(binding),
+                    ),
+            )
+            .on_hover(move |hovered, _window, cx| {
+                let next = (*hovered).then_some(idx);
+                view_hover.update(cx, |v, vcx| v.set_hovered_key(next, vcx));
+            })
+            .on_click(move |_ev, _window, cx| {
+                view_click.update(cx, |v, vcx| v.click_key(idx, vcx));
+            })
+    }
 }
 
 /// One invisible click-target over a function key. Selecting it opens the
@@ -612,7 +615,7 @@ fn key_click_target(
     highlighted: bool,
     (img_w, img_h): (f32, f32),
     view: &Entity<FunctionRowView>,
-) -> AnyElement {
+) -> impl IntoElement {
     let idx = slot.idx;
     let x_frac = slot.x_frac;
     let y_frac = slot.y_frac;
@@ -662,7 +665,6 @@ fn key_click_target(
         .on_click(move |_ev, _window, cx| {
             view_click.update(cx, |v, vcx| v.click_key(idx, vcx));
         })
-        .into_any_element()
 }
 
 fn binding_label(action: Option<&Action>) -> gpui::SharedString {
@@ -799,7 +801,6 @@ impl FunctionRowView {
                 self.workflow_draft.clone(),
                 view,
                 pal,
-                cx,
             );
         }
 
@@ -856,7 +857,7 @@ fn panel_action_rows(
     pal: &Palette,
 ) -> Vec<AnyElement> {
     let mut children = action_rows("panel-action", current, on_pick, *pal);
-    children.push(editor_section(tr!("Power User").to_string(), *pal));
+    children.push(editor_section(tr!("Power User").to_string(), *pal).into_any_element());
 
     let power_user_actions: &[(PowerUserKind, &str, &'static str)] = &[
         (

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -355,7 +355,7 @@ struct KeySlot {
 #[derive(IntoElement)]
 struct InspectorRow {
     keyboard: KeyboardPane,
-    panel: Option<AnyElement>,
+    panel: Option<gpui::Div>,
 }
 
 impl InspectorRow {
@@ -367,8 +367,8 @@ impl InspectorRow {
     }
 
     #[must_use]
-    fn panel(mut self, panel: impl Into<Option<AnyElement>>) -> Self {
-        self.panel = panel.into();
+    fn panel(mut self, panel: Option<gpui::Div>) -> Self {
+        self.panel = panel;
         self
     }
 }
@@ -786,7 +786,7 @@ impl FunctionRowView {
         slots: &[KeySlot],
         view: &Entity<Self>,
         cx: &mut Context<Self>,
-    ) -> AnyElement {
+    ) -> gpui::Div {
         let pal = theme::palette(cx);
         let slot = &slots[selected_idx];
         let trigger = slot.trigger.clone();
@@ -828,7 +828,6 @@ impl FunctionRowView {
             .child(title_header(&key_name, &pal))
             .child(divider(pal))
             .child(editor_scroll_list("key-panel-scroll", rows))
-            .into_any_element()
     }
 }
 
@@ -855,9 +854,8 @@ fn panel_action_rows(
     on_pick: &PickFn,
     view: &Entity<FunctionRowView>,
     pal: &Palette,
-) -> Vec<AnyElement> {
+) -> Vec<gpui::Div> {
     let mut children = action_rows("panel-action", current, on_pick, *pal);
-    children.push(editor_section(tr!("Power User").to_string(), *pal).into_any_element());
 
     let power_user_actions: &[(PowerUserKind, &str, &'static str)] = &[
         (
@@ -882,52 +880,55 @@ fn panel_action_rows(
         ),
     ];
 
-    for (idx, (kind, label, icon_path)) in power_user_actions.iter().enumerate() {
-        let kind = *kind;
-        let view = view.clone();
-        let selected = matches!(
-            (current, kind),
-            (Some(Action::TypeText(_)), PowerUserKind::TypeText)
-                | (
-                    Some(Action::RunAppleScript(_)),
-                    PowerUserKind::RunAppleScript
-                )
-                | (
-                    Some(Action::RunShellCommand(_)),
-                    PowerUserKind::RunShellCommand
-                )
-                | (Some(Action::Workflow(_)), PowerUserKind::Workflow)
-        );
-        children.push(
-            MenuRow::new(format!("panel-power-{idx}"))
-                .selected(selected)
-                .role(Role::MenuItem)
-                .child(
-                    h_flex()
-                        .items_center()
-                        .gap_2()
+    children.push(
+        v_flex()
+            .child(editor_section(tr!("Power User").to_string(), *pal))
+            .children(power_user_actions.iter().enumerate().map(
+                |(idx, (kind, label, icon_path))| {
+                    let kind = *kind;
+                    let view = view.clone();
+                    let selected = matches!(
+                        (current, kind),
+                        (Some(Action::TypeText(_)), PowerUserKind::TypeText)
+                            | (
+                                Some(Action::RunAppleScript(_)),
+                                PowerUserKind::RunAppleScript
+                            )
+                            | (
+                                Some(Action::RunShellCommand(_)),
+                                PowerUserKind::RunShellCommand
+                            )
+                            | (Some(Action::Workflow(_)), PowerUserKind::Workflow)
+                    );
+                    MenuRow::new(format!("panel-power-{idx}"))
+                        .selected(selected)
+                        .role(Role::MenuItem)
                         .child(
-                            svg()
-                                .path(*icon_path)
-                                .size_4()
-                                .flex_none()
-                                .text_color(pal.text_muted),
+                            h_flex()
+                                .items_center()
+                                .gap_2()
+                                .child(
+                                    svg()
+                                        .path(*icon_path)
+                                        .size_4()
+                                        .flex_none()
+                                        .text_color(pal.text_muted),
+                                )
+                                .child(div().child((*label).to_string())),
                         )
-                        .child(div().child((*label).to_string())),
-                )
-                .when(selected, |s| {
-                    s.child(
-                        gpui_component::Icon::new(gpui_component::IconName::Check)
-                            .size_3()
-                            .text_color(rgb(ACCENT_BLUE)),
-                    )
-                })
-                .on_click(move |_ev, _window, cx| {
-                    view.update(cx, |v, vcx| v.open_editor(kind, vcx));
-                })
-                .into_any_element(),
-        );
-    }
+                        .when(selected, |s| {
+                            s.child(
+                                gpui_component::Icon::new(gpui_component::IconName::Check)
+                                    .size_3()
+                                    .text_color(rgb(ACCENT_BLUE)),
+                            )
+                        })
+                        .on_click(move |_ev, _window, cx| {
+                            view.update(cx, |v, vcx| v.open_editor(kind, vcx));
+                        })
+                },
+            )),
+    );
     children
 }
 

--- a/crates/openlogi-desktop/src/features/lighting/device.rs
+++ b/crates/openlogi-desktop/src/features/lighting/device.rs
@@ -6,9 +6,8 @@
 //! (the agent, over IPC — the GUI has no device I/O of its own).
 
 use gpui::{
-    AnyElement, AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement,
-    Render, Role, StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, div, px,
-    rgb,
+    AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement, Render, Role,
+    StatefulInteractiveElement as _, Styled, Subscription, Toggled, Window, div, px, rgb,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -117,7 +116,7 @@ impl Render for LightingPanel {
                 .update(cx, |slider, cx| slider.set_value(value, window, cx));
         }
 
-        let swatches: Vec<AnyElement> = PALETTE
+        let swatches: Vec<_> = PALETTE
             .iter()
             .map(|&color| swatch(color, &lighting, pal))
             .collect();
@@ -174,7 +173,7 @@ impl Render for LightingPanel {
 }
 
 /// One color swatch. Clicking it turns lighting on and sets that color.
-fn swatch(color: Rgb, current: &Lighting, pal: Palette) -> AnyElement {
+fn swatch(color: Rgb, current: &Lighting, pal: Palette) -> impl IntoElement {
     let selected = current.enabled && current.color == color;
     BaseButton::new(("light-swatch", color.packed()))
         .role(Role::RadioButton)
@@ -209,7 +208,6 @@ fn swatch(color: Rgb, current: &Lighting, pal: Palette) -> AnyElement {
                 }
             });
         })
-        .into_any_element()
 }
 
 /// Snap a raw slider read to a 0–100 brightness percent.

--- a/crates/openlogi-desktop/src/features/lighting/standalone.rs
+++ b/crates/openlogi-desktop/src/features/lighting/standalone.rs
@@ -216,43 +216,46 @@ impl Render for LightPanel {
         let effective_enabled = AppState::try_read(cx).is_some_and(AppState::light_enabled);
         let power = capabilities.is_some_and(|caps| caps.power);
 
-        let mut panel = v_flex().gap_4().w_full();
-        if power {
-            panel = panel.child(light_hero(&device_name, online, effective_enabled, pal));
-            #[cfg(target_os = "macos")]
-            {
-                panel = panel.child(camera_automation(settings, pal));
-            }
-            panel = panel.child(div().h(px(1.)).w_full().bg(pal.border.opacity(0.55)));
-        }
-        if let (Some(range), Some(slider)) = (self.brightness_range, &self.brightness) {
-            let value = range
-                .native_for_percent(settings.brightness_percent)
-                .unwrap_or_else(|| range.min());
-            panel = panel.child(control_well(
-                tr!("Brightness"),
-                format_light_value(value, range.unit()),
-                format_range_endpoints(range),
-                Slider::new(slider).horizontal(),
-                pal,
-            ));
-        }
-        if let (Some(range), Some(slider)) = (self.temperature_range, &self.temperature) {
-            let value = settings
-                .temperature_kelvin
-                .map_or_else(|| midpoint(range), |kelvin| range.quantize(kelvin));
-            panel = panel.child(control_well(
-                tr!("Colour temperature"),
-                format_light_value(value, range.unit()),
-                format_range_endpoints(range),
-                Slider::new(slider).horizontal(),
-                pal,
-            ));
-        }
-        if let Some(status) = AppState::try_read(cx).and_then(AppState::light_command_status) {
-            panel = panel.child(light_command_status(status, pal));
-        }
-        panel
+        let brightness = self.brightness_range.zip(self.brightness.as_ref());
+        let temperature = self.temperature_range.zip(self.temperature.as_ref());
+        let status = AppState::try_read(cx).and_then(AppState::light_command_status);
+
+        v_flex()
+            .gap_4()
+            .w_full()
+            .when(power, |panel| {
+                let panel = panel.child(light_hero(&device_name, online, effective_enabled, pal));
+                #[cfg(target_os = "macos")]
+                let panel = panel.child(camera_automation(settings, pal));
+                panel.child(div().h(px(1.)).w_full().bg(pal.border.opacity(0.55)))
+            })
+            .when_some(brightness, |panel, (range, slider)| {
+                let value = range
+                    .native_for_percent(settings.brightness_percent)
+                    .unwrap_or_else(|| range.min());
+                panel.child(control_well(
+                    tr!("Brightness"),
+                    format_light_value(value, range.unit()),
+                    format_range_endpoints(range),
+                    Slider::new(slider).horizontal(),
+                    pal,
+                ))
+            })
+            .when_some(temperature, |panel, (range, slider)| {
+                let value = settings
+                    .temperature_kelvin
+                    .map_or_else(|| midpoint(range), |kelvin| range.quantize(kelvin));
+                panel.child(control_well(
+                    tr!("Colour temperature"),
+                    format_light_value(value, range.unit()),
+                    format_range_endpoints(range),
+                    Slider::new(slider).horizontal(),
+                    pal,
+                ))
+            })
+            .when_some(status, |panel, status| {
+                panel.child(light_command_status(status, pal))
+            })
     }
 }
 

--- a/crates/openlogi-desktop/src/features/lighting/visual.rs
+++ b/crates/openlogi-desktop/src/features/lighting/visual.rs
@@ -4,7 +4,9 @@
 //! the protocol-neutral generated visual and never borrow another model's
 //! image or diffuser geometry.
 
-use gpui::{AnyElement, BoxShadow, IntoElement, ParentElement, Styled, div, hsla, img, point, px};
+use gpui::{
+    BoxShadow, ParentElement, Styled, div, hsla, img, point, prelude::FluentBuilder as _, px,
+};
 use gpui_component::{Icon, IconName};
 use openlogi_core::config::LightSettings;
 
@@ -18,14 +20,14 @@ pub(crate) fn gallery(
     enabled: bool,
     settings: LightSettings,
     pal: Palette,
-) -> AnyElement {
-    if let Some(asset) = asset {
-        visual_container()
-            .child(product_image(asset, 210., 180., online))
-            .into_any_element()
-    } else {
-        generated_visual(210., 180., online, enabled, settings, pal).into_any_element()
-    }
+) -> gpui::Div {
+    visual_container()
+        .when_some(asset, |container, asset| {
+            container.child(product_image(asset, 210., 180., online))
+        })
+        .when(asset.is_none(), |container| {
+            container.child(generated_visual(210., 180., online, enabled, settings, pal))
+        })
 }
 
 /// Render a standalone light as the large hero in its detail view.
@@ -36,11 +38,6 @@ pub(crate) fn detail(
     settings: LightSettings,
     pal: Palette,
 ) -> gpui::Div {
-    let content = if let Some(asset) = asset {
-        product_image(asset, 536., 460., online)
-    } else {
-        generated_visual(536., 460., online, enabled, settings, pal)
-    };
     visual_container()
         .flex_1()
         .min_w(px(440.))
@@ -50,7 +47,12 @@ pub(crate) fn detail(
         .border_color(pal.border)
         .bg(pal.panel)
         .overflow_hidden()
-        .child(content)
+        .when_some(asset, |container, asset| {
+            container.child(product_image(asset, 536., 460., online))
+        })
+        .when(asset.is_none(), |container| {
+            container.child(generated_visual(536., 460., online, enabled, settings, pal))
+        })
 }
 
 fn product_image(asset: &ResolvedAsset, width: f32, height: f32, online: bool) -> gpui::Div {

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -23,7 +23,7 @@ use super::view::MouseModelView;
 use crate::state::AppState;
 use crate::ui::action::localized_action_label;
 use crate::ui::components::{MenuRow, control_button, control_input};
-use crate::ui::theme::{ACCENT_BLUE, Palette, Typography as _};
+use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 
 pub(super) const INSPECTOR_W: f32 = 328.;
 
@@ -49,9 +49,9 @@ pub(super) fn binding_inspector(
     data: BindingInspectorData<'_>,
     action_search: &Entity<InputState>,
     view: &Entity<MouseModelView>,
-    pal: Palette,
     cx: &Context<MouseModelView>,
 ) -> gpui::Div {
+    let pal = theme::palette(cx);
     let picker = ActionPickerContext {
         open: data.action_picker_open,
         search: action_search,

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -62,14 +62,16 @@ pub(super) fn binding_inspector(
             data.editing_app,
             data.overridden.map_or(0, BTreeMap::len),
             pal,
-        ),
+        )
+        .into_any_element(),
         Some(MouseControlId::ThumbwheelRotation) => thumbwheel_inspector(
             data.bindings,
             data.editing_app,
             data.overridden,
             picker,
             pal,
-        ),
+        )
+        .into_any_element(),
         Some(MouseControlId::Button(button)) => button_inspector(button, &data, picker, pal, cx),
     };
 
@@ -93,7 +95,7 @@ pub(super) fn binding_inspector(
         .into_any_element()
 }
 
-fn empty_inspector(app: Option<&str>, override_count: usize, pal: Palette) -> AnyElement {
+fn empty_inspector(app: Option<&str>, override_count: usize, pal: Palette) -> impl IntoElement {
     let summary = match (app, override_count) {
         (Some(app), 0) => tr!(
             "No overrides yet. Select a button to customize for %{app}.",
@@ -114,7 +116,6 @@ fn empty_inspector(app: Option<&str>, override_count: usize, pal: Palette) -> An
         .gap_3()
         .child(inspector_heading(tr!("Button inspector"), None, pal))
         .child(div().text_body().text_color(pal.text_muted).child(summary))
-        .into_any_element()
 }
 
 fn button_inspector(
@@ -345,7 +346,7 @@ fn gesture_directions(
     button: ButtonId,
     view: &Entity<MouseModelView>,
     pal: Palette,
-) -> AnyElement {
+) -> impl IntoElement {
     v_flex()
         .gap_1()
         .child(editor_section(tr!("Direction"), pal))
@@ -391,7 +392,6 @@ fn gesture_directions(
                         })
                 }),
         )
-        .into_any_element()
 }
 
 fn thumbwheel_inspector(
@@ -504,7 +504,7 @@ fn inspector_heading(
     title: gpui::SharedString,
     status: Option<gpui::SharedString>,
     pal: Palette,
-) -> AnyElement {
+) -> impl IntoElement {
     v_flex()
         .gap_1()
         .child(div().text_heading().child(title))
@@ -514,14 +514,13 @@ fn inspector_heading(
                 .text_color(pal.text_muted)
                 .child(status)
         }))
-        .into_any_element()
 }
 
 fn current_action_card(
     action: &Action,
     picker: ActionPickerContext<'_>,
     pal: Palette,
-) -> AnyElement {
+) -> impl IntoElement {
     selection_card(
         "inspector-current-action",
         tr!("Current action"),
@@ -532,7 +531,7 @@ fn current_action_card(
     )
 }
 
-fn gesture_summary_card(picker: ActionPickerContext<'_>, pal: Palette) -> AnyElement {
+fn gesture_summary_card(picker: ActionPickerContext<'_>, pal: Palette) -> impl IntoElement {
     selection_card(
         "inspector-current-gesture-summary",
         tr!("Current action"),
@@ -550,7 +549,7 @@ fn selection_card(
     value: gpui::SharedString,
     picker: ActionPickerContext<'_>,
     pal: Palette,
-) -> AnyElement {
+) -> impl IntoElement {
     let toggle = picker.view.clone();
     let search = picker.search.clone();
     let opening = !picker.open;
@@ -615,7 +614,6 @@ fn selection_card(
                 cx.notify();
             });
         })
-        .into_any_element()
 }
 
 fn action_library(
@@ -625,7 +623,7 @@ fn action_library(
     on_pick: &PickFn,
     pal: Palette,
     cx: &Context<MouseModelView>,
-) -> AnyElement {
+) -> impl IntoElement {
     let query = action_search.read(cx).value();
     let rows = action_rows_matching(id_prefix, current, &query, on_pick, pal);
     v_flex()
@@ -647,7 +645,6 @@ fn action_library(
                 })
                 .children(rows),
         )
-        .into_any_element()
 }
 
 fn gesture_action(

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use gpui::{
-    AnyElement, Context, Entity, InteractiveElement, IntoElement, ParentElement, Role,
+    Context, Entity, InteractiveElement, IntoElement, ParentElement, Role,
     StatefulInteractiveElement as _, Styled, div, prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_base::Button as BaseButton;
@@ -51,7 +51,7 @@ pub(super) fn binding_inspector(
     view: &Entity<MouseModelView>,
     pal: Palette,
     cx: &Context<MouseModelView>,
-) -> AnyElement {
+) -> gpui::Div {
     let picker = ActionPickerContext {
         open: data.action_picker_open,
         search: action_search,
@@ -62,16 +62,14 @@ pub(super) fn binding_inspector(
             data.editing_app,
             data.overridden.map_or(0, BTreeMap::len),
             pal,
-        )
-        .into_any_element(),
+        ),
         Some(MouseControlId::ThumbwheelRotation) => thumbwheel_inspector(
             data.bindings,
             data.editing_app,
             data.overridden,
             picker,
             pal,
-        )
-        .into_any_element(),
+        ),
         Some(MouseControlId::Button(button)) => button_inspector(button, &data, picker, pal, cx),
     };
 
@@ -92,10 +90,9 @@ pub(super) fn binding_inspector(
                 .p_4()
                 .child(body),
         )
-        .into_any_element()
 }
 
-fn empty_inspector(app: Option<&str>, override_count: usize, pal: Palette) -> impl IntoElement {
+fn empty_inspector(app: Option<&str>, override_count: usize, pal: Palette) -> gpui::Div {
     let summary = match (app, override_count) {
         (Some(app), 0) => tr!(
             "No overrides yet. Select a button to customize for %{app}.",
@@ -124,7 +121,7 @@ fn button_inspector(
     picker: ActionPickerContext<'_>,
     pal: Palette,
     cx: &Context<MouseModelView>,
-) -> AnyElement {
+) -> gpui::Div {
     let gesture_map = data.gesture_maps.get(&button);
     let overridden = data
         .overridden
@@ -219,7 +216,6 @@ fn button_inspector(
                 cx,
             ))
         })
-        .into_any_element()
 }
 
 fn inherited_gesture_inspector(
@@ -228,7 +224,7 @@ fn inherited_gesture_inspector(
     picker: ActionPickerContext<'_>,
     pal: Palette,
     cx: &Context<MouseModelView>,
-) -> AnyElement {
+) -> gpui::Div {
     let observer = picker.view.clone();
     let on_pick: PickFn = Rc::new(move |action, _window, cx| {
         AppState::update_bindings(cx, |state| state.commit_binding(button, action));
@@ -273,7 +269,6 @@ fn inherited_gesture_inspector(
                 cx,
             ))
         })
-        .into_any_element()
 }
 
 fn gesture_inspector(
@@ -283,7 +278,7 @@ fn gesture_inspector(
     picker: ActionPickerContext<'_>,
     pal: Palette,
     cx: &Context<MouseModelView>,
-) -> AnyElement {
+) -> gpui::Div {
     let direction = selected_direction.unwrap_or(GestureDirection::Click);
     let current = gesture_action(gesture_map, button, direction);
     let observer = picker.view.clone();
@@ -337,7 +332,6 @@ fn gesture_inspector(
                 cx,
             ))
         })
-        .into_any_element()
 }
 
 fn gesture_directions(
@@ -400,7 +394,7 @@ fn thumbwheel_inspector(
     overridden: Option<&BTreeMap<ButtonId, Action>>,
     picker: ActionPickerContext<'_>,
     pal: Palette,
-) -> AnyElement {
+) -> gpui::Div {
     let backward = bindings
         .get(&ButtonId::ThumbwheelScrollDown)
         .cloned()
@@ -497,7 +491,6 @@ fn thumbwheel_inspector(
                     }),
             )
         })
-        .into_any_element()
 }
 
 fn inspector_heading(

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -3,9 +3,8 @@
 use std::rc::Rc;
 
 use gpui::{
-    AnyElement, App, InteractiveElement, IntoElement, ParentElement, Role,
-    StatefulInteractiveElement as _, Styled, Window, div, prelude::FluentBuilder as _, px, rgb,
-    svg,
+    App, InteractiveElement, IntoElement, ParentElement, Role, StatefulInteractiveElement as _,
+    Styled, Window, div, prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_component::{Icon, IconName, Selectable as _, h_flex, v_flex};
 use openlogi_core::binding::{Action, Category};
@@ -100,7 +99,7 @@ pub(crate) fn action_rows(
     current: Option<&Action>,
     on_pick: &PickFn,
     pal: Palette,
-) -> Vec<AnyElement> {
+) -> Vec<gpui::Div> {
     action_rows_matching(id_prefix, current, "", on_pick, pal)
 }
 
@@ -111,10 +110,10 @@ pub(crate) fn action_rows_matching(
     query: &str,
     on_pick: &PickFn,
     pal: Palette,
-) -> Vec<AnyElement> {
+) -> Vec<gpui::Div> {
     let query = query.trim().to_lowercase();
     let mut catalog_index = 0usize;
-    let mut children: Vec<AnyElement> = Vec::new();
+    let mut sections = Vec::new();
     for (category, actions) in grouped_catalog() {
         let category_label = rust_i18n::t!(category.label());
         let category_matches = category_label.to_lowercase().contains(&query);
@@ -139,44 +138,44 @@ pub(crate) fn action_rows_matching(
         if actions.is_empty() {
             continue;
         }
-        children.push(editor_section(category_label.into_owned(), pal));
-        for (action_key, action) in actions {
-            let selected = current == Some(&action);
-            let label = tr!(action.label());
-            let accessible_label = label.clone();
-            let icon_path = action_icon_path(&action);
-            let on_pick = on_pick.clone();
-            children.push(
-                MenuRow::new((id_prefix, action_key))
-                    .selected(selected)
-                    .role(Role::MenuItem)
-                    .aria_label(accessible_label)
-                    .child(
-                        h_flex()
-                            .items_center()
-                            .gap_2()
-                            .child(
-                                svg()
-                                    .path(icon_path)
-                                    .size_4()
-                                    .flex_none()
-                                    .text_color(pal.text_muted),
-                            )
-                            .child(div().child(label)),
-                    )
-                    .when(selected, |row| {
-                        row.child(
-                            Icon::new(IconName::Check)
-                                .size_3()
-                                .text_color(rgb(ACCENT_BLUE)),
+        sections.push(
+            v_flex()
+                .child(editor_section(category_label.into_owned(), pal))
+                .children(actions.into_iter().map(|(action_key, action)| {
+                    let selected = current == Some(&action);
+                    let label = tr!(action.label());
+                    let accessible_label = label.clone();
+                    let icon_path = action_icon_path(&action);
+                    let on_pick = on_pick.clone();
+                    MenuRow::new((id_prefix, action_key))
+                        .selected(selected)
+                        .role(Role::MenuItem)
+                        .aria_label(accessible_label)
+                        .child(
+                            h_flex()
+                                .items_center()
+                                .gap_2()
+                                .child(
+                                    svg()
+                                        .path(icon_path)
+                                        .size_4()
+                                        .flex_none()
+                                        .text_color(pal.text_muted),
+                                )
+                                .child(div().child(label)),
                         )
-                    })
-                    .on_click(move |_event, window, cx| (on_pick)(action.clone(), window, cx))
-                    .into_any_element(),
-            );
-        }
+                        .when(selected, |row| {
+                            row.child(
+                                Icon::new(IconName::Check)
+                                    .size_3()
+                                    .text_color(rgb(ACCENT_BLUE)),
+                            )
+                        })
+                        .on_click(move |_event, window, cx| (on_pick)(action.clone(), window, cx))
+                })),
+        );
     }
-    children
+    sections
 }
 
 /// Shared card surface for compact binding panels and menus.
@@ -191,13 +190,8 @@ pub(crate) fn compact_panel(pal: Palette) -> gpui::Div {
 }
 
 /// A group heading inset to line up with the rows under it.
-pub(crate) fn editor_section(label: impl Into<gpui::SharedString>, pal: Palette) -> AnyElement {
-    section_label(label, pal)
-        .w_full()
-        .px_2()
-        .pt_2()
-        .pb_0p5()
-        .into_any_element()
+pub(crate) fn editor_section(label: impl Into<gpui::SharedString>, pal: Palette) -> gpui::Div {
+    section_label(label, pal).w_full().px_2().pt_2().pb_0p5()
 }
 
 /// Compact editor title.
@@ -216,7 +210,10 @@ pub(crate) fn divider(pal: Palette) -> impl IntoElement {
 }
 
 /// Height-capped scroll region for compact editor rows.
-pub(crate) fn editor_scroll_list(id: &'static str, rows: Vec<AnyElement>) -> impl IntoElement {
+pub(crate) fn editor_scroll_list(
+    id: &'static str,
+    rows: impl IntoIterator<Item = impl IntoElement>,
+) -> impl IntoElement {
     div()
         .id(id)
         .max_h(px(EDITOR_LIST_MAX_H))

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -269,8 +269,7 @@ impl Render for MouseModelView {
         let highlight = self.hovered.or(active);
         let view = cx.entity();
         let hovered = self.hovered;
-        let pal = theme::palette(cx);
-        let profile_status = profile_canvas_status(pal, cx);
+        let profile_status = profile_canvas_status(cx);
 
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
@@ -321,7 +320,6 @@ impl Render for MouseModelView {
             },
             &self.action_search,
             &view,
-            pal,
             cx,
         );
         workspace_layout(canvas, profile_status, inspector, &self.focus_handle)
@@ -973,7 +971,6 @@ mod tests {
                 },
                 &view.action_search,
                 &entity,
-                theme::palette(cx),
                 cx,
             );
         });

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -29,7 +29,7 @@ use crate::features::profile_scope::{friendly_app_name, profile_canvas_status};
 use crate::services::assets::{GlowGeometry, ResolvedAsset};
 use crate::state::{AppState, StateEvent};
 use crate::ui::action::localized_action_label;
-use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
+use crate::ui::theme::{self, ACCENT_BLUE, Typography as _};
 
 const SIDE_GAP: f32 = 24.;
 const LABEL_W: f32 = 156.;
@@ -275,7 +275,7 @@ impl Render for MouseModelView {
         let hotspots_outer = hotspots.clone();
         let labels_outer = labels.clone();
         let leader_canvas = leader_canvas(hotspots, labels, highlight, mouse_left, mouse_w);
-        let breathing_art = breathing_art(asset, mouse_left, mouse_w, mouse_h, pal, glow);
+        let breathing_art = breathing_art(asset, mouse_left, mouse_w, mouse_h, glow);
         let model = ModelRect {
             left: mouse_left,
             width: mouse_w,
@@ -324,21 +324,16 @@ impl Render for MouseModelView {
             pal,
             cx,
         );
-        workspace_layout(
-            canvas.into_any_element(),
-            profile_status,
-            inspector,
-            &self.focus_handle,
-        )
+        workspace_layout(canvas, profile_status, inspector, &self.focus_handle)
     }
 }
 
 fn workspace_layout(
-    canvas: AnyElement,
-    profile_status: Option<AnyElement>,
-    inspector: AnyElement,
+    canvas: impl IntoElement,
+    profile_status: Option<gpui::Div>,
+    inspector: impl IntoElement,
     focus_handle: &FocusHandle,
-) -> AnyElement {
+) -> impl IntoElement {
     h_flex()
         .flex_1()
         .min_h_0()
@@ -367,7 +362,6 @@ fn workspace_layout(
                 ),
         )
         .child(inspector)
-        .into_any_element()
 }
 
 struct ModelLayout {
@@ -497,7 +491,6 @@ fn breathing_art(
     mouse_left: f32,
     mouse_w: f32,
     mouse_h: f32,
-    pal: Palette,
     glow: Option<(Arc<GlowGeometry>, Hsla)>,
 ) -> impl IntoElement {
     let device_art: AnyElement = match asset {
@@ -505,7 +498,11 @@ fn breathing_art(
             .w(px(mouse_w))
             .h(px(mouse_h))
             .into_any_element(),
-        None => silhouette(mouse_w, mouse_h, pal).into_any_element(),
+        None => Silhouette {
+            w: mouse_w,
+            h: mouse_h,
+        }
+        .into_any_element(),
     };
     div()
         .absolute()
@@ -566,7 +563,7 @@ fn label_control(
     model: ModelRect,
     selected: bool,
     view: &Entity<MouseModelView>,
-) -> AnyElement {
+) -> gpui::Div {
     let x = match label.side {
         Side::Left => model.left - SIDE_GAP - LABEL_W,
         Side::Right => model.left + model.width + SIDE_GAP,
@@ -587,7 +584,6 @@ fn label_control(
         .w(px(LABEL_W))
         .h(px(LABEL_H))
         .child(trigger)
-        .into_any_element()
 }
 
 struct BindingLabel {
@@ -780,45 +776,55 @@ fn binding_label_for_control(
 /// Its `rounded_*` values are illustration proportions — the body shell and the
 /// two drawn side buttons — not UI chrome, so they stay fixed rather than
 /// tracking the `Palette` radius tokens the way real cards and controls do.
-fn silhouette(w: f32, h: f32, pal: Palette) -> impl IntoElement {
-    div()
-        .absolute()
-        .inset_0()
-        .w(px(w))
-        .h(px(h))
-        .rounded_3xl()
-        .border_1()
-        .border_color(pal.text_muted)
-        .bg(pal.muted)
-        .child(
-            div()
-                .absolute()
-                .left(px(w / 2. - 14.))
-                .top(px(90.))
-                .w(px(28.))
-                .h(px(110.))
-                .rounded_md()
-                .bg(hsla(0., 0., 0.25, 1.0)),
-        )
-        .child(
-            div()
-                .absolute()
-                .left(px(w / 2.))
-                .top(px(20.))
-                .w(px(1.))
-                .h(px(240.))
-                .bg(pal.border),
-        )
-        .child(
-            div()
-                .absolute()
-                .left(px(8.))
-                .top(px(210.))
-                .w(px(34.))
-                .h(px(150.))
-                .rounded_md()
-                .bg(hsla(0., 0., 0.25, 1.0)),
-        )
+#[derive(IntoElement)]
+struct Silhouette {
+    w: f32,
+    h: f32,
+}
+
+impl RenderOnce for Silhouette {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let Self { w, h } = self;
+        let pal = theme::palette(cx);
+        div()
+            .absolute()
+            .inset_0()
+            .w(px(w))
+            .h(px(h))
+            .rounded_3xl()
+            .border_1()
+            .border_color(pal.text_muted)
+            .bg(pal.muted)
+            .child(
+                div()
+                    .absolute()
+                    .left(px(w / 2. - 14.))
+                    .top(px(90.))
+                    .w(px(28.))
+                    .h(px(110.))
+                    .rounded_md()
+                    .bg(hsla(0., 0., 0.25, 1.0)),
+            )
+            .child(
+                div()
+                    .absolute()
+                    .left(px(w / 2.))
+                    .top(px(20.))
+                    .w(px(1.))
+                    .h(px(240.))
+                    .bg(pal.border),
+            )
+            .child(
+                div()
+                    .absolute()
+                    .left(px(8.))
+                    .top(px(210.))
+                    .w(px(34.))
+                    .h(px(150.))
+                    .rounded_md()
+                    .bg(hsla(0., 0., 0.25, 1.0)),
+            )
+    }
 }
 
 fn hotspot_control(
@@ -828,7 +834,7 @@ fn hotspot_control(
     active: Option<MouseControlId>,
     selected: bool,
     view: &Entity<MouseModelView>,
-) -> AnyElement {
+) -> gpui::Div {
     let view = view.clone();
     let trigger = HotspotTrigger {
         id: ("hotspot-trigger", idx).into(),
@@ -844,7 +850,6 @@ fn hotspot_control(
         .w(px(hotspot.w))
         .h(px(hotspot.h))
         .child(trigger)
-        .into_any_element()
 }
 
 #[derive(IntoElement)]

--- a/crates/openlogi-desktop/src/features/pointer/dpi.rs
+++ b/crates/openlogi-desktop/src/features/pointer/dpi.rs
@@ -196,7 +196,7 @@ impl Render for DpiPanel {
         // Highlight at most one chip: when several presets snap to the same
         // supported value as the current DPI, only the first is "active".
         let mut already_highlighted = false;
-        let preset_chips: Vec<AnyElement> = snapshot
+        let preset_chips: Vec<_> = snapshot
             .presets
             .iter()
             .enumerate()
@@ -359,7 +359,7 @@ const CHIP_H: f32 = 28.;
 
 /// One DPI preset rendered as a chip. Clicking the chip writes that DPI to
 /// the device and updates `AppState.dpi`; the small × removes the preset.
-fn preset_chip(idx: usize, value: Dpi, active: bool, presets: &[Dpi]) -> AnyElement {
+fn preset_chip(idx: usize, value: Dpi, active: bool, presets: &[Dpi]) -> impl IntoElement {
     let presets_for_remove: Vec<Dpi> = presets.to_vec();
     PresetChip::new(("dpi-preset-chip", idx))
         .selected(active)
@@ -409,11 +409,10 @@ fn preset_chip(idx: usize, value: Dpi, active: bool, presets: &[Dpi]) -> AnyElem
                     });
                 }),
         )
-        .into_any_element()
 }
 
 /// "+" chip that snapshots `AppState.dpi` as a new preset.
-fn add_preset_chip() -> AnyElement {
+fn add_preset_chip() -> impl IntoElement {
     Button::new("dpi-preset-add")
         .compact()
         .outline()
@@ -434,5 +433,4 @@ fn add_preset_chip() -> AnyElement {
                 }
             });
         })
-        .into_any_element()
 }

--- a/crates/openlogi-desktop/src/features/pointer/smartshift.rs
+++ b/crates/openlogi-desktop/src/features/pointer/smartshift.rs
@@ -175,9 +175,9 @@ impl SmartShiftPanel {
         &mut self,
         status: SmartShiftStatus,
         window: &mut Window,
-        pal: Palette,
         cx: &mut Context<Self>,
-    ) -> AnyElement {
+    ) -> gpui::Div {
+        let pal = theme::palette(cx);
         let mode = status.mode;
         let permanent = status.auto_disengage.is_permanent();
         let ratchet = matches!(mode, SmartShiftMode::Ratchet);
@@ -215,7 +215,6 @@ impl SmartShiftPanel {
                             mode: SmartShiftMode::Free,
                             ..status
                         },
-                        pal,
                     ))
                     .child(mode_pill(
                         tr!("Ratchet"),
@@ -229,7 +228,6 @@ impl SmartShiftPanel {
                             auto_disengage: SmartShiftAutoDisengage::Threshold(committed),
                             ..status
                         },
-                        pal,
                     )),
             );
 
@@ -255,13 +253,13 @@ impl SmartShiftPanel {
             .child(if sensitivity_enabled {
                 Slider::new(&self.threshold).horizontal().into_any_element()
             } else {
-                disabled_track(pal)
+                disabled_track(pal).into_any_element()
             })
             .child(div().text_caption().text_color(pal.text_muted).child(tr!(
                 "Higher keeps the ratchet engaged longer before free-spin."
             )));
 
-        let wheel_row = self.wheel_sensitivity_row(window, pal, cx);
+        let wheel_row = self.wheel_sensitivity_row(window, cx);
 
         let permanent_row = permanent_row(permanent, ratchet, restore_threshold, status, pal);
 
@@ -272,7 +270,6 @@ impl SmartShiftPanel {
             .child(sensitivity_row)
             .child(permanent_row)
             .child(wheel_row)
-            .into_any_element()
     }
 }
 
@@ -280,12 +277,8 @@ impl SmartShiftPanel {
     /// The per-device thumb-wheel sensitivity row: label, live value, slider.
     /// Reads the selected device's effective value and re-seats the thumb on a
     /// device switch / external config change, never mid-drag.
-    fn wheel_sensitivity_row(
-        &mut self,
-        window: &mut Window,
-        pal: Palette,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
+    fn wheel_sensitivity_row(&mut self, window: &mut Window, cx: &mut Context<Self>) -> gpui::Div {
+        let pal = theme::palette(cx);
         let committed = AppState::try_read(cx)
             .and_then(|state| {
                 state
@@ -314,12 +307,7 @@ impl SmartShiftPanel {
                             .child(format!("{display}")),
                     ),
             )
-            .child(
-                Slider::new(&self.wheel_sensitivity)
-                    .horizontal()
-                    .into_any_element(),
-            )
-            .into_any_element()
+            .child(Slider::new(&self.wheel_sensitivity).horizontal())
     }
 }
 
@@ -341,7 +329,7 @@ impl Render for SmartShiftPanel {
 
         let show_write_status = matches!(status, SmartShiftLoad::Ready(_));
         let content: AnyElement = match status {
-            SmartShiftLoad::Ready(s) => self.ready_body(*s, window, pal, cx),
+            SmartShiftLoad::Ready(s) => self.ready_body(*s, window, cx).into_any_element(),
             SmartShiftLoad::Loading | SmartShiftLoad::Unknown if !reachable => {
                 status_line(tr!("Device offline — SmartShift unavailable."), pal).into_any_element()
             }
@@ -446,12 +434,7 @@ fn permanent_row(
 
 /// One wheel-mode pill. Clicking it writes `target` while preserving the
 /// device's current threshold + torque.
-fn mode_pill(
-    label: SharedString,
-    selected: bool,
-    status: SmartShiftStatus,
-    _pal: Palette,
-) -> AnyElement {
+fn mode_pill(label: SharedString, selected: bool, status: SmartShiftStatus) -> impl IntoElement {
     let id = match status.mode {
         SmartShiftMode::Free => "smartshift-mode-free",
         SmartShiftMode::Ratchet => "smartshift-mode-ratchet",
@@ -463,17 +446,11 @@ fn mode_pill(
         .on_click(move |_event, _window, cx| {
             AppState::update_smartshift(cx, status);
         })
-        .into_any_element()
 }
 
 /// A greyed bar standing in for the slider when sensitivity isn't adjustable.
-fn disabled_track(pal: Palette) -> AnyElement {
-    div()
-        .w_full()
-        .h(px(6.))
-        .rounded_full()
-        .bg(pal.border)
-        .into_any_element()
+fn disabled_track(pal: Palette) -> gpui::Div {
+    div().w_full().h(px(6.)).rounded_full().bg(pal.border)
 }
 
 /// Round + clamp a raw slider read into the friendly threshold range.

--- a/crates/openlogi-desktop/src/features/pointer/smartshift.rs
+++ b/crates/openlogi-desktop/src/features/pointer/smartshift.rs
@@ -12,6 +12,7 @@
 //! the current value through the agent when selection/inventory lifecycle
 //! events make a device active; this view only consumes the resulting cache.
 
+use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, AppContext as _, Context, Entity, IntoElement, ParentElement, Render,
     SharedString, Styled, Subscription, Window, div, px, rgb,
@@ -250,11 +251,10 @@ impl SmartShiftPanel {
                             .child(format!("{display}")),
                     ),
             )
-            .child(if sensitivity_enabled {
-                Slider::new(&self.threshold).horizontal().into_any_element()
-            } else {
-                disabled_track(pal).into_any_element()
+            .when(sensitivity_enabled, |row| {
+                row.child(Slider::new(&self.threshold).horizontal())
             })
+            .when(!sensitivity_enabled, |row| row.child(disabled_track(pal)))
             .child(div().text_caption().text_color(pal.text_muted).child(tr!(
                 "Higher keeps the ratchet engaged longer before free-spin."
             )));

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -409,7 +409,8 @@ impl RenderOnce for ProfileScopeBar {
 }
 
 /// Profile inheritance and active-app context shown above the device canvas.
-pub(crate) fn profile_canvas_status(pal: Palette, cx: &App) -> Option<gpui::Div> {
+pub(crate) fn profile_canvas_status(cx: &App) -> Option<gpui::Div> {
+    let pal = theme::palette(cx);
     let state = AppState::try_read(cx)?;
     if !state.current_device_is_persistent() {
         return None;

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use appcatalog::{Application, ApplicationIdentity, IdentityKind};
 use gpui::{
-    Anchor, AnyElement, App, AppContext as _, Context, Entity, InteractiveElement, IntoElement,
-    ParentElement, RenderImage, Role, StatefulInteractiveElement as _, Styled, Subscription, Task,
+    Anchor, App, AppContext as _, Context, Entity, InteractiveElement, IntoElement, ParentElement,
+    RenderImage, RenderOnce, Role, StatefulInteractiveElement as _, Styled, Subscription, Task,
     UniformListScrollHandle, WeakEntity, Window, div, img, prelude::FluentBuilder as _, px,
     uniform_list,
 };
@@ -297,12 +297,11 @@ fn preferred_identity_kind(runtime: Option<IdentityKind>) -> IdentityKind {
 
 /// A direct profile switcher. The foreground app may change which profile is
 /// active, but never changes which profile this editor has open.
-pub fn profile_scope_bar(
-    pal: Palette,
+pub(crate) fn profile_scope_bar(
     icons: &ProfileIconCache,
     catalog: &Entity<AppCatalogPicker>,
     cx: &mut App,
-) -> Option<AnyElement> {
+) -> Option<ProfileScopeBar> {
     let state = AppState::try_read(cx)?;
     if !state.current_device_is_persistent() {
         return None;
@@ -370,23 +369,47 @@ pub fn profile_scope_bar(
     let loading = matches!(catalog.read(cx).load, CatalogLoad::Loading);
     let failed = matches!(catalog.read(cx).load, CatalogLoad::Failed);
 
-    Some(profile_scope_content(
-        editing_app.as_deref(),
-        &profiles,
-        AddAppChoices {
+    Some(ProfileScopeBar {
+        editing_app,
+        profiles,
+        choices: AddAppChoices {
             recent: available_recent,
             applications: available_catalog,
             loading,
             failed,
         },
-        catalog,
-        icons,
-        pal,
-    ))
+        catalog: catalog.clone(),
+        icons: icons.clone(),
+    })
+}
+
+/// The profile selector owns the complete profile-switching toolbar and its
+/// add/remove menus, including their theme resolution.
+#[derive(IntoElement)]
+pub(crate) struct ProfileScopeBar {
+    editing_app: Option<String>,
+    profiles: Vec<ProfileChoice>,
+    choices: AddAppChoices,
+    catalog: Entity<AppCatalogPicker>,
+    icons: ProfileIconCache,
+}
+
+impl RenderOnce for ProfileScopeBar {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        profile_scope_content(
+            self.editing_app.as_deref(),
+            &self.profiles,
+            self.choices,
+            self.catalog,
+            self.icons,
+            pal,
+        )
+    }
 }
 
 /// Profile inheritance and active-app context shown above the device canvas.
-pub(crate) fn profile_canvas_status(pal: Palette, cx: &App) -> Option<AnyElement> {
+pub(crate) fn profile_canvas_status(pal: Palette, cx: &App) -> Option<gpui::Div> {
     let state = AppState::try_read(cx)?;
     if !state.current_device_is_persistent() {
         return None;
@@ -417,8 +440,7 @@ pub(crate) fn profile_canvas_status(pal: Palette, cx: &App) -> Option<AnyElement
                 div()
                     .flex_none()
                     .child(tr!("Active: %{profile}", profile => active)),
-            )
-            .into_any_element(),
+            ),
     )
 }
 
@@ -426,10 +448,10 @@ fn profile_scope_content(
     editing_app: Option<&str>,
     profiles: &[ProfileChoice],
     choices: AddAppChoices,
-    catalog: &Entity<AppCatalogPicker>,
-    icons: &ProfileIconCache,
+    catalog: Entity<AppCatalogPicker>,
+    icons: ProfileIconCache,
     pal: Palette,
-) -> AnyElement {
+) -> impl IntoElement + use<> {
     let default_selected = editing_app.is_none();
     let selected_profile = editing_app
         .and_then(|app| profiles.iter().find(|profile| profile.app == app))
@@ -501,23 +523,17 @@ fn profile_scope_content(
                 )
                 .children(profile_tabs),
         )
-        .child(add_app_popover(
-            choices,
-            catalog.clone(),
-            icons.clone(),
-            pal,
-        ))
+        .child(add_app_popover(choices, catalog, icons, pal))
         .when_some(
             selected_profile.filter(|profile| profile.persisted),
             |row, profile| row.child(profile_options_popover(profile, pal)),
         )
-        .into_any_element()
 }
 
 fn profile_tab(
     id: impl Into<gpui::ElementId>,
     label: impl Into<gpui::SharedString>,
-    leading: Option<AnyElement>,
+    leading: Option<gpui::Div>,
     selected: bool,
     pal: Palette,
 ) -> BaseButton {
@@ -556,21 +572,20 @@ fn profile_tab(
         .child(label)
 }
 
-fn application_mark(icon: AppIconState, name: &str, edge: f32, pal: Palette) -> AnyElement {
+fn application_mark(icon: AppIconState, name: &str, edge: f32, pal: Palette) -> gpui::Div {
     let slot = h_flex()
         .size(px(edge))
         .flex_none()
         .items_center()
         .justify_center();
     match icon {
-        AppIconState::Ready(icon) => img(icon).size(px(edge)).flex_none().into_any_element(),
+        AppIconState::Ready(icon) => slot.child(img(icon).size(px(edge)).flex_none()),
         AppIconState::Loading => slot
             .child(
                 Spinner::new()
                     .with_size(px(edge * 0.6))
                     .color(pal.text_muted),
-            )
-            .into_any_element(),
+            ),
         AppIconState::Missing => {
             let initial = name
                 .chars()
@@ -587,7 +602,6 @@ fn application_mark(icon: AppIconState, name: &str, edge: f32, pal: Palette) -> 
                 })
                 .text_color(pal.text_muted)
                 .child(initial)
-                .into_any_element()
         }
     }
 }
@@ -618,7 +632,7 @@ fn add_app_popover(
     catalog: Entity<AppCatalogPicker>,
     icons: ProfileIconCache,
     pal: Palette,
-) -> AnyElement {
+) -> impl IntoElement {
     let catalog_on_open = catalog.clone();
     Popover::new("add-app-popover")
         .anchor(Anchor::TopRight)
@@ -637,7 +651,6 @@ fn add_app_popover(
             }
         })
         .content(move |_state, _window, cx| add_app_content(&choices, &catalog, &icons, pal, cx))
-        .into_any_element()
 }
 
 fn add_app_content(
@@ -900,7 +913,7 @@ fn application_list_height(rows: usize) -> f32 {
     }
 }
 
-fn profile_options_popover(profile: ProfileChoice, pal: Palette) -> AnyElement {
+fn profile_options_popover(profile: ProfileChoice, pal: Palette) -> impl IntoElement {
     Popover::new("profile-options-popover")
         .anchor(Anchor::TopRight)
         // `compact_panel` is the surface here too; see `add_app_popover`.
@@ -936,7 +949,6 @@ fn profile_options_popover(profile: ProfileChoice, pal: Palette) -> AnyElement {
                         }),
                 )
         })
-        .into_any_element()
 }
 
 fn open_remove_confirmation(window: &mut Window, cx: &mut App, profile: &ProfileChoice) {

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -581,12 +581,11 @@ fn application_mark(icon: AppIconState, name: &str, edge: f32, pal: Palette) -> 
         .justify_center();
     match icon {
         AppIconState::Ready(icon) => slot.child(img(icon).size(px(edge)).flex_none()),
-        AppIconState::Loading => slot
-            .child(
-                Spinner::new()
-                    .with_size(px(edge * 0.6))
-                    .color(pal.text_muted),
-            ),
+        AppIconState::Loading => slot.child(
+            Spinner::new()
+                .with_size(px(edge * 0.6))
+                .color(pal.text_muted),
+        ),
         AppIconState::Missing => {
             let initial = name
                 .chars()

--- a/crates/openlogi-desktop/src/ui/carousel.rs
+++ b/crates/openlogi-desktop/src/ui/carousel.rs
@@ -115,7 +115,7 @@ impl Carousel {
     /// reaches the first card) once they overflow. Prev/next arrows hug the
     /// screen edges; each card's click and selected styling come from
     /// `render_item`.
-    fn render_row(self, window: &mut Window, cx: &mut App) -> AnyElement {
+    fn render_row(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let Self {
             id,
             card_w,
@@ -125,81 +125,79 @@ impl Carousel {
             gap,
             on_select,
         } = self;
-        let Some(render_item) = render_item.filter(|_| len > 0) else {
-            return div().into_any_element();
-        };
-        let selected = selected.min(len - 1);
-        let multi = len > 1;
+        v_flex().when_some(render_item.filter(|_| len > 0), |this, render_item| {
+            let selected = selected.min(len - 1);
+            let multi = len > 1;
 
-        let scroll_state = window.use_keyed_state((id.clone(), "scroll"), cx, |_, _| {
-            (usize::MAX, ScrollHandle::new())
-        });
-        let previous = scroll_state.read(cx).0;
-        let scroll_handle = scroll_state.read(cx).1.clone();
-        if previous != selected {
-            scroll_handle.scroll_to_item(selected + 1);
-            scroll_state.update(cx, |state, _| state.0 = selected);
-        }
-
-        let mut items = Vec::with_capacity(len);
-        for i in 0..len {
-            items.push(
-                div()
-                    .w(card_w)
-                    .flex_shrink_0()
-                    .child(render_item(i, i == selected, window, cx))
-                    .into_any_element(),
-            );
-        }
-
-        // Flexible edge spacers centre short rows without putting overflowing
-        // cards at a negative, unreachable offset. They are immediate children,
-        // so the scroll handle targets cards at `selected + 1`.
-        let edge_spacer = rems((ROW_PAD.0 - gap.0).max(0.));
-        let row = h_flex()
-            .id((id.clone(), "row"))
-            .flex_1()
-            .min_w_0()
-            .h_full()
-            .overflow_x_scroll()
-            .track_scroll(&scroll_handle)
-            .items_center()
-            .gap(gap)
-            .py_4()
-            .child(div().flex_1().min_w(edge_spacer))
-            .children(items)
-            .child(div().flex_1().min_w(edge_spacer));
-
-        // Prev/next arrows hug the left and right edges, flanking the row.
-        let stage = h_flex()
-            .w_full()
-            .flex_1()
-            .min_h_0()
-            .items_center()
-            .px_4()
-            .when(multi, |this| {
-                this.child(arrow(
-                    (id.clone(), "previous").into(),
-                    IconName::ChevronLeft,
-                    selected.saturating_sub(1),
-                    selected == 0,
-                    Size::Large,
-                    on_select.clone(),
-                ))
-            })
-            .child(row)
-            .when(multi, |this| {
-                this.child(arrow(
-                    (id.clone(), "next").into(),
-                    IconName::ChevronRight,
-                    (selected + 1).min(len - 1),
-                    selected + 1 >= len,
-                    Size::Large,
-                    on_select.clone(),
-                ))
+            let scroll_state = window.use_keyed_state((id.clone(), "scroll"), cx, |_, _| {
+                (usize::MAX, ScrollHandle::new())
             });
+            let previous = scroll_state.read(cx).0;
+            let scroll_handle = scroll_state.read(cx).1.clone();
+            if previous != selected {
+                scroll_handle.scroll_to_item(selected + 1);
+                scroll_state.update(cx, |state, _| state.0 = selected);
+            }
 
-        v_flex().size_full().pb_6().child(stage).into_any_element()
+            let mut items = Vec::with_capacity(len);
+            for i in 0..len {
+                items.push(div().w(card_w).flex_shrink_0().child(render_item(
+                    i,
+                    i == selected,
+                    window,
+                    cx,
+                )));
+            }
+
+            // Flexible edge spacers centre short rows without putting overflowing
+            // cards at a negative, unreachable offset. They are immediate children,
+            // so the scroll handle targets cards at `selected + 1`.
+            let edge_spacer = rems((ROW_PAD.0 - gap.0).max(0.));
+            let row = h_flex()
+                .id((id.clone(), "row"))
+                .flex_1()
+                .min_w_0()
+                .h_full()
+                .overflow_x_scroll()
+                .track_scroll(&scroll_handle)
+                .items_center()
+                .gap(gap)
+                .py_4()
+                .child(div().flex_1().min_w(edge_spacer))
+                .children(items)
+                .child(div().flex_1().min_w(edge_spacer));
+
+            // Prev/next arrows hug the left and right edges, flanking the row.
+            let stage = h_flex()
+                .w_full()
+                .flex_1()
+                .min_h_0()
+                .items_center()
+                .px_4()
+                .when(multi, |this| {
+                    this.child(arrow(
+                        (id.clone(), "previous").into(),
+                        IconName::ChevronLeft,
+                        selected.saturating_sub(1),
+                        selected == 0,
+                        Size::Large,
+                        on_select.clone(),
+                    ))
+                })
+                .child(row)
+                .when(multi, |this| {
+                    this.child(arrow(
+                        (id.clone(), "next").into(),
+                        IconName::ChevronRight,
+                        (selected + 1).min(len - 1),
+                        selected + 1 >= len,
+                        Size::Large,
+                        on_select.clone(),
+                    ))
+                });
+
+            this.size_full().pb_6().child(stage)
+        })
     }
 }
 

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -198,10 +198,10 @@ impl RenderOnce for PanelCard {
             .border_1()
             .border_color(pal.border)
             .bg(pal.panel)
-            .p(theme::CARD_PAD)
+            .p(theme::CARD_PAD.rems())
             .child(
                 v_flex()
-                    .gap(theme::CARD_GAP)
+                    .gap(theme::CARD_GAP.rems())
                     .when(!self.title.is_empty(), |this| {
                         this.child(
                             h_flex()

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -8,5 +8,6 @@ pub(crate) mod components;
 #[cfg(debug_assertions)]
 pub(crate) mod gallery;
 pub mod section;
+pub mod spacing;
 pub mod status;
 pub mod theme;

--- a/crates/openlogi-desktop/src/ui/spacing.rs
+++ b/crates/openlogi-desktop/src/ui/spacing.rs
@@ -1,0 +1,62 @@
+//! Interface-scale-aware spacing tokens.
+//!
+//! Values name their size at OpenLogi's 16 px baseline and resolve to rems, so
+//! the existing interface-scale setting changes text and spacing together.
+
+use gpui::{Rems, rems};
+
+const BASE_REM_SIZE_IN_PX: f32 = 16.;
+
+/// A finite spacing scale for layout that should follow the interface size.
+///
+/// The variant name is the token's size in pixels at the standard 16 px rem.
+/// Fixed geometry such as one-pixel borders and device artwork should continue
+/// to use pixels directly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum DynamicSpacing {
+    /// 12 px at standard scale.
+    Base12,
+    /// 16 px at standard scale.
+    Base16,
+    /// 20 px at standard scale.
+    Base20,
+}
+
+impl DynamicSpacing {
+    /// Resolve this token in rems so the window's interface scale applies it.
+    #[must_use]
+    pub const fn rems(self) -> Rems {
+        rems(self.base_pixels() / BASE_REM_SIZE_IN_PX)
+    }
+
+    const fn base_pixels(self) -> f32 {
+        match self {
+            Self::Base12 => 12.,
+            Self::Base16 => 16.,
+            Self::Base20 => 20.,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::px;
+
+    use super::*;
+
+    #[test]
+    fn tokens_preserve_their_baseline_pixel_values() {
+        let cases = [
+            (DynamicSpacing::Base12, 12.),
+            (DynamicSpacing::Base16, 16.),
+            (DynamicSpacing::Base20, 20.),
+        ];
+
+        for (spacing, expected) in cases {
+            assert_eq!(
+                spacing.rems().to_pixels(px(BASE_REM_SIZE_IN_PX)),
+                px(expected)
+            );
+        }
+    }
+}

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -20,6 +20,8 @@ use openlogi_core::config::{Appearance, UiScale};
 
 use crate::state::AppState;
 
+use super::spacing::DynamicSpacing;
+
 // The brand accent lives in `openlogi-ui` so the overlay paints the same blue
 // this app does — it cannot depend on this crate, and a local copy is how the
 // ring ended up with a blue of its own. Re-exported so screens keep reading it
@@ -87,9 +89,9 @@ impl ContentWidth {
 ///   two-column grid is sized against this exact value; see its card min-width).
 /// - `CARD_PAD` / `CARD_GAP` — a card's inner padding and its title-to-content
 ///   gap, so every [`panel_card`](crate::app) reads the same.
-pub const SCREEN_PAD: Rems = rems(1.25);
-pub const CARD_PAD: Rems = rems(1.);
-pub const CARD_GAP: Rems = rems(0.75);
+pub const SCREEN_PAD: DynamicSpacing = DynamicSpacing::Base20;
+pub const CARD_PAD: DynamicSpacing = DynamicSpacing::Base16;
+pub const CARD_GAP: DynamicSpacing = DynamicSpacing::Base12;
 
 /// Apple HIG / WCAG minimum contrast for normal text up to 17pt.
 const MIN_TEXT_CONTRAST: f32 = 4.5;

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -16,8 +16,8 @@
 
 use gpui::{
     App, Context, FocusHandle, FontWeight, Global, InteractiveElement, IntoElement,
-    ParentElement as _, Render, SharedString, Size, Styled as _, Subscription, Window, div,
-    prelude::FluentBuilder as _, px,
+    ParentElement as _, Render, RenderOnce, SharedString, Size, Styled as _, Subscription, Window,
+    div, prelude::FluentBuilder as _, px,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
@@ -211,13 +211,25 @@ impl Render for AddDeviceView {
                             .text_heading()
                             .child(tr!("Add Device")),
                     )
-                    .child(body(&state, pal)),
+                    .child(AddDeviceBody { state }),
             )
     }
 }
 
-/// The state-dependent body of the window.
-fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
+/// The state-dependent body owns theme resolution for the complete pairing flow.
+#[derive(IntoElement)]
+struct AddDeviceBody {
+    state: PairingUi,
+}
+
+impl RenderOnce for AddDeviceBody {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        pairing_body(self.state, pal)
+    }
+}
+
+fn pairing_body(state: PairingUi, pal: Palette) -> impl IntoElement {
     let mut col = v_flex().w_full().flex_1().gap_4();
     match state {
         PairingUi::Idle => {
@@ -233,7 +245,7 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
         }
         PairingUi::Searching => {
             col = col
-                .child(status_line(tr!("Searching for devices…"), pal))
+                .child(status_line(tr!("Searching for devices…")))
                 .child(hint(
                     tr!("Make sure the device is on and in pairing mode."),
                     pal,
@@ -241,12 +253,12 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
                 .child(cancel_button());
         }
         PairingUi::Found(devices) => {
-            col = col.child(status_line(tr!("Searching for devices…"), pal));
+            col = col.child(status_line(tr!("Searching for devices…")));
             if devices.is_empty() {
                 col = col.child(hint(tr!("No devices found yet…"), pal));
             } else {
                 col = col.child(hint(tr!("Select a device to pair:"), pal));
-                for device in devices {
+                for device in &devices {
                     col = col.child(device_row(device, pal));
                 }
             }
@@ -254,12 +266,12 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
         }
         PairingUi::Pairing => {
             col = col
-                .child(status_line(tr!("Pairing…"), pal))
+                .child(status_line(tr!("Pairing…")))
                 .child(hint(tr!("Follow the instructions on your device."), pal))
                 .child(cancel_button());
         }
         PairingUi::Passkey(method) => {
-            col = col.child(passkey_panel(method, pal));
+            col = col.child(passkey_panel(&method));
             col = col.child(cancel_button());
         }
         PairingUi::Paired { slot } => {
@@ -271,7 +283,7 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
                         .child(tr!("Device paired")),
                 )
                 .child(hint(
-                    tr!("Paired to slot %{slot}.", slot => (*slot).to_string()),
+                    tr!("Paired to slot %{slot}.", slot => slot.to_string()),
                     pal,
                 ))
                 .child(
@@ -287,7 +299,7 @@ fn body(state: &PairingUi, pal: Palette) -> impl IntoElement {
                         .font_weight(FontWeight::MEDIUM)
                         .child(tr!("Pairing failed")),
                 )
-                .child(hint(pairing_failure_text(failure), pal))
+                .child(hint(pairing_failure_text(&failure), pal))
                 .when(
                     matches!(failure, PairingFailure::ReceiverNotFound),
                     |this| {
@@ -334,15 +346,14 @@ fn device_row(device: &FoundDevice, pal: Palette) -> impl IntoElement {
 }
 
 /// The passkey-entry instructions panel.
-fn passkey_panel(method: &PasskeyMethod, pal: Palette) -> impl IntoElement {
+fn passkey_panel(method: &PasskeyMethod) -> impl IntoElement {
     let mut col = v_flex().w_full().gap_3();
     match method {
         PasskeyMethod::Keyboard(digits) => {
             col = col
-                .child(status_line(
-                    tr!("Type this passkey on the new keyboard, then press Enter:"),
-                    pal,
-                ))
+                .child(status_line(tr!(
+                    "Type this passkey on the new keyboard, then press Enter:"
+                )))
                 .child(div().text_title().child(SharedString::from(digits.clone())));
         }
         PasskeyMethod::Pointer { clicks, .. } => {
@@ -355,17 +366,16 @@ fn passkey_panel(method: &PasskeyMethod, pal: Palette) -> impl IntoElement {
                 .collect::<Vec<_>>()
                 .join(" ");
             col = col
-                .child(status_line(
-                    tr!("On the new mouse, click in this order, then press both buttons together:"),
-                    pal,
-                ))
+                .child(status_line(tr!(
+                    "On the new mouse, click in this order, then press both buttons together:"
+                )))
                 .child(div().text_title().child(SharedString::from(sequence)));
         }
     }
     col
 }
 
-fn status_line(text: impl Into<SharedString>, _pal: Palette) -> impl IntoElement {
+fn status_line(text: impl Into<SharedString>) -> impl IntoElement {
     div()
         .text_body()
         .font_weight(FontWeight::MEDIUM)

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -12,8 +12,8 @@
 pub(super) use std::rc::Rc;
 
 pub(super) use gpui::{
-    AnyElement, App, AppContext, Axis, ClipboardItem, Context, Entity, FocusHandle, FontWeight,
-    Hsla, InteractiveElement, IntoElement, ParentElement, Render, SharedString, Size,
+    App, AppContext, Axis, ClipboardItem, Context, Entity, FocusHandle, FontWeight, Hsla,
+    InteractiveElement, IntoElement, ParentElement, Render, SharedString, Size,
     StatefulInteractiveElement, Styled, Subscription, Window, div, img, prelude::FluentBuilder, px,
     rgb,
 };
@@ -443,31 +443,29 @@ impl Render for SettingsView {
                 self.vertical_scroll_sensitivity_slider.clone(),
                 self.thumbwheel_sensitivity_slider.clone(),
             ))
-            .page(updates::updates_page(self.updater.clone(), pal));
+            .page(updates::updates_page(self.updater.clone()));
         // Registered only where grants exist to manage — see the `mod
         // permissions` cfg for why Windows skips it.
         #[cfg(any(target_os = "macos", target_os = "linux"))]
-        let settings = settings.page(permissions::permissions_page(pal, has_camera));
+        let settings = settings.page(permissions::permissions_page(has_camera));
         let settings = settings
             .page(appearance::appearance_page(
                 view.clone(),
                 self.theme_filter,
                 self.theme_search.clone(),
                 self.language_select.clone(),
-                pal,
             ))
             .page(assets::assets_page(
                 view.clone(),
                 self.asset_source_select.clone(),
-                pal,
                 self.asset_cache_desc.clone(),
             ))
-            .page(about::about_page(view, self.copied, pal));
+            .page(about::about_page(view, self.copied));
         // Surfaces competing macOS event taps (a pointer-lag cause) and, in debug
         // builds, the full tap list and a live event monitor. Appended after
         // About so [`SettingsPage::index`] stays platform-independent.
         #[cfg(target_os = "macos")]
-        let settings = settings.page(diagnostics::diagnostics_page(pal));
+        let settings = settings.page(diagnostics::diagnostics_page());
 
         div()
             .size_full()

--- a/crates/openlogi-desktop/src/windows/settings/about.rs
+++ b/crates/openlogi-desktop/src/windows/settings/about.rs
@@ -1,30 +1,28 @@
 //! About settings page.
 
 use super::{
-    AnyElement, App, Button, ButtonVariants, ClipboardItem, Entity, FontWeight, HELP_URL, Icon,
-    IconName, IntoElement, Palette, ParentElement, RELEASES_URL, REPO_URL, SettingGroup,
-    SettingItem, SettingPage, SettingsView, SharedString, Sizable, Styled, div, h_flex, img, px,
-    v_flex,
+    App, Button, ButtonVariants, ClipboardItem, Entity, FontWeight, HELP_URL, Icon, IconName,
+    ParentElement, RELEASES_URL, REPO_URL, SettingGroup, SettingItem, SettingPage, SettingsView,
+    SharedString, Sizable, Styled, div, h_flex, img, px, v_flex,
 };
 use crate::ui::theme::Typography as _;
 
 /// The About page: a hero card with the build identity and outbound links, the
 /// on-disk config location, and a trademark disclaimer.
-pub(super) fn about_page(view: Entity<SettingsView>, copied: bool, pal: Palette) -> SettingPage {
+pub(super) fn about_page(view: Entity<SettingsView>, copied: bool) -> SettingPage {
     let hero = SettingGroup::new().item(SettingItem::render(move |_, _, cx| {
-        about_hero(&view, copied, pal, cx)
+        about_hero(&view, copied, cx)
     }));
-    let config = SettingGroup::new().item(SettingItem::render(move |_, _, _| about_config(pal)));
-    let footer = SettingGroup::new().item(SettingItem::render(move |_, _, _| {
+    let config = SettingGroup::new().item(SettingItem::render(move |_, _, cx| about_config(cx)));
+    let footer = SettingGroup::new().item(SettingItem::render(move |_, _, cx| {
+        let pal = crate::ui::theme::palette(cx);
         div()
             .text_caption()
             .text_color(pal.text_muted)
             .child(tr!(
                 "Not affiliated with Logitech. \"Logitech\", \"MX Master\", and \"Options+\" are trademarks of Logitech International S.A."
             ))
-            .into_any_element()
     }));
-
     SettingPage::new(tr!("About"))
         .icon(IconName::Info)
         .resettable(false)
@@ -38,7 +36,8 @@ pub(super) fn about_page(view: Entity<SettingsView>, copied: bool, pal: Palette)
 
 /// The About hero row: logo, wordmark, the clickable build line, and the link /
 /// diagnostics buttons.
-fn about_hero(view: &Entity<SettingsView>, copied: bool, pal: Palette, _: &mut App) -> AnyElement {
+fn about_hero(view: &Entity<SettingsView>, copied: bool, cx: &mut App) -> gpui::Div {
+    let pal = crate::ui::theme::palette(cx);
     let diag_label = if copied {
         tr!("Copied!")
     } else {
@@ -130,11 +129,11 @@ fn about_hero(view: &Entity<SettingsView>, copied: bool, pal: Palette, _: &mut A
                         ),
                 ),
         )
-        .into_any_element()
 }
 
 /// The config-file location row with a reveal-in-file-manager button.
-fn about_config(pal: Palette) -> AnyElement {
+fn about_config(cx: &App) -> gpui::Div {
+    let pal = crate::ui::theme::palette(cx);
     let path = openlogi_core::paths::config_path()
         .map(|p| p.display().to_string())
         .unwrap_or_default();
@@ -175,7 +174,6 @@ fn about_config(pal: Palette) -> AnyElement {
                     }),
             ),
         )
-        .into_any_element()
 }
 
 /// A subtle ghost button with a leading icon that opens `href`, used for the

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -24,7 +24,6 @@ pub(super) fn appearance_page(
     filter: ThemeFilter,
     theme_search: Entity<InputState>,
     language_select: Entity<SelectState<Vec<LanguageOption>>>,
-    pal: Palette,
 ) -> SettingPage {
     // Titled groups so the sidebar shows them as sub-items (gpui-component
     // renders a page's groups as nested sidebar entries once there's more than
@@ -34,7 +33,7 @@ pub(super) fn appearance_page(
         .item(
             SettingItem::new(
                 tr!("Appearance mode"),
-                SettingField::render(move |_, _, cx| mode_segment(pal, cx)),
+                SettingField::render(move |_, _, cx| mode_segment(cx)),
             )
             .layout(Axis::Vertical)
             .description(tr!(
@@ -45,7 +44,7 @@ pub(super) fn appearance_page(
             SettingItem::new(
                 tr!("Color theme"),
                 SettingField::render(move |_, _, cx| {
-                    theme_picker(&view, &theme_search, filter, pal, cx)
+                    theme_picker(&view, &theme_search, filter, cx)
                 }),
             )
             .layout(Axis::Vertical),
@@ -57,7 +56,7 @@ pub(super) fn appearance_page(
         theme_group = theme_group.item(
             SettingItem::new(
                 tr!("App icon"),
-                SettingField::render(move |_, _, cx| icon_picker(pal, cx)),
+                SettingField::render(move |_, _, cx| icon_picker(cx)),
             )
             .layout(Axis::Vertical)
             .description(tr!(
@@ -136,7 +135,8 @@ fn set_scale(cx: &mut App, scale: UiScale) {
 
 /// The Light / Dark / Follow-system appearance picker — three macOS-style
 /// preview thumbnails, each with a radio + label, mirroring System Settings.
-fn mode_segment(pal: Palette, cx: &App) -> gpui::Div {
+fn mode_segment(cx: &App) -> gpui::Div {
+    let pal = theme::palette(cx);
     let current = appearance_of(cx);
     let accent = cx.theme().primary;
     h_flex().gap_4().items_start().children([
@@ -242,7 +242,8 @@ fn mode_card(
 /// The app-icon picker: one card per icon, each showing a render of the
 /// compiled icon rather than its artwork, so the choice looks like what macOS
 /// will draw.
-fn icon_picker(pal: Palette, cx: &App) -> gpui::Div {
+fn icon_picker(cx: &App) -> gpui::Div {
+    let pal = theme::palette(cx);
     let current =
         AppState::try_read(cx).map_or_else(AppIcon::default, |state| state.app_settings().app_icon);
     let accent = cx.theme().primary;
@@ -434,9 +435,9 @@ fn theme_picker(
     view: &Entity<SettingsView>,
     theme_search: &Entity<InputState>,
     filter: ThemeFilter,
-    pal: Palette,
     cx: &App,
 ) -> gpui::Div {
+    let pal = theme::palette(cx);
     let active = cx.theme().theme_name().clone();
     let query = theme_search.read(cx).value().trim().to_lowercase();
     // Collect just the preview colours per theme (small + `Copy`), so the 1.8 KB

--- a/crates/openlogi-desktop/src/windows/settings/assets.rs
+++ b/crates/openlogi-desktop/src/windows/settings/assets.rs
@@ -61,7 +61,6 @@ pub(super) fn selected_source_index(
 pub(super) fn assets_page(
     view: Entity<SettingsView>,
     asset_source_select: Entity<SelectState<Vec<AssetSourceOption>>>,
-    pal: Palette,
     cache_desc: SharedString,
 ) -> SettingPage {
     let refresh_view = view.clone();
@@ -105,8 +104,9 @@ pub(super) fn assets_page(
         .item(
             SettingItem::new(
                 tr!("Refresh assets"),
-                SettingField::render(move |_, _, _| {
+                SettingField::render(move |_, _, cx| {
                     let view = refresh_view.clone();
+                    let pal = crate::ui::theme::palette(cx);
                     action_button("assets-refresh", tr!("Refresh"), pal, move |cx| {
                         send_asset_command(cx, AssetCommand::Refresh);
                         // Give the spawned sync a moment to land small fetches,
@@ -122,8 +122,9 @@ pub(super) fn assets_page(
         .item(
             SettingItem::new(
                 tr!("Clear cache"),
-                SettingField::render(move |_, _, _| {
+                SettingField::render(move |_, _, cx| {
                     let view = view.clone();
+                    let pal = crate::ui::theme::palette(cx);
                     action_button("assets-clear", tr!("Clear"), pal, move |cx| {
                         send_asset_command(cx, AssetCommand::ClearCache);
                         // The wipe runs on the main loop's channel arm, not
@@ -139,7 +140,8 @@ pub(super) fn assets_page(
         .item(
             SettingItem::new(
                 tr!("Cache location"),
-                SettingField::render(move |_, _, _| {
+                SettingField::render(move |_, _, cx| {
+                    let pal = crate::ui::theme::palette(cx);
                     action_button("assets-open", tr!("Open"), pal, |_| {
                         crate::services::assets::reveal_cache_in_file_manager();
                     })

--- a/crates/openlogi-desktop/src/windows/settings/diagnostics.rs
+++ b/crates/openlogi-desktop/src/windows/settings/diagnostics.rs
@@ -9,14 +9,14 @@ use openlogi_hook::Hook;
 #[cfg(debug_assertions)]
 use super::AppState;
 use super::{
-    AnyElement, App, Axis, IconName, IntoElement, Palette, ParentElement, SettingField,
-    SettingGroup, SettingItem, SettingPage, Styled, div, v_flex,
+    App, Axis, IconName, IntoElement, Palette, ParentElement, SettingField, SettingGroup,
+    SettingItem, SettingPage, Styled, div, v_flex,
 };
 
 /// The Diagnostics page: the curated input-conflict check, plus (debug) the raw
 /// tap list and the live event monitor polled by
 /// [`SettingsView`](super::SettingsView)'s task.
-pub(super) fn diagnostics_page(pal: Palette) -> SettingPage {
+pub(super) fn diagnostics_page() -> SettingPage {
     SettingPage::new(tr!("Diagnostics"))
         .icon(IconName::Info)
         .resettable(false)
@@ -24,7 +24,7 @@ pub(super) fn diagnostics_page(pal: Palette) -> SettingPage {
             SettingGroup::new().item(
                 SettingItem::new(
                     tr!("Input interception"),
-                    SettingField::render(move |_, _, cx| input_conflict_field(pal, cx)),
+                    SettingField::render(move |_, _, cx| input_conflict_field(cx)),
                 )
                 .description(tr!(
                     "Detects other apps tapping the mouse event stream — a common cause of pointer lag."
@@ -40,7 +40,8 @@ pub(super) fn diagnostics_page(pal: Palette) -> SettingPage {
 /// Live status: the curated known-conflict check over the current event taps
 /// (see [`current_taps`]), plus (debug) the full tap list. Re-rendered whenever
 /// the window repaints.
-fn input_conflict_field(pal: Palette, cx: &mut App) -> AnyElement {
+fn input_conflict_field(cx: &mut App) -> gpui::Div {
+    let pal = crate::ui::theme::palette(cx);
     let taps = current_taps(cx);
 
     // Dedup the product names of input-gating taps owned by known conflicts.
@@ -79,12 +80,7 @@ fn input_conflict_field(pal: Palette, cx: &mut App) -> AnyElement {
         col = col.child(debug_tap_list(&taps, pal));
         col = col.child(monitor_list(pal, cx));
     }
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = pal;
-    }
-
-    col.into_any_element()
+    col
 }
 
 /// The event taps the conflict check inspects. Debug builds read the snapshot

--- a/crates/openlogi-desktop/src/windows/settings/general.rs
+++ b/crates/openlogi-desktop/src/windows/settings/general.rs
@@ -1,9 +1,9 @@
 //! General settings page.
 
 use super::{
-    AnyElement, App, AppState, Entity, FluentBuilder, IconName, IntoElement, ParentElement,
-    SettingField, SettingGroup, SettingItem, SettingPage, Slider, SliderState, StateEvent, Styled,
-    ThumbwheelSensitivity, VerticalScrollSensitivity, div, h_flex, px, theme, v_flex,
+    App, AppState, Entity, FluentBuilder, IconName, ParentElement, SettingField, SettingGroup,
+    SettingItem, SettingPage, Slider, SliderState, StateEvent, Styled, ThumbwheelSensitivity,
+    VerticalScrollSensitivity, div, h_flex, px, theme, v_flex,
 };
 use crate::ui::theme::Typography as _;
 
@@ -116,7 +116,7 @@ pub(super) fn general_page(
         .group(group)
 }
 
-fn thumbwheel_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
+fn thumbwheel_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> gpui::Div {
     let value = ThumbwheelSensitivity::from_rounded(slider.read(cx).value().start());
     sensitivity_field(
         slider,
@@ -126,7 +126,7 @@ fn thumbwheel_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> A
     )
 }
 
-fn vertical_scroll_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> AnyElement {
+fn vertical_scroll_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> gpui::Div {
     let value = VerticalScrollSensitivity::from_rounded(slider.read(cx).value().start());
     sensitivity_field(
         slider,
@@ -141,7 +141,7 @@ fn sensitivity_field(
     value: String,
     is_default: bool,
     cx: &mut App,
-) -> AnyElement {
+) -> gpui::Div {
     let pal = theme::palette(cx);
     v_flex()
         .flex_shrink_0()
@@ -168,5 +168,4 @@ fn sensitivity_field(
                     .child(format!("({})", rust_i18n::t!("Default"))),
             )
         })
-        .into_any_element()
 }

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -1,7 +1,7 @@
 //! Permissions settings page (macOS / Linux).
 
 #[cfg(target_os = "macos")]
-use super::{AnyElement, App, AppState, InteractiveElement, Permission};
+use super::{App, AppState, InteractiveElement, Permission};
 use super::{IconName, Palette, SettingPage};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use super::{
@@ -21,7 +21,7 @@ use openlogi_permissions as permissions;
         reason = "`has_camera` only gates a macOS/Linux row; elsewhere the page is empty"
     )
 )]
-pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
+pub(super) fn permissions_page(has_camera: bool) -> SettingPage {
     let page = SettingPage::new(tr!("Permissions"))
         .icon(IconName::Info)
         .resettable(false);
@@ -47,16 +47,14 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
                         None => PermissionStatus::Unknown,
                     }
                 },
-                pal,
             ))
-            .item(input_monitoring_item(pal))
+            .item(input_monitoring_item())
             .item(permission_item(
                 "perm-bluetooth",
                 tr!("Bluetooth"),
                 tr!("Allows OpenLogi to use CoreBluetooth (not required for HID access)."),
                 Permission::Bluetooth,
                 |_| permissions::bluetooth(),
-                pal,
             ));
         // Camera access is only worth asking for once a Logitech webcam is
         // actually connected — it then appears on the main page, and granting
@@ -70,7 +68,6 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
                 ),
                 Permission::Camera,
                 |_| permissions::camera(),
-                pal,
             ));
         }
         page.group(group)
@@ -85,7 +82,8 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
         // when everything is already working.
         SettingItem::new(
             tr!("Input device access"),
-            SettingField::render(move |_, _, _| {
+            SettingField::render(move |_, _, cx| {
+                let pal = theme::palette(cx);
                 let status = permissions::input_device_access();
                 let field = gpui_component::v_flex()
                     .gap_1()
@@ -116,7 +114,7 @@ pub(super) fn permissions_page(pal: Palette, has_camera: bool) -> SettingPage {
 }
 
 #[cfg(target_os = "macos")]
-fn input_monitoring_item(pal: Palette) -> SettingItem {
+fn input_monitoring_item() -> SettingItem {
     SettingItem::new(
                 tr!("Input Monitoring"),
                 SettingField::render(move |_, _, cx| {
@@ -139,8 +137,9 @@ fn input_monitoring_item(pal: Palette) -> SettingItem {
                         "perm-input-monitoring",
                         badge,
                         Permission::InputMonitoring,
-                        pal,
+                        cx,
                     ));
+                    let pal = theme::palette(cx);
                     if stalled {
                         field.child(div().text_caption().text_color(pal.text_muted).child(
                             tr!(
@@ -164,11 +163,10 @@ fn permission_item(
     description: SharedString,
     permission: Permission,
     status: impl Fn(&App) -> PermissionStatus + 'static,
-    pal: Palette,
 ) -> SettingItem {
     SettingItem::new(
         title,
-        SettingField::render(move |_, _, cx| permission_field(id, status(cx), permission, pal)),
+        SettingField::render(move |_, _, cx| permission_field(id, status(cx), permission, cx)),
     )
     .description(description)
 }
@@ -201,16 +199,22 @@ fn permission_field(
     id: &'static str,
     status: PermissionStatus,
     permission: Permission,
-    pal: Palette,
+    cx: &App,
 ) -> impl IntoElement {
+    let pal = theme::palette(cx);
     // "Not determined" means never requested — Bluetooth deliberately never is
     // (BLE mice go through IOHIDManager) — so don't label it "Unknown".
     let never_requested = matches!(status, PermissionStatus::Unknown)
         && matches!(permission, Permission::Bluetooth | Permission::Camera);
-    let status_el: AnyElement = if never_requested {
-        badge(tr!("Not requested"), theme::STATUS_OFFLINE, pal).into_any_element()
+    let status_el = if never_requested {
+        badge(tr!("Not requested"), theme::STATUS_OFFLINE, pal)
     } else {
-        status_badge(status, pal).into_any_element()
+        let (label, color) = match status {
+            PermissionStatus::Granted => (tr!("Granted"), theme::STATUS_CONNECTED),
+            PermissionStatus::Denied => (tr!("Not granted"), theme::STATUS_CONNECTING),
+            PermissionStatus::Unknown => (tr!("Unknown"), theme::STATUS_OFFLINE),
+        };
+        badge(label, color, pal)
     };
     let prompts_here = never_requested && matches!(permission, Permission::Camera);
     let action_label = if prompts_here {

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -200,7 +200,7 @@ fn permission_field(
     status: PermissionStatus,
     permission: Permission,
     cx: &App,
-) -> impl IntoElement {
+) -> gpui::Div {
     let pal = theme::palette(cx);
     // "Not determined" means never requested — Bluetooth deliberately never is
     // (BLE mice go through IOHIDManager) — so don't label it "Unknown".

--- a/crates/openlogi-desktop/src/windows/settings/permissions.rs
+++ b/crates/openlogi-desktop/src/windows/settings/permissions.rs
@@ -5,8 +5,8 @@ use super::{App, AppState, InteractiveElement, Permission};
 use super::{IconName, Palette, SettingPage};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use super::{
-    IntoElement, ParentElement, PermissionStatus, SettingField, SettingGroup, SettingItem,
-    SharedString, Styled, div, h_flex, px, rgb, theme,
+    ParentElement, PermissionStatus, SettingField, SettingGroup, SettingItem, SharedString, Styled,
+    div, h_flex, px, rgb, theme,
 };
 use crate::ui::theme::Typography as _;
 #[cfg(target_os = "macos")]
@@ -173,7 +173,7 @@ fn permission_item(
 
 /// A readable status word with colour retained as a supplemental marker.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn status_badge(status: PermissionStatus, pal: Palette) -> impl IntoElement {
+fn status_badge(status: PermissionStatus, pal: Palette) -> gpui::Div {
     let (label, color) = match status {
         PermissionStatus::Granted => (tr!("Granted"), theme::STATUS_CONNECTED),
         PermissionStatus::Denied => (tr!("Not granted"), theme::STATUS_CONNECTING),
@@ -183,7 +183,7 @@ fn status_badge(status: PermissionStatus, pal: Palette) -> impl IntoElement {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn badge(label: SharedString, color: u32, pal: Palette) -> impl IntoElement {
+fn badge(label: SharedString, color: u32, pal: Palette) -> gpui::Div {
     h_flex()
         .items_center()
         .gap_1()
@@ -209,12 +209,7 @@ fn permission_field(
     let status_el = if never_requested {
         badge(tr!("Not requested"), theme::STATUS_OFFLINE, pal)
     } else {
-        let (label, color) = match status {
-            PermissionStatus::Granted => (tr!("Granted"), theme::STATUS_CONNECTED),
-            PermissionStatus::Denied => (tr!("Not granted"), theme::STATUS_CONNECTING),
-            PermissionStatus::Unknown => (tr!("Unknown"), theme::STATUS_OFFLINE),
-        };
-        badge(label, color, pal)
+        status_badge(status, pal)
     };
     let prompts_here = never_requested && matches!(permission, Permission::Camera);
     let action_label = if prompts_here {

--- a/crates/openlogi-desktop/src/windows/settings/updates.rs
+++ b/crates/openlogi-desktop/src/windows/settings/updates.rs
@@ -1,19 +1,18 @@
 //! Updates settings page.
 
 use super::{
-    AnyElement, App, AppState, Button, ButtonVariants, Disableable, Entity, FontWeight, IconName,
-    IntoElement, Palette, ParentElement, RELEASES_URL, SettingField, SettingGroup, SettingItem,
-    SettingPage, Sizable, StateEvent, Styled, Tag, UpdateStatus, Updater, div, h_flex, img, px,
-    v_flex,
+    App, AppState, Button, ButtonVariants, Disableable, Entity, FontWeight, IconName,
+    ParentElement, RELEASES_URL, SettingField, SettingGroup, SettingItem, SettingPage, Sizable,
+    StateEvent, Styled, Tag, UpdateStatus, Updater, div, h_flex, img, px, v_flex,
 };
 use crate::ui::theme::Typography as _;
 
 /// The Updates page: a hero card with the running build, its update status, and
 /// the contextual check / install / restart action; the opt-in auto-check and
 /// auto-install switches; and where updates come from.
-pub(super) fn updates_page(updater: Entity<Updater>, pal: Palette) -> SettingPage {
+pub(super) fn updates_page(updater: Entity<Updater>) -> SettingPage {
     let hero = SettingGroup::new().item(SettingItem::render(move |_, _, cx| {
-        update_hero(&updater, pal, cx)
+        update_hero(&updater, cx)
     }));
 
     let toggles = SettingGroup::new()
@@ -55,8 +54,7 @@ pub(super) fn updates_page(updater: Entity<Updater>, pal: Palette) -> SettingPag
             )),
         );
 
-    let source = SettingGroup::new().item(SettingItem::render(move |_, _, _| update_source(pal)));
-
+    let source = SettingGroup::new().item(SettingItem::render(move |_, _, cx| update_source(cx)));
     SettingPage::new(tr!("Updates"))
         .icon(IconName::ArrowDown)
         .resettable(false)
@@ -70,7 +68,8 @@ pub(super) fn updates_page(updater: Entity<Updater>, pal: Palette) -> SettingPag
 
 /// The Updates hero row: logo, name + version, a status pill, the live status
 /// message (or channel), and the one contextual action button.
-fn update_hero(updater: &Entity<Updater>, pal: Palette, cx: &mut App) -> AnyElement {
+fn update_hero(updater: &Entity<Updater>, cx: &mut App) -> gpui::Div {
+    let pal = crate::ui::theme::palette(cx);
     let status = updater.read(cx).status().clone();
 
     // A short status tag for the settled states (semantic colours from the theme);
@@ -169,11 +168,11 @@ fn update_hero(updater: &Entity<Updater>, pal: Palette, cx: &mut App) -> AnyElem
                 ),
         )
         .child(div().flex_shrink_0().child(action.disabled(busy)))
-        .into_any_element()
 }
 
 /// The "where updates come from" row plus the privacy footnote.
-fn update_source(pal: Palette) -> AnyElement {
+fn update_source(cx: &App) -> gpui::Div {
+    let pal = crate::ui::theme::palette(cx);
     v_flex()
         .w_full()
         .gap_3()
@@ -221,5 +220,4 @@ fn update_source(pal: Palette) -> AnyElement {
                     "No background updater — OpenLogi only connects when you turn on automatic checks or click Check for Updates."
                 )),
         )
-        .into_any_element()
 }


### PR DESCRIPTION
## Summary

Modernize the desktop UI rendering pipeline with scaled spacing tokens, clearer render ownership, and substantially narrower GPUI type-erasure boundaries.

## Changes

- add rem-based `DynamicSpacing` tokens that follow the existing UI scale
- move palette resolution into coherent render owners instead of threading it through unrelated render layers
- keep homogeneous GPUI builders statically typed and reserve `AnyElement` for heterogeneous routes, collections, callback contracts, and custom child storage
- introduce focused render owners for profile scope, keyboard workflows and callouts, mouse silhouettes, and add-device content
- retain the latest shared `BatteryIndicator` component while keeping its homogeneous render branches statically typed
- reduce `pal: Palette` parameters from 153 to 103, `AnyElement` references from 127 to 27, and `.into_any_element()` calls from 144 to 58

The remaining palette parameters are pure styling helpers inside owned render subtrees. The remaining `AnyElement` uses are intentional framework or heterogeneous-content boundaries rather than prematurely erased builders.

## Testing

- `RUSTFLAGS=\"-D warnings\" cargo fmt --all -- --check`
- `RUSTFLAGS=\"-D warnings\" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS=\"-D warnings\" cargo test --workspace`
- `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci clippy-windows`
- `cargo test -p openlogi-desktop ui::battery`
- `git diff --check`

Not runtime-tested on hardware.