### PR TITLE
ci(nix): integrate cachix for binary caching

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -8,6 +8,8 @@ name: Nix CI
 # flake.lock pins nixpkgs exactly; update-flake-lock.yml advances it in a tested
 # PR instead of allowing an unreviewed upstream channel to drift under builds.
 on:
+  push:
+    branches: [main, master]
   schedule:
     # Mondays, 04:17 UTC. Off-peak, and far from the release cadence.
     - cron: "17 4 * * 1"
@@ -83,6 +85,13 @@ jobs:
         run: test "$(uname -m)" = "${{ matrix.machine }}"
       - name: Install upstream Nix
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+      - name: Setup Cachix
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+        with:
+          name: "${{ secrets.CACHIX_CACHE_NAME }}"
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          pushFilter: '(-source$|\.tar\.gz$|\.tar\.xz$)'
+          skipPush: ${{ github.event_name == 'pull_request' }}
       - name: Restore and save Nix store paths
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,11 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [ "https://yangkx.cachix.org" ];
+    extra-trusted-public-keys = [ "yangkx.cachix.org-1:Pj7xCU2U9D/4cahR+7K/ILyGgpITtMINuvDxd3dUNQc=" ];
+  };
+
   # The dev shell lives in devenv.nix (devenv.yaml). This flake owns the Linux
   # package, its NixOS integration, checks, and formatter.
   outputs =


### PR DESCRIPTION
Hi! Thank you for the amazing work on OpenLogi.

I noticed that while the Nix CI builds the packages correctly, users and contributors currently have to build the Rust project from source on their local machines when running nix build or nix run.

To significantly speed up local builds and improve the developer experience, I've integrated Cachix into the Nix CI workflow, inspired by similar setups in the community (e.g., [noctalia-greeter](https://github.com/noctalia-dev/noctalia-greeter)).

(Note: I have successfully tested this entire workflow on my fork, and the cache pushing/pulling mechanism works flawlessly.)

What this PR does:
- `nix.yml`: Added the cachix/cachix-action to push compiled Nix store paths to Cachix.
- Push logic: The CI will only push to the cache on push to main/master, schedule, or workflow_dispatch. During regular PR runs, it elegantly falls back to a read-only mode, pulling the existing cache without polluting your cache pool.
- `flake.nix`: Added the Cachix URL and public key to nixConfig. When users run nix run github:AprilNEA/OpenLogi, Nix will prompt them to trust the cache, allowing them to download the pre-compiled binaries in seconds instead of waiting for a full local Rust compilation.

⚠️  TODO for the Maintainer (Before merging):

Since I tested this on my fork, the flake.nix currently points to my personal Cachix (yangkx.cachix.org). Before you merge this PR, please follow these steps to set up the official OpenLogi cache:

1. [ ] Create a Cachix account & cache: Go to cachix.org, sign in, and create a free open-source cache (e.g., named openlogi).
 2. [ ] Add Secrets to GitHub: In this repository, go to Settings -> Secrets and variables -> Actions and add two new Repository Secrets:
      • CACHIX_CACHE_NAME (e.g., openlogi)
      • CACHIX_AUTH_TOKEN (The auth token generated in your Cachix dashboard)
3. [ ] Update flake.nix in this PR: Please edit flake.nix in this PR to replace my cache info with yours:
      • Change https://yangkx.cachix.org to https://<YOUR_CACHE_NAME>.cachix.org
      • Change yangkx.cachix.org-1:Pj7xCU2U9D/4cahR+7K/ILyGgpITtMINuvDxd3dUNQc= to your new cache's Public Key.

Once these are set, you can safely merge this PR! Let me know if you need any help setting this up. Thanks again for your time!