### PR TITLE
fix(linux): open the Actions Ring at the cursor on Wayland

### DIFF
--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -29,8 +29,10 @@ use tracing_subscriber::EnvFilter;
 use openlogi_core::action_ring::DISPLAY_LIFETIME;
 
 use crate::agent::{Ipc, OverlayCommand, spawn_ipc};
-use crate::ring::{RingView, ring_window_options};
-use crate::session::{ClickAwaySession, claim_the_role, spawn_click_away_dismissal};
+use crate::ring::{RingView, ring_windows};
+use crate::session::{
+    ClickAwaySession, claim_the_role, close_ring_windows, spawn_click_away_dismissal,
+};
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -73,29 +75,34 @@ fn main() -> Result<()> {
                     for handle in cx.windows() {
                         let _ = handle.update(cx, |_, window, _| window.remove_window());
                     }
-                    let options = ring_window_options(cx);
-                    let commands = commands.clone();
                     let timeout_commands = commands.clone();
                     let session_id = invocation.session_id;
-                    match cx.open_window(options, |_, cx| {
-                        cx.new(|_| RingView::new(invocation, commands))
-                    }) {
-                        Ok(handle) => {
-                            live_session.set(session_id);
-                            platform::configure_windows();
-                            cx.spawn(async move |cx| {
-                                cx.background_executor().timer(DISPLAY_LIFETIME).await;
-                                if handle
-                                    .update(cx, |_, window, _| window.remove_window())
-                                    .is_ok()
-                                {
-                                    let _ = timeout_commands
-                                        .send(OverlayCommand::Cancel { session_id });
-                                }
-                            })
-                            .detach();
+                    // Wayland needs one window per display (see `ring_windows`),
+                    // so a ring is a set of windows, and one that fails to open
+                    // must not sink the others: the ring is showing as long as
+                    // any of them made it.
+                    let mut opened = false;
+                    for (options, placement) in ring_windows(cx) {
+                        let invocation = invocation.clone();
+                        let commands = commands.clone();
+                        match cx.open_window(options, |_, cx| {
+                            cx.new(|_| RingView::new(invocation, commands, placement))
+                        }) {
+                            Ok(_) => opened = true,
+                            Err(error) => warn!(%error, "could not open Actions Ring window"),
                         }
-                        Err(error) => warn!(%error, "could not open Actions Ring window"),
+                    }
+                    if opened {
+                        live_session.set(session_id);
+                        platform::configure_windows();
+                        cx.spawn(async move |cx| {
+                            cx.background_executor().timer(DISPLAY_LIFETIME).await;
+                            if cx.update(|cx| close_ring_windows(cx, session_id)) {
+                                let _ =
+                                    timeout_commands.send(OverlayCommand::Cancel { session_id });
+                            }
+                        })
+                        .detach();
                     }
                 });
             }

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -1,23 +1,37 @@
 //! The ring itself: the GPUI view, and the window it is drawn in.
 //!
-//! Placement is the interesting part — the panel is centred on the cursor and
-//! clamped to the display it came up on, so a ring raised near a screen edge
-//! stays whole instead of being cut off.
+//! Placement is the interesting part, and it takes two shapes because the
+//! platforms disagree about who may position a window.
+//!
+//! Where a client can place its own windows — macOS, Windows, X11 — the window
+//! *is* the ring: a 360×360 panel centred on the cursor and clamped to its
+//! display, so a ring raised near a screen edge stays whole.
+//!
+//! Wayland allows neither half of that. No protocol reports the global pointer
+//! position to an ordinary client, and an `xdg_toplevel` cannot choose its own
+//! origin — `WindowOptions::window_bounds` carries an origin the backend
+//! ignores. So there the ring covers the whole display instead, transparent
+//! and empty until the compositor's pointer-enter tells it where the cursor
+//! is, and the panel is placed at that point *within* the window. One such
+//! window per display: `wl_pointer.enter` goes to exactly the surface under
+//! the cursor, so the compositor picks the right display for us.
 
 use gpui::{
-    Bounds, Context, Hsla, InteractiveElement, IntoElement, ParentElement, Pixels, Point, Render,
-    SharedString, Size, StatefulInteractiveElement as _, Styled, Window,
-    WindowBackgroundAppearance, WindowBounds, WindowKind, WindowOptions, div, point,
-    prelude::FluentBuilder as _, px, svg,
+    Bounds, Context, Div, Hsla, InteractiveElement, IntoElement, MouseMoveEvent, ParentElement,
+    Pixels, PlatformDisplay, Point, Render, SharedString, Size, StatefulInteractiveElement as _,
+    Styled, Window, WindowBackgroundAppearance, WindowBounds, WindowKind, WindowOptions, div,
+    point, prelude::FluentBuilder as _, px, svg,
 };
 use openlogi_core::binding::ActionRingSlot;
 use openlogi_ipc::ActionRingInvocation;
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
 use openlogi_ui::color;
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use crate::agent::OverlayCommand;
 use crate::platform;
+use crate::session;
 
 pub(crate) const WINDOW_SIZE: f32 = 360.0;
 pub(crate) const SLOT_SIZE: f32 = 54.0;
@@ -49,10 +63,24 @@ const fn neutral(lightness: f32, alpha: f32) -> Hsla {
 const SELECTED_FILL_L: f32 = 0.48;
 const SELECTED_BORDER_L: f32 = 0.78;
 
+/// Where the ring's panel sits inside the window it was given.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Placement {
+    /// The window is the ring: it was opened at the cursor already, so the
+    /// panel fills it.
+    Window,
+    /// The window covers a whole display and the panel is drawn at the pointer
+    /// within it. `center` stays `None` until the compositor reports a pointer
+    /// position for this window — on the displays the cursor is not on, it
+    /// stays `None` for the ring's whole life and nothing is drawn.
+    AtPointer { center: Option<Point<Pixels>> },
+}
+
 pub(crate) struct RingView {
     invocation: ActionRingInvocation,
     commands: mpsc::UnboundedSender<OverlayCommand>,
     hovered: Option<ActionRingSlot>,
+    placement: Placement,
 }
 
 impl RingView {
@@ -60,11 +88,13 @@ impl RingView {
     pub(crate) const fn new(
         invocation: ActionRingInvocation,
         commands: mpsc::UnboundedSender<OverlayCommand>,
+        placement: Placement,
     ) -> Self {
         Self {
             invocation,
             commands,
             hovered: None,
+            placement,
         }
     }
 
@@ -128,20 +158,20 @@ impl RingView {
                         cx.notify();
                     }
                 }))
-                .on_click(move |_, window, cx| {
+                .on_click(move |_, _, cx| {
                     cx.stop_propagation();
                     let _ = activate.send(OverlayCommand::Activate { session_id, slot });
-                    window.remove_window();
+                    session::close_ring_windows(cx, session_id);
                 })
                 .into_any_element(),
         )
     }
-}
 
-impl Render for RingView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    /// The ring panel: a fixed 360×360 square holding the backdrop, the eight
+    /// slots, the cancel affordance and the hovered label. It is the same
+    /// element under both placements — only where it is anchored differs.
+    fn panel(&self, cx: &mut Context<Self>) -> Div {
         let session_id = self.invocation.session_id;
-        let root_commands = self.commands.clone();
         let center_commands = self.commands.clone();
         let hovered_label = self.hovered.and_then(|slot| {
             let presentation = self.invocation.slots.get(&slot)?;
@@ -161,9 +191,8 @@ impl Render for RingView {
             .collect::<Vec<_>>();
 
         div()
-            .id("ring-root")
             .relative()
-            .size_full()
+            .size(px(WINDOW_SIZE))
             .child(
                 div()
                     .absolute()
@@ -190,10 +219,10 @@ impl Render for RingView {
                     .text_color(CANCEL_GLYPH)
                     .cursor_pointer()
                     .child(svg().path(RING_CANCEL_ICON).size(px(20.0)).flex_none())
-                    .on_click(move |_, window, cx| {
+                    .on_click(move |_, _, cx| {
                         cx.stop_propagation();
                         let _ = center_commands.send(OverlayCommand::Cancel { session_id });
-                        window.remove_window();
+                        session::close_ring_windows(cx, session_id);
                     }),
             )
             .when_some(hovered_label, |ring, label| {
@@ -209,9 +238,46 @@ impl Render for RingView {
                         .child(label),
                 )
             })
-            .on_click(move |_, window, _| {
+    }
+}
+
+impl Render for RingView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let session_id = self.invocation.session_id;
+        let root_commands = self.commands.clone();
+        let placement = self.placement;
+
+        let panel = panel_origin(placement, window.viewport_size()).map(|origin| {
+            div()
+                .absolute()
+                .left(origin.x)
+                .top(origin.y)
+                .child(self.panel(cx))
+        });
+
+        div()
+            .id("ring-root")
+            .relative()
+            .size_full()
+            .when(matches!(placement, Placement::AtPointer { .. }), |root| {
+                // The MouseMove GPUI synthesizes from `wl_pointer.enter` is the
+                // only report of the cursor a Wayland client gets, and the
+                // display the cursor is not on never sends one. Latch the first
+                // one: the ring stays where it was raised instead of following
+                // the pointer around the display.
+                root.on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _, cx| {
+                    if let Placement::AtPointer { center } = &mut this.placement
+                        && center.is_none()
+                    {
+                        *center = Some(event.position);
+                        cx.notify();
+                    }
+                }))
+            })
+            .children(panel)
+            .on_click(move |_, _, cx| {
                 let _ = root_commands.send(OverlayCommand::Cancel { session_id });
-                window.remove_window();
+                session::close_ring_windows(cx, session_id);
             })
     }
 }
@@ -220,7 +286,7 @@ impl Render for RingView {
     clippy::cast_possible_truncation,
     reason = "native cursor coordinates are screen-sized and exactly usable as GPUI f32 pixels"
 )]
-pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
+fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
     let cursor = openlogi_hook::cursor_position();
     let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
     // GPUI window bounds are display-relative (`display.bounds()` zeroes every
@@ -284,6 +350,120 @@ pub(crate) fn ring_window_options(cx: &mut gpui::App) -> WindowOptions {
     }
 }
 
+/// A transparent window covering `display`, for the placement Wayland forces.
+///
+/// Covering the display rather than sitting at the cursor because an
+/// `xdg_toplevel` cannot choose its own origin. It is also what makes the
+/// pointer reachable at all: the compositor reports a position only in
+/// surface-local coordinates, and only to the surface under the cursor.
+///
+/// Maximized, specifically — **not** fullscreen. `xdg_toplevel.set_fullscreen`
+/// gets the same coverage, but a compositor presents a fullscreen surface
+/// against black rather than against the desktop, so a transparent one renders
+/// as a black screen (observed on Mutter). Maximizing asks for the same area
+/// without entering that presentation mode.
+///
+/// The bounds passed here are only the restore size a maximized window would
+/// return to, which this window never does. They are also in a different unit
+/// from the one the window ends up reporting — GPUI gives display bounds in
+/// logical pixels and window bounds in device pixels, which differ under
+/// fractional scaling — so nothing may derive a pointer-space coordinate from
+/// them. [`panel_origin`] measures against the viewport for that reason.
+fn covering_window_options(display: &std::rc::Rc<dyn PlatformDisplay>) -> WindowOptions {
+    WindowOptions {
+        window_bounds: Some(WindowBounds::Maximized(display.bounds())),
+        titlebar: None,
+        focus: false,
+        show: true,
+        kind: WindowKind::PopUp,
+        is_movable: false,
+        is_resizable: false,
+        is_minimizable: false,
+        display_id: Some(display.id()),
+        window_background: WindowBackgroundAppearance::Transparent,
+        // Client-side, and this window draws none. Left at the default the
+        // compositor dresses a display-sized window in a title bar.
+        window_decorations: Some(gpui::WindowDecorations::Client),
+        app_id: Some("openlogi-action-ring".to_string()),
+        ..WindowOptions::default()
+    }
+}
+
+/// Every window one ring invocation should open, with the placement its view
+/// must use.
+///
+/// One window everywhere a client may position its own — and on Wayland one
+/// per display, because nothing here can know which display holds the cursor.
+/// The compositor settles it: `wl_pointer.enter` reaches exactly the surface
+/// under the pointer, so the window that hears from the pointer is the one
+/// that draws, and the rest stay empty and transparent until the ring closes.
+pub(crate) fn ring_windows(cx: &mut gpui::App) -> Vec<(WindowOptions, Placement)> {
+    if !on_wayland() {
+        return vec![(ring_window_options(cx), Placement::Window)];
+    }
+    let displays = cx.displays();
+    if displays.is_empty() {
+        // Nothing to cover. The positioned path cannot place the ring on
+        // Wayland either, but it still puts a ring on screen, which beats
+        // opening no window at all.
+        warn!("no displays reported; falling back to a positioned Actions Ring window");
+        return vec![(ring_window_options(cx), Placement::Window)];
+    }
+    displays
+        .iter()
+        .map(|display| {
+            (
+                covering_window_options(display),
+                Placement::AtPointer { center: None },
+            )
+        })
+        .collect()
+}
+
+/// Whether GPUI is talking to a Wayland compositor.
+///
+/// `guess_compositor` is GPUI's own backend selection, so asking it is the one
+/// way to stay in step with the backend actually in use rather than guessing
+/// from the environment a second time.
+fn on_wayland() -> bool {
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    {
+        gpui::guess_compositor() == "Wayland"
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+    {
+        false
+    }
+}
+
+/// Top-left of the ring panel within its window, or `None` while there is
+/// nothing to draw.
+///
+/// Under [`Placement::Window`] the window is the panel, so the two corners
+/// coincide. Under [`Placement::AtPointer`] the panel is centred on the pointer
+/// and clamped into the window, which covers the display — the same rule the
+/// positioned path applies to the window itself, one level in. A pointer this
+/// window has not seen yields `None`: on a multi-display Wayland session that
+/// is every display except the cursor's, and they draw nothing at all.
+///
+/// `viewport` and not the display's bounds: GPUI reports display bounds in
+/// logical pixels and the pointer in the window's device pixels, so under
+/// fractional scaling the two disagree (a 1.5× display reports 1128×752 while
+/// its window reports 1692×1128). The viewport is the space the pointer
+/// arrives in, so it is the only one this may clamp against.
+fn panel_origin(placement: Placement, viewport: Size<Pixels>) -> Option<Point<Pixels>> {
+    let center = match placement {
+        Placement::Window => return Some(Point::default()),
+        Placement::AtPointer { center } => center?,
+    };
+    let size = Size::new(px(WINDOW_SIZE), px(WINDOW_SIZE));
+    Some(clamp_window_origin(
+        point(center.x - size.width / 2.0, center.y - size.height / 2.0),
+        size,
+        Bounds::new(Point::default(), viewport),
+    ))
+}
+
 pub(crate) fn clamp_window_origin(
     desired: Point<Pixels>,
     window_size: Size<Pixels>,
@@ -311,6 +491,55 @@ mod tests {
         assert_eq!(
             clamp_window_origin(point(px(700.0), px(500.0)), size, display),
             point(px(500.0), px(250.0))
+        );
+    }
+
+    #[test]
+    fn a_window_sized_ring_fills_its_window() {
+        assert_eq!(
+            panel_origin(Placement::Window, Size::new(px(360.0), px(360.0))),
+            Some(Point::default())
+        );
+    }
+
+    #[test]
+    fn a_display_sized_ring_draws_nothing_until_the_pointer_is_known() {
+        // Every display except the cursor's stays in this state for the ring's
+        // whole life, so "no pointer yet" and "no ring here" are the same case.
+        assert_eq!(
+            panel_origin(
+                Placement::AtPointer { center: None },
+                Size::new(px(1920.0), px(1080.0))
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_display_sized_ring_centers_on_the_pointer() {
+        assert_eq!(
+            panel_origin(
+                Placement::AtPointer {
+                    center: Some(point(px(900.0), px(500.0))),
+                },
+                Size::new(px(1920.0), px(1080.0))
+            ),
+            Some(point(px(720.0), px(320.0)))
+        );
+    }
+
+    #[test]
+    fn a_display_sized_ring_stays_whole_against_an_edge() {
+        // A ring raised in the corner would hang off the window, and the window
+        // is the display: clamping is the only thing keeping it on screen.
+        assert_eq!(
+            panel_origin(
+                Placement::AtPointer {
+                    center: Some(point(px(4.0), px(1076.0))),
+                },
+                Size::new(px(1920.0), px(1080.0))
+            ),
+            Some(point(px(0.0), px(720.0)))
         );
     }
 

--- a/crates/openlogi-overlay/src/session.rs
+++ b/crates/openlogi-overlay/src/session.rs
@@ -88,19 +88,44 @@ pub(crate) fn spawn_click_away_dismissal(cx: &mut gpui::App, live: Arc<ClickAway
 #[cfg(not(target_os = "macos"))]
 const fn drop_unused_click_away_monitor(_monitor: Option<platform::ClickAwayMonitor>) {}
 
-/// Cancel the open ring only if it is still the session the click named.
-pub(crate) fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
+/// Close every window showing ring `session_id`, reporting whether any was.
+///
+/// A ring is one window per display on Wayland (see [`crate::ring`]), so
+/// closing "the" ring means closing all of them: the windows the cursor was
+/// not on are transparent, but they still cover their display and would go on
+/// swallowing input after the ring the user interacted with had gone. The
+/// session id is what keeps a late teardown — a timeout, a queued click — from
+/// closing a ring that opened after it.
+pub(crate) fn close_ring_windows(cx: &mut gpui::App, session_id: u64) -> bool {
+    let mut closed = false;
     for handle in cx.windows() {
         let Some(ring) = handle.downcast::<RingView>() else {
             continue;
         };
-        let _ = ring.update(cx, |view, window, _| {
-            if !click_away_targets(session_id, view.session_id()) {
-                return;
+        let removed = ring.update(cx, |view, window, _| {
+            if view.session_id() != session_id {
+                return false;
             }
-            view.cancel();
             window.remove_window();
+            true
         });
+        closed |= removed.unwrap_or(false);
+    }
+    closed
+}
+
+/// Cancel the open ring only if it is still the session the click named.
+pub(crate) fn dismiss_click_away(cx: &mut gpui::App, session_id: u64) {
+    let target = cx.windows().into_iter().find_map(|handle| {
+        let ring = handle.downcast::<RingView>()?;
+        ring.update(cx, |view, _, _| {
+            click_away_targets(session_id, view.session_id()).then(|| view.cancel())
+        })
+        .ok()
+        .flatten()
+    });
+    if target.is_some() {
+        close_ring_windows(cx, session_id);
     }
 }
 


### PR DESCRIPTION
## Summary

On Wayland the Actions Ring opened in the centre of the screen instead of under
the pointer. Both halves of the existing placement are unavailable to an
ordinary Wayland client:

- **The cursor cannot be read.** No protocol reports the global pointer position,
  so `openlogi_hook::cursor_position()` — X11 only — has no Wayland answer. Under
  XWayland it is worse than nothing: it returns a stale position pinned to a
  screen corner, which looks like a real reading.
- **The window cannot place itself.** An `xdg_toplevel` has no say in its own
  origin, so the computed bounds were discarded even when they were correct.

`WindowKind::LayerShell` would solve both, but it needs `zwlr_layer_shell_v1`,
which Mutter does not implement — so it cannot be the fix for GNOME.

Instead the ring gets a second placement. On Wayland the window covers a display
and the panel is drawn at the pointer *inside* it, using the position the
compositor delivers with pointer-enter — the one report of the cursor a Wayland
client does get. One window per display, since nothing here can know which
display holds the cursor: `wl_pointer.enter` reaches exactly the surface under
the pointer, so the compositor settles it.

macOS, Windows and X11 keep the positioned window unchanged. The path is chosen
with `gpui::guess_compositor()`, GPUI's own backend selection, so the two cannot
drift apart.

Two details worth flagging for review:

- **Maximized, not fullscreen.** Both cover the display, but a compositor
  presents a fullscreen surface against black rather than against the desktop,
  so a transparent one renders as a black screen. Observed on Mutter; maximizing
  gets the same area without entering that presentation mode.
- **The clamp measures against the window's viewport, not the display's bounds.**
  GPUI reports display bounds in logical pixels and the pointer in device pixels,
  which disagree under fractional scaling — a 1.5x display reports 1128x752 while
  its window reports 1692x1128. Clamping against display bounds would be wrong on
  every fractionally-scaled setup.

## Changes

**`crates/openlogi-overlay`**

- `ring.rs`: new `Placement` enum — `Window` (today's behaviour) and
  `AtPointer { center }` (Wayland). The panel is extracted into
  `RingView::panel()` so both placements render the identical element.
  `ring_windows()` returns the window set for one invocation;
  `covering_window_options()` builds the display-covering window; `panel_origin()`
  is the pure placement rule.
- `session.rs`: `close_ring_windows()`. A ring is now several windows, so
  activating a slot must close all of them — the other displays' windows are
  transparent but still cover their display and would go on swallowing input.
  Keyed on the session id so a late teardown cannot close a ring that opened
  after it.
- `main.rs`: opens the window set, treating the ring as showing if any window
  opened.

Side effect: outside clicks now dismiss the ring on Wayland. The click-away
monitor is macOS-only, so that never worked elsewhere; the covering window means
the click reaches our own root handler.

## Testing

```
cargo xtask ci
# 10 passed, 0 failed, 2 skipped
# PASS rustfmt, typos, publish closure, shell, clippy, MSRV (cargo check, linux)
#      rustc 1.98, rustdoc (non-GUI crates), tests (linux), cargo-deny,
#      clippy (windows) proxy
# SKIP tests (macos) — this host is linux
# SKIP wasm (portable crates) — missing wasm32-unknown-unknown std
```

```
cargo clippy -p openlogi-overlay --all-targets -- -D warnings
cargo test -p openlogi-overlay      # 20 passed
```

Four new tests cover `panel_origin`: window-sized, pointer-not-yet-known,
centred on the pointer, and clamped against an edge.

**Runtime-tested on hardware** — GNOME 49 / Wayland, 1.5x fractional scaling,
MX Master 3S over Bluetooth, `ShowActionsRing` bound to the gesture button.
The ring opens centred on the cursor, clamps to stay whole when raised against a
screen edge, and dismisses on an outside click.

**Not tested:** macOS and Windows (unchanged code path), X11 (unchanged code
path), and KDE/wlroots. Those compositors do implement `zwlr_layer_shell_v1`,
which GPUI already exposes as `WindowKind::LayerShell` and which would be a
cleaner fit than a maximized window — worth a follow-up rather than widening
this change.

Fixes #774