### PR TITLE
fix(gui): survive and complete the live language switch

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -64,6 +64,19 @@ paths:
   (device, route, query, selection, or request), capture their identity or generation
   at launch and compare again before committing the result. Cancellation is useful,
   but is not the stale-result fence.
+- Never call a function that reads `AppState` (menu rebuild, most `windows::`/`app::`
+  helpers) from inside an `AppState::update` closure — the entity lease is still held
+  and the re-entrant read panics ("cannot read … while it is already being updated";
+  the 0.8.0 language-switch crash). Run such side effects after the update returns,
+  the way `runtime.rs` orders its rebuilds, or `cx.defer` them from within.
+- A `tr!` string stored in entity state goes stale on a live language switch: an
+  `InputState` placeholder keeps the text it was constructed with, and a cached
+  localized description keeps its old locale. Placeholders re-derive in the owning
+  render via `ui::components::localize_placeholder` (guarded — never call
+  `set_placeholder` bare per render, it notifies unconditionally); other cached
+  localized text recomputes on `StateEvent::LanguageChanged`. Native window titles
+  are restamped by `windows::retitle_open`, already wired into
+  `AppState::set_language`.
 - When changing reusable controls, prefer focused `#[gpui::test]` behavior contracts
   over screenshot coverage: keyboard activation, disabled no-op, controlled selected
   state/callbacks, and independent parent/child interaction targets.

--- a/crates/openlogi-desktop/src/app.rs
+++ b/crates/openlogi-desktop/src/app.rs
@@ -261,10 +261,13 @@ impl AppView {
                             && active_key.as_ref() == Some(key))
                 }
                 StateEvent::CameraChanged => on_home || view.active_tab == DetailTab::Light,
-                // Child entities own these surfaces and subscribe directly.
+                // Child entities own these surfaces and subscribe directly. A
+                // language switch already refreshes every window, and the root
+                // caches no localized text.
                 StateEvent::SmartShiftChanged(_)
                 | StateEvent::CameraPermissionChanged
-                | StateEvent::DiagnosticsChanged => false,
+                | StateEvent::DiagnosticsChanged
+                | StateEvent::LanguageChanged => false,
                 // App-wide settings render in their own window. The root only
                 // cares when a persistence/reload failure opens or closes its
                 // fail-closed configuration-error screen.

--- a/crates/openlogi-desktop/src/features/action_ring.rs
+++ b/crates/openlogi-desktop/src/features/action_ring.rs
@@ -175,9 +175,16 @@ fn editor_input(
     window: &mut Window,
     cx: &mut Context<ActionRingPanel>,
 ) -> Entity<InputState> {
+    let placeholder = placeholder.into();
+    let state = state
+        .get_or_insert_with(|| {
+            cx.new(|cx| InputState::new(window, cx).placeholder(placeholder.clone()))
+        })
+        .clone();
+    // Callers pass a per-render `tr!` string, so a cached input follows a live
+    // language switch instead of keeping the placeholder it was built with.
+    crate::ui::components::localize_placeholder(&state, placeholder, window, cx);
     state
-        .get_or_insert_with(|| cx.new(|cx| InputState::new(window, cx).placeholder(placeholder)))
-        .clone()
 }
 
 fn current_device_supports_haptics(cx: &Context<ActionRingPanel>) -> bool {

--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -299,7 +299,14 @@ impl Render for FunctionRowView {
                     }
                 }
                 _ => {
-                    if self.text_state.is_none() {
+                    if let Some(state) = self.text_state.clone() {
+                        crate::ui::components::localize_placeholder(
+                            &state,
+                            tr!(text_editor_placeholder(kind)),
+                            window,
+                            cx,
+                        );
+                    } else {
                         self.new_text_state(
                             text_editor_seed(current_action, kind),
                             text_editor_placeholder(kind),

--- a/crates/openlogi-desktop/src/features/mouse/view.rs
+++ b/crates/openlogi-desktop/src/features/mouse/view.rs
@@ -229,6 +229,12 @@ fn set_control_hovered(
 
 impl Render for MouseModelView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        crate::ui::components::localize_placeholder(
+            &self.action_search,
+            tr!("Search actions…"),
+            window,
+            cx,
+        );
         let (empty_bindings, empty_gesture_maps) = (BTreeMap::new(), BTreeMap::new());
         let MouseWorkspaceData {
             device_key,

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -650,7 +650,16 @@ fn add_app_popover(
                 catalog_on_open.update(cx, |catalog, cx| catalog.clear_search(window, cx));
             }
         })
-        .content(move |_state, _window, cx| add_app_content(&choices, &catalog, &icons, pal, cx))
+        .content(move |_state, window, cx| {
+            let search = catalog.read(cx).search.clone();
+            crate::ui::components::localize_placeholder(
+                &search,
+                tr!("Search applications…"),
+                window,
+                cx,
+            );
+            add_app_content(&choices, &catalog, &icons, pal, cx)
+        })
 }
 
 fn add_app_content(

--- a/crates/openlogi-desktop/src/services/i18n.rs
+++ b/crates/openlogi-desktop/src/services/i18n.rs
@@ -24,6 +24,11 @@
 use openlogi_core::config::AppSettings;
 use openlogi_ui::locale::activate;
 
+/// Serializes tests that mutate `rust_i18n`'s process-global locale, so a
+/// locale switch in one test cannot interleave with another's assertions.
+#[cfg(test)]
+pub(crate) static LOCALE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Apply the configured language to the process-global locale at startup.
 /// Safe to call before any window opens — the locale is a plain atomic.
 pub fn apply(settings: &AppSettings) {
@@ -32,19 +37,24 @@ pub fn apply(settings: &AppSettings) {
 
 #[cfg(test)]
 mod tests {
+    use openlogi_core::binding::{Action, ButtonId, GestureDirection};
+
+    use crate::features::mouse::thumbwheel::ThumbwheelPreset;
+
     /// End-to-end check that `locales/*.yml` loaded and the gettext-style
     /// English keys match — a typo'd key silently falls back to English, which
     /// this catches. All locale-dependent assertions live in this one test on
     /// purpose: `rust_i18n`'s locale is a process-global, so splitting them into
-    /// separate `#[test]`s would race under the parallel harness.
+    /// separate `#[test]`s would race under the parallel harness. Tests that
+    /// must switch the locale for other reasons hold [`super::LOCALE_LOCK`].
     #[test]
     fn locale_file_resolves_keys() {
-        use openlogi_core::binding::{Action, ButtonId, GestureDirection};
-
-        use crate::features::mouse::thumbwheel::ThumbwheelPreset;
-
         // The accessibility blurb is the longest, most typo-prone key.
         const BLURB: &str = "OpenLogi captures mouse buttons (Back / Forward / gesture button) through the system Accessibility permission and runs the actions you bind. Features that talk to the device directly — DPI, SmartShift — are unaffected.";
+
+        // A poisoned lock still holds the guard inside the `Err`, so a panic
+        // in one locale test cannot unlock the others.
+        let _locale = super::LOCALE_LOCK.lock();
 
         rust_i18n::set_locale("zh-CN");
         assert_eq!(rust_i18n::t!("Settings"), "设置"); // GUI chrome

--- a/crates/openlogi-desktop/src/state.rs
+++ b/crates/openlogi-desktop/src/state.rs
@@ -117,6 +117,10 @@ pub(crate) enum StateEvent {
     DeviceConfigChanged(DeviceKey),
     /// Application-wide preferences changed.
     SettingsChanged,
+    /// The interface language switched live. Views re-render localized strings
+    /// on the accompanying refresh; this event is for localized text *cached
+    /// in state*, which must be recomputed in the new locale.
+    LanguageChanged,
 }
 
 struct GlobalAppState(Entity<AppState>);

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -316,6 +316,9 @@ impl AppState {
         openlogi_ui::locale::activate(self.config.app_settings.language.as_deref());
         // Locale lookup is process-global, so every open window must repaint.
         cx.refresh_windows();
-        crate::app::menu::rebuild(cx);
+        // Deferred: the Device menu reads this entity, whose lease is still
+        // held here (callers switch language inside `AppState::update`), and a
+        // re-entrant read panics.
+        cx.defer(crate::app::menu::rebuild);
     }
 }

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -1,7 +1,7 @@
 //! App-level settings (launch-at-login, theme, assets, language).
 
-use super::AppState;
-use gpui::App;
+use super::{AppState, StateEvent};
+use gpui::Context;
 use openlogi_core::config::{
     AppIcon, AppSettings, Appearance, AssetSourcePreference, DeviceViewMode, ThumbwheelSensitivity,
     UiScale, VerticalScrollSensitivity,
@@ -306,7 +306,7 @@ impl AppState {
     /// Set the UI language (`None` = follow system), persist it, switch the
     /// process-global locale via [`openlogi_ui::locale`], and repaint open UI.
     /// No-op when unchanged.
-    pub fn set_language(&mut self, language: Option<String>, cx: &mut App) {
+    pub fn set_language(&mut self, language: Option<String>, cx: &mut Context<Self>) {
         if self.config.app_settings.language == language {
             return;
         }
@@ -314,11 +314,17 @@ impl AppState {
             .edit(|config| config.app_settings.language = language);
         self.persist_config("language setting");
         openlogi_ui::locale::activate(self.config.app_settings.language.as_deref());
-        // Locale lookup is process-global, so every open window must repaint.
+        // Locale lookup is process-global, so every open window must repaint;
+        // localized text cached in view state re-derives on this event.
+        cx.emit(StateEvent::LanguageChanged);
         cx.refresh_windows();
         // Deferred: the Device menu reads this entity, whose lease is still
         // held here (callers switch language inside `AppState::update`), and a
-        // re-entrant read panics.
-        cx.defer(crate::app::menu::rebuild);
+        // re-entrant read panics. The native window titles ride along — they
+        // are stamped at open and don't re-render with the refresh.
+        cx.defer(|cx| {
+            crate::app::menu::rebuild(cx);
+            crate::windows::retitle_open(cx);
+        });
     }
 }

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -18,6 +18,7 @@ use openlogi_core::hid::{
     Dpi, SmartShiftAutoDisengage, SmartShiftMode, SmartShiftStatus, SmartShiftThreshold, WriteError,
 };
 
+use gpui::AppContext as _;
 use openlogi_core::app::ForegroundApp;
 use openlogi_ipc::ForegroundApps;
 
@@ -85,6 +86,41 @@ fn smooth_scroll_change_reloads_the_agent_once() {
 
     state.set_smooth_scroll(true);
     assert!(receiver.try_recv().is_err());
+}
+
+/// A live language switch runs inside `AppState::update`, and the menu rebuild
+/// it schedules reads the same entity (the Device menu lists devices). Rebuilt
+/// synchronously that read is re-entrant and panics ("cannot read … while it is
+/// already being updated"), which crashed 0.8.0 on every language change —
+/// `set_language` must defer the rebuild until the update returns the lease.
+#[gpui::test]
+fn language_switch_rebuilds_menus_after_the_state_update(cx: &mut gpui::TestAppContext) {
+    let _locale = crate::services::i18n::LOCALE_LOCK.lock();
+    let cache = AssetResolver::new();
+    let (commands, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let state = AppState::with_runtime(
+        Config::ephemeral(),
+        &[],
+        &[],
+        &cache,
+        &[],
+        ConfigPersistence::MemoryOnly,
+        commands,
+    );
+
+    cx.update(|cx| {
+        AppState::set_global(cx.new(|_| state), cx);
+        AppState::update(cx, |state, cx| {
+            state.set_language(Some("zh-CN".into()), cx);
+        });
+    });
+
+    cx.read(|cx| {
+        assert_eq!(
+            AppState::try_read(cx).and_then(AppState::language),
+            Some("zh-CN")
+        );
+    });
 }
 
 #[test]

--- a/crates/openlogi-desktop/src/ui/components.rs
+++ b/crates/openlogi-desktop/src/ui/components.rs
@@ -42,6 +42,24 @@ pub(crate) fn control_input(state: &Entity<InputState>) -> Input {
     Input::new(state).small().min_h(px(theme::CONTROL_H))
 }
 
+/// Re-derive an input's placeholder from the current locale.
+///
+/// Placeholders are stored inside [`InputState`] at construction, so a live
+/// language switch leaves them stale — the owning view calls this from render
+/// with a fresh `tr!` string to keep them current. Guarded, because
+/// `set_placeholder` notifies unconditionally and a bare per-render call would
+/// re-render forever.
+pub(crate) fn localize_placeholder(
+    state: &Entity<InputState>,
+    text: SharedString,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    if *state.read(cx).presentation().placeholder() != text {
+        state.update(cx, |state, cx| state.set_placeholder(text, window, cx));
+    }
+}
+
 /// A select trigger at the house control height; see [`control_button`].
 pub(crate) fn control_select<D: SearchableListDelegate + 'static>(
     state: &Entity<SelectState<D>>,
@@ -536,7 +554,8 @@ mod tests {
     use std::{cell::Cell, rc::Rc};
 
     use gpui::{
-        Context, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, Render, TestAppContext, point,
+        AppContext as _, Context, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, Render,
+        TestAppContext, point,
     };
 
     use super::*;
@@ -721,6 +740,40 @@ mod tests {
         activate_key(cx, "space");
 
         assert_eq!(activations.get(), 2);
+    }
+
+    /// The guard is the point: `set_placeholder` notifies unconditionally, so
+    /// an unguarded per-render restamp would re-render forever. Same text must
+    /// not notify; a changed text must land.
+    #[gpui::test]
+    fn localize_placeholder_restamps_only_on_change(cx: &mut TestAppContext) {
+        struct Blank;
+        impl Render for Blank {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                gpui::Empty
+            }
+        }
+
+        cx.update(gpui_component::init);
+        let (_, cx) = cx.add_window_view(|_, _| Blank);
+        let input =
+            cx.update(|window, cx| cx.new(|cx| InputState::new(window, cx).placeholder("old")));
+        let notifies = Rc::new(Cell::new(0_usize));
+        let _obs = cx.update(|_, cx| {
+            cx.observe(&input, {
+                let notifies = notifies.clone();
+                move |_, _| notifies.set(notifies.get() + 1)
+            })
+        });
+
+        cx.update(|window, cx| localize_placeholder(&input, "old".into(), window, cx));
+        assert_eq!(notifies.get(), 0, "unchanged text must not notify");
+
+        cx.update(|window, cx| localize_placeholder(&input, "new".into(), window, cx));
+        assert_eq!(notifies.get(), 1);
+        cx.update(|_, cx| {
+            assert_eq!(*input.read(cx).presentation().placeholder(), "new");
+        });
     }
 
     #[gpui::test]

--- a/crates/openlogi-desktop/src/windows.rs
+++ b/crates/openlogi-desktop/src/windows.rs
@@ -78,6 +78,24 @@ pub fn aux_title_bar(title: impl Into<SharedString>, cx: &App) -> impl IntoEleme
     )
 }
 
+/// Restamp the native titles of the open auxiliary windows after a live
+/// language switch. The Linux client-side titlebar re-renders with the window
+/// refresh, but the macOS / Windows native titlebar keeps the string stamped
+/// at open. The main and update-consent windows are titled with the product
+/// name, which never changes.
+pub fn retitle_open(cx: &mut App) {
+    let registry = cx.default_global::<WindowRegistry>();
+    let retitles = [
+        (registry.settings, settings::window_title()),
+        (registry.add_device, add_device::window_title()),
+    ];
+    for (handle, title) in retitles {
+        if let Some(handle) = handle {
+            let _ = handle.update(cx, |_, window, _| window.set_window_title(&title));
+        }
+    }
+}
+
 /// Implemented by every auxiliary root view so [`open_or_focus`] can hand it
 /// the appearance observer to hold onto — dropping the [`Subscription`] would
 /// detach the OS light/dark tracking and leave the window stuck on one theme.

--- a/crates/openlogi-desktop/src/windows/add_device.rs
+++ b/crates/openlogi-desktop/src/windows/add_device.rs
@@ -70,11 +70,17 @@ pub fn open(cx: &mut App) {
     }
     windows::open_or_focus(
         |reg| &mut reg.add_device,
-        tr!("Add Device"),
+        window_title(),
         Size::new(px(520.), px(460.)),
         AddDeviceView::new,
         cx,
     );
+}
+
+/// The window's native title — one definition for open and the live-language
+/// retitle ([`windows::retitle_open`]), so the two cannot drift.
+pub(crate) fn window_title() -> SharedString {
+    tr!("Add Device")
 }
 
 /// Show the agent's pairing session. `None` is no session — including after a

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -153,7 +153,13 @@ impl SettingsView {
         let updater = crate::platform::updater::shared(cx)
             .unwrap_or_else(|| crate::platform::updater::new_entity(cx));
         let updater_obs = cx.observe(&updater, |_, _, cx| cx.notify());
-        let state_obs = cx.subscribe(&AppState::global(cx), |_, _, event: &StateEvent, cx| {
+        let state_obs = cx.subscribe(&AppState::global(cx), |this, _, event: &StateEvent, cx| {
+            if matches!(event, StateEvent::LanguageChanged) {
+                // The cache-size line is localized text cached in view state
+                // (it interpolates an IO-derived size); rebuild it in the new
+                // locale.
+                this.asset_cache_desc = assets::cache_size_description();
+            }
             if matches!(
                 event,
                 StateEvent::AgentChanged
@@ -161,6 +167,7 @@ impl SettingsView {
                     | StateEvent::InventoryChanged
                     | StateEvent::CameraPermissionChanged
                     | StateEvent::SettingsChanged
+                    | StateEvent::LanguageChanged
             ) {
                 cx.notify();
             }
@@ -404,10 +411,16 @@ pub fn open(cx: &mut App) {
 /// Open the Settings window on a specific page, or focus it if it's already
 /// open. The page only steers a *fresh* open — an already-open window is just
 /// focused on whatever page it last showed (the Settings widget owns selection).
+/// The window's native title — one definition for open and the live-language
+/// retitle ([`windows::retitle_open`]), so the two cannot drift.
+pub(crate) fn window_title() -> SharedString {
+    tr!("Settings")
+}
+
 pub fn open_at(page: SettingsPage, cx: &mut App) {
     windows::open_or_focus(
         |reg| &mut reg.settings,
-        tr!("Settings"),
+        window_title(),
         // Wide enough that the pages' custom rows keep slack under fonts wider
         // than the macOS system font (Segoe UI tipped the old 840 into
         // clipping the hero rows' trailing buttons on Windows).
@@ -420,6 +433,12 @@ pub fn open_at(page: SettingsPage, cx: &mut App) {
 impl Render for SettingsView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         theme::apply_ui_scale(window, cx);
+        crate::ui::components::localize_placeholder(
+            &self.theme_search,
+            tr!("Filter themes…"),
+            window,
+            cx,
+        );
         let pal = theme::palette(cx);
         let view = cx.entity();
         // Only surface the Camera permission when a webcam is actually present,


### PR DESCRIPTION
## Summary

Switching the interface language in 0.8.0 aborts the app on every attempt (SIGABRT in the mouse-up dispatch). `AppState::set_language` runs inside `AppState::update`, and the menu rebuild it triggered synchronously re-enters the leased entity — the Device menu lists devices, so `device_menu_items` calls `state.read(cx)` while the update lease is still held, and gpui panics with "cannot read AppState while it is already being updated"; the unwind then crosses gpui's `extern "C"` AppKit callback and becomes an abort. This is a regression from the Global→Entity conversion (a3bf5b29): under the old Global model the same re-entrant read returned `None` from `try_global` during the lease and the menu just rendered its empty state.

The first commit fixes the crash by deferring the menu rebuild until the update returns the lease. The second commit completes the live switch: everything localized once and then *stored* kept its old locale — native window titles stamped at open, `InputState` placeholders stamped at construction, and the cached asset-cache-size line — while render-derived strings already refreshed correctly.

An audit of all `AppState::update` call sites found `set_language` to be the only re-entrant path; the `runtime.rs` rebuilds already run after their update closures return. Both patterns (the update-lease re-entrancy rule and the stored-localized-text rule) are now documented in `.claude/rules/gui.md`.

## Changes

- `openlogi-desktop`
  - `state/settings.rs`: `set_language` defers `menu::rebuild` + the new `windows::retitle_open` via `cx.defer`, takes `Context<AppState>`, and emits the new `StateEvent::LanguageChanged`.
  - `windows.rs`, `windows/settings.rs`, `windows/add_device.rs`: `retitle_open` restamps the Settings / Add Device native titles from the same `window_title()` definitions their open sites use (the main and update-consent windows are titled with the invariant product name).
  - `ui/components.rs`: `localize_placeholder` re-derives a placeholder in the owning render, guarded because `set_placeholder` notifies unconditionally and a bare per-render call would re-render forever; all five construction-stamped placeholders (theme filter, action search, application search, Actions Ring editors, F-row editor) now route through it.
  - `state.rs`, `app.rs`: new `StateEvent::LanguageChanged` for localized text cached in state; the Settings view recomputes its cache-size description on it.
  - `state/tests.rs`, `services/i18n.rs`, `ui/components.rs`: regression test for the crash (verified red against the unfixed `set_language`), a `LOCALE_LOCK` serializing tests that mutate the process-global locale, and a behavior test pinning the `localize_placeholder` guard.
- `.claude/rules/gui.md`: the two rules above.

Known residuals, both out of reach of this crate: gpui-component's Settings sidebar search placeholder is stamped inside the component's private keyed state and needs an upstream change to restamp per render; the agent's tray is not localized at all (hardcoded English, independent of live switching) and deserves its own issue.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy -p openlogi-desktop --all-targets -- -D warnings`
- `cargo test -p openlogi-desktop` — 186 passed; the crash regression test was additionally verified to fail against the unfixed `set_language`.
- Pre-push hook ran full-workspace clippy and non-GUI rustdoc.
- Runtime: the crash reproduces on the installed 0.8.0 release (scripted zh-CN → English switch, stderr shows the entity re-entrancy panic followed by the nounwind abort), and the same scripted switch on a patched dev build survives with the full page re-rendering in the new locale. The second commit's title/placeholder restamp is covered by the unit tests but was not visually verified in the running app — to verify: Settings → Appearance → switch language; the native window title and the "Filter themes…" placeholder should update immediately without reopening the window.
