### PR TITLE
feat(cli): add openlogi unpair to remove a stale receiver pairing slot

### DIFF
--- a/crates/openlogi-cli/src/cmd/mod.rs
+++ b/crates/openlogi-cli/src/cmd/mod.rs
@@ -10,6 +10,7 @@ pub mod diag;
 pub mod light;
 pub mod list;
 pub mod snapshot;
+pub mod unpair;
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
@@ -30,6 +31,8 @@ pub enum Command {
     /// Inspect and control standalone Logitech lights.
     #[command(subcommand)]
     Light(light::LightCmd),
+    /// Remove a device from a receiver's pairing table.
+    Unpair(unpair::UnpairArgs),
 }
 
 impl Command {
@@ -49,6 +52,7 @@ impl Command {
             Self::Assets(cmd) => cmd.run()?,
             Self::Diag(cmd) => cmd.run().await?,
             Self::Light(cmd) => cmd.run().await?,
+            Self::Unpair(args) => unpair::run(args).await?,
         }
         Ok(ExitCode::SUCCESS)
     }

--- a/crates/openlogi-cli/src/cmd/unpair.rs
+++ b/crates/openlogi-cli/src/cmd/unpair.rs
@@ -1,0 +1,62 @@
+//! `openlogi unpair` — remove a device from a receiver's pairing table.
+//!
+//! Standard Logi Bolt / Unifying receiver operation: it only forgets the
+//! slot, it never touches the physical device. A device removed this way
+//! re-pairs normally afterwards.
+
+use anyhow::{Context, Result};
+use clap::Args;
+use openlogi_hid::ReceiverSelector;
+
+#[derive(Debug, Args)]
+pub struct UnpairArgs {
+    /// Bolt receiver unique ID to target, when more than one receiver is
+    /// connected. Defaults to the first supported receiver found.
+    #[arg(long, value_name = "UID")]
+    pub receiver: Option<String>,
+
+    /// Pairing slot to remove, as shown by `openlogi list`.
+    #[arg(long)]
+    pub slot: u8,
+}
+
+pub async fn run(args: UnpairArgs) -> Result<()> {
+    let inventories = openlogi_hid::enumerate()
+        .await
+        .context("failed to enumerate HID++ devices")?;
+
+    let inv = match &args.receiver {
+        Some(uid) => inventories
+            .iter()
+            .find(|inv| inv.receiver.unique_id.as_deref() == Some(uid.as_str()))
+            .with_context(|| format!("no connected receiver with UID {uid}"))?,
+        None => inventories
+            .first()
+            .context("no connected Logitech HID++ receiver found")?,
+    };
+
+    let label = inv.paired.iter().find(|d| d.slot == args.slot).map_or_else(
+        || format!("slot {}", args.slot),
+        |d| {
+            format!(
+                "slot {} — {}",
+                d.slot,
+                d.codename.as_deref().unwrap_or("Unknown device")
+            )
+        },
+    );
+    println!("unpairing {label} from {} ...", inv.receiver.name);
+
+    let selector = match &args.receiver {
+        Some(uid) => ReceiverSelector::BoltUid(uid.clone()),
+        None => ReceiverSelector::First,
+    };
+    openlogi_hid::unpair(selector, args.slot)
+        .await
+        .context("unpair failed")?;
+
+    println!(
+        "✓ unpaired — the receiver has forgotten this slot; re-pair the device normally to bring it back"
+    );
+    Ok(())
+}


### PR DESCRIPTION
`openlogi_hid::pairing::unpair()` has existed since the pairing module was written, but nothing in the codebase calls it — no CLI subcommand, no GUI control. A device that gets replaced, re-paired under a different name, or otherwise goes stale has no supported way to free its slot short of reinstalling Logi Options+ to do it.

## What's added

```
openlogi unpair --slot <n> [--receiver <uid>]
```

Follows the existing `backlight`/`diag` command style: resolve the target device via `enumerate()` first so the confirmation line names what's actually being removed (codename + kind, not just a bare slot number), then call the existing `unpair()`. `--receiver` is optional and defaults to the first supported receiver found, matching `ReceiverSelector`'s own documented common-case default — same pattern `backlight --device` and `diag`'s device selection already use for their equivalent options.

This only removes the pairing record from the receiver's table. It never touches the physical device — the device re-pairs normally afterward, same as if you'd removed it from Options+.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — all green
- Hardware-verified against a physical Logi Bolt receiver: ran `openlogi unpair --slot 2` and `--slot 3` against two stale pairings (an old MX Master 3S and an MX Mechanical Mini that had drifted out of use), confirmed both disappeared from `openlogi list` afterward, and confirmed the two still-paired devices (slots 1 and 4) were unaffected and stayed online throughout.

```
$ openlogi unpair --slot 2
unpairing slot 2 — MX Master 3S from Logi Bolt Receiver ...
✓ unpaired — the receiver has forgotten this slot; re-pair the device normally to bring it back
```
