### PR TITLE
fix(gui): stop the Function Row picker from inventing phantom F13-F19 keys

### DIFF
--- a/crates/openlogi-desktop/src/features/keyboard/function_row.rs
+++ b/crates/openlogi-desktop/src/features/keyboard/function_row.rs
@@ -960,6 +960,23 @@ fn key_points(asset: Option<&ResolvedAsset>) -> Vec<KeyPoint> {
             out.extend(f1_to_f19.iter().copied().map(calibrated_marker_point));
             return out;
         }
+
+        // Neither specialized layout fit, but the depot still has real markers
+        // for a shorter row (e.g. the Alto Keys K98M's 12: nine F-row icon
+        // keys plus End/Page Up/Page Down, with no Easy-Switch row at all —
+        // its `device_easyswitch_image` markers are on-photo host-indicator
+        // dots over the number row, not a physical button). Surface exactly
+        // that many real, marker-positioned keys instead of falling through
+        // to 20 evenly-spaced slots: the caller already tolerates a short
+        // `Vec` (`FUNCTION_KEYS.iter().zip(points.iter())` truncates to the
+        // shorter side), so a real 12-key row must not get padded out to
+        // phantom F13–F19 slots that don't exist on the physical keyboard.
+        if !key_markers.is_empty() {
+            let mut out = Vec::with_capacity(key_markers.len() + 1);
+            out.push(synthesized_esc_point(key_markers[0]));
+            out.extend(key_markers.iter().copied().map(calibrated_marker_point));
+            return out;
+        }
     }
     fallback_key_points()
 }
@@ -1209,6 +1226,36 @@ mod tests {
         assert_approx_eq(points[19].x_frac, 0.967);
         assert_approx_eq(points[19].y_frac, 0.153);
         assert_approx_eq(key_target_top_px(points[19].y_frac, 220.0, 30.0), 18.66);
+    }
+
+    /// The Alto Keys K98M's real depot data: 12 `device_keys_image` markers
+    /// (nine F-row icon keys plus End/Page Up/Page Down — see
+    /// `crates/openlogi-hid/src/keyboard.rs`'s `KeyCircle`/`KeyTriangle`/
+    /// `KeyDiamond` for those three) and 3 `device_easyswitch_image` markers
+    /// that are on-photo host-indicator dots over the number row, not a
+    /// physical Easy-Switch button row. 12 is below both the MX-Keys (≥16)
+    /// and full-row (≥19) thresholds, so this must resolve to exactly 12 real
+    /// keys rather than either misfiring the MX-Keys branch or padding out to
+    /// 20 phantom F-keys via the even-spacing fallback.
+    #[test]
+    fn k98m_style_short_row_resolves_to_its_real_key_count() {
+        let key_markers = vec![
+            26.45, 34.4, 39.2, 43.95, 48.74, 56.75, 61.55, 66.4, 71.1, 83.1, 87.9, 92.7,
+        ];
+        let easy_switch_markers = vec![12.0, 16.7, 21.5];
+        let asset = asset_with_markers(&key_markers, &easy_switch_markers);
+
+        let points = key_points(Some(&asset));
+
+        assert_eq!(points.len(), 13, "Esc + 12 real keys, no phantom F13-F19");
+        assert_approx_eq(points[1].x_frac, 0.2645 + FRONT_MARKER_X_OFFSET_FRAC);
+        assert_approx_eq(points[12].x_frac, 0.927 + FRONT_MARKER_X_OFFSET_FRAC);
+        assert!(
+            points
+                .windows(2)
+                .all(|pair| pair[0].x_frac < pair[1].x_frac),
+            "points stay in physical left-to-right order"
+        );
     }
 
     /// The G513 family's `metadata_full.json`: `device_image` markers in


### PR DESCRIPTION
`key_points()` — the function that decides which physical keys the "Function Row" picker (Settings → device → Keys) points its callouts at — has exactly two marker-based layouts: an MX-Keys-style board (≥16 `device_keys_image` markers plus a real 3-button Easy-Switch row) and a full 20-key row (≥19 markers). Anything in between falls straight through to `fallback_key_points()`, which unconditionally pads out to all 20 Esc+F1-F19 slots with even spacing — regardless of how many keys the board actually has.

## The bug

The Alto Keys K98M has 12 real `device_keys_image` markers (nine F-row icon keys plus End/Page Up/Page Down) and 3 `device_easyswitch_image` markers — but those three are on-photo host-indicator dots positioned over the number row, not a physical Easy-Switch button row. That satisfies neither threshold, so it falls to the fallback. The GUI then shows F13 through F19 as if they existed, mapped onto physical keys (End, Page Up, Page Down, and a phantom fourth slot) that don't send those keycodes at all — binding an action to "F19" there does nothing on real hardware, since no physical key on this board produces it.

Confirmed against the K98M's actual cached asset metadata: exactly 12 `device_keys_image` entries, 3 `device_easyswitch_image` entries positioned at the low end of the row (over the number keys), and no dedicated Easy-Switch geometry at all.

## The fix

A middle branch: when there are real markers but not enough for either specialized layout, return exactly that many real, marker-positioned keys instead of padding out to 20. This mirrors a principle the legacy pixel-marker path already follows (see the existing G513 test, literally titled "Esc + F1-F12, no phantom F13-F19") and the project's own mouse-hotspot rule — if the metadata doesn't have a marker for something, don't synthesize one. The caller already tolerates a short `Vec` (`FUNCTION_KEYS.iter().zip(points.iter())` truncates to the shorter side, and there's an existing comment anticipating "a device switch to a shorter F-row"), so this isn't a workaround — it's using a case the design already accounted for but a code path that had no route to it.

**What this doesn't solve:** the K98M's real End/Page Up/Page Down keys still get positionally labeled "F10"/"F11"/"F12" here, since `key_points()` has no notion of the metadata's actual `slotName` field (the same metadata file has `SLOT_NAME_END`, `SLOT_NAME_PAGE_UP`, `SLOT_NAME_PAGE_DOWN` sitting right there, unused by this picker). Teaching this picker to source real semantic labels is a bigger change than fixing the phantom-key bug; this PR only removes the nonexistent slots.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — all green
- Added `k98m_style_short_row_resolves_to_its_real_key_count`, built from the K98M's real cached marker coordinates, asserting exactly 13 points (Esc + 12 real keys) instead of 20
- Hardware-verified in the running app against a physical Alto Keys K98M: before this fix, the Keys tab showed Esc through F19 (20 slots), the last four mapped onto the physical End/Page Up/Page Down/del-home keys; after, it shows exactly Esc through F12 (13 slots), each correctly positioned over its real icon key in the keyboard photo.
