### PR TITLE
ci: replace target caches with sccache

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -40,8 +40,10 @@ direnv exec . cargo xtask ci      # when cargo is only inside devenv
 devenv tasks run openlogi:ci      # same as the command
 ```
 
-The runner sets the same env CI does (`RUSTFLAGS=-D warnings`). A rustc warning
-that host clippy `-D warnings` does not surface still fails CI.
+The runner sets CI's semantic compiler env (`RUSTFLAGS=-D warnings`). CI also
+sets `CARGO_INCREMENTAL=0` and wraps rustc with sccache; those only change how
+compiler outputs are produced and reused, not what the jobs validate. A rustc
+warning that host clippy `-D warnings` does not surface still fails CI.
 
 ## Job map (`ci.yml`)
 
@@ -61,7 +63,10 @@ that host clippy `-D warnings` does not surface still fails CI.
 | `wasm (portable crates)` | `cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown` then `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown` | any (needs the `wasm32-unknown-unknown` std; devenv installs it) |
 
 CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`,
-`RUSTFLAGS=-D warnings`. There is no Windows test job — only `clippy (windows)`.
+`RUSTFLAGS=-D warnings`, and `RUSTC_WRAPPER=sccache`. `rust-cache` stores only
+Cargo registry/git inputs (`cache-targets: false`); sccache owns compiler
+outputs. PRs read the default branch's sccache objects but do not write their
+isolated merge-ref cache. There is no Windows test job — only `clippy (windows)`.
 
 ### MSRV trap
 

--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -62,11 +62,13 @@ warning that host clippy `-D warnings` does not surface still fails CI.
 | `clippy (windows)` | `cargo clippy --workspace --all-targets -- -D warnings` | **Windows**. Elsewhere: `devenv tasks run openlogi:check-windows` (ring-free subset, not the full workspace) |
 | `wasm (portable crates)` | `cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown` then `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown` | any (needs the `wasm32-unknown-unknown` std; devenv installs it) |
 
-CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`,
-`RUSTFLAGS=-D warnings`, and `RUSTC_WRAPPER=sccache`. `rust-cache` stores only
-Cargo registry/git inputs (`cache-targets: false`); sccache owns compiler
-outputs. PRs read the default branch's sccache objects but do not write their
-isolated merge-ref cache. There is no Windows test job — only `clippy (windows)`.
+CI always sets `CARGO_TERM_COLOR=always`, `CARGO_INCREMENTAL=0`, and
+`RUSTFLAGS=-D warnings`. Compilation jobs also set `RUSTC_WRAPPER=sccache`;
+`cargo-deny` clears it because metadata probes rustc without compiling and the
+job deliberately skips sccache setup. `rust-cache` stores only Cargo registry/git
+inputs (`cache-targets: false`); sccache owns compiler outputs. PRs read the
+default branch's sccache objects but do not write their isolated merge-ref cache.
+There is no Windows test job — only `clippy (windows)`.
 
 ### MSRV trap
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
 
@@ -362,7 +362,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
 
@@ -794,7 +794,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,11 @@ env:
   CARGO_INCREMENTAL: 0
   MACOSX_DEPLOYMENT_TARGET: "13.0"
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  # PR merge refs and release tags cannot warm another ref. Only dispatches
+  # and other branch-scoped runs write reusable compiler objects.
+  SCCACHE_GHA_RW_MODE: ${{ (github.event_name != 'pull_request' && github.ref_type != 'tag') && 'READ_WRITE' || 'READ_ONLY' }}
 
 jobs:
   # Opt-in gate for PR builds. Non-PR triggers (workflow_call / dispatch)
@@ -123,14 +128,19 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
+
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           # Release profile (fat LTO) — never share with CI debug keys.
           shared-key: macos-stable-release
-          # Packaging never runs on master push; allow same-repo PRs/dispatch/release
-          # to refresh the shared release cache (few keys, not per-job thrash).
-          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          cache-targets: false
+          # PR and tag caches are isolated to that ref. Restore there, but only
+          # save Cargo inputs from branch-scoped dispatches/callers.
+          save-if: ${{ github.event_name != 'pull_request' && github.ref_type != 'tag' }}
 
       - name: Verify runner architecture
         run: test "$(uname -m)" = "${{ matrix.arch }}"
@@ -352,15 +362,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      # Release builds need their own cache (crt-static RUSTFLAGS + --release).
-      # Shared per matrix.arch so labeled PR packaging and dispatch runs warm
-      # each other; tag-only saves were pure quota churn under the old per-ref
-      # keys, but a shared-key entry is restorable across PR/dispatch/release.
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
+
+      # Both targets consume the same Cargo registry/git inputs. Compiler
+      # outputs stay isolated by sccache's command and target-triple hashes.
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
-          shared-key: windows-stable-release-${{ matrix.arch }}
-          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          prefix-key: v2-cargo
+          shared-key: windows-stable-release
+          cache-targets: false
+          save-if: ${{ github.event_name != 'pull_request' && github.ref_type != 'tag' }}
 
       # Azure signing config lives in 1Password, matching the macOS job's secret flow.
       # load-secrets-action is a node action, so it runs on Windows runners too. The
@@ -781,13 +794,19 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
+
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           # Cargo does not include the host GLIBC in its freshness checks. Do
-          # not restore release objects previously linked on Ubuntu 24.04.
+          # not share Cargo inputs under the Ubuntu 24.04 CI key; sccache hashes
+          # the compiler command and target environment independently.
           shared-key: linux-jammy-stable-release
-          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          cache-targets: false
+          save-if: ${{ github.event_name != 'pull_request' && github.ref_type != 'tag' }}
 
       # The nfpm `arch` and the runner's native arch must agree — the packages
       # are built natively, not cross-compiled, so a mismatched runner would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -97,7 +97,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.98
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -169,7 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -242,7 +242,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -259,6 +259,10 @@ jobs:
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest
+    env:
+      # cargo-deny calls `rustc -vV` through cargo metadata but does not compile.
+      # This job deliberately skips the sccache setup used by compilation jobs.
+      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v6
       # Prebuilt binary install is faster than cargo-deny-action's bootstrap path
@@ -283,7 +287,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -308,7 +312,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,19 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-D warnings"
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  # PR caches are isolated to refs/pull/*/merge and still consume the repo's
+  # 10 GB allowance. Let PRs reuse master's compiler objects without filling
+  # the cache with entries no other PR can read.
+  SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && 'READ_WRITE' || 'READ_ONLY' }}
 
-# rust-cache policy (see PR description for measured rationale):
-# - prefix-key v1-rust: bust the thrashing v0-rust multi-GB entries (~21 GB).
-# - shared-key groups jobs that share OS + rustc channel + debug profile.
-# - save-if master/main only: PRs restore base-branch caches without writing
-#   new multi-GB keys that evict Windows/MSRV under the 10 GB soft limit.
+# Cache policy:
+# - rust-cache keeps Cargo's registry/git inputs only; caching target/ produced
+#   0.8-1.4 GB archives whose transfer often cost more than the cache saved.
+# - sccache stores compiler outputs individually, so jobs fetch only objects
+#   they need and can share unchanged dependencies across Cargo commands.
+# - only master/main writes CI caches; PR-scoped entries cannot warm other PRs.
 jobs:
   fmt:
     name: rustfmt
@@ -51,10 +58,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           shared-key: linux-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: cargo xtask release check-publish
 
@@ -86,10 +97,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           shared-key: linux-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: |
           sudo apt-get update
@@ -124,11 +139,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.98
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           # Host OS splits Linux vs macOS; the rustc version is already in the key.
           shared-key: msrv-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - if: runner.os == 'Linux'
         run: |
@@ -150,12 +169,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           # Share debug deps with clippy/test-linux; RUSTDOCFLAGS is step-scoped
           # below so it does not fork the rust-cache env hash.
           shared-key: linux-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: |
           sudo apt-get update
@@ -187,10 +210,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           shared-key: linux-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - run: |
           sudo apt-get update
@@ -215,11 +242,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           # Host triple already splits arm64 vs x86_64 in the final cache key.
           shared-key: macos-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       - name: Verify runner architecture
         run: test "$(uname -m)" = "${{ matrix.arch }}"
@@ -252,10 +283,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           shared-key: windows-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       # Whole workspace, matching the Linux jobs — GPUI's DirectX backend
       # covers the GUI on Windows. clippy subsumes `cargo check` and
@@ -273,10 +308,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
-          shared-key: wasm-stable-debug
+          prefix-key: v2-cargo
+          # Only Cargo inputs are cached, so the host's stable registry/git
+          # cache is reusable even though rustc emits wasm objects via sccache.
+          shared-key: linux-stable-debug
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       # A portability gate, not a deliverable: nothing here is built for the
       # browser. `wasm32-unknown-unknown` has no OS under it, so a crate that

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,8 +8,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
-  # Keep rust-cache's environment hash aligned with CI.
+  # Keep Cargo/sccache inputs aligned with CI.
   RUSTFLAGS: "-D warnings"
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_RW_MODE: READ_WRITE
 
 jobs:
   release-pr:
@@ -27,10 +30,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           shared-key: linux-stable-debug
+          cache-targets: false
           save-if: false
       - name: Install Linux build deps
         run: |
@@ -164,15 +171,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
+      # Restore Cargo inputs before compiling the xtask that selects the
+      # version-bump commit. Compiler outputs come from sccache across commits.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v2-cargo
+          shared-key: linux-stable-debug
+          cache-targets: false
+          save-if: false
       - name: Check out the version-bump commit
         id: release_commit
         run: cargo xtask release checkout-version-bump
-      - uses: Swatinem/rust-cache@v2
-        if: steps.release_commit.outputs.skip != 'true'
-        with:
-          prefix-key: v1-rust
-          shared-key: linux-stable-debug
-          save-if: false
       - name: Install Linux build deps
         if: steps.release_commit.outputs.skip != 'true'
         run: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       - uses: Swatinem/rust-cache@v2
@@ -171,7 +171,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
       # Restore Cargo inputs before compiling the xtask that selects the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ env:
   CARGO_INCREMENTAL: 0
   MACOSX_DEPLOYMENT_TARGET: "13.0"
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  # Tag-scoped cache entries cannot warm the next release.
+  SCCACHE_GHA_RW_MODE: READ_ONLY
 
 jobs:
   # Build (and sign/notarize) every platform's installers. The build matrix
@@ -125,15 +129,20 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      # Match CI's RUSTFLAGS so the rust-cache env hash hits linux-stable-debug.
-      - name: Align rust-cache env with CI
+      # Match CI so Cargo inputs and sccache compiler objects are reusable.
+      - name: Align compiler inputs with CI
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
+
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
 
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v1-rust
+          prefix-key: v2-cargo
           shared-key: linux-stable-debug
-          # Tag publish is not a useful cache writer; restore CI deps only.
+          cache-targets: false
+          # Tag publish is not a useful cache writer; restore Cargo inputs only.
           save-if: false
 
       - uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Align compiler inputs with CI
         run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
 
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
 

--- a/.github/workflows/windows-sign-dryrun.yml
+++ b/.github/workflows/windows-sign-dryrun.yml
@@ -12,6 +12,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_RW_MODE: READ_WRITE
 
 jobs:
   sign:
@@ -41,6 +44,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: "v0.16.0"
+
+      # Share Cargo inputs and compiler objects with build.yml's equivalent
+      # release target; this dry run should warm the real signing path too.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v2-cargo
+          shared-key: windows-stable-release
+          cache-targets: false
 
       - name: Load Azure signing config from 1Password
         id: azure_config

--- a/.github/workflows/windows-sign-dryrun.yml
+++ b/.github/workflows/windows-sign-dryrun.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: "v0.16.0"
 


### PR DESCRIPTION
## Summary

Replace multi-gigabyte `target/` archives with granular sccache compiler-output caching while retaining a smaller Cargo registry/git cache.

The repository currently has 10.59 GB of active Actions caches. Individual target archives reach 1.52 GB on Windows and 1.34 GB on macOS, making cache transfer and eviction a material part of CI runtime.

## Changes

- install `mozilla-actions/sccache-action@v0.0.11` with sccache v0.16.0 in all Rust build, CI, release, and signing jobs
- configure `Swatinem/rust-cache` with `cache-targets: false` so it stores Cargo inputs instead of complete build directories
- allow cache writes only from reusable branch scopes; PR merge refs and release tags restore caches read-only
- share Cargo input caches across Linux/Wasm jobs and Windows release target architectures
- restore release-plz Cargo inputs before compiling the checkout-selection xtask
- document the Cargo/sccache split in the local CI guide

## Testing

- `actionlint 1.7.12 .github/workflows/*.yml`
- `cargo test -p xtask commands::ci::jobs::tests::` — 10 passed
- `cargo xtask ci --dry-run` — rendered 7 runnable jobs and reported 5 host/tool-dependent jobs as skipped; commands were not executed by design
- `git diff --check`
- Hardware: not applicable (CI-only change)