### PR TITLE
feat(hid): support the Alto Keys K98M's three shape-labeled action keys

### DIFF
--- a/crates/openlogi-core/src/binding/button.rs
+++ b/crates/openlogi-core/src/binding/button.rs
@@ -64,9 +64,29 @@ pub enum ButtonId {
     /// (Logi metadata slot `ASSIGNMENT_NAME_SHOW_RADIAL_MENU`, HID++ CID
     /// `0x01a0`). A separate physical control from [`ButtonId::GestureButton`];
     /// captured over HID++ like it, and eligible as the gesture owner.
+    HapticPanel,
+    /// Keyboard "Circle" control (CID `0x01a3`) — one of three generic,
+    /// shape-labeled programmable keys above the numpad on the Alto Keys
+    /// K98M, with no counterpart on the Signature series. Unlike the F-row
+    /// icon keys, these have no fixed function of their own: Logitech's
+    /// control catalog names them after the shape printed on the keycap, not
+    /// a task, and Options+ (like this binding) assigns their meaning in
+    /// software. Name cross-checked against Solaar's `special_keys.py`; the
+    /// CID-to-physical-key correspondence has not been verified against
+    /// hardware — see the PR description before trusting which physical key
+    /// this fires for.
+    KeyCircle,
+    /// Keyboard "Triangle" control (CID `0x01a4`) — see
+    /// [`ButtonId::KeyCircle`] for the shape-labeled-key family and its
+    /// unverified CID-to-physical-key mapping.
+    KeyTriangle,
+    /// Keyboard "Diamond" control (CID `0x01a5`) — see
+    /// [`ButtonId::KeyCircle`] for the shape-labeled-key family and its
+    /// unverified CID-to-physical-key mapping.
+    ///
     /// Declared last: the TOML config and any serialized form encode the
     /// variant identifier / index, so new buttons are append-only.
-    HapticPanel,
+    KeyDiamond,
 }
 
 impl ButtonId {
@@ -87,11 +107,12 @@ impl ButtonId {
         ButtonId::HapticPanel,
     ];
 
-    /// The divertable keyboard F-row controls, in F-row order. Kept out of
-    /// [`ButtonId::ALL`]: that array seeds mouse defaults and the mouse
-    /// popover trigger list, while keyboard keys stay native unless the user
-    /// binds them (an unbound key is never diverted).
-    pub const KEYBOARD_KEYS: [ButtonId; 9] = [
+    /// The divertable keyboard controls OpenLogi models: the F-row icon keys
+    /// (F-row order) plus the K98M-only action keys above the numpad. Kept
+    /// out of [`ButtonId::ALL`]: that array seeds mouse defaults and the
+    /// mouse popover trigger list, while keyboard keys stay native unless the
+    /// user binds them (an unbound key is never diverted).
+    pub const KEYBOARD_KEYS: [ButtonId; 12] = [
         ButtonId::KeySearch,
         ButtonId::KeyDictation,
         ButtonId::KeyEmoji,
@@ -101,6 +122,9 @@ impl ButtonId {
         ButtonId::KeyMute,
         ButtonId::KeyVolumeDown,
         ButtonId::KeyVolumeUp,
+        ButtonId::KeyCircle,
+        ButtonId::KeyTriangle,
+        ButtonId::KeyDiamond,
     ];
 
     /// Whether this button is one the OS hook (macOS `CGEventTap` / Linux evdev)
@@ -152,6 +176,9 @@ impl ButtonId {
             ButtonId::KeyVolumeDown => "Volume Down Key",
             ButtonId::KeyVolumeUp => "Volume Up Key",
             ButtonId::HapticPanel => "Haptic Panel",
+            ButtonId::KeyCircle => "Circle Key",
+            ButtonId::KeyTriangle => "Triangle Key",
+            ButtonId::KeyDiamond => "Diamond Key",
         }
     }
 }

--- a/crates/openlogi-core/src/binding/defaults.rs
+++ b/crates/openlogi-core/src/binding/defaults.rs
@@ -48,7 +48,10 @@ pub fn default_binding(button: ButtonId) -> Action {
         | ButtonId::KeyPlayPause
         | ButtonId::KeyMute
         | ButtonId::KeyVolumeDown
-        | ButtonId::KeyVolumeUp => Action::None,
+        | ButtonId::KeyVolumeUp
+        | ButtonId::KeyCircle
+        | ButtonId::KeyTriangle
+        | ButtonId::KeyDiamond => Action::None,
     }
 }
 

--- a/crates/openlogi-hid/src/keyboard.rs
+++ b/crates/openlogi-hid/src/keyboard.rs
@@ -34,11 +34,14 @@ use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
 use crate::route::{DeviceRoute, open_route_channel};
 use crate::write::SharedChannel;
 
-/// The divertable keyboard F-row controls OpenLogi models, as
-/// `(0x1b04 control ID, ButtonId)` pairs. CID values match Logitech's control
-/// catalog (cross-checked against Solaar's `special_keys.py`); the F-row
-/// positions are the Signature-series layout.
-pub const KEYBOARD_KEY_CIDS: [(u16, ButtonId); 9] = [
+/// The divertable keyboard controls OpenLogi models, as `(0x1b04 control ID,
+/// ButtonId)` pairs. CID values match Logitech's control catalog
+/// (cross-checked against Solaar's `special_keys.py`); the first nine are the
+/// Signature-series F-row layout. The last three (`Circle`/`Triangle`/
+/// `Diamond`) are the Alto Keys K98M's generic, shape-labeled action keys
+/// above the numpad — see [`ButtonId::KeyCircle`] for what "generic" means
+/// here and the caveat on their CID-to-physical-key mapping.
+pub const KEYBOARD_KEY_CIDS: [(u16, ButtonId); 12] = [
     (0x00d4, ButtonId::KeySearch),
     (0x0103, ButtonId::KeyDictation),
     (0x0108, ButtonId::KeyEmoji),
@@ -48,6 +51,9 @@ pub const KEYBOARD_KEY_CIDS: [(u16, ButtonId); 9] = [
     (0x00e7, ButtonId::KeyMute),
     (0x00e8, ButtonId::KeyVolumeDown),
     (0x00e9, ButtonId::KeyVolumeUp),
+    (0x01a3, ButtonId::KeyCircle),
+    (0x01a4, ButtonId::KeyTriangle),
+    (0x01a5, ButtonId::KeyDiamond),
 ];
 
 /// Capture the requested keyboard controls on `route` until `shutdown`


### PR DESCRIPTION
Adds support for the Alto Keys K98M's three programmable action keys above the numpad — currently OpenLogi keeps them entirely undivertable, so they're stuck on whatever native firmware/Options+ function they last had, with no `config.toml` binding available.

## What's there

These keys have no counterpart on the Signature series (which `KEYBOARD_KEY_CIDS` was originally built for). Unlike the F-row icon keys — Search, Dictation, Emoji, Screen Capture, etc., which each have one fixed, named function — Logitech's HID++ `0x1b04` control catalog names these three after the shape printed on the keycap rather than a task:

- `Circle` — CID `0x01a3`
- `Triangle` — CID `0x01a4`
- `Diamond` — CID `0x01a5`

Names cross-checked against Solaar's `special_keys.py`, the same source the existing nine `KEYBOARD_KEY_CIDS` entries cite. Their actual meaning is entirely software-assigned — Options+ does the same thing, letting you point each one at an app, a shortcut, whatever.

## Implementation

- `ButtonId::KeyCircle` / `KeyTriangle` / `KeyDiamond`, appended per the enum's append-only stability contract (existing variant order is the wire format).
- Three new `(cid, ButtonId)` rows in `KEYBOARD_KEY_CIDS`.

That's the entire diff. No new capture or dispatch logic — the existing generic keyboard-diversion path (`orchestrator::keyboard_spec_for` → `run_keyboard_capture_session`) already treats every `KEYBOARD_KEY_CIDS` entry uniformly: unbound stays native, bound gets diverted and dispatched like any other keyboard control.

## An honest gap

I could not find any documentation anywhere — including Solaar — mapping these three CIDs to which physical key position they sit at (Solaar names them by shape, not position, and the K98M's printed keycap icons don't obviously match "Circle/Triangle/Diamond" at a glance). I resolved this empirically: bound all three to distinct, easily distinguishable actions and pressed each physical key once, watching the agent's own dispatch logs. If a future 12-key or other Alto-family variant ships a different physical arrangement, this CID set should still be correct — it's a property of the control catalog, not the printed legend — but I want to flag that the physical mapping was hardware-verified on one unit, not sourced from a spec.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — all green
- `RUSTDOCFLAGS="-D warnings" cargo doc -p openlogi-hid -p openlogi-hidpp -p openlogi-hidpp-derive --no-deps --document-private-items`
- Hardware-verified against a physical Alto Keys K98M over a Logi Bolt receiver: bound `KeyCircle` to Cmd+Q, `KeyTriangle` to open Calculator, `KeyDiamond` to Cmd+Option+Space, then pressed all three physical keys — each fired correctly. Confirmed via the agent's own debug logs (`keyboard key capture active ... keys=4`, and a per-press `keyboard key → executing bound action` line for each).

Fixes nothing tracked (found while adding K98M support generally) — happy to open a tracking issue too if that's preferred for a hardware-specific addition like this.
