### PR TITLE
docs: character stand-in icon rule + crate-homed agent guides

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -41,10 +41,25 @@ paths:
   `#[cfg(target_os = "macos")]`-gated `use gpui::StatefulInteractiveElement as _;`
   compiles fine locally but breaks the Linux/Windows CI jobs the moment an ungated
   element calls `.id(..).on_click(..)`. When adding such an element, ungate the import.
-- Icons are not limited to gpui-component's `IconName`: vendor any SVG (must use
-  `stroke="currentColor"`) into `crates/openlogi-ui/action-icons/`, register it in that
-  crate's `app_assets.rs` `ACTION_ICONS`, render via
-  `Icon::empty().path("action-icons/….svg")`. Both binaries serve the same set.
+- **An icon is never a text character.** `×` for close, `·` for a centre press, `+`
+  for add, `←`/`→` for anything — all of them are bugs, not shortcuts. A glyph's
+  advance width is set by the font, so a row of them does not align and no two read
+  at the same weight; a screen reader announces "multiplication sign". Reach for
+  `IconName` first, then a vendored SVG. Punctuation *between* text stays text: `·`
+  as a metadata separator and `…` on a menu item that opens a dialog are correct.
+- Icons are not limited to gpui-component's `IconName` (which is lucide, generated
+  from the `gpui-component-assets` icon directory): vendor any SVG (must use
+  `stroke="currentColor"`) into `crates/openlogi-ui/action-icons/`, register it in
+  that crate's `action_icons.rs` `ACTION_ICONS`, render via
+  `Icon::empty().path("action-icons/….svg")` or `svg().path(..)`. Both binaries
+  serve the same set — the overlay pays for every entry, so prefer `IconName` when
+  it has the icon. The overlay itself has no `IconName`: it does not depend on
+  gpui-component, so anything both processes draw (the ring's cancel target) has to
+  be vendored and named through one shared const, never spelled out on each side.
+- `Icon` does **not** keep its own default size: its render overwrites the base
+  style refinement with the caller's, so a bare `Icon` falls through to the current
+  font size instead of the 16px `Default` sets. Any icon meant to line up with a
+  neighbouring `svg().size_4()` needs an explicit `.size_4()`.
 - Config panels/tabs gate on `Capabilities` (derived from the HID++ feature table),
   **never** on device `kind` — kind is identity-only (icon/label). A new panel means a
   new capability in `Capabilities::from_feature_ids` plus a `tabs_for` arm.

--- a/.claude/rules/ipc-protocol.md
+++ b/.claude/rules/ipc-protocol.md
@@ -2,31 +2,13 @@
 paths:
   - "crates/openlogi-agent-core/**"
   - "crates/openlogi-agent/**"
-  - "crates/openlogi-ipc/**"
   - "crates/openlogi-core/**"
   - "crates/openlogi-hid/**"
 ---
 
-# Agent IPC — the wire format is append-only
+# Serde types here ride the IPC wire
 
-The GUI and agent speak tarpc over bincode on an `interprocess` local socket
-(`openlogi-ipc/src/ipc.rs`). bincode encodes the enum **variant index** and
-tarpc encodes the **method order**, so the wire format is positional:
-
-- Service methods are append-only; never reorder or remove. `protocol_version` must
-  remain method 0 forever — the takeover handshake probes it across versions.
-- serde enums that cross the IPC boundary are append-only too. serde encodes the
-  declaration index, NOT a `#[repr(u8)]` discriminant — the two can disagree. The wire
-  surface is wider than this crate: serde types from `openlogi-core` (device model,
-  `DeviceKind`, actions, config) and `openlogi-hid` (write errors) ride inside RPC
-  payloads, so the same rule binds them.
-- Any wire change bumps `PROTOCOL_VERSION` (checked strict-equal at connect) and
-  regenerates the golden tests in `crates/openlogi-ipc/tests/wire_format.rs`,
-  including the pinned-version assertion — the failure message prints the bytes
-  (`left` is the new encoding). Run `cargo test -p openlogi-ipc --test wire_format`
-  before any push that touched wire types.
-- The goldens use tokio-serde's `Bincode::default()` = bincode `DefaultOptions`
-  (varint, little-endian); the free `bincode::serialize` functions are fixint and do
-  NOT produce matching bytes.
-- Debug-build agents never take over a running release agent — that is by design (a
-  dev agent must not displace the user's production agent), not a bug.
+The append-only wire-format contract — method order, enum variant order,
+`PROTOCOL_VERSION`, the golden tests — lives with the contract itself in
+`crates/openlogi-ipc/AGENTS.md`. Read it before changing any serde type that
+crosses the agent↔GUI boundary.

--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -94,6 +94,27 @@ Encode invariants in the type system instead of checking them at runtime:
   surface as **errors** (`UnsupportedResponse`-style), never as silent fallbacks.
 - Replace long parameter lists with Change/Params structs; make illegal combinations
   unrepresentable rather than validated.
+- A `bool` parameter is boolean-blind at its call sites. When only a couple of
+  combinations are ever used, split into intent-named methods
+  (`divert_cid`/`undivert_cid`, not `set_cid_reporting(cid, bool, bool)`).
+  Otherwise name the facts: a struct with named fields when they are independent
+  (`ScanPass { complete, healthy }`), a sum type when they are correlated and
+  some combinations are meaningless (`Inversion { Unsupported, Normal, Inverted }`
+  for what was `(supported, inverted)`). An `Option<bool>` encoding a genuine
+  three-state is the same defect (`HidrawProbe { Accessible, Denied,
+  NonePresent }`). `struct_excessive_bools` firing is the signal to re-type,
+  not to `expect`.
+- When a loop scatters mutable locals that feed one free decision function, fold
+  the state and the rule into a sans-I/O object: events become named methods,
+  the decision method is pure and takes an explicit `now`, and all I/O stays in
+  the loop (`SpawnReflex`, `OneShotScan`; older precedents `RearmBudget`, the
+  haptics `Budget`, `QueryState`). Tests then drive real transitions and cannot
+  construct unreachable states; a total decision function earns one exhaustive
+  truth-table test rather than scattered single-case asserts.
+- Lifecycles are typestate: stages are types, transitions consume `self`
+  (`Booted::arm(self) -> Armed`), and a resource legal in only some stages
+  travels inside the stage that may hold it — a third consumer then cannot
+  exist by construction.
 - Ownership models resources (`Retained<T>` in the ObjC FFI) and thread affinity is
   proven by types (`MainThreadMarker`, `!Send` handles), not by runtime checks.
 - Libraries return `thiserror` types; binaries may use `anyhow`.

--- a/.claude/rules/xtask.md
+++ b/.claude/rules/xtask.md
@@ -1,64 +1,12 @@
 ---
 paths:
-  - "xtask/**"
   - "packaging/**"
   - ".github/scripts/**"
 ---
 
-# xtask & packaging tooling
+# Packaging inputs feed `cargo xtask`
 
-- `xtask/README.md` is the contract for this crate — module layout mirrors the CLI
-  hierarchy, `xshell` for short-lived external tools (`cargo`, `create-dmg`, `codesign`,
-  `nfpm`), `std::process::Command` only for real process control, crates (not shell-outs)
-  for structured data, no thin wrappers around tools that already own a task. Read it
-  before adding a command.
-- xtask is linted like product code: the workspace `clippy::pedantic` +
-  `unwrap_used`/`expect_used` warns run with `-D warnings` — use `?` and combinators,
-  not `unwrap`/`expect`, even in "script" code.
-- App icon: the master is the **committed** Icon Composer document
-  `design/icon/openlogi.icon` (its `icon.json` plus the artwork it names);
-  `cargo xtask macos icon` compiles it with `actool` into `AppIcon.icns` (what
-  macOS 13–25 draw, and what every helper bundle ships) and `Assets.car` (what
-  macOS 26 composes the layered icon from — the app carries it, the helpers do
-  not). `actool` names its outputs after the document, so the compile stages a
-  copy called `AppIcon.icon`; it ships with Xcode (not the command line tools)
-  and has to be **Xcode 26 or newer**, since that is where Icon Composer
-  documents arrived. `OPENLOGI_DEVELOPER_DIR` picks which Xcode every macOS
-  build command runs under — `build.yml` pins it so both native and
-  cross-compiled distribution targets use the same Icon Composer-capable SDK.
-  `design/icon/openlogi.png` stays the master for Linux packaging and the GUI's
-  embedded logo, and `openlogi.ico` for the Windows executables. The icon set
-  itself lives in `xtask/src/icon.rs` (`AppIcon` plus the `IconPipeline` trait a
-  platform implements); `icon/macos.rs` is the only implementation so far — add
-  one there rather than growing a second icon vocabulary when Windows or Linux
-  needs a build step. The build never
-  fetches the icon from the CDN — a build-time fetch was tried and deliberately
-  reverted; don't reintroduce it. After changing the icon, macOS caches by bundle
-  path: `touch target/dev/OpenLogi.app && killall Dock` to see it.
-- Package contents are declarative, not coded: Linux `.deb`/`.rpm` in
-  `packaging/linux/nfpm.yaml` (plus udev rules, systemd unit, desktop entry beside it),
-  Windows MSI in `packaging/windows/OpenLogi.wxs`. Packaging env overrides
-  (`OPENLOGI_SIGN_IDENTITY`, `OPENLOGI_BUNDLE_ASSETS`, `PKG_ARCH`, …) are documented in
-  `docs/DEVELOPMENT.md`.
-- `cargo xtask ci` is the local CI runner (`xtask/src/commands/ci/`). Facts about a
-  job — CI name, the names it answers to, the hosts CI gives it, whether a bare run
-  includes it — are one `Spec` row returned from one match in `ci/jobs.rs`; behaviour
-  is `ci/jobs/steps.rs`. Host gating is a runtime `Host` value, not `cfg!`, so which
-  job skips where is data a test reads. It is also the only place the Windows
-  cross-lint crate list lives — `devenv.nix`'s `openlogi:check-windows` calls it
-  rather than repeating the `-p` flags. Adding a job to `ci.yml` means a `Job`
-  variant + `Spec` row, its steps, and a row in `.claude/rules/ci.md`; `--list`
-  renders itself from the rows. It does not repeat the commands — `--dry-run`
-  prints the real argv, and a hand-copied third version of what `ci.yml` says
-  is a version that can be wrong.
-- `.cargo/run-macos.sh` stays a shell script — cargo execs it for every binary of every
-  `cargo run`/`test`/`bench`, including xtask's own, so the passthrough must stay cheap —
-  but it holds no bundling logic: that is `xtask macos dev-bundle`, which shares the
-  identity/helper/plist tables with `macos bundle`. Keep it that way; the two drifted
-  badly while they were separate implementations.
-  `.github/scripts/release-notes/` is a dedicated Node/Octokit tool; don't wrap it in xtask.
-- Shell that is really program logic belongs here instead: `cargo xtask release changelog`
-  replaced a script whose version parsing and changelog editing were two embedded Python
-  heredocs. The release-plz workflow builds the binary on `master` before checking out
-  the release branch, so the tool must keep reading the version from the tree at run
-  time — `env!("CARGO_PKG_VERSION")` would bake in the pre-bump one.
+The tooling contract — module layout, icon pipeline, declarative package
+manifests, the `cargo xtask ci` runner, what belongs in xtask versus shell —
+lives in `xtask/AGENTS.md` (plus `xtask/README.md`). Read it before changing
+these files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,6 +300,7 @@ before editing that area.
 | reproducing CI jobs locally (every `ci.yml` job → command) | `.claude/rules/ci.md` |
 | any `*.rs` / `Cargo.toml` (workspace Rust standards) | `.claude/rules/rust.md` |
 | `crates/openlogi-desktop/**`, `crates/openlogi-ui/**`, `crates/openlogi-overlay/**` (GPUI) | `.claude/rules/gui.md` |
+| `crates/openlogi-desktop/**` (that crate's own contract and map) | `crates/openlogi-desktop/AGENTS.md` |
 | `crates/openlogi-ui/locales/**`, `openlogi-ui/src/locale.rs`, `openlogi-desktop/src/services/i18n.rs` | `.claude/rules/i18n.md` |
 | `crates/openlogi-agent-core/**`, `crates/openlogi-agent/**`, `crates/openlogi-ipc/**`, plus `openlogi-core`/`openlogi-device` (their serde types ride the wire) | `.claude/rules/ipc-protocol.md` |
 | `crates/openlogi-hook/**`, `crates/openlogi-inject/**`, `crates/openlogi-hid/**` (cfg-gated platform code) | `.claude/rules/cross-platform.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ sits beneath both.
 | `xtask` | `cargo xtask` maintenance: bundling, packaging, release manifest |
 
 - GUI ↔ agent speak tarpc/bincode over an `interprocess` local socket. The wire format
-  is versioned and **append-only** — read `.claude/rules/ipc-protocol.md` before touching
+  is versioned and **append-only** — read `crates/openlogi-ipc/AGENTS.md` before touching
   it.
 - Three processes ship in the bundle — GUI, agent, overlay — and the overlay is a
   *sibling* of the GUI, not a part of it: it links `openlogi-ui`, never
@@ -197,7 +197,7 @@ backstop, not a substitute for running the gate yourself after a rebase.
    `.claude/rules/cross-platform.md`.
 5. If wire types changed: `PROTOCOL_VERSION` bumped and
    `cargo test -p openlogi-ipc --test wire_format` green — see
-   `.claude/rules/ipc-protocol.md`.
+   `crates/openlogi-ipc/AGENTS.md`.
 6. If locales changed: every `crates/openlogi-ui/locales/*.yml` carries the same keys
    as `en.yml` (new keys at the same position); run
    `cargo test -p openlogi-desktop i18n` — see `.claude/rules/i18n.md`.
@@ -292,7 +292,8 @@ never re-run a failed release job or re-dispatch on an existing tag.
 
 ## Subsystem rules — read before touching
 
-Claude Code loads these automatically per path; other agents: read the listed file
+Claude Code loads the `.claude/rules/` files per matching path and a crate's
+own `AGENTS.md` when working inside it; other agents: read the listed file
 before editing that area.
 
 | Area | Rule file |
@@ -302,12 +303,12 @@ before editing that area.
 | `crates/openlogi-desktop/**`, `crates/openlogi-ui/**`, `crates/openlogi-overlay/**` (GPUI) | `.claude/rules/gui.md` |
 | `crates/openlogi-desktop/**` (that crate's own contract and map) | `crates/openlogi-desktop/AGENTS.md` |
 | `crates/openlogi-ui/locales/**`, `openlogi-ui/src/locale.rs`, `openlogi-desktop/src/services/i18n.rs` | `.claude/rules/i18n.md` |
-| `crates/openlogi-agent-core/**`, `crates/openlogi-agent/**`, `crates/openlogi-ipc/**`, plus `openlogi-core`/`openlogi-device` (their serde types ride the wire) | `.claude/rules/ipc-protocol.md` |
+| `crates/openlogi-ipc/**`, plus every crate whose serde types ride the wire (`openlogi-agent-core`, `openlogi-agent`, `openlogi-core`, `openlogi-hid`) | `crates/openlogi-ipc/AGENTS.md` |
 | `crates/openlogi-hook/**`, `crates/openlogi-inject/**`, `crates/openlogi-hid/**` (cfg-gated platform code) | `.claude/rules/cross-platform.md` |
 | `crates/openlogi-hidpp/**` (hard fork of `hidpp`) | `crates/openlogi-hidpp/AGENTS.md` |
-| `crates/openlogi-device/**`, `crates/openlogi-hid/**` | `.claude/rules/hidpp.md` |
-| `crates/openlogi-hook/**` (event taps) | `.claude/rules/hook.md` |
-| `xtask/**`, `packaging/**`, `.github/scripts/**` | `.claude/rules/xtask.md` (+ `xtask/README.md`) |
+| `crates/openlogi-device/**`, `crates/openlogi-hid/**` (the HID++ layer seam) | `crates/openlogi-device/AGENTS.md` |
+| `crates/openlogi-hook/**` (event taps) | `crates/openlogi-hook/AGENTS.md` |
+| `xtask/**`, `packaging/**`, `.github/scripts/**` | `xtask/AGENTS.md` (+ `xtask/README.md`) |
 | macOS native FFI wherever it lives — `openlogi-{agent,camera,hook,inject,overlay,permissions}` + `openlogi-desktop/src/platform/**` | `.claude/rules/objc-ffi.md` |
 
 ## Task skills — invoke when the task matches, not when a path matches

--- a/crates/openlogi-agent-core/src/watchers/accessibility.rs
+++ b/crates/openlogi-agent-core/src/watchers/accessibility.rs
@@ -11,7 +11,7 @@ use super::poll::{self, Poll};
 ///
 /// Poll it for as long as a hook is installed: an active event tap that
 /// outlives its grant wedges system input until reboot, so the agent has to
-/// learn about a revocation on its own (see `.claude/rules/hook.md`).
+/// learn about a revocation on its own (see `crates/openlogi-hook/AGENTS.md`).
 pub fn spawn(period: Duration) -> mpsc::UnboundedReceiver<bool> {
     if !cfg!(target_os = "macos") {
         // Linux and Windows gate the hook below the privacy layer, so there is

--- a/crates/openlogi-core/src/app.rs
+++ b/crates/openlogi-core/src/app.rs
@@ -4,7 +4,7 @@
 //! shape and none of them can see the others: `openlogi-hook` reads it from the
 //! window server, `openlogi-agent-core` holds it, and `openlogi-ipc` puts it on
 //! the wire. That last one makes this a wire type — see
-//! `.claude/rules/ipc-protocol.md`.
+//! `crates/openlogi-ipc/AGENTS.md`.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/openlogi-desktop/AGENTS.md
+++ b/crates/openlogi-desktop/AGENTS.md
@@ -1,0 +1,95 @@
+# openlogi-desktop — the settings app
+
+The GPUI + gpui-component window users actually open: device gallery, per-device
+panels, Settings, pairing. It is one of three processes in the bundle and the
+only one with a settings UI.
+
+This file is the crate's own contract and map. The cross-cutting rules for
+writing GPUI code — components, theming, element IDs, icons, task ownership —
+live in [`.claude/rules/gui.md`](../../.claude/rules/gui.md) and are **not**
+restated here; read that file before editing any `.rs` in this crate. Workspace
+standards (lints, module layout, commits, the local gate) are in the root
+[`AGENTS.md`](../../AGENTS.md).
+
+## The hard contract: this crate never touches a device
+
+`openlogi-desktop` is a **pure IPC client**. The agent owns the input hook and
+every byte of HID++ I/O; this crate reads and writes device state only by
+calling the agent over tarpc.
+
+When a panel needs a device value the app cannot currently see, the fix is a new
+call in `openlogi-ipc` plus a handler in `openlogi-agent`/`openlogi-agent-core`
+— never an `openlogi-hid` call from here, and never a "just this once" direct
+read. Wire changes are append-only and versioned; see
+[`.claude/rules/ipc-protocol.md`](../../.claude/rules/ipc-protocol.md).
+
+Two more things this crate is not:
+
+- **Not the overlay's parent.** `openlogi-overlay` is a *sibling* process. It
+  links `openlogi-ui`, never this crate. Anything both frontends need moves into
+  `openlogi-ui` — and every dependency added there is added to the overlay too,
+  which is why `gpui-component` is not one of them.
+- **Not a home for shared presentation.** Ring geometry, the shared asset
+  source, locale negotiation: those are `openlogi-ui`'s. What only the settings
+  app draws stays here.
+
+## Map of `src/`
+
+| Path | What lives there |
+|---|---|
+| `main.rs` | Process bootstrap **only** — logging, single-instance guard, config, locale, the IPC client, then `gpui::run`. It also defines the `tr!` macro above the `mod` declarations, which is why every submodule gets `tr!` without an import (textual macro scope). |
+| `runtime.rs` | Everything the app does that isn't a render: one task, one `select!` arm per source that can change long-lived state (agent updates, camera scan, asset commands, finished downloads, `openlogi://` deeplinks). |
+| `app.rs`, `app/` | The main window's shell — home gallery, device detail, menu bar, status line, deeplink handling. |
+| `windows.rs`, `windows/` | The windows themselves plus the registry that keeps each a singleton. About and Updates are **pages inside Settings**, not windows of their own. |
+| `features/` | One module per device-feature panel: `mouse`, `pointer`, `keyboard`, `lighting`, `camera`, `action_ring`, `profile_scope`. |
+| `state.rs`, `state/` | `AppState`, the GPUI global every view reads. Anything two views share belongs here; per-component scratch (hover index, open popover) stays in the owning entity. |
+| `services/` | Infrastructure, not UI: the IPC client, asset resolution and download, device reads, diagnostics, i18n. |
+| `ui/` | Shared components and the hand-painted `Palette` (`theme.rs`). |
+| `platform/` | OS integration — app icon, OS facts, updater. |
+| `app_assets.rs` | The GPUI asset source, composed in order: embedded logo → `openlogi-ui`'s `action-icons/` → gpui-component's bundled lucide set. A new icon path that resolves nowhere renders blank rather than failing to build. |
+
+Panels gate on `Capabilities`, never on device `kind`; commits go through
+`AppState`, never straight to `Config`. Both rules are spelled out in
+`.claude/rules/gui.md`.
+
+## Running and verifying
+
+- `cargo run -p openlogi-desktop` — a cargo runner wraps the build into
+  `target/dev/OpenLogi.app` with the identity, helpers and plist tables
+  packaging uses. **`cargo build` does not refresh that bundle**, and a second
+  instance exits on the singleton lock: quit the running app and re-`run` before
+  judging a UI change "not applied".
+- The window shows only the empty state unless an agent is running. With no
+  hardware, `cargo run -p openlogi-agent --bin openlogi-agent-mock` serves a
+  scripted inventory.
+- `OPENLOGI_COMPONENT_GALLERY=1` on a debug build opens `ui/gallery.rs` instead
+  of the app — every shared component rendered without app state. **When you
+  change a reusable component, update its gallery entry in the same commit**;
+  the gallery is not covered by tests and silently drifts from production
+  otherwise.
+- The macOS build needs full Xcode for GPUI's Metal shaders. devenv sets the
+  environment when Xcode is present (`direnv reload` if the shader compile
+  fails).
+
+## Build inputs that are not source
+
+- `build.rs` asks `cargo metadata` where gpui-component's source actually sits
+  and copies its `themes/` into `OUT_DIR`, because the compiled crate does not
+  ship them. **Do not vendor copies of those themes into this repo.**
+  `OPENLOGI_THEMES_DIR` overrides the lookup.
+- `themes/openlogi.json` is the app's own theme, layered on that upstream set.
+- `bundle/` holds `OpenLogi.entitlements` and one `Info.plist` per bundled
+  binary (`desktop-dev`, `agent-release`, `overlay-release`). `cargo xtask`
+  packaging reads them; they are the app's macOS identity, not decoration —
+  changing one changes what TCC sees. See
+  [`.claude/rules/xtask.md`](../../.claude/rules/xtask.md).
+
+## Related rules
+
+| When you touch | Read |
+|---|---|
+| any `.rs` here (GPUI house style) | [`.claude/rules/gui.md`](../../.claude/rules/gui.md) |
+| `services/i18n.rs`, any user-facing string | [`.claude/rules/i18n.md`](../../.claude/rules/i18n.md) |
+| anything crossing the agent boundary | [`.claude/rules/ipc-protocol.md`](../../.claude/rules/ipc-protocol.md) |
+| `platform/**` or any macOS FFI | [`.claude/rules/objc-ffi.md`](../../.claude/rules/objc-ffi.md) |
+| a permission symptom or the bundle identity | [`.claude/skills/openlogi-macos-permissions/SKILL.md`](../../.claude/skills/openlogi-macos-permissions/SKILL.md) |

--- a/crates/openlogi-desktop/AGENTS.md
+++ b/crates/openlogi-desktop/AGENTS.md
@@ -21,7 +21,7 @@ When a panel needs a device value the app cannot currently see, the fix is a new
 call in `openlogi-ipc` plus a handler in `openlogi-agent`/`openlogi-agent-core`
 — never an `openlogi-hid` call from here, and never a "just this once" direct
 read. Wire changes are append-only and versioned; see
-[`.claude/rules/ipc-protocol.md`](../../.claude/rules/ipc-protocol.md).
+[`crates/openlogi-ipc/AGENTS.md`](../openlogi-ipc/AGENTS.md).
 
 Two more things this crate is not:
 
@@ -82,7 +82,7 @@ Panels gate on `Capabilities`, never on device `kind`; commits go through
   binary (`desktop-dev`, `agent-release`, `overlay-release`). `cargo xtask`
   packaging reads them; they are the app's macOS identity, not decoration —
   changing one changes what TCC sees. See
-  [`.claude/rules/xtask.md`](../../.claude/rules/xtask.md).
+  [`xtask/AGENTS.md`](../../xtask/AGENTS.md).
 
 ## Related rules
 
@@ -90,6 +90,6 @@ Panels gate on `Capabilities`, never on device `kind`; commits go through
 |---|---|
 | any `.rs` here (GPUI house style) | [`.claude/rules/gui.md`](../../.claude/rules/gui.md) |
 | `services/i18n.rs`, any user-facing string | [`.claude/rules/i18n.md`](../../.claude/rules/i18n.md) |
-| anything crossing the agent boundary | [`.claude/rules/ipc-protocol.md`](../../.claude/rules/ipc-protocol.md) |
+| anything crossing the agent boundary | [`crates/openlogi-ipc/AGENTS.md`](../openlogi-ipc/AGENTS.md) |
 | `platform/**` or any macOS FFI | [`.claude/rules/objc-ffi.md`](../../.claude/rules/objc-ffi.md) |
 | a permission symptom or the bundle identity | [`.claude/skills/openlogi-macos-permissions/SKILL.md`](../../.claude/skills/openlogi-macos-permissions/SKILL.md) |

--- a/crates/openlogi-desktop/CLAUDE.md
+++ b/crates/openlogi-desktop/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/openlogi-device/AGENTS.md
+++ b/crates/openlogi-device/AGENTS.md
@@ -1,10 +1,7 @@
----
-paths:
-  - "crates/openlogi-device/**"
-  - "crates/openlogi-hid/**"
----
+# openlogi-device / openlogi-hid — the HID++ device layer
 
-# openlogi-device / openlogi-hid
+This guide covers the two-crate seam; it lives here because `openlogi-device`
+owns the layer. `crates/openlogi-hid/AGENTS.md` points back here.
 
 - The HID++ layer is split at `openlogi_device::backend::HidBackend`.
   `openlogi-device` holds everything that knows the protocol and nothing about

--- a/crates/openlogi-device/CLAUDE.md
+++ b/crates/openlogi-device/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/openlogi-hid/AGENTS.md
+++ b/crates/openlogi-hid/AGENTS.md
@@ -1,0 +1,12 @@
+# openlogi-hid — the host-side HID backend
+
+The `HidBackend` implementation for this machine: `async-hid` transport, the
+Windows composite channel, macOS Input Monitoring, the on-disk probe cache,
+plus `host`, which supplies it to `openlogi-device`'s entry points.
+
+The layer's contract — the `HidBackend` seam, the device-kind vocabularies,
+enumeration grace — is [`crates/openlogi-device/AGENTS.md`](../openlogi-device/AGENTS.md);
+read it before changing this crate. Serde types here ride the IPC wire
+([`crates/openlogi-ipc/AGENTS.md`](../openlogi-ipc/AGENTS.md)), and the
+cfg-gated platform code falls under
+[`.claude/rules/cross-platform.md`](../../.claude/rules/cross-platform.md).

--- a/crates/openlogi-hid/CLAUDE.md
+++ b/crates/openlogi-hid/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/openlogi-hidpp/AGENTS.md
+++ b/crates/openlogi-hidpp/AGENTS.md
@@ -44,7 +44,7 @@ protocol-correctness contract:
   (`UnsupportedResponse`-style) — never falls back to a silent default.
 - Feature `0x0005` (`device_type_and_name`) is one of four incompatible "device
   kind" vocabularies used across the workspace; the cross-crate rule about never
-  mixing them by raw value lives in `.claude/rules/hidpp.md` (the
+  mixing them by raw value lives in `crates/openlogi-device/AGENTS.md` (the
   `openlogi-hid` side), not duplicated here.
 
 ## Settled: this crate answers to the workspace like any other

--- a/crates/openlogi-hook/AGENTS.md
+++ b/crates/openlogi-hook/AGENTS.md
@@ -1,9 +1,11 @@
----
-paths:
-  - "crates/openlogi-hook/**"
----
+# openlogi-hook — OS input capture
 
-# Input hook (CGEventTap / evdev / WH_MOUSE_LL)
+The event-tap crate: CGEventTap on macOS, evdev+uinput on Linux, WH_MOUSE_LL
+on Windows. Cross-platform cfg discipline is
+[`.claude/rules/cross-platform.md`](../../.claude/rules/cross-platform.md), and
+the macOS FFI contract is
+[`.claude/rules/objc-ffi.md`](../../.claude/rules/objc-ffi.md); this file is the
+crate's own load-bearing behavior.
 
 - macOS: the CGEventTap freeze-hazard state machine is load-bearing. The tap must
   self-disable when Accessibility is revoked, on its own thread, with the bounded

--- a/crates/openlogi-hook/CLAUDE.md
+++ b/crates/openlogi-hook/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/openlogi-ipc/AGENTS.md
+++ b/crates/openlogi-ipc/AGENTS.md
@@ -1,0 +1,23 @@
+# openlogi-ipc — the wire format is append-only
+
+The GUI and agent speak tarpc over bincode on an `interprocess` local socket
+(`openlogi-ipc/src/ipc.rs`). bincode encodes the enum **variant index** and
+tarpc encodes the **method order**, so the wire format is positional:
+
+- Service methods are append-only; never reorder or remove. `protocol_version` must
+  remain method 0 forever — the takeover handshake probes it across versions.
+- serde enums that cross the IPC boundary are append-only too. serde encodes the
+  declaration index, NOT a `#[repr(u8)]` discriminant — the two can disagree. The wire
+  surface is wider than this crate: serde types from `openlogi-core` (device model,
+  `DeviceKind`, actions, config) and `openlogi-hid` (write errors) ride inside RPC
+  payloads, so the same rule binds them.
+- Any wire change bumps `PROTOCOL_VERSION` (checked strict-equal at connect) and
+  regenerates the golden tests in `crates/openlogi-ipc/tests/wire_format.rs`,
+  including the pinned-version assertion — the failure message prints the bytes
+  (`left` is the new encoding). Run `cargo test -p openlogi-ipc --test wire_format`
+  before any push that touched wire types.
+- The goldens use tokio-serde's `Bincode::default()` = bincode `DefaultOptions`
+  (varint, little-endian); the free `bincode::serialize` functions are fixint and do
+  NOT produce matching bytes.
+- Debug-build agents never take over a running release agent — that is by design (a
+  dev agent must not displace the user's production agent), not a bug.

--- a/crates/openlogi-ipc/CLAUDE.md
+++ b/crates/openlogi-ipc/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/xtask/AGENTS.md
+++ b/xtask/AGENTS.md
@@ -1,0 +1,57 @@
+# xtask — build, packaging, and CI tooling
+
+- `xtask/README.md` is the contract for this crate — module layout mirrors the CLI
+  hierarchy, `xshell` for short-lived external tools (`cargo`, `create-dmg`, `codesign`,
+  `nfpm`), `std::process::Command` only for real process control, crates (not shell-outs)
+  for structured data, no thin wrappers around tools that already own a task. Read it
+  before adding a command.
+- xtask is linted like product code: the workspace `clippy::pedantic` +
+  `unwrap_used`/`expect_used` warns run with `-D warnings` — use `?` and combinators,
+  not `unwrap`/`expect`, even in "script" code.
+- App icon: the master is the **committed** Icon Composer document
+  `design/icon/openlogi.icon` (its `icon.json` plus the artwork it names);
+  `cargo xtask macos icon` compiles it with `actool` into `AppIcon.icns` (what
+  macOS 13–25 draw, and what every helper bundle ships) and `Assets.car` (what
+  macOS 26 composes the layered icon from — the app carries it, the helpers do
+  not). `actool` names its outputs after the document, so the compile stages a
+  copy called `AppIcon.icon`; it ships with Xcode (not the command line tools)
+  and has to be **Xcode 26 or newer**, since that is where Icon Composer
+  documents arrived. `OPENLOGI_DEVELOPER_DIR` picks which Xcode every macOS
+  build command runs under — `build.yml` pins it so both native and
+  cross-compiled distribution targets use the same Icon Composer-capable SDK.
+  `design/icon/openlogi.png` stays the master for Linux packaging and the GUI's
+  embedded logo, and `openlogi.ico` for the Windows executables. The icon set
+  itself lives in `xtask/src/icon.rs` (`AppIcon` plus the `IconPipeline` trait a
+  platform implements); `icon/macos.rs` is the only implementation so far — add
+  one there rather than growing a second icon vocabulary when Windows or Linux
+  needs a build step. The build never
+  fetches the icon from the CDN — a build-time fetch was tried and deliberately
+  reverted; don't reintroduce it. After changing the icon, macOS caches by bundle
+  path: `touch target/dev/OpenLogi.app && killall Dock` to see it.
+- Package contents are declarative, not coded: Linux `.deb`/`.rpm` in
+  `packaging/linux/nfpm.yaml` (plus udev rules, systemd unit, desktop entry beside it),
+  Windows MSI in `packaging/windows/OpenLogi.wxs`. Packaging env overrides
+  (`OPENLOGI_SIGN_IDENTITY`, `OPENLOGI_BUNDLE_ASSETS`, `PKG_ARCH`, …) are documented in
+  `docs/DEVELOPMENT.md`.
+- `cargo xtask ci` is the local CI runner (`xtask/src/commands/ci/`). Facts about a
+  job — CI name, the names it answers to, the hosts CI gives it, whether a bare run
+  includes it — are one `Spec` row returned from one match in `ci/jobs.rs`; behaviour
+  is `ci/jobs/steps.rs`. Host gating is a runtime `Host` value, not `cfg!`, so which
+  job skips where is data a test reads. It is also the only place the Windows
+  cross-lint crate list lives — `devenv.nix`'s `openlogi:check-windows` calls it
+  rather than repeating the `-p` flags. Adding a job to `ci.yml` means a `Job`
+  variant + `Spec` row, its steps, and a row in `.claude/rules/ci.md`; `--list`
+  renders itself from the rows. It does not repeat the commands — `--dry-run`
+  prints the real argv, and a hand-copied third version of what `ci.yml` says
+  is a version that can be wrong.
+- `.cargo/run-macos.sh` stays a shell script — cargo execs it for every binary of every
+  `cargo run`/`test`/`bench`, including xtask's own, so the passthrough must stay cheap —
+  but it holds no bundling logic: that is `xtask macos dev-bundle`, which shares the
+  identity/helper/plist tables with `macos bundle`. Keep it that way; the two drifted
+  badly while they were separate implementations.
+  `.github/scripts/release-notes/` is a dedicated Node/Octokit tool; don't wrap it in xtask.
+- Shell that is really program logic belongs here instead: `cargo xtask release changelog`
+  replaced a script whose version parsing and changelog editing were two embedded Python
+  heredocs. The release-plz workflow builds the binary on `master` before checking out
+  the release branch, so the tool must keep reading the version from the tree at run
+  time — `env!("CARGO_PKG_VERSION")` would bake in the pre-bump one.

--- a/xtask/CLAUDE.md
+++ b/xtask/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Documentation follow-up to #1022, in three commits.

That PR fixed six places where a text character stood in for an icon. Nothing in the repo had ever said not to write them, so each one had been an independent decision — the first commit writes the rule down, along with the two facts that only turned up while fixing them.

The second adds a crate-level guide for `openlogi-desktop`, and the third applies that motion to the rest of `.claude/rules/`: every rule with one obvious home moves into the crate it governs.

## Changes

**`.claude/rules/gui.md`** — an icon is never a text character, with the reasons that make it a defect rather than a style preference: glyph advance widths differ, so a column of them never aligns, and a screen reader announces the character. Punctuation between text (`·` as a separator, `…` on a menu item that opens a dialog) is explicitly still text, so the rule cannot be read as banning them.

Two facts beside it. `Icon` drops its own default size once the caller styles it — its render overwrites the base style refinement, so a bare `Icon` falls through to the current font size rather than the 16px `Default` sets, which is why the gesture direction rows need an explicit `.size_4()` to line up with the `svg().size_4()` rows below them. And the overlay has no `IconName` at all, so anything both processes draw has to be vendored and named through one shared const.

Corrects the registration path while here: `ACTION_ICONS` lives in openlogi-ui's `action_icons.rs`, not an `app_assets.rs`.

**`crates/openlogi-desktop/AGENTS.md`** (+ a `CLAUDE.md` that includes it, matching `openlogi-hidpp`) — the pure-IPC-client contract and what to do when a panel needs a value the app cannot currently see; a map of `src/` giving the reason each directory exists; the build inputs that are not source, meaning `build.rs` pulling gpui-component's themes out of its own checkout and `bundle/` being the app's macOS identity rather than decoration; and `OPENLOGI_COMPONENT_GALLERY=1`, which nothing documented.

It deliberately does not restate the GPUI house style — those rules stay in `.claude/rules/gui.md` and the file says so in its second paragraph, the way `openlogi-hidpp`'s guide defers to the HID++-layer guide. Two guides both describing how to write a component would drift within a month.

One new rule in it: a reusable component and its `ui/gallery.rs` entry change in the same commit. The gallery has no test coverage, and #1022 found an entry still drawing a `×` long after the production control had moved to `IconName::Close`.

Indexed in the root `AGENTS.md` subsystem table.

**Rule migration** — four rules now live with their subject, each as a crate `AGENTS.md` plus a one-line `CLAUDE.md` include (the `openlogi-hidpp` pattern): `hook.md` → `crates/openlogi-hook/AGENTS.md`; `hidpp.md` → `crates/openlogi-device/AGENTS.md`, with a thin `crates/openlogi-hid/AGENTS.md` pointing across the seam; `ipc-protocol.md` → `crates/openlogi-ipc/AGENTS.md`, the rule file surviving as a pointer whose `paths:` cover the satellite crates whose serde types ride the wire; `xtask.md` → `xtask/AGENTS.md`, the rule surviving as a pointer for `packaging/**` and `.github/scripts/**`, which have no crate to host a guide. The cross-cutting rules (`gui`, `i18n`, `cross-platform`, `objc-ffi`, `rust`, `ci`) stay in `.claude/rules/` — no single home exists for them. Every in-tree reference was repointed: the root subsystem table, the desktop and hidpp guides, and one doc comment in `openlogi-agent-core`.

A fourth commit records the typed-decision idioms in `.claude/rules/rust.md`'s type-system section, with their in-tree exemplars: intent-named methods over flag bools, named structs vs sum types for fact pairs (`Option<bool>` tri-states included), sans-I/O decision objects with explicit clocks, and typestate lifecycles — so the next occurrence gets recognized instead of re-derived.

## Testing

Documentation plus one repointed doc comment in `openlogi-agent-core` — the pre-push hook ran the full-workspace clippy + rustdoc gate on the final tree. `prek` ran typos and the whitespace hooks at commit; every relative link in the new and touched guides was checked to resolve.


