### PR TITLE
refactor(linux): make the hidraw probe outcome an explicit enum

### DIFF
--- a/crates/openlogi-permissions/src/linux.rs
+++ b/crates/openlogi-permissions/src/linux.rs
@@ -21,7 +21,11 @@ use crate::PermissionStatus;
 /// - `Unknown` — uinput is fine but no Logitech hidraw is connected.
 #[must_use]
 pub fn input_device_access() -> PermissionStatus {
-    classify(probe_uinput(), probe_logitech_hidraw())
+    Probes {
+        uinput_writable: probe_uinput(),
+        hidraw: probe_logitech_hidraw(),
+    }
+    .into()
 }
 
 /// What probing the Logitech `/dev/hidraw*` nodes established.
@@ -35,12 +39,23 @@ pub(crate) enum HidrawProbe {
     NonePresent,
 }
 
-/// Split from the probes so it is testable without device nodes.
-pub(crate) fn classify(uinput_ok: bool, hidraw: HidrawProbe) -> PermissionStatus {
-    match (uinput_ok, hidraw) {
-        (true, HidrawProbe::Accessible) => PermissionStatus::Granted,
-        (false, _) | (_, HidrawProbe::Denied) => PermissionStatus::Denied,
-        (true, HidrawProbe::NonePresent) => PermissionStatus::Unknown,
+/// Both probes, taken together.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Probes {
+    /// `/dev/uinput` opened for writing.
+    pub(crate) uinput_writable: bool,
+    pub(crate) hidraw: HidrawProbe,
+}
+
+/// The verdict is a total function of the two probes — split from the
+/// probing itself so it is testable without device nodes.
+impl From<Probes> for PermissionStatus {
+    fn from(probes: Probes) -> Self {
+        match (probes.uinput_writable, probes.hidraw) {
+            (true, HidrawProbe::Accessible) => Self::Granted,
+            (false, _) | (_, HidrawProbe::Denied) => Self::Denied,
+            (true, HidrawProbe::NonePresent) => Self::Unknown,
+        }
     }
 }
 

--- a/crates/openlogi-permissions/src/linux.rs
+++ b/crates/openlogi-permissions/src/linux.rs
@@ -24,12 +24,23 @@ pub fn input_device_access() -> PermissionStatus {
     classify(probe_uinput(), probe_logitech_hidraw())
 }
 
+/// What probing the Logitech `/dev/hidraw*` nodes established.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HidrawProbe {
+    /// At least one Logitech hidraw opened read/write.
+    Accessible,
+    /// A Logitech hidraw is present but `open()` was refused.
+    Denied,
+    /// No Logitech hidraw is connected to probe.
+    NonePresent,
+}
+
 /// Split from the probes so it is testable without device nodes.
-pub(crate) fn classify(uinput_ok: bool, hidraw_ok: Option<bool>) -> PermissionStatus {
-    match (uinput_ok, hidraw_ok) {
-        (true, Some(true)) => PermissionStatus::Granted,
-        (false, _) | (_, Some(false)) => PermissionStatus::Denied,
-        (true, None) => PermissionStatus::Unknown,
+pub(crate) fn classify(uinput_ok: bool, hidraw: HidrawProbe) -> PermissionStatus {
+    match (uinput_ok, hidraw) {
+        (true, HidrawProbe::Accessible) => PermissionStatus::Granted,
+        (false, _) | (_, HidrawProbe::Denied) => PermissionStatus::Denied,
+        (true, HidrawProbe::NonePresent) => PermissionStatus::Unknown,
     }
 }
 
@@ -41,13 +52,13 @@ fn probe_uinput() -> bool {
         .is_ok()
 }
 
-/// `Some(true)` — a Logitech hidraw is accessible; `Some(false)` — one is
-/// present but permission is denied; `None` — none connected.
-fn probe_logitech_hidraw() -> Option<bool> {
-    let mut any_accessible = false;
+fn probe_logitech_hidraw() -> HidrawProbe {
     let mut any_denied = false;
 
-    for entry in fs::read_dir("/dev").ok()?.filter_map(Result::ok) {
+    let Ok(entries) = fs::read_dir("/dev") else {
+        return HidrawProbe::NonePresent;
+    };
+    for entry in entries.filter_map(Result::ok) {
         let Ok(name) = entry.file_name().into_string() else {
             continue;
         };
@@ -59,21 +70,16 @@ fn probe_logitech_hidraw() -> Option<bool> {
             .write(true)
             .open(Path::new("/dev").join(&name))
         {
-            Ok(_) => {
-                any_accessible = true;
-                break; // one accessible device is enough
-            }
+            Ok(_) => return HidrawProbe::Accessible, // one accessible device is enough
             Err(e) if matches!(e.kind(), ErrorKind::PermissionDenied) => any_denied = true,
             Err(_) => {} // device gone or other transient error — skip
         }
     }
 
-    if any_accessible {
-        Some(true)
-    } else if any_denied {
-        Some(false)
+    if any_denied {
+        HidrawProbe::Denied
     } else {
-        None
+        HidrawProbe::NonePresent
     }
 }
 

--- a/crates/openlogi-permissions/src/tests.rs
+++ b/crates/openlogi-permissions/src/tests.rs
@@ -1,26 +1,44 @@
 //! Pure `classify` cases — no device nodes involved.
 
 use crate::PermissionStatus;
-use crate::linux::classify;
+use crate::linux::{HidrawProbe, classify};
 
 #[test]
 fn classify_granted_when_both_ok() {
-    assert_eq!(classify(true, Some(true)), PermissionStatus::Granted);
+    assert_eq!(
+        classify(true, HidrawProbe::Accessible),
+        PermissionStatus::Granted
+    );
 }
 
 #[test]
 fn classify_denied_when_uinput_not_ok() {
-    assert_eq!(classify(false, Some(true)), PermissionStatus::Denied);
-    assert_eq!(classify(false, Some(false)), PermissionStatus::Denied);
-    assert_eq!(classify(false, None), PermissionStatus::Denied);
+    assert_eq!(
+        classify(false, HidrawProbe::Accessible),
+        PermissionStatus::Denied
+    );
+    assert_eq!(
+        classify(false, HidrawProbe::Denied),
+        PermissionStatus::Denied
+    );
+    assert_eq!(
+        classify(false, HidrawProbe::NonePresent),
+        PermissionStatus::Denied
+    );
 }
 
 #[test]
 fn classify_denied_when_hidraw_denied() {
-    assert_eq!(classify(true, Some(false)), PermissionStatus::Denied);
+    assert_eq!(
+        classify(true, HidrawProbe::Denied),
+        PermissionStatus::Denied
+    );
 }
 
 #[test]
 fn classify_unknown_when_no_logitech_device_connected() {
-    assert_eq!(classify(true, None), PermissionStatus::Unknown);
+    assert_eq!(
+        classify(true, HidrawProbe::NonePresent),
+        PermissionStatus::Unknown
+    );
 }

--- a/crates/openlogi-permissions/src/tests.rs
+++ b/crates/openlogi-permissions/src/tests.rs
@@ -3,52 +3,60 @@
 use crate::PermissionStatus;
 use crate::linux::{HidrawProbe, Probes};
 
+/// The whole truth table: both probes pass → `Granted`; an unwritable
+/// uinput or a denied hidraw → `Denied`; only "nothing connected to probe"
+/// is `Unknown`.
 #[test]
-fn granted_when_both_probes_pass() {
-    assert_eq!(
-        PermissionStatus::from(Probes {
-            uinput_writable: true,
-            hidraw: HidrawProbe::Accessible,
-        }),
-        PermissionStatus::Granted
-    );
-}
-
-#[test]
-fn denied_when_uinput_is_not_writable() {
-    for hidraw in [
-        HidrawProbe::Accessible,
-        HidrawProbe::Denied,
-        HidrawProbe::NonePresent,
-    ] {
-        assert_eq!(
-            PermissionStatus::from(Probes {
+fn every_probe_combination_maps_to_its_verdict() {
+    let cases = [
+        (
+            Probes {
+                uinput_writable: true,
+                hidraw: HidrawProbe::Accessible,
+            },
+            PermissionStatus::Granted,
+        ),
+        (
+            Probes {
+                uinput_writable: true,
+                hidraw: HidrawProbe::Denied,
+            },
+            PermissionStatus::Denied,
+        ),
+        (
+            Probes {
+                uinput_writable: true,
+                hidraw: HidrawProbe::NonePresent,
+            },
+            PermissionStatus::Unknown,
+        ),
+        (
+            Probes {
                 uinput_writable: false,
-                hidraw,
-            }),
-            PermissionStatus::Denied
+                hidraw: HidrawProbe::Accessible,
+            },
+            PermissionStatus::Denied,
+        ),
+        (
+            Probes {
+                uinput_writable: false,
+                hidraw: HidrawProbe::Denied,
+            },
+            PermissionStatus::Denied,
+        ),
+        (
+            Probes {
+                uinput_writable: false,
+                hidraw: HidrawProbe::NonePresent,
+            },
+            PermissionStatus::Denied,
+        ),
+    ];
+    for (probes, expected) in cases {
+        assert_eq!(
+            PermissionStatus::from(probes),
+            expected,
+            "probes: {probes:?}"
         );
     }
-}
-
-#[test]
-fn denied_when_hidraw_is_denied() {
-    assert_eq!(
-        PermissionStatus::from(Probes {
-            uinput_writable: true,
-            hidraw: HidrawProbe::Denied,
-        }),
-        PermissionStatus::Denied
-    );
-}
-
-#[test]
-fn unknown_when_no_logitech_device_is_connected() {
-    assert_eq!(
-        PermissionStatus::from(Probes {
-            uinput_writable: true,
-            hidraw: HidrawProbe::NonePresent,
-        }),
-        PermissionStatus::Unknown
-    );
 }

--- a/crates/openlogi-permissions/src/tests.rs
+++ b/crates/openlogi-permissions/src/tests.rs
@@ -1,44 +1,54 @@
-//! Pure `classify` cases — no device nodes involved.
+//! Pure probe-classification cases — no device nodes involved.
 
 use crate::PermissionStatus;
-use crate::linux::{HidrawProbe, classify};
+use crate::linux::{HidrawProbe, Probes};
 
 #[test]
-fn classify_granted_when_both_ok() {
+fn granted_when_both_probes_pass() {
     assert_eq!(
-        classify(true, HidrawProbe::Accessible),
+        PermissionStatus::from(Probes {
+            uinput_writable: true,
+            hidraw: HidrawProbe::Accessible,
+        }),
         PermissionStatus::Granted
     );
 }
 
 #[test]
-fn classify_denied_when_uinput_not_ok() {
+fn denied_when_uinput_is_not_writable() {
+    for hidraw in [
+        HidrawProbe::Accessible,
+        HidrawProbe::Denied,
+        HidrawProbe::NonePresent,
+    ] {
+        assert_eq!(
+            PermissionStatus::from(Probes {
+                uinput_writable: false,
+                hidraw,
+            }),
+            PermissionStatus::Denied
+        );
+    }
+}
+
+#[test]
+fn denied_when_hidraw_is_denied() {
     assert_eq!(
-        classify(false, HidrawProbe::Accessible),
-        PermissionStatus::Denied
-    );
-    assert_eq!(
-        classify(false, HidrawProbe::Denied),
-        PermissionStatus::Denied
-    );
-    assert_eq!(
-        classify(false, HidrawProbe::NonePresent),
+        PermissionStatus::from(Probes {
+            uinput_writable: true,
+            hidraw: HidrawProbe::Denied,
+        }),
         PermissionStatus::Denied
     );
 }
 
 #[test]
-fn classify_denied_when_hidraw_denied() {
+fn unknown_when_no_logitech_device_is_connected() {
     assert_eq!(
-        classify(true, HidrawProbe::Denied),
-        PermissionStatus::Denied
-    );
-}
-
-#[test]
-fn classify_unknown_when_no_logitech_device_connected() {
-    assert_eq!(
-        classify(true, HidrawProbe::NonePresent),
+        PermissionStatus::from(Probes {
+            uinput_writable: true,
+            hidraw: HidrawProbe::NonePresent,
+        }),
         PermissionStatus::Unknown
     );
 }


### PR DESCRIPTION
## Summary

The last surveyed boolean-blindness site: the Linux permission classifier encoded a three-state probe outcome as `Option<bool>` — `Some(true)` accessible, `Some(false)` present-but-denied, `None` nothing connected — a reader-hostile encoding for a genuinely ternary fact.

## Changes

- `openlogi-permissions`: `probe_logitech_hidraw` now returns `HidrawProbe { Accessible, Denied, NonePresent }`, the accessible-early-exit replaces the `break`-plus-flag dance, and the free `classify(bool, …)` function becomes a conversion: `Probes { uinput_writable, hidraw }` names both inputs and `impl From<Probes> for PermissionStatus` carries the (unchanged) truth table, so `input_device_access` reads `Probes { … }.into()`. The pure tests collapse into one exhaustive truth-table loop over all six `Probes` combinations (named-field rows, the failing row printed via `Debug`) — no positional bool survives, and the domain is visibly total.

## Testing

- This host has no Linux toolchain (devenv carries no Linux std), so the edit is hand-audited: the `match` is exhaustive and maps every input pair to the same `PermissionStatus` the old `(bool, Option<bool>)` table produced, and `cargo check -p openlogi-permissions` covers the macOS arm. The Linux CI jobs (clippy + tests) are the compile-and-test gate for this file — this PR should not merge before they pass.
