### PR TITLE
refactor(hid): name the divert intents instead of passing flag bools

### DIFF
--- a/crates/openlogi-device/src/lib.rs
+++ b/crates/openlogi-device/src/lib.rs
@@ -48,10 +48,7 @@ pub use pairing::{
     Click, DiscoveredDevice, PairingCommand, PairingError, PairingEvent, PairingReceiver,
     PasskeyMethod, ReceiverFamily, ReceiverSelector, list_pairing_receivers, run_pairing, unpair,
 };
-pub use session::gesture::{
-    CaptureChannel, CaptureStop, CapturedInput, GestureError, run_capture_session,
-    run_capture_session_with_stop_reason,
-};
+pub use session::gesture::{CaptureChannel, CapturedInput, GestureError, run_capture_session};
 pub use session::host_switch::{
     HostSwitchError, HostSwitchStopReason, run_host_switch_session, switch_linked_hosts,
 };

--- a/crates/openlogi-device/src/reprog_controls.rs
+++ b/crates/openlogi-device/src/reprog_controls.rs
@@ -244,20 +244,23 @@ impl ReprogControlsV4 {
         self.inner.reset_all_cid_report_settings().await
     }
 
-    /// Set (or clear) temporary diversion and raw-XY reporting for `cid`.
-    ///
-    /// `remap` is left at `0` (no persistent remapping). After enabling, the
-    /// device emits [`RawControlEvent`]s on this feature index; clear both flags
-    /// on teardown to hand the control back to the firmware.
-    pub async fn set_cid_reporting(
-        &self,
-        cid: u16,
-        diverted: bool,
-        raw_xy: bool,
-    ) -> Result<(), Hidpp20Error> {
+    /// Divert `cid`'s reports to software. Raw XY stays off and remapping is
+    /// left untouched; the device then emits [`RawControlEvent`]s on this
+    /// feature index.
+    pub async fn divert_cid(&self, cid: u16) -> Result<(), Hidpp20Error> {
         self.set_cid_reporting_full(
             cid,
-            hidpp_reprog::CidReportingChange::temporary_diversion(diverted, raw_xy),
+            hidpp_reprog::CidReportingChange::temporary_diversion(true, false),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Hand `cid` back to the firmware: clear temporary diversion and raw XY.
+    pub async fn undivert_cid(&self, cid: u16) -> Result<(), Hidpp20Error> {
+        self.set_cid_reporting_full(
+            cid,
+            hidpp_reprog::CidReportingChange::temporary_diversion(false, false),
         )
         .await?;
         Ok(())

--- a/crates/openlogi-device/src/reprog_controls.rs
+++ b/crates/openlogi-device/src/reprog_controls.rs
@@ -250,7 +250,11 @@ impl ReprogControlsV4 {
     pub async fn divert_cid(&self, cid: u16) -> Result<(), Hidpp20Error> {
         self.set_cid_reporting_full(
             cid,
-            hidpp_reprog::CidReportingChange::temporary_diversion(true, false),
+            hidpp_reprog::CidReportingChange {
+                diverted: Some(true),
+                raw_xy: Some(false),
+                ..Default::default()
+            },
         )
         .await?;
         Ok(())
@@ -260,7 +264,11 @@ impl ReprogControlsV4 {
     pub async fn undivert_cid(&self, cid: u16) -> Result<(), Hidpp20Error> {
         self.set_cid_reporting_full(
             cid,
-            hidpp_reprog::CidReportingChange::temporary_diversion(false, false),
+            hidpp_reprog::CidReportingChange {
+                diverted: Some(false),
+                raw_xy: Some(false),
+                ..Default::default()
+            },
         )
         .await?;
         Ok(())

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -46,15 +46,6 @@ const LIVENESS_PING_STRIKES: u8 = 2;
 /// whenever no session is connected.
 pub type CaptureChannel = Arc<RwLock<Option<SharedChannel>>>;
 
-/// Why a capture session is shutting down.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CaptureStop {
-    /// Normal stop — restore diverted controls.
-    Graceful,
-    /// Lease revoked / channel dying — skip restore writes.
-    Revoked,
-}
-
 /// One input captured from the active device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapturedInput {
@@ -354,34 +345,6 @@ fn thumbwheel_input(
         .then_some(CapturedInput::ButtonPulse(ButtonId::Thumbwheel))
 }
 
-/// Reason-aware capture: maps stop reasons onto a unit oneshot shutdown.
-pub async fn run_capture_session_with_stop_reason(
-    backend: &dyn HidBackend,
-    route: DeviceRoute,
-    capture_thumbwheel: bool,
-    divert_gesture_button: bool,
-    sink: mpsc::UnboundedSender<CapturedInput>,
-    shutdown: oneshot::Receiver<CaptureStop>,
-    channel_slot: CaptureChannel,
-) -> Result<(), GestureError> {
-    let (tx, rx) = oneshot::channel();
-    tokio::spawn(async move {
-        let _ = shutdown.await;
-        let _ = tx.send(());
-    });
-    let spec = CaptureSpec {
-        capture_thumbwheel,
-        // The bool-era API only ever meant the dedicated gesture button; the
-        // haptic panel is reachable through [`CaptureSpec`] itself.
-        divert_gesture_sources: divert_gesture_button
-            .then_some(reprog_controls::GESTURE_BUTTON_CID)
-            .into_iter()
-            .collect(),
-        divert_buttons: Vec::new(),
-    };
-    run_capture_session(backend, route, spec, sink, rx, channel_slot).await
-}
-
 /// The set of controls a session has diverted, kept so they can be handed back
 /// to the firmware on teardown.
 #[derive(Default)]
@@ -559,8 +522,12 @@ async fn arm_reprog_control(
         // replayed on restore, leaving the button dead.
         debug!(cid, "control was already diverted before arming");
     }
-    let mut change = reprog_controls::CidReportingChange::temporary_diversion(true, raw_xy);
-    change.remap = original.remap;
+    let change = reprog_controls::CidReportingChange {
+        diverted: Some(true),
+        raw_xy: Some(raw_xy),
+        remap: original.remap,
+        ..Default::default()
+    };
     if let Err(error) = rc.set_cid_reporting_full(cid, change).await {
         let error = GestureError::Hidpp(format!("{error:?}"));
         restore_reporting(rc, ArmedCid { cid, original }, "failed diversion").await;
@@ -583,9 +550,12 @@ async fn arm_reprog_control(
 fn undivert_change(
     reporting: reprog_controls::CidReporting,
 ) -> reprog_controls::CidReportingChange {
-    let mut change = reprog_controls::CidReportingChange::temporary_diversion(false, false);
-    change.remap = reporting.remap;
-    change
+    reprog_controls::CidReportingChange {
+        diverted: Some(false),
+        raw_xy: Some(false),
+        remap: reporting.remap,
+        ..Default::default()
+    }
 }
 
 async fn restore_reporting(rc: &ReprogControlsV4, armed: ArmedCid, what: &str) {

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -30,7 +30,7 @@ use crate::backend::{BackendError, HidBackend};
 use crate::channel::route::{DeviceRoute, open_route_channel};
 
 use crate::reprog_controls::{self, RawControlEvent, ReprogControlsV4};
-use crate::thumbwheel::{self, Thumbwheel, WheelResolution};
+use crate::thumbwheel::{self, Thumbwheel, WheelDirection, WheelResolution};
 
 /// How often the capture session pings its device to prove the channel still
 /// delivers input reports. Cheap: one HID++ round-trip per interval.
@@ -418,7 +418,7 @@ impl ArmedControls {
             }
         }
         if let Some((tw, _, _)) = self.thumb.as_ref() {
-            restore(tw.set_reporting(false, false).await, "thumb wheel");
+            restore(tw.undivert().await, "thumb wheel");
         }
     }
 }
@@ -534,12 +534,9 @@ async fn arm_controls_into(
         if !supports_single_tap {
             debug!("thumb wheel reports no single tap — click not capturable");
         }
-        if let Err(error) = tw.set_reporting(true, false).await {
+        if let Err(error) = tw.divert(WheelDirection::Default).await {
             let error = GestureError::Hidpp(format!("{error:?}"));
-            restore(
-                tw.set_reporting(false, false).await,
-                "failed thumb wheel diversion",
-            );
+            restore(tw.undivert().await, "failed thumb wheel diversion");
             return Err(error);
         }
         armed.thumb = Some((tw, info.index, resolution));

--- a/crates/openlogi-device/src/session/host_switch.rs
+++ b/crates/openlogi-device/src/session/host_switch.rs
@@ -261,11 +261,7 @@ async fn arm_host_controls_inner(
             });
             match mode {
                 ReportingMode::Diverted => {
-                    timed_hidpp(
-                        "diverting host control",
-                        controls.set_cid_reporting(info.cid, true, false),
-                    )
-                    .await?;
+                    timed_hidpp("diverting host control", controls.divert_cid(info.cid)).await?;
                 }
                 ReportingMode::Analytics => {
                     timed_hidpp(
@@ -707,15 +703,17 @@ mod tests {
         assert!(!change.required);
     }
 
-    fn reporting(diverted: bool, raw_xy: bool, analytics_key_events: bool) -> CidReporting {
+    /// A reporting snapshot with unrelated bits deliberately set, so the
+    /// cleanup tests prove that only the bits they vary are restored.
+    fn noisy_reporting() -> CidReporting {
         CidReporting {
             cid: ControlId(0x00d3),
-            diverted,
+            diverted: false,
             persistently_diverted: true,
             force_raw_xy: true,
-            raw_xy,
+            raw_xy: false,
             remap: Some(ControlId(0x1234)),
-            analytics_key_events,
+            analytics_key_events: false,
             raw_wheel: true,
         }
     }
@@ -758,7 +756,7 @@ mod tests {
             cid: 0x00d3,
             host: 2,
             mode: ReportingMode::Analytics,
-            original: reporting(false, false, false),
+            original: noisy_reporting(),
         }];
         let mut events = [AnalyticsKeyEvent::default(); 5];
         events[0] = AnalyticsKeyEvent {
@@ -795,7 +793,11 @@ mod tests {
             cid: 0x00d3,
             host: 2,
             mode: ReportingMode::Diverted,
-            original: reporting(true, true, false),
+            original: CidReporting {
+                diverted: true,
+                raw_xy: true,
+                ..noisy_reporting()
+            },
         });
 
         assert_eq!(change.diverted, Some(true));
@@ -811,7 +813,10 @@ mod tests {
             cid: 0x00d3,
             host: 2,
             mode: ReportingMode::Analytics,
-            original: reporting(false, false, true),
+            original: CidReporting {
+                analytics_key_events: true,
+                ..noisy_reporting()
+            },
         });
 
         assert_eq!(change.analytics_key_events, Some(true));

--- a/crates/openlogi-device/src/session/keyboard.rs
+++ b/crates/openlogi-device/src/session/keyboard.rs
@@ -198,10 +198,7 @@ async fn run_keyboard_capture_session_on(
         *slot = None;
     }
     for &cid in diverted.keys() {
-        restore(
-            rc.set_cid_reporting(cid, false, false).await,
-            "keyboard key",
-        );
+        restore(rc.undivert_cid(cid).await, "keyboard key");
     }
     debug!(index = device_index, "keyboard key capture stopped");
     Ok(())
@@ -243,7 +240,7 @@ async fn arm_keys(
     let mut diverted = BTreeMap::new();
     for (&cid, &button) in wanted {
         if controls.iter().any(|c| c.cid == cid && c.is_divertable()) {
-            rc.set_cid_reporting(cid, true, false)
+            rc.divert_cid(cid)
                 .await
                 .map_err(|e| GestureError::Hidpp(format!("{e:?}")))?;
             diverted.insert(cid, button);
@@ -265,7 +262,7 @@ async fn rearm_keys(rc: &ReprogControlsV4, diverted: &BTreeMap<u16, ButtonId>) {
     // occasionally before the device accepts feature writes again.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     for &cid in diverted.keys() {
-        if let Err(e) = rc.set_cid_reporting(cid, true, false).await {
+        if let Err(e) = rc.divert_cid(cid).await {
             warn!(
                 cid = format_args!("{cid:#06x}"),
                 error = ?e,

--- a/crates/openlogi-device/src/thumbwheel.rs
+++ b/crates/openlogi-device/src/thumbwheel.rs
@@ -258,16 +258,33 @@ impl Thumbwheel {
         })
     }
 
-    /// Enter (or leave) diverted reporting. `inv_dir` inverts the rotation sign
-    /// relative to `default_dir`. Set `diverted = false` on teardown to hand
-    /// native scrolling back to the firmware.
-    pub async fn set_reporting(&self, diverted: bool, inv_dir: bool) -> Result<(), Hidpp20Error> {
+    /// Enter diverted reporting; wheel events then arrive on this feature
+    /// index instead of moving the native scroll.
+    pub async fn divert(&self, direction: WheelDirection) -> Result<(), Hidpp20Error> {
         let mut params = [0u8; 16];
-        params[0] = if diverted { MODE_DIVERTED } else { MODE_NATIVE };
-        params[1] = u8::from(inv_dir);
+        params[0] = MODE_DIVERTED;
+        params[1] = u8::from(direction == WheelDirection::Inverted);
         self.call(FN_SET_REPORTING, params).await?;
         Ok(())
     }
+
+    /// Hand native scrolling back to the firmware.
+    pub async fn undivert(&self) -> Result<(), Hidpp20Error> {
+        let mut params = [0u8; 16];
+        params[0] = MODE_NATIVE;
+        self.call(FN_SET_REPORTING, params).await?;
+        Ok(())
+    }
+}
+
+/// Rotation sign for diverted wheel reports, relative to the wheel's
+/// `default_dir`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WheelDirection {
+    /// Report rotation with the wheel's default sign.
+    Default,
+    /// Invert the rotation sign.
+    Inverted,
 }
 
 #[cfg(test)]

--- a/crates/openlogi-hid/examples/thumbwheel_trace.rs
+++ b/crates/openlogi-hid/examples/thumbwheel_trace.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use openlogi_hid::thumbwheel::{self, Thumbwheel};
+use openlogi_hid::thumbwheel::{self, Thumbwheel, WheelDirection};
 use openlogi_hid::{ChannelPool, DeviceRoute, host};
 
 /// Seconds the wheel stays diverted while reports are printed.
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     });
 
-    tw.set_reporting(true, false)
+    tw.divert(WheelDirection::Default)
         .await
         .map_err(|e| format!("could not divert the wheel: {e:?}"))?;
     println!("\n>>> diverted — roll the wheel, then lift your thumb off it ({WATCH:?})\n");
@@ -100,7 +100,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     drop(listener);
-    if let Err(e) = tw.set_reporting(false, false).await {
+    if let Err(e) = tw.undivert().await {
         println!("could not restore native reporting: {e:?}");
     }
     println!("\n<<< native reporting restored");

--- a/crates/openlogi-hidpp/src/feature/reprog_controls.rs
+++ b/crates/openlogi-hidpp/src/feature/reprog_controls.rs
@@ -331,16 +331,6 @@ pub struct CidReportingChange {
 }
 
 impl CidReportingChange {
-    /// Change only the temporary diverted/raw-XY bits.
-    #[must_use]
-    pub fn temporary_diversion(diverted: bool, raw_xy: bool) -> Self {
-        Self {
-            diverted: Some(diverted),
-            raw_xy: Some(raw_xy),
-            ..Self::default()
-        }
-    }
-
     fn to_payload(self, cid: ControlId) -> [u8; 16] {
         let mut payload = [0u8; 16];
         let [cid_hi, cid_lo] = cid.0.to_be_bytes();

--- a/crates/openlogi-hidpp/src/feature/reprog_controls/tests.rs
+++ b/crates/openlogi-hidpp/src/feature/reprog_controls/tests.rs
@@ -33,7 +33,12 @@ fn parses_cid_info_flags_and_metadata() {
 
 #[test]
 fn builds_temporary_diversion_payload() {
-    let payload = CidReportingChange::temporary_diversion(true, true).to_payload(ControlId(0x00c3));
+    let payload = CidReportingChange {
+        diverted: Some(true),
+        raw_xy: Some(true),
+        ..Default::default()
+    }
+    .to_payload(ControlId(0x00c3));
 
     assert_eq!(&payload[0..=1], &0x00c3u16.to_be_bytes());
     assert_eq!(payload[2], 0x33);


### PR DESCRIPTION
## Summary

Completes the item deferred from #1070's survey: the divert APIs' bare positional bools. Bitflags — the shape considered there — turned out to be wrong for both wires, so the refactor names the intents instead.

## Changes

Why not bitflags: `setCidReporting`'s wire is valid+value bit *pairs* — per-flag tri-state (set, clear, leave unchanged) — which the fork's `CidReportingChange { diverted: Option<bool>, … }` already encodes faithfully; a flag set cannot express "leave unchanged". The thumbwheel's `setReporting` wire is two independent bytes (a mode and an inversion byte), not a flag set either.

- `openlogi-device`: `ReprogControls::set_cid_reporting(cid, bool, bool)` → `divert_cid(cid)` / `undivert_cid(cid)` over the existing typed change (the only combinations any caller used); `Thumbwheel::set_reporting(bool, bool)` → `divert(WheelDirection)` / `undivert()`, with `WheelDirection { Default, Inverted }` mirroring the wire's inversion byte. The gesture/keyboard/host-switch call sites lose their `(true, false)` guessing.
- host-switch tests: the `reporting(bool, bool, bool)` fixture becomes `noisy_reporting()` plus struct-update at the three sites, naming exactly the bits each case varies.
- `openlogi-hid`: the `thumbwheel_trace` example follows the new API.

Second commit, the bool-era residue:

- `run_capture_session_with_stop_reason(…, capture_thumbwheel: bool, divert_gesture_button: bool, …)` is deleted along with its `CaptureStop` reason enum: it has had zero callers since the real caller moved to `run_capture_session(spec)`, and its "reason-aware" name was never true — it mapped every reason onto the same unit shutdown. Dead `pub` API in a lib emits no dead-code warning, which is how it survived.
- `CidReportingChange::temporary_diversion(bool, bool)` is deleted from the fork; every site now spells the change as a named-field struct literal (`diverted: Some(…), raw_xy: Some(…), ..Default::default()`), including the arming/undivert paths in the gesture session and the fork's own payload-bytes test.

## Testing

- Byte-identical by construction: `divert_cid`/`undivert_cid` build the same `CidReportingChange` the old wrapper's constructor produced (now as named-field literals; the fork's payload test pins the bytes), and `divert(Default)`/`undivert()` emit the same `params` bytes the old `(true, false)`/`(false, false)` calls did.
- `cargo test -p openlogi-device -p openlogi-hid -p openlogi-hidpp` (181 + 16 + 203 green), `cargo clippy --all-targets -- -D warnings` across the touched crates plus `openlogi-agent-core`, `cargo fmt`, `cargo xtask ci wasm` — all green.
- Not runtime-tested on hardware: the divert paths run inside the gesture/keyboard capture sessions; the byte-equivalence above is the review handle.
