### PR TITLE
fix(agent): harden capture sessions, arming, and observe staleness

### DIFF
--- a/crates/openlogi-agent-core/src/observable.rs
+++ b/crates/openlogi-agent-core/src/observable.rs
@@ -165,14 +165,20 @@ impl ObservableState {
         });
     }
 
-    /// Publish an Accessibility trust change, as observed by
-    /// [`watchers::accessibility`](crate::watchers::accessibility).
-    pub fn set_accessibility_granted(&self, granted: bool) {
+    /// Publish an Accessibility trust change (as observed by
+    /// [`watchers::accessibility`](crate::watchers::accessibility)) together
+    /// with the hook state it produced. One generation on purpose: published
+    /// separately, a revoke would briefly serve a state claiming the hook is
+    /// installed without the permission it requires.
+    pub fn set_accessibility_and_hook(&self, granted: bool, hook_installed: bool) {
         self.update(|snapshot| {
-            if snapshot.status.accessibility_granted == granted {
+            if snapshot.status.accessibility_granted == granted
+                && snapshot.status.hook_installed == hook_installed
+            {
                 return false;
             }
             snapshot.status.accessibility_granted = granted;
+            snapshot.status.hook_installed = hook_installed;
             true
         });
     }
@@ -244,17 +250,6 @@ impl ObservableState {
                 recent.truncate(RECENT_APPS);
             }
             snapshot.foreground.current = app;
-            true
-        });
-    }
-
-    /// Publish whether the OS input hook is currently installed.
-    pub fn set_hook_installed(&self, installed: bool) {
-        self.update(|snapshot| {
-            if snapshot.status.hook_installed == installed {
-                return false;
-            }
-            snapshot.status.hook_installed = installed;
             true
         });
     }
@@ -420,14 +415,29 @@ mod tests {
         let state = state();
         state.set_inventory(InventoryHealth::Ready, &[inventory(true)], &[], false);
 
-        state.set_hook_installed(true);
-        state.set_accessibility_granted(true);
+        state.set_accessibility_and_hook(true, true);
 
         let snapshot = state.snapshot();
         assert!(snapshot.status.hook_installed);
         assert!(snapshot.status.accessibility_granted);
         assert_eq!(snapshot.inventory.len(), 1);
         assert_eq!(snapshot.status.inventory, InventoryHealth::Ready);
+    }
+
+    #[test]
+    fn a_revoke_retires_the_hook_in_the_same_generation() {
+        let state = state();
+        state.set_accessibility_and_hook(true, true);
+        let before = state.subscribe().borrow().generation;
+
+        state.set_accessibility_and_hook(false, false);
+
+        let after = state.subscribe().borrow().generation;
+        assert_eq!(
+            after,
+            before + 1,
+            "no intermediate generation may claim the hook without its permission"
+        );
     }
 
     #[tokio::test]
@@ -457,7 +467,7 @@ mod tests {
         let writer = Arc::clone(&state);
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            writer.set_hook_installed(true);
+            writer.set_accessibility_and_hook(true, true);
         });
 
         let observed = state.observe(1).await;
@@ -477,12 +487,12 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn a_silent_write_does_not_end_the_hold() {
         let state = Arc::new(state());
-        state.set_hook_installed(true);
+        state.set_accessibility_and_hook(true, true);
         let writer = Arc::clone(&state);
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            // Same value: this must not be mistaken for news.
-            writer.set_hook_installed(true);
+            // Same values: this must not be mistaken for news.
+            writer.set_accessibility_and_hook(true, true);
         });
 
         let observed = state.observe(2).await;
@@ -492,13 +502,13 @@ mod tests {
     #[test]
     fn an_unchanged_flag_notifies_nobody() {
         let state = state();
-        state.set_hook_installed(true);
+        state.set_accessibility_and_hook(true, true);
         let rx = state.subscribe();
 
-        state.set_hook_installed(true);
+        state.set_accessibility_and_hook(true, true);
         assert!(!rx.has_changed().unwrap());
 
-        state.set_hook_installed(false);
+        state.set_accessibility_and_hook(true, false);
         assert!(rx.has_changed().unwrap());
     }
 }

--- a/crates/openlogi-agent-core/src/runtime/button.rs
+++ b/crates/openlogi-agent-core/src/runtime/button.rs
@@ -24,15 +24,36 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 /// Lets the worker observe the out-of-band shutdown channel even while idle.
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-/// Stable identity of one HID++ capture-session incarnation.
+/// Stable identity of one HID++ capture-session incarnation, unique across
+/// every manager that mints one: the shared button and scroll runtimes key
+/// cancellation on it, so two live sessions with equal identities would
+/// cancel each other's presses.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct HidppSessionId {
     device_key: Arc<str>,
     epoch: u64,
 }
 
+/// Feeds [`HidppSessionId::new`] — one counter for the whole process.
+static NEXT_SESSION_EPOCH: AtomicU64 = AtomicU64::new(1);
+
 impl HidppSessionId {
-    pub(crate) fn new(device_key: &str, epoch: u64) -> Self {
+    /// Mint the identity for a fresh capture-session incarnation. The epoch
+    /// is allocated here rather than by the calling manager, so uniqueness
+    /// holds by construction: the gesture and keyboard managers both run a
+    /// session for an online bound keyboard, and manager-local counters would
+    /// deterministically collide on its first sessions.
+    pub(crate) fn new(device_key: &str) -> Self {
+        Self {
+            device_key: Arc::from(device_key),
+            epoch: NEXT_SESSION_EPOCH.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+
+    /// Test-only: an id with a chosen epoch, so stale-vs-current cases are
+    /// constructible regardless of minting order.
+    #[cfg(test)]
+    pub(crate) fn with_epoch(device_key: &str, epoch: u64) -> Self {
         Self {
             device_key: Arc::from(device_key),
             epoch,

--- a/crates/openlogi-agent-core/src/runtime/button/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/button/tests.rs
@@ -56,8 +56,8 @@ fn repress_replaces_the_old_press_with_a_new_identity() {
 #[test]
 fn cancellation_is_scoped_to_one_session() {
     let mut state = ButtonState::default();
-    let first_source = ButtonSource::Hidpp(HidppSessionId::new("mouse-a", 7));
-    let second_source = ButtonSource::Hidpp(HidppSessionId::new("mouse-b", 3));
+    let first_source = ButtonSource::Hidpp(HidppSessionId::with_epoch("mouse-a", 7));
+    let second_source = ButtonSource::Hidpp(HidppSessionId::with_epoch("mouse-b", 3));
     let first = ActivePress {
         token: PressToken {
             id: PressId(1),
@@ -89,7 +89,7 @@ fn hook_cancellation_leaves_hidpp_presses_active() {
         token: PressToken {
             id: PressId(2),
             key: PressKey::new(
-                ButtonSource::Hidpp(HidppSessionId::new("mouse-a", 7)),
+                ButtonSource::Hidpp(HidppSessionId::with_epoch("mouse-a", 7)),
                 ButtonId::Forward,
             ),
             generation: 0,
@@ -154,7 +154,7 @@ fn source_cancellation_invalidates_queued_gesture_work() {
     })
     .expect("button worker should start");
     let input = owner.input();
-    let session = HidppSessionId::new("mouse-a", 7);
+    let session = HidppSessionId::with_epoch("mouse-a", 7);
     let token = input
         .try_hidpp_down(&session, ButtonId::Back, None)
         .expect("down should be queued");
@@ -274,7 +274,7 @@ fn pulse_has_an_immediate_balanced_lifecycle() {
     })
     .expect("button worker should start");
     let input = owner.input();
-    let session = HidppSessionId::new("mouse-a", 7);
+    let session = HidppSessionId::with_epoch("mouse-a", 7);
     let binding = Binding::Single(Action::HoldShortcut(
         "Ctrl+Space".parse().expect("valid shortcut"),
     ));
@@ -419,7 +419,7 @@ fn pulse_degrades_long_press_to_its_short_action() {
     })
     .expect("button worker should start");
     let input = owner.input();
-    let session = HidppSessionId::new("keyboard-a", 4);
+    let session = HidppSessionId::with_epoch("keyboard-a", 4);
     let binding = long_press(Action::Copy, Action::Paste);
 
     assert!(input.try_hidpp_pulse(&session, ButtonId::Back, Some(&binding)));

--- a/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/tests.rs
@@ -8,7 +8,7 @@ fn source() -> ScrollSource {
 }
 
 fn hidpp_source(device_key: &str, epoch: u64) -> ScrollSource {
-    ScrollSource::Hidpp(HidppSessionId::new(device_key, epoch))
+    ScrollSource::Hidpp(HidppSessionId::with_epoch(device_key, epoch))
 }
 
 fn wheel(x: f64, y: f64) -> WheelDelta {

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn hidpp_smoothing_does_not_apply_main_wheel_sensitivity() {
         let (input, receiver, _controls) = standalone_input(1, preferences(true, 7));
-        let session = HidppSessionId::new("mouse-a", 7);
+        let session = HidppSessionId::with_epoch("mouse-a", 7);
         assert!(input.try_hidpp_scroll(&session, ScrollDelta::wheel_ticks(0.0, 2.0)));
 
         let queued = queued_input(&receiver);
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn hidpp_cancellation_targets_its_session() {
         let (input, commands, _controls) = standalone_input(1, preferences(true, 14));
-        let session = HidppSessionId::new("mouse-a", 7);
+        let session = HidppSessionId::with_epoch("mouse-a", 7);
         input.cancel_hidpp_session(&session);
 
         let ScrollCommand::CancelSource(ScrollSource::Hidpp(cancelled)) =
@@ -542,8 +542,8 @@ mod tests {
     fn cancellation_overtakes_a_full_queue_without_discarding_another_source() {
         let preferences = preferences(true, 14);
         let (input, commands, controls) = standalone_input(2, Arc::clone(&preferences));
-        let cancelled = HidppSessionId::new("mouse-a", 7);
-        let survivor = HidppSessionId::new("mouse-b", 3);
+        let cancelled = HidppSessionId::with_epoch("mouse-a", 7);
+        let survivor = HidppSessionId::with_epoch("mouse-b", 3);
         assert!(input.try_hidpp_scroll(&cancelled, ScrollDelta::wheel_ticks(1.0, 0.0)));
         assert!(input.try_hidpp_scroll(&survivor, ScrollDelta::wheel_ticks(0.0, 1.0)));
 

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -262,7 +262,6 @@ async fn manage(
         done: done_tx,
         capture: capture_channel,
     };
-    let mut epoch: u64 = 0;
     // The capture-vs-pairing arbiter hands out one exclusive lease. All session
     // tasks share it through an `Arc`; the manager keeps only a `Weak` so the
     // lease frees itself when the last session exits (letting pairing proceed).
@@ -326,8 +325,7 @@ async fn manage(
                         lease = Arc::downgrade(&fresh);
                         fresh
                     };
-                    epoch = epoch.wrapping_add(1);
-                    let id = HidppSessionId::new(&key, epoch);
+                    let id = HidppSessionId::new(&key);
                     let session = spawn_session(
                         id,
                         target,

--- a/crates/openlogi-agent-core/src/watchers/gesture.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture.rs
@@ -173,9 +173,11 @@ struct SessionChannels {
     capture: CaptureChannel,
 }
 
-/// What the manager should do with one session-completion report.
+/// What a capture-session manager should do with one session-completion
+/// report. Shared with the keyboard manager, which tracks its single session
+/// under the same rules.
 #[derive(Debug, PartialEq)]
-enum DoneAction {
+pub(super) enum DoneAction {
     /// A stale report from a session the manager no longer tracks — ignore it.
     Ignore,
     /// The tracked session's task has fully exited: drop its entry so the next

--- a/crates/openlogi-agent-core/src/watchers/gesture/dispatch/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/dispatch/tests.rs
@@ -14,8 +14,8 @@ fn scale() -> ScrollScale {
 
 #[test]
 fn replacement_session_does_not_inherit_progress_or_cooldown() {
-    let old = HidppSessionId::new("mouse-a", 7);
-    let replacement = HidppSessionId::new("mouse-a", 8);
+    let old = HidppSessionId::with_epoch("mouse-a", 7);
+    let replacement = HidppSessionId::with_epoch("mouse-a", 8);
     let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
     let now = Instant::now();
     let mut wheels = SessionWheels::default();
@@ -46,8 +46,8 @@ fn replacement_session_does_not_inherit_progress_or_cooldown() {
 
 #[test]
 fn replacement_session_does_not_inherit_partial_progress() {
-    let old = HidppSessionId::new("mouse-a", 7);
-    let replacement = HidppSessionId::new("mouse-a", 8);
+    let old = HidppSessionId::with_epoch("mouse-a", 7);
+    let replacement = HidppSessionId::with_epoch("mouse-a", 8);
     let threshold = ThumbwheelSensitivity::DEFAULT.action_threshold();
     let now = Instant::now();
     let mut wheels = SessionWheels::default();

--- a/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
+++ b/crates/openlogi-agent-core/src/watchers/gesture/tests.rs
@@ -9,7 +9,7 @@ fn route() -> DeviceRoute {
 }
 
 fn session_id(epoch: u64) -> HidppSessionId {
-    HidppSessionId::new("mouse-a", epoch)
+    HidppSessionId::with_epoch("mouse-a", epoch)
 }
 
 fn stopped_session_with_epoch(epoch: u64) -> RunningSession {
@@ -55,7 +55,7 @@ fn ignores_a_stale_session_superseded_by_a_restart() {
 fn ignores_a_completion_from_another_device_at_the_same_epoch() {
     assert_eq!(
         on_done(
-            &HidppSessionId::new("mouse-b", 7),
+            &HidppSessionId::with_epoch("mouse-b", 7),
             Some(&live_session_with_epoch(7))
         ),
         DoneAction::Ignore

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -24,6 +24,7 @@ use openlogi_hid::{
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, info, warn};
 
+use super::gesture::DoneAction;
 use crate::receiver_access::ReceiverAccess;
 use crate::runtime::{ActionDispatcher, HidppSessionId};
 
@@ -74,7 +75,32 @@ impl KeyboardTarget {
 struct RunningKeyboardSession {
     id: HidppSessionId,
     target: KeyboardTarget,
-    stop: oneshot::Sender<()>,
+    /// Present while the session runs; taken to request a stop. `None` means
+    /// the session is draining — deliberately stopped, but its task (and the
+    /// control-restore writes in its teardown) may still be in flight.
+    stop: Option<oneshot::Sender<()>>,
+}
+
+/// Decide the [`DoneAction`] for a completion report, given the session the
+/// manager currently tracks. The gesture manager's rule, applied to the
+/// single keyboard slot: only the current session's report settles anything;
+/// one whose stop sender is gone was stopped deliberately and merely frees
+/// the slot, while one still holding it exited on its own and warrants a
+/// warning alongside the re-arm.
+fn on_done(done_session: &HidppSessionId, live: Option<&RunningKeyboardSession>) -> DoneAction {
+    match live {
+        Some(session) if session.id == *done_session => DoneAction::Remove {
+            unexpected: session.stop.is_some(),
+        },
+        _ => DoneAction::Ignore,
+    }
+}
+
+/// Whether an input belongs to the current, still-live session. A draining
+/// session has already had its presses cancelled, so even its correctly
+/// tagged queued events must not enter the replacement lifecycle.
+fn accepts_input(input_session: &HidppSessionId, live: Option<&RunningKeyboardSession>) -> bool {
+    live.is_some_and(|session| session.id == *input_session && session.stop.is_some())
 }
 
 struct KeyboardInput {
@@ -179,15 +205,14 @@ async fn manage(
     loop {
         tokio::select! {
             Some(input) = rx.recv() => {
-                let Some(running) = current.as_ref() else {
-                    continue;
-                };
                 let live_spec = spec.read().ok().and_then(|guard| guard.clone());
-                let current_target = live_spec.as_ref().is_some_and(|live| running.target.matches(live));
-                if input.session != running.id
-                    || receiver_access.exclusive_requested()
-                    || !current_target
-                {
+                let deliverable = accepts_input(&input.session, current.as_ref())
+                    && !receiver_access.exclusive_requested()
+                    && current
+                        .as_ref()
+                        .zip(live_spec.as_ref())
+                        .is_some_and(|(running, live)| running.target.matches(live));
+                if !deliverable {
                     dispatcher.cancel_hidpp_session(&input.session);
                     debug!(epoch = input.session.epoch(), "input from a stale keyboard session — ignored");
                     continue;
@@ -201,18 +226,22 @@ async fn manage(
                 // While pairing is waiting or active, release the capture
                 // session so run_pairing can own the receiver's HID node.
                 let want = wanted_session(&receiver_access, &spec);
-                if current
-                    .as_ref()
-                    .is_some_and(|running| Some(&running.target) == want.as_ref())
-                {
-                    continue;
-                }
-                // Spec changed (or first tick): stop the old session and start
-                // one for the new state. Sending on the oneshot lets the old
-                // session restore the diverted controls.
-                if let Some(running) = current.take() {
-                    dispatcher.cancel_hidpp_session(&running.id);
-                    let _ = running.stop.send(());
+                if let Some(running) = current.as_mut() {
+                    // Stop a session that no longer matches the spec; sending
+                    // on the oneshot lets it restore the diverted controls.
+                    // The entry stays tracked — stop sender taken — until its
+                    // task reports completion below, and a tracked keyboard
+                    // is never re-armed: arming the replacement while the old
+                    // task may still be mid-restore could interleave its
+                    // divert writes with the restore writes on the same
+                    // device, leaving a control un-diverted while the new
+                    // session believes it owns it (the gesture manager
+                    // documents the same hazard).
+                    let keep = want.as_ref() == Some(&running.target);
+                    if !keep && let Some(stop) = running.stop.take() {
+                        dispatcher.cancel_hidpp_session(&running.id);
+                        let _ = stop.send(());
+                    }
                     continue;
                 }
                 if let Some(target) = want {
@@ -257,19 +286,98 @@ async fn manage(
                     current = Some(RunningKeyboardSession {
                         id,
                         target,
-                        stop: stop_tx,
+                        stop: Some(stop_tx),
                     });
                 }
             }
             Some(done_session) = done_rx.recv() => {
-                // A capture session ended on its own; re-arm only the live one
-                // (see gesture watcher for the epoch/pacing rationale).
-                if current.as_ref().is_some_and(|running| running.id == done_session) {
+                // The session's task has fully exited — restore writes
+                // included — so clearing the slot lets the next tick arm a
+                // successor, paced by TARGET_POLL; a stale epoch belongs to a
+                // session already superseded (see `on_done`).
+                if let DoneAction::Remove { unexpected } = on_done(&done_session, current.as_ref()) {
                     dispatcher.cancel_hidpp_session(&done_session);
-                    warn!("keyboard capture session ended unexpectedly, re-arming");
+                    if unexpected {
+                        warn!("keyboard capture session ended unexpectedly, re-arming");
+                    }
                     current = None;
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> KeyboardTarget {
+        KeyboardTarget {
+            config_key: "keyboard-a".to_string(),
+            route: DeviceRoute::Direct {
+                vendor_id: 0x046d,
+                product_id: 0xc548,
+            },
+            wanted: BTreeMap::new(),
+        }
+    }
+
+    fn session_id(epoch: u64) -> HidppSessionId {
+        HidppSessionId::with_epoch("keyboard-a", epoch)
+    }
+
+    fn draining_session(epoch: u64) -> RunningKeyboardSession {
+        RunningKeyboardSession {
+            id: session_id(epoch),
+            target: target(),
+            stop: None,
+        }
+    }
+
+    fn live_session(epoch: u64) -> RunningKeyboardSession {
+        let (stop, _rx) = oneshot::channel();
+        RunningKeyboardSession {
+            stop: Some(stop),
+            ..draining_session(epoch)
+        }
+    }
+
+    #[test]
+    fn rearms_when_the_current_session_dies() {
+        assert_eq!(
+            on_done(&session_id(7), Some(&live_session(7))),
+            DoneAction::Remove { unexpected: true }
+        );
+    }
+
+    #[test]
+    fn settles_a_draining_session_quietly() {
+        assert_eq!(
+            on_done(&session_id(7), Some(&draining_session(7))),
+            DoneAction::Remove { unexpected: false }
+        );
+    }
+
+    #[test]
+    fn ignores_stale_and_untracked_completions() {
+        assert_eq!(
+            on_done(&session_id(6), Some(&live_session(7))),
+            DoneAction::Ignore
+        );
+        assert_eq!(on_done(&session_id(7), None), DoneAction::Ignore);
+    }
+
+    #[test]
+    fn accepts_inputs_only_from_the_current_live_session() {
+        assert!(accepts_input(&session_id(7), Some(&live_session(7))));
+        assert!(
+            !accepts_input(&session_id(6), Some(&live_session(7))),
+            "a superseded session's queued input is stale"
+        );
+        assert!(
+            !accepts_input(&session_id(7), Some(&draining_session(7))),
+            "a draining session's queued input must not enter the replacement lifecycle"
+        );
+        assert!(!accepts_input(&session_id(7), None));
     }
 }

--- a/crates/openlogi-agent-core/src/watchers/keyboard.rs
+++ b/crates/openlogi-agent-core/src/watchers/keyboard.rs
@@ -175,7 +175,6 @@ async fn manage(
     // unexpected exit of the *current* session re-arms while stale completions
     // are ignored — same pacing/starvation reasoning as the gesture watcher.
     let (done_tx, mut done_rx) = mpsc::unbounded_channel::<HidppSessionId>();
-    let mut epoch: u64 = 0;
 
     loop {
         tokio::select! {
@@ -223,8 +222,7 @@ async fn manage(
                     let (stop_tx, stop_rx) = oneshot::channel();
                     let slot = Arc::clone(&keyboard_channel);
                     let session_registry = registry.clone();
-                    epoch = epoch.wrapping_add(1);
-                    let id = HidppSessionId::new(&target.config_key, epoch);
+                    let id = HidppSessionId::new(&target.config_key);
                     let (sink, mut session_rx) = mpsc::unbounded_channel();
                     let forward = tx.clone();
                     let forward_id = id.clone();

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -346,17 +346,19 @@ impl Armed {
         }
     }
 
-    /// Fold one Accessibility-grant change into the hook and publish the
-    /// resulting hook state — one publish on every path.
+    /// Fold one Accessibility-grant change into the hook, then publish the
+    /// permission and the hook state it produced as one generation — no
+    /// observation can claim the hook is installed without the permission it
+    /// requires.
     fn apply_accessibility(&mut self, granted: bool) {
-        self.observable.set_accessibility_granted(granted);
         if !granted {
             self.stop_hook();
         }
         if granted && self.hook.is_none() {
             self.hook = self.start_hook();
         }
-        self.observable.set_hook_installed(self.hook.is_some());
+        self.observable
+            .set_accessibility_and_hook(granted, self.hook.is_some());
     }
 
     /// Install the OS mouse hook, or say why it stays off.

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -3,17 +3,19 @@
 //! Every process start walks the same ladder, and each state is a type:
 //!
 //! ```text
-//! startup::bootstrap ──► Booted ──gate──► Booted ──arm──► Armed ──run──► exit
-//!         │                 │ (macOS only)                       │
+//! startup::bootstrap ──► Booted ──gate──► Wanted ──arm──► Armed ──run──► exit
+//!         │                 │                                    │
 //!         └─ init failed    └─ dormant start nobody wanted       └─ signal / uninstall
 //! ```
 //!
-//! The moves are the type protection for two contracts: the uninstall
+//! The moves are the type protection for three contracts: the uninstall
 //! receiver travels inside the states (gate consumes it first, then the run
-//! loop — no third consumer can exist), and the demand channel dies at
-//! [`Booted::arm`]. The gate exists only on macOS, where the sunk
-//! launch-at-login switch makes an unwanted login start possible; Windows
-//! and Linux only ever start wanted, so they arm unconditionally.
+//! loop — no third consumer can exist), the demand channel dies at
+//! [`Wanted::arm`], and arming without settling the dormancy question is
+//! unrepresentable — `arm` exists only on [`Wanted`], whose sole producer is
+//! the gate. The gate *waits* only on macOS, where the sunk launch-at-login
+//! switch makes an unwanted login start possible; Windows and Linux only ever
+//! start wanted, so their gate passes unconditionally.
 
 use std::sync::Arc;
 #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -74,14 +76,16 @@ pub(crate) async fn run(
         return;
     };
     #[cfg(target_os = "macos")]
-    let Some(booted) = booted.gate().await else {
+    let Some(wanted) = booted.gate().await else {
         return;
     };
-    booted.arm().run().await;
+    #[cfg(not(target_os = "macos"))]
+    let wanted = booted.gate();
+    wanted.arm().run().await;
 }
 
 /// A bootstrapped, not-yet-armed agent: the IPC socket is serving, nothing
-/// user-visible has happened. The only ways out are [`Self::arm`] and being
+/// user-visible has happened. The only ways out are [`Self::gate`] and being
 /// dropped (exit).
 struct Booted {
     core: Core,
@@ -133,9 +137,9 @@ impl Booted {
     /// connection: other clients are served without waking anything, and the
     /// takeover probe never declares at all.
     #[cfg(target_os = "macos")]
-    async fn gate(mut self) -> Option<Self> {
+    async fn gate(mut self) -> Option<Wanted> {
         if self.launch_at_login {
-            return Some(self);
+            return Some(Wanted(self));
         }
         info!("launch_at_login is off — dormant until a client demands arming");
         // The deadline is absolute: a served-but-not-arming client does not
@@ -147,7 +151,7 @@ impl Booted {
                 Some(kind) = self.core.demand.recv() => match kind {
                     ClientKind::Gui => {
                         info!("GUI connected — arming");
-                        return Some(self);
+                        return Some(Wanted(self));
                     }
                     kind => info!(client = ?kind, "served while dormant — not arming"),
                 },
@@ -167,10 +171,24 @@ impl Booted {
         }
     }
 
+    /// Windows and Linux have no login trigger to second-guess: every start
+    /// was asked for, so the gate passes unconditionally.
+    #[cfg(not(target_os = "macos"))]
+    fn gate(self) -> Wanted {
+        Wanted(self)
+    }
+}
+
+/// A booted agent whose dormancy question is settled: somebody wants it
+/// running. [`Booted::gate`] is the only producer, so an agent that never
+/// consulted the gate cannot arm.
+struct Wanted(Booted);
+
+impl Wanted {
     /// The arming point: the tray may show, the overlay may start,
     /// permissions may prompt, devices may open.
     fn arm(self) -> Armed {
-        let Self {
+        let Booted {
             core,
             signals,
             uninstalled,
@@ -180,7 +198,7 @@ impl Booted {
             #[cfg(any(target_os = "macos", target_os = "windows"))]
             resume_pending,
             ..
-        } = self;
+        } = self.0;
         #[cfg(target_os = "macos")]
         let _ = armed_tx.send(());
         overlay::spawn();

--- a/crates/openlogi-agent/src/startup.rs
+++ b/crates/openlogi-agent/src/startup.rs
@@ -270,9 +270,10 @@ pub(crate) fn spawn_state_watchers(
 }
 
 /// Seed the permission facts with non-prompting reads, so a client that
-/// connects before the watchers' first tick doesn't see a default.
+/// connects before the watchers' first tick doesn't see a default. No hook is
+/// installed this early — arming is what may install one.
 #[cfg(target_os = "macos")]
 fn seed_permission_facts(observable: &ObservableState) {
-    observable.set_accessibility_granted(Hook::has_accessibility());
+    observable.set_accessibility_and_hook(Hook::has_accessibility(), false);
     observable.set_input_monitoring_granted(openlogi_hid::permissions::has_access());
 }

--- a/crates/openlogi-desktop/src/services/ipc.rs
+++ b/crates/openlogi-desktop/src/services/ipc.rs
@@ -186,16 +186,15 @@ async fn observe_loop(
     update_tx: &mpsc::UnboundedSender<GuiUpdate>,
     cmd_rx: &mut mpsc::UnboundedReceiver<Command>,
 ) {
-    let mut client: Option<AgentClient> = None;
+    let mut link: Option<LiveConnection> = None;
+    // Connect counter feeding `LiveConnection::id` — never reused, so a
+    // result from a replaced connection can always be told apart.
+    let mut conn_seq: u64 = 0;
     // The agent is normally started by launchd, but the GUI brings it up when
     // the socket is down (see `launch::spawn_agent`), gated by the reflex.
     let mut reflex = SpawnReflex::new(Instant::now());
     let mut notified_unreachable = false;
     let mut notified_outdated = false;
-    // Generation 0 means "I have seen nothing", so the first answer is the
-    // agent's whole state rather than a wait for the next change. Reset on
-    // every disconnect: the replacement agent numbers its own generations.
-    let mut seen: Generation = 0;
     let mut inflight: Option<ObserveFuture> = None;
     let mut retry = ticker(RECONNECT_DELAY);
     loop {
@@ -203,45 +202,60 @@ async fn observe_loop(
         // it while the others hand it back untouched.
         let mut pending = inflight.take();
         let woken = tokio::select! {
-            observed = maybe(pending.as_mut()) => Woken::Observed(observed),
+            (id, observed) = maybe(pending.as_mut()) => Woken::Observed(id, observed),
             cmd = cmd_rx.recv() => Woken::Command(cmd),
             _ = retry.tick(), if pending.is_none() => Woken::Reconnect,
         };
         match woken {
-            // The poll answered: apply it and arm the next one. `pending` is
-            // finished, so it is deliberately not handed back.
-            Woken::Observed(Ok(observation)) => {
-                reflex.connected();
-                notified_unreachable = false;
-                notified_outdated = false;
-                if observation.generation != seen {
-                    seen = observation.generation;
-                    let _ = update_tx.send(GuiUpdate::Snapshot(observation.snapshot));
+            // The poll answered. `pending` is finished, so it is deliberately
+            // not handed back — the arms below arm a successor instead.
+            Woken::Observed(id, observed) => match link.as_mut() {
+                Some(conn) if conn.id == id => {
+                    if let Ok(observation) = observed {
+                        reflex.connected();
+                        notified_unreachable = false;
+                        notified_outdated = false;
+                        if observation.generation != conn.seen {
+                            conn.seen = observation.generation;
+                            let _ = update_tx.send(GuiUpdate::Snapshot(observation.snapshot));
+                        }
+                        inflight = Some(observe(conn));
+                    } else {
+                        // The connection dropped (agent self-exec on update,
+                        // or a crash). Reconnecting re-reads the whole state,
+                        // so nothing is lost.
+                        link = None;
+                        reflex.lost(Instant::now());
+                    }
                 }
-                if let Some(client) = client.as_ref() {
-                    inflight = Some(observe(client, seen));
+                // A poll from a connection this loop no longer holds — a
+                // command reconnected while it was in flight, or the link is
+                // down. Its result, success or failure, says nothing about
+                // the live connection, so it must neither advance `seen` nor
+                // tear anything down. What it does mean: the live connection
+                // (created mid-command with the old poll still occupying the
+                // slot) has no observe yet — arm its first one.
+                _ => {
+                    if let Some(conn) = link.as_ref() {
+                        inflight = Some(observe(conn));
+                    }
                 }
-            }
-            // The connection dropped (agent self-exec on update, or a crash).
-            // Reconnecting re-reads the whole state, so nothing is lost.
-            Woken::Observed(Err(())) => {
-                client = None;
-                seen = 0;
-                reflex.lost(Instant::now());
-            }
+            },
             Woken::Command(None) => break, // GUI dropped the sender → shut down
             Woken::Command(Some(cmd)) => {
                 inflight = pending;
-                if handle(&mut client, update_tx, cmd).await.is_err() {
-                    client = None;
-                    seen = 0;
+                if handle(&mut link, &mut conn_seq, update_tx, cmd)
+                    .await
+                    .is_err()
+                {
+                    link = None;
                     reflex.lost(Instant::now());
                 }
             }
-            Woken::Reconnect => match ensure(&mut client).await {
-                Ok(client) => {
+            Woken::Reconnect => match ensure(&mut link, &mut conn_seq).await {
+                Ok(conn) => {
                     reflex.connected();
-                    inflight = Some(observe(client, seen));
+                    inflight = Some(observe(conn));
                 }
                 Err(ConnectFailure::Unreachable) => reflex.agent_unreachable(),
                 Err(ConnectFailure::NewerAgent) => {
@@ -358,11 +372,27 @@ impl SpawnReflex {
     }
 }
 
+/// A usable, declared connection, carrying everything that is true only *of
+/// this connection*: the identity that tags its in-flight poll, and the
+/// generation ledger — a replacement agent numbers its own generations, so
+/// `seen` lives and dies with the connection instead of being reset by
+/// discipline at every disconnect site.
+struct LiveConnection {
+    client: AgentClient,
+    /// This connection's slot in the connect sequence. A settled poll tagged
+    /// with another id belongs to a connection already gone, and is dropped.
+    id: u64,
+    /// Latest generation seen on this connection. Starts at 0 — "I have seen
+    /// nothing" — so the first answer is the agent's whole state.
+    seen: Generation,
+}
+
 /// Why [`observe_loop`] woke up. Named so the in-flight poll can be handed back
 /// after the select ends rather than mutated from inside a borrowed arm.
 enum Woken {
-    /// The long-poll answered, or its connection dropped.
-    Observed(Result<Observation, ()>),
+    /// The long-poll answered, or its connection dropped — tagged with the
+    /// [`LiveConnection::id`] it was armed on.
+    Observed(u64, Result<Observation, ()>),
     /// A device command, or `None` once the GUI drops the sender.
     Command(Option<Command>),
     /// Time to try connecting again.
@@ -370,19 +400,23 @@ enum Woken {
 }
 
 /// A long-poll in flight. Boxed because it is stored across loop turns, and it
-/// owns a clone of the client so the loop can still replace its own `client`
-/// while the poll is outstanding.
-type ObserveFuture = Pin<Box<dyn Future<Output = Result<Observation, ()>> + Send>>;
+/// owns a clone of the client so the loop can still replace its own link
+/// while the poll is outstanding — which is why the output carries the
+/// connection id: the loop must be able to tell whose answer this is.
+type ObserveFuture = Pin<Box<dyn Future<Output = (u64, Result<Observation, ()>)> + Send>>;
 
-/// Ask for the next state newer than `seen`.
-fn observe(client: &AgentClient, seen: Generation) -> ObserveFuture {
-    let client = client.clone();
+/// Ask for the next state newer than what this connection has seen.
+fn observe(conn: &LiveConnection) -> ObserveFuture {
+    let client = conn.client.clone();
+    let id = conn.id;
+    let seen = conn.seen;
     Box::pin(async move {
         let mut ctx = context::current();
         ctx.deadline = Instant::now() + OBSERVE_DEADLINE;
-        client.observe(ctx, seen).await.map_err(|error| {
+        let observed = client.observe(ctx, seen).await.map_err(|error| {
             debug!(%error, "observe failed — reconnecting");
-        })
+        });
+        (id, observed)
     })
 }
 
@@ -416,9 +450,12 @@ enum ConnectFailure {
     NewerAgent,
 }
 
-/// Ensure a live client, connecting on demand.
-async fn ensure(client: &mut Option<AgentClient>) -> Result<&AgentClient, ConnectFailure> {
-    if client.is_none() {
+/// Ensure a live connection, connecting — and stamping a fresh id — on demand.
+async fn ensure<'a>(
+    link: &'a mut Option<LiveConnection>,
+    conn_seq: &mut u64,
+) -> Result<&'a LiveConnection, ConnectFailure> {
+    if link.is_none() {
         // The handshake happens before any real RPC: mismatched bincode layouts
         // would otherwise surface only as opaque RpcErrors and a silently empty
         // device list. Refuse with a clear log instead, and report the
@@ -439,7 +476,12 @@ async fn ensure(client: &mut Option<AgentClient>) -> Result<&AgentClient, Connec
                         debug!(%error, "agent dropped during the declare handshake");
                         ConnectFailure::Unreachable
                     })?;
-                *client = Some(connection.client);
+                *conn_seq += 1;
+                *link = Some(LiveConnection {
+                    client: connection.client,
+                    id: *conn_seq,
+                    seen: 0,
+                });
                 debug!("connected to agent IPC socket");
             }
             version if version < PROTOCOL_VERSION => {
@@ -460,23 +502,25 @@ async fn ensure(client: &mut Option<AgentClient>) -> Result<&AgentClient, Connec
             }
         }
     }
-    // `client` is `Some` here (just set, or already was); the `None` arm is
+    // `link` is `Some` here (just set, or already was); the `None` arm is
     // unreachable but keeps this `expect`-free.
-    client.as_ref().ok_or(ConnectFailure::Unreachable)
+    link.as_ref().ok_or(ConnectFailure::Unreachable)
 }
 
 /// Run one device command. `Err` signals a dropped connection so the caller
 /// reconnects; the command's own failure is reported back over its oneshot.
 async fn handle(
-    client: &mut Option<AgentClient>,
+    link: &mut Option<LiveConnection>,
+    conn_seq: &mut u64,
     update_tx: &mpsc::UnboundedSender<GuiUpdate>,
     cmd: Command,
 ) -> Result<(), ()> {
-    // keep `client` None on connect failure; that's not a dropped live connection
-    let Ok(client) = ensure(client).await else {
+    // keep `link` None on connect failure; that's not a dropped live connection
+    let Ok(conn) = ensure(link, conn_seq).await else {
         reply_disconnected(update_tx, cmd);
         return Ok(());
     };
+    let client = &conn.client;
     let ctx = context::current();
     match cmd {
         Command::SetDpi(route, dpi) => log_apply(client.set_dpi(ctx, route, dpi).await)?,

--- a/crates/openlogi-device/src/session/gesture.rs
+++ b/crates/openlogi-device/src/session/gesture.rs
@@ -91,36 +91,73 @@ pub enum GestureError {
     Hidpp(String),
 }
 
+/// The hold that owns raw-XY motion, or the absence of one. Raw-XY reports
+/// carry no source attribution, so the first held source owns the accumulated
+/// motion until it is released (first hold wins); the per-hold qualifiers live
+/// inside the variant so none can outlive the hold it belongs to.
+#[derive(Default)]
+enum HoldState {
+    /// No armed gesture source is held: raw-XY reports are stray and dropped.
+    #[default]
+    Idle,
+    /// `cid` began the current hold; its events dispatch as `button`. When the
+    /// holder releases, a still-held source takes the hold over.
+    Holding {
+        /// The `0x1b04` control that owns this hold.
+        cid: u16,
+        /// The [`ButtonId`] the hold's gestures dispatch as.
+        button: ButtonId,
+        /// Mid-swipe travel accumulated over this hold.
+        swipe: SwipeAccumulator,
+        /// A second armed source is held alongside the holder. Overlap motion
+        /// could belong to either control — dropped until the overlap ends.
+        overlap: bool,
+        /// The hold's next raw-XY sample must be dropped: the haptic panel's
+        /// first sample after contact is an absolute position jump, not a
+        /// delta (see [`reprog_controls::HAPTIC_PANEL_CID`]).
+        skip_first_raw_xy: bool,
+    },
+}
+
+/// Begin a hold for `cid`, its swipe accumulator started fresh.
+fn begin_hold(cid: u16, button: ButtonId, overlap: bool, skip_first_raw_xy: bool) -> HoldState {
+    let mut swipe = SwipeAccumulator::default();
+    swipe.begin();
+    HoldState::Holding {
+        cid,
+        button,
+        swipe,
+        overlap,
+        skip_first_raw_xy,
+    }
+}
+
 /// Movement + button state accumulated across messages. Lives behind a `Mutex`
 /// because the channel's read thread invokes the listener by shared reference.
 #[derive(Default)]
 struct CaptureAccum {
-    /// Mid-swipe state for the currently held gesture source (raw-XY).
-    swipe: SwipeAccumulator,
-    /// The gesture source that began the current hold, with the [`ButtonId`]
-    /// its events dispatch as. Raw-XY reports carry no source attribution, so
-    /// the first held source owns the accumulated motion until it is released
-    /// (first hold wins). While a second source is held alongside it, motion
-    /// is dropped instead of miscommitted (see [`Self::overlap`]); when the
-    /// holder releases, a still-held source takes the hold over.
-    gesture_source: Option<(u16, ButtonId)>,
-    /// Whether a second armed source is held alongside the holder. Raw-XY
-    /// reports are unattributed on the wire, so overlap motion could belong to
-    /// either control — it is dropped until the overlap ends.
-    overlap: bool,
+    /// The hold owning raw-XY motion, if any (see [`HoldState`]).
+    hold: HoldState,
     /// The armed gesture sources held in the last event, for edge detection:
     /// a source not previously held that becomes the holder is a fresh touch
     /// (the haptic panel's first sample is then a contact jump to discard).
     gestures_down: Vec<u16>,
-    /// Whether the current hold's next raw-XY sample must be dropped: the
-    /// haptic panel's first sample after contact is an absolute position
-    /// jump, not a delta (see [`reprog_controls::HAPTIC_PANEL_CID`]).
-    skip_first_raw_xy: bool,
     /// Whether any DPI/ModeShift control was held in the last event — for
     /// rising-edge press detection.
     dpi_down: bool,
     /// Diverted standard-button CIDs held in the last event.
     buttons_down: Vec<u16>,
+}
+
+#[cfg(test)]
+impl CaptureAccum {
+    /// Test-only seam mirroring [`SwipeAccumulator::backdate_hold_for_test`]
+    /// for the current hold. A no-op while idle.
+    fn backdate_hold_for_test(&mut self) {
+        if let HoldState::Holding { swipe, .. } = &mut self.hold {
+            swipe.backdate_hold_for_test();
+        }
+    }
 }
 
 /// HID++-divertable standard buttons: the `0x1b04` control ID and the
@@ -626,39 +663,51 @@ fn handle_reprog(
                 .filter(|cid| cids.contains(cid))
                 .filter_map(|&cid| gesture_source_button(cid).map(|b| (cid, b)))
                 .collect();
-            match acc.gesture_source {
-                Some((cid, _)) if cids.contains(&cid) => {
-                    // The holder is still down. While a second armed source is
-                    // held alongside it, unattributed raw-XY motion is dropped
-                    // (see `CaptureAccum::overlap`).
-                    acc.overlap = held.len() > 1;
-                }
+            acc.hold = match std::mem::take(&mut acc.hold) {
+                // The holder is still down. While a second armed source is
+                // held alongside it, unattributed raw-XY motion is dropped
+                // (see [`HoldState::Holding::overlap`]).
+                HoldState::Holding {
+                    cid,
+                    button,
+                    swipe,
+                    skip_first_raw_xy,
+                    ..
+                } if cids.contains(&cid) => HoldState::Holding {
+                    cid,
+                    button,
+                    swipe,
+                    overlap: held.len() > 1,
+                    skip_first_raw_xy,
+                },
                 previous => {
                     // No holder, or the holder released: a released hold that
                     // never committed a direction is a plain click...
-                    if let Some((_, button)) = previous {
-                        acc.gesture_source = None;
-                        acc.overlap = false;
-                        if acc.swipe.end() {
-                            debug!(%button, "gesture click");
-                            let _ =
-                                sink.send(CapturedInput::Gesture(button, GestureDirection::Click));
-                        }
+                    if let HoldState::Holding {
+                        button, mut swipe, ..
+                    } = previous
+                        && swipe.end()
+                    {
+                        debug!(%button, "gesture click");
+                        let _ = sink.send(CapturedInput::Gesture(button, GestureDirection::Click));
                     }
                     // ...and the first still-held source begins (or takes
                     // over) the hold. A source not down in the previous event
                     // is a fresh touch, so the panel's contact-jump discard
                     // applies; one that was already held has had its jump
                     // dropped during the overlap.
-                    if let Some(&(cid, button)) = held.first() {
-                        acc.gesture_source = Some((cid, button));
-                        acc.swipe.begin();
-                        acc.overlap = held.len() > 1;
-                        acc.skip_first_raw_xy = cid == reprog_controls::HAPTIC_PANEL_CID
-                            && !acc.gestures_down.contains(&cid);
+                    match held.first() {
+                        Some(&(cid, button)) => begin_hold(
+                            cid,
+                            button,
+                            held.len() > 1,
+                            cid == reprog_controls::HAPTIC_PANEL_CID
+                                && !acc.gestures_down.contains(&cid),
+                        ),
+                        None => HoldState::Idle,
                     }
                 }
-            }
+            };
             // Gesture semantics stay separate from the physical lifecycle:
             // click/swipe remains one completed action, while every armed
             // source also contributes one rising and one falling edge to the
@@ -700,27 +749,34 @@ fn handle_reprog(
         RawControlEvent::RawXy { dx, dy } => {
             // Motion is attributed to the holding source; outside a hold the
             // report is stray and dropped.
-            let Some((_, button)) = acc.gesture_source else {
+            let HoldState::Holding {
+                button,
+                swipe,
+                overlap,
+                skip_first_raw_xy,
+                ..
+            } = &mut acc.hold
+            else {
                 return;
             };
             // While two armed sources are held the report could belong to
             // either control — drop it rather than miscommit a swipe through
             // the holder's map.
-            if acc.overlap {
+            if *overlap {
                 return;
             }
             // The haptic panel's first sample after contact is a position
             // jump; summing it would commit a bogus direction instantly.
-            if acc.skip_first_raw_xy {
-                acc.skip_first_raw_xy = false;
+            if *skip_first_raw_xy {
+                *skip_first_raw_xy = false;
                 return;
             }
             // Commit the instant a clean direction emerges (mid-swipe, once per
             // hold); the accumulator gates on hold duration internally and drops
             // travel that arrives outside a hold.
-            if let Some(direction) = acc.swipe.accumulate(i32::from(dx), i32::from(dy)) {
+            if let Some(direction) = swipe.accumulate(i32::from(dx), i32::from(dy)) {
                 debug!(?direction, %button, "gesture committed");
-                let _ = sink.send(CapturedInput::Gesture(button, direction));
+                let _ = sink.send(CapturedInput::Gesture(*button, direction));
             }
         }
     }

--- a/crates/openlogi-device/src/session/gesture/tests.rs
+++ b/crates/openlogi-device/src/session/gesture/tests.rs
@@ -106,7 +106,7 @@ fn a_still_held_second_source_takes_over_when_the_holder_releases() {
         "the released holder still clicks"
     );
 
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
@@ -140,7 +140,7 @@ fn raw_xy_during_a_two_source_overlap_is_dropped_not_misattributed() {
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     handle_reprog(&mut acc, both_press(), BOTH, &[], &[], &tx);
     handle_reprog(
         &mut acc,
@@ -157,7 +157,7 @@ fn raw_xy_during_a_two_source_overlap_is_dropped_not_misattributed() {
 
     // The panel lifts; the surviving hold accumulates again.
     handle_reprog(&mut acc, press(), BOTH, &[], &[], &tx);
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
@@ -195,7 +195,7 @@ fn a_same_report_swap_to_the_panel_still_discards_its_contact_jump() {
         "the swapped-out holder still clicks"
     );
 
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     // The contact jump — leftward, far past every threshold — must be dropped.
     handle_reprog(
         &mut acc,
@@ -262,7 +262,7 @@ fn a_held_gesture_commits_a_swipe_and_does_not_also_click() {
 
     handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
     // Pretend the button has been held well past the swipe gate.
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
@@ -296,7 +296,7 @@ fn the_haptic_panel_gestures_when_diverted_for_gestures() {
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, panel_press(), PANEL, &[], &[], &tx);
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     // The panel's contact jump, discarded before the accumulator sees it.
     handle_reprog(
         &mut acc,
@@ -361,7 +361,7 @@ fn the_panels_first_raw_xy_sample_after_contact_is_discarded() {
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, panel_press(), PANEL, &[], &[], &tx);
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     // The contact jump — leftward, far past every threshold.
     handle_reprog(
         &mut acc,
@@ -402,7 +402,7 @@ fn the_dedicated_buttons_first_sample_is_not_discarded() {
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, press(), GESTURE, &[], &[], &tx);
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },
@@ -431,7 +431,7 @@ fn an_undiverted_gesture_source_does_not_gesture() {
     let mut acc = CaptureAccum::default();
 
     handle_reprog(&mut acc, press(), PANEL, &[], &[], &tx);
-    acc.swipe.backdate_hold_for_test();
+    acc.backdate_hold_for_test();
     handle_reprog(
         &mut acc,
         RawControlEvent::RawXy { dx: 120, dy: 5 },


### PR DESCRIPTION
## Summary

The six commits left on the local branch after #1031 merged, re-homed onto master (the seventh — deleting the reason-aware capture entry point — was dropped by the rebase as already upstream via #1071). Four correctness fixes around the capture sessions and the agent link, plus two continuations of the typed-decision patterns.

## Changes

- `openlogi-agent-core`: HID++ session identities are minted from one process-wide counter — the gesture and keyboard managers both run a session for an online bound keyboard, and their manager-local epochs deterministically collided on its first sessions, letting two live sessions cancel each other's presses. The keyboard manager now tracks a deliberately stopped session until its task reports done, under the gesture manager's shared `DoneAction` rules: a draining keyboard is never re-armed while its teardown's control-restore writes may still be in flight, and its queued events are refused (`accepts_input`).
- `openlogi-agent`: Accessibility and hook state publish in one generation (`set_accessibility_and_hook`) — published separately, a revoke briefly served a state claiming the hook was installed without the permission it requires; a regression test pins the single-generation property. And arming without settling the dormancy question is now unrepresentable: `arm` moved onto a new `Wanted(Booted)` stage whose sole producer is the gate (which waits on macOS and passes unconditionally elsewhere).
- `openlogi-desktop`: the observe loop tags each in-flight long-poll with a `LiveConnection` id — a poll settling after its connection was replaced (a command reconnected mid-flight, or the link dropped) no longer advances `seen` or tears down the live link; the generation ledger now lives inside the connection instead of being reset by discipline at every disconnect site.
- `openlogi-device`: the gesture session's hold bookkeeping folds into a `HoldState` sum type — the per-hold qualifiers (overlap suppression, the haptic panel's absolute-first-sample skip) live inside the holding variant, so none can outlive the hold it belongs to.

## Testing

- Full local tier on the rebased tree (`cargo fmt --all -- --check`, workspace clippy with `-D warnings`, workspace tests, non-GUI rustdoc) and the Windows cross-lint proxy (`cargo xtask ci clippy-windows`).
- Not runtime-tested on hardware. The session-identity collision and the draining-keyboard rules need a bound keyboard alongside gesture capture to exercise live; the one-generation publish and observe-staleness fixes are pinned by unit tests.
