### PR TITLE
refactor(gui): draw the character stand-in icons as real icons

### DIFF
--- a/crates/openlogi-core/src/binding/gesture.rs
+++ b/crates/openlogi-core/src/binding/gesture.rs
@@ -50,18 +50,6 @@ impl GestureDirection {
             GestureDirection::Click => "Click",
         }
     }
-
-    /// Arrow glyph for compact list rendering.
-    #[must_use]
-    pub fn glyph(self) -> &'static str {
-        match self {
-            GestureDirection::Up => "↑",
-            GestureDirection::Down => "↓",
-            GestureDirection::Left => "←",
-            GestureDirection::Right => "→",
-            GestureDirection::Click => "·",
-        }
-    }
 }
 
 impl fmt::Display for GestureDirection {

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -14,6 +14,7 @@ use gpui_component::{
     v_flex,
 };
 use openlogi_core::binding::{ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot};
+use openlogi_ui::action_icons::RING_CANCEL_ICON;
 
 use self::action_icons::action_icon_path;
 use self::editor::action_library;
@@ -249,7 +250,7 @@ fn ring_preview(
                 .rounded_full()
                 .bg(pal.muted)
                 .text_color(pal.text_muted)
-                .child("×"),
+                .child(svg().path(RING_CANCEL_ICON).size(px(20.0)).flex_none()),
         )
         .children(ActionRingSlot::ALL.into_iter().map(|slot| {
             slot_button(

--- a/crates/openlogi-desktop/src/features/camera/controls.rs
+++ b/crates/openlogi-desktop/src/features/camera/controls.rs
@@ -19,7 +19,7 @@ use gpui::{
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
-    Selectable as _, h_flex,
+    IconName, Selectable as _, h_flex,
     slider::{Slider, SliderEvent, SliderState},
     v_flex,
 };
@@ -791,11 +791,11 @@ fn profiles_row(key: &str, cx: &mut Context<CameraControlsPanel>) -> gpui::Div {
         );
     }
     row = row.child(
-        ProfileTab::new("camera-profile-save", format!("+ {}", tr!("New"))).on_click(cx.listener(
-            |panel, _: &ClickEvent, _window, cx| {
+        ProfileTab::new("camera-profile-save", tr!("New"))
+            .icon(IconName::Plus)
+            .on_click(cx.listener(|panel, _: &ClickEvent, _window, cx| {
                 panel.save_profile(cx);
-            },
-        )),
+            })),
     );
     row
 }

--- a/crates/openlogi-desktop/src/features/mouse/inspector.rs
+++ b/crates/openlogi-desktop/src/features/mouse/inspector.rs
@@ -17,6 +17,7 @@ use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding
 use super::hotspots::MouseControlId;
 use super::picker::{
     GESTURE_BUTTON_ICON, PickFn, action_icon_path, action_rows_matching, editor_section,
+    gesture_direction_icon,
 };
 use super::thumbwheel::ThumbwheelPreset;
 use super::view::MouseModelView;
@@ -356,19 +357,25 @@ fn gesture_directions(
                         .selected(selected)
                         .role(Role::Button)
                         .child(
-                            v_flex()
+                            h_flex()
                                 .min_w_0()
-                                .child(div().text_body().child(format!(
-                                    "{}  {}",
-                                    direction.glyph(),
-                                    tr!(direction.label())
-                                )))
+                                .gap_2()
+                                // `.size_4()` is not decoration: a bare `Icon`
+                                // falls through to the current font size, which
+                                // would leave these a step under the 16px leading
+                                // column the action rows below use.
+                                .child(gesture_direction_icon(direction).size_4())
                                 .child(
-                                    div()
-                                        .truncate()
-                                        .text_caption()
-                                        .text_color(pal.text_muted)
-                                        .child(localized_action_label(&action)),
+                                    v_flex()
+                                        .min_w_0()
+                                        .child(div().text_body().child(tr!(direction.label())))
+                                        .child(
+                                            div()
+                                                .truncate()
+                                                .text_caption()
+                                                .text_color(pal.text_muted)
+                                                .child(localized_action_label(&action)),
+                                        ),
                                 ),
                         )
                         .when(selected, |row| {

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -7,7 +7,7 @@ use gpui::{
     Styled, Window, div, prelude::FluentBuilder as _, px, rgb, svg,
 };
 use gpui_component::{Icon, IconName, Selectable as _, h_flex, v_flex};
-use openlogi_core::binding::{Action, Category};
+use openlogi_core::binding::{Action, Category, GestureDirection};
 
 use crate::ui::components::MenuRow;
 use crate::ui::section::section_label;
@@ -39,6 +39,20 @@ pub(crate) fn grouped_catalog() -> Vec<(Category, Vec<Action>)> {
 
 /// Icon for a gesture-mode button's five-direction summary.
 pub(crate) const GESTURE_BUTTON_ICON: &str = "action-icons/move.svg";
+
+/// Icon for one gesture direction: an arrow away from the centre, or the
+/// centre itself for the click. Four come from gpui-component's bundled set
+/// and the dot is vendored, but all five are lucide at the same stroke weight
+/// as the action icons they sit above.
+pub(crate) fn gesture_direction_icon(direction: GestureDirection) -> Icon {
+    match direction {
+        GestureDirection::Up => Icon::new(IconName::ArrowUp),
+        GestureDirection::Down => Icon::new(IconName::ArrowDown),
+        GestureDirection::Left => Icon::new(IconName::ArrowLeft),
+        GestureDirection::Right => Icon::new(IconName::ArrowRight),
+        GestureDirection::Click => Icon::empty().path("action-icons/circle-dot.svg"),
+    }
+}
 
 /// Asset path of the vendored glyph for an action. Exhaustive so a new action
 /// must deliberately choose an icon.

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -324,6 +324,7 @@ impl RenderOnce for MenuRow {
 pub(crate) struct ProfileTab {
     base: BaseButton,
     label: SharedString,
+    icon: Option<Icon>,
     selected: bool,
     children: Vec<AnyElement>,
     on_click: Option<ClickHandler>,
@@ -335,11 +336,20 @@ impl ProfileTab {
         Self {
             base: BaseButton::new(id).role(Role::Tab),
             label: label.into(),
+            icon: None,
             selected: false,
             children: Vec::new(),
             on_click: None,
             delete: None,
         }
+    }
+
+    /// A mark before the label, for a tab that is an action rather than a
+    /// profile (the one that creates a new profile).
+    #[must_use]
+    pub(crate) fn icon(mut self, icon: impl Into<Icon>) -> Self {
+        self.icon = Some(icon.into());
+        self
     }
 
     #[must_use]
@@ -437,6 +447,7 @@ impl RenderOnce for ProfileTab {
                     })
                     .border_color(accent)
             })
+            .when_some(self.icon, |tab, icon| tab.child(icon.size_3()))
             .child(label.clone())
             .children(self.children)
             .when_some(self.on_click, |tab, handler| {
@@ -445,13 +456,13 @@ impl RenderOnce for ProfileTab {
             .when_some(self.delete, |tab, (id, handler)| {
                 tab.child(
                     BaseButton::new(id)
-                        .accessibility_label(format!("{label} ×"))
+                        .accessibility_label(tr!("Remove %{name}", name => label.to_string()))
                         .px_0p5()
                         .rounded_full()
                         .text_color(pal.text_muted)
                         .hover(|style| style.text_color(pal.text_primary))
                         .focus_visible(|style| style.text_color(pal.text_primary))
-                        .child("×")
+                        .child(Icon::new(IconName::Close).size_3())
                         .on_click(move |event, window, cx| {
                             cx.stop_propagation();
                             handler(event, window, cx);
@@ -592,7 +603,7 @@ mod tests {
                     )
                     .child(
                         BaseButton::new("keyboard-preset-remove")
-                            .child("×")
+                            .child(Icon::new(IconName::Close).size_3())
                             .on_click(move |_, _, _| removals.set(removals.get() + 1)),
                     ),
             )

--- a/crates/openlogi-desktop/src/ui/gallery.rs
+++ b/crates/openlogi-desktop/src/ui/gallery.rs
@@ -338,7 +338,7 @@ impl ComponentGallery {
                         .accessibility_label("Remove preset")
                         .px_1()
                         .text_color(pal.text_muted)
-                        .child("×"),
+                        .child(Icon::new(IconName::Close).size_3()),
                 ),
             pal,
         )

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -16,13 +16,13 @@
 
 use gpui::{
     App, Context, FocusHandle, FontWeight, Global, InteractiveElement, IntoElement,
-    ParentElement as _, Render, RenderOnce, SharedString, Size, Styled as _, Subscription, Window,
-    div, prelude::FluentBuilder as _, px,
+    ParentElement as _, Render, RenderOnce, SharedString, Size, StatefulInteractiveElement as _,
+    Styled as _, Subscription, Window, div, prelude::FluentBuilder as _, px, svg,
 };
 use gpui_base::Button as BaseButton;
 use gpui_component::{
     button::{Button, ButtonVariants as _},
-    v_flex,
+    h_flex, v_flex,
 };
 use openlogi_core::hid::{Click, PasskeyMethod, ReceiverSelector};
 use openlogi_ipc::{FoundDevice, PairingFailure, PairingPhase};
@@ -271,7 +271,7 @@ fn pairing_body(state: PairingUi, pal: Palette) -> impl IntoElement {
                 .child(cancel_button());
         }
         PairingUi::Passkey(method) => {
-            col = col.child(passkey_panel(&method));
+            col = col.child(passkey_panel(&method, pal));
             col = col.child(cancel_button());
         }
         PairingUi::Paired { slot } => {
@@ -346,7 +346,7 @@ fn device_row(device: &FoundDevice, pal: Palette) -> impl IntoElement {
 }
 
 /// The passkey-entry instructions panel.
-fn passkey_panel(method: &PasskeyMethod) -> impl IntoElement {
+fn passkey_panel(method: &PasskeyMethod, pal: Palette) -> impl IntoElement {
     let mut col = v_flex().w_full().gap_3();
     match method {
         PasskeyMethod::Keyboard(digits) => {
@@ -357,22 +357,58 @@ fn passkey_panel(method: &PasskeyMethod) -> impl IntoElement {
                 .child(div().text_title().child(SharedString::from(digits.clone())));
         }
         PasskeyMethod::Pointer { clicks, .. } => {
-            let sequence: String = clicks
-                .iter()
-                .map(|c| match c {
-                    Click::Left => "←",
-                    Click::Right => "→",
-                })
-                .collect::<Vec<_>>()
-                .join(" ");
             col = col
                 .child(status_line(tr!(
                     "On the new mouse, click in this order, then press both buttons together:"
                 )))
-                .child(div().text_title().child(SharedString::from(sequence)));
+                .child(
+                    h_flex()
+                        .id("passkey-sequence")
+                        // The icons carry no text of their own, so the order is
+                        // spelled out once here rather than left to assistive
+                        // tech as a row of unlabelled images.
+                        .aria_label(spoken_click_sequence(clicks))
+                        .gap_2()
+                        .children(clicks.iter().enumerate().map(|(step, click)| {
+                            v_flex()
+                                .items_center()
+                                .gap_0p5()
+                                .child(svg().path(click_icon(*click)).size_6().flex_none())
+                                .child(
+                                    div()
+                                        .text_caption()
+                                        .text_color(pal.text_muted)
+                                        .child((step + 1).to_string()),
+                                )
+                        })),
+                );
         }
     }
     col
+}
+
+/// The mouse body with the button this step wants filled in.
+fn click_icon(click: Click) -> &'static str {
+    match click {
+        Click::Left => "action-icons/mouse-left.svg",
+        Click::Right => "action-icons/mouse-right.svg",
+    }
+}
+
+/// The click sequence as an ordered sentence, for the accessibility tree.
+fn spoken_click_sequence(clicks: &[Click]) -> String {
+    clicks
+        .iter()
+        .enumerate()
+        .map(|(step, click)| {
+            let label = match click {
+                Click::Left => tr!("Left Click"),
+                Click::Right => tr!("Right Click"),
+            };
+            format!("{}. {label}", step + 1)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn status_line(text: impl Into<SharedString>) -> impl IntoElement {

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -12,6 +12,7 @@ use gpui::{
 };
 use openlogi_core::binding::ActionRingSlot;
 use openlogi_ipc::ActionRingInvocation;
+use openlogi_ui::action_icons::RING_CANCEL_ICON;
 use openlogi_ui::color;
 use tokio::sync::mpsc;
 
@@ -187,9 +188,8 @@ impl Render for RingView {
                     .rounded_full()
                     .bg(CANCEL_RESTING)
                     .text_color(CANCEL_GLYPH)
-                    .text_lg()
                     .cursor_pointer()
-                    .child("×")
+                    .child(svg().path(RING_CANCEL_ICON).size(px(20.0)).flex_none())
                     .on_click(move |_, window, cx| {
                         cx.stop_propagation();
                         let _ = center_commands.send(OverlayCommand::Cancel { session_id });

--- a/crates/openlogi-ui/action-icons/circle-dot.svg
+++ b/crates/openlogi-ui/action-icons/circle-dot.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <circle cx="12" cy="12" r="1" />
+</svg>

--- a/crates/openlogi-ui/action-icons/mouse-left.svg
+++ b/crates/openlogi-ui/action-icons/mouse-left.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 9A7 7 0 0 1 12 2v8H5z" fill="currentColor" stroke="none" />
+  <rect x="5" y="2" width="14" height="20" rx="7" />
+  <path d="M12 3v6" />
+</svg>

--- a/crates/openlogi-ui/action-icons/mouse-right.svg
+++ b/crates/openlogi-ui/action-icons/mouse-right.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M19 9A7 7 0 0 0 12 2v8h7z" fill="currentColor" stroke="none" />
+  <rect x="5" y="2" width="14" height="20" rx="7" />
+  <path d="M12 3v6" />
+</svg>

--- a/crates/openlogi-ui/action-icons/x.svg
+++ b/crates/openlogi-ui/action-icons/x.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M18 6 6 18" />
+  <path d="m6 6 12 12" />
+</svg>

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Fjern %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "%{name} entfernen"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Κατάργηση %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Remove %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Eliminar %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Poista %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Supprimer %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Rimuovi %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "%{name} を削除"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "%{name} 제거"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Fjern %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "%{name} verwijderen"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Usuń %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Remover %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Remover %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Удалить %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Ta bort %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -466,6 +466,7 @@ _version: 1
 "Profile options": "Profil seçenekleri"
 "Remove %{app} profile and its %{count} overrides?": "%{app} profili ve %{count} geçersiz kılması kaldırılsın mı?"
 "Remove %{app} profile and its 1 override?": "%{app} profili ve 1 geçersiz kılması kaldırılsın mı?"
+"Remove %{name}": "%{name} öğesini kaldır"
 "Remove profile": "Profili kaldır"
 "Remove profile…": "Profili kaldır…"
 "Select a button on the device to change what it does.": "Ne yapacağını değiştirmek için cihaz üzerinde bir düğme seçin."

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "Видалити %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "移除 %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "移除 %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -468,6 +468,7 @@ _version: 1
 "Profile options": "Profile options"
 "Remove %{app} profile and its %{count} overrides?": "Remove %{app} profile and its %{count} overrides?"
 "Remove %{app} profile and its 1 override?": "Remove %{app} profile and its 1 override?"
+"Remove %{name}": "移除 %{name}"
 "Remove profile": "Remove profile"
 "Remove profile…": "Remove profile…"
 "Select a button on the device to change what it does.": "Select a button on the device to change what it does."

--- a/crates/openlogi-ui/src/action_icons.rs
+++ b/crates/openlogi-ui/src/action_icons.rs
@@ -13,13 +13,17 @@ use std::borrow::Cow;
 
 use gpui::{AssetSource, Result, SharedString};
 
-/// Vendored [lucide](https://lucide.dev) icons (ISC license) for the binding
-/// menus, embedded so they resolve identically in a packaged `.app` and a dev
-/// build. Served under the `action-icons/` path prefix and rendered by
-/// the settings action picker via `svg().path(..)`. These are
-/// command glyphs (paste / cut / volume / lock / …) plus a couple of About-page
-/// icons (changelog, bug) that gpui-component's bundled `IconName` set does not
-/// cover.
+/// Vendored [lucide](https://lucide.dev) icons (ISC license), embedded so they
+/// resolve identically in a packaged `.app` and a dev build. Served under the
+/// `action-icons/` path prefix and rendered via `svg().path(..)` or
+/// `Icon::empty().path(..)`. Mostly command glyphs for the binding menus
+/// (paste / cut / volume / lock / …), plus the chrome marks gpui-component's
+/// bundled `IconName` set does not cover — About-page icons, and `mouse-left` /
+/// `mouse-right`, which are lucide's `mouse` with one button filled in.
+///
+/// `x.svg` duplicates `IconName::Close` on purpose: the overlay does not depend
+/// on gpui-component, and its ring cancel target has to match the settings-side
+/// preview of the same ring exactly.
 #[rustfmt::skip]
 const ACTION_ICONS: &[(&str, &[u8])] = &[
     ("action-icons/arrow-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/arrow-left.svg"))),
@@ -55,7 +59,9 @@ const ACTION_ICONS: &[(&str, &[u8])] = &[
     ("action-icons/list-checks.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/list-checks.svg"))),
     ("action-icons/lock.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/lock.svg"))),
     ("action-icons/monitor.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/monitor.svg"))),
+    ("action-icons/mouse-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse-left.svg"))),
     ("action-icons/mouse-pointer-click.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse-pointer-click.svg"))),
+    ("action-icons/mouse-right.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse-right.svg"))),
     ("action-icons/mouse.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/mouse.svg"))),
     ("action-icons/move.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/move.svg"))),
     ("action-icons/palette.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/palette.svg"))),
@@ -86,7 +92,13 @@ const ACTION_ICONS: &[(&str, &[u8])] = &[
     ("action-icons/volume-1.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/volume-1.svg"))),
     ("action-icons/volume-2.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/volume-2.svg"))),
     ("action-icons/volume-x.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/volume-x.svg"))),
+    ("action-icons/x.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/x.svg"))),
 ];
+
+/// The Actions Ring's centre cancel mark. Both processes draw that target —
+/// the overlay for real, the settings app as a preview — and they have to be
+/// the same mark, so neither side names the asset itself.
+pub const RING_CANCEL_ICON: &str = "action-icons/x.svg";
 
 /// GPUI asset source for the embedded ring glyphs, and nothing else.
 pub struct ActionIcons;
@@ -113,6 +125,17 @@ mod tests {
     use openlogi_core::binding::ActionRingIcon;
 
     use super::*;
+
+    #[test]
+    fn the_shared_ring_cancel_icon_is_embedded() {
+        // Both processes render this path; a rename that missed the array
+        // would blank the overlay's cancel target rather than fail to build.
+        let loaded = ActionIcons.load(RING_CANCEL_ICON);
+        assert!(
+            matches!(loaded, Ok(Some(_))),
+            "{RING_CANCEL_ICON} is missing"
+        );
+    }
 
     #[test]
     fn every_ring_gallery_icon_is_embedded() {

--- a/crates/openlogi-ui/src/action_icons.rs
+++ b/crates/openlogi-ui/src/action_icons.rs
@@ -40,6 +40,7 @@ const ACTION_ICONS: &[(&str, &[u8])] = &[
     ("action-icons/chevrons-up.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/chevrons-up.svg"))),
     ("action-icons/circle-arrow-left.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/circle-arrow-left.svg"))),
     ("action-icons/circle-arrow-right.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/circle-arrow-right.svg"))),
+    ("action-icons/circle-dot.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/circle-dot.svg"))),
     ("action-icons/clipboard-paste.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/clipboard-paste.svg"))),
     ("action-icons/copy.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/copy.svg"))),
     ("action-icons/file.svg", include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/action-icons/file.svg"))),


### PR DESCRIPTION
## Summary

Six places in the GUI typed a character where an icon belonged. Two of them were visible bugs — the gesture direction rows did not line up, and the pairing passkey told you to "move left" when it meant "press the left button" — and the rest were inconsistencies with panels that had already moved to real icons.

The direction rows were the report that started this: the glyph and the label shared one text run, so the label began wherever that glyph's advance width left off. The arrows are near an em wide and the click's middle dot is barely a third of one, which is both the misalignment and the "click's icon looks smaller" complaint. Every row now opens with the same 16px leading column the action rows below it use.

## Changes

- **openlogi-core**: drop `GestureDirection::glyph`. The inspector was its only consumer, and which asset a frontend draws is not this crate's business.
- **openlogi-ui**: vendor `circle-dot.svg` and `x.svg` from lucide, and add `mouse-left.svg` / `mouse-right.svg` — lucide's `mouse` with one button filled in. Add `RING_CANCEL_ICON` so the overlay's ring and the settings preview of that same ring cannot drift apart, plus a test that it stays embedded: a rename that missed the array would blank the overlay's cancel target without failing the build. Add the `Remove %{name}` key to all 22 catalogs.
- **openlogi-desktop**: draw the gesture directions with lucide icons on a shared 16px column; replace the `×` on the ring preview and the profile tab, and the `+` on the chip that saves a camera profile; give `ProfileTab` a leading-icon slot, because a plus could otherwise only be prefixed onto the label as a string; draw the pairing passkey's click sequence as numbered mouse icons.
- **openlogi-overlay**: the ring's centre cancel target takes the shared icon. It cannot reach `IconName` — it deliberately does not depend on gpui-component — which is why `x.svg` is vendored even though it duplicates `IconName::Close`.

Two details worth flagging for review:

`Icon`'s render overwrites its own default style refinement with the caller's, so a bare `Icon` falls through to the current font size rather than the 16px its `Default` sets. The explicit `.size_4()` on the direction rows is load-bearing, not decoration.

The passkey icons carry no text, so a screen reader saw a row of unlabelled images. The row now spells the whole sequence out once (`1. Left Click, 2. Right Click, …`), and `ProfileTab`'s delete button — which announced itself as `<name> ×` — now says `Remove <name>`.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (with `RUSTFLAGS=-D warnings`)
- `cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` excluding the GPUI crates
- `cargo test -p openlogi-ui locale` and `cargo test -p openlogi-desktop i18n` for the new catalog key

Not runtime-tested on hardware. The gesture rows, ring preview, camera profile chips and pairing panel all need an attached device and a running agent to reach. The new SVGs were rasterized and checked at 16px and 256px, and the ring cancel target was composited at its real 48px/20px proportion, but nothing here has been seen inside the running app.

No cfg-gated code changed, and no wire types changed.
