### PR TITLE
refactor(hid): fold the one-shot retry state into a OneShotScan type

### DIFF
--- a/crates/openlogi-device/src/inventory.rs
+++ b/crates/openlogi-device/src/inventory.rs
@@ -311,51 +311,78 @@ pub async fn enumerate(
     // probe must keep using the full retry budget so the next attempt can reopen
     // the channel and recover.
     let mut enumerator = Enumerator::with_backend(backend);
-    let mut previous_inventories: Option<Vec<DeviceInventory>> = None;
-    let mut attempt = 1u8;
+    let mut scan = OneShotScan::new();
     loop {
         let (inventories, all_complete, all_healthy) =
             enumerator.enumerate_reporting_completeness().await?;
-        if one_shot_should_stop(
-            previous_inventories.as_deref(),
-            &inventories,
-            all_complete,
-            all_healthy,
-            attempt,
-        ) {
+        let pass = ScanPass {
+            complete: all_complete,
+            healthy: all_healthy,
+        };
+        if scan.is_settled(&inventories, pass) {
             return Ok(inventories);
         }
         debug!(
-            attempt,
-            all_complete,
-            all_healthy,
+            attempt = scan.attempt,
+            complete = pass.complete,
+            healthy = pass.healthy,
             "one-shot enumerate inventory incomplete or still changing — retrying"
         );
-        // Only a healthy pass is valid evidence for the unchanged-inventory
-        // stop, so the equality check below only ever compares two consecutive
-        // healthy snapshots. A failed/timed-out probe (replayed last-good or
-        // partial live result) is cleared so it can't count as one of the two
-        // "stable" reads and short-circuit a later healthy-but-short pass.
-        previous_inventories = if all_healthy { Some(inventories) } else { None };
+        scan.advance(inventories, pass);
         tokio::time::sleep(ONESHOT_RETRY_DELAY).await;
-        attempt += 1;
     }
 }
 
-/// Stop the one-shot retry loop when the snapshot is complete, when a healthy
-/// but short pass has stabilized (the expected Unifying offline-drain case), or
-/// when the explicit attempt cap is reached. An unchanged inventory from a
-/// failed probe is not stable evidence; it must keep retrying until the cap.
-fn one_shot_should_stop(
-    previous: Option<&[DeviceInventory]>,
-    current: &[DeviceInventory],
-    all_complete: bool,
-    all_healthy: bool,
+/// What one enumerate pass established about its own trustworthiness.
+#[derive(Clone, Copy)]
+struct ScanPass {
+    /// Every expected device is present in the snapshot.
+    complete: bool,
+    /// Every probe answered — the only kind of pass that counts as stability
+    /// evidence.
+    healthy: bool,
+}
+
+/// The one-shot retry loop's memory: the snapshot that may serve as stability
+/// evidence, and how many passes have run. [`Self::is_settled`] is the stop
+/// rule the tests pin.
+struct OneShotScan {
+    /// The previous pass's snapshot, kept only when that pass was healthy —
+    /// the unchanged-inventory stop only ever compares two consecutive
+    /// healthy snapshots. A failed/timed-out probe (a replayed last-good or
+    /// partial live result) is cleared so it can't count as one of the two
+    /// "stable" reads and short-circuit a later healthy-but-short pass.
+    stable_candidate: Option<Vec<DeviceInventory>>,
     attempt: u8,
-) -> bool {
-    all_complete
-        || (all_healthy && previous.is_some_and(|previous| previous == current))
-        || attempt >= ONESHOT_ATTEMPTS
+}
+
+impl OneShotScan {
+    fn new() -> Self {
+        Self {
+            stable_candidate: None,
+            attempt: 1,
+        }
+    }
+
+    /// Stop when the snapshot is complete, when a healthy but short pass has
+    /// stabilized (the expected Unifying offline-drain case), or when the
+    /// attempt cap is reached.
+    fn is_settled(&self, current: &[DeviceInventory], pass: ScanPass) -> bool {
+        pass.complete
+            || (pass.healthy
+                && self
+                    .stable_candidate
+                    .as_deref()
+                    .is_some_and(|previous| previous == current))
+            || self.attempt >= ONESHOT_ATTEMPTS
+    }
+
+    /// Fold one finished, unsettled pass in: a healthy snapshot becomes the
+    /// stability candidate, an unhealthy one clears it.
+    fn advance(&mut self, inventories: Vec<DeviceInventory>, pass: ScanPass) {
+        self.stable_candidate = pass.healthy.then_some(inventories);
+        self.attempt += 1;
+    }
 }
 
 /// Attempts a one-shot [`enumerate`] makes before returning whatever it last

--- a/crates/openlogi-device/src/inventory/tests.rs
+++ b/crates/openlogi-device/src/inventory/tests.rs
@@ -18,8 +18,8 @@ use super::probe::{
     preferred_direct_codename, probe_unifying_slot, unifying_probe_budget,
 };
 use super::{
-    ChannelCache, Enumerator, ONESHOT_ATTEMPTS, UNIFYING_CACHED_SLOT_PROBE, UNIFYING_SLOT_PROBE,
-    one_shot_should_stop, retained_nodes, routes_for_inventories, settle_unhealthy_node,
+    ChannelCache, Enumerator, ONESHOT_ATTEMPTS, OneShotScan, ScanPass, UNIFYING_CACHED_SLOT_PROBE,
+    UNIFYING_SLOT_PROBE, retained_nodes, routes_for_inventories, settle_unhealthy_node,
 };
 use crate::channel::scripted::{
     ScriptedBackend, ScriptedNode, ScriptedRawHidChannel, scripted_channel, scripted_node_info,
@@ -369,9 +369,16 @@ fn retiring_node_inventory_expires_after_the_existing_ledger_grace() {
 #[test]
 fn one_shot_retry_stops_when_first_attempt_is_complete() {
     let current = inventory(&[1, 2]);
+    let scan = OneShotScan::new();
 
     assert!(
-        one_shot_should_stop(None, &current, true, true, 1),
+        scan.is_settled(
+            &current,
+            ScanPass {
+                complete: true,
+                healthy: true
+            }
+        ),
         "complete inventories keep the one-pass happy path"
     );
 }
@@ -380,17 +387,24 @@ fn one_shot_retry_stops_when_first_attempt_is_complete() {
 fn one_shot_retry_waits_for_healthy_incomplete_inventory_to_stabilize() {
     let partial = inventory(&[1]);
     let full = inventory(&[1, 2]);
+    let healthy = ScanPass {
+        complete: false,
+        healthy: true,
+    };
+    let mut scan = OneShotScan::new();
 
     assert!(
-        !one_shot_should_stop(None, &partial, false, true, 1),
+        !scan.is_settled(&partial, healthy),
         "the first incomplete pass has no previous inventory to compare"
     );
+    scan.advance(partial, healthy);
     assert!(
-        !one_shot_should_stop(Some(partial.as_slice()), &full, false, true, 2),
+        !scan.is_settled(&full, healthy),
         "a changed inventory should get another retry window"
     );
+    scan.advance(full.clone(), healthy);
     assert!(
-        one_shot_should_stop(Some(full.as_slice()), &full, false, true, 3),
+        scan.is_settled(&full, healthy),
         "once the returned inventory stabilizes, retrying stops"
     );
 }
@@ -398,9 +412,15 @@ fn one_shot_retry_waits_for_healthy_incomplete_inventory_to_stabilize() {
 #[test]
 fn one_shot_retry_stops_on_unchanged_incomplete_inventory() {
     let partial = inventory(&[1]);
+    let healthy = ScanPass {
+        complete: false,
+        healthy: true,
+    };
+    let mut scan = OneShotScan::new();
 
+    scan.advance(partial.clone(), healthy);
     assert!(
-        one_shot_should_stop(Some(partial.as_slice()), &partial, false, true, 2),
+        scan.is_settled(&partial, healthy),
         "stable partial inventories should not burn every retry attempt"
     );
 }
@@ -408,26 +428,48 @@ fn one_shot_retry_stops_on_unchanged_incomplete_inventory() {
 #[test]
 fn one_shot_retry_keeps_unchanged_inventory_after_unhealthy_probe() {
     let partial = inventory(&[1]);
+    let mut scan = OneShotScan::new();
 
+    // The replayed snapshot arrived from an earlier healthy pass…
+    scan.advance(
+        partial.clone(),
+        ScanPass {
+            complete: false,
+            healthy: true,
+        },
+    );
+    // …but this pass failed, so the unchanged replay is not stability
+    // evidence.
     assert!(
-        !one_shot_should_stop(Some(partial.as_slice()), &partial, false, false, 2),
+        !scan.is_settled(
+            &partial,
+            ScanPass {
+                complete: false,
+                healthy: false
+            }
+        ),
         "unchanged replay after a failed probe must keep retrying before the cap"
     );
 }
 
 #[test]
 fn one_shot_retry_stops_at_attempt_cap_when_inventory_keeps_changing() {
-    let previous = inventory(&[1]);
-    let current = inventory(&[1, 2]);
+    let unhealthy = ScanPass {
+        complete: false,
+        healthy: false,
+    };
+    let mut scan = OneShotScan::new();
 
+    while scan.attempt < ONESHOT_ATTEMPTS {
+        let changing = inventory(&[scan.attempt]);
+        assert!(
+            !scan.is_settled(&changing, unhealthy),
+            "attempts below the cap keep retrying"
+        );
+        scan.advance(changing, unhealthy);
+    }
     assert!(
-        one_shot_should_stop(
-            Some(previous.as_slice()),
-            &current,
-            false,
-            false,
-            ONESHOT_ATTEMPTS
-        ),
+        scan.is_settled(&inventory(&[1, 2]), unhealthy),
         "the retry loop must remain bounded even if the inventory changes every time"
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to the `SpawnReflex` refactor on #1031: a workspace survey for the same shape — a free decision function fed by loop-scattered state and positional bools — found exactly one more genuine instance, the one-shot enumerate retry rule in `openlogi-device`.

## Changes

- `openlogi-device`: `one_shot_should_stop(previous, current, bool, bool, attempt)` and the loop locals feeding it (`previous_inventories`, `attempt`) fold into `OneShotScan` (`is_settled` / `advance`), with `ScanPass { complete, healthy }` naming what a pass established about its own trustworthiness. The healthy-passes-only evidence rule moves from a loop comment onto the field that enforces it. The tests port to real transitions: they can no longer construct unreachable states (a stability candidate no healthy pass produced), and their call sites lose the positional-bool guessing (`(Some(partial), &partial, false, true, 2)`).

Surveyed and deliberately left alone: single-value classifiers (`is_receiver_pid`, `is_hex_word`, …) are honest predicates; GPUI render helpers taking view state (`light_hero`, `gallery`, `permanent_row`) would gain only ceremony; `ensure_action(status, stale)` owns no state and its call site is self-documenting; the HID++ divert-flag setters (`set_cid_reporting(cid, bool, bool)`, `set_reporting(bool, bool)`) are a different smell with a different fix (typed flags at the wire boundary) and are left for their own change; `permissions::linux::classify` is not lintable on this host.

## Testing

- `cargo test -p openlogi-device` — 181 green, the five one-shot tests ported to transitions.
- `cargo clippy -p openlogi-device --all-targets -- -D warnings` and `cargo fmt` — clean.
- `cargo xtask ci wasm` — the portability job guarding this crate, green.
- `openlogi list` against real hardware (agent unreachable, so the CLI's direct read exercises the refactored one-shot path): the Bolt receiver and its paired MX Master 4 enumerate correctly.

No public API or behavior change intended; the debug log's field names tightened (`all_complete` → `complete`).
