### PR TITLE
feat(device): Detect Logitech G735 headset dongle

### DIFF
--- a/crates/openlogi-device-registry/src/headset.rs
+++ b/crates/openlogi-device-registry/src/headset.rs
@@ -1,0 +1,118 @@
+//! Logitech gaming-headset raw-HID identities.
+//!
+//! These headsets don't speak the eQuad HID++ receiver protocol mice and
+//! keyboards use. Their dongle exposes a proprietary vendor collection
+//! instead, and no publicly documented reverse-engineering of that protocol
+//! is known yet (checked against the `HeadsetControl` project's Logitech
+//! drivers, none of which match this family's usage page). So, like Litra,
+//! these are surfaced as standalone raw-HID devices for identity only: no
+//! battery, mute, or sidetone control until the wire protocol is worked out.
+
+use crate::LOGITECH_VENDOR_ID;
+
+/// Stable driver-family identifier carried by standalone headset inventory.
+pub const GAMING_HEADSET_DRIVER_ID: &str = "logitech-gaming-headset";
+
+/// A known Logitech gaming-headset raw-HID identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GamingHeadsetDescriptor {
+    /// USB vendor ID.
+    pub vendor_id: u16,
+    /// USB product ID of the headset's dongle.
+    pub product_id: u16,
+    /// HID usage page of the vendor collection used as this device's stable
+    /// identity node.
+    pub usage_page: u16,
+    /// HID usage ID of that vendor collection.
+    pub usage_id: u16,
+    /// Marketed product name.
+    pub name: &'static str,
+}
+
+impl GamingHeadsetDescriptor {
+    const fn logitech(product_id: u16, usage_page: u16, usage_id: u16, name: &'static str) -> Self {
+        Self {
+            vendor_id: LOGITECH_VENDOR_ID,
+            product_id,
+            usage_page,
+            usage_id,
+            name,
+        }
+    }
+}
+
+/// All standalone gaming-headset raw-HID identities OpenLogi recognizes.
+pub const GAMING_HEADSETS: &[GamingHeadsetDescriptor] = &[
+    // G735 LIGHTSPEED. Its dongle (046D:0AD8) exposes vendor collections on
+    // 0xff00/0x0001 and 0xff03/0x0001..0x0003; 0xff00/0x0001 is used here as
+    // the stable identity node, matching the precedent of the older G533/G930
+    // vendor page. Identity only — no control protocol implemented.
+    GamingHeadsetDescriptor::logitech(0x0ad8, 0xff00, 0x0001, "G735 Gaming Headset"),
+];
+
+/// Finds a gaming-headset descriptor by its complete raw-HID identity.
+#[must_use]
+pub fn find_gaming_headset(
+    vendor_id: u16,
+    product_id: u16,
+    usage_page: u16,
+    usage_id: u16,
+) -> Option<&'static GamingHeadsetDescriptor> {
+    GAMING_HEADSETS.iter().find(|device| {
+        device.vendor_id == vendor_id
+            && device.product_id == product_id
+            && device.usage_page == usage_page
+            && device.usage_id == usage_id
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GAMING_HEADSET_DRIVER_ID, GAMING_HEADSETS, find_gaming_headset};
+    use crate::LOGITECH_VENDOR_ID;
+
+    #[test]
+    fn gaming_headset_identities_are_unique() {
+        for (index, device) in GAMING_HEADSETS.iter().enumerate() {
+            assert!(
+                GAMING_HEADSETS[..index].iter().all(|other| {
+                    (
+                        other.vendor_id,
+                        other.product_id,
+                        other.usage_page,
+                        other.usage_id,
+                    ) != (
+                        device.vendor_id,
+                        device.product_id,
+                        device.usage_page,
+                        device.usage_id,
+                    )
+                }),
+                "duplicate gaming headset identity {:04x}:{:04x}/{:04x}:{:04x}",
+                device.vendor_id,
+                device.product_id,
+                device.usage_page,
+                device.usage_id
+            );
+        }
+    }
+
+    #[test]
+    fn complete_identity_selects_g735_metadata() {
+        let g735 =
+            find_gaming_headset(LOGITECH_VENDOR_ID, 0x0ad8, 0xff00, 0x0001).expect("G735 identity");
+
+        assert_eq!(g735.name, "G735 Gaming Headset");
+        assert!(find_gaming_headset(LOGITECH_VENDOR_ID, 0x0ad8, 0xff03, 0x0001).is_none());
+    }
+
+    #[test]
+    fn lookup_requires_the_matching_vendor() {
+        assert!(find_gaming_headset(0xffff, 0x0ad8, 0xff00, 0x0001).is_none());
+    }
+
+    #[test]
+    fn driver_id_is_stable() {
+        assert_eq!(GAMING_HEADSET_DRIVER_ID, "logitech-gaming-headset");
+    }
+}

--- a/crates/openlogi-device-registry/src/lib.rs
+++ b/crates/openlogi-device-registry/src/lib.rs
@@ -11,6 +11,7 @@
 #![deny(rustdoc::bare_urls)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+pub mod headset;
 pub mod litra;
 pub mod receiver;
 

--- a/crates/openlogi-device/src/inventory/standalone.rs
+++ b/crates/openlogi-device/src/inventory/standalone.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use openlogi_core::device::{DeviceKind, RawDeviceAddress, StandaloneDevice};
+use openlogi_device_registry::headset::{GAMING_HEADSET_DRIVER_ID, find_gaming_headset};
 use openlogi_device_registry::litra::find_litra;
 
 use super::InventoryError;
@@ -20,37 +21,70 @@ pub async fn enumerate_standalone(
     let devices = backend.enumerate().await?;
     let devices: Vec<_> = devices
         .into_iter()
-        .filter_map(|device| {
-            let descriptor = find_litra(
-                device.vendor_id,
-                device.product_id,
-                device.usage_page,
-                device.usage_id,
-            )?;
-            let identity = device.identity();
-            Some(StandaloneDevice {
-                address: RawDeviceAddress {
-                    vendor_id: device.vendor_id,
-                    product_id: device.product_id,
-                    usage_page: device.usage_page,
-                    usage_id: device.usage_id,
-                    identity,
-                },
-                display_name: device.name.clone(),
-                manufacturer: device.manufacturer.clone(),
-                serial_number: device.serial_number.clone(),
-                unit_id: [0; 4],
-                kind: DeviceKind::Light,
-                online: true,
-                capabilities: None,
-                light_capabilities: Some(litra_capabilities(descriptor.model)),
-                driver_id: descriptor.driver_id.to_owned(),
-                registry_model_id: Some(descriptor.registry_model_id.to_owned()),
-            })
-        })
+        .filter_map(|device| standalone_device(&device))
         .collect();
     validate_no_ambiguous_nodes(&devices)?;
     Ok(devices)
+}
+
+/// Classifies one enumerated HID node against every standalone driver family
+/// OpenLogi recognizes, in precedence order. `None` when no family claims it.
+fn standalone_device(device: &crate::backend::NodeInfo) -> Option<StandaloneDevice> {
+    if let Some(descriptor) = find_litra(
+        device.vendor_id,
+        device.product_id,
+        device.usage_page,
+        device.usage_id,
+    ) {
+        return Some(StandaloneDevice {
+            address: RawDeviceAddress {
+                vendor_id: device.vendor_id,
+                product_id: device.product_id,
+                usage_page: device.usage_page,
+                usage_id: device.usage_id,
+                identity: device.identity(),
+            },
+            display_name: device.name.clone(),
+            manufacturer: device.manufacturer.clone(),
+            serial_number: device.serial_number.clone(),
+            unit_id: [0; 4],
+            kind: DeviceKind::Light,
+            online: true,
+            capabilities: None,
+            light_capabilities: Some(litra_capabilities(descriptor.model)),
+            driver_id: descriptor.driver_id.to_owned(),
+            registry_model_id: Some(descriptor.registry_model_id.to_owned()),
+        });
+    }
+
+    if let Some(descriptor) = find_gaming_headset(
+        device.vendor_id,
+        device.product_id,
+        device.usage_page,
+        device.usage_id,
+    ) {
+        return Some(StandaloneDevice {
+            address: RawDeviceAddress {
+                vendor_id: device.vendor_id,
+                product_id: device.product_id,
+                usage_page: device.usage_page,
+                usage_id: device.usage_id,
+                identity: device.identity(),
+            },
+            display_name: descriptor.name.to_owned(),
+            manufacturer: device.manufacturer.clone(),
+            serial_number: device.serial_number.clone(),
+            unit_id: [0; 4],
+            kind: DeviceKind::Headset,
+            online: true,
+            capabilities: None,
+            light_capabilities: None,
+            driver_id: GAMING_HEADSET_DRIVER_ID.to_owned(),
+            registry_model_id: None,
+        });
+    }
+
+    None
 }
 
 /// Reject multiple nodes that the route cannot distinguish safely.


### PR DESCRIPTION
- The G735's Lightspeed dongle doesn't speak the eQuad HID++ receiver protocol mice/keyboards use, so it was invisible to OpenLogi entirely.
- Adds it to a new `device-registry::headset` module (mirrors the existing Litra standalone-driver pattern) and wires it into `enumerate_standalone`, so it now shows up as a Headset-kind device in the GUI and `openlogi light list`.
- Identity only, no battery/mute/sidetone control. Checked against HeadsetControl's Logitech drivers; none match this device's usage pages (0xff00/0xff03), so the control protocol is still undocumented I think?

## Test plan
- [x] `cargo test -p openlogi-device-registry -p openlogi-device`
- [x] `cargo clippy -p openlogi-device-registry -p openlogi-device --all-targets -- -D warnings`
- [x] Verified against real hardware: `openlogi light list` reports "G735 Gaming Headset ... (046d:0ad8 usage ff00:0001)"

## Demo
<img width="1614" height="1129" alt="image" src="https://github.com/user-attachments/assets/77baa154-f79e-4d6d-b84d-cd6a1d203c78" />
<img width="1780" height="1202" alt="image" src="https://github.com/user-attachments/assets/a1fc36d0-737a-41d3-ae10-62352faac2d4" />
