### PR TITLE
fix(linux): dispatch window actions on GNOME

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5667,9 +5667,11 @@ dependencies = [
 name = "openlogi-inject"
 version = "0.8.3"
 dependencies = [
+ "async-io",
  "core-foundation 0.10.0",
  "core-graphics 0.25.0",
  "evdev",
+ "futures-lite",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-graphics",

--- a/crates/openlogi-inject/Cargo.toml
+++ b/crates/openlogi-inject/Cargo.toml
@@ -24,7 +24,9 @@ tracing-subscriber = { workspace = true }
 workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+async-io = "2"
 evdev = { workspace = true }
+futures-lite.workspace = true
 zbus = "5"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -185,11 +185,11 @@ fn held_keys(combo: &KeyCombo) -> Vec<HeldKey> {
 /// handled at the hook/HID layer, logging a trace here.
 ///
 /// On Linux, key and scroll events are injected via a lazily-created `uinput`
-/// virtual device. Mouse clicks inject `BTN_*` events. macOS-only window
-/// manager actions (`MissionControl`, `AppExpose`, `ShowDesktop`,
-/// `LaunchpadShow`) have no universal Linux equivalent and are silently
-/// skipped (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes to
-/// Linux key codes; macOS Cmd maps to Ctrl.
+/// virtual device. Mouse clicks inject `BTN_*` events. GNOME window-manager
+/// actions use a bounded Shell D-Bus operation, with standard shortcuts as
+/// fallbacks; desktops without a stable equivalent skip those actions
+/// (debug-logged). `CustomShortcut` maps macOS `kVK_*` codes to Linux key codes;
+/// macOS Cmd maps to Ctrl.
 ///
 /// On Windows, key and mouse events are synthesised via `SendInput`. The
 /// macOS window-manager actions map to their Windows equivalents (e.g.

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -19,6 +19,8 @@ use openlogi_core::scroll::ScrollDelta;
 
 use super::{HeldKey, KeyPhase, QuantizedScroll, ScrollQuantizer};
 
+mod gnome_shell;
+
 const HIGH_RES_UNITS_PER_TICK: f64 = 120.0;
 
 #[derive(Default)]
@@ -138,13 +140,48 @@ fn dispatch_media(key: MediaKey) {
     }
 }
 
-/// Dispatch a window-manager or power [`NativeAction`]. `action` is only
-/// used for its label in the "no Linux equivalent" debug log.
+/// Dispatch a window-manager or power [`NativeAction`].
 fn dispatch_native(action: &Action, native: NativeAction) {
     let ctrl = KeyCode::KEY_LEFTCTRL;
     let alt = KeyCode::KEY_LEFTALT;
+    let meta = KeyCode::KEY_LEFTMETA;
     match native {
-        // No universal Linux equivalent; the compositor shortcut varies.
+        NativeAction::MissionControl | NativeAction::AppExpose if current_desktop_is("gnome") => {
+            match gnome_shell::toggle_overview() {
+                Ok(()) => tracing::debug!("GNOME overview toggled via D-Bus"),
+                Err(error) if error.fallback_is_safe() => {
+                    tracing::warn!(
+                        %error,
+                        "GNOME overview D-Bus operation failed before delivery; falling back to Super"
+                    );
+                    press_key(&[], meta);
+                }
+                Err(error) => tracing::warn!(
+                    %error,
+                    "GNOME overview D-Bus outcome is uncertain; suppressing Super fallback"
+                ),
+            }
+        }
+        NativeAction::ShowDesktop if current_desktop_is("gnome") => {
+            press_key(&[meta], KeyCode::KEY_D);
+        }
+        NativeAction::LaunchpadShow if current_desktop_is("gnome") => {
+            match gnome_shell::show_applications() {
+                Ok(()) => tracing::debug!("GNOME applications shown via D-Bus"),
+                Err(error) if error.fallback_is_safe() => {
+                    tracing::warn!(
+                        %error,
+                        "GNOME applications D-Bus operation failed before delivery; falling back to Super+A"
+                    );
+                    press_key(&[meta], KeyCode::KEY_A);
+                }
+                Err(error) => tracing::warn!(
+                    %error,
+                    "GNOME applications D-Bus outcome is uncertain; suppressing Super+A fallback"
+                ),
+            }
+        }
+        // Other compositors do not share a stable shortcut or D-Bus API.
         NativeAction::MissionControl
         | NativeAction::AppExpose
         | NativeAction::ShowDesktop
@@ -167,6 +204,23 @@ fn dispatch_native(action: &Action, native: NativeAction) {
         // logind Suspend() via the system bus.
         NativeAction::Sleep => sleep_system(),
     }
+}
+
+fn current_desktop_is(expected: &str) -> bool {
+    [
+        "XDG_CURRENT_DESKTOP",
+        "XDG_SESSION_DESKTOP",
+        "DESKTOP_SESSION",
+    ]
+    .into_iter()
+    .filter_map(|name| std::env::var(name).ok())
+    .flat_map(|value| {
+        value
+            .split([':', ';'])
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    })
+    .any(|name| name.eq_ignore_ascii_case(expected))
 }
 
 fn dispatch_script(script: Script<'_>) {

--- a/crates/openlogi-inject/src/inject/linux/gnome_shell.rs
+++ b/crates/openlogi-inject/src/inject/linux/gnome_shell.rs
@@ -1,0 +1,172 @@
+//! GNOME Shell actions with one deadline covering connection setup and calls.
+
+use std::cell::Cell;
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+
+use async_io::Timer;
+use futures_lite::future;
+use zbus::connection::Builder;
+use zbus::{Connection, Proxy};
+
+const OPERATION_TIMEOUT: Duration = Duration::from_millis(250);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeliveryState {
+    NotSent,
+    MayHaveExecuted,
+}
+
+#[derive(Debug)]
+pub(super) struct ActionError {
+    delivery: DeliveryState,
+    detail: String,
+}
+
+impl ActionError {
+    fn new(detail: String, delivery: DeliveryState) -> Self {
+        Self { delivery, detail }
+    }
+
+    pub(super) fn fallback_is_safe(&self) -> bool {
+        self.delivery == DeliveryState::NotSent
+    }
+}
+
+impl fmt::Display for ActionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+pub(super) fn toggle_overview() -> Result<(), ActionError> {
+    let delivery = Cell::new(DeliveryState::NotSent);
+    run_bounded(toggle_overview_inner(&delivery), &delivery)
+}
+
+pub(super) fn show_applications() -> Result<(), ActionError> {
+    let delivery = Cell::new(DeliveryState::NotSent);
+    run_bounded(show_applications_inner(&delivery), &delivery)
+}
+
+fn run_bounded<F>(operation: F, delivery: &Cell<DeliveryState>) -> Result<(), ActionError>
+where
+    F: Future<Output = zbus::Result<()>>,
+{
+    run_before(operation, delivery, OPERATION_TIMEOUT)
+}
+
+fn run_before<F>(
+    operation: F,
+    delivery: &Cell<DeliveryState>,
+    timeout: Duration,
+) -> Result<(), ActionError>
+where
+    F: Future<Output = zbus::Result<()>>,
+{
+    match zbus::block_on(complete_before(operation, timeout)) {
+        Some(result) => result.map_err(|error| ActionError::new(error.to_string(), delivery.get())),
+        None => Err(ActionError::new(
+            format!("operation timed out after {timeout:?}"),
+            delivery.get(),
+        )),
+    }
+}
+
+async fn complete_before<F>(operation: F, timeout: Duration) -> Option<F::Output>
+where
+    F: Future,
+{
+    future::race(async move { Some(operation.await) }, async move {
+        Timer::after(timeout).await;
+        None
+    })
+    .await
+}
+
+async fn connect() -> zbus::Result<Connection> {
+    Builder::session()?.build().await
+}
+
+async fn shell_proxy(connection: &Connection) -> zbus::Result<Proxy<'_>> {
+    Proxy::new(
+        connection,
+        "org.gnome.Shell",
+        "/org/gnome/Shell",
+        "org.gnome.Shell",
+    )
+    .await
+}
+
+async fn properties_proxy(connection: &Connection) -> zbus::Result<Proxy<'_>> {
+    Proxy::new(
+        connection,
+        "org.gnome.Shell",
+        "/org/gnome/Shell",
+        "org.freedesktop.DBus.Properties",
+    )
+    .await
+}
+
+async fn toggle_overview_inner(delivery: &Cell<DeliveryState>) -> zbus::Result<()> {
+    let connection = connect().await?;
+    let active = shell_proxy(&connection)
+        .await?
+        .get_property::<bool>("OverviewActive")
+        .await?;
+    let proxy = properties_proxy(&connection).await?;
+    delivery.set(DeliveryState::MayHaveExecuted);
+    proxy
+        .call::<_, _, ()>(
+            "Set",
+            &(
+                "org.gnome.Shell",
+                "OverviewActive",
+                zbus::zvariant::Value::new(!active),
+            ),
+        )
+        .await
+}
+
+async fn show_applications_inner(delivery: &Cell<DeliveryState>) -> zbus::Result<()> {
+    let connection = connect().await?;
+    let proxy = shell_proxy(&connection).await?;
+    delivery.set(DeliveryState::MayHaveExecuted);
+    proxy.call::<_, _, ()>("ShowApplications", &()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::future;
+    use std::time::Duration;
+
+    use super::{DeliveryState, run_before};
+
+    #[test]
+    fn connection_timeout_allows_keyboard_fallback() {
+        let delivery = Cell::new(DeliveryState::NotSent);
+        let error = run_before(
+            future::pending::<zbus::Result<()>>(),
+            &delivery,
+            Duration::from_millis(1),
+        )
+        .expect_err("the pending operation should time out");
+
+        assert!(error.fallback_is_safe());
+    }
+
+    #[test]
+    fn timeout_after_side_effect_suppresses_keyboard_fallback() {
+        let delivery = Cell::new(DeliveryState::NotSent);
+        let operation = async {
+            delivery.set(DeliveryState::MayHaveExecuted);
+            future::pending::<zbus::Result<()>>().await
+        };
+        let error = run_before(operation, &delivery, Duration::from_millis(1))
+            .expect_err("the pending operation should time out");
+
+        assert!(!error.fallback_is_safe());
+    }
+}


### PR DESCRIPTION
## Summary

Make the existing App Expose, Mission Control, Launchpad, and Show Desktop actions functional on GNOME instead of silently skipping them.

This complements #648: that PR adds a separate GNOME-only Overview action, while this change gives the existing cross-platform window actions GNOME behavior and also covers Show Desktop and the application grid.

## Changes

- `openlogi-inject`: detect GNOME using the standard XDG desktop variables.
- Toggle GNOME Shell Overview and Show Applications through the Shell D-Bus API.
- Bound each GNOME Shell operation, including session-bus connection setup and all method calls, to one 250 ms deadline while leaving the shared MPRIS connection unchanged.
- Fall back to Super and Super+A only when an operation fails before the side-effecting D-Bus call begins; suppress the fallback when an in-flight request may already have executed.
- Map Show Desktop to Super+D while preserving the existing no-op behavior on other Linux desktops.
- Add regression coverage for both connection setup timeouts and ambiguous timeouts after delivery begins.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --workspace`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `RUSTFLAGS="-D warnings" cargo xtask ci clippy-windows`
- `RUSTFLAGS="-D warnings" cargo clippy --target aarch64-unknown-linux-musl -p openlogi-hook -p openlogi-inject -p openlogi-hid -p openlogi-hidpp -p openlogi-core -p openlogi-agent -p openlogi-agent-core -p openlogi-ipc -p openlogi-permissions --all-targets -- -D warnings`
- `cargo deny --config .cargo/deny.toml --all-features --manifest-path crates/openlogi/Cargo.toml check`
- Runtime verified on Debian 13 GNOME Wayland by running the built `inject_action` example directly: invoking App Expose changed GNOME Shell `OverviewActive` from `false` to `true`, and a second invocation restored it to `false`.
- Hardware verified with an MX Master 2S: a gesture-button click bound to App Expose toggles Overview, and directional workspace gestures continue to work.

Fixes #1042