### PR TITLE
refactor(gui): name the scrolling card's facts instead of a five-tuple

### DIFF
--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -604,7 +604,12 @@ fn light_tab(
             .gap_4()
             .flex_wrap()
             .items_start()
-            .child(light_visual::detail(asset, online, enabled, settings, pal))
+            .child(light_visual::detail(
+                asset,
+                light_visual::LightView { online, enabled },
+                settings,
+                pal,
+            ))
             .child(
                 div()
                     .w(LIGHT_CONTROLS_W)

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -336,24 +336,69 @@ fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
         .child(card)
 }
 
+/// What the scrolling card shows for the selected device — `Default` is the
+/// no-device (or unreadable-state) blank.
+#[derive(Default)]
+struct ScrollingFacts {
+    inversion: Inversion,
+    resolution: Option<openlogi_core::config::ScrollResolution>,
+    hires: HiresWheel,
+}
+
+/// The current link's native scroll-inversion state.
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+enum Inversion {
+    /// The device does not report HID++ inversion support.
+    #[default]
+    Unsupported,
+    /// Supported, scrolling with the default sign.
+    Normal,
+    /// Supported and inverted.
+    Inverted,
+}
+
+/// Where the device offers hi-res wheel control.
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+enum HiresWheel {
+    /// On the current link.
+    Here,
+    /// Only on another of its links.
+    Elsewhere,
+    /// Nowhere.
+    #[default]
+    Nowhere,
+}
+
 /// Scrolling card: per-device native inversion and wheel-resolution controls.
 /// Pure config — no hardware read — so it is a plain settings block rather than
 /// an `Entity` panel like DPI / SmartShift.
 fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
-    let (inverted, inversion_supported, resolution, hires_supported, hires_elsewhere) =
-        AppState::try_read(cx).map_or((false, false, None, false, false), |state| {
-            (
-                state.current_invert_scroll(),
-                state.current_scroll_inversion_supported(),
-                state.current_scroll_resolution(),
-                state.current_hires_wheel_supported(),
-                state.hires_wheel_supported_on_another_link(),
-            )
-        });
-    let inversion_description = if inversion_supported {
-        tr!("Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.")
-    } else {
+    let ScrollingFacts {
+        inversion,
+        resolution,
+        hires,
+    } = AppState::try_read(cx).map_or_else(ScrollingFacts::default, |state| ScrollingFacts {
+        inversion: match (
+            state.current_scroll_inversion_supported(),
+            state.current_invert_scroll(),
+        ) {
+            (false, _) => Inversion::Unsupported,
+            (true, false) => Inversion::Normal,
+            (true, true) => Inversion::Inverted,
+        },
+        resolution: state.current_scroll_resolution(),
+        hires: if state.current_hires_wheel_supported() {
+            HiresWheel::Here
+        } else if state.hires_wheel_supported_on_another_link() {
+            HiresWheel::Elsewhere
+        } else {
+            HiresWheel::Nowhere
+        },
+    });
+    let inversion_description = if inversion == Inversion::Unsupported {
         tr!("This device does not report native HID++ scroll inversion support.")
+    } else {
+        tr!("Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.")
     };
     let inversion_row = h_flex()
         .justify_between()
@@ -376,9 +421,9 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
         )
         .child(
             Toggle::new("invert-scroll-toggle")
-                .selected(inverted)
-                .disabled(!inversion_supported)
-                .label((!inversion_supported).then(|| tr!("Unavailable")))
+                .selected(inversion == Inversion::Inverted)
+                .disabled(inversion == Inversion::Unsupported)
+                .label((inversion == Inversion::Unsupported).then(|| tr!("Unavailable")))
                 .on_change(|inverted, _window, cx| {
                     AppState::update(cx, |state, cx| {
                         let key = state.current_record().map(DeviceRecord::device_key);
@@ -389,18 +434,18 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
                     });
                 }),
         );
-    let resolution_description = if hires_supported {
-        match resolution {
+    let resolution_description = match hires {
+        HiresWheel::Here => match resolution {
             None => tr!("OpenLogi does not change the wheel resolution."),
             Some(ScrollResolution::Low) => tr!("Scrolls once per physical ratchet step."),
             Some(ScrollResolution::High) => {
                 tr!("Detects finer movement between ratchet steps.")
             }
+        },
+        HiresWheel::Elsewhere => {
+            tr!("This device supports wheel resolution on its other connection, but not this one.")
         }
-    } else if hires_elsewhere {
-        tr!("This device supports wheel resolution on its other connection, but not this one.")
-    } else {
-        tr!("This device does not support wheel resolution control.")
+        HiresWheel::Nowhere => tr!("This device does not support wheel resolution control."),
     };
     let resolution_row = v_flex()
         .gap_2()
@@ -419,7 +464,10 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
                         .child(resolution_description),
                 ),
         )
-        .child(wheel_resolution_control(resolution, hires_supported));
+        .child(wheel_resolution_control(
+            resolution,
+            hires == HiresWheel::Here,
+        ));
     PanelCard::new(
         tr!("Scrolling"),
         Icon::empty().path("action-icons/mouse.svg"),

--- a/crates/openlogi-desktop/src/app/detail.rs
+++ b/crates/openlogi-desktop/src/app/detail.rs
@@ -340,21 +340,15 @@ fn pointer_grid_card(card: impl IntoElement) -> impl IntoElement {
 /// no-device (or unreadable-state) blank.
 #[derive(Default)]
 struct ScrollingFacts {
-    inversion: Inversion,
+    /// The persisted inversion setting. Independent of
+    /// `inversion_supported` — a configured inversion on a link without
+    /// support still renders, checked and disabled — so these are two named
+    /// fields, not a sum type.
+    inverted: bool,
+    /// Whether the current link reports HID++ inversion support.
+    inversion_supported: bool,
     resolution: Option<openlogi_core::config::ScrollResolution>,
     hires: HiresWheel,
-}
-
-/// The current link's native scroll-inversion state.
-#[derive(Default, Clone, Copy, PartialEq, Eq)]
-enum Inversion {
-    /// The device does not report HID++ inversion support.
-    #[default]
-    Unsupported,
-    /// Supported, scrolling with the default sign.
-    Normal,
-    /// Supported and inverted.
-    Inverted,
 }
 
 /// Where the device offers hi-res wheel control.
@@ -374,18 +368,13 @@ enum HiresWheel {
 /// an `Entity` panel like DPI / SmartShift.
 fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
     let ScrollingFacts {
-        inversion,
+        inverted,
+        inversion_supported,
         resolution,
         hires,
     } = AppState::try_read(cx).map_or_else(ScrollingFacts::default, |state| ScrollingFacts {
-        inversion: match (
-            state.current_scroll_inversion_supported(),
-            state.current_invert_scroll(),
-        ) {
-            (false, _) => Inversion::Unsupported,
-            (true, false) => Inversion::Normal,
-            (true, true) => Inversion::Inverted,
-        },
+        inverted: state.current_invert_scroll(),
+        inversion_supported: state.current_scroll_inversion_supported(),
         resolution: state.current_scroll_resolution(),
         hires: if state.current_hires_wheel_supported() {
             HiresWheel::Here
@@ -395,10 +384,10 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
             HiresWheel::Nowhere
         },
     });
-    let inversion_description = if inversion == Inversion::Unsupported {
-        tr!("This device does not report native HID++ scroll inversion support.")
-    } else {
+    let inversion_description = if inversion_supported {
         tr!("Reverse this mouse's scroll wheel. Your trackpad keeps the system scroll direction.")
+    } else {
+        tr!("This device does not report native HID++ scroll inversion support.")
     };
     let inversion_row = h_flex()
         .justify_between()
@@ -421,9 +410,9 @@ fn scrolling_card(pal: Palette, cx: &mut Context<AppView>) -> impl IntoElement {
         )
         .child(
             Toggle::new("invert-scroll-toggle")
-                .selected(inversion == Inversion::Inverted)
-                .disabled(inversion == Inversion::Unsupported)
-                .label((inversion == Inversion::Unsupported).then(|| tr!("Unavailable")))
+                .selected(inverted)
+                .disabled(!inversion_supported)
+                .label((!inversion_supported).then(|| tr!("Unavailable")))
                 .on_change(|inverted, _window, cx| {
                     AppState::update(cx, |state, cx| {
                         let key = state.current_record().map(DeviceRecord::device_key);

--- a/crates/openlogi-desktop/src/app/home.rs
+++ b/crates/openlogi-desktop/src/app/home.rs
@@ -543,8 +543,10 @@ fn device_image(
     if record.kind == DeviceKind::Light {
         return light_visual::gallery(
             record.asset.as_ref(),
-            record.online,
-            light_enabled,
+            light_visual::LightView {
+                online: record.online,
+                enabled: light_enabled,
+            },
             light_settings,
             pal,
         )

--- a/crates/openlogi-desktop/src/features/lighting/standalone.rs
+++ b/crates/openlogi-desktop/src/features/lighting/standalone.rs
@@ -2,6 +2,8 @@
 
 use crate::state::{AppState, DeviceRecord, LightCommandStatus, StateEvent};
 use crate::ui::components::Toggle;
+
+use super::visual::LightView;
 use crate::ui::theme::{self, ACCENT_BLUE, Palette, Typography as _};
 use gpui::{
     App, AppContext as _, BoxShadow, Context, Entity, Hsla, IntoElement, ParentElement, Render,
@@ -224,7 +226,14 @@ impl Render for LightPanel {
             .gap_4()
             .w_full()
             .when(power, |panel| {
-                let panel = panel.child(light_hero(&device_name, online, effective_enabled, pal));
+                let panel = panel.child(light_hero(
+                    &device_name,
+                    LightView {
+                        online,
+                        enabled: effective_enabled,
+                    },
+                    pal,
+                ));
                 #[cfg(target_os = "macos")]
                 let panel = panel.child(camera_automation(settings, pal));
                 panel.child(div().h(px(1.)).w_full().bg(pal.border.opacity(0.55)))
@@ -259,12 +268,11 @@ impl Render for LightPanel {
     }
 }
 
-fn light_hero(
-    device_name: &str,
-    online: bool,
-    effective_enabled: bool,
-    pal: Palette,
-) -> impl IntoElement {
+fn light_hero(device_name: &str, view: LightView, pal: Palette) -> impl IntoElement {
+    let LightView {
+        online,
+        enabled: effective_enabled,
+    } = view;
     h_flex()
         .gap_3()
         .items_center()
@@ -275,7 +283,13 @@ fn light_hero(
                 .flex_1()
                 .min_w_0()
                 .child(div().text_heading().child(device_name.to_owned()))
-                .child(light_status(online, effective_enabled, pal)),
+                .child(light_status(
+                    LightView {
+                        online,
+                        enabled: effective_enabled,
+                    },
+                    pal,
+                )),
         )
         .child(
             Toggle::new("standalone-light-toggle")
@@ -379,7 +393,8 @@ fn camera_automation(current: LightSettings, pal: Palette) -> impl IntoElement {
         )
 }
 
-fn light_status(online: bool, enabled: bool, pal: Palette) -> impl IntoElement {
+fn light_status(view: LightView, pal: Palette) -> impl IntoElement {
+    let LightView { online, enabled } = view;
     let (label, color) = if !online {
         (tr!("Offline"), theme::STATUS_OFFLINE)
     } else if enabled {

--- a/crates/openlogi-desktop/src/features/lighting/visual.rs
+++ b/crates/openlogi-desktop/src/features/lighting/visual.rs
@@ -13,28 +13,35 @@ use openlogi_core::config::LightSettings;
 use crate::services::assets::ResolvedAsset;
 use crate::ui::theme::Palette;
 
+/// What a light's visual reflects about the device — connection and power
+/// are independent facts (an enabled light can be offline), so this is a
+/// named pair rather than two adjacent `bool`s.
+#[derive(Clone, Copy)]
+pub(crate) struct LightView {
+    pub(crate) online: bool,
+    pub(crate) enabled: bool,
+}
+
 /// Render a standalone light inside a home-gallery image slot.
 pub(crate) fn gallery(
     asset: Option<&ResolvedAsset>,
-    online: bool,
-    enabled: bool,
+    view: LightView,
     settings: LightSettings,
     pal: Palette,
 ) -> gpui::Div {
     visual_container()
         .when_some(asset, |container, asset| {
-            container.child(product_image(asset, 210., 180., online))
+            container.child(product_image(asset, 210., 180., view.online))
         })
         .when(asset.is_none(), |container| {
-            container.child(generated_visual(210., 180., online, enabled, settings, pal))
+            container.child(generated_visual(210., 180., view, settings, pal))
         })
 }
 
 /// Render a standalone light as the large hero in its detail view.
 pub(crate) fn detail(
     asset: Option<&ResolvedAsset>,
-    online: bool,
-    enabled: bool,
+    view: LightView,
     settings: LightSettings,
     pal: Palette,
 ) -> gpui::Div {
@@ -48,10 +55,10 @@ pub(crate) fn detail(
         .bg(pal.panel)
         .overflow_hidden()
         .when_some(asset, |container, asset| {
-            container.child(product_image(asset, 536., 460., online))
+            container.child(product_image(asset, 536., 460., view.online))
         })
         .when(asset.is_none(), |container| {
-            container.child(generated_visual(536., 460., online, enabled, settings, pal))
+            container.child(generated_visual(536., 460., view, settings, pal))
         })
 }
 
@@ -84,11 +91,11 @@ fn visual_container() -> gpui::Div {
 fn generated_visual(
     width: f32,
     height: f32,
-    online: bool,
-    enabled: bool,
+    view: LightView,
     settings: LightSettings,
     pal: Palette,
 ) -> gpui::Div {
+    let LightView { online, enabled } = view;
     let powered = online && enabled;
     let glow = light_color(settings.temperature_kelvin.unwrap_or(4600));
     let brightness = f32::from(settings.brightness_percent.min(100)) / 100.;

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -471,8 +471,10 @@ impl Render for SettingsView {
                 group_ix: None,
             })
             .page(general::general_page(
-                self.vertical_scroll_sensitivity_slider.clone(),
-                self.thumbwheel_sensitivity_slider.clone(),
+                general::SensitivitySliders {
+                    vertical_scroll: self.vertical_scroll_sensitivity_slider.clone(),
+                    thumbwheel: self.thumbwheel_sensitivity_slider.clone(),
+                },
                 self.registration_status,
             ))
             .page(updates::updates_page(self.updater.clone()));

--- a/crates/openlogi-desktop/src/windows/settings/general.rs
+++ b/crates/openlogi-desktop/src/windows/settings/general.rs
@@ -10,36 +10,28 @@ use gpui_base::Button as BaseButton;
 
 use crate::platform::registration::ServiceStatus;
 
+/// The page's two sensitivity sliders, named so a call site cannot swap two
+/// same-typed `Entity<SliderState>`s without the compiler noticing.
+pub(super) struct SensitivitySliders {
+    pub(super) vertical_scroll: Entity<SliderState>,
+    pub(super) thumbwheel: Entity<SliderState>,
+}
+
 pub(super) fn general_page(
-    vertical_scroll_sensitivity_slider: Entity<SliderState>,
-    thumbwheel_sensitivity_slider: Entity<SliderState>,
+    sliders: SensitivitySliders,
     registration_status: ServiceStatus,
 ) -> SettingPage {
+    let SensitivitySliders {
+        vertical_scroll,
+        thumbwheel,
+    } = sliders;
     let group = SettingGroup::new()
-        .item(
-            SettingItem::new(
-                tr!("Smooth scrolling"),
-                SettingField::switch(
-                    |cx| {
-                        AppState::try_read(cx).is_some_and(|s| s.app_settings().smooth_scroll)
-                    },
-                    |enabled, cx| {
-                        AppState::update(cx, move |state, cx| {
-                            state.set_smooth_scroll(enabled);
-                            cx.emit(StateEvent::SettingsChanged);
-                        });
-                    },
-                ),
-            )
-            .description(tr!(
-                "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
-            )),
-        )
+        .item(smooth_scrolling_item())
         .item(
             SettingItem::new(
                 tr!("Vertical Scroll Sensitivity"),
                 SettingField::render(move |_, _, cx| {
-                    vertical_scroll_sensitivity_field(&vertical_scroll_sensitivity_slider, cx)
+                    vertical_scroll_sensitivity_field(&vertical_scroll, cx)
                 }),
             )
             .description(tr!(
@@ -50,7 +42,7 @@ pub(super) fn general_page(
             SettingItem::new(
                 tr!("Thumb Wheel Sensitivity"),
                 SettingField::render(move |_, _, cx| {
-                    thumbwheel_sensitivity_field(&thumbwheel_sensitivity_slider, cx)
+                    thumbwheel_sensitivity_field(&thumbwheel, cx)
                 }),
             )
             .description(tr!(
@@ -105,6 +97,25 @@ pub(super) fn general_page(
         .icon(IconName::Settings)
         .resettable(false)
         .group(group)
+}
+
+/// The smooth-scrolling switch.
+fn smooth_scrolling_item() -> SettingItem {
+    SettingItem::new(
+        tr!("Smooth scrolling"),
+        SettingField::switch(
+            |cx| AppState::try_read(cx).is_some_and(|s| s.app_settings().smooth_scroll),
+            |enabled, cx| {
+                AppState::update(cx, move |state, cx| {
+                    state.set_smooth_scroll(enabled);
+                    cx.emit(StateEvent::SettingsChanged);
+                });
+            },
+        ),
+    )
+    .description(tr!(
+        "Animate traditional mouse-wheel input while leaving trackpad scrolling unchanged."
+    ))
 }
 
 fn thumbwheel_sensitivity_field(slider: &Entity<SliderState>, cx: &mut App) -> gpui::Div {


### PR DESCRIPTION
## Summary

The last surveyed bool-blindness site: the scrolling card destructured a five-tuple whose default read `(false, false, None, false, false)` — four positional bools a reader must count to identify.

## Changes

- `openlogi-desktop`: `scrolling_card`'s facts become `ScrollingFacts { inverted, inversion_supported, resolution, hires }`. The hi-res pair collapses into a real sum type, `HiresWheel { Here, Elsewhere, Nowhere }` (mirroring the description's if/else-if precedence — a device supporting hi-res on both links reads as `Here`). The inversion pair deliberately stays two named fields: `inverted` is persisted config and `inversion_supported` a per-link capability — independent facts, and review caught that a first-draft `Inversion` sum type erased the configured-but-unsupported state (the toggle must render checked-and-disabled there); a field comment now records why this pair must not become a sum type. `Default` is the no-device blank the tuple's positional default used to spell.

Two follow-up commits from the same survey:

- `general_page` takes `SensitivitySliders { vertical_scroll, thumbwheel }` instead of two adjacent same-typed `Entity<SliderState>`s a call site could swap silently; the smooth-scrolling item is extracted as `smooth_scrolling_item()` (the page crossed clippy's 100-line bound, and named item builders are this file's existing idiom).
- The lighting visuals share `LightView { online, enabled }` — connection and power are independent facts (an enabled light can be offline), so a named pair rather than adjacent bools — threaded through `gallery`/`detail`/`generated_visual`/`light_hero`/`light_status` and their call sites.

## Testing

- `cargo test -p openlogi-desktop` — 187 green; `cargo clippy --all-targets -- -D warnings`, `cargo fmt` — clean.
- Rendering-only restructure: every branch maps one-to-one onto the old bool conditions (`HiresWheel` keeps the supported-first precedence; the inversion fields feed the exact original `selected`/`disabled`/description expressions). Not visually re-verified in a running GUI.
- Rebased onto current master (the `general_page` signature conflict with the merged #1031 resolved by combining `SensitivitySliders` with `registration_status`); the full local tier ran green on the rebased tree.

