### PR TITLE
fix(hook): mirror the real device identity onto the Linux uinput mouse

### DIFF
--- a/crates/openlogi-hook/src/linux.rs
+++ b/crates/openlogi-hook/src/linux.rs
@@ -292,7 +292,16 @@ fn is_hookable_mouse(
 }
 
 fn build_virtual_device(device: &Device) -> io::Result<evdev::uinput::VirtualDevice> {
-    let builder = VirtualDevice::builder()?.name(VIRTUAL_DEVICE_NAME);
+    // Mirroring the physical device's bus/vendor/product/version is what lets
+    // the desktop keep treating this the same mouse. GNOME and KDE both key a
+    // per-device pointer-speed profile off that identity; leaving it at
+    // evdev's uinput default (a literal placeholder — vendor 0x1234, product
+    // 0x5678) makes the grabbed-and-reinjected mouse read as brand-new
+    // hardware, so the user's own speed setting for it silently stops
+    // applying (#1075).
+    let builder = VirtualDevice::builder()?
+        .name(VIRTUAL_DEVICE_NAME)
+        .input_id(device.input_id());
 
     let builder = if let Some(keys) = device.supported_keys() {
         builder.with_keys(keys)?


### PR DESCRIPTION
## Summary

Fixes the root cause of #1075: on Linux, OpenLogi grabs a Logitech mouse exclusively
and re-emits its events through a `uinput` virtual device. That virtual device was
built with no `input_id`, so it fell back to the `evdev` crate's own uinput
placeholder — I read the crate source directly and confirmed it's literally labeled
`/* sample vendor */` / `/* sample product */` (bus USB, vendor `0x1234`, product
`0x5678`).

GNOME and KDE both key a per-device pointer-speed/acceleration profile off that
identity. The moment OpenLogi starts and regrabs the mouse, the desktop stops seeing
"the MX Master/M650 the user tuned in system settings" and instead sees brand-new,
unrecognized hardware with no saved profile — which is exactly what #1075 describes:
sensitivity reset, "ignores system settings," feels much slower than before OpenLogi
touched it.

## Changes

**`crates/openlogi-hook/src/linux.rs`**

- `build_virtual_device` now passes `device.input_id()` into the builder. It's a
  typed, lossless mirror — `Device::input_id()` and
  `VirtualDeviceBuilder::input_id()` share the exact same `InputId` struct, so
  there's no conversion or truncation involved.

## Testing

- `cargo fmt --all -- --check` — pass
- `cargo clippy -p openlogi-hook --all-targets -- -D warnings` — pass
- `cargo test -p openlogi-hook` — pass, 43 tests + 1 doctest (unchanged; the actual
  fix has no unit-testable surface of its own — `build_virtual_device` needs a real,
  opened `evdev::Device` from a live `/dev/input` node, which a unit test can't
  construct without root/uinput access. Per this crate's own `AGENTS.md`: "CI lints
  them; treat the linux/windows CI jobs as the check, not local builds.")
- `cargo clippy --target x86_64-pc-windows-gnu -p openlogi-hook --all-targets -D
  warnings` — pass (this file is Linux-only, but the workspace cross-lints clean)

**Runtime verification (real hardware, this machine):** built a throwaway scratch
harness (not part of this diff) that creates a synthetic `uinput` device presenting
Logitech's vendor ID (`0x046d`) with `BTN_LEFT`/`REL_X`/`REL_Y`, starts the real hook
against it, and reads back the resulting virtual device's `input_id` from
`/dev/input`. Before the fix: `vendor=0x1234 product=0x5678` regardless of what the
physical device reported. After: the synthetic device (`vendor=0x046d
product=0xbeef`) and — as a bonus, my own Signature M650 happened to reconnect mid-test
(`bus=Bluetooth vendor=0x046d product=0xb02a`) — both produced virtual devices
mirroring their physical counterpart's identity exactly.

Fixes #1075