### PR TITLE
fix(agent): divert the gesture button for its default click

### DIFF
--- a/crates/openlogi-agent-core/src/capture_plan.rs
+++ b/crates/openlogi-agent-core/src/capture_plan.rs
@@ -147,10 +147,12 @@ pub fn plan_for_device(
                     return true;
                 }
                 let action = binding.click_action();
-                // The panel's default is ShowActionsRing, which must be
-                // diverted to open the ring. Action::None means "leave native
-                // firmware haptics alone", so treat None as the only non-divert.
-                if *button == ButtonId::HapticPanel {
+                // For the haptic panel (MX Master 4) and the gesture button
+                // (most MX mice), divert unless the action is None: neither
+                // control has a native function, so even the default action
+                // needs the divert. None means "leave native firmware
+                // behavior alone".
+                if button.is_hidpp_gesture_source() {
                     action != Action::None
                 } else {
                     action != default_binding(*button)
@@ -456,11 +458,37 @@ mod tests {
     }
 
     #[test]
-    fn gestures_off_default_gesture_button_stays_native() {
-        // With gestures off and no explicit binding, the gesture button keeps
-        // its native HID behavior — same contract as the standard buttons.
+    fn gestures_off_gesture_button_at_its_default_click_is_plain_diverted() {
+        // Leaving gesture mode stores the gesture button as Single of its
+        // default click, MissionControl. The button has no native function,
+        // so that action fires only via a plain HID++ divert.
         let mut cfg = Config::default();
         cfg.set_gesture_mode("2b042", ButtonId::GestureButton, false);
+
+        let plan = plan_for_device(&cfg, "2b042", route(), None, 0, true);
+        assert!(
+            plan.dispatch.gesture_bindings.is_empty(),
+            "gestures are off — no raw-XY gesture divert"
+        );
+        assert!(
+            plan.target
+                .spec
+                .divert_buttons
+                .contains(&(GESTURE_BUTTON_CID, ButtonId::GestureButton)),
+            "the default click must be plain-diverted, or the binding the GUI shows never fires"
+        );
+    }
+
+    #[test]
+    fn explicit_none_gesture_button_stays_native() {
+        // Action::None is the one way to leave the gesture button alone — the
+        // same contract as the haptic panel.
+        let mut cfg = Config::default();
+        cfg.set_binding(
+            "2b042",
+            ButtonId::GestureButton,
+            Binding::Single(Action::None),
+        );
 
         let plan = plan_for_device(&cfg, "2b042", route(), None, 0, true);
         assert!(
@@ -470,7 +498,7 @@ mod tests {
                 .divert_buttons
                 .iter()
                 .any(|&(cid, _)| cid == GESTURE_BUTTON_CID),
-            "an unbound gesture button must not be captured"
+            "an explicitly unbound gesture button must not be captured"
         );
     }
 


### PR DESCRIPTION
## Summary

**Version**: openlogi 0.6.25 (nixpkgs)

**Device**: MX Master 3S

**Current behavior (undesired):** with "Gesture Button" set to "Off", and the Gesture Button bound to "Mission Control", clicking the Gesture Button should open Mission Control. It does nothing.

**Root cause:** `plan_for_device` diverts a button only when its action differs from the button's default. That is right for Middle, Back, and Forward: at their default they keep their native HID behavior, so no divert is needed. The gesture button has no native function, so a binding on it can only fire through a divert — and its default is Mission Control, so the default-comparison rule skips the divert and leaves the button dead. Any other action works, which is what makes this easy to miss. The MX Master 4 haptic panel already had the correct rule (divert unless the action is `None`); this applies it to every HID++ gesture source.

## Changes

- `openlogi-agent-core`: `plan_for_device` diverts a HID++ gesture source outside gesture mode for any single action but `None`. The test that pinned the old behavior now asserts the divert; a new test covers an explicit `None` staying native.

## Testing

Rebased onto `master` at `0b0b24ea`. The two tests are written against the current `plan_for_device` arity and the `CaptureTarget` / `DispatchPlan` split introduced by #722 and #1136; the production hunk itself needed no adaptation.

Full local gate, run on the final tree (macOS arm64, Rust 1.98.0):

- `cargo fmt --all -- --check` — clean
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets -- -D warnings` — clean, the three GPUI crates included
- `RUSTFLAGS="-D warnings" cargo test --workspace` — 1367 passed, 0 failed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` with the four documented exclusions — clean
- `cargo xtask ci rustfmt publish-closure rustdoc` — 3 passed, 0 failed, 0 skipped

That workspace test run sets `GIT_CONFIG_GLOBAL=/dev/null`, which matches CI, where no global git config exists. Without it, `xtask`'s `commands::release::checkout_version_bump::tests::existing_release_tag_skips_publishing` fails on any machine whose global config sets `tag.gpgsign = true`: the fixture disables `commit.gpgsign` but not `tag.gpgsign`, so its `git tag v0.7.5` becomes a signed annotated tag, demands a message, and exits 128. That is a pre-existing gap in the fixture and is unrelated to this change.

Not run on this host:

- `clippy` and `tests (linux)` — Linux compilation.
- `MSRV` — no rustup here; the host toolchain is 1.98, the floor.
- `clippy (windows)` and `wasm` — cross targets not installed.
- `typos` — typos-cli not installed here.
- `cargo-deny` — cargo-deny not installed here. The rebase picks up `d540cd67`, which replaces the yanked `chacha20 0.10.1` with `0.10.2`. `Cargo.lock` is now byte-identical to master's, and master's own CI run at `0b0b24ea` is green on that job.

Runtime-tested on hardware: MX Master 3S (Bluetooth-direct), macOS 26. With the Gesture Button set to "Off" and bound to Mission Control, a press logged `HID++ button → binding button=GestureButton action=Mission Control` and Mission Control opened. Before the change the same press did nothing. That run predates the rebase, which left the production hunk unchanged.
