### PR TITLE
perf(release): accelerate macOS packaging

### DIFF
--- a/.claude/rules/xtask.md
+++ b/.claude/rules/xtask.md
@@ -24,8 +24,8 @@ paths:
   copy called `AppIcon.icon`; it ships with Xcode (not the command line tools)
   and has to be **Xcode 26 or newer**, since that is where Icon Composer
   documents arrived. `OPENLOGI_DEVELOPER_DIR` picks which Xcode every macOS
-  build command runs under — `build.yml` sets it per leg, because the Intel
-  runner image still defaults to Xcode 16.
+  build command runs under — `build.yml` pins it so both native and
+  cross-compiled distribution targets use the same Icon Composer-capable SDK.
   `design/icon/openlogi.png` stays the master for Linux packaging and the GUI's
   embedded logo, and `openlogi.ico` for the Windows executables. The icon set
   itself lives in `xtask/src/icon.rs` (`AppIcon` plus the `IconPipeline` trait a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,10 @@ jobs:
     name: macOS DMG (${{ matrix.arch }})
     needs: should-build
     if: ${{ needs.should-build.outputs.run == 'true' }}
-    runs-on: ${{ matrix.runner }}
+    # Apple Silicon compiles both slices. Building the Intel slice on the arm64
+    # runner is supported by Rust and Xcode and avoids the much slower hosted
+    # Intel runner; every bundled Mach-O is checked below before it can ship.
+    runs-on: macos-latest
     # Bound a stuck brew/linker/notarize hang so it can't hold a PR build slot
     # for the 6-hour runner default (the signed path also notarizes).
     timeout-minutes: 60
@@ -116,9 +119,9 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-latest
+            target: aarch64-apple-darwin
           - arch: x86_64
-            runner: macos-15-intel
+            target: x86_64-apple-darwin
     permissions:
       contents: read
     env:
@@ -127,6 +130,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
@@ -143,13 +148,10 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' && github.ref_type != 'tag' }}
 
       - name: Verify runner architecture
-        run: test "$(uname -m)" = "${{ matrix.arch }}"
+        run: test "$(uname -m)" = arm64
 
-      # The two macOS legs run on different images, and their default Xcode is
-      # whatever `/Applications/Xcode.app` happens to point at — 26.x on the
-      # arm64 image, 16.4 on the Intel one. Compiling the app icon needs an
-      # Icon Composer-capable actool (Xcode 26+), and a bundle should not be
-      # built by two different toolchains depending on which leg produced it.
+      # Pin both target builds to an Icon Composer-capable Xcode instead of
+      # relying on whatever `/Applications/Xcode.app` points at today.
       - name: Select the Xcode both legs build with
         run: |
           # An unmatched glob stays literal, which `-d` then rejects — where
@@ -188,13 +190,16 @@ jobs:
           path: |
             ~/Library/Caches/Homebrew
             ~/Library/Caches/Homebrew/downloads
-          key: brew-macos-${{ runner.arch }}-librsvg-create-dmg-v1
+          key: brew-macos-${{ runner.arch }}-librsvg-create-dmg-cargo-bundle-v2
           restore-keys: |
             brew-macos-${{ runner.arch }}-
 
       - name: Install packaging tools
         run: |
-          brew install librsvg create-dmg
+          # cargo-bundle has bottles for both hosted macOS architectures.
+          # Installing the bottle avoids compiling the tool from source in
+          # every release leg before OpenLogi itself can start building.
+          brew install librsvg create-dmg cargo-bundle
 
       - name: Validate release secrets
         if: ${{ inputs.sign }}
@@ -238,10 +243,28 @@ jobs:
           set -euo pipefail
           export OPENLOGI_UPDATE_MANIFEST_URL="${OPENLOGI_UPDATE_BASE_URL%/}/channels/stable/latest.json"
           if [ "${{ inputs.sign }}" = "true" ]; then
-            cargo run -p xtask -- macos package --sign-identity "$APPLE_SIGNING_IDENTITY"
+            cargo run -p xtask -- macos package --target ${{ matrix.target }} --sign-identity "$APPLE_SIGNING_IDENTITY"
           else
-            cargo run -p xtask -- macos package
+            cargo run -p xtask -- macos package --target ${{ matrix.target }}
           fi
+
+      - name: Verify bundled architectures
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          app="target/release/bundle/osx/OpenLogi.app"
+          binaries=(
+            "$app/Contents/MacOS/openlogi-desktop"
+            "$app/Contents/MacOS/openlogi"
+            "$app/Contents/Library/LoginItems/OpenLogi Agent.app/Contents/MacOS/openlogi-agent"
+            "$app/Contents/Library/LoginItems/OpenLogi Overlay.app/Contents/MacOS/openlogi-overlay"
+          )
+          for binary in "${binaries[@]}"; do
+            archs=$(lipo -archs "$binary")
+            echo "$binary: $archs"
+            test "$archs" = "$EXPECTED_ARCH"
+          done
 
       # xtask stamps and verifies this itself; re-checking the artifact here is
       # deliberate redundancy, because a bundle that ships with the `.dev`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -225,6 +225,8 @@ lint (shellcheck + shfmt) are separate CI jobs. Reproduce those with
 
 ```sh
 cargo run -p xtask -- macos package    # → target/release/OpenLogi.dmg
+# Cross-compile a distribution DMG (aarch64 or x86_64):
+cargo run -p xtask -- macos package --target x86_64-apple-darwin
 ```
 
 Environment overrides:

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -52,9 +52,10 @@ package anything but a production bundle once it is given a signing identity, so
 a dev build cannot reach users. That check is what releases 0.6.24–0.6.26 lacked
 when the release workflow shipped `.dev` identifiers.
 
-The raw DMG emitted by `cargo-bundle` is deleted during `macos bundle` because it
-is created before xtask embeds and signs the helpers; use `macos package` when
-you need a DMG.
+`macos bundle` asks `cargo-bundle` for the base `.app` only, then embeds and signs
+the helpers. Use `macos package` when you need the final DMG. The package command
+also accepts `--target aarch64-apple-darwin` or `--target x86_64-apple-darwin` so
+CI can cross-compile either distribution architecture.
 
 ### The dev bundle
 

--- a/xtask/src/commands/macos.rs
+++ b/xtask/src/commands/macos.rs
@@ -22,7 +22,7 @@ pub(crate) enum Command {
     Dmg(dmg::Args),
     /// Build the app bundle for distribution, optionally sign it, and package
     /// the branded DMG.
-    Package(dmg::Args),
+    Package(PackageArgs),
 }
 
 #[derive(Parser)]
@@ -34,6 +34,15 @@ pub(crate) struct BundleArgs {
     channel: Channel,
 }
 
+#[derive(Parser)]
+pub(crate) struct PackageArgs {
+    #[command(flatten)]
+    dmg: dmg::Args,
+    /// Rust target to package. Omit it for the host architecture.
+    #[arg(long, value_enum)]
+    target: Option<bundle::DistributionTarget>,
+}
+
 pub(crate) fn run(command: Command) -> Result<()> {
     match command {
         Command::Icon => AppBundle.compile(),
@@ -41,8 +50,8 @@ pub(crate) fn run(command: Command) -> Result<()> {
         Command::DevBundle(args) => dev_bundle::run(&args),
         Command::Dmg(args) => dmg::run(&args),
         Command::Package(args) => {
-            bundle::run_for_distribution(args.sign_identity.as_deref())?;
-            dmg::run(&args)
+            bundle::run_for_distribution(args.dmg.sign_identity.as_deref(), args.target)?;
+            dmg::run(&args.dmg)
         }
     }
 }

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -101,7 +101,7 @@ fn run_with_channel(
         .collect();
     cmd!(
         sh,
-        "cargo bundle --release --package openlogi-desktop --bin openlogi-desktop --format osx {target_args...}"
+        "cargo bundle --release --package openlogi-desktop --format osx {target_args...}"
     )
     .env("CARGO_BUNDLE_SKIP_BUILD", "1")
     .envs(xcode_env.iter().map(|(key, value)| (key, value)))

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -99,13 +99,14 @@ fn run_with_channel(
         .into_iter()
         .flat_map(|triple| ["--target", triple])
         .collect();
-    cmd!(
-        sh,
-        "cargo bundle --release --package openlogi-desktop --format osx {target_args...}"
-    )
-    .env("CARGO_BUNDLE_SKIP_BUILD", "1")
-    .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-    .run()?;
+    {
+        let gui_dir = root.join("crates/openlogi-desktop");
+        let _gui = sh.push_dir(gui_dir);
+        cmd!(sh, "cargo bundle --release --format osx {target_args...}")
+            .env("CARGO_BUNDLE_SKIP_BUILD", "1")
+            .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+            .run()?;
+    }
 
     let built_app = release_dir.join("bundle/osx/OpenLogi.app");
     ensure_dir(&built_app)?;

--- a/xtask/src/commands/macos/bundle.rs
+++ b/xtask/src/commands/macos/bundle.rs
@@ -5,9 +5,10 @@ pub(crate) mod identity;
 mod signing;
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};
+use clap::ValueEnum;
 use strum::VariantArray as _;
 use xshell::{Shell, cmd};
 
@@ -23,23 +24,49 @@ use identity::{Channel, Component};
 pub(super) use embed::{HELPERS, Helper};
 pub(super) use signing::quoted_identity;
 
+#[derive(Clone, Copy, ValueEnum)]
+pub(crate) enum DistributionTarget {
+    #[value(name = "aarch64-apple-darwin")]
+    Aarch64,
+    #[value(name = "x86_64-apple-darwin")]
+    X8664,
+}
+
+impl DistributionTarget {
+    fn triple(self) -> &'static str {
+        match self {
+            Self::Aarch64 => "aarch64-apple-darwin",
+            Self::X8664 => "x86_64-apple-darwin",
+        }
+    }
+}
+
 /// Build `OpenLogi.app` wearing `channel`'s identity, signing it with whatever
 /// local identity is available (dev) or leaving it unsigned (production).
 pub(crate) fn run(channel: Channel) -> Result<()> {
-    run_with_channel(channel, None)
+    run_with_channel(channel, None, None)
 }
 
 /// Build the bundle that ships: always the production identity, signed with the
 /// Developer ID identity when one is given.
-pub(crate) fn run_for_distribution(sign_identity: Option<&str>) -> Result<()> {
-    run_with_channel(Channel::Production, sign_identity)
+pub(crate) fn run_for_distribution(
+    sign_identity: Option<&str>,
+    target: Option<DistributionTarget>,
+) -> Result<()> {
+    run_with_channel(Channel::Production, sign_identity, target)
 }
 
-fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()> {
+fn run_with_channel(
+    channel: Channel,
+    sign_identity: Option<&str>,
+    target: Option<DistributionTarget>,
+) -> Result<()> {
     let root = repo_root()?;
     let sh = Shell::new()?;
     let _repo = sh.push_dir(&root);
     let xcode_env = xcode::env()?;
+    let target_triple = target.map(DistributionTarget::triple);
+    let release_dir = release_dir(&root, target_triple);
 
     println!("==> app icon");
     AppBundle.compile()?;
@@ -67,20 +94,26 @@ fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()>
             .envs(xcode_env.iter().map(|(key, value)| (key, value)))
             .run()?;
     }
-    {
-        let gui_dir = root.join("crates/openlogi-desktop");
-        let _gui = sh.push_dir(gui_dir);
-        cmd!(sh, "cargo bundle --release")
-            .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-            .run()?;
-    }
-    remove_cargo_bundle_dmg(&root)?;
+    embed::build_release_binaries(&root, &xcode_env, target_triple)?;
+    let target_args: Vec<&str> = target_triple
+        .into_iter()
+        .flat_map(|triple| ["--target", triple])
+        .collect();
+    cmd!(
+        sh,
+        "cargo bundle --release --package openlogi-desktop --bin openlogi-desktop --format osx {target_args...}"
+    )
+    .env("CARGO_BUNDLE_SKIP_BUILD", "1")
+    .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+    .run()?;
 
+    let built_app = release_dir.join("bundle/osx/OpenLogi.app");
+    ensure_dir(&built_app)?;
     let app = root.join("target/release/bundle/osx/OpenLogi.app");
-    ensure_dir(&app)?;
+    move_to_canonical_path(&built_app, &app)?;
     AppBundle.install(&app)?;
-    embed::embed_helpers(&root, &app, &xcode_env, channel)?;
-    embed::embed_cli(&root, &app, &xcode_env)?;
+    embed::embed_helpers(&root, &release_dir, &app, channel)?;
+    embed::embed_cli(&release_dir, &app)?;
     embed::verify_bundle_binaries(&app, channel)?;
     info_plist::stamp_privacy_usage_descriptions(&app)?;
     // Identity first, then the checks, then signing — a signature seals the
@@ -103,14 +136,70 @@ fn run_with_channel(channel: Channel, sign_identity: Option<&str>) -> Result<()>
     Ok(())
 }
 
-fn remove_cargo_bundle_dmg(root: &Path) -> Result<()> {
-    let dmg = root.join("target/release/bundle/dmg/OpenLogi.dmg");
-    if dmg.exists() {
-        fs_err::remove_file(&dmg)
-            .with_context(|| format!("could not remove stale {}", dmg.display()))?;
-        println!(
-            "    removed cargo-bundle DMG before helper embedding; use `macos package` for a DMG"
-        );
+fn release_dir(root: &Path, target: Option<&str>) -> PathBuf {
+    let mut dir = root.join("target");
+    if let Some(target) = target {
+        dir.push(target);
     }
+    dir.join("release")
+}
+
+fn move_to_canonical_path(source: &Path, destination: &Path) -> Result<()> {
+    if source == destination {
+        return Ok(());
+    }
+    if destination.exists() {
+        fs_err::remove_dir_all(destination)
+            .with_context(|| format!("could not remove {}", destination.display()))?;
+    }
+    if let Some(parent) = destination.parent() {
+        fs_err::create_dir_all(parent)
+            .with_context(|| format!("could not create {}", parent.display()))?;
+    }
+    fs_err::rename(source, destination).with_context(|| {
+        format!(
+            "could not move {} to {}",
+            source.display(),
+            destination.display()
+        )
+    })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_bundle_already_has_the_canonical_path() {
+        let root = tempfile::tempdir().unwrap();
+        let app = release_dir(root.path(), None).join("bundle/osx/OpenLogi.app");
+        fs_err::create_dir_all(&app).unwrap();
+        fs_err::write(app.join("binary"), []).unwrap();
+
+        assert_eq!(
+            app,
+            root.path().join("target/release/bundle/osx/OpenLogi.app")
+        );
+        move_to_canonical_path(&app, &app).unwrap();
+        assert!(app.join("binary").is_file());
+    }
+
+    #[test]
+    fn cross_compiled_bundle_replaces_the_canonical_app() {
+        let root = tempfile::tempdir().unwrap();
+        let source =
+            release_dir(root.path(), Some("x86_64-apple-darwin")).join("bundle/osx/OpenLogi.app");
+        let destination = root.path().join("target/release/bundle/osx/OpenLogi.app");
+        fs_err::create_dir_all(&source).unwrap();
+        fs_err::write(source.join("new"), []).unwrap();
+        fs_err::create_dir_all(&destination).unwrap();
+        fs_err::write(destination.join("stale"), []).unwrap();
+
+        move_to_canonical_path(&source, &destination).unwrap();
+
+        assert!(!source.exists());
+        assert!(destination.join("new").is_file());
+        assert!(!destination.join("stale").exists());
+    }
 }

--- a/xtask/src/commands/macos/bundle/embed.rs
+++ b/xtask/src/commands/macos/bundle/embed.rs
@@ -44,7 +44,32 @@ pub(crate) const HELPERS: [Helper; 2] = [
     },
 ];
 
-/// Build each helper and embed it as a nested login-item bundle.
+/// Build every executable the distribution bundle contains in one Cargo
+/// invocation so their shared dependency features are unified once.
+pub(super) fn build_release_binaries(
+    root: &Path,
+    xcode_env: &[(String, String)],
+    target: Option<&str>,
+) -> Result<()> {
+    let sh = Shell::new()?;
+    let _repo = sh.push_dir(root);
+    let mut targets = vec!["--package", "openlogi-desktop", "--bin", "openlogi-desktop"];
+    for helper in &HELPERS {
+        targets.extend(["--package", helper.package, "--bin", helper.binary]);
+    }
+    targets.extend(["--package", "openlogi", "--bin", "openlogi"]);
+    if let Some(target) = target {
+        targets.extend(["--target", target]);
+    }
+
+    println!("==> release binaries (build)");
+    cmd!(sh, "cargo build --locked --release {targets...}")
+        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
+        .run()?;
+    Ok(())
+}
+
+/// Embed each helper as a nested login-item bundle.
 ///
 /// The agent is the always-on process (hook + device I/O + menu bar); shipping
 /// it inside the GUI bundle keeps one notarized artifact, lets `open -b`
@@ -56,39 +81,29 @@ pub(crate) const HELPERS: [Helper; 2] = [
 /// pane, Login Items. Icon generation already ran, so the icns is on disk.
 pub(super) fn embed_helpers(
     root: &Path,
+    release_dir: &Path,
     app: &Path,
-    xcode_env: &[(String, String)],
     channel: Channel,
 ) -> Result<()> {
     let icon = root.join("crates/openlogi-desktop/icon/AppIcon.icns");
     ensure_file(&icon)?;
     for helper in &HELPERS {
-        embed_helper(root, app, xcode_env, helper, &icon, channel)?;
+        embed_helper(root, release_dir, app, helper, &icon, channel)?;
     }
     Ok(())
 }
 
 fn embed_helper(
     root: &Path,
+    release_dir: &Path,
     app: &Path,
-    xcode_env: &[(String, String)],
     helper: &Helper,
     icon: &Path,
     channel: Channel,
 ) -> Result<()> {
-    let sh = Shell::new()?;
-    let _repo = sh.push_dir(root);
-    let Helper {
-        package,
-        binary,
-        label,
-        ..
-    } = *helper;
-    println!("==> {label} (build)");
-    cmd!(sh, "cargo build -p {package} --bin {binary} --release")
-        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-        .run()?;
-    let built = root.join("target/release").join(binary);
+    let Helper { binary, label, .. } = *helper;
+    println!("==> {label} (embed)");
+    let built = release_dir.join(binary);
     ensure_file(&built)?;
 
     let bundle = helper.component.root(app, channel);
@@ -115,14 +130,9 @@ fn embed_helper(
     Ok(())
 }
 
-pub(super) fn embed_cli(root: &Path, app: &Path, xcode_env: &[(String, String)]) -> Result<()> {
-    let sh = Shell::new()?;
-    let _repo = sh.push_dir(root);
-    println!("==> cli (build)");
-    cmd!(sh, "cargo build -p openlogi --release")
-        .envs(xcode_env.iter().map(|(key, value)| (key, value)))
-        .run()?;
-    let cli_bin = root.join("target/release/openlogi");
+pub(super) fn embed_cli(release_dir: &Path, app: &Path) -> Result<()> {
+    println!("==> cli (embed)");
+    let cli_bin = release_dir.join("openlogi");
     ensure_file(&cli_bin)?;
 
     let macos = app.join("Contents/MacOS");


### PR DESCRIPTION
## Summary

Reduce the release critical path without giving up fat LTO's measured artifact-size savings. Build both macOS distribution targets on Apple Silicon, avoid the slow and queue-constrained hosted Intel runner, and remove repeated Cargo builds from app-bundle assembly.

## Changes

- **Build workflow:** cross-compile the x86_64 DMG on `macos-latest`, install the bottled `cargo-bundle`, and reject any bundle whose four Mach-O executables do not match the matrix architecture.
- **xtask:** build the desktop, agent, overlay, and CLI in one Cargo invocation; make `cargo-bundle` package-only; support typed macOS distribution targets; and stage target-specific bundles at the existing canonical path before signing and DMG creation.
- **Docs:** document the cross-target package command and update the packaging contract.

## Testing

- `RUSTFLAGS="-D warnings" cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo test -p xtask commands::macos` — 22 passed
- `cargo run -p xtask -- macos package --help`
- `npx --yes prettier@3.6.2 --check .github/workflows/build.yml`
- [Unsigned Build workflow dispatch](https://github.com/AprilNEA/OpenLogi/actions/runs/32948775133) — passed in 21m 17s; macOS arm64 completed in 13m 45s and x86_64 in 16m 04s, with all four bundled Mach-O executables validated for each target architecture
- Not runtime-tested on physical hardware
