### PR TITLE
fix: make configured button bindings actually fire

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -184,6 +184,37 @@ mod tests {
     }
 
     #[test]
+    fn thumb_button_bound_to_a_browser_action_is_diverted() {
+        // The thumb buttons send mouse buttons 4/5 in firmware, which no
+        // Safari-style host consumes — reaching a browser action means the
+        // agent has to inject it, and that needs the button diverted. Seeding
+        // the default with `BrowserBack` made that unreachable: picking it
+        // matched the default, so the button stayed native and the action could
+        // never fire. Binding one side must arm its `0x1b04` divert.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b023",
+            ButtonId::Back,
+            Binding::Single(Action::BrowserBack),
+        );
+
+        let plan = plan_for_device(&cfg, "2b023", route(), None, 0);
+        assert!(
+            plan.divert_buttons.contains(&(0x0053, ButtonId::Back)),
+            "a thumb button bound to a browser action must be diverted, or the binding can never \
+             fire: {:?}",
+            plan.divert_buttons
+        );
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(_, button)| button == ButtonId::Forward),
+            "the untouched forward button must keep its native button 5"
+        );
+    }
+
+    #[test]
     fn haptic_panel_gestures_when_promoted() {
         // The MX Master 4 haptic panel is a HID++ gesture source: promoting it
         // into gesture mode must arm the raw-XY gesture divert, exactly like

--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -81,10 +81,20 @@ pub fn plan_for_device(
         .filter(|(_, button)| !oshook.contains_key(button))
         .filter(|(_, button)| {
             bindings.get(button).is_some_and(|action| {
-                // The panel's default is ShowActionsRing, which must be
-                // diverted to open the ring. Action::None means "leave native
-                // firmware haptics alone", so treat None as the only non-divert.
-                if *button == ButtonId::HapticPanel {
+                // A gesture source has no OS-visible native path — the hook
+                // never sees its CID — so "equals the default" cannot mean
+                // "leave it native" the way it does for a standard button.
+                // Skipping the divert there leaves the *firmware's* behavior
+                // in place instead of the bound action, which is how a gesture
+                // button bound to its own default action (Mission Control) ran
+                // the mouse's built-in app switcher instead. Action::None is
+                // the one binding that does ask for the firmware's behavior
+                // (native haptics on the panel), so it stays the sole
+                // non-divert.
+                if GESTURE_SOURCE_BUTTONS
+                    .iter()
+                    .any(|&(_, source)| source == *button)
+                {
                     *action != Action::None
                 } else {
                     *action != default_binding(*button)
@@ -257,6 +267,60 @@ mod tests {
     }
 
     #[test]
+    fn single_bound_gesture_button_is_diverted_even_at_its_default_action() {
+        // A gesture source's CID never reaches the OS hook, so there is no
+        // native path a skipped divert could fall back to — only the mouse's
+        // own firmware behavior, which is not what the binding says. The
+        // gesture button's single default happens to be MissionControl, and
+        // comparing against that default left the button undiverted: the
+        // firmware's app switcher ran instead of Mission Control.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b023",
+            ButtonId::GestureButton,
+            Binding::Single(Action::MissionControl),
+        );
+
+        let plan = plan_for_device(&cfg, "2b023", route(), None, 0);
+        assert!(
+            plan.divert_buttons
+                .contains(&(GESTURE_BUTTON_CID, ButtonId::GestureButton)),
+            "a single-bound gesture button must be diverted whatever the action, or the binding \
+             can never fire: {:?}",
+            plan.divert_buttons
+        );
+    }
+
+    #[test]
+    fn gesture_source_bound_to_none_keeps_its_firmware_behavior() {
+        // Action::None is the one binding that genuinely asks for the
+        // firmware's own behavior, so it must stay the sole non-divert for
+        // both gesture sources — otherwise "Do Nothing" would swallow the
+        // press instead of leaving the hardware alone.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b042",
+            ButtonId::GestureButton,
+            Binding::Single(Action::None),
+        );
+        cfg.set_binding(
+            "2b042",
+            ButtonId::HapticPanel,
+            Binding::Single(Action::None),
+        );
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
+        assert!(
+            !plan
+                .divert_buttons
+                .iter()
+                .any(|&(cid, _)| cid == GESTURE_BUTTON_CID || cid == HAPTIC_PANEL_CID),
+            "an Action::None gesture source must keep its firmware behavior: {:?}",
+            plan.divert_buttons
+        );
+    }
+
+    #[test]
     fn haptic_panel_default_is_diverted_for_actions_ring() {
         // Default binding is ShowActionsRing — the panel has no native OS path
         // and must be HID++-diverted so the ring can open.
@@ -337,19 +401,25 @@ mod tests {
     }
 
     #[test]
-    fn gestures_off_default_gesture_button_stays_native() {
-        // With gestures off and no explicit binding, the gesture button keeps
-        // its native HID behavior — same contract as the standard buttons.
+    fn gestures_off_gesture_button_is_diverted_for_its_demoted_action() {
+        // Turning gestures off demotes the button to a single action — with no
+        // stored Click that is its `default_binding`, Mission Control. This
+        // used to assert the opposite ("stays native — same contract as the
+        // standard buttons"), but that analogy does not hold: a standard
+        // button's default action *is* what its firmware sends, while a
+        // gesture source's is not, and its CID never reaches the OS hook. So
+        // "native" here meant the mouse's built-in app switcher while the GUI
+        // showed Mission Control. Divert, so the shown action is the one that
+        // fires.
         let mut cfg = Config::default();
         cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
 
         let plan = plan_for_device(&cfg, "2b042", route(), None, 0);
         assert!(
-            !plan
-                .divert_buttons
-                .iter()
-                .any(|&(cid, _)| cid == GESTURE_BUTTON_CID),
-            "an unbound gesture button must not be captured"
+            plan.divert_buttons
+                .contains(&(GESTURE_BUTTON_CID, ButtonId::GestureButton)),
+            "a gestures-off button must deliver its demoted action, not the firmware's: {:?}",
+            plan.divert_buttons
         );
     }
 }

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -48,8 +48,15 @@ pub fn default_binding(button: ButtonId) -> Action {
             reason = "see the left tilt above — same control pair, mirrored direction"
         )]
         ButtonId::WheelTiltRight => Action::HorizontalScrollRight,
-        ButtonId::Back => Action::BrowserBack,
-        ButtonId::Forward => Action::BrowserForward,
+        // The thumb buttons send mouse buttons 4/5 in firmware — the very
+        // pairing `is_native_click` treats as native. Seeding that action is
+        // what keeps an untouched thumb button native (the capture plan diverts
+        // a control only when its binding leaves this default, see
+        // `capture_plan`), and it is what makes the browser actions selectable
+        // at all: seeded with `BrowserBack`, choosing `BrowserBack` matched the
+        // default, so the button was never diverted and the action never fired.
+        ButtonId::Back => Action::MouseBack,
+        ButtonId::Forward => Action::MouseForward,
         ButtonId::DpiToggle => Action::CycleDpiPresets,
         #[expect(
             clippy::match_same_arms,

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1365,7 +1365,7 @@ fn set_gesture_mode_off_without_click_falls_back_to_the_default() {
 
     assert_eq!(
         cfg.bindings_for("2b042").get(&ButtonId::Back),
-        Some(&Binding::Single(Action::BrowserBack))
+        Some(&Binding::Single(Action::MouseBack))
     );
 }
 

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -81,12 +81,15 @@ fn combo(shortcut: Shortcut) -> KeyCombo {
         Shortcut::SelectAll => "Cmd+A",
         Shortcut::Find => "Cmd+F",
         Shortcut::Save => "Cmd+S",
-        // Cmd+[ / Cmd+] for Chrome and other apps. Safari is handled
-        // upstream via ax_navigate_browser() with the PID captured at press
-        // time — by the time execute() is called the AX path has already
-        // run, so this is the fallback for non-Safari browsers only.
-        Shortcut::BrowserBack => "Cmd+[",
-        Shortcut::BrowserForward => "Cmd+]",
+        // Arrows, not Cmd+[ / Cmd+]: `hid_usage_to_macos` resolves a usage to
+        // a *fixed ANSI* virtual key, so the bracket usage presses whatever
+        // character that position carries — `Ü` on a German layout, where no
+        // browser navigates. The arrow block carries no layout variance, and
+        // every macOS browser takes it for history navigation. `inject.rs`
+        // also has an `ax_navigate_browser` for a Safari-specific AX path,
+        // but nothing calls it, so this table is the only path that runs.
+        Shortcut::BrowserBack => "Cmd+Left",
+        Shortcut::BrowserForward => "Cmd+Right",
         Shortcut::NewTab => "Cmd+T",
         Shortcut::CloseTab => "Cmd+W",
         Shortcut::ReopenTab => "Cmd+Shift+T",
@@ -439,7 +442,7 @@ mod tests {
     fn combo_table_pins_representative_shortcuts() {
         assert_eq!(combo(Shortcut::Copy).rendered_label(), "Cmd+C");
         assert_eq!(combo(Shortcut::Redo).rendered_label(), "Cmd+Shift+Z");
-        assert_eq!(combo(Shortcut::BrowserBack).rendered_label(), "Cmd+[");
+        assert_eq!(combo(Shortcut::BrowserBack).rendered_label(), "Cmd+Left");
         assert_eq!(combo(Shortcut::NextTab).rendered_label(), "Ctrl+Tab");
         // hid_usage_to_macos must actually resolve every table entry, or a
         // `Shortcut` silently no-ops instead of pressing anything (see
@@ -452,6 +455,25 @@ mod tests {
             assert!(
                 hid_usage_to_macos(key).is_some(),
                 "{shortcut:?} table entry has no macOS virtual-key mapping"
+            );
+        }
+    }
+
+    /// Browser history navigation must not depend on the host keyboard
+    /// layout. `hid_usage_to_macos` maps a usage to a fixed ANSI virtual key,
+    /// so a punctuation or letter chord presses whichever character that ANSI
+    /// *position* carries on the active layout — ⌘[ becomes ⌘Ü on a German
+    /// one, and the browser stays put. Only the named navigation block
+    /// (`0x4a..=0x52`: home/page/end and the four arrows) is position-stable
+    /// across layouts, so browser navigation has to live there.
+    #[test]
+    fn browser_navigation_uses_layout_invariant_keys() {
+        for shortcut in [Shortcut::BrowserBack, Shortcut::BrowserForward] {
+            let usage = combo(shortcut).key().code();
+            assert!(
+                (0x4a..=0x52).contains(&usage),
+                "{shortcut:?} presses usage {usage:#04x}, whose ANSI position carries a \
+                 different character on every keyboard layout"
             );
         }
     }


### PR DESCRIPTION
# fix: make configured button bindings actually fire

Three independent defects that share one shape: a binding the GUI displays was
unreachable at runtime, so the mouse did something else and nothing in the logs
said why. Found while debugging "back/forward works in Firefox but not Safari" on
an MX Master 3 over a Unifying receiver, macOS 26.6, German keyboard layout.

Each commit stands alone and can be reviewed or dropped on its own.

---

## 1. `fix(core)` — thumb buttons were seeded with an action they could never run

`default_binding` seeded `Back`/`Forward` with `BrowserBack`/`BrowserForward`.
The capture plan diverts a control only when its binding *leaves* that default
(`capture_plan.rs`), so selecting `BrowserBack` matched the default, the button
was never diverted, and the raw HID button 4 went to the OS instead. Firefox
consumes buttons 4/5 itself and looked fine; Safari ignores them, so it got
nothing. The single setting meant to fix Safari was the one that guaranteed it
would stay broken.

Observable as `buttons=0` in `control capture active` while the config clearly
carried `Back = "BrowserBack"`.

Fixed by seeding `MouseBack`/`MouseForward` — what the firmware actually sends,
and the pairing `is_native_click` already treats as native. This is the same
reasoning the wheel-tilt defaults spell out twenty lines above; Back/Forward
just did not follow it.

An untouched thumb button behaves exactly as before. The browser actions become
selectable for the first time.

## 2. `fix(macos)` — browser navigation pressed the wrong physical key

With the button finally diverted, Safari still did not move. `hid_usage_to_macos`
resolves a HID usage to a **fixed ANSI** virtual key, so `⌘[` pressed whatever
character that ANSI position carries. Resolved against the active layout with
`UCKeyTranslate`:

```
kVK_ANSI_LeftBracket -> 'ü'   (German)
```

So the agent pressed `⌘Ü` and no browser navigated. Nothing in the injector
consults the keyboard layout — no `UCKeyTranslate`, no
`TISCopyCurrentKeyboardLayout`.

Fixed by using `⌘←` / `⌘→`, which every macOS browser accepts for history
navigation and which carry no layout variance. The Linux backend already used
`Alt+Left` for the same reason.

The new test pins the *property*, not the value: browser navigation must resolve
inside the named navigation block `0x4a..=0x52`, so an edit back to a punctuation
chord fails instead of silently regressing one keyboard layout.

Also removed the comment claiming Safari is served upstream via
`ax_navigate_browser()`. That function has **no call site anywhere in the
workspace** — only its definition and a re-export. The comment sent me chasing an
AX path that does not exist. The function itself is left in place; wiring it up or
deleting it is a separate decision.

## 3. `fix(agent)` — a gesture button bound to Mission Control ran the mouse's app switcher

Same default-equality trap, but worse, because a gesture source has no native
path to fall back to. `capture_plan.rs` says it directly: *"The HID++ gesture
sources never reach the OS hook."* Skipping the divert therefore does not leave
the button "native" — it leaves the **firmware's** behavior in place.

`default_binding(GestureButton)` is `MissionControl`, so a gesture button bound
to Mission Control was never diverted, and the mouse's built-in app switcher ran
while the GUI showed Mission Control.

The haptic panel already carried exactly the needed exception. Extended it to
both gesture sources: divert unless the binding is `Action::None`, which is the
one binding that genuinely asks for the firmware's behavior.

### Behavior change worth a reviewer's attention

This inverts `gestures_off_default_gesture_button_stays_native`, which asserted
the opposite:

> With gestures off and no explicit binding, the gesture button keeps its native
> HID behavior — same contract as the standard buttons.

That premise does not hold. A standard button's default action *is* what its
firmware sends (explicitly so after commit 1); a gesture source's is not. Under
the old contract "native" meant the built-in app switcher while the GUI showed
Mission Control.

The consequence reaches past the reported symptom: a gesture button with gestures
off and *no* explicit binding is now captured too, and runs its displayed action.
Scoping it narrower is not possible in this filter — an explicit
`Single(MissionControl)` and a default-derived one are the same value by the time
`plan_for_device` sees them, since `bindings` is the effective map, not the stored
one. Distinguishing them would be a data-model change.

---

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` (GPUI crates excluded, per the documented gate)

Every new test was confirmed to fail without its fix, not just to pass with it:

| Test | Failure without the fix |
|---|---|
| `thumb_button_bound_to_a_browser_action_is_diverted` | `divert_buttons` held only `[(416, HapticPanel)]` |
| `browser_navigation_uses_layout_invariant_keys` | `BrowserBack presses usage 0x2f, whose ANSI position carries a different character on every keyboard layout` |
| `single_bound_gesture_button_is_diverted_even_at_its_default_action` | gesture button absent from `divert_buttons` |

Confirmed on hardware (MX Master 3, macOS 26.6, German layout): back/forward now
work in Safari *and* still work in Firefox. `control capture active` tracks each
fix landing — `buttons=0` before, `buttons=2` once the thumb buttons could be
diverted, `buttons=3` once the gesture source was diverted too.

No wire types changed — `Action` gains no variant and none are reordered, so
`PROTOCOL_VERSION` is untouched.

Cross-platform lints (`aarch64-unknown-linux-musl`, Windows) were **not** run
locally; the target is not installed on this machine. `linux.rs` and `windows.rs`
are untouched and no shared names or signatures changed, but that is reasoning,
not a green run — CI's word is the one that counts.

## Deliberately not included

- **The layout bug's root cause.** `hid_usage_to_macos` is a positional ANSI map
  with no layout translation, and commit 2 only steers browser navigation clear
  of it. `Undo`/`Redo` are still broken on any layout that moves `Z`: measured on
  German, `⌘Z` presses `⌘Y`. The real fix is resolving named shortcuts through
  the active layout (`TISCopyCurrentKeyboardLayoutInputSource` +
  `UCKeyTranslate`), which would also let commit 2's arrows be reconsidered.
  `CustomShortcut` should arguably keep positional semantics — there the user
  meant a key, not a character. That is Carbon FFI in `openlogi-inject` and wants
  its own PR.
- **`ax_navigate_browser`.** Left as-is, minus the misleading comment.
- **A channel-scoped LaunchAgent label.** `LABEL` is hardcoded
  `org.openlogi.agent`, so a dev build and a production install fight over one
  autostart plist — whichever reconciled last owns it. Unrelated to these three
  fixes.