### PR TITLE
feat(agent): localize the menu-bar tray

### DIFF
--- a/.claude/rules/gui.md
+++ b/.claude/rules/gui.md
@@ -10,16 +10,18 @@ paths:
 - The UI stack is GPUI + gpui-component — a settled choice; don't propose alternatives.
 - **Three crates, not one.** `openlogi-desktop` is the settings app; `openlogi-overlay` is
   the Actions Ring helper, a separate process and a pure IPC client; `openlogi-ui` is
-  what they share — ring geometry/icons, the GPUI asset source, locale negotiation.
+  what they share — ring geometry/icons, the GPUI asset source, the locale catalogs.
   The overlay must never depend on `openlogi-desktop`. Before putting anything in
   `openlogi-ui`, check both binaries actually need it: every dependency added there is
   also added to the overlay, which is why `gpui-component` is *not* one of them.
-- One catalog, in `openlogi-ui/locales/`, beside the `locale` module that negotiates
-  over it. `t!` resolves against a backend the invoking crate must generate itself, so
-  each binary still expands its own `rust_i18n::i18n!` over that shared directory by
-  relative path. A wrong path there compiles to an **empty catalog** rather than an
-  error, and every string silently renders as its English key —
-  `the_shared_catalog_is_wired_up` in `openlogi-overlay` is what makes that fail loudly.
+- One catalog, in `openlogi-ui/locales/`; the negotiation over its codes lives in
+  `openlogi_core::locale` (the platform-free core, where the GUI-less agent reaches it
+  for the tray). `t!` resolves against a backend the invoking crate must generate
+  itself, so each localized binary — the app, the overlay, and the agent — expands its
+  own `rust_i18n::i18n!` over that shared directory by relative path. A wrong path
+  there compiles to an **empty catalog** rather than an error, and every string
+  silently renders as its English key — `the_shared_catalog_is_wired_up` in
+  `openlogi-overlay` and `openlogi-agent` is what makes that fail loudly.
 - `gpui`/`gpui_platform` track zed's default branch on purpose; the compatible zed
   commit is pinned **only in `Cargo.lock`**, in lockstep with the `gpui-component` rev.
   After any `cargo add`/`cargo update`, check the pins didn't move; restore with

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -1,7 +1,8 @@
 ---
 paths:
   - "crates/openlogi-ui/locales/**"
-  - "crates/openlogi-ui/src/locale.rs"
+  - "crates/openlogi-ui/src/catalog_parity.rs"
+  - "crates/openlogi-core/src/locale.rs"
   - "crates/openlogi-desktop/src/services/i18n.rs"
   - ".config/crowdin.yml"
   - ".github/scripts/i18n/**"
@@ -20,18 +21,20 @@ paths:
   do not leave keys missing — the parity test fails the build.
 - YAML is parsed at **compile time** — a syntax error fails the entire GUI
   build. Quote values containing `: ` or a trailing `:`.
-- The locale key test (`i18n.rs`, `locale_files_have_the_same_keys`) requires
-  every non-English file to carry **exactly** the keys in `en.yml` (no lag, no
-  extras; key order is not checked).
+- The locale key test (`openlogi-ui/src/catalog_parity.rs`,
+  `locale_files_have_the_same_keys`) requires every non-English file to carry
+  **exactly** the keys in `en.yml` (no lag, no extras; key order is not checked).
 - Adding a locale: drop the `.yml` in `crates/openlogi-ui/locales/` and add the
-  `SUPPORTED` entry in that crate's `locale.rs` (picker order: native-name
+  `SUPPORTED` entry in `openlogi-core`'s `locale.rs` (picker order: native-name
   alphabetical per script). The parity test's `include_str!` list must grow too —
   it asserts its own coverage against `SUPPORTED`, so forgetting fails the build
   rather than silently leaving a catalog unchecked.
 - Check with `cargo test -p openlogi-ui locale` (catalog parity, runs everywhere)
   and `cargo test -p openlogi-desktop i18n` (end-to-end key resolution; CI's Linux
   tests exclude the app crate, so that one runs on macOS CI and locally, and needs
-  the Xcode/Metal env from devenv).
+  the Xcode/Metal env from devenv). The overlay and agent each pin one non-English
+  key in their `the_shared_catalog_is_wired_up` test, so a broken relative
+  `i18n!` path fails loudly instead of silently serving English.
 - Crowdin workflow (`.config/crowdin.yml` + `.github/workflows/crowdin.yml`):
   1. Snapshot complete `locales/*.yml`
   2. Upload `en.yml` sources + per-language translations from git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ sits beneath both.
 | Crate | Role |
 |---|---|
 | `crates/openlogi` | The CLI binary — thin wrapper over `openlogi-cli` |
-| `crates/openlogi-core` | Pure types: TOML config, device model, action catalog. No I/O, no async |
+| `crates/openlogi-core` | Pure types: TOML config, device model, action catalog, locale negotiation. No I/O, no async (feature-gated host reads: `fs`, `locale`) |
 | `crates/openlogi-device-registry` | Pure hardware identity registry: receiver protocols and standalone-device driver metadata |
 | `crates/openlogi-hidpp` | Vendored fork of the `hidpp` protocol crate (**lib name `hidpp`**, 0BSD) |
 | `crates/openlogi-device` | The HID++ device layer: enumeration, probing, writes, sessions, pairing. Knows no host — expressed against `HidBackend` |
@@ -34,7 +34,7 @@ sits beneath both.
 | `crates/openlogi-ipc` | The tarpc IPC contract (`src/ipc.rs`) + its local-socket transport, shared by agent and GUI |
 | `crates/openlogi-agent` | The `openlogi-agent` binary — hook + device I/O server |
 | `crates/openlogi-permissions` | Privacy-permission status + System-Settings deep links: macOS TCC reads, Linux device-file probes. Reads only — never prompts |
-| `crates/openlogi-ui` | Presentation shared by the two GPUI processes: ring geometry/icons, the GPUI asset source, locale negotiation. Depends on `gpui` but **not** `gpui-component` |
+| `crates/openlogi-ui` | Presentation shared by the two GPUI processes: ring geometry/icons, the GPUI asset source, the shared locale catalogs. Depends on `gpui` but **not** `gpui-component` |
 | `crates/openlogi-desktop` | GPUI + gpui-component desktop app — polls the agent, no device I/O |
 | `crates/openlogi-overlay` | The `openlogi-overlay` binary — cursor-centred Actions Ring, a pure IPC client |
 | `xtask` | `cargo xtask` maintenance: bundling, packaging, release manifest |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5499,12 +5499,15 @@ dependencies = [
  "atomic-write-file",
  "az",
  "etcetera",
+ "fluent-langneg",
  "num_enum",
  "nutype",
  "openlogi-device-registry",
  "plist",
+ "rust-i18n",
  "serde",
  "strum",
+ "sys-locale",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
@@ -5727,11 +5730,8 @@ dependencies = [
 name = "openlogi-ui"
 version = "0.8.1"
 dependencies = [
- "fluent-langneg",
  "gpui",
  "openlogi-core",
- "rust-i18n",
- "sys-locale",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5395,6 +5395,7 @@ dependencies = [
  "openlogi-hid",
  "openlogi-hook",
  "openlogi-ipc",
+ "rust-i18n",
  "succession",
  "sysinfo 0.38.4",
  "tarpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/openlogi-agent/Cargo.toml
+++ b/crates/openlogi-agent/Cargo.toml
@@ -31,6 +31,7 @@ tarpc = { workspace = true }
 interprocess = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "signal"] }
 futures = "0.3"
+rust-i18n = "4"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }

--- a/crates/openlogi-agent/src/main.rs
+++ b/crates/openlogi-agent/src/main.rs
@@ -23,6 +23,11 @@ mod overlay;
 mod pairing;
 #[cfg(target_os = "windows")]
 mod resume_windows;
+// The shared locale catalogs live in `openlogi-ui`; the negotiation that picks
+// one is `openlogi_core::locale`. `t!` resolves against a backend each binary
+// generates itself, hence the relative path — see
+// `tests::the_shared_catalog_is_wired_up` for why a wrong path is silent.
+rust_i18n::i18n!("../openlogi-ui/locales", fallback = "en");
 mod server;
 mod shutdown;
 mod startup;
@@ -84,6 +89,10 @@ fn main() {
         warn!(error = %e, "could not load config.toml; using defaults");
         Config::default()
     });
+    // The tray renders localized strings; resolve the stored preference (or
+    // the system locale) before any menu is built. A live language switch
+    // reaches the running agent through `reload_config`.
+    openlogi_core::locale::activate(config.app_settings.language.as_deref());
 
     let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -148,5 +157,21 @@ fn main() {
         }
         #[cfg(not(target_os = "windows"))]
         runtime.block_on(lifecycle::run(config, uninstalled));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    /// Mirror of the overlay's guard: the `i18n!` at the top reaches the
+    /// shared catalog by relative path, and a wrong path does **not** fail the
+    /// build — `rust_i18n` compiles it to an empty catalog, and every tray
+    /// string silently renders in English in all locales. Pin one tray key in
+    /// a non-English locale so that breakage is loud.
+    #[test]
+    fn the_shared_catalog_is_wired_up() {
+        rust_i18n::set_locale("zh-CN");
+        assert_eq!(rust_i18n::t!("Show Main Window"), "显示主窗口");
+        rust_i18n::set_locale("en");
     }
 }

--- a/crates/openlogi-agent/src/server.rs
+++ b/crates/openlogi-agent/src/server.rs
@@ -121,6 +121,7 @@ impl Agent for AgentServer {
                 let launch_at_login = config.app_settings.launch_at_login;
                 #[cfg(target_os = "macos")]
                 let app_icon = config.app_settings.app_icon;
+                let language = config.app_settings.language.clone();
                 self.orchestrator.lock().await.reload_config(config);
                 self.dispatcher.cancel_all_buttons();
                 // The GUI's launch-at-login toggle reaches us through this
@@ -130,6 +131,13 @@ impl Agent for AgentServer {
                 // restyle — the GUI can only reach the Dock and the bundle.
                 #[cfg(target_os = "macos")]
                 crate::tray::set_icon(app_icon);
+                // And the interface language: re-resolve the process locale
+                // (the Windows popup rebuilds per show and picks it up alone)
+                // and rebuild the macOS menu, whose titles were stamped at
+                // install.
+                openlogi_core::locale::activate(language.as_deref());
+                #[cfg(target_os = "macos")]
+                crate::tray::relocalize();
                 Ok(())
             }
             Err(error) => {

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -292,19 +292,35 @@ fn install_status_item(
     STATUS_ITEM.with_borrow_mut(|slot| *slot = Some(status_item.clone()));
     let menu = status_item::new_menu(mtm);
 
-    let show =
-        status_item::new_action_item(mtm, "Show Main Window", sel!(openOpenLogi:), &target, "m");
+    let show = status_item::new_action_item(
+        mtm,
+        &rust_i18n::t!("Show Main Window"),
+        sel!(openOpenLogi:),
+        &target,
+        "m",
+    );
     menu.addItem(&show);
     status_item::add_separator(&menu, mtm);
 
-    let settings =
-        status_item::new_action_item(mtm, "Settings…", sel!(openSettings:), &target, ",");
+    let settings = status_item::new_action_item(
+        mtm,
+        &rust_i18n::t!("Settings…"),
+        sel!(openSettings:),
+        &target,
+        ",",
+    );
     menu.addItem(&settings);
-    let about = status_item::new_action_item(mtm, "About OpenLogi", sel!(openAbout:), &target, "");
+    let about = status_item::new_action_item(
+        mtm,
+        &rust_i18n::t!("About OpenLogi"),
+        sel!(openAbout:),
+        &target,
+        "",
+    );
     menu.addItem(&about);
     let updates = status_item::new_action_item(
         mtm,
-        "Check for Updates…",
+        &rust_i18n::t!("Check for Updates…"),
         sel!(checkForUpdates:),
         &target,
         "u",
@@ -312,11 +328,16 @@ fn install_status_item(
     menu.addItem(&updates);
     status_item::add_separator(&menu, mtm);
 
-    let quit =
-        status_item::new_action_item(mtm, "Quit OpenLogi", sel!(quitOpenLogi:), &target, "q");
+    let quit = status_item::new_action_item(
+        mtm,
+        &rust_i18n::t!("Quit OpenLogi"),
+        sel!(quitOpenLogi:),
+        &target,
+        "q",
+    );
     if let Some(image) = NSImage::imageWithSystemSymbolName_accessibilityDescription(
         &NSString::from_str("xmark.square"),
-        Some(&NSString::from_str("Quit")),
+        Some(&NSString::from_str(&rust_i18n::t!("Quit OpenLogi"))),
     ) {
         image.setTemplate(true);
         quit.setImage(Some(&image));

--- a/crates/openlogi-agent/src/tray.rs
+++ b/crates/openlogi-agent/src/tray.rs
@@ -41,12 +41,20 @@ use tracing::{info, warn};
 
 use crate::status_item;
 
+/// The installed menu-bar item plus the action target its menu items weakly
+/// reference — everything a later config reload needs to restyle the icon or
+/// rebuild the menu in a new language.
+struct TrayState {
+    item: Retained<NSStatusItem>,
+    target: Retained<MenuTarget>,
+}
+
 thread_local! {
-    /// The installed status item, kept where a later config reload can find it.
+    /// The installed tray state, kept where a later config reload can find it.
     /// A `thread_local` rather than a global: everything that touches it runs
     /// on the main thread, which is the same thread that installed it, so the
     /// affinity AppKit demands is the affinity the storage already has.
-    static STATUS_ITEM: RefCell<Option<Retained<NSStatusItem>>> = const { RefCell::new(None) };
+    static TRAY: RefCell<Option<TrayState>> = const { RefCell::new(None) };
 }
 
 /// The menu-bar glyph for `icon`: a monochrome template the system tints for
@@ -70,9 +78,29 @@ pub fn set_icon(icon: AppIcon) {
         let Some(mtm) = MainThreadMarker::new() else {
             return;
         };
-        STATUS_ITEM.with_borrow(|item| {
-            if let Some(item) = item.as_ref() {
-                status_item::set_png_icon(item, mtm, glyph(icon), "OpenLogi");
+        TRAY.with_borrow(|state| {
+            if let Some(state) = state.as_ref() {
+                status_item::set_png_icon(&state.item, mtm, glyph(icon), "OpenLogi");
+            }
+        });
+    });
+}
+
+/// Rebuild the menu-bar menu with the current locale's titles, after a config
+/// reload switched the interface language. Same shape as [`set_icon`]: the
+/// work hops to the main queue, and a hidden item is a no-op.
+pub fn relocalize() {
+    DispatchQueue::main().exec_async(|| {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return;
+        };
+        TRAY.with_borrow(|state| {
+            if let Some(state) = state.as_ref() {
+                // The status item retains the menu; the fresh one replaces the
+                // old wholesale so titles, order, and key equivalents cannot
+                // drift from `build_menu`.
+                let menu = build_menu(mtm, &state.target);
+                state.item.setMenu(Some(&menu));
             }
         });
     });
@@ -289,14 +317,29 @@ fn install_status_item(
     let target = MenuTarget::new(mtm);
     let status_item = status_item::create_status_item();
     status_item::set_png_icon(&status_item, mtm, glyph(app_icon), "OpenLogi");
-    STATUS_ITEM.with_borrow_mut(|slot| *slot = Some(status_item.clone()));
+    TRAY.with_borrow_mut(|slot| {
+        *slot = Some(TrayState {
+            item: status_item.clone(),
+            target: target.clone(),
+        });
+    });
+    let menu = build_menu(mtm, &target);
+    status_item.setMenu(Some(&menu));
+
+    info!("menu-bar item installed");
+    (status_item, target, menu)
+}
+
+/// Build the tray menu with the current locale's titles. The one constructor
+/// for both the install and a [`relocalize`] rebuild, so the two cannot drift.
+fn build_menu(mtm: MainThreadMarker, target: &MenuTarget) -> Retained<objc2_app_kit::NSMenu> {
     let menu = status_item::new_menu(mtm);
 
     let show = status_item::new_action_item(
         mtm,
         &rust_i18n::t!("Show Main Window"),
         sel!(openOpenLogi:),
-        &target,
+        target,
         "m",
     );
     menu.addItem(&show);
@@ -306,7 +349,7 @@ fn install_status_item(
         mtm,
         &rust_i18n::t!("Settings…"),
         sel!(openSettings:),
-        &target,
+        target,
         ",",
     );
     menu.addItem(&settings);
@@ -314,7 +357,7 @@ fn install_status_item(
         mtm,
         &rust_i18n::t!("About OpenLogi"),
         sel!(openAbout:),
-        &target,
+        target,
         "",
     );
     menu.addItem(&about);
@@ -322,7 +365,7 @@ fn install_status_item(
         mtm,
         &rust_i18n::t!("Check for Updates…"),
         sel!(checkForUpdates:),
-        &target,
+        target,
         "u",
     );
     menu.addItem(&updates);
@@ -332,7 +375,7 @@ fn install_status_item(
         mtm,
         &rust_i18n::t!("Quit OpenLogi"),
         sel!(quitOpenLogi:),
-        &target,
+        target,
         "q",
     );
     if let Some(image) = NSImage::imageWithSystemSymbolName_accessibilityDescription(
@@ -343,10 +386,7 @@ fn install_status_item(
         quit.setImage(Some(&image));
     }
     menu.addItem(&quit);
-    status_item.setMenu(Some(&menu));
-
-    info!("menu-bar item installed");
-    (status_item, target, menu)
+    menu
 }
 
 #[cfg(test)]

--- a/crates/openlogi-agent/src/tray_windows.rs
+++ b/crates/openlogi-agent/src/tray_windows.rs
@@ -256,9 +256,21 @@ unsafe fn show_menu(hwnd: HWND) {
         if menu.is_null() {
             return;
         }
-        AppendMenuW(menu, MF_STRING, ID_SHOW, wide("Show Main Window").as_ptr());
+        // Built fresh on every right-click, so `t!` follows a live language
+        // switch with no rebuild plumbing.
+        AppendMenuW(
+            menu,
+            MF_STRING,
+            ID_SHOW,
+            wide(&rust_i18n::t!("Show Main Window")).as_ptr(),
+        );
         AppendMenuW(menu, MF_SEPARATOR, 0, std::ptr::null());
-        AppendMenuW(menu, MF_STRING, ID_QUIT, wide("Quit OpenLogi").as_ptr());
+        AppendMenuW(
+            menu,
+            MF_STRING,
+            ID_QUIT,
+            wide(&rust_i18n::t!("Quit OpenLogi")).as_ptr(),
+        );
 
         let mut pt = POINT { x: 0, y: 0 };
         GetCursorPos(&raw mut pt);

--- a/crates/openlogi-core/Cargo.toml
+++ b/crates/openlogi-core/Cargo.toml
@@ -11,11 +11,15 @@ keywords = ["logitech", "hidpp", "config", "mouse", "hid"]
 categories = ["hardware-support", "config"]
 
 [features]
-default = ["fs"]
+default = ["fs", "locale"]
 # The line between the host-touching config I/O and everything else here, which
 # is pure data and stays checkable against `wasm32-unknown-unknown` (see xtask's
 # `WASM_PORTABLE_CRATES`). On by default, so no consumer here is affected.
 fs = ["dep:atomic-write-file", "dep:etcetera", "dep:toml_edit"]
+# Locale negotiation over the shared catalogs in `openlogi-ui/locales/`. Gated
+# for the same wasm reason as `fs`: `sys-locale` reads the host's language
+# preference and `rust-i18n` owns the process-global locale.
+locale = ["dep:fluent-langneg", "dep:rust-i18n", "dep:sys-locale"]
 
 [dependencies]
 openlogi-device-registry = { workspace = true }
@@ -25,6 +29,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 etcetera = { version = "0.11.0", optional = true }
 atomic-write-file = { workspace = true, optional = true }
+fluent-langneg = { version = "0.14.2", optional = true }
+rust-i18n = { version = "4", optional = true }
+sys-locale = { version = "0.3.2", optional = true }
 num_enum = { workspace = true }
 strum = { version = "0.27", features = ["derive"] }
 toml_edit = { version = "0.22", optional = true }

--- a/crates/openlogi-core/src/lib.rs
+++ b/crates/openlogi-core/src/lib.rs
@@ -5,9 +5,10 @@
 //! `hidpp`, `async-hid`, or any platform-specific event/window API; those live
 //! in sibling crates.
 //!
-//! The one exception is reading and writing that config file, which is gated
-//! behind the `fs` feature (on by default). Without it this crate touches no
-//! host at all, which is what the `wasm (portable crates)` CI job checks.
+//! The exceptions are feature-gated (both on by default): reading and writing
+//! that config file (`fs`), and locale negotiation (`locale`), which reads the
+//! host's language preference. Without them this crate touches no host at all,
+//! which is what the `wasm (portable crates)` CI job checks.
 
 #![deny(missing_docs)]
 
@@ -22,6 +23,8 @@ pub mod device;
 pub mod device_order;
 pub mod diagnostics;
 pub mod hid;
+#[cfg(feature = "locale")]
+pub mod locale;
 #[cfg(feature = "fs")]
 pub mod paths;
 pub mod scroll;

--- a/crates/openlogi-core/src/locale.rs
+++ b/crates/openlogi-core/src/locale.rs
@@ -1,14 +1,21 @@
 //! Locale negotiation: which shipped catalog a BCP-47 code resolves to.
 //!
-//! Shared by both binaries — the settings app picks the locale from its stored
-//! [`AppSettings`](openlogi_core::config::AppSettings) (see `i18n`), the
-//! overlay helper from the code the agent hands it per invocation. Keeping one
-//! implementation is what stops the two processes from disagreeing about, say,
+//! Shared by every process that renders localized text — the settings app
+//! picks the locale from its stored [`AppSettings`](crate::config::AppSettings),
+//! the agent from the same setting for its menu-bar tray, and the overlay
+//! helper from the code the agent hands it per invocation. Keeping one
+//! implementation is what stops the processes from disagreeing about, say,
 //! whether `zh-Hant-HK` is Hong Kong or Taiwan.
 //!
+//! The catalogs themselves stay in `crates/openlogi-ui/locales/` (each binary
+//! expands its own `rust_i18n::i18n!` over that directory by relative path);
+//! this module is only the negotiation over their codes, so it can live in the
+//! platform-free core where the GUI-less agent can reach it.
+//!
 //! Setting the locale is global: `rust_i18n` stores it in a process-wide atomic
-//! that gpui-component reads too, so [`crate::locale::activate`] re-localizes
-//! the framework's own widget strings alongside ours.
+//! that gpui-component reads too, so in the settings app
+//! [`crate::locale::activate`] re-localizes the framework's own widget strings
+//! alongside ours.
 
 use fluent_langneg::{LanguageIdentifier, NegotiationStrategy, negotiate_languages};
 
@@ -183,76 +190,5 @@ mod tests {
                 .iter()
                 .any(|(c, _)| *c == resolve(Some("klingon")))
         );
-    }
-
-    /// Every shipped locale must carry the same keys as `en.yml`. New UI copy
-    /// is added to all catalogs in the same change; Crowdin later improves the
-    /// non-English values (never English fill-in).
-    #[test]
-    fn locale_files_have_the_same_keys() {
-        use std::collections::BTreeSet;
-
-        let source: BTreeSet<&str> = locale_keys(include_str!("../locales/en.yml"))
-            .into_iter()
-            .collect();
-        assert!(
-            !source.is_empty(),
-            "en.yml is the string source of truth and must define keys"
-        );
-
-        let catalogs = [
-            ("ja", include_str!("../locales/ja.yml")),
-            ("ru", include_str!("../locales/ru.yml")),
-            ("uk", include_str!("../locales/uk.yml")),
-            ("zh-CN", include_str!("../locales/zh-CN.yml")),
-            ("zh-HK", include_str!("../locales/zh-HK.yml")),
-            ("zh-TW", include_str!("../locales/zh-TW.yml")),
-            ("it", include_str!("../locales/it.yml")),
-            ("da", include_str!("../locales/da.yml")),
-            ("de", include_str!("../locales/de.yml")),
-            ("el", include_str!("../locales/el.yml")),
-            ("es", include_str!("../locales/es.yml")),
-            ("fi", include_str!("../locales/fi.yml")),
-            ("fr", include_str!("../locales/fr.yml")),
-            ("ko", include_str!("../locales/ko.yml")),
-            ("nb", include_str!("../locales/nb.yml")),
-            ("nl", include_str!("../locales/nl.yml")),
-            ("pl", include_str!("../locales/pl.yml")),
-            ("pt-BR", include_str!("../locales/pt-BR.yml")),
-            ("pt-PT", include_str!("../locales/pt-PT.yml")),
-            ("sv", include_str!("../locales/sv.yml")),
-            ("tr", include_str!("../locales/tr.yml")),
-        ];
-
-        // `include_str!` needs literal paths, so this list is written out by
-        // hand — which means it can silently fall behind [`SUPPORTED`], and a
-        // locale nobody parity-checks is exactly how a catalog drifts.
-        let checked: BTreeSet<&str> = catalogs
-            .iter()
-            .map(|(locale, _)| *locale)
-            .chain(["en"])
-            .collect();
-        let shipped: BTreeSet<&str> = SUPPORTED.iter().map(|(code, _)| *code).collect();
-        assert_eq!(
-            checked, shipped,
-            "every locale in SUPPORTED must be parity-checked here"
-        );
-
-        for (locale, file) in catalogs {
-            let keys: BTreeSet<&str> = locale_keys(file).into_iter().collect();
-            let missing: Vec<&str> = source.difference(&keys).copied().collect();
-            let extras: Vec<&str> = keys.difference(&source).copied().collect();
-            assert!(
-                missing.is_empty() && extras.is_empty(),
-                "{locale}.yml key mismatch vs en.yml — missing: {missing:?}, extras: {extras:?}"
-            );
-        }
-    }
-
-    fn locale_keys(file: &str) -> Vec<&str> {
-        file.lines()
-            .filter_map(|line| line.strip_prefix('"'))
-            .filter_map(|line| line.split_once("\": ").map(|(key, _)| key))
-            .collect()
     }
 }

--- a/crates/openlogi-desktop/src/services/i18n.rs
+++ b/crates/openlogi-desktop/src/services/i18n.rs
@@ -4,7 +4,7 @@
 //! compile time by the `rust_i18n::i18n!` macro in `main.rs` (fallback `"en"`).
 //! **`en.yml` is the English source of truth** (the English text IS the key).
 //! New or changed copy must land in **every** `locales/*.yml` in the same
-//! change — `openlogi_ui::locale`'s parity test enforces key-for-key match,
+//! change — `openlogi_core::locale`'s parity test enforces key-for-key match,
 //! against the catalogs it now sits beside. Crowdin improves
 //! non-English values over time and the workflow downloads only real
 //! translations (`skip_untranslated_strings`). Call sites use
@@ -19,10 +19,10 @@
 //! followed by a window refresh so open views re-render with the new locale.
 //!
 //! Which catalog a BCP-47 code resolves to is decided in
-//! [`openlogi_ui::locale`], shared with the overlay helper.
+//! [`openlogi_core::locale`], shared with the overlay helper.
 
 use openlogi_core::config::AppSettings;
-use openlogi_ui::locale::activate;
+use openlogi_core::locale::activate;
 
 /// Serializes tests that mutate `rust_i18n`'s process-global locale, so a
 /// locale switch in one test cannot interleave with another's assertions.

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -316,7 +316,9 @@ impl AppState {
         }
         self.config
             .edit(|config| config.app_settings.language = language);
-        self.persist_config("language setting");
+        // Reload, not just persist: the agent renders the menu-bar tray in the
+        // configured language and relocalizes it on config reload.
+        self.persist_and_reload("language setting");
         openlogi_core::locale::activate(self.config.app_settings.language.as_deref());
         // Locale lookup is process-global, so every open window must repaint;
         // localized text cached in view state re-derives on this event.

--- a/crates/openlogi-desktop/src/state/settings.rs
+++ b/crates/openlogi-desktop/src/state/settings.rs
@@ -308,7 +308,7 @@ impl AppState {
         self.config.app_settings.language.as_deref()
     }
     /// Set the UI language (`None` = follow system), persist it, switch the
-    /// process-global locale via [`openlogi_ui::locale`], and repaint open UI.
+    /// process-global locale via [`openlogi_core::locale`], and repaint open UI.
     /// No-op when unchanged.
     pub fn set_language(&mut self, language: Option<String>, cx: &mut Context<Self>) {
         if self.config.app_settings.language == language {
@@ -317,7 +317,7 @@ impl AppState {
         self.config
             .edit(|config| config.app_settings.language = language);
         self.persist_config("language setting");
-        openlogi_ui::locale::activate(self.config.app_settings.language.as_deref());
+        openlogi_core::locale::activate(self.config.app_settings.language.as_deref());
         // Locale lookup is process-global, so every open window must repaint;
         // localized text cached in view state re-derives on this event.
         cx.emit(StateEvent::LanguageChanged);

--- a/crates/openlogi-desktop/src/windows/settings/language.rs
+++ b/crates/openlogi-desktop/src/windows/settings/language.rs
@@ -37,7 +37,7 @@ pub(super) fn language_options() -> Vec<LanguageOption> {
         localize_label: true,
     }];
     options.extend(
-        openlogi_ui::locale::SUPPORTED
+        openlogi_core::locale::SUPPORTED
             .iter()
             .map(|(code, name)| LanguageOption {
                 label: name,
@@ -61,7 +61,7 @@ pub(super) fn selected_language_index(
 }
 
 /// The language picker field. "Follow system" clears the stored preference
-/// (`None`); explicit locale entries come from [`openlogi_ui::locale::SUPPORTED`].
+/// (`None`); explicit locale entries come from [`openlogi_core::locale::SUPPORTED`].
 #[expect(
     clippy::needless_pass_by_value,
     reason = "built inside an `Fn` render closure, so a `&Entity` parameter would make \

--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
         )
         .init();
 
-    openlogi_ui::locale::activate(None);
+    openlogi_core::locale::activate(None);
     // Held for the whole run: dropping it hands the role to the replacement.
     let _tenancy = claim_the_role()?;
     let Ipc {
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
                     });
                     continue;
                 };
-                openlogi_ui::locale::activate(invocation.language.as_deref());
+                openlogi_core::locale::activate(invocation.language.as_deref());
                 cx.update(|cx| {
                     live_session.clear();
                     for handle in cx.windows() {

--- a/crates/openlogi-ui/Cargo.toml
+++ b/crates/openlogi-ui/Cargo.toml
@@ -16,9 +16,6 @@ openlogi-core = { path = "../openlogi-core" }
 # dependency added here lands in the overlay helper too, so the widget kit and
 # the artwork only the app draws both stay on the app's side.
 gpui = { workspace = true }
-fluent-langneg = "0.14.2"
-rust-i18n = "4"
-sys-locale = "0.3.2"
 
 [lints]
 workspace = true

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Fra"
 "Open OpenLogi": "Åbn OpenLogi"
 "Quit OpenLogi": "Slut OpenLogi"
+"Show Main Window": "Vis hovedvindue"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Tilslut eller par en understøttet Logitech-enhed — den vises her automatisk. Ved direkte Bluetooth-forbindelser skal du parre i computerens Bluetooth-indstillinger."
 "No active device": "Ingen aktiv enhed"
 "Active device": "Aktiv enhed"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Aus"
 "Open OpenLogi": "OpenLogi öffnen"
 "Quit OpenLogi": "OpenLogi beenden"
+"Show Main Window": "Hauptfenster anzeigen"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Schließe ein unterstütztes Logitech-Gerät an oder koppele es – es erscheint dann automatisch hier. Bei direkten Bluetooth-Verbindungen koppele das Gerät in den Bluetooth-Einstellungen deines Computers."
 "No active device": "Kein aktives Gerät"
 "Active device": "Aktives Gerät"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Ανενεργό"
 "Open OpenLogi": "Άνοιγμα του OpenLogi"
 "Quit OpenLogi": "Τερματισμός OpenLogi"
+"Show Main Window": "Εμφάνιση κύριου παραθύρου"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Συνδέστε ή αντιστοιχίστε μια υποστηριζόμενη συσκευή Logitech — θα εμφανιστεί εδώ αυτόματα. Για απευθείας συνδέσεις Bluetooth, αντιστοιχίστε τη συσκευή στις ρυθμίσεις Bluetooth του υπολογιστή σας."
 "No active device": "Καμία ενεργή συσκευή"
 "Active device": "Ενεργή συσκευή"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Off"
 "Open OpenLogi": "Open OpenLogi"
 "Quit OpenLogi": "Quit OpenLogi"
+"Show Main Window": "Show Main Window"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings."
 "No active device": "No active device"
 "Active device": "Active device"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Desactivado"
 "Open OpenLogi": "Abrir OpenLogi"
 "Quit OpenLogi": "Salir de OpenLogi"
+"Show Main Window": "Mostrar la ventana principal"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Conecta o empareja un dispositivo Logitech compatible: aparecerá aquí automáticamente. Para conexiones Bluetooth directas, empareja en los ajustes de Bluetooth de tu ordenador."
 "No active device": "Ningún dispositivo activo"
 "Active device": "Dispositivo activo"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Pois"
 "Open OpenLogi": "Avaa OpenLogi"
 "Quit OpenLogi": "Lopeta OpenLogi"
+"Show Main Window": "Näytä pääikkuna"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Liitä tai parita tuettu Logitech-laite — se näkyy täällä automaattisesti. Suoria Bluetooth-yhteyksiä varten paritus tehdään tietokoneen Bluetooth-asetuksissa."
 "No active device": "Ei aktiivista laitetta"
 "Active device": "Aktiivinen laite"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Désactivé"
 "Open OpenLogi": "Ouvrir OpenLogi"
 "Quit OpenLogi": "Quitter OpenLogi"
+"Show Main Window": "Afficher la fenêtre principale"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Branchez ou associez un appareil Logitech pris en charge — il apparaîtra ici automatiquement. Pour les connexions Bluetooth directes, associez-le dans les réglages Bluetooth de votre ordinateur."
 "No active device": "Aucun appareil actif"
 "Active device": "Appareil actif"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Off"
 "Open OpenLogi": "Apri OpenLogi"
 "Quit OpenLogi": "Esci da OpenLogi"
+"Show Main Window": "Mostra finestra principale"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Collega o associa un dispositivo Logitech supportato: apparirà qui automaticamente. Per connessioni Bluetooth dirette, associa il dispositivo nelle impostazioni Bluetooth del computer."
 "No active device": "Nessun dispositivo attivo"
 "Active device": "Dispositivo attivo"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "オフ"
 "Open OpenLogi": "OpenLogi を開く"
 "Quit OpenLogi": "OpenLogi を終了"
+"Show Main Window": "メインウィンドウを表示"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "対応する Logitech デバイスを接続またはペアリングすると、ここに自動的に表示されます。直接 Bluetooth 接続の場合は、コンピューターの Bluetooth 設定でペアリングしてください。"
 "No active device": "アクティブなデバイスがありません"
 "Active device": "アクティブなデバイス"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "꺼짐"
 "Open OpenLogi": "OpenLogi 열기"
 "Quit OpenLogi": "OpenLogi 종료"
+"Show Main Window": "메인 창 표시"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "지원되는 Logitech 기기를 연결하거나 페어링하면 여기에 자동으로 표시됩니다. 직접 블루투스로 연결하려면 컴퓨터의 블루투스 설정에서 페어링하세요."
 "No active device": "활성 기기 없음"
 "Active device": "활성 기기"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Av"
 "Open OpenLogi": "Åpne OpenLogi"
 "Quit OpenLogi": "Avslutt OpenLogi"
+"Show Main Window": "Vis hovedvindu"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Koble til eller par en støttet Logitech-enhet — den vises automatisk her. For direkte Bluetooth-tilkoblinger parer du i datamaskinens Bluetooth-innstillinger."
 "No active device": "Ingen aktiv enhet"
 "Active device": "Aktiv enhet"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Uit"
 "Open OpenLogi": "OpenLogi openen"
 "Quit OpenLogi": "Stop OpenLogi"
+"Show Main Window": "Hoofdvenster tonen"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Sluit een ondersteund Logitech-apparaat aan of koppel het — het verschijnt hier automatisch. Voor directe Bluetooth-verbindingen koppel je het apparaat in de Bluetooth-instellingen van je computer."
 "No active device": "Geen actief apparaat"
 "Active device": "Actief apparaat"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Wył."
 "Open OpenLogi": "Otwórz OpenLogi"
 "Quit OpenLogi": "Zakończ OpenLogi"
+"Show Main Window": "Pokaż okno główne"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Podłącz lub sparuj obsługiwane urządzenie Logitech — pojawi się tutaj automatycznie. W przypadku bezpośrednich połączeń Bluetooth sparuj urządzenie w ustawieniach Bluetooth komputera."
 "No active device": "Brak aktywnego urządzenia"
 "Active device": "Aktywne urządzenie"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Desligado"
 "Open OpenLogi": "Abrir o OpenLogi"
 "Quit OpenLogi": "Encerrar OpenLogi"
+"Show Main Window": "Mostrar a janela principal"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Conecte ou pareie um dispositivo Logitech compatível — ele aparecerá aqui automaticamente. Para conexões Bluetooth diretas, pareie nas configurações de Bluetooth do seu computador."
 "No active device": "Nenhum dispositivo ativo"
 "Active device": "Dispositivo ativo"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Desativado"
 "Open OpenLogi": "Abrir o OpenLogi"
 "Quit OpenLogi": "Sair do OpenLogi"
+"Show Main Window": "Mostrar a janela principal"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Ligue ou emparelhe um dispositivo Logitech compatível — aparecerá aqui automaticamente. Para ligações Bluetooth diretas, emparelhe nas definições de Bluetooth do seu computador."
 "No active device": "Nenhum dispositivo ativo"
 "Active device": "Dispositivo ativo"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Выкл"
 "Open OpenLogi": "Открыть OpenLogi"
 "Quit OpenLogi": "Выйти из OpenLogi"
+"Show Main Window": "Показать главное окно"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Подключите или сопрягите поддерживаемое устройство Logitech — оно автоматически появится здесь. Для прямых Bluetooth-подключений выполните сопряжение в настройках Bluetooth вашего компьютера."
 "No active device": "Нет активного устройства"
 "Active device": "Активное устройство"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Av"
 "Open OpenLogi": "Öppna OpenLogi"
 "Quit OpenLogi": "Avsluta OpenLogi"
+"Show Main Window": "Visa huvudfönstret"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Anslut eller para ihop en Logitech-enhet som stöds — den visas här automatiskt. För direkta Bluetooth-anslutningar parar du ihop i datorns Bluetooth-inställningar."
 "No active device": "Ingen aktiv enhet"
 "Active device": "Aktiv enhet"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Kapalı"
 "Open OpenLogi": "OpenLogi'yi aç"
 "Quit OpenLogi": "OpenLogi'den çık"
+"Show Main Window": "Ana pencereyi göster"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Desteklenen bir Logitech cihazını takın veya eşleştirin — burada otomatik olarak görünecektir. Doğrudan Bluetooth bağlantıları için bilgisayarınızın Bluetooth ayarlarından eşleştirin."
 "No active device": "Etkin cihaz yok"
 "Active device": "Etkin cihaz"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "Вимк."
 "Open OpenLogi": "Відкрити OpenLogi"
 "Quit OpenLogi": "Вийти з OpenLogi"
+"Show Main Window": "Показати головне вікно"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "Підключіть підтримуваний пристрій Logitech — він з'явиться тут автоматично. Для прямих Bluetooth-з'єднань виконайте підключення в налаштуваннях Bluetooth вашого комп'ютера."
 "No active device": "Немає активного пристрою"
 "Active device": "Активний пристрій"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "关"
 "Open OpenLogi": "打开 OpenLogi"
 "Quit OpenLogi": "退出 OpenLogi"
+"Show Main Window": "显示主窗口"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "接入或配对受支持的 Logitech 设备，它会自动显示在这里。如需直接蓝牙连接，请在电脑的蓝牙设置中配对。"
 "No active device": "没有活动设备"
 "Active device": "当前设备"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "關"
 "Open OpenLogi": "開啟 OpenLogi"
 "Quit OpenLogi": "結束 OpenLogi"
+"Show Main Window": "顯示主視窗"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "接入或配對受支援的 Logitech 裝置，它會自動顯示在這裡。如需直接藍牙連接，請在電腦的藍牙設定中配對。"
 "No active device": "沒有使用中的裝置"
 "Active device": "使用中的裝置"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -16,6 +16,7 @@ _version: 1
 "Off": "關"
 "Open OpenLogi": "開啟 OpenLogi"
 "Quit OpenLogi": "結束 OpenLogi"
+"Show Main Window": "顯示主視窗"
 "Plug in or pair a supported Logitech device — it'll show up here automatically. For direct Bluetooth connections, pair in your computer's bluetooth settings.": "接上或配對相容的 Logitech 裝置，裝置就會自動顯示在這裡。若要使用直接藍牙連線，請在電腦的藍牙設定中配對。"
 "No active device": "沒有使用中的裝置"
 "Active device": "使用中的裝置"

--- a/crates/openlogi-ui/src/catalog_parity.rs
+++ b/crates/openlogi-ui/src/catalog_parity.rs
@@ -1,0 +1,80 @@
+//! Key parity for the shared locale catalogs in `locales/`.
+//!
+//! The negotiation over these catalogs' codes lives in
+//! [`openlogi_core::locale`] (where the GUI-less agent can reach it); the
+//! `.yml` files stay here, and this test is what keeps the two in lockstep:
+//! every catalog carries exactly `en.yml`'s keys, and every code in
+//! [`openlogi_core::locale::SUPPORTED`] has a parity-checked catalog.
+
+use std::collections::BTreeSet;
+
+use openlogi_core::locale::SUPPORTED;
+
+/// Every shipped locale must carry the same keys as `en.yml`. New UI copy
+/// is added to all catalogs in the same change; Crowdin later improves the
+/// non-English values (never English fill-in).
+#[test]
+fn locale_files_have_the_same_keys() {
+    let source: BTreeSet<&str> = locale_keys(include_str!("../locales/en.yml"))
+        .into_iter()
+        .collect();
+    assert!(
+        !source.is_empty(),
+        "en.yml is the string source of truth and must define keys"
+    );
+
+    let catalogs = [
+        ("ja", include_str!("../locales/ja.yml")),
+        ("ru", include_str!("../locales/ru.yml")),
+        ("uk", include_str!("../locales/uk.yml")),
+        ("zh-CN", include_str!("../locales/zh-CN.yml")),
+        ("zh-HK", include_str!("../locales/zh-HK.yml")),
+        ("zh-TW", include_str!("../locales/zh-TW.yml")),
+        ("it", include_str!("../locales/it.yml")),
+        ("da", include_str!("../locales/da.yml")),
+        ("de", include_str!("../locales/de.yml")),
+        ("el", include_str!("../locales/el.yml")),
+        ("es", include_str!("../locales/es.yml")),
+        ("fi", include_str!("../locales/fi.yml")),
+        ("fr", include_str!("../locales/fr.yml")),
+        ("ko", include_str!("../locales/ko.yml")),
+        ("nb", include_str!("../locales/nb.yml")),
+        ("nl", include_str!("../locales/nl.yml")),
+        ("pl", include_str!("../locales/pl.yml")),
+        ("pt-BR", include_str!("../locales/pt-BR.yml")),
+        ("pt-PT", include_str!("../locales/pt-PT.yml")),
+        ("sv", include_str!("../locales/sv.yml")),
+        ("tr", include_str!("../locales/tr.yml")),
+    ];
+
+    // `include_str!` needs literal paths, so this list is written out by
+    // hand — which means it can silently fall behind [`SUPPORTED`], and a
+    // locale nobody parity-checks is exactly how a catalog drifts.
+    let checked: BTreeSet<&str> = catalogs
+        .iter()
+        .map(|(locale, _)| *locale)
+        .chain(["en"])
+        .collect();
+    let shipped: BTreeSet<&str> = SUPPORTED.iter().map(|(code, _)| *code).collect();
+    assert_eq!(
+        checked, shipped,
+        "every locale in SUPPORTED must be parity-checked here"
+    );
+
+    for (locale, file) in catalogs {
+        let keys: BTreeSet<&str> = locale_keys(file).into_iter().collect();
+        let missing: Vec<&str> = source.difference(&keys).copied().collect();
+        let extras: Vec<&str> = keys.difference(&source).copied().collect();
+        assert!(
+            missing.is_empty() && extras.is_empty(),
+            "{locale}.yml key mismatch vs en.yml — missing: {missing:?}, extras: {extras:?}"
+        );
+    }
+}
+
+fn locale_keys(file: &str) -> Vec<&str> {
+    file.lines()
+        .filter_map(|line| line.strip_prefix('"'))
+        .filter_map(|line| line.split_once("\": ").map(|(key, _)| key))
+        .collect()
+}

--- a/crates/openlogi-ui/src/lib.rs
+++ b/crates/openlogi-ui/src/lib.rs
@@ -7,5 +7,6 @@
 //! reach the overlay through the back door.
 
 pub mod action_icons;
+#[cfg(test)]
+mod catalog_parity;
 pub mod color;
-pub mod locale;


### PR DESCRIPTION
## Summary

The agent's menu-bar tray was never localized — every string was hardcoded English regardless of the configured interface language, on macOS and Windows alike (the residual noted in #1033). Localizing it required the locale negotiation to be reachable from the agent, which links neither gpui nor openlogi-ui, so the branch first moves that module and then wires the tray to it, including live language switches.

## Changes

- `openlogi-core`: gains the `locale` module (moved verbatim from `openlogi-ui`, resolution tests included) behind a default-on `locale` feature, so the wasm portability check keeps excluding the host-locale read the way it excludes `fs`. Manifest gains `fluent-langneg` / `rust-i18n` / `sys-locale` as optional deps — all already in the workspace graph; the gpui pins in `Cargo.lock` did not move.
- `openlogi-ui`: drops the negotiation module and its three deps; the catalogs stay in `locales/` with their key-parity test, now in `catalog_parity.rs` (its `include_str!` paths anchor to the crate owning the files, and it checks its coverage against `openlogi_core::locale::SUPPORTED`).
- `openlogi-desktop`, `openlogi-overlay`: consumers point at `openlogi_core::locale`; the GUI persists a language switch via the existing `persist_and_reload` so the running agent hears about it (no wire change — ReloadConfig already existed).
- `openlogi-agent`: expands `rust_i18n::i18n!` over the shared catalogs (same relative-path arrangement as the overlay, with the same `the_shared_catalog_is_wired_up` guard test), resolves the stored language at startup, and renders every tray string through `t!`. On config reload it re-resolves the locale and rebuilds the macOS menu via the same `build_menu` the install uses (the `STATUS_ITEM` thread-local grows into `TrayState` carrying the action target the rebuild needs). The Windows popup is built fresh per right-click, so it follows the locale with no extra plumbing.
- Catalogs: "Show Main Window" added to all 22 files (best-effort translations; every other tray key already existed for the GUI's menus).
- Docs: `AGENTS.md` crate rows, `.claude/rules/gui.md` catalog bullet, and `.claude/rules/i18n.md` paths/test locations follow the move.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 1266 passed, including the moved resolution tests in core, the relocated catalog parity test, the agent's new wired-up guard, and the desktop's language-switch regression test over the reload-sending path.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` (non-GUI set)
- `cargo check -p openlogi-core --no-default-features --target wasm32-unknown-unknown` (the wasm job's core leg)
- `devenv tasks run openlogi:check-windows` — the windows-gnu cross-lint covers `openlogi-agent` and `openlogi-core`, green.
- Not run locally: cargo-deny (not installed; the dep change only moves existing workspace crates between manifests) and the Linux clippy/test legs (no local Linux toolchain) — CI is the gate for both.
- Not runtime-tested on hardware: the tray needs the real agent process. To verify — run the agent with a non-English `language` in config.toml and check the menu-bar item's five entries render localized; then switch the interface language in Settings → Appearance while the agent runs and re-open the tray menu (macOS should rebuild via reload; Windows localizes on next right-click).
