### PR TITLE
fix: resolve remaining state-machine audit findings

### DIFF
--- a/.claude/rules/rust.md
+++ b/.claude/rules/rust.md
@@ -92,8 +92,15 @@ Encode invariants in the type system instead of checking them at runtime:
 - Wire/firmware values get typed wrappers: `num_enum` for discriminants, `bitflags`
   (`from_bits_retain` when unknown bits are legal) for flag sets. Unknown wire values
   surface as **errors** (`UnsupportedResponse`-style), never as silent fallbacks.
+- Write-only protocol sentinels stay in the encoder. Read-side and domain types
+  exclude them with `Option`, `NonZero*`, or a validated newtype, converting to the
+  sentinel only at the serialization boundary.
 - Replace long parameter lists with Change/Params structs; make illegal combinations
   unrepresentable rather than validated.
+- One domain fact has one mutable owner and one transition authority. Flags,
+  `Option`s, caches, atomics, and loop locals may mirror it only as derived state
+  published by that same authority; callers never coordinate separate writers to
+  keep the mirrors aligned.
 - A `bool` parameter is boolean-blind at its call sites. When only a couple of
   combinations are ever used, split into intent-named methods
   (`divert_cid`/`undivert_cid`, not `set_cid_reporting(cid, bool, bool)`).
@@ -114,12 +121,22 @@ Encode invariants in the type system instead of checking them at runtime:
   haptics `Budget`, `QueryState`). Tests then drive real transitions and cannot
   construct unreachable states; a total decision function earns one exhaustive
   truth-table test rather than scattered single-case asserts.
+- A last-writer-wins slot (session, connection, request) carries its complete
+  publication identity, not just a shared payload pointer or per-owner counter.
+  Results and cleanup compare that identity before mutation; stale work must not clear
+  or overwrite its successor.
+- A representable but unreachable state is not alone a reason to refactor. Preserve
+  its single-constructor, single-writer, or ordering proof in a load-bearing test or
+  comment; re-type it when another constructor, writer, or lifecycle path appears.
 - Lifecycles are typestate: stages are types, transitions consume `self`
   (`Booted::arm(self) -> Armed`), and a resource legal in only some stages
   travels inside the stage that may hold it — a third consumer then cannot
   exist by construction.
 - Ownership models resources (`Retained<T>` in the ObjC FFI) and thread affinity is
   proven by types (`MainThreadMarker`, `!Send` handles), not by runtime checks.
+- Caches and leases do not extend a lifecycle they merely borrow. Their cleanup is
+  RAII, and reusable leases return only after dependent workers and OS handles have
+  shut down.
 - Libraries return `thiserror` types; binaries may use `anyhow`.
 
 House style:
@@ -134,6 +151,9 @@ House style:
   the lock; restore with `cargo update -p gpui --precise <rev>`).
 - Module layout: a module with its own semantics is `foo.rs` (children in a sibling
   `foo/`); `foo/mod.rs` is only for pure namespace shells. Never both for one module.
+- Sibling implementations that differ are an investigation signal, not proof that
+  either is wrong. Establish the semantic reason first; without one, reuse the proven
+  state shape instead of inventing an independent model.
 - Platform-divergent code: once more than one function diverges, use one module per
   OS selected by a single `cfg` at the module declaration, with a thin facade owning
   the shared types and dispatch — `inject.rs` → `inject/{macos,linux,windows}.rs`,

--- a/crates/openlogi-agent-core/src/event_monitor.rs
+++ b/crates/openlogi-agent-core/src/event_monitor.rs
@@ -11,7 +11,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
 
 use openlogi_hook::MouseEvent;
@@ -29,21 +29,45 @@ const CAPACITY: usize = 256;
 /// How often the janitor checks for an idle (no-longer-polled) monitor.
 const IDLE_TICK: Duration = Duration::from_secs(3);
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum MonitorState {
+    Disabled = 0,
+    Polled = 1,
+    Idle = 2,
+}
+
+impl MonitorState {
+    fn from_raw(raw: u8) -> Self {
+        match raw {
+            0 => Self::Disabled,
+            1 => Self::Polled,
+            2 => Self::Idle,
+            _ => unreachable!("EventMonitor stores only MonitorState discriminants"),
+        }
+    }
+}
+
 /// Buffers the hook's observed events for the GUI's live monitor when enabled.
-#[derive(Default)]
 pub struct EventMonitor {
-    enabled: AtomicBool,
-    /// Set on every [`Self::poll`]; the janitor clears it each tick and treats a
-    /// tick with no intervening poll as "the GUI stopped watching".
-    polled: AtomicBool,
+    state: AtomicU8,
     buf: Mutex<VecDeque<MonitorEvent>>,
+}
+
+impl Default for EventMonitor {
+    fn default() -> Self {
+        Self {
+            state: AtomicU8::new(MonitorState::Disabled as u8),
+            buf: Mutex::default(),
+        }
+    }
 }
 
 impl EventMonitor {
     /// Whether monitoring is currently on — the one check the hot hook path runs.
     #[must_use]
     pub fn enabled(&self) -> bool {
-        self.enabled.load(Ordering::Relaxed)
+        MonitorState::from_raw(self.state.load(Ordering::Relaxed)) != MonitorState::Disabled
     }
 
     /// Record a hook event, if monitoring is on. Pointer moves are dropped: they
@@ -85,23 +109,41 @@ impl EventMonitor {
     /// Enable monitoring (idempotent) and drain everything buffered since the
     /// last poll. Called from the IPC `poll_event_monitor` handler.
     pub fn poll(&self) -> Vec<MonitorEvent> {
-        // Mark the poll *before* enabling, and publish `enabled` with `Release`.
-        // The janitor loads `enabled` with `Acquire`, so a tick that observes
-        // `enabled == true` is guaranteed to also see this `polled = true` and
-        // won't disable a monitor that was just enabled by this very poll.
-        self.polled.store(true, Ordering::Relaxed);
-        self.enabled.store(true, Ordering::Release);
+        self.state
+            .store(MonitorState::Polled as u8, Ordering::Release);
         self.buf
             .lock()
             .map(|mut buf| buf.drain(..).collect())
             .unwrap_or_default()
     }
 
-    /// Turn monitoring off and discard any buffered events.
-    fn disable(&self) {
-        self.enabled.store(false, Ordering::Relaxed);
-        if let Ok(mut buf) = self.buf.lock() {
-            buf.clear();
+    fn idle_tick(&self) {
+        let mut raw = self.state.load(Ordering::Acquire);
+        loop {
+            let current = MonitorState::from_raw(raw);
+            let next = match current {
+                MonitorState::Disabled => return,
+                MonitorState::Polled => MonitorState::Idle,
+                MonitorState::Idle => MonitorState::Disabled,
+            };
+            match self.state.compare_exchange_weak(
+                raw,
+                next as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    if next == MonitorState::Disabled
+                        && let Ok(mut buf) = self.buf.lock()
+                        && MonitorState::from_raw(self.state.load(Ordering::Acquire))
+                            == MonitorState::Disabled
+                    {
+                        buf.clear();
+                    }
+                    return;
+                }
+                Err(actual) => raw = actual,
+            }
         }
     }
 
@@ -118,15 +160,7 @@ impl EventMonitor {
             tokio::time::interval_at(tokio::time::Instant::now() + IDLE_TICK, IDLE_TICK);
         loop {
             ticker.tick().await;
-            // Acquire-load `enabled` to pair with `poll`'s Release store: seeing
-            // `enabled == true` here guarantees the matching `polled = true` is
-            // visible, so a monitor enabled by a poll just before this tick is
-            // never torn down for a stale `polled == false`. `swap` then consumes
-            // the flag — a poll since the last tick keeps monitoring alive; an
-            // untouched flag means no poll happened this interval.
-            if self.enabled.load(Ordering::Acquire) && !self.polled.swap(false, Ordering::Relaxed) {
-                self.disable();
-            }
+            self.idle_tick();
         }
     }
 }
@@ -184,5 +218,26 @@ mod tests {
             });
         }
         assert_eq!(m.poll().len(), CAPACITY, "never grows past the cap");
+    }
+
+    #[test]
+    fn idle_lifecycle_requires_a_full_tick_without_a_poll_to_disable() {
+        let m = EventMonitor::default();
+        m.idle_tick();
+        assert!(!m.enabled());
+
+        m.poll();
+        m.idle_tick();
+        assert!(m.enabled(), "the first tick consumes the enabling poll");
+
+        m.poll();
+        m.idle_tick();
+        assert!(m.enabled(), "a poll refreshes an idle monitor");
+
+        m.idle_tick();
+        assert!(
+            !m.enabled(),
+            "one whole interval without a poll disables it"
+        );
     }
 }

--- a/crates/openlogi-agent-core/src/receiver_access.rs
+++ b/crates/openlogi-agent-core/src/receiver_access.rs
@@ -5,7 +5,7 @@
 //! sessions stop, then wait for an exclusive write lease.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
@@ -18,7 +18,14 @@ pub struct ReceiverAccess {
 #[derive(Default)]
 struct ReceiverAccessInner {
     lease: Arc<RwLock<()>>,
-    exclusive_requests: Arc<AtomicU8>,
+    exclusive_requests: Arc<ExclusiveRequests>,
+}
+
+#[derive(Default)]
+struct ExclusiveRequests {
+    total: AtomicUsize,
+    pairing: AtomicUsize,
+    host_transition: AtomicUsize,
 }
 
 /// Operation requiring sole ownership of a receiver transport.
@@ -31,11 +38,21 @@ pub enum ExclusiveAccessReason {
 }
 
 impl ExclusiveAccessReason {
-    const fn bit(self) -> u8 {
+    fn counter(self, requests: &ExclusiveRequests) -> &AtomicUsize {
         match self {
-            Self::Pairing => 1 << 0,
-            Self::HostTransition => 1 << 1,
+            Self::Pairing => &requests.pairing,
+            Self::HostTransition => &requests.host_transition,
         }
+    }
+}
+
+impl ExclusiveRequests {
+    fn any(&self) -> bool {
+        self.total.load(Ordering::Acquire) != 0
+    }
+
+    fn requested(&self, reason: ExclusiveAccessReason) -> bool {
+        reason.counter(self).load(Ordering::Acquire) != 0
     }
 }
 
@@ -54,13 +71,13 @@ impl ReceiverAccess {
     /// Whether any exclusive operation is waiting for or holding receiver access.
     #[must_use]
     pub fn exclusive_requested(&self) -> bool {
-        self.inner.exclusive_requests.load(Ordering::Acquire) != 0
+        self.inner.exclusive_requests.any()
     }
 
     /// Whether `reason` is waiting for or holding receiver access.
     #[must_use]
     pub fn requested(&self, reason: ExclusiveAccessReason) -> bool {
-        self.inner.exclusive_requests.load(Ordering::Acquire) & reason.bit() != 0
+        self.inner.exclusive_requests.requested(reason)
     }
 
     /// Try to acquire receiver access for a pooled HID++ session.
@@ -104,21 +121,24 @@ impl ReceiverAccess {
 }
 
 struct ExclusiveRequest {
-    requests: Arc<AtomicU8>,
+    requests: Arc<ExclusiveRequests>,
     reason: ExclusiveAccessReason,
 }
 
 impl ExclusiveRequest {
-    fn new(requests: Arc<AtomicU8>, reason: ExclusiveAccessReason) -> Self {
-        requests.fetch_or(reason.bit(), Ordering::AcqRel);
+    fn new(requests: Arc<ExclusiveRequests>, reason: ExclusiveAccessReason) -> Self {
+        requests.total.fetch_add(1, Ordering::AcqRel);
+        reason.counter(&requests).fetch_add(1, Ordering::AcqRel);
         Self { requests, reason }
     }
 }
 
 impl Drop for ExclusiveRequest {
     fn drop(&mut self) {
-        self.requests
-            .fetch_and(!self.reason.bit(), Ordering::AcqRel);
+        self.reason
+            .counter(&self.requests)
+            .fetch_sub(1, Ordering::AcqRel);
+        self.requests.total.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -181,6 +201,26 @@ mod tests {
         assert!(!access.exclusive_requested());
         drop(capture);
         assert!(access.try_acquire_for_session().is_some());
+    }
+
+    #[test]
+    fn same_reason_overlap_stays_requested_until_every_request_drops() {
+        let access = ReceiverAccess::default();
+        let first = ExclusiveRequest::new(
+            Arc::clone(&access.inner.exclusive_requests),
+            ExclusiveAccessReason::Pairing,
+        );
+        let second = ExclusiveRequest::new(
+            Arc::clone(&access.inner.exclusive_requests),
+            ExclusiveAccessReason::Pairing,
+        );
+
+        drop(first);
+        assert!(access.requested(ExclusiveAccessReason::Pairing));
+        assert!(access.exclusive_requested());
+
+        drop(second);
+        assert!(!access.exclusive_requested());
     }
 
     #[tokio::test]

--- a/crates/openlogi-agent-core/src/runtime.rs
+++ b/crates/openlogi-agent-core/src/runtime.rs
@@ -14,7 +14,7 @@ use std::io;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
-use openlogi_core::binding::{Action, Binding, ButtonId, KeyCombo};
+use openlogi_core::binding::{Action, Binding, ButtonId};
 use openlogi_hid::{CaptureChannel, ChannelRegistry};
 use tracing::{info, warn};
 
@@ -26,41 +26,33 @@ use crate::hardware::{toggle_smartshift_in_background, write_dpi_in_background};
 use crate::receiver_access::ReceiverAccess;
 use crate::{DpiCycleState, DpiCycles};
 
-/// Output transition when an action starts within one physical press.
-#[derive(Debug, PartialEq, Eq)]
-enum HoldStart {
-    /// The action is instantaneous and belongs to ordinary dispatch.
-    NotHeld,
-    /// This press newly owns one held chord.
-    Started(KeyCombo),
-    /// The same press changed its held action.
-    Replaced { old: KeyCombo, new: KeyCombo },
-}
-
 /// Held output owned by accepted press capabilities rather than by a capture
 /// backend. Because every [`PressToken`] has exactly one terminal event, this
-/// map gives release, cancellation, invalidation, and shutdown one path.
+/// map gives release, cancellation, invalidation, shutdown, and unwinding one
+/// RAII path.
 #[derive(Default)]
 struct HeldShortcuts {
-    by_press: HashMap<PressToken, KeyCombo>,
+    by_press: HashMap<PressToken, openlogi_inject::HeldChord>,
 }
 
 impl HeldShortcuts {
-    fn start(&mut self, press: &PressToken, action: &Action) -> HoldStart {
+    fn start(&mut self, press: &PressToken, action: &Action) -> bool {
         let Some(combo) = action.held_combo() else {
-            return HoldStart::NotHeld;
+            return false;
         };
-        match self.by_press.insert(press.clone(), combo.clone()) {
-            Some(old) => HoldStart::Replaced {
-                old,
-                new: combo.clone(),
-            },
-            None => HoldStart::Started(combo.clone()),
+        match self.by_press.entry(press.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut held) => {
+                held.get_mut().replace(combo);
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert(openlogi_inject::press_hold(combo));
+            }
         }
+        true
     }
 
-    fn end(&mut self, press: &PressToken) -> Option<KeyCombo> {
-        self.by_press.remove(press)
+    fn end(&mut self, press: &PressToken) {
+        self.by_press.remove(press);
     }
 }
 
@@ -179,9 +171,7 @@ impl ButtonEventHandler {
                 self.start_action(press.token(), &action, press.device_key());
             }
             ButtonRuntimeEvent::Ended { press, reason } => {
-                if let Some(combo) = self.held.end(press.token()) {
-                    openlogi_inject::release_hold(&combo);
-                }
+                self.held.end(press.token());
                 if let EndReason::Canceled(reason) = reason {
                     match press.control() {
                         PressControl::Button(button) => {
@@ -197,12 +187,8 @@ impl ButtonEventHandler {
     }
 
     fn start_action(&mut self, press: &PressToken, action: &Action, device_key: Option<&str>) {
-        match self.held.start(press, action) {
-            HoldStart::NotHeld => self.executor.dispatch(action, device_key),
-            HoldStart::Started(combo) => openlogi_inject::press_hold(&combo),
-            HoldStart::Replaced { old, new } => {
-                openlogi_inject::replace_hold(&old, &new);
-            }
+        if !self.held.start(press, action) {
+            self.executor.dispatch(action, device_key);
         }
     }
 }
@@ -386,62 +372,12 @@ fn browser_nav_debounce_ok(action: &Action) -> bool {
 mod tests {
     use super::*;
 
-    fn hold(label: &str) -> Action {
-        Action::HoldShortcut(label.parse().expect("test shortcut must be valid"))
-    }
-
-    #[test]
-    fn held_output_is_owned_by_the_exact_press_until_its_terminal_event() {
-        let first = PressToken::hook_for_test(1, ButtonId::Back);
-        let second = PressToken::hook_for_test(2, ButtonId::Forward);
-        let mut held = HeldShortcuts::default();
-
-        assert_eq!(
-            held.start(&first, &hold("Ctrl+Space")),
-            HoldStart::Started("Ctrl+Space".parse().expect("valid shortcut"))
-        );
-        assert_eq!(
-            held.start(&second, &hold("Alt+F2")),
-            HoldStart::Started("Alt+F2".parse().expect("valid shortcut"))
-        );
-        assert_eq!(
-            held.end(&first),
-            Some("Ctrl+Space".parse().expect("valid shortcut"))
-        );
-        assert_eq!(held.end(&first), None, "a press releases at most once");
-        assert_eq!(
-            held.end(&second),
-            Some("Alt+F2".parse().expect("valid shortcut"))
-        );
-    }
-
-    #[test]
-    fn changing_a_hold_within_one_press_balances_the_previous_chord() {
-        let press = PressToken::hook_for_test(1, ButtonId::Back);
-        let mut held = HeldShortcuts::default();
-        let old: KeyCombo = "Ctrl+Space".parse().expect("valid shortcut");
-        let new: KeyCombo = "Alt+F2".parse().expect("valid shortcut");
-
-        assert_eq!(
-            held.start(&press, &Action::HoldShortcut(old.clone())),
-            HoldStart::Started(old.clone())
-        );
-        assert_eq!(
-            held.start(&press, &Action::HoldShortcut(new.clone())),
-            HoldStart::Replaced {
-                old,
-                new: new.clone(),
-            }
-        );
-        assert_eq!(held.end(&press), Some(new));
-    }
-
     #[test]
     fn instantaneous_actions_do_not_enter_held_state() {
         let press = PressToken::hook_for_test(1, ButtonId::Back);
         let mut held = HeldShortcuts::default();
 
-        assert_eq!(held.start(&press, &Action::Copy), HoldStart::NotHeld);
-        assert_eq!(held.end(&press), None);
+        assert!(!held.start(&press, &Action::Copy));
+        held.end(&press);
     }
 }

--- a/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
+++ b/crates/openlogi-agent-core/src/runtime/scroll/worker.rs
@@ -1,6 +1,6 @@
 //! Worker ownership and non-blocking producer capability for wheel output.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
@@ -111,8 +111,59 @@ struct ShutdownRequest {
 
 /// Lossless fallback for overflow cancellation and graceful shutdown.
 enum ScrollControl {
-    CancelOverflowSource(ScrollSource),
+    CancelOverflowSession {
+        session: HidppSessionId,
+        generation: u64,
+    },
     Shutdown(ShutdownRequest),
+}
+
+/// Highest overflow-cancelled HID++ session epoch per device in this worker
+/// generation. A successor may emit while late input from its predecessor
+/// remains rejected, and repeated session restarts replace one watermark.
+struct OverflowCancellations {
+    generation: u64,
+    sessions: HashMap<String, u64>,
+}
+
+impl OverflowCancellations {
+    fn new(generation: u64) -> Self {
+        Self {
+            generation,
+            sessions: HashMap::new(),
+        }
+    }
+
+    fn cancel(&mut self, session: &HidppSessionId, generation: u64) -> bool {
+        if generation != self.generation {
+            return false;
+        }
+        self.sessions
+            .entry(session.device_key().to_owned())
+            .and_modify(|epoch| *epoch = (*epoch).max(session.epoch()))
+            .or_insert_with(|| session.epoch());
+        true
+    }
+
+    fn advance_to(&mut self, generation: u64) -> bool {
+        if generation == self.generation {
+            return false;
+        }
+        self.generation = generation;
+        self.sessions.clear();
+        true
+    }
+
+    fn accepts(&self, input: &ScrollInput) -> bool {
+        input.generation == self.generation
+            && match &input.source {
+                ScrollSource::OsHook(_) => true,
+                ScrollSource::Hidpp(session) => self
+                    .sessions
+                    .get(session.device_key())
+                    .is_none_or(|cancelled_epoch| session.epoch() > *cancelled_epoch),
+            }
+    }
 }
 
 /// Cloneable, non-owning capability for physical input producers.
@@ -210,6 +261,7 @@ impl ScrollInputHandle {
 
     /// Cancel output belonging to one HID++ capture-session incarnation.
     pub(crate) fn cancel_hidpp_session(&self, session: &HidppSessionId) {
+        let generation = self.generation.load(Ordering::Acquire);
         let source = ScrollSource::Hidpp(session.clone());
         match self
             .commands
@@ -219,7 +271,10 @@ impl ScrollInputHandle {
             Err(mpsc::TrySendError::Full(_)) => {
                 if self
                     .controls
-                    .send(ScrollControl::CancelOverflowSource(source))
+                    .send(ScrollControl::CancelOverflowSession {
+                        session: session.clone(),
+                        generation,
+                    })
                     .is_ok()
                 {
                     self.wake();
@@ -347,14 +402,17 @@ fn run_worker(
     let mut engine = ScrollEngine::default();
     // An overflow-cancelled incarnation stays tombstoned so accepted input that
     // was already queued when control overtook the saturated queue is ignored.
-    let mut overflow_cancelled_sources = HashSet::new();
-    let mut generation = shared_generation.load(Ordering::Acquire);
+    let mut cancellations = OverflowCancellations::new(shared_generation.load(Ordering::Acquire));
     loop {
         while let Ok(control) = controls.try_recv() {
             match control {
-                ScrollControl::CancelOverflowSource(source) => {
-                    engine.cancel_source(&source, emit_smooth);
-                    overflow_cancelled_sources.insert(source);
+                ScrollControl::CancelOverflowSession {
+                    session,
+                    generation: cancelled_generation,
+                } => {
+                    if cancellations.cancel(&session, cancelled_generation) {
+                        engine.cancel_source(&ScrollSource::Hidpp(session), emit_smooth);
+                    }
                 }
                 ScrollControl::Shutdown(request) => {
                     engine.cancel_all(emit_smooth);
@@ -365,9 +423,14 @@ fn run_worker(
         }
 
         let current_generation = shared_generation.load(Ordering::Acquire);
-        if current_generation != generation || !preferences.smooth_scroll_enabled() {
+        if cancellations.advance_to(current_generation) {
             engine.cancel_all(emit_smooth);
-            generation = current_generation;
+            // Every accepted command from before the transition carries the
+            // old generation and is rejected below, so its source tombstone
+            // can no longer protect anything. A delayed old-generation control
+            // is also ignored above instead of recreating it.
+        } else if !preferences.smooth_scroll_enabled() {
+            engine.cancel_all(emit_smooth);
         }
 
         let command = engine.next_deadline().map_or_else(
@@ -379,10 +442,7 @@ fn run_worker(
             |deadline| commands.recv_timeout(deadline.saturating_duration_since(Instant::now())),
         );
         match command {
-            Ok(ScrollCommand::Input(input))
-                if input.generation == generation
-                    && !overflow_cancelled_sources.contains(&input.source) =>
-            {
+            Ok(ScrollCommand::Input(input)) if cancellations.accepts(&input) => {
                 match input.output {
                     ScrollOutputMode::Smooth { at } if preferences.smooth_scroll_enabled() => {
                         engine.impulse(input.source, input.impulse, at, emit_smooth);
@@ -600,6 +660,114 @@ mod tests {
                 .iter()
                 .all(|frame| frame.phase != openlogi_inject::SmoothScrollPhase::Cancelled)
         );
+    }
+
+    #[test]
+    fn generation_transition_retires_overflow_tombstone_without_reviving_late_input() {
+        let cancelled = HidppSessionId::with_epoch("mouse-a", 7);
+        let successor = HidppSessionId::with_epoch("mouse-a", 8);
+        let input = |session: &HidppSessionId, generation| ScrollInput {
+            generation,
+            source: ScrollSource::Hidpp(session.clone()),
+            impulse: WheelDelta { x: 0.0, y: 1.0 },
+            output: ScrollOutputMode::Direct,
+        };
+        let mut cancellations = OverflowCancellations::new(0);
+        cancellations.cancel(&cancelled, 0);
+        assert!(!cancellations.accepts(&input(&cancelled, 0)));
+        assert!(cancellations.accepts(&input(&successor, 0)));
+        assert!(
+            !cancellations.accepts(&input(&cancelled, 0)),
+            "a newer session must not resurrect late accepted input from its predecessor"
+        );
+
+        cancellations.cancel(&successor, 0);
+        assert_eq!(
+            cancellations.sessions.len(),
+            1,
+            "new session epochs replace rather than accumulate tombstones"
+        );
+
+        assert!(cancellations.advance_to(1));
+        assert!(cancellations.sessions.is_empty());
+        assert!(!cancellations.accepts(&input(&successor, 0)));
+        assert!(cancellations.accepts(&input(&successor, 1)));
+
+        assert!(!cancellations.cancel(&successor, 0));
+        assert!(
+            cancellations.accepts(&input(&successor, 1)),
+            "a delayed old-generation control must not recreate its tombstone"
+        );
+    }
+
+    #[test]
+    fn stale_overflow_control_does_not_cancel_current_generation_motion() {
+        let preferences = preferences(true, 14);
+        let (commands, command_rx) = mpsc::sync_channel(2);
+        let (controls, control_rx) = mpsc::channel();
+        let generation = Arc::new(AtomicU64::new(1));
+        let session = HidppSessionId::with_epoch("mouse-a", 7);
+        let (emitted, frames) = mpsc::channel();
+        let worker_generation = Arc::clone(&generation);
+        let worker = thread::spawn(move || {
+            run_worker(
+                &command_rx,
+                &control_rx,
+                &worker_generation,
+                &preferences,
+                &mut |frame| emitted.send(frame).expect("frame receiver remains open"),
+                &mut |_| {},
+            );
+        });
+
+        commands
+            .send(ScrollCommand::Input(ScrollInput {
+                generation: 1,
+                source: ScrollSource::Hidpp(session.clone()),
+                impulse: WheelDelta { x: 0.0, y: 1.0 },
+                output: ScrollOutputMode::Smooth { at: Instant::now() },
+            }))
+            .expect("worker command channel remains open");
+        assert_eq!(
+            frames
+                .recv_timeout(Duration::from_secs(1))
+                .expect("current-generation motion begins")
+                .phase,
+            openlogi_inject::SmoothScrollPhase::Began
+        );
+
+        controls
+            .send(ScrollControl::CancelOverflowSession {
+                session,
+                generation: 0,
+            })
+            .expect("worker control channel remains open");
+        commands
+            .send(ScrollCommand::Wake)
+            .expect("wake reaches the worker");
+
+        let terminal = loop {
+            let phase = frames
+                .recv_timeout(Duration::from_secs(1))
+                .expect("current-generation motion reaches a terminal phase")
+                .phase;
+            if matches!(
+                phase,
+                openlogi_inject::SmoothScrollPhase::Ended
+                    | openlogi_inject::SmoothScrollPhase::Cancelled
+            ) {
+                break phase;
+            }
+        };
+        assert_eq!(
+            terminal,
+            openlogi_inject::SmoothScrollPhase::Ended,
+            "a stale control must not cancel current-generation engine state"
+        );
+
+        drop(commands);
+        drop(controls);
+        worker.join().expect("worker exits cleanly");
     }
 
     #[test]

--- a/crates/openlogi-agent-core/src/watchers/pairing.rs
+++ b/crates/openlogi-agent-core/src/watchers/pairing.rs
@@ -3,13 +3,14 @@
 //! Unlike the polling watchers, this one is event-driven: it idles until the
 //! "Add device" window sends [`Control::Start`], then runs a single
 //! [`openlogi_hid::run_pairing`] session — forwarding the user's device pick
-//! and cancel into it — and streams [`PairingEvent`]s back to the GPUI thread.
+//! and cancel into it — and streams [`SessionEvent`]s back to the agent.
 //! When the session ends it returns to idle, ready for the next open.
 //!
 //! Keeping the thread long-lived means the consumer's select loop can own one
-//! fixed `PairingEvent` receiver and one [`Control`] sender (published as a
+//! fixed [`SessionEvent`] receiver and one [`Control`] sender (published as a
 //! global), instead of wiring a fresh channel on every window open.
 
+use std::future::Future;
 use std::thread;
 
 use openlogi_hid::{
@@ -22,20 +23,54 @@ use tracing::{debug, warn};
 #[derive(Debug)]
 pub enum Control {
     /// Begin a pairing session against the chosen receiver.
-    Start(ReceiverSelector),
+    Start {
+        /// Identity assigned by the agent when it admits the session.
+        session: SessionId,
+        /// Receiver the session should open.
+        selector: ReceiverSelector,
+    },
     /// Bolt: pair with a discovered device.
-    Pair(DiscoveredDevice),
+    Pair {
+        /// Session that discovered the device.
+        session: SessionId,
+        /// Full device data retained inside the agent.
+        device: DiscoveredDevice,
+    },
     /// Abort the in-progress session.
-    Cancel,
+    Cancel {
+        /// Session to cancel.
+        session: SessionId,
+    },
+}
+
+/// Process-local identity for one admitted pairing session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SessionId(u64);
+
+impl SessionId {
+    /// Construct an identity from the agent's monotonic session counter.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Pairing event tagged with the session that produced it.
+#[derive(Debug)]
+pub struct SessionEvent {
+    /// Session that produced `event`.
+    pub session: SessionId,
+    /// Progress or terminal result from the HID pairing flow.
+    pub event: PairingEvent,
 }
 
 /// Spawn the watcher. Returns a sender for [`Control`] messages and a receiver
-/// of [`PairingEvent`]s. Dropping the control sender stops the watcher after
+/// of [`SessionEvent`]s. Dropping the control sender stops the watcher after
 /// the current session.
 #[must_use]
 pub fn spawn() -> (
     mpsc::UnboundedSender<Control>,
-    mpsc::UnboundedReceiver<PairingEvent>,
+    mpsc::UnboundedReceiver<SessionEvent>,
 ) {
     let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel();
     let (evt_tx, evt_rx) = mpsc::unbounded_channel();
@@ -63,48 +98,132 @@ pub fn spawn() -> (
 
 /// Idle ↔ session driver. Returns when every [`Control`] sender is dropped.
 async fn run(
-    mut ctrl_rx: mpsc::UnboundedReceiver<Control>,
-    evt_tx: mpsc::UnboundedSender<PairingEvent>,
+    ctrl_rx: mpsc::UnboundedReceiver<Control>,
+    evt_tx: mpsc::UnboundedSender<SessionEvent>,
 ) {
+    run_with(
+        ctrl_rx,
+        evt_tx,
+        |_session, target, commands, events| async move {
+            let backend = openlogi_hid::host::backend();
+            run_pairing(&*backend, target, commands, events).await
+        },
+    )
+    .await;
+}
+
+/// The session driver is parameterized so teardown ordering can be tested
+/// without opening a host HID device.
+async fn run_with<F, Fut>(
+    mut ctrl_rx: mpsc::UnboundedReceiver<Control>,
+    evt_tx: mpsc::UnboundedSender<SessionEvent>,
+    mut start_session: F,
+) where
+    F: FnMut(
+        SessionId,
+        ReceiverSelector,
+        mpsc::UnboundedReceiver<PairingCommand>,
+        mpsc::UnboundedSender<PairingEvent>,
+    ) -> Fut,
+    Fut: Future<Output = Result<(), PairingError>>,
+{
+    let mut queued_start = None;
     loop {
         // Idle until a Start arrives; ignore stray in-session commands.
-        let target = loop {
-            match ctrl_rx.recv().await {
-                Some(Control::Start(target)) => break target,
-                // Stray Pair/Cancel while idle: ignore and keep waiting.
-                Some(_) => {}
-                None => return,
+        let (session_id, target) = if let Some(start) = queued_start.take() {
+            start
+        } else {
+            loop {
+                match ctrl_rx.recv().await {
+                    Some(Control::Start { session, selector }) => break (session, selector),
+                    // Stray Pair/Cancel while idle: ignore and keep waiting.
+                    Some(_) => {}
+                    None => return,
+                }
             }
         };
 
         // One session: a fresh command channel feeds run_pairing while we relay
-        // the user's Pair/Cancel into it, racing against the session finishing.
+        // the user's Pair/Cancel into it. Events first land on a session-local
+        // channel so the terminal event is not published until `run_pairing`
+        // has finished restoring the receiver.
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<PairingCommand>();
-        let backend = openlogi_hid::host::backend();
-        let mut session = Box::pin(run_pairing(&*backend, target, cmd_rx, evt_tx.clone()));
+        let (raw_tx, mut raw_rx) = mpsc::unbounded_channel();
+        let mut session = Box::pin(start_session(session_id, target, cmd_rx, raw_tx));
+        let mut terminal = None;
+        let mut events_open = true;
 
-        loop {
+        let result = loop {
             tokio::select! {
-                result = &mut session => {
-                    log_session_end(&result);
-                    break;
-                }
+                result = &mut session => break result,
+                event = raw_rx.recv(), if events_open => match event {
+                    Some(event) => relay_event(session_id, event, &evt_tx, &mut terminal),
+                    None => events_open = false,
+                },
                 ctrl = ctrl_rx.recv() => match ctrl {
-                    Some(Control::Pair(device)) => {
-                        if cmd_tx.send(PairingCommand::Pair(device)).is_err() {
-                            break;
-                        }
+                    Some(Control::Pair { session, device }) if session == session_id => {
+                        let _ = cmd_tx.send(PairingCommand::Pair(device));
                     }
-                    Some(Control::Cancel) => {
+                    Some(Control::Cancel { session }) if session == session_id => {
                         let _ = cmd_tx.send(PairingCommand::Cancel);
                     }
-                    // Already mid-session; a second Start is a no-op.
-                    Some(Control::Start(_)) => {}
+                    // Carry a start received during the old session's wind-down
+                    // into the next idle iteration instead of consuming it.
+                    Some(Control::Start { session, selector }) => {
+                        if queued_start.is_none() {
+                            queued_start = Some((session, selector));
+                        } else {
+                            warn!(?session, "pairing start received while another start is queued");
+                        }
+                    }
+                    Some(Control::Pair { .. } | Control::Cancel { .. }) => {}
                     // App shutting down: dropping `session` cancels it.
                     None => return,
                 },
             }
+        };
+
+        // `run_pairing` sends its terminal event before returning. Drain any
+        // event that became ready in the same select turn, then publish one
+        // terminal result only after receiver restoration has completed.
+        while let Ok(event) = raw_rx.try_recv() {
+            relay_event(session_id, event, &evt_tx, &mut terminal);
         }
+        log_session_end(&result);
+        let terminal = terminal.unwrap_or_else(|| {
+            warn!(
+                ?session_id,
+                "pairing session ended without a terminal event"
+            );
+            PairingEvent::Failed(match result {
+                Ok(()) => PairingError::Hid("pairing session ended without a result".to_string()),
+                Err(error) => error,
+            })
+        });
+        let _ = evt_tx.send(SessionEvent {
+            session: session_id,
+            event: terminal,
+        });
+    }
+}
+
+fn relay_event(
+    session: SessionId,
+    event: PairingEvent,
+    events: &mpsc::UnboundedSender<SessionEvent>,
+    terminal: &mut Option<PairingEvent>,
+) {
+    if matches!(event, PairingEvent::Paired { .. } | PairingEvent::Failed(_)) {
+        if terminal.is_none() {
+            *terminal = Some(event);
+        } else {
+            warn!(
+                ?session,
+                "pairing session emitted more than one terminal event"
+            );
+        }
+    } else {
+        let _ = events.send(SessionEvent { session, event });
     }
 }
 
@@ -112,5 +231,92 @@ fn log_session_end(result: &Result<(), PairingError>) {
     match result {
         Ok(()) => debug!("pairing session ended"),
         Err(e) => debug!(error = %e, "pairing session ended with error"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn start_received_during_teardown_runs_as_the_next_session() {
+        let (ctrl_tx, ctrl_rx) = mpsc::unbounded_channel();
+        let (evt_tx, mut evt_rx) = mpsc::unbounded_channel();
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        let (finish_first_tx, finish_first_rx) = oneshot::channel();
+        let (finish_second_tx, finish_second_rx) = oneshot::channel();
+        let finishes = Arc::new(Mutex::new(VecDeque::from([
+            finish_first_rx,
+            finish_second_rx,
+        ])));
+
+        let driver = tokio::spawn(run_with(ctrl_rx, evt_tx, {
+            let finishes = Arc::clone(&finishes);
+            move |session, _selector, _commands, events| {
+                let finish = finishes
+                    .lock()
+                    .expect("finish queue lock should not be poisoned")
+                    .pop_front()
+                    .expect("each fake session has a completion signal");
+                let started_tx = started_tx.clone();
+                async move {
+                    let _ = started_tx.send(session);
+                    let error = PairingError::Cancelled;
+                    let _ = events.send(PairingEvent::Failed(error.clone()));
+                    let _ = finish.await;
+                    Err(error)
+                }
+            }
+        }));
+
+        let first = SessionId::new(1);
+        let second = SessionId::new(2);
+        ctrl_tx
+            .send(Control::Start {
+                session: first,
+                selector: ReceiverSelector::First,
+            })
+            .expect("watcher control channel should be open");
+        assert_eq!(started_rx.recv().await, Some(first));
+
+        ctrl_tx
+            .send(Control::Start {
+                session: second,
+                selector: ReceiverSelector::First,
+            })
+            .expect("watcher control channel should be open");
+        assert!(
+            evt_rx.try_recv().is_err(),
+            "terminal event must wait for the old session's teardown"
+        );
+
+        finish_first_tx
+            .send(())
+            .expect("first fake session should still be running");
+        let first_terminal = evt_rx.recv().await.expect("first terminal event");
+        assert_eq!(first_terminal.session, first);
+        assert!(matches!(
+            first_terminal.event,
+            PairingEvent::Failed(PairingError::Cancelled)
+        ));
+        assert_eq!(started_rx.recv().await, Some(second));
+
+        finish_second_tx
+            .send(())
+            .expect("second fake session should still be running");
+        let second_terminal = evt_rx.recv().await.expect("second terminal event");
+        assert_eq!(second_terminal.session, second);
+        assert!(matches!(
+            second_terminal.event,
+            PairingEvent::Failed(PairingError::Cancelled)
+        ));
+
+        drop(ctrl_tx);
+        driver.await.expect("watcher driver should exit cleanly");
     }
 }

--- a/crates/openlogi-agent/src/bin/mock_agent.rs
+++ b/crates/openlogi-agent/src/bin/mock_agent.rs
@@ -274,6 +274,9 @@ struct State {
     /// unique here because the script has a single receiver.
     settings: HashMap<u8, DeviceSettings>,
     pairing: Option<PairingSession>,
+    /// Event stream for the most recently started pairing session. It outlives
+    /// the live session long enough for a client to drain its terminal update.
+    pairing_updates: Option<UnboundedReceiver<PairingUpdate>>,
     /// Where pairing stands, for the observable snapshot. Outlives
     /// [`Self::pairing`]: a terminal phase is the session's result.
     phase: Option<PairingPhase>,
@@ -327,6 +330,7 @@ impl State {
             next_slot: KEYBOARD_SLOT + 1,
             settings,
             pairing: None,
+            pairing_updates: None,
             phase: None,
             next_pairing_id: 0,
             started: Instant::now(),
@@ -339,16 +343,23 @@ impl State {
         self.phase = Some(phase);
     }
 
-    /// Register a new pairing session and return its id.
-    fn begin_pairing(&mut self, updates: UnboundedSender<PairingUpdate>) -> u64 {
+    /// Register a new pairing session and publish its initial phase together.
+    fn begin_pairing(&mut self) -> Result<u64, PairingCommandError> {
+        if self.pairing.is_some() {
+            return Err(PairingCommandError::AlreadyActive);
+        }
+        let (updates, update_rx) = mpsc::unbounded_channel();
         let id = self.next_pairing_id;
         self.next_pairing_id += 1;
+        let _ = updates.send(PairingUpdate::Searching);
         self.pairing = Some(PairingSession {
             id,
             updates,
             discovered: None,
         });
-        id
+        self.pairing_updates = Some(update_rx);
+        self.set_phase(PairingPhase::Searching);
+        Ok(id)
     }
 
     /// The live session, but only if it is still the one `id` started.
@@ -363,6 +374,42 @@ impl State {
         } else {
             None
         }
+    }
+
+    /// Select one device and publish `Pairing` in the same state transition.
+    fn select_pairing_device(
+        &mut self,
+        address: [u8; 6],
+    ) -> Result<(u64, UnboundedSender<PairingUpdate>, String), PairingCommandError> {
+        let Some(session) = self.pairing.as_ref() else {
+            return Err(PairingCommandError::NoActiveSession);
+        };
+        let Some(found) = session
+            .discovered
+            .as_ref()
+            .filter(|found| found.address == address)
+        else {
+            return Err(PairingCommandError::UnknownDevice);
+        };
+        let selected = (session.id, session.updates.clone(), found.name.clone());
+        self.set_phase(PairingPhase::Pairing);
+        Ok(selected)
+    }
+
+    /// Cancel the live session, or dismiss a terminal result, as one transition.
+    fn cancel_pairing(&mut self) {
+        self.phase = None;
+        if let Some(session) = self.pairing.take() {
+            let _ = session
+                .updates
+                .send(PairingUpdate::Failed(PairingFailure::Cancelled));
+        }
+    }
+
+    fn next_pairing_update(&mut self) -> Option<PairingUpdate> {
+        self.pairing_updates
+            .as_mut()
+            .and_then(|updates| updates.try_recv().ok())
     }
 
     /// Whether a host camera is "in use" right now — flipped on a timer so the
@@ -674,9 +721,6 @@ fn agent_status() -> AgentStatus {
 #[derive(Clone)]
 struct MockAgent {
     state: Arc<Mutex<State>>,
-    /// Long-poll side of the pairing channel, outside [`MockAgent::state`] so a
-    /// held `next_pairing` can't block `snapshot`.
-    pairing_rx: Arc<Mutex<Option<UnboundedReceiver<PairingUpdate>>>>,
     /// The last [`Observation`] handed out, so `observe` can stamp a new
     /// generation when the rendered state differs from it.
     served: Arc<Mutex<Observation>>,
@@ -690,7 +734,6 @@ impl MockAgent {
         };
         Self {
             state: Arc::new(Mutex::new(state)),
-            pairing_rx: Arc::new(Mutex::new(None)),
             served: Arc::new(Mutex::new(served)),
         }
     }
@@ -879,17 +922,10 @@ impl Agent for MockAgent {
         _: Context,
         _selector: ReceiverSelector,
     ) -> Result<(), PairingCommandError> {
-        let (tx, rx) = mpsc::unbounded_channel();
         let id = {
             let mut state = self.state.lock().await;
-            if state.pairing.is_some() {
-                return Err(PairingCommandError::AlreadyActive);
-            }
-            state.begin_pairing(tx.clone())
+            state.begin_pairing()?
         };
-        *self.pairing_rx.lock().await = Some(rx);
-        let _ = tx.send(PairingUpdate::Searching);
-        self.state.lock().await.set_phase(PairingPhase::Searching);
 
         let state = Arc::clone(&self.state);
         tokio::spawn(async move {
@@ -913,21 +949,7 @@ impl Agent for MockAgent {
     }
 
     async fn pair_device(self, _: Context, address: [u8; 6]) -> Result<(), PairingCommandError> {
-        let (id, tx, name) = {
-            let state = self.state.lock().await;
-            let Some(session) = state.pairing.as_ref() else {
-                return Err(PairingCommandError::NoActiveSession);
-            };
-            let Some(found) = session
-                .discovered
-                .as_ref()
-                .filter(|found| found.address == address)
-            else {
-                return Err(PairingCommandError::UnknownDevice);
-            };
-            (session.id, session.updates.clone(), found.name.clone())
-        };
-        self.state.lock().await.set_phase(PairingPhase::Pairing);
+        let (id, tx, name) = { self.state.lock().await.select_pairing_device(address)? };
 
         let state = Arc::clone(&self.state);
         tokio::spawn(async move {
@@ -942,8 +964,8 @@ impl Agent for MockAgent {
                     return;
                 }
                 state.set_phase(PairingPhase::Passkey(method.clone()));
+                let _ = tx.send(PairingUpdate::Passkey(method));
             }
-            let _ = tx.send(PairingUpdate::Passkey(method));
             tokio::time::sleep(PASSKEY_TYPING_DELAY).await;
             let mut state = state.lock().await;
             // No session of ours left = cancelled while the "user" was typing.
@@ -963,14 +985,7 @@ impl Agent for MockAgent {
         // Cancelling with nothing active is `Ok` in the real agent, so it is
         // `Ok` here — the GUI must not see a different contract from the mock.
         let mut state = self.state.lock().await;
-        // A cancelled session leaves no result, and dismissing a finished one
-        // clears its result — both are "no session" (see the real agent).
-        state.phase = None;
-        if let Some(session) = state.pairing.take() {
-            let _ = session
-                .updates
-                .send(PairingUpdate::Failed(PairingFailure::Cancelled));
-        }
+        state.cancel_pairing();
         Ok(())
     }
 
@@ -982,13 +997,7 @@ impl Agent for MockAgent {
         // which is what keeps the GUI's poll loop from spinning.
         let started = Instant::now();
         while started.elapsed() < PAIRING_HOLD {
-            if let Some(update) = self
-                .pairing_rx
-                .lock()
-                .await
-                .as_mut()
-                .and_then(|rx| rx.try_recv().ok())
-            {
+            if let Some(update) = self.state.lock().await.next_pairing_update() {
                 return Some(update);
             }
             tokio::time::sleep(PAIRING_POLL_TICK).await;
@@ -1039,5 +1048,69 @@ impl Agent for MockAgent {
         }
         info!(%route, enabled, "set_light_manual_power");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_with_discovery() -> State {
+        let mut state = State::new().expect("mock state should be valid");
+        let id = state
+            .begin_pairing()
+            .expect("idle mock should admit pairing");
+        state
+            .pairing_session(id)
+            .expect("new pairing session should be active")
+            .discovered = Some(FoundDevice {
+            address: CANDIDATE_ADDRESS,
+            name: "ERGO K860".to_string(),
+        });
+        state.set_phase(PairingPhase::Found(vec![FoundDevice {
+            address: CANDIDATE_ADDRESS,
+            name: "ERGO K860".to_string(),
+        }]));
+        state
+    }
+
+    #[test]
+    fn cancel_and_device_selection_are_atomic_in_either_order() {
+        let mut cancel_first = state_with_discovery();
+        cancel_first.cancel_pairing();
+
+        assert!(matches!(
+            cancel_first.select_pairing_device(CANDIDATE_ADDRESS),
+            Err(PairingCommandError::NoActiveSession)
+        ));
+        assert!(cancel_first.pairing.is_none());
+        assert_eq!(cancel_first.phase, None);
+        assert!(matches!(
+            cancel_first.next_pairing_update(),
+            Some(PairingUpdate::Searching)
+        ));
+        assert!(matches!(
+            cancel_first.next_pairing_update(),
+            Some(PairingUpdate::Failed(PairingFailure::Cancelled))
+        ));
+
+        let mut select_first = state_with_discovery();
+        select_first
+            .select_pairing_device(CANDIDATE_ADDRESS)
+            .expect("discovered device should be selectable");
+        assert_eq!(select_first.phase, Some(PairingPhase::Pairing));
+
+        select_first.cancel_pairing();
+
+        assert!(select_first.pairing.is_none());
+        assert_eq!(select_first.phase, None);
+        assert!(matches!(
+            select_first.next_pairing_update(),
+            Some(PairingUpdate::Searching)
+        ));
+        assert!(matches!(
+            select_first.next_pairing_update(),
+            Some(PairingUpdate::Failed(PairingFailure::Cancelled))
+        ));
     }
 }

--- a/crates/openlogi-agent/src/lifecycle.rs
+++ b/crates/openlogi-agent/src/lifecycle.rs
@@ -278,9 +278,33 @@ impl Armed {
         }
     }
 
+    /// Retire a terminal Windows hook worker and publish that input capture is
+    /// no longer installed. The native callbacks have already been cleared,
+    /// so the interval before this check remains pass-through rather than
+    /// suppressing input without a consumer.
+    #[cfg(target_os = "windows")]
+    fn apply_hook_health(&mut self) {
+        let Some(hook) = self.hook.as_ref() else {
+            return;
+        };
+        if hook.is_running() {
+            return;
+        }
+        warn!("Windows hook worker exited — marking input capture unavailable");
+        self.stop_hook();
+        self.observable
+            .set_accessibility_and_hook(Hook::has_accessibility(), false);
+    }
+
     /// Fold one watcher event into the agent's state.
     async fn apply_watcher(&mut self, event: startup::WatcherEvent) {
         use startup::{Watcher, WatcherEvent};
+
+        // Inventory and foreground-app samples make this a periodic health
+        // reconciliation without another timer in the control-plane loop.
+        #[cfg(target_os = "windows")]
+        self.apply_hook_health();
+
         match event {
             WatcherEvent::Inventory(event) => self.apply_inventory(event).await,
             WatcherEvent::Camera(active) => {

--- a/crates/openlogi-agent/src/pairing.rs
+++ b/crates/openlogi-agent/src/pairing.rs
@@ -15,13 +15,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use openlogi_agent_core::observable::ObservableState;
 use openlogi_agent_core::orchestrator::SharedRuntime;
 use openlogi_agent_core::receiver_access::{ExclusiveAccessReason, ExclusiveReceiverLease};
-use openlogi_agent_core::watchers::pairing::{self, Control};
+use openlogi_agent_core::watchers::pairing::{self, Control, SessionEvent, SessionId};
 use openlogi_hid::{DiscoveredDevice, PairingEvent, ReceiverSelector};
 use openlogi_ipc::{FoundDevice, PairingCommandError, PairingFailure, PairingPhase, PairingUpdate};
 use tokio::sync::{Mutex, mpsc};
@@ -36,20 +35,102 @@ const RECEIVER_LEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Address-keyed cache of the full discovered devices, so the GUI can pair by
 /// address without round-tripping the non-serializable `DiscoveredDevice`.
-type DeviceCache = Arc<StdMutex<HashMap<[u8; 6], DiscoveredDevice>>>;
-type ReceiverLeaseSlot = Arc<StdMutex<Option<ExclusiveReceiverLease>>>;
+type DeviceCache = HashMap<[u8; 6], DiscoveredDevice>;
+type SharedSessionOwner = Arc<StdMutex<SessionOwner>>;
+
+/// The one owner of pairing admission, live-session resources, and discovery.
+struct SessionOwner {
+    next_id: u64,
+    state: SessionState,
+}
+
+enum SessionState {
+    Idle,
+    Admitting(SessionId),
+    Active(ActiveSession),
+}
+
+struct ActiveSession {
+    id: SessionId,
+    devices: DeviceCache,
+    _receiver_lease: ExclusiveReceiverLease,
+}
+
+impl Default for SessionOwner {
+    fn default() -> Self {
+        Self {
+            next_id: 0,
+            state: SessionState::Idle,
+        }
+    }
+}
+
+impl SessionOwner {
+    fn begin_admission(&mut self) -> Result<SessionId, PairingCommandError> {
+        if !matches!(self.state, SessionState::Idle) {
+            return Err(PairingCommandError::AlreadyActive);
+        }
+        let id = SessionId::new(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+        self.state = SessionState::Admitting(id);
+        Ok(id)
+    }
+
+    fn activate(&mut self, id: SessionId, receiver_lease: ExclusiveReceiverLease) -> bool {
+        if !matches!(self.state, SessionState::Admitting(admitted) if admitted == id) {
+            return false;
+        }
+        self.state = SessionState::Active(ActiveSession {
+            id,
+            devices: HashMap::new(),
+            _receiver_lease: receiver_lease,
+        });
+        true
+    }
+
+    fn roll_back_admission(&mut self, id: SessionId) {
+        if matches!(self.state, SessionState::Admitting(admitted) if admitted == id) {
+            self.state = SessionState::Idle;
+        }
+    }
+
+    fn active(&self) -> Option<&ActiveSession> {
+        match &self.state {
+            SessionState::Active(session) => Some(session),
+            SessionState::Idle | SessionState::Admitting(_) => None,
+        }
+    }
+
+    fn active_mut(&mut self, id: SessionId) -> Option<&mut ActiveSession> {
+        match &mut self.state {
+            SessionState::Active(session) if session.id == id => Some(session),
+            SessionState::Idle | SessionState::Admitting(_) | SessionState::Active(_) => None,
+        }
+    }
+
+    fn end(&mut self, id: SessionId) -> bool {
+        if matches!(&self.state, SessionState::Active(session) if session.id == id) {
+            self.state = SessionState::Idle;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn abort(&mut self) -> bool {
+        if matches!(self.state, SessionState::Idle) {
+            return false;
+        }
+        self.state = SessionState::Idle;
+        true
+    }
+}
 
 /// Owns the pairing watcher and translates its event stream for the IPC layer.
 pub struct PairingManager {
     ctrl: mpsc::UnboundedSender<Control>,
     updates: Mutex<mpsc::UnboundedReceiver<PairingUpdate>>,
-    devices: DeviceCache,
-    /// Count of outstanding pairing sessions. The watcher is single-session,
-    /// so `start` atomically transitions this 0 → 1. The translator decrements
-    /// it on each terminal event and releases the receiver lease when it returns
-    /// to zero. Balanced: one accepted `start` ⇒ exactly one terminal.
-    sessions: Arc<AtomicUsize>,
-    receiver_lease: ReceiverLeaseSlot,
+    session: SharedSessionOwner,
     shared: SharedRuntime,
     /// Where the session's progress is published for the GUI to observe. The
     /// event channel above is the same information as a stream; this is the
@@ -64,23 +145,17 @@ impl PairingManager {
     pub fn new(shared: SharedRuntime, observable: Arc<ObservableState>) -> Self {
         let (ctrl, raw_events) = pairing::spawn();
         let (upd_tx, upd_rx) = mpsc::unbounded_channel();
-        let devices: DeviceCache = Arc::new(StdMutex::new(HashMap::new()));
-        let sessions = Arc::new(AtomicUsize::new(0));
-        let receiver_lease = Arc::new(StdMutex::new(None));
+        let session = Arc::new(StdMutex::new(SessionOwner::default()));
         tokio::spawn(translate(
             raw_events,
             upd_tx.clone(),
-            Arc::clone(&devices),
-            Arc::clone(&sessions),
-            Arc::clone(&receiver_lease),
+            Arc::clone(&session),
             Arc::clone(&observable),
         ));
         Self {
             ctrl,
             updates: Mutex::new(upd_rx),
-            devices,
-            sessions,
-            receiver_lease,
+            session,
             shared,
             observable,
         }
@@ -88,19 +163,14 @@ impl PairingManager {
 
     /// Begin a session: forget the previous discovery, pause capture, then start.
     pub async fn start(&self, selector: ReceiverSelector) -> Result<(), PairingCommandError> {
-        if self
-            .sessions
-            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            warn!("pairing start requested while a session is already active");
-            return Err(PairingCommandError::AlreadyActive);
-        }
-        let admission = SessionAdmission::new(Arc::clone(&self.sessions));
-
-        if let Ok(mut devices) = self.devices.lock() {
-            devices.clear();
-        }
+        let admission = match SessionAdmission::new(Arc::clone(&self.session)) {
+            Ok(admission) => admission,
+            Err(error) => {
+                debug_assert_eq!(error, PairingCommandError::AlreadyActive);
+                warn!("pairing start requested while a session is already active");
+                return Err(error);
+            }
+        };
         let Ok(receiver_lease) = tokio::time::timeout(
             RECEIVER_LEASE_TIMEOUT,
             self.shared
@@ -112,54 +182,48 @@ impl PairingManager {
             warn!("timed out waiting for receiver capture to stop; pairing not started");
             return Err(PairingCommandError::ReceiverBusy);
         };
-        with_receiver_lease_slot(&self.receiver_lease, |slot| {
-            *slot = Some(receiver_lease);
-        });
-        if let Err(e) = self.ctrl.send(Control::Start(selector)) {
-            self.release_receiver_lease();
-            warn!(error = %e, "could not start pairing session; pairing watcher is unavailable");
-            return Err(PairingCommandError::WatcherUnavailable);
-        }
-        admission.commit();
-        // A session exists the moment it is admitted, before the watcher's own
-        // first event: the user clicked Add Device and the window must show it.
-        self.observable.set_pairing(Some(PairingPhase::Searching));
-        Ok(())
+        admission.accept(receiver_lease, selector, &self.ctrl, &self.observable)
     }
 
     /// Pair with a previously discovered device by address.
     pub fn pair(&self, address: [u8; 6]) -> Result<(), PairingCommandError> {
-        let device = self
-            .devices
-            .lock()
-            .ok()
-            .and_then(|devices| devices.get(&address).cloned());
-        if let Some(device) = device {
+        with_session_owner(&self.session, |owner| {
+            let Some(session) = owner.active() else {
+                warn!(?address, "pair requested without an active session");
+                return Err(PairingCommandError::NoActiveSession);
+            };
+            let Some(device) = session.devices.get(&address).cloned() else {
+                warn!(?address, "pair requested for an unknown device");
+                return Err(PairingCommandError::UnknownDevice);
+            };
             self.ctrl
-                .send(Control::Pair(device))
+                .send(Control::Pair {
+                    session: session.id,
+                    device,
+                })
                 .map_err(|_| PairingCommandError::WatcherUnavailable)?;
             self.observable.set_pairing(Some(PairingPhase::Pairing));
             Ok(())
-        } else {
-            warn!(?address, "pair requested for an unknown device");
-            Err(PairingCommandError::UnknownDevice)
-        }
+        })
     }
 
     /// Cancel the in-progress session. The resulting `Failed(Cancelled)` event
     /// releases the receiver lease via the translator — don't release it here, or
     /// capture could re-acquire the receiver while `run_pairing` still holds it.
     pub fn cancel(&self) -> Result<(), PairingCommandError> {
-        if self.sessions.load(Ordering::Acquire) == 0 {
-            // Nothing running, so this is the GUI dismissing a *finished*
-            // session's result. Clearing the phase is the whole job — without
-            // it the next observation would put the result straight back.
-            self.observable.set_pairing(None);
-            return Ok(());
-        }
-        self.ctrl
-            .send(Control::Cancel)
-            .map_err(|_| PairingCommandError::WatcherUnavailable)
+        with_session_owner(&self.session, |owner| {
+            let Some(session) = owner.active() else {
+                // Nothing running, so this is the GUI dismissing a *finished*
+                // session's result. Clearing the phase is the whole job.
+                self.observable.set_pairing(None);
+                return Ok(());
+            };
+            self.ctrl
+                .send(Control::Cancel {
+                    session: session.id,
+                })
+                .map_err(|_| PairingCommandError::WatcherUnavailable)
+        })
     }
 
     /// Long-poll the next pairing step; `None` when the hold window elapses.
@@ -167,76 +231,102 @@ impl PairingManager {
         let mut rx = self.updates.lock().await;
         tokio::time::timeout(HOLD, rx.recv()).await.ok().flatten()
     }
-
-    fn release_receiver_lease(&self) {
-        with_receiver_lease_slot(&self.receiver_lease, |slot| {
-            *slot = None;
-        });
-    }
 }
 
-fn with_receiver_lease_slot<T>(
-    receiver_lease: &ReceiverLeaseSlot,
-    f: impl FnOnce(&mut Option<ExclusiveReceiverLease>) -> T,
+fn with_session_owner<T>(
+    session: &SharedSessionOwner,
+    f: impl FnOnce(&mut SessionOwner) -> T,
 ) -> T {
-    match receiver_lease.lock() {
-        Ok(mut slot) => f(&mut slot),
+    match session.lock() {
+        Ok(mut owner) => f(&mut owner),
         Err(poisoned) => {
-            warn!("pairing receiver lease lock poisoned; recovering lease slot");
-            let mut slot = poisoned.into_inner();
-            f(&mut slot)
+            warn!("pairing session owner lock poisoned; recovering session state");
+            let mut owner = poisoned.into_inner();
+            f(&mut owner)
         }
     }
 }
 
 struct SessionAdmission {
-    sessions: Arc<AtomicUsize>,
-    committed: bool,
+    owner: SharedSessionOwner,
+    id: SessionId,
+    finished: bool,
 }
 
 impl SessionAdmission {
-    fn new(sessions: Arc<AtomicUsize>) -> Self {
-        Self {
-            sessions,
-            committed: false,
-        }
+    fn new(owner: SharedSessionOwner) -> Result<Self, PairingCommandError> {
+        let id = with_session_owner(&owner, SessionOwner::begin_admission)?;
+        Ok(Self {
+            owner,
+            id,
+            finished: false,
+        })
     }
 
-    fn commit(mut self) {
-        self.committed = true;
+    fn accept(
+        mut self,
+        receiver_lease: ExclusiveReceiverLease,
+        selector: ReceiverSelector,
+        ctrl: &mpsc::UnboundedSender<Control>,
+        observable: &ObservableState,
+    ) -> Result<(), PairingCommandError> {
+        let result = with_session_owner(&self.owner, |owner| {
+            if !owner.activate(self.id, receiver_lease) {
+                warn!(session = ?self.id, "pairing admission changed before activation");
+                return Err(PairingCommandError::WatcherUnavailable);
+            }
+            // Publish before the watcher can emit a terminal result; otherwise
+            // this call could overwrite that result with `Searching`.
+            observable.set_pairing(Some(PairingPhase::Searching));
+            if let Err(error) = ctrl.send(Control::Start {
+                session: self.id,
+                selector,
+            }) {
+                owner.end(self.id);
+                observable.set_pairing(None);
+                warn!(error = %error, "could not start pairing session; pairing watcher is unavailable");
+                return Err(PairingCommandError::WatcherUnavailable);
+            }
+            Ok(())
+        });
+        self.finished = true;
+        result
     }
 }
 
 impl Drop for SessionAdmission {
     fn drop(&mut self) {
-        if !self.committed {
-            self.sessions.store(0, Ordering::Release);
+        if !self.finished {
+            with_session_owner(&self.owner, |owner| {
+                owner.roll_back_admission(self.id);
+            });
         }
     }
 }
 
-/// Translate raw [`PairingEvent`]s into wire [`PairingUpdate`]s: cache each
-/// discovered device by address (so `pair_device` can look it up), and resume
-/// the agent's capture on every terminal event.
-async fn translate(
-    mut raw: mpsc::UnboundedReceiver<PairingEvent>,
-    upd_tx: mpsc::UnboundedSender<PairingUpdate>,
-    devices: DeviceCache,
-    sessions: Arc<AtomicUsize>,
-    receiver_lease: ReceiverLeaseSlot,
-    observable: Arc<ObservableState>,
-) {
-    while let Some(event) = raw.recv().await {
-        let update = match event {
+/// Translate one session-tagged event into the wire update and observable
+/// phase. Events from an ended session are ignored, including duplicate
+/// terminals, so they cannot clean up a replacement session.
+fn apply_session_event(
+    event: SessionEvent,
+    session: &SharedSessionOwner,
+    observable: &ObservableState,
+) -> Option<PairingUpdate> {
+    with_session_owner(session, |owner| {
+        if owner.active().map(|session| session.id) != Some(event.session) {
+            return None;
+        }
+        let update = match event.event {
             PairingEvent::Searching => PairingUpdate::Searching,
             PairingEvent::DeviceFound(device) => {
                 let found = FoundDevice {
                     address: device.address,
                     name: device.name.clone(),
                 };
-                if let Ok(mut devices) = devices.lock() {
-                    devices.insert(device.address, device);
-                }
+                owner
+                    .active_mut(event.session)?
+                    .devices
+                    .insert(device.address, device);
                 PairingUpdate::DeviceFound(found)
             }
             PairingEvent::Passkey(method) => PairingUpdate::Passkey(method),
@@ -263,28 +353,34 @@ async fn translate(
             update,
             PairingUpdate::Paired { .. } | PairingUpdate::Failed(_)
         ) {
-            // Lift the capture pause when the accepted single session ends.
-            // Balanced: `start()` admits one active session, and that session
-            // emits exactly one terminal event.
-            if sessions.fetch_sub(1, Ordering::Relaxed) == 1 {
-                with_receiver_lease_slot(&receiver_lease, |lease| {
-                    *lease = None;
-                });
-            }
+            let ended = owner.end(event.session);
+            debug_assert!(ended, "matching active pairing session must end once");
         }
+        Some(update)
+    })
+}
+
+/// Translate raw [`SessionEvent`]s into wire [`PairingUpdate`]s and release the
+/// active session's receiver lease on its one terminal event.
+async fn translate(
+    mut raw: mpsc::UnboundedReceiver<SessionEvent>,
+    upd_tx: mpsc::UnboundedSender<PairingUpdate>,
+    session: SharedSessionOwner,
+    observable: Arc<ObservableState>,
+) {
+    while let Some(event) = raw.recv().await {
+        let Some(update) = apply_session_event(event, &session, &observable) else {
+            continue;
+        };
         if upd_tx.send(update).is_err() {
-            break; // the manager (and its receiver) is gone
+            break;
         }
     }
-    // The watcher channel closed — its thread exited, most likely because
-    // run_pairing panicked and unwound the watcher thread, dropping evt_tx before
-    // any terminal event. Don't leave the receiver lease held: release it so
-    // gesture / DPI-cycle / thumbwheel remapping keeps working (only pairing
-    // itself is then unavailable until the agent restarts).
-    sessions.store(0, Ordering::Relaxed);
-    with_receiver_lease_slot(&receiver_lease, |lease| {
-        *lease = None;
-    });
+    // The watcher channel closed — its thread exited, most likely because its
+    // session panicked. Drop any admission/session resource so capture resumes.
+    if with_session_owner(&session, SessionOwner::abort) {
+        observable.set_pairing(None);
+    }
 }
 
 #[cfg(test)]
@@ -298,6 +394,7 @@ mod tests {
     use openlogi_agent_core::runtime::hook::HookMaps;
     use openlogi_agent_core::runtime::scroll::ScrollPreferences;
     use openlogi_core::config::VerticalScrollSensitivity;
+    use openlogi_hid::PairingError;
 
     fn shared_runtime() -> SharedRuntime {
         SharedRuntime {
@@ -325,12 +422,39 @@ mod tests {
         PairingManager {
             ctrl,
             updates: Mutex::new(upd_rx),
-            devices: Arc::new(StdMutex::new(HashMap::new())),
-            sessions: Arc::new(AtomicUsize::new(0)),
-            receiver_lease: Arc::new(StdMutex::new(None)),
+            session: Arc::new(StdMutex::new(SessionOwner::default())),
             shared: shared_runtime(),
             observable: Arc::new(ObservableState::new("test".to_string())),
         }
+    }
+
+    async fn start_session(
+        manager: &PairingManager,
+        ctrl_rx: &mut mpsc::UnboundedReceiver<Control>,
+    ) -> SessionId {
+        manager
+            .start(ReceiverSelector::First)
+            .await
+            .expect("test session should start");
+        match ctrl_rx.recv().await.expect("start control") {
+            Control::Start { session, .. } => session,
+            control => panic!("expected start control, got {control:?}"),
+        }
+    }
+
+    fn discovered_device() -> DiscoveredDevice {
+        DiscoveredDevice {
+            address: [1, 2, 3, 4, 5, 6],
+            authentication: 0,
+            kind: openlogi_hid::pairing::BoltDeviceKind::Unknown,
+            name: "existing".to_string(),
+        }
+    }
+
+    fn is_idle(manager: &PairingManager) -> bool {
+        with_session_owner(&manager.session, |owner| {
+            matches!(owner.state, SessionState::Idle)
+        })
     }
 
     #[tokio::test]
@@ -342,7 +466,8 @@ mod tests {
         let result = manager.start(ReceiverSelector::First).await;
 
         assert_eq!(result, Err(PairingCommandError::WatcherUnavailable));
-        assert_eq!(manager.sessions.load(Ordering::Acquire), 0);
+        assert!(is_idle(&manager));
+        assert_eq!(manager.observable.snapshot().pairing, None);
         assert!(!manager.shared.receiver_access.exclusive_requested());
         assert!(
             manager
@@ -351,6 +476,28 @@ mod tests {
                 .try_acquire_for_session()
                 .is_some()
         );
+    }
+
+    #[test]
+    fn admission_is_owned_and_rolled_back_by_session_identity() {
+        let sessions = Arc::new(StdMutex::new(SessionOwner::default()));
+        let first = SessionAdmission::new(Arc::clone(&sessions))
+            .expect("idle owner should admit a session");
+
+        assert!(matches!(
+            SessionAdmission::new(Arc::clone(&sessions)),
+            Err(PairingCommandError::AlreadyActive)
+        ));
+        let first_id = first.id;
+        drop(first);
+
+        let second = SessionAdmission::new(Arc::clone(&sessions))
+            .expect("dropping an admission should reopen the owner");
+        assert_ne!(second.id, first_id);
+        with_session_owner(&sessions, |owner| owner.roll_back_admission(first_id));
+        assert!(with_session_owner(&sessions, |owner| {
+            matches!(owner.state, SessionState::Admitting(id) if id == second.id)
+        }));
     }
 
     #[tokio::test]
@@ -368,18 +515,62 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn release_receiver_lease_recovers_poisoned_slot() {
-        let (ctrl_tx, _ctrl_rx) = mpsc::unbounded_channel();
+    #[test]
+    fn pair_without_active_session_does_not_publish_pairing() {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
         let manager = manager_with_ctrl(ctrl_tx);
-        let receiver_lease = manager
-            .shared
-            .receiver_access
-            .acquire_exclusive(ExclusiveAccessReason::Pairing)
-            .await;
-        with_receiver_lease_slot(&manager.receiver_lease, |slot| {
-            *slot = Some(receiver_lease);
-        });
+        manager
+            .observable
+            .set_pairing(Some(PairingPhase::Paired { slot: 3 }));
+
+        let result = manager.pair(discovered_device().address);
+
+        assert_eq!(result, Err(PairingCommandError::NoActiveSession));
+        assert_eq!(
+            manager.observable.snapshot().pairing,
+            Some(PairingPhase::Paired { slot: 3 })
+        );
+        assert!(
+            ctrl_rx.try_recv().is_err(),
+            "pair without a session must not reach the watcher"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_ignores_overlapping_session_without_clearing_or_sending() {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        let session = start_session(&manager, &mut ctrl_rx).await;
+        apply_session_event(
+            SessionEvent {
+                session,
+                event: PairingEvent::DeviceFound(discovered_device()),
+            },
+            &manager.session,
+            &manager.observable,
+        );
+
+        let result = manager.start(ReceiverSelector::First).await;
+
+        assert_eq!(result, Err(PairingCommandError::AlreadyActive));
+        assert_eq!(
+            with_session_owner(&manager.session, |owner| owner
+                .active()
+                .map(|active| active.devices.len())),
+            Some(1)
+        );
+        let sent = ctrl_rx.try_recv();
+        assert!(
+            sent.is_err(),
+            "an overlapping start must not reach the watcher, got {sent:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_cleanup_is_exactly_once_and_releases_receiver_lease() {
+        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
+        let manager = manager_with_ctrl(ctrl_tx);
+        let first = start_session(&manager, &mut ctrl_rx).await;
         assert!(
             manager
                 .shared
@@ -387,16 +578,20 @@ mod tests {
                 .requested(ExclusiveAccessReason::Pairing)
         );
 
-        let slot = Arc::clone(&manager.receiver_lease);
-        let _ = std::panic::catch_unwind(move || {
-            let Ok(_guard) = slot.lock() else {
-                panic!("test receiver lease slot should start unpoisoned");
-            };
-            panic!("poison receiver lease slot");
-        });
+        let first_terminal = apply_session_event(
+            SessionEvent {
+                session: first,
+                event: PairingEvent::Failed(PairingError::Cancelled),
+            },
+            &manager.session,
+            &manager.observable,
+        );
 
-        manager.release_receiver_lease();
-
+        assert!(matches!(
+            first_terminal,
+            Some(PairingUpdate::Failed(PairingFailure::Cancelled))
+        ));
+        assert!(is_idle(&manager));
         assert!(!manager.shared.receiver_access.exclusive_requested());
         assert!(
             manager
@@ -405,40 +600,44 @@ mod tests {
                 .try_acquire_for_session()
                 .is_some()
         );
-    }
 
-    #[tokio::test]
-    async fn start_ignores_overlapping_session_without_clearing_or_sending() {
-        let (ctrl_tx, mut ctrl_rx) = mpsc::unbounded_channel();
-        let manager = manager_with_ctrl(ctrl_tx);
-        manager.sessions.store(1, Ordering::Release);
-        {
-            let Ok(mut devices) = manager.devices.lock() else {
-                panic!("test device cache lock should not be poisoned");
-            };
-            devices.insert(
-                [1, 2, 3, 4, 5, 6],
-                DiscoveredDevice {
-                    address: [1, 2, 3, 4, 5, 6],
-                    authentication: 0,
-                    kind: openlogi_hid::pairing::BoltDeviceKind::Unknown,
-                    name: "existing".to_string(),
-                },
-            );
-        }
-
-        let result = manager.start(ReceiverSelector::First).await;
-
-        assert_eq!(result, Err(PairingCommandError::AlreadyActive));
-        assert_eq!(manager.sessions.load(Ordering::Acquire), 1);
-        let Ok(devices) = manager.devices.lock() else {
-            panic!("test device cache lock should not be poisoned");
-        };
-        assert_eq!(devices.len(), 1);
-        let sent = ctrl_rx.try_recv();
-        assert!(
-            sent.is_err(),
-            "an overlapping start must not reach the watcher, got {sent:?}"
+        let second = start_session(&manager, &mut ctrl_rx).await;
+        assert_ne!(second, first);
+        let duplicate = apply_session_event(
+            SessionEvent {
+                session: first,
+                event: PairingEvent::Failed(PairingError::Cancelled),
+            },
+            &manager.session,
+            &manager.observable,
         );
+
+        assert!(duplicate.is_none());
+        assert_eq!(
+            with_session_owner(&manager.session, |owner| owner
+                .active()
+                .map(|session| session.id)),
+            Some(second)
+        );
+        assert!(manager.shared.receiver_access.exclusive_requested());
+        assert_eq!(
+            manager.observable.snapshot().pairing,
+            Some(PairingPhase::Searching)
+        );
+
+        let second_terminal = apply_session_event(
+            SessionEvent {
+                session: second,
+                event: PairingEvent::Paired { slot: 4 },
+            },
+            &manager.session,
+            &manager.observable,
+        );
+        assert!(matches!(
+            second_terminal,
+            Some(PairingUpdate::Paired { slot: 4 })
+        ));
+        assert!(is_idle(&manager));
+        assert!(!manager.shared.receiver_access.exclusive_requested());
     }
 }

--- a/crates/openlogi-assets/src/source.rs
+++ b/crates/openlogi-assets/src/source.rs
@@ -50,6 +50,29 @@ pub enum AssetSource {
     Override(String),
 }
 
+#[derive(Clone, Copy, Debug)]
+enum BuiltInSource {
+    Production,
+    Pages,
+    JsDelivr,
+}
+
+impl From<BuiltInSource> for AssetSource {
+    fn from(source: BuiltInSource) -> Self {
+        match source {
+            BuiltInSource::Production => Self::Production,
+            BuiltInSource::Pages => Self::Pages,
+            BuiltInSource::JsDelivr => Self::JsDelivr,
+        }
+    }
+}
+
+impl fmt::Display for BuiltInSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        AssetSource::from(*self).fmt(formatter)
+    }
+}
+
 impl fmt::Display for AssetSource {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -151,13 +174,13 @@ fn probe_default_sources(dir: &Path) -> Result<AssetRegistry, AssetError> {
     let (sender, receiver) = mpsc::channel();
 
     for (source, base) in [
-        (AssetSource::Production, PRODUCTION_BASE),
-        (AssetSource::Pages, PAGES_BASE),
+        (BuiltInSource::Production, PRODUCTION_BASE),
+        (BuiltInSource::Pages, PAGES_BASE),
     ] {
         let sender = sender.clone();
         thread::spawn(move || {
             let result = probe_uniform(base);
-            if sender.send((source.clone(), result)).is_err() {
+            if sender.send((source, result)).is_err() {
                 debug!(%source, "asset source probe finished after a winner was selected");
             }
         });
@@ -166,7 +189,7 @@ fn probe_default_sources(dir: &Path) -> Result<AssetRegistry, AssetError> {
     thread::spawn(move || {
         let result = probe_jsdelivr();
         if jsdelivr_sender
-            .send((AssetSource::JsDelivr, result))
+            .send((BuiltInSource::JsDelivr, result))
             .is_err()
         {
             debug!("jsDelivr probe finished after a winner was selected");
@@ -181,17 +204,14 @@ fn probe_default_sources(dir: &Path) -> Result<AssetRegistry, AssetError> {
         match result {
             Ok(probe) => {
                 // A local persistence failure is independent of the selected mirror.
-                return registry_from_probe(source, probe, dir);
+                return registry_from_probe(source.into(), probe, dir);
             }
             Err(error) => {
                 warn!(%source, error = ?error, "asset source probe failed");
                 match source {
-                    AssetSource::Production => production_error = Some(error),
-                    AssetSource::Pages => pages_error = Some(error),
-                    AssetSource::JsDelivr => jsdelivr_error = Some(error),
-                    AssetSource::Override(_) => {
-                        unreachable!("override is not sent by source probes")
-                    }
+                    BuiltInSource::Production => production_error = Some(error),
+                    BuiltInSource::Pages => pages_error = Some(error),
+                    BuiltInSource::JsDelivr => jsdelivr_error = Some(error),
                 }
             }
         }

--- a/crates/openlogi-camera/src/capture_windows.rs
+++ b/crates/openlogi-camera/src/capture_windows.rs
@@ -53,6 +53,27 @@ struct Shared {
     stop: AtomicBool,
 }
 
+/// Cooperative setup cancellation. Media Foundation's setup calls are
+/// synchronous and expose no cancellation handle, so this can stop only at
+/// the resource-safe boundaries between them.
+struct SetupCancellation<'a> {
+    stop: &'a AtomicBool,
+}
+
+impl SetupCancellation<'_> {
+    fn is_cancelled(&self) -> bool {
+        self.stop.load(Ordering::Relaxed)
+    }
+
+    fn checkpoint(&self) -> Result<(), CaptureError> {
+        if self.is_cancelled() {
+            Err(CaptureError::Timeout)
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// A live preview stream. Holds the reader thread; [`CameraStream::take_frame`]
 /// hands out the most recent frame each time it's polled. Dropping it stops
 /// the camera.
@@ -181,6 +202,11 @@ fn reader_thread(unique_id: &str, shared: &Shared, setup: &mpsc::Sender<Result<(
     // interface built below is a COM object, and releasing one after its
     // apartment closed is exactly the bug these guards exist to prevent.
     let com = ComApartment::enter();
+    let cancellation = SetupCancellation { stop: &shared.stop };
+    if let Err(error) = cancellation.checkpoint() {
+        let _ = setup.send(Err(error));
+        return;
+    }
     let media_foundation = match com.start_media_foundation() {
         Ok(started) => started,
         Err(e) => {
@@ -192,10 +218,17 @@ fn reader_thread(unique_id: &str, shared: &Shared, setup: &mpsc::Sender<Result<(
     // The whole object graph lives in this `match`, so the reader — and with it
     // the media source and every media type — has released by the time the
     // platform guard drops at the end of the function.
-    match open_reader(&media_foundation, unique_id) {
+    let opened = cancellation
+        .checkpoint()
+        .and_then(|()| open_reader(&media_foundation, unique_id, &cancellation));
+    match opened {
         Ok((reader, stride_hint)) => {
-            let _ = setup.send(Ok(()));
-            pump_frames(&reader, shared, stride_hint);
+            // A disconnected receiver means the caller's timeout already won.
+            // Do not enter ReadSample even if the relaxed stop load has not yet
+            // observed that store; dropping the reader shuts the source down.
+            if setup.send(Ok(())).is_ok() {
+                pump_frames(&reader, shared, stride_hint);
+            }
         }
         Err(e) => {
             let _ = setup.send(Err(e));
@@ -259,6 +292,7 @@ struct StrideHint {
 fn open_reader(
     platform: &MediaFoundation<'_>,
     unique_id: &str,
+    cancellation: &SetupCancellation<'_>,
 ) -> Result<(IMFSourceReader, StrideHint), CaptureError> {
     // SAFETY: the `platform` borrow is the precondition every call below needs
     // — Media Foundation started, inside an apartment — and the caller holds
@@ -270,16 +304,29 @@ fn open_reader(
     // against a live interface, and the reader is handed back to the very thread
     // that will pull samples from it.
     unsafe {
-        let source = activate_source(platform, unique_id)?;
-
         let mut reader_attrs = None;
         MFCreateAttributes(&raw mut reader_attrs, 1).map_err(setup_err)?;
         let reader_attrs = reader_attrs.ok_or_else(|| setup_err("MFCreateAttributes"))?;
         reader_attrs
             .SetUINT32(&MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, 1)
             .map_err(setup_err)?;
-        let reader = MFCreateSourceReaderFromMediaSource(&source, &reader_attrs)
-            .map_err(|e| access_or_setup(&e))?;
+        cancellation.checkpoint()?;
+
+        let source = activate_source(platform, unique_id, cancellation)?;
+        if let Err(error) = cancellation.checkpoint() {
+            shutdown_source(&source);
+            return Err(error);
+        }
+        let reader = match MFCreateSourceReaderFromMediaSource(&source, &reader_attrs) {
+            Ok(reader) => reader,
+            Err(error) => {
+                // No source reader exists to perform its documented source
+                // shutdown on drop, so balance the successful activation here.
+                shutdown_source(&source);
+                return Err(access_or_setup(&error));
+            }
+        };
+        cancellation.checkpoint()?;
 
         // Prefer the native type closest to the preview's target width, so a
         // 4K-capable camera doesn't stream (and we don't convert) 8x the
@@ -290,7 +337,11 @@ fn open_reader(
         let stream = MF_SOURCE_READER_FIRST_VIDEO_STREAM.0.cast_unsigned();
         let mut best: Option<(u32, IMFMediaType)> = None;
         let mut index = 0u32;
-        while let Ok(native) = reader.GetNativeMediaType(stream, index) {
+        loop {
+            cancellation.checkpoint()?;
+            let Ok(native) = reader.GetNativeMediaType(stream, index) else {
+                break;
+            };
             index += 1;
             let convertible = native.GetGUID(&MF_MT_SUBTYPE).is_ok_and(|subtype| {
                 [
@@ -312,6 +363,7 @@ fn open_reader(
                 }
             }
         }
+        cancellation.checkpoint()?;
         // Selecting the native type switches the device to that mode — a size
         // hint on the RGB32 output type alone is quietly dropped (the legacy
         // processor converts but never scales), leaving whatever mode the
@@ -320,6 +372,7 @@ fn open_reader(
             reader
                 .SetCurrentMediaType(stream, None, native)
                 .map_err(setup_err)?;
+            cancellation.checkpoint()?;
         }
 
         let output = MFCreateMediaType().map_err(setup_err)?;
@@ -332,6 +385,7 @@ fn open_reader(
         reader
             .SetCurrentMediaType(stream, None, &output)
             .map_err(setup_err)?;
+        cancellation.checkpoint()?;
 
         // Read the negotiated geometry back — the converter may have kept the
         // native size, and the stride tells us whether rows arrive bottom-up.
@@ -342,6 +396,7 @@ fn open_reader(
         let stride = current
             .GetUINT32(&MF_MT_DEFAULT_STRIDE)
             .map_or_else(|_| width.cast_signed() * 4, u32::cast_signed);
+        cancellation.checkpoint()?;
         Ok((
             reader,
             StrideHint {
@@ -361,6 +416,7 @@ fn open_reader(
 fn activate_source(
     _platform: &MediaFoundation<'_>,
     unique_id: &str,
+    cancellation: &SetupCancellation<'_>,
 ) -> Result<IMFMediaSource, CaptureError> {
     // SAFETY: the `_platform` borrow proves Media Foundation is started inside
     // an apartment on this thread, which is what these MF calls require of it.
@@ -383,6 +439,7 @@ fn activate_source(
                 &MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID,
             )
             .map_err(setup_err)?;
+        cancellation.checkpoint()?;
 
         let (mut devices, mut count) = (std::ptr::null_mut::<Option<IMFActivate>>(), 0u32);
         MFEnumDeviceSources(&enum_attrs, &raw mut devices, &raw mut count).map_err(setup_err)?;
@@ -398,7 +455,7 @@ fn activate_source(
             let Some(activate) = slot.take() else {
                 continue;
             };
-            if chosen.is_some() {
+            if chosen.is_some() || cancellation.is_cancelled() {
                 continue;
             }
             let (mut link, mut len) = (windows::core::PWSTR::null(), 0u32);
@@ -418,14 +475,33 @@ fn activate_source(
                 chosen = Some(activate);
             }
         }
-        let result = match chosen {
-            Some(activate) => activate
-                .ActivateObject::<IMFMediaSource>()
-                .map_err(|e| access_or_setup(&e)),
-            None => Err(CaptureError::NotFound),
+        let result = match cancellation.checkpoint() {
+            Err(error) => Err(error),
+            Ok(()) => match chosen {
+                // ActivateObject is synchronous and provides no cancellation
+                // handle. A timeout while the driver is inside this call can
+                // only be observed after it returns; `open_reader` then shuts
+                // the returned source down before doing any further setup.
+                Some(activate) => activate
+                    .ActivateObject::<IMFMediaSource>()
+                    .map_err(|e| access_or_setup(&e)),
+                None => Err(CaptureError::NotFound),
+            },
         };
         CoTaskMemFree(Some(devices.cast()));
         result
+    }
+}
+
+/// Shut down an activated source when no source reader exists to own that
+/// responsibility. The COM wrapper still drops afterward, before the Media
+/// Foundation and apartment guards in [`reader_thread`].
+fn shutdown_source(source: &IMFMediaSource) {
+    // SAFETY: `source` is a live media source activated on this thread. This
+    // call is the documented teardown for an activated media source that was
+    // not transferred into an IMFSourceReader.
+    if let Err(error) = unsafe { source.Shutdown() } {
+        tracing::warn!(%error, "could not shut down cancelled camera source");
     }
 }
 
@@ -494,13 +570,30 @@ fn access_or_setup(e: &windows::core::Error) -> CaptureError {
 
 #[cfg(test)]
 mod tests {
-    use super::device_instance;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{CaptureError, SetupCancellation, device_instance};
 
     // The same StreamCam function, as DirectShow enumerates it (KSCATEGORY_VIDEO)
     // vs. as Media Foundation enumerates it (KSCATEGORY_VIDEO_CAMERA): identical
     // but for the trailing interface-class GUID.
     const DIRECTSHOW: &str = r"\\?\usb#vid_046d&pid_0893&mi_00#9&56d9c30&0&0000#{65e8773d-8f56-11d0-a3b9-00a0c9223196}\global";
     const MEDIA_FOUNDATION: &str = r"\\?\usb#vid_046d&pid_0893&mi_00#9&56d9c30&0&0000#{e5323777-f976-4f5b-9b55-b94699c46e44}\global";
+
+    #[test]
+    fn setup_stops_at_the_first_checkpoint_after_cancellation() {
+        let stop = AtomicBool::new(false);
+        let cancellation = SetupCancellation { stop: &stop };
+        cancellation
+            .checkpoint()
+            .expect("setup may continue before cancellation");
+
+        stop.store(true, Ordering::Relaxed);
+        assert!(matches!(
+            cancellation.checkpoint(),
+            Err(CaptureError::Timeout)
+        ));
+    }
 
     #[test]
     fn instance_matches_across_interface_class_guids() {

--- a/crates/openlogi-core/src/config/file.rs
+++ b/crates/openlogi-core/src/config/file.rs
@@ -273,6 +273,7 @@ fn parse_config(path: &Path, source: &str) -> Result<(Config, u32), ConfigError>
     if header.schema_version <= 4 {
         config.migrate_transport_scoped_keys();
     }
+    config.repair_duplicate_routes();
     config.schema_version = SCHEMA_VERSION;
     Ok((config, header.schema_version))
 }

--- a/crates/openlogi-core/src/config/identity.rs
+++ b/crates/openlogi-core/src/config/identity.rs
@@ -44,6 +44,42 @@ pub fn canonical_device_key(
 }
 
 impl Config {
+    /// Restore the route index's one-owner invariant after loading and schema
+    /// migration.
+    ///
+    /// A hand-edited file can put one route in several entries, and a key
+    /// migration can add a link that an existing entry already claims. Device
+    /// keys are stored in a [`BTreeMap`](std::collections::BTreeMap), so the
+    /// lexicographically first key keeps its complete
+    /// [`LinkConfig`](crate::config::LinkConfig) and later claims are removed.
+    /// This matches the owner an ambiguous index resolved
+    /// to before the repair, when [`Self::resolve_device_key`] used the first
+    /// matching map entry.
+    ///
+    /// Only the route index is repaired. Device entries are neither renamed
+    /// nor consumed, so [`Self::selected_device`] and
+    /// [`DeviceConfig::host_switch_targets`] keep referring to the same
+    /// physical configuration entries.
+    #[cfg(feature = "fs")]
+    pub(super) fn repair_duplicate_routes(&mut self) {
+        let mut owners = std::collections::BTreeMap::<String, String>::new();
+        for (device_key, device) in &mut self.devices {
+            device.links.retain(|route_key, _| {
+                let Some(owner) = owners.get(route_key) else {
+                    owners.insert(route_key.clone(), device_key.clone());
+                    return true;
+                };
+                tracing::warn!(
+                    %route_key,
+                    %owner,
+                    duplicate_owner = %device_key,
+                    "route is indexed by multiple devices; keeping the first owner"
+                );
+                false
+            });
+        }
+    }
+
     /// The configuration key to *read and write* for a device reached by
     /// `stable`, given whatever `identity` the current probe could read.
     ///

--- a/crates/openlogi-core/src/config/tests.rs
+++ b/crates/openlogi-core/src/config/tests.rs
@@ -1848,6 +1848,93 @@ Forward = "BrowserForward"
 }
 
 #[test]
+fn loading_hand_edited_duplicate_routes_keeps_the_first_device_key() {
+    let source = r#"
+schema_version = 6
+selected_device = "unit:ffffffff"
+
+[devices.keyboard]
+host_switch_targets = ["unit:ffffffff"]
+
+[devices."unit:11111111".links."receiver:82839805:slot:1".overrides]
+dpi = 800
+
+[devices."unit:ffffffff".links."receiver:82839805:slot:1".overrides]
+dpi = 1600
+"#;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, source).expect("write hand-edited config");
+
+    let config = Config::load_from_path(&path).expect("load");
+
+    assert_eq!(
+        config.devices["unit:11111111"].links["receiver:82839805:slot:1"]
+            .overrides
+            .dpi,
+        Some(Dpi::new(800)),
+        "the lexicographically first device key keeps its complete link"
+    );
+    assert!(
+        !config.devices["unit:ffffffff"]
+            .links
+            .contains_key("receiver:82839805:slot:1"),
+        "the later duplicate no longer indexes the route"
+    );
+    assert_eq!(config.selected_device.as_deref(), Some("unit:ffffffff"));
+    assert_eq!(
+        config.devices["keyboard"].host_switch_targets,
+        vec!["unit:ffffffff".to_string()],
+        "repairing an index does not rename the referenced device entry"
+    );
+}
+
+#[test]
+fn loading_v4_repairs_duplicate_routes_created_by_key_migration() {
+    let source = r#"
+schema_version = 4
+selected_device = "direct:046d:c08d:unit:11111111"
+
+[devices.keyboard]
+host_switch_targets = ["direct:046d:c08d:unit:11111111"]
+
+[devices."direct:046d:c08d:unit:11111111"]
+dpi = 1600
+
+[devices."unit:ffffffff".links."direct:046d:c08d".overrides]
+dpi = 800
+"#;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("config.toml");
+    fs::write(&path, source).expect("write v4 config");
+
+    let config = Config::load_from_path(&path).expect("load and migrate");
+
+    assert!(
+        config.devices["unit:11111111"]
+            .links
+            .contains_key("direct:046d:c08d"),
+        "the first post-migration device key owns the route"
+    );
+    assert!(
+        !config.devices["unit:ffffffff"]
+            .links
+            .contains_key("direct:046d:c08d"),
+        "the pre-existing duplicate is removed"
+    );
+    assert_eq!(
+        config.selected_device.as_deref(),
+        Some("unit:11111111"),
+        "selection follows the migrated device key"
+    );
+    assert_eq!(
+        config.devices["keyboard"].host_switch_targets,
+        vec!["unit:11111111".to_string()],
+        "host-switch references follow the migrated device key"
+    );
+}
+
+#[test]
 fn an_empty_link_table_survives_a_save_and_reload() {
     // The set of `links` keys *is* the route index — the only thing that can
     // identify a sleeping device from its route alone. A link with nothing

--- a/crates/openlogi-core/src/hid/pairing.rs
+++ b/crates/openlogi-core/src/hid/pairing.rs
@@ -74,6 +74,9 @@ pub enum PairingError {
     /// Pairing flow was cancelled by the caller.
     #[error("pairing was cancelled")]
     Cancelled,
+    /// The command is not valid for the active receiver family.
+    #[error("pairing command is not supported by the active receiver")]
+    UnsupportedCommand,
     /// A receiver notification failed to decode; authentication cannot
     /// proceed safely, so the flow fails instead of presenting bogus data.
     #[error("malformed pairing notification ({0})")]

--- a/crates/openlogi-desktop/src/features/profile_scope.rs
+++ b/crates/openlogi-desktop/src/features/profile_scope.rs
@@ -48,9 +48,7 @@ struct ProfileChoice {
 
 struct AddAppChoices {
     recent: Vec<ProfileChoice>,
-    applications: Vec<ProfileChoice>,
-    loading: bool,
-    failed: bool,
+    catalog: CatalogPresentation,
 }
 
 /// Installed application icons are immutable for a GUI session. The store
@@ -86,6 +84,12 @@ enum AppIconState {
 enum CatalogLoad {
     Loading,
     Ready(Vec<Application>),
+    Failed,
+}
+
+enum CatalogPresentation {
+    Loading,
+    Ready(Vec<ProfileChoice>),
     Failed,
 }
 
@@ -203,9 +207,11 @@ impl AppCatalogPicker {
         &self,
         observed: &HashSet<String>,
         unavailable: &HashSet<String>,
-    ) -> Vec<ProfileChoice> {
-        let CatalogLoad::Ready(applications) = &self.load else {
-            return Vec::new();
+    ) -> CatalogPresentation {
+        let applications = match &self.load {
+            CatalogLoad::Loading => return CatalogPresentation::Loading,
+            CatalogLoad::Ready(applications) => applications,
+            CatalogLoad::Failed => return CatalogPresentation::Failed,
         };
         let mut seen = HashSet::new();
         let mut profiles = applications
@@ -229,7 +235,7 @@ impl AppCatalogPicker {
                 .cmp(&right.name.to_lowercase())
                 .then_with(|| left.app.cmp(&right.app))
         });
-        profiles
+        CatalogPresentation::Ready(profiles)
     }
 }
 
@@ -363,20 +369,16 @@ pub(crate) fn profile_scope_bar(
             picker.ensure_icon(&profile.app, cx);
         }
     });
-    let available_catalog = catalog
+    let catalog_presentation = catalog
         .read(cx)
         .available_profiles(&observed_ids, &unavailable);
-    let loading = matches!(catalog.read(cx).load, CatalogLoad::Loading);
-    let failed = matches!(catalog.read(cx).load, CatalogLoad::Failed);
 
     Some(ProfileScopeBar {
         editing_app,
         profiles,
         choices: AddAppChoices {
             recent: available_recent,
-            applications: available_catalog,
-            loading,
-            failed,
+            catalog: catalog_presentation,
         },
         catalog: catalog.clone(),
         icons: icons.clone(),
@@ -690,15 +692,16 @@ fn add_app_content(
             application_row(choice, icon, pal, popover.clone())
         })
         .collect::<Vec<_>>();
-    let application_rows = choices
-        .applications
-        .iter()
-        .filter(|choice| profile_matches_query(choice, &query))
-        .cloned()
-        .collect::<Vec<_>>();
-    let no_matches = application_rows.is_empty()
-        && !choices.loading
-        && !choices.failed
+    let application_rows = match &choices.catalog {
+        CatalogPresentation::Ready(applications) => applications
+            .iter()
+            .filter(|choice| profile_matches_query(choice, &query))
+            .cloned()
+            .collect::<Vec<_>>(),
+        CatalogPresentation::Loading | CatalogPresentation::Failed => Vec::new(),
+    };
+    let no_matches = matches!(&choices.catalog, CatalogPresentation::Ready(_))
+        && application_rows.is_empty()
         && (query.is_empty() || recent_rows.is_empty());
     let catalog_for_toggle = catalog.clone();
     let list_catalog = catalog.clone();
@@ -733,15 +736,19 @@ fn add_app_content(
             catalog_for_toggle,
             pal,
         ))
-        .when(show_applications && choices.loading, |card| {
-            card.child(catalog_message(tr!("Loading applications…"), pal))
-        })
-        .when(show_applications && choices.failed, |card| {
-            card.child(catalog_message(
-                tr!("Application catalog unavailable."),
-                pal,
-            ))
-        })
+        .when(
+            show_applications && matches!(&choices.catalog, CatalogPresentation::Loading),
+            |card| card.child(catalog_message(tr!("Loading applications…"), pal)),
+        )
+        .when(
+            show_applications && matches!(&choices.catalog, CatalogPresentation::Failed),
+            |card| {
+                card.child(catalog_message(
+                    tr!("Application catalog unavailable."),
+                    pal,
+                ))
+            },
+        )
         .when(show_applications && list_len > 0, |card| {
             card.child(catalog_list(
                 application_rows,

--- a/crates/openlogi-desktop/src/state/device_runtime.rs
+++ b/crates/openlogi-desktop/src/state/device_runtime.rs
@@ -9,10 +9,10 @@ use super::smartshift::SmartShiftDeviceState;
 /// Replaces six parallel `BTreeMap<String, _>` fields that all shared the
 /// same device-key domain — manual camera-light override, volatile light
 /// settings, an in-flight light command, the inventory-miss counter, a
-/// pending SmartShift write id, and the SmartShift write-confirmation status
-/// — with one row per device. The row also keeps light-command status scoped to
-/// the device that produced it. A device absent from the owning map is
-/// equivalent to every field here at its default.
+/// SmartShift write lifecycle, and its confirmation status — with one row per
+/// device. The row also keeps light-command status scoped to the device that
+/// produced it. A device absent from the owning map is equivalent to every
+/// field here at its default.
 #[derive(Debug, Default)]
 pub(super) struct DeviceRuntimeState {
     /// Consecutive inventory snapshots that omitted this device.

--- a/crates/openlogi-desktop/src/state/inventory.rs
+++ b/crates/openlogi-desktop/src/state/inventory.rs
@@ -158,8 +158,7 @@ impl AppState {
         for key in &rerouted {
             self.pointer.reads.remove(key);
             if let Some(entry) = self.devices.runtime.get_mut(key) {
-                entry.smartshift.pending_confirm = None;
-                entry.smartshift.write_status = None;
+                entry.smartshift.reset();
             }
         }
         let present: HashSet<_> = self

--- a/crates/openlogi-desktop/src/state/smartshift.rs
+++ b/crates/openlogi-desktop/src/state/smartshift.rs
@@ -10,13 +10,80 @@ use super::devices::DeviceRecord;
 use super::load::SmartShiftLoad;
 use super::{AppState, SmartShiftWriteStatus, StateEvent};
 
-/// Write/confirmation state scoped to one device.
+/// One device's SmartShift write lifecycle.
+///
+/// A queued confirmation and an in-flight one are different states: only the
+/// latter may accept a read tagged with its request id. Keeping that distinction
+/// here also makes resetting a write after a route change atomic.
 #[derive(Debug, Default)]
-pub(super) struct SmartShiftDeviceState {
-    /// Identity of the write awaiting a confirming re-read.
-    pub(super) pending_confirm: Option<u64>,
-    /// Visible outcome of post-write confirmation.
-    pub(super) write_status: Option<SmartShiftWriteStatus>,
+pub(super) enum SmartShiftDeviceState {
+    #[default]
+    Idle,
+    Queued {
+        expected: SmartShiftStatus,
+        write_id: u64,
+    },
+    Confirming {
+        expected: SmartShiftStatus,
+        write_id: u64,
+    },
+    Confirmed,
+    Failed,
+}
+
+impl SmartShiftDeviceState {
+    fn status(&self) -> Option<SmartShiftWriteStatus> {
+        match *self {
+            Self::Idle => None,
+            Self::Queued { expected, write_id } | Self::Confirming { expected, write_id } => {
+                Some(SmartShiftWriteStatus::Applying { expected, write_id })
+            }
+            Self::Confirmed => Some(SmartShiftWriteStatus::Confirmed),
+            Self::Failed => Some(SmartShiftWriteStatus::Failed),
+        }
+    }
+
+    pub(super) fn queue(&mut self, expected: SmartShiftStatus, write_id: u64) {
+        *self = Self::Queued { expected, write_id };
+    }
+
+    pub(super) fn begin_confirmation(&mut self) -> Option<u64> {
+        let Self::Queued { expected, write_id } = *self else {
+            return None;
+        };
+        *self = Self::Confirming { expected, write_id };
+        Some(write_id)
+    }
+
+    fn confirming_expected(&self, write_id: u64) -> Option<SmartShiftStatus> {
+        match *self {
+            Self::Confirming {
+                expected,
+                write_id: current,
+            } if current == write_id => Some(expected),
+            Self::Idle
+            | Self::Queued { .. }
+            | Self::Confirming { .. }
+            | Self::Confirmed
+            | Self::Failed => None,
+        }
+    }
+
+    fn fail_confirmation(&mut self, write_id: u64) {
+        if matches!(
+            self,
+            Self::Confirming {
+                write_id: current,
+                ..
+            } if *current == write_id
+        ) {
+            *self = Self::Failed;
+        }
+    }
+
+    pub(super) fn reset(&mut self) {
+        *self = Self::Idle;
+    }
 }
 
 impl AppState {
@@ -93,7 +160,7 @@ impl AppState {
             self.devices
                 .runtime
                 .get(&record.device_key())
-                .and_then(|entry| entry.smartshift.write_status)
+                .and_then(|entry| entry.smartshift.status())
         })
     }
     /// Drop `key`'s recorded SmartShift status so the caller can re-run
@@ -103,40 +170,40 @@ impl AppState {
     pub fn retry_smartshift(&mut self, key: &DeviceKey) {
         self.pointer.reads.retry_smartshift(key);
         if let Some(entry) = self.devices.runtime.get_mut(key) {
-            entry.smartshift.write_status = None;
+            entry.smartshift.reset();
         }
     }
     /// Apply a settled query to write-confirmation state if it still belongs to
     /// the current write. The service's generation guard independently rejects
     /// callbacks from queries replaced by a newer confirmation.
     pub(crate) fn apply_smartshift_read(&mut self, key: &DeviceKey, write_id: Option<u64>) {
-        let current_write_status = self
-            .devices
-            .runtime
-            .get(key)
-            .and_then(|entry| entry.smartshift.write_status);
-        if !smartshift_read_is_current(write_id, current_write_status.as_ref()) {
+        let current_write = self.devices.runtime.get(key).map(|entry| &entry.smartshift);
+        if !smartshift_read_is_current(write_id, current_write) {
             debug!(key = %key, ?write_id, "stale SmartShift read result ignored");
             return;
         }
-        let expected = match self
+        let Some(write_id) = write_id else {
+            return;
+        };
+        let expected = self
             .devices
             .runtime
             .get(key)
-            .and_then(|entry| entry.smartshift.write_status)
-        {
-            Some(SmartShiftWriteStatus::Applying { expected, .. }) => Some(expected),
-            Some(SmartShiftWriteStatus::Confirmed | SmartShiftWriteStatus::Failed) | None => None,
+            .and_then(|entry| entry.smartshift.confirming_expected(write_id));
+        let Some(expected) = expected else {
+            return;
         };
-        if let Some(status) = expected.and_then(|expected| {
+        if let Some(outcome) =
             smartshift_write_outcome(expected, self.pointer.reads.smartshift_load(key))
-        }) {
+        {
             self.devices
                 .runtime
                 .entry(key.clone())
                 .or_default()
-                .smartshift
-                .write_status = Some(status);
+                .smartshift = match outcome {
+                ConfirmationOutcome::Confirmed => SmartShiftDeviceState::Confirmed,
+                ConfirmationOutcome::Failed => SmartShiftDeviceState::Failed,
+            };
         }
     }
     /// Write a full SmartShift configuration to the active device (best-effort,
@@ -183,18 +250,12 @@ impl AppState {
                 .entry(key.clone())
                 .or_default()
                 .smartshift
-                .pending_confirm = Some(write_id);
+                .queue(expected, write_id);
             write_id
         });
-        self.devices
-            .runtime
-            .entry(key)
-            .or_default()
-            .smartshift
-            .write_status = Some(match write_id {
-            Some(write_id) => SmartShiftWriteStatus::Applying { expected, write_id },
-            None => SmartShiftWriteStatus::Failed,
-        });
+        if write_id.is_none() {
+            self.devices.runtime.entry(key).or_default().smartshift = SmartShiftDeviceState::Failed;
+        }
     }
     /// Take the active device's pending SmartShift confirm, if any. Returns
     /// the `(device key, route, write_id)` for a one-shot re-read that
@@ -209,37 +270,34 @@ impl AppState {
             .runtime
             .get_mut(&key)?
             .smartshift
-            .pending_confirm
-            .take()?;
+            .begin_confirmation()?;
         Some((key, route, write_id))
     }
     /// Mark a post-write confirmation as failed when its reply channel closes.
     pub fn fail_smartshift_confirm(&mut self, key: &DeviceKey, write_id: u64) {
-        if let Some(entry) = self.devices.runtime.get_mut(key)
-            && matches!(
-                entry.smartshift.write_status,
-                Some(SmartShiftWriteStatus::Applying {
-                    write_id: current,
-                    ..
-                }) if current == write_id
-            )
-        {
-            entry.smartshift.write_status = Some(SmartShiftWriteStatus::Failed);
+        if let Some(entry) = self.devices.runtime.get_mut(key) {
+            entry.smartshift.fail_confirmation(write_id);
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConfirmationOutcome {
+    Confirmed,
+    Failed,
 }
 
 pub(crate) fn smartshift_write_outcome(
     expected: SmartShiftStatus,
     load: Option<&SmartShiftLoad>,
-) -> Option<SmartShiftWriteStatus> {
+) -> Option<ConfirmationOutcome> {
     match load {
         Some(SmartShiftLoad::Ready(actual)) if **actual == expected => {
-            Some(SmartShiftWriteStatus::Confirmed)
+            Some(ConfirmationOutcome::Confirmed)
         }
-        Some(SmartShiftLoad::Ready(_)) => Some(SmartShiftWriteStatus::Failed),
+        Some(SmartShiftLoad::Ready(_)) => Some(ConfirmationOutcome::Failed),
         Some(SmartShiftLoad::Failed(_) | SmartShiftLoad::Unsupported(_)) => {
-            Some(SmartShiftWriteStatus::Failed)
+            Some(ConfirmationOutcome::Failed)
         }
         None | Some(SmartShiftLoad::Unknown | SmartShiftLoad::Loading) => None,
     }
@@ -247,16 +305,20 @@ pub(crate) fn smartshift_write_outcome(
 
 pub(crate) fn smartshift_read_is_current(
     read_id: Option<u64>,
-    write_status: Option<&SmartShiftWriteStatus>,
+    write: Option<&SmartShiftDeviceState>,
 ) -> bool {
-    match (read_id, write_status) {
+    match (read_id, write) {
         (
             Some(read_id),
-            Some(SmartShiftWriteStatus::Applying {
+            Some(SmartShiftDeviceState::Confirming {
                 write_id: current, ..
             }),
         ) => read_id == *current,
-        (None, Some(SmartShiftWriteStatus::Applying { .. })) | (Some(_), _) => false,
+        (
+            None,
+            Some(SmartShiftDeviceState::Queued { .. } | SmartShiftDeviceState::Confirming { .. }),
+        )
+        | (Some(_), _) => false,
         (None, _) => true,
     }
 }

--- a/crates/openlogi-desktop/src/state/tests.rs
+++ b/crates/openlogi-desktop/src/state/tests.rs
@@ -28,8 +28,11 @@ use crate::services::assets::AssetResolver;
 use super::bindings::apply_thumbwheel_pair;
 use super::devices::build_device_list;
 use super::scroll::set_scroll_resolution_if_supported;
-use super::smartshift::{smartshift_read_is_current, smartshift_write_outcome};
-use super::{AppState, ConfigPersistence, LightCommandStatus, Load, SmartShiftWriteStatus};
+use super::smartshift::{
+    ConfirmationOutcome, SmartShiftDeviceState, smartshift_read_is_current,
+    smartshift_write_outcome,
+};
+use super::{AppState, ConfigPersistence, LightCommandStatus, Load};
 
 #[test]
 fn read_only_config_rolls_back_mutations_and_does_not_reload_agent() {
@@ -1001,7 +1004,7 @@ fn smartshift_write_feedback_requires_the_written_value() {
     assert_eq!(smartshift_write_outcome(expected, None), None);
     assert_eq!(
         smartshift_write_outcome(expected, Some(&Load::Ready(Arc::new(expected)))),
-        Some(SmartShiftWriteStatus::Confirmed)
+        Some(ConfirmationOutcome::Confirmed)
     );
     assert_eq!(
         smartshift_write_outcome(
@@ -1013,7 +1016,7 @@ fn smartshift_write_feedback_requires_the_written_value() {
                 ..expected
             }))),
         ),
-        Some(SmartShiftWriteStatus::Failed)
+        Some(ConfirmationOutcome::Failed)
     );
     assert_eq!(
         smartshift_write_outcome(
@@ -1022,7 +1025,7 @@ fn smartshift_write_feedback_requires_the_written_value() {
                 "timeout".to_string(),
             ))
         ),
-        Some(SmartShiftWriteStatus::Failed)
+        Some(ConfirmationOutcome::Failed)
     );
 }
 
@@ -1033,18 +1036,20 @@ fn stale_smartshift_reads_do_not_resolve_newer_writes() {
         auto_disengage: SmartShiftAutoDisengage::Threshold(SmartShiftThreshold::from_rounded(12.0)),
         tunable_torque: None,
     };
-    let applying = SmartShiftWriteStatus::Applying {
-        expected,
-        write_id: 2,
-    };
+    let mut write = SmartShiftDeviceState::default();
+    write.queue(expected, 2);
 
-    assert!(smartshift_read_is_current(Some(2), Some(&applying)));
-    assert!(!smartshift_read_is_current(Some(1), Some(&applying)));
-    assert!(!smartshift_read_is_current(None, Some(&applying)));
-    assert!(!smartshift_read_is_current(
-        Some(2),
-        Some(&SmartShiftWriteStatus::Confirmed)
-    ));
+    assert!(
+        !smartshift_read_is_current(Some(2), Some(&write)),
+        "a tagged read cannot land before its confirmation request starts"
+    );
+    assert!(!smartshift_read_is_current(None, Some(&write)));
+    assert_eq!(write.begin_confirmation(), Some(2));
+    assert!(smartshift_read_is_current(Some(2), Some(&write)));
+    assert!(!smartshift_read_is_current(Some(1), Some(&write)));
+    assert!(!smartshift_read_is_current(None, Some(&write)));
+    write.reset();
+    assert!(!smartshift_read_is_current(Some(2), Some(&write)));
     assert!(smartshift_read_is_current(None, None));
 }
 

--- a/crates/openlogi-desktop/src/windows/settings.rs
+++ b/crates/openlogi-desktop/src/windows/settings.rs
@@ -106,6 +106,8 @@ pub(super) enum ThemeFilter {
 pub struct SettingsView {
     focus_handle: FocusHandle,
     appearance_obs: Option<Subscription>,
+    /// Refreshes host-owned snapshots when Settings becomes active again.
+    _activation_obs: Subscription,
     _state_obs: Subscription,
     /// Which themes the Appearance grid shows (All / Light / Dark).
     theme_filter: ThemeFilter,
@@ -137,10 +139,10 @@ pub struct SettingsView {
     /// after a Clear.
     asset_cache_desc: SharedString,
     /// Snapshot of the agent service's registration status, taken when the
-    /// window opens and after every settings change (the status read is an
-    /// XPC round-trip, so it must not run per frame). Drives the General
-    /// page's "switched off in System Settings" notice; a flip made outside
-    /// the app shows up on the next settings change or reopen.
+    /// window opens, regains focus, and after every settings change (the status
+    /// read is an XPC round-trip, so it must not run per frame). Drives the
+    /// General page's "switched off in System Settings" notice while keeping
+    /// the render path on this intentional cache.
     registration_status: crate::platform::registration::ServiceStatus,
     /// Drives the debug live event monitor: polls the agent on a timer while the
     /// Settings window is open. Dropping it with the view stops polling, which
@@ -178,11 +180,12 @@ impl SettingsView {
                 // A settings change may have run the opportunistic
                 // registration ensure, so re-read the status snapshot.
                 if matches!(event, StateEvent::SettingsChanged) {
-                    this.registration_status = crate::platform::registration::status();
+                    this.refresh_registration_status(cx);
                 }
                 cx.notify();
             }
         });
+        let activation_obs = Self::observe_registration_status(window, cx);
 
         let theme_search =
             cx.new(|cx| InputState::new(window, cx).placeholder(tr!("Filter themes…")));
@@ -251,6 +254,7 @@ impl SettingsView {
         Self {
             focus_handle,
             appearance_obs: None,
+            _activation_obs: activation_obs,
             _state_obs: state_obs,
             theme_filter: ThemeFilter::All,
             theme_search,
@@ -268,6 +272,22 @@ impl SettingsView {
             #[cfg(all(target_os = "macos", debug_assertions))]
             _monitor_task: monitor_task,
         }
+    }
+
+    fn refresh_registration_status(&mut self, cx: &mut Context<Self>) {
+        let status = crate::platform::registration::status();
+        if self.registration_status != status {
+            self.registration_status = status;
+            cx.notify();
+        }
+    }
+
+    fn observe_registration_status(window: &mut Window, cx: &mut Context<Self>) -> Subscription {
+        cx.observe_window_activation(window, |this, window, cx| {
+            if window.is_window_active() {
+                this.refresh_registration_status(cx);
+            }
+        })
     }
 
     fn thumbwheel_sensitivity_slider(

--- a/crates/openlogi-device/src/inventory/features.rs
+++ b/crates/openlogi-device/src/inventory/features.rs
@@ -39,9 +39,19 @@ pub(super) struct ProbedFeatures {
     /// such as Windows Bluetooth's plain `"Mouse"`.
     pub(super) marketing_name: Option<String>,
     /// Configuration capabilities derived from the device's feature table.
+    ///
+    /// Invariant: `capabilities_incomplete` implies this is `Some`. The sole
+    /// non-test writer, [`probe_features`], returns `Default` when the feature
+    /// table is unavailable and only sets the qualifier after constructing the
+    /// capability set. The cache only replaces that set with another `Some`,
+    /// and persistence only round-trips probes produced here. If another writer
+    /// is added, preserve this proof or replace the pair with a sum type.
     pub(super) capabilities: Option<Capabilities>,
     /// A `DeviceInformation` read *failed* (vs. the feature being absent), so
     /// the identity fields above may be missing data the device does have.
+    /// This is intentionally independent of `model_info`: `true` with `Some`
+    /// means only the serial-number read failed, while `true` with `None` means
+    /// the whole device-information read failed.
     pub(super) identity_incomplete: bool,
     /// A capability read *failed* (vs. the device not having the capability),
     /// so `capabilities` above understates what the device can do. Memoizing

--- a/crates/openlogi-device/src/pairing.rs
+++ b/crates/openlogi-device/src/pairing.rs
@@ -319,6 +319,9 @@ async fn drive(
 
             cmd = commands.recv() => match cmd {
                 Some(PairingCommand::Pair(device)) => {
+                    if family != ReceiverFamily::Bolt {
+                        return Err(PairingError::UnsupportedCommand);
+                    }
                     pairing_auth = Some(device.authentication);
                     if *phase == PairingPhase::BoltDiscovery {
                         *phase = PairingPhase::BoltPairing;

--- a/crates/openlogi-device/src/pairing/tests.rs
+++ b/crates/openlogi-device/src/pairing/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::{error::Error, io, time::Duration};
 
 use hidpp::{
-    channel::{LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel},
+    channel::{LONG_REPORT_ID, LONG_REPORT_LENGTH, RawHidChannel, SHORT_REPORT_ID},
     protocol::v10::MessageType,
 };
 
@@ -36,6 +36,80 @@ fn passkey_clicks_are_msb_first_10_bits() {
             Click::Left,
             Click::Right,
         ]
+    );
+}
+
+#[tokio::test]
+async fn unifying_session_rejects_bolt_pair_command_before_writing_it() {
+    let (raw, mut written_reports) = EchoRawHidChannel::new();
+    let Ok(channel) = HidppChannel::from_raw_channel(raw).await else {
+        panic!("mock must support HID++");
+    };
+    let (command_tx, mut commands) = mpsc::unbounded_channel();
+    let (_notification_tx, mut notifications) = mpsc::unbounded_channel();
+    let (event_tx, _events) = mpsc::unbounded_channel();
+
+    assert!(
+        command_tx
+            .send(PairingCommand::Pair(DiscoveredDevice {
+                address: [0xde, 0xad, 0xbe, 0xef, 0x01, 0x02],
+                authentication: 0x01,
+                kind: BoltDeviceKind::Keyboard,
+                name: "Test Keyboard".into(),
+            }))
+            .is_ok(),
+        "the pair command must reach the session's command receiver"
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(2),
+        run_session(
+            &channel,
+            ReceiverFamily::Unifying,
+            &mut commands,
+            &mut notifications,
+            &event_tx,
+        ),
+    )
+    .await;
+    let Ok(result) = result else {
+        panic!("pairing session did not terminate");
+    };
+    assert!(matches!(result, Err(PairingError::UnsupportedCommand)));
+
+    let reports: Vec<_> = std::iter::from_fn(|| written_reports.try_recv().ok()).collect();
+    assert_eq!(
+        reports,
+        vec![
+            vec![
+                SHORT_REPORT_ID,
+                RECEIVER_INDEX,
+                u8::from(MessageType::SetRegister),
+                NOTIFICATIONS,
+                0x00,
+                0x09,
+                0x00,
+            ],
+            vec![
+                SHORT_REPORT_ID,
+                RECEIVER_INDEX,
+                u8::from(MessageType::SetRegister),
+                UNIFYING_PAIRING,
+                0x01,
+                0x00,
+                DISCOVERY_TIMEOUT,
+            ],
+            vec![
+                SHORT_REPORT_ID,
+                RECEIVER_INDEX,
+                u8::from(MessageType::SetRegister),
+                UNIFYING_PAIRING,
+                0x02,
+                0x00,
+                0x00,
+            ],
+        ],
+        "only notification setup, Unifying lock-open, and Unifying cancel may be written"
     );
 }
 

--- a/crates/openlogi-hid/src/transport/windows.rs
+++ b/crates/openlogi-hid/src/transport/windows.rs
@@ -89,7 +89,7 @@ impl HidEndpoint {
 pub(super) struct WindowsHidppChannel {
     info: DeviceInfo,
     short: Option<HidEndpoint>,
-    long: Option<HidEndpoint>,
+    long: HidEndpoint,
     /// Cleared the first time either endpoint reports a permanently dead
     /// handle. Read by [`RawHidChannel::is_connected`], which is what lets
     /// `inventory::ledger` evict this channel — the node-vanish path never
@@ -105,7 +105,7 @@ impl WindowsHidppChannel {
     ) -> Result<Self, async_hid::HidError> {
         let short_dev = find_windows_short_collection(&long_info).await?;
         let (long_reader, long_writer) = long_dev.open().await?;
-        let long = Some(HidEndpoint::new(long_reader, long_writer, &long_info));
+        let long = HidEndpoint::new(long_reader, long_writer, &long_info);
 
         let short = match short_dev {
             Some(dev) => {
@@ -137,7 +137,7 @@ impl WindowsHidppChannel {
             name = %long_info.name,
             pid = format_args!("{:04x}", long_info.product_id),
             supports_short = short.is_some(),
-            supports_long = long.is_some(),
+            supports_long = true,
             "opened Windows HID++ composite channel"
         );
 
@@ -249,7 +249,7 @@ impl RawHidChannel for WindowsHidppChannel {
     async fn write_report(&self, src: &[u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
         let endpoint = match src.first().copied().and_then(endpoint_for_report_id) {
             Some(ReportEndpoint::Short) => self.short.as_ref(),
-            Some(ReportEndpoint::Long) => self.long.as_ref(),
+            Some(ReportEndpoint::Long) => Some(&self.long),
             _ => None,
         }
         .ok_or_else(|| {
@@ -272,43 +272,36 @@ impl RawHidChannel for WindowsHidppChannel {
     }
 
     async fn read_report(&self, buf: &mut [u8]) -> Result<usize, Box<dyn Error + Send + Sync>> {
-        match (&self.short, &self.long) {
-            (Some(short), Some(long)) => {
-                let mut short_buf = [0u8; SHORT_REPORT_LENGTH];
-                let mut long_buf = [0u8; LONG_REPORT_LENGTH];
-                let mut short_reader = short.reader.lock().await;
-                let mut long_reader = long.reader.lock().await;
-                // `select!` drops the losing read future, but no report is lost:
-                // async-hid's win32 `IoBuffer` owns the in-flight OVERLAPPED read and
-                // its buffer (not the future), so the pending operation survives the
-                // drop, and the next `read_report` — re-locking this same endpoint —
-                // resumes it and retrieves the report. This relies on reusing the
-                // per-endpoint reader across calls; do not reopen readers per read.
-                tokio::select! {
-                    res = short_reader.read_input_report(&mut short_buf) => match res {
-                        Ok(len) => copy_report(&short_buf, len, buf),
-                        Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
-                        Err(e) => Err(e.into()),
-                    },
-                    res = long_reader.read_input_report(&mut long_buf) => match res {
-                        Ok(len) => copy_report(&long_buf, len, buf),
-                        Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
-                        Err(e) => Err(e.into()),
-                    },
-                }
-            }
-            (Some(endpoint), None) | (None, Some(endpoint)) => {
-                let mut reader = endpoint.reader.lock().await;
-                match reader.read_input_report(buf).await {
-                    Ok(len) => Ok(len),
+        if let Some(short) = &self.short {
+            let mut short_buf = [0u8; SHORT_REPORT_LENGTH];
+            let mut long_buf = [0u8; LONG_REPORT_LENGTH];
+            let mut short_reader = short.reader.lock().await;
+            let mut long_reader = self.long.reader.lock().await;
+            // `select!` drops the losing read future, but no report is lost:
+            // async-hid's win32 `IoBuffer` owns the in-flight OVERLAPPED read and
+            // its buffer (not the future), so the pending operation survives the
+            // drop, and the next `read_report` — re-locking this same endpoint —
+            // resumes it and retrieves the report. This relies on reusing the
+            // per-endpoint reader across calls; do not reopen readers per read.
+            return tokio::select! {
+                res = short_reader.read_input_report(&mut short_buf) => match res {
+                    Ok(len) => copy_report(&short_buf, len, buf),
                     Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
                     Err(e) => Err(e.into()),
-                }
-            }
-            (None, None) => Err(Box::new(io::Error::new(
-                io::ErrorKind::NotConnected,
-                "no Windows HID++ endpoints are open",
-            ))),
+                },
+                res = long_reader.read_input_report(&mut long_buf) => match res {
+                    Ok(len) => copy_report(&long_buf, len, buf),
+                    Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
+                    Err(e) => Err(e.into()),
+                },
+            };
+        }
+
+        let mut reader = self.long.reader.lock().await;
+        match reader.read_input_report(buf).await {
+            Ok(len) => Ok(len),
+            Err(async_hid::HidError::Disconnected) => self.park_disconnected().await,
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -317,7 +310,7 @@ impl RawHidChannel for WindowsHidppChannel {
     }
 
     fn supports_short_long_hidpp(&self) -> Option<(bool, bool)> {
-        Some((self.short.is_some(), self.long.is_some()))
+        Some((self.short.is_some(), true))
     }
 
     async fn get_report_descriptor(

--- a/crates/openlogi-hidpp/src/channel.rs
+++ b/crates/openlogi-hidpp/src/channel.rs
@@ -208,7 +208,7 @@ impl Drop for HidppChannel {
 
 /// Represents a message that was sent and is waiting for a response.
 struct PendingMessage {
-    /// Unique ID used to remove this request if it times out.
+    /// Unique ID used to remove this request when its waiter goes away.
     id: u64,
 
     /// The predicate that has to match for an incoming message to be classified
@@ -218,6 +218,52 @@ struct PendingMessage {
     /// The oneshot sender used to provide the response message to the receiving
     /// end.
     sender: oneshot::Sender<HidppMessage>,
+}
+
+/// One registered request and the receiver waiting for its response.
+///
+/// Dropping this value unregisters the request, including when an outer async
+/// deadline cancels [`HidppChannel::send_with_timeout`] during its write.
+struct PendingRequest {
+    id: u64,
+    pending_messages: Arc<Mutex<VecDeque<PendingMessage>>>,
+    receiver: oneshot::Receiver<HidppMessage>,
+}
+
+impl PendingRequest {
+    fn register(
+        id: u64,
+        pending_messages: Arc<Mutex<VecDeque<PendingMessage>>>,
+        response_predicate: impl Fn(&HidppMessage) -> bool + Send + 'static,
+    ) -> Self {
+        let (sender, receiver) = oneshot::channel();
+        let request = Self {
+            id,
+            pending_messages,
+            receiver,
+        };
+        lock(&request.pending_messages).push_back(PendingMessage {
+            id,
+            response_predicate: Box::new(response_predicate),
+            sender,
+        });
+        request
+    }
+
+    async fn receive(mut self) -> Result<HidppMessage, ChannelError> {
+        (&mut self.receiver)
+            .await
+            .map_err(|_| ChannelError::NoResponse)
+    }
+}
+
+impl Drop for PendingRequest {
+    fn drop(&mut self) {
+        let mut pending = lock(&self.pending_messages);
+        if let Some(pos) = pending.iter().position(|message| message.id == self.id) {
+            pending.remove(pos);
+        }
+    }
 }
 
 impl HidppChannel {
@@ -386,41 +432,29 @@ impl HidppChannel {
         let (dev, feat, func) = msg.header();
         trace!(dev, feat, func, "hidpp request");
 
-        let (sender, receiver) = oneshot::channel::<HidppMessage>();
         let pending_id = self.pending_message_id.fetch_add(1, Ordering::SeqCst);
-
-        {
-            let mut pending = lock(&self.pending_messages);
-            // Drop abandoned requests before queuing this one. Timeouts and
-            // write failures remove their entry eagerly below, but a caller
-            // cancelled mid-flight (an outer `timeout(..)` dropping the whole
-            // future) still leaves its `PendingMessage` behind. On a channel
-            // reused across inventory ticks those would accumulate unboundedly
-            // — and a late response could be mis-delivered to a recycled
-            // software id. `is_canceled()` is true once the receiver is gone,
-            // so this prunes exactly the give-ups.
-            pending.retain(|m| !m.sender.is_canceled());
-            pending.push_back(PendingMessage {
-                id: pending_id,
-                response_predicate: Box::new(response_predicate),
-                sender,
-            });
-        }
+        let pending_request = PendingRequest::register(
+            pending_id,
+            Arc::clone(&self.pending_messages),
+            response_predicate,
+        );
 
         // The deadline covers the write as well: `write_report` has no
         // bounded-time contract of its own, so a wedged device could otherwise
         // park `send` forever before the response wait even starts.
-        let mut request = std::pin::pin!(
-            async {
-                self.send_and_forget(msg).await?;
-                receiver.await.map_err(|_| ChannelError::NoResponse)
-            }
-            .fuse()
-        );
+        let result = {
+            let mut request = std::pin::pin!(
+                async move {
+                    self.send_and_forget(msg).await?;
+                    pending_request.receive().await
+                }
+                .fuse()
+            );
 
-        let result = select! {
-            result = request => result,
-            () = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
+            select! {
+                result = request => result,
+                () = futures_timer::Delay::new(timeout).fuse() => Err(ChannelError::Timeout),
+            }
         };
 
         match &result {
@@ -428,21 +462,7 @@ impl HidppChannel {
             Err(e) => trace!(dev, feat, error = ?e, "hidpp no response"),
         }
 
-        if result.is_err() {
-            // A timeout or write failure leaves the entry queued — remove it
-            // eagerly. After a matched response the read thread has already
-            // taken it, so this is a no-op then.
-            self.remove_pending_message(pending_id);
-        }
-
         result
-    }
-
-    fn remove_pending_message(&self, id: u64) {
-        let mut pending = lock(&self.pending_messages);
-        if let Some(pos) = pending.iter().position(|msg| msg.id == id) {
-            pending.remove(pos);
-        }
     }
 
     /// Sends a HID++ message across the channel and does not wait for a

--- a/crates/openlogi-hidpp/src/channel/tests.rs
+++ b/crates/openlogi-hidpp/src/channel/tests.rs
@@ -139,6 +139,37 @@ fn send_times_out_and_removes_pending_message() {
 }
 
 #[test]
+fn cancelled_send_removes_pending_before_a_late_response() {
+    futures::executor::block_on(async {
+        let (raw, handle) = MockRawHidChannel::new();
+        handle.park_writes();
+        let channel = channel_with_reader(raw).await;
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let listener_events = Arc::clone(&events);
+        channel.add_msg_listener(move |msg, matched| {
+            listener_events.lock().unwrap().push((msg, matched));
+        });
+
+        let late_response = short_msg(0x20);
+        let mut send = Box::pin(channel.send_with_timeout(
+            short_msg(0x10),
+            move |candidate| *candidate == late_response,
+            Duration::from_secs(1),
+        ));
+
+        assert!(futures::poll!(send.as_mut()).is_pending());
+        assert_eq!(channel.pending_messages.lock().unwrap().len(), 1);
+
+        drop(send);
+        assert_pending_empty(&channel);
+
+        handle.send_incoming(late_response).await;
+        wait_for_event_count(&events, 1).await;
+        assert_eq!(events.lock().unwrap()[0], (late_response, false));
+    });
+}
+
+#[test]
 fn timeout_removes_only_its_own_pending_message() {
     futures::executor::block_on(async {
         let (raw, handle) = MockRawHidChannel::new();

--- a/crates/openlogi-hidpp/src/receiver/bolt.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt.rs
@@ -26,7 +26,7 @@ use crate::{
 
 mod event;
 
-pub use event::{DeviceConnection, DeviceKind, Event, PairingError, PairingPasskeyPressType};
+pub use event::{DeviceConnection, DeviceKind, Event, PairingPasskeyPressType};
 
 /// All known registers of the Bolt receiver.
 ///

--- a/crates/openlogi-hidpp/src/receiver/bolt/event.rs
+++ b/crates/openlogi-hidpp/src/receiver/bolt/event.rs
@@ -32,9 +32,6 @@ enum Notification {
 
     /// Device discovery was enabled or disabled.
     DeviceDiscoveryStatus = 0x53,
-
-    /// A pairing attempt progressed, succeeded, or failed.
-    PairingStatus = 0x54,
 }
 
 /// The two payload kinds a [`Notification::DeviceDiscovery`] report carries,
@@ -103,16 +100,6 @@ pub(super) fn decode(msg: &v10::Message) -> Option<Event> {
 
         Notification::DeviceDiscoveryStatus => Some(Event::DeviceDiscoveryStatus {
             discovery_enabled: payload[0] == 0x00,
-        }),
-
-        Notification::PairingStatus => Some(Event::PairingStatus {
-            device_address: address6(&payload, 2),
-            // `payload[0]` carries some further status this crate does not
-            // model. An unrecognised error code still means "pairing failed" —
-            // dropping it would turn the failure into a session timeout, so
-            // carry the raw code instead.
-            pairing_error: (payload[1] != 0x00).then(|| PairingError::from(payload[1])),
-            slot: (payload[8] != 0x00).then_some(payload[8]),
         }),
 
         Notification::PairingPasskeyRequest => Some(Event::PairingPasskeyRequest {
@@ -244,19 +231,6 @@ pub enum Event {
         name: String,
     },
 
-    /// Is emitted whenever the status of a pairing process changes.
-    PairingStatus {
-        /// BTLE address of the device being paired.
-        device_address: [u8; 6],
-
-        /// Optional pairing error reported by the receiver.
-        pairing_error: Option<PairingError>,
-
-        /// The receiver slot the newly paired device was paired to. This can be
-        /// used as the device index for subsequent operations.
-        slot: Option<u8>,
-    },
-
     /// Is emitted once the receiver requests a passkey to be entered on a
     /// device that should be paired to it.
     PairingPasskeyRequest {
@@ -356,23 +330,6 @@ pub enum DeviceKind {
     Headset = 0x0d,
 }
 
-/// Represents an error during device pairing.
-///
-/// This is reported by the [`Event::PairingStatus`] event.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, FromPrimitive, IntoPrimitive)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[non_exhaustive]
-#[repr(u8)]
-pub enum PairingError {
-    /// Device timed out during pairing.
-    DeviceTimeout = 0x01,
-    /// Pairing failed.
-    Failed = 0x02,
-    /// An error code this crate does not model; carries the raw byte.
-    #[num_enum(catch_all)]
-    Other(u8),
-}
-
 /// Represents the type of a single passkey press.
 ///
 /// This is reported by the [`Event::PairingPasskeyPressed`] event, which also
@@ -396,8 +353,7 @@ pub enum PairingPasskeyPressType {
 #[cfg(test)]
 mod tests {
     use super::{
-        DeviceConnection, DeviceKind, Event, PairingError, PairingPasskeyPressType, decode,
-        discovery_name,
+        DeviceConnection, DeviceKind, Event, PairingPasskeyPressType, decode, discovery_name,
     };
     use crate::{
         protocol::v10::{Message, MessageHeader},
@@ -550,39 +506,6 @@ mod tests {
             enabled(0x01),
             Event::DeviceDiscoveryStatus {
                 discovery_enabled: false
-            }
-        );
-    }
-
-    #[test]
-    fn pairing_status_carries_an_unmodelled_error_code_rather_than_dropping_it() {
-        // Dropping an unrecognised code would turn a reported failure into a
-        // silent session timeout.
-        let mut payload = [0u8; 17];
-        payload[1] = 0x7f;
-        payload[2..8].copy_from_slice(&[9, 8, 7, 6, 5, 4]);
-        payload[8] = 2;
-
-        assert_eq!(
-            decode(&from_receiver(0x54, payload)).unwrap(),
-            Event::PairingStatus {
-                device_address: [9, 8, 7, 6, 5, 4],
-                pairing_error: Some(PairingError::Other(0x7f)),
-                slot: Some(2),
-            }
-        );
-    }
-
-    #[test]
-    fn pairing_status_reports_success_as_no_error_and_slot_zero_as_none() {
-        let payload = [0u8; 17];
-
-        assert_eq!(
-            decode(&from_receiver(0x54, payload)).unwrap(),
-            Event::PairingStatus {
-                device_address: [0; 6],
-                pairing_error: None,
-                slot: None,
             }
         );
     }

--- a/crates/openlogi-hook/src/lib.rs
+++ b/crates/openlogi-hook/src/lib.rs
@@ -338,6 +338,13 @@ trait HookBackend {
     /// Stop the hook and join its threads.
     fn stop(running: Self::Running);
 
+    /// Whether the platform worker is still delivering events. Backends whose
+    /// workers are joined only during teardown have no separate terminal
+    /// state, so their live handle is sufficient by default.
+    fn is_running(_running: &Self::Running) -> bool {
+        true
+    }
+
     /// See [`Hook::has_accessibility`]. Platforms that gate the hook below the
     /// privacy layer answer `true`.
     fn has_accessibility() -> bool {
@@ -439,6 +446,16 @@ impl Hook {
         self.shutdown();
     }
 
+    /// Whether the platform worker is still able to deliver events.
+    ///
+    /// A Windows message-pump error is terminal: the worker clears its callback
+    /// so native input passes through, and this method then returns `false`
+    /// even though the [`Hook`] handle has not yet been dropped.
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        self.inner.as_ref().is_some_and(Backend::is_running)
+    }
+
     /// Tear down the platform hook if it is still running. Idempotent: the
     /// first call takes `inner`, so the `Drop` after an explicit [`Self::stop`]
     /// is a no-op.
@@ -527,6 +544,9 @@ mod macos;
 
 #[cfg(target_os = "linux")]
 mod linux;
+
+#[cfg(any(target_os = "windows", test))]
+mod windows_worker;
 
 #[cfg(target_os = "windows")]
 mod windows;

--- a/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
+++ b/crates/openlogi-hook/src/linux/wlr_foreign_toplevel.rs
@@ -77,14 +77,28 @@ const INIT_TIMEOUT: Duration = Duration::from_secs(5);
 const POLL_CAP_MS: u64 = 25;
 
 /// Accumulated per-toplevel data. wlr sends individual property events and then
-/// a `done` marking a consistent snapshot, so updates are staged in `pending_*`
-/// and committed on `done`.
+/// a `done` marking a consistent snapshot. Despite their names, `pending_*`
+/// hold the latest protocol-reported values, not one-shot unconsumed events:
+/// properties omitted from a later batch retain their previous value.
 #[derive(Default)]
 struct Toplevel {
     app_id: Option<String>,
     activated: bool,
     pending_app_id: Option<String>,
     pending_activated: bool,
+}
+
+impl Toplevel {
+    fn commit_latest(&mut self) {
+        // `app_id` may arrive after an initial State + Done, so None means
+        // "not reported yet", not "clear the committed id". Do not `take`
+        // either pending field: Wayland may omit unchanged properties from
+        // later batches, and these fields are the latest known snapshot.
+        if self.pending_app_id.is_some() {
+            self.app_id = self.pending_app_id.clone();
+        }
+        self.activated = self.pending_activated;
+    }
 }
 
 /// Dispatch state: the bound manager plus the toplevels seen so far.
@@ -184,16 +198,7 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for State {
             }
             Event::Done => {
                 if let Some(toplevel) = state.toplevels.get_mut(&id) {
-                    // app_id is sent only when it changes, and a compositor may
-                    // emit State + Done before the first AppId. Committing
-                    // `pending_app_id` unconditionally would clobber a known id
-                    // (or the initial one) with None, so only overwrite when a
-                    // value is actually pending. `activated` defaults to false,
-                    // which is the correct state for a window that sent none.
-                    if toplevel.pending_app_id.is_some() {
-                        toplevel.app_id = toplevel.pending_app_id.clone();
-                    }
-                    toplevel.activated = toplevel.pending_activated;
+                    toplevel.commit_latest();
                 }
             }
             Event::Closed => {
@@ -475,7 +480,26 @@ pub(super) fn candidate() -> Option<Box<dyn FrontmostSource>> {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::millis_until;
+    use super::{Toplevel, millis_until};
+
+    #[test]
+    fn done_reuses_latest_values_for_omitted_properties() {
+        let mut toplevel = Toplevel {
+            pending_app_id: Some("org.example.App".into()),
+            pending_activated: true,
+            ..Toplevel::default()
+        };
+
+        toplevel.commit_latest();
+        assert_eq!(toplevel.app_id.as_deref(), Some("org.example.App"));
+        assert!(toplevel.activated);
+
+        // A later Done with no new AppId or State event must preserve both
+        // latest values; pending means latest, not unconsumed.
+        toplevel.commit_latest();
+        assert_eq!(toplevel.app_id.as_deref(), Some("org.example.App"));
+        assert!(toplevel.activated);
+    }
 
     #[test]
     fn millis_until_elapsed_deadline_is_zero() {

--- a/crates/openlogi-hook/src/macos.rs
+++ b/crates/openlogi-hook/src/macos.rs
@@ -9,7 +9,7 @@ mod watchdog;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, mpsc};
 use std::thread;
 use std::time::Duration;
@@ -35,8 +35,8 @@ use crate::{
     TapLocation,
 };
 use watchdog::{
-    LifecycleDecision, LifecycleExitReason, LifecycleObservation, LifecycleWatchdog, RearmBudget,
-    TapPhase, WatchdogSignals, stuck_callback,
+    CallbackActivity, LifecycleDecision, LifecycleExitReason, LifecycleObservation,
+    LifecycleWatchdog, RearmBudget, TapPhase, WatchdogSignals, stuck_callback,
 };
 
 /// Everything `Hook` needs to control the background thread.
@@ -753,8 +753,7 @@ fn run_tap_callback(
 /// the agent so macOS tears the tap down and system input recovers.
 fn spawn_callback_watchdog(
     signals: Arc<WatchdogSignals>,
-    in_callback: Arc<AtomicBool>,
-    entered_at_ms: Arc<AtomicU64>,
+    callback_activity: Arc<CallbackActivity>,
 ) -> std::io::Result<()> {
     thread::Builder::new()
         .name("openlogi-hook-watchdog".into())
@@ -765,21 +764,15 @@ fn spawn_callback_watchdog(
                     return;
                 }
                 thread::sleep(CALLBACK_WATCHDOG_POLL_INTERVAL);
-                if !in_callback.load(Ordering::Acquire) {
+                let Some(entered) = callback_activity.entered_at_ms() else {
                     continue;
-                }
-                let entered = entered_at_ms.load(Ordering::Acquire);
-                if entered == 0 {
-                    continue;
-                }
+                };
                 let Some(elapsed) = stuck_callback(signals.now_millis(), entered) else {
                     continue;
                 };
                 // Re-sample: a fresh high-frequency event may have rewritten
-                // the stamp between the first loads and the budget check.
-                if !in_callback.load(Ordering::Acquire)
-                    || entered_at_ms.load(Ordering::Acquire) != entered
-                {
+                // the complete activity state during the budget check.
+                if callback_activity.entered_at_ms() != Some(entered) {
                     continue;
                 }
                 if signals.phase() != TapPhase::Armed {
@@ -953,16 +946,14 @@ fn thread_main(
     signals.mark_tap_progress();
     signals.set_phase(TapPhase::Arming);
 
-    let in_callback = Arc::new(AtomicBool::new(false));
-    let entered_at_ms = Arc::new(AtomicU64::new(0));
+    let callback_activity = Arc::new(CallbackActivity::default());
     // Latched by the callback when the OS disables the tap, consumed by the
     // run-loop slice that decides whether to re-arm it.
     let tap_disabled = Arc::new(AtomicBool::new(false));
 
     let tap_result = {
         let callback_signals = Arc::clone(&signals);
-        let in_callback = Arc::clone(&in_callback);
-        let entered_at_ms = Arc::clone(&entered_at_ms);
+        let callback_activity = Arc::clone(&callback_activity);
         let tap_disabled = Arc::clone(&tap_disabled);
         CGEventTap::new(
             CGEventTapLocation::HID,
@@ -976,10 +967,9 @@ fn thread_main(
                 ) {
                     tap_disabled.store(true, Ordering::Release);
                 }
-                entered_at_ms.store(callback_signals.now_millis(), Ordering::Relaxed);
-                in_callback.store(true, Ordering::Release);
+                callback_activity.enter(callback_signals.now_millis());
                 let disposition = run_tap_callback(cb.as_ref(), etype, event);
-                in_callback.store(false, Ordering::Release);
+                callback_activity.exit();
                 disposition
             },
         )
@@ -1007,11 +997,9 @@ fn thread_main(
         run_loop.add_source(&loop_source, kCFRunLoopCommonModes);
     }
     signals.mark_tap_progress();
-    if let Err(error) = spawn_callback_watchdog(
-        Arc::clone(&signals),
-        Arc::clone(&in_callback),
-        Arc::clone(&entered_at_ms),
-    ) {
+    if let Err(error) =
+        spawn_callback_watchdog(Arc::clone(&signals), Arc::clone(&callback_activity))
+    {
         error!(%error, "could not spawn callback watchdog — refusing to arm HID tap");
         return;
     }

--- a/crates/openlogi-hook/src/macos/watchdog.rs
+++ b/crates/openlogi-hook/src/macos/watchdog.rs
@@ -26,6 +26,51 @@ pub(super) enum TapPhase {
     ThreadExited,
 }
 
+impl TapPhase {
+    const fn decode(value: u8) -> Self {
+        if value > Self::ThreadExited as u8 {
+            // An unknown byte cannot prove that the HID tap was destroyed.
+            // Treat it as hazardous so both watchdogs remain armed and the
+            // lifecycle timeout can fail safe instead of panicking or disarming.
+            return Self::Armed;
+        }
+        match value {
+            0 => Self::Starting,
+            1 => Self::Arming,
+            2 => Self::Armed,
+            3 => Self::TapStopped,
+            _ => Self::ThreadExited,
+        }
+    }
+}
+
+/// Whether the tap callback is idle or the monotonic millisecond when it entered.
+///
+/// Zero is idle; [`WatchdogSignals::now_millis`] reserves nonzero values for
+/// entries. One Release store publishes each whole state, so an Acquire load
+/// cannot observe "entered" without its matching timestamp as it could with
+/// separate flag and timestamp atomics.
+#[derive(Debug, Default)]
+pub(super) struct CallbackActivity(AtomicU64);
+
+impl CallbackActivity {
+    pub fn enter(&self, entered_at_ms: u64) {
+        debug_assert_ne!(entered_at_ms, 0);
+        self.0.store(entered_at_ms, Ordering::Release);
+    }
+
+    pub fn exit(&self) {
+        self.0.store(0, Ordering::Release);
+    }
+
+    pub fn entered_at_ms(&self) -> Option<u64> {
+        match self.0.load(Ordering::Acquire) {
+            0 => None,
+            entered_at_ms => Some(entered_at_ms),
+        }
+    }
+}
+
 /// Atomics shared by the tap, stopper, and watchdog threads.
 ///
 /// A stop request is a separate latch from `phase`: it must never imply that
@@ -63,14 +108,7 @@ impl WatchdogSignals {
     }
 
     pub fn phase(&self) -> TapPhase {
-        match self.phase.load(Ordering::Acquire) {
-            0 => TapPhase::Starting,
-            1 => TapPhase::Arming,
-            2 => TapPhase::Armed,
-            3 => TapPhase::TapStopped,
-            4 => TapPhase::ThreadExited,
-            _ => unreachable!("invalid tap lifecycle phase"),
-        }
+        TapPhase::decode(self.phase.load(Ordering::Acquire))
     }
 
     pub fn set_phase(&self, phase: TapPhase) {
@@ -215,6 +253,36 @@ pub(super) fn stuck_callback(now_ms: u64, entered_at_ms: u64) -> Option<Duration
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tap_phase_decoder_is_total_and_fails_safe() {
+        assert_eq!(TapPhase::decode(0), TapPhase::Starting);
+        assert_eq!(TapPhase::decode(1), TapPhase::Arming);
+        assert_eq!(TapPhase::decode(2), TapPhase::Armed);
+        assert_eq!(TapPhase::decode(3), TapPhase::TapStopped);
+        assert_eq!(TapPhase::decode(4), TapPhase::ThreadExited);
+        assert_eq!(TapPhase::decode(5), TapPhase::Armed);
+        assert_eq!(TapPhase::decode(u8::MAX), TapPhase::Armed);
+
+        let signals = WatchdogSignals::default();
+        signals.phase.store(u8::MAX, Ordering::Relaxed);
+        assert_eq!(signals.phase(), TapPhase::Armed);
+    }
+
+    #[test]
+    fn callback_activity_publishes_one_complete_state() {
+        let activity = CallbackActivity::default();
+        assert_eq!(activity.entered_at_ms(), None);
+
+        activity.enter(42);
+        assert_eq!(activity.entered_at_ms(), Some(42));
+
+        activity.enter(43);
+        assert_eq!(activity.entered_at_ms(), Some(43));
+
+        activity.exit();
+        assert_eq!(activity.entered_at_ms(), None);
+    }
 
     fn observation(
         phase: TapPhase,

--- a/crates/openlogi-hook/src/windows.rs
+++ b/crates/openlogi-hook/src/windows.rs
@@ -27,6 +27,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     WM_XBUTTONDOWN, WM_XBUTTONUP, XBUTTON1, XBUTTON2,
 };
 
+use crate::windows_worker::{WorkerEvent, WorkerPhase, WorkerStatus};
 use crate::{
     ButtonId, CursorPosition, EventDisposition, ForegroundApp, HookBackend, HookError, HookEvent,
     KeyEvent, KeyModifiers, MouseEvent, ScrollDelta,
@@ -53,6 +54,7 @@ static CALLBACK: Mutex<Option<HookCallback>> = Mutex::new(None);
 pub(crate) struct HookInner {
     thread_id: u32,
     join: Option<thread::JoinHandle<()>>,
+    worker: Arc<WorkerStatus>,
 }
 
 /// The Windows backend: `WH_MOUSE_LL` / `WH_KEYBOARD_LL` hooks on a thread
@@ -67,9 +69,11 @@ impl HookBackend for Backend {
     ) -> Result<HookInner, HookError> {
         let callback: HookCallback = Arc::new(cb);
         let (ready_tx, ready_rx) = mpsc::channel();
+        let worker = Arc::new(WorkerStatus::new());
+        let thread_worker = Arc::clone(&worker);
         let join = thread::Builder::new()
             .name("openlogi-windows-hook".into())
-            .spawn(move || hook_thread(callback, ready_tx))
+            .spawn(move || hook_thread(callback, ready_tx, &thread_worker))
             .map_err(|e| HookError::WindowsHook(format!("could not spawn hook thread: {e}")))?;
 
         match ready_rx
@@ -79,6 +83,7 @@ impl HookBackend for Backend {
             Ok(thread_id) => Ok(HookInner {
                 thread_id,
                 join: Some(join),
+                worker,
             }),
             Err(e) => {
                 let _ = join.join();
@@ -88,21 +93,28 @@ impl HookBackend for Backend {
     }
 
     fn stop(mut inner: HookInner) {
-        // SAFETY: PostThreadMessageW takes the target thread id and the message by
-        // value (no pointers); `thread_id` was returned by the hook thread's own
-        // GetCurrentThreadId, so it names a real thread with a message queue.
-        let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
-        if posted == 0 {
-            // SAFETY: GetLastError reads the calling thread's last-error code and
-            // has no preconditions.
-            let err = unsafe { GetLastError() };
-            tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
+        let previous = inner.worker.transition(WorkerEvent::StopRequested);
+        if previous == WorkerPhase::Running {
+            // SAFETY: PostThreadMessageW takes the target thread id and the message by
+            // value (no pointers); `thread_id` was returned by the hook thread's own
+            // GetCurrentThreadId, so it names a real thread with a message queue.
+            let posted = unsafe { PostThreadMessageW(inner.thread_id, WM_QUIT, 0, 0) };
+            if posted == 0 {
+                // SAFETY: GetLastError reads the calling thread's last-error code and
+                // has no preconditions.
+                let err = unsafe { GetLastError() };
+                tracing::warn!(error = err, "could not post WM_QUIT to Windows hook thread");
+            }
         }
         if let Some(join) = inner.join.take()
             && let Err(e) = join.join()
         {
             tracing::warn!(?e, "Windows hook thread panicked while stopping");
         }
+    }
+
+    fn is_running(inner: &HookInner) -> bool {
+        inner.worker.phase().is_running()
     }
 
     #[expect(
@@ -180,7 +192,11 @@ impl HookBackend for Backend {
     clippy::needless_pass_by_value,
     reason = "callback and ready are moved into the thread's hook state and channel"
 )]
-fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError>>) {
+fn hook_thread(
+    callback: HookCallback,
+    ready: mpsc::Sender<Result<u32, HookError>>,
+    worker: &WorkerStatus,
+) {
     match CALLBACK.lock() {
         Ok(mut slot) if slot.is_none() => {
             *slot = Some(callback);
@@ -257,26 +273,53 @@ fn hook_thread(callback: HookCallback, ready: mpsc::Sender<Result<u32, HookError
         return;
     }
 
+    worker.transition(WorkerEvent::Started);
     let _ = ready.send(Ok(thread_id));
-    message_loop();
+    let exit = message_loop();
 
+    let failure = match exit {
+        MessageLoopExit::Quit => {
+            worker.transition(WorkerEvent::MessageLoopQuit);
+            None
+        }
+        MessageLoopExit::Failed(error) => {
+            worker.transition(WorkerEvent::MessageLoopFailed);
+            Some(error)
+        }
+    };
+    // Clear callback ownership before unhooking so even a stray native call
+    // during teardown can only pass through.
+    clear_callback();
     // SAFETY: both handles are the live ones returned by SetWindowsHookExW,
     // each unhooked exactly once here as the thread exits.
     unsafe {
         UnhookWindowsHookEx(keyboard_hook);
         UnhookWindowsHookEx(mouse_hook);
     }
-    clear_callback();
+    if let Some(error) = failure {
+        tracing::error!(error, "Windows hook message loop failed");
+    }
 }
 
-fn message_loop() {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MessageLoopExit {
+    Quit,
+    Failed(u32),
+}
+
+fn message_loop() -> MessageLoopExit {
     let mut msg = MSG::default();
     loop {
         // SAFETY: `msg` is a live, owned MSG; a null window handle retrieves
-        // messages for the calling thread. Returns <= 0 on WM_QUIT or error.
+        // messages for the calling thread. Returns 0 on WM_QUIT and -1 on error.
         let result = unsafe { GetMessageW(&raw mut msg, std::ptr::null_mut(), 0, 0) };
-        if result <= 0 {
-            break;
+        if result == 0 {
+            return MessageLoopExit::Quit;
+        }
+        if result < 0 {
+            // SAFETY: GetLastError reads the calling thread's last-error code
+            // immediately after the failed GetMessageW call.
+            return MessageLoopExit::Failed(unsafe { GetLastError() });
         }
         // SAFETY: `msg` was just populated by GetMessageW and outlives the call.
         unsafe { TranslateMessage(&raw const msg) };

--- a/crates/openlogi-hook/src/windows_worker.rs
+++ b/crates/openlogi-hook/src/windows_worker.rs
@@ -1,0 +1,100 @@
+//! Pure lifecycle state for the Windows hook worker.
+
+#[cfg(target_os = "windows")]
+use std::sync::{Mutex, PoisonError};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WorkerPhase {
+    Starting,
+    Running,
+    StopRequested,
+    Stopped,
+    Failed,
+}
+
+impl WorkerPhase {
+    pub(super) const fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum WorkerEvent {
+    Started,
+    StopRequested,
+    MessageLoopQuit,
+    MessageLoopFailed,
+}
+
+pub(super) const fn worker_transition(phase: WorkerPhase, event: WorkerEvent) -> WorkerPhase {
+    match (phase, event) {
+        (WorkerPhase::Starting, WorkerEvent::Started) => WorkerPhase::Running,
+        (WorkerPhase::Running, WorkerEvent::StopRequested) => WorkerPhase::StopRequested,
+        (WorkerPhase::Running | WorkerPhase::StopRequested, WorkerEvent::MessageLoopQuit) => {
+            WorkerPhase::Stopped
+        }
+        (WorkerPhase::Running | WorkerPhase::StopRequested, WorkerEvent::MessageLoopFailed) => {
+            WorkerPhase::Failed
+        }
+        _ => phase,
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub(super) struct WorkerStatus {
+    phase: Mutex<WorkerPhase>,
+}
+
+#[cfg(target_os = "windows")]
+impl WorkerStatus {
+    pub(super) const fn new() -> Self {
+        Self {
+            phase: Mutex::new(WorkerPhase::Starting),
+        }
+    }
+
+    pub(super) fn phase(&self) -> WorkerPhase {
+        *self.phase.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    pub(super) fn transition(&self, event: WorkerEvent) -> WorkerPhase {
+        let mut phase = self.phase.lock().unwrap_or_else(PoisonError::into_inner);
+        let previous = *phase;
+        *phase = worker_transition(previous, event);
+        previous
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_stop_has_an_explicit_terminal_path() {
+        let running = worker_transition(WorkerPhase::Starting, WorkerEvent::Started);
+        assert_eq!(running, WorkerPhase::Running);
+        assert!(running.is_running());
+
+        let stopping = worker_transition(running, WorkerEvent::StopRequested);
+        assert_eq!(stopping, WorkerPhase::StopRequested);
+        assert!(!stopping.is_running());
+
+        let stopped = worker_transition(stopping, WorkerEvent::MessageLoopQuit);
+        assert_eq!(stopped, WorkerPhase::Stopped);
+        assert!(!stopped.is_running());
+    }
+
+    #[test]
+    fn message_loop_error_is_terminal_before_and_during_stop() {
+        for phase in [WorkerPhase::Running, WorkerPhase::StopRequested] {
+            let failed = worker_transition(phase, WorkerEvent::MessageLoopFailed);
+            assert_eq!(failed, WorkerPhase::Failed);
+            assert!(!failed.is_running());
+            assert_eq!(
+                worker_transition(failed, WorkerEvent::StopRequested),
+                WorkerPhase::Failed,
+                "teardown must not revive a failed worker"
+            );
+        }
+    }
+}

--- a/crates/openlogi-inject/src/inject.rs
+++ b/crates/openlogi-inject/src/inject.rs
@@ -238,33 +238,52 @@ pub fn execute(action: &Action) {
     }
 }
 
-/// Synthesise the down edge of `combo`, leaving its output held.
+/// One synthetic held chord, released exactly once when dropped.
 ///
-/// Every successful lifecycle start must be paired with [`release_hold`],
-/// including cancellation and shutdown paths. Prefer [`execute`] when the
-/// caller does not own a matching terminal event.
-pub fn press_hold(combo: &KeyCombo) {
-    hold_transition(None, Some(combo));
+/// Keep this value with the physical press lifecycle. Replacing its chord
+/// preserves physical keys shared by the old and new chords; cancellation,
+/// shutdown, and unwinding all release the current chord through [`Drop`].
+#[must_use = "dropping the held chord immediately releases its synthetic output"]
+pub struct HeldChord {
+    combo: KeyCombo,
 }
 
-/// Synthesise the up edge matching a prior [`press_hold`].
-///
-/// Each successful [`press_hold`] must be released exactly once. The lifecycle
-/// owner provides that guarantee; duplicate releases would consume ownership
-/// retained for an overlapping chord.
-pub fn release_hold(combo: &KeyCombo) {
-    hold_transition(Some(combo), None);
+impl HeldChord {
+    /// Replace this held chord without releasing physical keys shared by both.
+    pub fn replace(&mut self, combo: &KeyCombo) {
+        let old = std::mem::replace(&mut self.combo, combo.clone());
+        hold_transition(Some(&old), Some(&self.combo));
+    }
 }
 
-/// Replace one held chord without releasing physical keys shared by both.
-pub fn replace_hold(old: &KeyCombo, new: &KeyCombo) {
-    hold_transition(Some(old), Some(new));
+impl Drop for HeldChord {
+    fn drop(&mut self) {
+        hold_transition(Some(&self.combo), None);
+    }
+}
+
+/// Synthesise the down edge of `combo` and return its release owner.
+///
+/// Keep the returned [`HeldChord`] until the physical press ends. Prefer
+/// [`execute`] when the caller does not own a matching terminal event.
+pub fn press_hold(combo: &KeyCombo) -> HeldChord {
+    // Construct the owner before posting the edge so unwinding from the
+    // platform backend still balances any ownership transition it completed.
+    let held = HeldChord {
+        combo: combo.clone(),
+    };
+    hold_transition(None, Some(&held.combo));
+    held
 }
 
 fn hold_transition(released: Option<&KeyCombo>, pressed: Option<&KeyCombo>) {
     cfg_select! {
         target_os = "macos" => {
             let mut output = HELD_OUTPUT.lock().unwrap_or_else(PoisonError::into_inner);
+            // `HeldOutput::owners` is the only persistent modifier state. This
+            // bitmask is an event-ordering cursor: derive it from the map while
+            // holding the same mutex, advance it through the exact transition
+            // edges, then prove it reached the map's post-transition state.
             let modifiers = output.modifiers();
             let transition = output.transition(released, pressed);
             let modifiers = macos::hold_keys(&transition.up, KeyPhase::Up, modifiers);

--- a/crates/openlogi-inject/src/inject/macos.rs
+++ b/crates/openlogi-inject/src/inject/macos.rs
@@ -1298,25 +1298,25 @@ mod symbolic_hotkey {
         // SAFETY: resolved AppServices symbol called with its expected
         // signature.
         let was_enabled = unsafe { (cgs.is_enabled)(hotkey) };
-        if !was_enabled {
+        let _restore = if was_enabled {
+            None
+        } else {
             // SAFETY: resolved AppServices symbol called with its expected
             // signature.
             let err = unsafe { (cgs.set_enabled)(hotkey, true) };
             if err != 0 {
                 tracing::warn!(hotkey, err, "CGSSetSymbolicHotKeyEnabled(true) failed");
             }
-        }
+            // Restore even when the enable call reported an error: the SPI may
+            // have changed state before returning it, and this preserves the
+            // old unconditional best-effort disable behavior.
+            Some(HotkeyRestore {
+                hotkey,
+                set_enabled: cgs.set_enabled,
+            })
+        };
 
         post_key(virtual_key, modifiers);
-
-        if !was_enabled {
-            // SAFETY: resolved AppServices symbol called with its expected
-            // signature.
-            let err = unsafe { (cgs.set_enabled)(hotkey, false) };
-            if err != 0 {
-                tracing::warn!(hotkey, err, "CGSSetSymbolicHotKeyEnabled(false) failed");
-            }
-        }
     }
 
     fn post_key(vk: u16, modifiers: u32) {
@@ -1352,6 +1352,26 @@ mod symbolic_hotkey {
     type CgsIsSymbolicHotKeyEnabledFn = unsafe extern "C" fn(c_uint) -> bool;
     type CgsSetSymbolicHotKeyEnabledFn = unsafe extern "C" fn(c_uint, bool) -> c_int;
 
+    struct HotkeyRestore {
+        hotkey: u32,
+        set_enabled: CgsSetSymbolicHotKeyEnabledFn,
+    }
+
+    impl Drop for HotkeyRestore {
+        fn drop(&mut self) {
+            // SAFETY: this is the same resolved AppServices function and hotkey
+            // id used to open the temporary enable window.
+            let err = unsafe { (self.set_enabled)(self.hotkey, false) };
+            if err != 0 {
+                tracing::warn!(
+                    hotkey = self.hotkey,
+                    err,
+                    "CGSSetSymbolicHotKeyEnabled(false) failed"
+                );
+            }
+        }
+    }
+
     fn cgs_hotkey_api() -> Option<CgsHotkeyApi> {
         let get_value = app_services_symbol(c"CGSGetSymbolicHotKeyValue")?;
         let is_enabled = app_services_symbol(c"CGSIsSymbolicHotKeyEnabled")?;
@@ -1372,5 +1392,37 @@ mod symbolic_hotkey {
                 ),
             }
         })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        use super::HotkeyRestore;
+
+        static RESTORED_HOTKEY: AtomicU32 = AtomicU32::new(0);
+
+        unsafe extern "C" fn record_restore(hotkey: u32, enabled: bool) -> i32 {
+            if !enabled {
+                RESTORED_HOTKEY.store(hotkey, Ordering::Relaxed);
+            }
+            0
+        }
+
+        #[test]
+        fn temporary_enable_is_restored_during_unwind() {
+            RESTORED_HOTKEY.store(0, Ordering::Relaxed);
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                let _restore = HotkeyRestore {
+                    hotkey: super::SPACE_LEFT,
+                    set_enabled: record_restore,
+                };
+                panic!("exercise unwind cleanup");
+            }));
+
+            assert!(result.is_err());
+            assert_eq!(RESTORED_HOTKEY.load(Ordering::Relaxed), super::SPACE_LEFT);
+        }
     }
 }

--- a/crates/openlogi-inject/src/lib.rs
+++ b/crates/openlogi-inject/src/lib.rs
@@ -3,8 +3,8 @@
 mod inject;
 
 pub use inject::{
-    SYNTHETIC_EVENT_USER_DATA, SmoothScrollPhase, ax_navigate_browser, execute, post_scroll,
-    post_smooth_scroll, press_hold, release_hold, replace_hold,
+    HeldChord, SYNTHETIC_EVENT_USER_DATA, SmoothScrollPhase, ax_navigate_browser, execute,
+    post_scroll, post_smooth_scroll, press_hold,
 };
 
 #[cfg(target_os = "linux")]

--- a/crates/openlogi-ipc/src/ipc.rs
+++ b/crates/openlogi-ipc/src/ipc.rs
@@ -319,6 +319,11 @@ impl From<PairingError> for PairingFailure {
             PairingError::Timeout => Self::Timeout,
             PairingError::Device(code) => Self::Device { code },
             PairingError::Cancelled => Self::Cancelled,
+            // The public agent API prevents this library-boundary rejection;
+            // retain the existing wire enum if an in-process caller violates it.
+            PairingError::UnsupportedCommand => Self::Hid {
+                message: "pairing command is not supported by the active receiver".into(),
+            },
             // Carried as the generic transport-failure message so the wire
             // format stays unchanged (PairingFailure variants are append-only).
             PairingError::MalformedNotification(what) => Self::Hid {

--- a/crates/openlogi-overlay/src/agent.rs
+++ b/crates/openlogi-overlay/src/agent.rs
@@ -140,38 +140,78 @@ const GIVE_UP_AFTER: Duration = Duration::from_mins(1);
 /// How long to wait between attempts to reach an agent.
 const RETRY_PERIOD: Duration = Duration::from_secs(1);
 
-/// Record a failed attempt to reach an agent, and say whether to give up.
+/// Invocation observer phase and the state meaningful within each phase.
 ///
-/// `unreachable_since` is armed by the first failure of a run and cleared by
-/// the caller on every success, so a helper whose agent keeps flapping back
-/// within the deadline never accumulates its way to an exit.
-fn give_up(unreachable_since: &mut Option<Instant>, now: Instant) -> bool {
-    let armed = *unreachable_since.get_or_insert(now);
-    now.duration_since(armed) >= GIVE_UP_AFTER
+/// A successful connection owns its generation cursor; a reconnect episode
+/// owns its give-up clock. Transitioning between them resets the fact from the
+/// previous phase by construction.
+enum InvocationPollState<C> {
+    Reconnecting { unreachable_since: Option<Instant> },
+    Observing { client: C, seen: Generation },
+}
+
+impl<C> Default for InvocationPollState<C> {
+    fn default() -> Self {
+        Self::Reconnecting {
+            unreachable_since: None,
+        }
+    }
+}
+
+impl<C> InvocationPollState<C> {
+    fn connected(&mut self, client: C) {
+        *self = Self::Observing { client, seen: 0 };
+    }
+
+    fn connection_failed(&mut self, now: Instant) -> bool {
+        let Self::Reconnecting { unreachable_since } = self else {
+            return false;
+        };
+        let armed = *unreachable_since.get_or_insert(now);
+        now.duration_since(armed) >= GIVE_UP_AFTER
+    }
+
+    fn observation(&self) -> Option<(&C, Generation)> {
+        match self {
+            Self::Observing { client, seen } => Some((client, *seen)),
+            Self::Reconnecting { .. } => None,
+        }
+    }
+
+    fn observed(&mut self, generation: Generation) {
+        if let Self::Observing { seen, .. } = self {
+            *seen = generation;
+        }
+    }
+
+    fn disconnected(&mut self) {
+        *self = Self::Reconnecting {
+            unreachable_since: None,
+        };
+    }
 }
 
 async fn poll_invocations(tx: mpsc::UnboundedSender<Option<ActionRingInvocation>>) {
-    let mut client = None;
-    // Generation 0 says "I have seen nothing", so the first answer is whatever
-    // is showing right now — an overlay restarted mid-ring paints the live one
-    // instead of having missed its invocation. Reset on every disconnect: the
-    // replacement agent numbers its own generations.
-    let mut seen: Generation = 0;
-    // Armed while no agent is answering; see `give_up`.
-    let mut unreachable_since: Option<Instant> = None;
+    let mut state = InvocationPollState::default();
     loop {
-        if client.is_none() {
-            client = connect().await;
-            seen = 0;
-        }
-        let Some(active) = client.as_ref() else {
-            if give_up(&mut unreachable_since, Instant::now()) {
-                stand_down(&format!("no agent has answered for {GIVE_UP_AFTER:?}"));
+        if matches!(&state, InvocationPollState::Reconnecting { .. }) {
+            if let Some(client) = connect().await {
+                // Generation 0 says "I have seen nothing", so the first
+                // answer is whatever is showing right now. A replacement
+                // agent numbers its own generations, so every connection
+                // starts there independently.
+                state.connected(client);
+            } else {
+                if state.connection_failed(Instant::now()) {
+                    stand_down(&format!("no agent has answered for {GIVE_UP_AFTER:?}"));
+                }
+                tokio::time::sleep(RETRY_PERIOD).await;
+                continue;
             }
-            tokio::time::sleep(RETRY_PERIOD).await;
+        }
+        let Some((active, seen)) = state.observation() else {
             continue;
         };
-        unreachable_since = None;
         let mut ctx = context::current();
         // Above the agent's hold, or tarpc would cancel the handler mid-wait.
         ctx.deadline = std::time::Instant::now() + OBSERVE_HOLD + Duration::from_secs(5);
@@ -180,14 +220,14 @@ async fn poll_invocations(tx: mpsc::UnboundedSender<Option<ActionRingInvocation>
                 if observed.generation == seen {
                     continue; // the hold elapsed: still alive, still nothing new
                 }
-                seen = observed.generation;
+                state.observed(observed.generation);
                 if tx.send(observed.invocation).is_err() {
                     return;
                 }
             }
             Err(error) => {
                 debug!(?error, "Actions Ring state channel disconnected");
-                client = None;
+                state.disconnected();
             }
         }
     }
@@ -392,37 +432,66 @@ mod tests {
 
     #[test]
     fn the_first_failed_attempt_only_arms_the_give_up_clock() {
-        let mut since = None;
+        let mut state = InvocationPollState::<()>::default();
         let now = Instant::now();
-        assert!(!give_up(&mut since, now));
-        assert_eq!(since, Some(now));
+        assert!(!state.connection_failed(now));
+        assert!(matches!(
+            state,
+            InvocationPollState::Reconnecting {
+                unreachable_since: Some(armed)
+            } if armed == now
+        ));
     }
 
     #[test]
     fn an_agent_that_stays_away_past_the_deadline_ends_the_overlay() {
         let start = Instant::now();
-        let mut since = None;
-        assert!(!give_up(&mut since, start));
-        assert!(!give_up(&mut since, start + GIVE_UP_AFTER / 2));
-        assert!(give_up(&mut since, start + GIVE_UP_AFTER));
+        let mut state = InvocationPollState::<()>::default();
+        assert!(!state.connection_failed(start));
+        assert!(!state.connection_failed(start + GIVE_UP_AFTER / 2));
+        assert!(state.connection_failed(start + GIVE_UP_AFTER));
     }
 
     #[test]
     fn an_agent_that_keeps_coming_back_never_accumulates_its_way_to_an_exit() {
         let start = Instant::now();
-        let mut since = None;
+        let mut state = InvocationPollState::default();
         // Each round the agent is gone for half the deadline, then answers —
-        // which is what clears the clock at the call site. Five rounds is two
-        // and a half deadlines in total, so a version that kept the clock
-        // running across outages would have exited by the third.
+        // which moves the clock out of the reconnecting phase. Five rounds is
+        // two and a half deadlines in total, so a version that kept the clock
+        // across transitions would have exited by the third.
         for round in 1..=5 {
             let gone = start + (GIVE_UP_AFTER / 2) * round;
             assert!(
-                !give_up(&mut since, gone),
+                !state.connection_failed(gone),
                 "a reachable agent must not inherit the previous outage's clock"
             );
-            since = None;
+            state.connected(());
+            assert_eq!(
+                state.observation().map(|observation| observation.1),
+                Some(0)
+            );
+            state.disconnected();
         }
+    }
+
+    #[test]
+    fn a_replacement_agent_starts_with_its_own_generation_cursor() {
+        let mut state = InvocationPollState::default();
+        state.connected(());
+        state.observed(17);
+        assert_eq!(
+            state.observation().map(|observation| observation.1),
+            Some(17)
+        );
+
+        state.disconnected();
+        state.connected(());
+
+        assert_eq!(
+            state.observation().map(|observation| observation.1),
+            Some(0)
+        );
     }
 
     #[test]

--- a/crates/openlogi-overlay/src/main.rs
+++ b/crates/openlogi-overlay/src/main.rs
@@ -69,7 +69,6 @@ fn main() -> Result<()> {
                 };
                 openlogi_core::locale::activate(invocation.language.as_deref());
                 cx.update(|cx| {
-                    live_session.clear();
                     for handle in cx.windows() {
                         let _ = handle.update(cx, |_, window, _| window.remove_window());
                     }
@@ -78,10 +77,9 @@ fn main() -> Result<()> {
                     let timeout_commands = commands.clone();
                     let session_id = invocation.session_id;
                     match cx.open_window(options, |_, cx| {
-                        cx.new(|_| RingView::new(invocation, commands))
+                        cx.new(|_| RingView::new(invocation, commands, &live_session))
                     }) {
                         Ok(handle) => {
-                            live_session.set(session_id);
                             platform::configure_windows();
                             cx.spawn(async move |cx| {
                                 cx.background_executor().timer(DISPLAY_LIFETIME).await;

--- a/crates/openlogi-overlay/src/ring.rs
+++ b/crates/openlogi-overlay/src/ring.rs
@@ -14,10 +14,12 @@ use openlogi_core::binding::ActionRingSlot;
 use openlogi_ipc::ActionRingInvocation;
 use openlogi_ui::action_icons::RING_CANCEL_ICON;
 use openlogi_ui::color;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::agent::OverlayCommand;
 use crate::platform;
+use crate::session::{ClickAwaySession, ShowingRing};
 
 pub(crate) const WINDOW_SIZE: f32 = 360.0;
 pub(crate) const SLOT_SIZE: f32 = 54.0;
@@ -53,18 +55,23 @@ pub(crate) struct RingView {
     invocation: ActionRingInvocation,
     commands: mpsc::UnboundedSender<OverlayCommand>,
     hovered: Option<ActionRingSlot>,
+    /// Publishes click-away identity for exactly this view's lifetime.
+    _showing: ShowingRing,
 }
 
 impl RingView {
     /// Open a view on `invocation`, reporting interactions through `commands`.
-    pub(crate) const fn new(
+    pub(crate) fn new(
         invocation: ActionRingInvocation,
         commands: mpsc::UnboundedSender<OverlayCommand>,
+        live: &Arc<ClickAwaySession>,
     ) -> Self {
+        let showing = live.showing(invocation.session_id);
         Self {
             invocation,
             commands,
             hovered: None,
+            _showing: showing,
         }
     }
 

--- a/crates/openlogi-overlay/src/session.rs
+++ b/crates/openlogi-overlay/src/session.rs
@@ -18,19 +18,28 @@ use crate::ring::RingView;
 
 pub(crate) struct ClickAwaySession(AtomicU64);
 
+/// Publication guard tied to the lifetime of one ring view.
+///
+/// Dropping an older view cannot clear a replacement's session: teardown uses
+/// a compare-and-exchange against the id this guard published.
+#[must_use = "the guard must live as long as its ring view"]
+pub(crate) struct ShowingRing {
+    live: Arc<ClickAwaySession>,
+    session_id: u64,
+}
+
 impl ClickAwaySession {
     pub(crate) const fn new() -> Self {
         Self(AtomicU64::new(0))
     }
 
-    /// Publish which ring is showing, or `0` while none is.
-    pub(crate) fn set(&self, session_id: u64) {
+    /// Publish `session_id` until the returned ring-lifetime guard is dropped.
+    pub(crate) fn showing(self: &Arc<Self>, session_id: u64) -> ShowingRing {
         self.0.store(session_id, Ordering::Release);
-    }
-
-    /// Forget the showing session so later clicks cannot name it.
-    pub(crate) fn clear(&self) {
-        self.set(0);
+        ShowingRing {
+            live: Arc::clone(self),
+            session_id,
+        }
     }
 
     /// Session id at click time, or `None` when no ring is showing.
@@ -40,6 +49,15 @@ impl ClickAwaySession {
             0 => None,
             session_id => Some(session_id),
         }
+    }
+}
+
+impl Drop for ShowingRing {
+    fn drop(&mut self) {
+        let _ =
+            self.live
+                .0
+                .compare_exchange(self.session_id, 0, Ordering::AcqRel, Ordering::Acquire);
     }
 }
 
@@ -146,29 +164,33 @@ mod tests {
 
     #[test]
     fn no_click_is_observed_when_no_ring_is_showing() {
-        let live = ClickAwaySession::new();
+        let live = Arc::new(ClickAwaySession::new());
         assert_eq!(live.observe(), None);
-        live.set(11);
-        live.clear();
+        let showing = live.showing(11);
+        assert_eq!(live.observe(), Some(11));
+        drop(showing);
         assert_eq!(live.observe(), None);
     }
 
     #[test]
     fn a_click_queued_before_a_new_ring_does_not_target_it() {
-        let live = ClickAwaySession::new();
-        live.set(11);
+        let live = Arc::new(ClickAwaySession::new());
+        let previous = live.showing(11);
         let queued = live.observe().expect("a showing ring is observable");
-        live.set(12);
+        let replacement = live.showing(12);
+        drop(previous);
         assert!(
             !click_away_targets(queued, live.observe().expect("replacement is showing")),
             "a click snapshotted against the previous session must not close the new ring"
         );
+        drop(replacement);
+        assert_eq!(live.observe(), None);
     }
 
     #[test]
     fn a_click_against_the_showing_ring_targets_it() {
-        let live = ClickAwaySession::new();
-        live.set(7);
+        let live = Arc::new(ClickAwaySession::new());
+        let _showing = live.showing(7);
         let queued = live.observe().expect("a showing ring is observable");
         assert!(click_away_targets(queued, 7));
     }


### PR DESCRIPTION
## Summary

Follow up on #1080 and complete the public state-machine audit. This fixes every remaining actionable finding, hardens partial findings where another lifecycle path could violate the invariant, and records load-bearing proofs where a representable state is intentionally unreachable.

## Changes

- **agent / agent-core**: unify pairing-session ownership, isolate stale watcher generations, bound scroll cancellation state, make event-monitor state atomic, and count overlapping receiver-access leases with RAII.
- **core / assets / device / HID++**: repair duplicate route ownership on load, type built-in mirror sources, reject Bolt-only pairing commands on Unifying receivers, remove dead pairing status state, and unregister cancelled pending requests immediately.
- **hook / inject / camera / HID**: own held chords through RAII, publish macOS callback/watchdog state atomically, restore symbolic hotkeys on all exits, expose terminal Windows hook failure, cooperatively cancel Windows camera setup, and require the Windows long HID endpoint structurally.
- **desktop / overlay**: type SmartShift, catalog, observation, reconnect, registration-refresh, and click-away lifecycles so stale work cannot mutate successor state.
- **guidance**: codify one-fact/one-authority, complete async publication identity, RAII cache/lease, sentinel-boundary, sibling-divergence, and representable-but-unreachable rules in `.claude/rules/rust.md`.

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent`
- `cargo xtask ci clippy-windows`
- `RUSTFLAGS='-D warnings' cargo check --target x86_64-apple-darwin -p openlogi-inject -p openlogi-hook -p openlogi-agent-core --tests`
- `RUSTFLAGS='-D warnings' cargo clippy --target x86_64-apple-darwin -p openlogi-inject -p openlogi-hook --tests -- -D warnings`
- IPC wire-format golden tests: 14 passed
- Not runtime-tested on real Logitech hardware, macOS, Windows, or a live Wayland compositor. Maintainer verification should exercise pairing start/cancel/restart, interrupted held shortcuts, overlay reconnect/click-away, and Windows camera/hook shutdown.

Follow-up to #1080
