### PR TITLE
fix(macos): stop pinning unavailable Xcode path

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,12 +19,9 @@ linker = "/usr/bin/cc"
 # holding this config file — the repo root — so it works from any cwd.
 runner = ".cargo/run-macos.sh"
 
-# Belt-and-suspenders DEVELOPER_DIR for contributors who run cargo outside
-# the devenv shell and have xcode-select pointing at the Command Line Tools
-# only (no Metal toolchain). `force = false` means a real DEVELOPER_DIR
-# already exported in the shell (devenv users, CI runners) wins.
-[env]
-DEVELOPER_DIR = { value = "/Applications/Xcode.app/Contents/Developer", force = false }
+# Do not set DEVELOPER_DIR here: Cargo applies it to every package, so a fixed
+# Xcode path also breaks non-GUI builds on Command Line Tools-only machines.
+# GUI/devenv builds select their required full-Xcode toolchain explicitly.
 
 [alias]
 xtask = "run -p xtask --"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -22,6 +22,12 @@ Nix/devenv is optional. A normal Rust toolchain is enough.
 
 ### Without Nix
 
+Before a direct GUI build on macOS, expose full Xcode to Cargo even when `xcode-select` remains on Command Line Tools. This is not needed for CLI or non-GUI packages:
+
+```sh
+export DEVELOPER_DIR="${OPENLOGI_DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+```
+
 ```sh
 # rustup installs the stable toolchain pinned in rust-toolchain.toml
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh


### PR DESCRIPTION
## Summary

Stop Cargo from overriding the active macOS developer directory for every package. The fixed Xcode.app path prevents CLI and non-GUI contributors from building on machines that intentionally have only Apple Command Line Tools installed.

Full GUI builds still select their required Xcode and Metal toolchain explicitly through devenv or the documented environment setup.

## Changes

- remove the repository-wide DEVELOPER_DIR value from .cargo/config.toml
- document why a fixed Xcode path must not be reintroduced at Cargo config scope

## Testing

Reproduced on macOS with xcode-select pointing to /Library/Developer/CommandLineTools and no /Applications/Xcode.app:

- before: a minimal Cargo build under the repository fails before compiling project code because xcrun receives the nonexistent Xcode.app developer directory
- after: the same minimal Cargo build passes
- cargo check -p openlogi-core
- cargo fmt --all -- --check
- cargo clippy -p openlogi-core --all-targets -- -D warnings
- cargo test -p openlogi-core (259 passed)
- cargo test --workspace --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items --exclude openlogi-ui --exclude openlogi-desktop --exclude openlogi-overlay --exclude openlogi-agent

The full workspace Clippy command was attempted and reached gpui_macos, but cannot complete on this Command Line Tools-only host because the Metal compiler is not installed. No Logitech hardware runtime test was needed for this build-configuration change.

Fixes #1079