### PR TITLE
feat(gui): load custom themes from config

### DIFF
--- a/crates/openlogi-desktop/AGENTS.md
+++ b/crates/openlogi-desktop/AGENTS.md
@@ -79,6 +79,9 @@ for a never-probed offline device stays centralized in `tabs_for`. Commits go th
   ship them. **Do not vendor copies of those themes into this repo.**
   `OPENLOGI_THEMES_DIR` overrides the lookup.
 - `themes/openlogi.json` is the app's own theme, layered on that upstream set.
+- User themes are individual gpui-component theme-set JSON files under
+  `<config directory>/themes`; the desktop creates that directory and loads its
+  `.json` files at startup after the bundled themes.
 - `bundle/` holds `OpenLogi.entitlements` and one `Info.plist` per bundled
   binary (`desktop-dev`, `agent-release`, `overlay-release`). `cargo xtask`
   packaging reads them; they are the app's macOS identity, not decoration —

--- a/crates/openlogi-desktop/src/main.rs
+++ b/crates/openlogi-desktop/src/main.rs
@@ -125,6 +125,7 @@ fn main() -> Result<()> {
     app.run(move |cx| {
         gpui_component::init(cx);
         theme::register_builtin_themes(cx);
+        theme::register_user_themes(cx);
         app::menu::install(cx);
 
         // Seed the Add Device window's initial state. Its buttons only send

--- a/crates/openlogi-desktop/src/ui/theme.rs
+++ b/crates/openlogi-desktop/src/ui/theme.rs
@@ -17,6 +17,7 @@ use gpui::rgb;
 use gpui::{App, FontWeight, Hsla, Pixels, Rems, Rgba, Styled, Window, hsla, px, relative, rems};
 use gpui_component::{ActiveTheme as _, Theme, ThemeMode, ThemeRegistry};
 use openlogi_core::config::{Appearance, UiScale};
+use std::path::{Path, PathBuf};
 
 use crate::state::AppState;
 
@@ -261,6 +262,105 @@ pub fn register_builtin_themes(cx: &mut App) {
     }
 }
 
+/// Register user theme files from `<config directory>/themes`.
+///
+/// Each `.json` file uses the same gpui-component theme-set schema as
+/// `themes/openlogi.json`. Files are loaded in filename order after the bundled
+/// themes, so a custom theme must use a unique display name. Invalid files are
+/// ignored without preventing the app from starting.
+pub fn register_user_themes(cx: &mut App) {
+    let Ok(themes_dir) = user_themes_dir() else {
+        tracing::warn!("could not resolve the custom themes directory");
+        return;
+    };
+    register_user_themes_from(&themes_dir, cx);
+}
+
+/// Create and open the user's custom-theme directory in the OS file manager.
+pub fn open_user_themes_dir() {
+    let Ok(themes_dir) = user_themes_dir() else {
+        tracing::warn!("could not resolve the custom themes directory");
+        return;
+    };
+    if let Err(error) = std::fs::create_dir_all(&themes_dir) {
+        tracing::warn!(
+            %error,
+            path = %themes_dir.display(),
+            "could not create the custom themes directory"
+        );
+        return;
+    }
+    if let Err(error) = opener::open(&themes_dir) {
+        tracing::warn!(
+            %error,
+            path = %themes_dir.display(),
+            "could not open the custom themes directory"
+        );
+    }
+}
+
+/// Reload bundled and user themes from disk, then reapply the stored selection.
+///
+/// Replacing the registry first removes user themes whose files were deleted;
+/// registering the bundled set again keeps the framework reload from reducing
+/// the picker to only its two defaults.
+pub fn reload_themes(cx: &mut App) {
+    cx.set_global(ThemeRegistry::default());
+    register_builtin_themes(cx);
+    register_user_themes(cx);
+    apply_from_settings(None, cx);
+}
+
+fn user_themes_dir() -> Result<PathBuf, openlogi_core::paths::PathsError> {
+    Ok(openlogi_core::paths::config_dir()?.join("themes"))
+}
+
+fn register_user_themes_from(themes_dir: &Path, cx: &mut App) {
+    if let Err(error) = std::fs::create_dir_all(themes_dir) {
+        tracing::warn!(
+            %error,
+            path = %themes_dir.display(),
+            "could not create the custom themes directory"
+        );
+        return;
+    }
+
+    let Ok(entries) = std::fs::read_dir(themes_dir) else {
+        tracing::warn!(path = %themes_dir.display(), "could not read the custom themes directory");
+        return;
+    };
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry.path()),
+            Err(error) => {
+                tracing::warn!(%error, path = %themes_dir.display(), "could not read a custom theme entry");
+                None
+            }
+        })
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .extension()
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+        })
+        .collect();
+    files.sort();
+
+    let registry = ThemeRegistry::global_mut(cx);
+    for path in files {
+        match std::fs::read_to_string(&path) {
+            Ok(json) => {
+                if let Err(error) = registry.load_themes_from_str(&json) {
+                    tracing::warn!(%error, path = %path.display(), "ignored invalid custom theme file");
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, path = %path.display(), "could not read custom theme file");
+            }
+        }
+    }
+}
+
 fn rem_size(scale: UiScale) -> Pixels {
     px(BASE_REM_SIZE * f32::from(scale.percent()) / 100.)
 }
@@ -463,6 +563,108 @@ impl<E: Styled> Typography for E {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[gpui::test]
+    fn user_theme_files_are_loaded_and_the_directory_is_created(cx: &mut gpui::TestAppContext) {
+        let temp = tempfile::tempdir().expect("create temporary config directory");
+        let themes_dir = temp.path().join("themes");
+
+        cx.update(gpui_component::init);
+        cx.update(|cx| {
+            register_user_themes_from(&themes_dir, cx);
+            assert!(themes_dir.is_dir());
+        });
+
+        std::fs::write(
+            themes_dir.join("custom.json"),
+            r##"{
+                "name": "Custom",
+                "themes": [{
+                    "name": "Custom Test Theme",
+                    "mode": "dark",
+                    "colors": { "background": "#101010" }
+                }]
+            }"##,
+        )
+        .expect("write custom theme");
+        std::fs::write(themes_dir.join("ignored.txt"), "not a theme").expect("write ignored file");
+
+        cx.update(|cx| {
+            register_user_themes_from(&themes_dir, cx);
+            assert!(
+                ThemeRegistry::global(cx)
+                    .themes()
+                    .contains_key("Custom Test Theme")
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn invalid_user_theme_does_not_block_valid_theme(cx: &mut gpui::TestAppContext) {
+        let temp = tempfile::tempdir().expect("create temporary themes directory");
+        std::fs::write(temp.path().join("a-invalid.json"), "{").expect("write invalid theme");
+        std::fs::write(
+            temp.path().join("b-valid.json"),
+            r##"{
+                "name": "Custom",
+                "themes": [{
+                    "name": "Valid After Invalid",
+                    "mode": "light",
+                    "colors": { "background": "#fafafa" }
+                }]
+            }"##,
+        )
+        .expect("write valid theme");
+
+        cx.update(gpui_component::init);
+        cx.update(|cx| {
+            register_user_themes_from(temp.path(), cx);
+            assert!(
+                ThemeRegistry::global(cx)
+                    .themes()
+                    .contains_key("Valid After Invalid")
+            );
+        });
+    }
+
+    #[gpui::test]
+    fn rebuilding_registry_removes_deleted_user_theme(cx: &mut gpui::TestAppContext) {
+        let temp = tempfile::tempdir().expect("create temporary themes directory");
+        let theme_path = temp.path().join("removed.json");
+        std::fs::write(
+            &theme_path,
+            r##"{
+                "name": "Custom",
+                "themes": [{
+                    "name": "Removed Theme",
+                    "mode": "dark",
+                    "colors": { "background": "#101010" }
+                }]
+            }"##,
+        )
+        .expect("write custom theme");
+
+        cx.update(gpui_component::init);
+        cx.update(|cx| {
+            register_builtin_themes(cx);
+            register_user_themes_from(temp.path(), cx);
+            assert!(
+                ThemeRegistry::global(cx)
+                    .themes()
+                    .contains_key("Removed Theme")
+            );
+        });
+
+        std::fs::remove_file(theme_path).expect("remove custom theme");
+        cx.update(|cx| {
+            cx.set_global(ThemeRegistry::default());
+            register_builtin_themes(cx);
+            register_user_themes_from(temp.path(), cx);
+            let registry = ThemeRegistry::global(cx);
+            assert!(!registry.themes().contains_key("Removed Theme"));
+            assert!(registry.themes().contains_key(OPENLOGI_DARK));
+        });
+    }
 
     #[test]
     fn content_width_scale_preserves_the_standard_layout() {

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -2,14 +2,15 @@
 
 use super::language::{LanguageOption, language_select_field};
 use gpui::{ElementId, img};
+use gpui_base::Button as BaseButton;
 use openlogi_core::config::AppIcon;
 
 use super::{
     ActiveTheme, App, AppState, Appearance, Axis, Button, ButtonGroup, Entity, FluentBuilder, Hsla,
-    IconName, InputState, InteractiveElement, IntoElement, Palette, ParentElement, Rc, SelectState,
-    Selectable, SettingField, SettingGroup, SettingItem, SettingPage, SettingsView, SharedString,
-    StateEvent, StatefulInteractiveElement, Styled, Theme, ThemeColor, ThemeConfig, ThemeFilter,
-    ThemeMode, ThemeRegistry, UiScale, div, h_flex, px, rgb, theme, v_flex,
+    Icon, IconName, InputState, InteractiveElement, IntoElement, Palette, ParentElement, Rc,
+    SelectState, Selectable, SettingField, SettingGroup, SettingItem, SettingPage, SettingsView,
+    SharedString, StateEvent, StatefulInteractiveElement, Styled, Theme, ThemeColor, ThemeConfig,
+    ThemeFilter, ThemeMode, ThemeRegistry, UiScale, div, h_flex, px, rgb, theme, v_flex,
 };
 use crate::platform::app_icon;
 use crate::ui::choice_card::ChoiceCard;
@@ -481,55 +482,104 @@ fn theme_picker(
     v_flex()
         .w_full()
         .gap_3()
+        .child(theme_toolbar(view, theme_search, filter, pal))
+        .child(grid)
+}
+
+fn theme_toolbar(
+    view: &Entity<SettingsView>,
+    theme_search: &Entity<InputState>,
+    filter: ThemeFilter,
+    pal: Palette,
+) -> impl IntoElement {
+    // Translated chip labels may wrap so the fixed-width search and actions
+    // remain available in narrower Settings windows.
+    h_flex()
+        .w_full()
+        .items_center()
+        .justify_between()
+        .gap_3()
         .child(
             h_flex()
-                .w_full()
-                .items_center()
-                .justify_between()
-                .gap_3()
-                .child(
-                    // Translated chip labels vary in width; let the chip row
-                    // yield (wrapping onto a second line if it must) so the
-                    // fixed-width search input is never pushed out of view.
-                    h_flex()
-                        .gap_2()
-                        .flex_1()
-                        .min_w_0()
-                        .flex_wrap()
-                        .child(filter_chip(
-                            view,
-                            "filter-all",
-                            tr!("common.all"),
-                            ThemeFilter::All,
-                            filter,
-                            pal,
-                        ))
-                        .child(filter_chip(
-                            view,
-                            "filter-light",
-                            tr!("common.light"),
-                            ThemeFilter::Light,
-                            filter,
-                            pal,
-                        ))
-                        .child(filter_chip(
-                            view,
-                            "filter-dark",
-                            tr!("appearance.dark"),
-                            ThemeFilter::Dark,
-                            filter,
-                            pal,
-                        )),
-                )
-                .child(
-                    div().w(px(200.)).flex_shrink_0().child(
-                        control_input(theme_search)
-                            .cleanable(true)
-                            .prefix(IconName::Search),
-                    ),
-                ),
+                // Translated chip labels vary in width; let the chip row
+                // yield (wrapping onto a second line if it must) so the
+                // fixed-width search input is never pushed out of view.
+                .gap_2()
+                .flex_1()
+                .min_w_0()
+                .flex_wrap()
+                .child(filter_chip(
+                    view,
+                    "filter-all",
+                    tr!("common.all"),
+                    ThemeFilter::All,
+                    filter,
+                    pal,
+                ))
+                .child(filter_chip(
+                    view,
+                    "filter-light",
+                    tr!("common.light"),
+                    ThemeFilter::Light,
+                    filter,
+                    pal,
+                ))
+                .child(filter_chip(
+                    view,
+                    "filter-dark",
+                    tr!("appearance.dark"),
+                    ThemeFilter::Dark,
+                    filter,
+                    pal,
+                )),
         )
-        .child(grid)
+        .child(
+            div().w(px(200.)).flex_shrink_0().child(
+                control_input(theme_search)
+                    .cleanable(true)
+                    .prefix(IconName::Search),
+            ),
+        )
+        .child(theme_action_button(
+            "themes-open",
+            tr!("common.open"),
+            IconName::FolderOpen,
+            pal,
+            |_| theme::open_user_themes_dir(),
+        ))
+        .child(theme_action_button(
+            "themes-refresh",
+            tr!("common.refresh"),
+            IconName::Undo,
+            pal,
+            theme::reload_themes,
+        ))
+}
+
+fn theme_action_button(
+    id: &'static str,
+    label: SharedString,
+    icon: IconName,
+    pal: Palette,
+    on_click: impl Fn(&mut App) + 'static,
+) -> impl IntoElement {
+    BaseButton::new(id)
+        .accessibility_label(label.clone())
+        .flex_shrink_0()
+        .px_2()
+        .py_1()
+        .gap_1()
+        .rounded(pal.control_radius)
+        .border_1()
+        .border_color(pal.border)
+        .text_caption()
+        .cursor_pointer()
+        .bg(pal.control)
+        .hover(move |style| style.bg(pal.control_hover))
+        .focus_visible(move |style| style.bg(pal.control_hover))
+        .child(Icon::new(icon).size_3())
+        .child(label)
+        .on_click(move |_, _, cx| on_click(cx))
 }
 
 /// Resolve a theme config's colours into a concrete [`ThemeColor`] for its

--- a/crates/openlogi-desktop/src/windows/settings/appearance.rs
+++ b/crates/openlogi-desktop/src/windows/settings/appearance.rs
@@ -492,10 +492,11 @@ fn theme_toolbar(
     filter: ThemeFilter,
     pal: Palette,
 ) -> impl IntoElement {
-    // Translated chip labels may wrap so the fixed-width search and actions
-    // remain available in narrower Settings windows.
+    // Let the whole toolbar wrap so fixed-width controls stay accessible when
+    // translated labels or a narrow window exhaust the first row.
     h_flex()
         .w_full()
+        .flex_wrap()
         .items_center()
         .justify_between()
         .gap_3()


### PR DESCRIPTION
## Summary

Allow users to install gpui-component theme JSON files in their OpenLogi config directory and use them alongside the bundled themes.

## Changes

- Load sorted `.json` theme files from `<config directory>/themes` at desktop startup.
- Add Appearance actions to open the themes directory and refresh themes without restarting.
- Rebuild the registry during refresh so added, changed, and deleted files are reflected while bundled themes remain available.
- Ignore invalid theme files with path-specific warnings instead of blocking startup.
- Cover directory creation, valid/invalid loading, and deleted-theme removal with GPUI tests.

## Testing

- `RUSTFLAGS="-D warnings" DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" TOOLCHAINS="com.apple.dt.toolchain.Metal.32023.883" cargo clippy -p openlogi-desktop --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" TOOLCHAINS="com.apple.dt.toolchain.Metal.32023.883" cargo test -p openlogi-desktop` (200 passed)
- `cargo fmt --all -- --check`
- Runtime-tested on macOS with a custom Drive theme: startup discovery, selection, folder opening, and in-app refresh verified.
- Not runtime-tested on Linux or Windows.