### PR TITLE
feat(gui): add polished battery indicator

### DIFF
--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -39,9 +39,6 @@ mod widgets;
 // gallery card, so it reaches these through the crate-stable `crate::app::…`
 // path rather than the internal `app::home` submodule.
 pub(crate) use home::{glow_canvas, keyboard_glow};
-// Tray menu and other crate-level callers need the cold-start charging quirk.
-pub(crate) use widgets::battery_charging_no_reading;
-
 /// Which screen the root view is showing.
 ///
 /// GPUI has no router, so navigation is a tiny view-local enum that selects
@@ -644,8 +641,9 @@ impl Render for AppView {
 
 #[cfg(test)]
 mod tests {
-    use super::home::{battery_needs_attention, connection_icon_path, ordered_device_indices};
-    use super::{Capabilities, DetailTab, DeviceKind, DeviceRecord, battery_charging_no_reading};
+    use super::home::{connection_icon_path, ordered_device_indices};
+    use super::{Capabilities, DetailTab, DeviceKind, DeviceRecord};
+    use crate::ui::battery::{battery_charging_no_reading, battery_needs_attention};
     use openlogi_core::device::{
         BatteryInfo, BatteryLevel, BatteryStatus, DeviceTransports, LightCapabilities,
         LightValueRange, LightValueUnit,

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -16,13 +16,10 @@ use gpui_component::{
     v_flex,
 };
 use openlogi_core::config::ScrollResolution;
-use openlogi_core::device::{BatteryStatus, DeviceKind};
+use openlogi_core::device::DeviceKind;
 use openlogi_core::hid::DeviceRoute;
 
-use super::widgets::{
-    back_button, battery_charging_no_reading, battery_summary, kind_label, route_label,
-    sidebar_action, status_badge,
-};
+use super::widgets::{back_button, kind_label, route_label, sidebar_action, status_badge};
 use super::{AppView, DetailTab};
 use crate::app::menu::file_url;
 use crate::features::action_ring::ActionRingPanel;
@@ -37,6 +34,7 @@ use crate::features::pointer::dpi::DpiPanel;
 use crate::features::pointer::smartshift::SmartShiftPanel;
 use crate::features::profile_scope::{AppCatalogPicker, ProfileIconCache, profile_scope_bar};
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::battery::BatteryIndicator;
 use crate::ui::components::{PanelCard, Toggle};
 use crate::ui::theme::{
     ContentWidth, DETAIL_RAIL_W, HEADER_H, Palette, SCREEN_PAD, Typography as _,
@@ -58,33 +56,9 @@ pub(super) fn detail_header(
 ) -> impl IntoElement {
     let name = record.map_or_else(|| tr!("Device").to_string(), |r| r.display_name.clone());
     let online = record.map(|r| r.online);
-    let battery = record.and_then(|r| r.battery.as_ref()).map(|battery| {
-        let icon = if matches!(
-            battery.status,
-            BatteryStatus::Charging | BatteryStatus::ChargingSlow
-        ) {
-            IconName::BatteryCharging
-        } else if battery.percentage < 20 {
-            IconName::BatteryLow
-        } else if battery.percentage < 60 {
-            IconName::BatteryMedium
-        } else {
-            IconName::BatteryFull
-        };
-        let label = if battery_charging_no_reading(battery) {
-            tr!("Charging").to_string()
-        } else {
-            format!("{}%", battery.percentage)
-        };
-        h_flex()
-            .items_center()
-            .gap_1()
-            .text_caption()
-            .text_color(pal.text_muted)
-            .child(Icon::new(icon).size_4())
-            .child(label)
-            .into_any_element()
-    });
+    let battery = record
+        .and_then(|r| r.battery.as_ref())
+        .map(BatteryIndicator::inline);
     h_flex()
         .h(px(HEADER_H))
         .flex_shrink_0()
@@ -634,7 +608,7 @@ fn device_details_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElem
                         pal,
                     ))
                     .when_some(record.battery.as_ref(), |this, battery| {
-                        this.child(battery_summary(battery, pal))
+                        this.child(BatteryIndicator::summary(battery))
                     })
                     .child(device_description_list(record))
                     .into_any_element()

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -25,9 +25,7 @@ use gpui_component::{
     v_flex,
 };
 use openlogi_core::config::{DeviceViewMode, LightSettings};
-use openlogi_core::device::{
-    BatteryInfo, BatteryLevel, BatteryStatus, DeviceKind, DeviceTransports,
-};
+use openlogi_core::device::{DeviceKind, DeviceTransports};
 use openlogi_core::hid::DeviceRoute;
 
 use super::AppView;
@@ -38,6 +36,7 @@ use super::widgets::{
 use crate::features::lighting::visual as light_visual;
 use crate::services::assets::GlowGeometry;
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::battery::BatteryIndicator;
 use crate::ui::theme::{
     self, ContentWidth, HEADER_H, Palette, SelectableStyle as _, Typography as _,
 };
@@ -248,7 +247,7 @@ fn device_card(
                             .border_t_1()
                             .border_color(pal.border)
                             .pt_2()
-                            .child(battery_view(battery, record.online, pal))
+                            .child(BatteryIndicator::status(battery, record.online))
                     },
                 )),
         )
@@ -431,58 +430,6 @@ fn device_image(
         .justify_center()
         .child(Icon::new(icon).size_8().text_color(pal.text_muted))
         .into_any_element()
-}
-
-/// Battery readout for a gallery card. A low reading is one of the few states
-/// that needs to interrupt the otherwise-neutral grid, so both the glyph and
-/// text turn amber and an explicit label accompanies the percentage.
-fn battery_view(b: &BatteryInfo, online: bool, pal: Palette) -> AnyElement {
-    let low = battery_needs_attention(b);
-    let color = if low {
-        rgb(theme::STATUS_CONNECTING).into()
-    } else {
-        pal.text_muted
-    };
-    let row = h_flex()
-        .w_full()
-        .gap_1()
-        .items_center()
-        .text_caption()
-        .text_color(color)
-        .child(Icon::new(battery_icon(b)).size_3())
-        .when(!online, |this| this.child(tr!("Last known battery")));
-    if super::widgets::battery_charging_no_reading(b) {
-        row.child(tr!("Charging")).into_any_element()
-    } else {
-        row.child(format!("{}%", b.percentage))
-            .when(low, |this| this.child("·").child(tr!("Low battery")))
-            .into_any_element()
-    }
-}
-
-pub(super) fn battery_needs_attention(battery: &BatteryInfo) -> bool {
-    battery.percentage <= 20
-        && !matches!(
-            battery.status,
-            BatteryStatus::Charging | BatteryStatus::ChargingSlow | BatteryStatus::Full
-        )
-}
-
-/// Pick the battery glyph from charge state first (charging / full / error),
-/// then fall back to the discrete charge level for a plain discharge.
-fn battery_icon(b: &BatteryInfo) -> IconName {
-    match b.status {
-        BatteryStatus::Charging | BatteryStatus::ChargingSlow => IconName::BatteryCharging,
-        BatteryStatus::Full => IconName::BatteryFull,
-        BatteryStatus::Error => IconName::BatteryWarning,
-        BatteryStatus::Discharging | BatteryStatus::Unknown => match b.level {
-            BatteryLevel::Critical => IconName::BatteryWarning,
-            BatteryLevel::Low => IconName::BatteryLow,
-            BatteryLevel::Good => IconName::BatteryMedium,
-            BatteryLevel::Full => IconName::BatteryFull,
-            BatteryLevel::Unknown => IconName::Battery,
-        },
-    }
 }
 
 /// Connection-type glyph for a gallery card: a dongle for receiver-paired

--- a/crates/openlogi-desktop/src/app/home/views.rs
+++ b/crates/openlogi-desktop/src/app/home/views.rs
@@ -17,10 +17,11 @@ use openlogi_core::config::DeviceViewMode;
 use openlogi_core::device::DeviceKind;
 
 use super::{
-    AppView, battery_view, connection_summary, connection_view, device_card,
-    device_identity_subtitle, device_image, device_ring, keyboard_glow, rename_device_button,
+    AppView, connection_summary, connection_view, device_card, device_identity_subtitle,
+    device_image, device_ring, keyboard_glow, rename_device_button,
 };
 use crate::state::{AppState, DeviceRecord, StateEvent};
+use crate::ui::battery::{BatteryIndicator, battery_charging_no_reading};
 use crate::ui::carousel::Carousel;
 use crate::ui::theme::{self, ContentWidth, Palette, SelectableStyle as _, Typography as _};
 
@@ -324,7 +325,7 @@ fn device_list_row(
                     )
                 })
                 .when_some(record.battery.as_ref(), |this, battery| {
-                    this.child(battery_view(battery, record.online, pal))
+                    this.child(BatteryIndicator::status(battery, record.online))
                 })
                 .when(record.persistent, |this| {
                     this.child(rename_device_button(record, pal))
@@ -357,7 +358,14 @@ fn device_accessibility_description(record: &DeviceRecord) -> SharedString {
     };
     let metadata = format!("{status}. {identity}. {}.", connection_summary(record));
     if let Some(battery) = record.battery.as_ref() {
-        format!("{metadata} {} {}%.", tr!("Battery"), battery.percentage).into()
+        let battery = if battery_charging_no_reading(battery) {
+            tr!("Charging").to_string()
+        } else if record.online {
+            format!("{} {}%", tr!("Battery"), battery.percentage)
+        } else {
+            format!("{} {}%", tr!("Last known battery"), battery.percentage)
+        };
+        format!("{metadata} {battery}.").into()
     } else {
         metadata.into()
     }

--- a/crates/openlogi-desktop/src/app/menu.rs
+++ b/crates/openlogi-desktop/src/app/menu.rs
@@ -14,6 +14,7 @@ use openlogi_core::brand::{HELP_URL, RELEASES_URL, REPO_URL};
 use url::Url;
 
 use crate::state::AppState;
+use crate::ui::battery::battery_charging_no_reading;
 
 /// Keymap context installed on the main application surface.
 pub(crate) const APP_KEY_CONTEXT: &str = "OpenLogi";
@@ -227,7 +228,7 @@ fn device_menu_items(cx: &App) -> Vec<MenuItem> {
         Some(state) if !state.devices().is_empty() => {
             for record in state.devices() {
                 let title = match &record.battery {
-                    Some(battery) if crate::app::battery_charging_no_reading(battery) => {
+                    Some(battery) if battery_charging_no_reading(battery) => {
                         format!("{} · {}", record.display_name, tr!("Charging"))
                     }
                     Some(battery) => format!("{} · {}%", record.display_name, battery.percentage),

--- a/crates/openlogi-desktop/src/app/widgets.rs
+++ b/crates/openlogi-desktop/src/app/widgets.rs
@@ -3,30 +3,20 @@
 //! screens.
 
 use gpui::{
-    AnyElement, Context, Hsla, IntoElement, ParentElement, SharedString, Styled, div,
-    prelude::FluentBuilder as _, px, relative, rgb,
+    AnyElement, Context, IntoElement, ParentElement, SharedString, Styled, div,
+    prelude::FluentBuilder as _,
 };
 use gpui_component::{
     IconName, Sizable as _,
     button::{Button, ButtonVariants as _},
-    h_flex, v_flex,
+    h_flex,
 };
-use openlogi_core::device::{BatteryInfo, BatteryStatus, DeviceKind};
+use openlogi_core::device::DeviceKind;
 use openlogi_core::hid::DeviceRoute;
 
 use super::AppView;
 use crate::state::AppState;
-use crate::ui::theme::{self, Palette, Typography as _};
-
-/// True when the device is charging but still reports 0% — the MX2S `0x1000`
-/// firmware can't gauge charge under load, and on a cold start there's no
-/// pre-charge % cached to carry forward. Show "Charging" without the bogus 0%.
-pub(crate) fn battery_charging_no_reading(b: &BatteryInfo) -> bool {
-    matches!(
-        b.status,
-        BatteryStatus::Charging | BatteryStatus::ChargingSlow
-    ) && b.percentage == 0
-}
+use crate::ui::theme::{Palette, Typography as _};
 
 /// "← Devices" affordance on the detail screen; returns to the gallery without
 /// changing the active-device selection.
@@ -104,53 +94,6 @@ pub(super) fn connectivity_dot(online: bool, pal: Palette) -> impl IntoElement {
         .border_1()
         .border_color(pal.text_muted)
         .when(online, |dot| dot.bg(pal.text_primary))
-}
-
-pub(super) fn battery_summary(battery: &BatteryInfo, pal: Palette) -> impl IntoElement {
-    let status = match battery.status {
-        BatteryStatus::Charging | BatteryStatus::ChargingSlow => tr!("Charging"),
-        BatteryStatus::Full => tr!("Full"),
-        BatteryStatus::Error => tr!("Battery error"),
-        BatteryStatus::Discharging | BatteryStatus::Unknown => tr!("Battery"),
-    };
-    v_flex()
-        .gap_2()
-        .child(
-            h_flex()
-                .justify_between()
-                .text_caption()
-                .text_color(pal.text_muted)
-                .child(status)
-                .child(if battery_charging_no_reading(battery) {
-                    String::new()
-                } else {
-                    format!("{}%", battery.percentage)
-                }),
-        )
-        .child({
-            let track = div().h(px(6.)).w_full().rounded_full().bg(pal.muted);
-            // Charging with no reliable %: leave the track empty rather than
-            // drawing the 1%-wide red critical sliver that percentage==0 yields.
-            if battery_charging_no_reading(battery) {
-                track
-            } else {
-                track.child(
-                    div()
-                        .h_full()
-                        .w(relative(f32::from(battery.percentage.clamp(1, 100)) / 100.))
-                        .rounded_full()
-                        .bg(battery_color(battery.percentage, pal)),
-                )
-            }
-        })
-}
-
-fn battery_color(percentage: u8, pal: Palette) -> Hsla {
-    match percentage {
-        0..=20 => rgb(0x00ef_4444).into(),
-        21..=50 => rgb(theme::STATUS_CONNECTING).into(),
-        _ => pal.text_primary,
-    }
 }
 
 pub(super) fn sidebar_action(

--- a/crates/openlogi-desktop/src/ui/battery.rs
+++ b/crates/openlogi-desktop/src/ui/battery.rs
@@ -1,0 +1,508 @@
+//! Theme-aware battery visuals and readouts.
+//!
+//! The device gallery, detail header, and device-information panel all use
+//! this component so charge thresholds, status labels, and the cold-start
+//! charging state stay visually consistent.
+
+use gpui::{
+    App, BorderStyle, Bounds, Corners, FontWeight, Hsla, IntoElement, ParentElement, PathBuilder,
+    RenderOnce, Styled, Window, canvas, point, prelude::FluentBuilder as _, px, quad, rgb, size,
+};
+use gpui_component::h_flex;
+use openlogi_core::device::{BatteryInfo, BatteryLevel, BatteryStatus};
+
+use super::theme::{self, Palette, Typography as _};
+
+/// True when a charging device has not supplied a usable percentage yet.
+///
+/// Some devices cannot gauge charge while under load. On a cold start they
+/// report 0% until a later poll, which must not be presented as an empty or
+/// critically depleted battery.
+pub(crate) fn battery_charging_no_reading(battery: &BatteryInfo) -> bool {
+    is_charging(battery.status) && battery.percentage == 0
+}
+
+/// Whether a discharging battery should draw the user's attention.
+pub(crate) fn battery_needs_attention(battery: &BatteryInfo) -> bool {
+    battery.percentage <= 20
+        && !matches!(
+            battery.status,
+            BatteryStatus::Charging | BatteryStatus::ChargingSlow | BatteryStatus::Full
+        )
+}
+
+/// A battery readout with presentations sized for each desktop context.
+#[derive(IntoElement)]
+pub(crate) struct BatteryIndicator {
+    battery: BatteryInfo,
+    presentation: Presentation,
+}
+
+#[derive(Clone, Copy)]
+enum Presentation {
+    Inline,
+    Status { online: bool },
+    Summary,
+}
+
+impl BatteryIndicator {
+    /// A terse glyph and value for the device-detail title bar.
+    pub(crate) fn inline(battery: &BatteryInfo) -> Self {
+        Self {
+            battery: battery.clone(),
+            presentation: Presentation::Inline,
+        }
+    }
+
+    /// A gallery-card readout with status and last-known context.
+    pub(crate) fn status(battery: &BatteryInfo, online: bool) -> Self {
+        Self {
+            battery: battery.clone(),
+            presentation: Presentation::Status { online },
+        }
+    }
+
+    /// A larger readout for the device-information panel.
+    pub(crate) fn summary(battery: &BatteryInfo) -> Self {
+        Self {
+            battery: battery.clone(),
+            presentation: Presentation::Summary,
+        }
+    }
+}
+
+impl RenderOnce for BatteryIndicator {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let pal = theme::palette(cx);
+        match self.presentation {
+            Presentation::Inline => inline_readout(&self.battery, pal).into_any_element(),
+            Presentation::Status { online } => {
+                status_readout(&self.battery, online, pal).into_any_element()
+            }
+            Presentation::Summary => summary_readout(&self.battery, pal).into_any_element(),
+        }
+    }
+}
+
+fn inline_readout(battery: &BatteryInfo, pal: Palette) -> impl IntoElement {
+    h_flex()
+        .items_center()
+        .gap_2()
+        .text_caption()
+        .child(battery_glyph(battery, pal, GlyphSize::Compact, pal.page))
+        .child(
+            gpui::div()
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(pal.text_primary)
+                .child(value_label(battery)),
+        )
+}
+
+fn status_readout(battery: &BatteryInfo, online: bool, pal: Palette) -> impl IntoElement {
+    h_flex()
+        .w_full()
+        .items_center()
+        .gap_2()
+        .text_caption()
+        .child(battery_glyph(battery, pal, GlyphSize::Compact, pal.panel))
+        .child(
+            gpui::div()
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(pal.text_primary)
+                .child(value_label(battery)),
+        )
+        .when_some(context_label(battery, online), |row, label| {
+            row.child(gpui::div().text_color(pal.text_muted).child(label))
+        })
+}
+
+fn summary_readout(battery: &BatteryInfo, pal: Palette) -> impl IntoElement {
+    h_flex()
+        .w_full()
+        .items_center()
+        .gap_4()
+        .child(battery_glyph(battery, pal, GlyphSize::Summary, pal.panel))
+        .child(
+            gpui::div()
+                .text_heading()
+                .text_color(pal.text_primary)
+                .child(value_label(battery)),
+        )
+        .child(
+            gpui::div()
+                .text_caption()
+                .text_color(pal.text_muted)
+                .child(summary_label(battery)),
+        )
+}
+
+fn value_label(battery: &BatteryInfo) -> String {
+    if battery_charging_no_reading(battery) {
+        tr!("Charging").to_string()
+    } else {
+        format!("{}%", battery.percentage)
+    }
+}
+
+fn secondary_label(battery: &BatteryInfo) -> Option<gpui::SharedString> {
+    if battery_charging_no_reading(battery) {
+        None
+    } else {
+        match battery.status {
+            BatteryStatus::Charging | BatteryStatus::ChargingSlow => Some(tr!("Charging")),
+            BatteryStatus::Full => Some(tr!("Full")),
+            BatteryStatus::Error => Some(tr!("Battery error")),
+            BatteryStatus::Discharging | BatteryStatus::Unknown => {
+                battery_needs_attention(battery).then(|| tr!("Low battery"))
+            }
+        }
+    }
+}
+
+fn context_label(battery: &BatteryInfo, online: bool) -> Option<String> {
+    match (!online, secondary_label(battery)) {
+        (true, Some(status)) => Some(format!("{} · {status}", tr!("Last known battery"))),
+        (true, None) => Some(tr!("Last known battery").to_string()),
+        (false, Some(status)) => Some(status.to_string()),
+        (false, None) => None,
+    }
+}
+
+fn summary_label(battery: &BatteryInfo) -> gpui::SharedString {
+    if battery_charging_no_reading(battery) {
+        return tr!("Battery");
+    }
+    match battery.status {
+        BatteryStatus::Charging | BatteryStatus::ChargingSlow => tr!("Charging"),
+        BatteryStatus::Full => tr!("Full"),
+        BatteryStatus::Error => tr!("Battery error"),
+        BatteryStatus::Discharging | BatteryStatus::Unknown => {
+            if battery_needs_attention(battery) {
+                tr!("Low battery")
+            } else {
+                tr!("Battery")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BatteryTone {
+    Normal,
+    Charging,
+    Full,
+    Low,
+    Critical,
+    Error,
+}
+
+fn battery_tone(battery: &BatteryInfo) -> BatteryTone {
+    match battery.status {
+        BatteryStatus::Charging | BatteryStatus::ChargingSlow => BatteryTone::Charging,
+        BatteryStatus::Error => BatteryTone::Error,
+        BatteryStatus::Full => BatteryTone::Full,
+        BatteryStatus::Discharging | BatteryStatus::Unknown => {
+            if battery.level == BatteryLevel::Critical {
+                BatteryTone::Critical
+            } else if battery_needs_attention(battery) {
+                BatteryTone::Low
+            } else {
+                BatteryTone::Normal
+            }
+        }
+    }
+}
+
+fn tone_color(tone: BatteryTone, pal: Palette) -> Hsla {
+    match tone {
+        BatteryTone::Charging | BatteryTone::Full => rgb(theme::STATUS_CONNECTED).into(),
+        BatteryTone::Low => rgb(theme::STATUS_CONNECTING).into(),
+        BatteryTone::Critical | BatteryTone::Error => rgb(theme::STATUS_DISABLED).into(),
+        BatteryTone::Normal => pal.text_primary,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GlyphSize {
+    Compact,
+    Summary,
+}
+
+impl GlyphSize {
+    const fn dimensions(self) -> (f32, f32) {
+        match self {
+            Self::Compact => (27., 14.),
+            Self::Summary => (46., 22.),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GlyphMark {
+    None,
+    Charging,
+    Error,
+}
+
+#[derive(Clone, Copy)]
+struct GlyphPaint {
+    percentage: Option<u8>,
+    track: Hsla,
+    fill: Hsla,
+    outline: Hsla,
+    mark: GlyphMark,
+    mark_color: Hsla,
+    mark_contrast: Hsla,
+}
+
+fn battery_glyph(
+    battery: &BatteryInfo,
+    pal: Palette,
+    glyph_size: GlyphSize,
+    background: Hsla,
+) -> impl IntoElement {
+    let tone = battery_tone(battery);
+    let color = tone_color(tone, pal);
+    let mark = match battery.status {
+        BatteryStatus::Charging | BatteryStatus::ChargingSlow => GlyphMark::Charging,
+        BatteryStatus::Error => GlyphMark::Error,
+        BatteryStatus::Discharging | BatteryStatus::Full | BatteryStatus::Unknown => {
+            GlyphMark::None
+        }
+    };
+    let paint = GlyphPaint {
+        percentage: (!battery_charging_no_reading(battery)).then_some(battery.percentage),
+        track: pal.muted,
+        fill: color,
+        outline: pal.text_muted.opacity(0.78),
+        mark,
+        mark_color: color,
+        mark_contrast: background,
+    };
+    let (width, height) = glyph_size.dimensions();
+    canvas(
+        move |_, _, _| paint,
+        move |bounds, paint, window, _| paint_battery(bounds, paint, window),
+    )
+    .flex_none()
+    .w(px(width))
+    .h(px(height))
+}
+
+fn paint_battery(bounds: Bounds<gpui::Pixels>, paint: GlyphPaint, window: &mut Window) {
+    let width = f32::from(bounds.size.width);
+    let height = f32::from(bounds.size.height);
+    let large = height > 14.;
+    let cap_width = if large { 3. } else { 2. };
+    let body_height = height - 2.;
+    let body_width = width - cap_width;
+    let body_x = f32::from(bounds.origin.x);
+    let body_y = f32::from(bounds.origin.y) + 1.;
+    let body = Bounds {
+        origin: point(px(body_x), px(body_y)),
+        size: size(px(body_width), px(body_height)),
+    };
+    let terminal_height = body_height * 0.38;
+    let terminal = Bounds {
+        origin: point(
+            px(body_x + body_width - 0.5),
+            px(body_y + (body_height - terminal_height) / 2.),
+        ),
+        size: size(px(cap_width), px(terminal_height)),
+    };
+    window.paint_quad(quad(
+        terminal,
+        px(cap_width / 2.),
+        paint.outline,
+        px(0.),
+        paint.outline,
+        BorderStyle::default(),
+    ));
+
+    let radius = px(if large { 4. } else { 3. });
+    window.paint_quad(quad(
+        body,
+        radius,
+        paint.track,
+        px(1.),
+        paint.outline,
+        BorderStyle::default(),
+    ));
+
+    if let Some(percentage) = paint.percentage.filter(|percentage| *percentage > 0) {
+        let inset = 2.;
+        let inner_width = body_width - inset * 2.;
+        let inner_height = body_height - inset * 2.;
+        let fill_width = (inner_width * f32::from(percentage.min(100)) / 100.).max(1.);
+        let fill_bounds = Bounds {
+            origin: point(px(body_x + inset), px(body_y + inset)),
+            size: size(px(fill_width), px(inner_height)),
+        };
+        let fill_radius: f32 = if large { 2.5 } else { 1.5 };
+        let left_radius = px(fill_radius.min(fill_width / 2.));
+        let right_radius = px(if percentage >= 96 { fill_radius } else { 0.5 });
+        window.paint_quad(quad(
+            fill_bounds,
+            Corners {
+                top_left: left_radius,
+                top_right: right_radius,
+                bottom_right: right_radius,
+                bottom_left: left_radius,
+            },
+            paint.fill,
+            px(0.),
+            paint.fill,
+            BorderStyle::default(),
+        ));
+    }
+
+    match paint.mark {
+        GlyphMark::None => {}
+        GlyphMark::Charging => {
+            paint_charging_mark(body, mark_color(paint), window);
+        }
+        GlyphMark::Error => {
+            paint_error_mark(body, mark_color(paint), window);
+        }
+    }
+}
+
+fn mark_color(paint: GlyphPaint) -> Hsla {
+    if paint.percentage.is_some_and(|percentage| percentage >= 55) {
+        paint.mark_contrast
+    } else {
+        paint.mark_color
+    }
+}
+
+fn paint_charging_mark(body: Bounds<gpui::Pixels>, color: Hsla, window: &mut Window) {
+    let center_x = f32::from(body.origin.x) + f32::from(body.size.width) / 2.;
+    let center_y = f32::from(body.origin.y) + f32::from(body.size.height) / 2.;
+    let mark_height = f32::from(body.size.height) * 0.76;
+    let mark_width = mark_height * 0.54;
+    let mut path = PathBuilder::fill();
+    path.add_polygon(
+        &[
+            point(
+                px(center_x + mark_width * 0.12),
+                px(center_y - mark_height / 2.),
+            ),
+            point(
+                px(center_x - mark_width * 0.42),
+                px(center_y + mark_height * 0.05),
+            ),
+            point(
+                px(center_x - mark_width * 0.06),
+                px(center_y + mark_height * 0.05),
+            ),
+            point(
+                px(center_x - mark_width * 0.18),
+                px(center_y + mark_height / 2.),
+            ),
+            point(
+                px(center_x + mark_width * 0.45),
+                px(center_y - mark_height * 0.12),
+            ),
+            point(
+                px(center_x + mark_width * 0.08),
+                px(center_y - mark_height * 0.12),
+            ),
+        ],
+        true,
+    );
+    if let Ok(path) = path.build() {
+        window.paint_path(path, color);
+    }
+}
+
+fn paint_error_mark(body: Bounds<gpui::Pixels>, color: Hsla, window: &mut Window) {
+    let center_x = f32::from(body.origin.x) + f32::from(body.size.width) / 2.;
+    let center_y = f32::from(body.origin.y) + f32::from(body.size.height) / 2.;
+    let height = f32::from(body.size.height);
+    let stroke = (height * 0.13).max(1.);
+    let line_height = height * 0.34;
+    window.paint_quad(quad(
+        Bounds {
+            origin: point(px(center_x - stroke / 2.), px(center_y - height * 0.32)),
+            size: size(px(stroke), px(line_height)),
+        },
+        px(stroke / 2.),
+        color,
+        px(0.),
+        color,
+        BorderStyle::default(),
+    ));
+    window.paint_quad(quad(
+        Bounds {
+            origin: point(px(center_x - stroke / 2.), px(center_y + height * 0.2)),
+            size: size(px(stroke), px(stroke)),
+        },
+        px(stroke / 2.),
+        color,
+        px(0.),
+        color,
+        BorderStyle::default(),
+    ));
+}
+
+const fn is_charging(status: BatteryStatus) -> bool {
+    matches!(
+        status,
+        BatteryStatus::Charging | BatteryStatus::ChargingSlow
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tone_respects_status_priority_and_discharge_thresholds() {
+        let cases = [
+            (
+                5,
+                BatteryLevel::Critical,
+                BatteryStatus::Charging,
+                BatteryTone::Charging,
+            ),
+            (
+                80,
+                BatteryLevel::Good,
+                BatteryStatus::Error,
+                BatteryTone::Error,
+            ),
+            (
+                5,
+                BatteryLevel::Critical,
+                BatteryStatus::Full,
+                BatteryTone::Full,
+            ),
+            (
+                8,
+                BatteryLevel::Critical,
+                BatteryStatus::Discharging,
+                BatteryTone::Critical,
+            ),
+            (
+                20,
+                BatteryLevel::Low,
+                BatteryStatus::Discharging,
+                BatteryTone::Low,
+            ),
+            (
+                21,
+                BatteryLevel::Low,
+                BatteryStatus::Discharging,
+                BatteryTone::Normal,
+            ),
+        ];
+        for (percentage, level, status, expected) in cases {
+            let battery = BatteryInfo {
+                percentage,
+                level,
+                status,
+            };
+            assert_eq!(battery_tone(&battery), expected);
+        }
+    }
+}

--- a/crates/openlogi-desktop/src/ui/gallery.rs
+++ b/crates/openlogi-desktop/src/ui/gallery.rs
@@ -15,7 +15,9 @@ use gpui_component::{
 };
 use openlogi_core::brand::APP_ID;
 use openlogi_core::config::UiScale;
+use openlogi_core::device::{BatteryInfo, BatteryLevel, BatteryStatus};
 
+use super::battery::BatteryIndicator;
 use super::carousel::Carousel;
 use super::choice_card::ChoiceCard;
 use super::components::{MenuRow, PanelCard, PresetChip, ProfileTab, Toggle};
@@ -184,6 +186,7 @@ impl ComponentGallery {
             .child(self.menu_panel(pal, cx))
             .child(self.profile_panel(pal, cx))
             .child(self.preset_panel(pal, cx))
+            .child(Self::battery_panel(pal))
     }
 
     fn choice_panel(&self, pal: Palette, cx: &mut Context<Self>) -> gpui::Div {
@@ -337,6 +340,47 @@ impl ComponentGallery {
                         .text_color(pal.text_muted)
                         .child("×"),
                 ),
+            pal,
+        )
+    }
+
+    fn battery_panel(pal: Palette) -> gpui::Div {
+        let battery = |percentage, level, status| BatteryInfo {
+            percentage,
+            level,
+            status,
+        };
+        gallery_panel(
+            "BatteryIndicator",
+            IconName::Battery,
+            v_flex()
+                .gap_3()
+                .child(BatteryIndicator::summary(&battery(
+                    78,
+                    BatteryLevel::Good,
+                    BatteryStatus::Discharging,
+                )))
+                .child(BatteryIndicator::status(
+                    &battery(100, BatteryLevel::Full, BatteryStatus::Full),
+                    true,
+                ))
+                .child(BatteryIndicator::status(
+                    &battery(42, BatteryLevel::Good, BatteryStatus::Charging),
+                    true,
+                ))
+                .child(BatteryIndicator::status(
+                    &battery(0, BatteryLevel::Unknown, BatteryStatus::Charging),
+                    true,
+                ))
+                .child(BatteryIndicator::status(
+                    &battery(14, BatteryLevel::Low, BatteryStatus::Discharging),
+                    false,
+                ))
+                .child(BatteryIndicator::summary(&battery(
+                    35,
+                    BatteryLevel::Unknown,
+                    BatteryStatus::Error,
+                ))),
             pal,
         )
     }

--- a/crates/openlogi-desktop/src/ui/mod.rs
+++ b/crates/openlogi-desktop/src/ui/mod.rs
@@ -1,6 +1,7 @@
 //! Shared settings-app UI components and theme.
 
 pub(crate) mod action;
+pub(crate) mod battery;
 pub(crate) mod carousel;
 pub(crate) mod choice_card;
 pub(crate) mod components;


### PR DESCRIPTION
## Summary

Replace the desktop's fragmented battery glyph and progress-bar treatments with one polished, theme-aware `BatteryIndicator` component.

## Changes

- **openlogi-desktop**
  - add custom GPUI canvas rendering with a connected terminal, restrained inner corners, and percentage-accurate fill
  - provide inline, status, and summary presentations for headers, device cards/lists, and device details
  - centralize charging, full, low, critical, and error semantics, including charging devices without a usable reading
  - keep semantic color on the battery graphic while preserving clear value/status text hierarchy
  - improve offline and charging accessibility descriptions
  - add representative battery states to the debug component gallery

## Testing

- `env RUSTFLAGS='-D warnings' cargo fmt --all -- --check`
- `env RUSTFLAGS='-D warnings' cargo clippy -p openlogi-desktop --all-targets -- -D warnings`
- `env RUSTFLAGS='-D warnings' cargo test -p openlogi-desktop` — 165 passed
- Runtime-verified with `openlogi-agent-mock` in the real desktop client across grid, list, detail header, and device details views in light and dark appearances
- Not runtime-tested on physical Logitech hardware; the scripted mock exercised live battery updates and full/normal battery states

## Screenshots

### Device grid — light

![Battery indicator in the light device grid](https://ampcode.com/user-content/artifacts/915071a16faba04082d09c4d7146839973197ee4e89e9b171896a51105e2588f-file.png)

### Device details — light

![Battery indicator in the detail header and device details card](https://ampcode.com/user-content/artifacts/fa4b9f4bc60ea5e3b1d50504fb31d67e7f70f6aa459cd15af2480c17e990ce48-file.png)

### Device list — dark

![Battery indicator in the dark device list](https://ampcode.com/user-content/artifacts/fa75a1a619f53f9fa14b721fd4d9d87ba3348d07e2917824b171e2ec59417ddc-file.png)