### PR TITLE
feat(macos): add held mouse button 6 action

### DIFF
--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, Binding, ButtonId, KeyCombo};
+use openlogi_core::binding::{Action, Binding, ButtonId, HeldAction, KeyCombo};
 use openlogi_hid::{CaptureChannel, ChannelRegistry};
 use tracing::{info, warn};
 
@@ -31,36 +31,71 @@ use crate::{DpiCycleState, DpiCycles};
 enum HoldStart {
     /// The action is instantaneous and belongs to ordinary dispatch.
     NotHeld,
-    /// This press newly owns one held chord.
-    Started(KeyCombo),
+    /// This press newly owns one held output.
+    Started(HeldOutput),
     /// The same press changed its held action.
-    Replaced { old: KeyCombo, new: KeyCombo },
+    Replaced { old: HeldOutput, new: HeldOutput },
 }
 
 /// Held output owned by accepted press capabilities rather than by a capture
 /// backend. Because every [`PressToken`] has exactly one terminal event, this
 /// map gives release, cancellation, invalidation, and shutdown one path.
-#[derive(Default)]
-struct HeldShortcuts {
-    by_press: HashMap<PressToken, KeyCombo>,
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum HeldOutput {
+    /// A keyboard chord held through the injector's shared-key ownership.
+    Shortcut(KeyCombo),
+    /// Standard macOS Mouse Button 6.
+    MouseButton6,
 }
 
-impl HeldShortcuts {
+#[derive(Default)]
+struct HeldOutputs {
+    by_press: HashMap<PressToken, HeldOutput>,
+}
+
+impl HeldOutputs {
     fn start(&mut self, press: &PressToken, action: &Action) -> HoldStart {
-        let Some(combo) = action.held_combo() else {
+        let Some(output) = action.held_action().map(|action| match action {
+            HeldAction::Shortcut(combo) => HeldOutput::Shortcut(combo.clone()),
+            HeldAction::MouseButton6 => HeldOutput::MouseButton6,
+        }) else {
             return HoldStart::NotHeld;
         };
-        match self.by_press.insert(press.clone(), combo.clone()) {
-            Some(old) => HoldStart::Replaced {
-                old,
-                new: combo.clone(),
-            },
-            None => HoldStart::Started(combo.clone()),
+        match self.by_press.insert(press.clone(), output.clone()) {
+            Some(old) => HoldStart::Replaced { old, new: output },
+            None => HoldStart::Started(output),
         }
     }
 
-    fn end(&mut self, press: &PressToken) -> Option<KeyCombo> {
+    fn end(&mut self, press: &PressToken) -> Option<HeldOutput> {
         self.by_press.remove(press)
+    }
+}
+
+fn press_held_output(output: &HeldOutput) {
+    match output {
+        HeldOutput::Shortcut(combo) => openlogi_inject::press_hold(combo),
+        HeldOutput::MouseButton6 => openlogi_inject::press_hold_mouse_button6(),
+    }
+}
+
+fn release_held_output(output: &HeldOutput) {
+    match output {
+        HeldOutput::Shortcut(combo) => openlogi_inject::release_hold(combo),
+        HeldOutput::MouseButton6 => openlogi_inject::release_hold_mouse_button6(),
+    }
+}
+
+fn replace_held_output(old: &HeldOutput, new: &HeldOutput) {
+    match (old, new) {
+        (HeldOutput::Shortcut(old), HeldOutput::Shortcut(new)) => {
+            openlogi_inject::replace_hold(old, new);
+        }
+        (HeldOutput::MouseButton6, HeldOutput::MouseButton6) => {}
+        _ => {
+            release_held_output(old);
+            press_held_output(new);
+        }
     }
 }
 
@@ -157,14 +192,14 @@ impl ActionExecutor {
 
 struct ButtonEventHandler {
     executor: ActionExecutor,
-    held: HeldShortcuts,
+    held: HeldOutputs,
 }
 
 impl ButtonEventHandler {
     fn new(executor: ActionExecutor) -> Self {
         Self {
             executor,
-            held: HeldShortcuts::default(),
+            held: HeldOutputs::default(),
         }
     }
 
@@ -179,8 +214,8 @@ impl ButtonEventHandler {
                 self.start_action(press.token(), &action, press.device_key());
             }
             ButtonRuntimeEvent::Ended { press, reason } => {
-                if let Some(combo) = self.held.end(press.token()) {
-                    openlogi_inject::release_hold(&combo);
+                if let Some(output) = self.held.end(press.token()) {
+                    release_held_output(&output);
                 }
                 if let EndReason::Canceled(reason) = reason {
                     match press.control() {
@@ -199,9 +234,9 @@ impl ButtonEventHandler {
     fn start_action(&mut self, press: &PressToken, action: &Action, device_key: Option<&str>) {
         match self.held.start(press, action) {
             HoldStart::NotHeld => self.executor.dispatch(action, device_key),
-            HoldStart::Started(combo) => openlogi_inject::press_hold(&combo),
+            HoldStart::Started(output) => press_held_output(&output),
             HoldStart::Replaced { old, new } => {
-                openlogi_inject::replace_hold(&old, &new);
+                replace_held_output(&old, &new);
             }
         }
     }
@@ -391,55 +426,76 @@ mod tests {
     }
 
     #[test]
+    fn held_mouse_button6_is_owned_until_its_press_ends() {
+        let token = PressToken::hook_for_test(7, ButtonId::GestureButton);
+        let mut held = HeldOutputs::default();
+
+        assert_eq!(
+            held.start(&token, &Action::HoldMouseButton6),
+            HoldStart::Started(HeldOutput::MouseButton6)
+        );
+        assert_eq!(held.end(&token), Some(HeldOutput::MouseButton6));
+        assert_eq!(held.end(&token), None);
+    }
+
+    #[test]
     fn held_output_is_owned_by_the_exact_press_until_its_terminal_event() {
         let first = PressToken::hook_for_test(1, ButtonId::Back);
         let second = PressToken::hook_for_test(2, ButtonId::Forward);
-        let mut held = HeldShortcuts::default();
+        let mut held = HeldOutputs::default();
 
         assert_eq!(
             held.start(&first, &hold("Ctrl+Space")),
-            HoldStart::Started("Ctrl+Space".parse().expect("valid shortcut"))
+            HoldStart::Started(HeldOutput::Shortcut(
+                "Ctrl+Space".parse().expect("valid shortcut")
+            ))
         );
         assert_eq!(
             held.start(&second, &hold("Alt+F2")),
-            HoldStart::Started("Alt+F2".parse().expect("valid shortcut"))
+            HoldStart::Started(HeldOutput::Shortcut(
+                "Alt+F2".parse().expect("valid shortcut")
+            ))
         );
         assert_eq!(
             held.end(&first),
-            Some("Ctrl+Space".parse().expect("valid shortcut"))
+            Some(HeldOutput::Shortcut(
+                "Ctrl+Space".parse().expect("valid shortcut")
+            ))
         );
         assert_eq!(held.end(&first), None, "a press releases at most once");
         assert_eq!(
             held.end(&second),
-            Some("Alt+F2".parse().expect("valid shortcut"))
+            Some(HeldOutput::Shortcut(
+                "Alt+F2".parse().expect("valid shortcut")
+            ))
         );
     }
 
     #[test]
     fn changing_a_hold_within_one_press_balances_the_previous_chord() {
         let press = PressToken::hook_for_test(1, ButtonId::Back);
-        let mut held = HeldShortcuts::default();
+        let mut held = HeldOutputs::default();
         let old: KeyCombo = "Ctrl+Space".parse().expect("valid shortcut");
         let new: KeyCombo = "Alt+F2".parse().expect("valid shortcut");
 
         assert_eq!(
             held.start(&press, &Action::HoldShortcut(old.clone())),
-            HoldStart::Started(old.clone())
+            HoldStart::Started(HeldOutput::Shortcut(old.clone()))
         );
         assert_eq!(
             held.start(&press, &Action::HoldShortcut(new.clone())),
             HoldStart::Replaced {
-                old,
-                new: new.clone(),
+                old: HeldOutput::Shortcut(old),
+                new: HeldOutput::Shortcut(new.clone()),
             }
         );
-        assert_eq!(held.end(&press), Some(new));
+        assert_eq!(held.end(&press), Some(HeldOutput::Shortcut(new)));
     }
 
     #[test]
     fn instantaneous_actions_do_not_enter_held_state() {
         let press = PressToken::hook_for_test(1, ButtonId::Back);
-        let mut held = HeldShortcuts::default();
+        let mut held = HeldOutputs::default();
 
         assert_eq!(held.start(&press, &Action::Copy), HoldStart::NotHeld);
         assert_eq!(held.end(&press), None);

--- a/crates/openlogi-agent-core/src/runtime/hook.rs
+++ b/crates/openlogi-agent-core/src/runtime/hook.rs
@@ -408,7 +408,7 @@ fn handle_key(
     };
 
     info!(keycode, action = %action.label(), "key → executing bound action");
-    let queued = if action.held_combo().is_some() {
+    let queued = if action.held_action().is_some() {
         let queued = dispatcher.try_hook_key_down(keycode, &action);
         if queued {
             HELD_KEYS.with_borrow_mut(|keys| {

--- a/crates/openlogi-core/src/binding.rs
+++ b/crates/openlogi-core/src/binding.rs
@@ -24,7 +24,7 @@ mod value;
 #[cfg(test)]
 mod tests;
 
-pub use action::{Action, WorkflowStep};
+pub use action::{Action, HeldAction, WorkflowStep};
 pub use action_ring::{
     ActionRingConfig, ActionRingEntry, ActionRingIcon, ActionRingLayout, ActionRingSlot,
     RingAction, RingActionError,

--- a/crates/openlogi-core/src/binding/action.rs
+++ b/crates/openlogi-core/src/binding/action.rs
@@ -187,6 +187,20 @@ pub enum Action {
     /// cancellation and shutdown. Dispatchers without a release context must
     /// degrade this action to a balanced tap rather than leave keys held.
     HoldShortcut(KeyCombo),
+    /// Hold standard macOS Mouse Button 6 for the source press lifetime.
+    ///
+    /// The picker exposes this action only on macOS. Other platforms preserve
+    /// configuration compatibility but do not synthesize a substitute event.
+    HoldMouseButton6,
+}
+
+/// An output that a lifecycle-aware runtime keeps active for a physical press.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HeldAction<'a> {
+    /// A recorded keyboard chord.
+    Shortcut(&'a KeyCombo),
+    /// Standard macOS Mouse Button 6.
+    MouseButton6,
 }
 
 /// One step in a [`Action::Workflow`]. A workflow is a `Vec<WorkflowStep>`
@@ -238,6 +252,7 @@ macro_rules! for_each_unit_action {
             MiddleClick "Middle Click" Mouse Mouse,
             MouseBack "Back (Button 4)" Mouse MouseBack,
             MouseForward "Forward (Button 5)" Mouse MouseForward,
+            HoldMouseButton6 "Button 6 (Hold)" Mouse Mouse macos_only,
             // Editing
             Copy "Copy" Editing Copy,
             Paste "Paste" Editing Paste,
@@ -356,6 +371,9 @@ macro_rules! derive_action_core {
     (@item $variant:ident not_pickable) => {
         None
     };
+    (@item $variant:ident macos_only) => {
+        cfg!(target_os = "macos").then_some(Action::$variant)
+    };
 }
 
 for_each_unit_action!(derive_action_core);
@@ -367,6 +385,17 @@ impl Action {
     pub fn held_combo(&self) -> Option<&KeyCombo> {
         match self {
             Self::HoldShortcut(combo) => Some(combo),
+            _ => None,
+        }
+    }
+
+    /// The output whose down edge must remain active until the originating
+    /// physical press ends, or `None` for an instantaneous action.
+    #[must_use]
+    pub fn held_action(&self) -> Option<HeldAction<'_>> {
+        match self {
+            Self::HoldShortcut(combo) => Some(HeldAction::Shortcut(combo)),
+            Self::HoldMouseButton6 => Some(HeldAction::MouseButton6),
             _ => None,
         }
     }

--- a/crates/openlogi-core/src/binding/action_ring.rs
+++ b/crates/openlogi-core/src/binding/action_ring.rs
@@ -109,13 +109,17 @@ pub enum RingActionError {
     /// A ring cannot recursively open itself.
     #[error("Show Actions Ring cannot be assigned inside an Actions Ring")]
     RecursiveTrigger,
+    /// A ring slot has no physical press lifecycle to own this action.
+    #[error("Button 6 (Hold) requires a physical press lifecycle")]
+    HeldMouseButton,
 }
 
 /// An action that is valid inside an Actions Ring.
 ///
 /// Construction and deserialization reject actions that would make the ring's
-/// state ambiguous (`None`) or recursively invoke another ring
-/// (`ShowActionsRing`).
+/// state ambiguous (`None`), recursively invoke another ring
+/// (`ShowActionsRing`), or require a physical press lifecycle
+/// (`HoldMouseButton6`).
 #[nutype(
     validate(with = validate_ring_action, error = RingActionError),
     derive(Clone, Debug, PartialEq, Eq, Hash, AsRef, TryFrom, Into, Serialize, Deserialize),
@@ -145,6 +149,7 @@ fn validate_ring_action(action: &Action) -> Result<(), RingActionError> {
     match action {
         Action::None => Err(RingActionError::EmptyAction),
         Action::ShowActionsRing => Err(RingActionError::RecursiveTrigger),
+        Action::HoldMouseButton6 => Err(RingActionError::HeldMouseButton),
         _ => Ok(()),
     }
 }
@@ -361,6 +366,10 @@ mod tests {
         assert_eq!(
             RingAction::new(Action::ShowActionsRing),
             Err(RingActionError::RecursiveTrigger)
+        );
+        assert_eq!(
+            RingAction::new(Action::HoldMouseButton6),
+            Err(RingActionError::HeldMouseButton)
         );
     }
 

--- a/crates/openlogi-core/src/binding/effect.rs
+++ b/crates/openlogi-core/src/binding/effect.rs
@@ -42,6 +42,10 @@ pub enum Effect<'a> {
     /// runtime. A one-shot executor treats this as [`Effect::Key`] so direct
     /// dispatch remains balanced when no matching release can arrive.
     HeldKey(&'a KeyCombo),
+    /// Standard macOS Mouse Button 6 whose output is held by a
+    /// lifecycle-aware runtime. A one-shot executor treats this as a balanced
+    /// click so it cannot leave a button held down.
+    HeldMouseButton6,
     /// Synthesise one scroll tick. `dx`/`dy` are unit direction (-1/0/1);
     /// each backend applies its own tick magnitude.
     Scroll {
@@ -275,6 +279,7 @@ impl Action {
 
             Action::CustomShortcut(combo) => Effect::Key(combo),
             Action::HoldShortcut(combo) => Effect::HeldKey(combo),
+            Action::HoldMouseButton6 => Effect::HeldMouseButton6,
 
             Action::TypeText(text) => Effect::Text(text),
             Action::RunAppleScript(src) => Effect::Script(Script::AppleScript(src)),

--- a/crates/openlogi-core/src/binding/tests.rs
+++ b/crates/openlogi-core/src/binding/tests.rs
@@ -52,6 +52,29 @@ fn hold_shortcut_has_distinct_lifecycle_semantics() {
 }
 
 #[test]
+fn hold_mouse_button6_has_lifecycle_semantics() {
+    let action = Action::HoldMouseButton6;
+
+    assert_eq!(action.label(), "Button 6 (Hold)");
+    assert_eq!(action.category(), Category::Mouse);
+    assert_eq!(action.held_action(), Some(HeldAction::MouseButton6));
+    assert_matches!(action.effect(), Effect::HeldMouseButton6);
+    assert_eq!(roundtrip(&action), action);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn hold_mouse_button6_is_pickable_on_macos() {
+    assert!(Action::catalog().contains(&Action::HoldMouseButton6));
+}
+
+#[cfg(not(target_os = "macos"))]
+#[test]
+fn hold_mouse_button6_is_not_pickable_off_macos() {
+    assert!(!Action::catalog().contains(&Action::HoldMouseButton6));
+}
+
+#[test]
 fn hold_shortcut_roundtrips_toml() {
     let action = Action::HoldShortcut("Alt+Space".parse().expect("valid shortcut failed"));
     assert_eq!(roundtrip(&action), action);
@@ -336,6 +359,7 @@ fn persisted_action_variant_names_are_stable() {
         "Find",
         "HorizontalScrollLeft",
         "HorizontalScrollRight",
+        "HoldMouseButton6",
         "HoldShortcut",
         "LaunchpadShow",
         "LeftClick",

--- a/crates/openlogi-desktop/src/features/mouse/picker.rs
+++ b/crates/openlogi-desktop/src/features/mouse/picker.rs
@@ -46,7 +46,7 @@ pub(crate) fn action_icon_path(action: &Action) -> &'static str {
     match action {
         Action::None => "action-icons/ban.svg",
         Action::LeftClick | Action::RightClick => "action-icons/mouse-pointer-click.svg",
-        Action::MiddleClick => "action-icons/mouse.svg",
+        Action::MiddleClick | Action::HoldMouseButton6 => "action-icons/mouse.svg",
         Action::MouseBack => "action-icons/circle-arrow-left.svg",
         Action::MouseForward => "action-icons/circle-arrow-right.svg",
         Action::Copy => "action-icons/copy.svg",
@@ -219,4 +219,19 @@ pub(crate) fn editor_scroll_list(
         .max_h(px(EDITOR_LIST_MAX_H))
         .overflow_y_scroll()
         .children(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use openlogi_core::binding::Action;
+
+    use super::action_icon_path;
+
+    #[test]
+    fn held_button6_uses_the_mouse_icon() {
+        assert_eq!(
+            action_icon_path(&Action::HoldMouseButton6),
+            "action-icons/mouse.svg"
+        );
+    }
 }

--- a/crates/openlogi-inject/examples/inject_action.rs
+++ b/crates/openlogi-inject/examples/inject_action.rs
@@ -26,7 +26,7 @@
 //!
 //! # Available actions
 //!
-//! LeftClick RightClick MiddleClick MouseBack MouseForward
+//! LeftClick RightClick MiddleClick MouseBack MouseForward HoldMouseButton6 (macOS-first balanced click)
 //! Copy Paste Cut Undo Redo SelectAll Find Save
 //! BrowserBack BrowserForward NewTab CloseTab ReopenTab NextTab PrevTab ReloadPage
 //! MissionControl AppExpose PreviousDesktop NextDesktop ShowDesktop LaunchpadShow

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -261,6 +261,38 @@ pub fn replace_hold(old: &KeyCombo, new: &KeyCombo) {
     hold_transition(Some(old), Some(new));
 }
 
+/// Synthesise the down edge of standard macOS Mouse Button 6.
+///
+/// Every successful lifecycle start must be paired with
+/// [`release_hold_mouse_button6`], including cancellation and shutdown paths.
+/// On platforms without a verified Button 6 mapping this logs a warning and
+/// emits no substitute event.
+pub fn press_hold_mouse_button6() {
+    cfg_select! {
+        target_os = "macos" => {
+            macos::post_button6_phase(macos::MousePhase::Down);
+        }
+        _ => {
+            tracing::warn!("held Mouse Button 6 output is unsupported on this platform");
+        }
+    }
+}
+
+/// Synthesise the up edge matching a prior [`press_hold_mouse_button6`].
+///
+/// On platforms without a verified Button 6 mapping this logs a warning and
+/// emits no substitute event.
+pub fn release_hold_mouse_button6() {
+    cfg_select! {
+        target_os = "macos" => {
+            macos::post_button6_phase(macos::MousePhase::Up);
+        }
+        _ => {
+            tracing::warn!("held Mouse Button 6 output is unsupported on this platform");
+        }
+    }
+}
+
 fn hold_transition(released: Option<&KeyCombo>, pressed: Option<&KeyCombo>) {
     cfg_select! {
         target_os = "macos" => {

--- a/crates/openlogi-inject/src/inject/linux.rs
+++ b/crates/openlogi-inject/src/inject/linux.rs
@@ -40,6 +40,9 @@ pub(super) fn execute(action: &Action) {
         Effect::Click(button) => click(mouse_button_code(button)),
         Effect::Shortcut(shortcut) => press_combo(&combo(shortcut)),
         Effect::Key(combo) | Effect::HeldKey(combo) => press_combo(combo),
+        Effect::HeldMouseButton6 => {
+            tracing::warn!("held Mouse Button 6 output is unsupported on Linux");
+        }
         Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         Effect::Media(key) => dispatch_media(key),
         Effect::Native(native) => dispatch_native(action, native),

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -38,6 +38,28 @@ const NX_KEYTYPE_PLAY: i32 = 16;
 const NX_KEYTYPE_NEXT: i32 = 17;
 const NX_KEYTYPE_PREVIOUS: i32 = 18;
 
+/// One edge of a synthetic extra-mouse-button press.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MousePhase {
+    /// Button press.
+    Down,
+    /// Button release.
+    Up,
+}
+
+/// CoreGraphics' zero-based number for standard Mouse Button 6.
+pub(super) const fn button6_number() -> i64 {
+    5
+}
+
+/// CoreGraphics event kind for an extra-mouse-button edge.
+pub(super) const fn other_mouse_event_type(phase: MousePhase) -> CGEventType {
+    match phase {
+        MousePhase::Down => CGEventType::OtherMouseDown,
+        MousePhase::Up => CGEventType::OtherMouseUp,
+    }
+}
+
 /// macOS implementation: classify `action` into an [`Effect`] and dispatch
 /// to the appropriate event helper.
 pub(super) fn execute(action: &Action) {
@@ -50,6 +72,7 @@ pub(super) fn execute(action: &Action) {
         Effect::Click(button) => dispatch_click(button),
         Effect::Shortcut(shortcut) => post_keycombo(&combo(shortcut)),
         Effect::Key(combo) | Effect::HeldKey(combo) => post_keycombo(combo),
+        Effect::HeldMouseButton6 => post_button6(),
         Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         // Media/volume controls are NX system-defined keys, not ordinary
         // keyboard virtual-key events. Posting kVK_Volume* through
@@ -211,24 +234,42 @@ fn post_click(button: CGMouseButton) {
 /// buttons ≥ 3. Tagged via [`tag_synthetic`] so OpenLogi's own event tap
 /// ignores it instead of re-translating it into a Back/Forward press.
 fn post_other_button(button_number: i64) {
+    for phase in [MousePhase::Down, MousePhase::Up] {
+        post_other_button_phase(button_number, phase);
+    }
+}
+
+/// Post one extra-mouse-button edge by its zero-based button number.
+fn post_other_button_phase(button_number: i64, phase: MousePhase) {
     let Ok(src) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
         tracing::warn!("CGEventSource::new failed for extra mouse button");
         return;
     };
     let location =
         CGEvent::new(src.clone()).map_or_else(|()| CGPoint::new(0., 0.), |e| e.location());
-    for (kind, phase) in [
-        (CGEventType::OtherMouseDown, "down"),
-        (CGEventType::OtherMouseUp, "up"),
-    ] {
-        if let Ok(ev) = CGEvent::new_mouse_event(src.clone(), kind, location, CGMouseButton::Center)
-        {
-            ev.set_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER, button_number);
-            tag_synthetic(&ev);
-            ev.post(CGEventTapLocation::HID);
-        } else {
-            tracing::warn!(phase, "CGEvent::new_mouse_event failed for extra button");
-        }
+    if let Ok(ev) = CGEvent::new_mouse_event(
+        src,
+        other_mouse_event_type(phase),
+        location,
+        CGMouseButton::Center,
+    ) {
+        ev.set_integer_value_field(EventField::MOUSE_EVENT_BUTTON_NUMBER, button_number);
+        tag_synthetic(&ev);
+        ev.post(CGEventTapLocation::HID);
+    } else {
+        tracing::warn!(?phase, "CGEvent::new_mouse_event failed for extra button");
+    }
+}
+
+/// Post one standard Mouse Button 6 edge.
+pub(super) fn post_button6_phase(phase: MousePhase) {
+    post_other_button_phase(button6_number(), phase);
+}
+
+/// Post a balanced standard Mouse Button 6 click.
+fn post_button6() {
+    for phase in [MousePhase::Down, MousePhase::Up] {
+        post_button6_phase(phase);
     }
 }
 
@@ -430,10 +471,13 @@ fn hid_usage_to_macos(usage: u8) -> Option<u16> {
 
 #[cfg(test)]
 mod tests {
-    use core_graphics::event::CGEventFlags;
+    use core_graphics::event::{CGEventFlags, CGEventType};
     use openlogi_core::binding::Shortcut;
 
-    use super::{combo, held_key_event, hid_usage_to_macos};
+    use super::{
+        MousePhase, button6_number, combo, held_key_event, hid_usage_to_macos,
+        other_mouse_event_type,
+    };
     use crate::inject::{HeldKey, HeldModifiers, KeyPhase};
 
     #[test]
@@ -444,6 +488,19 @@ mod tests {
         assert_eq!(hid_usage_to_macos(0x3a), Some(0x7a));
         assert_eq!(hid_usage_to_macos(0x6f), Some(0x5a));
         assert_eq!(hid_usage_to_macos(0xff), None);
+    }
+
+    #[test]
+    fn button6_uses_other_mouse_edges_and_raw_number_five() {
+        assert_eq!(button6_number(), 5);
+        assert_eq!(
+            other_mouse_event_type(MousePhase::Down) as u32,
+            CGEventType::OtherMouseDown as u32
+        );
+        assert_eq!(
+            other_mouse_event_type(MousePhase::Up) as u32,
+            CGEventType::OtherMouseUp as u32
+        );
     }
 
     /// Pin a handful of representative `Shortcut -> KeyCombo` rows so an

--- a/crates/openlogi-inject/src/inject/windows.rs
+++ b/crates/openlogi-inject/src/inject/windows.rs
@@ -59,6 +59,9 @@ pub(super) fn execute(action: &Action) {
         Effect::Click(button) => post_click(button),
         Effect::Shortcut(shortcut) => press_shortcut(shortcut),
         Effect::Key(combo) | Effect::HeldKey(combo) => post_custom_shortcut(combo),
+        Effect::HeldMouseButton6 => {
+            tracing::warn!("held Mouse Button 6 output is unsupported on Windows");
+        }
         Effect::Scroll { dx, dy } => dispatch_scroll(dx, dy),
         Effect::Media(key) => dispatch_media(key),
         Effect::Native(native) => dispatch_native(native),

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -4,7 +4,8 @@ mod inject;
 
 pub use inject::{
     SYNTHETIC_EVENT_USER_DATA, SmoothScrollPhase, ax_navigate_browser, execute, post_scroll,
-    post_smooth_scroll, press_hold, release_hold, replace_hold,
+    post_smooth_scroll, press_hold, press_hold_mouse_button6, release_hold,
+    release_hold_mouse_button6, replace_hold,
 };
 
 #[cfg(target_os = "linux")]

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -59,7 +59,8 @@ pub use succession::Identity;
 /// v27: `AgentSnapshot::foreground` appended — the frontmost application the
 ///      agent matches per-app profiles against, plus the ones it saw recently.
 /// v28: `Action::HoldShortcut` appended for lifecycle-held keyboard output.
-pub const PROTOCOL_VERSION: u32 = 28;
+/// v29: `Action::HoldMouseButton6` appended for macOS held Button 6 output.
+pub const PROTOCOL_VERSION: u32 = 29;
 
 /// Environment variable through which the agent hands a supervised helper the
 /// run token it will serve, so the helper knows which agent it belongs to

--- a/crates/openlogi-ipc/tests/wire_format.rs
+++ b/crates/openlogi-ipc/tests/wire_format.rs
@@ -31,7 +31,7 @@ use std::fmt::Write;
 
 use bincode::Options;
 use openlogi_core::app::ForegroundApp;
-use openlogi_core::binding::{ActionRingIcon, ActionRingSlot};
+use openlogi_core::binding::{Action, ActionRingIcon, ActionRingSlot};
 use openlogi_core::config::Lighting;
 use openlogi_core::device::{
     BatteryInfo, BatteryLevel, BatteryStatus, Capabilities, DeviceInventory, DeviceKind,
@@ -101,7 +101,12 @@ fn representative_smartshift_status() -> SmartShiftStatus {
 /// that makes that visible in the same diff.
 #[test]
 fn protocol_version_is_pinned() {
-    assert_eq!(PROTOCOL_VERSION, 28);
+    assert_eq!(PROTOCOL_VERSION, 29);
+}
+
+#[test]
+fn held_mouse_button6_action_is_append_only_on_the_wire() {
+    assert_wire(&Action::HoldMouseButton6, "35");
 }
 
 #[test]

--- a/crates/openlogi-ui/locales/da.yml
+++ b/crates/openlogi-ui/locales/da.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Vip til højre"
 "Back (Button 4)": "Tilbage (knap 4)"
 "Forward (Button 5)": "Frem (knap 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Tilbage"
 "Forward": "Frem"
 "DPI Toggle": "DPI-skift"

--- a/crates/openlogi-ui/locales/de.yml
+++ b/crates/openlogi-ui/locales/de.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Kippen rechts"
 "Back (Button 4)": "Zurück (Taste 4)"
 "Forward (Button 5)": "Vor (Taste 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Zurück"
 "Forward": "Vor"
 "DPI Toggle": "DPI-Umschaltung"

--- a/crates/openlogi-ui/locales/el.yml
+++ b/crates/openlogi-ui/locales/el.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Κλίση δεξιά"
 "Back (Button 4)": "Πίσω (κουμπί 4)"
 "Forward (Button 5)": "Εμπρός (κουμπί 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Πίσω"
 "Forward": "Εμπρός"
 "DPI Toggle": "Εναλλαγή DPI"

--- a/crates/openlogi-ui/locales/en.yml
+++ b/crates/openlogi-ui/locales/en.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Tilt Right"
 "Back (Button 4)": "Back (Button 4)"
 "Forward (Button 5)": "Forward (Button 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Back"
 "Forward": "Forward"
 "DPI Toggle": "DPI Toggle"

--- a/crates/openlogi-ui/locales/es.yml
+++ b/crates/openlogi-ui/locales/es.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Inclinación derecha"
 "Back (Button 4)": "Atrás (botón 4)"
 "Forward (Button 5)": "Adelante (botón 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Atrás"
 "Forward": "Adelante"
 "DPI Toggle": "Cambiar DPI"

--- a/crates/openlogi-ui/locales/fi.yml
+++ b/crates/openlogi-ui/locales/fi.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Kallista oikealle"
 "Back (Button 4)": "Takaisin (painike 4)"
 "Forward (Button 5)": "Eteenpäin (painike 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Takaisin"
 "Forward": "Eteenpäin"
 "DPI Toggle": "DPI-vaihto"

--- a/crates/openlogi-ui/locales/fr.yml
+++ b/crates/openlogi-ui/locales/fr.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Inclinaison droite"
 "Back (Button 4)": "Précédent (bouton 4)"
 "Forward (Button 5)": "Suivant (bouton 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Précédent"
 "Forward": "Suivant"
 "DPI Toggle": "Bascule DPI"

--- a/crates/openlogi-ui/locales/it.yml
+++ b/crates/openlogi-ui/locales/it.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Inclinazione destra"
 "Back (Button 4)": "Indietro (pulsante 4)"
 "Forward (Button 5)": "Avanti (pulsante 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Indietro"
 "Forward": "Avanti"
 "DPI Toggle": "Cambia DPI"

--- a/crates/openlogi-ui/locales/ja.yml
+++ b/crates/openlogi-ui/locales/ja.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "右チルト"
 "Back (Button 4)": "戻る（サイドボタン4）"
 "Forward (Button 5)": "進む（サイドボタン5）"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "戻る"
 "Forward": "進む"
 "DPI Toggle": "DPI 切り替え"

--- a/crates/openlogi-ui/locales/ko.yml
+++ b/crates/openlogi-ui/locales/ko.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "오른쪽 틸트"
 "Back (Button 4)": "뒤로 (버튼 4)"
 "Forward (Button 5)": "앞으로 (버튼 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "뒤로"
 "Forward": "앞으로"
 "DPI Toggle": "DPI 전환"

--- a/crates/openlogi-ui/locales/nb.yml
+++ b/crates/openlogi-ui/locales/nb.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Vipp til høyre"
 "Back (Button 4)": "Tilbake (knapp 4)"
 "Forward (Button 5)": "Frem (knapp 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Tilbake"
 "Forward": "Frem"
 "DPI Toggle": "DPI-veksling"

--- a/crates/openlogi-ui/locales/nl.yml
+++ b/crates/openlogi-ui/locales/nl.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Kantelen rechts"
 "Back (Button 4)": "Vorige (knop 4)"
 "Forward (Button 5)": "Volgende (knop 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Vorige"
 "Forward": "Volgende"
 "DPI Toggle": "DPI wisselen"

--- a/crates/openlogi-ui/locales/pl.yml
+++ b/crates/openlogi-ui/locales/pl.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Przechył w prawo"
 "Back (Button 4)": "Wstecz (przycisk 4)"
 "Forward (Button 5)": "Do przodu (przycisk 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Wstecz"
 "Forward": "Do przodu"
 "DPI Toggle": "Przełącznik DPI"

--- a/crates/openlogi-ui/locales/pt-BR.yml
+++ b/crates/openlogi-ui/locales/pt-BR.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Inclinar à direita"
 "Back (Button 4)": "Voltar (botão 4)"
 "Forward (Button 5)": "Avançar (botão 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Voltar"
 "Forward": "Avançar"
 "DPI Toggle": "Alternar DPI"

--- a/crates/openlogi-ui/locales/pt-PT.yml
+++ b/crates/openlogi-ui/locales/pt-PT.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Inclinar à direita"
 "Back (Button 4)": "Retroceder (botão 4)"
 "Forward (Button 5)": "Avançar (botão 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Retroceder"
 "Forward": "Avançar"
 "DPI Toggle": "Alternar DPI"

--- a/crates/openlogi-ui/locales/ru.yml
+++ b/crates/openlogi-ui/locales/ru.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Наклон вправо"
 "Back (Button 4)": "Назад (боковая кнопка 4)"
 "Forward (Button 5)": "Вперёд (боковая кнопка 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Назад"
 "Forward": "Вперёд"
 "DPI Toggle": "Переключение DPI"

--- a/crates/openlogi-ui/locales/sv.yml
+++ b/crates/openlogi-ui/locales/sv.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Luta höger"
 "Back (Button 4)": "Bakåt (knapp 4)"
 "Forward (Button 5)": "Framåt (knapp 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Bakåt"
 "Forward": "Framåt"
 "DPI Toggle": "DPI-växling"

--- a/crates/openlogi-ui/locales/tr.yml
+++ b/crates/openlogi-ui/locales/tr.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Sağa Yatır"
 "Back (Button 4)": "Geri (Düğme 4)"
 "Forward (Button 5)": "İleri (Düğme 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Geri"
 "Forward": "İleri"
 "DPI Toggle": "DPI Değiştir"

--- a/crates/openlogi-ui/locales/uk.yml
+++ b/crates/openlogi-ui/locales/uk.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "Нахил праворуч"
 "Back (Button 4)": "Назад (кнопка 4)"
 "Forward (Button 5)": "Вперед (кнопка 5)"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "Назад"
 "Forward": "Вперед"
 "DPI Toggle": "Перемикач DPI"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -179,7 +179,7 @@ _version: 1
 "Tilt Right": "向右倾斜"
 "Back (Button 4)": "后退（侧键4）"
 "Forward (Button 5)": "前进（侧键5）"
-"Button 6 (Hold)": "Button 6 (Hold)"
+"Button 6 (Hold)": "按住按钮 6"
 "Back": "后退"
 "Forward": "前进"
 "DPI Toggle": "灵敏度切换"

--- a/crates/openlogi-ui/locales/zh-CN.yml
+++ b/crates/openlogi-ui/locales/zh-CN.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "向右倾斜"
 "Back (Button 4)": "后退（侧键4）"
 "Forward (Button 5)": "前进（侧键5）"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "后退"
 "Forward": "前进"
 "DPI Toggle": "灵敏度切换"

--- a/crates/openlogi-ui/locales/zh-HK.yml
+++ b/crates/openlogi-ui/locales/zh-HK.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "向右傾斜"
 "Back (Button 4)": "後退（側鍵4）"
 "Forward (Button 5)": "前進（側鍵5）"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "後退"
 "Forward": "前進"
 "DPI Toggle": "靈敏度切換"

--- a/crates/openlogi-ui/locales/zh-TW.yml
+++ b/crates/openlogi-ui/locales/zh-TW.yml
@@ -179,6 +179,7 @@ _version: 1
 "Tilt Right": "向右傾斜"
 "Back (Button 4)": "後退（側鍵4）"
 "Forward (Button 5)": "前進（側鍵5）"
+"Button 6 (Hold)": "Button 6 (Hold)"
 "Back": "後退"
 "Forward": "前進"
 "DPI Toggle": "靈敏度切換"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -101,6 +101,20 @@ the chord down until the originating physical button is released, and also
 releases it if capture is interrupted, the binding becomes invalid, or the
 agent shuts down. Use it for push-to-talk and other hold-to-activate controls.
 
+`HoldMouseButton6` is a macOS-first held output for applications that bind
+standard extra Mouse Button 6. It emits `OtherMouseDown` on press and the
+matching `OtherMouseUp` on release, including every interruption or shutdown
+outcome. Bind it directly to a lifecycle-capable control, for example:
+
+```toml
+GestureButton = "HoldMouseButton6"
+```
+
+It appears in the macOS action picker only. Linux and Windows preserve the
+configuration value but warn rather than emit an invented Button 6 mapping.
+It cannot be assigned to an Actions Ring slot because ring selections have no
+physical press lifetime to hold.
+
 A `{ short = ..., long = ... }` binding waits for the button's outcome instead
 of firing on press. Releasing before 500 ms fires `short`; keeping the button
 down for 500 ms fires `long` exactly once, and the later release does not also
@@ -122,3 +136,5 @@ Top = { action = { CustomShortcut = "Cmd+Shift+P" }, icon = "Keyboard", label = 
 ```
 
 `ShowActionsRing` is rejected inside a ring slot to prevent recursive rings.
+`HoldMouseButton6` is also rejected there because it requires a physical press
+lifecycle.


### PR DESCRIPTION
## Summary

- add a macOS-first `HoldMouseButton6` action which emits `OtherMouseDown` and `OtherMouseUp` at raw button number 5
- preserve the held output release edge on cancellation, source replacement, invalidation, and agent shutdown
- expose `Button 6 (Hold)` in mouse binding pickers and localization/documentation; disallow it in Actions Ring slots because a slot has no press lifecycle

## Validation

- focused core, agent lifecycle, injector, IPC wire-format, UI picker, locale-parity, changed-package Clippy, and documentation checks pass with Rust 1.98 and the Metal Toolchain
- manual macOS test: original MX Master `GestureButton` through OpenLogi produced `OtherMouseDown` and `OtherMouseUp` at raw button 5; a third-party app recognized Mouse Button 6, including held behavior
- `cargo test --workspace`: 184 passed and 1 failed: `state::devices::tests::standalone_registry_identity_is_preserved_without_hidpp_model_info`. The same test fails unchanged on upstream `origin/master` at `afb10a4`, so it is an unrelated baseline failure.