### PR TITLE
fix(linux): install udev rules to /usr/lib and declare package runtime dependencies

### DIFF
--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -96,7 +96,7 @@ Install the bundled udev rules to grant access to the active-seat user without
 requiring `sudo` or group membership (requires `systemd-logind`):
 
 ```sh
-sudo cp packaging/linux/udev/70-openlogi.rules /etc/udev/rules.d/
+sudo cp packaging/linux/udev/70-openlogi.rules /usr/lib/udev/rules.d/
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -96,7 +96,7 @@ Install the bundled udev rules to grant access to the active-seat user without
 requiring `sudo` or group membership (requires `systemd-logind`):
 
 ```sh
-sudo cp packaging/linux/udev/70-openlogi.rules /usr/lib/udev/rules.d/
+sudo install -Dm644 packaging/linux/udev/70-openlogi.rules /usr/lib/udev/rules.d/70-openlogi.rules
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -101,6 +101,17 @@ sudo udevadm control --reload-rules
 sudo udevadm trigger
 ```
 
+Versions before 0.9 installed the rules to `/etc/udev/rules.d`, and a
+same-named file there overrides the vendor copy you just installed, keeping
+newer rules from taking effect. Unless you customized that file as a
+deliberate policy, remove it and reload again:
+
+```sh
+sudo rm -f /etc/udev/rules.d/70-openlogi.rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
 Verify access (should open without error):
 
 ```sh

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -86,22 +86,34 @@ sudo install -Dm755 "${BUILD_DIR}/openlogi-agent" "${BINDIR}/openlogi-agent"
 echo "Installing udev rules …"
 sudo install -Dm644 "${SCRIPT_DIR}/udev/70-openlogi.rules" \
   /usr/lib/udev/rules.d/70-openlogi.rules
-# A same-named file in the admin directory shadows the vendor file. Remove it
-# only when its effective rules (comments and blank lines aside, so a pre-0.9
-# copy still matches after header-only edits here) equal the packaged ones —
-# anything else may be a deliberate admin override, which /etc/udev/rules.d
-# exists for: leave it and say so.
+# A same-named file in the admin directory shadows the vendor file. Pre-0.9
+# releases installed there, so remove a copy whose effective rules (comments
+# and blank lines aside, so header-only edits don't matter) match a body ever
+# shipped — an unmodified leftover. Anything else may be a deliberate admin
+# override, which /etc/udev/rules.d exists for: leave it and say so.
 effective_rules() {
   sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$1"
 }
+# The only two bodies ever installed to /etc: the original, and the one after
+# the input event-node rules were added (#530). 0.9+ never writes /etc, so
+# this set is frozen — it needs no update when the packaged rules change.
+SHIPPED_RULES_V1='SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", TAG+="uaccess"
+SUBSYSTEM=="hidraw", KERNELS=="*:046D:*", TAG+="uaccess"
+KERNEL=="uinput", TAG+="uaccess", OPTIONS+="static_node=uinput"'
+SHIPPED_RULES_V2="${SHIPPED_RULES_V1}"'
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", ATTRS{idVendor}=="046d", TAG+="uaccess"
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", KERNELS=="*:046D:*", TAG+="uaccess"'
 ETC_RULES=/etc/udev/rules.d/70-openlogi.rules
 if [ -f "$ETC_RULES" ]; then
-  if [ "$(effective_rules "$ETC_RULES")" = \
-    "$(effective_rules "${SCRIPT_DIR}/udev/70-openlogi.rules")" ]; then
+  # A read failure (say, a root-owned 0600 override) must fall through to the
+  # warning, not trip set -e and abort the install half-done.
+  ETC_EFFECTIVE="$(effective_rules "$ETC_RULES")" || ETC_EFFECTIVE=
+  if [ "$ETC_EFFECTIVE" = "$SHIPPED_RULES_V1" ] ||
+    [ "$ETC_EFFECTIVE" = "$SHIPPED_RULES_V2" ]; then
     sudo rm -f "$ETC_RULES"
   else
-    echo "Warning: $ETC_RULES differs from the packaged rules and overrides the" >&2
-    echo "vendor file just installed. If it is only a leftover from an old install:" >&2
+    echo "Warning: $ETC_RULES does not match any rules OpenLogi ever shipped and" >&2
+    echo "overrides the vendor file just installed. If it is not a deliberate override:" >&2
     echo "  sudo rm $ETC_RULES && sudo udevadm control --reload-rules" >&2
   fi
 fi

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -48,7 +48,7 @@ The script installs:
   PREFIX/bin/openlogi-desktop
   PREFIX/bin/openlogi-overlay
   PREFIX/bin/openlogi-agent
-  /etc/udev/rules.d/70-openlogi.rules
+  /usr/lib/udev/rules.d/70-openlogi.rules
   /usr/lib/systemd/user/openlogi-agent.service  (if systemd is present)
   /usr/share/applications/openlogi.desktop
   /usr/share/icons/hicolor/<size>/apps/openlogi.png  (16 … 1024)
@@ -85,7 +85,9 @@ sudo install -Dm755 "${BUILD_DIR}/openlogi-agent" "${BINDIR}/openlogi-agent"
 
 echo "Installing udev rules …"
 sudo install -Dm644 "${SCRIPT_DIR}/udev/70-openlogi.rules" \
-  /etc/udev/rules.d/70-openlogi.rules
+  /usr/lib/udev/rules.d/70-openlogi.rules
+# A leftover copy in the admin directory would shadow the vendor file.
+sudo rm -f /etc/udev/rules.d/70-openlogi.rules
 
 if command -v udevadm >/dev/null 2>&1; then
   echo "Reloading udev rules …"

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -86,8 +86,25 @@ sudo install -Dm755 "${BUILD_DIR}/openlogi-agent" "${BINDIR}/openlogi-agent"
 echo "Installing udev rules …"
 sudo install -Dm644 "${SCRIPT_DIR}/udev/70-openlogi.rules" \
   /usr/lib/udev/rules.d/70-openlogi.rules
-# A leftover copy in the admin directory would shadow the vendor file.
-sudo rm -f /etc/udev/rules.d/70-openlogi.rules
+# A same-named file in the admin directory shadows the vendor file. Remove it
+# only when its effective rules (comments and blank lines aside, so a pre-0.9
+# copy still matches after header-only edits here) equal the packaged ones —
+# anything else may be a deliberate admin override, which /etc/udev/rules.d
+# exists for: leave it and say so.
+effective_rules() {
+  sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$1"
+}
+ETC_RULES=/etc/udev/rules.d/70-openlogi.rules
+if [ -f "$ETC_RULES" ]; then
+  if [ "$(effective_rules "$ETC_RULES")" = \
+    "$(effective_rules "${SCRIPT_DIR}/udev/70-openlogi.rules")" ]; then
+    sudo rm -f "$ETC_RULES"
+  else
+    echo "Warning: $ETC_RULES differs from the packaged rules and overrides the" >&2
+    echo "vendor file just installed. If it is only a leftover from an old install:" >&2
+    echo "  sudo rm $ETC_RULES && sudo udevadm control --reload-rules" >&2
+  fi
+fi
 
 if command -v udevadm >/dev/null 2>&1; then
   echo "Reloading udev rules …"

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -113,6 +113,12 @@ contents:
 archlinux:
   packager: "AprilNEA <dev@aprilnea.me>"
 
+# The lists below come from a readelf/dlopen audit of the release binaries:
+# linked are libc/libm/libgcc_s plus libxcb and libxkbcommon{,-x11} (GUIs);
+# dlopened are libvulkan, libEGL, libwayland-client, and libwayland-egl.
+# libdbus is never loaded (zbus speaks the wire protocol over the socket —
+# `dbus` is the daemon dependency), and fonts.conf is read by a pure-Rust
+# parser, so the dependency is on whichever package owns that file.
 overrides:
   archlinux:
     depends:
@@ -120,12 +126,41 @@ overrides:
       - fontconfig
       - gcc-libs
       - glibc
+      - hicolor-icon-theme
       - libglvnd
       - libxcb
       - libxkbcommon
       - libxkbcommon-x11
       - vulkan-icd-loader
       - wayland
+  deb:
+    depends:
+      - dbus
+      - fontconfig-config
+      - hicolor-icon-theme
+      - libc6
+      - libegl1
+      - libgcc-s1
+      - libvulkan1
+      - libwayland-client0
+      - libwayland-egl1
+      - libxcb1
+      - libxkbcommon-x11-0
+      - libxkbcommon0
+  rpm:
+    depends:
+      - dbus
+      - fontconfig
+      - glibc
+      - hicolor-icon-theme
+      - libgcc
+      - libglvnd-egl
+      - libwayland-client
+      - libwayland-egl
+      - libxcb
+      - libxkbcommon
+      - libxkbcommon-x11
+      - vulkan-loader
 
 scripts:
   postinstall: packaging/linux/nfpm-scripts/postinstall.sh

--- a/packaging/linux/nfpm.yaml
+++ b/packaging/linux/nfpm.yaml
@@ -42,8 +42,11 @@ contents:
       mode: 0755
 
   # ── udev rules ──────────────────────────────────────────────────────────────
+  # Vendor directory, not /etc: /etc/udev/rules.d is reserved for the admin, and
+  # on Arch only usr/lib/udev/rules.d/* triggers the systemd hook that reloads
+  # and re-applies rules after a transaction.
   - src: packaging/linux/udev/70-openlogi.rules
-    dst: /etc/udev/rules.d/70-openlogi.rules
+    dst: /usr/lib/udev/rules.d/70-openlogi.rules
     file_info:
       mode: 0644
 

--- a/packaging/linux/udev/70-openlogi.rules
+++ b/packaging/linux/udev/70-openlogi.rules
@@ -5,7 +5,9 @@
 # on systems running systemd-logind (uaccess tag).
 #
 # Install (packages place this in /usr/lib/udev/rules.d, the vendor directory;
-# a same-named file in /etc/udev/rules.d overrides it):
+# a same-named file in /etc/udev/rules.d overrides it — pre-0.9 installs put
+# this file there, so remove an uncustomized leftover copy or it keeps
+# overriding this one):
 #   sudo install -Dm644 70-openlogi.rules /usr/lib/udev/rules.d/70-openlogi.rules
 #   sudo udevadm control --reload-rules
 #   sudo udevadm trigger

--- a/packaging/linux/udev/70-openlogi.rules
+++ b/packaging/linux/udev/70-openlogi.rules
@@ -4,8 +4,9 @@
 # input event nodes, and the uinput kernel module — no group membership required
 # on systems running systemd-logind (uaccess tag).
 #
-# Install:
-#   sudo cp 70-openlogi.rules /etc/udev/rules.d/
+# Install (packages place this in /usr/lib/udev/rules.d, the vendor directory;
+# a same-named file in /etc/udev/rules.d overrides it):
+#   sudo cp 70-openlogi.rules /usr/lib/udev/rules.d/
 #   sudo udevadm control --reload-rules
 #   sudo udevadm trigger
 #

--- a/packaging/linux/udev/70-openlogi.rules
+++ b/packaging/linux/udev/70-openlogi.rules
@@ -6,7 +6,7 @@
 #
 # Install (packages place this in /usr/lib/udev/rules.d, the vendor directory;
 # a same-named file in /etc/udev/rules.d overrides it):
-#   sudo cp 70-openlogi.rules /usr/lib/udev/rules.d/
+#   sudo install -Dm644 70-openlogi.rules /usr/lib/udev/rules.d/70-openlogi.rules
 #   sudo udevadm control --reload-rules
 #   sudo udevadm trigger
 #

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -8,6 +8,7 @@
 
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREFIX=/usr/local
 
 for arg in "$@"; do
@@ -51,8 +52,26 @@ sudo rm -f "${BINDIR}/openlogi" "${BINDIR}/openlogi-desktop" \
 # ── udev rules ────────────────────────────────────────────────────────────────
 
 echo "Removing udev rules …"
-# The /etc path is the pre-0.9 install location.
-sudo rm -f /usr/lib/udev/rules.d/70-openlogi.rules /etc/udev/rules.d/70-openlogi.rules
+sudo rm -f /usr/lib/udev/rules.d/70-openlogi.rules
+# The /etc path is the pre-0.9 install location — but it is also the admin
+# override directory, so only remove a copy whose effective rules (comments
+# and blank lines aside, so a pre-0.9 copy still matches after header-only
+# edits) equal the packaged ones; a modified file may be a deliberate policy
+# and stays.
+effective_rules() {
+  sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$1"
+}
+ETC_RULES=/etc/udev/rules.d/70-openlogi.rules
+if [ -f "$ETC_RULES" ]; then
+  if [ "$(effective_rules "$ETC_RULES")" = \
+    "$(effective_rules "${SCRIPT_DIR}/udev/70-openlogi.rules")" ]; then
+    sudo rm -f "$ETC_RULES"
+  else
+    echo "Warning: $ETC_RULES differs from the packaged rules and was left in" >&2
+    echo "place. If it is not a deliberate override, remove it with:" >&2
+    echo "  sudo rm $ETC_RULES && sudo udevadm control --reload-rules" >&2
+  fi
+fi
 if command -v udevadm >/dev/null 2>&1; then
   sudo udevadm control --reload-rules
   sudo udevadm trigger --subsystem-match=hidraw

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -8,7 +8,6 @@
 
 set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PREFIX=/usr/local
 
 for arg in "$@"; do
@@ -55,20 +54,31 @@ echo "Removing udev rules …"
 sudo rm -f /usr/lib/udev/rules.d/70-openlogi.rules
 # The /etc path is the pre-0.9 install location — but it is also the admin
 # override directory, so only remove a copy whose effective rules (comments
-# and blank lines aside, so a pre-0.9 copy still matches after header-only
-# edits) equal the packaged ones; a modified file may be a deliberate policy
-# and stays.
+# and blank lines aside, so header-only edits don't matter) match a body ever
+# shipped there; a modified file may be a deliberate policy and stays.
 effective_rules() {
   sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$1"
 }
+# The only two bodies ever installed to /etc: the original, and the one after
+# the input event-node rules were added (#530). 0.9+ never writes /etc, so
+# this set is frozen — it needs no update when the packaged rules change.
+SHIPPED_RULES_V1='SUBSYSTEM=="hidraw", ATTRS{idVendor}=="046d", TAG+="uaccess"
+SUBSYSTEM=="hidraw", KERNELS=="*:046D:*", TAG+="uaccess"
+KERNEL=="uinput", TAG+="uaccess", OPTIONS+="static_node=uinput"'
+SHIPPED_RULES_V2="${SHIPPED_RULES_V1}"'
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", ATTRS{idVendor}=="046d", TAG+="uaccess"
+SUBSYSTEM=="input", KERNEL=="event*", ENV{ID_INPUT_MOUSE}=="1", KERNELS=="*:046D:*", TAG+="uaccess"'
 ETC_RULES=/etc/udev/rules.d/70-openlogi.rules
 if [ -f "$ETC_RULES" ]; then
-  if [ "$(effective_rules "$ETC_RULES")" = \
-    "$(effective_rules "${SCRIPT_DIR}/udev/70-openlogi.rules")" ]; then
+  # A read failure (say, a root-owned 0600 override) must fall through to the
+  # warning, not trip set -e and abort the uninstall half-done.
+  ETC_EFFECTIVE="$(effective_rules "$ETC_RULES")" || ETC_EFFECTIVE=
+  if [ "$ETC_EFFECTIVE" = "$SHIPPED_RULES_V1" ] ||
+    [ "$ETC_EFFECTIVE" = "$SHIPPED_RULES_V2" ]; then
     sudo rm -f "$ETC_RULES"
   else
-    echo "Warning: $ETC_RULES differs from the packaged rules and was left in" >&2
-    echo "place. If it is not a deliberate override, remove it with:" >&2
+    echo "Warning: $ETC_RULES does not match any rules OpenLogi ever shipped and" >&2
+    echo "was left in place. If it is not a deliberate override, remove it with:" >&2
     echo "  sudo rm $ETC_RULES && sudo udevadm control --reload-rules" >&2
   fi
 fi

--- a/packaging/linux/uninstall.sh
+++ b/packaging/linux/uninstall.sh
@@ -51,7 +51,8 @@ sudo rm -f "${BINDIR}/openlogi" "${BINDIR}/openlogi-desktop" \
 # ── udev rules ────────────────────────────────────────────────────────────────
 
 echo "Removing udev rules …"
-sudo rm -f /etc/udev/rules.d/70-openlogi.rules
+# The /etc path is the pre-0.9 install location.
+sudo rm -f /usr/lib/udev/rules.d/70-openlogi.rules /etc/udev/rules.d/70-openlogi.rules
 if command -v udevadm >/dev/null 2>&1; then
   sudo udevadm control --reload-rules
   sudo udevadm trigger --subsystem-match=hidraw

--- a/xtask/src/commands/release/latest_json.rs
+++ b/xtask/src/commands/release/latest_json.rs
@@ -67,8 +67,9 @@ struct Asset {
 }
 
 /// The per-OS constants of an updater-relevant artifact, derived from its file
-/// name. The Linux packages (`.deb`/`.rpm`) are deliberately absent: those
-/// installs update through the distro package manager, not the in-app updater.
+/// name. The Linux packages (`.deb`/`.rpm`/`.pkg.tar.zst`) are deliberately
+/// absent: those installs update through the distro package manager, not the
+/// in-app updater.
 struct Classified {
     os: &'static str,
     arch: String,

--- a/xtask/src/commands/release/latest_json/tests.rs
+++ b/xtask/src/commands/release/latest_json/tests.rs
@@ -97,6 +97,7 @@ fn collect_assets_skips_linux_packages_and_foreign_archives() {
     for name in [
         "openlogi-v1.2.3-linux-amd64.deb",
         "openlogi-v1.2.3-linux-amd64.rpm",
+        "openlogi-v1.2.3-linux-amd64.pkg.tar.zst",
         "not-an-artifact.zip",
         "SHA256SUMS",
     ] {


### PR DESCRIPTION
## Summary

Three Linux packaging hygiene fixes. The udev rule installed to `/etc/udev/rules.d`, the admin directory — the vendor convention is `/usr/lib/udev/rules.d`, it matches what `package.nix` already does (and asserts), and on Arch it is what makes pacman's systemd hook (`udevadm control --reload` + `trigger -c change` + `settle`, fired only for `usr/lib/udev/rules.d/*`) re-apply device access on install/upgrade with no replug. The deb and rpm packages also declared no runtime dependencies at all, so a fresh install on a minimal system hit dlopen failures at first launch.

## Changes

- **packaging/linux**: udev rule destination moves to `/usr/lib/udev/rules.d/70-openlogi.rules` (`nfpm.yaml`, `install.sh`, `uninstall.sh`, the rules-file header, and the manual-install command in `docs/INSTALL-linux.md`). A pre-existing `/etc` copy would silently shadow the vendor file: `install.sh` and `uninstall.sh` remove it only when its effective rules (comments/blank lines aside) match the packaged ones — an unmodified pre-0.9 leftover — and otherwise leave it in place with a warning, since a modified file may be a deliberate admin override. The manual-install command uses `install -Dm644` so the vendor directory is created when absent.
- **packaging/linux**: new `deb.depends` and `rpm.depends`, and `hicolor-icon-theme` added to `archlinux.depends`. The lists mirror what the released binaries actually load (readelf `NEEDED` + dlopen-string audit of the v0.8.0 assets): `libwayland-egl` was missing from every obvious guess, while libdbus (zbus speaks the wire protocol — `dbus` covers the daemon), libfontconfig (a pure-Rust parser reads `fonts.conf`, so deb depends on `fontconfig-config`, which owns that file), and libGL/GLX (wgpu resolves GL through EGL only) are never loaded and are deliberately absent. nfpm cannot emit pacman optdepends (checked through 2.47.0), so that stays AUR-territory.
- **xtask**: the latest-json exclusion test and doc comment now cover `.pkg.tar.zst` alongside `.deb`/`.rpm` (behavior unchanged — `classify()` already excluded it).

## Testing

- `nfpm package` (2.46.3, CI's pinned version) for all three packagers against this branch: `bsdtar -tf` shows the rule at `usr/lib/udev/rules.d/` and no `etc/` entry in every format; `.INSTALL` still carries the udevadm script; `pacman -Qip` and the deb `control` show the new depends.
- `shellcheck` + `shfmt -d` on `install.sh`/`uninstall.sh`; `typos` 1.49.0 with `.config/typos.toml`; `udevadm verify` unaffected (rules content unchanged).
- Review-fix commit: reran the full CI `shell` job (shellcheck 0.10.0 + `shfmt -d` over every tracked shell file) and `typos` (1.29.4), both green; the effective-rules comparison was exercised against temp files — the v0.8.0 shipped rules (header-only drift) match and would be removed, a rule-line edit does not match and is kept with the warning. The sudo-owning install/uninstall paths are not runtime-tested as root.
- Second review-fix commit (89e3c38): reran the CI `shell` and `typos` jobs via `cargo xtask ci shell typos` (green). The leftover decision was exercised against temp files for all four branches: an unmodified original body (from the `eae97fa` shipped file), an unmodified post-#530 body with a header edit, an admin-modified body (kept, warning), and an unreadable 0600 file (kept, and `set -e` does not abort). Also asserted that the embedded `SHIPPED_RULES_V2` equals the current packaged body, so the frozen set stays honest.
- Rust gate (affected-package tier, run after installing rustup stable 1.98 = MSRV): `cargo fmt --all -- --check`, `cargo clippy -p xtask --all-targets -- -D warnings` with `RUSTFLAGS=-D warnings`, and `cargo test -p xtask` (59 passed; the affected set is `xtask` alone — `cargo tree --invert xtask` shows no workspace reverse-dependencies). One test (`existing_release_tag_skips_publishing`) fails only under a global `tag.gpgsign=true` git config, since its bare `git tag` then demands a message — host-config interaction, passes with isolated config; the test could set `GIT_CONFIG_GLOBAL` to be hermetic.
- Not run on this host (no nix): Nix CI (`nix fmt --check` / `nix flake check`) — the Nix CI workflow triggers on this PR via its `packaging/linux/**` path filter — and `cargo xtask linux package` (direct `nfpm` 2.46.3 invocation used instead, as above). Not runtime-tested on hardware.
- To verify on hardware (Arch): install the package, replug nothing, and check `getfacl /dev/hidraw*` shows the seat user's ACL; `pacman -Ql openlogi | grep udev` shows only the `usr/lib` path.
