### PR TITLE
fix(device): stabilize MX Ergo receiver and Bluetooth switching

### DIFF
--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -30,7 +30,10 @@ use std::time::Duration;
 use openlogi_core::config::ThumbwheelSensitivity;
 use openlogi_core::scroll::ScrollDelta;
 use openlogi_hid::session::gesture::{CaptureSpec, GESTURE_SOURCE_BUTTONS};
-use openlogi_hid::{CaptureChannel, CapturedInput, DeviceRoute, run_capture_session};
+use openlogi_hid::{
+    CaptureChannel, CapturedInput, ChannelRegistry, DeviceRoute,
+    run_capture_session_with_registry_spec,
+};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
@@ -80,6 +83,7 @@ pub fn spawn(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
     outputs: GestureOutputs,
 ) {
     thread::spawn(move || {
@@ -97,6 +101,7 @@ pub fn spawn(
             capture_plans,
             capture_channel,
             receiver_access,
+            registry,
             outputs,
         ));
     });
@@ -171,6 +176,7 @@ struct SessionChannels {
     inputs: mpsc::UnboundedSender<CapturedEvent>,
     done: mpsc::UnboundedSender<SessionDone>,
     capture: CaptureChannel,
+    registry: ChannelRegistry,
 }
 
 /// What the manager should do with one session-completion report.
@@ -243,6 +249,7 @@ async fn manage(
     capture_plans: SharedCapturePlans,
     capture_channel: CaptureChannel,
     receiver_access: ReceiverAccess,
+    registry: ChannelRegistry,
     outputs: GestureOutputs,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<CapturedEvent>();
@@ -261,6 +268,7 @@ async fn manage(
         inputs: tx,
         done: done_tx,
         capture: capture_channel,
+        registry,
     };
     let mut epoch: u64 = 0;
     // The capture-vs-pairing arbiter hands out one exclusive lease. All session
@@ -384,16 +392,16 @@ fn spawn_session(
     let session_route = target.route.clone();
     let session_spec = target.spec.clone();
     let slot = Arc::clone(&channels.capture);
+    let registry = channels.registry.clone();
     tokio::spawn(async move {
         let _lease = lease;
-        let backend = openlogi_hid::host::backend();
-        if let Err(e) = run_capture_session(
-            &*backend,
+        if let Err(e) = run_capture_session_with_registry_spec(
             session_route,
             session_spec,
             session_tx,
             stop_rx,
             slot,
+            &registry,
         )
         .await
         {

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -149,6 +149,7 @@ fn spawn_hidpp_watchers(shared: &SharedRuntime, inputs: &InputServices) {
         shared.capture_plans.clone(),
         shared.capture_channel.clone(),
         shared.receiver_access.clone(),
+        shared.channel_registry.clone(),
         GestureOutputs::new(inputs.dispatcher.clone(), inputs.scroll_input.clone()),
     );
     watchers::host_switch::spawn(

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -144,6 +144,96 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Import physical keys and route aliases written by pre-release custom
+    /// builds that used `device:<identity>` plus a top-level
+    /// `device_aliases` table.
+    ///
+    /// Only explicit alias evidence is converted into [`DeviceConfig::links`].
+    /// An alias whose target has no persisted device entry is deliberately
+    /// ignored: guessing its owner from a model name could merge two physical
+    /// mice of the same model. The caller keeps the original source as a
+    /// migration backup before the normalized config is saved.
+    pub(crate) fn migrate_legacy_device_keys(
+        &mut self,
+        legacy_aliases: BTreeMap<String, String>,
+    ) -> bool {
+        fn normalized_identity_key(key: &str) -> Option<String> {
+            let identity = key.strip_prefix("device:")?;
+            PhysicalDeviceKey::parse(identity).map(|_| identity.to_string())
+        }
+
+        fn normalized_route_key(key: &str) -> Option<String> {
+            if let Some(rest) = key.strip_prefix("direct:") {
+                let mut parts = rest.splitn(3, ':');
+                let vendor = parts.next()?;
+                let product = parts.next()?;
+                let identity = parts.next()?;
+                PhysicalDeviceKey::parse(identity)?;
+                return Some(format!("direct:{vendor}:{product}"));
+            }
+            key.starts_with("receiver:").then(|| key.to_string())
+        }
+
+        let mut changed = false;
+        let old_keys = self.devices.keys().cloned().collect::<Vec<_>>();
+        for old in old_keys {
+            let Some(new) = normalized_identity_key(&old) else {
+                continue;
+            };
+            let Some(legacy) = self.devices.remove(&old) else {
+                continue;
+            };
+            if let Some(existing) = self.devices.get_mut(&new) {
+                // A mixed custom/current file can contain both spellings.
+                // Preserve any disagreement on the historical key instead of
+                // overwriting either side silently.
+                identity::fold(existing, legacy, &old);
+            } else {
+                self.devices.insert(new, legacy);
+            }
+            changed = true;
+        }
+
+        if let Some(new) = self
+            .selected_device
+            .as_deref()
+            .and_then(normalized_identity_key)
+        {
+            self.selected_device = Some(new);
+            changed = true;
+        }
+        for device in self.devices.values_mut() {
+            for target in &mut device.host_switch_targets {
+                if let Some(new) = normalized_identity_key(target) {
+                    *target = new;
+                    changed = true;
+                }
+            }
+            device.host_switch_targets.sort();
+            device.host_switch_targets.dedup();
+        }
+
+        for (alias, target) in legacy_aliases {
+            let target = normalized_identity_key(&target).unwrap_or(target);
+            let Some(canonical) = PhysicalDeviceKey::parse(&target) else {
+                continue;
+            };
+            if !self.devices.contains_key(canonical.as_str()) {
+                tracing::warn!(
+                    %alias,
+                    target = %canonical.as_str(),
+                    "legacy device alias has no persisted target; leaving it unmerged"
+                );
+                continue;
+            }
+            let Some(route) = normalized_route_key(&alias) else {
+                continue;
+            };
+            changed |= self.adopt_route(&canonical, &route, None);
+        }
+        changed
+    }
+
     /// A config that never touches the on-disk file: [`Self::save_atomic`] is
     /// a no-op. For tests that drive the state layer's persistence paths —
     /// with a default config those would overwrite the developer's real

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -1,7 +1,7 @@
 //! Version-aware configuration loading and conflict-safe persistence.
 
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     ffi::OsString,
     fs, io,
     path::{Path, PathBuf},
@@ -123,9 +123,9 @@ impl ConfigFile {
     pub fn load_from_path(path: &Path) -> Result<(Config, Self), ConfigError> {
         match fs::read_to_string(path) {
             Ok(source) => {
-                let (config, loaded_version) = parse_config(path, &source)?;
-                let migrated_from =
-                    (loaded_version < SCHEMA_VERSION).then(|| (loaded_version, source.clone()));
+                let (config, loaded_version, migrated_legacy_keys) = parse_config(path, &source)?;
+                let migrated_from = (loaded_version < SCHEMA_VERSION || migrated_legacy_keys)
+                    .then(|| (loaded_version, source.clone()));
                 Ok((
                     config,
                     Self {
@@ -245,9 +245,10 @@ impl Config {
 }
 
 /// Parse `source`, applying every migration its declared `schema_version`
-/// needs. Returns the migrated config plus the version the file actually
-/// declared, so callers can tell a migrated load from an already-current one.
-fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError> {
+/// needs. Returns the migrated config, the version the file actually declared,
+/// and whether same-schema private-build keys were normalized, so callers can
+/// retain a recovery copy before either kind of migration is saved.
+fn parse_config(path: &Path, source: &str) -> Result<(Config, u32, bool), ConfigError> {
     let header: ConfigHeader = toml::from_str(source).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source: Box::new(source),
@@ -259,10 +260,29 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
         });
     }
     reject_obsolete_fields(path, source, header.schema_version)?;
-    let mut config: Config = toml::from_str(source).map_err(|source| ConfigError::Parse {
+    let mut value: toml::Value = toml::from_str(source).map_err(|source| ConfigError::Parse {
         path: path.to_path_buf(),
         source: Box::new(source),
     })?;
+    // Private builds predating schema 6 persisted transport aliases in a
+    // top-level `device_aliases` table. It was never part of the released
+    // schema, so keep the strict Config shape and consume it only inside this
+    // one-way migration adapter.
+    let legacy_aliases = value
+        .as_table_mut()
+        .and_then(|table| table.remove("device_aliases"))
+        .map(toml::Value::try_into)
+        .transpose()
+        .map_err(|source| ConfigError::Parse {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?
+        .unwrap_or_else(BTreeMap::new);
+    let mut config: Config = value.try_into().map_err(|source| ConfigError::Parse {
+        path: path.to_path_buf(),
+        source: Box::new(source),
+    })?;
+    let migrated_legacy_keys = config.migrate_legacy_device_keys(legacy_aliases);
     if header.schema_version <= 3 {
         config.migrate_owner_locked_gestures();
     }
@@ -274,7 +294,7 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
         config.migrate_transport_scoped_keys();
     }
     config.schema_version = SCHEMA_VERSION;
-    Ok((config, header.schema_version))
+    Ok((config, header.schema_version, migrated_legacy_keys))
 }
 
 fn reject_obsolete_fields(path: &Path, source: &str, version: u32) -> Result<(), ConfigError> {

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1797,6 +1797,83 @@ dpi = 1600
 }
 
 #[test]
+fn custom_device_aliases_migrate_to_identity_keys_and_links() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    let original = r#"
+schema_version = 6
+selected_device = "device:serial:abc123"
+
+[device_aliases]
+"direct:046d:b03e:serial:abc123" = "device:serial:abc123"
+"receiver:82839805:slot:2" = "device:serial:abc123"
+"receiver:82839805:slot:3" = "device:unit:05060708"
+
+[devices."device:serial:abc123"]
+dpi = 1600
+
+[devices."device:serial:abc123".identity]
+display_name = "MX Ergo S"
+kind = "trackball"
+
+[devices."device:serial:abc123".identity.capabilities]
+buttons = true
+pointer = true
+lighting = false
+scroll_inversion = false
+hires_wheel = false
+thumbwheel = false
+haptic_feedback = false
+haptic_panel = false
+
+[devices."device:unit:01020304"]
+dpi = 800
+
+[devices."device:unit:01020304".identity]
+display_name = "MX Ergo S"
+kind = "trackball"
+
+[devices."device:unit:01020304".identity.capabilities]
+buttons = true
+pointer = true
+lighting = false
+scroll_inversion = false
+hires_wheel = false
+thumbwheel = false
+haptic_feedback = false
+haptic_panel = false
+"#;
+    fs::write(&path, original).expect("write custom config");
+
+    let (config, mut file) = ConfigFile::load_from_path(&path).expect("load custom config");
+    assert_eq!(config.selected_device.as_deref(), Some("serial:abc123"));
+    assert!(config.devices.contains_key("serial:abc123"));
+    assert!(config.devices.contains_key("unit:01020304"));
+    assert!(!config.devices.contains_key("device:serial:abc123"));
+    let links = &config.devices["serial:abc123"].links;
+    assert!(links.contains_key("direct:046d:b03e"));
+    assert!(links.contains_key("receiver:82839805:slot:2"));
+    assert!(
+        config
+            .devices
+            .values()
+            .all(|device| !device.links.contains_key("receiver:82839805:slot:3")),
+        "an alias whose target has no persisted identity is not guessed onto a same-model mouse"
+    );
+
+    file.save(&config).expect("save migrated config");
+    assert_eq!(
+        fs::read(path.with_file_name("config.toml.v6.bak")).expect("read migration backup"),
+        original.as_bytes(),
+        "same-schema custom migrations still preserve their original source"
+    );
+    let written = fs::read_to_string(&path).expect("read migrated config");
+    assert!(!written.contains("device_aliases"));
+    assert!(!written.contains("device:serial:"));
+    assert!(!written.contains("device:unit:"));
+}
+
+#[test]
 fn migrating_two_direct_routes_of_one_device_folds_instead_of_dropping_one() {
     // An MX Master 3S reached over USB *and* over Bluetooth-direct has two v4
     // entries whose keys both rename to `unit:6be9d300`. Inserting would let

--- a/crates/openlogi-desktop/src/state/devices.rs
+++ b/crates/openlogi-desktop/src/state/devices.rs
@@ -209,7 +209,7 @@ pub(super) fn build_device_list(
                 .or_else(|| paired.codename.as_deref().map(prettify_codename))
                 .unwrap_or_else(|| format!("Slot {}", paired.slot));
             let kind = effective_kind(paired.kind, asset.as_ref().map(|a| a.kind));
-            list.push(DeviceRecord {
+            let mut record = DeviceRecord {
                 config_key,
                 canonical_key,
                 persistent,
@@ -232,7 +232,9 @@ pub(super) fn build_device_list(
                 slot: paired.slot,
                 online: paired.online,
                 battery: paired.battery.clone(),
-            });
+            };
+            record = hydrate_offline_linked_record(record, cache, config);
+            list.push(record);
         }
     }
     append_standalone(&mut list, standalone, cache, config);
@@ -263,6 +265,28 @@ pub(super) fn build_device_list(
     apply_custom_names(&mut list, config);
     sort_device_list(&mut list);
     list
+}
+
+/// Restore persisted model metadata for an offline sighting attributed to a
+/// known physical device through its recorded route link.
+fn hydrate_offline_linked_record(
+    record: DeviceRecord,
+    cache: &AssetResolver,
+    config: &Config,
+) -> DeviceRecord {
+    // A receiver continues to enumerate its paired slot after the device
+    // switches to another transport or goes to sleep. That sighting often has
+    // neither model info nor a WPID, but `resolve_device_key` can still
+    // attribute the route to the physical device previously adopted online.
+    // Never guess by model name: two devices of the same model stay distinct.
+    if record.online {
+        return record;
+    }
+    let Some(identity) = config.device_identity(&record.config_key) else {
+        return record;
+    };
+    let known = offline_record(&record.config_key, identity, cache);
+    adopt_transient_record(&known, record)
 }
 
 fn apply_custom_names(list: &mut [DeviceRecord], config: &Config) {
@@ -839,8 +863,9 @@ mod tests {
 
     use super::{
         Camera, Capabilities, DeviceIdentity, DeviceKind, DeviceModelInfo, DeviceRecord,
-        DeviceTransports, append_offline_known, build_device_list, direct_key_prefix,
-        effective_kind, fold_by_inventory_key, offline_record, pick_initial_device,
+        DeviceTransports, PhysicalDeviceKey, append_offline_known, build_device_list,
+        direct_key_prefix, effective_kind, fold_by_inventory_key, offline_record,
+        pick_initial_device,
     };
     use crate::state::inventory::adopt_routes;
     use openlogi_core::hid::Dpi;
@@ -1173,6 +1198,59 @@ mod tests {
         let cache = AssetResolver::new();
         let list = build_device_list(&[inv], &[], &cache, &Config::default(), &[]);
         assert_eq!(list[0].display_name, "Slot 2");
+    }
+
+    #[test]
+    fn adopted_offline_receiver_route_uses_its_persisted_identity() {
+        let route_key = "receiver:da2699e1:slot:2";
+        let canonical = PhysicalDeviceKey::parse("serial:2540zae0hzr8")
+            .expect("the test key is a physical identity");
+        let mut config = Config::default();
+        config.set_device_identity(
+            canonical.as_str(),
+            DeviceIdentity {
+                display_name: "MX Ergo S".into(),
+                kind: DeviceKind::Trackball,
+                capabilities: Capabilities::presumed_from_kind(DeviceKind::Trackball),
+                light_capabilities: None,
+                model_info: Some(DeviceModelInfo {
+                    entity_count: 4,
+                    serial_number: Some("2540ZAE0HZR8".into()),
+                    unit_id: [0; 4],
+                    transports: DeviceTransports::default(),
+                    model_ids: [0xb03e, 0, 0],
+                    extended_model_id: 0,
+                }),
+                codename: Some("MX Ergo S".into()),
+                driver_id: None,
+                registry_model_id: None,
+            },
+        );
+        assert!(config.adopt_route(&canonical, route_key, None));
+
+        let mut paired = paired_device_no_model_info(2, None);
+        paired.codename = Some("MX Ergo S".into());
+        paired.kind = DeviceKind::Mouse;
+        paired.online = false;
+        let list = build_device_list(
+            &[inventory_with(vec![paired])],
+            &[],
+            &AssetResolver::new(),
+            &config,
+            &[],
+        );
+
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].config_key, canonical.as_str());
+        assert_eq!(list[0].display_name, "MX Ergo S");
+        assert_eq!(list[0].kind, DeviceKind::Trackball);
+        assert_eq!(
+            list[0].model_info.as_ref().map(|info| info.model_ids[0]),
+            Some(0xb03e)
+        );
+        assert_eq!(list[0].route_key, route_key);
+        assert!(list[0].route.is_some());
+        assert!(!list[0].online);
     }
 
     #[test]

--- a/crates/openlogi-desktop/src/state/devices.rs
+++ b/crates/openlogi-desktop/src/state/devices.rs
@@ -7,7 +7,7 @@ use openlogi_camera::Camera;
 use openlogi_core::config::{Config, DeviceIdentity, canonical_device_key};
 use openlogi_core::device::{
     BatteryInfo, Capabilities, DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports,
-    LightCapabilities, StandaloneDevice,
+    LightCapabilities, PairedDevice, StandaloneDevice,
 };
 use openlogi_core::device_order::{
     DeviceIdentity as RouteIdentity, DeviceStableId, PhysicalDeviceKey,
@@ -161,81 +161,11 @@ pub(super) fn build_device_list(
 ) -> Vec<DeviceRecord> {
     let mut list = Vec::new();
     for inv in inventories {
-        for paired in &inv.paired {
-            let route = DeviceRoute::device_route_for(inv, paired.slot);
-            let (model_key, asset, model_info, codename, serial_number, unit_id) =
-                if let Some(model) = paired.model_info.as_ref() {
-                    let asset = cache.resolve(model, paired.codename.as_deref());
-                    (
-                        model.config_key(),
-                        asset,
-                        Some(model.clone()),
-                        paired.codename.clone(),
-                        model.serial_number.clone(),
-                        model.unit_id,
-                    )
-                } else {
-                    // No HID++ 2.0 model info — HID++ 1.0 device or feature walk
-                    // timed out. Surface the device anyway using the wpid (or slot
-                    // as a last-resort model key) so it appears in the gallery
-                    // with a stable display fallback.
-                    let key = paired.wpid.map_or_else(
-                        || format!("slot{}", paired.slot),
-                        |w| format!("wpid{w:04x}"),
-                    );
-                    (key, None, None, paired.codename.clone(), None, [0u8; 4])
-                };
-            let stable_id = DeviceStableId::from_parts(
-                route.as_ref(),
-                paired.slot,
-                serial_number.as_deref(),
-                unit_id,
-            );
-            let identity = RouteIdentity::from_parts(serial_number.as_deref(), unit_id);
-            let (config_key, persistent) = config
-                .resolve_device_key(&stable_id, paired.online.then_some(&identity))
-                .map_or_else(
-                    || (stable_id.runtime_key(), false),
-                    |key| (key.into_string(), true),
-                );
-            let canonical_key =
-                canonical_device_key(&stable_id, paired.online.then_some(&identity))
-                    .map(PhysicalDeviceKey::into_string);
-            let route_key = stable_id.route_key();
-
-            let display_name = asset
-                .as_ref()
-                .map(|a| a.display_name.clone())
-                .or_else(|| paired.codename.as_deref().map(prettify_codename))
-                .unwrap_or_else(|| format!("Slot {}", paired.slot));
-            let kind = effective_kind(paired.kind, asset.as_ref().map(|a| a.kind));
-            let mut record = DeviceRecord {
-                config_key,
-                canonical_key,
-                persistent,
-                route_key,
-                model_key,
-                model_name: display_name.clone(),
-                display_name,
-                asset,
-                model_info,
-                codename,
-                serial_number,
-                unit_id,
-                driver_id: None,
-                registry_model_id: None,
-                route,
-                capture_id: None,
-                kind,
-                capabilities: paired.capabilities,
-                light_capabilities: None,
-                slot: paired.slot,
-                online: paired.online,
-                battery: paired.battery.clone(),
-            };
-            record = hydrate_offline_linked_record(record, cache, config);
-            list.push(record);
-        }
+        list.extend(
+            inv.paired
+                .iter()
+                .filter_map(|paired| paired_record(inv, paired, cache, config)),
+        );
     }
     append_standalone(&mut list, standalone, cache, config);
     #[cfg(debug_assertions)]
@@ -265,6 +195,102 @@ pub(super) fn build_device_list(
     apply_custom_names(&mut list, config);
     sort_device_list(&mut list);
     list
+}
+
+/// Build one receiver/direct inventory record, or suppress an unknown offline
+/// receiver pairing until it has been observed online once.
+fn paired_record(
+    inventory: &DeviceInventory,
+    paired: &PairedDevice,
+    cache: &AssetResolver,
+    config: &Config,
+) -> Option<DeviceRecord> {
+    let route = DeviceRoute::device_route_for(inventory, paired.slot);
+    let (model_key, asset, model_info, codename, serial_number, unit_id) =
+        if let Some(model) = paired.model_info.as_ref() {
+            let asset = cache.resolve(model, paired.codename.as_deref());
+            (
+                model.config_key(),
+                asset,
+                Some(model.clone()),
+                paired.codename.clone(),
+                model.serial_number.clone(),
+                model.unit_id,
+            )
+        } else {
+            // No HID++ 2.0 model info — HID++ 1.0 device or feature walk
+            // timed out. Surface an online device using WPID (or slot as the
+            // last-resort model key) so it remains actionable.
+            let key = paired.wpid.map_or_else(
+                || format!("slot{}", paired.slot),
+                |wpid| format!("wpid{wpid:04x}"),
+            );
+            (key, None, None, paired.codename.clone(), None, [0; 4])
+        };
+    let stable_id = DeviceStableId::from_parts(
+        route.as_ref(),
+        paired.slot,
+        serial_number.as_deref(),
+        unit_id,
+    );
+    let identity = RouteIdentity::from_parts(serial_number.as_deref(), unit_id);
+    // Receiver pairing registers retain a physical unit id while the mouse
+    // sleeps or uses Bluetooth. That identity is authoritative even when
+    // offline; all-zero identities remain excluded by `config_key()`.
+    let physical_identity = identity.config_key().is_some().then_some(&identity);
+    let (config_key, persistent) = config
+        .resolve_device_key(&stable_id, physical_identity)
+        .map_or_else(
+            || (stable_id.runtime_key(), false),
+            |key| (key.into_string(), true),
+        );
+    let canonical_key =
+        canonical_device_key(&stable_id, physical_identity).map(PhysicalDeviceKey::into_string);
+    let route_key = stable_id.route_key();
+
+    // A receiver can retain pairings OpenLogi has never observed. An offline
+    // slot with no persisted device entry has neither actionable settings nor
+    // reliable presentation metadata and used to render as anonymous `Slot N`
+    // cards. Known devices remain visible for continuity.
+    let receiver_route = matches!(
+        route.as_ref(),
+        Some(DeviceRoute::Bolt { .. } | DeviceRoute::Unifying { .. })
+    );
+    if receiver_route && !paired.online && !config.devices.contains_key(&config_key) {
+        return None;
+    }
+
+    let display_name = asset
+        .as_ref()
+        .map(|asset| asset.display_name.clone())
+        .or_else(|| paired.codename.as_deref().map(prettify_codename))
+        .unwrap_or_else(|| format!("Slot {}", paired.slot));
+    let kind = effective_kind(paired.kind, asset.as_ref().map(|asset| asset.kind));
+    let record = DeviceRecord {
+        config_key,
+        canonical_key,
+        persistent,
+        route_key,
+        model_key,
+        model_name: display_name.clone(),
+        display_name,
+        asset,
+        model_info,
+        codename,
+        serial_number,
+        unit_id,
+        driver_id: None,
+        registry_model_id: None,
+        route,
+        capture_id: None,
+        kind,
+        capabilities: paired.capabilities,
+        light_capabilities: None,
+        slot: paired.slot,
+        online: paired.online,
+        battery: paired.battery.clone(),
+    };
+    Some(hydrate_offline_linked_record(record, cache, config))
 }
 
 /// Restore persisted model metadata for an offline sighting attributed to a
@@ -1198,6 +1224,75 @@ mod tests {
         let cache = AssetResolver::new();
         let list = build_device_list(&[inv], &[], &cache, &Config::default(), &[]);
         assert_eq!(list[0].display_name, "Slot 2");
+    }
+
+    #[test]
+    fn unknown_offline_receiver_slots_do_not_create_gallery_cards() {
+        let mut slot_one = paired_device_no_model_info(1, Some(0x4051));
+        slot_one.online = false;
+        let mut slot_two = paired_device_no_model_info(2, None);
+        slot_two.online = false;
+
+        let list = build_device_list(
+            &[inventory_with(vec![slot_one, slot_two])],
+            &[],
+            &AssetResolver::new(),
+            &Config::default(),
+            &[],
+        );
+
+        assert!(
+            list.is_empty(),
+            "never-seen offline pairings must not render as anonymous Slot cards"
+        );
+    }
+
+    #[test]
+    fn offline_unifying_unit_id_resolves_the_known_physical_device() {
+        let unit_id = [0x29, 0x16, 0xdb, 0xbe];
+        let model = DeviceModelInfo {
+            entity_count: 0,
+            serial_number: None,
+            unit_id,
+            transports: DeviceTransports {
+                equad: true,
+                btle: true,
+                ..DeviceTransports::default()
+            },
+            model_ids: [0xb027, 0x4051, 0],
+            extended_model_id: 0,
+        };
+        let mut config = Config::default();
+        config.set_device_identity(
+            "unit:2916dbbe",
+            DeviceIdentity {
+                display_name: "Ergo M575".into(),
+                kind: DeviceKind::Trackball,
+                capabilities: Capabilities::presumed_from_kind(DeviceKind::Trackball),
+                light_capabilities: None,
+                model_info: Some(model.clone()),
+                codename: Some("Ergo M575".into()),
+                driver_id: None,
+                registry_model_id: None,
+            },
+        );
+        let mut paired = paired_device_no_model_info(3, Some(0x4051));
+        paired.online = false;
+        paired.kind = DeviceKind::Trackball;
+        paired.model_info = Some(model);
+
+        let list = build_device_list(
+            &[inventory_with(vec![paired])],
+            &[],
+            &AssetResolver::new(),
+            &config,
+            &[],
+        );
+
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].config_key, "unit:2916dbbe");
+        assert_eq!(list[0].display_name, "Ergo M575");
+        assert!(!list[0].online);
     }
 
     #[test]

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -38,9 +38,9 @@ use probe::{NodeProbe, probe_one};
 /// ping; we err on the side of waiting.
 const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
 
-/// Maximum number of pairing slots a Bolt receiver supports. We iterate this
-/// range to surface paired-but-offline devices that won't fire arrival events.
-const MAX_BOLT_SLOTS: u8 = 6;
+/// Maximum number of pairing slots a receiver supports. We iterate this range
+/// to surface paired-but-offline devices that won't fire arrival events.
+const MAX_RECEIVER_SLOTS: u8 = 6;
 
 /// Upper bound on probing one HID node. `hidpp`'s request/response has no
 /// timeout of its own, so without this a single unresponsive (e.g. asleep)

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -155,7 +155,6 @@ pub struct Enumerator {
     /// Optional publication sink used by the persistent Agent watcher. One-shot
     /// callers keep this `None` and retain the route-opening library behavior.
     registry: Option<ChannelRegistry>,
-    tick: u64,
     /// Where the immutable probe cache is kept across restarts, `None` for a
     /// memory-only enumerator (one-shot CLI calls, tests).
     store: Option<Arc<dyn ProbeCacheStore>>,
@@ -435,7 +434,6 @@ impl Enumerator {
             channels: ChannelCache::default(),
             ledger: NodeLedger::default(),
             registry: None,
-            tick: 0,
             store: None,
             cache_dirty: false,
             open_failures_last_tick: false,
@@ -576,8 +574,6 @@ impl Enumerator {
     async fn enumerate_reporting_completeness(
         &mut self,
     ) -> Result<(Vec<DeviceInventory>, bool, bool), InventoryError> {
-        self.tick = self.tick.wrapping_add(1);
-        let tick = self.tick;
         let backend = Arc::clone(&self.backend);
         let candidates = backend.enumerate_hidpp().await?;
         debug!(count = candidates.len(), "HID++ candidate interfaces");
@@ -611,8 +607,7 @@ impl Enumerator {
                     } else {
                         PROBE_BUDGET
                     };
-                    let probe =
-                        timeout(budget, probe_one(info, Arc::clone(&channel), cache, tick)).await;
+                    let probe = timeout(budget, probe_one(info, Arc::clone(&channel), cache)).await;
                     (node, channel, probe, budget, receiver)
                 })
                 .collect::<Vec<_>>()
@@ -727,7 +722,7 @@ impl Enumerator {
                     self.cache_dirty |= persist::is_persistable(&key);
                     self.cache.insert(key, cached);
                 }
-                CacheOutcome::Update(key, cached) => {
+                CacheOutcome::Update(key, cached) | CacheOutcome::Bind(key, cached) => {
                     seen_keys.insert(key.clone());
                     self.cache.insert(key, cached);
                 }

--- a/crates/openlogi-device/src/inventory/cache.rs
+++ b/crates/openlogi-device/src/inventory/cache.rs
@@ -13,11 +13,8 @@ use crate::backend::NodeId;
 pub(super) enum CacheKey {
     /// Bolt: the unit id from the pairing register (cheap, read every tick).
     Bolt { unit_id: [u8; 4] },
-    /// Unifying: keyed on the full receiver serial number + pairing slot.
-    /// Using the complete serial (not just a prefix) avoids collisions between
-    /// two receivers whose serials share a common prefix (e.g. "DA2699E1" and
-    /// "DA2604F2" share "DA2").
-    UnifyingSlot { receiver_uid: String, slot: u8 },
+    /// Unifying: the unit id from the extended pairing register.
+    Unifying { unit_id: [u8; 4] },
     /// Direct (Bluetooth/USB): the OS-assigned HID node id (macOS registry-entry
     /// id, Linux dev path, Windows interface path). Unique *per node*, so two
     /// units of the same model never collide, and stable while connected so the

--- a/crates/openlogi-device/src/inventory/cache.rs
+++ b/crates/openlogi-device/src/inventory/cache.rs
@@ -1,20 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use hidpp::channel::HidppChannel;
 use openlogi_core::device::{BatteryInfo, BatteryStatus};
 
 use super::features::{BatteryProbe, ProbedFeatures, probe_features, read_battery};
 use crate::backend::NodeId;
-
-/// How many `enumerate` ticks a device's probe is reused before a fresh read.
-/// The expensive part of a probe (the `enumerate_features` feature-table walk)
-/// reads *immutable* data — model, capabilities, marketing type — so it never
-/// needs re-reading for a known device; the periodic full probe is kept only as
-/// a self-healing pass (e.g. a firmware update reshuffling the feature table).
-/// The volatile battery does NOT ride this window: cache hits re-read it every
-/// tick through the memoized feature index (see [`read_battery`]), so it stays
-/// as fresh as it was before the cache existed (#153).
-pub(super) const REFRESH_TICKS: u64 = 15;
 
 /// Stable identity used to memoize a device's probe across `enumerate` ticks.
 /// Keyed on the device's *own* identity (never its slot) so a re-paired or
@@ -40,7 +30,13 @@ pub(super) enum CacheKey {
 /// device's memoized data.
 pub(super) const CACHE_MISS_GRACE: u8 = 3;
 
-/// A memoized probe result plus the tick it was taken on.
+/// A memoized immutable probe result and the channel generation that produced
+/// (or last validated) it.
+///
+/// `None` is a persisted warm-start entry. The first live channel adopts it
+/// without a feature-table walk. A replacement channel validates it once
+/// before reuse, preventing runtime feature indexes from leaking across
+/// reconnects without periodically interrupting live control capture.
 #[derive(Clone)]
 pub(super) struct Cached {
     pub(super) probe: ProbedFeatures,
@@ -49,7 +45,25 @@ pub(super) struct Cached {
     /// round-trip — no `Device::new` ping, no table walk. `None` when the device
     /// exposes neither `0x1004` nor the legacy `0x1000`.
     pub(super) battery: Option<BatteryProbe>,
-    pub(super) probed_tick: u64,
+    pub(super) channel: Option<Weak<HidppChannel>>,
+}
+
+impl Cached {
+    fn belongs_to(&self, channel: &Arc<HidppChannel>) -> bool {
+        self.channel.as_ref().is_some_and(|cached| {
+            cached
+                .upgrade()
+                .is_some_and(|cached| Arc::ptr_eq(&cached, channel))
+        })
+    }
+
+    fn bind_to(&mut self, channel: &Arc<HidppChannel>) {
+        self.channel = Some(Arc::downgrade(channel));
+    }
+
+    pub(super) fn needs_validation(&self, channel: &Arc<HidppChannel>) -> bool {
+        self.channel.is_some() && !self.belongs_to(channel)
+    }
 }
 
 /// The legacy `0x1000` battery feature (MX2S-era mice) reports `discharge_level
@@ -90,13 +104,17 @@ fn hold_percentage_while_charging(
 }
 
 /// What a probed device contributes to the cache this tick. The key lets stale
-/// entries be evicted; `Fresh` (a full probe) and `Update` (a cache hit whose
-/// volatile battery was re-read) also carry the value to insert. `Unkeyed` is a
-/// device we can't (or won't) cache — an all-zero unit id, or a rejected
-/// non-peripheral — so its key is neither inserted nor kept alive.
+/// entries be evicted; `Fresh` (a full probe), `Update` (a cache hit whose
+/// volatile battery was re-read), and `Bind` (runtime channel association
+/// only) also carry the value to insert. `Unkeyed` is a device we can't (or
+/// won't) cache — an all-zero unit id, or a rejected non-peripheral — so its
+/// key is neither inserted nor kept alive.
 pub(super) enum CacheOutcome {
     Fresh(CacheKey, Cached),
     Update(CacheKey, Cached),
+    /// Associate immutable data with a runtime channel without claiming that
+    /// volatile device I/O succeeded.
+    Bind(CacheKey, Cached),
     Seen(CacheKey),
     Unkeyed,
 }
@@ -106,13 +124,9 @@ pub(super) fn seen(id: Option<CacheKey>) -> CacheOutcome {
     id.map_or(CacheOutcome::Unkeyed, CacheOutcome::Seen)
 }
 
-/// Whether `cached` is stale enough that the device should be re-probed.
-pub(super) fn is_stale(cached: &Cached, tick: u64) -> bool {
-    tick.wrapping_sub(cached.probed_tick) >= REFRESH_TICKS
-}
-
-/// Decide a device's probe: reuse a fresh cache, or (online + miss/stale)
-/// re-probe — but keep the last-known immutable data if the re-probe fails
+/// Decide a device's probe: reuse a cache associated with this channel, or
+/// (online + miss/replacement channel) re-probe — but keep the last-known
+/// immutable data if the re-probe fails
 /// rather than overwriting it with an empty default. An unprobed offline device
 /// with no cache yields a default probe. Returns the probe plus its cache
 /// contribution (only a *successful* probe is cached).
@@ -122,9 +136,9 @@ pub(super) async fn probe_or_reuse(
     id: Option<CacheKey>,
     cached: Option<&Cached>,
     online: bool,
-    tick: u64,
 ) -> (ProbedFeatures, CacheOutcome) {
-    if online && cached.is_none_or(|c| is_stale(c, tick)) {
+    let channel_replaced = cached.is_some_and(|c| c.needs_validation(channel));
+    if online && (cached.is_none() || channel_replaced) {
         let (mut fresh, battery) = probe_features(channel, index).await;
         if let (Some(reading), Some(probe)) = (fresh.battery.take(), battery) {
             fresh.battery = Some(hold_percentage_while_charging(
@@ -141,18 +155,25 @@ pub(super) async fn probe_or_reuse(
             }
             // A first-sight probe whose identity reads failed is served but not
             // memoized: caching it would pin a wrong (all-zero unit or
-            // serial-less) config key for `REFRESH_TICKS` (#482). The next tick
-            // re-probes instead.
+            // serial-less) config key for this channel's lifetime (#482). The
+            // next tick re-probes instead.
             if fresh.identity_incomplete && cached.is_none() {
                 return (fresh, seen(id));
             }
             // Same reasoning for a capability read that failed part-way: the
-            // walk understates the device, and memoizing that hides a panel in
-            // the GUI for `REFRESH_TICKS`. A previous complete walk outranks
-            // this partial one, so defer to it and re-probe next tick.
+            // walk understates the device, and memoizing it would hide a panel
+            // for this channel's lifetime. A previous complete walk outranks
+            // this partial one and is rebound to the new channel.
             if fresh.capabilities_incomplete {
                 if let Some(c) = cached {
                     keep_known_capabilities(&mut fresh, &c.probe);
+                    if let Some(key) = id {
+                        let mut value = c.clone();
+                        value.probe = fresh.clone();
+                        value.battery = battery.or(c.battery);
+                        value.bind_to(channel);
+                        return (fresh, CacheOutcome::Bind(key, value));
+                    }
                 }
                 return (fresh, seen(id));
             }
@@ -161,7 +182,7 @@ pub(super) async fn probe_or_reuse(
                     let value = Cached {
                         probe: fresh.clone(),
                         battery,
-                        probed_tick: tick,
+                        channel: Some(Arc::downgrade(channel)),
                     };
                     (fresh, CacheOutcome::Fresh(key, value))
                 }
@@ -171,9 +192,14 @@ pub(super) async fn probe_or_reuse(
         // Re-probe failed: don't cache the failure. Fall back to the last-known
         // data so a transient glitch doesn't drop the device or its battery.
         // No battery re-read either — the device just proved unresponsive.
-        return match cached {
-            Some(c) => (c.probe.clone(), seen(id)),
-            None => (fresh, seen(id)),
+        return match (cached, id) {
+            (Some(c), Some(key)) => {
+                let mut value = c.clone();
+                value.bind_to(channel);
+                (c.probe.clone(), CacheOutcome::Bind(key, value))
+            }
+            (Some(c), None) => (c.probe.clone(), CacheOutcome::Unkeyed),
+            (None, id) => (fresh, seen(id)),
         };
     }
     match cached {
@@ -191,7 +217,16 @@ pub(super) async fn probe_or_reuse(
                     hold_percentage_while_charging(battery, c.probe.battery.as_ref(), probe);
                 let mut entry = c.clone();
                 entry.probe.battery = Some(battery);
+                entry.bind_to(channel);
                 return (entry.probe.clone(), CacheOutcome::Update(key, entry));
+            }
+            if online
+                && c.channel.is_none()
+                && let Some(key) = id
+            {
+                let mut entry = c.clone();
+                entry.bind_to(channel);
+                return (entry.probe.clone(), CacheOutcome::Bind(key, entry));
             }
             (c.probe.clone(), seen(id))
         }
@@ -294,5 +329,111 @@ mod hold_tests {
             BatteryProbe::Unified(0),
         );
         assert_eq!(live.percentage, 0);
+    }
+}
+
+#[cfg(test)]
+mod channel_generation_tests {
+    use std::sync::Arc;
+
+    use openlogi_core::device::Capabilities;
+
+    use super::{CacheKey, CacheOutcome, Cached, ProbedFeatures, probe_or_reuse};
+    use crate::channel::scripted::{ScriptedRawHidChannel, feature_error, scripted_channel};
+
+    fn reject_feature_request(request: &[u8]) -> Option<Vec<u8>> {
+        let _report_id = request.first()?;
+        Some(feature_error(request, 2))
+    }
+
+    async fn rejecting_channel() -> (
+        Arc<hidpp::channel::HidppChannel>,
+        crate::channel::scripted::ScriptedRawHidHandle,
+    ) {
+        let (raw, handle) = ScriptedRawHidChannel::with_responder(reject_feature_request);
+        (scripted_channel(raw).await, handle)
+    }
+
+    fn cached_for(channel: &Arc<hidpp::channel::HidppChannel>) -> Cached {
+        Cached {
+            probe: ProbedFeatures {
+                capabilities: Some(Capabilities::default()),
+                ..ProbedFeatures::default()
+            },
+            battery: None,
+            channel: Some(Arc::downgrade(channel)),
+        }
+    }
+
+    #[tokio::test]
+    async fn immutable_probe_is_reused_for_the_whole_channel_generation() {
+        let (channel, handle) = rejecting_channel().await;
+        let cached = cached_for(&channel);
+        let id = CacheKey::Bolt { unit_id: [1; 4] };
+
+        for _ in 0..32 {
+            let (_, outcome) =
+                probe_or_reuse(&channel, 1, Some(id.clone()), Some(&cached), true).await;
+            assert!(matches!(outcome, CacheOutcome::Seen(_)));
+        }
+
+        assert!(
+            handle.written_reports().is_empty(),
+            "time alone must never trigger another feature-table walk"
+        );
+    }
+
+    #[tokio::test]
+    async fn replacement_channel_is_validated_once_even_when_probe_fails() {
+        let (old_channel, _) = rejecting_channel().await;
+        let cached = cached_for(&old_channel);
+        let (replacement, handle) = rejecting_channel().await;
+        let id = CacheKey::Bolt { unit_id: [2; 4] };
+
+        let (_, outcome) =
+            probe_or_reuse(&replacement, 1, Some(id.clone()), Some(&cached), true).await;
+        let rebound = match outcome {
+            CacheOutcome::Bind(key, rebound) => {
+                assert_eq!(key, id);
+                rebound
+            }
+            _ => panic!("a cached fallback must bind to the replacement channel"),
+        };
+        assert!(!rebound.needs_validation(&replacement));
+        assert!(!handle.written_reports().is_empty());
+
+        let writes_after_validation = handle.written_reports().len();
+        let (_, outcome) = probe_or_reuse(&replacement, 1, Some(id), Some(&rebound), true).await;
+        assert!(matches!(outcome, CacheOutcome::Seen(_)));
+        assert_eq!(
+            handle.written_reports().len(),
+            writes_after_validation,
+            "a failed validation must not become a two-second retry loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn persisted_cache_adoption_does_not_claim_live_io() {
+        let (channel, handle) = rejecting_channel().await;
+        let cached = Cached {
+            probe: ProbedFeatures::default(),
+            battery: None,
+            channel: None,
+        };
+        let id = CacheKey::Bolt { unit_id: [3; 4] };
+
+        let (_, outcome) = probe_or_reuse(&channel, 1, Some(id.clone()), Some(&cached), true).await;
+        let rebound = match outcome {
+            CacheOutcome::Bind(key, rebound) => {
+                assert_eq!(key, id);
+                rebound
+            }
+            _ => panic!("adoption without live I/O must not claim a volatile update"),
+        };
+        assert!(!rebound.needs_validation(&channel));
+        assert!(
+            handle.written_reports().is_empty(),
+            "warm-start adoption should not repeat the immutable probe"
+        );
     }
 }

--- a/crates/openlogi-device/src/inventory/features.rs
+++ b/crates/openlogi-device/src/inventory/features.rs
@@ -45,7 +45,7 @@ pub(super) struct ProbedFeatures {
     pub(super) identity_incomplete: bool,
     /// A capability read *failed* (vs. the device not having the capability),
     /// so `capabilities` above understates what the device can do. Memoizing
-    /// that would hide a panel in the GUI for `REFRESH_TICKS`.
+    /// that would hide a panel in the GUI for the channel's lifetime.
     pub(super) capabilities_incomplete: bool,
 }
 
@@ -319,9 +319,9 @@ async fn probe_extra_capabilities(
 /// Whether the device exposes a divertable haptic panel, or `None` when a read
 /// failed part-way through the ~40-entry control walk.
 ///
-/// The distinction matters because the answer is memoized for `REFRESH_TICKS`:
-/// reporting a lost reply as `false` hides the Actions Ring binding for half a
-/// minute on a device that has the panel.
+/// The distinction matters because the answer is memoized for the channel's
+/// lifetime: reporting a lost reply as `false` could hide the Actions Ring
+/// binding until the device reconnects.
 async fn has_haptic_panel(feature: &ReprogControlsFeature) -> Option<bool> {
     let count = feature.get_count().await.ok()?;
     for index in 0..count {

--- a/crates/openlogi-device/src/inventory/persist.rs
+++ b/crates/openlogi-device/src/inventory/persist.rs
@@ -12,10 +12,10 @@
 //! can silently reassign. A `CacheKey::UnifyingSlot` is `receiver + slot`: a
 //! different device paired into that slot while the agent is down would
 //! inherit the previous occupant's probe on warm start. A `CacheKey::Direct`
-//! is an OS-runtime node id with no cross-boot stability. Loaded entries get
-//! `probed_tick = 0`, so the regular `cache::REFRESH_TICKS`
-//! self-healing pass re-walks them on schedule; until (and unless) that walk
-//! succeeds, the persisted data serves exactly like an in-memory cache hit.
+//! is an OS-runtime node id with no cross-boot stability. Loaded entries have
+//! no runtime channel association. The first live channel adopts them without
+//! repeating the immutable feature-table walk; a replacement channel validates
+//! them once before reuse.
 //!
 //! *Where* a snapshot is kept is the host's business, not this module's: the
 //! enumerator writes through a [`ProbeCacheStore`]; `openlogi-hid` supplies
@@ -175,11 +175,7 @@ impl ProbeCacheSnapshot {
                     Cached {
                         probe: entry.probe,
                         battery: entry.battery,
-                        // Restart the refresh clock: the entry serves
-                        // immediately as a cache hit, and the periodic
-                        // self-healing re-walk decides when it is due for a
-                        // fresh read.
-                        probed_tick: 0,
+                        channel: None,
                     },
                 )
             })
@@ -229,7 +225,7 @@ mod tests {
                     ..Default::default()
                 },
                 battery: Some(BatteryProbe::Unified(9)),
-                probed_tick: 7,
+                channel: None,
             },
         );
         cache.insert(
@@ -240,7 +236,7 @@ mod tests {
             Cached {
                 probe: ProbedFeatures::default(),
                 battery: None,
-                probed_tick: 3,
+                channel: None,
             },
         );
 
@@ -261,9 +257,9 @@ mod tests {
             bolt.probe.battery.is_none(),
             "the battery *reading* is volatile — restoring it would resurrect a stale value"
         );
-        assert_eq!(
-            bolt.probed_tick, 0,
-            "a restored entry restarts the refresh clock"
+        assert!(
+            bolt.channel.is_none(),
+            "a restored entry must not retain a runtime channel"
         );
         assert!(
             !restored.contains_key(&CacheKey::UnifyingSlot {

--- a/crates/openlogi-device/src/inventory/persist.rs
+++ b/crates/openlogi-device/src/inventory/persist.rs
@@ -7,15 +7,12 @@
 //! fully probed once keeps its identity across restarts, even on transports
 //! where a fresh walk is slow or failing (see `BOLT_SLOT_PROBE`).
 //!
-//! Only Bolt identities are persisted, because only they are keyed on the
-//! device's *own* identity (the pairing-register unit id), which no re-pairing
-//! can silently reassign. A `CacheKey::UnifyingSlot` is `receiver + slot`: a
-//! different device paired into that slot while the agent is down would
-//! inherit the previous occupant's probe on warm start. A `CacheKey::Direct`
-//! is an OS-runtime node id with no cross-boot stability. Loaded entries have
-//! no runtime channel association. The first live channel adopts them without
-//! repeating the immutable feature-table walk; a replacement channel validates
-//! them once before reuse.
+//! Bolt and Unifying identities are persisted because both are keyed on the
+//! device's *own* unit id from their pairing registers, which no re-pairing can
+//! silently reassign. A `CacheKey::Direct` is an OS-runtime node id with no
+//! cross-boot stability. Loaded entries have no runtime channel association.
+//! The first live channel adopts them without repeating the immutable
+//! feature-table walk; a replacement channel validates them once before reuse.
 //!
 //! *Where* a snapshot is kept is the host's business, not this module's: the
 //! enumerator writes through a [`ProbeCacheStore`]; `openlogi-hid` supplies
@@ -31,8 +28,9 @@ use super::features::{BatteryProbe, ProbedFeatures};
 
 /// Bumped when the persisted shape changes; a mismatched snapshot is discarded
 /// (the cache is a warm-start optimization, not data anyone must keep).
-/// v2 dropped the `UnifyingSlot` key (slot-keyed, so not re-pair-safe).
-const SCHEMA_VERSION: u32 = 2;
+/// v3 restores Unifying entries under the device's own extended-pairing unit
+/// id, replacing the unsafe receiver-slot key removed by v2.
+const SCHEMA_VERSION: u32 = 3;
 
 impl ProbeCacheError {
     /// Report why a store could not keep a snapshot.
@@ -85,16 +83,18 @@ struct PersistedEntry {
     battery: Option<BatteryProbe>,
 }
 
-/// The persistable subset of [`CacheKey`] — Bolt only (see the module docs).
+/// The persistable subset of [`CacheKey`] (see the module docs).
 #[derive(Clone, Copy, Serialize, Deserialize)]
 enum PersistedKey {
     Bolt { unit_id: [u8; 4] },
+    Unifying { unit_id: [u8; 4] },
 }
 
 fn persistable(key: &CacheKey) -> Option<PersistedKey> {
     match key {
         CacheKey::Bolt { unit_id } => Some(PersistedKey::Bolt { unit_id: *unit_id }),
-        CacheKey::UnifyingSlot { .. } | CacheKey::Direct(_) => None,
+        CacheKey::Unifying { unit_id } => Some(PersistedKey::Unifying { unit_id: *unit_id }),
+        CacheKey::Direct(_) => None,
     }
 }
 
@@ -108,6 +108,7 @@ pub(super) fn is_persistable(key: &CacheKey) -> bool {
 fn runtime_key(key: PersistedKey) -> CacheKey {
     match key {
         PersistedKey::Bolt { unit_id } => CacheKey::Bolt { unit_id },
+        PersistedKey::Unifying { unit_id } => CacheKey::Unifying { unit_id },
     }
 }
 
@@ -199,7 +200,7 @@ mod tests {
     /// the whole point of the snapshot — but only the parts that are actually
     /// immutable, and only for keys a re-pair cannot silently reassign.
     #[test]
-    fn a_snapshot_keeps_bolt_identity_and_drops_the_volatile_reading() {
+    fn a_snapshot_keeps_receiver_identities_and_drops_volatile_readings() {
         let model = DeviceModelInfo {
             entity_count: 1,
             serial_number: Some("TESTSERIAL01".into()),
@@ -228,13 +229,19 @@ mod tests {
                 channel: None,
             },
         );
+        let unifying_key = CacheKey::Unifying {
+            unit_id: [0x11, 0x22, 0x33, 0x44],
+        };
         cache.insert(
-            CacheKey::UnifyingSlot {
-                receiver_uid: "DA2699E1".into(),
-                slot: 2,
-            },
+            unifying_key.clone(),
             Cached {
-                probe: ProbedFeatures::default(),
+                probe: ProbedFeatures {
+                    model_info: Some(DeviceModelInfo {
+                        unit_id: [0x11, 0x22, 0x33, 0x44],
+                        ..model.clone()
+                    }),
+                    ..Default::default()
+                },
                 battery: None,
                 channel: None,
             },
@@ -262,12 +269,8 @@ mod tests {
             "a restored entry must not retain a runtime channel"
         );
         assert!(
-            !restored.contains_key(&CacheKey::UnifyingSlot {
-                receiver_uid: "DA2699E1".into(),
-                slot: 2,
-            }),
-            "unifying entries are slot-keyed, so a re-pair while the agent is \
-             down could hand them to a different device — never persisted"
+            restored.contains_key(&unifying_key),
+            "a Unifying unit id is a physical identity and survives restart"
         );
     }
 

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -14,7 +14,9 @@ use hidpp::{
         },
     },
 };
-use openlogi_core::device::{DeviceInventory, DeviceKind, PairedDevice, ReceiverInfo};
+use openlogi_core::device::{
+    DeviceInventory, DeviceKind, DeviceModelInfo, DeviceTransports, PairedDevice, ReceiverInfo,
+};
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
@@ -25,7 +27,8 @@ use crate::channel::route::DIRECT_DEVICE_INDEX;
 use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
 use super::{
-    ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
+    ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_RECEIVER_SLOTS, UNIFYING_CACHED_SLOT_PROBE,
+    UNIFYING_SLOT_PROBE,
 };
 
 /// One probed node's contribution this tick: its inventory (if any), whether
@@ -95,7 +98,7 @@ async fn probe_bolt_receiver(
     // (wrong unit id / online / kind). They are cheap register reads, so
     // serializing them costs little.
     let mut identities = Vec::new();
-    for slot in 1u8..=MAX_BOLT_SLOTS {
+    for slot in 1u8..=MAX_RECEIVER_SLOTS {
         if let Some(identity) =
             read_bolt_slot_identity(&bolt, &channel, by_slot.get(&slot), slot).await
         {
@@ -183,83 +186,69 @@ async fn probe_unifying_receiver(
     debug!(pairing_count, "receiver reports pairing count");
     let unique_id = unifying.get_unique_id().await.ok();
 
-    // Trigger device-arrival events and collect one event per paired slot.
-    // Each event carries the slot index, kind, wpid, and a link-status bit —
-    // enough to build a PairedDevice entry, online or not.
-    //
-    // Note: the Unifying `0xB5/0x5N` pairing-info register uses a different
-    // sub-register base than Bolt, so paired slots are not polled directly.
-    // A slot whose re-broadcast goes missing this tick cannot be backfilled
-    // until that register format is resolved.
-    //
-    // The drain is therefore the *only* device source on this path, so a
-    // failed arrival trigger is "couldn't check", not "no devices online":
-    // settle it as a failed probe and let the ledger replay the last snapshot.
-    let Some(connections) = drain_device_arrival_unifying(&unifying, pairing_count).await else {
-        return NodeProbe::failed();
-    };
-    debug!(events = connections.len(), "drained device-arrival events");
-
-    // The receiver can re-broadcast the same 0x41 for a slot more than once per
-    // trigger, so keep one connection per slot — otherwise the device is listed
-    // twice. Last write wins: a later event carries the freshest online flag.
-    let mut connections: Vec<_> = connections
+    // Arrival events remain the liveness authority, but they are not an
+    // inventory authority: a sleeping device often emits no event at all.
+    // Read every occupied slot from the receiver registers as the durable
+    // inventory, then overlay the freshest event's online bit when present.
+    let arrivals = drain_device_arrival_unifying(&unifying, pairing_count).await;
+    let arrival_ok = arrivals.is_some();
+    let by_slot: HashMap<u8, UnifyingDeviceConnection> = arrivals
+        .unwrap_or_default()
         .into_iter()
-        .map(|c| (c.index, c))
-        .collect::<HashMap<_, _>>()
-        .into_values()
+        .map(|connection| (connection.index, connection))
         .collect();
-    // HashMap iteration is unordered; sort by slot so the device list is stable
-    // across probe cycles instead of jittering.
-    connections.sort_by_key(|c| c.index);
+    debug!(events = by_slot.len(), "drained device-arrival events");
 
-    // Probe all online slots concurrently so a slow HID++ 2.0 feature walk on
-    // one device doesn't push the next slot past the PROBE_BUDGET deadline.
-    // Pass the receiver UID so each slot's cache key is scoped to this specific
-    // receiver — two Unifying receivers sharing a slot number must not share a
-    // cache entry (different devices, different capabilities).
-    let receiver_uid_fallback;
-    let receiver_uid = if let Some(uid) = unique_id.as_deref() {
-        uid
-    } else {
-        // UID fetch failed — use the product ID as a weaker discriminant so
-        // two receivers with the same PID still collide, but a receiver and a
-        // direct device never share a cache entry.
-        tracing::warn!("Unifying receiver UID unavailable; cache isolation may be degraded");
-        receiver_uid_fallback = format!("pid:{:04x}", info.product_id);
-        &receiver_uid_fallback
-    };
-    let slot_results = connections
+    // Pairing and extended-pairing reads all address receiver register 0xB5.
+    // The channel correlates those replies by register rather than by the slot
+    // encoded in the payload, so issue them sequentially. Extended pairing
+    // supplies the physical unit id that lets receiver and Bluetooth routes
+    // resolve to one device without ever merging two same-model units.
+    let mut identities = Vec::new();
+    for slot in 1u8..=MAX_RECEIVER_SLOTS {
+        if let Some(identity) =
+            read_unifying_slot_identity(&unifying, by_slot.get(&slot), slot).await
+        {
+            identities.push(identity);
+            if identities.len() == usize::from(pairing_count) {
+                break;
+            }
+        }
+    }
+
+    // Feature walks address separate device indexes and are safe to run in
+    // parallel. A sleeping slot skips I/O and still surfaces with its stable
+    // receiver-stored identity.
+    let mut slot_results = identities
         .iter()
-        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache))
+        .map(|identity| walk_unifying_slot(&channel, identity, cache))
         .collect::<Vec<_>>()
         .join()
         .await;
 
-    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().flatten().unzip();
+    // Legacy receiver codenames also share register 0xB5. Preserve the old
+    // fallback, but serialize it after feature walks so one missing receiver
+    // ACK cannot block a healthy HID++ 2.0 device from being identified.
+    for (device, _) in &mut slot_results {
+        if device.codename.is_none() && device.capabilities.is_some() {
+            device.codename = read_codename_unifying(&channel, device.slot).await;
+        }
+    }
+
+    let (paired, outcomes): (Vec<_>, Vec<_>) = slot_results.into_iter().unzip();
 
     if paired.len() != usize::from(pairing_count) {
         debug!(
             expected = pairing_count,
             found = paired.len(),
-            "arrival drain reported fewer slots than the pairing count"
+            "pairing registers reported fewer slots than the pairing count"
         );
     }
-    // Unlike Bolt, a count/list shortfall is tolerated here: not every
-    // firmware re-broadcasts all paired slots (offline slots in particular can
-    // go missing), and there is no register poll to backfill them, so ledger
-    // health can't ride on it. The
-    // ledger health signal is the pairing-count register answering at all: that
-    // proves the receiver round-trip worked this cycle, while `None` (e.g. a
-    // parked channel) is "couldn't fully check" — the ledger then replays the
-    // last good snapshot instead of presenting a possibly-empty list (#218).
-    //
-    // The one-shot CLI path still needs a retry when the count says more
-    // devices may appear after a late arrival drain. Report that separately as
-    // `complete = false`; the unchanged-inventory fallback stops expected
-    // offline Unifying shortfalls after they stabilize.
-    let healthy = true;
     let complete = paired.len() == usize::from(pairing_count);
+    // A missing arrival trigger means online state was not checked. Publish
+    // the register inventory as a fallback only after the ledger's normal
+    // failure grace; until then replay the last-good liveness snapshot.
+    let healthy = complete && arrival_ok;
 
     NodeProbe {
         inventory: Some(DeviceInventory {
@@ -275,6 +264,64 @@ async fn probe_unifying_receiver(
         complete,
         outcomes,
     }
+}
+
+/// Receiver-stored identity for one occupied Unifying slot.
+///
+/// The unit id is physical-device identity; slot and WPID are only route/model
+/// metadata. An all-zero unit id remains unkeyed and is never cached.
+pub(super) struct UnifyingSlotIdentity {
+    pub(super) slot: u8,
+    pub(super) id: Option<CacheKey>,
+    pub(super) unit_id: [u8; 4],
+    pub(super) online: bool,
+    pub(super) register_kind: DeviceKind,
+    pub(super) wpid: u16,
+}
+
+async fn read_unifying_slot_identity(
+    unifying: &UnifyingReceiver,
+    event: Option<&UnifyingDeviceConnection>,
+    slot: u8,
+) -> Option<UnifyingSlotIdentity> {
+    let pairing = match unifying.get_device_pairing_information(slot).await {
+        Ok(pairing) => pairing,
+        Err(error) => {
+            debug!(slot, ?error, "Unifying slot empty or unreadable");
+            return None;
+        }
+    };
+    let unit_id = match unifying.get_device_extended_pairing_information(slot).await {
+        Ok(extended) => extended.unit_id,
+        Err(error) => {
+            debug!(slot, ?error, "Unifying extended identity unavailable");
+            [0; 4]
+        }
+    };
+    let online = event.is_some_and(|connection| connection.online);
+    let register_kind = event.map_or_else(
+        || map_unifying_kind(pairing.kind),
+        |connection| map_unifying_kind(connection.kind),
+    );
+    let wpid = event.map_or(pairing.wpid, |connection| connection.wpid);
+    let id = (unit_id != [0; 4]).then_some(CacheKey::Unifying { unit_id });
+    debug!(
+        slot,
+        online,
+        wpid = format_args!("{wpid:04x}"),
+        ?register_kind,
+        ?unit_id,
+        has_event = event.is_some(),
+        "Unifying paired slot"
+    );
+    Some(UnifyingSlotIdentity {
+        slot,
+        id,
+        unit_id,
+        online,
+        register_kind,
+        wpid,
+    })
 }
 
 /// Identity read from the receiver's registers for one occupied Bolt slot
@@ -604,29 +651,18 @@ async fn drain_device_arrival_unifying(
     }
 }
 
-/// Probe a Unifying slot from a live device-connection event.
-///
-/// Device-arrival events carry the slot index, kind, wpid, and online status —
-/// enough to surface an entry for every currently-connected device. The
-/// unit_id (needed for stable caching across ticks) is not available without a
-/// working `get_device_pairing_information` call; we derive a stable cache key
-/// from the receiver UID + slot so the feature-table walk is amortised at ~30s
-/// and two receivers sharing a slot number don't collide in the cache.
-pub(super) async fn probe_unifying_slot(
+/// Walk one Unifying slot using the receiver-stored physical identity read in
+/// phase 1. Sleeping devices perform no device I/O but still carry their unit
+/// id into the inventory, allowing an offline receiver route to reconcile with
+/// the same unit's Bluetooth route.
+pub(super) async fn walk_unifying_slot(
     channel: &Arc<HidppChannel>,
-    event: &UnifyingDeviceConnection,
-    receiver_uid: &str,
+    identity: &UnifyingSlotIdentity,
     cache: &HashMap<CacheKey, Cached>,
-) -> Option<(PairedDevice, CacheOutcome)> {
-    let slot = event.index;
-    // Cache key: full receiver serial + slot so two Unifying receivers with
-    // a device on the same slot number never share a cache entry.
-    let id = CacheKey::UnifyingSlot {
-        receiver_uid: receiver_uid.to_string(),
-        slot,
-    };
-    let cached = cache.get(&id);
-    let register_kind = map_unifying_kind(event.kind);
+) -> (PairedDevice, CacheOutcome) {
+    let slot = identity.slot;
+    let id = identity.id.clone();
+    let cached = id.as_ref().and_then(|key| cache.get(key));
 
     // The 0x41 re-broadcast is the receiver's own slot report and its
     // link-status bit is the liveness authority (Solaar's trigger scan trusts
@@ -638,7 +674,7 @@ pub(super) async fn probe_unifying_slot(
     let probe_budget = unifying_probe_budget(cached, channel);
     let probe_result = timeout(
         probe_budget,
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, event.online),
+        probe_or_reuse(channel, slot, id.clone(), cached, identity.online),
     )
     .await;
     let (probe, outcome) = if let Ok(result) = probe_result {
@@ -647,26 +683,15 @@ pub(super) async fn probe_unifying_slot(
         debug!(slot, budget = ?probe_budget,
             "Unifying slot probe timed out; using cached data if available");
         let probe = cached.map_or_else(ProbedFeatures::default, |entry| entry.probe.clone());
-        (probe, CacheOutcome::Seen(id))
+        (probe, seen(id))
     };
 
-    // HID++ 2.0's marketing name is the same identity we need for display and
-    // avoids another receiver-register round trip. Keep the legacy codename
-    // read only for a completed feature walk that did not expose a name; never
-    // put it in front of the feature probe, where one missing receiver ACK can
-    // otherwise starve a healthy Lightspeed mouse forever.
-    let codename = if let Some(name) = probe.marketing_name.clone() {
-        Some(name)
-    } else if probe.capabilities.is_some() {
-        read_codename_unifying(channel, slot).await
-    } else {
-        None
-    };
+    let codename = probe.marketing_name.clone();
     debug!(
         slot,
-        online = event.online,
-        wpid = format_args!("{:04x}", event.wpid),
-        kind = ?event.kind,
+        online = identity.online,
+        wpid = format_args!("{:04x}", identity.wpid),
+        kind = ?identity.register_kind,
         codename = ?codename,
         "unifying paired slot"
     );
@@ -674,12 +699,13 @@ pub(super) async fn probe_unifying_slot(
     let device = assemble_unifying_device(
         slot,
         codename,
-        event.wpid,
-        register_kind,
+        identity.wpid,
+        identity.unit_id,
+        identity.register_kind,
         probe,
-        event.online,
+        identity.online,
     );
-    Some((device, outcome))
+    (device, outcome)
 }
 
 /// A cache hit needs only an optional battery refresh; first sight retains the
@@ -700,10 +726,34 @@ pub(super) fn assemble_unifying_device(
     slot: u8,
     codename: Option<String>,
     wpid: u16,
+    unit_id: [u8; 4],
     register_kind: DeviceKind,
-    probe: ProbedFeatures,
+    mut probe: ProbedFeatures,
     online: bool,
 ) -> PairedDevice {
+    // The extended pairing register is readable even while the device sleeps
+    // and is the same physical unit id HID++ 2.0 reports over Bluetooth. Fold
+    // it into the model payload so downstream identity resolution can unify
+    // routes without any model-name heuristic. A HID++ 1.0/offline device may
+    // have no feature-table model info at all; synthesize only the fields the
+    // receiver authoritatively owns.
+    if unit_id != [0; 4] {
+        if let Some(model) = probe.model_info.as_mut() {
+            model.unit_id = unit_id;
+        } else {
+            probe.model_info = Some(DeviceModelInfo {
+                entity_count: 0,
+                serial_number: None,
+                unit_id,
+                transports: DeviceTransports {
+                    equad: true,
+                    ..DeviceTransports::default()
+                },
+                model_ids: [wpid, 0, 0],
+                extended_model_id: 0,
+            });
+        }
+    }
     PairedDevice {
         slot,
         codename,

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -22,7 +22,7 @@ use super::mappings::{map_kind, map_unifying_kind, resolve_device_kind};
 use crate::backend::NodeInfo;
 use crate::channel::route::DIRECT_DEVICE_INDEX;
 
-use super::cache::{CacheKey, CacheOutcome, Cached, is_stale, probe_or_reuse, seen};
+use super::cache::{CacheKey, CacheOutcome, Cached, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
 use super::{
     ARRIVAL_DRAIN, BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
@@ -57,19 +57,18 @@ pub(super) async fn probe_one(
     info: NodeInfo,
     channel: Arc<HidppChannel>,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
 ) -> NodeProbe {
     match receiver::detect(Arc::clone(&channel)) {
-        Some(Receiver::Bolt(bolt)) => probe_bolt_receiver(channel, info, bolt, cache, tick).await,
+        Some(Receiver::Bolt(bolt)) => probe_bolt_receiver(channel, info, bolt, cache).await,
         Some(Receiver::Unifying(unifying)) => {
-            probe_unifying_receiver(channel, info, unifying, cache, tick).await
+            probe_unifying_receiver(channel, info, unifying, cache).await
         }
         None | Some(_) => {
             // No recognised receiver — this might be a directly-paired device
             // (Bluetooth-direct, USB-C cable). HID++ at device-index 0xff
             // addresses the device's own features. Probe in case it answers.
             // P2.4 — verified path; no Bolt-pairing slot indirection needed.
-            probe_direct(channel, &info, cache, tick).await
+            probe_direct(channel, &info, cache).await
         }
     }
 }
@@ -79,7 +78,6 @@ async fn probe_bolt_receiver(
     info: NodeInfo,
     bolt: BoltReceiver,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
 ) -> NodeProbe {
     let unique_id = bolt.get_unique_id().await.ok();
     let pairing_count = bolt.count_pairings().await.ok();
@@ -113,7 +111,7 @@ async fn probe_bolt_receiver(
     // device list stable across ticks without an explicit sort.
     let slot_results = identities
         .iter()
-        .map(|identity| walk_bolt_slot(&channel, identity, cache, tick))
+        .map(|identity| walk_bolt_slot(&channel, identity, cache))
         .collect::<Vec<_>>()
         .join()
         .await;
@@ -169,7 +167,6 @@ async fn probe_unifying_receiver(
     info: NodeInfo,
     unifying: UnifyingReceiver,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
 ) -> NodeProbe {
     // Pairing count is the health gate for this path: without it the result is
     // settled as a failed probe regardless of any later arrival events. Check
@@ -234,7 +231,7 @@ async fn probe_unifying_receiver(
     };
     let slot_results = connections
         .iter()
-        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache, tick))
+        .map(|conn| probe_unifying_slot(&channel, conn, receiver_uid, cache))
         .collect::<Vec<_>>()
         .join()
         .await;
@@ -352,7 +349,6 @@ async fn walk_bolt_slot(
     channel: &Arc<HidppChannel>,
     identity: &BoltSlotIdentity,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
 ) -> (PairedDevice, CacheOutcome) {
     let &BoltSlotIdentity {
         slot,
@@ -371,7 +367,7 @@ async fn walk_bolt_slot(
     // mirroring the Unifying path (#218).
     let probe_result = timeout(
         BOLT_SLOT_PROBE,
-        probe_or_reuse(channel, slot, id.clone(), cached, online, tick),
+        probe_or_reuse(channel, slot, id.clone(), cached, online),
     )
     .await;
     let (probe, outcome) = if let Ok(r) = probe_result {
@@ -435,14 +431,13 @@ async fn probe_direct(
     channel: Arc<HidppChannel>,
     info: &NodeInfo,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
 ) -> NodeProbe {
     let id = CacheKey::Direct(info.id.clone());
     let cached = cache.get(&id);
     // A direct device is always "present" (its HID node is the candidate), so
     // treat it as online: reuse the cached probe while fresh, otherwise probe.
     let (probe, outcome) =
-        probe_or_reuse(&channel, DIRECT_DEVICE_INDEX, Some(id), cached, true, tick).await;
+        probe_or_reuse(&channel, DIRECT_DEVICE_INDEX, Some(id), cached, true).await;
     // Hybrid peripheral discriminator. A genuine directly-attached device is
     // either wireless/Bluetooth — which reports a battery — or exposes a
     // configuration feature (buttons / pointer / lighting). A Bolt receiver's
@@ -622,7 +617,6 @@ pub(super) async fn probe_unifying_slot(
     event: &UnifyingDeviceConnection,
     receiver_uid: &str,
     cache: &HashMap<CacheKey, Cached>,
-    tick: u64,
 ) -> Option<(PairedDevice, CacheOutcome)> {
     let slot = event.index;
     // Cache key: full receiver serial + slot so two Unifying receivers with
@@ -641,10 +635,10 @@ pub(super) async fn probe_unifying_slot(
     // announced itself into "offline" — and don't probe an offline slot at
     // all, which would burn the budget on a link the receiver just reported
     // as not established.
-    let probe_budget = unifying_probe_budget(cached, tick);
+    let probe_budget = unifying_probe_budget(cached, channel);
     let probe_result = timeout(
         probe_budget,
-        probe_or_reuse(channel, slot, Some(id.clone()), cached, event.online, tick),
+        probe_or_reuse(channel, slot, Some(id.clone()), cached, event.online),
     )
     .await;
     let (probe, outcome) = if let Ok(result) = probe_result {
@@ -688,10 +682,14 @@ pub(super) async fn probe_unifying_slot(
     Some((device, outcome))
 }
 
-/// A fresh cache hit needs only an optional battery refresh; first-sight and
-/// stale entries retain the larger budget needed for a complete feature walk.
-pub(super) fn unifying_probe_budget(cached: Option<&Cached>, tick: u64) -> std::time::Duration {
-    if cached.is_some_and(|entry| !is_stale(entry, tick)) {
+/// A cache hit needs only an optional battery refresh; first sight retains the
+/// larger budget needed for a complete feature walk. A cache bound to a
+/// replaced channel also gets the full budget for its one validation walk.
+pub(super) fn unifying_probe_budget(
+    cached: Option<&Cached>,
+    channel: &Arc<HidppChannel>,
+) -> std::time::Duration {
+    if cached.is_some_and(|entry| !entry.needs_validation(channel)) {
         UNIFYING_CACHED_SLOT_PROBE
     } else {
         UNIFYING_SLOT_PROBE

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -9,8 +9,7 @@ use openlogi_core::device::{
 };
 
 use super::cache::{
-    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, REFRESH_TICKS, backfill_identity, is_stale,
-    keep_known_capabilities,
+    CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached, backfill_identity, keep_known_capabilities,
 };
 use super::features::ProbedFeatures;
 use super::probe::{
@@ -26,11 +25,11 @@ use crate::channel::scripted::{
 };
 use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
 
-fn cache_entry(probed_tick: u64) -> Cached {
+fn cache_entry() -> Cached {
     Cached {
         probe: ProbedFeatures::default(),
         battery: None,
-        probed_tick,
+        channel: None,
     }
 }
 
@@ -53,7 +52,7 @@ fn cache_dirty_tracks_only_persistable_keys() {
         receiver_uid: "DA2699E1".into(),
         slot: 1,
     };
-    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry(0))]);
+    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry())]);
     assert!(
         !e.cache_dirty,
         "non-persistable fresh probe dirtied the cache"
@@ -71,7 +70,7 @@ fn cache_dirty_tracks_only_persistable_keys() {
     let bolt = CacheKey::Bolt {
         unit_id: [1, 2, 3, 4],
     };
-    e.apply_outcomes(vec![CacheOutcome::Fresh(bolt, cache_entry(0))]);
+    e.apply_outcomes(vec![CacheOutcome::Fresh(bolt, cache_entry())]);
     assert!(
         e.cache_dirty,
         "persistable fresh probe must dirty the cache"
@@ -84,7 +83,7 @@ fn cache_entry_survives_grace_then_evicts() {
     let key = CacheKey::Bolt {
         unit_id: [1, 2, 3, 4],
     };
-    e.cache.insert(key.clone(), cache_entry(0));
+    e.cache.insert(key.clone(), cache_entry());
     let nobody = HashSet::new();
     // Missing for the whole grace window: kept.
     for _ in 0..CACHE_MISS_GRACE {
@@ -106,7 +105,7 @@ fn cache_entry_survives_grace_then_evicts() {
 fn being_seen_resets_the_miss_counter() {
     let mut e = Enumerator::with_backend(ScriptedBackend::new(Vec::new()));
     let key = CacheKey::Bolt { unit_id: [9; 4] };
-    e.cache.insert(key.clone(), cache_entry(0));
+    e.cache.insert(key.clone(), cache_entry());
     let nobody = HashSet::new();
     let seen: HashSet<CacheKey> = std::iter::once(key.clone()).collect();
     e.evict_unseen(&nobody); // miss 1
@@ -120,38 +119,26 @@ fn being_seen_resets_the_miss_counter() {
     );
 }
 
-#[test]
-fn cached_probe_is_reused_until_refresh_ticks() {
-    let cached = Cached {
-        probe: ProbedFeatures::default(),
-        battery: None,
-        probed_tick: 10,
-    };
-    assert!(!is_stale(&cached, 10), "same tick is fresh");
-    assert!(
-        !is_stale(&cached, 10 + REFRESH_TICKS - 1),
-        "just under the window is still fresh"
-    );
-    assert!(
-        is_stale(&cached, 10 + REFRESH_TICKS),
-        "at the window the probe is refreshed"
-    );
-}
-
-#[test]
-fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
-    let cached = cache_entry(10);
+#[tokio::test]
+async fn unifying_cache_hits_use_only_the_battery_refresh_budget() {
+    let (raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+    let channel = scripted_channel(raw).await;
+    let mut cached = cache_entry();
+    cached.channel = Some(Arc::downgrade(&channel));
     assert_eq!(
-        unifying_probe_budget(Some(&cached), 10),
+        unifying_probe_budget(Some(&cached), &channel),
         UNIFYING_CACHED_SLOT_PROBE
     );
+
+    let (replacement_raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+    let replacement = scripted_channel(replacement_raw).await;
     assert_eq!(
-        unifying_probe_budget(Some(&cached), 10 + REFRESH_TICKS),
+        unifying_probe_budget(Some(&cached), &replacement),
         UNIFYING_SLOT_PROBE,
-        "stale entries still get enough time for a full feature walk"
+        "a replacement channel needs enough time for one validation walk"
     );
     assert_eq!(
-        unifying_probe_budget(None, 10),
+        unifying_probe_budget(None, &channel),
         UNIFYING_SLOT_PROBE,
         "first sight still gets the full feature-walk budget"
     );
@@ -179,7 +166,7 @@ async fn offline_arrival_rebroadcasts_surface_without_probing_the_device() {
     let writes_before = handle.written_reports().len();
 
     let cache = HashMap::new();
-    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache, 0)
+    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache)
         .await
         .expect("an offline slot still surfaces from its re-broadcast");
 
@@ -544,8 +531,8 @@ fn probed(model_info: Option<DeviceModelInfo>, identity_incomplete: bool) -> Pro
 }
 
 /// A control-table read that fails half way reads exactly like "no haptic
-/// panel", and the answer is memoized for `REFRESH_TICKS` — so the Actions Ring
-/// binding would vanish from the GUI for half a minute on a device that has it.
+/// panel", and the answer is memoized for the channel's lifetime — so the
+/// Actions Ring binding would otherwise vanish until the device reconnects.
 #[test]
 fn an_incomplete_capability_walk_keeps_the_last_complete_answer() {
     let mut fresh = probed(None, false);

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -13,8 +13,8 @@ use super::cache::{
 };
 use super::features::ProbedFeatures;
 use super::probe::{
-    NodeProbe, assemble_bolt_probe, assemble_unifying_device, parse_codename_unifying,
-    preferred_direct_codename, probe_unifying_slot, unifying_probe_budget,
+    NodeProbe, UnifyingSlotIdentity, assemble_bolt_probe, assemble_unifying_device,
+    parse_codename_unifying, preferred_direct_codename, unifying_probe_budget, walk_unifying_slot,
 };
 use super::{
     ChannelCache, Enumerator, ONESHOT_ATTEMPTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
@@ -44,15 +44,12 @@ fn direct_codename_prefers_hidpp_marketing_name_over_generic_os_name() {
 
 #[test]
 fn cache_dirty_tracks_only_persistable_keys() {
-    // A system whose devices never persist (direct-only, or Unifying) must not
+    // A system whose devices never persist (direct-only) must not
     // rewrite probe-cache.json on every refresh pass: the file's content
     // wouldn't change.
     let mut e = Enumerator::with_backend(ScriptedBackend::new(Vec::new()));
-    let unifying = CacheKey::UnifyingSlot {
-        receiver_uid: "DA2699E1".into(),
-        slot: 1,
-    };
-    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying.clone(), cache_entry())]);
+    let direct = CacheKey::Direct("node-1".to_string().into());
+    e.apply_outcomes(vec![CacheOutcome::Fresh(direct.clone(), cache_entry())]);
     assert!(
         !e.cache_dirty,
         "non-persistable fresh probe dirtied the cache"
@@ -63,10 +60,10 @@ fn cache_dirty_tracks_only_persistable_keys() {
     for _ in 0..=CACHE_MISS_GRACE {
         e.evict_unseen(&nobody);
     }
-    assert!(!e.cache.contains_key(&unifying), "entry should be evicted");
+    assert!(!e.cache.contains_key(&direct), "entry should be evicted");
     assert!(!e.cache_dirty, "non-persistable eviction dirtied the cache");
 
-    // A Bolt probe is what the file stores — that one dirties it.
+    // Receiver probes have physical unit ids and do dirty the snapshot.
     let bolt = CacheKey::Bolt {
         unit_id: [1, 2, 3, 4],
     };
@@ -74,6 +71,15 @@ fn cache_dirty_tracks_only_persistable_keys() {
     assert!(
         e.cache_dirty,
         "persistable fresh probe must dirty the cache"
+    );
+    e.cache_dirty = false;
+    let unifying = CacheKey::Unifying {
+        unit_id: [5, 6, 7, 8],
+    };
+    e.apply_outcomes(vec![CacheOutcome::Fresh(unifying, cache_entry())]);
+    assert!(
+        e.cache_dirty,
+        "a Unifying physical unit id must be persistable"
     );
 }
 
@@ -166,9 +172,17 @@ async fn offline_arrival_rebroadcasts_surface_without_probing_the_device() {
     let writes_before = handle.written_reports().len();
 
     let cache = HashMap::new();
-    let (device, _) = probe_unifying_slot(&channel, &event, "SERIAL", &cache)
-        .await
-        .expect("an offline slot still surfaces from its re-broadcast");
+    let identity = UnifyingSlotIdentity {
+        slot: event.index,
+        id: Some(CacheKey::Unifying {
+            unit_id: [1, 2, 3, 4],
+        }),
+        unit_id: [1, 2, 3, 4],
+        online: event.online,
+        register_kind: DeviceKind::Mouse,
+        wpid: event.wpid,
+    };
+    let (device, _) = walk_unifying_slot(&channel, &identity, &cache).await;
 
     assert!(!device.online);
     assert_eq!(device.wpid, Some(0x4069));
@@ -185,6 +199,7 @@ fn unifying_arrival_liveness_survives_missing_feature_data() {
         1,
         None,
         0x40b8,
+        [0; 4],
         DeviceKind::Mouse,
         ProbedFeatures::default(),
         true,

--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -50,7 +50,7 @@ pub use pairing::{
 };
 pub use session::gesture::{
     CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
-    run_capture_session_with_stop_reason,
+    run_capture_session_with_registry_spec, run_capture_session_with_stop_reason,
 };
 pub use session::host_switch::{
     HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -41,6 +41,12 @@ const LIVENESS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// happen under pointer load) doesn't churn the session.
 const LIVENESS_PING_STRIKES: u8 = 2;
 
+/// How often a registry-backed capture verifies that inventory still publishes
+/// the exact channel it armed on. This is memory-only and deliberately faster
+/// than the HID++ liveness ping, so a reconnect replaces a stale listener
+/// without waiting for two wire timeouts.
+const REGISTRY_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Shared slot holding the active capture session's open channel, so DPI /
 /// SmartShift writes can reuse it instead of opening a fresh one. `None`
 /// whenever no session is connected.
@@ -202,6 +208,50 @@ pub async fn run_capture_session(
     let chan = open_route_channel(backend, &route)
         .await?
         .ok_or(GestureError::DeviceNotFound)?;
+    let shared = SharedChannel::new(chan, route.clone());
+    run_capture_session_on(route, spec, sink, shutdown, channel_slot, shared, None).await
+}
+
+/// Capture controls through the exact channel currently owned by the Agent's
+/// inventory enumerator.
+///
+/// A registry miss is retried by the watcher after a later inventory
+/// publication; it never opens a competing handle to the same Bluetooth HID
+/// node. If inventory replaces the publication after a reconnect, the session
+/// exits so its watcher can arm against the new generation.
+pub async fn run_capture_session_with_registry_spec(
+    route: DeviceRoute,
+    spec: CaptureSpec,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+    registry: &crate::ChannelRegistry,
+) -> Result<(), GestureError> {
+    let shared = registry
+        .lookup(&route)
+        .ok_or(GestureError::DeviceNotFound)?;
+    run_capture_session_on(
+        route,
+        spec,
+        sink,
+        shutdown,
+        channel_slot,
+        shared,
+        Some(registry),
+    )
+    .await
+}
+
+async fn run_capture_session_on(
+    route: DeviceRoute,
+    spec: CaptureSpec,
+    sink: mpsc::UnboundedSender<CapturedInput>,
+    shutdown: oneshot::Receiver<()>,
+    channel_slot: CaptureChannel,
+    shared: SharedChannel,
+    registry: Option<&crate::ChannelRegistry>,
+) -> Result<(), GestureError> {
+    let chan = Arc::clone(shared.channel());
     let device_index = route.device_index();
     let armed = arm_controls(&chan, device_index, &spec).await?;
 
@@ -256,47 +306,7 @@ pub async fn run_capture_session(
         "control capture active"
     );
 
-    // Liveness watchdog: this session's channel is the sole delivery path for
-    // every diverted control, and a channel whose input-report delivery dies
-    // (observed on macOS with concurrent opens of one node: writes accepted,
-    // replies and events silently routed elsewhere) turns every captured
-    // button to dead air with nothing to notice. Ping the device through this
-    // channel; consecutive all-silent pings mean the channel — not the device
-    // — is gone (a sleeping/unreachable device still gets us an error *reply*,
-    // which proves delivery and resets the count). Exiting lets the manager
-    // re-arm on a fresh channel.
-    let root = <hidpp::feature::root::RootFeature as hidpp::feature::CreatableFeature>::new(
-        Arc::clone(&chan),
-        device_index,
-        0,
-    );
-    let mut shutdown = std::pin::pin!(shutdown);
-    let mut silent_pings = 0u8;
-    let channel_dead = loop {
-        tokio::select! {
-            _ = &mut shutdown => break false,
-            () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
-                match root.ping(0x5a).await {
-                    Err(v20::Hidpp20Error::Channel(
-                        hidpp::channel::ChannelError::Timeout
-                        | hidpp::channel::ChannelError::NoResponse,
-                    )) => {
-                        silent_pings = silent_pings.saturating_add(1);
-                        if silent_pings >= LIVENESS_PING_STRIKES {
-                            warn!(
-                                index = device_index,
-                                "capture channel stopped delivering — restarting session on a fresh channel"
-                            );
-                            break true;
-                        }
-                    }
-                    // Any reply — pong, feature error, unreachable-device
-                    // error — proves the channel still delivers.
-                    _ => silent_pings = 0,
-                }
-            }
-        }
-    };
+    let channel_dead = monitor_channel(&chan, device_index, &shared, registry, shutdown).await;
 
     drop(listener);
     // The slot is one last-writer-wins cell shared by every session, so a
@@ -321,6 +331,63 @@ pub async fn run_capture_session(
     }
     debug!(index = device_index, "control capture stopped");
     Ok(())
+}
+
+/// Wait for shutdown while proving that the capture channel remains the live
+/// inventory publication and still carries HID++ replies.
+async fn monitor_channel(
+    chan: &Arc<HidppChannel>,
+    device_index: u8,
+    shared: &SharedChannel,
+    registry: Option<&crate::ChannelRegistry>,
+    shutdown: oneshot::Receiver<()>,
+) -> bool {
+    // This channel is the sole delivery path for every diverted control. A
+    // channel whose input-report delivery dies turns every captured button to
+    // dead air. Consecutive silent pings mean the channel — not the device —
+    // is gone; a sleeping device still returns an error reply, which proves
+    // delivery and clears the strike.
+    let root = <hidpp::feature::root::RootFeature as hidpp::feature::CreatableFeature>::new(
+        Arc::clone(chan),
+        device_index,
+        0,
+    );
+    let mut shutdown = std::pin::pin!(shutdown);
+    let mut silent_pings = 0u8;
+    let mut registry_checks = tokio::time::interval(REGISTRY_CHECK_INTERVAL);
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => return false,
+            _ = registry_checks.tick(), if registry.is_some() => {
+                if registry.is_some_and(|registry| !registry.is_current(shared)) {
+                    warn!(
+                        index = device_index,
+                        "inventory replaced the capture channel — restarting on the new generation"
+                    );
+                    return true;
+                }
+            }
+            () = tokio::time::sleep(LIVENESS_PING_INTERVAL) => {
+                match root.ping(0x5a).await {
+                    Err(v20::Hidpp20Error::Channel(
+                        hidpp::channel::ChannelError::Timeout
+                        | hidpp::channel::ChannelError::NoResponse,
+                    )) => {
+                        silent_pings = silent_pings.saturating_add(1);
+                        if silent_pings >= LIVENESS_PING_STRIKES {
+                            warn!(
+                                index = device_index,
+                                "capture channel stopped delivering — restarting session on a fresh channel"
+                            );
+                            return true;
+                        }
+                    }
+                    // Any reply proves the channel still delivers.
+                    _ => silent_pings = 0,
+                }
+            }
+        }
+    }
 }
 
 /// The single input one diverted thumb-wheel report stands for, if any.

--- a/crates/openlogi-hid/src/transport.rs
+++ b/crates/openlogi-hid/src/transport.rs
@@ -5,7 +5,8 @@
 //! that path by pre-filtering to the Logitech HID++ vendor collections at
 //! enumeration time (see [`HIDPP_LONG_COLLECTIONS`]) and reporting support
 //! straight from [`hidpp::channel::RawHidChannel::supports_short_long_hidpp`]: USB / receiver
-//! collections carry both reports; BLE-direct collections are long-only, and the
+//! collections carry both reports; BLE-direct collections and the Generic
+//! Desktop fallback exposed by some MX Ergo devices are long-only, and the
 //! `hidpp` channel up-converts outgoing short messages to long for them.
 
 #[cfg(not(target_os = "windows"))]
@@ -153,11 +154,27 @@ const HIDPP_LONG_COLLECTIONS: [(u16, u16, bool); 3] = [
     (0xff43, 0x0602, false),
 ];
 
+/// Generic Desktop Controls usage page.
+const GENERIC_DESKTOP_PAGE: u16 = 0x0001;
+/// Generic Desktop mouse usage.
+const GENERIC_DESKTOP_MOUSE: u16 = 0x0002;
+
 /// Whether `(usage_page, usage_id)` is one of the HID++ long-report collections.
 fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
     HIDPP_LONG_COLLECTIONS
         .iter()
         .any(|&(page, usage, _)| (page, usage) == (usage_page, usage_id))
+}
+
+/// Whether this is the fallback collection used by Logitech Bluetooth mice
+/// that do not publish a separate vendor-defined HID++ collection.
+///
+/// Direct Bluetooth product IDs use the `0xb0xx` family (including MX Ergo
+/// `0xb01d` and MX Ergo S `0xb03e`). Receiver and wired product IDs use other
+/// families, so their ordinary mouse collections remain excluded.
+fn is_bluetooth_mouse_fallback(product_id: u16, usage_page: u16, usage_id: u16) -> bool {
+    product_id & 0xff00 == 0xb000
+        && (usage_page, usage_id) == (GENERIC_DESKTOP_PAGE, GENERIC_DESKTOP_MOUSE)
 }
 
 /// Whether the matched HID++ collection exposes only the long report, so short
@@ -176,10 +193,11 @@ fn is_hidpp_long_collection(usage_page: u16, usage_id: u16) -> bool {
         reason = "long-only up-conversion is the non-Windows AsyncHidChannel path"
     )
 )]
-fn is_long_only_collection(usage_page: u16, usage_id: u16) -> bool {
-    HIDPP_LONG_COLLECTIONS
-        .iter()
-        .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
+fn is_long_only_collection(product_id: u16, usage_page: u16, usage_id: u16) -> bool {
+    is_bluetooth_mouse_fallback(product_id, usage_page, usage_id)
+        || HIDPP_LONG_COLLECTIONS
+            .iter()
+            .any(|&(page, usage, long_only)| long_only && (page, usage) == (usage_page, usage_id))
 }
 
 /// Process-wide HID backend, created once and reused for every enumeration.
@@ -230,7 +248,8 @@ pub(crate) async fn enumerate_devices() -> Result<Vec<async_hid::Device>, Backen
             pid = format_args!("{:04x}", d.product_id),
             usage_page = format_args!("{:#06x}", d.usage_page),
             usage_id = format_args!("{:#06x}", d.usage_id),
-            matched = is_hidpp_long_collection(d.usage_page, d.usage_id),
+            matched = is_hidpp_long_collection(d.usage_page, d.usage_id)
+                || is_bluetooth_mouse_fallback(d.product_id, d.usage_page, d.usage_id),
             "logitech HID node"
         );
     }
@@ -242,14 +261,22 @@ pub(crate) async fn enumerate_devices() -> Result<Vec<async_hid::Device>, Backen
 ///
 /// Wraps [`is_hidpp_candidate`] with the parts only this backend can answer:
 /// the platform node id needed to recognise a `hid-logitech-dj` child node.
-pub(crate) fn is_hidpp_node(device: &async_hid::Device) -> bool {
-    is_hidpp_candidate(
+pub(crate) fn is_hidpp_node(device: &async_hid::Device, vendor_collection_available: bool) -> bool {
+    is_preferred_hidpp_candidate(
         device.vendor_id,
         device.product_id,
         device.usage_page,
         device.usage_id,
         is_receiver_child_node(&device.id),
+        vendor_collection_available,
     )
+}
+
+/// Whether this node is a vendor-defined HID++ collection rather than the
+/// Generic Desktop fallback used by a subset of Bluetooth mice.
+pub(crate) fn is_vendor_hidpp_node(device: &async_hid::Device) -> bool {
+    device.vendor_id == LOGITECH_VENDOR_ID
+        && is_hidpp_long_collection(device.usage_page, device.usage_id)
 }
 
 /// Whether an enumerated node belongs to the HID++ channel path.
@@ -266,9 +293,24 @@ fn is_hidpp_candidate(
     receiver_child: bool,
 ) -> bool {
     vendor_id == LOGITECH_VENDOR_ID
-        && is_hidpp_long_collection(usage_page, usage_id)
+        && (is_hidpp_long_collection(usage_page, usage_id)
+            || is_bluetooth_mouse_fallback(product_id, usage_page, usage_id))
         && !matches_litra(vendor_id, product_id, usage_page, usage_id)
         && !receiver_child
+}
+
+/// Apply collection preference after the basic HID++ candidate check.
+fn is_preferred_hidpp_candidate(
+    vendor_id: u16,
+    product_id: u16,
+    usage_page: u16,
+    usage_id: u16,
+    receiver_child: bool,
+    vendor_collection_available: bool,
+) -> bool {
+    is_hidpp_candidate(vendor_id, product_id, usage_page, usage_id, receiver_child)
+        && !(vendor_collection_available
+            && is_bluetooth_mouse_fallback(product_id, usage_page, usage_id))
 }
 
 /// Returns `true` when a HID++ node is a virtual per-device interface created by
@@ -393,7 +435,7 @@ pub(crate) async fn open_hidpp_channel(
         let (reader, writer) = dev.open().await.map_err(open_error)?;
         // BLE-direct devices expose only the long HID++ report; flag the channel so
         // it advertises short-unsupported and the `hidpp` channel up-converts shorts.
-        let long_only = is_long_only_collection(info.usage_page, info.usage_id);
+        let long_only = is_long_only_collection(info.product_id, info.usage_page, info.usage_id);
         let raw = AsyncHidChannel::new(reader, writer, info.clone(), long_only);
         let channel = match HidppChannel::from_raw_channel(raw).await {
             Ok(mut c) => {

--- a/crates/openlogi-hid/src/transport/native.rs
+++ b/crates/openlogi-hid/src/transport/native.rs
@@ -4,7 +4,7 @@
 //! through this type. It is the only implementor in the tree today; a scripted
 //! one for tests and a WebHID one under wasm are the reasons the trait exists.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock, Mutex, PoisonError};
 
 use async_hid::{AsyncHidWrite as _, Device, DeviceWriter};
@@ -15,7 +15,9 @@ use openlogi_device::backend::{
     BackendError, HidBackend, HotplugStream, NodeId, NodeInfo, RawWriter,
 };
 
-use super::{enumerate_devices, is_hidpp_node, open_hidpp_channel, watch_nodes};
+use super::{
+    enumerate_devices, is_hidpp_node, is_vendor_hidpp_node, open_hidpp_channel, watch_nodes,
+};
 
 /// One logical top-level collection exposed by an OS HID node.
 ///
@@ -118,11 +120,22 @@ impl HidBackend for NativeBackend {
     }
 
     async fn enumerate_hidpp(&self) -> Result<Vec<NodeInfo>, BackendError> {
-        Ok(self
-            .refresh()
-            .await?
+        let devices = self.refresh().await?;
+        // On macOS every logical collection of one physical device carries the
+        // same IOKit registry id. Suppress its Generic Desktop fallback only
+        // when that exact physical node also exposes a vendor HID++ collection;
+        // keying by PID alone would hide a second same-model mouse.
+        let vendor_collections: HashSet<(NodeId, u16)> = devices
             .iter()
-            .filter(|device| is_hidpp_node(device))
+            .filter(|device| is_vendor_hidpp_node(device))
+            .map(|device| (super::node_id(device), device.product_id))
+            .collect();
+        Ok(devices
+            .iter()
+            .filter(|device| {
+                let key = (super::node_id(device), device.product_id);
+                is_hidpp_node(device, vendor_collections.contains(&key))
+            })
             .map(|device| super::node_info(device))
             .collect())
     }

--- a/crates/openlogi-hid/src/transport/tests.rs
+++ b/crates/openlogi-hid/src/transport/tests.rs
@@ -21,6 +21,7 @@ fn litra_ble_collection_is_not_a_hidpp_candidate() {
 fn only_ble_collection_is_long_only() {
     assert!(is_long_only_collection(0xb023, 0xff43, 0x0202)); // BLE vendor collection
     assert!(is_long_only_collection(0xb01d, 0x0001, 0x0002)); // MX Ergo BT fallback
+    assert!(is_long_only_collection(0xb027, 0x0001, 0x0002)); // Ergo M575 BT fallback
     assert!(is_long_only_collection(0xb03e, 0x0001, 0x0002)); // MX Ergo S BT fallback
     assert!(!is_long_only_collection(0xc548, 0xff00, 0x0002)); // receiver has both
     assert!(!is_long_only_collection(0xc33c, 0xff43, 0x0602)); // wired has both
@@ -28,8 +29,9 @@ fn only_ble_collection_is_long_only() {
 }
 
 #[test]
-fn mx_ergo_bluetooth_mouse_collection_is_a_candidate() {
+fn trackball_bluetooth_mouse_collection_is_a_candidate() {
     assert!(is_hidpp_candidate(0x046d, 0xb01d, 0x0001, 0x0002, false));
+    assert!(is_hidpp_candidate(0x046d, 0xb027, 0x0001, 0x0002, false));
     assert!(is_hidpp_candidate(0x046d, 0xb03e, 0x0001, 0x0002, false));
     assert!(!is_hidpp_candidate(0x046d, 0xc548, 0x0001, 0x0002, false));
     assert!(!is_hidpp_candidate(0x046d, 0xb01d, 0x0001, 0x0006, false));

--- a/crates/openlogi-hid/src/transport/tests.rs
+++ b/crates/openlogi-hid/src/transport/tests.rs
@@ -19,10 +19,34 @@ fn litra_ble_collection_is_not_a_hidpp_candidate() {
 
 #[test]
 fn only_ble_collection_is_long_only() {
-    assert!(is_long_only_collection(0xff43, 0x0202)); // BLE-direct → short-unsupported
-    assert!(!is_long_only_collection(0xff00, 0x0002)); // USB / receiver carries both reports
-    assert!(!is_long_only_collection(0xff43, 0x0602)); // wired G-series keyboard carries both
-    assert!(!is_long_only_collection(0x0001, 0x0002)); // not a HID++ collection at all
+    assert!(is_long_only_collection(0xb023, 0xff43, 0x0202)); // BLE vendor collection
+    assert!(is_long_only_collection(0xb01d, 0x0001, 0x0002)); // MX Ergo BT fallback
+    assert!(is_long_only_collection(0xb03e, 0x0001, 0x0002)); // MX Ergo S BT fallback
+    assert!(!is_long_only_collection(0xc548, 0xff00, 0x0002)); // receiver has both
+    assert!(!is_long_only_collection(0xc33c, 0xff43, 0x0602)); // wired has both
+    assert!(!is_long_only_collection(0xc548, 0x0001, 0x0002)); // receiver mouse node
+}
+
+#[test]
+fn mx_ergo_bluetooth_mouse_collection_is_a_candidate() {
+    assert!(is_hidpp_candidate(0x046d, 0xb01d, 0x0001, 0x0002, false));
+    assert!(is_hidpp_candidate(0x046d, 0xb03e, 0x0001, 0x0002, false));
+    assert!(!is_hidpp_candidate(0x046d, 0xc548, 0x0001, 0x0002, false));
+    assert!(!is_hidpp_candidate(0x046d, 0xb01d, 0x0001, 0x0006, false));
+    assert!(!is_hidpp_candidate(0x1234, 0xb01d, 0x0001, 0x0002, false));
+}
+
+#[test]
+fn vendor_collection_wins_over_generic_bluetooth_fallback() {
+    assert!(is_preferred_hidpp_candidate(
+        0x046d, 0xb023, 0xff43, 0x0202, false, true,
+    ));
+    assert!(!is_preferred_hidpp_candidate(
+        0x046d, 0xb023, 0x0001, 0x0002, false, true,
+    ));
+    assert!(is_preferred_hidpp_candidate(
+        0x046d, 0xb01d, 0x0001, 0x0002, false, false,
+    ));
 }
 
 #[test]

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use futures::{FutureExt, channel::oneshot, select};
+use futures::{FutureExt, channel::oneshot, lock::Mutex as AsyncMutex, select};
 use tracing::trace;
 
 use crate::{nibble::U4, sync::lock};
@@ -89,6 +89,16 @@ pub struct HidppChannel {
 
     /// The request ID assigned to the next pending message.
     pending_message_id: AtomicU64,
+
+    /// Serializes complete request/response transactions on this transport.
+    ///
+    /// Every open channel uses one fixed HID++ software id for its lifetime.
+    /// Allowing two requests to overlap on that id makes identical headers
+    /// indistinguishable and can also overrun receiver firmware while one
+    /// consumer inventories and another audits capture state. Keep the gate
+    /// for the response wait, not only the report write, so exactly one
+    /// transaction is in flight on a physical channel.
+    request_gate: AsyncMutex<()>,
 
     /// Registered listeners that will receive notifications about incoming
     /// messages.
@@ -204,6 +214,7 @@ impl HidppChannel {
             software_id: AtomicU8::new(0x01),
             pending_messages: pending_messages_rc,
             pending_message_id: AtomicU64::new(1),
+            request_gate: AsyncMutex::new(()),
             next_listener_hdl: AtomicU32::new(1),
             message_listeners: message_listeners_rc,
             read_thread_close: Some(close_sender),
@@ -317,13 +328,17 @@ impl HidppChannel {
     }
 
     /// Sends a HID++ message across the channel and waits for a response,
-    /// bounding the whole request — the report write plus the wait for a
-    /// matching response — by `timeout`.
+    /// bounding the report write plus the wait for a matching response by
+    /// `timeout` once this request reaches the transport.
     ///
-    /// On elapse the request's pending entry is removed (concurrent in-flight
-    /// requests are unaffected) and [`ChannelError::Timeout`] is returned; a
-    /// response that still arrives later reaches message listeners as an
-    /// unmatched message.
+    /// On elapse the request's pending entry is removed and
+    /// [`ChannelError::Timeout`] is returned; a response that still arrives
+    /// later reaches message listeners as an unmatched message. Requests on
+    /// one channel are serialized because they share one software id. Queue
+    /// time is deliberately separate from the device-response timeout: a
+    /// healthy request waiting behind one slow transaction must not be
+    /// misreported as a dead HID channel before it reaches the wire. Callers
+    /// that need a whole-operation deadline can bound this future externally.
     ///
     /// [`Self::send`] uses this with [`SEND_RESPONSE_TIMEOUT`], which suits
     /// requests to a device that may be asleep. Requests that should fail
@@ -345,6 +360,15 @@ impl HidppChannel {
         // below can name the same request.
         let (dev, feat, func) = msg.header();
         trace!(dev, feat, func, "hidpp request");
+
+        // A fixed software id identifies this open channel. Keep one complete
+        // transaction in flight so two requests with the same HID++ header
+        // cannot consume each other's response and receiver firmware is never
+        // driven concurrently by inventory and live-control maintenance.
+        // The timeout below starts only after this guard is acquired. Counting
+        // queue contention as transport silence made the capture watchdog
+        // retire healthy receiver channels while inventory owned the wire.
+        let _request_guard = self.request_gate.lock().await;
 
         let (sender, receiver) = oneshot::channel::<HidppMessage>();
         let pending_id = self.pending_message_id.fetch_add(1, Ordering::SeqCst);
@@ -372,7 +396,7 @@ impl HidppChannel {
         // park `send` forever before the response wait even starts.
         let mut request = std::pin::pin!(
             async {
-                self.send_and_forget(msg).await?;
+                self.write_message_unlocked(msg).await?;
                 receiver.await.map_err(|_| ChannelError::NoResponse)
             }
             .fuse()
@@ -415,6 +439,11 @@ impl HidppChannel {
             return Err(ChannelError::MessageTypeNotSupported);
         }
 
+        let _request_guard = self.request_gate.lock().await;
+        self.write_message_unlocked(msg).await
+    }
+
+    async fn write_message_unlocked(&self, msg: HidppMessage) -> Result<(), ChannelError> {
         let mut buf = [0u8; LONG_REPORT_LENGTH];
         let len = msg.write_raw(&mut buf);
         self.raw_channel
@@ -427,8 +456,10 @@ impl HidppChannel {
     /// Write one raw HID report through this channel's already-owned transport.
     ///
     /// Reports must contain `1..=64` bytes, including their report ID. The
-    /// operation is bounded by [`SEND_RESPONSE_TIMEOUT`] and returns the exact
-    /// byte count reported by the transport. This is intended for HID++ report
+    /// transport write is bounded by [`SEND_RESPONSE_TIMEOUT`] and returns the
+    /// exact byte count reported by the transport. Queue time behind another
+    /// transaction is not transport time; callers may impose an outer deadline
+    /// when needed. This is intended for HID++ report
     /// widths such as the 64-byte `0x12` lighting frame that [`HidppMessage`]
     /// cannot represent.
     pub async fn write_raw_report(&self, report: &[u8]) -> Result<usize, ChannelError> {
@@ -445,6 +476,7 @@ impl HidppChannel {
             return Err(ChannelError::InvalidRawReportLength(report.len()));
         }
 
+        let _request_guard = self.request_gate.lock().await;
         let mut write = std::pin::pin!(self.raw_channel.write_report(report).fuse());
         select! {
             result = write => result.map_err(ChannelError::Implementation),

--- a/crates/openlogi-hidpp/src/channel/tests.rs
+++ b/crates/openlogi-hidpp/src/channel/tests.rs
@@ -98,7 +98,7 @@ fn send_times_out_and_removes_pending_message() {
 }
 
 #[test]
-fn timeout_removes_only_its_own_pending_message() {
+fn timeout_does_not_remove_the_next_queued_request() {
     futures::executor::block_on(async {
         let (raw, handle) = MockRawHidChannel::new();
         let channel = channel_with_reader(raw).await;
@@ -116,8 +116,8 @@ fn timeout_removes_only_its_own_pending_message() {
             move |candidate| *candidate == slow_response,
             Duration::from_secs(1),
         );
-        // Answer the second request only after the first has timed out, so
-        // a removal that took the wrong entry would fail this test.
+        // Answer the queued request only after the active request has timed
+        // out, so timeout cleanup cannot poison the next transaction.
         let respond_late = async {
             futures_timer::Delay::new(Duration::from_millis(100)).await;
             handle.send_incoming(slow_response).await;
@@ -127,6 +127,83 @@ fn timeout_removes_only_its_own_pending_message() {
 
         assert!(matches!(timed_out.unwrap_err(), ChannelError::Timeout));
         assert_eq!(answered.unwrap(), slow_response);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn one_channel_has_only_one_request_in_flight() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = channel_with_reader(raw).await;
+        let first_response = short_msg(0x20);
+        let second_response = short_msg(0x21);
+
+        let first = channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == first_response,
+            Duration::from_secs(1),
+        );
+        let second = channel.send_with_timeout(
+            short_msg(0x11),
+            move |candidate| *candidate == second_response,
+            Duration::from_secs(1),
+        );
+        let respond_in_order = async {
+            wait_for_written_report_count(&handle, 1).await;
+            futures_timer::Delay::new(Duration::from_millis(25)).await;
+            assert_eq!(
+                handle.written_reports().len(),
+                1,
+                "a second request reused the channel software id before the first completed"
+            );
+            handle.send_incoming(first_response).await;
+            wait_for_written_report_count(&handle, 2).await;
+            handle.send_incoming(second_response).await;
+        };
+
+        let (first, second, ()) = futures::join!(first, second, respond_in_order);
+
+        assert_eq!(first.unwrap(), first_response);
+        assert_eq!(second.unwrap(), second_response);
+        assert_pending_empty(&channel);
+    });
+}
+
+#[test]
+fn queued_request_gets_its_full_wire_timeout_after_the_gate() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        let channel = channel_with_reader(raw).await;
+        let first_response = short_msg(0x20);
+        let queued_response = short_msg(0x21);
+
+        let first = channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == first_response,
+            Duration::from_secs(1),
+        );
+        let queued = channel.send_with_timeout(
+            short_msg(0x11),
+            move |candidate| *candidate == queued_response,
+            Duration::from_millis(25),
+        );
+        let finish_first = async {
+            wait_for_written_report_count(&handle, 1).await;
+            // Keep the first transaction active for far longer than the
+            // queued request's own wire timeout. Queueing is not device
+            // silence, so the second request must still reach the transport.
+            futures_timer::Delay::new(Duration::from_millis(100)).await;
+            handle.send_incoming(first_response).await;
+            wait_for_written_report_count(&handle, 2).await;
+            handle.send_incoming(queued_response).await;
+        };
+
+        let (first, queued, ()) = futures::join!(first, queued, finish_first);
+
+        assert_eq!(first.unwrap(), first_response);
+        assert_eq!(queued.unwrap(), queued_response);
+        assert_eq!(handle.written_reports().len(), 2);
         assert_pending_empty(&channel);
     });
 }
@@ -634,6 +711,18 @@ async fn wait_for_atomic_count(count: &AtomicUsize, expected: usize) {
     }
 
     panic!("timed out waiting for atomic count {expected}");
+}
+
+async fn wait_for_written_report_count(handle: &MockRawHidHandle, expected: usize) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(1) {
+        if handle.written_reports().len() >= expected {
+            return;
+        }
+        futures_timer::Delay::new(Duration::from_millis(10)).await;
+    }
+
+    panic!("timed out waiting for written report count {expected}");
 }
 
 fn mock_error() -> Box<dyn Error + Sync + Send> {

--- a/crates/openlogi-hidpp/src/receiver.rs
+++ b/crates/openlogi-hidpp/src/receiver.rs
@@ -77,4 +77,9 @@ pub enum ReceiverError {
     /// Indicates that a HID++1.0 register access resulted in an error.
     #[error("a HID++1.0 error occurred")]
     Protocol(#[from] Hidpp10Error),
+
+    /// Indicates that a receiver slot outside its supported 1-based range was
+    /// requested.
+    #[error("invalid receiver device index {0}; expected 1 through 6")]
+    InvalidDeviceIndex(u8),
 }

--- a/crates/openlogi-hidpp/src/receiver/unifying.rs
+++ b/crates/openlogi-hidpp/src/receiver/unifying.rs
@@ -4,9 +4,9 @@
 //! 2.4 GHz eQuad radio protocol. It uses HID++ 1.0 registers for receiver
 //! control; paired devices speak HID++ 2.0 once addressed via their slot index.
 //!
-//! The register layout for device enumeration (`0xB5/0x5N`, `0xB5/0x6N`) is
-//! identical to Bolt's. The device-kind encoding differs from Bolt at values 5+
-//! (see [`DeviceKind`]).
+//! Device enumeration follows the Unifying-specific `0xB5/0x2N` pairing,
+//! `0xB5/0x3N` extended-pairing, and `0xB5/0x4N` name sub-registers. Unlike
+//! Bolt's `0x5N`/`0x6N` layout, `N=0` addresses receiver slot 1.
 
 use std::sync::Arc;
 
@@ -52,19 +52,17 @@ pub enum InfoSubRegister {
     /// slot count).
     ReceiverInfo = 0x03,
 
-    /// Provides information about a specific paired device. The device index
-    /// (4 bits) must be added to this base address to form the actual
-    /// sub-register: `0x50 | (device_index & 0x0f)`.
-    DevicePairingInformation = 0x50,
+    /// Provides information about a specific paired device. Add the zero-based
+    /// slot number: `0x20 + (device_index - 1)`.
+    DevicePairingInformation = 0x20,
 
-    /// Provides the codename of a specific paired device. The device index (4
-    /// bits) must be added: `0x60 | (device_index & 0x0f)`.
-    ///
-    /// NOTE: `0x60` is the *Bolt* base. Wire-verified Unifying receivers store
-    /// names at base `0x40 + (n-1)` instead, so name reads go directly through
-    /// `read_codename_unifying` in `inventory.rs` rather than this constant —
-    /// don't reuse `DeviceCodename` for Unifying name reads.
-    DeviceCodename = 0x60,
+    /// Provides the stable serial number and report types for a paired device.
+    /// Add the zero-based slot number: `0x30 + (device_index - 1)`.
+    DeviceExtendedPairingInformation = 0x30,
+
+    /// Provides the codename of a specific paired device. Add the zero-based
+    /// slot number: `0x40 + (device_index - 1)`.
+    DeviceCodename = 0x40,
 }
 
 /// Implements the Unifying wireless receiver.
@@ -208,28 +206,40 @@ impl Receiver {
         &self,
         device_index: u8,
     ) -> Result<DevicePairingInformation, ReceiverError> {
+        let sub_register =
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, device_index)?;
         let response = self
             .chan
             .read_long_register(
                 RECEIVER_DEVICE_INDEX,
                 Register::ReceiverInfo.into(),
-                [
-                    u8::from(InfoSubRegister::DevicePairingInformation) | (device_index & 0x0f),
-                    0x00,
-                    0x00,
-                ],
+                [sub_register, 0x00, 0x00],
             )
             .await?;
 
-        Ok(DevicePairingInformation {
-            wpid: u16::from_le_bytes([response[2], response[3]]),
-            // Kind is identity-only: an unrecognised nibble folds to
-            // `Unknown` instead of failing the whole pairing-info read.
-            kind: DeviceKind::from(response[1] & 0x0f),
-            encrypted: response[1] & (1 << 5) != 0,
-            online: response[1] & (1 << 6) == 0,
-            unit_id: [response[4], response[5], response[6], response[7]],
-        })
+        Ok(parse_device_pairing_information(&response))
+    }
+
+    /// Retrieves the stable serial number and report types for one paired
+    /// device from the Unifying extended-pairing sub-register.
+    pub async fn get_device_extended_pairing_information(
+        &self,
+        device_index: u8,
+    ) -> Result<DeviceExtendedPairingInformation, ReceiverError> {
+        let sub_register = device_info_sub_register(
+            InfoSubRegister::DeviceExtendedPairingInformation,
+            device_index,
+        )?;
+        let response = self
+            .chan
+            .read_long_register(
+                RECEIVER_DEVICE_INDEX,
+                Register::ReceiverInfo.into(),
+                [sub_register, 0x00, 0x00],
+            )
+            .await?;
+
+        Ok(parse_device_extended_pairing_information(&response))
     }
 
     /// Provides the unique ID of the receiver (serial number).
@@ -308,19 +318,25 @@ pub struct DevicePairingInformation {
     pub wpid: u16,
     /// Device kind reported by the receiver.
     pub kind: DeviceKind,
-    /// Whether the link is encrypted.
-    pub encrypted: bool,
-    /// Whether the device is currently online.
-    pub online: bool,
-    /// Device unit ID.
+}
+
+/// Extended identity retained by a Unifying receiver for one paired device.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[non_exhaustive]
+pub struct DeviceExtendedPairingInformation {
+    /// Stable device serial number, also exposed by HID++ 2.0 as the unit ID.
     pub unit_id: [u8; 4],
+    /// HID report-type bitmap stored by the receiver.
+    pub report_types: [u8; 4],
+    /// Physical location of the device power switch (low nibble, per HID++
+    /// 1.0).
+    pub power_switch_location: u8,
 }
 
 /// Represents the kind of a device paired to a Unifying receiver.
 ///
-/// The encoding matches Bolt for values 1–4; from 5 onwards Unifying uses a
-/// shifted table (Remote=5, Trackball=6, Touchpad=7) while Bolt reserves those
-/// values and places them at 7–9.
+/// The encoding matches the Unifying HID++ 1.0 pairing and connection tables.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, IntoPrimitive, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[non_exhaustive]
@@ -341,9 +357,36 @@ pub enum DeviceKind {
     /// Remote-control device.
     Remote = 0x05,
     /// Trackball device.
-    Trackball = 0x06,
+    Trackball = 0x08,
     /// Touchpad device.
-    Touchpad = 0x07,
+    Touchpad = 0x09,
+}
+
+fn device_info_sub_register(base: InfoSubRegister, device_index: u8) -> Result<u8, ReceiverError> {
+    let zero_based = device_index
+        .checked_sub(1)
+        .filter(|index| *index < 6)
+        .ok_or(ReceiverError::InvalidDeviceIndex(device_index))?;
+    Ok(u8::from(base) + zero_based)
+}
+
+fn parse_device_pairing_information(response: &[u8; 16]) -> DevicePairingInformation {
+    DevicePairingInformation {
+        wpid: u16::from_be_bytes([response[3], response[4]]),
+        // Kind is identity-only: an unrecognised value folds to `Unknown`
+        // instead of making an otherwise valid occupied slot disappear.
+        kind: DeviceKind::from(response[7]),
+    }
+}
+
+fn parse_device_extended_pairing_information(
+    response: &[u8; 16],
+) -> DeviceExtendedPairingInformation {
+    DeviceExtendedPairingInformation {
+        unit_id: [response[1], response[2], response[3], response[4]],
+        report_types: [response[5], response[6], response[7], response[8]],
+        power_switch_location: response[9] & 0x0f,
+    }
 }
 
 /// Represents a device-connection event fired by the receiver when a paired
@@ -384,11 +427,14 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        DeviceConnection, DeviceKind, DevicePairingInformation, Event, InfoSubRegister, Receiver,
-        Register, decode_notification, update_wireless_notification_flag,
+        DeviceConnection, DeviceKind, Event, InfoSubRegister, Receiver, Register,
+        decode_notification, device_info_sub_register, parse_device_extended_pairing_information,
+        parse_device_pairing_information, update_wireless_notification_flag,
     };
+    use crate::channel::HidppMessage;
     use crate::channel::tests::{MockRawHidChannel, channel_with_reader};
-    use crate::protocol::v10::{Message, MessageHeader, MessageType};
+    use crate::protocol::v10::{Message, MessageHeader};
+    use crate::receiver::ReceiverError;
 
     /// Builds the long notification the receiver broadcasts, with `payload`
     /// laid out exactly as the 17 bytes following the header.
@@ -400,6 +446,20 @@ mod tests {
             },
             payload,
         )
+    }
+
+    fn long_register_response(register_data: [u8; 16]) -> HidppMessage {
+        let mut payload = [0u8; 17];
+        payload[0] = Register::ReceiverInfo.into();
+        payload[1..].copy_from_slice(&register_data);
+        Message::Long(
+            MessageHeader {
+                device_index: super::RECEIVER_DEVICE_INDEX,
+                sub_id: 0x83,
+            },
+            payload,
+        )
+        .into()
     }
 
     #[test]
@@ -453,61 +513,6 @@ mod tests {
     }
 
     #[test]
-    fn pairing_information_reads_encryption_from_bit_5() {
-        // The pairing register carries the same device-info byte as the 0x41
-        // notification, decoded independently — pin its bits too so the two
-        // paths cannot diverge unnoticed.
-        futures::executor::block_on(async {
-            let (raw, handle) = MockRawHidChannel::new();
-            let chan = Arc::new(channel_with_reader(raw).await);
-            let receiver =
-                Receiver::new(chan).expect("the mock's VID/PID routes as a Unifying receiver");
-
-            // First response: bit 5 + bit 6 — encrypted, offline. Second:
-            // bit 4 only (software present), which must not read as
-            // encryption.
-            for status in [0x62, 0x12] {
-                let mut payload = [0u8; 17];
-                payload[0] = Register::ReceiverInfo.into(); // RAP matches on the address echo
-                payload[1] = u8::from(InfoSubRegister::DevicePairingInformation) | 0x02;
-                payload[2] = status;
-                payload[3] = 0x69; // wpid, little-endian
-                payload[4] = 0x40;
-                payload[5..9].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
-                handle.queue_response(
-                    Message::Long(
-                        MessageHeader {
-                            device_index: super::RECEIVER_DEVICE_INDEX,
-                            sub_id: MessageType::GetLongRegister.into(),
-                        },
-                        payload,
-                    )
-                    .into(),
-                );
-            }
-
-            let encrypted_offline = receiver.get_device_pairing_information(2).await.unwrap();
-            assert_eq!(
-                encrypted_offline,
-                DevicePairingInformation {
-                    wpid: 0x4069,
-                    kind: DeviceKind::Mouse,
-                    encrypted: true,
-                    online: false,
-                    unit_id: [0xde, 0xad, 0xbe, 0xef],
-                }
-            );
-
-            let software_present = receiver.get_device_pairing_information(2).await.unwrap();
-            assert!(
-                !software_present.encrypted,
-                "bit 4 is software-present, not encryption"
-            );
-            assert!(software_present.online);
-        });
-    }
-
-    #[test]
     fn bit_6_is_set_when_the_device_is_offline() {
         let mut payload = [0u8; 17];
         payload[1] = 1 << 6;
@@ -534,8 +539,8 @@ mod tests {
         };
 
         assert_eq!(kind(0x05), DeviceKind::Remote);
-        assert_eq!(kind(0x06), DeviceKind::Trackball);
-        assert_eq!(kind(0x07), DeviceKind::Touchpad);
+        assert_eq!(kind(0x08), DeviceKind::Trackball);
+        assert_eq!(kind(0x09), DeviceKind::Touchpad);
     }
 
     #[test]
@@ -579,5 +584,96 @@ mod tests {
                 wpid: 0x4074,
             })
         );
+    }
+
+    #[test]
+    fn unifying_slot_sub_registers_are_zero_based_not_bolt_addresses() {
+        assert_eq!(
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, 1).unwrap(),
+            0x20
+        );
+        assert_eq!(
+            device_info_sub_register(InfoSubRegister::DeviceExtendedPairingInformation, 6).unwrap(),
+            0x35
+        );
+        assert!(matches!(
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, 0),
+            Err(ReceiverError::InvalidDeviceIndex(0))
+        ));
+        assert!(matches!(
+            device_info_sub_register(InfoSubRegister::DevicePairingInformation, 7),
+            Err(ReceiverError::InvalidDeviceIndex(7))
+        ));
+    }
+
+    #[test]
+    fn pairing_information_uses_the_unifying_wire_layout() {
+        let mut response = [0u8; 16];
+        response[0] = 0x20;
+        response[3] = 0x40;
+        response[4] = 0x67;
+        response[7] = 0x08;
+
+        let pairing = parse_device_pairing_information(&response);
+
+        assert_eq!(pairing.wpid, 0x4067);
+        assert_eq!(pairing.kind, DeviceKind::Trackball);
+    }
+
+    #[test]
+    fn extended_pairing_information_carries_the_stable_unit_id() {
+        let mut response = [0u8; 16];
+        response[0] = 0x30;
+        response[1..=4].copy_from_slice(&[0x29, 0x16, 0xdb, 0xbe]);
+        response[5..=8].copy_from_slice(&[0x01, 0x02, 0x04, 0x08]);
+        response[9] = 0xb3;
+
+        let extended = parse_device_extended_pairing_information(&response);
+
+        assert_eq!(extended.unit_id, [0x29, 0x16, 0xdb, 0xbe]);
+        assert_eq!(extended.report_types, [0x01, 0x02, 0x04, 0x08]);
+        assert_eq!(extended.power_switch_location, 0x03);
+    }
+
+    #[test]
+    fn receiver_reads_unifying_pairing_and_extended_registers_for_slot_one() {
+        futures::executor::block_on(async {
+            let (raw, handle) = MockRawHidChannel::new();
+            let channel = Arc::new(channel_with_reader(raw).await);
+            let receiver = Receiver::new(channel).expect("mock is a known Unifying receiver");
+
+            let mut pairing_response = [0u8; 16];
+            pairing_response[0] = 0x20;
+            pairing_response[3] = 0x40;
+            pairing_response[4] = 0x67;
+            pairing_response[7] = 0x08;
+            handle.queue_response(long_register_response(pairing_response));
+
+            let pairing = receiver
+                .get_device_pairing_information(1)
+                .await
+                .expect("pairing information");
+
+            let mut extended_response = [0u8; 16];
+            extended_response[0] = 0x30;
+            extended_response[1..=4].copy_from_slice(&[0x29, 0x16, 0xdb, 0xbe]);
+            handle.queue_response(long_register_response(extended_response));
+
+            let extended = receiver
+                .get_device_extended_pairing_information(1)
+                .await
+                .expect("extended pairing information");
+
+            assert_eq!(pairing.wpid, 0x4067);
+            assert_eq!(pairing.kind, DeviceKind::Trackball);
+            assert_eq!(extended.unit_id, [0x29, 0x16, 0xdb, 0xbe]);
+            assert_eq!(
+                handle.written_reports(),
+                vec![
+                    vec![0x10, 0xff, 0x83, 0xb5, 0x20, 0x00, 0x00],
+                    vec![0x10, 0xff, 0x83, 0xb5, 0x30, 0x00, 0x00],
+                ]
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary

- Add reliable MX Ergo S support across Bolt receiver and Bluetooth-direct connections.
- Preserve one logical device and one shortcut configuration while switching transports.
- Keep shortcut capture alive across reconnects, wakeups, and transport changes.

## Changes

- Bind cached HID++ features to the active channel generation.
- Serialize transactions that share a HID++ software ID.
- Read Unifying pairing data from the correct slot registers.
- Discover the Generic Desktop HID++ fallback exposed by MX Ergo Bluetooth devices.
- Prefer vendor HID++ collections per physical device when both collection types exist.
- Reuse the inventory channel for button and gesture capture.
- Migrate legacy route-specific aliases to stable physical-device identities.
- Hydrate offline linked devices without creating duplicate cards.
- Add Ergo M575 Bluetooth fallback regression coverage.

## Testing

- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.98.0 test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo +1.98.0 doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`
- `cargo +1.98.0 run -p xtask -- ci clippy-windows`

## Hardware verification

- Tested on macOS 26.6.2, Apple Silicon.
- MX Ergo S tested with both a Bolt receiver and Bluetooth-direct.
- Shortcut remapping and stable device identity tested after switching transports.
- Ergo M575 checked for regressions; its Bluetooth fallback is also covered by unit tests.
- A stale macOS Input Monitoring grant had to be removed and re-added before the running agent could access HID input again.

Fixes #366