### PR TITLE
fix(linux): preserve gesture capture across receiver probes

### DIFF
--- a/crates/openlogi-device/src/channel/scripted.rs
+++ b/crates/openlogi-device/src/channel/scripted.rs
@@ -38,17 +38,18 @@ pub(crate) async fn scripted_channel(raw: impl RawHidChannel) -> Arc<HidppChanne
     )
 }
 
-/// How a scripted node behaves when the layers above ask to open it.
+/// Outcome produced when the scripted backend opens a listed node.
 ///
-/// The two cases are distinct contracts the enumerator must not conflate: only
-/// [`Self::OpenFails`] is a failure the ledger replays a last-good snapshot
-/// through. A node that opens into a live HID++ channel belongs here too — add
-/// that variant with the test that drives it, so it never sits unconstructed.
-pub(crate) enum ScriptedNode {
+/// The cases are distinct contracts the enumerator must not conflate: only
+/// [`Self::Fails`] is a backend failure the ledger replays a last-good snapshot
+/// through.
+pub(crate) enum ScriptedOpen {
     /// The backend cannot open the node at all — unplugged mid-tick, or denied.
-    OpenFails,
+    Fails,
     /// The node opens but carries no HID++ collection.
     NotHidpp,
+    /// The node opens into a live HID++ channel that does not answer requests.
+    UnresponsiveHidpp,
 }
 
 /// A [`HidBackend`] over scripted nodes.
@@ -58,16 +59,16 @@ pub(crate) enum ScriptedNode {
 /// will not open, one that is not HID++ at all) that hardware cannot be asked
 /// to reproduce on demand.
 pub(crate) struct ScriptedBackend {
-    nodes: Vec<(NodeInfo, ScriptedNode)>,
+    nodes: Vec<(NodeInfo, ScriptedOpen)>,
 }
 
 impl ScriptedBackend {
     /// A backend presenting `nodes`, in the order given.
-    pub(crate) fn new(nodes: Vec<(NodeInfo, ScriptedNode)>) -> Arc<Self> {
+    pub(crate) fn new(nodes: Vec<(NodeInfo, ScriptedOpen)>) -> Arc<Self> {
         Arc::new(Self { nodes })
     }
 
-    fn node(&self, id: &NodeId) -> Option<&ScriptedNode> {
+    fn open_outcome(&self, id: &NodeId) -> Option<&ScriptedOpen> {
         self.nodes
             .iter()
             .find_map(|(info, node)| (info.id == *id).then_some(node))
@@ -85,9 +86,13 @@ impl HidBackend for ScriptedBackend {
     }
 
     async fn open_hidpp(&self, node: &NodeInfo) -> Result<Option<Arc<HidppChannel>>, BackendError> {
-        match self.node(&node.id) {
-            None | Some(ScriptedNode::OpenFails) => Err(BackendError::Disconnected),
-            Some(ScriptedNode::NotHidpp) => Ok(None),
+        match self.open_outcome(&node.id) {
+            None | Some(ScriptedOpen::Fails) => Err(BackendError::Disconnected),
+            Some(ScriptedOpen::NotHidpp) => Ok(None),
+            Some(ScriptedOpen::UnresponsiveHidpp) => {
+                let (raw, _) = ScriptedRawHidChannel::with_responder(|_| None);
+                Ok(Some(scripted_channel(raw).await))
+            }
         }
     }
 

--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -32,13 +32,35 @@ pub mod standalone;
 use cache::{CACHE_MISS_GRACE, CacheKey, CacheOutcome, Cached};
 use events::{ChannelEventSubscriptions, EventNotifier, EventSubscriptionHandle};
 use persist::{ProbeCacheSnapshot, ProbeCacheStore};
-use probe::{NodeProbe, probe_one};
+use probe::{NodeProbe, ProbeVerdict, probe_one};
 
 /// How long to wait for device-arrival event bursts before assuming the
 /// receiver has finished reporting. MX Master 4 (and other devices that may
 /// be asleep) need a generous window to wake and respond to the arrival
 /// ping; we err on the side of waiting.
 const ARRIVAL_DRAIN: Duration = Duration::from_millis(1500);
+
+/// A Unifying receiver can transiently stall the first arrival-trigger write
+/// while its previous scan settles. Retry once inside the same probe instead
+/// of making the inventory ledger treat that single write as a dead channel.
+const UNIFYING_TRIGGER_RETRY_DELAY: Duration = Duration::from_millis(300);
+
+/// One device-arrival trigger addresses the receiver itself and should ACK
+/// immediately. Keep each attempt well inside the enclosing receiver probe
+/// budget so a slow write still retains its liveness-aware probe verdict.
+const UNIFYING_TRIGGER_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// Receiver register operations are normally answered in a few milliseconds.
+/// Keep a stalled liveness/notification request from consuming the enclosing
+/// receiver probe budget, so a responsive channel can still report an
+/// `AliveButIncomplete` arrival replay instead of becoming an ordinary probe
+/// timeout.
+const RECEIVER_OPERATION_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// A receiver UID is cache metadata rather than a liveness gate. Give it a
+/// shorter window so a delayed serial-number read cannot crowd out the arrival
+/// replay and feature-walk budgets.
+const RECEIVER_UID_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Maximum number of pairing slots a Bolt receiver supports. We iterate this
 /// range to surface paired-but-offline devices that won't fire arrival events.
@@ -340,6 +362,18 @@ fn settle_unhealthy_node<Node: Eq + Hash + Clone>(
     ledger.settle(node, false, None).inventory
 }
 
+fn settle_probe<Node: Eq + Hash + Clone>(
+    ledger: &mut NodeLedger<Node>,
+    node: &Node,
+    verdict: ProbeVerdict,
+    inventory: Option<DeviceInventory>,
+) -> ledger::SettledNode {
+    match verdict {
+        ProbeVerdict::AliveButIncomplete => ledger.settle_arrival_replay_failure(node),
+        verdict => ledger.settle(node, verdict.is_healthy(), inventory),
+    }
+}
+
 /// Enumerate all Logitech HID++ receivers visible to the current process and
 /// the devices paired to each.
 ///
@@ -605,6 +639,11 @@ impl Enumerator {
             }
             match backend.open_hidpp(&info).await {
                 Ok(Some(channel)) => {
+                    // A channel that actually opened must not inherit probe or
+                    // arrival-replay eviction counts from its predecessor.
+                    // Inventory replay remains bounded until a probe produces
+                    // a new authoritative snapshot.
+                    self.ledger.reset_channel_failures_after_open(&node);
                     // Attach before the first feature/register check. Receiver
                     // events are recognizable immediately; per-device feature
                     // indexes are registered during the ensuing table walk.
@@ -770,9 +809,7 @@ impl Enumerator {
             all_complete &= probe.verdict.is_complete();
             all_healthy &= probe.verdict.is_healthy();
             outcomes.extend(probe.outcomes);
-            let settled = self
-                .ledger
-                .settle(&node, probe.verdict.is_healthy(), probe.inventory);
+            let settled = settle_probe(&mut self.ledger, &node, probe.verdict, probe.inventory);
             // Every node waits for the ledger's consecutive-failure threshold,
             // receivers included. One full-budget timeout is not evidence of
             // dead delivery: [`RECEIVER_PROBE_BUDGET`] leaves barely a second

--- a/crates/openlogi-device/src/inventory/ledger.rs
+++ b/crates/openlogi-device/src/inventory/ledger.rs
@@ -24,11 +24,12 @@ use std::hash::Hash;
 use openlogi_core::device::DeviceInventory;
 use tracing::{debug, warn};
 
-/// Ticks a node's last-good inventory keeps being served while its probe
-/// fails. Past this the live (partial or empty) result is surfaced, so a
-/// receiver that is genuinely wedged eventually shows the truth instead of an
-/// ever-staler snapshot. Mirrors the probe cache's `CACHE_MISS_GRACE`, so a
-/// node recovers with its memoized probes still warm.
+/// Ticks a node's last-good inventory keeps being served while its probe does
+/// not produce an authoritative result. Opening a replacement channel does not
+/// reset this clock: a receiver that is genuinely wedged must eventually show
+/// the truth instead of repeatedly resurrecting an ever-staler snapshot.
+/// Mirrors the probe cache's `CACHE_MISS_GRACE`, so a node recovers with its
+/// memoized probes still warm.
 const NODE_MISS_GRACE: u8 = 3;
 
 /// Consecutive failed probes after which the node's cached channel should be
@@ -38,22 +39,69 @@ const NODE_MISS_GRACE: u8 = 3;
 /// and node-vanish eviction never fires for a node the OS keeps listing.
 const CHANNEL_EVICT_AFTER: u8 = 2;
 
+/// Consecutive arrival-replay failures tolerated after the receiver answered
+/// its pairing-count register. This path gets a longer channel grace because
+/// it proves the transport is responsive, but cannot be trusted forever
+/// because the published device list may be stale.
+const ARRIVAL_REPLAY_EVICT_AFTER: u8 = NODE_MISS_GRACE + 1;
+
 /// What [`NodeLedger::settle`] decided for one node this tick.
 pub(crate) struct SettledNode {
     /// The inventory to report for the node: the live result, or the replayed
     /// last-good snapshot while the failure is within grace.
     pub inventory: Option<DeviceInventory>,
     /// Whether the node's cached channel should be dropped so the next tick
-    /// reopens it. `true` on every failed tick from [`CHANNEL_EVICT_AFTER`]
-    /// onwards, so a persistently sick node keeps getting a fresh channel.
+    /// reopens it. `true` once the current failure kind reaches its threshold,
+    /// so a persistently sick node keeps getting a fresh channel.
     pub evict_channel: bool,
 }
 
-/// Tracks, per HID node, the last completed inventory and how many
-/// consecutive probes have failed since.
+/// Tracks each HID node's last completed inventory, bounded replay age, and
+/// channel-local failure streaks.
 pub(crate) struct NodeLedger<K> {
     last_good: HashMap<K, DeviceInventory>,
-    failures: HashMap<K, u8>,
+    failures: HashMap<K, FailureCounts>,
+}
+
+#[derive(Default)]
+struct FailureCounts {
+    /// Consecutive probes that produced no liveness evidence.
+    probe: u8,
+    /// Failed arrival replays on the current channel generation.
+    arrival_replay: u8,
+    /// Non-authoritative ticks since the last complete inventory.
+    publication_misses: u8,
+}
+
+#[derive(Clone, Copy)]
+enum FailureKind {
+    Probe,
+    ArrivalReplay,
+}
+
+impl FailureKind {
+    fn record(self, counts: &mut FailureCounts) -> u8 {
+        match self {
+            Self::Probe => {
+                counts.probe = counts.probe.saturating_add(1);
+                counts.probe
+            }
+            Self::ArrivalReplay => {
+                // The pairing-count response proves transport liveness, so a
+                // later ordinary failure must start its own streak again.
+                counts.probe = 0;
+                counts.arrival_replay = counts.arrival_replay.saturating_add(1);
+                counts.arrival_replay
+            }
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Probe => "probe",
+            Self::ArrivalReplay => "arrival replay",
+        }
+    }
 }
 
 // Hand-written: `derive(Default)` would needlessly bound `K: Default`, which
@@ -68,6 +116,30 @@ impl<K> Default for NodeLedger<K> {
 }
 
 impl<K: Eq + Hash + Clone> NodeLedger<K> {
+    /// Start channel-eviction accounting again after the enumerator opens a
+    /// replacement channel, without re-arming expired inventory replay.
+    pub fn reset_channel_failures_after_open(&mut self, node: &K) {
+        if let Some(counts) = self.failures.get_mut(node) {
+            counts.probe = 0;
+            counts.arrival_replay = 0;
+        }
+    }
+
+    /// Keep the last complete inventory briefly after a receiver proved it can
+    /// still answer but could not replay its arrival notifications this tick.
+    ///
+    /// This is distinct from [`Self::settle`] with `healthy = false`: an
+    /// arrival-trigger write may fail transiently while ordinary receiver
+    /// registers and an already-armed capture session remain functional.
+    pub fn settle_arrival_replay_failure(&mut self, node: &K) -> SettledNode {
+        self.settle_failure(
+            node,
+            None,
+            ARRIVAL_REPLAY_EVICT_AFTER,
+            FailureKind::ArrivalReplay,
+        )
+    }
+
     /// Fold one node's probe result into the ledger and decide what to report.
     ///
     /// `healthy` means the node actually answered this tick — a completed
@@ -97,30 +169,47 @@ impl<K: Eq + Hash + Clone> NodeLedger<K> {
             };
         }
 
-        let failures = self.failures.entry(node.clone()).or_insert(0);
-        *failures = failures.saturating_add(1);
-        let failures = *failures;
-        let inventory = match self.last_good.get(node) {
-            Some(prev) if failures <= NODE_MISS_GRACE => {
+        self.settle_failure(node, live, CHANNEL_EVICT_AFTER, FailureKind::Probe)
+    }
+
+    fn settle_failure(
+        &mut self,
+        node: &K,
+        live: Option<DeviceInventory>,
+        evict_after: u8,
+        failure_kind: FailureKind,
+    ) -> SettledNode {
+        let counts = self.failures.entry(node.clone()).or_default();
+        let channel_failures = failure_kind.record(counts);
+        counts.publication_misses = counts.publication_misses.saturating_add(1);
+        let publication_misses = counts.publication_misses;
+        let failure_kind = failure_kind.label();
+        let inventory = if publication_misses <= NODE_MISS_GRACE {
+            if let Some(previous) = self.last_good.get(node) {
                 debug!(
-                    failures,
-                    "node probe failed — replaying its last good inventory"
+                    failures = publication_misses,
+                    channel_failures,
+                    failure_kind,
+                    "node check incomplete — replaying its last good inventory"
                 );
-                Some(prev.clone())
-            }
-            _ => {
-                if self.last_good.remove(node).is_some() {
-                    warn!(
-                        failures,
-                        "node probe failures exhausted the replay grace — surfacing the live result"
-                    );
-                }
+                Some(previous.clone())
+            } else {
                 live
             }
+        } else {
+            if self.last_good.remove(node).is_some() {
+                warn!(
+                    failures = publication_misses,
+                    channel_failures,
+                    failure_kind,
+                    "node check failures exhausted the replay grace — surfacing the live result"
+                );
+            }
+            live
         };
         SettledNode {
             inventory,
-            evict_channel: failures >= CHANNEL_EVICT_AFTER,
+            evict_channel: channel_failures >= evict_after,
         }
     }
 
@@ -141,7 +230,7 @@ impl<K: Eq + Hash + Clone> NodeLedger<K> {
 mod tests {
     use openlogi_core::device::{DeviceInventory, ReceiverInfo};
 
-    use super::{CHANNEL_EVICT_AFTER, NODE_MISS_GRACE, NodeLedger};
+    use super::{ARRIVAL_REPLAY_EVICT_AFTER, CHANNEL_EVICT_AFTER, NODE_MISS_GRACE, NodeLedger};
 
     fn inventory(name: &str) -> DeviceInventory {
         DeviceInventory {
@@ -198,6 +287,142 @@ mod tests {
             Some("bolt"),
             "the recovery should re-arm the full replay grace"
         );
+    }
+
+    #[test]
+    fn transient_arrival_replay_failures_keep_the_channel_and_snapshot() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        for _ in 1..ARRIVAL_REPLAY_EVICT_AFTER {
+            let retained = ledger.settle_arrival_replay_failure(&1);
+            assert_eq!(receiver_name(retained.inventory.as_ref()), Some("unifying"));
+            assert!(!retained.evict_channel);
+        }
+    }
+
+    #[test]
+    fn persistent_arrival_replay_failure_retires_the_channel_and_snapshot() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        for _ in 1..ARRIVAL_REPLAY_EVICT_AFTER {
+            ledger.settle_arrival_replay_failure(&1);
+        }
+
+        let exhausted = ledger.settle_arrival_replay_failure(&1);
+
+        assert!(exhausted.evict_channel);
+        assert!(exhausted.inventory.is_none());
+    }
+
+    #[test]
+    fn expired_arrival_snapshot_does_not_resurface_on_probe_failure() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        for _ in 0..ARRIVAL_REPLAY_EVICT_AFTER {
+            ledger.settle_arrival_replay_failure(&1);
+        }
+
+        let retiring = ledger.settle(&1, false, None);
+
+        assert!(retiring.inventory.is_none());
+        assert!(!retiring.evict_channel);
+    }
+
+    #[test]
+    fn complete_probe_resets_the_arrival_replay_failure_streak() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        for _ in 1..ARRIVAL_REPLAY_EVICT_AFTER {
+            ledger.settle_arrival_replay_failure(&1);
+        }
+        ledger.settle(&1, true, Some(inventory("unifying")));
+
+        let retained = ledger.settle_arrival_replay_failure(&1);
+
+        assert!(!retained.evict_channel);
+        assert_eq!(receiver_name(retained.inventory.as_ref()), Some("unifying"));
+    }
+
+    #[test]
+    fn one_probe_timeout_does_not_inherit_arrival_replay_failures() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        ledger.settle_arrival_replay_failure(&1);
+        ledger.settle_arrival_replay_failure(&1);
+
+        let first_probe_timeout = ledger.settle(&1, false, None);
+
+        assert!(!first_probe_timeout.evict_channel);
+        assert_eq!(
+            receiver_name(first_probe_timeout.inventory.as_ref()),
+            Some("unifying")
+        );
+        assert!(
+            ledger.settle(&1, false, None).evict_channel,
+            "ordinary failures still retire on their own second consecutive tick"
+        );
+    }
+
+    #[test]
+    fn mixed_timeouts_do_not_hide_persistent_arrival_replay_failure() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        for _ in 1..ARRIVAL_REPLAY_EVICT_AFTER {
+            assert!(!ledger.settle_arrival_replay_failure(&1).evict_channel);
+            assert!(!ledger.settle(&1, false, None).evict_channel);
+        }
+
+        let exhausted = ledger.settle_arrival_replay_failure(&1);
+
+        assert!(exhausted.evict_channel);
+        assert!(exhausted.inventory.is_none());
+    }
+
+    #[test]
+    fn replacement_channel_gets_fresh_eviction_grace_without_resurrecting_inventory() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        for _ in 0..ARRIVAL_REPLAY_EVICT_AFTER - 1 {
+            ledger.settle_arrival_replay_failure(&1);
+        }
+        assert!(!ledger.settle(&1, false, None).evict_channel);
+        let retired = ledger.settle(&1, false, None);
+        assert!(retired.evict_channel);
+        assert!(retired.inventory.is_none());
+
+        for _ in 0..=NODE_MISS_GRACE {
+            ledger.settle(&1, false, None);
+        }
+        assert!(
+            ledger.settle(&1, false, None).inventory.is_none(),
+            "a long retirement must still stop publishing stale inventory"
+        );
+
+        ledger.reset_channel_failures_after_open(&1);
+        let replacement_failure = ledger.settle_arrival_replay_failure(&1);
+
+        assert!(!replacement_failure.evict_channel);
+        assert!(replacement_failure.inventory.is_none());
+    }
+
+    #[test]
+    fn repeated_channel_opens_do_not_rearm_inventory_replay() {
+        let mut ledger = NodeLedger::default();
+        ledger.settle(&1, true, Some(inventory("unifying")));
+        let mut published = Vec::new();
+
+        for _ in 0..3 {
+            ledger.reset_channel_failures_after_open(&1);
+            let first = ledger.settle(&1, false, None);
+            published.push(first.inventory.is_some());
+            assert!(!first.evict_channel);
+
+            let second = ledger.settle(&1, false, None);
+            published.push(second.inventory.is_some());
+            assert!(second.evict_channel);
+        }
+
+        assert_eq!(published, vec![true, true, true, false, false, false]);
     }
 
     #[test]

--- a/crates/openlogi-device/src/inventory/probe.rs
+++ b/crates/openlogi-device/src/inventory/probe.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::HashMap,
+    fmt::Debug,
+    future::Future,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -29,7 +31,11 @@ use crate::channel::route::DIRECT_DEVICE_INDEX;
 
 use super::cache::{CacheKey, CacheOutcome, Cached, is_stale, probe_or_reuse, seen};
 use super::features::ProbedFeatures;
-use super::{BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE};
+use super::{
+    BOLT_SLOT_PROBE, MAX_BOLT_SLOTS, RECEIVER_OPERATION_TIMEOUT, RECEIVER_UID_TIMEOUT,
+    UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE, UNIFYING_TRIGGER_ATTEMPT_TIMEOUT,
+    UNIFYING_TRIGGER_RETRY_DELAY,
+};
 
 /// One node probe's verdict about its own trustworthiness. Three-valued on
 /// purpose: the old `healthy`/`complete` bool pair could also express
@@ -41,9 +47,13 @@ pub(super) enum ProbeVerdict {
     /// feature walk that never finished): the ledger replays the last-good
     /// snapshot instead of presenting the failure as truth.
     Failed,
-    /// The node answered — the only verdict that counts as stability
-    /// evidence. `complete` reports whether every expected device was seen,
-    /// which is what lets the one-shot retry stop early.
+    /// The receiver answered a liveness register, but the only operation that
+    /// can produce an authoritative device list failed. The ledger may replay
+    /// its last-good snapshot briefly, but must eventually reopen the channel.
+    AliveButIncomplete,
+    /// The node produced an authoritative inventory — the only verdict that
+    /// counts as stability evidence. `complete` reports whether every expected
+    /// device was seen, which is what lets the one-shot retry stop early.
     Healthy {
         /// Every expected device is present in this probe's inventory.
         complete: bool,
@@ -61,7 +71,7 @@ impl ProbeVerdict {
         }
     }
 
-    /// The node answered this tick (the ledger's replay gate).
+    /// The node produced an authoritative inventory this tick.
     pub(super) fn is_healthy(self) -> bool {
         matches!(self, Self::Healthy { .. })
     }
@@ -88,6 +98,16 @@ impl NodeProbe {
         Self {
             inventory: None,
             verdict: ProbeVerdict::Failed,
+            outcomes: Vec::new(),
+        }
+    }
+
+    /// A Unifying receiver that answered `count_pairings` but rejected the
+    /// synthetic arrival trigger remains usable for existing control capture.
+    fn arrival_replay_failed() -> Self {
+        Self {
+            inventory: None,
+            verdict: ProbeVerdict::AliveButIncomplete,
             outcomes: Vec::new(),
         }
     }
@@ -242,15 +262,25 @@ async fn probe_unifying_receiver(
     // it first and stop immediately on failure instead of spending two more
     // request timeouts enabling notifications and triggering arrivals on a
     // channel that has already stopped delivering receiver replies.
-    let pairing_count = match unifying.count_pairings().await {
-        Ok(count) => count,
-        Err(error) => {
+    let pairing_count = match timeout(RECEIVER_OPERATION_TIMEOUT, unifying.count_pairings()).await {
+        Ok(Ok(count)) => count,
+        Ok(Err(error)) => {
             debug!(?error, "receiver pairing-count read failed");
+            return NodeProbe::failed();
+        }
+        Err(_) => {
+            debug!(
+                budget = ?RECEIVER_OPERATION_TIMEOUT,
+                "receiver pairing-count read timed out"
+            );
             return NodeProbe::failed();
         }
     };
     debug!(pairing_count, "receiver reports pairing count");
-    let unique_id = unifying.get_unique_id().await.ok();
+    let unique_id = timeout(RECEIVER_UID_TIMEOUT, unifying.get_unique_id())
+        .await
+        .ok()
+        .and_then(Result::ok);
 
     // Trigger device-arrival events and collect one event per paired slot.
     // Each event carries the slot index, kind, wpid, and a link-status bit —
@@ -261,13 +291,14 @@ async fn probe_unifying_receiver(
     // A slot whose re-broadcast goes missing this tick cannot be backfilled
     // until that register format is resolved.
     //
-    // The drain is therefore the *only* device source on this path, so a
-    // failed arrival trigger is "couldn't check", not "no devices online":
-    // settle it as a failed probe and let the ledger replay the last snapshot.
+    // The drain is therefore the only source of a fresh device list. A failed
+    // trigger leaves that list unchanged, but the successful pairing-count
+    // read above proves the receiver channel is still live; don't tear down a
+    // working capture session for this narrower transient.
     let Some(connections) =
         drain_device_arrival_unifying(&unifying, pairing_count, arrival_drain, subscriptions).await
     else {
-        return NodeProbe::failed();
+        return NodeProbe::arrival_replay_failed();
     };
     debug!(events = connections.len(), "drained device-arrival events");
 
@@ -668,10 +699,12 @@ async fn drain_device_arrival_unifying(
     // flag). Ask first: c54d has been observed to answer this trigger while
     // occasionally withholding the ACK for the notification-register setup,
     // which otherwise stalls discovery before it reaches the useful request.
-    if let Err(e) = unifying.trigger_device_arrival().await {
-        debug!(error = ?e, "trigger_device_arrival failed; receiver may report no devices");
-        return None;
-    }
+    retry_arrival_trigger(
+        || unifying.trigger_device_arrival(),
+        UNIFYING_TRIGGER_ATTEMPT_TIMEOUT,
+        UNIFYING_TRIGGER_RETRY_DELAY,
+    )
+    .await?;
     let mut out = Vec::new();
     loop {
         match timeout(arrival_drain, rx.recv()).await {
@@ -682,12 +715,18 @@ async fn drain_device_arrival_unifying(
     }
     // Keep unsolicited lifecycle notifications enabled after the triggered
     // snapshot. This is read-modify-write and a no-op when already enabled.
-    let notification_result = unifying.set_wireless_notifications(true).await;
+    let notification_result = timeout(
+        RECEIVER_OPERATION_TIMEOUT,
+        unifying.set_wireless_notifications(true),
+    )
+    .await
+    .map_err(|_| ())
+    .and_then(|result| result.map_err(|_| ()));
     // A receiver with no pairings legitimately emits nothing: don't pay a
     // second drain window for it on every reconciliation.
     if !out.is_empty() || pairing_count == 0 {
-        if let Err(error) = notification_result {
-            debug!(?error, "enable persistent wireless notifications failed");
+        if notification_result.is_err() {
+            debug!("enable persistent wireless notifications failed");
         }
         return Some(out);
     }
@@ -695,25 +734,67 @@ async fn drain_device_arrival_unifying(
     // Classic Unifying receivers only re-broadcast 0x41 arrival events while
     // wireless notifications are on. Fall back to enabling that flag when the
     // direct trigger produced no device, then retry once on the same listener.
-    if let Err(error) = notification_result {
+    if notification_result.is_err() {
         // A register write the receiver stopped ACK'ing is "couldn't check",
         // exactly like a failed trigger: settle it as a failed probe so the
         // ledger replays the last snapshot, instead of publishing an
         // authoritative empty inventory that overwrites the node's last-good
         // device list.
-        debug!(?error, "enable wireless notifications failed");
+        debug!("enable wireless notifications failed");
         return None;
     }
-    if let Err(error) = unifying.trigger_device_arrival().await {
-        debug!(?error, "arrival retry after enabling notifications failed");
-        return None;
-    }
+    retry_arrival_trigger(
+        || unifying.trigger_device_arrival(),
+        UNIFYING_TRIGGER_ATTEMPT_TIMEOUT,
+        UNIFYING_TRIGGER_RETRY_DELAY,
+    )
+    .await?;
     out.clear();
     loop {
         match timeout(arrival_drain, rx.recv()).await {
             Ok(Ok(UnifyingEvent::DeviceConnection(connection))) => out.push(connection),
             Ok(Ok(_)) => {}
             Ok(Err(_)) | Err(_) => return Some(out),
+        }
+    }
+}
+
+/// Retry one transient receiver refusal without hiding persistent failures
+/// from the inventory ledger.
+pub(super) async fn retry_arrival_trigger<F, Fut, E>(
+    mut trigger: F,
+    attempt_timeout: Duration,
+    retry_delay: Duration,
+) -> Option<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<(), E>>,
+    E: Debug,
+{
+    match timeout(attempt_timeout, trigger()).await {
+        Ok(Ok(())) => return Some(()),
+        Ok(Err(error)) => debug!(?error, "trigger_device_arrival failed; retrying once"),
+        Err(_) => debug!(
+            ?attempt_timeout,
+            "trigger_device_arrival timed out; retrying once"
+        ),
+    }
+    tokio::time::sleep(retry_delay).await;
+    match timeout(attempt_timeout, trigger()).await {
+        Ok(Ok(())) => Some(()),
+        Ok(Err(error)) => {
+            debug!(
+                ?error,
+                "trigger_device_arrival retry failed; receiver may report no devices"
+            );
+            None
+        }
+        Err(_) => {
+            debug!(
+                ?attempt_timeout,
+                "trigger_device_arrival retry timed out; receiver may report no devices"
+            );
+            None
         }
     }
 }

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -17,14 +17,15 @@ use super::events::EventFeatureIndices;
 use super::features::ProbedFeatures;
 use super::probe::{
     NodeProbe, ProbeVerdict, assemble_bolt_probe, assemble_unifying_device,
-    parse_codename_unifying, preferred_direct_codename, probe_unifying_slot, unifying_probe_budget,
+    parse_codename_unifying, preferred_direct_codename, probe_unifying_slot, retry_arrival_trigger,
+    unifying_probe_budget,
 };
 use super::{
     ChannelCache, Enumerator, ONESHOT_ATTEMPTS, OneShotScan, ScanPass, UNIFYING_CACHED_SLOT_PROBE,
     UNIFYING_SLOT_PROBE, retained_nodes, routes_for_inventories, settle_unhealthy_node,
 };
 use crate::channel::scripted::{
-    ScriptedBackend, ScriptedNode, ScriptedRawHidChannel, scripted_channel, scripted_node_info,
+    ScriptedBackend, ScriptedOpen, ScriptedRawHidChannel, scripted_channel, scripted_node_info,
 };
 use crate::{DIRECT_DEVICE_INDEX, DeviceRoute};
 
@@ -210,6 +211,66 @@ fn unifying_arrival_liveness_survives_missing_feature_data() {
     assert!(device.online);
     assert_eq!(device.wpid, Some(0x40b8));
     assert_eq!(device.kind, DeviceKind::Mouse);
+}
+
+#[tokio::test]
+async fn unifying_arrival_trigger_retries_one_transient_failure() {
+    let mut attempts = 0;
+
+    let result = retry_arrival_trigger(
+        || {
+            attempts += 1;
+            std::future::ready((attempts > 1).then_some(()).ok_or("transient"))
+        },
+        std::time::Duration::from_secs(1),
+        std::time::Duration::ZERO,
+    )
+    .await;
+
+    assert_eq!(result, Some(()));
+    assert_eq!(attempts, 2);
+}
+
+#[tokio::test]
+async fn unifying_arrival_trigger_surfaces_a_persistent_failure() {
+    let mut attempts = 0;
+
+    let result = retry_arrival_trigger(
+        || {
+            attempts += 1;
+            std::future::ready(Err::<(), _>("persistent"))
+        },
+        std::time::Duration::from_secs(1),
+        std::time::Duration::ZERO,
+    )
+    .await;
+
+    assert_eq!(result, None);
+    assert_eq!(attempts, 2);
+}
+
+#[tokio::test]
+async fn unifying_arrival_trigger_bounds_two_stalled_attempts() {
+    let attempt_timeout = std::time::Duration::from_millis(1);
+    let retry_delay = std::time::Duration::from_millis(1);
+    let mut attempts = 0;
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_millis(100),
+        retry_arrival_trigger(
+            || {
+                attempts += 1;
+                std::future::pending::<Result<(), &str>>()
+            },
+            attempt_timeout,
+            retry_delay,
+        ),
+    )
+    .await
+    .expect("the trigger retry must finish inside its caller's budget");
+
+    assert_eq!(result, None);
+    assert_eq!(attempts, 2);
 }
 
 fn inventory(slots: &[u8]) -> Vec<DeviceInventory> {
@@ -743,10 +804,8 @@ fn live_cached_channel_survives_a_transient_enumeration_gap() {
 /// ledger keeps replaying that node's last-good snapshot.
 #[tokio::test]
 async fn a_node_that_will_not_open_makes_the_tick_unhealthy() {
-    let backend = ScriptedBackend::new(vec![(
-        scripted_node_info("wont-open"),
-        ScriptedNode::OpenFails,
-    )]);
+    let backend =
+        ScriptedBackend::new(vec![(scripted_node_info("wont-open"), ScriptedOpen::Fails)]);
     let mut enumerator = Enumerator::with_backend(backend);
 
     let (inventories, complete, healthy) = enumerator
@@ -765,6 +824,32 @@ async fn a_node_that_will_not_open_makes_the_tick_unhealthy() {
     assert!(!complete, "a failed open leaves the tick incomplete");
 }
 
+#[tokio::test]
+async fn successful_channel_open_resets_eviction_but_not_inventory_grace() {
+    let info = scripted_node_info("replacement");
+    let node = info.id.clone();
+    let backend = ScriptedBackend::new(vec![(info.clone(), ScriptedOpen::UnresponsiveHidpp)]);
+    let mut enumerator = Enumerator::with_backend(backend.clone());
+    enumerator
+        .ledger
+        .settle(&node, true, Some(inventory(&[1]).remove(0)));
+    let mut expired = None;
+    for _ in 0..8 {
+        expired = enumerator.ledger.settle(&node, false, None).inventory;
+    }
+    assert!(
+        expired.is_none(),
+        "retirement ticks must eventually stop publishing stale inventory"
+    );
+
+    let prepared = enumerator.prepare_nodes(backend.as_ref(), vec![info]).await;
+    assert_eq!(prepared.active.len(), 1, "the replacement must open");
+    let first_incomplete_probe = enumerator.ledger.settle_arrival_replay_failure(&node);
+
+    assert!(!first_incomplete_probe.evict_channel);
+    assert!(first_incomplete_probe.inventory.is_none());
+}
+
 /// A node that opens but does not speak HID++ is simply not ours. It must not
 /// be confused with a failed open: dragging the tick unhealthy for it would
 /// make every host with an unrelated HID device retry forever.
@@ -772,7 +857,7 @@ async fn a_node_that_will_not_open_makes_the_tick_unhealthy() {
 async fn a_non_hidpp_node_leaves_the_tick_healthy() {
     let backend = ScriptedBackend::new(vec![(
         scripted_node_info("not-hidpp"),
-        ScriptedNode::NotHidpp,
+        ScriptedOpen::NotHidpp,
     )]);
     let mut enumerator = Enumerator::with_backend(backend);
 


### PR DESCRIPTION
## Summary

Keep Linux gesture capture active when a responsive Unifying receiver transiently fails to replay device-arrival events during inventory probing.

## Changes

- `openlogi-device`: retry the initial and notification-fallback Unifying arrival triggers within bounded per-attempt deadlines.
- `openlogi-device`: bound receiver liveness, UID, and notification-register operations so stalled requests cannot consume the whole receiver probe budget.
- `openlogi-device`: distinguish responsive-but-incomplete arrival replay from ordinary probe failure.
- `openlogi-device`: track probe and arrival-replay failures independently while retaining the last complete inventory through bounded recovery.
- `openlogi-device`: retain the last complete inventory through retirement and reset failure accounting only after a replacement channel opens.
- Add regression tests for transient failures, stalled triggers, mixed failure sequences, channel replacement, and bounded retirement.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `RUSTFLAGS="-D warnings" cargo xtask ci wasm`
- `RUSTFLAGS="-D warnings" cargo xtask ci clippy-windows`
- `RUSTFLAGS="-D warnings" cargo clippy --target aarch64-unknown-linux-musl -p openlogi-hook -p openlogi-inject -p openlogi-hid -p openlogi-hidpp -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-ipc -p openlogi-permissions --all-targets -- -D warnings`
- `cargo deny --config .cargo/deny.toml --all-features --manifest-path crates/openlogi/Cargo.toml check`
- Hardware verified on Debian 13 GNOME Wayland with an MX Master 2S through a Unifying receiver. Capture remained active without channel retirement or re-arm.

Fixes #1041