### PR TITLE
feat: make thumb-wheel horizontal scroll direction reversible

### DIFF
--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -57,13 +57,17 @@ pub fn default_binding(button: ButtonId) -> Action {
                       not because the control stays native like the keyboard arm below"
         )]
         ButtonId::Thumbwheel => Action::None,
-        // The thumb wheel scrolls horizontally by default: rotating it produces
-        // continuous horizontal scroll, with "up" → right and "down" → left.
-        // The wheel watcher renders these two actions as smooth, sensitivity-
-        // scaled scrolling rather than the discrete per-press burst a button
-        // would get (see `watchers::gesture`).
-        ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollRight,
-        ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollLeft,
+        // The thumb wheel scrolls horizontally in firmware: "up" (forward)
+        // scrolls left and "down" scrolls right. As with the tilt above, the
+        // seed must match that native direction — once anything arms the
+        // divert, the injected scroll follows these actions, so a mismatched
+        // seed makes the swapped pair a felt no-op and flips the felt
+        // direction whenever something else (a sensitivity change) diverts the
+        // wheel. The wheel watcher renders these two actions as smooth,
+        // sensitivity-scaled scrolling rather than the discrete per-press
+        // burst a button would get (see `watchers::gesture`).
+        ButtonId::ThumbwheelScrollUp => Action::HorizontalScrollLeft,
+        ButtonId::ThumbwheelScrollDown => Action::HorizontalScrollRight,
         ButtonId::GestureButton => Action::MissionControl,
         ButtonId::HapticPanel => Action::ShowActionsRing,
         // Keyboard keys stay on their native firmware function until the user

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -533,6 +533,22 @@ fn wheel_tilt_defaults_to_the_scroll_its_firmware_already_does() {
     }
 }
 
+#[test]
+fn thumbwheel_defaults_to_the_scroll_its_firmware_already_does() {
+    // Same constraint as the wheel tilt above, with a sharper failure mode: a
+    // seed that doesn't match the wheel's native direction (up → left) makes
+    // the swapped binding pair a felt no-op and turns any other divert cause
+    // (a sensitivity change) into a silent direction flip.
+    assert_eq!(
+        default_binding(ButtonId::ThumbwheelScrollUp),
+        Action::HorizontalScrollLeft
+    );
+    assert_eq!(
+        default_binding(ButtonId::ThumbwheelScrollDown),
+        Action::HorizontalScrollRight
+    );
+}
+
 // ── Effect classification ─────────────────────────────────────────────────
 //
 // `Action::effect()` is the platform-neutral IR `openlogi-inject`'s three

--- a/crates/openlogi-core/src/config.rs
+++ b/crates/openlogi-core/src/config.rs
@@ -49,6 +49,13 @@ use settings::GestureOwner;
 /// persisted shape or enum vocabulary changes; readers inspect this value
 /// before consuming the rest of the file.
 ///
+/// v7 swaps the two thumb-wheel scroll defaults to the wheel's native firmware
+/// direction (up → left, down → right). A pre-v7 file whose thumb-wheel
+/// bindings sit on the old defaults — the pair the GUI's "Horizontal Scroll"
+/// preset wrote — is rewritten onto the new defaults
+/// (see `Config::migrate_thumbwheel_native_direction`) so it keeps scrolling
+/// natively instead of starting to divert into a felt reversal.
+///
 /// v6 adds threshold-based `{ short = ..., long = ... }` button bindings.
 ///
 /// v5 also drops the transport prefix from `direct:` keys: `direct:046d:c08d:unit:6be9d300`
@@ -86,7 +93,7 @@ use settings::GestureOwner;
 /// next save; [`Config::load_from_path`] accepts supported versions `1` through
 /// [`SCHEMA_VERSION`] so an invalid or forward file fails loudly instead of
 /// silently losing bindings.
-pub const SCHEMA_VERSION: u32 = 6;
+pub const SCHEMA_VERSION: u32 = 7;
 
 /// Top-level config document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -512,6 +519,48 @@ impl Config {
                 if let Some((new, _)) = renames.get(target) {
                     *target = new.clone();
                 }
+            }
+        }
+    }
+
+    /// One-time load migration for pre-v7 thumb-wheel scroll pairs.
+    ///
+    /// v7 swapped the two thumb-wheel scroll defaults to the wheel's native
+    /// firmware direction (see `binding::defaults`). A pre-v7 device whose
+    /// thumb-wheel trio sits entirely on the old defaults — the explicit pair
+    /// the GUI's "Horizontal Scroll" preset wrote — never diverted and
+    /// scrolled natively; left as written it would now differ from the new
+    /// defaults and divert into a felt reversal, so the pair is rewritten onto
+    /// the new defaults and keeps feeling exactly as it did. Any other
+    /// thumb-wheel binding means the wheel was already diverted with every
+    /// explicit direction injecting the action it names, which the swap does
+    /// not change — those devices, and per-app overlay entries (whose
+    /// old-default values were equally inert pre-v7), are left as written.
+    #[cfg(feature = "fs")]
+    fn migrate_thumbwheel_native_direction(&mut self) {
+        let old_up = Binding::Single(Action::HorizontalScrollRight);
+        let old_down = Binding::Single(Action::HorizontalScrollLeft);
+        for device in self.devices.values_mut() {
+            let trio_on_old_defaults = device
+                .bindings
+                .get(&ButtonId::ThumbwheelScrollUp)
+                .is_none_or(|binding| *binding == old_up)
+                && device
+                    .bindings
+                    .get(&ButtonId::ThumbwheelScrollDown)
+                    .is_none_or(|binding| *binding == old_down)
+                && device
+                    .bindings
+                    .get(&ButtonId::Thumbwheel)
+                    .is_none_or(|binding| *binding == Binding::Single(Action::None));
+            if !trio_on_old_defaults {
+                continue;
+            }
+            if let Some(binding) = device.bindings.get_mut(&ButtonId::ThumbwheelScrollUp) {
+                *binding = Binding::Single(Action::HorizontalScrollLeft);
+            }
+            if let Some(binding) = device.bindings.get_mut(&ButtonId::ThumbwheelScrollDown) {
+                *binding = Binding::Single(Action::HorizontalScrollRight);
             }
         }
     }

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -273,6 +273,12 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
     if header.schema_version <= 4 {
         config.migrate_transport_scoped_keys();
     }
+    // v7 swapped the thumb-wheel scroll defaults to the native firmware
+    // direction, so every released schema — v6 and below — may carry the old
+    // explicit pair that used to mean "keep native scroll".
+    if header.schema_version <= 6 {
+        config.migrate_thumbwheel_native_direction();
+    }
     config.schema_version = SCHEMA_VERSION;
     Ok((config, header.schema_version))
 }

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1047,6 +1047,91 @@ Click = \"Paste\"
 }
 
 #[test]
+fn migrates_pre_v7_thumbwheel_pair_on_old_defaults_to_the_new_defaults() {
+    // The pair the pre-v7 GUI wrote for "Horizontal Scroll": it equaled the
+    // old defaults, so the wheel never diverted and scrolled natively. On the
+    // new defaults it must land as the (swapped) new default pair to keep not
+    // diverting.
+    let v6 = "\
+schema_version = 6
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+ThumbwheelScrollDown = \"HorizontalScrollLeft\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v6).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v6");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollLeft))
+    );
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+}
+
+#[test]
+fn pre_v7_thumbwheel_migration_leaves_a_customized_trio_alone() {
+    // A nondefault thumb-wheel binding meant the wheel was already diverted,
+    // with every explicit direction injecting the action it names — the
+    // default swap changes nothing for it, so nothing may be rewritten.
+    let v6 = "\
+schema_version = 6
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+ThumbwheelScrollDown = \"NextTab\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v6).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v6");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::NextTab))
+    );
+}
+
+#[test]
+fn v7_thumbwheel_reversed_pair_survives_a_reload() {
+    // Post-v7 the old default pair is exactly what the GUI's "Horizontal
+    // Scroll (Reversed)" preset writes; the version gate is what keeps the
+    // migration from undoing that choice on every load.
+    let v7 = "\
+schema_version = 7
+
+[devices.\"unit:6be9d300\".bindings]
+ThumbwheelScrollUp = \"HorizontalScrollRight\"
+ThumbwheelScrollDown = \"HorizontalScrollLeft\"
+";
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, v7).expect("write");
+
+    let cfg = Config::load_from_path(&path).expect("load v7");
+    let bindings = cfg.bindings_for("unit:6be9d300");
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollUp),
+        Some(&Binding::Single(Action::HorizontalScrollRight))
+    );
+    assert_eq!(
+        bindings.get(&ButtonId::ThumbwheelScrollDown),
+        Some(&Binding::Single(Action::HorizontalScrollLeft))
+    );
+}
+
+#[test]
 fn migration_gesture_map_wins_over_legacy_single_gesture_button_entry() {
     // The data-loss guard: when a legacy single button_bindings[GestureButton]
     // entry coexists with a gesture_bindings map (reachable via hand-edited

--- a/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
+++ b/crates/openlogi-desktop/src/features/mouse/thumbwheel.rs
@@ -28,10 +28,11 @@ pub(crate) enum ThumbwheelPreset {
     VerticalScroll,
     VerticalScrollReversed,
     HorizontalScroll,
+    HorizontalScrollReversed,
 }
 
 impl ThumbwheelPreset {
-    pub(crate) const ALL: [Self; 12] = [
+    pub(crate) const ALL: [Self; 13] = [
         Self::BackForward,
         Self::UndoRedo,
         Self::BrowserHistory,
@@ -44,6 +45,7 @@ impl ThumbwheelPreset {
         Self::VerticalScroll,
         Self::VerticalScrollReversed,
         Self::HorizontalScroll,
+        Self::HorizontalScrollReversed,
     ];
 
     #[must_use]
@@ -60,7 +62,13 @@ impl ThumbwheelPreset {
             Self::CycleDpi => (Action::CycleDpiPresets, Action::CycleDpiPresets),
             Self::VerticalScroll => (Action::ScrollDown, Action::ScrollUp),
             Self::VerticalScrollReversed => (Action::ScrollUp, Action::ScrollDown),
-            Self::HorizontalScroll => (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
+            // The plain pair must equal the native-direction defaults so
+            // picking it never diverts the wheel; the reversed pair is the
+            // swap, which diverts and injects the opposite direction.
+            Self::HorizontalScroll => (Action::HorizontalScrollRight, Action::HorizontalScrollLeft),
+            Self::HorizontalScrollReversed => {
+                (Action::HorizontalScrollLeft, Action::HorizontalScrollRight)
+            }
         };
         ThumbwheelPair { backward, forward }
     }
@@ -90,6 +98,7 @@ impl ThumbwheelPreset {
             Self::VerticalScroll => "Vertical Scroll",
             Self::VerticalScrollReversed => "Vertical Scroll (Reversed)",
             Self::HorizontalScroll => "Horizontal Scroll",
+            Self::HorizontalScrollReversed => "Horizontal Scroll (Reversed)",
         }
     }
 
@@ -105,7 +114,9 @@ impl ThumbwheelPreset {
             Self::Volume | Self::VolumeReversed => "action-icons/volume-2.svg",
             Self::CycleDpi => "action-icons/gauge.svg",
             Self::VerticalScroll | Self::VerticalScrollReversed => "action-icons/chevrons-up.svg",
-            Self::HorizontalScroll => "action-icons/chevrons-right.svg",
+            Self::HorizontalScroll | Self::HorizontalScrollReversed => {
+                "action-icons/chevrons-right.svg"
+            }
         }
     }
 }
@@ -128,6 +139,7 @@ mod tests {
             (Action::CycleDpiPresets, Action::CycleDpiPresets),
             (Action::ScrollDown, Action::ScrollUp),
             (Action::ScrollUp, Action::ScrollDown),
+            (Action::HorizontalScrollRight, Action::HorizontalScrollLeft),
             (Action::HorizontalScrollLeft, Action::HorizontalScrollRight),
         ];
 

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Lodret rulning"
 "Vertical Scroll (Reversed)": "Lodret rulning (omvendt)"
 "Horizontal Scroll": "Vandret rulning"
+"Horizontal Scroll (Reversed)": "Vandret rulning (omvendt)"
 "Custom": "Brugerdefineret"
 "Gesture Button": "Bevægelsesknap"
 "Gestures": "Bevægelser"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Vertikales Scrollen"
 "Vertical Scroll (Reversed)": "Vertikales Scrollen (umgekehrt)"
 "Horizontal Scroll": "Horizontales Scrollen"
+"Horizontal Scroll (Reversed)": "Horizontales Scrollen (umgekehrt)"
 "Custom": "Benutzerdefiniert"
 "Gesture Button": "Gestentaste"
 "Gestures": "Gesten"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Κατακόρυφη κύλιση"
 "Vertical Scroll (Reversed)": "Κατακόρυφη κύλιση (αντίστροφη)"
 "Horizontal Scroll": "Οριζόντια κύλιση"
+"Horizontal Scroll (Reversed)": "Οριζόντια κύλιση (αντίστροφη)"
 "Custom": "Προσαρμοσμένο"
 "Gesture Button": "Κουμπί χειρονομιών"
 "Gestures": "Χειρονομίες"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Vertical Scroll"
 "Vertical Scroll (Reversed)": "Vertical Scroll (Reversed)"
 "Horizontal Scroll": "Horizontal Scroll"
+"Horizontal Scroll (Reversed)": "Horizontal Scroll (Reversed)"
 "Custom": "Custom"
 "Gesture Button": "Gesture Button"
 "Gestures": "Gestures"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Desplazamiento vertical"
 "Vertical Scroll (Reversed)": "Desplazamiento vertical (invertido)"
 "Horizontal Scroll": "Desplazamiento horizontal"
+"Horizontal Scroll (Reversed)": "Desplazamiento horizontal (invertido)"
 "Custom": "Personalizado"
 "Gesture Button": "Botón de gestos"
 "Gestures": "Gestos"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Pystyvieritys"
 "Vertical Scroll (Reversed)": "Pystyvieritys (käänteinen)"
 "Horizontal Scroll": "Vaakavieritys"
+"Horizontal Scroll (Reversed)": "Vaakavieritys (käänteinen)"
 "Custom": "Mukautettu"
 "Gesture Button": "Eletoiminto"
 "Gestures": "Eleet"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Défilement vertical"
 "Vertical Scroll (Reversed)": "Défilement vertical (inversé)"
 "Horizontal Scroll": "Défilement horizontal"
+"Horizontal Scroll (Reversed)": "Défilement horizontal (inversé)"
 "Custom": "Personnalisé"
 "Gesture Button": "Bouton de gestes"
 "Gestures": "Gestes"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Scorrimento verticale"
 "Vertical Scroll (Reversed)": "Scorrimento verticale (invertito)"
 "Horizontal Scroll": "Scorrimento orizzontale"
+"Horizontal Scroll (Reversed)": "Scorrimento orizzontale (invertito)"
 "Custom": "Personalizzato"
 "Gesture Button": "Pulsante gesture"
 "Gestures": "Gesture"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "縦スクロール"
 "Vertical Scroll (Reversed)": "縦スクロール（反転）"
 "Horizontal Scroll": "横スクロール"
+"Horizontal Scroll (Reversed)": "横スクロール（反転）"
 "Custom": "カスタム"
 "Gesture Button": "ジェスチャーボタン"
 "Gestures": "ジェスチャー"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "세로 스크롤"
 "Vertical Scroll (Reversed)": "세로 스크롤(반대 방향)"
 "Horizontal Scroll": "가로 스크롤"
+"Horizontal Scroll (Reversed)": "가로 스크롤(반대 방향)"
 "Custom": "사용자 지정"
 "Gesture Button": "제스처 버튼"
 "Gestures": "제스처"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Vertikal rulling"
 "Vertical Scroll (Reversed)": "Vertikal rulling (omvendt)"
 "Horizontal Scroll": "Horisontal rulling"
+"Horizontal Scroll (Reversed)": "Horisontal rulling (omvendt)"
 "Custom": "Egendefinert"
 "Gesture Button": "Bevegelsesknapp"
 "Gestures": "Bevegelser"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Verticaal scrollen"
 "Vertical Scroll (Reversed)": "Verticaal scrollen (omgekeerd)"
 "Horizontal Scroll": "Horizontaal scrollen"
+"Horizontal Scroll (Reversed)": "Horizontaal scrollen (omgekeerd)"
 "Custom": "Aangepast"
 "Gesture Button": "Gebarenknop"
 "Gestures": "Gebaren"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Przewijanie pionowe"
 "Vertical Scroll (Reversed)": "Przewijanie pionowe (odwrócone)"
 "Horizontal Scroll": "Przewijanie poziome"
+"Horizontal Scroll (Reversed)": "Przewijanie poziome (odwrócone)"
 "Custom": "Niestandardowe"
 "Gesture Button": "Przycisk gestów"
 "Gestures": "Gesty"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Rolagem vertical"
 "Vertical Scroll (Reversed)": "Rolagem vertical (invertida)"
 "Horizontal Scroll": "Rolagem horizontal"
+"Horizontal Scroll (Reversed)": "Rolagem horizontal (invertida)"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de Gesto"
 "Gestures": "Gestos"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Deslocamento vertical"
 "Vertical Scroll (Reversed)": "Deslocamento vertical (invertido)"
 "Horizontal Scroll": "Deslocamento horizontal"
+"Horizontal Scroll (Reversed)": "Deslocamento horizontal (invertido)"
 "Custom": "Personalizado"
 "Gesture Button": "Botão de gesto"
 "Gestures": "Gestos"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Вертикальная прокрутка"
 "Vertical Scroll (Reversed)": "Вертикальная прокрутка (обратная)"
 "Horizontal Scroll": "Горизонтальная прокрутка"
+"Horizontal Scroll (Reversed)": "Горизонтальная прокрутка (обратная)"
 "Custom": "Свой"
 "Gesture Button": "Кнопка жестов"
 "Gestures": "Жесты"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Vertikal rullning"
 "Vertical Scroll (Reversed)": "Vertikal rullning (omvänd)"
 "Horizontal Scroll": "Horisontell rullning"
+"Horizontal Scroll (Reversed)": "Horisontell rullning (omvänd)"
 "Custom": "Anpassad"
 "Gesture Button": "Gestknapp"
 "Gestures": "Gester"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Dikey Kaydırma"
 "Vertical Scroll (Reversed)": "Dikey Kaydırma (Ters)"
 "Horizontal Scroll": "Yatay Kaydırma"
+"Horizontal Scroll (Reversed)": "Yatay Kaydırma (Ters)"
 "Custom": "Özel"
 "Gesture Button": "Hareket Düğmesi"
 "Gestures": "Hareketler"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "Вертикальне прокручування"
 "Vertical Scroll (Reversed)": "Вертикальне прокручування (зворотне)"
 "Horizontal Scroll": "Горизонтальне прокручування"
+"Horizontal Scroll (Reversed)": "Горизонтальне прокручування (зворотне)"
 "Custom": "Власна"
 "Gesture Button": "Кнопка жестів"
 "Gestures": "Жести"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "垂直滚动"
 "Vertical Scroll (Reversed)": "垂直滚动（反向）"
 "Horizontal Scroll": "水平滚动"
+"Horizontal Scroll (Reversed)": "水平滚动（反向）"
 "Custom": "自定义"
 "Gesture Button": "手势按钮"
 "Gestures": "手势"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "垂直捲動"
 "Vertical Scroll (Reversed)": "垂直捲動（反向）"
 "Horizontal Scroll": "水平捲動"
+"Horizontal Scroll (Reversed)": "水平捲動（反向）"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
 "Gestures": "手勢"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -194,6 +194,7 @@ _version: 1
 "Vertical Scroll": "垂直捲動"
 "Vertical Scroll (Reversed)": "垂直捲動（反向）"
 "Horizontal Scroll": "水平捲動"
+"Horizontal Scroll (Reversed)": "水平捲動（反向）"
 "Custom": "自訂"
 "Gesture Button": "手勢按鈕"
 "Gestures": "手勢"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,11 +30,13 @@ Schema versions newer than the running build are rejected before their fields
 are parsed. v1 binding maps and the v2–v3 gesture-owner layout migrate on load.
 The v3 physical-device-key transition cannot safely assign older model-scoped
 device settings when two identical devices exist, so v2 model-key entries must
-be copied manually to the generated physical keys.
+be copied manually to the generated physical keys. Pre-v7 thumb-wheel scroll
+pairs sitting on the old defaults are rewritten onto the new native-direction
+defaults on load, so the wheel keeps scrolling the way it did.
 
 ## Shape
 
-`schema_version` is required and currently `5`. `selected_device` is an
+`schema_version` is required and currently `7`. `selected_device` is an
 optional physical device key.
 
 `[app_settings]` contains application-wide preferences:

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -1,5 +1,5 @@
 # OpenLogi configuration example. Copy only the sections you need.
-schema_version = 6
+schema_version = 7
 selected_device = "receiver:aabbccdd:slot:1"
 
 [app_settings]


### PR DESCRIPTION
## Summary

Makes the thumb wheel's horizontal scroll direction reversible, as tracked in #619.

Two pieces, because the preset alone cannot work: the wheel is only diverted when a thumb-wheel setting leaves its default, and the current defaults (`ThumbwheelScrollUp → HorizontalScrollRight`, down → left) are the opposite of the wheel's native firmware direction (up → left, verified on an MX Master 4 over Bolt on macOS — see #619). With that seed, the swapped binding pair diverts into the native direction (a felt no-op), and no combination of scroll bindings changes the felt direction. Swapping the defaults to match native fixes that, also fixes #619's bug 2 (a sensitivity change silently flipping scroll direction), and makes a "Horizontal Scroll (Reversed)" preset a working, honest option.

## Changes

- `openlogi-core`:
  - `binding/defaults.rs`: swap the two thumb-wheel scroll defaults to the native firmware direction (up → `HorizontalScrollLeft`, down → `HorizontalScrollRight`), with the comment rewritten to state the constraint (the old comment asserted the opposite direction as the firmware's).
  - `config.rs` / `config/file.rs`: schema v7 plus a one-time load migration. A pre-v7 device whose thumb-wheel trio sits entirely on the old defaults — the pair the GUI's "Horizontal Scroll" preset wrote — scrolled natively (undiverted); left as written it would now divert into a felt reversal, so the pair is rewritten onto the new defaults and keeps feeling exactly as it did. Devices with any other thumb-wheel binding were already diverted with each explicit direction injecting the action it names, which the swap does not change, so they are left as written.
  - Tests for the new defaults, the migration, its customized-trio edge, and the version gate (a v7 file carrying the reversed pair must survive reloads).
- `openlogi-desktop`: new "Horizontal Scroll (Reversed)" thumbwheel preset; the plain "Horizontal Scroll" preset now writes the (new) default pair so picking it keeps the wheel undiverted.
- `openlogi-ui`: the preset's label key added to all 22 locale catalogs (best-effort translations; Crowdin can refine).
- `docs`: `CONFIGURATION.md` migration note and current schema version (the text still said `5`), `config.example.toml` bumped to v7.

## Caveats

- Native direction is verified on one device (MX Master 4 / Bolt / macOS). If some thumb-wheel firmware scrolls the other way, its untouched-default feel is unchanged either way (undiverted), but the two presets' labels would be swapped for it.
- Per-app overlay entries holding the old default pair are deliberately not migrated: pre-v7 they were inert (equal to defaults → no divert), post-v7 they become an active per-app reversal matching what they literally say. Migrating them felt-preservingly would need per-app effective-trio analysis; can follow up if you want it.
- No wire-format change: only default values moved; no serde shapes or enum variants changed, so no `PROTOCOL_VERSION` bump.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude openlogi-desktop --exclude openlogi-overlay --all-targets -- -D warnings` (with `RUSTFLAGS="-D warnings"`)
- `cargo test --workspace --exclude openlogi-desktop --exclude openlogi-overlay` — includes the `openlogi-ipc` wire-format goldens and the `openlogi-ui` locale parity test
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo check -p openlogi-hidpp -p openlogi-device --target wasm32-unknown-unknown` and `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown`

Not run locally (this host has Command Line Tools only, so GPUI's Metal shaders don't build): `openlogi-desktop` / `openlogi-overlay` clippy and tests — that includes the updated `ThumbwheelPreset` unit tests and the desktop i18n coverage test; CI's Linux clippy and macOS `--all-targets` tests cover them. Also not run locally: typos, cargo-deny, MSRV, Windows clippy, shell (no shell changes; no dependency changes).

Not runtime-tested on hardware. To verify on an MX Master 4 (or any 0x2150 device): (1) default config — thumb wheel should keep scrolling natively, and moving the sensitivity slider off 1× should no longer flip the direction; (2) pick "Horizontal Scroll (Reversed)" — the direction should genuinely flip; (3) pick "Horizontal Scroll" — back to native. A pre-upgrade config that had picked "Horizontal Scroll" should load feeling unchanged (migration), and a v7 file with the reversed pair must keep it across restarts.

No screenshot: the new picker row reuses the existing preset row rendering (label + existing chevrons icon); I could not build the GUI on this host.

Fixes #619
