### PR TITLE
fix(gui): keep Back and Forward labels together

### DIFF
--- a/crates/openlogi-desktop/src/features/mouse/geometry.rs
+++ b/crates/openlogi-desktop/src/features/mouse/geometry.rs
@@ -13,6 +13,14 @@ use crate::services::assets::ResolvedAsset;
 /// marker point per button, not a rectangle, so we size by hand.
 const ASSET_HOTSPOT: f32 = 56.;
 
+/// Height of a side-label card. The layout needs it to group related cards
+/// without allowing them to overlap at the minimum model height.
+pub(super) const LABEL_H: f32 = 56.;
+
+/// Empty space between the grouped Back and Forward cards when the viewport
+/// has enough room to pull them closer than the regular even spacing.
+const NAVIGATION_GROUP_GAP: f32 = 16.;
+
 /// Whether label cards occupy one or both sides of the device render.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LabelDistribution {
@@ -168,17 +176,26 @@ pub fn labels_from_hotspots(
         let forward = vertical_order
             .iter()
             .position(|&index| labels[index].id == ButtonId::Forward.into());
-        if let (Some(back), Some(forward)) = (back, forward) {
+        let navigation_pair = if let (Some(back), Some(forward)) = (back, forward) {
             let first = back.min(forward);
             let second = back.max(forward);
             if second > first + 1 {
                 let navigation_button = vertical_order.remove(second);
                 vertical_order.insert(first + 1, navigation_button);
             }
-        }
+            Some((vertical_order[first], vertical_order[first + 1]))
+        } else {
+            None
+        };
         let step = mouse_h / (vertical_order.len() as f32 + 1.);
         for (slot, index) in vertical_order.into_iter().enumerate() {
             labels[index].y = step * (slot as f32 + 1.);
+        }
+        if let Some((first, second)) = navigation_pair {
+            let grouped_step = step.min(LABEL_H + NAVIGATION_GROUP_GAP);
+            let adjustment = (step - grouped_step) / 2.;
+            labels[first].y += adjustment;
+            labels[second].y -= adjustment;
         }
     }
 
@@ -321,6 +338,10 @@ mod tests {
                 MouseControlId::Button(ButtonId::HapticPanel),
             ]
         );
+        let navigation_gap = labels[1].y - labels[0].y;
+        let haptic_gap = labels[2].y - labels[1].y;
+        assert!(navigation_gap < haptic_gap);
+        assert!(navigation_gap >= LABEL_H);
     }
 
     #[test]

--- a/crates/openlogi-desktop/src/features/mouse/geometry.rs
+++ b/crates/openlogi-desktop/src/features/mouse/geometry.rs
@@ -119,8 +119,9 @@ pub fn asset_hotspots_for_png(asset: &ResolvedAsset, mouse_w: f32, mouse_h: f32)
 
 /// Lay labels out evenly down one or both sides of the mouse. A two-sided
 /// layout sends the leftmost half of the hotspots left and the rightmost half
-/// right, then orders each side by hotspot height so its leader lines do not
-/// cross.
+/// right, then orders each side by hotspot height. Back and Forward stay
+/// adjacent when both are on the same side because they form one navigation
+/// pair, even when another marker sits between them.
 #[expect(
     clippy::cast_precision_loss,
     reason = "hotspot count is bounded by ButtonId variants — well under f32 mantissa"
@@ -161,6 +162,20 @@ pub fn labels_from_hotspots(
             .filter_map(|(index, label)| (label.side == side).then_some(index))
             .collect();
         vertical_order.sort_by(|&a, &b| hotspots[a].center().1.total_cmp(&hotspots[b].center().1));
+        let back = vertical_order
+            .iter()
+            .position(|&index| labels[index].id == ButtonId::Back.into());
+        let forward = vertical_order
+            .iter()
+            .position(|&index| labels[index].id == ButtonId::Forward.into());
+        if let (Some(back), Some(forward)) = (back, forward) {
+            let first = back.min(forward);
+            let second = back.max(forward);
+            if second > first + 1 {
+                let navigation_button = vertical_order.remove(second);
+                vertical_order.insert(first + 1, navigation_button);
+            }
+        }
         let step = mouse_h / (vertical_order.len() as f32 + 1.);
         for (slot, index) in vertical_order.into_iter().enumerate() {
             labels[index].y = step * (slot as f32 + 1.);
@@ -266,6 +281,46 @@ mod tests {
         ys.sort_by(f32::total_cmp);
         ys.dedup();
         assert_eq!(ys.len(), labels.len(), "each label gets a distinct slot");
+    }
+
+    #[test]
+    fn navigation_labels_stay_together_when_haptic_marker_sits_between() {
+        let hotspots = [
+            Hotspot {
+                id: ButtonId::Forward.into(),
+                x: 0.,
+                y: 100.,
+                w: 10.,
+                h: 10.,
+            },
+            Hotspot {
+                id: ButtonId::HapticPanel.into(),
+                x: 0.,
+                y: 200.,
+                w: 10.,
+                h: 10.,
+            },
+            Hotspot {
+                id: ButtonId::Back.into(),
+                x: 0.,
+                y: 300.,
+                w: 10.,
+                h: 10.,
+            },
+        ];
+
+        let mut labels =
+            labels_from_hotspots(&hotspots, MOUSE_MODEL_SIZE.1, LabelDistribution::LeftOnly);
+        labels.sort_by(|a, b| a.y.total_cmp(&b.y));
+
+        assert_eq!(
+            labels.iter().map(|label| label.id).collect::<Vec<_>>(),
+            [
+                MouseControlId::Button(ButtonId::Forward),
+                MouseControlId::Button(ButtonId::Back),
+                MouseControlId::Button(ButtonId::HapticPanel),
+            ]
+        );
     }
 
     #[test]

--- a/crates/openlogi-desktop/src/features/mouse/leader_lines.rs
+++ b/crates/openlogi-desktop/src/features/mouse/leader_lines.rs
@@ -1,8 +1,8 @@
 //! Canvas-painted leader lines from each hotspot to its side-label anchor.
 //!
-//! Per UI.md Phase 7. Each polyline is hotspot-centre → short horizontal
-//! stub → diagonal to the label anchor. The active hotspot's line is
-//! coloured blue and stroked thicker; everything else stays muted.
+//! Each polyline is hotspot-centre → short horizontal stub → diagonal to the
+//! label anchor. The control being interacted with gets a blue, thicker line;
+//! the other controls keep muted lines so their mapping remains visible.
 
 use gpui::{Bounds, PathBuilder, Pixels, Point, Window, hsla, point, px, rgb};
 

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -16,8 +16,8 @@ use gpui_component::{
 use openlogi_core::binding::{Action, ButtonId, GestureDirection, default_binding};
 
 use super::geometry::{
-    LabelDistribution, asset_dimensions_for_png, asset_has_button_labels, asset_hotspots_for_png,
-    default_labels, labels_from_hotspots,
+    LABEL_H, LabelDistribution, asset_dimensions_for_png, asset_has_button_labels,
+    asset_hotspots_for_png, default_labels, labels_from_hotspots,
 };
 use super::hotspots::{Hotspot, MOUSE_MODEL_SIZE, MouseControlId, default_hotspots};
 use super::inspector::{BindingInspectorData, binding_inspector};
@@ -33,7 +33,6 @@ use crate::ui::theme::{self, ACCENT_BLUE, Typography as _};
 
 const SIDE_GAP: f32 = 24.;
 const LABEL_W: f32 = 156.;
-const LABEL_H: f32 = 56.;
 const LABEL_GUTTER: f32 = LABEL_W + SIDE_GAP;
 const TWO_SIDED_LABEL_MIN_W: f32 = 700.;
 
@@ -266,7 +265,7 @@ impl Render for MouseModelView {
         } = model_layout(asset, viewport_w, viewport_h, thumbwheel);
         let canvas_h = mouse_h;
 
-        let highlight = self.hovered.or(active);
+        let highlight = self.hovered.or(active).or(self.selected);
         let view = cx.entity();
         let hovered = self.hovered;
         let profile_status = profile_canvas_status(cx);


### PR DESCRIPTION
## Summary

Keep Back and Forward controls visually grouped in mouse diagrams instead of allowing an unrelated marker to split the navigation pair.

## Changes

- `openlogi-desktop`: keep same-side Back and Forward labels adjacent while preserving their physical relative order
- `openlogi-desktop`: tighten spacing inside the navigation pair and increase its separation from surrounding controls when space allows
- `openlogi-desktop`: keep muted leader lines visible by default and highlight the hovered, active, or selected control in blue
- `openlogi-desktop`: add a regression test for the MX Master 4-style Forward / Haptic Panel / Back marker sequence

## Screenshots

Before — the Haptic Panel label splits Forward and Back:

![MX Master 4 before](https://ampcode.com/user-content/artifacts/7cef8820cf2417bf60366cb0fe7b4b45e605ae0e73de031f01639510dee5fd3b-file.png)

After — Forward and Back form a tighter navigation group while leader lines remain visible:

![MX Master 4 after](https://ampcode.com/user-content/artifacts/6e6e42d1fb93d0e93bdf565912b08beee451756e083b68fbbe051a10ecfcd61f-file.png)

The resulting order is `Gesture Button → Forward → Back → Haptic Panel`. Because the MX Master 4 Haptic Panel marker physically sits between Forward and Back, grouping the navigation labels introduces one muted Back / Haptic Panel leader-line crossing. This is an accepted product tradeoff; the hovered, active, or selected control still gets a distinct blue line.

## Testing

```sh
export RUSTFLAGS="-D warnings"
cargo fmt --all -- --check
cargo clippy -p openlogi-desktop --all-targets -- -D warnings
cargo test -p openlogi-desktop
```

- MX Master 4 UI verified with the mock agent under Xvfb in the Linux orb
- Not runtime-tested on hardware