### PR TITLE
feat(release): add openlogi-bin AUR packaging with a dormant publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,10 @@ jobs:
     if: ${{ github.ref_type == 'tag' && !cancelled() && needs.build.outputs.macos_result == 'success' && needs.release-notes.result == 'success' }}
     permissions:
       contents: write
+    outputs:
+      pacman: ${{ steps.artifacts.outputs.pacman }}
+      pkg_sha256_amd64: ${{ steps.pkg_hashes.outputs.amd64 }}
+      pkg_sha256_arm64: ${{ steps.pkg_hashes.outputs.arm64 }}
     steps:
       # Needed to build & run the xtask manifest generator below.
       - uses: actions/checkout@v7
@@ -186,6 +190,18 @@ jobs:
           # agent exes (#347); no bare .exe ships anymore.
           shopt -s nullglob
           sha256sum -- *.dmg *.zip *.msi *.deb *.rpm *.pkg.tar.zst > SHA256SUMS
+
+      # Deliberately silent when a Linux leg is missing — the Linux packages
+      # are best-effort, so publish must not fail for AUR reasons. An empty
+      # output fails loudly in aur-publish's render asserts instead.
+      - name: Extract pacman package hashes for AUR
+        id: pkg_hashes
+        run: |
+          for arch in amd64 arm64; do
+            awk -v name="openlogi-${GITHUB_REF_NAME}-linux-${arch}.pkg.tar.zst" \
+              -v arch="$arch" '$2 == name { print arch "=" $1 }' \
+              dist/SHA256SUMS >> "$GITHUB_OUTPUT"
+          done
 
       # softprops' `files` can't list a glob that matches nothing without
       # tripping fail_on_unmatched_files. The Windows zip/msi (per arch leg)
@@ -369,3 +385,92 @@ jobs:
           event-type: update-openlogi
           client-payload: |
             {"version": "${{ github.ref_name }}"}
+
+  aur-publish:
+    name: Publish AUR openlogi-bin
+    runs-on: ubuntu-latest
+    needs: publish
+    # Dormant until the AUR co-maintainer cutover (#255 / #265): the current
+    # openlogi-bin maintainer's own CI updates the package today, and two
+    # writers to one AUR repo race each other. The job shows as skipped on
+    # every release until the repo variable AUR_PUBLISH_ENABLED is 'true'.
+    # The hyphen guard skips pre-release tags (not valid pacman pkgvers); no
+    # status function appears here, so the implicit success() gate on
+    # `needs: publish` still applies.
+    if: ${{ github.repository == 'AprilNEA/OpenLogi' && vars.AUR_PUBLISH_ENABLED == 'true' && needs.publish.outputs.pacman == 'true' && !contains(github.ref_name, '-') }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      # Rendered inside the workspace: the deploy action runs in a docker
+      # container that only has the workspace mounted, not runner.temp.
+      - name: Render PKGBUILD from the release checksums
+        env:
+          SHA_AMD64: ${{ needs.publish.outputs.pkg_sha256_amd64 }}
+          SHA_ARM64: ${{ needs.publish.outputs.pkg_sha256_arm64 }}
+        run: |
+          # The tag lands in a file makepkg sources as shell, and hyphenless
+          # tag names may legally contain ; $ ` ' & / — allow exactly semver.
+          [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "::error::tag '$GITHUB_REF_NAME' is not vMAJOR.MINOR.PATCH"
+            exit 1
+          }
+          # Never publish a PKGBUILD referencing a missing arch asset.
+          [[ "$SHA_AMD64" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "::error::amd64 .pkg.tar.zst hash missing from SHA256SUMS"
+            exit 1
+          }
+          [[ "$SHA_ARM64" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "::error::arm64 .pkg.tar.zst hash missing from SHA256SUMS"
+            exit 1
+          }
+          mkdir -p .release
+          sed -e "s/@PKGVER@/${GITHUB_REF_NAME#v}/g" \
+            -e "s/@SHA256_X86_64@/${SHA_AMD64}/g" \
+            -e "s/@SHA256_AARCH64@/${SHA_ARM64}/g" \
+            packaging/arch/openlogi-bin/PKGBUILD > .release/PKGBUILD
+          if grep -qE '@[A-Z0-9_]+@' .release/PKGBUILD; then
+            echo "::error::unrendered placeholder left in PKGBUILD"
+            exit 1
+          fi
+
+      - name: Load AUR SSH key from 1Password
+        id: aur_config
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AUR_SSH_PRIVATE_KEY_B64: ${{ secrets.OP_AUR_SECRET_ITEM }}/AUR_SSH_PRIVATE_KEY
+
+      # Stored base64-encoded (an unencrypted ed25519 key) so the multi-line
+      # body survives 1Password field handling, like the minisign key.
+      - name: Decode AUR SSH key
+        id: ssh_key
+        env:
+          KEY_B64: ${{ steps.aur_config.outputs.AUR_SSH_PRIVATE_KEY_B64 }}
+        run: |
+          : "${KEY_B64:?AUR_PUBLISH_ENABLED is set but the AUR key is missing}"
+          key="$(printf '%s' "$KEY_B64" | tr -d '[:space:]' | base64 -d)"
+          while IFS= read -r line; do echo "::add-mask::$line"; done <<< "$key"
+          {
+            echo "key<<OPENLOGI_AUR_KEY_EOF"
+            printf '%s\n' "$key"
+            echo "OPENLOGI_AUR_KEY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
+        with:
+          pkgname: openlogi-bin
+          pkgbuild: .release/PKGBUILD
+          assets: packaging/arch/openlogi-bin/openlogi-bin.install
+          commit_username: AprilNEA
+          commit_email: dev@aprilnea.me
+          commit_message: "upgpkg: openlogi-bin ${{ github.ref_name }}"
+          ssh_private_key: ${{ steps.ssh_key.outputs.key }}
+          # updpkgsums would recompute — and silently replace — the
+          # upstream-attested hashes; a mismatch must fail instead.
+          updpkgsums: false
+          test: false

--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ sudo dpkg -i openlogi_*.deb
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
 
-# Arch Linux
+# Arch Linux — from the AUR (updates with your system):
+paru -S openlogi-bin   # or: yay -S openlogi-bin
+# …or install the release package directly:
 sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Things OpenLogi does that Options+ won't:
 
 - Devices connected over Logi Bolt receivers, Unifying receivers, Bluetooth, or a wired connection, with battery percentage and charge state
 - Button remapping via the OS input hook: a built-in action catalog plus custom keyboard shortcuts authored in the TOML config, including independent short/long-press actions and hold-until-release chords for push-to-talk¹
-- Per-application profile overlays that auto-switch on app focus (macOS + Windows; Linux on X11 / XWayland only)
+- Per-application profile overlays that auto-switch on app focus (macOS + Windows; Linux on GNOME via the bundled Shell extension, on wlroots compositors, or on X11 / XWayland)
 - Litra lights: power, brightness, and color temperature, with optional auto power that follows camera activity
 
 **Mouse**

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -260,6 +260,14 @@ The Nix package uses the same shared resources and is declared in
 `packaging/linux/package.nix`; see the Nix package section above for its build
 commands.
 
+The AUR package `openlogi-bin` repackages the released `.pkg.tar.zst`; its
+template lives in `packaging/arch/openlogi-bin/` and is rendered and pushed by
+`release.yml`'s `aur-publish` job on each stable tag. The job stays skipped
+until the repository variable `AUR_PUBLISH_ENABLED` is `true` and the
+`OP_AUR_SECRET_ITEM` secret references a 1Password item whose
+`AUR_SSH_PRIVATE_KEY` field holds the base64-encoded (unencrypted) AUR SSH key
+— see the template's README for the coordination constraints.
+
 ## Release updater publishing
 
 Tagged releases still attach DMGs and `SHA256SUMS` to GitHub Releases for manual

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -183,5 +183,5 @@ openlogi-desktop
 
 | Limitation | Status |
 |---|---|
-| Wayland: per-application profile switching | Requires XWayland (`WM_CLASS` lookup uses X11) |
+| Wayland: per-application profile switching | Native on GNOME (bundled extension, `gnome-extensions enable` required) and wlroots compositors; other compositors need XWayland |
 | Button capture: middle / mode-shift / thumbwheel | Side buttons only today |

--- a/docs/INSTALL-linux.md
+++ b/docs/INSTALL-linux.md
@@ -59,10 +59,12 @@ nix build github:AprilNEA/OpenLogi#openlogi
 
 ## Build from source
 
-Pre-built `.deb` and `.rpm` packages are available on the
-[releases page](https://github.com/AprilNEA/OpenLogi/releases/latest) — see
-the main [README](../README.md#linux) for the package-based install. To build
-from source instead, use the stable Rust toolchain:
+Pre-built `.deb`, `.rpm`, and pacman `.pkg.tar.zst` packages are available on
+the [releases page](https://github.com/AprilNEA/OpenLogi/releases/latest) — see
+the main [README](../README.md#linux) for the package-based install. Arch users
+can install [`openlogi-bin`](https://aur.archlinux.org/packages/openlogi-bin)
+from the AUR instead, which tracks releases automatically. To build from source,
+use the stable Rust toolchain:
 
 ```sh
 git clone https://github.com/AprilNEA/OpenLogi

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -48,7 +48,7 @@ Was OpenLogi kann und Options+ nicht:
 
 - Geräte über Logi-Bolt-Empfänger, Unifying-Empfänger, Bluetooth oder Kabel, mit Akkustand und Ladezustand
 - Tastenumbelegung über den OS-Input-Hook: Katalog eingebauter Aktionen plus eigene Tastenkürzel (in TOML angelegt)¹
-- Profil-Overlays pro Anwendung mit Auto-Wechsel bei App-Fokus (macOS + Windows; Linux nur X11 / XWayland)
+- Profil-Overlays pro Anwendung mit Auto-Wechsel bei App-Fokus (macOS + Windows; Linux unter GNOME über die mitgelieferte Shell-Erweiterung, mit wlroots-Compositoren oder über X11 / XWayland)
 - Litra-Leuchten: Ein/Aus, Helligkeit und Farbtemperatur, auf Wunsch automatisch an die Kameraaktivität gekoppelt
 
 **Maus**

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -111,7 +111,9 @@ sudo dpkg -i openlogi_*.deb
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
 
-# Arch Linux
+# Arch Linux — aus dem AUR (aktualisiert sich mit dem System):
+paru -S openlogi-bin   # or: yay -S openlogi-bin
+# …oder das Release-Paket direkt installieren:
 sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -48,7 +48,7 @@ Ce qu'OpenLogi fait et qu'Options+ ne fait pas :
 
 - Appareils connectés via récepteurs Logi Bolt, récepteurs Unifying, Bluetooth ou câble, avec pourcentage de batterie et état de charge
 - Remappage des boutons via le hook d'entrée de l'OS : catalogue d'actions intégrées plus raccourcis clavier personnalisés (rédigés en TOML)¹
-- Surcouches de profil par application avec bascule automatique au focus (macOS + Windows ; Linux uniquement en X11 / XWayland)
+- Surcouches de profil par application avec bascule automatique au focus (macOS + Windows ; Linux sous GNOME via l'extension Shell fournie, avec les compositeurs wlroots, ou en X11 / XWayland)
 - Lampes Litra : alimentation, luminosité et température de couleur, avec allumage automatique optionnel suivant l'activité de la caméra
 
 **Souris**

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -111,7 +111,9 @@ sudo dpkg -i openlogi_*.deb
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
 
-# Arch Linux
+# Arch Linux — depuis l'AUR (mis à jour avec le système) :
+paru -S openlogi-bin   # or: yay -S openlogi-bin
+# …ou installer directement le paquet de la release :
 sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -48,7 +48,7 @@ OpenLogi にできて Options+ にできないこと：
 
 - Logi Bolt / Unifying レシーバー、Bluetooth、有線で接続されたデバイスに対応し、バッテリー残量と充電状態を表示
 - OS 入力フックによるボタン再マッピング：組み込みアクションカタログ + カスタムキーボードショートカット（TOML で作成）¹
-- アプリごとのプロファイルオーバーレイ（フォーカスで自動切替；macOS + Windows、Linux は X11 / XWayland のみ）
+- アプリごとのプロファイルオーバーレイ（フォーカスで自動切替；macOS + Windows、Linux は GNOME（同梱の Shell 拡張機能）、wlroots 系コンポジタ、または X11 / XWayland）
 - Litra ライト：電源、明るさ、色温度。カメラの使用状況に連動した自動オン / オフも可能
 
 **マウス**

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -111,7 +111,9 @@ sudo dpkg -i openlogi_*.deb
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
 
-# Arch Linux
+# Arch Linux — AUR から（システムと一緒に更新されます）:
+paru -S openlogi-bin   # or: yay -S openlogi-bin
+# …またはリリースパッケージを直接インストール:
 sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -48,7 +48,7 @@ OpenLogi는 되고 Options+는 안 되는 것들:
 
 - Logi Bolt 수신기, Unifying 수신기, Bluetooth, 유선으로 연결된 기기를 지원하며 배터리 잔량과 충전 상태 표시
 - OS 입력 훅을 통한 버튼 리매핑: 내장 액션 카탈로그 + 사용자 지정 키보드 단축키(TOML 작성)¹
-- 앱 포커스 시 자동 전환되는 앱별 프로필 오버레이(macOS + Windows; Linux는 X11 / XWayland 전용)
+- 앱 포커스 시 자동 전환되는 앱별 프로필 오버레이(macOS + Windows; Linux는 GNOME(번들 Shell 확장), wlroots 컴포지터 또는 X11 / XWayland)
 - Litra 조명: 전원, 밝기, 색온도 제어와 카메라 사용에 연동한 자동 켜기 / 끄기
 
 **마우스**

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -111,7 +111,9 @@ sudo dpkg -i openlogi_*.deb
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
 
-# Arch Linux
+# Arch Linux — AUR에서 설치(시스템과 함께 업데이트됨):
+paru -S openlogi-bin   # or: yay -S openlogi-bin
+# …또는 릴리스 패키지를 직접 설치:
 sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -111,7 +111,9 @@ sudo dpkg -i openlogi_*.deb
 # Fedora / RHEL
 sudo rpm -i openlogi-*.rpm
 
-# Arch Linux
+# Arch Linux — 从 AUR 安装（随系统一同更新）：
+paru -S openlogi-bin   # or: yay -S openlogi-bin
+# …或直接安装发布包：
 sudo pacman -U openlogi-*.pkg.tar.zst
 ```
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -48,7 +48,7 @@ OpenLogi 能做、而 Options+ 做不到的事：
 
 - 支持通过 Logi Bolt、Unifying 无线接收器、蓝牙或者有线连接的设备，并显示电池电量与充电状态
 - 经由 OS 输入钩子的按键重映射：内置动作目录 + 自定义键盘快捷键（TOML 编写）¹
-- 按应用的配置叠加层，应用获得焦点时自动切换（macOS + Windows；Linux 仅 X11 / XWayland）
+- 按应用的配置叠加层，应用获得焦点时自动切换（macOS + Windows；Linux 支持 GNOME（随附 Shell 扩展）、wlroots 合成器或 X11 / XWayland）
 - Litra 补光灯：开关、亮度、色温，还可跟随摄像头活动自动开关
 
 **鼠标**

--- a/packaging/arch/openlogi-bin/PKGBUILD
+++ b/packaging/arch/openlogi-bin/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: AprilNEA <dev@aprilnea.me>
+# Contributor: Nilesh Kevlani <njkevlani@gmail.com>
+#
+# Template: release.yml's aur-publish job fills @PKGVER@ and the hash
+# placeholders from the release's SHA256SUMS. See README.md in this directory.
+pkgname=openlogi-bin
+pkgver=@PKGVER@
+pkgrel=1
+pkgdesc="Logitech HID++ device control — local-first alternative to Logi Options+"
+arch=('x86_64' 'aarch64')
+url="https://github.com/AprilNEA/OpenLogi"
+license=('Apache-2.0 OR MIT')
+depends=('dbus'
+         'fontconfig'
+         'gcc-libs'
+         'glibc'
+         'hicolor-icon-theme'
+         'libglvnd'
+         'libxcb'
+         'libxkbcommon'
+         'libxkbcommon-x11'
+         'vulkan-icd-loader'
+         'wayland')
+optdepends=('gnome-shell: per-app profile switching on GNOME Wayland (bundled extension)')
+provides=("openlogi=${pkgver}")
+conflicts=('openlogi')
+install=openlogi-bin.install
+# Prebuilt release binaries: keep makepkg from stripping or debug-splitting them.
+options=('!strip' '!debug')
+source_x86_64=("${url}/releases/download/v${pkgver}/openlogi-v${pkgver}-linux-amd64.pkg.tar.zst")
+source_aarch64=("${url}/releases/download/v${pkgver}/openlogi-v${pkgver}-linux-arm64.pkg.tar.zst")
+sha256sums_x86_64=('@SHA256_X86_64@')
+sha256sums_aarch64=('@SHA256_AARCH64@')
+
+package() {
+  cp -a "${srcdir}/usr" "${pkgdir}/usr"
+  # Releases up to v0.8.0 ship the udev rule under /etc; relocate it to the
+  # vendor directory so pacman's udev hook reloads and re-applies it.
+  if [[ -f "${srcdir}/etc/udev/rules.d/70-openlogi.rules" ]]; then
+    install -Dm644 "${srcdir}/etc/udev/rules.d/70-openlogi.rules" \
+      "${pkgdir}/usr/lib/udev/rules.d/70-openlogi.rules"
+  fi
+}

--- a/packaging/arch/openlogi-bin/README.md
+++ b/packaging/arch/openlogi-bin/README.md
@@ -1,0 +1,28 @@
+# openlogi-bin (AUR)
+
+Template for the [`openlogi-bin`](https://aur.archlinux.org/packages/openlogi-bin)
+AUR package. It repackages the released `.pkg.tar.zst` for both architectures —
+a source build is impractical in makepkg because GPUI is a rev-less git
+dependency on the zed monorepo, pinned only by `Cargo.lock`.
+
+`release.yml`'s `aur-publish` job renders and pushes it on every stable tag:
+`@PKGVER@` becomes the tag without the `v`, and the hash placeholders take the
+matching lines from the release's `SHA256SUMS` — so the AUR hashes are always
+the upstream-attested ones, never recomputed. To render by hand:
+
+```sh
+sed -e 's/@PKGVER@/0.8.0/g' \
+    -e 's/@SHA256_X86_64@/<amd64 pkg sha256>/g' \
+    -e 's/@SHA256_AARCH64@/<arm64 pkg sha256>/g' PKGBUILD
+```
+
+The job is dormant: it runs only when the repository variable
+`AUR_PUBLISH_ENABLED` is `true`, and it loads the SSH key from the 1Password
+item referenced by the `OP_AUR_SECRET_ITEM` secret (field
+`AUR_SSH_PRIVATE_KEY`, base64-encoded, unencrypted key). **Do not enable it
+before the co-maintainer cutover with the current `openlogi-bin` maintainer
+(njkevlani — see #255 / #265):** their pipeline updates the package today, and
+two writers to one AUR repo race each other.
+
+`provides=(openlogi=$pkgver)` / `conflicts=(openlogi)` keep the package
+interchangeable with a future repo or source `openlogi` package.

--- a/packaging/arch/openlogi-bin/openlogi-bin.install
+++ b/packaging/arch/openlogi-bin/openlogi-bin.install
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+# udev reload/trigger and icon/desktop cache refresh are covered by alpm hooks;
+# this script only prints the steps pacman cannot do for the user.
+post_install() {
+  echo "Enable the background agent for your user with:"
+  echo "  systemctl --user enable --now openlogi-agent.service"
+  echo "On GNOME Wayland, enable per-app profiles with:"
+  echo "  gnome-extensions enable openlogi-frontmost@openlogi.dev"
+}


### PR DESCRIPTION
## Summary

In-repo AUR packaging for `openlogi-bin` plus a release-time publish job that stays **dormant** until coordination with the current AUR maintainer completes. `openlogi-bin` already exists on the AUR, maintained by njkevlani with their own same-day update automation — #265 deliberately deferred upstream publishing pending exactly this coordination (#255). The job is gated on the repo variable `AUR_PUBLISH_ENABLED` and shows as skipped on every release until it is set, so landing this changes nothing on the AUR by itself; until cutover the template is simply the canonical reference the current maintainer is welcome to adopt.

What Arch users get once it is live: an aarch64 leg (the AUR package is x86_64-only today), the native `.pkg.tar.zst` payload instead of a repacked `.deb` with sha256sums taken verbatim from the release's `SHA256SUMS`, an install script with the agent/extension enable hints, a pkgver without the nonstandard leading `v` (vercmp-verified to upgrade cleanly over the live `v0.8.0-1`, no epoch), and versioned `provides=(openlogi=$pkgver)`.

## Changes

- **packaging/arch** (new): `openlogi-bin/PKGBUILD` template (`@PKGVER@` / per-arch hash placeholders; `options=('!strip' '!debug')` for the prebuilt binaries; `package()` relocates the udev rule from `etc/` in ≤ v0.8.0 payloads into `usr/lib/udev/rules.d/`), `openlogi-bin.install` (post-install hints only — alpm hooks own udev reload/trigger and cache refresh once the rule is in the vendor dir), and a README covering render mechanics and the coordination constraints.
- **ci (release.yml)**: the `publish` job gains an `outputs:` block (`pacman`, plus the two per-arch package hashes extracted from `dist/SHA256SUMS` — deliberately silent on a missing best-effort Linux leg; the loud failure belongs downstream). New `aur-publish` job: gated on `AUR_PUBLISH_ENABLED`, upstream repo, `pacman == 'true'`, and a hyphen-free tag; renders the PKGBUILD inside the workspace (the deploy action is a docker action without `runner.temp` mounted on older runners), hard-asserts `vMAJOR.MINOR.PATCH` (hyphenless tag names may legally contain shell metacharacters, and a PKGBUILD is sourced as shell) and both hashes as 64-hex before `sed`; loads the SSH key from 1Password per the existing conventions (base64 field, per-line masking); pushes via `KSXGitHub/github-actions-deploy-aur` (SHA-pinned v4.2.0, `updpkgsums: false` so upstream-attested hashes are never overwritten, no force-push so a racing writer fails loudly).
- **docs**: `INSTALL-linux.md` no longer claims only `.deb`/`.rpm` prebuilt packages exist and points Arch users at the AUR; README leads the Arch instructions with `paru -S openlogi-bin`; `DEVELOPMENT.md` documents the template and the two settings that arm the job; the five hand-maintained README translations mirror the AUR line; the stale "Wayland per-app switching requires XWayland" claims are corrected to name the GNOME extension and wlroots backends (the last commit is best merged after #998 so "bundled" refers to the packaged extension).

## One-time setup before enabling

1. Coordinate with njkevlani (per #255/#265): co-maintainership for the AprilNEA AUR account, an agreed cutover tag, and their pipeline disabled at that tag so two writers never race.
2. A dedicated unencrypted ed25519 key; public half on the AUR account; private half base64-encoded in a 1Password item field `AUR_SSH_PRIVATE_KEY`, referenced by a new `OP_AUR_SECRET_ITEM` repo secret.
3. Set the repo variable `AUR_PUBLISH_ENABLED=true` — the only switch that wakes the job. Once set, a missing key fails the job loudly rather than skipping.

## Testing

- The exact hash-extraction awk and render steps from the workflow were executed against the real v0.8.0 `SHA256SUMS`: both hashes extracted, render clean; the rendered PKGBUILD then built end-to-end with `makepkg -f` (real 35 MB asset download, exercising the `etc/` relocation path) — single package, no debug split, rule at `usr/lib/udev/rules.d/`, four binaries, `pacman -Qip` shows the intended depends/provides/conflicts/install-script, and `vercmp 0.8.0-1 v0.8.0-1` → 1 confirms the upgrade over the live AUR version. `makepkg --printsrcinfo` output sane.
- Negative tests: a blanked hash, a `v0.8.0;x` tag, and an unrendered template each fail the respective guard with exit 1.
- `actionlint` clean on all workflows; `shellcheck --shell=bash` on the PKGBUILD and `.install` (PKGBUILD reports only the SC2034/SC2154 makepkg-variable false positives); `shfmt`/`shellcheck` on touched scripts; `typos` 1.49.0 clean.
- Not run on this host: cargo gates (no rust ≥ 1.98), namcap (not installed), and the real AUR push — that can only be proven on the first tagged release after the maintainer setup above. Not runtime-tested on hardware.

Refs #255, #265.