### PR TITLE
fix(gui): render dialog, sheet and notification layers

### DIFF
--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -1,11 +1,11 @@
 use gpui::{
-    App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement, IntoElement,
-    MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription, Window, div,
-    prelude::FluentBuilder as _, rgb,
+    AnyElement, App, AppContext as _, Context, Entity, FocusHandle, Focusable, InteractiveElement,
+    IntoElement, MouseButton, NavigationDirection, ParentElement, Render, Styled, Subscription,
+    Window, div, prelude::FluentBuilder as _, rgb,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
-    Icon, IconName, TitleBar,
+    Icon, IconName, Root, TitleBar,
     button::{Button, ButtonVariants as _},
     v_flex,
 };
@@ -467,12 +467,18 @@ fn app_title_bar(cx: &App) -> impl IntoElement {
     )
 }
 
-impl Render for AppView {
+impl AppView {
+    /// Every screen branch, without the overlay layers.
+    ///
+    /// Split from [`Render::render`] so the dialog / sheet / notification
+    /// layers are appended exactly once, after whichever branch returned —
+    /// the early-return branches (config issue, connecting, unreachable,
+    /// outdated GUI, accessibility gate) would otherwise render no overlays.
     #[expect(
         clippy::too_many_lines,
         reason = "root view assembles every screen branch inline"
     )]
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_content(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         theme::apply_ui_scale(window, cx);
         let pal = theme::palette(cx);
 
@@ -637,6 +643,21 @@ impl Render for AppView {
             .child(content_el)
             .when(!granted, |this| this.child(status::attention_footer(cx)))
             .into_any_element()
+    }
+}
+
+impl Render for AppView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        // `Root::render` draws only the view, tooltip and native-menu layers,
+        // so an app that never renders these three has dialogs, sheets and
+        // notifications registered but never drawn — they open silently and
+        // nothing appears. They go last so they stack above the content.
+        div()
+            .size_full()
+            .child(self.render_content(window, cx))
+            .children(Root::render_dialog_layer(window, cx))
+            .children(Root::render_sheet_layer(window, cx))
+            .children(Root::render_notification_layer(window, cx))
     }
 }
 


### PR DESCRIPTION
**Summary**

Every dialog in the desktop app opened silently and rendered nothing. Root::render composes only the view, tooltip and native-menu layers; the dialog, sheet and notification layers are the application's responsibility, and openlogi-desktop never rendered them. Dialogs were registered in Root::active_dialogs and never drawn.

The failure is silent because window.open_dialog succeeds — the window does carry a Root, so the lookup assertion never trips — and the builder closure is simply never invoked.

**Changes**

`openlogi-desktop`

Split the screen branches into `AppView::render_content`, returning `AnyElement`
Added a `Render` impl that appends `Root::render_dialog_layer`, `render_sheet_layer` and `render_notification_layer` around it

Wrapping the returned element covers the early-return branches too (config issue, connecting, unreachable, outdated GUI, accessibility gate), which would otherwise still swallow dialogs. Layers go last so they stack above content.

**Testing**
```
cargo fmt --all -- --check                                    clean
cargo clippy -p openlogi-desktop --all-targets -- -D warnings  clean
cargo test -p openlogi-desktop                                 184 passed
```

Affected-package tier: `openlogi-desktop` has no reverse dependencies.

Verified on real hardware (macOS 26.5.2, Apple M1). Before: the device card's Rename… and Delete device… both closed the menu and did nothing, with no error or log output. After: the dialog renders and works. Confirmed with temporary probes — the dialog builder closure fires only with this change applied.

One note for the PR: it fixes rename and delete visibly, but the same missing layers mean notifications and sheets were also never drawn.